### PR TITLE
Update Conductor styling

### DIFF
--- a/apps/journeys/src/components/Conductor/Conductor.stories.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.stories.tsx
@@ -27,47 +27,58 @@ export const Default = (): ReactElement => (
           nextBlockId: 'step2.id',
           children: [
             {
-              id: 'radioQuestion1.id',
-              __typename: 'RadioQuestionBlock',
+              id: 'card1.id',
+              __typename: 'CardBlock',
               parentBlockId: 'step1.id',
-              label: 'Step 1',
-              description: 'Start',
+              backgroundColor: null,
+              coverBlockId: null,
+              themeMode: null,
+              themeName: null,
               children: [
                 {
-                  id: 'radioOption2.id',
-                  __typename: 'RadioOptionBlock',
-                  parentBlockId: 'radioQuestion1.id',
-                  label: 'Step 2 (Locked)',
-                  action: {
-                    __typename: 'NavigateToBlockAction',
-                    gtmEventName: 'gtmEventName',
-                    blockId: 'step2.id'
-                  },
-                  children: []
-                },
-                {
-                  id: 'radioOption3.id',
-                  __typename: 'RadioOptionBlock',
-                  parentBlockId: 'radioQuestion1.id',
-                  label: 'Step 3 (No nextBlockId)',
-                  action: {
-                    __typename: 'NavigateToBlockAction',
-                    gtmEventName: 'gtmEventName',
-                    blockId: 'step3.id'
-                  },
-                  children: []
-                },
-                {
-                  id: 'radioOption4.id',
-                  __typename: 'RadioOptionBlock',
-                  parentBlockId: 'radioQuestion1.id',
-                  label: 'Step 4 (End)',
-                  action: {
-                    __typename: 'NavigateToBlockAction',
-                    gtmEventName: 'gtmEventName',
-                    blockId: 'step4.id'
-                  },
-                  children: []
+                  id: 'radioQuestion1.id',
+                  __typename: 'RadioQuestionBlock',
+                  parentBlockId: 'card1.id',
+                  label: 'Step 1',
+                  description: 'Start',
+                  children: [
+                    {
+                      id: 'radioOption2.id',
+                      __typename: 'RadioOptionBlock',
+                      parentBlockId: 'radioQuestion1.id',
+                      label: 'Step 2 (Locked)',
+                      action: {
+                        __typename: 'NavigateToBlockAction',
+                        gtmEventName: 'gtmEventName',
+                        blockId: 'step2.id'
+                      },
+                      children: []
+                    },
+                    {
+                      id: 'radioOption3.id',
+                      __typename: 'RadioOptionBlock',
+                      parentBlockId: 'radioQuestion1.id',
+                      label: 'Step 3 (No nextBlockId)',
+                      action: {
+                        __typename: 'NavigateToBlockAction',
+                        gtmEventName: 'gtmEventName',
+                        blockId: 'step3.id'
+                      },
+                      children: []
+                    },
+                    {
+                      id: 'radioOption4.id',
+                      __typename: 'RadioOptionBlock',
+                      parentBlockId: 'radioQuestion1.id',
+                      label: 'Step 4 (End)',
+                      action: {
+                        __typename: 'NavigateToBlockAction',
+                        gtmEventName: 'gtmEventName',
+                        blockId: 'step4.id'
+                      },
+                      children: []
+                    }
+                  ]
                 }
               ]
             }
@@ -81,47 +92,58 @@ export const Default = (): ReactElement => (
           nextBlockId: 'step3.id',
           children: [
             {
-              id: 'radioQuestion1.id',
-              __typename: 'RadioQuestionBlock',
+              id: 'card2.id',
+              __typename: 'CardBlock',
               parentBlockId: 'step2.id',
-              label: 'Step 2',
-              description: 'Locked',
+              backgroundColor: null,
+              coverBlockId: null,
+              themeMode: null,
+              themeName: null,
               children: [
                 {
-                  id: 'radioOption1.id',
-                  __typename: 'RadioOptionBlock',
-                  parentBlockId: 'radioQuestion1.id',
-                  label: 'Step 1 (Start)',
-                  action: {
-                    __typename: 'NavigateToBlockAction',
-                    gtmEventName: 'gtmEventName',
-                    blockId: 'step1.id'
-                  },
-                  children: []
-                },
-                {
-                  id: 'radioOption3.id',
-                  __typename: 'RadioOptionBlock',
-                  parentBlockId: 'radioQuestion1.id',
-                  label: 'Step 3 (No nextBlockId)',
-                  action: {
-                    __typename: 'NavigateToBlockAction',
-                    gtmEventName: 'gtmEventName',
-                    blockId: 'step3.id'
-                  },
-                  children: []
-                },
-                {
-                  id: 'radioOption4.id',
-                  __typename: 'RadioOptionBlock',
-                  parentBlockId: 'radioQuestion1.id',
-                  label: 'Step 4 (End)',
-                  action: {
-                    __typename: 'NavigateToBlockAction',
-                    gtmEventName: 'gtmEventName',
-                    blockId: 'step4.id'
-                  },
-                  children: []
+                  id: 'radioQuestion1.id',
+                  __typename: 'RadioQuestionBlock',
+                  parentBlockId: 'step2.id',
+                  label: 'Step 2',
+                  description: 'Locked',
+                  children: [
+                    {
+                      id: 'radioOption1.id',
+                      __typename: 'RadioOptionBlock',
+                      parentBlockId: 'radioQuestion1.id',
+                      label: 'Step 1 (Start)',
+                      action: {
+                        __typename: 'NavigateToBlockAction',
+                        gtmEventName: 'gtmEventName',
+                        blockId: 'step1.id'
+                      },
+                      children: []
+                    },
+                    {
+                      id: 'radioOption3.id',
+                      __typename: 'RadioOptionBlock',
+                      parentBlockId: 'radioQuestion1.id',
+                      label: 'Step 3 (No nextBlockId)',
+                      action: {
+                        __typename: 'NavigateToBlockAction',
+                        gtmEventName: 'gtmEventName',
+                        blockId: 'step3.id'
+                      },
+                      children: []
+                    },
+                    {
+                      id: 'radioOption4.id',
+                      __typename: 'RadioOptionBlock',
+                      parentBlockId: 'radioQuestion1.id',
+                      label: 'Step 4 (End)',
+                      action: {
+                        __typename: 'NavigateToBlockAction',
+                        gtmEventName: 'gtmEventName',
+                        blockId: 'step4.id'
+                      },
+                      children: []
+                    }
+                  ]
                 }
               ]
             }
@@ -135,47 +157,58 @@ export const Default = (): ReactElement => (
           nextBlockId: null,
           children: [
             {
-              id: 'radioQuestion1.id',
-              __typename: 'RadioQuestionBlock',
-              parentBlockId: 'step1.id',
-              label: 'Step 3',
-              description: 'No nextBlockId',
+              id: 'card3.id',
+              __typename: 'CardBlock',
+              parentBlockId: 'step3.id',
+              backgroundColor: null,
+              coverBlockId: null,
+              themeMode: null,
+              themeName: null,
               children: [
                 {
-                  id: 'radioOption1.id',
-                  __typename: 'RadioOptionBlock',
-                  parentBlockId: 'radioQuestion1.id',
-                  label: 'Step 1 (Start)',
-                  action: {
-                    __typename: 'NavigateToBlockAction',
-                    gtmEventName: 'gtmEventName',
-                    blockId: 'step1.id'
-                  },
-                  children: []
-                },
-                {
-                  id: 'radioOption2.id',
-                  __typename: 'RadioOptionBlock',
-                  parentBlockId: 'radioQuestion1.id',
-                  label: 'Step 2 (Locked)',
-                  action: {
-                    __typename: 'NavigateToBlockAction',
-                    gtmEventName: 'gtmEventName',
-                    blockId: 'step2.id'
-                  },
-                  children: []
-                },
-                {
-                  id: 'radioOption4.id',
-                  __typename: 'RadioOptionBlock',
-                  parentBlockId: 'radioQuestion1.id',
-                  label: 'Step 4 (End)',
-                  action: {
-                    __typename: 'NavigateToBlockAction',
-                    gtmEventName: 'gtmEventName',
-                    blockId: 'step4.id'
-                  },
-                  children: []
+                  id: 'radioQuestion1.id',
+                  __typename: 'RadioQuestionBlock',
+                  parentBlockId: 'card3.id',
+                  label: 'Step 3',
+                  description: 'No nextBlockId',
+                  children: [
+                    {
+                      id: 'radioOption1.id',
+                      __typename: 'RadioOptionBlock',
+                      parentBlockId: 'radioQuestion1.id',
+                      label: 'Step 1 (Start)',
+                      action: {
+                        __typename: 'NavigateToBlockAction',
+                        gtmEventName: 'gtmEventName',
+                        blockId: 'step1.id'
+                      },
+                      children: []
+                    },
+                    {
+                      id: 'radioOption2.id',
+                      __typename: 'RadioOptionBlock',
+                      parentBlockId: 'radioQuestion1.id',
+                      label: 'Step 2 (Locked)',
+                      action: {
+                        __typename: 'NavigateToBlockAction',
+                        gtmEventName: 'gtmEventName',
+                        blockId: 'step2.id'
+                      },
+                      children: []
+                    },
+                    {
+                      id: 'radioOption4.id',
+                      __typename: 'RadioOptionBlock',
+                      parentBlockId: 'radioQuestion1.id',
+                      label: 'Step 4 (End)',
+                      action: {
+                        __typename: 'NavigateToBlockAction',
+                        gtmEventName: 'gtmEventName',
+                        blockId: 'step4.id'
+                      },
+                      children: []
+                    }
+                  ]
                 }
               ]
             }
@@ -189,47 +222,58 @@ export const Default = (): ReactElement => (
           nextBlockId: null,
           children: [
             {
-              id: 'radioQuestion1.id',
-              __typename: 'RadioQuestionBlock',
+              id: 'card4.id',
+              __typename: 'CardBlock',
               parentBlockId: 'step4.id',
-              label: 'Step 4',
-              description: 'End',
+              backgroundColor: null,
+              coverBlockId: null,
+              themeMode: null,
+              themeName: null,
               children: [
                 {
-                  id: 'radioOption1.id',
-                  __typename: 'RadioOptionBlock',
-                  parentBlockId: 'radioQuestion1.id',
-                  label: 'Step 1 (Start)',
-                  action: {
-                    __typename: 'NavigateToBlockAction',
-                    gtmEventName: 'gtmEventName',
-                    blockId: 'step1.id'
-                  },
-                  children: []
-                },
-                {
-                  id: 'radioOption2.id',
-                  __typename: 'RadioOptionBlock',
-                  parentBlockId: 'radioQuestion1.id',
-                  label: 'Step 2 (Locked)',
-                  action: {
-                    __typename: 'NavigateToBlockAction',
-                    gtmEventName: 'gtmEventName',
-                    blockId: 'step2.id'
-                  },
-                  children: []
-                },
-                {
-                  id: 'radioOption3.id',
-                  __typename: 'RadioOptionBlock',
-                  parentBlockId: 'radioQuestion1.id',
-                  label: 'Step 3 (No nextBlockId)',
-                  action: {
-                    __typename: 'NavigateToBlockAction',
-                    gtmEventName: 'gtmEventName',
-                    blockId: 'step3.id'
-                  },
-                  children: []
+                  id: 'radioQuestion1.id',
+                  __typename: 'RadioQuestionBlock',
+                  parentBlockId: 'step4.id',
+                  label: 'Step 4',
+                  description: 'End',
+                  children: [
+                    {
+                      id: 'radioOption1.id',
+                      __typename: 'RadioOptionBlock',
+                      parentBlockId: 'radioQuestion1.id',
+                      label: 'Step 1 (Start)',
+                      action: {
+                        __typename: 'NavigateToBlockAction',
+                        gtmEventName: 'gtmEventName',
+                        blockId: 'step1.id'
+                      },
+                      children: []
+                    },
+                    {
+                      id: 'radioOption2.id',
+                      __typename: 'RadioOptionBlock',
+                      parentBlockId: 'radioQuestion1.id',
+                      label: 'Step 2 (Locked)',
+                      action: {
+                        __typename: 'NavigateToBlockAction',
+                        gtmEventName: 'gtmEventName',
+                        blockId: 'step2.id'
+                      },
+                      children: []
+                    },
+                    {
+                      id: 'radioOption3.id',
+                      __typename: 'RadioOptionBlock',
+                      parentBlockId: 'radioQuestion1.id',
+                      label: 'Step 3 (No nextBlockId)',
+                      action: {
+                        __typename: 'NavigateToBlockAction',
+                        gtmEventName: 'gtmEventName',
+                        blockId: 'step3.id'
+                      },
+                      children: []
+                    }
+                  ]
                 }
               ]
             }

--- a/apps/journeys/src/components/Conductor/Conductor.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.tsx
@@ -55,7 +55,11 @@ export function Conductor({ blocks }: ConductorProps): ReactElement {
         {treeBlocks.map((block) => (
           <SwiperSlide
             key={block.id}
-            style={{ width: 'calc(100% - 20px - 20px)' }}
+            style={{
+              width: 'calc(100% - 24px - 24px)',
+              paddingTop: '4px',
+              paddingBottom: '4px'
+            }}
           >
             <BlockRenderer {...block} />
           </SwiperSlide>


### PR DESCRIPTION
We should now be able to see the top/bottom shadows on cards and see the right edge of the last card.
Issue:
![image](https://user-images.githubusercontent.com/10802634/135777972-30c7b5ec-763e-47fd-a15c-5e9cee1c5d97.png)
Fix with 4px bottom padding:
![image](https://user-images.githubusercontent.com/10802634/135777983-9c900787-7921-49d0-afbc-40f6eed6c0dd.png)
Fix with 8px bottom padding:
![image](https://user-images.githubusercontent.com/10802634/135778014-0052bfed-6f58-4375-84f7-0c598cc8ed8e.png)

