### PR TITLE
Simplify Resolvers

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -235,6 +235,8 @@ type SignUpBlock implements Block {
   action: Action
   id: ID!
   parentBlockId: ID
+  submitIcon: Icon
+  submitLabel: String
 }
 
 type SignUpResponse implements Response {

--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -210,7 +210,7 @@ type RadioQuestionBlock implements Block {
 }
 
 type RadioQuestionResponse implements Response {
-  block: RadioQuestionBlock!
+  block: RadioQuestionBlock
   id: ID!
   radioOptionBlockId: ID!
   userId: ID!
@@ -240,7 +240,7 @@ type SignUpBlock implements Block {
 }
 
 type SignUpResponse implements Response {
-  block: SignUpBlock!
+  block: SignUpBlock
   email: String!
   id: ID!
   name: String!
@@ -333,7 +333,7 @@ type VideoBlock implements Block {
 }
 
 type VideoResponse implements Response {
-  block: VideoBlock!
+  block: VideoBlock
   id: ID!
   state: VideoResponseStateEnum!
   userId: ID!

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -187,7 +187,7 @@ type RadioQuestionResponse implements Response {
   id: ID!
   userId: ID!
   radioOptionBlockId: ID!
-  block: RadioQuestionBlock!
+  block: RadioQuestionBlock
 }
 
 input RadioQuestionResponseCreateInput {
@@ -217,7 +217,7 @@ type SignUpResponse implements Response {
   userId: ID!
   name: String!
   email: String!
-  block: SignUpBlock!
+  block: SignUpBlock
 }
 
 input SignUpResponseCreateInput {
@@ -308,7 +308,7 @@ type VideoResponse implements Response {
   id: ID!
   userId: ID!
   state: VideoResponseStateEnum!
-  block: VideoBlock!
+  block: VideoBlock
 }
 
 input VideoResponseCreateInput {

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -208,6 +208,8 @@ type SignUpBlock implements Block {
   id: ID!
   parentBlockId: ID
   action: Action
+  submitIcon: Icon
+  submitLabel: String
 }
 
 type SignUpResponse implements Response {

--- a/apps/api-journeys/src/__generated__/types.ts
+++ b/apps/api-journeys/src/__generated__/types.ts
@@ -236,7 +236,7 @@ export type RadioQuestionBlock = Block & {
 
 export type RadioQuestionResponse = Response & {
   __typename?: 'RadioQuestionResponse';
-  block: RadioQuestionBlock;
+  block?: Maybe<RadioQuestionBlock>;
   id: Scalars['ID'];
   radioOptionBlockId: Scalars['ID'];
   userId: Scalars['ID'];
@@ -265,7 +265,7 @@ export type SignUpBlock = Block & {
 
 export type SignUpResponse = Response & {
   __typename?: 'SignUpResponse';
-  block: SignUpBlock;
+  block?: Maybe<SignUpBlock>;
   email: Scalars['String'];
   id: Scalars['ID'];
   name: Scalars['String'];
@@ -352,7 +352,7 @@ export type VideoBlock = Block & {
 
 export type VideoResponse = Response & {
   __typename?: 'VideoResponse';
-  block: VideoBlock;
+  block?: Maybe<VideoBlock>;
   id: Scalars['ID'];
   state: VideoResponseStateEnum;
   userId: Scalars['ID'];
@@ -635,7 +635,7 @@ export type RadioQuestionBlockResolvers<ContextType = GraphQLModules.Context, Pa
 };
 
 export type RadioQuestionResponseResolvers<ContextType = GraphQLModules.Context, ParentType extends ResolversParentTypes['RadioQuestionResponse'] = ResolversParentTypes['RadioQuestionResponse']> = {
-  block?: Resolver<ResolversTypes['RadioQuestionBlock'], ParentType, ContextType>;
+  block?: Resolver<Maybe<ResolversTypes['RadioQuestionBlock']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   radioOptionBlockId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   userId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -658,7 +658,7 @@ export type SignUpBlockResolvers<ContextType = GraphQLModules.Context, ParentTyp
 };
 
 export type SignUpResponseResolvers<ContextType = GraphQLModules.Context, ParentType extends ResolversParentTypes['SignUpResponse'] = ResolversParentTypes['SignUpResponse']> = {
-  block?: Resolver<ResolversTypes['SignUpBlock'], ParentType, ContextType>;
+  block?: Resolver<Maybe<ResolversTypes['SignUpBlock']>, ParentType, ContextType>;
   email?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -696,7 +696,7 @@ export type VideoBlockResolvers<ContextType = GraphQLModules.Context, ParentType
 };
 
 export type VideoResponseResolvers<ContextType = GraphQLModules.Context, ParentType extends ResolversParentTypes['VideoResponse'] = ResolversParentTypes['VideoResponse']> = {
-  block?: Resolver<ResolversTypes['VideoBlock'], ParentType, ContextType>;
+  block?: Resolver<Maybe<ResolversTypes['VideoBlock']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   state?: Resolver<ResolversTypes['VideoResponseStateEnum'], ParentType, ContextType>;
   userId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;

--- a/apps/api-journeys/src/__generated__/types.ts
+++ b/apps/api-journeys/src/__generated__/types.ts
@@ -259,6 +259,8 @@ export type SignUpBlock = Block & {
   id: Scalars['ID'];
   parentBlockId?: Maybe<Scalars['ID']>;
   action?: Maybe<Action>;
+  submitIcon?: Maybe<Icon>;
+  submitLabel?: Maybe<Scalars['String']>;
 };
 
 export type SignUpResponse = Response & {
@@ -650,6 +652,8 @@ export type SignUpBlockResolvers<ContextType = GraphQLModules.Context, ParentTyp
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   parentBlockId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   action?: Resolver<Maybe<ResolversTypes['Action']>, ParentType, ContextType>;
+  submitIcon?: Resolver<Maybe<ResolversTypes['Icon']>, ParentType, ContextType>;
+  submitLabel?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/apps/api-journeys/src/modules/block/__generated__/types.ts
+++ b/apps/api-journeys/src/modules/block/__generated__/types.ts
@@ -13,7 +13,7 @@ export namespace BlockModule {
     ImageBlock: 'id' | 'parentBlockId' | 'src' | 'width' | 'height' | 'alt';
     RadioOptionBlock: 'id' | 'parentBlockId' | 'label' | 'action';
     RadioQuestionBlock: 'id' | 'parentBlockId' | 'label' | 'description';
-    SignUpBlock: 'id' | 'parentBlockId' | 'action';
+    SignUpBlock: 'id' | 'parentBlockId' | 'action' | 'submitIcon' | 'submitLabel';
     StepBlock: 'id' | 'nextBlockId' | 'locked' | 'parentBlockId';
     TypographyBlock: 'id' | 'parentBlockId' | 'content' | 'variant' | 'color' | 'align';
     VideoBlock: 'id' | 'parentBlockId' | 'src' | 'title' | 'description' | 'volume' | 'autoplay';
@@ -190,6 +190,8 @@ export namespace BlockModule {
       id?: gm.Middleware[];
       parentBlockId?: gm.Middleware[];
       action?: gm.Middleware[];
+      submitIcon?: gm.Middleware[];
+      submitLabel?: gm.Middleware[];
     };
     StepBlock?: {
       '*'?: gm.Middleware[];

--- a/apps/api-journeys/src/modules/block/index.spec.ts
+++ b/apps/api-journeys/src/modules/block/index.spec.ts
@@ -172,7 +172,13 @@ it('returns blocks', async () => {
       action: {
         gtmEventName: 'gtmEventName',
         journeyId: otherJourneyId
-      }
+      },
+      submitIcon: {
+        name: 'LockOpen',
+        color: 'secondary',
+        size: 'lg'
+      },
+      submitLabel: 'Unlock Now!'
     }
   }
   const button1: Block = {
@@ -249,6 +255,11 @@ it('returns blocks', async () => {
           target
         }
       }
+      fragment IconFields on Icon {
+        name
+        color
+        size
+      }
       query ($id: ID!) {
         journey(id: $id) {
           blocks {
@@ -261,14 +272,10 @@ it('returns blocks', async () => {
               color
               size
               startIcon {
-                name
-                color
-                size
+                ...IconFields
               }
               endIcon {
-                name
-                color
-                size
+                ...IconFields
               }
               action {
                 ...ActionFields
@@ -300,6 +307,10 @@ it('returns blocks', async () => {
               action {
                 ...ActionFields
               }
+              submitIcon {
+                ...IconFields
+              }
+              submitLabel
             }
             ... on StepBlock {
               locked
@@ -434,7 +445,13 @@ it('returns blocks', async () => {
         __typename: 'NavigateToJourneyAction',
         gtmEventName: 'gtmEventName',
         journeyId: otherJourneyId
-      }
+      },
+      submitIcon: {
+        name: 'LockOpen',
+        color: 'secondary',
+        size: 'lg'
+      },
+      submitLabel: 'Unlock Now!'
     },
     {
       id: button1.id,

--- a/apps/api-journeys/src/modules/block/index.spec.ts
+++ b/apps/api-journeys/src/modules/block/index.spec.ts
@@ -5,261 +5,71 @@ import dbMock from '../../../tests/dbMock'
 import journey from '../journey'
 import { v4 as uuidv4 } from 'uuid'
 import { Block, ThemeName, ThemeMode } from '.prisma/api-journeys-client'
+import { DocumentNode, ExecutionResult } from 'graphql'
 
-it('returns blocks', async () => {
-  const app = testkit.testModule(module, {
-    schemaBuilder,
-    modules: [journey]
-  })
-  const journeyId = uuidv4()
-  const otherJourneyId = uuidv4()
-  const nextBlockId = uuidv4()
-  dbMock.journey.findUnique.mockResolvedValue({
-    id: journeyId,
-    title: 'published',
-    published: true,
-    locale: 'en-US',
-    themeMode: ThemeMode.light,
-    themeName: ThemeName.base
-  })
-  const step1: Block = {
-    id: uuidv4(),
-    journeyId,
-    blockType: 'StepBlock',
-    parentBlockId: null,
-    parentOrder: 0,
-    extraAttrs: {
-      locked: true,
-      nextBlockId
-    }
-  }
-  const coverBlockId = uuidv4()
-  const card1: Block = {
-    id: uuidv4(),
-    journeyId,
-    blockType: 'CardBlock',
-    parentBlockId: step1.id,
-    parentOrder: 0,
-    extraAttrs: {
-      backgroundColor: '#FFF',
-      coverBlockId,
+describe('BlockModule', () => {
+  let app, journeyId
+
+  beforeEach(() => {
+    app = testkit.testModule(module, {
+      schemaBuilder,
+      modules: [journey]
+    })
+    journeyId = uuidv4()
+    dbMock.journey.findUnique.mockResolvedValue({
+      id: journeyId,
+      title: 'published',
+      published: true,
+      locale: 'en-US',
       themeMode: ThemeMode.light,
       themeName: ThemeName.base
-    }
-  }
-  const video1: Block = {
-    id: uuidv4(),
-    journeyId,
-    blockType: 'VideoBlock',
-    parentBlockId: card1.id,
-    parentOrder: 1,
-    extraAttrs: {
-      src: 'src',
-      title: 'title'
-    }
-  }
-  const radioQuestion1: Block = {
-    id: uuidv4(),
-    journeyId,
-    blockType: 'RadioQuestionBlock',
-    parentBlockId: card1.id,
-    parentOrder: 2,
-    extraAttrs: {
-      label: 'label',
-      description: 'description'
-    }
-  }
-  const radioOption1: Block = {
-    id: uuidv4(),
-    journeyId,
-    blockType: 'RadioOptionBlock',
-    parentBlockId: radioQuestion1.id,
-    parentOrder: 3,
-    extraAttrs: {
-      label: 'label',
-      description: 'description',
-      action: {
-        gtmEventName: 'gtmEventName',
-        blockId: step1.id
-      }
-    }
-  }
-  const radioOption2: Block = {
-    id: uuidv4(),
-    journeyId,
-    blockType: 'RadioOptionBlock',
-    parentBlockId: radioQuestion1.id,
-    parentOrder: 4,
-    extraAttrs: {
-      label: 'label',
-      description: 'description',
-      action: {
-        gtmEventName: 'gtmEventName',
-        journeyId: otherJourneyId
-      }
-    }
-  }
-  const radioOption3: Block = {
-    id: uuidv4(),
-    journeyId,
-    blockType: 'RadioOptionBlock',
-    parentBlockId: radioQuestion1.id,
-    parentOrder: 5,
-    extraAttrs: {
-      label: 'label',
-      description: 'description',
-      action: {
-        gtmEventName: 'gtmEventName',
-        url: 'https://jesusfilm.org'
-      }
-    }
-  }
-  const radioOption4: Block = {
-    id: uuidv4(),
-    journeyId,
-    blockType: 'RadioOptionBlock',
-    parentBlockId: radioQuestion1.id,
-    parentOrder: 6,
-    extraAttrs: {
-      label: 'label',
-      description: 'description',
-      action: {
-        gtmEventName: 'gtmEventName'
-      }
-    }
-  }
-  const typography1: Block = {
-    id: uuidv4(),
-    journeyId,
-    blockType: 'TypographyBlock',
-    parentBlockId: card1.id,
-    parentOrder: 7,
-    extraAttrs: {
-      content: 'text',
-      variant: 'h2',
-      color: 'primary',
-      align: 'left'
-    }
-  }
-  const step2: Block = {
-    id: nextBlockId,
-    journeyId,
-    blockType: 'StepBlock',
-    parentBlockId: null,
-    parentOrder: 7,
-    extraAttrs: {
-      locked: false
-    }
-  }
-  const card2: Block = {
-    id: uuidv4(),
-    journeyId,
-    blockType: 'CardBlock',
-    parentBlockId: step2.id,
-    parentOrder: 0,
-    extraAttrs: {
-      backgroundColor: null,
-      coverBlockId: null
-    }
-  }
-  const signUp1: Block = {
-    id: uuidv4(),
-    journeyId,
-    blockType: 'SignUpBlock',
-    parentBlockId: card2.id,
-    parentOrder: 2,
-    extraAttrs: {
-      action: {
-        gtmEventName: 'gtmEventName',
-        journeyId: otherJourneyId
+    })
+  })
+
+  async function query(document: DocumentNode): Promise<ExecutionResult> {
+    return await testkit.execute(app, {
+      document,
+      variableValues: {
+        id: journeyId
       },
-      submitIcon: {
-        name: 'LockOpen',
-        color: 'secondary',
-        size: 'lg'
-      },
-      submitLabel: 'Unlock Now!'
-    }
-  }
-  const button1: Block = {
-    id: uuidv4(),
-    journeyId,
-    blockType: 'ButtonBlock',
-    parentBlockId: card2.id,
-    parentOrder: 1,
-    extraAttrs: {
-      label: 'label',
-      variant: 'contained',
-      color: 'primary',
-      size: 'large',
-      startIcon: {
-        name: 'ArrowForward',
-        color: 'secondary',
-        size: 'lg'
-      },
-      endIcon: {
-        name: 'LockOpen',
-        color: 'action',
-        size: 'xl'
-      },
-      action: {
-        gtmEventName: 'gtmEventName',
-        url: 'https://jesusfilm.org',
-        target: 'target'
+      contextValue: {
+        db: dbMock
       }
-    }
+    })
   }
-  const image1: Block = {
-    id: uuidv4(),
-    journeyId,
-    blockType: 'ImageBlock',
-    parentBlockId: card2.id,
-    parentOrder: 2,
-    extraAttrs: {
-      src: 'https://source.unsplash.com/random/1920x1080',
-      alt: 'random image from unsplash',
-      width: 1920,
-      height: 1080
-    }
-  }
-  const blocks = [
-    step1,
-    card1,
-    video1,
-    radioQuestion1,
-    radioOption1,
-    radioOption2,
-    radioOption3,
-    radioOption4,
-    typography1,
-    step2,
-    card2,
-    signUp1,
-    button1,
-    image1
-  ]
-  dbMock.block.findMany.mockResolvedValue(blocks)
-  const { data } = await testkit.execute(app, {
-    document: gql`
-      fragment ActionFields on Action {
-        __typename
-        gtmEventName
-        ... on NavigateToBlockAction {
-          blockId
-        }
-        ... on NavigateToJourneyAction {
-          journeyId
-        }
-        ... on LinkAction {
-          url
-          target
+
+  it('returns ButtonBlock', async () => {
+    const parentBlockId = uuidv4()
+    const button: Block = {
+      id: uuidv4(),
+      journeyId,
+      blockType: 'ButtonBlock',
+      parentBlockId,
+      parentOrder: 1,
+      extraAttrs: {
+        label: 'label',
+        variant: 'contained',
+        color: 'primary',
+        size: 'large',
+        startIcon: {
+          name: 'ArrowForward',
+          color: 'secondary',
+          size: 'lg'
+        },
+        endIcon: {
+          name: 'LockOpen',
+          color: 'action',
+          size: 'xl'
+        },
+        action: {
+          gtmEventName: 'gtmEventName',
+          url: 'https://jesusfilm.org',
+          target: 'target'
         }
       }
-      fragment IconFields on Icon {
-        name
-        color
-        size
-      }
+    }
+    dbMock.block.findMany.mockResolvedValue([button])
+    const { data } = await query(gql`
       query ($id: ID!) {
         journey(id: $id) {
           blocks {
@@ -272,56 +82,521 @@ it('returns blocks', async () => {
               color
               size
               startIcon {
-                ...IconFields
+                name
+                color
+                size
               }
               endIcon {
-                ...IconFields
+                name
+                color
+                size
               }
               action {
-                ...ActionFields
+                __typename
+                gtmEventName
+                ... on NavigateToBlockAction {
+                  blockId
+                }
+                ... on NavigateToJourneyAction {
+                  journeyId
+                }
+                ... on LinkAction {
+                  url
+                  target
+                }
               }
             }
+          }
+        }
+      }
+    `)
+    expect(data?.journey.blocks).toEqual([
+      {
+        id: button.id,
+        __typename: 'ButtonBlock',
+        parentBlockId,
+        label: 'label',
+        variant: 'contained',
+        color: 'primary',
+        size: 'large',
+        startIcon: {
+          name: 'ArrowForward',
+          color: 'secondary',
+          size: 'lg'
+        },
+        endIcon: {
+          name: 'LockOpen',
+          color: 'action',
+          size: 'xl'
+        },
+        action: {
+          __typename: 'LinkAction',
+          gtmEventName: 'gtmEventName',
+          url: 'https://jesusfilm.org',
+          target: 'target'
+        }
+      }
+    ])
+  })
+
+  it('returns CardBlock', async () => {
+    const parentBlockId = uuidv4()
+    const coverBlockId = uuidv4()
+    const card: Block = {
+      id: uuidv4(),
+      journeyId,
+      blockType: 'CardBlock',
+      parentBlockId,
+      parentOrder: 0,
+      extraAttrs: {
+        backgroundColor: '#FFF',
+        coverBlockId,
+        themeMode: ThemeMode.light,
+        themeName: ThemeName.base
+      }
+    }
+    dbMock.block.findMany.mockResolvedValue([card])
+    const { data } = await query(gql`
+      query ($id: ID!) {
+        journey(id: $id) {
+          blocks {
+            id
+            __typename
+            parentBlockId
             ... on CardBlock {
               backgroundColor
               coverBlockId
               themeMode
               themeName
             }
+          }
+        }
+      }
+    `)
+    expect(data?.journey.blocks).toEqual([
+      {
+        id: card.id,
+        __typename: 'CardBlock',
+        parentBlockId,
+        backgroundColor: '#FFF',
+        coverBlockId,
+        themeMode: ThemeMode.light,
+        themeName: ThemeName.base
+      }
+    ])
+  })
+
+  it('returns ImageBlock', async () => {
+    const parentBlockId = uuidv4()
+    const image: Block = {
+      id: uuidv4(),
+      journeyId,
+      blockType: 'ImageBlock',
+      parentBlockId,
+      parentOrder: 2,
+      extraAttrs: {
+        src: 'https://source.unsplash.com/random/1920x1080',
+        alt: 'random image from unsplash',
+        width: 1920,
+        height: 1080
+      }
+    }
+    dbMock.block.findMany.mockResolvedValue([image])
+    const { data } = await query(gql`
+      query ($id: ID!) {
+        journey(id: $id) {
+          blocks {
+            id
+            __typename
+            parentBlockId
             ... on ImageBlock {
               src
               alt
               width
               height
             }
+          }
+        }
+      }
+    `)
+    expect(data?.journey.blocks).toEqual([
+      {
+        id: image.id,
+        __typename: 'ImageBlock',
+        parentBlockId,
+        src: 'https://source.unsplash.com/random/1920x1080',
+        alt: 'random image from unsplash',
+        width: 1920,
+        height: 1080
+      }
+    ])
+  })
+
+  it('returns RadioOptionBlock', async () => {
+    const radioQuestionId = uuidv4()
+    const blockId = uuidv4()
+    const radioOption1: Block = {
+      id: uuidv4(),
+      journeyId,
+      blockType: 'RadioOptionBlock',
+      parentBlockId: radioQuestionId,
+      parentOrder: 3,
+      extraAttrs: {
+        label: 'label',
+        description: 'description',
+        action: {
+          gtmEventName: 'gtmEventName',
+          blockId
+        }
+      }
+    }
+    const radioOption2: Block = {
+      id: uuidv4(),
+      journeyId,
+      blockType: 'RadioOptionBlock',
+      parentBlockId: radioQuestionId,
+      parentOrder: 4,
+      extraAttrs: {
+        label: 'label',
+        description: 'description',
+        action: {
+          gtmEventName: 'gtmEventName',
+          journeyId
+        }
+      }
+    }
+    const radioOption3: Block = {
+      id: uuidv4(),
+      journeyId,
+      blockType: 'RadioOptionBlock',
+      parentBlockId: radioQuestionId,
+      parentOrder: 5,
+      extraAttrs: {
+        label: 'label',
+        description: 'description',
+        action: {
+          gtmEventName: 'gtmEventName',
+          url: 'https://jesusfilm.org'
+        }
+      }
+    }
+    const radioOption4: Block = {
+      id: uuidv4(),
+      journeyId,
+      blockType: 'RadioOptionBlock',
+      parentBlockId: radioQuestionId,
+      parentOrder: 6,
+      extraAttrs: {
+        label: 'label',
+        description: 'description',
+        action: {
+          gtmEventName: 'gtmEventName'
+        }
+      }
+    }
+    dbMock.block.findMany.mockResolvedValue([
+      radioOption1,
+      radioOption2,
+      radioOption3,
+      radioOption4
+    ])
+    const { data } = await query(gql`
+      query ($id: ID!) {
+        journey(id: $id) {
+          blocks {
+            id
+            __typename
+            parentBlockId
             ... on RadioOptionBlock {
               label
               action {
-                ...ActionFields
+                __typename
+                gtmEventName
+                ... on NavigateToBlockAction {
+                  blockId
+                }
+                ... on NavigateToJourneyAction {
+                  journeyId
+                }
+                ... on LinkAction {
+                  url
+                  target
+                }
               }
             }
+          }
+        }
+      }
+    `)
+    expect(data?.journey.blocks).toEqual([
+      {
+        id: radioOption1.id,
+        __typename: 'RadioOptionBlock',
+        parentBlockId: radioQuestionId,
+        label: 'label',
+        action: {
+          __typename: 'NavigateToBlockAction',
+          gtmEventName: 'gtmEventName',
+          blockId
+        }
+      },
+      {
+        id: radioOption2.id,
+        __typename: 'RadioOptionBlock',
+        parentBlockId: radioQuestionId,
+        label: 'label',
+        action: {
+          __typename: 'NavigateToJourneyAction',
+          gtmEventName: 'gtmEventName',
+          journeyId
+        }
+      },
+      {
+        id: radioOption3.id,
+        __typename: 'RadioOptionBlock',
+        parentBlockId: radioQuestionId,
+        label: 'label',
+        action: {
+          __typename: 'LinkAction',
+          gtmEventName: 'gtmEventName',
+          url: 'https://jesusfilm.org',
+          target: null
+        }
+      },
+      {
+        id: radioOption4.id,
+        __typename: 'RadioOptionBlock',
+        parentBlockId: radioQuestionId,
+        label: 'label',
+        action: {
+          __typename: 'NavigateAction',
+          gtmEventName: 'gtmEventName'
+        }
+      }
+    ])
+  })
+
+  it('returns RadioQuestionBlock', async () => {
+    const parentBlockId = uuidv4()
+    const radioQuestion: Block = {
+      id: uuidv4(),
+      journeyId,
+      blockType: 'RadioQuestionBlock',
+      parentBlockId,
+      parentOrder: 2,
+      extraAttrs: {
+        label: 'label',
+        description: 'description'
+      }
+    }
+    dbMock.block.findMany.mockResolvedValue([radioQuestion])
+    const { data } = await query(gql`
+      query ($id: ID!) {
+        journey(id: $id) {
+          blocks {
+            id
+            __typename
+            parentBlockId
             ... on RadioQuestionBlock {
               label
               description
             }
-            ... on SignUpBlock {
-              action {
-                ...ActionFields
+          }
+        }
+      }
+    `)
+    expect(data?.journey.blocks).toEqual([
+      {
+        id: radioQuestion.id,
+        __typename: 'RadioQuestionBlock',
+        parentBlockId,
+        label: 'label',
+        description: 'description'
+      }
+    ])
+  })
+
+  it('returns SignUpBlock', async () => {
+    const parentBlockId = uuidv4()
+    const signUp: Block = {
+      id: uuidv4(),
+      journeyId,
+      blockType: 'SignUpBlock',
+      parentBlockId,
+      parentOrder: 2,
+      extraAttrs: {
+        action: {
+          gtmEventName: 'gtmEventName',
+          journeyId
+        },
+        submitIcon: {
+          name: 'LockOpen',
+          color: 'secondary',
+          size: 'lg'
+        },
+        submitLabel: 'Unlock Now!'
+      }
+    }
+    dbMock.block.findMany.mockResolvedValue([signUp])
+    const { data } = await query(gql`
+      query ($id: ID!) {
+        journey(id: $id) {
+          blocks {
+            id
+            __typename
+            parentBlockId
+            action {
+              __typename
+              gtmEventName
+              ... on NavigateToBlockAction {
+                blockId
               }
-              submitIcon {
-                ...IconFields
+              ... on NavigateToJourneyAction {
+                journeyId
               }
-              submitLabel
+              ... on LinkAction {
+                url
+                target
+              }
             }
+            submitIcon {
+              name
+              color
+              size
+            }
+            submitLabel
+          }
+        }
+      }
+    `)
+    expect(data?.journey.blocks).toEqual([
+      {
+        id: signUp.id,
+        __typename: 'SignUpBlock',
+        parentBlockId,
+        action: {
+          __typename: 'NavigateToJourneyAction',
+          gtmEventName: 'gtmEventName',
+          journeyId
+        },
+        submitIcon: {
+          name: 'LockOpen',
+          color: 'secondary',
+          size: 'lg'
+        },
+        submitLabel: 'Unlock Now!'
+      }
+    ])
+  })
+
+  it('returns StepBlock', async () => {
+    const parentBlockId = uuidv4()
+    const nextBlockId = uuidv4()
+    const step: Block = {
+      id: uuidv4(),
+      journeyId,
+      blockType: 'StepBlock',
+      parentBlockId,
+      parentOrder: 0,
+      extraAttrs: {
+        locked: true,
+        nextBlockId
+      }
+    }
+    dbMock.block.findMany.mockResolvedValue([step])
+    const { data } = await query(gql`
+      query ($id: ID!) {
+        journey(id: $id) {
+          blocks {
+            id
+            __typename
+            parentBlockId
             ... on StepBlock {
               locked
               nextBlockId
             }
+          }
+        }
+      }
+    `)
+    expect(data?.journey.blocks).toEqual([
+      {
+        id: step.id,
+        __typename: 'StepBlock',
+        parentBlockId,
+        locked: true,
+        nextBlockId
+      }
+    ])
+  })
+
+  it('returns TypographyBlock', async () => {
+    const parentBlockId = uuidv4()
+    const typography: Block = {
+      id: uuidv4(),
+      journeyId,
+      blockType: 'TypographyBlock',
+      parentBlockId,
+      parentOrder: 7,
+      extraAttrs: {
+        content: 'text',
+        variant: 'h2',
+        color: 'primary',
+        align: 'left'
+      }
+    }
+    dbMock.block.findMany.mockResolvedValue([typography])
+    const { data } = await query(gql`
+      query ($id: ID!) {
+        journey(id: $id) {
+          blocks {
+            id
+            __typename
+            parentBlockId
             ... on TypographyBlock {
               content
               variant
               color
               align
             }
+          }
+        }
+      }
+    `)
+    expect(data?.journey.blocks).toEqual([
+      {
+        id: typography.id,
+        __typename: 'TypographyBlock',
+        parentBlockId,
+        content: 'text',
+        variant: 'h2',
+        color: 'primary',
+        align: 'left'
+      }
+    ])
+  })
+
+  it('returns VideoBlock', async () => {
+    const parentBlockId = uuidv4()
+    const video: Block = {
+      id: uuidv4(),
+      journeyId,
+      blockType: 'VideoBlock',
+      parentBlockId,
+      parentOrder: 1,
+      extraAttrs: {
+        src: 'src',
+        title: 'title'
+      }
+    }
+    dbMock.block.findMany.mockResolvedValue([video])
+    const { data } = await query(gql`
+      query ($id: ID!) {
+        journey(id: $id) {
+          blocks {
+            id
+            __typename
+            parentBlockId
             ... on VideoBlock {
               src
               title
@@ -329,163 +604,15 @@ it('returns blocks', async () => {
           }
         }
       }
-    `,
-    variableValues: {
-      id: journeyId
-    },
-    contextValue: {
-      db: dbMock
-    }
+    `)
+    expect(data?.journey.blocks).toEqual([
+      {
+        id: video.id,
+        __typename: 'VideoBlock',
+        parentBlockId,
+        src: 'src',
+        title: 'title'
+      }
+    ])
   })
-  expect(data?.journey.blocks).toEqual([
-    {
-      id: step1.id,
-      __typename: 'StepBlock',
-      parentBlockId: null,
-      locked: true,
-      nextBlockId
-    },
-    {
-      id: card1.id,
-      __typename: 'CardBlock',
-      parentBlockId: step1.id,
-      backgroundColor: '#FFF',
-      coverBlockId,
-      themeMode: ThemeMode.light,
-      themeName: ThemeName.base
-    },
-    {
-      id: video1.id,
-      __typename: 'VideoBlock',
-      parentBlockId: card1.id,
-      src: 'src',
-      title: 'title'
-    },
-    {
-      id: radioQuestion1.id,
-      __typename: 'RadioQuestionBlock',
-      parentBlockId: card1.id,
-      label: 'label',
-      description: 'description'
-    },
-    {
-      id: radioOption1.id,
-      __typename: 'RadioOptionBlock',
-      parentBlockId: radioQuestion1.id,
-      label: 'label',
-      action: {
-        __typename: 'NavigateToBlockAction',
-        gtmEventName: 'gtmEventName',
-        blockId: step1.id
-      }
-    },
-    {
-      id: radioOption2.id,
-      __typename: 'RadioOptionBlock',
-      parentBlockId: radioQuestion1.id,
-      label: 'label',
-      action: {
-        __typename: 'NavigateToJourneyAction',
-        gtmEventName: 'gtmEventName',
-        journeyId: otherJourneyId
-      }
-    },
-    {
-      id: radioOption3.id,
-      __typename: 'RadioOptionBlock',
-      parentBlockId: radioQuestion1.id,
-      label: 'label',
-      action: {
-        __typename: 'LinkAction',
-        gtmEventName: 'gtmEventName',
-        url: 'https://jesusfilm.org',
-        target: null
-      }
-    },
-    {
-      id: radioOption4.id,
-      __typename: 'RadioOptionBlock',
-      parentBlockId: radioQuestion1.id,
-      label: 'label',
-      action: {
-        __typename: 'NavigateAction',
-        gtmEventName: 'gtmEventName'
-      }
-    },
-    {
-      id: typography1.id,
-      __typename: 'TypographyBlock',
-      parentBlockId: card1.id,
-      content: 'text',
-      variant: 'h2',
-      color: 'primary',
-      align: 'left'
-    },
-    {
-      id: step2.id,
-      __typename: 'StepBlock',
-      parentBlockId: null,
-      locked: false,
-      nextBlockId: null
-    },
-    {
-      id: card2.id,
-      __typename: 'CardBlock',
-      parentBlockId: step2.id,
-      backgroundColor: null,
-      coverBlockId: null,
-      themeMode: null,
-      themeName: null
-    },
-    {
-      id: signUp1.id,
-      __typename: 'SignUpBlock',
-      parentBlockId: card2.id,
-      action: {
-        __typename: 'NavigateToJourneyAction',
-        gtmEventName: 'gtmEventName',
-        journeyId: otherJourneyId
-      },
-      submitIcon: {
-        name: 'LockOpen',
-        color: 'secondary',
-        size: 'lg'
-      },
-      submitLabel: 'Unlock Now!'
-    },
-    {
-      id: button1.id,
-      __typename: 'ButtonBlock',
-      parentBlockId: card2.id,
-      label: 'label',
-      variant: 'contained',
-      color: 'primary',
-      size: 'large',
-      startIcon: {
-        name: 'ArrowForward',
-        color: 'secondary',
-        size: 'lg'
-      },
-      endIcon: {
-        name: 'LockOpen',
-        color: 'action',
-        size: 'xl'
-      },
-      action: {
-        __typename: 'LinkAction',
-        gtmEventName: 'gtmEventName',
-        url: 'https://jesusfilm.org',
-        target: 'target'
-      }
-    },
-    {
-      id: image1.id,
-      __typename: 'ImageBlock',
-      parentBlockId: card2.id,
-      src: 'https://source.unsplash.com/random/1920x1080',
-      alt: 'random image from unsplash',
-      width: 1920,
-      height: 1080
-    }
-  ])
 })

--- a/apps/api-journeys/src/modules/block/index.ts
+++ b/apps/api-journeys/src/modules/block/index.ts
@@ -159,6 +159,8 @@ const typeDefs = gql`
     id: ID!
     parentBlockId: ID
     action: Action
+    submitIcon: Icon
+    submitLabel: String
   }
 
   type StepBlock implements Block {
@@ -294,7 +296,9 @@ const resolvers: Resolvers = {
     alt: ({ extraAttrs }) => get(extraAttrs, 'alt')
   },
   SignUpBlock: {
-    action: ({ extraAttrs }) => get(extraAttrs, 'action')
+    action: ({ extraAttrs }) => get(extraAttrs, 'action'),
+    submitIcon: ({ extraAttrs }) => get(extraAttrs, 'submitIcon'),
+    submitLabel: ({ extraAttrs }) => get(extraAttrs, 'submitLabel')
   },
   StepBlock: {
     locked: ({ extraAttrs }) => get(extraAttrs, 'locked'),

--- a/apps/api-journeys/src/modules/response/index.spec.ts
+++ b/apps/api-journeys/src/modules/response/index.spec.ts
@@ -30,11 +30,10 @@ describe('Response', () => {
         extraAttrs: {}
       }
       dbMock.block.findUnique.mockResolvedValue(block1)
-      const response1: Response & { block: Block } = {
+      const response1: Response = {
         id: uuidv4(),
         type: 'SignUpResponse',
         blockId: block1.id,
-        block: block1,
         userId,
         extraAttrs: {
           name: 'Robert Smith',
@@ -119,11 +118,10 @@ describe('Response', () => {
         }
       }
       dbMock.block.findUnique.mockResolvedValue(block1)
-      const response1: Response & { block: Block } = {
+      const response1: Response = {
         id: uuidv4(),
         type: 'RadioQuestionResponse',
         blockId: block1.id,
-        block: block1,
         userId,
         extraAttrs: {
           radioOptionBlockId: uuidv4()
@@ -207,11 +205,10 @@ describe('Response', () => {
         }
       }
       dbMock.block.findUnique.mockResolvedValue(block1)
-      const response1: Response & { block: Block } = {
+      const response1: Response = {
         id: uuidv4(),
         type: 'VideoResponse',
         blockId: block1.id,
-        block: block1,
         userId,
         extraAttrs: {
           state: 'PLAYING'


### PR DESCRIPTION
- no longer need to define resolvers when part of the extraAttrs json object
- split large block test into independent tests for each block type