### PR TITLE
Remove styling from Video

### DIFF
--- a/apps/journeys/src/components/blocks/Video/Video.tsx
+++ b/apps/journeys/src/components/blocks/Video/Video.tsx
@@ -71,10 +71,7 @@ export function Video({ src, autoplay }: TreeBlock<VideoBlock>): ReactElement {
   }, [player, isReady, autoPlaySuccess, autoplay])
 
   return (
-    <Container
-      data-testid="VideoComponent"
-      maxWidth="md"
-    >
+    <Container data-testid="VideoComponent" maxWidth="md">
       <video ref={videoNode} className="video-js" />
     </Container>
   )

--- a/apps/journeys/src/components/blocks/Video/Video.tsx
+++ b/apps/journeys/src/components/blocks/Video/Video.tsx
@@ -1,23 +1,12 @@
 import videojs from 'video.js'
 import React, { ReactElement, useEffect, useRef, useState } from 'react'
 import { Container } from '@mui/material'
-import { makeStyles, createStyles } from '@mui/styles'
 import { GetJourney_journey_blocks_VideoBlock as VideoBlock } from '../../../../__generated__/GetJourney'
 import { TreeBlock } from '../../../libs/transformer/transformer'
 
 import 'video.js/dist/video-js.css'
 
-const useStyles = makeStyles(() =>
-  createStyles({
-    container: {
-      position: 'relative',
-      overflow: 'hidden'
-    }
-  })
-)
-
 export function Video({ src, autoplay }: TreeBlock<VideoBlock>): ReactElement {
-  const classes = useStyles()
   const videoNode = useRef<HTMLVideoElement>(null)
   const player = useRef<videojs.Player>()
   const [isReady, setIsReady] = useState<boolean | undefined>()
@@ -84,7 +73,6 @@ export function Video({ src, autoplay }: TreeBlock<VideoBlock>): ReactElement {
   return (
     <Container
       data-testid="VideoComponent"
-      className={classes.container}
       maxWidth="md"
     >
       <video ref={videoNode} className="video-js" />


### PR DESCRIPTION
- Remove the use of makeStyles as it is deprecated in MUI v5

https://mui.com/styles/basics/

Ended up removing the styling entirely as it's not getting used at the moment.