### PR TITLE
Cypress Tests

### DIFF
--- a/apps/journeys-e2e/cypress.json
+++ b/apps/journeys-e2e/cypress.json
@@ -3,7 +3,7 @@
   "fixturesFolder": "./src/fixtures",
   "integrationFolder": "./src/integration",
   "modifyObstructiveCode": false,
-  "pluginsFile": "./src/plugins/index",
+  "pluginsFile": "./src/plugins/index.ts",
   "supportFile": "./src/support/index.ts",
   "video": true,
   "videosFolder": "../../dist/cypress/apps/journeys-e2e/videos",

--- a/apps/journeys-e2e/src/integration/app.spec.ts
+++ b/apps/journeys-e2e/src/integration/app.spec.ts
@@ -1,9 +1,11 @@
-import { getGreeting } from '../support/app.po'
+// import { getGreeting } from '../support/app.po'
 
 describe('journeys', () => {
   beforeEach(() => cy.visit('/'))
 
-  it('should display welcome message', () => {
-    getGreeting().contains('Block renderer and conductor samples')
+  it('Should redirect to the first journey', () => {
+    cy.contains('#FallingPlates').click()
+
+    cy.url().should('include', 'c1fd3143-8a24-4031-a05f-e043cf8c4d21')
   })
 })

--- a/apps/journeys-e2e/src/integration/journeys/firstStep.spec.ts
+++ b/apps/journeys-e2e/src/integration/journeys/firstStep.spec.ts
@@ -1,0 +1,25 @@
+describe('journeys', () => {
+  beforeEach(() => cy.visit('/c1fd3143-8a24-4031-a05f-e043cf8c4d21'))
+
+  it('Should render the journey', () => {
+    cy.get('.MuiContainer-root').should('exist')
+    cy.get('.MuiPaper-root').should('exist')
+  })
+
+  it('Should play the video on click', () => {
+    cy.get('.vjs-big-play-button').click()
+    cy.get('.vjs-playing').should('exist')
+  })
+
+  it('Should render the question', () => {
+    cy.get('h3')
+      .contains('Jesus asks you, "Will you follow Me?"')
+      .should('exist')
+  })
+
+  it('Should render the options', () => {
+    cy.get('button').contains('I follow another faith').should('exist')
+    cy.get('button').contains('I want to start').should('exist')
+    cy.get('button').contains('I am already following').should('exist')
+  })
+})

--- a/apps/journeys-e2e/src/integration/journeys/home.spec.ts
+++ b/apps/journeys-e2e/src/integration/journeys/home.spec.ts
@@ -1,10 +1,8 @@
-// import { getGreeting } from '../support/app.po'
-
 describe('journeys', () => {
   beforeEach(() => cy.visit('/'))
 
   it('Should redirect to the first journey', () => {
-    cy.contains('#FallingPlates').click()
+    cy.get('.MuiButton-root').contains('#FallingPlates').click()
 
     cy.url().should('include', 'c1fd3143-8a24-4031-a05f-e043cf8c4d21')
   })

--- a/apps/journeys-e2e/src/plugins/index.ts
+++ b/apps/journeys-e2e/src/plugins/index.ts
@@ -11,12 +11,11 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
-const { preprocessTypescript } = require('@nrwl/cypress/plugins/preprocessor')
+import { preprocessTypescript } from '@nrwl/cypress/plugins/preprocessor.js'
 
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
-
   // Preprocess Typescript file using Nx helper
   on('file:preprocessor', preprocessTypescript(config))
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "core",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
@@ -64089,7 +64088,6 @@
       "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
       "dev": true,
       "requires": {
-        "@oclif/config": "^1.15.1",
         "@oclif/errors": "^1.3.3",
         "@oclif/parser": "^3.8.3",
         "@oclif/plugin-help": "^3",
@@ -71915,8 +71913,7 @@
         "global": "^4.4.0",
         "m3u8-parser": "4.7.0",
         "mpd-parser": "0.17.0",
-        "mux.js": "5.12.2",
-        "video.js": "^6 || ^7"
+        "mux.js": "5.12.2"
       }
     },
     "@videojs/vhs-utils": {


### PR DESCRIPTION
**_To be continued in the next cooldown if time permits_**

- Fix pluginsFile error
- Add basic cypress test

**Please note**
Cypress e2e testing is currently not optimized to run on our dev container. It needs to be run locally until optimized to do so.

**Fix pluginsFile error**
Steps I took to solve the issue: 
1. Change pluginsFile path from `"./src/plugins/index"` to `"./src/plugins/index.ts"`
2. Restarted VS Code
3. Updated how  `preprocessTypescript` in `./src/plugins/index.ts` is imported
4. Reinstall node_modules