### PR TITLE
Update storybook viewport toggles

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -9,15 +9,37 @@ Object.defineProperty(NextImage, 'default', {
     createElement(OriginalNextImage, { ...props, unoptimized: true })
 })
 
+const customViewports = {
+  mobile: {
+    name: 'Mobile',
+    styles: {
+      width: '320px',
+      height: '568px'
+    },
+    type: 'mobile'
+  },
+  tablet: {
+    name: 'Tablet',
+    styles: {
+      width: '768px',
+      height: '1024px'
+    },
+    type: 'tablet'
+  }
+}
+
 module.exports = {
   parameters: {
-    chromatic: { viewports: [640] },
-    controls: { disabled: true },
     backgrounds: {
       disable: true,
       grid: {
         disable: true
       }
+    },
+    chromatic: { viewports: [640] },
+    controls: { disabled: true },
+    viewport: {
+      viewports: customViewports
     }
   },
   globalTypes: {


### PR DESCRIPTION
Updated the mobile / tablet viewports to use our breakpoints. 
There is no desktop breakpoint as this is the default view (click reset viewport)

![image](https://user-images.githubusercontent.com/10802634/136860969-01ee547d-8eb7-4a59-8398-4d54577c4498.png)

You can also toggle between portrait and landscape mode by pressing the arrows between the dimensions.

These dimensions were built for viewing light/dark modes separately. 

![image](https://user-images.githubusercontent.com/10802634/136861290-d03e5ade-2b6f-4b81-b5c6-fdecdde6d1f6.png)
^ Don't do this, just use the default view and resize your browser to the appropriate width. 

Final breakpoints we've decided are:

xs, mobile portrait: 0
sm, mobile landscape: 568+ 
md, tablet portrait: 768+ 
lg,  tablet landscape: 1024+ 
xl, laptop/desktop: 1200+ 