### PR TITLE
Use custom breakpoints - large mobile fix

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -44,7 +44,9 @@ module.exports = {
         disable: true
       }
     },
-    chromatic: { viewports: [640] },
+    // 2x viewport breakpoints (XS, SM, MD) Largest out of bounds for Chromatic.
+    // TODO: Split out light / dark mode tests during Cooldown
+    chromatic: { viewports: [640, 1136, 1200] },
     controls: { disabled: true },
     viewport: {
       viewports: customViewports

--- a/libs/shared/ui/src/libs/themes/base/theme.stories.tsx
+++ b/libs/shared/ui/src/libs/themes/base/theme.stories.tsx
@@ -243,7 +243,7 @@ FullPalette.args = {
 const ViewportTemplate: Story<ThemeStoryProps> = (args) => {
   const theme = useTheme()
   const [width, setWidth] = useState(window.innerWidth)
-  const [height, setHeight] = useState(window.innerWidth)
+  const [height, setHeight] = useState(window.innerHeight)
 
   const maxBreakpointValue = (breakpoint: Breakpoint): string => {
     switch (breakpoint) {

--- a/libs/shared/ui/src/libs/themes/base/theme.stories.tsx
+++ b/libs/shared/ui/src/libs/themes/base/theme.stories.tsx
@@ -277,7 +277,7 @@ const ViewportTemplate: Story<ThemeStoryProps> = (args) => {
         flexDirection: 'column',
         justifyContent: 'center',
         alignItems: 'center',
-        height: window.innerWidth === 960 ? '320px' : '600px'
+        height: '600px'
       }}
     >
       {args.variants.map((variant: string) => {

--- a/libs/shared/ui/src/libs/themes/base/theme.stories.tsx
+++ b/libs/shared/ui/src/libs/themes/base/theme.stories.tsx
@@ -300,7 +300,26 @@ const ViewportTemplate: Story<ThemeStoryProps> = (args) => {
           </>
         )
       })}
-      <Typography variant="body2">{`Current width: ${width}px`}</Typography>
+      <Typography
+        variant="body2"
+        gutterBottom
+      >{`Current width: ${width}px`}</Typography>
+      <Typography
+        variant="overline"
+        align="center"
+        sx={{
+          height: '30px',
+          color: '#FC624E',
+          [theme.breakpoints.up('md')]: {
+            color: '#7fe0aa'
+          },
+          [theme.breakpoints.up('xl')]: {
+            color: '#4ec4fc'
+          }
+        }}
+      >
+        Mobile - red | Tablet - green | Desktop - blue
+      </Typography>
     </Box>
   )
 }
@@ -309,6 +328,7 @@ const breakpoints = themes.base.light.breakpoints
 
 export const Viewport = ViewportTemplate.bind({})
 Viewport.args = {
+  // sm breakpoint won't show when resizing default viewport due to orientation
   variants: ['xs', 'sm', 'md', 'lg', 'xl']
 }
 Viewport.parameters = {

--- a/libs/shared/ui/src/libs/themes/base/theme.stories.tsx
+++ b/libs/shared/ui/src/libs/themes/base/theme.stories.tsx
@@ -243,15 +243,27 @@ FullPalette.args = {
 const ViewportTemplate: Story<ThemeStoryProps> = (args) => {
   const theme = useTheme()
   const [width, setWidth] = useState(window.innerWidth)
+  const [height, setHeight] = useState(window.innerWidth)
 
-  const maxBreakpointValue = (breakpoint: Breakpoint): number =>
-    theme.breakpoints.values[
-      theme.breakpoints.keys[theme.breakpoints.keys.indexOf(breakpoint) + 1]
-    ] - 1
+  const maxBreakpointValue = (breakpoint: Breakpoint): string => {
+    switch (breakpoint) {
+      case 'xl':
+        return '+'
+      default:
+        return `${
+          theme.breakpoints.values[
+            theme.breakpoints.keys[
+              theme.breakpoints.keys.indexOf(breakpoint) + 1
+            ]
+          ] - 1
+        }`
+    }
+  }
 
   useEffect(() => {
     const updateWidth = (): void => {
       setWidth(window.innerWidth)
+      setHeight(window.innerHeight)
     }
 
     window.addEventListener('resize', updateWidth)
@@ -291,11 +303,9 @@ const ViewportTemplate: Story<ThemeStoryProps> = (args) => {
                 display: 'none'
               }}
             >
-              {`Range: ${theme.breakpoints.values[variant as Breakpoint]}${
-                variant === 'xl'
-                  ? '+'
-                  : `-${maxBreakpointValue(variant as Breakpoint)}`
-              }`}
+              {`Range: ${
+                theme.breakpoints.values[variant as Breakpoint]
+              }-${maxBreakpointValue(variant as Breakpoint)}`}
             </Typography>
           </>
         )
@@ -303,7 +313,7 @@ const ViewportTemplate: Story<ThemeStoryProps> = (args) => {
       <Typography
         variant="body2"
         gutterBottom
-      >{`Current width: ${width}px`}</Typography>
+      >{`Current width: ${width}px | Current height: ${height}px`}</Typography>
       <Typography
         variant="overline"
         align="center"
@@ -328,7 +338,7 @@ const breakpoints = themes.base.light.breakpoints
 
 export const Viewport = ViewportTemplate.bind({})
 Viewport.args = {
-  // sm breakpoint won't show when resizing default viewport due to orientation
+  // Height of viewport will alter breakpoints display.
   variants: ['xs', 'sm', 'md', 'lg', 'xl']
 }
 Viewport.parameters = {
@@ -338,7 +348,6 @@ Viewport.parameters = {
     viewports: [
       breakpoints.values.sm - 1,
       breakpoints.values.sm,
-      breakpoints.values.md - 1,
       breakpoints.values.md,
       breakpoints.values.lg - 1,
       breakpoints.values.lg,

--- a/libs/shared/ui/src/libs/themes/base/theme.stories.tsx
+++ b/libs/shared/ui/src/libs/themes/base/theme.stories.tsx
@@ -277,7 +277,7 @@ const ViewportTemplate: Story<ThemeStoryProps> = (args) => {
         flexDirection: 'column',
         justifyContent: 'center',
         alignItems: 'center',
-        height: '320px'
+        height: window.innerWidth === 960 ? '320px' : '600px'
       }}
     >
       {args.variants.map((variant: string) => {
@@ -348,6 +348,8 @@ Viewport.parameters = {
     viewports: [
       breakpoints.values.sm - 1,
       breakpoints.values.sm,
+      // Change to 960px when Chromatic can configure height
+      breakpoints.values.md - 1,
       breakpoints.values.md,
       breakpoints.values.lg - 1,
       breakpoints.values.lg,

--- a/libs/shared/ui/src/libs/themes/base/theme.ts
+++ b/libs/shared/ui/src/libs/themes/base/theme.ts
@@ -1,14 +1,16 @@
 import { createTheme } from '@mui/material'
 import { baseColorsLight, baseColorsDark } from './tokens/colors'
+import { baseBreakpoints } from './tokens/breakpoints'
+import { baseComponents } from './tokens/components'
 import { baseSpacing } from './tokens/spacing'
 import { baseTypography } from './tokens/typography'
-import { baseComponents } from './tokens/components'
 import { deepmerge } from '@mui/utils'
 
 export const baseTheme = {
   ...baseTypography,
   ...baseSpacing,
-  ...baseComponents
+  ...baseComponents,
+  ...baseBreakpoints
 }
 
 // DeepMerge no longer needed - remove or keep just in case for future?

--- a/libs/shared/ui/src/libs/themes/base/tokens/breakpoints.ts
+++ b/libs/shared/ui/src/libs/themes/base/tokens/breakpoints.ts
@@ -1,0 +1,81 @@
+import { Breakpoints, Breakpoint, ThemeOptions } from '@mui/material'
+import { createBreakpoints } from '@mui/system'
+
+const minWidths: { [key in Breakpoint]: number } = {
+  xs: 0, // Mobile (P)
+  sm: 568, // Mobile (L)
+  md: 768, // Tablet (P)
+  lg: 1024, // Tablet (L)
+  xl: 1200 // Laptop/Desktop
+}
+
+const minHeights: { [key in Breakpoint]: number } = {
+  xs: 0,
+  sm: 0,
+  md: 600,
+  lg: 600,
+  xl: 600
+}
+
+const maxWidths: { [key in Breakpoint]: number } = {
+  xs: minWidths.sm - 1,
+  sm: minWidths.md - 1,
+  md: minWidths.lg - 1,
+  lg: minWidths.xl - 1,
+  xl: 9999
+}
+
+const breakpointKeys = Object.keys(minWidths) as Breakpoint[]
+
+// mui .up() only checks min-width.
+// Use minHeight so large(960x540) Mobile (L) don't have Tablet (P) styling
+const up = (key: Breakpoint | number): string => {
+  const minWidth = typeof key === 'number' ? key : minWidths[key]
+  const minHeight =
+    typeof key === 'number'
+      ? key < minWidths.md
+        ? minHeights.sm
+        : minHeights.md
+      : minHeights[key]
+
+  return `@media (min-width:${minWidth}px) and (min-height:${minHeight}px)`
+}
+
+// mui .only() only checks min-width and max-width
+// Use minHeight so large(960x540) Mobile (L) don't have Tablet (P) styling
+// Use maxHeight so small(768x1024) Tablet (P) don't have Mobile (L) styling
+const only = (key: Breakpoint | number): string => {
+  const minChecks = up(key)
+
+  const maxWidth =
+    typeof key === 'number'
+      ? key + 1
+      : // override for large Mobile (L) - now width overlaps Tablet (P)
+      key === 'sm'
+      ? 960
+      : maxWidths[key]
+
+  // Constrain height to distinguish between overlapping Mobile (L) & Tablet (P)
+  // Could use orientation, but won't work for vertical desktops (edge case)
+  const maxHeight =
+    key === 'sm' || (key >= minWidths.sm && key < minWidths.md)
+      ? maxWidths.xs
+      : 9999
+
+  return `${minChecks} and (max-width: ${maxWidth}px) and (max-height: ${maxHeight}px)`
+}
+
+const breakpoints: Breakpoints = createBreakpoints({
+  values: minWidths,
+  keys: breakpointKeys,
+  unit: 'px',
+  up,
+  only,
+  // Redundant when we have up & only
+  down: undefined,
+  between: undefined
+})
+
+export const baseBreakpoints: Required<Pick<ThemeOptions, 'breakpoints'>> = {
+  breakpoints
+}

--- a/libs/shared/ui/src/libs/themes/base/tokens/breakpoints.ts
+++ b/libs/shared/ui/src/libs/themes/base/tokens/breakpoints.ts
@@ -4,8 +4,8 @@ import { createBreakpoints } from '@mui/system'
 const minWidths: { [key in Breakpoint]: number } = {
   xs: 0, // Mobile (P)
   sm: 568, // Mobile (L)
-  md: 768, // Tablet (P)
-  lg: 1024, // Tablet (L)
+  md: 600, // Tablet (P)
+  lg: 961, // Tablet (L)
   xl: 1200 // Laptop/Desktop
 }
 

--- a/libs/shared/ui/src/libs/themes/base/tokens/breakpoints.ts
+++ b/libs/shared/ui/src/libs/themes/base/tokens/breakpoints.ts
@@ -44,25 +44,21 @@ const up = (key: Breakpoint | number): string => {
 // mui .only() only checks min-width and max-width
 // Use minHeight so large(960x540) Mobile (L) don't have Tablet (P) styling
 // Use maxHeight so small(768x1024) Tablet (P) don't have Mobile (L) styling
-const only = (key: Breakpoint | number): string => {
-  const minChecks = up(key)
+const only = (key: Breakpoint): string => {
+  const minWidth = minWidths[key]
+  const maxWidth = maxWidths[key]
+  const minHeight = minHeights[key]
 
-  const maxWidth =
-    typeof key === 'number'
-      ? key + 1
-      : // override for large Mobile (L) - now width overlaps Tablet (P)
-      key === 'sm'
-      ? 960
-      : maxWidths[key]
+  const defaultBreakpointCheck = `(min-width: ${minWidth}px) and (max-width: ${maxWidth}px) and (min-height:${minHeight}px)`
 
-  // Constrain height to distinguish between overlapping Mobile (L) & Tablet (P)
-  // Could use orientation, but won't work for vertical desktops (edge case)
-  const maxHeight =
-    key === 'sm' || (key >= minWidths.sm && key < minWidths.md)
-      ? maxWidths.xs
-      : 9999
+  // Enable larger mobiles(960x540) to keep SM breakpoint
+  // Use max-height over orientation for storybook / chromatic checks
+  const overlappingMobileCheck =
+    key === 'sm'
+      ? `(min-width: ${minWidths.md}px) and (max-width: 961px) and (max-height: ${minHeights.md}px), `
+      : ''
 
-  return `${minChecks} and (max-width: ${maxWidth}px) and (max-height: ${maxHeight}px)`
+  return `@media ${overlappingMobileCheck}${defaultBreakpointCheck}`
 }
 
 const breakpoints: Breakpoints = createBreakpoints({

--- a/libs/shared/ui/src/libs/themes/base/tokens/spacing.ts
+++ b/libs/shared/ui/src/libs/themes/base/tokens/spacing.ts
@@ -1,18 +1,7 @@
 import { ThemeOptions, createTheme } from '@mui/material'
 
-export const baseSpacing: Required<
-  Pick<ThemeOptions, 'spacing' | 'breakpoints'>
-> = {
-  spacing: 4,
-  breakpoints: {
-    values: {
-      xs: 0, // Mobile (P)
-      sm: 568, // Mobile (L)
-      md: 768, // Tablet (P)
-      lg: 1024, // Tablet (L)
-      xl: 1200 // Laptop/Desktop
-    }
-  }
+export const baseSpacing: Required<Pick<ThemeOptions, 'spacing'>> = {
+  spacing: 4
 }
 
 // Required to use baseSpacing in theme tokens


### PR DESCRIPTION
Fix issue where large mobiles 540x960 held horizontally would adopt Tablet (P) styles.

This was done by checking for min-height.

As a result, I've constrained which APIs are callable from breakpoint. 

No more `.down` or `.between` as the same styling can be achieved using just `.up` and `.only`

I only made the fix for horizontal mobiles adopting the style of Tablet (P) because this is a common size of device looking a real user data. (sm -> md)

Data on real user mobile sizes showed we don't get such large phones that vertically held mobiles would adopt Mobile (L) styles. (xs -> sm)

Only the largest tablets - iPad Pro and Surface Pro 3, when held vertically would display Tablet (L) modes. Due to the change occurring within the same type of device, no fix was deemed necessary. (md -> lg)

And large Tablets (L) adopting desktop styling is ok because they're most likely the same orientation. (lg -> xl)

Demos have been updated to test both `.only` and `.up` methods.

I can't make a demo testing that large mobiles 540x960 use SM/Mobile (L) breakpoints because Chromatic doesn't allow us to configure height (will always be full height). So this can only be checked manually for now.. You can check it with the "Large Mobile" viewport in Storybook