### PR TITLE
Change useBreakpoint to use .up method over .only

### DIFF
--- a/apps/journeys/src/components/Conductor/Conductor.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.tsx
@@ -65,7 +65,7 @@ const Conductor = ({ blocks }: ConductorProps): ReactElement => {
 
   const edgeSlideWidth = 16
   const getResponsiveGap = (
-    minGapBetween = breakpoints.xs ? 16 : 44,
+    minGapBetween = breakpoints.sm ? 44 : 16,
     maxSlideWidth = 854
   ): number =>
     Math.max(

--- a/libs/shared/ui/src/libs/themes/base/theme.stories.tsx
+++ b/libs/shared/ui/src/libs/themes/base/theme.stories.tsx
@@ -286,15 +286,28 @@ const ViewportTemplate: Story<ThemeStoryProps> = (args) => {
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'center',
-        alignItems: 'center',
-        height: '600px'
+        height: '600px',
+        m: '20%'
       }}
     >
+      <Typography
+        variant="caption"
+        sx={{ display: 'flex', alignSelf: 'flex-end' }}
+      >
+        {`Current width: ${width}px`}
+      </Typography>
+      <Typography
+        variant="caption"
+        gutterBottom
+        sx={{ display: 'flex', alignSelf: 'flex-end' }}
+      >
+        {`Current height: ${height}px`}
+      </Typography>
       {args.variants.map((variant: string) => {
         return (
           <>
             <Typography
-              variant="h4"
+              variant="h2"
               sx={{
                 [theme.breakpoints.only(variant as Breakpoint)]: {
                   display: 'flex'
@@ -302,25 +315,37 @@ const ViewportTemplate: Story<ThemeStoryProps> = (args) => {
                 display: 'none'
               }}
             >
-              {`sx: theme.breakpoint: ${variant}`}
+              {/* Test breakpoints.only() */}
+              {`${variant.toUpperCase()}`}
             </Typography>
             <Typography
-              variant="h4"
-              align="center"
-              style={{
-                display: breakpoints[variant as Breakpoint] ? 'flex' : 'none'
-              }}
-            >
-              {`style: useBreakpoint: ${variant}`}
-            </Typography>
-            <Typography
-              variant="body1"
               sx={{
                 [theme.breakpoints.only(variant as Breakpoint)]: {
                   display: 'flex'
                 },
                 display: 'none'
               }}
+            >
+              {/* Test useBreakpoints */}
+              {breakpoints.xl
+                ? 'Desktop'
+                : breakpoints.lg
+                ? 'Tablet (L)'
+                : breakpoints.md
+                ? 'Tablet (P)'
+                : breakpoints.sm
+                ? 'Mobile (L)'
+                : 'Mobile (P)'}
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{
+                [theme.breakpoints.only(variant as Breakpoint)]: {
+                  display: 'flex'
+                },
+                display: 'none'
+              }}
+              gutterBottom
             >
               {`Range: ${
                 theme.breakpoints.values[variant as Breakpoint]
@@ -329,25 +354,23 @@ const ViewportTemplate: Story<ThemeStoryProps> = (args) => {
           </>
         )
       })}
-      <Typography
-        variant="body1"
-        gutterBottom
-      >{`Current width: ${width}px | Current height: ${height}px`}</Typography>
-      <Typography
-        variant="overline"
-        align="center"
+      {/* Test breakpoints.up() */}
+      <Box
         sx={{
           height: '30px',
-          color: '#FC624E',
+          width: '100%',
+          backgroundColor: '#FC624E',
           [theme.breakpoints.up('md')]: {
-            color: '#7fe0aa'
+            backgroundColor: '#7fe0aa'
           },
           [theme.breakpoints.up('xl')]: {
-            color: '#4ec4fc'
-          }
+            backgroundColor: '#4ec4fc'
+          },
+          mb: 1
         }}
-      >
-        Mobile - red | Tablet - green | Desktop - blue
+      />
+      <Typography variant="caption">
+        Mobile - Red | Tablet - Green | Desktop - Blue
       </Typography>
     </Box>
   )

--- a/libs/shared/ui/src/libs/useBreakpoints/useBreakpoints.ts
+++ b/libs/shared/ui/src/libs/useBreakpoints/useBreakpoints.ts
@@ -6,10 +6,10 @@ export const useBreakpoints = (): { [key in Breakpoint]: boolean } => {
   // Update if we need to SSR
   // https://mui.com/components/use-media-query/#server-side-rendering
   return {
-    xs: useMediaQuery(theme.breakpoints.only('xs'), { noSsr: true }),
-    sm: useMediaQuery(theme.breakpoints.only('sm'), { noSsr: true }),
-    md: useMediaQuery(theme.breakpoints.only('md'), { noSsr: true }),
-    lg: useMediaQuery(theme.breakpoints.only('lg'), { noSsr: true }),
-    xl: useMediaQuery(theme.breakpoints.only('xl'), { noSsr: true })
+    xs: useMediaQuery(theme.breakpoints.up('xs'), { noSsr: true }),
+    sm: useMediaQuery(theme.breakpoints.up('sm'), { noSsr: true }),
+    md: useMediaQuery(theme.breakpoints.up('md'), { noSsr: true }),
+    lg: useMediaQuery(theme.breakpoints.up('lg'), { noSsr: true }),
+    xl: useMediaQuery(theme.breakpoints.up('xl'), { noSsr: true })
   }
 }


### PR DESCRIPTION
.up() is considerably more useful than .only().

Consider the case where we want a component to render only on tablet and above - this can be done easily if useBreakpoint uses the .up() method. And this would be the most common use case.

Any checks already styling a component based on the .only() method can also be easily rewritten using only .up() checks. See the Conductor file for an example of refactoring.