### PR TITLE
Fix Journey data id references

### DIFF
--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
@@ -106,10 +106,10 @@ const steps: Array<TreeBlock<StepBlock>> = [
     nextBlockId: 'step2.id',
     children: [
       {
-        id: 'card0.id',
+        id: 'card1.id',
         __typename: 'CardBlock',
         parentBlockId: 'step1.id',
-        coverBlockId: 'image0.id',
+        coverBlockId: 'image1.id',
         backgroundColor: null,
         themeMode: null,
         themeName: null,
@@ -118,7 +118,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
           {
             id: 'typographyBlockId1',
             __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card1.id',
             align: null,
             color: null,
             content: 'a quick question...',
@@ -128,7 +128,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
           {
             id: 'typographyBlockId12',
             __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card1.id',
             align: null,
             color: null,
             content: 'Can we trust the story of Jesus ?',
@@ -138,7 +138,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
           {
             __typename: 'ButtonBlock',
             id: 'button',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card1.id',
             label: 'Watch Now',
             buttonVariant: ButtonVariant.contained,
             buttonColor: ButtonColor.primary,
@@ -157,13 +157,13 @@ const steps: Array<TreeBlock<StepBlock>> = [
             children: []
           },
           {
-            id: 'image0.id',
+            id: 'image1.id',
             __typename: 'ImageBlock',
             src: 'https://images.unsplash.com/photo-1558704164-ab7a0016c1f3?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
             width: 1920,
             height: 1080,
             alt: 'random image from unsplash',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card1.id',
             children: [],
             blurhash: 'LQEf1v^*XkEe*IyD$RnOyXTJRjjG'
           }
@@ -179,10 +179,10 @@ const steps: Array<TreeBlock<StepBlock>> = [
     nextBlockId: 'step3.id',
     children: [
       {
-        id: 'card0.id',
+        id: 'card2.id',
         __typename: 'CardBlock',
-        parentBlockId: 'step0.id',
-        coverBlockId: 'image0.id',
+        parentBlockId: 'step2.id',
+        coverBlockId: 'image2.id',
         backgroundColor: null,
         themeMode: null,
         themeName: null,
@@ -191,7 +191,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
           {
             id: 'typographyBlockId1',
             __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card2.id',
             align: null,
             color: null,
             content: 'if it’s true...',
@@ -199,20 +199,10 @@ const steps: Array<TreeBlock<StepBlock>> = [
             children: []
           },
           {
-            id: 'typographyBlockId12',
-            __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
-            align: null,
-            color: null,
-            content: 'What is Christianity to you?',
-            variant: TypographyVariant.h3,
-            children: []
-          },
-          {
             id: 'radioQuestion1.id',
             __typename: 'RadioQuestionBlock',
-            parentBlockId: 'step2.id',
-            label: '',
+            parentBlockId: 'card2.id',
+            label: 'What is Christianity to you?',
             description: '',
             children: [
               {
@@ -251,13 +241,13 @@ const steps: Array<TreeBlock<StepBlock>> = [
             ]
           },
           {
-            id: 'image0.id',
+            id: 'image2.id',
             __typename: 'ImageBlock',
             src: 'https://images.unsplash.com/photo-1477936821694-ec4233a9a1a0?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1136&q=80',
             width: 1920,
             height: 1080,
             alt: 'random image from unsplash',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card2.id',
             children: [],
             blurhash: 'L;KRQa-Rs-kA}ot4bZj@SMR,WWj@'
           }
@@ -273,10 +263,10 @@ const steps: Array<TreeBlock<StepBlock>> = [
     nextBlockId: 'step4.id',
     children: [
       {
-        id: 'card0.id',
+        id: 'card3.id',
         __typename: 'CardBlock',
-        parentBlockId: 'step0.id',
-        coverBlockId: 'image0.id',
+        parentBlockId: 'step3.id',
+        coverBlockId: 'image3.id',
         backgroundColor: null,
         themeMode: null,
         themeName: null,
@@ -285,7 +275,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
           {
             id: 'typographyBlockId1',
             __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card3.id',
             align: null,
             color: null,
             content: 'What do you think?',
@@ -293,20 +283,10 @@ const steps: Array<TreeBlock<StepBlock>> = [
             children: []
           },
           {
-            id: 'typographyBlockId12',
-            __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
-            align: null,
-            color: null,
-            content: 'Do you need to change to be good enough for God?',
-            variant: TypographyVariant.h3,
-            children: []
-          },
-          {
             id: 'radioQuestion1.id',
             __typename: 'RadioQuestionBlock',
-            parentBlockId: 'step2.id',
-            label: '',
+            parentBlockId: 'card3.id',
+            label: 'Do you need to change to be good enough for God?',
             description: '',
             children: [
               {
@@ -334,13 +314,13 @@ const steps: Array<TreeBlock<StepBlock>> = [
             ]
           },
           {
-            id: 'image0.id',
+            id: 'image3.id',
             __typename: 'ImageBlock',
             src: 'https://images.unsplash.com/photo-1527268835115-be8ff4ff5dec?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1235&q=80',
             width: 1920,
             height: 1080,
             alt: 'random image from unsplash',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card3.id',
             children: [],
             blurhash: 'L3CZt$_NyX4n=|?b00Ip8_IV00IA'
           }
@@ -356,10 +336,10 @@ const steps: Array<TreeBlock<StepBlock>> = [
     nextBlockId: null,
     children: [
       {
-        id: 'card0.id',
+        id: 'card4.id',
         __typename: 'CardBlock',
-        parentBlockId: 'step0.id',
-        coverBlockId: 'image0.id',
+        parentBlockId: 'step4.id',
+        coverBlockId: 'image4.id',
         backgroundColor: null,
         themeMode: null,
         themeName: null,
@@ -368,7 +348,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
           {
             id: 'typographyBlockId1',
             __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card4.id',
             align: null,
             color: null,
             content: 'a quote',
@@ -378,7 +358,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
           {
             id: 'typographyBlockId12',
             __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card4.id',
             align: null,
             color: null,
             content:
@@ -389,7 +369,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
           {
             id: 'typographyBlockId13',
             __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card4.id',
             align: null,
             color: null,
             content: '–  The Bible, John 3:17',
@@ -397,7 +377,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
             children: []
           },
           {
-            id: 'image0.id',
+            id: 'image4.id',
             __typename: 'ImageBlock',
             src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
             width: 1920,
@@ -410,7 +390,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
           {
             __typename: 'ButtonBlock',
             id: 'button',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card4.id',
             label: 'Start Over',
             buttonVariant: ButtonVariant.contained,
             buttonColor: ButtonColor.primary,

--- a/apps/journeys-admin/src/components/Editor/Canvas/Canvas.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/Canvas.stories.tsx
@@ -105,10 +105,10 @@ const steps: Array<TreeBlock<StepBlock>> = [
     nextBlockId: 'step2.id',
     children: [
       {
-        id: 'card0.id',
+        id: 'card1.id',
         __typename: 'CardBlock',
         parentBlockId: 'step1.id',
-        coverBlockId: 'image0.id',
+        coverBlockId: 'image1.id',
         backgroundColor: null,
         themeMode: null,
         themeName: null,
@@ -117,7 +117,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
           {
             id: 'typographyBlockId1',
             __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card1.id',
             align: null,
             color: null,
             content: 'a quick question...',
@@ -127,7 +127,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
           {
             id: 'typographyBlockId12',
             __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card1.id',
             align: null,
             color: null,
             content: 'Can we trust the story of Jesus ?',
@@ -137,7 +137,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
           {
             __typename: 'ButtonBlock',
             id: 'button',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card1.id',
             label: 'Watch Now',
             buttonVariant: ButtonVariant.contained,
             buttonColor: ButtonColor.primary,
@@ -156,13 +156,13 @@ const steps: Array<TreeBlock<StepBlock>> = [
             children: []
           },
           {
-            id: 'image0.id',
+            id: 'image1.id',
             __typename: 'ImageBlock',
             src: 'https://images.unsplash.com/photo-1558704164-ab7a0016c1f3?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
             width: 1920,
             height: 1080,
             alt: 'random image from unsplash',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card1.id',
             children: [],
             blurhash: 'LQEf1v^*XkEe*IyD$RnOyXTJRjjG'
           }
@@ -178,10 +178,10 @@ const steps: Array<TreeBlock<StepBlock>> = [
     nextBlockId: 'step3.id',
     children: [
       {
-        id: 'card0.id',
+        id: 'card2.id',
         __typename: 'CardBlock',
-        parentBlockId: 'step0.id',
-        coverBlockId: 'image0.id',
+        parentBlockId: 'step2.id',
+        coverBlockId: 'image2.id',
         backgroundColor: null,
         themeMode: null,
         themeName: null,
@@ -190,7 +190,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
           {
             id: 'typographyBlockId1',
             __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card2.id',
             align: null,
             color: null,
             content: 'if it’s true...',
@@ -198,20 +198,10 @@ const steps: Array<TreeBlock<StepBlock>> = [
             children: []
           },
           {
-            id: 'typographyBlockId12',
-            __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
-            align: null,
-            color: null,
-            content: 'What is Christianity to you?',
-            variant: TypographyVariant.h3,
-            children: []
-          },
-          {
             id: 'radioQuestion1.id',
             __typename: 'RadioQuestionBlock',
-            parentBlockId: 'step2.id',
-            label: '',
+            parentBlockId: 'card2.id',
+            label: 'What is Christianity to you?',
             description: '',
             children: [
               {
@@ -250,13 +240,13 @@ const steps: Array<TreeBlock<StepBlock>> = [
             ]
           },
           {
-            id: 'image0.id',
+            id: 'image2.id',
             __typename: 'ImageBlock',
             src: 'https://images.unsplash.com/photo-1477936821694-ec4233a9a1a0?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1136&q=80',
             width: 1920,
             height: 1080,
             alt: 'random image from unsplash',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card2.id',
             children: [],
             blurhash: 'L;KRQa-Rs-kA}ot4bZj@SMR,WWj@'
           }
@@ -272,10 +262,10 @@ const steps: Array<TreeBlock<StepBlock>> = [
     nextBlockId: 'step4.id',
     children: [
       {
-        id: 'card0.id',
+        id: 'card3.id',
         __typename: 'CardBlock',
-        parentBlockId: 'step0.id',
-        coverBlockId: 'image0.id',
+        parentBlockId: 'step3.id',
+        coverBlockId: 'image3.id',
         backgroundColor: null,
         themeMode: null,
         themeName: null,
@@ -284,7 +274,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
           {
             id: 'typographyBlockId1',
             __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card3.id',
             align: null,
             color: null,
             content: 'What do you think?',
@@ -292,20 +282,10 @@ const steps: Array<TreeBlock<StepBlock>> = [
             children: []
           },
           {
-            id: 'typographyBlockId12',
-            __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
-            align: null,
-            color: null,
-            content: 'Do you need to change to be good enough for God?',
-            variant: TypographyVariant.h3,
-            children: []
-          },
-          {
             id: 'radioQuestion1.id',
             __typename: 'RadioQuestionBlock',
-            parentBlockId: 'step2.id',
-            label: '',
+            parentBlockId: 'card3.id',
+            label: 'Do you need to change to be good enough for God?',
             description: '',
             children: [
               {
@@ -333,13 +313,13 @@ const steps: Array<TreeBlock<StepBlock>> = [
             ]
           },
           {
-            id: 'image0.id',
+            id: 'image3.id',
             __typename: 'ImageBlock',
             src: 'https://images.unsplash.com/photo-1527268835115-be8ff4ff5dec?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1235&q=80',
             width: 1920,
             height: 1080,
             alt: 'random image from unsplash',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card3.id',
             children: [],
             blurhash: 'L3CZt$_NyX4n=|?b00Ip8_IV00IA'
           }
@@ -355,10 +335,10 @@ const steps: Array<TreeBlock<StepBlock>> = [
     nextBlockId: null,
     children: [
       {
-        id: 'card0.id',
+        id: 'card4.id',
         __typename: 'CardBlock',
-        parentBlockId: 'step0.id',
-        coverBlockId: 'image0.id',
+        parentBlockId: 'step4.id',
+        coverBlockId: 'image4.id',
         backgroundColor: null,
         themeMode: null,
         themeName: null,
@@ -367,7 +347,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
           {
             id: 'typographyBlockId1',
             __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card4.id',
             align: null,
             color: null,
             content: 'a quote',
@@ -377,7 +357,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
           {
             id: 'typographyBlockId12',
             __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card4.id',
             align: null,
             color: null,
             content:
@@ -388,7 +368,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
           {
             id: 'typographyBlockId13',
             __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card4.id',
             align: null,
             color: null,
             content: '–  The Bible, John 3:17',
@@ -396,7 +376,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
             children: []
           },
           {
-            id: 'image0.id',
+            id: 'image4.id',
             __typename: 'ImageBlock',
             src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
             width: 1920,
@@ -409,7 +389,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
           {
             __typename: 'ButtonBlock',
             id: 'button',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card4.id',
             label: 'Start Over',
             buttonVariant: ButtonVariant.contained,
             buttonColor: ButtonColor.primary,
@@ -437,7 +417,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
 const Template: Story = () => {
   return (
     <MockedProvider>
-      <EditorProvider initialState={{ steps }}>
+      <EditorProvider initialState={{ steps: steps }}>
         <Canvas />
       </EditorProvider>
     </MockedProvider>

--- a/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
@@ -102,7 +102,7 @@ const blocks: GetJourneyForEdit_journey_blocks[] = [
     id: 'card1.id',
     __typename: 'CardBlock',
     parentBlockId: 'step1.id',
-    coverBlockId: 'image0.id',
+    coverBlockId: 'image1.id',
     backgroundColor: null,
     themeMode: null,
     themeName: null,
@@ -147,7 +147,7 @@ const blocks: GetJourneyForEdit_journey_blocks[] = [
     }
   },
   {
-    id: 'image0.id',
+    id: 'image1.id',
     __typename: 'ImageBlock',
     src: 'https://images.unsplash.com/photo-1558704164-ab7a0016c1f3?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
     width: 1920,
@@ -168,7 +168,7 @@ const blocks: GetJourneyForEdit_journey_blocks[] = [
     id: 'card2.id',
     __typename: 'CardBlock',
     parentBlockId: 'step2.id',
-    coverBlockId: 'image0.id',
+    coverBlockId: 'image2.id',
     backgroundColor: null,
     themeMode: null,
     themeName: null,
@@ -184,19 +184,10 @@ const blocks: GetJourneyForEdit_journey_blocks[] = [
     variant: TypographyVariant.h6
   },
   {
-    id: 'typographyBlockId6',
-    __typename: 'TypographyBlock',
-    parentBlockId: 'card2.id',
-    align: null,
-    color: null,
-    content: 'What is Christianity to you?',
-    variant: TypographyVariant.h3
-  },
-  {
     id: 'radioQuestion1.id',
     __typename: 'RadioQuestionBlock',
     parentBlockId: 'card2.id',
-    label: '',
+    label: 'What is Christianity to you?',
     description: ''
   },
   {
@@ -230,7 +221,7 @@ const blocks: GetJourneyForEdit_journey_blocks[] = [
     }
   },
   {
-    id: 'image0.id',
+    id: 'image2.id',
     __typename: 'ImageBlock',
     src: 'https://images.unsplash.com/photo-1477936821694-ec4233a9a1a0?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1136&q=80',
     width: 1920,
@@ -250,7 +241,7 @@ const blocks: GetJourneyForEdit_journey_blocks[] = [
     id: 'card3.id',
     __typename: 'CardBlock',
     parentBlockId: 'step3.id',
-    coverBlockId: 'image0.id',
+    coverBlockId: 'image3.id',
     backgroundColor: null,
     themeMode: null,
     themeName: null,
@@ -266,19 +257,10 @@ const blocks: GetJourneyForEdit_journey_blocks[] = [
     variant: TypographyVariant.h6
   },
   {
-    id: 'typographyBlockId8',
-    __typename: 'TypographyBlock',
-    parentBlockId: 'card3.id',
-    align: null,
-    color: null,
-    content: 'Do you need to change to be good enough for God?',
-    variant: TypographyVariant.h3
-  },
-  {
     id: 'radioQuestion2.id',
     __typename: 'RadioQuestionBlock',
     parentBlockId: 'card3.id',
-    label: '',
+    label: 'Do you need to change to be good enough for God?',
     description: ''
   },
   {
@@ -302,7 +284,7 @@ const blocks: GetJourneyForEdit_journey_blocks[] = [
     }
   },
   {
-    id: 'image0.id',
+    id: 'image3.id',
     __typename: 'ImageBlock',
     src: 'https://images.unsplash.com/photo-1527268835115-be8ff4ff5dec?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1235&q=80',
     width: 1920,
@@ -322,7 +304,7 @@ const blocks: GetJourneyForEdit_journey_blocks[] = [
     id: 'card4.id',
     __typename: 'CardBlock',
     parentBlockId: 'step4.id',
-    coverBlockId: 'image0.id',
+    coverBlockId: 'image4.id',
     backgroundColor: null,
     themeMode: null,
     themeName: null,
@@ -357,7 +339,7 @@ const blocks: GetJourneyForEdit_journey_blocks[] = [
     variant: TypographyVariant.caption
   },
   {
-    id: 'image0.id',
+    id: 'image4.id',
     __typename: 'ImageBlock',
     src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
     width: 1920,

--- a/apps/journeys-admin/src/components/JourneyView/CardView/data.ts
+++ b/apps/journeys-admin/src/components/JourneyView/CardView/data.ts
@@ -169,10 +169,10 @@ export const steps: Array<TreeBlock<StepBlock>> = [
     nextBlockId: 'step2.id',
     children: [
       {
-        id: 'card0.id',
+        id: 'card1.id',
         __typename: 'CardBlock',
         parentBlockId: 'step1.id',
-        coverBlockId: 'image0.id',
+        coverBlockId: 'image1.id',
         backgroundColor: null,
         themeMode: null,
         themeName: null,
@@ -181,7 +181,7 @@ export const steps: Array<TreeBlock<StepBlock>> = [
           {
             id: 'typographyBlockId1',
             __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card1.id',
             align: null,
             color: null,
             content: 'a quick question...',
@@ -191,7 +191,7 @@ export const steps: Array<TreeBlock<StepBlock>> = [
           {
             id: 'typographyBlockId12',
             __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card1.id',
             align: null,
             color: null,
             content: 'Can we trust the story of Jesus ?',
@@ -201,7 +201,7 @@ export const steps: Array<TreeBlock<StepBlock>> = [
           {
             __typename: 'ButtonBlock',
             id: 'button',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card1.id',
             label: 'Watch Now',
             buttonVariant: ButtonVariant.contained,
             buttonColor: ButtonColor.primary,
@@ -220,13 +220,13 @@ export const steps: Array<TreeBlock<StepBlock>> = [
             children: []
           },
           {
-            id: 'image0.id',
+            id: 'image1.id',
             __typename: 'ImageBlock',
             src: 'https://images.unsplash.com/photo-1558704164-ab7a0016c1f3?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
             width: 1920,
             height: 1080,
             alt: 'random image from unsplash',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card1.id',
             children: [],
             blurhash: 'LQEf1v^*XkEe*IyD$RnOyXTJRjjG'
           }
@@ -242,10 +242,10 @@ export const steps: Array<TreeBlock<StepBlock>> = [
     nextBlockId: 'step3.id',
     children: [
       {
-        id: 'card0.id',
+        id: 'card2.id',
         __typename: 'CardBlock',
-        parentBlockId: 'step0.id',
-        coverBlockId: 'image0.id',
+        parentBlockId: 'step2.id',
+        coverBlockId: 'image2.id',
         backgroundColor: null,
         themeMode: null,
         themeName: null,
@@ -254,7 +254,7 @@ export const steps: Array<TreeBlock<StepBlock>> = [
           {
             id: 'typographyBlockId1',
             __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card2.id',
             align: null,
             color: null,
             content: 'if it’s true...',
@@ -262,20 +262,10 @@ export const steps: Array<TreeBlock<StepBlock>> = [
             children: []
           },
           {
-            id: 'typographyBlockId12',
-            __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
-            align: null,
-            color: null,
-            content: 'What is Christianity to you?',
-            variant: TypographyVariant.h3,
-            children: []
-          },
-          {
             id: 'radioQuestion1.id',
             __typename: 'RadioQuestionBlock',
-            parentBlockId: 'step2.id',
-            label: '',
+            parentBlockId: 'card2.id',
+            label: 'What is Christianity to you?',
             description: '',
             children: [
               {
@@ -314,13 +304,13 @@ export const steps: Array<TreeBlock<StepBlock>> = [
             ]
           },
           {
-            id: 'image0.id',
+            id: 'image2.id',
             __typename: 'ImageBlock',
             src: 'https://images.unsplash.com/photo-1477936821694-ec4233a9a1a0?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1136&q=80',
             width: 1920,
             height: 1080,
             alt: 'random image from unsplash',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card2.id',
             children: [],
             blurhash: 'L;KRQa-Rs-kA}ot4bZj@SMR,WWj@'
           }
@@ -336,10 +326,10 @@ export const steps: Array<TreeBlock<StepBlock>> = [
     nextBlockId: 'step4.id',
     children: [
       {
-        id: 'card0.id',
+        id: 'card3.id',
         __typename: 'CardBlock',
-        parentBlockId: 'step0.id',
-        coverBlockId: 'image0.id',
+        parentBlockId: 'step3.id',
+        coverBlockId: 'image3.id',
         backgroundColor: null,
         themeMode: null,
         themeName: null,
@@ -348,7 +338,7 @@ export const steps: Array<TreeBlock<StepBlock>> = [
           {
             id: 'typographyBlockId1',
             __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card3.id',
             align: null,
             color: null,
             content: 'What do you think?',
@@ -356,20 +346,10 @@ export const steps: Array<TreeBlock<StepBlock>> = [
             children: []
           },
           {
-            id: 'typographyBlockId12',
-            __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
-            align: null,
-            color: null,
-            content: 'Do you need to change to be good enough for God?',
-            variant: TypographyVariant.h3,
-            children: []
-          },
-          {
             id: 'radioQuestion1.id',
             __typename: 'RadioQuestionBlock',
-            parentBlockId: 'step2.id',
-            label: '',
+            parentBlockId: 'card3.id',
+            label: 'Do you need to change to be good enough for God?',
             description: '',
             children: [
               {
@@ -397,13 +377,13 @@ export const steps: Array<TreeBlock<StepBlock>> = [
             ]
           },
           {
-            id: 'image0.id',
+            id: 'image3.id',
             __typename: 'ImageBlock',
             src: 'https://images.unsplash.com/photo-1527268835115-be8ff4ff5dec?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1235&q=80',
             width: 1920,
             height: 1080,
             alt: 'random image from unsplash',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card3.id',
             children: [],
             blurhash: 'L3CZt$_NyX4n=|?b00Ip8_IV00IA'
           }
@@ -419,10 +399,10 @@ export const steps: Array<TreeBlock<StepBlock>> = [
     nextBlockId: null,
     children: [
       {
-        id: 'card0.id',
+        id: 'card4.id',
         __typename: 'CardBlock',
-        parentBlockId: 'step0.id',
-        coverBlockId: 'image0.id',
+        parentBlockId: 'step4.id',
+        coverBlockId: 'image4.id',
         backgroundColor: null,
         themeMode: null,
         themeName: null,
@@ -431,7 +411,7 @@ export const steps: Array<TreeBlock<StepBlock>> = [
           {
             id: 'typographyBlockId1',
             __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card4.id',
             align: null,
             color: null,
             content: 'a quote',
@@ -441,7 +421,7 @@ export const steps: Array<TreeBlock<StepBlock>> = [
           {
             id: 'typographyBlockId12',
             __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card4.id',
             align: null,
             color: null,
             content:
@@ -452,7 +432,7 @@ export const steps: Array<TreeBlock<StepBlock>> = [
           {
             id: 'typographyBlockId13',
             __typename: 'TypographyBlock',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card4.id',
             align: null,
             color: null,
             content: '–  The Bible, John 3:17',
@@ -460,7 +440,7 @@ export const steps: Array<TreeBlock<StepBlock>> = [
             children: []
           },
           {
-            id: 'image0.id',
+            id: 'image4.id',
             __typename: 'ImageBlock',
             src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
             width: 1920,
@@ -473,7 +453,7 @@ export const steps: Array<TreeBlock<StepBlock>> = [
           {
             __typename: 'ButtonBlock',
             id: 'button',
-            parentBlockId: 'card0.id',
+            parentBlockId: 'card4.id',
             label: 'Start Over',
             buttonVariant: ButtonVariant.contained,
             buttonColor: ButtonColor.primary,


### PR DESCRIPTION
Would be nice to keep the mock data for these card previews in a central place...

Also this just fixes the parentBlockId references for block selection to work. It'd be nice to have the consolidated format for id's / id naming fixes done once in a shared data file..