### PR TITLE
fix: add branch to worker deployment

### DIFF
--- a/.github/workflows/api-deploy-worker.yml
+++ b/.github/workflows/api-deploy-worker.yml
@@ -9,6 +9,9 @@ on:
       repository:
         required: true
         type: string
+      branch:
+        required: true
+        type: string
     secrets:
       ARANGODB_URL:
         required: true
@@ -29,7 +32,7 @@ jobs:
   build-and-deploy:
     environment: Production
     env:
-      ENV_SUFFIX: ${{ github.ref_name }}
+      ENV_SUFFIX: ${{ inputs.branch }}
       ECR_REPOSITORY: ${{ inputs.repository }}
       KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
       IMAGE_TAG: ${{ github.sha }}

--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -23,6 +23,7 @@ jobs:
     with:
       name: api-users
       repository: jfp-api-users
+      branch: ${{ github.ref }}
     secrets:
       ARANGODB_URL: ${{ secrets.ARANGODB_URL }}
       ARANGODB_USER: ${{ secrets.ARANGODB_USER }}


### PR DESCRIPTION
This uses the branch from the main github action, allowing stage api to deploy properly