### PR TITLE
Add parentBlockId to action

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -18,6 +18,7 @@ directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
 interface Action {
   gtmEventName: String
+  parentBlockId: ID!
 }
 
 interface Block {
@@ -311,6 +312,7 @@ input JourneyUpdateInput {
 
 type LinkAction implements Action {
   gtmEventName: String
+  parentBlockId: ID!
   target: String
   url: String!
 }
@@ -361,6 +363,7 @@ closest ancestor StepBlock.
 """
 type NavigateAction implements Action {
   gtmEventName: String
+  parentBlockId: ID!
 }
 
 input NavigateActionInput {
@@ -370,6 +373,7 @@ input NavigateActionInput {
 type NavigateToBlockAction implements Action {
   blockId: String!
   gtmEventName: String
+  parentBlockId: ID!
 }
 
 input NavigateToBlockActionInput {
@@ -381,6 +385,7 @@ type NavigateToJourneyAction implements Action {
   gtmEventName: String
   journey: Journey
   journeyId: String!
+  parentBlockId: ID!
 }
 
 input NavigateToJourneyActionInput {

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -53,6 +53,7 @@ enum ThemeName {
 }
 
 interface Action {
+  parentBlockId: ID!
   gtmEventName: String
 }
 
@@ -61,21 +62,25 @@ NavigateAction is an Action that navigates to the nextBlockId field set on the
 closest ancestor StepBlock.
 """
 type NavigateAction implements Action {
+  parentBlockId: ID!
   gtmEventName: String
 }
 
 type NavigateToBlockAction implements Action {
+  parentBlockId: ID!
   gtmEventName: String
   blockId: String!
 }
 
 type NavigateToJourneyAction implements Action {
+  parentBlockId: ID!
   gtmEventName: String
   journeyId: String!
   journey: Journey
 }
 
 type LinkAction implements Action {
+  parentBlockId: ID!
   gtmEventName: String
   url: String!
   target: String

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -337,6 +337,7 @@ export class VideoResponseCreateInput {
 }
 
 export interface Action {
+    parentBlockId: string;
     gtmEventName?: Nullable<string>;
 }
 
@@ -365,17 +366,20 @@ export class Icon {
 
 export class NavigateAction implements Action {
     __typename?: 'NavigateAction';
+    parentBlockId: string;
     gtmEventName?: Nullable<string>;
 }
 
 export class NavigateToBlockAction implements Action {
     __typename?: 'NavigateToBlockAction';
+    parentBlockId: string;
     gtmEventName?: Nullable<string>;
     blockId: string;
 }
 
 export class NavigateToJourneyAction implements Action {
     __typename?: 'NavigateToJourneyAction';
+    parentBlockId: string;
     gtmEventName?: Nullable<string>;
     journeyId: string;
     journey?: Nullable<Journey>;
@@ -383,6 +387,7 @@ export class NavigateToJourneyAction implements Action {
 
 export class LinkAction implements Action {
     __typename?: 'LinkAction';
+    parentBlockId: string;
     gtmEventName?: Nullable<string>;
     url: string;
     target?: Nullable<string>;

--- a/apps/api-journeys/src/app/modules/action/action.graphql
+++ b/apps/api-journeys/src/app/modules/action/action.graphql
@@ -1,4 +1,5 @@
 interface Action {
+  parentBlockId: ID!
   gtmEventName: String
 }
 
@@ -7,20 +8,24 @@ NavigateAction is an Action that navigates to the nextBlockId field set on the
 closest ancestor StepBlock.
 """
 type NavigateAction implements Action {
+  parentBlockId: ID!
   gtmEventName: String
 }
 
 type NavigateToBlockAction implements Action {
+  parentBlockId: ID!
   gtmEventName: String
   blockId: String!
 }
 
 type NavigateToJourneyAction implements Action {
+  parentBlockId: ID!
   gtmEventName: String
   journeyId: String!
 }
 
 type LinkAction implements Action {
+  parentBlockId: ID!
   gtmEventName: String
   url: String!
   target: String


### PR DESCRIPTION
Add parentBlockId to actions so we have a unique identifier on which to cache actions (allows optimized response). 

**This assumes that there will only ever be 1 action per block.**

- [Basecamp](https://3.basecamp.com/3105655/buckets/26244169/todos/4632617491)

# How should this PR be QA Tested?

- [ ] Pass checks
- [ ] Unit tests

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
