### PR TITLE
fix: add missing branch variable to deployment

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -10,6 +10,7 @@ jobs:
     with:
       name: api-journeys
       repository: jfp-api-journeys
+      branch: ${{ github.ref }}
     secrets:
       ARANGODB_URL: ${{ secrets.ARANGODB_URL }}
       ARANGODB_USER: ${{ secrets.ARANGODB_USER }}


### PR DESCRIPTION
# Description

The api-deploy script was missing a variable. This resolves the issue.