### PR TITLE
feature: adding card block

### DIFF
--- a/apps/api-journeys/src/app/modules/block/card/card.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/card/card.resolver.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { Database } from 'arangojs'
 import { mockDeep } from 'jest-mock-extended'
-import { ThemeMode, ThemeName } from '../../../__generated__/graphql'
+import { CardBlock, ThemeMode, ThemeName } from '../../../__generated__/graphql'
 import { UserJourneyService } from '../../userJourney/userJourney.service'
 import { BlockResolver } from '../block.resolver'
 import { BlockService } from '../block.service'
@@ -120,6 +120,24 @@ describe('CardBlockResolver', () => {
         .cardBlockUpdate(block._key, block.journeyId, blockUpdate)
         .catch((err) => console.log(err))
       expect(service.update).toHaveBeenCalledWith(block._key, blockUpdate)
+    })
+  })
+
+  describe('fullscreen', () => {
+    it('returns fullscreen when true', () => {
+      expect(
+        resolver.fullscreen({ fullscreen: true } as unknown as CardBlock)
+      ).toEqual(true)
+    })
+
+    it('returns fullscreen when false', () => {
+      expect(
+        resolver.fullscreen({ fullscreen: false } as unknown as CardBlock)
+      ).toEqual(false)
+    })
+
+    it('returns false when fullscreen is not set', () => {
+      expect(resolver.fullscreen({} as unknown as CardBlock)).toEqual(false)
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/block/card/card.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/card/card.resolver.ts
@@ -1,5 +1,5 @@
 import { UseGuards } from '@nestjs/common'
-import { Args, Mutation, Resolver } from '@nestjs/graphql'
+import { Args, Mutation, Parent, ResolveField, Resolver } from '@nestjs/graphql'
 import { IdAsKey, KeyAsId } from '@core/nest/decorators'
 import {
   CardBlock,
@@ -46,5 +46,12 @@ export class CardBlockResolver {
     @Args('input') input: CardBlockUpdateInput
   ): Promise<CardBlock> {
     return await this.blockService.update(id, input)
+  }
+
+  @ResolveField()
+  fullscreen(@Parent() card: CardBlock): boolean {
+    if (card.fullscreen != null) return card.fullscreen
+
+    return false
   }
 }

--- a/apps/api-journeys/src/app/modules/block/step/step.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/step/step.resolver.spec.ts
@@ -4,6 +4,7 @@ import { mockDeep } from 'jest-mock-extended'
 import { UserJourneyService } from '../../userJourney/userJourney.service'
 import { BlockResolver } from '../block.resolver'
 import { BlockService } from '../block.service'
+import { StepBlock } from '../../../__generated__/graphql'
 import { StepBlockResolver } from './step.resolver'
 
 describe('StepBlockResolver', () => {
@@ -104,6 +105,24 @@ describe('StepBlockResolver', () => {
         .stepBlockUpdate(block._key, block.journeyId, blockUpdate)
         .catch((err) => console.log(err))
       expect(service.update).toHaveBeenCalledWith(block._key, blockUpdate)
+    })
+  })
+
+  describe('locked', () => {
+    it('returns locked when true', () => {
+      expect(resolver.locked({ locked: true } as unknown as StepBlock)).toEqual(
+        true
+      )
+    })
+
+    it('returns locked when false', () => {
+      expect(
+        resolver.locked({ locked: false } as unknown as StepBlock)
+      ).toEqual(false)
+    })
+
+    it('returns false when locked is not set', () => {
+      expect(resolver.locked({} as unknown as StepBlock)).toEqual(false)
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/block/step/step.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/step/step.resolver.ts
@@ -1,5 +1,5 @@
 import { UseGuards } from '@nestjs/common'
-import { Args, Mutation, Resolver } from '@nestjs/graphql'
+import { Args, Mutation, Parent, ResolveField, Resolver } from '@nestjs/graphql'
 import { IdAsKey, KeyAsId } from '@core/nest/decorators'
 import {
   StepBlock,
@@ -43,5 +43,12 @@ export class StepBlockResolver {
     @Args('input') input: StepBlockUpdateInput
   ): Promise<StepBlock> {
     return await this.blockService.update(id, input)
+  }
+
+  @ResolveField()
+  locked(@Parent() step: StepBlock): boolean {
+    if (step.locked != null) return step.locked
+
+    return false
   }
 }

--- a/apps/journeys-admin/__generated__/StepAndCardBlockCreate.ts
+++ b/apps/journeys-admin/__generated__/StepAndCardBlockCreate.ts
@@ -1,0 +1,73 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { ThemeMode, ThemeName } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: StepAndCardBlockCreate
+// ====================================================
+
+export interface StepAndCardBlockCreate_stepBlockCreate {
+  __typename: "StepBlock";
+  id: string;
+  parentBlockId: string | null;
+  parentOrder: number | null;
+  /**
+   * locked will be set to true if the user should not be able to manually
+   * advance to the next step.
+   */
+  locked: boolean;
+  /**
+   * nextBlockId contains the preferred block to navigate to when a
+   * NavigateAction occurs or if the user manually tries to advance to the next
+   * step. If no nextBlockId is set it can be assumed that this step represents
+   * the end of the current journey.
+   */
+  nextBlockId: string | null;
+}
+
+export interface StepAndCardBlockCreate_cardBlockCreate {
+  __typename: "CardBlock";
+  id: string;
+  parentBlockId: string | null;
+  parentOrder: number | null;
+  /**
+   * backgroundColor should be a HEX color value e.g #FFFFFF for white.
+   */
+  backgroundColor: string | null;
+  /**
+   * coverBlockId is present if a child block should be used as a cover.
+   * This child block should not be rendered normally, instead it should be used
+   * as a background. Blocks are often of type ImageBlock or VideoBlock.
+   */
+  coverBlockId: string | null;
+  /**
+   * themeMode can override journey themeMode. If nothing is set then use
+   * themeMode from journey
+   */
+  themeMode: ThemeMode | null;
+  /**
+   * themeName can override journey themeName. If nothing is set then use
+   * themeName from journey
+   */
+  themeName: ThemeName | null;
+  /**
+   * fullscreen should control how the coverBlock is displayed. When fullscreen
+   * is set to true the coverBlock Image should be displayed as a blur in the
+   * background.
+   */
+  fullscreen: boolean;
+}
+
+export interface StepAndCardBlockCreate {
+  stepBlockCreate: StepAndCardBlockCreate_stepBlockCreate;
+  cardBlockCreate: StepAndCardBlockCreate_cardBlockCreate;
+}
+
+export interface StepAndCardBlockCreateVariables {
+  journeyId: string;
+  stepId: string;
+  cardId?: string | null;
+}

--- a/apps/journeys-admin/pages/journeys/[journeySlug]/edit.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeySlug]/edit.tsx
@@ -38,7 +38,10 @@ function JourneyEditPage(): ReactElement {
             backHref={`/journeys/${router.query.journeySlug as string}`}
             AuthUser={AuthUser}
           >
-            <Editor journey={data.journey} />
+            <Editor
+              journey={data.journey}
+              selectedStepId={router.query.stepId as string | undefined}
+            />
           </PageWrapper>
         </>
       )}

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.spec.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.spec.tsx
@@ -18,7 +18,7 @@ jest.mock('uuid', () => ({
 const mockUuidv4 = uuidv4 as jest.MockedFunction<typeof uuidv4>
 
 describe('CardPreview', () => {
-  it('calls onSelect when step is clicked', () => {
+  it('should call onSelect when step is clicked', () => {
     const onSelect = jest.fn()
     const step: TreeBlock<StepBlock> = {
       id: 'step.id',
@@ -38,7 +38,7 @@ describe('CardPreview', () => {
     expect(onSelect).toHaveBeenCalledWith(step)
   })
 
-  it('creates step and card when add button is clicked', async () => {
+  it('should create step and card when add button is clicked', async () => {
     mockUuidv4.mockReturnValueOnce('stepId')
     mockUuidv4.mockReturnValueOnce('cardId')
     const onSelect = jest.fn()

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.spec.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.spec.tsx
@@ -1,10 +1,24 @@
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, waitFor } from '@testing-library/react'
 import { TreeBlock } from '@core/journeys/ui'
-import { GetJourney_journey_blocks_StepBlock as StepBlock } from '../../../__generated__/GetJourney'
+import { MockedProvider } from '@apollo/client/testing'
+import { v4 as uuidv4 } from 'uuid'
+import {
+  GetJourney_journey as Journey,
+  GetJourney_journey_blocks_StepBlock as StepBlock
+} from '../../../__generated__/GetJourney'
+import { JourneyProvider } from '../../libs/context'
+import { STEP_AND_CARD_BLOCK_CREATE } from './CardPreview'
 import { CardPreview } from '.'
 
+jest.mock('uuid', () => ({
+  __esModule: true,
+  v4: jest.fn()
+}))
+
+const mockUuidv4 = uuidv4 as jest.MockedFunction<typeof uuidv4>
+
 describe('CardPreview', () => {
-  it('should call onSelect when step is clicked on', () => {
+  it('calls onSelect when step is clicked', () => {
     const onSelect = jest.fn()
     const step: TreeBlock<StepBlock> = {
       id: 'step.id',
@@ -16,9 +30,85 @@ describe('CardPreview', () => {
       children: []
     }
     const { getByTestId } = render(
-      <CardPreview onSelect={onSelect} steps={[step]} />
+      <MockedProvider>
+        <CardPreview onSelect={onSelect} steps={[step]} />
+      </MockedProvider>
     )
     fireEvent.click(getByTestId('preview-step.id'))
     expect(onSelect).toHaveBeenCalledWith(step)
+  })
+
+  it('creates step and card when add button is clicked', async () => {
+    mockUuidv4.mockReturnValueOnce('stepId')
+    mockUuidv4.mockReturnValueOnce('cardId')
+    const onSelect = jest.fn()
+    const { getByRole } = render(
+      <MockedProvider
+        mocks={[
+          {
+            request: {
+              query: STEP_AND_CARD_BLOCK_CREATE,
+              variables: {
+                journeyId: 'journeyId',
+                stepId: 'stepId',
+                cardId: 'cardId'
+              }
+            },
+            result: {
+              data: {
+                stepBlockCreate: {
+                  id: 'stepId',
+                  parentBlockId: null,
+                  parentOrder: 0,
+                  locked: false,
+                  nextBlockId: null,
+                  __typename: 'StepBlock'
+                },
+                cardBlockCreate: {
+                  id: 'cardId',
+                  parentBlockId: 'stepId',
+                  parentOrder: 0,
+                  backgroundColor: null,
+                  coverBlockId: null,
+                  themeMode: null,
+                  themeName: null,
+                  fullscreen: false,
+                  __typename: 'CardBlock'
+                }
+              }
+            }
+          }
+        ]}
+      >
+        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+          <CardPreview steps={[]} onSelect={onSelect} showAddButton />
+        </JourneyProvider>
+      </MockedProvider>
+    )
+    fireEvent.click(getByRole('button'))
+    await waitFor(() =>
+      expect(onSelect).toHaveBeenCalledWith({
+        __typename: 'StepBlock',
+        children: [
+          {
+            __typename: 'CardBlock',
+            backgroundColor: null,
+            children: [],
+            coverBlockId: null,
+            fullscreen: false,
+            id: 'cardId',
+            parentBlockId: 'stepId',
+            parentOrder: 0,
+            themeMode: null,
+            themeName: null
+          }
+        ],
+        id: 'stepId',
+        locked: false,
+        nextBlockId: null,
+        parentBlockId: null,
+        parentOrder: 0
+      })
+    )
   })
 })

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
@@ -468,19 +468,25 @@ const steps: Array<TreeBlock<StepBlock>> = [
   }
 ]
 
-const Template: Story = () => {
+const Template: Story = ({ ...args }) => {
   const [selected, setSelectedStep] = useState<TreeBlock<StepBlock>>(steps[0])
   return (
     <MockedProvider>
       <CardPreview
         onSelect={(step) => setSelectedStep(step)}
         selected={selected}
-        steps={steps}
+        steps={args.steps ?? steps}
+        showAddButton={args.showAddButton}
       />
     </MockedProvider>
   )
 }
 
 export const Default = Template.bind({})
+
+export const AddButton = Template.bind({})
+AddButton.args = {
+  showAddButton: true
+}
 
 export default CardPreviewStory as Meta

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
@@ -1,29 +1,140 @@
 import Box from '@mui/material/Box'
 import { ReactElement } from 'react'
-import { BlockRenderer, TreeBlock } from '@core/journeys/ui'
+import {
+  BlockRenderer,
+  CARD_FIELDS,
+  STEP_FIELDS,
+  TreeBlock,
+  transformer
+} from '@core/journeys/ui'
 import { ThemeProvider } from '@core/shared/ui'
+import AddIcon from '@mui/icons-material/Add'
+import Card from '@mui/material/Card'
+import CardActionArea from '@mui/material/CardActionArea'
+import { v4 as uuidv4 } from 'uuid'
+import { useMutation, gql } from '@apollo/client'
+import { StepAndCardBlockCreate } from '../../../__generated__/StepAndCardBlockCreate'
 import { FramePortal } from '../FramePortal'
 import { GetJourney_journey_blocks_StepBlock as StepBlock } from '../../../__generated__/GetJourney'
 import { ThemeName, ThemeMode } from '../../../__generated__/globalTypes'
 import { HorizontalSelect } from '../HorizontalSelect'
+import { useJourney } from '../../libs/context'
 
 export interface CardPreviewProps {
   onSelect?: (card: TreeBlock<StepBlock>) => void
   selected?: TreeBlock<StepBlock>
   steps: Array<TreeBlock<StepBlock>>
+  showAddButton?: boolean
 }
+
+export const STEP_AND_CARD_BLOCK_CREATE = gql`
+  ${STEP_FIELDS}
+  ${CARD_FIELDS}
+  mutation StepAndCardBlockCreate($journeyId: ID!, $stepId: ID!, $cardId: ID) {
+    stepBlockCreate(input: { id: $stepId, journeyId: $journeyId }) {
+      ...StepFields
+    }
+    cardBlockCreate(
+      input: { id: $cardId, journeyId: $journeyId, parentBlockId: $stepId }
+    ) {
+      ...CardFields
+    }
+  }
+`
 
 export function CardPreview({
   steps,
   selected,
-  onSelect
+  onSelect,
+  showAddButton
 }: CardPreviewProps): ReactElement {
+  const [stepAndCardBlockCreate] = useMutation<StepAndCardBlockCreate>(
+    STEP_AND_CARD_BLOCK_CREATE
+  )
+  const { id: journeyId } = useJourney()
+
   const handleChange = (selectedId: string): void => {
     const selectedStep = steps.find(({ id }) => id === selectedId)
     selectedStep != null && onSelect?.(selectedStep)
   }
+
+  const handleClick = async (): Promise<void> => {
+    const stepId = uuidv4()
+    const cardId = uuidv4()
+    const { data } = await stepAndCardBlockCreate({
+      variables: {
+        journeyId,
+        stepId,
+        cardId
+      },
+      update(cache, { data }) {
+        if (data?.stepBlockCreate != null && data?.cardBlockCreate != null) {
+          cache.modify({
+            id: cache.identify({ __typename: 'Journey', id: journeyId }),
+            fields: {
+              blocks(existingBlockRefs = []) {
+                const newStepBlockRef = cache.writeFragment({
+                  data: data.stepBlockCreate,
+                  fragment: gql`
+                    fragment NewBlock on Block {
+                      id
+                    }
+                  `
+                })
+                const newCardBlockRef = cache.writeFragment({
+                  data: data.cardBlockCreate,
+                  fragment: gql`
+                    fragment NewBlock on Block {
+                      id
+                    }
+                  `
+                })
+                return [...existingBlockRefs, newStepBlockRef, newCardBlockRef]
+              }
+            }
+          })
+        }
+      }
+    })
+    if (data?.stepBlockCreate != null)
+      onSelect?.(
+        transformer([
+          data.stepBlockCreate,
+          data.cardBlockCreate
+        ])[0] as TreeBlock<StepBlock>
+      )
+  }
+
   return (
-    <HorizontalSelect onChange={handleChange} id={selected?.id}>
+    <HorizontalSelect
+      onChange={handleChange}
+      id={selected?.id}
+      footer={
+        showAddButton === true && (
+          <Card
+            id="CardPreviewAddButton"
+            variant="outlined"
+            sx={{
+              display: 'flex',
+              width: 87,
+              height: 132,
+              m: 1
+            }}
+          >
+            <CardActionArea
+              sx={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center'
+              }}
+              onClick={handleClick}
+            >
+              <AddIcon color="primary" />
+            </CardActionArea>
+          </Card>
+        )
+      }
+    >
       {steps.map((step) => (
         <Box
           id={step.id}

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
@@ -21,7 +21,7 @@ import { HorizontalSelect } from '../HorizontalSelect'
 import { useJourney } from '../../libs/context'
 
 export interface CardPreviewProps {
-  onSelect?: (card: TreeBlock<StepBlock>) => void
+  onSelect?: (step: TreeBlock<StepBlock>) => void
   selected?: TreeBlock<StepBlock>
   steps: Array<TreeBlock<StepBlock>>
   showAddButton?: boolean

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.tsx
@@ -75,6 +75,7 @@ export function ControlPanel(): ReactElement {
           selected={selectedStep}
           onSelect={handleSelectStep}
           steps={steps}
+          showAddButton
         />
       </TabPanel>
       <TabPanel name="control-panel" value={activeTab} index={1}>

--- a/apps/journeys-admin/src/components/Editor/Editor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.spec.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react'
 import { TreeBlock } from '@core/journeys/ui'
 import { MockedProvider } from '@apollo/client/testing'
+import { GetJourney_journey as Journey } from '../../../__generated__/GetJourney'
 import {
   JourneyStatus,
   ThemeMode,
@@ -10,42 +11,63 @@ import { ThemeProvider } from '../ThemeProvider'
 import { Editor } from '.'
 
 describe('Editor', () => {
+  const journey: Journey = {
+    __typename: 'Journey',
+    id: 'journeyId',
+    themeName: ThemeName.base,
+    themeMode: ThemeMode.light,
+    title: 'my journey',
+    slug: 'my-journey',
+    locale: 'en-US',
+    description: 'my cool journey',
+    status: JourneyStatus.draft,
+    createdAt: '2021-11-19T12:34:56.647Z',
+    publishedAt: null,
+    blocks: [
+      {
+        id: 'step0.id',
+        __typename: 'StepBlock',
+        parentBlockId: null,
+        parentOrder: 0,
+        locked: false,
+        nextBlockId: 'step1.id'
+      },
+      {
+        id: 'step1.id',
+        __typename: 'StepBlock',
+        parentBlockId: null,
+        parentOrder: 0,
+        locked: false,
+        nextBlockId: 'step1.id'
+      }
+    ] as TreeBlock[],
+    primaryImageBlock: null,
+    userJourneys: []
+  }
+
   it('should render the element', () => {
     const { getByText } = render(
       <MockedProvider>
         <ThemeProvider>
-          <Editor
-            journey={{
-              __typename: 'Journey',
-              id: 'journeyId',
-              themeName: ThemeName.base,
-              themeMode: ThemeMode.light,
-              title: 'my journey',
-              slug: 'my-journey',
-              locale: 'en-US',
-              description: 'my cool journey',
-              status: JourneyStatus.draft,
-              createdAt: '2021-11-19T12:34:56.647Z',
-              publishedAt: null,
-              blocks: [
-                {
-                  id: 'step0.id',
-                  __typename: 'StepBlock',
-                  parentBlockId: null,
-                  parentOrder: 0,
-                  locked: false,
-                  nextBlockId: 'step1.id'
-                }
-              ] as TreeBlock[],
-              primaryImageBlock: null,
-              userJourneys: []
-            }}
-          />
+          <Editor journey={journey} />
         </ThemeProvider>
       </MockedProvider>
     )
     expect(getByText('Cards')).toBeInTheDocument()
     expect(getByText('Social Share Appearance')).toBeInTheDocument()
     expect(getByText('Social Image')).toBeInTheDocument()
+  })
+
+  it('should select step based on ID', () => {
+    const { getByTestId } = render(
+      <MockedProvider>
+        <ThemeProvider>
+          <Editor journey={journey} selectedStepId="step1.id" />
+        </ThemeProvider>
+      </MockedProvider>
+    )
+    expect(getByTestId('preview-step1.id').parentElement).toHaveStyle(
+      'outline: 2px solid #C52D3A'
+    )
   })
 })

--- a/apps/journeys-admin/src/components/Editor/Editor.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.tsx
@@ -11,16 +11,22 @@ import { SocialShareAppearance } from './Drawer/SocialShareAppearance'
 
 interface EditorProps {
   journey: Journey
+  selectedStepId?: string
 }
 
-export function Editor({ journey }: EditorProps): ReactElement {
+export function Editor({ journey, selectedStepId }: EditorProps): ReactElement {
   const steps = transformer(journey.blocks ?? []) as Array<TreeBlock<StepBlock>>
+  const selectedStep =
+    selectedStepId != null
+      ? steps.find(({ id }) => id === selectedStepId)
+      : undefined
 
   return (
     <JourneyProvider value={journey}>
       <EditorProvider
         initialState={{
           steps,
+          selectedStep,
           drawerTitle: 'Social Share Appearance',
           drawerChildren: <SocialShareAppearance id={journey.id} />
         }}

--- a/apps/journeys-admin/src/components/HorizontalSelect/HorizontalSelect.spec.tsx
+++ b/apps/journeys-admin/src/components/HorizontalSelect/HorizontalSelect.spec.tsx
@@ -27,7 +27,7 @@ describe('HorizontalSelect', () => {
     )
   })
 
-  it('should display foolter', () => {
+  it('should display footer', () => {
     const { getByTestId } = render(
       <HorizontalSelect
         onChange={jest.fn()}

--- a/apps/journeys-admin/src/components/HorizontalSelect/HorizontalSelect.spec.tsx
+++ b/apps/journeys-admin/src/components/HorizontalSelect/HorizontalSelect.spec.tsx
@@ -3,7 +3,7 @@ import Box from '@mui/material/Box'
 import { HorizontalSelect } from '.'
 
 describe('HorizontalSelect', () => {
-  it('should call onChange when step is clicked on', () => {
+  it('calls onChange when step is clicked on', () => {
     const onChange = jest.fn()
     const { getByText } = render(
       <HorizontalSelect onChange={onChange}>
@@ -15,7 +15,7 @@ describe('HorizontalSelect', () => {
     expect(onChange).toHaveBeenCalledWith('step1.id')
   })
 
-  it('should show border around selected', () => {
+  it('shows border around selected', () => {
     const { getByText } = render(
       <HorizontalSelect onChange={jest.fn()} id="step1.id">
         <Box id="step1.id">Option 1</Box>
@@ -25,5 +25,19 @@ describe('HorizontalSelect', () => {
     expect(getByText('Option 1').parentElement).toHaveStyle(
       'outline: 2px solid #1976d2'
     )
+  })
+
+  it('displays foolter', () => {
+    const { getByTestId } = render(
+      <HorizontalSelect
+        onChange={jest.fn()}
+        id="step1.id"
+        footer={<div data-testid="this-is-a-test">Hello World</div>}
+      >
+        <Box id="step1.id">Option 1</Box>
+        <Box id="step2.id">Option 2</Box>
+      </HorizontalSelect>
+    )
+    expect(getByTestId('this-is-a-test')).toHaveTextContent('Hello World')
   })
 })

--- a/apps/journeys-admin/src/components/HorizontalSelect/HorizontalSelect.spec.tsx
+++ b/apps/journeys-admin/src/components/HorizontalSelect/HorizontalSelect.spec.tsx
@@ -3,7 +3,7 @@ import Box from '@mui/material/Box'
 import { HorizontalSelect } from '.'
 
 describe('HorizontalSelect', () => {
-  it('calls onChange when step is clicked on', () => {
+  it('should call onChange when step is clicked on', () => {
     const onChange = jest.fn()
     const { getByText } = render(
       <HorizontalSelect onChange={onChange}>
@@ -15,7 +15,7 @@ describe('HorizontalSelect', () => {
     expect(onChange).toHaveBeenCalledWith('step1.id')
   })
 
-  it('shows border around selected', () => {
+  it('should show border around selected', () => {
     const { getByText } = render(
       <HorizontalSelect onChange={jest.fn()} id="step1.id">
         <Box id="step1.id">Option 1</Box>
@@ -27,7 +27,7 @@ describe('HorizontalSelect', () => {
     )
   })
 
-  it('displays foolter', () => {
+  it('should display foolter', () => {
     const { getByTestId } = render(
       <HorizontalSelect
         onChange={jest.fn()}

--- a/apps/journeys-admin/src/components/HorizontalSelect/HorizontalSelect.tsx
+++ b/apps/journeys-admin/src/components/HorizontalSelect/HorizontalSelect.tsx
@@ -9,13 +9,15 @@ export interface HorizontalSelectProps {
   id?: string
   children: ReactNode
   sx?: SxProps<Theme>
+  footer?: ReactNode
 }
 
 export function HorizontalSelect({
   children,
   id,
   onChange,
-  sx
+  sx,
+  footer
 }: HorizontalSelectProps): ReactElement {
   return (
     <Stack
@@ -42,7 +44,8 @@ export function HorizontalSelect({
                   id === child.props.id
                     ? `2px solid ${theme.palette.primary.main} `
                     : '2px solid transparent',
-                border: '3px solid transparent'
+                border: '3px solid transparent',
+                cursor: 'pointer'
               }}
               onClick={() => onChange?.(child.props.id)}
             >
@@ -59,6 +62,15 @@ export function HorizontalSelect({
               {child}
             </Box>
           )
+      )}
+      {footer != null && (
+        <Box
+          sx={{
+            border: '3px solid transparent'
+          }}
+        >
+          {footer}
+        </Box>
       )}
     </Stack>
   )

--- a/apps/journeys-admin/src/components/JourneyView/CardView/CardView.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/CardView/CardView.tsx
@@ -28,7 +28,7 @@ export function CardView({ slug, blocks }: CardViewProps): ReactElement {
     <>
       {stepBlockLength > 0 ? (
         <>
-          <CardPreview steps={blocks} />
+          <CardPreview steps={blocks} showAddButton />
         </>
       ) : (
         <Box

--- a/apps/journeys-admin/src/components/JourneyView/CardView/CardView.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/CardView/CardView.tsx
@@ -1,10 +1,8 @@
 import { ReactElement } from 'react'
 import Typography from '@mui/material/Typography'
-import Card from '@mui/material/Card'
-import Box from '@mui/material/Box'
-import AddIcon from '@mui/icons-material/Add'
 import { TreeBlock } from '@core/journeys/ui'
 import { useBreakpoints } from '@core/shared/ui'
+import { useRouter } from 'next/router'
 import { BlockFields_StepBlock as StepBlock } from '../../../../__generated__/BlockFields'
 import { CardPreview } from '../../CardPreview'
 
@@ -15,6 +13,14 @@ export interface CardViewProps {
 
 export function CardView({ slug, blocks }: CardViewProps): ReactElement {
   const breakpoints = useBreakpoints()
+  const router = useRouter()
+
+  const handleSelect = (step: { id: string }): void => {
+    void router.push({
+      pathname: '/journeys/[slug]/edit',
+      query: { slug, stepId: step.id }
+    })
+  }
 
   const stepBlockLength =
     blocks?.filter((block) => block.__typename === 'StepBlock').length ?? 0
@@ -26,34 +32,7 @@ export function CardView({ slug, blocks }: CardViewProps): ReactElement {
 
   return (
     <>
-      {stepBlockLength > 0 ? (
-        <>
-          <CardPreview steps={blocks} showAddButton />
-        </>
-      ) : (
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'center',
-            mt: 6,
-            mb: 8
-          }}
-        >
-          <Card
-            variant="outlined"
-            aria-label="add-card"
-            sx={{
-              width: '89px',
-              height: '134px',
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center'
-            }}
-          >
-            <AddIcon color="primary" />
-          </Card>
-        </Box>
-      )}
+      <CardPreview onSelect={handleSelect} steps={blocks} showAddButton />
       <Typography variant="body1" sx={{ pt: 2, textAlign: 'center' }}>
         {stepBlockLength > 0
           ? breakpoints.md


### PR DESCRIPTION
# Description

- CardPreview should optionally have an add button that allows you to add a card.
- CardView and ControlPanel should opt into having the add button visible.
- Clicking a card in CardView should reroute you to the edit page with the selected step highlighted.
- Add default for fullscreen in Card Resolver.
- Add default for locked in Step Resolver.
- [Basecamp Todo](https://3.basecamp.com/3105655/buckets/26244166/todolists/4637157436)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Navigate to Journey View page. Click on add button in card preview section. Card should be added and page should reroute to edit page with the new card selected for editing.
- [x] Navigate to Journey View page. Click on any visible card in the preview section. Page should reroute to edit page with the card clicked on selected for editing.
- [x] Navigate to Journey Edit page. Click on add button on cards tab. New card should be added with new card selected for editing.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
