### PR TITLE
fix: Add parentBlockId to action in api-journeys

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -18,6 +18,7 @@ directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
 interface Action {
   gtmEventName: String
+  parentBlockId: ID!
 }
 
 interface Block {
@@ -351,6 +352,7 @@ input JourneyUpdateInput {
 
 type LinkAction implements Action {
   gtmEventName: String
+  parentBlockId: ID!
   target: String
   url: String!
 }
@@ -406,6 +408,7 @@ closest ancestor StepBlock.
 """
 type NavigateAction implements Action {
   gtmEventName: String
+  parentBlockId: ID!
 }
 
 input NavigateActionInput {
@@ -415,6 +418,7 @@ input NavigateActionInput {
 type NavigateToBlockAction implements Action {
   blockId: String!
   gtmEventName: String
+  parentBlockId: ID!
 }
 
 input NavigateToBlockActionInput {
@@ -426,6 +430,7 @@ type NavigateToJourneyAction implements Action {
   gtmEventName: String
   journey: Journey
   journeyId: String!
+  parentBlockId: ID!
 }
 
 input NavigateToJourneyActionInput {

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -11,6 +11,7 @@ enum ThemeName {
 }
 
 interface Action {
+  parentBlockId: ID!
   gtmEventName: String
 }
 
@@ -19,21 +20,25 @@ NavigateAction is an Action that navigates to the nextBlockId field set on the
 closest ancestor StepBlock.
 """
 type NavigateAction implements Action {
+  parentBlockId: ID!
   gtmEventName: String
 }
 
 type NavigateToBlockAction implements Action {
+  parentBlockId: ID!
   gtmEventName: String
   blockId: String!
 }
 
 type NavigateToJourneyAction implements Action {
+  parentBlockId: ID!
   gtmEventName: String
   journeyId: String!
   journey: Journey
 }
 
 type LinkAction implements Action {
+  parentBlockId: ID!
   gtmEventName: String
   url: String!
   target: String

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -373,6 +373,7 @@ export class VideoResponseCreateInput {
 }
 
 export interface Action {
+    parentBlockId: string;
     gtmEventName?: Nullable<string>;
 }
 
@@ -394,17 +395,20 @@ export interface Response {
 
 export class NavigateAction implements Action {
     __typename?: 'NavigateAction';
+    parentBlockId: string;
     gtmEventName?: Nullable<string>;
 }
 
 export class NavigateToBlockAction implements Action {
     __typename?: 'NavigateToBlockAction';
+    parentBlockId: string;
     gtmEventName?: Nullable<string>;
     blockId: string;
 }
 
 export class NavigateToJourneyAction implements Action {
     __typename?: 'NavigateToJourneyAction';
+    parentBlockId: string;
     gtmEventName?: Nullable<string>;
     journeyId: string;
     journey?: Nullable<Journey>;
@@ -412,6 +416,7 @@ export class NavigateToJourneyAction implements Action {
 
 export class LinkAction implements Action {
     __typename?: 'LinkAction';
+    parentBlockId: string;
     gtmEventName?: Nullable<string>;
     url: string;
     target?: Nullable<string>;

--- a/apps/api-journeys/src/app/modules/action/action.graphql
+++ b/apps/api-journeys/src/app/modules/action/action.graphql
@@ -1,4 +1,5 @@
 interface Action {
+  parentBlockId: ID!
   gtmEventName: String
 }
 
@@ -7,20 +8,24 @@ NavigateAction is an Action that navigates to the nextBlockId field set on the
 closest ancestor StepBlock.
 """
 type NavigateAction implements Action {
+  parentBlockId: ID!
   gtmEventName: String
 }
 
 type NavigateToBlockAction implements Action {
+  parentBlockId: ID!
   gtmEventName: String
   blockId: String!
 }
 
 type NavigateToJourneyAction implements Action {
+  parentBlockId: ID!
   gtmEventName: String
   journeyId: String!
 }
 
 type LinkAction implements Action {
+  parentBlockId: ID!
   gtmEventName: String
   url: String!
   target: String

--- a/apps/api-journeys/src/app/modules/action/action.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/action/action.resolver.spec.ts
@@ -19,6 +19,7 @@ describe('ActionResolver', () => {
     label: 'label',
     description: 'description',
     action: {
+      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       blockId: '4'
     }
@@ -33,6 +34,7 @@ describe('ActionResolver', () => {
     label: 'label',
     description: 'description',
     action: {
+      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       blockId: '4'
     }
@@ -47,6 +49,7 @@ describe('ActionResolver', () => {
     label: 'label',
     description: 'description',
     action: {
+      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       journeyId: '4'
     }
@@ -61,6 +64,7 @@ describe('ActionResolver', () => {
     label: 'label',
     description: 'description',
     action: {
+      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       journeyId: '4'
     }
@@ -75,6 +79,7 @@ describe('ActionResolver', () => {
     label: 'label',
     description: 'description',
     action: {
+      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       url: 'https://google.com'
     }
@@ -89,6 +94,7 @@ describe('ActionResolver', () => {
     label: 'label',
     description: 'description',
     action: {
+      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       url: 'https://google.com'
     }
@@ -103,6 +109,7 @@ describe('ActionResolver', () => {
     label: 'label',
     description: 'description',
     action: {
+      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       url: 'https://google.com'
     }
@@ -117,6 +124,7 @@ describe('ActionResolver', () => {
     label: 'label',
     description: 'description',
     action: {
+      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       url: 'https://google.com'
     }

--- a/apps/api-journeys/src/app/modules/action/linkAction/linkAction.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/action/linkAction/linkAction.resolver.spec.ts
@@ -19,6 +19,7 @@ describe('LinkActionResolver', () => {
     label: 'label',
     description: 'description',
     action: {
+      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       url: 'https://google.com'
     }

--- a/apps/api-journeys/src/app/modules/action/linkAction/linkAction.resolver.ts
+++ b/apps/api-journeys/src/app/modules/action/linkAction/linkAction.resolver.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../__generated__/graphql'
 import { BlockService } from '../../block/block.service'
 
-@Resolver('LinkActionResolver')
+@Resolver('LinkAction')
 export class LinkActionResolver {
   constructor(private readonly blockService: BlockService) {}
 

--- a/apps/api-journeys/src/app/modules/action/navigateAction/navigateAction.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/action/navigateAction/navigateAction.resolver.spec.ts
@@ -18,12 +18,13 @@ describe('NavigateActionResolver', () => {
     label: 'label',
     description: 'description',
     action: {
+      parentBlockId: '1',
       gtmEventName: 'gtmEventName'
     }
   }
 
   const navigateActionInput = {
-    gtmEventName: 'gtmEventName',
+    gtmEventName: 'gtmEventNameUpdated',
     blockId: null,
     journeyId: null,
     url: null,

--- a/apps/api-journeys/src/app/modules/action/navigateAction/navigateAction.resolver.ts
+++ b/apps/api-journeys/src/app/modules/action/navigateAction/navigateAction.resolver.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../__generated__/graphql'
 import { BlockService } from '../../block/block.service'
 
-@Resolver('NavigateActionResolver')
+@Resolver('NavigateAction')
 export class NavigateActionResolver {
   constructor(private readonly blockService: BlockService) {}
 

--- a/apps/api-journeys/src/app/modules/action/navigateToBlockAction/navigateToBlockAction.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/action/navigateToBlockAction/navigateToBlockAction.resolver.spec.ts
@@ -18,6 +18,7 @@ describe('NavigateToBlockActionResolver', () => {
     label: 'label',
     description: 'description',
     action: {
+      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       blockId: '4'
     }

--- a/apps/api-journeys/src/app/modules/action/navigateToBlockAction/navigateToBlockAction.resolver.ts
+++ b/apps/api-journeys/src/app/modules/action/navigateToBlockAction/navigateToBlockAction.resolver.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../__generated__/graphql'
 import { BlockService } from '../../block/block.service'
 
-@Resolver('NavigateToBlockActionResolver')
+@Resolver('NavigateToBlockAction')
 export class NavigateToBlockActionResolver {
   constructor(private readonly blockService: BlockService) {}
 

--- a/apps/api-journeys/src/app/modules/action/navigateToJourney/navigateToJourney.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/action/navigateToJourney/navigateToJourney.resolver.spec.ts
@@ -23,6 +23,7 @@ describe('NavigateToJourneyActionResolver', () => {
     label: 'label',
     description: 'description',
     action: {
+      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       journeyId: '4'
     }
@@ -37,6 +38,7 @@ describe('NavigateToJourneyActionResolver', () => {
     label: 'label',
     description: 'description',
     action: {
+      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       journeyId: '4'
     }

--- a/apps/api-journeys/src/app/modules/block/block.module.ts
+++ b/apps/api-journeys/src/app/modules/block/block.module.ts
@@ -18,6 +18,7 @@ import {
   RadioOptionBlockResolver,
   RadioQuestionBlockResolver
 } from './radioQuestion/radioQuestion.resolver'
+import { VideoTriggerResolver } from './videoTrigger/videoTrigger.resolver'
 
 @Module({
   imports: [DatabaseModule],
@@ -34,7 +35,8 @@ import {
     TypographyBlockResolver,
     VideoBlockResolver,
     VideoContentResolver,
-    VideoArclightResolver
+    VideoArclightResolver,
+    VideoTriggerResolver
   ],
   exports: [BlockService]
 })

--- a/apps/api-journeys/src/app/modules/block/button/button.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/button/button.resolver.spec.ts
@@ -6,7 +6,8 @@ import { BlockService } from '../block.service'
 import {
   ButtonVariant,
   ButtonColor,
-  ButtonSize
+  ButtonSize,
+  ButtonBlock
 } from '../../../__generated__/graphql'
 import { UserJourneyService } from '../../userJourney/userJourney.service'
 import { ButtonBlockResolver } from './button.resolver'
@@ -29,6 +30,7 @@ describe('Button', () => {
     startIconId: 'start1',
     endIconId: 'end1',
     action: {
+      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       url: 'https://jesusfilm.org',
       target: 'target'
@@ -48,6 +50,7 @@ describe('Button', () => {
     startIconId: 'start1',
     endIconId: 'end1',
     action: {
+      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       url: 'https://jesusfilm.org',
       target: 'target'
@@ -119,8 +122,8 @@ describe('Button', () => {
         }
       ]
     }).compile()
-    blockResolver = module.get<BlockResolver>(BlockResolver)
     resolver = module.get<ButtonBlockResolver>(ButtonBlockResolver)
+    blockResolver = module.get<BlockResolver>(BlockResolver)
     service = await module.resolve(BlockService)
   })
 
@@ -131,6 +134,12 @@ describe('Button', () => {
         blockResponse,
         blockResponse
       ])
+    })
+
+    it('returns ButtonBlock action with parentBlockId', async () => {
+      expect(await resolver.action(blockResponse as ButtonBlock)).toEqual(
+        block.action
+      )
     })
   })
 

--- a/apps/api-journeys/src/app/modules/block/button/button.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/button/button.resolver.spec.ts
@@ -30,11 +30,16 @@ describe('Button', () => {
     startIconId: 'start1',
     endIconId: 'end1',
     action: {
-      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       url: 'https://jesusfilm.org',
       target: 'target'
     }
+  }
+
+  const blockWithId = {
+    ...block,
+    id: block._key,
+    _key: undefined
   }
 
   const blockResponse = {
@@ -101,9 +106,9 @@ describe('Button', () => {
   const blockService = {
     provide: BlockService,
     useFactory: () => ({
-      get: jest.fn(() => block),
-      getAll: jest.fn(() => [block, block]),
-      getSiblings: jest.fn(() => [block, block]),
+      get: jest.fn(() => blockResponse),
+      getAll: jest.fn(() => [blockResponse, blockResponse]),
+      getSiblings: jest.fn(() => [blockResponse, blockResponse]),
       save: jest.fn((input) => input),
       update: jest.fn((input) => input)
     })
@@ -137,9 +142,9 @@ describe('Button', () => {
     })
 
     it('returns ButtonBlock action with parentBlockId', async () => {
-      expect(await resolver.action(blockResponse as ButtonBlock)).toEqual(
-        block.action
-      )
+      expect(
+        await resolver.action(blockWithId as unknown as ButtonBlock)
+      ).toEqual(blockResponse.action)
     })
   })
 

--- a/apps/api-journeys/src/app/modules/block/button/button.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/button/button.resolver.spec.ts
@@ -55,11 +55,15 @@ describe('Button', () => {
     startIconId: 'start1',
     endIconId: 'end1',
     action: {
-      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       url: 'https://jesusfilm.org',
       target: 'target'
     }
+  }
+
+  const actionResponse = {
+    ...blockResponse.action,
+    parentBlockId: block._key
   }
 
   const blockInput = {
@@ -106,9 +110,9 @@ describe('Button', () => {
   const blockService = {
     provide: BlockService,
     useFactory: () => ({
-      get: jest.fn(() => blockResponse),
-      getAll: jest.fn(() => [blockResponse, blockResponse]),
-      getSiblings: jest.fn(() => [blockResponse, blockResponse]),
+      get: jest.fn(() => block),
+      getAll: jest.fn(() => [block, block]),
+      getSiblings: jest.fn(() => [block, block]),
       save: jest.fn((input) => input),
       update: jest.fn((input) => input)
     })
@@ -140,11 +144,13 @@ describe('Button', () => {
         blockResponse
       ])
     })
+  })
 
+  describe('action', () => {
     it('returns ButtonBlock action with parentBlockId', async () => {
       expect(
         await resolver.action(blockWithId as unknown as ButtonBlock)
-      ).toEqual(blockResponse.action)
+      ).toEqual(actionResponse)
     })
   })
 

--- a/apps/api-journeys/src/app/modules/block/button/button.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/button/button.resolver.ts
@@ -17,12 +17,12 @@ export class ButtonBlockResolver {
 
   @ResolveField()
   action(@Parent() block: ButtonBlock): Action | null {
-    return block.action != null
-      ? {
-          ...block.action,
-          parentBlockId: block.id
-        }
-      : null
+    if (block.action == null) return null
+
+    return {
+      ...block.action,
+      parentBlockId: block.id
+    }
   }
 
   @Mutation()

--- a/apps/api-journeys/src/app/modules/block/button/button.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/button/button.resolver.ts
@@ -1,7 +1,8 @@
 import { UseGuards } from '@nestjs/common'
-import { Args, Mutation, Resolver } from '@nestjs/graphql'
+import { Args, Mutation, ResolveField, Resolver, Parent } from '@nestjs/graphql'
 import { IdAsKey, KeyAsId } from '@core/nest/decorators'
 import {
+  Action,
   ButtonBlock,
   ButtonBlockCreateInput,
   ButtonBlockUpdateInput,
@@ -13,6 +14,17 @@ import { RoleGuard } from '../../../lib/roleGuard/roleGuard'
 @Resolver('ButtonBlock')
 export class ButtonBlockResolver {
   constructor(private readonly blockService: BlockService) {}
+
+  @ResolveField()
+  action(@Parent() block: ButtonBlock): Action | null {
+    return block.action != null
+      ? {
+          ...block.action,
+          parentBlockId: block.id
+        }
+      : null
+  }
+
   @Mutation()
   @UseGuards(
     RoleGuard('input.journeyId', [

--- a/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { Database } from 'arangojs'
 import { mockDeep } from 'jest-mock-extended'
+import { RadioOptionBlock } from '../../../__generated__/graphql'
 import { UserJourneyService } from '../../userJourney/userJourney.service'
 import { BlockResolver } from '../block.resolver'
 import { BlockService } from '../block.service'
@@ -24,6 +25,7 @@ describe('RadioQuestionBlockResolver', () => {
     label: 'label',
     description: 'description',
     action: {
+      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       blockId: '4'
     }
@@ -38,6 +40,7 @@ describe('RadioQuestionBlockResolver', () => {
     label: 'label',
     description: 'description',
     action: {
+      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       blockId: '4'
     }
@@ -106,13 +109,19 @@ describe('RadioQuestionBlockResolver', () => {
     service = await module.resolve(BlockService)
   })
 
-  describe('RadioQuestionBlock', () => {
-    it('returns RadioQuestionBlock', async () => {
+  describe('RadioOptionBlock', () => {
+    it('returns RadioOptionBlock', async () => {
       expect(await blockResolver.block('1')).toEqual(blockResponse)
       expect(await blockResolver.blocks()).toEqual([
         blockResponse,
         blockResponse
       ])
+    })
+
+    it('returns RadioOptionBlock action with parentBlockId', async () => {
+      expect(
+        await radioOptionBlockResolver.action(blockResponse as RadioOptionBlock)
+      ).toEqual(block.action)
     })
   })
 

--- a/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.spec.ts
@@ -25,10 +25,15 @@ describe('RadioQuestionBlockResolver', () => {
     label: 'label',
     description: 'description',
     action: {
-      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       blockId: '4'
     }
+  }
+
+  const blockWithId = {
+    ...block,
+    id: block._key,
+    _key: undefined
   }
 
   const blockResponse = {
@@ -77,9 +82,9 @@ describe('RadioQuestionBlockResolver', () => {
   const blockService = {
     provide: BlockService,
     useFactory: () => ({
-      get: jest.fn(() => block),
-      getAll: jest.fn(() => [block, block]),
-      getSiblings: jest.fn(() => [block, block]),
+      get: jest.fn(() => blockResponse),
+      getAll: jest.fn(() => [blockResponse, blockResponse]),
+      getSiblings: jest.fn(() => [blockResponse, blockResponse]),
       save: jest.fn((input) => input),
       update: jest.fn((input) => input)
     })
@@ -120,8 +125,10 @@ describe('RadioQuestionBlockResolver', () => {
 
     it('returns RadioOptionBlock action with parentBlockId', async () => {
       expect(
-        await radioOptionBlockResolver.action(blockResponse as RadioOptionBlock)
-      ).toEqual(block.action)
+        await radioOptionBlockResolver.action(
+          blockWithId as unknown as RadioOptionBlock
+        )
+      ).toEqual(blockResponse.action)
     })
   })
 

--- a/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.spec.ts
@@ -45,10 +45,14 @@ describe('RadioQuestionBlockResolver', () => {
     label: 'label',
     description: 'description',
     action: {
-      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       blockId: '4'
     }
+  }
+
+  const actionResponse = {
+    ...blockResponse.action,
+    parentBlockId: block._key
   }
 
   const radioOptionInput = {
@@ -82,9 +86,9 @@ describe('RadioQuestionBlockResolver', () => {
   const blockService = {
     provide: BlockService,
     useFactory: () => ({
-      get: jest.fn(() => blockResponse),
-      getAll: jest.fn(() => [blockResponse, blockResponse]),
-      getSiblings: jest.fn(() => [blockResponse, blockResponse]),
+      get: jest.fn(() => block),
+      getAll: jest.fn(() => [block, block]),
+      getSiblings: jest.fn(() => [block, block]),
       save: jest.fn((input) => input),
       update: jest.fn((input) => input)
     })
@@ -122,13 +126,15 @@ describe('RadioQuestionBlockResolver', () => {
         blockResponse
       ])
     })
+  })
 
+  describe('action', () => {
     it('returns RadioOptionBlock action with parentBlockId', async () => {
       expect(
         await radioOptionBlockResolver.action(
           blockWithId as unknown as RadioOptionBlock
         )
-      ).toEqual(blockResponse.action)
+      ).toEqual(actionResponse)
     })
   })
 

--- a/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.ts
@@ -1,7 +1,8 @@
 import { UseGuards } from '@nestjs/common'
-import { Args, Mutation, Resolver } from '@nestjs/graphql'
+import { Args, Mutation, ResolveField, Resolver, Parent } from '@nestjs/graphql'
 import { IdAsKey, KeyAsId } from '@core/nest/decorators'
 import {
+  Action,
   RadioOptionBlock,
   RadioQuestionBlock,
   RadioOptionBlockCreateInput,
@@ -16,6 +17,17 @@ import { RoleGuard } from '../../../lib/roleGuard/roleGuard'
 @Resolver('RadioOptionBlock')
 export class RadioOptionBlockResolver {
   constructor(private readonly blockService: BlockService) {}
+
+  @ResolveField()
+  action(@Parent() block: RadioOptionBlock): Action | null {
+    return block.action != null
+      ? {
+          ...block.action,
+          parentBlockId: block.id
+        }
+      : null
+  }
+
   @Mutation()
   @UseGuards(
     RoleGuard('input.journeyId', [

--- a/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.ts
@@ -20,12 +20,12 @@ export class RadioOptionBlockResolver {
 
   @ResolveField()
   action(@Parent() block: RadioOptionBlock): Action | null {
-    return block.action != null
-      ? {
-          ...block.action,
-          parentBlockId: block.id
-        }
-      : null
+    if (block.action == null) return null
+
+    return {
+      ...block.action,
+      parentBlockId: block.id
+    }
   }
 
   @Mutation()

--- a/apps/api-journeys/src/app/modules/block/signUp/signUp.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/signUp/signUp.resolver.spec.ts
@@ -20,9 +20,8 @@ describe('SignUpBlockResolver', () => {
     journeyId: '2',
     parentBlockId: '0',
     __typename: 'SignUpBlock',
-    parentOrder: 2,
+    parentOrder: 1,
     action: {
-      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       journeyId: '2'
     },
@@ -30,12 +29,18 @@ describe('SignUpBlockResolver', () => {
     submitLabel: 'Unlock Now!'
   }
 
+  const blockWithId = {
+    ...block,
+    id: block._key,
+    _key: undefined
+  }
+
   const blockResponse = {
     id: '1',
     journeyId: '2',
     parentBlockId: '0',
     __typename: 'SignUpBlock',
-    parentOrder: 2,
+    parentOrder: 1,
     action: {
       parentBlockId: '1',
       gtmEventName: 'gtmEventName',
@@ -48,7 +53,7 @@ describe('SignUpBlockResolver', () => {
   const input: SignUpBlockCreateInput & { __typename: string } = {
     __typename: '',
     id: '1',
-    parentBlockId: '0',
+    parentBlockId: '',
     journeyId: '2',
     submitLabel: 'Submit'
   }
@@ -58,7 +63,7 @@ describe('SignUpBlockResolver', () => {
     parentBlockId: input.parentBlockId,
     journeyId: input.journeyId,
     __typename: 'SignUpBlock',
-    parentOrder: 1,
+    parentOrder: 2,
     submitLabel: input.submitLabel
   }
 
@@ -72,9 +77,9 @@ describe('SignUpBlockResolver', () => {
   const blockService = {
     provide: BlockService,
     useFactory: () => ({
-      get: jest.fn(() => block),
-      getAll: jest.fn(() => [block, block]),
-      getSiblings: jest.fn(() => [block]),
+      get: jest.fn(() => blockResponse),
+      getAll: jest.fn(() => [blockResponse, blockResponse]),
+      getSiblings: jest.fn(() => [blockResponse, blockResponse]),
       save: jest.fn((input) => input),
       update: jest.fn((input) => input)
     })
@@ -108,9 +113,9 @@ describe('SignUpBlockResolver', () => {
     })
 
     it('returns SignUpBlock action with parentBlockId', async () => {
-      expect(await resolver.action(blockResponse as SignUpBlock)).toEqual(
-        block.action
-      )
+      expect(
+        await resolver.action(blockWithId as unknown as SignUpBlock)
+      ).toEqual(blockResponse.action)
     })
   })
 

--- a/apps/api-journeys/src/app/modules/block/signUp/signUp.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/signUp/signUp.resolver.spec.ts
@@ -42,12 +42,16 @@ describe('SignUpBlockResolver', () => {
     __typename: 'SignUpBlock',
     parentOrder: 1,
     action: {
-      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       journeyId: '2'
     },
     submitIconId: 'icon1',
     submitLabel: 'Unlock Now!'
+  }
+
+  const actionResponse = {
+    ...blockResponse.action,
+    parentBlockId: block._key
   }
 
   const input: SignUpBlockCreateInput & { __typename: string } = {
@@ -77,9 +81,9 @@ describe('SignUpBlockResolver', () => {
   const blockService = {
     provide: BlockService,
     useFactory: () => ({
-      get: jest.fn(() => blockResponse),
-      getAll: jest.fn(() => [blockResponse, blockResponse]),
-      getSiblings: jest.fn(() => [blockResponse, blockResponse]),
+      get: jest.fn(() => block),
+      getAll: jest.fn(() => [block, block]),
+      getSiblings: jest.fn(() => [block, block]),
       save: jest.fn((input) => input),
       update: jest.fn((input) => input)
     })
@@ -111,11 +115,13 @@ describe('SignUpBlockResolver', () => {
         blockResponse
       ])
     })
+  })
 
+  describe('action', () => {
     it('returns SignUpBlock action with parentBlockId', async () => {
       expect(
         await resolver.action(blockWithId as unknown as SignUpBlock)
-      ).toEqual(blockResponse.action)
+      ).toEqual(actionResponse)
     })
   })
 

--- a/apps/api-journeys/src/app/modules/block/signUp/signUp.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/signUp/signUp.resolver.spec.ts
@@ -1,7 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { Database } from 'arangojs'
 import { mockDeep } from 'jest-mock-extended'
-import { SignUpBlockCreateInput } from '../../../__generated__/graphql'
+import {
+  SignUpBlock,
+  SignUpBlockCreateInput
+} from '../../../__generated__/graphql'
 import { UserJourneyService } from '../../userJourney/userJourney.service'
 import { BlockResolver } from '../block.resolver'
 import { BlockService } from '../block.service'
@@ -19,12 +22,14 @@ describe('SignUpBlockResolver', () => {
     __typename: 'SignUpBlock',
     parentOrder: 2,
     action: {
+      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       journeyId: '2'
     },
     submitIconId: 'icon1',
     submitLabel: 'Unlock Now!'
   }
+
   const blockResponse = {
     id: '1',
     journeyId: '2',
@@ -32,6 +37,7 @@ describe('SignUpBlockResolver', () => {
     __typename: 'SignUpBlock',
     parentOrder: 2,
     action: {
+      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       journeyId: '2'
     },
@@ -99,6 +105,12 @@ describe('SignUpBlockResolver', () => {
         blockResponse,
         blockResponse
       ])
+    })
+
+    it('returns SignUpBlock action with parentBlockId', async () => {
+      expect(await resolver.action(blockResponse as SignUpBlock)).toEqual(
+        block.action
+      )
     })
   })
 

--- a/apps/api-journeys/src/app/modules/block/signUp/signUp.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/signUp/signUp.resolver.ts
@@ -1,7 +1,8 @@
 import { UseGuards } from '@nestjs/common'
-import { Args, Mutation, Resolver } from '@nestjs/graphql'
+import { Args, Mutation, Resolver, ResolveField, Parent } from '@nestjs/graphql'
 import { IdAsKey, KeyAsId } from '@core/nest/decorators'
 import {
+  Action,
   SignUpBlock,
   SignUpBlockCreateInput,
   SignUpBlockUpdateInput,
@@ -13,6 +14,17 @@ import { RoleGuard } from '../../../lib/roleGuard/roleGuard'
 @Resolver('SignUpBlock')
 export class SignUpBlockResolver {
   constructor(private readonly blockService: BlockService) {}
+
+  @ResolveField()
+  action(@Parent() block: SignUpBlock): Action | null {
+    return block.action != null
+      ? {
+          ...block.action,
+          parentBlockId: block.id
+        }
+      : null
+  }
+
   @Mutation()
   @UseGuards(
     RoleGuard('input.journeyId', [

--- a/apps/api-journeys/src/app/modules/block/signUp/signUp.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/signUp/signUp.resolver.ts
@@ -17,12 +17,12 @@ export class SignUpBlockResolver {
 
   @ResolveField()
   action(@Parent() block: SignUpBlock): Action | null {
-    return block.action != null
-      ? {
-          ...block.action,
-          parentBlockId: block.id
-        }
-      : null
+    if (block.action == null) return null
+
+    return {
+      ...block.action,
+      parentBlockId: block.id
+    }
   }
 
   @Mutation()

--- a/apps/api-journeys/src/app/modules/block/videoTrigger/videoTrigger.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/videoTrigger/videoTrigger.resolver.spec.ts
@@ -34,17 +34,21 @@ describe('VideoTriggerBlockResolver', () => {
     parentOrder: 0,
     triggerStart: 5,
     action: {
-      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       journeyId: '4'
     }
   }
 
+  const actionResponse = {
+    ...blockResponse.action,
+    parentBlockId: block._key
+  }
+
   const blockService = {
     provide: BlockService,
     useFactory: () => ({
-      get: jest.fn(() => blockResponse),
-      getAll: jest.fn(() => [blockResponse, blockResponse])
+      get: jest.fn(() => block),
+      getAll: jest.fn(() => [block, block])
     })
   }
 
@@ -64,11 +68,13 @@ describe('VideoTriggerBlockResolver', () => {
         blockResponse
       ])
     })
+  })
 
+  describe('action', () => {
     it('returns VideoTriggerBlock action with parentBlockId', async () => {
       expect(
         await resolver.action(blockWithId as unknown as VideoTriggerBlock)
-      ).toEqual(blockResponse.action)
+      ).toEqual(actionResponse)
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/block/videoTrigger/videoTrigger.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/videoTrigger/videoTrigger.resolver.spec.ts
@@ -15,10 +15,15 @@ describe('VideoTriggerBlockResolver', () => {
     parentOrder: 0,
     triggerStart: 5,
     action: {
-      parentBlockId: '1',
       gtmEventName: 'gtmEventName',
       journeyId: '4'
     }
+  }
+
+  const blockWithId = {
+    ...block,
+    id: block._key,
+    _key: undefined
   }
 
   const blockResponse = {
@@ -38,8 +43,8 @@ describe('VideoTriggerBlockResolver', () => {
   const blockService = {
     provide: BlockService,
     useFactory: () => ({
-      get: jest.fn(() => block),
-      getAll: jest.fn(() => [block, block])
+      get: jest.fn(() => blockResponse),
+      getAll: jest.fn(() => [blockResponse, blockResponse])
     })
   }
 
@@ -61,9 +66,9 @@ describe('VideoTriggerBlockResolver', () => {
     })
 
     it('returns VideoTriggerBlock action with parentBlockId', async () => {
-      expect(await resolver.action(blockResponse as VideoTriggerBlock)).toEqual(
-        block.action
-      )
+      expect(
+        await resolver.action(blockWithId as unknown as VideoTriggerBlock)
+      ).toEqual(blockResponse.action)
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/block/videoTrigger/videoTrigger.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/videoTrigger/videoTrigger.resolver.spec.ts
@@ -1,9 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing'
+import { VideoTriggerBlock } from '../../../__generated__/graphql'
 import { BlockResolver } from '../block.resolver'
 import { BlockService } from '../block.service'
+import { VideoTriggerResolver } from './videoTrigger.resolver'
 
 describe('VideoTriggerBlockResolver', () => {
-  let resolver: BlockResolver
+  let resolver: VideoTriggerResolver, blockResolver: BlockResolver
 
   const block = {
     _key: '1',
@@ -11,12 +13,11 @@ describe('VideoTriggerBlockResolver', () => {
     __typename: 'VideoTriggerBlock',
     parentBlockId: '3',
     parentOrder: 0,
-    extraAttrs: {
-      triggerStart: 5,
-      action: {
-        gtmEventName: 'gtmEventName',
-        journeyId: '4'
-      }
+    triggerStart: 5,
+    action: {
+      parentBlockId: '1',
+      gtmEventName: 'gtmEventName',
+      journeyId: '4'
     }
   }
 
@@ -26,12 +27,11 @@ describe('VideoTriggerBlockResolver', () => {
     __typename: 'VideoTriggerBlock',
     parentBlockId: '3',
     parentOrder: 0,
-    extraAttrs: {
-      triggerStart: 5,
-      action: {
-        gtmEventName: 'gtmEventName',
-        journeyId: '4'
-      }
+    triggerStart: 5,
+    action: {
+      parentBlockId: '1',
+      gtmEventName: 'gtmEventName',
+      journeyId: '4'
     }
   }
 
@@ -45,15 +45,25 @@ describe('VideoTriggerBlockResolver', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [BlockResolver, blockService]
+      providers: [BlockResolver, blockService, VideoTriggerResolver]
     }).compile()
-    resolver = module.get<BlockResolver>(BlockResolver)
+    resolver = module.get<VideoTriggerResolver>(VideoTriggerResolver)
+    blockResolver = module.get<BlockResolver>(BlockResolver)
   })
 
   describe('VideoTriggerBlock', () => {
     it('returns VideoTriggerBlock', async () => {
-      expect(await resolver.block('1')).toEqual(blockResponse)
-      expect(await resolver.blocks()).toEqual([blockResponse, blockResponse])
+      expect(await blockResolver.block('1')).toEqual(blockResponse)
+      expect(await blockResolver.blocks()).toEqual([
+        blockResponse,
+        blockResponse
+      ])
+    })
+
+    it('returns VideoTriggerBlock action with parentBlockId', async () => {
+      expect(await resolver.action(blockResponse as VideoTriggerBlock)).toEqual(
+        block.action
+      )
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/block/videoTrigger/videoTrigger.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/videoTrigger/videoTrigger.resolver.ts
@@ -1,0 +1,13 @@
+import { ResolveField, Resolver, Parent } from '@nestjs/graphql'
+import { Action, VideoTriggerBlock } from '../../../__generated__/graphql'
+
+@Resolver('VideoTriggerBlock')
+export class VideoTriggerResolver {
+  @ResolveField()
+  action(@Parent() block: VideoTriggerBlock): Action {
+    return {
+      ...block.action,
+      parentBlockId: block.id
+    }
+  }
+}


### PR DESCRIPTION
# Description

Add parentOrderId to action so we can used optimised response in editing actions. This unblocks Siyang

[Basecamp](https://3.basecamp.com/3105655/buckets/26244169/todos/4632617491)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Updated Unit tests
- [x] Viewed data returned by apollo server

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
