### PR TITLE
feature: add automatic slug creation to journey

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -313,8 +313,11 @@ input JourneyCreateInput {
   """
   Slug should be unique amongst all journeys
   (server will throw BAD_USER_INPUT error if not)
+  If not required will use title formatted with kebab-case
+  If the generated slug is not unique the uuid will be placed
+  at the end of the slug guaranteeing uniqueness
   """
-  slug: String!
+  slug: String
   themeMode: ThemeMode
   themeName: ThemeName
   title: String!

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -613,8 +613,11 @@ input JourneyCreateInput {
   """
   Slug should be unique amongst all journeys
   (server will throw BAD_USER_INPUT error if not)
+  If not required will use title formatted with kebab-case
+  If the generated slug is not unique the uuid will be placed
+  at the end of the slug guaranteeing uniqueness
   """
-  slug: String!
+  slug: String
 }
 
 input JourneyUpdateInput {

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -328,7 +328,7 @@ export class JourneyCreateInput {
     themeMode?: Nullable<ThemeMode>;
     themeName?: Nullable<ThemeName>;
     description?: Nullable<string>;
-    slug: string;
+    slug?: Nullable<string>;
 }
 
 export class JourneyUpdateInput {

--- a/apps/api-journeys/src/app/modules/journey/journey.graphql
+++ b/apps/api-journeys/src/app/modules/journey/journey.graphql
@@ -42,8 +42,11 @@ input JourneyCreateInput {
   """
   Slug should be unique amongst all journeys
   (server will throw BAD_USER_INPUT error if not)
+  If not required will use title formatted with kebab-case
+  If the generated slug is not unique the uuid will be placed
+  at the end of the slug guaranteeing uniqueness
   """
-  slug: String!
+  slug: String
 }
 
 input JourneyUpdateInput {

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -360,6 +360,26 @@ describe('JourneyResolver', () => {
       await resolver.journeyUpdate('1', journeyUpdate)
       expect(service.update).toHaveBeenCalledWith('1', journeyUpdate)
     })
+
+    it('throws UserInputErrror', async () => {
+      const mockUpdate = service.update as jest.MockedFunction<
+        typeof service.update
+      >
+      mockUpdate.mockRejectedValueOnce({ errorNum: 1210 })
+      await expect(
+        resolver.journeyUpdate('journeyId', { slug: 'untitled-journey' })
+      ).rejects.toThrow('Slug is not unique')
+    })
+
+    it('throws error gracefully', async () => {
+      const mockUpdate = service.update as jest.MockedFunction<
+        typeof service.update
+      >
+      mockUpdate.mockRejectedValueOnce(new Error('database error'))
+      await expect(
+        resolver.journeyUpdate('journeyId', { title: 'Untitled Journey' })
+      ).rejects.toThrow('database error')
+    })
   })
 
   describe('journeyPublish', () => {

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -114,12 +114,12 @@ export class JourneyResolver {
       try {
         const journey: Journey & { _key: string } =
           await this.journeyService.save({
-            ...input,
+            themeName: ThemeName.base,
+            themeMode: ThemeMode.light,
             createdAt: new Date().toISOString(),
-            themeName: input.themeName ?? ThemeName.base,
-            themeMode: input.themeMode ?? ThemeMode.light,
-            locale: input.locale ?? 'en-US',
-            status: JourneyStatus.draft
+            locale: 'en-US',
+            status: JourneyStatus.draft,
+            ...input
           })
         await this.userJourneyService.save({
           userId,

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -12,6 +12,7 @@ import { UseGuards } from '@nestjs/common'
 import { GqlAuthGuard } from '@core/nest/gqlAuthGuard'
 import { ForbiddenError } from 'apollo-server-errors'
 import { get } from 'lodash'
+import { v4 as uuidv4 } from 'uuid'
 import { BlockService } from '../block/block.service'
 import {
   Block,
@@ -100,27 +101,43 @@ export class JourneyResolver {
   @UseGuards(GqlAuthGuard)
   @IdAsKey()
   async journeyCreate(
-    @Args('input') input: JourneyCreateInput,
+    @Args('input') input: JourneyCreateInput & { _key?: string },
     @CurrentUserId() userId: string
-  ): Promise<Journey> {
-    if (input.slug != null)
-      input.slug = slugify(input.slug ?? input.title, {
-        remove: /[*+~.()'"!:@#]/g
-      })
-    const journey: Journey & { _key: string } = await this.journeyService.save({
-      ...input,
-      createdAt: new Date().toISOString(),
-      themeName: input.themeName ?? ThemeName.base,
-      themeMode: input.themeMode ?? ThemeMode.light,
-      locale: input.locale ?? 'en-US',
-      status: JourneyStatus.draft
+  ): Promise<Journey | undefined> {
+    input._key = input._key ?? uuidv4()
+    input.slug = slugify(input.slug ?? input.title, {
+      lower: true,
+      strict: true
     })
-    await this.userJourneyService.save({
-      userId,
-      journeyId: journey._key,
-      role: UserJourneyRole.owner
-    })
-    return journey
+    let retry = true
+    while (retry) {
+      try {
+        const journey: Journey & { _key: string } =
+          await this.journeyService.save({
+            ...input,
+            createdAt: new Date().toISOString(),
+            themeName: input.themeName ?? ThemeName.base,
+            themeMode: input.themeMode ?? ThemeMode.light,
+            locale: input.locale ?? 'en-US',
+            status: JourneyStatus.draft
+          })
+        await this.userJourneyService.save({
+          userId,
+          journeyId: journey._key,
+          role: UserJourneyRole.owner
+        })
+        retry = false
+        return journey
+      } catch (err) {
+        const ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED = 1210
+        if (err.errorNum === ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED) {
+          input.slug = slugify(`${input.slug}-${input._key}`)
+        } else {
+          retry = false
+          throw err
+        }
+      }
+    }
   }
 
   @Mutation()


### PR DESCRIPTION
# Description

- slug shouldn't be required on journey create
- try use title as slug on create
- if slug not unique add id to end of slug on create
- if slug not unique throw error on update
- [Link to Basecamp Todo #1](https://3.basecamp.com/3105655/buckets/26244166/todos/4641516321)
- [Link to Basecamp Todo #2](https://3.basecamp.com/3105655/buckets/26244166/todos/4641532533)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Create a new journey without specifying a slug. Output slug should be downcased with dashes
- [ ] Create the same journey. Output slug should be downcased with dashes and uuid at the end

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
