### PR TITLE
fix: block reorder ids as _keys

### DIFF
--- a/apps/api-journeys/src/app/modules/block/block.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/block.resolver.ts
@@ -47,13 +47,16 @@ export class BlockResolver {
     @Args('journeyId') journeyId: string,
     @Args('parentOrder') parentOrder: number
   ): Promise<Array<{ _key: string; parentOrder: number }>> {
-    const selectedBlock: Block = await this.block(_key)
+    const selectedBlock: Block = await this.blockService.get(_key)
 
     if (
       selectedBlock.journeyId === journeyId &&
       selectedBlock.parentOrder != null
     ) {
-      const siblings = await this.siblings(selectedBlock)
+      const siblings = await this.blockService.getSiblings(
+        journeyId,
+        selectedBlock.parentBlockId
+      )
       siblings.splice(selectedBlock.parentOrder, 1)
       siblings.splice(parentOrder, 0, selectedBlock)
 

--- a/libs/nest/database/src/lib/base.service.spec.ts
+++ b/libs/nest/database/src/lib/base.service.spec.ts
@@ -1,9 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { Database } from 'arangojs'
 import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
-import { mockCollectionUpdateAllResult } from '@core/nest/database'
 import { DocumentCollection } from 'arangojs/collection'
 import { Injectable } from '@nestjs/common'
+import { mockCollectionUpdateAllResult } from './dbMock'
 import { BaseService } from './base.service'
 
 @Injectable()

--- a/libs/nest/database/src/lib/base.service.spec.ts
+++ b/libs/nest/database/src/lib/base.service.spec.ts
@@ -1,0 +1,84 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { Database } from 'arangojs'
+import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
+import {
+  mockCollectionRemoveResult,
+  mockCollectionSaveResult,
+  mockCollectionUpdateAllResult,
+  mockDbQueryResult
+} from '@core/nest/database'
+import { DocumentCollection } from 'arangojs/collection'
+import { Injectable } from '@nestjs/common'
+import {
+  ThemeMode,
+  ThemeName
+} from '../../../../journeys/ui/__generated__/globalTypes'
+import { BaseService } from './base.service'
+
+@Injectable()
+export class MockService extends BaseService {
+  collection: DocumentCollection = this.db.collection('mocks')
+}
+
+const block = {
+  _key: '1',
+  journeyId: '2',
+  __typename: 'CardBlock',
+  parentBlockId: '3',
+  parentOrder: 0,
+  backgroundColor: '#FFF',
+  coverBlockId: '4',
+  themeMode: ThemeMode.light,
+  themeName: ThemeName.base,
+  fullscreen: true
+}
+
+const block2 = {
+  _key: '2',
+  journeyId: '2',
+  __typename: 'CardBlock',
+  parentBlockId: '3',
+  parentOrder: 2,
+  backgroundColor: '#FFF',
+  coverBlockId: '4',
+  themeMode: ThemeMode.light,
+  themeName: ThemeName.base,
+  fullscreen: true
+}
+
+describe('Base Service', () => {
+  let service: MockService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MockService,
+        {
+          provide: 'DATABASE',
+          useFactory: () => mockDeep<Database>()
+        }
+      ]
+    }).compile()
+
+    service = module.get<MockService>(MockService)
+    service.collection = mockDeep<DocumentCollection>()
+  })
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('updateAll', () => {
+    it('should return updated objects', async () => {
+      ;(
+        service.collection as DeepMockProxy<DocumentCollection>
+      ).updateAll.mockReturnValue(
+        mockCollectionUpdateAllResult(service.collection, [block, block2])
+      )
+      expect(await service.updateAll([block, block2])).toEqual([block, block2])
+      expect(service.collection.updateAll).toHaveBeenCalledWith(
+        [block, block2],
+        { returnNew: true }
+      )
+    })
+  })
+})

--- a/libs/nest/database/src/lib/base.service.spec.ts
+++ b/libs/nest/database/src/lib/base.service.spec.ts
@@ -1,12 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { Database } from 'arangojs'
 import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
-import {
-  mockCollectionRemoveResult,
-  mockCollectionSaveResult,
-  mockCollectionUpdateAllResult,
-  mockDbQueryResult
-} from '@core/nest/database'
+import { mockCollectionUpdateAllResult } from '@core/nest/database'
 import { DocumentCollection } from 'arangojs/collection'
 import { Injectable } from '@nestjs/common'
 import {

--- a/libs/nest/database/src/lib/base.service.spec.ts
+++ b/libs/nest/database/src/lib/base.service.spec.ts
@@ -4,10 +4,6 @@ import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
 import { mockCollectionUpdateAllResult } from '@core/nest/database'
 import { DocumentCollection } from 'arangojs/collection'
 import { Injectable } from '@nestjs/common'
-import {
-  ThemeMode,
-  ThemeName
-} from '../../../../journeys/ui/__generated__/globalTypes'
 import { BaseService } from './base.service'
 
 @Injectable()
@@ -23,8 +19,8 @@ const block = {
   parentOrder: 0,
   backgroundColor: '#FFF',
   coverBlockId: '4',
-  themeMode: ThemeMode.light,
-  themeName: ThemeName.base,
+  themeMode: 'light',
+  themeName: 'base',
   fullscreen: true
 }
 
@@ -36,8 +32,8 @@ const block2 = {
   parentOrder: 2,
   backgroundColor: '#FFF',
   coverBlockId: '4',
-  themeMode: ThemeMode.light,
-  themeName: ThemeName.base,
+  themeMode: 'light',
+  themeName: 'base',
   fullscreen: true
 }
 

--- a/libs/nest/database/src/lib/base.service.ts
+++ b/libs/nest/database/src/lib/base.service.ts
@@ -38,7 +38,7 @@ export abstract class BaseService {
   }
 
   async updateAll<T>(
-    arr: Array<(Patch<DocumentData<T>> & { _key: string }) | { _id: string }>
+    arr: Array<Patch<DocumentData<T>> & ({ _key: string } | { _id: string })>
   ): Promise<T[]> {
     const result = await this.collection.updateAll(arr, {
       returnNew: true


### PR DESCRIPTION
# Description
block reordering was passing ids to the service

# How should this PR be QA Tested?
- [x] Rearrange block in Admin


# Checklist

- [x] I have performed a self-review of my own code
- [ x I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
