### PR TITLE
fix: make iconName nullable

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -183,7 +183,7 @@ type IconBlock implements Block {
   color: IconColor
   id: ID!
   journeyId: ID!
-  name: IconName!
+  name: IconName
   parentBlockId: ID
   parentOrder: Int
   size: IconSize
@@ -197,14 +197,14 @@ input IconBlockCreateInput {
   """
   id: ID
   journeyId: ID!
-  name: IconName!
+  name: IconName
   parentBlockId: ID!
   size: IconSize
 }
 
 input IconBlockUpdateInput {
   color: IconColor
-  name: IconName!
+  name: IconName
   size: IconSize
 }
 
@@ -229,7 +229,6 @@ enum IconName {
   LiveTvRounded
   LockOpenRounded
   MenuBookRounded
-  None
   PlayArrowRounded
   RadioButtonUncheckedRounded
   SendRounded

--- a/apps/api-journeys/db/seeds/nua1.ts
+++ b/apps/api-journeys/db/seeds/nua1.ts
@@ -154,7 +154,7 @@ export async function nua1(): Promise<void> {
     journeyId: journey._key,
     __typename: 'IconBlock',
     parentBlockId: button1._key,
-    name: 'None'
+    name: null
   })
   await db
     .collection('blocks')
@@ -422,7 +422,7 @@ export async function nua1(): Promise<void> {
     journeyId: journey._key,
     __typename: 'IconBlock',
     parentBlockId: button2._key,
-    name: 'None'
+    name: null
   })
   await db
     .collection('blocks')

--- a/apps/api-journeys/db/seeds/nua2.ts
+++ b/apps/api-journeys/db/seeds/nua2.ts
@@ -153,7 +153,7 @@ export async function nua2(): Promise<void> {
     journeyId: journey._key,
     __typename: 'IconBlock',
     parentBlockId: button1._key,
-    name: 'None'
+    name: null
   })
   await db
     .collection('blocks')
@@ -430,7 +430,7 @@ export async function nua2(): Promise<void> {
     journeyId: journey._key,
     __typename: 'IconBlock',
     parentBlockId: button2._key,
-    name: 'None'
+    name: null
   })
   await db
     .collection('blocks')

--- a/apps/api-journeys/db/seeds/nua8.ts
+++ b/apps/api-journeys/db/seeds/nua8.ts
@@ -152,7 +152,7 @@ export async function nua8(): Promise<void> {
     journeyId: journey._key,
     __typename: 'IconBlock',
     parentBlockId: button1._key,
-    name: 'None'
+    name: null
   })
   await db
     .collection('blocks')
@@ -418,7 +418,7 @@ export async function nua8(): Promise<void> {
     journeyId: journey._key,
     __typename: 'IconBlock',
     parentBlockId: button2._key,
-    name: 'None'
+    name: null
   })
   await db
     .collection('blocks')

--- a/apps/api-journeys/db/seeds/nua9.ts
+++ b/apps/api-journeys/db/seeds/nua9.ts
@@ -154,7 +154,7 @@ export async function nua9(): Promise<void> {
     journeyId: journey._key,
     __typename: 'IconBlock',
     parentBlockId: button1._key,
-    name: 'None'
+    name: null
   })
   await db
     .collection('blocks')
@@ -390,7 +390,7 @@ export async function nua9(): Promise<void> {
     journeyId: journey._key,
     __typename: 'IconBlock',
     parentBlockId: button2._key,
-    name: 'None'
+    name: null
   })
   await db
     .collection('blocks')
@@ -480,7 +480,7 @@ export async function nua9(): Promise<void> {
     journeyId: journey._key,
     __typename: 'IconBlock',
     parentBlockId: button3._key,
-    name: 'None'
+    name: null
   })
   await db
     .collection('blocks')
@@ -570,7 +570,7 @@ export async function nua9(): Promise<void> {
     journeyId: journey._key,
     __typename: 'IconBlock',
     parentBlockId: button4._key,
-    name: 'None'
+    name: null
   })
   await db
     .collection('blocks')
@@ -771,7 +771,7 @@ export async function nua9(): Promise<void> {
     journeyId: journey._key,
     __typename: 'IconBlock',
     parentBlockId: button5._key,
-    name: 'None'
+    name: null
   })
   await db
     .collection('blocks')
@@ -971,7 +971,7 @@ export async function nua9(): Promise<void> {
     journeyId: journey._key,
     __typename: 'IconBlock',
     parentBlockId: button6._key,
-    name: 'None'
+    name: null
   })
   await db
     .collection('blocks')
@@ -1171,7 +1171,7 @@ export async function nua9(): Promise<void> {
     journeyId: journey._key,
     __typename: 'IconBlock',
     parentBlockId: button7._key,
-    name: 'None'
+    name: null
   })
   await db
     .collection('blocks')
@@ -1429,7 +1429,7 @@ export async function nua9(): Promise<void> {
     journeyId: journey._key,
     __typename: 'IconBlock',
     parentBlockId: button8._key,
-    name: 'None'
+    name: null
   })
   await db.collection('blocks').update(button8._key, {
     startIconId: icon12a._key,

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -238,7 +238,6 @@ type GridItemBlock implements Block {
 
 """IconName is equivalent to the icons found in @mui/icons-material"""
 enum IconName {
-  None
   PlayArrowRounded
   TranslateRounded
   CheckCircleRounded
@@ -278,7 +277,7 @@ type IconBlock implements Block {
   journeyId: ID!
   parentBlockId: ID
   parentOrder: Int
-  name: IconName!
+  name: IconName
   color: IconColor
   size: IconSize
 }
@@ -290,13 +289,13 @@ input IconBlockCreateInput {
   id: ID
   parentBlockId: ID!
   journeyId: ID!
-  name: IconName!
+  name: IconName
   color: IconColor
   size: IconSize
 }
 
 input IconBlockUpdateInput {
-  name: IconName!
+  name: IconName
   color: IconColor
   size: IconSize
 }

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -55,7 +55,6 @@ export enum GridAlignItems {
 }
 
 export enum IconName {
-    None = "None",
     PlayArrowRounded = "PlayArrowRounded",
     TranslateRounded = "TranslateRounded",
     CheckCircleRounded = "CheckCircleRounded",
@@ -203,13 +202,13 @@ export class IconBlockCreateInput {
     id?: Nullable<string>;
     parentBlockId: string;
     journeyId: string;
-    name: IconName;
+    name?: Nullable<IconName>;
     color?: Nullable<IconColor>;
     size?: Nullable<IconSize>;
 }
 
 export class IconBlockUpdateInput {
-    name: IconName;
+    name?: Nullable<IconName>;
     color?: Nullable<IconColor>;
     size?: Nullable<IconSize>;
 }
@@ -495,7 +494,7 @@ export class IconBlock implements Block {
     journeyId: string;
     parentBlockId?: Nullable<string>;
     parentOrder?: Nullable<number>;
-    name: IconName;
+    name?: Nullable<IconName>;
     color?: Nullable<IconColor>;
     size?: Nullable<IconSize>;
 }

--- a/apps/api-journeys/src/app/modules/block/icon/icon.graphql
+++ b/apps/api-journeys/src/app/modules/block/icon/icon.graphql
@@ -2,7 +2,6 @@
 IconName is equivalent to the icons found in @mui/icons-material
 """
 enum IconName {
-  None
   PlayArrowRounded
   TranslateRounded
   CheckCircleRounded
@@ -42,7 +41,7 @@ type IconBlock implements Block {
   journeyId: ID!
   parentBlockId: ID
   parentOrder: Int
-  name: IconName!
+  name: IconName
   color: IconColor
   size: IconSize
 }
@@ -54,13 +53,13 @@ input IconBlockCreateInput {
   id: ID
   parentBlockId: ID!
   journeyId: ID!
-  name: IconName!
+  name: IconName
   color: IconColor
   size: IconSize
 }
 
 input IconBlockUpdateInput {
-  name: IconName!
+  name: IconName
   color: IconColor
   size: IconSize
 }

--- a/apps/journeys-admin/__generated__/BlockFields.ts
+++ b/apps/journeys-admin/__generated__/BlockFields.ts
@@ -117,7 +117,7 @@ export interface BlockFields_IconBlock {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  iconName: IconName;
+  iconName: IconName | null;
   iconSize: IconSize | null;
   iconColor: IconColor | null;
 }

--- a/apps/journeys-admin/__generated__/ButtonBlockCreate.ts
+++ b/apps/journeys-admin/__generated__/ButtonBlockCreate.ts
@@ -19,7 +19,7 @@ export interface ButtonBlockCreate_startIcon {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  iconName: IconName;
+  iconName: IconName | null;
   iconSize: IconSize | null;
   iconColor: IconColor | null;
 }
@@ -29,7 +29,7 @@ export interface ButtonBlockCreate_endIcon {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  iconName: IconName;
+  iconName: IconName | null;
   iconSize: IconSize | null;
   iconColor: IconColor | null;
 }

--- a/apps/journeys-admin/__generated__/GetJourney.ts
+++ b/apps/journeys-admin/__generated__/GetJourney.ts
@@ -117,7 +117,7 @@ export interface GetJourney_journey_blocks_IconBlock {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  iconName: IconName;
+  iconName: IconName | null;
   iconSize: IconSize | null;
   iconColor: IconColor | null;
 }

--- a/apps/journeys-admin/__generated__/IconFields.ts
+++ b/apps/journeys-admin/__generated__/IconFields.ts
@@ -14,7 +14,7 @@ export interface IconFields {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  iconName: IconName;
+  iconName: IconName | null;
   iconSize: IconSize | null;
   iconColor: IconColor | null;
 }

--- a/apps/journeys-admin/__generated__/SignUpBlockCreate.ts
+++ b/apps/journeys-admin/__generated__/SignUpBlockCreate.ts
@@ -19,7 +19,7 @@ export interface SignUpBlockCreate_submitIcon {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  iconName: IconName;
+  iconName: IconName | null;
   iconSize: IconSize | null;
   iconColor: IconColor | null;
 }

--- a/apps/journeys-admin/__generated__/globalTypes.ts
+++ b/apps/journeys-admin/__generated__/globalTypes.ts
@@ -68,7 +68,6 @@ export enum IconName {
   LiveTvRounded = "LiveTvRounded",
   LockOpenRounded = "LockOpenRounded",
   MenuBookRounded = "MenuBookRounded",
-  None = "None",
   PlayArrowRounded = "PlayArrowRounded",
   RadioButtonUncheckedRounded = "RadioButtonUncheckedRounded",
   SendRounded = "SendRounded",
@@ -170,7 +169,7 @@ export interface IconBlockCreateInput {
   color?: IconColor | null;
   id?: string | null;
   journeyId: string;
-  name: IconName;
+  name?: IconName | null;
   parentBlockId: string;
   size?: IconSize | null;
 }

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewButtonButton/NewButtonButton.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewButtonButton/NewButtonButton.spec.tsx
@@ -59,7 +59,7 @@ describe('Button', () => {
           journeyId: 'journeyId',
           parentBlockId: 'buttonBlockId',
           parentOrder: null,
-          iconName: 'None',
+          iconName: null,
           iconColor: null,
           iconSize: null
         },
@@ -69,7 +69,7 @@ describe('Button', () => {
           journeyId: 'journeyId',
           parentBlockId: 'buttonBlockId',
           parentOrder: null,
-          iconName: 'None',
+          iconName: null,
           iconColor: null,
           iconSize: null
         },
@@ -108,13 +108,13 @@ describe('Button', () => {
                   id: 'startIconId',
                   journeyId: 'journeyId',
                   parentBlockId: 'buttonBlockId',
-                  name: 'None'
+                  name: null
                 },
                 iconBlockCreateInput2: {
                   id: 'endIconId',
                   journeyId: 'journeyId',
                   parentBlockId: 'buttonBlockId',
-                  name: 'None'
+                  name: null
                 },
                 id: 'buttonBlockId',
                 journeyId: 'journeyId',
@@ -164,7 +164,7 @@ describe('Button', () => {
           journeyId: 'journeyId',
           parentBlockId: 'buttonBlockId',
           parentOrder: null,
-          iconName: 'None',
+          iconName: null,
           iconColor: null,
           iconSize: null
         },
@@ -174,7 +174,7 @@ describe('Button', () => {
           journeyId: 'journeyId',
           parentBlockId: 'buttonBlockId',
           parentOrder: null,
-          iconName: 'None',
+          iconName: null,
           iconColor: null,
           iconSize: null
         },
@@ -215,13 +215,13 @@ describe('Button', () => {
                   id: 'startIconId',
                   journeyId: 'journeyId',
                   parentBlockId: 'buttonBlockId',
-                  name: 'None'
+                  name: null
                 },
                 iconBlockCreateInput2: {
                   id: 'endIconId',
                   journeyId: 'journeyId',
                   parentBlockId: 'buttonBlockId',
-                  name: 'None'
+                  name: null
                 },
                 id: 'buttonBlockId',
                 journeyId: 'journeyId',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewButtonButton/NewButtonButton.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewButtonButton/NewButtonButton.stories.tsx
@@ -39,13 +39,13 @@ export const Default: Story = () => {
                 id: 'startIconId',
                 journeyId: 'journeyId',
                 parentBlockId: 'buttonBlockId',
-                name: 'None'
+                name: null
               },
               iconBlockCreateInput2: {
                 id: 'endIconId',
                 journeyId: 'journeyId',
                 parentBlockId: 'buttonBlockId',
-                name: 'None'
+                name: null
               },
               id: 'buttonBlockId',
               journeyId: 'journeyId',
@@ -66,7 +66,7 @@ export const Default: Story = () => {
                 journeyId: 'journeyId',
                 parentBlockId: 'buttonBlockId',
                 parentOrder: null,
-                iconName: 'None',
+                iconName: null,
                 iconColor: null,
                 iconSize: null
               },
@@ -76,7 +76,7 @@ export const Default: Story = () => {
                 journeyId: 'journeyId',
                 parentBlockId: 'buttonBlockId',
                 parentOrder: null,
-                iconName: 'None',
+                iconName: null,
                 iconColor: null,
                 iconSize: null
               },

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewButtonButton/NewButtonButton.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewButtonButton/NewButtonButton.tsx
@@ -15,8 +15,7 @@ import { ButtonBlockCreate } from '../../../../../../__generated__/ButtonBlockCr
 import {
   ButtonVariant,
   ButtonColor,
-  ButtonSize,
-  IconName
+  ButtonSize
 } from '../../../../../../__generated__/globalTypes'
 import { useJourney } from '../../../../../libs/context'
 
@@ -78,13 +77,13 @@ export function NewButtonButton(): ReactElement {
             id: startId,
             journeyId,
             parentBlockId: id,
-            name: IconName.None
+            name: null
           },
           iconBlockCreateInput2: {
             id: endId,
             journeyId,
             parentBlockId: id,
-            name: IconName.None
+            name: null
           },
           id,
           journeyId,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewSignUpButton/NewSignUpButton.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewSignUpButton/NewSignUpButton.spec.tsx
@@ -52,7 +52,7 @@ describe('SignUp', () => {
           id: 'iconId',
           journeyId: 'journeyId',
           parentBlockId: 'signUpBlockId',
-          name: 'None'
+          name: null
         },
         signUpBlockUpdate: {
           id: 'signUpBlockId',
@@ -86,7 +86,7 @@ describe('SignUp', () => {
                   id: 'iconId',
                   journeyId: 'journeyId',
                   parentBlockId: 'signUpBlockId',
-                  name: 'None'
+                  name: null
                 },
                 id: 'signUpBlockId',
                 journeyId: 'journeyId',
@@ -134,7 +134,7 @@ describe('SignUp', () => {
           journeyId: 'journeyId',
           parentBlockId: 'signUpBlockId',
           parentOrder: null,
-          iconName: 'None',
+          iconName: null,
           iconColor: null,
           iconSize: null
         },
@@ -172,7 +172,7 @@ describe('SignUp', () => {
                   id: 'iconId',
                   journeyId: 'journeyId',
                   parentBlockId: 'signUpBlockId',
-                  name: 'None'
+                  name: null
                 },
                 id: 'signUpBlockId',
                 journeyId: 'journeyId',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewSignUpButton/NewSignUpButton.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewSignUpButton/NewSignUpButton.stories.tsx
@@ -31,7 +31,7 @@ export const Default: Story = () => {
                 id: 'iconId',
                 journeyId: 'journeyId',
                 parentBlockId: 'signUpBlockId',
-                name: 'None'
+                name: null
               },
               id: 'signUpBlockId',
               journeyId: 'journeyId',
@@ -52,7 +52,7 @@ export const Default: Story = () => {
                 journeyId: 'journeyId',
                 parentBlockId: 'signUpBlockId',
                 parentOrder: null,
-                iconName: 'None',
+                iconName: null,
                 iconColor: null,
                 iconSize: null
               },

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewSignUpButton/NewSignUpButton.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewSignUpButton/NewSignUpButton.tsx
@@ -12,7 +12,6 @@ import DraftsRounded from '@mui/icons-material/DraftsRounded'
 import { useJourney } from '../../../../../libs/context'
 import { GetJourney_journey_blocks_CardBlock as CardBlock } from '../../../../../../__generated__/GetJourney'
 import { SignUpBlockCreate } from '../../../../../../__generated__/SignUpBlockCreate'
-import { IconName } from '../../../../../../__generated__/globalTypes'
 import { Button } from '../../Button'
 
 export const SIGN_UP_BLOCK_CREATE = gql`
@@ -67,7 +66,7 @@ export function NewSignUpButton(): ReactElement {
             id: submitId,
             journeyId,
             parentBlockId: id,
-            name: IconName.None
+            name: null
           },
           id,
           journeyId,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.spec.tsx
@@ -229,7 +229,7 @@ describe('ControlPanel', () => {
                   id: 'uuid',
                   journeyId: 'journeyId',
                   parentBlockId: 'uuid',
-                  name: 'None'
+                  name: null
                 },
                 id: 'uuid',
                 journeyId: 'journeyId',
@@ -250,7 +250,7 @@ describe('ControlPanel', () => {
                   journeyId: 'journeyId',
                   parentBlockId: 'uuid',
                   parentOrder: null,
-                  iconName: 'None',
+                  iconName: null,
                   iconColor: null,
                   iconSize: null
                 },
@@ -557,13 +557,13 @@ describe('ControlPanel', () => {
                   id: 'uuid',
                   journeyId: 'journeyId',
                   parentBlockId: 'uuid',
-                  name: 'None'
+                  name: null
                 },
                 iconBlockCreateInput2: {
                   id: 'uuid',
                   journeyId: 'journeyId',
                   parentBlockId: 'uuid',
-                  name: 'None'
+                  name: null
                 },
                 id: 'uuid',
                 journeyId: 'journeyId',
@@ -584,7 +584,7 @@ describe('ControlPanel', () => {
                   journeyId: 'journeyId',
                   parentBlockId: 'uuid',
                   parentOrder: null,
-                  iconName: 'None',
+                  iconName: null,
                   iconColor: null,
                   iconSize: null
                 },
@@ -594,7 +594,7 @@ describe('ControlPanel', () => {
                   journeyId: 'journeyId',
                   parentBlockId: 'uuid',
                   parentOrder: null,
-                  iconName: 'None',
+                  iconName: null,
                   iconColor: null,
                   iconSize: null
                 },

--- a/apps/journeys/__generated__/BlockFields.ts
+++ b/apps/journeys/__generated__/BlockFields.ts
@@ -117,7 +117,7 @@ export interface BlockFields_IconBlock {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  iconName: IconName;
+  iconName: IconName | null;
   iconSize: IconSize | null;
   iconColor: IconColor | null;
 }

--- a/apps/journeys/__generated__/GetJourney.ts
+++ b/apps/journeys/__generated__/GetJourney.ts
@@ -122,7 +122,7 @@ export interface GetJourney_journey_blocks_IconBlock {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  iconName: IconName;
+  iconName: IconName | null;
   iconSize: IconSize | null;
   iconColor: IconColor | null;
 }

--- a/apps/journeys/__generated__/IconFields.ts
+++ b/apps/journeys/__generated__/IconFields.ts
@@ -14,7 +14,7 @@ export interface IconFields {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  iconName: IconName;
+  iconName: IconName | null;
   iconSize: IconSize | null;
   iconColor: IconColor | null;
 }

--- a/apps/journeys/__generated__/globalTypes.ts
+++ b/apps/journeys/__generated__/globalTypes.ts
@@ -68,7 +68,6 @@ export enum IconName {
   LiveTvRounded = "LiveTvRounded",
   LockOpenRounded = "LockOpenRounded",
   MenuBookRounded = "MenuBookRounded",
-  None = "None",
   PlayArrowRounded = "PlayArrowRounded",
   RadioButtonUncheckedRounded = "RadioButtonUncheckedRounded",
   SendRounded = "SendRounded",

--- a/libs/journeys/ui/__generated__/globalTypes.ts
+++ b/libs/journeys/ui/__generated__/globalTypes.ts
@@ -68,7 +68,6 @@ export enum IconName {
   LiveTvRounded = "LiveTvRounded",
   LockOpenRounded = "LockOpenRounded",
   MenuBookRounded = "MenuBookRounded",
-  None = "None",
   PlayArrowRounded = "PlayArrowRounded",
   RadioButtonUncheckedRounded = "RadioButtonUncheckedRounded",
   SendRounded = "SendRounded",

--- a/libs/journeys/ui/src/components/Icon/Icon.spec.tsx
+++ b/libs/journeys/ui/src/components/Icon/Icon.spec.tsx
@@ -25,7 +25,7 @@ describe('Icon', () => {
     expect(getByTestId('CheckCircleRoundedIcon')).toHaveClass('MuiSvgIcon-root')
   })
   it('should render nothing', () => {
-    const { getByTestId } = render(<Icon {...block} iconName={IconName.None} />)
+    const { getByTestId } = render(<Icon {...block} iconName={null} />)
     expect(getByTestId('None')).toBeInTheDocument()
   })
   it('should render small icon', () => {

--- a/libs/journeys/ui/src/components/Icon/Icon.tsx
+++ b/libs/journeys/ui/src/components/Icon/Icon.tsx
@@ -53,7 +53,7 @@ export function Icon({
     ContactSupportRounded
   }
 
-  return iconName === 'None' ? (
+  return iconName === null ? (
     <div data-testid={'None'} />
   ) : (
     createElement(icons[iconName], {

--- a/libs/journeys/ui/src/components/Icon/__generated__/IconFields.ts
+++ b/libs/journeys/ui/src/components/Icon/__generated__/IconFields.ts
@@ -14,7 +14,7 @@ export interface IconFields {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  iconName: IconName;
+  iconName: IconName | null;
   iconSize: IconSize | null;
   iconColor: IconColor | null;
 }

--- a/libs/journeys/ui/src/libs/transformer/__generated__/BlockFields.ts
+++ b/libs/journeys/ui/src/libs/transformer/__generated__/BlockFields.ts
@@ -117,7 +117,7 @@ export interface BlockFields_IconBlock {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  iconName: IconName;
+  iconName: IconName | null;
   iconSize: IconSize | null;
   iconColor: IconColor | null;
 }


### PR DESCRIPTION
# Description

Make iconName nullable instead of adding in a new enum value. Needs to be reviewed before Siyang can start Icon work.

Needed to add both FE and api changes in one else we get a codegen linting error.

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] PR checks pass
- [x] Manually checked icons were still being created in journeys-admin / journeys

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
