### PR TITLE
feature: InlineEditWrapper and TypographyEdit component

### DIFF
--- a/apps/journeys-admin/__generated__/TypographyBlockUpdateContent.ts
+++ b/apps/journeys-admin/__generated__/TypographyBlockUpdateContent.ts
@@ -1,0 +1,26 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { TypographyBlockUpdateInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: TypographyBlockUpdateContent
+// ====================================================
+
+export interface TypographyBlockUpdateContent_typographyBlockUpdate {
+  __typename: "TypographyBlock";
+  id: string;
+  content: string;
+}
+
+export interface TypographyBlockUpdateContent {
+  typographyBlockUpdate: TypographyBlockUpdateContent_typographyBlockUpdate;
+}
+
+export interface TypographyBlockUpdateContentVariables {
+  id: string;
+  journeyId: string;
+  input: TypographyBlockUpdateInput;
+}

--- a/apps/journeys-admin/src/components/Editor/Canvas/Canvas.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/Canvas.tsx
@@ -15,6 +15,7 @@ import { FramePortal } from '../../FramePortal'
 import { DRAWER_WIDTH } from '../Drawer'
 import 'swiper/swiper.min.css'
 import { useJourney } from '../../../libs/context'
+import { InlineEditWrapper } from './InlineEditWrapper'
 
 const EDGE_SLIDE_WIDTH = 24
 const MIN_SPACE_BETWEEN = 16
@@ -132,7 +133,12 @@ export function Canvas(): ReactElement {
               <FramePortal width={356} height={536}>
                 <ThemeProvider themeName={themeName} themeMode={themeMode}>
                   <Box sx={{ p: 1, height: '100%' }}>
-                    <BlockRenderer block={step} />
+                    <BlockRenderer
+                      block={step}
+                      wrappers={{
+                        TypographyWrapper: InlineEditWrapper
+                      }}
+                    />
                   </Box>
                 </ThemeProvider>
               </FramePortal>

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditWrapper.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditWrapper.spec.tsx
@@ -1,0 +1,71 @@
+import { render, fireEvent } from '@testing-library/react'
+import { MockedProvider } from '@apollo/client/testing'
+import {
+  EditorProvider,
+  TreeBlock,
+  ActiveFab,
+  Typography
+} from '@core/journeys/ui'
+import { TypographyVariant } from '../../../../../__generated__/globalTypes'
+import { TypographyFields } from '../../../../../__generated__/TypographyFields'
+import { InlineEditWrapper } from '.'
+
+describe('TypographyEdit', () => {
+  const block: TreeBlock<TypographyFields> = {
+    __typename: 'TypographyBlock',
+    id: 'typography.id',
+    parentBlockId: 'parent.id',
+    parentOrder: 0,
+    variant: TypographyVariant.body1,
+    content: 'test content',
+    color: null,
+    align: null,
+    children: []
+  }
+  const step: TreeBlock = {
+    __typename: 'StepBlock',
+    id: 'step.id',
+    parentBlockId: null,
+    parentOrder: 0,
+    locked: true,
+    nextBlockId: null,
+    children: [block]
+  }
+  const props = {
+    block,
+    children: <Typography {...block} />
+  }
+  it('renders children by default', () => {
+    const { getByText } = render(
+      <MockedProvider>
+        <EditorProvider>
+          <InlineEditWrapper {...props} />
+        </EditorProvider>
+      </MockedProvider>
+    )
+    expect(getByText('test content')).toBeInTheDocument()
+  })
+
+  it('should edit typography on double click', async () => {
+    const { getByRole, getByText } = render(
+      <MockedProvider>
+        <EditorProvider
+          initialState={{
+            steps: [step],
+            activeFab: ActiveFab.Add
+          }}
+        >
+          <InlineEditWrapper {...props} />
+        </EditorProvider>
+      </MockedProvider>
+    )
+
+    fireEvent.click(getByText('test content'))
+    fireEvent.click(getByText('test content'))
+    const input = getByRole('textbox')
+    expect(input).toBeInTheDocument()
+    // Check it doesn't deselected on click
+    fireEvent.click(input)
+    expect(input).toBeInTheDocument()
+  })
+})

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditWrapper.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditWrapper.tsx
@@ -1,0 +1,28 @@
+import { ReactElement } from 'react'
+import { useEditor, ActiveFab, WrapperProps } from '@core/journeys/ui'
+import { TypographyFields } from '../../../../../__generated__/TypographyFields'
+import { TypographyEdit } from './TypographyEdit'
+
+interface InlineEditWrapperProps extends WrapperProps<TypographyFields> {}
+
+export function InlineEditWrapper({
+  block,
+  children
+}: InlineEditWrapperProps): ReactElement {
+  const {
+    state: { selectedBlock, activeFab }
+  } = useEditor()
+
+  const EditComponent =
+    block.__typename === 'TypographyBlock' ? (
+      <TypographyEdit {...block} />
+    ) : (
+      <></>
+    )
+
+  return activeFab === ActiveFab.Save && selectedBlock?.id === block.id ? (
+    EditComponent
+  ) : (
+    <>{children}</>
+  )
+}

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.spec.tsx
@@ -10,7 +10,9 @@ describe('TypographyEdit', () => {
   const props = {
     id: 'typography.id',
     variant: TypographyVariant.body1,
-    content: 'test content'
+    content: 'test content',
+    align: null,
+    color: null
   }
   it('selects the input on click', () => {
     const { getByRole } = render(

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.spec.tsx
@@ -1,0 +1,71 @@
+import { render, fireEvent, waitFor } from '@testing-library/react'
+import { MockedProvider } from '@apollo/client/testing'
+import { EditorProvider } from '@core/journeys/ui'
+import { TypographyVariant } from '../../../../../../__generated__/globalTypes'
+import { GetJourney_journey as Journey } from '../../../../../../__generated__/GetJourney'
+import { JourneyProvider } from '../../../../../libs/context'
+import { TypographyEdit, TYPOGRAPHY_BLOCK_UPDATE_CONTENT } from '.'
+
+describe('TypographyEdit', () => {
+  const props = {
+    id: 'typography.id',
+    variant: TypographyVariant.body1,
+    content: 'test content'
+  }
+  it('selects the input on click', () => {
+    const { getByRole } = render(
+      <MockedProvider>
+        <TypographyEdit {...props} />
+      </MockedProvider>
+    )
+    const input = getByRole('textbox')
+    fireEvent.click(input)
+    expect(input).toHaveFocus()
+  })
+
+  it('saves the text content on blur', async () => {
+    const result = jest.fn(() => ({
+      data: {
+        typographyBlockUpdate: [
+          {
+            __typename: 'TypographyBlock',
+            id: 'typography.id',
+            content: 'updated content'
+          }
+        ]
+      }
+    }))
+
+    const { getByRole } = render(
+      <MockedProvider
+        mocks={[
+          {
+            request: {
+              query: TYPOGRAPHY_BLOCK_UPDATE_CONTENT,
+              variables: {
+                id: 'typography.id',
+                journeyId: 'journeyId',
+                input: {
+                  content: 'updated content'
+                }
+              }
+            },
+            result
+          }
+        ]}
+      >
+        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+          <EditorProvider>
+            <TypographyEdit {...props} />
+          </EditorProvider>
+        </JourneyProvider>
+      </MockedProvider>
+    )
+
+    const input = getByRole('textbox')
+    fireEvent.click(input)
+    fireEvent.change(input, { target: { value: '    updated content    ' } })
+    fireEvent.blur(input)
+    await waitFor(() => expect(result).toHaveBeenCalled())
+  })
+})

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.stories.tsx
@@ -1,0 +1,143 @@
+import { Story, Meta } from '@storybook/react'
+import { TreeBlock, EditorProvider, ActiveFab } from '@core/journeys/ui'
+import { MockedProvider } from '@apollo/client/testing'
+import {
+  GetJourney_journey_blocks_StepBlock as StepBlock,
+  GetJourney_journey as Journey
+} from '../../../../../../__generated__/GetJourney'
+import { TypographyFields } from '../../../../../../__generated__/TypographyFields'
+import {
+  ThemeMode,
+  ThemeName,
+  TypographyVariant
+} from '../../../../../../__generated__/globalTypes'
+import { simpleComponentConfig } from '../../../../../libs/storybook'
+import { JourneyProvider } from '../../../../../libs/context'
+import { Canvas } from '../../Canvas'
+
+const TypographyEditStory = {
+  ...simpleComponentConfig,
+  component: Canvas,
+  title: 'Journeys-Admin/Editor/Canvas/TypographyEdit'
+}
+
+const heading: TreeBlock<TypographyFields> = {
+  id: 'typographyBlockId1',
+  __typename: 'TypographyBlock',
+  parentBlockId: 'card0.id',
+  parentOrder: 1,
+  align: null,
+  color: null,
+  content: "What's our purpose, and how did we get here?",
+  variant: TypographyVariant.h3,
+  children: []
+}
+
+const body: TreeBlock<TypographyFields> = {
+  id: 'typographyBlockId2',
+  __typename: 'TypographyBlock',
+  parentBlockId: 'card0.id',
+  parentOrder: 2,
+  align: null,
+  color: null,
+  content:
+    'Follow the journey of a curious Irishman traveling around the world looking for answers and wrestling with the things that just don’t seem to make sense. ',
+  variant: null,
+  children: []
+}
+
+const caption: TreeBlock<TypographyFields> = {
+  id: 'typographyBlockId3',
+  __typename: 'TypographyBlock',
+  parentBlockId: 'card0.id',
+  parentOrder: 3,
+  align: null,
+  color: null,
+  content: 'This is a caption',
+  variant: TypographyVariant.caption,
+  children: []
+}
+
+const steps: Array<TreeBlock<StepBlock>> = [
+  {
+    id: 'step0.id',
+    __typename: 'StepBlock',
+    parentBlockId: null,
+    parentOrder: 0,
+    locked: false,
+    nextBlockId: 'step1.id',
+    children: [
+      {
+        id: 'card0.id',
+        __typename: 'CardBlock',
+        parentBlockId: 'step0.id',
+        coverBlockId: 'image0.id',
+        parentOrder: 0,
+        backgroundColor: null,
+        themeMode: null,
+        themeName: null,
+        fullscreen: false,
+        children: [
+          {
+            id: 'image0.id',
+            __typename: 'ImageBlock',
+            src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
+            width: 1920,
+            height: 1080,
+            alt: 'random image from unsplash',
+            parentBlockId: 'card6.id',
+            parentOrder: 0,
+            children: [],
+            blurhash: 'LFALX]%g4Tf+?^jEMxo#00Mx%gjZ'
+          },
+          heading,
+          body,
+          caption
+        ]
+      }
+    ]
+  }
+]
+
+const Template: Story = ({ ...args }) => {
+  return (
+    <MockedProvider>
+      <JourneyProvider
+        value={
+          {
+            id: 'journeyId',
+            themeMode: ThemeMode.light,
+            themeName: ThemeName.base
+          } as unknown as Journey
+        }
+      >
+        <EditorProvider
+          initialState={{
+            ...args,
+            steps,
+            activeFab: ActiveFab.Save
+          }}
+        >
+          <Canvas />
+        </EditorProvider>
+      </JourneyProvider>
+    </MockedProvider>
+  )
+}
+
+export const Heading = Template.bind({})
+Heading.args = {
+  selectedBlock: heading
+}
+
+export const Body = Template.bind({})
+Body.args = {
+  selectedBlock: body
+}
+
+export const Caption = Template.bind({})
+Caption.args = {
+  selectedBlock: caption
+}
+
+export default TypographyEditStory as Meta

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.stories.tsx
@@ -9,7 +9,9 @@ import { TypographyFields } from '../../../../../../__generated__/TypographyFiel
 import {
   ThemeMode,
   ThemeName,
-  TypographyVariant
+  TypographyVariant,
+  TypographyAlign,
+  TypographyColor
 } from '../../../../../../__generated__/globalTypes'
 import { simpleComponentConfig } from '../../../../../libs/storybook'
 import { JourneyProvider } from '../../../../../libs/context'
@@ -26,7 +28,7 @@ const heading: TreeBlock<TypographyFields> = {
   __typename: 'TypographyBlock',
   parentBlockId: 'card0.id',
   parentOrder: 1,
-  align: null,
+  align: TypographyAlign.center,
   color: null,
   content: "What's our purpose, and how did we get here?",
   variant: TypographyVariant.h3,
@@ -52,7 +54,7 @@ const caption: TreeBlock<TypographyFields> = {
   parentBlockId: 'card0.id',
   parentOrder: 3,
   align: null,
-  color: null,
+  color: TypographyColor.error,
   content: 'This is a caption',
   variant: TypographyVariant.caption,
   children: []

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useState, useRef } from 'react'
+import { ReactElement, useState } from 'react'
 import { gql, useMutation } from '@apollo/client'
 import { styled, SimplePaletteColorOptions } from '@mui/material/styles'
 import InputBase, { InputBaseProps } from '@mui/material/InputBase'
@@ -21,21 +21,28 @@ export const TYPOGRAPHY_BLOCK_UPDATE_CONTENT = gql`
   }
 `
 interface TypographyEditProps
-  extends Pick<TreeBlock<TypographyFields>, 'id' | 'variant' | 'content'> {}
+  extends Pick<
+    TreeBlock<TypographyFields>,
+    'id' | 'variant' | 'align' | 'color' | 'content'
+  > {}
 
 interface StyledInputProps
   extends InputBaseProps,
-    Pick<TreeBlock<TypographyFields>, 'variant'> {}
+    Pick<TreeBlock<TypographyFields>, 'variant' | 'align'> {}
 
 const adminPrimaryColor = adminTheme.palette
   .primary as SimplePaletteColorOptions
 
 const StyledInput = styled(InputBase)<StyledInputProps>(
-  ({ variant, theme }) => ({
+  ({ variant, align, color, theme }) => ({
     '& .MuiInputBase-input': {
       ...theme.components?.MuiTypography,
       ...theme.typography[variant ?? 'body1'],
-      marginBottom: 0
+      marginBottom: 0,
+      // TODO: Use locale alignment as default
+      textAlign: align ?? 'left',
+      color:
+        color != null ? theme.palette[color].main : theme.palette.primary.main
     },
     marginBottom: 16,
     ...theme.typography[variant ?? 'body1'],
@@ -50,6 +57,8 @@ const StyledInput = styled(InputBase)<StyledInputProps>(
 export function TypographyEdit({
   id,
   variant,
+  align,
+  color,
   content
 }: TypographyEditProps): ReactElement {
   const [typographyBlockUpdate] = useMutation<TypographyBlockUpdateContent>(
@@ -60,7 +69,6 @@ export function TypographyEdit({
   } = useEditor()
   const journey = useJourney()
   const [value, setValue] = useState(content)
-  const inputRef = useRef()
 
   async function handleSaveBlock(): Promise<void> {
     const content = value.trimStart().trimEnd()
@@ -82,9 +90,10 @@ export function TypographyEdit({
 
   return (
     <StyledInput
-      inputRef={inputRef}
       name={`edit-${id}`}
       variant={variant}
+      align={align}
+      color={color ?? 'primary'}
       multiline
       fullWidth
       autoFocus

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.tsx
@@ -1,0 +1,106 @@
+import { ReactElement, useState, useRef } from 'react'
+import { gql, useMutation } from '@apollo/client'
+import { styled, SimplePaletteColorOptions } from '@mui/material/styles'
+import InputBase, { InputBaseProps } from '@mui/material/InputBase'
+import { TreeBlock, useEditor } from '@core/journeys/ui'
+import { useJourney } from '../../../../../libs/context'
+import { adminTheme } from '../../../../ThemeProvider/admin/theme'
+import { TypographyBlockUpdateContent } from '../../../../../../__generated__/TypographyBlockUpdateContent'
+import { TypographyFields } from '../../../../../../__generated__/TypographyFields'
+
+export const TYPOGRAPHY_BLOCK_UPDATE_CONTENT = gql`
+  mutation TypographyBlockUpdateContent(
+    $id: ID!
+    $journeyId: ID!
+    $input: TypographyBlockUpdateInput!
+  ) {
+    typographyBlockUpdate(id: $id, journeyId: $journeyId, input: $input) {
+      id
+      content
+    }
+  }
+`
+interface TypographyEditProps
+  extends Pick<TreeBlock<TypographyFields>, 'id' | 'variant' | 'content'> {}
+
+interface StyledInputProps
+  extends InputBaseProps,
+    Pick<TreeBlock<TypographyFields>, 'variant'> {}
+
+const adminPrimaryColor = adminTheme.palette
+  .primary as SimplePaletteColorOptions
+
+const StyledInput = styled(InputBase)<StyledInputProps>(
+  ({ variant, theme }) => ({
+    '& .MuiInputBase-input': {
+      ...theme.components?.MuiTypography,
+      ...theme.typography[variant ?? 'body1'],
+      marginBottom: 0
+    },
+    marginBottom: 16,
+    ...theme.typography[variant ?? 'body1'],
+    '&:last-child': {
+      marginBottom: 0
+    },
+    padding: 0,
+    caretColor: adminPrimaryColor.main
+  })
+)
+
+export function TypographyEdit({
+  id,
+  variant,
+  content
+}: TypographyEditProps): ReactElement {
+  const [typographyBlockUpdate] = useMutation<TypographyBlockUpdateContent>(
+    TYPOGRAPHY_BLOCK_UPDATE_CONTENT
+  )
+  const {
+    state: { selectedBlock }
+  } = useEditor()
+  const journey = useJourney()
+  const [value, setValue] = useState(content)
+  const inputRef = useRef()
+
+  async function handleSaveBlock(): Promise<void> {
+    const content = value.trimStart().trimEnd()
+    await typographyBlockUpdate({
+      variables: {
+        id,
+        journeyId: journey.id,
+        input: { content }
+      },
+      optimisticResponse: {
+        typographyBlockUpdate: {
+          id,
+          __typename: 'TypographyBlock',
+          content
+        }
+      }
+    })
+  }
+
+  return (
+    <StyledInput
+      inputRef={inputRef}
+      name={`edit-${id}`}
+      variant={variant}
+      multiline
+      fullWidth
+      autoFocus
+      sx={{
+        outline:
+          selectedBlock?.id === id
+            ? `3px solid ${adminPrimaryColor.main}`
+            : 'none',
+        outlineOffset: '5px'
+      }}
+      value={value}
+      onBlur={handleSaveBlock}
+      onChange={(e) => {
+        setValue(e.currentTarget.value)
+      }}
+      onClick={(e) => e.stopPropagation()}
+    />
+  )
+}

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/index.ts
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/index.ts
@@ -1,0 +1,4 @@
+export {
+  TypographyEdit,
+  TYPOGRAPHY_BLOCK_UPDATE_CONTENT
+} from './TypographyEdit'

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/index.ts
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/index.ts
@@ -1,0 +1,1 @@
+export { InlineEditWrapper } from './InlineEditWrapper'

--- a/apps/journeys/src/components/Conductor/Conductor.stories.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.stories.tsx
@@ -720,6 +720,18 @@ const imageBlocks: TreeBlock[] = [
         fullscreen: false,
         children: [
           {
+            id: 'image0.id',
+            __typename: 'ImageBlock',
+            src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
+            width: 1920,
+            height: 1080,
+            alt: 'random image from unsplash',
+            parentBlockId: 'card0.id',
+            parentOrder: null,
+            children: [],
+            blurhash: 'LFALX]%g4Tf+?^jEMxo#00Mx%gjZ'
+          },
+          {
             id: 'typographyBlockId1',
             __typename: 'TypographyBlock',
             parentBlockId: 'card0.id',
@@ -785,18 +797,6 @@ const imageBlocks: TreeBlock[] = [
             ]
           }
         ]
-      },
-      {
-        id: 'image0.id',
-        __typename: 'ImageBlock',
-        src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
-        width: 1920,
-        height: 1080,
-        alt: 'random image from unsplash',
-        parentBlockId: 'card0.id',
-        parentOrder: 0,
-        children: [],
-        blurhash: 'LFALX]%g4Tf+?^jEMxo#00Mx%gjZ'
       }
     ]
   }

--- a/libs/journeys/ui/src/components/BlockRenderer/BlockRenderer.tsx
+++ b/libs/journeys/ui/src/components/BlockRenderer/BlockRenderer.tsx
@@ -28,7 +28,7 @@ import {
   BlockFields_VideoBlock as VideoBlock
 } from '../../libs/transformer/__generated__/BlockFields'
 
-interface WrapperProps<T = Block> {
+export interface WrapperProps<T = Block> {
   block: TreeBlock<T>
   children: ReactNode
 }

--- a/libs/journeys/ui/src/components/BlockRenderer/index.ts
+++ b/libs/journeys/ui/src/components/BlockRenderer/index.ts
@@ -1,2 +1,3 @@
 export { BlockRenderer } from './BlockRenderer'
 export type { WrappersProps } from './BlockRenderer'
+export type { WrapperProps } from './BlockRenderer'

--- a/libs/journeys/ui/src/components/Card/Cover/Cover.tsx
+++ b/libs/journeys/ui/src/components/Card/Cover/Cover.tsx
@@ -135,7 +135,7 @@ export function Cover({
       >
         <Box
           sx={{
-            margin: 'auto',
+            my: 'auto',
             p: {
               xs: `calc(6vw + ${theme.spacing(4)}) ${theme.spacing(
                 7

--- a/libs/journeys/ui/src/components/Typography/Typography.spec.tsx
+++ b/libs/journeys/ui/src/components/Typography/Typography.spec.tsx
@@ -44,7 +44,7 @@ describe('Typography', () => {
 })
 
 describe('Admin Typography', () => {
-  it('should edit text on click ', () => {
+  it('should select text on click ', () => {
     const { getByText } = render(
       <EditorProvider
         initialState={{
@@ -69,6 +69,5 @@ describe('Admin Typography', () => {
     fireEvent.click(getByText(block.content))
 
     expect(getByText(block.content)).toHaveStyle('outline: 3px solid #C52D3A')
-    // Check editable when implemented
   })
 })

--- a/libs/journeys/ui/src/components/Typography/Typography.tsx
+++ b/libs/journeys/ui/src/components/Typography/Typography.tsx
@@ -43,6 +43,7 @@ export function Typography({
       color={color ?? undefined}
       paragraph={variant === 'overline' || variant === 'caption'}
       gutterBottom
+      whiteSpace={'pre-line'}
       sx={{
         outline: selectedBlock?.id === props.id ? '3px solid #C52D3A' : 'none',
         outlineOffset: '5px'

--- a/libs/journeys/ui/src/components/index.ts
+++ b/libs/journeys/ui/src/components/index.ts
@@ -1,4 +1,5 @@
-export { BlockRenderer, WrapperProps } from './BlockRenderer'
+export { BlockRenderer } from './BlockRenderer'
+export type { WrapperProps } from './BlockRenderer'
 export { Button } from './Button'
 export { Card, CardWrapper, CardCover } from './Card'
 export { Image } from './Image'

--- a/libs/journeys/ui/src/components/index.ts
+++ b/libs/journeys/ui/src/components/index.ts
@@ -1,4 +1,4 @@
-export { BlockRenderer, WrappersProps } from './BlockRenderer'
+export { BlockRenderer, WrapperProps } from './BlockRenderer'
 export { Button } from './Button'
 export { Card, CardWrapper, CardCover } from './Card'
 export { Image } from './Image'

--- a/libs/journeys/ui/src/components/index.ts
+++ b/libs/journeys/ui/src/components/index.ts
@@ -1,4 +1,4 @@
-export { BlockRenderer } from './BlockRenderer'
+export { BlockRenderer, WrappersProps } from './BlockRenderer'
 export { Button } from './Button'
 export { Card, CardWrapper, CardCover } from './Card'
 export { Image } from './Image'

--- a/libs/journeys/ui/src/index.ts
+++ b/libs/journeys/ui/src/index.ts
@@ -1,6 +1,6 @@
 export {
   BlockRenderer,
-  WrappersProps,
+  WrapperProps,
   Button,
   Card,
   CardWrapper,

--- a/libs/journeys/ui/src/index.ts
+++ b/libs/journeys/ui/src/index.ts
@@ -1,6 +1,5 @@
 export {
   BlockRenderer,
-  WrapperProps,
   Button,
   Card,
   CardWrapper,
@@ -15,6 +14,7 @@ export {
   Video,
   VideoTrigger
 } from './components'
+export type { WrapperProps } from './components'
 export {
   handleAction,
   useEditor,

--- a/libs/journeys/ui/src/index.ts
+++ b/libs/journeys/ui/src/index.ts
@@ -1,5 +1,6 @@
 export {
   BlockRenderer,
+  WrappersProps,
   Button,
   Card,
   CardWrapper,


### PR DESCRIPTION
# Description

This creates the editable Typography Textfield and inline edit wrapper which switches between the editable / non-editable text blocks. 

Out of scope / nice to have for this PR is making the caret appear at the end of the text and pausing the blinking so we can see its position in VR tests.

[Basecamp](https://3.basecamp.com/3105655/buckets/26244169/todos/4632657595)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] PR checks
- [x] Manual testing locally. 
- Tested that double click took us to edit mode
- Clicking on the card + clicking done saved the progress. Clicking outside the card cancelled changes.
- We can support paragraphs within a TypographyBlock but whitespace at the start/end is stripped.
- Styling for all Typography variants is correct in edit mode
- Margins for all Typography variants are correct no matter the positioning on Card

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
