### PR TITLE
feat: Inline edit button

### DIFF
--- a/apps/journeys-admin/__generated__/ButtonBlockUpdateContent.ts
+++ b/apps/journeys-admin/__generated__/ButtonBlockUpdateContent.ts
@@ -1,0 +1,26 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { ButtonBlockUpdateInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: ButtonBlockUpdateContent
+// ====================================================
+
+export interface ButtonBlockUpdateContent_buttonBlockUpdate {
+  __typename: "ButtonBlock";
+  id: string;
+  label: string;
+}
+
+export interface ButtonBlockUpdateContent {
+  buttonBlockUpdate: ButtonBlockUpdateContent_buttonBlockUpdate | null;
+}
+
+export interface ButtonBlockUpdateContentVariables {
+  id: string;
+  journeyId: string;
+  input: ButtonBlockUpdateInput;
+}

--- a/apps/journeys-admin/src/components/Editor/Canvas/Canvas.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/Canvas.tsx
@@ -136,7 +136,8 @@ export function Canvas(): ReactElement {
                     <BlockRenderer
                       block={step}
                       wrappers={{
-                        TypographyWrapper: InlineEditWrapper
+                        TypographyWrapper: InlineEditWrapper,
+                        ButtonWrapper: InlineEditWrapper
                       }}
                     />
                   </Box>

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.spec.tsx
@@ -1,0 +1,81 @@
+import { render, fireEvent, waitFor } from '@testing-library/react'
+import { MockedProvider } from '@apollo/client/testing'
+import { EditorProvider, TreeBlock } from '@core/journeys/ui'
+import { ButtonVariant } from '../../../../../../__generated__/globalTypes'
+import { ButtonFields } from '../../../../../../__generated__/ButtonFields'
+import { GetJourney_journey as Journey } from '../../../../../../__generated__/GetJourney'
+import { JourneyProvider } from '../../../../../libs/context'
+import { ButtonEdit, BUTTON_BLOCK_UPDATE_CONTENT } from '.'
+
+describe('ButtonEdit', () => {
+  const props: TreeBlock<ButtonFields> = {
+    __typename: 'ButtonBlock',
+    id: 'button.id',
+    label: 'test label',
+    parentBlockId: 'card',
+    parentOrder: 0,
+    buttonVariant: ButtonVariant.contained,
+    buttonColor: null,
+    size: null,
+    startIconId: null,
+    endIconId: null,
+    action: null,
+    children: []
+  }
+  it('selects the input on click', () => {
+    const { getByRole } = render(
+      <MockedProvider>
+        <ButtonEdit {...props} />
+      </MockedProvider>
+    )
+    const input = getByRole('textbox')
+    fireEvent.click(input)
+    expect(input).toHaveFocus()
+  })
+
+  it('saves the button label on blur', async () => {
+    const result = jest.fn(() => ({
+      data: {
+        buttonBlockUpdate: [
+          {
+            __typename: 'ButtonBlock',
+            id: 'button.id',
+            label: 'updated label'
+          }
+        ]
+      }
+    }))
+
+    const { getByRole } = render(
+      <MockedProvider
+        mocks={[
+          {
+            request: {
+              query: BUTTON_BLOCK_UPDATE_CONTENT,
+              variables: {
+                id: 'button.id',
+                journeyId: 'journeyId',
+                input: {
+                  label: 'updated label'
+                }
+              }
+            },
+            result
+          }
+        ]}
+      >
+        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+          <EditorProvider>
+            <ButtonEdit {...props} />
+          </EditorProvider>
+        </JourneyProvider>
+      </MockedProvider>
+    )
+
+    const input = getByRole('textbox')
+    fireEvent.click(input)
+    fireEvent.change(input, { target: { value: '    updated label    ' } })
+    fireEvent.blur(input)
+    await waitFor(() => expect(result).toHaveBeenCalled())
+  })
+})

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.stories.tsx
@@ -1,0 +1,174 @@
+import { Story, Meta } from '@storybook/react'
+import { TreeBlock, EditorProvider, ActiveFab } from '@core/journeys/ui'
+import { MockedProvider } from '@apollo/client/testing'
+import {
+  GetJourney_journey_blocks_StepBlock as StepBlock,
+  GetJourney_journey as Journey
+} from '../../../../../../__generated__/GetJourney'
+import { ButtonFields } from '../../../../../../__generated__/ButtonFields'
+import {
+  ThemeMode,
+  ThemeName,
+  ButtonVariant,
+  ButtonColor,
+  IconName
+} from '../../../../../../__generated__/globalTypes'
+import { simpleComponentConfig } from '../../../../../libs/storybook'
+import { JourneyProvider } from '../../../../../libs/context'
+import { Canvas } from '../../Canvas'
+
+const ButtonEditStory = {
+  ...simpleComponentConfig,
+  component: Canvas,
+  title: 'Journeys-Admin/Editor/Canvas/ButtonEdit'
+}
+
+const filled: TreeBlock<ButtonFields> = {
+  id: 'buttonBlockId0',
+  __typename: 'ButtonBlock',
+  parentBlockId: 'card0.id',
+  parentOrder: 1,
+  buttonColor: null,
+  size: null,
+  label: 'This is a very very very very long button',
+  buttonVariant: null,
+  startIconId: 'icon1',
+  endIconId: 'icon2',
+  action: null,
+  children: [
+    {
+      id: 'icon1',
+      __typename: 'IconBlock',
+      parentBlockId: 'button',
+      parentOrder: 0,
+      iconName: IconName.PlayArrowRounded,
+      iconColor: null,
+      iconSize: null,
+      children: []
+    },
+    {
+      id: 'icon2',
+      __typename: 'IconBlock',
+      parentBlockId: 'button',
+      parentOrder: 0,
+      iconName: IconName.SubscriptionsRounded,
+      iconColor: null,
+      iconSize: null,
+      children: []
+    }
+  ]
+}
+
+const contained: TreeBlock<ButtonFields> = {
+  id: 'buttonBlockId1',
+  __typename: 'ButtonBlock',
+  parentBlockId: 'card0.id',
+  parentOrder: 1,
+  buttonColor: null,
+  size: null,
+  label: 'Who is Jesus?',
+  buttonVariant: null,
+  startIconId: null,
+  endIconId: null,
+  action: null,
+  children: []
+}
+
+const text: TreeBlock<ButtonFields> = {
+  id: 'buttonBlockId2',
+  __typename: 'ButtonBlock',
+  parentBlockId: 'card0.id',
+  parentOrder: 2,
+  buttonColor: ButtonColor.error,
+  size: null,
+  label: 'Text Link ',
+  buttonVariant: ButtonVariant.text,
+  startIconId: null,
+  endIconId: null,
+  action: null,
+  children: []
+}
+
+const steps: Array<TreeBlock<StepBlock>> = [
+  {
+    id: 'step0.id',
+    __typename: 'StepBlock',
+    parentBlockId: null,
+    parentOrder: 0,
+    locked: false,
+    nextBlockId: 'step1.id',
+    children: [
+      {
+        id: 'card0.id',
+        __typename: 'CardBlock',
+        parentBlockId: 'step0.id',
+        coverBlockId: 'image0.id',
+        parentOrder: 0,
+        backgroundColor: null,
+        themeMode: null,
+        themeName: null,
+        fullscreen: false,
+        children: [
+          {
+            id: 'image0.id',
+            __typename: 'ImageBlock',
+            src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
+            width: 1920,
+            height: 1080,
+            alt: 'random image from unsplash',
+            parentBlockId: 'card6.id',
+            parentOrder: 0,
+            children: [],
+            blurhash: 'LFALX]%g4Tf+?^jEMxo#00Mx%gjZ'
+          },
+          contained,
+          filled,
+          text
+        ]
+      }
+    ]
+  }
+]
+
+const Template: Story = ({ ...args }) => {
+  return (
+    <MockedProvider>
+      <JourneyProvider
+        value={
+          {
+            id: 'journeyId',
+            themeMode: ThemeMode.light,
+            themeName: ThemeName.base
+          } as unknown as Journey
+        }
+      >
+        <EditorProvider
+          initialState={{
+            ...args,
+            steps,
+            activeFab: ActiveFab.Save
+          }}
+        >
+          <Canvas />
+        </EditorProvider>
+      </JourneyProvider>
+    </MockedProvider>
+  )
+}
+
+export const Default = Template.bind({})
+Default.args = {
+  selectedBlock: contained
+}
+
+export const Filled = Template.bind({})
+Filled.args = {
+  selectedBlock: filled
+}
+
+export const Text = Template.bind({})
+Text.args = {
+  selectedBlock: text
+}
+
+export default ButtonEditStory as Meta

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.tsx
@@ -1,0 +1,114 @@
+import { ReactElement, useState } from 'react'
+import { gql, useMutation } from '@apollo/client'
+import { styled, SimplePaletteColorOptions } from '@mui/material/styles'
+import InputBase, { InputBaseProps } from '@mui/material/InputBase'
+import { Button, TreeBlock } from '@core/journeys/ui'
+import { useJourney } from '../../../../../libs/context'
+import { adminTheme } from '../../../../ThemeProvider/admin/theme'
+import { ButtonBlockUpdateContent } from '../../../../../../__generated__/ButtonBlockUpdateContent'
+import { ButtonFields } from '../../../../../../__generated__/ButtonFields'
+import { ButtonVariant } from '../../../../../../__generated__/globalTypes'
+
+export const BUTTON_BLOCK_UPDATE_CONTENT = gql`
+  mutation ButtonBlockUpdateContent(
+    $id: ID!
+    $journeyId: ID!
+    $input: ButtonBlockUpdateInput!
+  ) {
+    buttonBlockUpdate(id: $id, journeyId: $journeyId, input: $input) {
+      id
+      label
+    }
+  }
+`
+interface ButtonEditProps extends TreeBlock<ButtonFields> {}
+
+interface StyledInputProps
+  extends InputBaseProps,
+    Pick<TreeBlock<ButtonFields>, 'buttonVariant' | 'buttonColor'> {}
+
+const adminPrimaryColor = adminTheme.palette
+  .primary as SimplePaletteColorOptions
+
+const StyledInput = styled(InputBase)<StyledInputProps>(() => ({
+  '& .MuiInputBase-input': {
+    textAlign: 'inherit'
+  },
+  color: 'inherit',
+  fontSize: 'inherit',
+  fontWeight: 'inherit',
+  lineHeight: 'inherit',
+  letterSpacing: 'inherit',
+  textTransform: 'inherit',
+  padding: '0px',
+  caretColor: adminPrimaryColor.main
+}))
+
+export function ButtonEdit({
+  id,
+  buttonVariant,
+  buttonColor,
+  label,
+  ...buttonProps
+}: ButtonEditProps): ReactElement {
+  const [buttonBlockUpdate] = useMutation<ButtonBlockUpdateContent>(
+    BUTTON_BLOCK_UPDATE_CONTENT
+  )
+
+  const journey = useJourney()
+  const [value, setValue] = useState(label)
+
+  async function handleSaveBlock(): Promise<void> {
+    const label = value.trimStart().trimEnd()
+    await buttonBlockUpdate({
+      variables: {
+        id,
+        journeyId: journey.id,
+        input: { label }
+      },
+      optimisticResponse: {
+        buttonBlockUpdate: {
+          id,
+          __typename: 'ButtonBlock',
+          label
+        }
+      }
+    })
+  }
+
+  const input = (
+    <StyledInput
+      name={`edit-${id}`}
+      buttonVariant={buttonVariant}
+      buttonColor={buttonColor}
+      fullWidth
+      multiline
+      autoFocus
+      value={value}
+      onBlur={handleSaveBlock}
+      onChange={(e) => {
+        setValue(e.currentTarget.value)
+      }}
+      onClick={(e) => e.stopPropagation()}
+    />
+  )
+
+  return (
+    <Button
+      {...buttonProps}
+      id={id}
+      buttonVariant={buttonVariant}
+      buttonColor={buttonColor}
+      label={label}
+      editableLabel={input}
+      sx={{
+        '&:hover': {
+          backgroundColor:
+            buttonVariant === ButtonVariant.text
+              ? 'transparent'
+              : `${buttonColor ?? 'primary'}.main`
+        }
+      }}
+    />
+  )
+}

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.tsx
@@ -59,7 +59,7 @@ export function ButtonEdit({
   const [value, setValue] = useState(label)
 
   async function handleSaveBlock(): Promise<void> {
-    const label = value.trimStart().trimEnd()
+    const label = value.trim().replace(/\n/g, '')
     await buttonBlockUpdate({
       variables: {
         id,

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.tsx
@@ -54,7 +54,6 @@ export function ButtonEdit({
   const [buttonBlockUpdate] = useMutation<ButtonBlockUpdateContent>(
     BUTTON_BLOCK_UPDATE_CONTENT
   )
-
   const journey = useJourney()
   const [value, setValue] = useState(label)
 

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/index.ts
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/index.ts
@@ -1,0 +1,1 @@
+export { ButtonEdit, BUTTON_BLOCK_UPDATE_CONTENT } from './ButtonEdit'

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditWrapper.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditWrapper.spec.tsx
@@ -4,14 +4,17 @@ import {
   EditorProvider,
   TreeBlock,
   ActiveFab,
+  Button,
   Typography
 } from '@core/journeys/ui'
+import { ButtonFields } from '../../../../../__generated__/ButtonFields'
+import { StepFields } from '../../../../../__generated__/StepFields'
 import { TypographyVariant } from '../../../../../__generated__/globalTypes'
 import { TypographyFields } from '../../../../../__generated__/TypographyFields'
 import { InlineEditWrapper } from '.'
 
-describe('TypographyEdit', () => {
-  const block: TreeBlock<TypographyFields> = {
+describe('InlineEditWrapper', () => {
+  const typographyBlock: TreeBlock<TypographyFields> = {
     __typename: 'TypographyBlock',
     id: 'typography.id',
     parentBlockId: 'parent.id',
@@ -22,24 +25,26 @@ describe('TypographyEdit', () => {
     align: null,
     children: []
   }
-  const step: TreeBlock = {
-    __typename: 'StepBlock',
-    id: 'step.id',
-    parentBlockId: null,
-    parentOrder: 0,
-    locked: true,
-    nextBlockId: null,
-    children: [block]
+
+  const step = (block: TreeBlock): TreeBlock<StepFields> => {
+    return {
+      __typename: 'StepBlock',
+      id: 'step.id',
+      parentBlockId: null,
+      parentOrder: 0,
+      locked: true,
+      nextBlockId: null,
+      children: [block]
+    }
   }
-  const props = {
-    block,
-    children: <Typography {...block} />
-  }
+
   it('renders children by default', () => {
     const { getByText } = render(
       <MockedProvider>
         <EditorProvider>
-          <InlineEditWrapper {...props} />
+          <InlineEditWrapper block={typographyBlock}>
+            <Typography {...typographyBlock} />
+          </InlineEditWrapper>
         </EditorProvider>
       </MockedProvider>
     )
@@ -47,24 +52,65 @@ describe('TypographyEdit', () => {
   })
 
   it('should edit typography on double click', async () => {
-    const { getByRole, getByText } = render(
+    const { getByDisplayValue, getByText } = render(
       <MockedProvider>
         <EditorProvider
           initialState={{
-            steps: [step],
+            steps: [step(typographyBlock)],
             activeFab: ActiveFab.Add
           }}
         >
-          <InlineEditWrapper {...props} />
+          <InlineEditWrapper block={typographyBlock}>
+            <Typography {...typographyBlock} />
+          </InlineEditWrapper>
         </EditorProvider>
       </MockedProvider>
     )
 
     fireEvent.click(getByText('test content'))
     fireEvent.click(getByText('test content'))
-    const input = getByRole('textbox')
+    const input = getByDisplayValue('test content')
     expect(input).toBeInTheDocument()
     // Check it doesn't deselected on click
+    fireEvent.click(input)
+    expect(input).toBeInTheDocument()
+  })
+
+  it('should edit button on double click', async () => {
+    const block: TreeBlock<ButtonFields> = {
+      __typename: 'ButtonBlock',
+      id: 'button.id',
+      parentBlockId: 'parent.id',
+      parentOrder: 0,
+      label: 'test label',
+      buttonVariant: null,
+      buttonColor: null,
+      size: null,
+      startIconId: null,
+      endIconId: null,
+      action: null,
+      children: []
+    }
+
+    const { getByDisplayValue, getByText } = render(
+      <MockedProvider>
+        <EditorProvider
+          initialState={{
+            steps: [step(block)],
+            activeFab: ActiveFab.Add
+          }}
+        >
+          <InlineEditWrapper block={block}>
+            <Button {...block} />
+          </InlineEditWrapper>
+        </EditorProvider>
+      </MockedProvider>
+    )
+
+    fireEvent.click(getByText('test label'))
+    fireEvent.click(getByText('test label'))
+    const input = getByDisplayValue('test label')
+    expect(input).toBeInTheDocument()
     fireEvent.click(input)
     expect(input).toBeInTheDocument()
   })

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditWrapper.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditWrapper.tsx
@@ -1,9 +1,12 @@
 import { ReactElement } from 'react'
 import { useEditor, ActiveFab, WrapperProps } from '@core/journeys/ui'
 import { TypographyFields } from '../../../../../__generated__/TypographyFields'
+import { ButtonFields } from '../../../../../__generated__/ButtonFields'
 import { TypographyEdit } from './TypographyEdit'
+import { ButtonEdit } from './ButtonEdit'
 
-interface InlineEditWrapperProps extends WrapperProps<TypographyFields> {}
+interface InlineEditWrapperProps
+  extends WrapperProps<TypographyFields | ButtonFields> {}
 
 export function InlineEditWrapper({
   block,
@@ -16,6 +19,8 @@ export function InlineEditWrapper({
   const EditComponent =
     block.__typename === 'TypographyBlock' ? (
       <TypographyEdit {...block} />
+    ) : block.__typename === 'ButtonBlock' ? (
+      <ButtonEdit {...block} />
     ) : (
       <></>
     )

--- a/libs/journeys/ui/src/components/Button/Button.spec.tsx
+++ b/libs/journeys/ui/src/components/Button/Button.spec.tsx
@@ -144,7 +144,7 @@ describe('Button', () => {
 })
 
 describe('Admin Button', () => {
-  it('should edit label on click', () => {
+  it('should select label on click', () => {
     const { getByRole } = render(
       <EditorProvider
         initialState={{
@@ -169,6 +169,5 @@ describe('Admin Button', () => {
     fireEvent.click(getByRole('button'))
 
     expect(getByRole('button')).toHaveStyle('outline: 3px solid #C52D3A')
-    // Test editable when implemented
   })
 })

--- a/libs/journeys/ui/src/components/Button/Button.tsx
+++ b/libs/journeys/ui/src/components/Button/Button.tsx
@@ -1,10 +1,16 @@
 import { ReactElement, MouseEvent } from 'react'
 import { useRouter } from 'next/router'
+import { SxProps } from '@mui/system/styleFunctionSx'
 import MuiButton from '@mui/material/Button'
-import { handleAction, TreeBlock, useEditor, ActiveTab } from '../..'
+import { handleAction, TreeBlock, useEditor, ActiveTab, ActiveFab } from '../..'
 import { IconFields } from '../Icon/__generated__/IconFields'
 import { Icon } from '../Icon'
 import { ButtonFields } from './__generated__/ButtonFields'
+
+interface ButtonProps extends TreeBlock<ButtonFields> {
+  editableLabel?: ReactElement
+  sx?: SxProps
+}
 
 export function Button({
   buttonVariant,
@@ -15,8 +21,10 @@ export function Button({
   endIconId,
   action,
   children,
+  sx,
+  editableLabel,
   ...props
-}: TreeBlock<ButtonFields>): ReactElement {
+}: ButtonProps): ReactElement {
   const startIcon = children.find((block) => block.id === startIconId) as
     | TreeBlock<IconFields>
     | undefined
@@ -50,9 +58,17 @@ export function Button({
       ...props
     }
 
-    dispatch({ type: 'SetSelectedBlockAction', block })
-    dispatch({ type: 'SetActiveTabAction', activeTab: ActiveTab.Properties })
-    dispatch({ type: 'SetSelectedAttributeIdAction', id: undefined })
+    if (selectedBlock?.id === block.id) {
+      dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Save })
+    } else {
+      dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Edit })
+      dispatch({
+        type: 'SetActiveTabAction',
+        activeTab: ActiveTab.Properties
+      })
+      dispatch({ type: 'SetSelectedBlockAction', block })
+      dispatch({ type: 'SetSelectedAttributeIdAction', id: undefined })
+    }
   }
 
   return (
@@ -63,13 +79,15 @@ export function Button({
       startIcon={startIcon != null ? <Icon {...startIcon} /> : undefined}
       endIcon={endIcon != null ? <Icon {...endIcon} /> : undefined}
       sx={{
+        ...sx,
         outline: selectedBlock?.id === props.id ? '3px solid #C52D3A' : 'none',
-        outlineOffset: '5px'
+        outlineOffset: '5px',
+        minHeight: '36.5px'
       }}
       onClick={selectedBlock === undefined ? handleClick : handleSelectBlock}
       fullWidth
     >
-      {label}
+      {editableLabel ?? label}
     </MuiButton>
   )
 }


### PR DESCRIPTION
# Description

Allow inline editing of the button label. No new line characters allowed in label.

[Basecamp](https://3.basecamp.com/3105655/buckets/26244169/todos/4709748729)

# How should this PR be QA Tested?

- [ ] PR checks pass
**Manual testing**
- [ ] Inline editing of button saved when clicking DONE or within card
- [ ] Text doesn't update when we click in gap between cards
- [ ] Check with Vlad it's ok that the Icon shifts to button edge
- [ ] Icon displayed properly after label saved
- [ ] Start / End Whitespace is not saved
- [ ] New line characters not saved
- [ ] Button without label keeps shape

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
