### PR TITLE
fix: switch back to edit fab when selecting another block

### DIFF
--- a/libs/journeys/ui/src/components/Button/Button.tsx
+++ b/libs/journeys/ui/src/components/Button/Button.tsx
@@ -1,7 +1,7 @@
 import { ReactElement, MouseEvent } from 'react'
 import { useRouter } from 'next/router'
 import MuiButton from '@mui/material/Button'
-import { handleAction, TreeBlock, useEditor, ActiveTab } from '../..'
+import { handleAction, TreeBlock, useEditor, ActiveTab, ActiveFab } from '../..'
 import { IconFields } from '../Icon/__generated__/IconFields'
 import { Icon } from '../Icon'
 import { ButtonFields } from './__generated__/ButtonFields'
@@ -50,9 +50,14 @@ export function Button({
       ...props
     }
 
-    dispatch({ type: 'SetSelectedBlockAction', block })
-    dispatch({ type: 'SetActiveTabAction', activeTab: ActiveTab.Properties })
-    dispatch({ type: 'SetSelectedAttributeIdAction', id: undefined })
+    if (selectedBlock?.id === block.id) {
+      dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Save })
+    } else {
+      dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Edit })
+      dispatch({ type: 'SetActiveTabAction', activeTab: ActiveTab.Properties })
+      dispatch({ type: 'SetSelectedBlockAction', block })
+      dispatch({ type: 'SetSelectedAttributeIdAction', id: undefined })
+    }
   }
 
   return (

--- a/libs/journeys/ui/src/components/Image/Image.tsx
+++ b/libs/journeys/ui/src/components/Image/Image.tsx
@@ -5,7 +5,7 @@ import { Theme } from '@mui/material/styles'
 import Box from '@mui/material/Box'
 import Paper from '@mui/material/Paper'
 import ImageRoundedIcon from '@mui/icons-material/ImageRounded'
-import { TreeBlock, useEditor, ActiveTab } from '../..'
+import { TreeBlock, useEditor, ActiveTab, ActiveFab } from '../..'
 import { ImageFields } from './__generated__/ImageFields'
 
 interface ImageProps extends TreeBlock<ImageFields> {
@@ -37,6 +37,7 @@ export function Image({
     }
 
     dispatch({ type: 'SetSelectedBlockAction', block })
+    dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Edit })
     dispatch({ type: 'SetActiveTabAction', activeTab: ActiveTab.Properties })
     dispatch({ type: 'SetSelectedAttributeIdAction', id: undefined })
   }

--- a/libs/journeys/ui/src/components/Image/Image.tsx
+++ b/libs/journeys/ui/src/components/Image/Image.tsx
@@ -37,7 +37,7 @@ export function Image({
     }
 
     dispatch({ type: 'SetSelectedBlockAction', block })
-    dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Edit })
+    dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Add })
     dispatch({ type: 'SetActiveTabAction', activeTab: ActiveTab.Properties })
     dispatch({ type: 'SetSelectedAttributeIdAction', id: undefined })
   }

--- a/libs/journeys/ui/src/components/RadioQuestion/RadioOption/RadioOption.tsx
+++ b/libs/journeys/ui/src/components/RadioQuestion/RadioOption/RadioOption.tsx
@@ -4,7 +4,13 @@ import Button from '@mui/material/Button'
 import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import { useRouter } from 'next/router'
-import { TreeBlock, handleAction, useEditor, ActiveTab } from '../../..'
+import {
+  TreeBlock,
+  handleAction,
+  useEditor,
+  ActiveTab,
+  ActiveFab
+} from '../../..'
 import { RadioOptionFields } from './__generated__/RadioOptionFields'
 
 export interface RadioOptionProps extends TreeBlock<RadioOptionFields> {
@@ -48,10 +54,21 @@ export function RadioOption({
     const parentSelected = selectedBlock?.id === block.parentBlockId
     const siblingSelected = selectedBlock?.parentBlockId === block.parentBlockId
 
-    if (parentSelected || siblingSelected) {
+    console.log(selectedBlock, block)
+
+    if (selectedBlock?.id === block.id) {
       e.stopPropagation()
+
+      dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Save })
+    } else if (parentSelected || siblingSelected) {
+      e.stopPropagation()
+
+      dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Edit })
+      dispatch({
+        type: 'SetActiveTabAction',
+        activeTab: ActiveTab.Properties
+      })
       dispatch({ type: 'SetSelectedBlockAction', block })
-      dispatch({ type: 'SetActiveTabAction', activeTab: ActiveTab.Properties })
       dispatch({ type: 'SetSelectedAttributeIdAction', id: undefined })
     }
   }

--- a/libs/journeys/ui/src/components/RadioQuestion/RadioOption/RadioOption.tsx
+++ b/libs/journeys/ui/src/components/RadioQuestion/RadioOption/RadioOption.tsx
@@ -54,8 +54,6 @@ export function RadioOption({
     const parentSelected = selectedBlock?.id === block.parentBlockId
     const siblingSelected = selectedBlock?.parentBlockId === block.parentBlockId
 
-    console.log(selectedBlock, block)
-
     if (selectedBlock?.id === block.id) {
       e.stopPropagation()
 

--- a/libs/journeys/ui/src/components/RadioQuestion/RadioQuestion.tsx
+++ b/libs/journeys/ui/src/components/RadioQuestion/RadioQuestion.tsx
@@ -4,7 +4,7 @@ import Box from '@mui/material/Box'
 import ButtonGroup from '@mui/material/ButtonGroup'
 import Typography from '@mui/material/Typography'
 import { useMutation, gql } from '@apollo/client'
-import { TreeBlock, useEditor, ActiveTab } from '../..'
+import { TreeBlock, useEditor, ActiveTab, ActiveFab } from '../..'
 import { RadioOption } from './RadioOption'
 import { RadioQuestionResponseCreate } from './__generated__/RadioQuestionResponseCreate'
 import { RadioQuestionFields } from './__generated__/RadioQuestionFields'
@@ -73,9 +73,14 @@ export function RadioQuestion({
       ...props
     }
 
-    dispatch({ type: 'SetSelectedBlockAction', block })
-    dispatch({ type: 'SetActiveTabAction', activeTab: ActiveTab.Properties })
-    dispatch({ type: 'SetSelectedAttributeIdAction', id: undefined })
+    if (selectedBlock?.id === block.id) {
+      dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Save })
+    } else {
+      dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Edit })
+      dispatch({ type: 'SetActiveTabAction', activeTab: ActiveTab.Properties })
+      dispatch({ type: 'SetSelectedBlockAction', block })
+      dispatch({ type: 'SetSelectedAttributeIdAction', id: undefined })
+    }
   }
 
   return (

--- a/libs/journeys/ui/src/components/SignUp/SignUp.tsx
+++ b/libs/journeys/ui/src/components/SignUp/SignUp.tsx
@@ -5,7 +5,7 @@ import { object, string } from 'yup'
 import { useMutation, gql } from '@apollo/client'
 import Button from '@mui/material/Button'
 import { v4 as uuidv4 } from 'uuid'
-import { TreeBlock, handleAction, useEditor, ActiveTab } from '../..'
+import { TreeBlock, handleAction, useEditor, ActiveTab, ActiveFab } from '../..'
 import { Icon } from '../Icon'
 import { IconFields } from '../Icon/__generated__/IconFields'
 import { SignUpResponseCreate } from './__generated__/SignUpResponseCreate'
@@ -100,9 +100,14 @@ export const SignUp = ({
       ...props
     }
 
-    dispatch({ type: 'SetSelectedBlockAction', block })
-    dispatch({ type: 'SetActiveTabAction', activeTab: ActiveTab.Properties })
-    dispatch({ type: 'SetSelectedAttributeIdAction', id: undefined })
+    if (selectedBlock?.id === block.id) {
+      dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Save })
+    } else {
+      dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Edit })
+      dispatch({ type: 'SetActiveTabAction', activeTab: ActiveTab.Properties })
+      dispatch({ type: 'SetSelectedBlockAction', block })
+      dispatch({ type: 'SetSelectedAttributeIdAction', id: undefined })
+    }
   }
 
   return (

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -4,7 +4,7 @@ import { useMutation, gql } from '@apollo/client'
 import Box from '@mui/material/Box'
 import Paper from '@mui/material/Paper'
 import VideocamRounded from '@mui/icons-material/VideocamRounded'
-import { TreeBlock, useEditor, ActiveTab } from '../..'
+import { TreeBlock, useEditor, ActiveTab, ActiveFab } from '../..'
 import { VideoResponseStateEnum } from '../../../__generated__/globalTypes'
 import { ImageFields } from '../Image/__generated__/ImageFields'
 import { VideoResponseCreate } from './__generated__/VideoResponseCreate'
@@ -154,7 +154,7 @@ export function Video({
 
       dispatch({ type: 'SetSelectedBlockAction', block })
     }
-
+    dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Edit })
     dispatch({
       type: 'SetActiveTabAction',
       activeTab: ActiveTab.Properties

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -154,7 +154,7 @@ export function Video({
 
       dispatch({ type: 'SetSelectedBlockAction', block })
     }
-    dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Edit })
+    dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Add })
     dispatch({
       type: 'SetActiveTabAction',
       activeTab: ActiveTab.Properties


### PR DESCRIPTION
# Description

Previous I added a fab "Done" state #324  &  implemented it with TypographyBlock. This switches between "Edit" and "Done" fab modes when clicking between the other blocks.

There should be no "Done" / Inline edit mode for Video or Image. 

Should be e2e tested later. Only VR changes are the randomly generated thumbnail image changes.

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] PR checks
- [x] Manual testing clicking and double clicking between blocks
- [x] Clicking the Card still changes Fab state back to "Add"

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
