### PR TITLE
feature: set next card 

### DIFF
--- a/apps/journeys-admin/__generated__/StepBlockDefaultNextBlockUpdate.ts
+++ b/apps/journeys-admin/__generated__/StepBlockDefaultNextBlockUpdate.ts
@@ -1,0 +1,32 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { StepBlockUpdateInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: StepBlockDefaultNextBlockUpdate
+// ====================================================
+
+export interface StepBlockDefaultNextBlockUpdate_stepBlockUpdate {
+  __typename: "StepBlock";
+  id: string;
+  /**
+   * nextBlockId contains the preferred block to navigate to when a
+   * NavigateAction occurs or if the user manually tries to advance to the next
+   * step. If no nextBlockId is set it can be assumed that this step represents
+   * the end of the current journey.
+   */
+  nextBlockId: string | null;
+}
+
+export interface StepBlockDefaultNextBlockUpdate {
+  stepBlockUpdate: StepBlockDefaultNextBlockUpdate_stepBlockUpdate;
+}
+
+export interface StepBlockDefaultNextBlockUpdateVariables {
+  id: string;
+  journeyId: string;
+  input: StepBlockUpdateInput;
+}

--- a/apps/journeys-admin/__generated__/StepBlockNextBlockUpdate.ts
+++ b/apps/journeys-admin/__generated__/StepBlockNextBlockUpdate.ts
@@ -1,0 +1,32 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { StepBlockUpdateInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: StepBlockNextBlockUpdate
+// ====================================================
+
+export interface StepBlockNextBlockUpdate_stepBlockUpdate {
+  __typename: "StepBlock";
+  id: string;
+  /**
+   * nextBlockId contains the preferred block to navigate to when a
+   * NavigateAction occurs or if the user manually tries to advance to the next
+   * step. If no nextBlockId is set it can be assumed that this step represents
+   * the end of the current journey.
+   */
+  nextBlockId: string | null;
+}
+
+export interface StepBlockNextBlockUpdate {
+  stepBlockUpdate: StepBlockNextBlockUpdate_stepBlockUpdate;
+}
+
+export interface StepBlockNextBlockUpdateVariables {
+  id: string;
+  journeyId: string;
+  input: StepBlockUpdateInput;
+}

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/Cards.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/Cards.spec.tsx
@@ -1,0 +1,86 @@
+import { MockedProvider } from '@apollo/client/testing'
+import { EditorProvider, TreeBlock } from '@core/journeys/ui'
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import { JourneyProvider } from '../../../../../../../../libs/context'
+import {
+  GetJourney_journey_blocks_StepBlock as StepBlock,
+  GetJourney_journey as Journey
+} from '../../../../../../../../../__generated__/GetJourney'
+import {
+  ThemeName,
+  ThemeMode
+} from '../../../../../../../../../__generated__/globalTypes'
+import { Cards, STEP_BLOCK_NEXT_BLOCK_UPDATE } from './Cards'
+
+describe('Cards', () => {
+  it('updates the next step on click', async () => {
+    const selectedBlock: TreeBlock<StepBlock> = {
+      id: 'step1.id',
+      __typename: 'StepBlock',
+      parentBlockId: null,
+      nextBlockId: 'step2.id',
+      parentOrder: 0,
+      locked: false,
+      children: []
+    }
+
+    const nextBlock: TreeBlock<StepBlock> = {
+      id: 'step2.id',
+      __typename: 'StepBlock',
+      parentBlockId: null,
+      nextBlockId: 'step0.id',
+      parentOrder: 0,
+      locked: false,
+      children: []
+    }
+
+    const steps = [selectedBlock, nextBlock]
+
+    const result = jest.fn(() => ({
+      data: {
+        stepBlockUpdate: {
+          id: 'step1.id',
+          journeyId: 'journeyId',
+          nextBlockId: 'step2.id'
+        }
+      }
+    }))
+
+    const { getByTestId } = render(
+      <MockedProvider
+        mocks={[
+          {
+            request: {
+              query: STEP_BLOCK_NEXT_BLOCK_UPDATE,
+              variables: {
+                id: selectedBlock.id,
+                journeyId: 'journeyId',
+                input: {
+                  nextBlockId: selectedBlock.nextBlockId
+                }
+              }
+            },
+            result
+          }
+        ]}
+      >
+        <JourneyProvider
+          value={
+            {
+              id: 'journeyId',
+              themeMode: ThemeMode.light,
+              themeName: ThemeName.base
+            } as unknown as Journey
+          }
+        >
+          <EditorProvider initialState={{ steps, selectedBlock }}>
+            <Cards />
+          </EditorProvider>
+        </JourneyProvider>
+      </MockedProvider>
+    )
+
+    fireEvent.click(getByTestId('preview-step2.id'))
+    await waitFor(() => expect(result).toHaveBeenCalled())
+  })
+})

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/Cards.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/Cards.spec.tsx
@@ -40,7 +40,6 @@ describe('Cards', () => {
       data: {
         stepBlockUpdate: {
           id: 'step1.id',
-          journeyId: 'journeyId',
           nextBlockId: 'step2.id'
         }
       }

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/Cards.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/Cards.tsx
@@ -29,10 +29,10 @@ export function Cards(): ReactElement {
     state: { steps, selectedBlock }
   } = useEditor()
   const journey = useJourney()
-  const { id } = selectedBlock
+  const { id, nextBlockId } = selectedBlock as TreeBlock<StepFields>
 
   const nextStep: TreeBlock<StepFields> | undefined = steps.find(
-    ({ id }) => selectedBlock.nextBlockId === id
+    ({ id }) => nextBlockId === id
   )
 
   async function handleSelectStep(step: TreeBlock<StepFields>): Promise<void> {
@@ -47,7 +47,6 @@ export function Cards(): ReactElement {
       optimisticResponse: {
         stepBlockUpdate: {
           id,
-          journeyId: journey.id,
           __typename: 'StepBlock',
           nextBlockId: step.id
         }

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/Cards.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/Cards.tsx
@@ -1,0 +1,72 @@
+import { ReactElement } from 'react'
+import { gql, useMutation } from '@apollo/client'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import { useEditor, TreeBlock } from '@core/journeys/ui'
+import { useJourney } from '../../../../../../../../libs/context'
+import { StepFields } from '../../../../../../../../../__generated__/StepFields'
+import { StepBlockNextBlockUpdate } from '../../../../../../../../../__generated__/StepBlockNextBlockUpdate'
+import { CardPreview } from '../../../../../../../CardPreview'
+
+export const STEP_BLOCK_NEXT_BLOCK_UPDATE = gql`
+  mutation StepBlockNextBlockUpdate(
+    $id: ID!
+    $journeyId: ID!
+    $input: StepBlockUpdateInput!
+  ) {
+    stepBlockUpdate(id: $id, journeyId: $journeyId, input: $input) {
+      id
+      nextBlockId
+    }
+  }
+`
+
+export function Cards(): ReactElement {
+  const [stepBlockNextBlockUpdate] = useMutation<StepBlockNextBlockUpdate>(
+    STEP_BLOCK_NEXT_BLOCK_UPDATE
+  )
+  const {
+    state: { steps, selectedBlock }
+  } = useEditor()
+  const journey = useJourney()
+  const { id } = selectedBlock
+
+  const nextStep: TreeBlock<StepFields> | undefined = steps.find(
+    ({ id }) => selectedBlock.nextBlockId === id
+  )
+
+  async function handleSelectStep(step: TreeBlock<StepFields>): Promise<void> {
+    await stepBlockNextBlockUpdate({
+      variables: {
+        id,
+        journeyId: journey.id,
+        input: {
+          nextBlockId: step.id
+        }
+      },
+      optimisticResponse: {
+        stepBlockUpdate: {
+          id,
+          journeyId: journey.id,
+          __typename: 'StepBlock',
+          nextBlockId: step.id
+        }
+      }
+    })
+  }
+
+  return (
+    <>
+      <Box sx={{ px: 6, py: 4 }}>
+        <Typography variant="subtitle2" gutterBottom>
+          Cards
+        </Typography>
+      </Box>
+      <CardPreview
+        selected={nextStep}
+        steps={steps}
+        onSelect={handleSelectStep}
+      />
+    </>
+  )
+}

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/Cards.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/Cards.tsx
@@ -1,4 +1,5 @@
 import { ReactElement } from 'react'
+import { useTheme } from '@mui/material'
 import { gql, useMutation } from '@apollo/client'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
@@ -29,6 +30,7 @@ export function Cards(): ReactElement {
     state: { steps, selectedBlock }
   } = useEditor()
   const journey = useJourney()
+  const theme = useTheme()
   const { id, nextBlockId } = selectedBlock as TreeBlock<StepFields>
 
   const nextStep: TreeBlock<StepFields> | undefined = steps.find(
@@ -56,8 +58,11 @@ export function Cards(): ReactElement {
 
   return (
     <>
-      <Box sx={{ px: 6, py: 4 }}>
-        <Typography variant="subtitle2" gutterBottom>
+      <Box sx={{ pl: 6, pr: 4, pt: 4 }}>
+        <Typography
+          variant="subtitle2"
+          sx={{ [theme.breakpoints.down('sm')]: { display: 'none' } }}
+        >
           Cards
         </Typography>
       </Box>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/index.ts
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/index.ts
@@ -1,0 +1,1 @@
+export { Cards } from './Cards'

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/index.ts
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/index.ts
@@ -1,1 +1,1 @@
-export { Cards } from './Cards'
+export { Cards, STEP_BLOCK_NEXT_BLOCK_UPDATE } from './Cards'

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Conditions/Conditions.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Conditions/Conditions.spec.tsx
@@ -1,0 +1,63 @@
+import { MockedProvider } from '@apollo/client/testing'
+import { EditorProvider, TreeBlock } from '@core/journeys/ui'
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import { JourneyProvider } from '../../../../../../../../libs/context'
+import {
+  GetJourney_journey_blocks_StepBlock as StepBlock,
+  GetJourney_journey as Journey
+} from '../../../../../../../../../__generated__/GetJourney'
+import { Conditions, STEP_BLOCK_LOCK_UPDATE } from './Conditions'
+
+describe('Conditions', () => {
+  it('changes the locked step state on click', async () => {
+    const selectedBlock: TreeBlock<StepBlock> = {
+      id: 'step1.id',
+      __typename: 'StepBlock',
+      parentBlockId: null,
+      nextBlockId: 'step2.id',
+      parentOrder: 0,
+      locked: false,
+      children: []
+    }
+
+    const result = jest.fn(() => ({
+      data: {
+        stepBlockUpdate: {
+          id: 'step1.id',
+          journeyId: 'journeyId',
+          locked: false
+        }
+      }
+    }))
+
+    const { getByRole } = render(
+      <MockedProvider
+        mocks={[
+          {
+            request: {
+              query: STEP_BLOCK_LOCK_UPDATE,
+              variables: {
+                id: selectedBlock.id,
+                journeyId: 'journeyId',
+                input: {
+                  locked: true
+                }
+              }
+            },
+            result
+          }
+        ]}
+      >
+        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+          <EditorProvider initialState={{ selectedBlock }}>
+            <Conditions />
+          </EditorProvider>
+        </JourneyProvider>
+      </MockedProvider>
+    )
+
+    expect(getByRole('checkbox')).not.toBeChecked()
+    fireEvent.click(getByRole('checkbox'))
+    await waitFor(() => expect(result).toHaveBeenCalled())
+  })
+})

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Conditions/Conditions.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Conditions/Conditions.spec.tsx
@@ -24,7 +24,6 @@ describe('Conditions', () => {
       data: {
         stepBlockUpdate: {
           id: 'step1.id',
-          journeyId: 'journeyId',
           locked: false
         }
       }

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Conditions/Conditions.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Conditions/Conditions.tsx
@@ -1,0 +1,77 @@
+import { ReactElement } from 'react'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import { gql, useMutation } from '@apollo/client'
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
+import { TreeBlock, useEditor } from '@core/journeys/ui'
+import { useJourney } from '../../../../../../../../libs/context'
+import { StepFields } from '../../../../../../../../../__generated__/StepFields'
+
+import { StepBlockLockUpdate } from '../../../../../../../../../__generated__/StepBlockLockUpdate'
+import { ToggleOption } from '../../../../ToggleOption'
+
+export const STEP_BLOCK_LOCK_UPDATE = gql`
+  mutation StepBlockLockUpdate(
+    $id: ID!
+    $journeyId: ID!
+    $input: StepBlockUpdateInput!
+  ) {
+    stepBlockUpdate(id: $id, journeyId: $journeyId, input: $input) {
+      id
+      locked
+    }
+  }
+`
+
+export function Conditions(): ReactElement {
+  const [stepBlockLockUpdate] = useMutation<StepBlockLockUpdate>(
+    STEP_BLOCK_LOCK_UPDATE
+  )
+  const {
+    state: { selectedBlock }
+  } = useEditor()
+  const journey = useJourney()
+  const { id, locked } = selectedBlock as TreeBlock<StepFields>
+
+  async function handleChange(): Promise<void> {
+    await stepBlockLockUpdate({
+      variables: {
+        id,
+        journeyId: journey.id,
+        input: {
+          locked: !locked
+        }
+      },
+      optimisticResponse: {
+        stepBlockUpdate: {
+          id,
+          journeyId: journey.id,
+          __typename: 'StepBlock',
+          locked: !locked
+        }
+      }
+    })
+  }
+
+  return (
+    <Box sx={{ px: 6, py: 4 }}>
+      <Typography variant="subtitle2" gutterBottom>
+        Conditions
+      </Typography>
+      <ToggleOption
+        heading={'Lock the next step'}
+        description={"Don't allow to skip the current card"}
+        checked={selectedBlock.locked}
+        handleChange={handleChange}
+      >
+        <Box display={'flex'} alignItems={'center'} color={'text.secondary'}>
+          <InfoOutlinedIcon sx={{ mr: 4 }} />
+          <Typography variant="caption">
+            User can&apos;t skip interaction on the current card, like watching
+            video or interacting with questions.
+          </Typography>
+        </Box>
+      </ToggleOption>
+    </Box>
+  )
+}

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Conditions/Conditions.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Conditions/Conditions.tsx
@@ -45,7 +45,6 @@ export function Conditions(): ReactElement {
       optimisticResponse: {
         stepBlockUpdate: {
           id,
-          journeyId: journey.id,
           __typename: 'StepBlock',
           locked: !locked
         }
@@ -61,7 +60,7 @@ export function Conditions(): ReactElement {
       <ToggleOption
         heading={'Lock the next step'}
         description={"Don't allow to skip the current card"}
-        checked={selectedBlock.locked}
+        checked={locked}
         handleChange={handleChange}
       >
         <Box display={'flex'} alignItems={'center'} color={'text.secondary'}>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Conditions/Conditions.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Conditions/Conditions.tsx
@@ -1,4 +1,5 @@
 import { ReactElement } from 'react'
+import { useTheme } from '@mui/material'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { gql, useMutation } from '@apollo/client'
@@ -31,36 +32,41 @@ export function Conditions(): ReactElement {
     state: { selectedBlock }
   } = useEditor()
   const journey = useJourney()
-  const { id, locked } = selectedBlock as TreeBlock<StepFields>
+  const theme = useTheme()
+  const block = selectedBlock as TreeBlock<StepFields>
 
   async function handleChange(): Promise<void> {
     await stepBlockLockUpdate({
       variables: {
-        id,
+        id: block.id,
         journeyId: journey.id,
         input: {
-          locked: !locked
+          locked: !block.locked
         }
       },
       optimisticResponse: {
         stepBlockUpdate: {
-          id,
+          id: block.id,
           __typename: 'StepBlock',
-          locked: !locked
+          locked: !block.locked
         }
       }
     })
   }
 
   return (
-    <Box sx={{ px: 6, py: 4 }}>
-      <Typography variant="subtitle2" gutterBottom>
+    <Box sx={{ p: 4, pl: 6 }}>
+      <Typography
+        variant="subtitle2"
+        gutterBottom
+        sx={{ [theme.breakpoints.down('sm')]: { display: 'none' }, mb: 4 }}
+      >
         Conditions
       </Typography>
       <ToggleOption
         heading={'Lock the next step'}
         description={"Don't allow to skip the current card"}
-        checked={locked}
+        checked={block.locked}
         handleChange={handleChange}
       >
         <Box display={'flex'} alignItems={'center'} color={'text.secondary'}>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Conditions/index.ts
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Conditions/index.ts
@@ -1,0 +1,1 @@
+export { Conditions } from './Conditions'

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/NextCard.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/NextCard.spec.tsx
@@ -1,11 +1,19 @@
 import { MockedProvider } from '@apollo/client/testing'
 import { EditorProvider, TreeBlock } from '@core/journeys/ui'
-import { fireEvent, render, waitFor } from '@testing-library/react'
-import { GetJourney_journey_blocks_StepBlock as StepBlock } from '../../../../../../../../__generated__/GetJourney'
-import { NextCard, STEP_BLOCK_LOCK_UPDATE } from './NextCard'
+import { fireEvent, render } from '@testing-library/react'
+import { JourneyProvider } from '../../../../../../../libs/context'
+import {
+  GetJourney_journey_blocks_StepBlock as StepBlock,
+  GetJourney_journey as Journey
+} from '../../../../../../../../__generated__/GetJourney'
+import {
+  ThemeName,
+  ThemeMode
+} from '../../../../../../../../__generated__/globalTypes'
+import { NextCard } from './NextCard'
 
 describe('NextCard', () => {
-  it('changes the locked step state on click', async () => {
+  it('changes between cards and conditions tabs', () => {
     const selectedBlock: TreeBlock<StepBlock> = {
       id: 'step1.id',
       __typename: 'StepBlock',
@@ -16,41 +24,41 @@ describe('NextCard', () => {
       children: []
     }
 
-    const result = jest.fn(() => ({
-      data: {
-        stepBlockUpdate: {
-          id: 'step1.id',
-          locked: false
-        }
-      }
-    }))
-
     const { getByRole } = render(
-      <MockedProvider
-        mocks={[
-          {
-            request: {
-              query: STEP_BLOCK_LOCK_UPDATE,
-              variables: {
-                id: selectedBlock.id,
-                input: {
-                  locked: true,
-                  nextBlockId: selectedBlock.nextBlockId
-                }
-              }
-            },
-            result
+      <MockedProvider>
+        <JourneyProvider
+          value={
+            {
+              id: 'journeyId',
+              themeMode: ThemeMode.light,
+              themeName: ThemeName.base
+            } as unknown as Journey
           }
-        ]}
-      >
-        <EditorProvider initialState={{ selectedBlock }}>
-          <NextCard id="step1.id" />
-        </EditorProvider>
+        >
+          <EditorProvider initialState={{ selectedBlock }}>
+            <NextCard />
+          </EditorProvider>
+        </JourneyProvider>
       </MockedProvider>
     )
 
-    expect(getByRole('checkbox')).not.toBeChecked()
-    fireEvent.click(getByRole('checkbox'))
-    await waitFor(() => expect(result).toHaveBeenCalled())
+    expect(getByRole('tab', { name: 'Cards' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+
+    fireEvent.click(getByRole('tab', { name: 'Conditions' }))
+
+    expect(getByRole('tab', { name: 'Conditions' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+
+    fireEvent.click(getByRole('tab', { name: 'Cards' }))
+
+    expect(getByRole('tab', { name: 'Cards' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
   })
 })

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/NextCard.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/NextCard.stories.tsx
@@ -2,8 +2,19 @@ import { Story, Meta } from '@storybook/react'
 import { EditorProvider, TreeBlock } from '@core/journeys/ui'
 import { MockedProvider } from '@apollo/client/testing'
 import { Drawer } from '../../../../../Drawer'
+import { JourneyProvider } from '../../../../../../../libs/context'
 import { journeysAdminConfig } from '../../../../../../../libs/storybook'
-import { GetJourney_journey_blocks_StepBlock as StepBlock } from '../../../../../../../../__generated__/GetJourney'
+import {
+  ThemeName,
+  ThemeMode,
+  TypographyVariant,
+  TypographyAlign
+} from '../../../../../../../../__generated__/globalTypes'
+import {
+  GetJourney_journey_blocks_CardBlock as CardBlock,
+  GetJourney_journey_blocks_StepBlock as StepBlock,
+  GetJourney_journey as Journey
+} from '../../../../../../../../__generated__/GetJourney'
 import { NextCard } from '.'
 
 const NextCardStory = {
@@ -12,30 +23,87 @@ const NextCardStory = {
   component: NextCard
 }
 
-export const Default: Story = () => {
-  const selectedBlock: TreeBlock<StepBlock> = {
-    id: 'step1.id',
-    __typename: 'StepBlock',
-    parentBlockId: null,
-    nextBlockId: null,
+const card = (index: number): TreeBlock<CardBlock> => {
+  return {
+    id: `card${index}.id`,
+    __typename: 'CardBlock',
+    parentBlockId: `step${index}.id`,
     parentOrder: 0,
-    locked: false,
-    children: []
+    backgroundColor: '#DDDDDD',
+    coverBlockId: null,
+    fullscreen: false,
+    themeMode: null,
+    themeName: null,
+    children: [
+      {
+        id: `typography${index}.id`,
+        __typename: 'TypographyBlock',
+        parentBlockId: `card${index}.id`,
+        parentOrder: 0,
+        align: TypographyAlign.center,
+        color: null,
+        content: `Card ${index + 1}`,
+        variant: TypographyVariant.h1,
+        children: []
+      }
+    ]
   }
+}
+
+const selectedBlock: TreeBlock<StepBlock> = {
+  id: 'step0.id',
+  __typename: 'StepBlock',
+  parentBlockId: null,
+  nextBlockId: 'step1.id',
+  parentOrder: 0,
+  locked: true,
+  children: [card(0)]
+}
+
+const noSelectedBlock: TreeBlock<StepBlock> = {
+  id: 'step1.id',
+  __typename: 'StepBlock',
+  parentBlockId: null,
+  nextBlockId: null,
+  parentOrder: 0,
+  locked: false,
+  children: [card(1)]
+}
+
+const journeyTheme = {
+  id: 'journeyId',
+  themeMode: ThemeMode.light,
+  themeName: ThemeName.base
+} as unknown as Journey
+
+const Template: Story = ({ ...args }) => {
   return (
     <MockedProvider>
-      <EditorProvider
-        initialState={{
-          selectedBlock,
-          drawerChildren: <NextCard id={selectedBlock.id} />,
-          drawerTitle: 'Next Card Properties',
-          drawerMobileOpen: true
-        }}
-      >
-        <Drawer />
-      </EditorProvider>
+      <JourneyProvider value={journeyTheme}>
+        <EditorProvider
+          initialState={{
+            ...args,
+            steps: [selectedBlock, noSelectedBlock],
+            drawerTitle: 'Next Card Properties',
+            drawerChildren: <NextCard />,
+            drawerMobileOpen: true
+          }}
+        >
+          <Drawer />
+        </EditorProvider>
+      </JourneyProvider>
     </MockedProvider>
   )
+}
+
+export const Default = Template.bind({})
+Default.args = {
+  selectedBlock: noSelectedBlock
+}
+
+export const Selected = Template.bind({})
+Selected.args = {
+  selectedBlock: selectedBlock
 }
 
 export default NextCardStory as Meta

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/NextCard.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/NextCard.tsx
@@ -1,84 +1,56 @@
-import { ReactElement } from 'react'
+import { ReactElement, useState } from 'react'
 import Box from '@mui/material/Box'
-import Typography from '@mui/material/Typography'
-import { gql, useMutation } from '@apollo/client'
-import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
-import { useEditor } from '@core/journeys/ui'
-import { useJourney } from '../../../../../../../libs/context'
-import { StepBlockLockUpdate } from '../../../../../../../../__generated__/StepBlockLockUpdate'
-import { ToggleOption } from '../../../ToggleOption'
+import Divider from '@mui/material/Divider'
+import Tab from '@mui/material/Tab'
+import Tabs from '@mui/material/Tabs'
+import { useTheme } from '@mui/material'
+import { TabPanel, tabA11yProps } from '@core/shared/ui'
+import { Conditions } from './Conditions'
+import { Cards } from './Cards'
+import { SelectedCard } from './SelectedCard'
 
-export const STEP_BLOCK_LOCK_UPDATE = gql`
-  mutation StepBlockLockUpdate(
-    $id: ID!
-    $journeyId: ID!
-    $input: StepBlockUpdateInput!
-  ) {
-    stepBlockUpdate(id: $id, journeyId: $journeyId, input: $input) {
-      id
-      locked
-    }
-  }
-`
+export function NextCard(): ReactElement {
+  const theme = useTheme()
+  const [tabValue, setTabValue] = useState(0)
 
-interface NextCardProps {
-  id: string
-}
-
-export function NextCard({ id }: NextCardProps): ReactElement {
-  const [stepBlockLockUpdate] = useMutation<StepBlockLockUpdate>(
-    STEP_BLOCK_LOCK_UPDATE
-  )
-  const {
-    state: { selectedBlock }
-  } = useEditor()
-
-  const stepBlock =
-    selectedBlock?.__typename === 'StepBlock' ? selectedBlock : null
-
-  const journey = useJourney()
-
-  async function handleChange(): Promise<void> {
-    if (stepBlock != null) {
-      await stepBlockLockUpdate({
-        variables: {
-          id,
-          journeyId: journey.id,
-          input: {
-            locked: !stepBlock.locked,
-            nextBlockId: stepBlock.nextBlockId
-          }
-        },
-        optimisticResponse: {
-          stepBlockUpdate: {
-            id,
-            __typename: 'StepBlock',
-            locked: !stepBlock.locked
-          }
-        }
-      })
-    }
+  const handleTabChange = (event, newValue): void => {
+    setTabValue(newValue)
   }
 
   return (
-    <Box sx={{ px: 6, py: 4 }}>
-      <Typography variant="subtitle2" gutterBottom>
-        Conditions
-      </Typography>
-      <ToggleOption
-        heading={'Lock the next step'}
-        description={"Don't allow to skip the current card"}
-        checked={stepBlock?.locked ?? false}
-        handleChange={handleChange}
+    <>
+      <SelectedCard />
+      <Box
+        sx={{
+          [theme.breakpoints.up('sm')]: {
+            display: 'none'
+          }
+        }}
       >
-        <Box display={'flex'} alignItems={'center'} color={'text.secondary'}>
-          <InfoOutlinedIcon sx={{ mr: 4 }} />
-          <Typography variant="caption">
-            User can&apos;t skip interaction on the current card, like watching
-            video or interacting with questions.
-          </Typography>
-        </Box>
-      </ToggleOption>
-    </Box>
+        <Tabs
+          value={tabValue}
+          onChange={handleTabChange}
+          aria-label="next card tabs"
+          centered
+          variant="fullWidth"
+        >
+          <Tab label="Cards" {...tabA11yProps('cardSelection', 0)} />
+          <Tab label="Conditions" {...tabA11yProps('cardConditions', 1)} />
+        </Tabs>
+        <Divider />
+        <TabPanel name="nextCardSelection" value={tabValue} index={0}>
+          <Cards />
+        </TabPanel>
+        <TabPanel name="cardConditions" value={tabValue} index={1}>
+          <Conditions />
+        </TabPanel>
+      </Box>
+      <Box sx={{ [theme.breakpoints.down('sm')]: { display: 'none' } }}>
+        <Divider />
+        <Cards />
+        <Divider />
+        <Conditions />
+      </Box>
+    </>
   )
 }

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/SelectedCard.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/SelectedCard.spec.tsx
@@ -1,0 +1,89 @@
+import { MockedProvider } from '@apollo/client/testing'
+import { EditorProvider, TreeBlock } from '@core/journeys/ui'
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import { JourneyProvider } from '../../../../../../../../libs/context'
+import {
+  GetJourney_journey_blocks_StepBlock as StepBlock,
+  GetJourney_journey as Journey
+} from '../../../../../../../../../__generated__/GetJourney'
+import {
+  ThemeName,
+  ThemeMode
+} from '../../../../../../../../../__generated__/globalTypes'
+import { SelectedCard, STEP_BLOCK_DEFAULT_NEXT_BLOCK_UPDATE } from '.'
+
+describe('Selected Card', () => {
+  const selectedBlock: TreeBlock<StepBlock> = {
+    id: 'step0.id',
+    nextBlockId: 'step2.id',
+    parentBlockId: null,
+    __typename: 'StepBlock',
+    parentOrder: 0,
+    locked: false,
+    children: []
+  }
+
+  const nextBlock: TreeBlock<StepBlock> = {
+    ...selectedBlock,
+    id: 'step1.id',
+    nextBlockId: 'step2.id'
+  }
+
+  const lastBlock: TreeBlock<StepBlock> = {
+    ...selectedBlock,
+    id: 'step2.id',
+    nextBlockId: 'step0.id'
+  }
+
+  const steps = [selectedBlock, nextBlock, lastBlock]
+
+  console.log('STEPS', steps)
+
+  it('updates nextBlockId to the step itself on remove button click', async () => {
+    const result = jest.fn(() => ({
+      data: {
+        stepBlockUpdate: {
+          id: 'step0.id',
+          nextBlockId: 'step0.id'
+        }
+      }
+    }))
+
+    const { getByTestId } = render(
+      <MockedProvider
+        mocks={[
+          {
+            request: {
+              query: STEP_BLOCK_DEFAULT_NEXT_BLOCK_UPDATE,
+              variables: {
+                id: selectedBlock.id,
+                journeyId: 'journeyId',
+                input: {
+                  nextBlockId: selectedBlock.id
+                }
+              }
+            },
+            result
+          }
+        ]}
+      >
+        <JourneyProvider
+          value={
+            {
+              id: 'journeyId',
+              themeMode: ThemeMode.light,
+              themeName: ThemeName.base
+            } as unknown as Journey
+          }
+        >
+          <EditorProvider initialState={{ steps, selectedBlock }}>
+            <SelectedCard />
+          </EditorProvider>
+        </JourneyProvider>
+      </MockedProvider>
+    )
+
+    fireEvent.click(getByTestId('removeCustomNextStep'))
+    await waitFor(() => expect(result).toHaveBeenCalled())
+  })
+})

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/SelectedCard.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/SelectedCard.tsx
@@ -1,0 +1,130 @@
+import { ReactElement, useState, useEffect } from 'react'
+import { gql, useMutation } from '@apollo/client'
+import Box from '@mui/material/Box'
+import IconButton from '@mui/material/IconButton'
+import Typography from '@mui/material/Typography'
+import Stack from '@mui/material/Stack'
+import RemoveCircleOutlineRoundedIcon from '@mui/icons-material/RemoveCircleOutlineRounded'
+import LockRoundedIcon from '@mui/icons-material/LockRounded'
+import { ThemeProvider } from '@core/shared/ui'
+import { useEditor, TreeBlock, BlockRenderer } from '@core/journeys/ui'
+import { useJourney } from '../../../../../../../../libs/context'
+import { StepFields } from '../../../../../../../../../__generated__/StepFields'
+import { StepBlockNextBlockUpdate } from '../../../../../../../../../__generated__/StepBlockNextBlockUpdate'
+import { FramePortal } from '../../../../../../../FramePortal'
+
+export const STEP_BLOCK_DEFAULT_NEXT_BLOCK_UPDATE = gql`
+  mutation StepBlockDefaultNextBlockUpdate(
+    $id: ID!
+    $journeyId: ID!
+    $input: StepBlockUpdateInput!
+  ) {
+    stepBlockUpdate(id: $id, journeyId: $journeyId, input: $input) {
+      id
+      nextBlockId
+    }
+  }
+`
+
+export function SelectedCard(): ReactElement {
+  const [stepBlockDefaultNextBlockUpdate] =
+    useMutation<StepBlockNextBlockUpdate>(STEP_BLOCK_DEFAULT_NEXT_BLOCK_UPDATE)
+  const {
+    state: { steps, selectedBlock }
+  } = useEditor()
+  const journey = useJourney()
+  const { id, nextBlockId, locked } = selectedBlock as TreeBlock<StepFields>
+  const [nextStep, setNextStep] = useState(
+    steps.find((step) => nextBlockId === step.id)
+  )
+
+  useEffect(() => {
+    setNextStep(steps.find((step) => nextBlockId === step.id))
+  }, [steps, nextBlockId])
+
+  // TODO: Set as block itself for now, still need to manually set next block
+  async function handleRemoveCustomNextStep(): Promise<void> {
+    await stepBlockDefaultNextBlockUpdate({
+      variables: {
+        id,
+        journeyId: journey.id,
+        input: {
+          nextBlockId: id
+        }
+      },
+      optimisticResponse: {
+        stepBlockUpdate: {
+          id,
+          __typename: 'StepBlock',
+          nextBlockId: id
+        }
+      }
+    })
+  }
+
+  return (
+    <Stack
+      direction="row"
+      justifyContent="space-between"
+      alignItems={'center'}
+      sx={{ p: 4, pl: 6 }}
+    >
+      <Stack direction="row" spacing={4}>
+        <Box
+          id={id}
+          key={id}
+          data-testid={`next-step-${id}`}
+          sx={{
+            width: 58,
+            height: 90
+          }}
+        >
+          <Box
+            sx={{
+              transform: 'scale(0.16)',
+              transformOrigin: 'top left'
+            }}
+          >
+            <FramePortal width={380} height={560}>
+              <ThemeProvider
+                themeName={journey.themeName}
+                themeMode={journey.themeMode}
+              >
+                <Box sx={{ p: 4, height: '100%' }}>
+                  <BlockRenderer
+                    block={
+                      nextStep != null
+                        ? nextStep
+                        : (selectedBlock as TreeBlock<StepFields>)
+                    }
+                  />
+                </Box>
+              </ThemeProvider>
+            </FramePortal>
+          </Box>
+        </Box>
+        <Stack direction="column" justifyContent="center">
+          <Typography variant="subtitle2">Selected Step</Typography>
+          {locked && (
+            <Stack direction="row" spacing={1}>
+              <LockRoundedIcon
+                sx={{ fontSize: '18px', color: 'secondary.light' }}
+              />
+              <Typography variant="caption" sx={{ color: 'secondary.light' }}>
+                Locked With Interaction
+              </Typography>
+            </Stack>
+          )}
+        </Stack>
+      </Stack>
+      {nextStep != null && nextStep.id !== id && (
+        <IconButton
+          onClick={handleRemoveCustomNextStep}
+          data-testId="removeCustomNextStep"
+        >
+          <RemoveCircleOutlineRoundedIcon color="primary" />
+        </IconButton>
+      )}
+    </Stack>
+  )
+}

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/index.ts
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/index.ts
@@ -1,0 +1,4 @@
+export {
+  SelectedCard,
+  STEP_BLOCK_DEFAULT_NEXT_BLOCK_UPDATE
+} from './SelectedCard'

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.spec.tsx
@@ -1,7 +1,15 @@
 import { TreeBlock, EditorProvider } from '@core/journeys/ui'
 import { render, fireEvent } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
-import { GetJourney_journey_blocks_StepBlock as StepBlock } from '../../../../../../../__generated__/GetJourney'
+import { JourneyProvider } from '../../../../../../libs/context'
+import {
+  GetJourney_journey_blocks_StepBlock as StepBlock,
+  GetJourney_journey as Journey
+} from '../../../../../../../__generated__/GetJourney'
+import {
+  ThemeName,
+  ThemeMode
+} from '../../../../../../../__generated__/globalTypes'
 import { Drawer } from '../../../../Drawer'
 import { ThemeProvider } from '../../../../../ThemeProvider'
 import { Step } from '.'
@@ -36,10 +44,20 @@ describe('Step', () => {
       const { getByText } = render(
         <MockedProvider>
           <ThemeProvider>
-            <EditorProvider initialState={{ selectedBlock: step }}>
-              <Drawer />
-              <Step {...step} />
-            </EditorProvider>
+            <JourneyProvider
+              value={
+                {
+                  id: 'journeyId',
+                  themeMode: ThemeMode.light,
+                  themeName: ThemeName.base
+                } as unknown as Journey
+              }
+            >
+              <EditorProvider initialState={{ selectedBlock: step }}>
+                <Drawer />
+                <Step {...step} />
+              </EditorProvider>
+            </JourneyProvider>
           </ThemeProvider>
         </MockedProvider>
       )

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.tsx
@@ -39,14 +39,12 @@ export function Step({
       }
       description={locked ? 'Locked With Interaction' : 'Unlocked Card'}
       onClick={() => {
-        if (nextBlock != null) {
-          dispatch({
-            type: 'SetDrawerPropsAction',
-            title: 'Next Card Properties',
-            mobileOpen: true,
-            children: <NextCard />
-          })
-        }
+        dispatch({
+          type: 'SetDrawerPropsAction',
+          title: 'Next Card Properties',
+          mobileOpen: true,
+          children: <NextCard />
+        })
       }}
     />
   )

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.tsx
@@ -39,12 +39,14 @@ export function Step({
       }
       description={locked ? 'Locked With Interaction' : 'Unlocked Card'}
       onClick={() => {
-        dispatch({
-          type: 'SetDrawerPropsAction',
-          title: 'Next Card Properties',
-          mobileOpen: true,
-          children: <NextCard id={id} />
-        })
+        if (nextBlock != null) {
+          dispatch({
+            type: 'SetDrawerPropsAction',
+            title: 'Next Card Properties',
+            mobileOpen: true,
+            children: <NextCard />
+          })
+        }
       }}
     />
   )


### PR DESCRIPTION
# Description

Allows us to set the next card. Slightly different functionality after talking to Vlad:

On creation of a new card, `nextBlockId` is set as null. In this case, Vlad wants us to show the nextBlockId is the card itself. 
When the step itself is selected it will display like:
<img width="338" alt="image" src="https://user-images.githubusercontent.com/10802634/157785327-87b2e899-ff92-4ad9-9fd6-786aa04f19ab.png">

When another step is selected, we'll add a remove button:
<img width="338" alt="image" src="https://user-images.githubusercontent.com/10802634/157785398-37d2be80-a936-4b7a-b89f-e665a75a1ee3.png">

There will no longer be this placeholder state. 
<img width="316" alt="image" src="https://user-images.githubusercontent.com/10802634/157785457-e1933d41-725c-45d4-bbbd-6fdedfb96535.png">

[Basecamp](https://3.basecamp.com/3105655/buckets/26244169/todos/4632660680)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] PR checks
## Manual testing:
- [ ] New steps created are self-selected
- [ ] We can change the next step to another step
- [ ] Clicking on the remove button self-selects the step
- [ ] Clicking on the locked toggle works displays the locked text in Select Card display

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
