### PR TITLE
fix: blockDelete null parentBlockId

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -375,7 +375,7 @@ input LinkActionInput {
 
 type Mutation {
   """blockDelete returns the updated sibling blocks on successful delete"""
-  blockDelete(id: ID!, journeyId: ID!, parentBlockId: ID!): [Block!]! @join__field(graph: JOURNEYS)
+  blockDelete(id: ID!, journeyId: ID!, parentBlockId: ID): [Block!]! @join__field(graph: JOURNEYS)
   blockDeleteAction(id: ID!, journeyId: ID!): Block! @join__field(graph: JOURNEYS)
   blockOrderUpdate(id: ID!, journeyId: ID!, parentOrder: Int!): [Block!]! @join__field(graph: JOURNEYS)
   blockUpdateLinkAction(id: ID!, input: LinkActionInput!, journeyId: ID!): LinkAction! @join__field(graph: JOURNEYS)

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -730,7 +730,7 @@ extend type Mutation {
   blockUpdateLinkAction(id: ID!, journeyId: ID!, input: LinkActionInput!): LinkAction!
 
   """blockDelete returns the updated sibling blocks on successful delete"""
-  blockDelete(id: ID!, parentBlockId: ID!, journeyId: ID!): [Block!]!
+  blockDelete(id: ID!, journeyId: ID!, parentBlockId: ID): [Block!]!
   blockOrderUpdate(id: ID!, journeyId: ID!, parentOrder: Int!): [Block!]!
   buttonBlockCreate(input: ButtonBlockCreateInput!): ButtonBlock!
   buttonBlockUpdate(id: ID!, journeyId: ID!, input: ButtonBlockUpdateInput!): ButtonBlock

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -651,7 +651,7 @@ export abstract class IMutation {
 
     abstract blockUpdateLinkAction(id: string, journeyId: string, input: LinkActionInput): LinkAction | Promise<LinkAction>;
 
-    abstract blockDelete(id: string, parentBlockId: string, journeyId: string): Block[] | Promise<Block[]>;
+    abstract blockDelete(id: string, journeyId: string, parentBlockId?: Nullable<string>): Block[] | Promise<Block[]>;
 
     abstract blockOrderUpdate(id: string, journeyId: string, parentOrder: number): Block[] | Promise<Block[]>;
 

--- a/apps/api-journeys/src/app/modules/block/block.graphql
+++ b/apps/api-journeys/src/app/modules/block/block.graphql
@@ -13,6 +13,6 @@ extend type Mutation {
   """
   blockDelete returns the updated sibling blocks on successful delete
   """
-  blockDelete(id: ID!, parentBlockId: ID!, journeyId: ID!): [Block!]!
+  blockDelete(id: ID!, journeyId: ID!, parentBlockId: ID): [Block!]!
   blockOrderUpdate(id: ID!, journeyId: ID!, parentOrder: Int!): [Block!]!
 }

--- a/apps/api-journeys/src/app/modules/block/block.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/block.resolver.spec.ts
@@ -75,13 +75,13 @@ describe('BlockResolver', () => {
 
   describe('blockDelete', () => {
     it('removes the block and its children', async () => {
-      const data = await resolver.blockDelete('image1', 'card1', '2')
+      const data = await resolver.blockDelete('image1', '2', 'card1')
 
       expect(service.removeBlockAndChildren).toBeCalledTimes(1)
       expect(service.removeBlockAndChildren).toHaveBeenCalledWith(
         'image1',
-        'card1',
-        '2'
+        '2',
+        'card1'
       )
       expect(data).toEqual([image1, image2, image3])
     })

--- a/apps/api-journeys/src/app/modules/block/block.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/block.resolver.ts
@@ -72,13 +72,13 @@ export class BlockResolver {
   )
   async blockDelete(
     @Args('id') id: string,
-    @Args('parentBlockId') parentBlockId: string,
-    @Args('journeyId') journeyId: string
+    @Args('journeyId') journeyId: string,
+    @Args('parentBlockId') parentBlockId?: string
   ): Promise<Block[]> {
     return await this.blockService.removeBlockAndChildren(
       id,
-      parentBlockId,
-      journeyId
+      journeyId,
+      parentBlockId
     )
   }
 

--- a/apps/api-journeys/src/app/modules/block/block.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/block.service.spec.ts
@@ -221,8 +221,8 @@ describe('BlockService', () => {
       expect(
         await service.removeBlockAndChildren(
           block._key,
-          block.parentBlockId,
-          journey.id
+          journey.id,
+          block.parentBlockId
         )
       ).toEqual([
         { _key: block._key, parentOrder: 0 },
@@ -232,6 +232,13 @@ describe('BlockService', () => {
         journey.id,
         block.parentBlockId
       )
+    })
+
+    it('should remove blocks and return empty array', async () => {
+      expect(
+        await service.removeBlockAndChildren(block._key, journey.id)
+      ).toEqual([])
+      expect(service.updateChildrenParentOrder).not.toHaveBeenCalled()
     })
 
     it('should update parent order', async () => {

--- a/apps/api-journeys/src/app/modules/block/block.service.ts
+++ b/apps/api-journeys/src/app/modules/block/block.service.ts
@@ -84,15 +84,15 @@ export class BlockService extends BaseService {
 
   async removeBlockAndChildren(
     blockId: string,
-    parentBlockId: string,
-    journeyId: string
+    journeyId: string,
+    parentBlockId?: string
   ): Promise<Block[]> {
     const res: Block = await this.remove(blockId)
     await this.removeAllBlocksForParentId([blockId], [res])
-    const result = await this.updateChildrenParentOrder(
-      journeyId,
-      parentBlockId
-    )
+    const result =
+      parentBlockId == null
+        ? []
+        : await this.updateChildrenParentOrder(journeyId, parentBlockId)
     return result as unknown as Block[]
   }
 


### PR DESCRIPTION
# Description

This allows for deletion of blocks without parentBlockIds

- https://3.basecamp.com/3105655/buckets/26244194/todolists/4719368538

# How should this PR be QA Tested?

Delete a block without a parentBlockId (currently not available in UI)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
