### PR TITLE
fix: Center selected card on Horizontal Select

### DIFF
--- a/apps/journeys-admin/setupTests.tsx
+++ b/apps/journeys-admin/setupTests.tsx
@@ -8,3 +8,5 @@ jest.mock('next/image', () => ({
     return <img {...props} alt={props.alt} />
   }
 }))
+
+Element.prototype.scrollIntoView = jest.fn()

--- a/apps/journeys-admin/src/components/HorizontalSelect/HorizontalSelect.tsx
+++ b/apps/journeys-admin/src/components/HorizontalSelect/HorizontalSelect.tsx
@@ -1,8 +1,15 @@
+import {
+  ReactElement,
+  Children,
+  ReactNode,
+  isValidElement,
+  useRef,
+  useEffect
+} from 'react'
 import Box from '@mui/material/Box'
 import Stack from '@mui/material/Stack'
 import { SxProps } from '@mui/system/styleFunctionSx'
 import { Theme } from '@mui/material/styles'
-import { ReactElement, Children, ReactNode, isValidElement } from 'react'
 
 export interface HorizontalSelectProps {
   onChange?: (id: string) => void
@@ -19,6 +26,14 @@ export function HorizontalSelect({
   sx,
   footer
 }: HorizontalSelectProps): ReactElement {
+  const selectedRef = useRef<HTMLElement>(null)
+
+  useEffect(() => {
+    if (selectedRef?.current != null) {
+      selectedRef.current.scrollIntoView({ inline: 'center' })
+    }
+  }, [])
+
   return (
     <Stack
       direction="row"
@@ -37,6 +52,7 @@ export function HorizontalSelect({
           isValidElement(child) && (
             <Box
               key={child.props.id}
+              ref={id === child.props.id ? selectedRef : undefined}
               sx={{
                 borderRadius: 2,
                 transition: '0.2s border-color ease-out',


### PR DESCRIPTION
# Description

Simple scroll to center Horizontal Select on selected Card. `scrollIntoView` works for all browsers except IE. 
<img width="331" alt="image" src="https://user-images.githubusercontent.com/10802634/158302950-967e0fb4-ab7b-41af-88cd-5156fe511da7.png">

But won't center on Safari (scrolls just into view see below). A while ago we determined that we weren't as concerned for Safari as it wasn't a common web browser our users used. 
<img width="331" alt="image" src="https://user-images.githubusercontent.com/10802634/158302982-a8c7d6d2-8635-4e47-a6b6-797408aaeddc.png">

Perhaps this is ok for MVP? I'm also aware that we want to avoid package bloat where we can so didn't go to a scrolling library

[Basecamp](https://3.basecamp.com/3105655/buckets/26244194/todos/4732680217)

# How should this PR be QA Tested?

- [ ] PR Checks
- [ ] VR tests should show CardPreview snapshots being centered.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
