### PR TITLE
chore: move id decorators

### DIFF
--- a/apps/api-journeys/src/app/modules/action/action.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/action/action.resolver.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { Database } from 'arangojs'
 import { mockDeep } from 'jest-mock-extended'
+
 import { Action, RadioOptionBlock } from '../../__generated__/graphql'
 import { BlockResolver } from '../block/block.resolver'
 import { BlockService } from '../block/block.service'
@@ -13,21 +14,6 @@ describe('ActionResolver', () => {
     service: BlockService
 
   const block1 = {
-    _key: '1',
-    journeyId: '2',
-    __typename: 'RadioOptionBlock',
-    parentBlockId: '3',
-    parentOrder: 3,
-    label: 'label',
-    description: 'description',
-    action: {
-      parentBlockId: '1',
-      gtmEventName: 'gtmEventName',
-      blockId: '4'
-    }
-  }
-
-  const blockResponse1 = {
     id: '1',
     journeyId: '2',
     __typename: 'RadioOptionBlock',
@@ -43,28 +29,7 @@ describe('ActionResolver', () => {
   }
 
   const block2 = {
-    _key: '1',
-    journeyId: '2',
-    __typename: 'RadioOptionBlock',
-    parentBlockId: '3',
-    parentOrder: 3,
-    label: 'label',
-    description: 'description',
-    action: {
-      parentBlockId: '1',
-      gtmEventName: 'gtmEventName',
-      journeyId: '4'
-    }
-  }
-
-  const blockResponse2 = {
-    id: '1',
-    journeyId: '2',
-    __typename: 'RadioOptionBlock',
-    parentBlockId: '3',
-    parentOrder: 3,
-    label: 'label',
-    description: 'description',
+    ...block1,
     action: {
       parentBlockId: '1',
       gtmEventName: 'gtmEventName',
@@ -73,28 +38,7 @@ describe('ActionResolver', () => {
   }
 
   const block3 = {
-    _key: '1',
-    journeyId: '2',
-    __typename: 'RadioOptionBlock',
-    parentBlockId: '3',
-    parentOrder: 3,
-    label: 'label',
-    description: 'description',
-    action: {
-      parentBlockId: '1',
-      gtmEventName: 'gtmEventName',
-      url: 'https://google.com'
-    }
-  }
-
-  const blockResponse3 = {
-    id: '1',
-    journeyId: '2',
-    __typename: 'RadioOptionBlock',
-    parentBlockId: '3',
-    parentOrder: 3,
-    label: 'label',
-    description: 'description',
+    ...block1,
     action: {
       parentBlockId: '1',
       gtmEventName: 'gtmEventName',
@@ -103,28 +47,7 @@ describe('ActionResolver', () => {
   }
 
   const block4 = {
-    _key: '1',
-    journeyId: '2',
-    __typename: 'RadioOptionBlock',
-    parentBlockId: '3',
-    parentOrder: 3,
-    label: 'label',
-    description: 'description',
-    action: {
-      parentBlockId: '1',
-      gtmEventName: 'gtmEventName',
-      url: 'https://google.com'
-    }
-  }
-
-  const blockResponse4 = {
-    id: '1',
-    journeyId: '2',
-    __typename: 'RadioOptionBlock',
-    parentBlockId: '3',
-    parentOrder: 3,
-    label: 'label',
-    description: 'description',
+    ...block1,
     action: {
       parentBlockId: '1',
       gtmEventName: 'gtmEventName',
@@ -204,12 +127,20 @@ describe('ActionResolver', () => {
         })
       }
       const module: TestingModule = await Test.createTestingModule({
-        providers: [BlockResolver, blockService]
+        providers: [
+          BlockResolver,
+          blockService,
+          UserJourneyService,
+          {
+            provide: 'DATABASE',
+            useFactory: () => mockDeep<Database>()
+          }
+        ]
       }).compile()
       blockResolver = module.get<BlockResolver>(BlockResolver)
     })
     it('returns NavigateToBlockAction', async () => {
-      expect(await blockResolver.block('1')).toEqual(blockResponse1)
+      expect(await blockResolver.block('1')).toEqual(block1)
       expect(
         ((await blockResolver.block('1')) as RadioOptionBlock).action
       ).toHaveProperty('blockId')
@@ -225,12 +156,20 @@ describe('ActionResolver', () => {
         })
       }
       const module: TestingModule = await Test.createTestingModule({
-        providers: [BlockResolver, blockService]
+        providers: [
+          BlockResolver,
+          blockService,
+          UserJourneyService,
+          {
+            provide: 'DATABASE',
+            useFactory: () => mockDeep<Database>()
+          }
+        ]
       }).compile()
       blockResolver = module.get<BlockResolver>(BlockResolver)
     })
     it('returns NavigateToBlockAction', async () => {
-      expect(await blockResolver.block('1')).toEqual(blockResponse2)
+      expect(await blockResolver.block('1')).toEqual(block2)
       expect(
         ((await blockResolver.block('1')) as RadioOptionBlock).action
       ).toHaveProperty('journeyId')
@@ -246,12 +185,20 @@ describe('ActionResolver', () => {
         })
       }
       const module: TestingModule = await Test.createTestingModule({
-        providers: [BlockResolver, blockService]
+        providers: [
+          BlockResolver,
+          blockService,
+          UserJourneyService,
+          {
+            provide: 'DATABASE',
+            useFactory: () => mockDeep<Database>()
+          }
+        ]
       }).compile()
       blockResolver = module.get<BlockResolver>(BlockResolver)
     })
     it('returns LinkAction', async () => {
-      expect(await blockResolver.block('1')).toEqual(blockResponse3)
+      expect(await blockResolver.block('1')).toEqual(block3)
       expect(
         ((await blockResolver.block('1')) as RadioOptionBlock).action
       ).toHaveProperty('url')
@@ -267,12 +214,20 @@ describe('ActionResolver', () => {
         })
       }
       const module: TestingModule = await Test.createTestingModule({
-        providers: [BlockResolver, blockService]
+        providers: [
+          BlockResolver,
+          blockService,
+          UserJourneyService,
+          {
+            provide: 'DATABASE',
+            useFactory: () => mockDeep<Database>()
+          }
+        ]
       }).compile()
       blockResolver = module.get<BlockResolver>(BlockResolver)
     })
     it('returns NavigateAction', async () => {
-      expect(await blockResolver.block('1')).toEqual(blockResponse4)
+      expect(await blockResolver.block('1')).toEqual(block4)
     })
   })
 
@@ -301,9 +256,9 @@ describe('ActionResolver', () => {
       service = await module.resolve(BlockService)
     })
     it('removes the block action', async () => {
-      await resolver.blockDeleteAction(block1._key, block1.journeyId)
+      await resolver.blockDeleteAction(block1.id, block1.journeyId)
 
-      expect(service.update).toHaveBeenCalledWith(block1._key, {
+      expect(service.update).toHaveBeenCalledWith(block1.id, {
         action: null
       })
     })

--- a/apps/api-journeys/src/app/modules/action/action.resolver.ts
+++ b/apps/api-journeys/src/app/modules/action/action.resolver.ts
@@ -1,6 +1,5 @@
 import { Args, Mutation, ResolveField, Resolver } from '@nestjs/graphql'
 import { UseGuards } from '@nestjs/common'
-import { KeyAsId } from '@core/nest/decorators'
 import { get, includes } from 'lodash'
 import { UserInputError } from 'apollo-server-errors'
 import { RoleGuard } from '../../lib/roleGuard/roleGuard'
@@ -23,12 +22,13 @@ export class ActionResolver {
   @UseGuards(
     RoleGuard('journeyId', [UserJourneyRole.owner, UserJourneyRole.editor])
   )
-  @KeyAsId()
   async blockDeleteAction(
     @Args('id') id: string,
     @Args('journeyId') journeyId: string
   ): Promise<Block> {
-    const block = await this.blockService.get<{ __typename: string }>(id)
+    const block = await this.blockService.get<Block & { __typename: string }>(
+      id
+    )
 
     if (
       !includes(

--- a/apps/api-journeys/src/app/modules/action/linkAction/linkAction.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/action/linkAction/linkAction.resolver.spec.ts
@@ -11,7 +11,7 @@ describe('LinkActionResolver', () => {
   let resolver: LinkActionResolver, service: BlockService
 
   const block = {
-    _key: '1',
+    id: '1',
     journeyId: '2',
     __typename: 'RadioOptionBlock',
     parentBlockId: '3',
@@ -59,11 +59,11 @@ describe('LinkActionResolver', () => {
 
   it('updates link action', async () => {
     await resolver.blockUpdateLinkAction(
-      block._key,
+      block.id,
       block.journeyId,
       linkActionInput
     )
-    expect(service.update).toHaveBeenCalledWith(block._key, {
+    expect(service.update).toHaveBeenCalledWith(block.id, {
       action: { ...linkActionInput, parentBlockId: block.action.parentBlockId }
     })
   })
@@ -76,7 +76,7 @@ describe('LinkActionResolver', () => {
     service.get = jest.fn().mockResolvedValue(wrongBlock)
     await resolver
       .blockUpdateLinkAction(
-        wrongBlock._key,
+        wrongBlock.id,
         wrongBlock.journeyId,
         linkActionInput
       )

--- a/apps/api-journeys/src/app/modules/action/linkAction/linkAction.resolver.ts
+++ b/apps/api-journeys/src/app/modules/action/linkAction/linkAction.resolver.ts
@@ -1,12 +1,12 @@
 import { Args, Mutation, Resolver } from '@nestjs/graphql'
 import { UseGuards } from '@nestjs/common'
-import { KeyAsId } from '@core/nest/decorators'
 import { includes } from 'lodash'
 import { UserInputError } from 'apollo-server-errors'
 import { RoleGuard } from '../../../lib/roleGuard/roleGuard'
 
 import {
   Action,
+  Block,
   LinkActionInput,
   UserJourneyRole
 } from '../../../__generated__/graphql'
@@ -20,16 +20,14 @@ export class LinkActionResolver {
   @UseGuards(
     RoleGuard('journeyId', [UserJourneyRole.owner, UserJourneyRole.editor])
   )
-  @KeyAsId()
   async blockUpdateLinkAction(
     @Args('id') id: string,
     @Args('journeyId') journeyId: string,
     @Args('input') input: LinkActionInput
   ): Promise<Action> {
-    const block = await this.blockService.get<{
-      __typename: string
-      _key: string
-    }>(id)
+    const block = await this.blockService.get<Block & { __typename: string }>(
+      id
+    )
 
     if (
       !includes(
@@ -45,7 +43,7 @@ export class LinkActionResolver {
       {
         action: {
           ...input,
-          parentBlockId: block._key,
+          parentBlockId: block.id,
           blockId: null,
           journeyId: null
         }

--- a/apps/api-journeys/src/app/modules/action/navigateAction/navigateAction.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/action/navigateAction/navigateAction.resolver.spec.ts
@@ -10,7 +10,7 @@ describe('NavigateActionResolver', () => {
   let resolver: NavigateActionResolver, service: BlockService
 
   const block = {
-    _key: '1',
+    id: '1',
     journeyId: '2',
     __typename: 'RadioOptionBlock',
     parentBlockId: '3',
@@ -57,11 +57,11 @@ describe('NavigateActionResolver', () => {
 
   it('updates navigate action', async () => {
     await resolver.blockUpdateNavigateAction(
-      block._key,
+      block.id,
       block.journeyId,
       navigateActionInput
     )
-    expect(service.update).toHaveBeenCalledWith(block._key, {
+    expect(service.update).toHaveBeenCalledWith(block.id, {
       action: {
         ...navigateActionInput,
         parentBlockId: block.action.parentBlockId
@@ -77,7 +77,7 @@ describe('NavigateActionResolver', () => {
     service.get = jest.fn().mockResolvedValue(wrongBlock)
     await resolver
       .blockUpdateNavigateAction(
-        wrongBlock._key,
+        wrongBlock.id,
         wrongBlock.journeyId,
         navigateActionInput
       )

--- a/apps/api-journeys/src/app/modules/action/navigateAction/navigateAction.resolver.ts
+++ b/apps/api-journeys/src/app/modules/action/navigateAction/navigateAction.resolver.ts
@@ -1,11 +1,12 @@
 import { Args, Mutation, Resolver } from '@nestjs/graphql'
 import { UseGuards } from '@nestjs/common'
-import { KeyAsId } from '@core/nest/decorators'
 import { includes } from 'lodash'
 import { UserInputError } from 'apollo-server-errors'
+
 import { RoleGuard } from '../../../lib/roleGuard/roleGuard'
 import {
   Action,
+  Block,
   NavigateActionInput,
   UserJourneyRole
 } from '../../../__generated__/graphql'
@@ -19,16 +20,16 @@ export class NavigateActionResolver {
   @UseGuards(
     RoleGuard('journeyId', [UserJourneyRole.owner, UserJourneyRole.editor])
   )
-  @KeyAsId()
   async blockUpdateNavigateAction(
     @Args('id') id: string,
     @Args('journeyId') journeyId: string,
     @Args('input') input: NavigateActionInput
   ): Promise<Action> {
-    const block = await this.blockService.get<{
-      __typename: string
-      _key: string
-    }>(id)
+    const block = await this.blockService.get<
+      Block & {
+        __typename: string
+      }
+    >(id)
 
     if (
       !includes(
@@ -44,7 +45,7 @@ export class NavigateActionResolver {
       {
         action: {
           ...input,
-          parentBlockId: block._key,
+          parentBlockId: block.id,
           blockId: null,
           journeyId: null,
           url: null,

--- a/apps/api-journeys/src/app/modules/action/navigateToBlockAction/navigateToBlockAction.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/action/navigateToBlockAction/navigateToBlockAction.resolver.spec.ts
@@ -10,7 +10,7 @@ describe('NavigateToBlockActionResolver', () => {
   let resolver: NavigateToBlockActionResolver, service: BlockService
 
   const block = {
-    _key: '1',
+    id: '1',
     journeyId: '2',
     __typename: 'RadioOptionBlock',
     parentBlockId: '3',
@@ -60,11 +60,11 @@ describe('NavigateToBlockActionResolver', () => {
 
   it('updates the navigate to block action', async () => {
     await resolver.blockUpdateNavigateToBlockAction(
-      block._key,
+      block.id,
       block.journeyId,
       navigateToBlockInput
     )
-    expect(service.update).toHaveBeenCalledWith(block._key, {
+    expect(service.update).toHaveBeenCalledWith(block.id, {
       action: {
         ...navigateToBlockInput,
         parentBlockId: block.action.parentBlockId
@@ -80,7 +80,7 @@ describe('NavigateToBlockActionResolver', () => {
     service.get = jest.fn().mockResolvedValue(wrongBlock)
     await resolver
       .blockUpdateNavigateToBlockAction(
-        wrongBlock._key,
+        wrongBlock.id,
         wrongBlock.journeyId,
         navigateToBlockInput
       )

--- a/apps/api-journeys/src/app/modules/action/navigateToBlockAction/navigateToBlockAction.resolver.ts
+++ b/apps/api-journeys/src/app/modules/action/navigateToBlockAction/navigateToBlockAction.resolver.ts
@@ -1,11 +1,12 @@
 import { Args, Mutation, Resolver } from '@nestjs/graphql'
 import { UseGuards } from '@nestjs/common'
-import { KeyAsId } from '@core/nest/decorators'
 import { includes } from 'lodash'
 import { UserInputError } from 'apollo-server-errors'
+
 import { RoleGuard } from '../../../lib/roleGuard/roleGuard'
 import {
   Action,
+  Block,
   NavigateToBlockActionInput,
   UserJourneyRole
 } from '../../../__generated__/graphql'
@@ -19,16 +20,16 @@ export class NavigateToBlockActionResolver {
   @UseGuards(
     RoleGuard('journeyId', [UserJourneyRole.owner, UserJourneyRole.editor])
   )
-  @KeyAsId()
   async blockUpdateNavigateToBlockAction(
     @Args('id') id: string,
     @Args('journeyId') journeyId: string,
     @Args('input') input: NavigateToBlockActionInput
   ): Promise<Action> {
-    const block = await this.blockService.get<{
-      __typename: string
-      _key: string
-    }>(id)
+    const block = await this.blockService.get<
+      Block & {
+        __typename: string
+      }
+    >(id)
 
     if (
       !includes(
@@ -46,7 +47,7 @@ export class NavigateToBlockActionResolver {
       {
         action: {
           ...input,
-          parentBlockId: block._key,
+          parentBlockId: block.id,
           journeyId: null,
           url: null,
           target: null

--- a/apps/api-journeys/src/app/modules/action/navigateToJourney/navigateToJourney.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/action/navigateToJourney/navigateToJourney.resolver.spec.ts
@@ -15,21 +15,6 @@ describe('NavigateToJourneyActionResolver', () => {
     service: BlockService
 
   const block = {
-    _key: '1',
-    journeyId: '2',
-    __typename: 'RadioOptionBlock',
-    parentBlockId: '3',
-    parentOrder: 3,
-    label: 'label',
-    description: 'description',
-    action: {
-      parentBlockId: '1',
-      gtmEventName: 'gtmEventName',
-      journeyId: '4'
-    }
-  }
-
-  const blockResponse = {
     id: '1',
     journeyId: '2',
     __typename: 'RadioOptionBlock',
@@ -45,16 +30,6 @@ describe('NavigateToJourneyActionResolver', () => {
   }
 
   const journey = {
-    _key: '4',
-    title: 'Fact or Fiction',
-    status: JourneyStatus.published,
-    locale: 'en-US',
-    themeMode: 'light',
-    themeName: 'base',
-    slug: 'fact-or-fiction'
-  }
-
-  const journeyResponse = {
     id: '4',
     title: 'Fact or Fiction',
     status: JourneyStatus.published,
@@ -110,21 +85,21 @@ describe('NavigateToJourneyActionResolver', () => {
 
   describe('NavigateToJourneyAction', () => {
     it('returns NavigateToJourneyAction', async () => {
-      expect(await blockResolver.block('1')).toEqual(blockResponse)
+      expect(await blockResolver.block('1')).toEqual(block)
     })
 
     it('returns Journey from action', async () => {
-      expect(await resolver.journey(block.action)).toEqual(journeyResponse)
+      expect(await resolver.journey(block.action)).toEqual(journey)
     })
 
     it('updates the navigate to journey action', async () => {
       await resolver.blockUpdateNavigateToJourneyAction(
-        block._key,
+        block.id,
         block.journeyId,
         navigateToJourneyInput
       )
-      expect(service.update).toHaveBeenCalledWith(block._key, {
-        action: { ...navigateToJourneyInput, parentBlockId: block._key }
+      expect(service.update).toHaveBeenCalledWith(block.id, {
+        action: { ...navigateToJourneyInput, parentBlockId: block.id }
       })
     })
   })
@@ -137,7 +112,7 @@ describe('NavigateToJourneyActionResolver', () => {
     service.get = jest.fn().mockResolvedValue(wrongBlock)
     await resolver
       .blockUpdateNavigateToJourneyAction(
-        wrongBlock._key,
+        wrongBlock.id,
         wrongBlock.journeyId,
         navigateToJourneyInput
       )

--- a/apps/api-journeys/src/app/modules/action/navigateToJourney/navigateToJourney.resolver.ts
+++ b/apps/api-journeys/src/app/modules/action/navigateToJourney/navigateToJourney.resolver.ts
@@ -1,11 +1,12 @@
 import { Args, Mutation, Parent, ResolveField, Resolver } from '@nestjs/graphql'
 import { UseGuards } from '@nestjs/common'
-import { KeyAsId } from '@core/nest/decorators'
 import { includes } from 'lodash'
 import { UserInputError } from 'apollo-server-errors'
+
 import { RoleGuard } from '../../../lib/roleGuard/roleGuard'
 import {
   Action,
+  Block,
   Journey,
   NavigateToJourneyAction,
   NavigateToJourneyActionInput,
@@ -22,7 +23,6 @@ export class NavigateToJourneyActionResolver {
   ) {}
 
   @ResolveField()
-  @KeyAsId()
   async journey(@Parent() action: NavigateToJourneyAction): Promise<Journey> {
     return await this.journeyService.get(action.journeyId)
   }
@@ -31,16 +31,16 @@ export class NavigateToJourneyActionResolver {
   @UseGuards(
     RoleGuard('journeyId', [UserJourneyRole.owner, UserJourneyRole.editor])
   )
-  @KeyAsId()
   async blockUpdateNavigateToJourneyAction(
     @Args('id') id: string,
     @Args('journeyId') journeyId: string,
     @Args('input') input: NavigateToJourneyActionInput
   ): Promise<Action> {
-    const block = await this.blockService.get<{
-      __typename: string
-      _key: string
-    }>(id)
+    const block = await this.blockService.get<
+      Block & {
+        __typename: string
+      }
+    >(id)
 
     if (
       !includes(
@@ -57,7 +57,7 @@ export class NavigateToJourneyActionResolver {
       {
         action: {
           ...input,
-          parentBlockId: block._key,
+          parentBlockId: block.id,
           blockId: null,
           url: null,
           target: null

--- a/apps/api-journeys/src/app/modules/block/block.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/block.resolver.spec.ts
@@ -51,9 +51,9 @@ describe('BlockResolver', () => {
       getSiblings: jest.fn(() => [image1, image2, image3]),
       removeBlockAndChildren: jest.fn(() => [image1, image2, image3]),
       reorderSiblings: jest.fn(() => [
-        { _key: 'image2', parentOrder: 0 },
-        { _key: 'image3', parentOrder: 1 },
-        { _key: 'image1', parentOrder: 2 }
+        { id: 'image2', parentOrder: 0 },
+        { id: 'image3', parentOrder: 1 },
+        { id: 'image1', parentOrder: 2 }
       ])
     })
   }
@@ -112,9 +112,9 @@ describe('BlockResolver', () => {
           get: jest.fn(() => coverImage1),
           getSiblings: jest.fn(() => [coverImage1, image2, image3]),
           reorderSiblings: jest.fn(() => [
-            { _key: 'image2', parentOrder: 0 },
-            { _key: 'image3', parentOrder: 1 },
-            { _key: 'image1', parentOrder: 2 }
+            { id: 'image2', parentOrder: 0 },
+            { id: 'image3', parentOrder: 1 },
+            { id: 'image1', parentOrder: 2 }
           ])
         })
       }

--- a/apps/api-journeys/src/app/modules/block/block.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/block.resolver.ts
@@ -8,7 +8,6 @@ import {
   Mutation,
   Parent
 } from '@nestjs/graphql'
-import { KeyAsId } from '@core/nest/decorators'
 import { UseGuards } from '@nestjs/common'
 import { Block, UserJourneyRole } from '../../__generated__/graphql'
 import { RoleGuard } from '../../lib/roleGuard/roleGuard'
@@ -26,28 +25,25 @@ export class BlockResolver {
   }
 
   @Query()
-  @KeyAsId()
   async blocks(): Promise<Block[]> {
     return await this.blockService.getAll()
   }
 
   @Query()
-  @KeyAsId()
-  async block(@Args('id') _key: string): Promise<Block> {
-    return await this.blockService.get(_key)
+  async block(@Args('id') id: string): Promise<Block> {
+    return await this.blockService.get(id)
   }
 
   @Mutation()
-  @KeyAsId()
   @UseGuards(
     RoleGuard('journeyId', [UserJourneyRole.owner, UserJourneyRole.editor])
   )
   async blockOrderUpdate(
-    @Args('id') _key: string,
+    @Args('id') id: string,
     @Args('journeyId') journeyId: string,
     @Args('parentOrder') parentOrder: number
   ): Promise<Block[]> {
-    const selectedBlock: Block = await this.blockService.get(_key)
+    const selectedBlock: Block = await this.blockService.get(id)
 
     if (
       selectedBlock.journeyId === journeyId &&
@@ -66,7 +62,6 @@ export class BlockResolver {
   }
 
   @Mutation()
-  @KeyAsId()
   @UseGuards(
     RoleGuard('journeyId', [UserJourneyRole.owner, UserJourneyRole.editor])
   )
@@ -82,7 +77,6 @@ export class BlockResolver {
     )
   }
 
-  @KeyAsId()
   async siblings(@Parent() block: Block): Promise<Block[]> {
     return await this.blockService.getSiblings(
       block.journeyId,
@@ -90,11 +84,10 @@ export class BlockResolver {
     )
   }
 
-  @KeyAsId()
   async updateOrder(
-    @Args('id') _key: string,
+    @Args('id') id: string,
     @Args('parentOrder') parentOrder: number
   ): Promise<Block> {
-    return await this.blockService.update(_key, { parentOrder })
+    return await this.blockService.update(id, { parentOrder })
   }
 }

--- a/apps/api-journeys/src/app/modules/block/block.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/block.service.spec.ts
@@ -8,6 +8,8 @@ import {
   mockDbQueryResult
 } from '@core/nest/database'
 import { DocumentCollection } from 'arangojs/collection'
+import { keyAsId } from '@core/nest/decorators'
+
 import {
   JourneyStatus,
   ThemeMode,
@@ -37,32 +39,6 @@ describe('BlockService', () => {
     jest.resetAllMocks()
   })
 
-  const block = {
-    _key: '1',
-    journeyId: '2',
-    __typename: 'CardBlock',
-    parentBlockId: '3',
-    parentOrder: 0,
-    backgroundColor: '#FFF',
-    coverBlockId: '4',
-    themeMode: ThemeMode.light,
-    themeName: ThemeName.base,
-    fullscreen: true
-  }
-
-  const blockResponse = {
-    id: '1',
-    journeyId: '2',
-    __typename: 'CardBlock',
-    parentBlockId: '3',
-    parentOrder: 0,
-    backgroundColor: '#FFF',
-    coverBlockId: '4',
-    themeMode: ThemeMode.light,
-    themeName: ThemeName.base,
-    fullscreen: true
-  }
-
   const journey = {
     id: '1',
     title: 'published',
@@ -76,6 +52,20 @@ describe('BlockService', () => {
     slug: 'published-slug'
   }
 
+  const block = {
+    _key: '1',
+    journeyId: journey.id,
+    __typename: 'CardBlock',
+    parentBlockId: '3',
+    parentOrder: 0,
+    backgroundColor: '#FFF',
+    coverBlockId: '4',
+    themeMode: ThemeMode.light,
+    themeName: ThemeName.base,
+    fullscreen: true
+  }
+  const blockWithId = keyAsId(block)
+
   describe('getAll', () => {
     beforeEach(() => {
       ;(service.db as DeepMockProxy<Database>).query.mockReturnValue(
@@ -84,7 +74,7 @@ describe('BlockService', () => {
     })
 
     it('should return an array of all blocks', async () => {
-      expect(await service.getAll()).toEqual([block, block])
+      expect(await service.getAll()).toEqual([blockWithId, blockWithId])
     })
   })
 
@@ -96,7 +86,10 @@ describe('BlockService', () => {
     })
 
     it('should return all blocks in a journey', async () => {
-      expect(await service.forJourney(journey)).toEqual([block, block])
+      expect(await service.forJourney(journey)).toEqual([
+        blockWithId,
+        blockWithId
+      ])
     })
   })
 
@@ -110,7 +103,7 @@ describe('BlockService', () => {
     it('should return all siblings of a block', async () => {
       expect(
         await service.getSiblings(block.journeyId, block.parentBlockId)
-      ).toEqual([block, block])
+      ).toEqual([blockWithId, blockWithId])
     })
   })
 
@@ -122,7 +115,7 @@ describe('BlockService', () => {
     })
 
     it('should return a block', async () => {
-      expect(await service.get('1')).toEqual(block)
+      expect(await service.get('1')).toEqual(blockWithId)
     })
   })
 
@@ -136,7 +129,7 @@ describe('BlockService', () => {
     })
 
     it('should return a saved block', async () => {
-      expect(await service.save(block)).toEqual(block)
+      expect(await service.save(block)).toEqual(blockWithId)
     })
   })
 
@@ -150,7 +143,7 @@ describe('BlockService', () => {
     })
 
     it('should return an updated block', async () => {
-      expect(await service.update(block._key, block)).toEqual(block)
+      expect(await service.update(block._key, block)).toEqual(blockWithId)
     })
   })
 
@@ -225,8 +218,8 @@ describe('BlockService', () => {
           block.parentBlockId
         )
       ).toEqual([
-        { _key: block._key, parentOrder: 0 },
-        { _key: block._key, parentOrder: 1 }
+        { id: block._key, parentOrder: 0 },
+        { id: block._key, parentOrder: 1 }
       ])
       expect(service.updateChildrenParentOrder).toHaveBeenCalledWith(
         journey.id,
@@ -251,7 +244,7 @@ describe('BlockService', () => {
         ])
       )
       service.getSiblings = jest.fn(
-        async () => await Promise.resolve([blockResponse, blockResponse])
+        async () => await Promise.resolve([blockWithId, blockWithId])
       )
       expect(
         await service.updateChildrenParentOrder(journey.id, block.parentBlockId)

--- a/apps/api-journeys/src/app/modules/block/block.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/block.service.spec.ts
@@ -244,7 +244,7 @@ describe('BlockService', () => {
         ])
       )
       service.getSiblings = jest.fn(
-        async () => await Promise.resolve([blockWithId, blockWithId])
+        async () => await Promise.resolve([blockWithId, blockWithId] as Block[])
       )
       expect(
         await service.updateChildrenParentOrder(journey.id, block.parentBlockId)

--- a/apps/api-journeys/src/app/modules/block/block.service.ts
+++ b/apps/api-journeys/src/app/modules/block/block.service.ts
@@ -2,12 +2,15 @@ import { Injectable } from '@nestjs/common'
 import { aql } from 'arangojs'
 import { BaseService } from '@core/nest/database'
 import { DocumentCollection } from 'arangojs/collection'
+import { KeyAsId } from '@core/nest/decorators'
 
 import { Block, Journey } from '../../__generated__/graphql'
 
 @Injectable()
 export class BlockService extends BaseService {
+  @KeyAsId()
   async forJourney(journey: Journey): Promise<Block[]> {
+    console.log('jid', journey.id)
     const primaryImageBlockId = journey.primaryImageBlock?.id ?? null
     const res = await this.db.query(aql`
       FOR block in ${this.collection}
@@ -19,6 +22,7 @@ export class BlockService extends BaseService {
     return await res.all()
   }
 
+  @KeyAsId()
   async getSiblings(
     journeyId: string,
     parentBlockId?: string | null
@@ -82,6 +86,7 @@ export class BlockService extends BaseService {
     ])
   }
 
+  @KeyAsId()
   async removeBlockAndChildren(
     blockId: string,
     journeyId: string,

--- a/apps/api-journeys/src/app/modules/block/block.service.ts
+++ b/apps/api-journeys/src/app/modules/block/block.service.ts
@@ -10,7 +10,6 @@ import { Block, Journey } from '../../__generated__/graphql'
 export class BlockService extends BaseService {
   @KeyAsId()
   async forJourney(journey: Journey): Promise<Block[]> {
-    console.log('jid', journey.id)
     const primaryImageBlockId = journey.primaryImageBlock?.id ?? null
     const res = await this.db.query(aql`
       FOR block in ${this.collection}

--- a/apps/api-journeys/src/app/modules/block/button/button.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/button/button.resolver.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { Database } from 'arangojs'
 import { mockDeep } from 'jest-mock-extended'
+
 import { BlockResolver } from '../block.resolver'
 import { BlockService } from '../block.service'
 import {
@@ -19,31 +20,6 @@ describe('Button', () => {
     service: BlockService
 
   const block = {
-    _key: '1',
-    journeyId: '2',
-    __typename: 'ButtonBlock',
-    parentBlockId: '0',
-    parentOrder: 1,
-    label: 'label',
-    variant: ButtonVariant.contained,
-    color: ButtonColor.primary,
-    size: ButtonSize.large,
-    startIconId: 'start1',
-    endIconId: 'end1',
-    action: {
-      gtmEventName: 'gtmEventName',
-      url: 'https://jesusfilm.org',
-      target: 'target'
-    }
-  }
-
-  const blockWithId = {
-    ...block,
-    id: block._key,
-    _key: undefined
-  }
-
-  const blockResponse = {
     id: '1',
     journeyId: '2',
     __typename: 'ButtonBlock',
@@ -63,8 +39,8 @@ describe('Button', () => {
   }
 
   const actionResponse = {
-    ...blockResponse.action,
-    parentBlockId: block._key
+    ...block.action,
+    parentBlockId: block.id
   }
 
   const blockInput: ButtonBlockCreateInput & { __typename: string } = {
@@ -79,7 +55,7 @@ describe('Button', () => {
   }
 
   const blockCreateResponse = {
-    _key: '1',
+    id: '1',
     journeyId: '2',
     __typename: 'ButtonBlock',
     parentBlockId: '0',
@@ -140,19 +116,16 @@ describe('Button', () => {
 
   describe('ButtonBlock', () => {
     it('returns ButtonBlock', async () => {
-      expect(await blockResolver.block('1')).toEqual(blockResponse)
-      expect(await blockResolver.blocks()).toEqual([
-        blockResponse,
-        blockResponse
-      ])
+      expect(await blockResolver.block('1')).toEqual(block)
+      expect(await blockResolver.blocks()).toEqual([block, block])
     })
   })
 
   describe('action', () => {
     it('returns ButtonBlock action with parentBlockId', async () => {
-      expect(
-        await resolver.action(blockWithId as unknown as ButtonBlock)
-      ).toEqual(actionResponse)
+      expect(await resolver.action(block as unknown as ButtonBlock)).toEqual(
+        actionResponse
+      )
     })
   })
 
@@ -175,8 +148,8 @@ describe('Button', () => {
       mockValidate.mockResolvedValueOnce(true)
       mockValidate.mockResolvedValueOnce(true)
 
-      await resolver.buttonBlockUpdate(block._key, block.journeyId, blockUpdate)
-      expect(service.update).toHaveBeenCalledWith(block._key, blockUpdate)
+      await resolver.buttonBlockUpdate(block.id, block.journeyId, blockUpdate)
+      expect(service.update).toHaveBeenCalledWith(block.id, blockUpdate)
     })
 
     it('should throw error with an invalid startIconId', async () => {
@@ -187,7 +160,7 @@ describe('Button', () => {
       mockValidate.mockResolvedValueOnce(true)
 
       await resolver
-        .buttonBlockUpdate(block._key, block.journeyId, {
+        .buttonBlockUpdate(block.id, block.journeyId, {
           ...blockUpdate,
           startIconId: 'wrong!'
         })
@@ -205,7 +178,7 @@ describe('Button', () => {
       mockValidate.mockResolvedValueOnce(false)
 
       await resolver
-        .buttonBlockUpdate(block._key, block.journeyId, {
+        .buttonBlockUpdate(block.id, block.journeyId, {
           ...blockUpdate,
           endIconId: 'wrong!'
         })

--- a/apps/api-journeys/src/app/modules/block/button/button.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/button/button.resolver.ts
@@ -1,7 +1,6 @@
 import { UserInputError } from 'apollo-server-errors'
 import { UseGuards } from '@nestjs/common'
 import { Args, Mutation, ResolveField, Resolver, Parent } from '@nestjs/graphql'
-import { IdAsKey, KeyAsId } from '@core/nest/decorators'
 import {
   Action,
   ButtonBlock,
@@ -33,7 +32,6 @@ export class ButtonBlockResolver {
       UserJourneyRole.editor
     ])
   )
-  @IdAsKey()
   async buttonBlockCreate(
     @Args('input') input: ButtonBlockCreateInput & { __typename }
   ): Promise<ButtonBlock> {
@@ -49,7 +47,6 @@ export class ButtonBlockResolver {
   }
 
   @Mutation()
-  @KeyAsId()
   @UseGuards(
     RoleGuard('journeyId', [UserJourneyRole.owner, UserJourneyRole.editor])
   )

--- a/apps/api-journeys/src/app/modules/block/card/card.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/card/card.resolver.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { Database } from 'arangojs'
 import { mockDeep } from 'jest-mock-extended'
+
 import { CardBlock, ThemeMode, ThemeName } from '../../../__generated__/graphql'
 import { UserJourneyService } from '../../userJourney/userJourney.service'
 import { BlockResolver } from '../block.resolver'
@@ -13,7 +14,7 @@ describe('CardBlockResolver', () => {
     service: BlockService
 
   const block = {
-    _key: '1',
+    id: '1',
     journeyId: '2',
     __typename: 'CardBlock',
     parentBlockId: '3',
@@ -42,19 +43,6 @@ describe('CardBlockResolver', () => {
     __typename: 'CardBlock',
     parentBlockId: '3',
     parentOrder: 2,
-    backgroundColor: '#FFF',
-    coverBlockId: '4',
-    themeMode: ThemeMode.light,
-    themeName: ThemeName.base,
-    fullscreen: true
-  }
-
-  const blockResponse = {
-    id: '1',
-    journeyId: '2',
-    __typename: 'CardBlock',
-    parentBlockId: '3',
-    parentOrder: 0,
     backgroundColor: '#FFF',
     coverBlockId: '4',
     themeMode: ThemeMode.light,
@@ -93,11 +81,8 @@ describe('CardBlockResolver', () => {
 
   describe('CardBlock', () => {
     it('returns CardBlock', async () => {
-      expect(await blockResolver.block('1')).toEqual(blockResponse)
-      expect(await blockResolver.blocks()).toEqual([
-        blockResponse,
-        blockResponse
-      ])
+      expect(await blockResolver.block('1')).toEqual(block)
+      expect(await blockResolver.blocks()).toEqual([block, block])
     })
   })
 
@@ -117,9 +102,9 @@ describe('CardBlockResolver', () => {
   describe('cardBlockUpdate', () => {
     it('updates a CardBlock', async () => {
       resolver
-        .cardBlockUpdate(block._key, block.journeyId, blockUpdate)
+        .cardBlockUpdate(block.id, block.journeyId, blockUpdate)
         .catch((err) => console.log(err))
-      expect(service.update).toHaveBeenCalledWith(block._key, blockUpdate)
+      expect(service.update).toHaveBeenCalledWith(block.id, blockUpdate)
     })
   })
 

--- a/apps/api-journeys/src/app/modules/block/card/card.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/card/card.resolver.ts
@@ -1,6 +1,5 @@
 import { UseGuards } from '@nestjs/common'
 import { Args, Mutation, Parent, ResolveField, Resolver } from '@nestjs/graphql'
-import { IdAsKey, KeyAsId } from '@core/nest/decorators'
 import {
   CardBlock,
   CardBlockCreateInput,
@@ -20,7 +19,6 @@ export class CardBlockResolver {
       UserJourneyRole.editor
     ])
   )
-  @IdAsKey()
   async cardBlockCreate(
     @Args('input') input: CardBlockCreateInput & { __typename }
   ): Promise<CardBlock> {
@@ -36,7 +34,6 @@ export class CardBlockResolver {
   }
 
   @Mutation()
-  @KeyAsId()
   @UseGuards(
     RoleGuard('journeyId', [UserJourneyRole.owner, UserJourneyRole.editor])
   )

--- a/apps/api-journeys/src/app/modules/block/gridContainer/gridContainer.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/gridContainer/gridContainer.resolver.spec.ts
@@ -1,4 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing'
+import { Database } from 'arangojs'
+import { mockDeep } from 'jest-mock-extended'
+import { UserJourneyService } from '../../userJourney/userJourney.service'
+
 import { BlockResolver } from '../block.resolver'
 import { BlockService } from '../block.service'
 
@@ -6,17 +10,6 @@ describe('GridContainerResolver', () => {
   let resolver: BlockResolver
 
   const block = {
-    _key: '1',
-    journeyId: '2',
-    __typename: 'GridContainerBlock',
-    parentBlockId: '3',
-    parentOrder: 2,
-    spacing: 3,
-    direction: 'row',
-    justifyContent: 'flexStart',
-    alignItems: 'center'
-  }
-  const blockResponse = {
     id: '1',
     journeyId: '2',
     __typename: 'GridContainerBlock',
@@ -38,15 +31,23 @@ describe('GridContainerResolver', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [BlockResolver, blockService]
+      providers: [
+        BlockResolver,
+        blockService,
+        UserJourneyService,
+        {
+          provide: 'DATABASE',
+          useFactory: () => mockDeep<Database>()
+        }
+      ]
     }).compile()
     resolver = module.get<BlockResolver>(BlockResolver)
   })
 
   describe('GridContainerBlock', () => {
     it('returns GridContainerBlock', async () => {
-      expect(await resolver.block('1')).toEqual(blockResponse)
-      expect(await resolver.blocks()).toEqual([blockResponse, blockResponse])
+      expect(await resolver.block('1')).toEqual(block)
+      expect(await resolver.blocks()).toEqual([block, block])
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/block/gridItem/gridItem.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/gridItem/gridItem.resolver.spec.ts
@@ -1,4 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing'
+import { Database } from 'arangojs'
+import { mockDeep } from 'jest-mock-extended'
+import { UserJourneyService } from '../../userJourney/userJourney.service'
+
 import { BlockResolver } from '../block.resolver'
 import { BlockService } from '../block.service'
 
@@ -6,16 +10,6 @@ describe('GridItemResolver', () => {
   let resolver: BlockResolver
 
   const block = {
-    _key: '1',
-    journeyId: '2',
-    __typename: 'GridItemBlock',
-    parentBlockId: '3',
-    parentOrder: 2,
-    xl: 6,
-    lg: 6,
-    sm: 6
-  }
-  const blockResponse = {
     id: '1',
     journeyId: '2',
     __typename: 'GridItemBlock',
@@ -36,15 +30,23 @@ describe('GridItemResolver', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [BlockResolver, blockService]
+      providers: [
+        BlockResolver,
+        blockService,
+        UserJourneyService,
+        {
+          provide: 'DATABASE',
+          useFactory: () => mockDeep<Database>()
+        }
+      ]
     }).compile()
     resolver = module.get<BlockResolver>(BlockResolver)
   })
 
   describe('GridItemBlock', () => {
     it('returns GridItemBlock', async () => {
-      expect(await resolver.block('1')).toEqual(blockResponse)
-      expect(await resolver.blocks()).toEqual([blockResponse, blockResponse])
+      expect(await resolver.block('1')).toEqual(block)
+      expect(await resolver.blocks()).toEqual([block, block])
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/block/icon/icon.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/icon/icon.resolver.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { Database } from 'arangojs'
 import { mockDeep } from 'jest-mock-extended'
+
 import { BlockResolver } from '../block.resolver'
 import { BlockService } from '../block.service'
 import {
@@ -18,20 +19,9 @@ describe('Icon', () => {
     service: BlockService
 
   const block = {
-    _key: '1',
-    journeyId: '2',
-    __typename: 'IconBlock',
-    parentBlockId: '0',
-    parentOrder: 0,
-    name: 'ArrowForwardRounded',
-    color: 'secondary',
-    size: 'lg'
-  }
-
-  const blockResponse = {
-    __typename: 'IconBlock',
     id: '1',
     journeyId: '2',
+    __typename: 'IconBlock',
     parentBlockId: '0',
     parentOrder: 0,
     name: 'ArrowForwardRounded',
@@ -49,15 +39,9 @@ describe('Icon', () => {
     size: IconSize.lg
   }
 
-  const createResponse = {
-    _key: '1',
-    __typename: 'IconBlock',
-    journeyId: '2',
-    parentBlockId: '0',
-    parentOrder: null,
-    name: 'ArrowForwardRounded',
-    color: 'secondary',
-    size: 'lg'
+  const create = {
+    ...block,
+    parentOrder: null
   }
 
   const inputUpdate = {
@@ -107,26 +91,26 @@ describe('Icon', () => {
 
   describe('IconBlock', () => {
     it('returns IconBlock', async () => {
-      expect(await resolver.block('1')).toEqual(blockResponse)
-      expect(await resolver.blocks()).toEqual([blockResponse, blockResponse])
+      expect(await resolver.block('1')).toEqual(block)
+      expect(await resolver.blocks()).toEqual([block, block])
     })
   })
 
   describe('IconBlockCreate', () => {
     it('creates an IconBlock', async () => {
       await iconBlockResolver.iconBlockCreate(input)
-      expect(service.save).toHaveBeenCalledWith(createResponse)
+      expect(service.save).toHaveBeenCalledWith(create)
     })
   })
 
   describe('IconBlockUpdate', () => {
     it('updates a IconBlock', async () => {
       void iconBlockResolver.iconBlockUpdate(
-        block._key,
+        block.id,
         block.journeyId,
         inputUpdate
       )
-      expect(service.update).toHaveBeenCalledWith(block._key, updateResponse)
+      expect(service.update).toHaveBeenCalledWith(block.id, updateResponse)
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/block/icon/icon.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/icon/icon.resolver.ts
@@ -1,6 +1,5 @@
 import { UseGuards } from '@nestjs/common'
 import { Args, Mutation, Resolver } from '@nestjs/graphql'
-import { KeyAsId, IdAsKey } from '@core/nest/decorators'
 import {
   IconBlock,
   IconBlockCreateInput,
@@ -21,7 +20,6 @@ export class IconBlockResolver {
       UserJourneyRole.editor
     ])
   )
-  @IdAsKey()
   async iconBlockCreate(
     @Args('input') input: IconBlockCreateInput & { __typename }
   ): Promise<IconBlock> {
@@ -34,7 +32,6 @@ export class IconBlockResolver {
   }
 
   @Mutation()
-  @KeyAsId()
   @UseGuards(
     RoleGuard('journeyId', [UserJourneyRole.owner, UserJourneyRole.editor])
   )

--- a/apps/api-journeys/src/app/modules/block/image/image.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/image/image.resolver.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { Database } from 'arangojs'
 import { mockDeep } from 'jest-mock-extended'
+
 import { ImageBlockCreateInput } from '../../../__generated__/graphql'
 import { UserJourneyService } from '../../userJourney/userJourney.service'
 import { BlockResolver } from '../block.resolver'
@@ -13,17 +14,6 @@ describe('ImageBlockResolver', () => {
     service: BlockService
 
   const block = {
-    _key: '1',
-    journeyId: '2',
-    __typename: 'ImageBlock',
-    parentBlockId: '3',
-    parentOrder: 0,
-    src: 'https://source.unsplash.com/random/1920x1080',
-    alt: 'random image from unsplash',
-    width: 1920,
-    height: 1080
-  }
-  const blockResponse = {
     id: '1',
     journeyId: '2',
     __typename: 'ImageBlock',
@@ -52,8 +42,8 @@ describe('ImageBlockResolver', () => {
     alt: 'grid image'
   }
 
-  const imageBlockResponse = {
-    _key: input.id,
+  const inputWithId = {
+    id: input.id,
     parentBlockId: input.parentBlockId,
     parentOrder: 2,
     journeyId: input.journeyId,
@@ -105,11 +95,8 @@ describe('ImageBlockResolver', () => {
 
   describe('ImageBlock', () => {
     it('returns ImageBlock', async () => {
-      expect(await blockResolver.block('1')).toEqual(blockResponse)
-      expect(await blockResolver.blocks()).toEqual([
-        blockResponse,
-        blockResponse
-      ])
+      expect(await blockResolver.block('1')).toEqual(block)
+      expect(await blockResolver.blocks()).toEqual([block, block])
     })
   })
 
@@ -120,7 +107,7 @@ describe('ImageBlockResolver', () => {
         input.journeyId,
         input.parentBlockId
       )
-      expect(service.save).toHaveBeenCalledWith(imageBlockResponse)
+      expect(service.save).toHaveBeenCalledWith(inputWithId)
     })
   })
 

--- a/apps/api-journeys/src/app/modules/block/image/image.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/image/image.resolver.ts
@@ -1,7 +1,6 @@
 import { UseGuards } from '@nestjs/common'
 import { Args, Mutation, Resolver } from '@nestjs/graphql'
 import { UserInputError } from 'apollo-server-errors'
-import { IdAsKey, KeyAsId } from '@core/nest/decorators'
 import { encode } from 'blurhash'
 import { createCanvas, loadImage, Image } from 'canvas'
 import { BlockService } from '../block.service'
@@ -65,7 +64,6 @@ export class ImageBlockResolver {
       UserJourneyRole.editor
     ])
   )
-  @IdAsKey()
   async imageBlockCreate(
     @Args('input') input: ImageBlockCreateInput & { __typename }
   ): Promise<ImageBlock> {
@@ -85,7 +83,6 @@ export class ImageBlockResolver {
   @UseGuards(
     RoleGuard('journeyId', [UserJourneyRole.owner, UserJourneyRole.editor])
   )
-  @KeyAsId()
   async imageBlockUpdate(
     @Args('id') id: string,
     @Args('journeyId') journeyId: string,

--- a/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.spec.ts
@@ -156,10 +156,7 @@ describe('RadioQuestionBlockResolver', () => {
         block.journeyId,
         radioQuestionInput
       )
-      expect(service.update).toHaveBeenCalledWith(
-        block.id,
-        radioQuestionInput
-      )
+      expect(service.update).toHaveBeenCalledWith(block.id, radioQuestionInput)
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { Database } from 'arangojs'
 import { mockDeep } from 'jest-mock-extended'
+
 import { RadioOptionBlock } from '../../../__generated__/graphql'
 import { UserJourneyService } from '../../userJourney/userJourney.service'
 import { BlockResolver } from '../block.resolver'
@@ -17,26 +18,6 @@ describe('RadioQuestionBlockResolver', () => {
     service: BlockService
 
   const block = {
-    _key: '1',
-    journeyId: '2',
-    __typename: 'RadioOptionBlock',
-    parentBlockId: '3',
-    parentOrder: 3,
-    label: 'label',
-    description: 'description',
-    action: {
-      gtmEventName: 'gtmEventName',
-      blockId: '4'
-    }
-  }
-
-  const blockWithId = {
-    ...block,
-    id: block._key,
-    _key: undefined
-  }
-
-  const blockResponse = {
     id: '1',
     journeyId: '2',
     __typename: 'RadioOptionBlock',
@@ -51,8 +32,8 @@ describe('RadioQuestionBlockResolver', () => {
   }
 
   const actionResponse = {
-    ...blockResponse.action,
-    parentBlockId: block._key
+    ...block.action,
+    parentBlockId: block.id
   }
 
   const radioOptionInput = {
@@ -120,11 +101,8 @@ describe('RadioQuestionBlockResolver', () => {
 
   describe('RadioOptionBlock', () => {
     it('returns RadioOptionBlock', async () => {
-      expect(await blockResolver.block('1')).toEqual(blockResponse)
-      expect(await blockResolver.blocks()).toEqual([
-        blockResponse,
-        blockResponse
-      ])
+      expect(await blockResolver.block('1')).toEqual(block)
+      expect(await blockResolver.blocks()).toEqual([block, block])
     })
   })
 
@@ -132,7 +110,7 @@ describe('RadioQuestionBlockResolver', () => {
     it('returns RadioOptionBlock action with parentBlockId', async () => {
       expect(
         await radioOptionBlockResolver.action(
-          blockWithId as unknown as RadioOptionBlock
+          block as unknown as RadioOptionBlock
         )
       ).toEqual(actionResponse)
     })
@@ -163,23 +141,23 @@ describe('RadioQuestionBlockResolver', () => {
   describe('radioOptionBlockUpdate', () => {
     it('updates a RadioOptionBlock', async () => {
       await radioOptionBlockResolver.radioOptionBlockUpdate(
-        block._key,
+        block.id,
         block.journeyId,
         radioOptionUpdate
       )
-      expect(service.update).toHaveBeenCalledWith(block._key, radioOptionUpdate)
+      expect(service.update).toHaveBeenCalledWith(block.id, radioOptionUpdate)
     })
   })
 
   describe('radioQuestionBlockUpdate', () => {
     it('updates a RadioQuestionBlock', async () => {
       await resolver.radioQuestionBlockUpdate(
-        block._key,
+        block.id,
         block.journeyId,
         radioQuestionInput
       )
       expect(service.update).toHaveBeenCalledWith(
-        block._key,
+        block.id,
         radioQuestionInput
       )
     })

--- a/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.ts
@@ -1,6 +1,5 @@
 import { UseGuards } from '@nestjs/common'
 import { Args, Mutation, ResolveField, Resolver, Parent } from '@nestjs/graphql'
-import { IdAsKey, KeyAsId } from '@core/nest/decorators'
 import {
   Action,
   RadioOptionBlock,
@@ -35,7 +34,6 @@ export class RadioOptionBlockResolver {
       UserJourneyRole.editor
     ])
   )
-  @IdAsKey()
   async radioOptionBlockCreate(
     @Args('input') input: RadioOptionBlockCreateInput & { __typename }
   ): Promise<RadioOptionBlock> {
@@ -51,7 +49,6 @@ export class RadioOptionBlockResolver {
   }
 
   @Mutation()
-  @KeyAsId()
   @UseGuards(
     RoleGuard('journeyId', [UserJourneyRole.owner, UserJourneyRole.editor])
   )
@@ -74,7 +71,6 @@ export class RadioQuestionBlockResolver {
       UserJourneyRole.editor
     ])
   )
-  @IdAsKey()
   async radioQuestionBlockCreate(
     @Args('input') input: RadioQuestionBlockCreateInput & { __typename }
   ): Promise<RadioQuestionBlock> {
@@ -90,7 +86,6 @@ export class RadioQuestionBlockResolver {
   }
 
   @Mutation()
-  @KeyAsId()
   @UseGuards(
     RoleGuard('journeyId', [UserJourneyRole.owner, UserJourneyRole.editor])
   )

--- a/apps/api-journeys/src/app/modules/block/signUp/signUp.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/signUp/signUp.resolver.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { Database } from 'arangojs'
 import { mockDeep } from 'jest-mock-extended'
+
 import {
   SignUpBlock,
   SignUpBlockCreateInput
@@ -16,26 +17,6 @@ describe('SignUpBlockResolver', () => {
     service: BlockService
 
   const block = {
-    _key: '1',
-    journeyId: '2',
-    parentBlockId: '0',
-    __typename: 'SignUpBlock',
-    parentOrder: 1,
-    action: {
-      gtmEventName: 'gtmEventName',
-      journeyId: '2'
-    },
-    submitIconId: 'icon1',
-    submitLabel: 'Unlock Now!'
-  }
-
-  const blockWithId = {
-    ...block,
-    id: block._key,
-    _key: undefined
-  }
-
-  const blockResponse = {
     id: '1',
     journeyId: '2',
     parentBlockId: '0',
@@ -50,8 +31,8 @@ describe('SignUpBlockResolver', () => {
   }
 
   const actionResponse = {
-    ...blockResponse.action,
-    parentBlockId: block._key
+    ...block.action,
+    parentBlockId: block.id
   }
 
   const input: SignUpBlockCreateInput & { __typename: string } = {
@@ -63,7 +44,7 @@ describe('SignUpBlockResolver', () => {
   }
 
   const signUpBlockResponse = {
-    _key: input.id,
+    id: input.id,
     parentBlockId: input.parentBlockId,
     journeyId: input.journeyId,
     __typename: 'SignUpBlock',
@@ -110,19 +91,16 @@ describe('SignUpBlockResolver', () => {
 
   describe('SignUpBlock', () => {
     it('returns SignUpBlock', async () => {
-      expect(await blockResolver.block('1')).toEqual(blockResponse)
-      expect(await blockResolver.blocks()).toEqual([
-        blockResponse,
-        blockResponse
-      ])
+      expect(await blockResolver.block('1')).toEqual(block)
+      expect(await blockResolver.blocks()).toEqual([block, block])
     })
   })
 
   describe('action', () => {
     it('returns SignUpBlock action with parentBlockId', async () => {
-      expect(
-        await resolver.action(blockWithId as unknown as SignUpBlock)
-      ).toEqual(actionResponse)
+      expect(await resolver.action(block as unknown as SignUpBlock)).toEqual(
+        actionResponse
+      )
     })
   })
 
@@ -140,8 +118,8 @@ describe('SignUpBlockResolver', () => {
       >
       mockValidate.mockResolvedValueOnce(true)
 
-      await resolver.signUpBlockUpdate(block._key, block.journeyId, blockUpdate)
-      expect(service.update).toHaveBeenCalledWith(block._key, blockUpdate)
+      await resolver.signUpBlockUpdate(block.id, block.journeyId, blockUpdate)
+      expect(service.update).toHaveBeenCalledWith(block.id, blockUpdate)
     })
 
     it('should throw error with an invalid submitIconId', async () => {
@@ -151,7 +129,7 @@ describe('SignUpBlockResolver', () => {
       mockValidate.mockResolvedValueOnce(false)
 
       await resolver
-        .signUpBlockUpdate(block._key, block.journeyId, {
+        .signUpBlockUpdate(block.id, block.journeyId, {
           ...blockUpdate,
           submitIconId: 'wrong!'
         })

--- a/apps/api-journeys/src/app/modules/block/signUp/signUp.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/signUp/signUp.resolver.ts
@@ -1,7 +1,7 @@
 import { UserInputError } from 'apollo-server-errors'
 import { UseGuards } from '@nestjs/common'
 import { Args, Mutation, Resolver, ResolveField, Parent } from '@nestjs/graphql'
-import { IdAsKey, KeyAsId } from '@core/nest/decorators'
+
 import {
   Action,
   SignUpBlock,
@@ -33,7 +33,6 @@ export class SignUpBlockResolver {
       UserJourneyRole.editor
     ])
   )
-  @IdAsKey()
   async signUpBlockCreate(
     @Args('input') input: SignUpBlockCreateInput & { __typename }
   ): Promise<SignUpBlock> {
@@ -49,7 +48,6 @@ export class SignUpBlockResolver {
   }
 
   @Mutation()
-  @KeyAsId()
   @UseGuards(
     RoleGuard('journeyId', [UserJourneyRole.owner, UserJourneyRole.editor])
   )

--- a/apps/api-journeys/src/app/modules/block/step/step.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/step/step.resolver.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { Database } from 'arangojs'
 import { mockDeep } from 'jest-mock-extended'
+
 import { UserJourneyService } from '../../userJourney/userJourney.service'
 import { BlockResolver } from '../block.resolver'
 import { BlockService } from '../block.service'
@@ -13,7 +14,7 @@ describe('StepBlockResolver', () => {
     service: BlockService
 
   const block = {
-    _key: '1',
+    id: '1',
     journeyId: '2',
     __typename: 'StepBlock',
     parentBlockId: '3',
@@ -36,16 +37,6 @@ describe('StepBlockResolver', () => {
     __typename: 'StepBlock',
     parentBlockId: '3',
     parentOrder: 2,
-    locked: true,
-    nextBlockId: '4'
-  }
-
-  const blockResponse = {
-    id: '1',
-    journeyId: '2',
-    __typename: 'StepBlock',
-    parentBlockId: '3',
-    parentOrder: 0,
     locked: true,
     nextBlockId: '4'
   }
@@ -81,11 +72,8 @@ describe('StepBlockResolver', () => {
 
   describe('StepBlock', () => {
     it('returns StepBlock', async () => {
-      expect(await blockResolver.block('1')).toEqual(blockResponse)
-      expect(await blockResolver.blocks()).toEqual([
-        blockResponse,
-        blockResponse
-      ])
+      expect(await blockResolver.block('1')).toEqual(block)
+      expect(await blockResolver.blocks()).toEqual([block, block])
     })
   })
 
@@ -102,9 +90,9 @@ describe('StepBlockResolver', () => {
   describe('stepBlockUpdate', () => {
     it('updates a StepBlock', async () => {
       resolver
-        .stepBlockUpdate(block._key, block.journeyId, blockUpdate)
+        .stepBlockUpdate(block.id, block.journeyId, blockUpdate)
         .catch((err) => console.log(err))
-      expect(service.update).toHaveBeenCalledWith(block._key, blockUpdate)
+      expect(service.update).toHaveBeenCalledWith(block.id, blockUpdate)
     })
   })
 

--- a/apps/api-journeys/src/app/modules/block/step/step.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/step/step.resolver.ts
@@ -1,6 +1,6 @@
 import { UseGuards } from '@nestjs/common'
 import { Args, Mutation, Parent, ResolveField, Resolver } from '@nestjs/graphql'
-import { IdAsKey, KeyAsId } from '@core/nest/decorators'
+
 import {
   StepBlock,
   StepBlockCreateInput,
@@ -20,7 +20,6 @@ export class StepBlockResolver {
       UserJourneyRole.editor
     ])
   )
-  @IdAsKey()
   async stepBlockCreate(
     @Args('input') input: StepBlockCreateInput & { __typename }
   ): Promise<StepBlock> {
@@ -36,7 +35,6 @@ export class StepBlockResolver {
   @UseGuards(
     RoleGuard('journeyId', [UserJourneyRole.owner, UserJourneyRole.editor])
   )
-  @KeyAsId()
   async stepBlockUpdate(
     @Args('id') id: string,
     @Args('journeyId') journeyId: string,

--- a/apps/api-journeys/src/app/modules/block/typography/typography.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/typography/typography.resolver.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { Database } from 'arangojs'
 import { mockDeep } from 'jest-mock-extended'
+
 import {
   TypographyAlign,
   TypographyColor,
@@ -17,7 +18,7 @@ describe('TypographyBlockResolver', () => {
     service: BlockService
 
   const block = {
-    _key: '1',
+    id: '1',
     journeyId: '2',
     __typename: 'TypographyBlock',
     parentBlockId: '3',
@@ -44,18 +45,6 @@ describe('TypographyBlockResolver', () => {
     __typename: 'TypographyBlock',
     parentBlockId: '3',
     parentOrder: 2,
-    content: 'text',
-    variant: TypographyVariant.h2,
-    color: TypographyColor.primary,
-    align: TypographyAlign.left
-  }
-
-  const blockResponse = {
-    id: '1',
-    journeyId: '2',
-    __typename: 'TypographyBlock',
-    parentBlockId: '3',
-    parentOrder: 7,
     content: 'text',
     variant: TypographyVariant.h2,
     color: TypographyColor.primary,
@@ -93,11 +82,8 @@ describe('TypographyBlockResolver', () => {
 
   describe('TypographyBlock', () => {
     it('returns TypographyBlock', async () => {
-      expect(await blockResolver.block('1')).toEqual(blockResponse)
-      expect(await blockResolver.blocks()).toEqual([
-        blockResponse,
-        blockResponse
-      ])
+      expect(await blockResolver.block('1')).toEqual(block)
+      expect(await blockResolver.blocks()).toEqual([block, block])
     })
   })
 
@@ -115,11 +101,11 @@ describe('TypographyBlockResolver', () => {
   describe('typographyBlockUpdate', () => {
     it('updates a TypographyBlock', async () => {
       void resolver.typographyBlockUpdate(
-        block._key,
+        block.id,
         block.journeyId,
         blockUpdate
       )
-      expect(service.update).toHaveBeenCalledWith(block._key, blockUpdate)
+      expect(service.update).toHaveBeenCalledWith(block.id, blockUpdate)
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/block/typography/typography.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/typography/typography.resolver.ts
@@ -1,6 +1,6 @@
 import { UseGuards } from '@nestjs/common'
 import { Args, Mutation, Resolver } from '@nestjs/graphql'
-import { IdAsKey, KeyAsId } from '@core/nest/decorators'
+
 import {
   TypographyBlock,
   TypographyBlockCreateInput,
@@ -20,7 +20,6 @@ export class TypographyBlockResolver {
       UserJourneyRole.editor
     ])
   )
-  @IdAsKey()
   async typographyBlockCreate(
     @Args('input') input: TypographyBlockCreateInput & { __typename }
   ): Promise<TypographyBlock> {
@@ -36,7 +35,6 @@ export class TypographyBlockResolver {
   }
 
   @Mutation()
-  @KeyAsId()
   @UseGuards(
     RoleGuard('journeyId', [UserJourneyRole.owner, UserJourneyRole.editor])
   )

--- a/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
@@ -13,7 +13,7 @@ describe('VideoBlockResolver', () => {
     service: BlockService
 
   const block1 = {
-    _key: '1',
+    id: '1',
     journeyId: '2',
     __typename: 'VideoBlock',
     parentBlockId: '3',
@@ -29,36 +29,15 @@ describe('VideoBlockResolver', () => {
   }
 
   const blockResponse1 = {
-    id: '1',
-    journeyId: '2',
-    __typename: 'VideoBlock',
-    parentBlockId: '3',
-    parentOrder: 1,
+    ...block1,
     videoContent: {
       mediaComponentId: '2_0-FallingPlates',
       languageId: '529',
       src: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    },
-    title: 'title',
-    posterBlockId: 'posterBlockId',
-    fullscreen: true
+    },    
   }
 
   const block2 = {
-    _key: '1',
-    journeyId: '2',
-    __typename: 'VideoBlock',
-    parentBlockId: '3',
-    parentOrder: 1,
-    videoContent: {
-      src: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    },
-    title: 'title',
-    posterBlockId: 'posterBlockId',
-    fullsize: true
-  }
-
-  const blockResponse2 = {
     id: '1',
     journeyId: '2',
     __typename: 'VideoBlock',
@@ -173,7 +152,7 @@ describe('VideoBlockResolver', () => {
       blockResolver = module.get<BlockResolver>(BlockResolver)
     })
     it('returns VideoBlock', async () => {
-      expect(await blockResolver.block('1')).toEqual(blockResponse2)
+      expect(await blockResolver.block('1')).toEqual(block2)
     })
   })
 

--- a/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
@@ -34,7 +34,7 @@ describe('VideoBlockResolver', () => {
       mediaComponentId: '2_0-FallingPlates',
       languageId: '529',
       src: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    },    
+    }
   }
 
   const block2 = {

--- a/apps/api-journeys/src/app/modules/block/video/video.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/video/video.resolver.ts
@@ -1,8 +1,8 @@
 import { UserInputError } from 'apollo-server-errors'
 import { Args, Mutation, Parent, ResolveField, Resolver } from '@nestjs/graphql'
-import { IdAsKey, KeyAsId } from '@core/nest/decorators'
 import { UseGuards } from '@nestjs/common'
 import { has } from 'lodash'
+
 import { BlockService } from '../block.service'
 import {
   UserJourneyRole,
@@ -48,7 +48,6 @@ export class VideoBlockResolver {
       UserJourneyRole.editor
     ])
   )
-  @IdAsKey()
   async videoBlockCreate(
     @Args('input') input: VideoBlockCreateInput & { __typename }
   ): Promise<VideoBlock> {
@@ -72,7 +71,6 @@ export class VideoBlockResolver {
   @UseGuards(
     RoleGuard('journeyId', [UserJourneyRole.owner, UserJourneyRole.editor])
   )
-  @KeyAsId()
   async videoBlockUpdate(
     @Args('id') id: string,
     @Args('journeyId') journeyId: string,

--- a/apps/api-journeys/src/app/modules/block/videoTrigger/videoTrigger.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/videoTrigger/videoTrigger.resolver.spec.ts
@@ -1,5 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing'
+import { Database } from 'arangojs'
+import { mockDeep } from 'jest-mock-extended'
 import { VideoTriggerBlock } from '../../../__generated__/graphql'
+import { UserJourneyService } from '../../userJourney/userJourney.service'
 import { BlockResolver } from '../block.resolver'
 import { BlockService } from '../block.service'
 import { VideoTriggerResolver } from './videoTrigger.resolver'
@@ -8,7 +11,7 @@ describe('VideoTriggerBlockResolver', () => {
   let resolver: VideoTriggerResolver, blockResolver: BlockResolver
 
   const block = {
-    _key: '1',
+    id: '1',
     journeyId: '2',
     __typename: 'VideoTriggerBlock',
     parentBlockId: '3',
@@ -18,12 +21,6 @@ describe('VideoTriggerBlockResolver', () => {
       gtmEventName: 'gtmEventName',
       journeyId: '4'
     }
-  }
-
-  const blockWithId = {
-    ...block,
-    id: block._key,
-    _key: undefined
   }
 
   const blockResponse = {
@@ -41,7 +38,7 @@ describe('VideoTriggerBlockResolver', () => {
 
   const actionResponse = {
     ...blockResponse.action,
-    parentBlockId: block._key
+    parentBlockId: block.id
   }
 
   const blockService = {
@@ -54,7 +51,16 @@ describe('VideoTriggerBlockResolver', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [BlockResolver, blockService, VideoTriggerResolver]
+      providers: [
+        BlockResolver,
+        blockService,
+        VideoTriggerResolver,
+        UserJourneyService,
+        {
+          provide: 'DATABASE',
+          useFactory: () => mockDeep<Database>()
+        }
+      ]
     }).compile()
     resolver = module.get<VideoTriggerResolver>(VideoTriggerResolver)
     blockResolver = module.get<BlockResolver>(BlockResolver)
@@ -73,7 +79,7 @@ describe('VideoTriggerBlockResolver', () => {
   describe('action', () => {
     it('returns VideoTriggerBlock action with parentBlockId', async () => {
       expect(
-        await resolver.action(blockWithId as unknown as VideoTriggerBlock)
+        await resolver.action(block as unknown as VideoTriggerBlock)
       ).toEqual(actionResponse)
     })
   })

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -37,7 +37,7 @@ describe('JourneyResolver', () => {
   const createdAt = new Date('2021-11-19T12:34:56.647Z').toISOString()
 
   const journey = {
-    _key: '1',
+    id: '1',
     title: 'published',
     status: JourneyStatus.published,
     locale: 'en-US',
@@ -51,18 +51,6 @@ describe('JourneyResolver', () => {
   }
 
   const block = {
-    _key: '2',
-    journeyId: '1',
-    __typename: 'ImageBlock',
-    parentBlockId: '3',
-    parentOrder: 2,
-    src: 'https://source.unsplash.com/random/1920x1080',
-    alt: 'random image from unsplash',
-    width: 1920,
-    height: 1080
-  }
-
-  const blockResponse = {
     id: '2',
     journeyId: '1',
     __typename: 'ImageBlock',
@@ -85,16 +73,7 @@ describe('JourneyResolver', () => {
   }
 
   const journeyResponse = {
-    id: '1',
-    title: 'published',
-    locale: 'en-US',
-    themeMode: ThemeMode.light,
-    themeName: ThemeName.base,
-    description: null,
-    primaryImageBlockId: '2',
-    slug: 'published-slug',
-    createdAt,
-    publishedAt,
+    ...journey,
     status: JourneyStatus.published
   }
 
@@ -136,13 +115,6 @@ describe('JourneyResolver', () => {
   }
 
   const userJourney = {
-    _key: '1',
-    userId: '1',
-    journeyId: '1',
-    role: UserJourneyRole.editor
-  }
-
-  const userJourneyResponse = {
     id: '1',
     userId: '1',
     journeyId: '1',
@@ -150,14 +122,14 @@ describe('JourneyResolver', () => {
   }
 
   const ownerUserJourney = {
-    _key: '2',
+    id: '2',
     userId: '2',
     journeyId: '1',
     role: UserJourneyRole.owner
   }
 
   const invitedUserJourney = {
-    _key: '3',
+    id: '3',
     userId: '3',
     journeyId: '1',
     role: UserJourneyRole.inviteRequested
@@ -196,8 +168,8 @@ describe('JourneyResolver', () => {
     provide: UserJourneyService,
     useFactory: () => ({
       get: jest.fn((key) => {
-        if (key === ownerUserJourney._key) return ownerUserJourney
-        if (key === invitedUserJourney._key) return invitedUserJourney
+        if (key === ownerUserJourney.id) return ownerUserJourney
+        if (key === invitedUserJourney.id) return invitedUserJourney
         return userJourney
       }),
       save: jest.fn((input) => input),
@@ -230,7 +202,7 @@ describe('JourneyResolver', () => {
       expect(await resolver.adminJourney('2', 'slug')).toEqual(journeyResponse)
       expect(service.getBySlug).toHaveBeenCalledWith('slug')
       expect(ujService.forJourneyUser).toHaveBeenCalledWith(
-        userJourneyResponse.journeyId,
+        userJourney.journeyId,
         '2'
       )
     })
@@ -279,16 +251,14 @@ describe('JourneyResolver', () => {
 
   describe('Blocks', () => {
     it('returns Block', async () => {
-      expect(await resolver.blocks(journeyResponse)).toEqual([blockResponse])
+      expect(await resolver.blocks(journeyResponse)).toEqual([block])
     })
   })
 
   // need working example to diagnose
   describe('primaryImageBlock', () => {
     it('returns primaryImageBlock', async () => {
-      expect(await resolver.primaryImageBlock(piJourneyResponse)).toEqual(
-        blockResponse
-      )
+      expect(await resolver.primaryImageBlock(piJourneyResponse)).toEqual(block)
     })
     it('should return null', async () => {
       expect(await resolver.primaryImageBlock(piJourneyResponsenull)).toEqual(
@@ -397,8 +367,8 @@ describe('JourneyResolver', () => {
   describe('userJourneys', () => {
     it('should get userJourneys', async () => {
       expect(await resolver.userJourneys(journeyResponse)).toEqual([
-        userJourneyResponse,
-        userJourneyResponse
+        userJourney,
+        userJourney
       ])
       expect(ujService.forJourney).toHaveBeenCalledWith(journeyResponse)
     })

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -6,13 +6,14 @@ import {
   ResolveField,
   Resolver
 } from '@nestjs/graphql'
-import { CurrentUserId, IdAsKey, KeyAsId } from '@core/nest/decorators'
+import { CurrentUserId } from '@core/nest/decorators'
 import slugify from 'slugify'
 import { UseGuards } from '@nestjs/common'
 import { GqlAuthGuard } from '@core/nest/gqlAuthGuard'
 import { ForbiddenError, UserInputError } from 'apollo-server-errors'
 import { get } from 'lodash'
 import { v4 as uuidv4 } from 'uuid'
+
 import { BlockService } from '../block/block.service'
 import {
   Block,
@@ -48,25 +49,23 @@ export class JourneyResolver {
   ) {}
 
   @Query()
-  @KeyAsId()
   async adminJourneys(@CurrentUserId() userId: string): Promise<Journey[]> {
     return await this.journeyService.getAllByOwnerEditor(userId)
   }
 
   @Query()
-  @KeyAsId()
   async adminJourney(
     @CurrentUserId() userId: string,
-    @Args('id') _key: string,
+    @Args('id') id: string,
     @Args('idType') idType: IdType = IdType.slug
   ): Promise<Journey> {
     const result: Journey =
       idType === IdType.slug
-        ? await this.journeyService.getBySlug(_key)
-        : await this.journeyService.get(_key)
+        ? await this.journeyService.getBySlug(id)
+        : await this.journeyService.get(id)
     const resolved = resolveStatus(result)
     const ujResult = await this.userJourneyService.forJourneyUser(
-      get(resolved, '_key'),
+      get(resolved, 'id'),
       userId
     )
     if (ujResult == null)
@@ -80,33 +79,30 @@ export class JourneyResolver {
   }
 
   @Query()
-  @KeyAsId()
   async journeys(): Promise<Journey[]> {
     return await this.journeyService.getAllPublishedJourneys()
   }
 
   @Query()
-  @KeyAsId()
   async journey(
-    @Args('id') _key: string,
+    @Args('id') id: string,
     @Args('idType') idType: IdType = IdType.slug
   ): Promise<Journey | null> {
     const result: Journey =
       idType === IdType.slug
-        ? await this.journeyService.getBySlug(_key)
-        : await this.journeyService.get(_key)
+        ? await this.journeyService.getBySlug(id)
+        : await this.journeyService.get(id)
     const resolved = resolveStatus(result)
     return resolved.status === JourneyStatus.published ? resolved : null
   }
 
   @Mutation()
   @UseGuards(GqlAuthGuard)
-  @IdAsKey()
   async journeyCreate(
-    @Args('input') input: JourneyCreateInput & { _key?: string },
+    @Args('input') input: JourneyCreateInput & { id?: string },
     @CurrentUserId() userId: string
   ): Promise<Journey | undefined> {
-    input._key = input._key ?? uuidv4()
+    input.id = input.id ?? uuidv4()
     input.slug = slugify(input.slug ?? input.title, {
       lower: true,
       strict: true
@@ -114,25 +110,24 @@ export class JourneyResolver {
     let retry = true
     while (retry) {
       try {
-        const journey: Journey & { _key: string } =
-          await this.journeyService.save({
-            themeName: ThemeName.base,
-            themeMode: ThemeMode.light,
-            createdAt: new Date().toISOString(),
-            locale: 'en-US',
-            status: JourneyStatus.draft,
-            ...input
-          })
+        const journey: Journey = await this.journeyService.save({
+          themeName: ThemeName.base,
+          themeMode: ThemeMode.light,
+          createdAt: new Date().toISOString(),
+          locale: 'en-US',
+          status: JourneyStatus.draft,
+          ...input
+        })
         await this.userJourneyService.save({
           userId,
-          journeyId: journey._key,
+          journeyId: journey.id,
           role: UserJourneyRole.owner
         })
         retry = false
         return journey
       } catch (err) {
         if (err.errorNum === ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED) {
-          input.slug = slugify(`${input.slug}-${input._key}`)
+          input.slug = slugify(`${input.slug}-${input.id}`)
         } else {
           retry = false
           throw err
@@ -173,13 +168,11 @@ export class JourneyResolver {
   }
 
   @ResolveField()
-  @KeyAsId()
   async blocks(@Parent() journey: Journey): Promise<Block[]> {
     return await this.blockService.forJourney(journey)
   }
 
   @ResolveField()
-  @KeyAsId()
   async primaryImageBlock(
     @Parent() journey: Journey
   ): Promise<ImageBlock | null> {
@@ -188,7 +181,6 @@ export class JourneyResolver {
   }
 
   @ResolveField()
-  @KeyAsId()
   async userJourneys(@Parent() journey: Journey): Promise<UserJourney[]> {
     return await this.userJourneyService.forJourney(journey)
   }

--- a/apps/api-journeys/src/app/modules/journey/journey.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.service.spec.ts
@@ -6,6 +6,8 @@ import {
   mockDbQueryResult
 } from '@core/nest/database'
 import { DocumentCollection } from 'arangojs/collection'
+import { keyAsId } from '@core/nest/decorators'
+
 import {
   JourneyStatus,
   ThemeMode,
@@ -46,6 +48,8 @@ describe('JourneyService', () => {
     slug: 'published-slug'
   }
 
+  const journeyWithId = keyAsId(journey)
+
   describe('getAll', () => {
     beforeEach(() => {
       ;(service.db as DeepMockProxy<Database>).query.mockReturnValue(
@@ -54,7 +58,7 @@ describe('JourneyService', () => {
     })
 
     it('should return an array of journeys', async () => {
-      expect(await service.getAll()).toEqual([journey, journey])
+      expect(await service.getAll()).toEqual([journeyWithId, journeyWithId])
     })
   })
 
@@ -66,7 +70,7 @@ describe('JourneyService', () => {
     })
 
     it('should return a journey', async () => {
-      expect(await service.get('1')).toEqual(journey)
+      expect(await service.get('1')).toEqual(journeyWithId)
     })
   })
 
@@ -78,7 +82,7 @@ describe('JourneyService', () => {
     })
 
     it('should return a journey', async () => {
-      expect(await service.getBySlug('slug')).toEqual(journey)
+      expect(await service.getBySlug('slug')).toEqual(journeyWithId)
     })
   })
 
@@ -90,7 +94,7 @@ describe('JourneyService', () => {
     })
 
     it('should return published journeys', async () => {
-      expect(await service.getAllPublishedJourneys()).toEqual([journey])
+      expect(await service.getAllPublishedJourneys()).toEqual([journeyWithId])
     })
   })
 
@@ -102,7 +106,7 @@ describe('JourneyService', () => {
     })
 
     it('should return all for user', async () => {
-      expect(await service.getAllByOwnerEditor('1')).toEqual([journey])
+      expect(await service.getAllByOwnerEditor('1')).toEqual([journeyWithId])
     })
   })
 
@@ -116,7 +120,7 @@ describe('JourneyService', () => {
     })
 
     it('should return a saved journey', async () => {
-      expect(await service.save(journey)).toEqual(journey)
+      expect(await service.save(journey)).toEqual(journeyWithId)
     })
   })
 
@@ -130,7 +134,7 @@ describe('JourneyService', () => {
     })
 
     it('should return a saved journey', async () => {
-      expect(await service.update(journey._key, journey)).toEqual(journey)
+      expect(await service.update(journey._key, journey)).toEqual(journeyWithId)
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/journey/journey.service.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@nestjs/common'
 import { aql } from 'arangojs'
 import { BaseService } from '@core/nest/database'
 import { DocumentCollection } from 'arangojs/collection'
+import { KeyAsId } from '@core/nest/decorators'
+
 import {
   Journey,
   JourneyStatus,
@@ -10,6 +12,7 @@ import {
 
 @Injectable()
 export class JourneyService extends BaseService {
+  @KeyAsId()
   async getAllPublishedJourneys(): Promise<Journey[]> {
     const rst = await this.db.query(aql`
     FOR journey IN ${this.collection}
@@ -18,6 +21,7 @@ export class JourneyService extends BaseService {
     return await rst.all()
   }
 
+  @KeyAsId()
   async getBySlug(_key: string): Promise<Journey> {
     const result = await this.db.query(aql`
       FOR journey in ${this.collection}
@@ -28,6 +32,7 @@ export class JourneyService extends BaseService {
     return await result.next()
   }
 
+  @KeyAsId()
   async getAllByOwnerEditor(userId: string): Promise<Journey[]> {
     const result = await this.db.query(aql`
     FOR userJourney in userJourneys

--- a/apps/api-journeys/src/app/modules/response/radioQuestion/radioQuestion.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/response/radioQuestion/radioQuestion.resolver.spec.ts
@@ -6,14 +6,6 @@ describe('RadioQuestionResponseResolver', () => {
   let resolver: RadioQuestionResponseResolver
 
   const response = {
-    _key: '1',
-    __typename: 'RadioQuestionResponse',
-    blockId: '2',
-    userId: '3',
-    radioOptionBlockId: '4'
-  }
-
-  const responseResponse = {
     id: '1',
     __typename: 'RadioQuestionResponse',
     blockId: '2',
@@ -40,7 +32,7 @@ describe('RadioQuestionResponseResolver', () => {
   describe('radioQuestionResponseCreate', () => {
     it('returns RadioQuestionResponse', async () => {
       expect(await resolver.radioQuestionResponseCreate(response)).toEqual(
-        responseResponse
+        response
       )
     })
   })

--- a/apps/api-journeys/src/app/modules/response/radioQuestion/radioQuestion.resolver.ts
+++ b/apps/api-journeys/src/app/modules/response/radioQuestion/radioQuestion.resolver.ts
@@ -2,7 +2,6 @@
 
 import { UseGuards } from '@nestjs/common'
 import { Args, Mutation, Resolver } from '@nestjs/graphql'
-import { IdAsKey } from '@core/nest/decorators'
 import { GqlAuthGuard } from '@core/nest/gqlAuthGuard'
 import {
   RadioQuestionResponse,
@@ -15,7 +14,6 @@ export class RadioQuestionResponseResolver {
   constructor(private readonly responseService: ResponseService) {}
   @Mutation()
   @UseGuards(GqlAuthGuard)
-  @IdAsKey()
   async radioQuestionResponseCreate(
     @Args('input') input: RadioQuestionResponseCreateInput & { __typename }
   ): Promise<RadioQuestionResponse> {

--- a/apps/api-journeys/src/app/modules/response/signUp/signUp.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/response/signUp/signUp.resolver.spec.ts
@@ -6,15 +6,6 @@ describe('SignUpResponseResolver', () => {
   let resolver: SignUpResponseResolver
 
   const response = {
-    _key: '1',
-    __typename: 'SignUpResponse',
-    blockId: '2',
-    userId: '3',
-    name: 'Robert Smith',
-    email: 'robert.smith@jesusfilm.org'
-  }
-
-  const responseResponse = {
     id: '1',
     __typename: 'SignUpResponse',
     blockId: '2',
@@ -39,9 +30,7 @@ describe('SignUpResponseResolver', () => {
 
   describe('SignUpResponse', () => {
     it('returns SignUpResponse', async () => {
-      expect(await resolver.signUpResponseCreate(response)).toEqual(
-        responseResponse
-      )
+      expect(await resolver.signUpResponseCreate(response)).toEqual(response)
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/response/signUp/signUp.resolver.ts
+++ b/apps/api-journeys/src/app/modules/response/signUp/signUp.resolver.ts
@@ -2,7 +2,6 @@
 
 import { UseGuards } from '@nestjs/common'
 import { Args, Mutation, Resolver } from '@nestjs/graphql'
-import { IdAsKey } from '@core/nest/decorators'
 import { GqlAuthGuard } from '@core/nest/gqlAuthGuard'
 import {
   SignUpResponse,
@@ -15,7 +14,6 @@ export class SignUpResponseResolver {
   constructor(private readonly responseService: ResponseService) {}
   @Mutation()
   @UseGuards(GqlAuthGuard)
-  @IdAsKey()
   async signUpResponseCreate(
     @Args('input') input: SignUpResponseCreateInput & { __typename }
   ): Promise<SignUpResponse> {

--- a/apps/api-journeys/src/app/modules/response/video/video.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/response/video/video.resolver.spec.ts
@@ -7,15 +7,6 @@ describe('VideoResponseResolver', () => {
   let resolver: VideoResponseResolver
 
   const response = {
-    _key: '1',
-    __typename: 'VideoResponse',
-    blockId: '2',
-    userId: '3',
-    state: VideoResponseStateEnum.PLAYING,
-    position: 30
-  }
-
-  const responseResponse = {
     id: '1',
     __typename: 'VideoResponse',
     blockId: '2',
@@ -40,9 +31,7 @@ describe('VideoResponseResolver', () => {
 
   describe('videoResponseCreate', () => {
     it('returns VideoResponse', async () => {
-      expect(await resolver.videoResponseCreate(response)).toEqual(
-        responseResponse
-      )
+      expect(await resolver.videoResponseCreate(response)).toEqual(response)
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/response/video/video.resolver.ts
+++ b/apps/api-journeys/src/app/modules/response/video/video.resolver.ts
@@ -1,6 +1,5 @@
 import { UseGuards } from '@nestjs/common'
 import { Args, Mutation, Resolver } from '@nestjs/graphql'
-import { IdAsKey } from '@core/nest/decorators'
 import { GqlAuthGuard } from '@core/nest/gqlAuthGuard'
 import {
   VideoResponse,
@@ -13,7 +12,6 @@ export class VideoResponseResolver {
   constructor(private readonly responseService: ResponseService) {}
   @Mutation()
   @UseGuards(GqlAuthGuard)
-  @IdAsKey()
   async videoResponseCreate(
     @Args('input') input: VideoResponseCreateInput & { __typename }
   ): Promise<VideoResponse> {

--- a/apps/api-journeys/src/app/modules/userJourney/userJourney.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/userJourney/userJourney.resolver.spec.ts
@@ -15,21 +15,21 @@ describe('UserJourneyResolver', () => {
   let resolver: UserJourneyResolver, service: UserJourneyService
 
   const userJourney = {
-    _key: '1',
+    id: '1',
     userId: '1',
     journeyId: '2',
     role: UserJourneyRole.editor
   }
 
   const actorUserJourney = {
-    _key: '2',
+    id: '2',
     userId: '2',
     journeyId: '2',
     role: UserJourneyRole.owner
   }
 
   const userJourneyInvited = {
-    _key: '1',
+    id: '1',
     userId: '1',
     journeyId: '1',
     role: UserJourneyRole.inviteRequested
@@ -39,7 +39,7 @@ describe('UserJourneyResolver', () => {
   const createdAt = new Date('2021-11-19T12:34:56.647Z').toISOString()
 
   const journey = {
-    _key: '1',
+    id: '1',
     title: 'published',
     status: JourneyStatus.published,
     locale: 'en-US',
@@ -55,7 +55,7 @@ describe('UserJourneyResolver', () => {
   const journeyService = {
     provide: JourneyService,
     useFactory: () => ({
-      get: jest.fn((_key) => (_key === journey._key ? journey : undefined)),
+      get: jest.fn((id) => (id === journey.id ? journey : undefined)),
       getBySlug: jest.fn((slug) =>
         slug === journey.slug ? journey : undefined
       )
@@ -66,7 +66,7 @@ describe('UserJourneyResolver', () => {
     provide: UserJourneyService,
     useFactory: () => ({
       get: jest.fn((key) => {
-        if (key === actorUserJourney._key) return actorUserJourney
+        if (key === actorUserJourney.id) return actorUserJourney
         return userJourney
       }),
       getAll: jest.fn(() => [userJourney, userJourney]),
@@ -90,15 +90,15 @@ describe('UserJourneyResolver', () => {
 
   describe('userJourneyRequest', () => {
     it('creates a UserJourney when journeyId is databaseId', async () => {
-      await resolver.userJourneyRequest(journey._key, IdType.databaseId, '1')
+      await resolver.userJourneyRequest(journey.id, IdType.databaseId, '1')
       expect(service.save).toHaveBeenCalledWith(
-        omit(userJourneyInvited, ['_key'])
+        omit(userJourneyInvited, ['id'])
       )
     })
     it('creates a UserJourney when journeyId is slug', async () => {
       await resolver.userJourneyRequest(journey.slug, IdType.slug, '1')
       expect(service.save).toHaveBeenCalledWith(
-        omit(userJourneyInvited, ['_key'])
+        omit(userJourneyInvited, ['id'])
       )
     })
 
@@ -114,7 +114,7 @@ describe('UserJourneyResolver', () => {
   describe('userJourneyApprove', () => {
     it('updates a UserJourney to editor status', async () => {
       await resolver
-        .userJourneyApprove(userJourney._key, actorUserJourney.userId)
+        .userJourneyApprove(userJourney.id, actorUserJourney.userId)
         .catch((err) => console.log(err))
       expect(service.update).toHaveBeenCalledWith('1', {
         role: UserJourneyRole.editor
@@ -122,7 +122,7 @@ describe('UserJourneyResolver', () => {
     })
     it('should not update a UserJourney to editor status', async () => {
       await resolver
-        .userJourneyApprove(userJourney._key, userJourney.userId)
+        .userJourneyApprove(userJourney.id, userJourney.userId)
         .catch((err) => console.log(err))
       expect(service.update).not.toHaveBeenCalled()
     })
@@ -131,7 +131,7 @@ describe('UserJourneyResolver', () => {
   describe('userJourneyPromote', () => {
     it('updates a UserJourney to owner status', async () => {
       await resolver
-        .userJourneyPromote(userJourney._key, actorUserJourney.userId)
+        .userJourneyPromote(userJourney.id, actorUserJourney.userId)
         .catch((err) => console.log(err))
       expect(service.update).toHaveBeenCalledWith('1', {
         role: UserJourneyRole.owner
@@ -142,13 +142,13 @@ describe('UserJourneyResolver', () => {
     })
     it('should not update a UserJourney', async () => {
       await resolver
-        .userJourneyPromote(userJourney._key, userJourney.userId)
+        .userJourneyPromote(userJourney.id, userJourney.userId)
         .catch((err) => console.log(err))
       expect(service.update).not.toHaveBeenCalled()
     })
     it('should not update a UserJourney scenario 2', async () => {
       await resolver
-        .userJourneyPromote(actorUserJourney._key, actorUserJourney.userId)
+        .userJourneyPromote(actorUserJourney.id, actorUserJourney.userId)
         .catch((err) => console.log(err))
       expect(service.update).not.toHaveBeenCalled()
     })
@@ -157,9 +157,9 @@ describe('UserJourneyResolver', () => {
   describe('userJourneyRemove', () => {
     it('removes a UserJourney', async () => {
       await resolver
-        .userJourneyRemove(actorUserJourney._key, actorUserJourney.userId)
+        .userJourneyRemove(actorUserJourney.id, actorUserJourney.userId)
         .catch((err) => console.log(err))
-      expect(service.remove).toHaveBeenCalledWith(actorUserJourney._key)
+      expect(service.remove).toHaveBeenCalledWith(actorUserJourney.id)
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/userJourney/userJourney.resolver.ts
+++ b/apps/api-journeys/src/app/modules/userJourney/userJourney.resolver.ts
@@ -6,7 +6,7 @@ import {
   Query,
   ResolveField
 } from '@nestjs/graphql'
-import { CurrentUserId, IdAsKey, KeyAsId } from '@core/nest/decorators'
+import { CurrentUserId } from '@core/nest/decorators'
 import { UseGuards } from '@nestjs/common'
 import { GqlAuthGuard } from '@core/nest/gqlAuthGuard'
 import { AuthenticationError, UserInputError } from 'apollo-server-errors'
@@ -27,20 +27,18 @@ export class UserJourneyResolver {
   ) {}
 
   @Query()
-  @IdAsKey()
   async userJourneys(@Parent() journey: Journey): Promise<UserJourney[]> {
     return await this.userJourneyService.forJourney(journey)
   }
 
   @Mutation()
   @UseGuards(GqlAuthGuard)
-  @KeyAsId()
   async userJourneyRequest(
     @Args('journeyId') journeyId: string,
     @Args('idType') idType: IdType = IdType.slug,
     @CurrentUserId() userId: string
   ): Promise<UserJourney> {
-    const journey =
+    const journey: Journey =
       idType === IdType.slug
         ? await this.journeyService.getBySlug(journeyId)
         : await this.journeyService.get(journeyId)
@@ -49,12 +47,11 @@ export class UserJourneyResolver {
 
     return await this.userJourneyService.save({
       userId,
-      journeyId: (journey as { _key: string })._key,
+      journeyId: journey.id,
       role: 'inviteRequested'
     })
   }
 
-  @KeyAsId()
   async checkOwnership(id: string, userId: string): Promise<UserJourney> {
     // can only update user journey roles if you are the journey's owner.
     const actor: UserJourney = await this.userJourneyService.forJourneyUser(
@@ -78,7 +75,6 @@ export class UserJourneyResolver {
 
   @Mutation()
   @UseGuards(GqlAuthGuard)
-  @KeyAsId()
   async userJourneyApprove(
     @Args('id') id: string,
     @CurrentUserId() userId: string
@@ -92,7 +88,6 @@ export class UserJourneyResolver {
 
   @Mutation()
   @UseGuards(GqlAuthGuard)
-  @KeyAsId()
   async userJourneyPromote(
     @Args('id') id: string,
     @CurrentUserId() userId: string
@@ -117,7 +112,6 @@ export class UserJourneyResolver {
 
   @Mutation()
   @UseGuards(GqlAuthGuard)
-  @KeyAsId()
   async userJourneyRemove(
     @Args('id') id: string,
     @CurrentUserId() userId: string
@@ -128,7 +122,6 @@ export class UserJourneyResolver {
   }
 
   @ResolveField()
-  @KeyAsId()
   async journey(@Parent() userJourney: UserJourney): Promise<Journey> {
     return await this.journeyService.get(userJourney.journeyId)
   }

--- a/apps/api-journeys/src/app/modules/userJourney/userJourney.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/userJourney/userJourney.service.spec.ts
@@ -7,6 +7,8 @@ import {
   mockDbQueryResult
 } from '@core/nest/database'
 import { DocumentCollection } from 'arangojs/collection'
+import { keyAsId } from '@core/nest/decorators'
+
 import {
   JourneyStatus,
   ThemeMode,
@@ -43,6 +45,8 @@ describe('UserJourneyService', () => {
     role: UserJourneyRole.editor
   }
 
+  const userJourneyWithId = keyAsId(userJourney)
+
   const journey = {
     id: '1',
     title: 'published',
@@ -65,8 +69,8 @@ describe('UserJourneyService', () => {
 
     it('should return an array of userjourneys', async () => {
       expect(await service.forJourney(journey)).toEqual([
-        userJourney,
-        userJourney
+        userJourneyWithId,
+        userJourneyWithId
       ])
     })
   })
@@ -79,7 +83,7 @@ describe('UserJourneyService', () => {
     })
 
     it('should return a userjourney', async () => {
-      expect(await service.forJourneyUser('1', '2')).toEqual(userJourney)
+      expect(await service.forJourneyUser('1', '2')).toEqual(userJourneyWithId)
     })
   })
 
@@ -93,7 +97,7 @@ describe('UserJourneyService', () => {
     })
 
     it('should return a removed userJourney', async () => {
-      expect(await service.remove('1')).toEqual(userJourney)
+      expect(await service.remove('1')).toEqual(userJourneyWithId)
     })
   })
 
@@ -107,7 +111,7 @@ describe('UserJourneyService', () => {
     })
 
     it('should return a saved userJourney', async () => {
-      expect(await service.save(userJourney)).toEqual(userJourney)
+      expect(await service.save(userJourney)).toEqual(userJourneyWithId)
     })
   })
 
@@ -121,7 +125,7 @@ describe('UserJourneyService', () => {
     })
 
     it('should return an updated userJourney', async () => {
-      expect(await service.update('1', userJourney)).toEqual(userJourney)
+      expect(await service.update('1', userJourney)).toEqual(userJourneyWithId)
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/userJourney/userJourney.service.ts
+++ b/apps/api-journeys/src/app/modules/userJourney/userJourney.service.ts
@@ -2,12 +2,15 @@ import { BaseService } from '@core/nest/database'
 import { Injectable } from '@nestjs/common'
 import { aql } from 'arangojs'
 import { DocumentCollection } from 'arangojs/collection'
+import { KeyAsId } from '@core/nest/decorators'
+
 import { Journey, UserJourney } from '../../__generated__/graphql'
 
 @Injectable()
 export class UserJourneyService extends BaseService {
   collection: DocumentCollection = this.db.collection('userJourneys')
 
+  @KeyAsId()
   async forJourney(journey: Journey): Promise<UserJourney[]> {
     const res = await this.db.query(aql`
       FOR j in ${this.collection}
@@ -17,6 +20,7 @@ export class UserJourneyService extends BaseService {
     return await res.all()
   }
 
+  @KeyAsId()
   async forJourneyUser(
     journeyId: string,
     userId: string

--- a/apps/api-languages/src/app/modules/language/language.resolver.ts
+++ b/apps/api-languages/src/app/modules/language/language.resolver.ts
@@ -1,5 +1,5 @@
 import { Resolver, Query, Args, ResolveField, Parent } from '@nestjs/graphql'
-import { KeyAsId, TranslationField } from '@core/nest/decorators'
+import { TranslationField } from '@core/nest/decorators'
 import { Language } from '../../__generated__/graphql'
 import { LanguageService } from './language.service'
 
@@ -8,7 +8,6 @@ export class LanguageResolver {
   constructor(private readonly languageService: LanguageService) {}
 
   @Query()
-  @KeyAsId()
   async languages(
     @Args('page') page: number,
     @Args('limit') limit: number
@@ -17,9 +16,8 @@ export class LanguageResolver {
   }
 
   @Query()
-  @KeyAsId()
-  async language(@Args('id') _key: string): Promise<Language> {
-    return await this.languageService.get(_key)
+  async language(@Args('id') id: string): Promise<Language> {
+    return await this.languageService.get(id)
   }
 
   @ResolveField()

--- a/apps/api-languages/src/app/modules/language/language.service.spec.ts
+++ b/apps/api-languages/src/app/modules/language/language.service.spec.ts
@@ -7,6 +7,8 @@ import {
   mockDbQueryResult
 } from '@core/nest/database'
 import { DocumentCollection } from 'arangojs/collection'
+import { keyAsId } from '@core/nest/decorators'
+
 import { LanguageService } from './language.service'
 
 describe('LanguageService', () => {
@@ -41,6 +43,8 @@ describe('LanguageService', () => {
     ]
   }
 
+  const languageWithId = keyAsId(language)
+
   describe('getAll', () => {
     beforeEach(() => {
       ;(service.db as DeepMockProxy<Database>).query.mockReturnValue(
@@ -49,7 +53,10 @@ describe('LanguageService', () => {
     })
 
     it('should retun an array of languages', async () => {
-      expect(await service.getAll(1, 2)).toEqual([language, language])
+      expect(await service.getAll(1, 2)).toEqual([
+        languageWithId,
+        languageWithId
+      ])
     })
   })
 
@@ -63,7 +70,7 @@ describe('LanguageService', () => {
     })
 
     it('should return a language', async () => {
-      expect(await service.save(language)).toEqual(language)
+      expect(await service.save(language)).toEqual(languageWithId)
     })
   })
 
@@ -77,7 +84,7 @@ describe('LanguageService', () => {
     })
 
     it('should return a language', async () => {
-      expect(await service.remove('1')).toEqual(language)
+      expect(await service.remove('1')).toEqual(languageWithId)
     })
   })
 })

--- a/apps/api-languages/src/app/modules/language/language.service.ts
+++ b/apps/api-languages/src/app/modules/language/language.service.ts
@@ -2,11 +2,13 @@ import { BaseService } from '@core/nest/database'
 import { Injectable } from '@nestjs/common'
 import { aql } from 'arangojs'
 import { DocumentCollection } from 'arangojs/collection'
+import { KeyAsId } from '@core/nest/decorators'
 
 @Injectable()
 export class LanguageService extends BaseService {
   collection: DocumentCollection = this.db.collection('languages')
 
+  @KeyAsId()
   async getAll<T>(page = 1, limit = 1000): Promise<T[]> {
     const offset = limit * (page - 1)
     const res = await this.db.query(aql`

--- a/apps/api-languages/src/app/modules/translation/translation.resolver.ts
+++ b/apps/api-languages/src/app/modules/translation/translation.resolver.ts
@@ -1,4 +1,3 @@
-import { KeyAsId } from '@core/nest/decorators'
 import { Resolver, ResolveField, Parent } from '@nestjs/graphql'
 import { Language } from '../../__generated__/graphql'
 import { LanguageService } from '../language/language.service'
@@ -8,7 +7,6 @@ export class TranslationResolver {
   constructor(private readonly languageService: LanguageService) {}
 
   @ResolveField()
-  @KeyAsId()
   async language(@Parent() translation): Promise<Language> {
     return await this.languageService.get(translation.languageId)
   }

--- a/apps/api-users/src/app/modules/user/user.resolver.spec.ts
+++ b/apps/api-users/src/app/modules/user/user.resolver.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing'
+
 import { UserResolver } from './user.resolver'
 import { UserService } from './user.service'
 
@@ -6,14 +7,6 @@ describe('UserResolver', () => {
   let resolver: UserResolver
 
   const user = {
-    _key: '1',
-    firstName: 'fo',
-    lastName: 'sho',
-    email: 'tho@no.co',
-    imageUrl: 'po'
-  }
-
-  const userResponse = {
     id: '1',
     firstName: 'fo',
     lastName: 'sho',
@@ -39,15 +32,15 @@ describe('UserResolver', () => {
 
   describe('me', () => {
     it('returns User', async () => {
-      expect(await resolver.me(user._key)).toEqual(userResponse)
+      expect(await resolver.me(user.id)).toEqual(user)
     })
   })
 
   describe('resolveReference', () => {
     it('returns User', async () => {
       expect(
-        await resolver.resolveReference({ __typename: 'User', id: user._key })
-      ).toEqual(userResponse)
+        await resolver.resolveReference({ __typename: 'User', id: user.id })
+      ).toEqual(user)
     })
   })
 })

--- a/apps/api-users/src/app/modules/user/user.resolver.ts
+++ b/apps/api-users/src/app/modules/user/user.resolver.ts
@@ -1,5 +1,5 @@
 import { Resolver, Query, ResolveReference } from '@nestjs/graphql'
-import { CurrentUserId, KeyAsId } from '@core/nest/decorators'
+import { CurrentUserId } from '@core/nest/decorators'
 import { UseGuards } from '@nestjs/common'
 import { GqlAuthGuard } from '@core/nest/gqlAuthGuard'
 import { User } from '../../__generated__/graphql'
@@ -12,7 +12,6 @@ export class UserResolver {
 
   @Query()
   @UseGuards(GqlAuthGuard)
-  @KeyAsId()
   async me(@CurrentUserId() userId: string): Promise<User> {
     const existingUser: User = await this.userService.getByUserId(userId)
 
@@ -37,7 +36,6 @@ export class UserResolver {
   }
 
   @ResolveReference()
-  @KeyAsId()
   async resolveReference(reference: {
     __typename: string
     id: string

--- a/apps/api-users/src/app/modules/user/user.service.spec.ts
+++ b/apps/api-users/src/app/modules/user/user.service.spec.ts
@@ -6,6 +6,8 @@ import {
   mockDbQueryResult
 } from '@core/nest/database'
 import { DocumentCollection } from 'arangojs/collection'
+import { keyAsId } from '@core/nest/decorators'
+
 import { UserService } from './user.service'
 
 describe('UserService', () => {
@@ -37,6 +39,8 @@ describe('UserService', () => {
     imageUrl: 'po'
   }
 
+  const userWithId = keyAsId(user)
+
   describe('getAll', () => {
     beforeEach(() => {
       ;(service.db as DeepMockProxy<Database>).query.mockReturnValue(
@@ -45,7 +49,7 @@ describe('UserService', () => {
     })
 
     it('should return an array of users', async () => {
-      expect(await service.getAll()).toEqual([user, user])
+      expect(await service.getAll()).toEqual([userWithId, userWithId])
     })
   })
 
@@ -57,7 +61,7 @@ describe('UserService', () => {
     })
 
     it('should return a user', async () => {
-      expect(await service.get('1')).toEqual(user)
+      expect(await service.get('1')).toEqual(userWithId)
     })
   })
 
@@ -69,7 +73,7 @@ describe('UserService', () => {
     })
 
     it('should return a user', async () => {
-      expect(await service.getByUserId('1')).toEqual(user)
+      expect(await service.getByUserId('1')).toEqual(userWithId)
     })
   })
 
@@ -81,7 +85,7 @@ describe('UserService', () => {
     })
 
     it('should return a saved user', async () => {
-      expect(await service.save(user)).toEqual(user)
+      expect(await service.save(user)).toEqual(userWithId)
     })
   })
 })

--- a/apps/api-users/src/app/modules/user/user.service.ts
+++ b/apps/api-users/src/app/modules/user/user.service.ts
@@ -2,11 +2,14 @@ import { BaseService } from '@core/nest/database'
 import { Injectable } from '@nestjs/common'
 import { aql } from 'arangojs'
 import { DocumentCollection } from 'arangojs/collection'
+import { KeyAsId } from '@core/nest/decorators'
+
 import { User } from '../../__generated__/graphql'
 
 @Injectable()
 export class UserService extends BaseService {
   collection: DocumentCollection = this.db.collection('users')
+  @KeyAsId()
   async getByUserId(userId: string): Promise<User> {
     const res = await this.db.query(aql`
     FOR user in ${this.collection}

--- a/apps/api-videos/src/app/modules/video/video.resolver.ts
+++ b/apps/api-videos/src/app/modules/video/video.resolver.ts
@@ -1,5 +1,4 @@
 import { Resolver, Query, Args, Info } from '@nestjs/graphql'
-import { KeyAsId } from '@core/nest/decorators'
 import { Video, VideosFilter } from '../../__generated__/graphql'
 import { VideoService } from './video.service'
 
@@ -8,7 +7,6 @@ export class VideoResolver {
   constructor(private readonly videoService: VideoService) {}
 
   @Query()
-  @KeyAsId()
   async videos(
     @Info() info,
     @Args('where') where?: VideosFilter,

--- a/apps/api-videos/src/app/modules/video/video.service.ts
+++ b/apps/api-videos/src/app/modules/video/video.service.ts
@@ -2,6 +2,7 @@ import { BaseService } from '@core/nest/database'
 import { Injectable } from '@nestjs/common'
 import { aql } from 'arangojs'
 import { DocumentCollection } from 'arangojs/collection'
+import { KeyAsId } from '@core/nest/decorators'
 
 interface VideosFilter {
   title?: string
@@ -14,6 +15,7 @@ interface VideosFilter {
 export class VideoService extends BaseService {
   collection: DocumentCollection = this.db.collection('videos')
 
+  @KeyAsId()
   async filterAll<T>(filter?: VideosFilter): Promise<T[]> {
     const {
       title,

--- a/libs/nest/database/src/lib/base.service.spec.ts
+++ b/libs/nest/database/src/lib/base.service.spec.ts
@@ -3,6 +3,8 @@ import { Database } from 'arangojs'
 import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
 import { DocumentCollection } from 'arangojs/collection'
 import { Injectable } from '@nestjs/common'
+import { omit } from 'lodash'
+
 import { mockCollectionUpdateAllResult } from './dbMock'
 import { BaseService } from './base.service'
 
@@ -24,6 +26,14 @@ const block = {
   fullscreen: true
 }
 
+const blockResponse = omit(
+  {
+    id: '1',
+    ...block
+  },
+  ['_key']
+)
+
 const block2 = {
   _key: '2',
   journeyId: '2',
@@ -36,6 +46,14 @@ const block2 = {
   themeName: 'base',
   fullscreen: true
 }
+
+const blockResponse2 = omit(
+  {
+    id: '2',
+    ...block2
+  },
+  ['_key']
+)
 
 describe('Base Service', () => {
   let service: MockService
@@ -65,7 +83,10 @@ describe('Base Service', () => {
       ).updateAll.mockReturnValue(
         mockCollectionUpdateAllResult(service.collection, [block, block2])
       )
-      expect(await service.updateAll([block, block2])).toEqual([block, block2])
+      expect(await service.updateAll([block, block2])).toEqual([
+        blockResponse,
+        blockResponse2
+      ])
       expect(service.collection.updateAll).toHaveBeenCalledWith(
         [block, block2],
         { returnNew: true }

--- a/libs/nest/database/src/lib/base.service.ts
+++ b/libs/nest/database/src/lib/base.service.ts
@@ -3,6 +3,7 @@ import { DocumentCollection } from 'arangojs/collection'
 import { aql, Database } from 'arangojs'
 import { DeepMockProxy } from 'jest-mock-extended'
 import { DocumentData, Patch } from 'arangojs/documents'
+import { KeyAsId, IdAsKey } from '@core/nest/decorators'
 
 @Injectable()
 export abstract class BaseService {
@@ -16,6 +17,7 @@ export abstract class BaseService {
     return str.replace(/'/g, '')
   }
 
+  @KeyAsId()
   async getAll<T>(): Promise<T[]> {
     const rst = await this.db.query(aql`
     FOR item IN ${this.collection}
@@ -23,6 +25,7 @@ export abstract class BaseService {
     return await rst.all()
   }
 
+  @KeyAsId()
   async get<T>(_key: string): Promise<T> {
     const rst = await this.db.query(aql`
     FOR item IN ${this.collection}
@@ -32,11 +35,13 @@ export abstract class BaseService {
     return await rst.next()
   }
 
+  @KeyAsId()
   async update<T, T2>(_key: string, body: T2): Promise<T> {
     const result = await this.collection.update(_key, body, { returnNew: true })
     return result.new
   }
 
+  @IdAsKey()
   async updateAll<T>(
     arr: Array<Patch<DocumentData<T>> & ({ _key: string } | { _id: string })>
   ): Promise<T[]> {
@@ -46,11 +51,13 @@ export abstract class BaseService {
     return result.map((item) => item.new)
   }
 
+  @IdAsKey()
   async save<T, T2>(body: T2): Promise<T> {
     const result = await this.collection.save(body, { returnNew: true })
     return result.new
   }
 
+  @KeyAsId()
   async remove<T>(_key: string): Promise<T> {
     const result = await this.collection.remove(_key, { returnOld: true })
     return result.old

--- a/libs/nest/decorators/src/lib/decorators.ts
+++ b/libs/nest/decorators/src/lib/decorators.ts
@@ -10,12 +10,12 @@ interface TransformObject {
   id?: string
 }
 
-const idAsKey = (obj: TransformObject): TransformObject =>
+export const idAsKey = (obj: TransformObject): TransformObject =>
   has(obj, 'id') && obj.id != null
     ? omit({ ...obj, _key: obj.id }, ['id'])
     : obj
 
-const keyAsId = (obj: TransformObject): TransformObject =>
+export const keyAsId = (obj: TransformObject): TransformObject =>
   has(obj, '_key') ? omit({ ...obj, id: obj._key }, ['_key']) : obj
 
 export function IdAsKey() {


### PR DESCRIPTION
# Description

This moves the KeyAsId and IdAsKey decorators to the service layer, keeping ids in the resolvers

# How should this PR be QA Tested?

No functional changes have been made, but I have run through the app functionality and updated the unit tests accordingly

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
