### PR TITLE
fix: languages endpoint needs platform parameter

### DIFF
--- a/apps/api-videos/db/seed.ts
+++ b/apps/api-videos/db/seed.ts
@@ -118,7 +118,7 @@ async function getMediaComponentLanguage(
     _embedded: { mediaComponentLanguage: MediaComponentLanguage[] }
   } = await (
     await fetch(
-      `https://api.arclight.org/v2/media-components/${mediaComponentId}/languages?apiKey=${
+      `https://api.arclight.org/v2/media-components/${mediaComponentId}/languages?platform=android&apiKey=${
         process.env.ARCLIGHT_API_KEY ?? ''
       }`
     )


### PR DESCRIPTION
ap-videos seed updated to allow importing video variants. HLS values were not being returned if android wasn't being set as the platform.