### PR TITLE
fix: journeys-admin linting

### DIFF
--- a/apps/journeys-admin/__generated__/GetLanguages.ts
+++ b/apps/journeys-admin/__generated__/GetLanguages.ts
@@ -16,7 +16,7 @@ export interface GetLanguages_languages_name {
 export interface GetLanguages_languages {
   __typename: "Language";
   id: string;
-  name: (GetLanguages_languages_name | null)[];
+  name: GetLanguages_languages_name[];
 }
 
 export interface GetLanguages {

--- a/apps/journeys-admin/src/components/Editor/VideoLibrary/LanguageFilter/Drawer/Drawer.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoLibrary/LanguageFilter/Drawer/Drawer.tsx
@@ -125,15 +125,10 @@ export function Drawer({
               <ListItemText
                 id={id}
                 primary={
-                  name.find((translation) => translation?.primary === false)
-                    ?.value ??
-                  name.find((translation) => translation?.primary === true)
-                    ?.value
+                  name.find(({ primary }) => !primary)?.value ??
+                  name.find(({ primary }) => primary)?.value
                 }
-                secondary={
-                  name.find((translation) => translation?.primary === true)
-                    ?.value
-                }
+                secondary={name.find(({ primary }) => primary)?.value}
               />
             </ListItemButton>
           </ListItem>


### PR DESCRIPTION
should not compare booleans to booleans. Initially when this code was pushed through translation object was optional. This has since been updated in api-journeys. This updates the codegen for journeys-admin and fixes the lint error created by that change.