### PR TITLE
refactor: added margin bottom for sign up

### DIFF
--- a/libs/journeys/ui/src/components/SignUp/SignUp.tsx
+++ b/libs/journeys/ui/src/components/SignUp/SignUp.tsx
@@ -136,7 +136,8 @@ export const SignUp = ({
             flexDirection: 'column',
             outline:
               selectedBlock?.id === blockId ? '3px solid #C52D3A' : 'none',
-            outlineOffset: '5px'
+            outlineOffset: '5px',
+            marginBottom: '16px'
           }}
           onClick={selectedBlock === undefined ? undefined : handleSelectBlock}
         >


### PR DESCRIPTION
# Description

Added bottom margin for the sign up component

- [Basecamp todo](https://3.basecamp.com/3105655/buckets/26787371/todos/4752742134)

# How should this PR be QA Tested?

- [ ] Sign up on journeys should have a bottom margin of 16px

# Checklist

- [x] I have performed a self-review of my own code
