### PR TITLE
fix: buttons have same bottom margin

### DIFF
--- a/libs/journeys/ui/src/components/Button/Button.tsx
+++ b/libs/journeys/ui/src/components/Button/Button.tsx
@@ -77,6 +77,7 @@ export function Button({
       endIcon={endIcon != null ? <Icon {...endIcon} /> : undefined}
       sx={{
         ...sx,
+        mb: 5,
         outline: selectedBlock?.id === props.id ? '3px solid #C52D3A' : 'none',
         outlineOffset: '5px'
       }}


### PR DESCRIPTION
# Description

Button bottom margins where different depending on the size variant. Changed so that all buttons have same margin bottom.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/26787371/todos/4752594220)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Button margins should be the same on all variants

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
