### PR TITLE
refactor: removed extra divider

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.tsx
@@ -1,11 +1,6 @@
 import { ReactElement, useEffect, useState, MouseEvent } from 'react'
 import Box from '@mui/material/Box'
-import {
-  ToggleButton,
-  ToggleButtonGroup,
-  Stack,
-  styled
-} from '@mui/material'
+import { ToggleButton, ToggleButtonGroup, Stack, styled } from '@mui/material'
 import { Image as ImageIcon, Videocam } from '@mui/icons-material'
 import { useEditor, TreeBlock } from '@core/journeys/ui'
 import { GetJourney_journey_blocks_CardBlock as CardBlock } from '../../../../../../../../__generated__/GetJourney'
@@ -22,8 +17,8 @@ export function BackgroundMedia(): ReactElement {
     selectedBlock?.__typename === 'CardBlock'
       ? selectedBlock
       : selectedBlock?.children.find(
-        (child) => child.__typename === 'CardBlock'
-      )
+          (child) => child.__typename === 'CardBlock'
+        )
   ) as TreeBlock<CardBlock>
 
   const coverBlock =

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.tsx
@@ -3,7 +3,6 @@ import Box from '@mui/material/Box'
 import {
   ToggleButton,
   ToggleButtonGroup,
-  Divider,
   Stack,
   styled
 } from '@mui/material'
@@ -23,8 +22,8 @@ export function BackgroundMedia(): ReactElement {
     selectedBlock?.__typename === 'CardBlock'
       ? selectedBlock
       : selectedBlock?.children.find(
-          (child) => child.__typename === 'CardBlock'
-        )
+        (child) => child.__typename === 'CardBlock'
+      )
   ) as TreeBlock<CardBlock>
 
   const coverBlock =
@@ -91,7 +90,6 @@ export function BackgroundMedia(): ReactElement {
           </ToggleButton>
         </StyledToggleButtonGroup>
       </Box>
-      <Divider sx={{ sm: 'none' }} />
       {blockType === 'ImageBlock' && (
         <BackgroundMediaImage cardBlock={cardBlock} />
       )}


### PR DESCRIPTION
# Description

Remove extra divider between the video/image and selected file

[Basecamp todo](https://3.basecamp.com/3105655/buckets/26787371/todos/4752761176)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] In background media property, there should be no divider between the video/image and selected file

# Checklist

- [ ] I have performed a self-review of my own code
