### PR TITLE
fix: clears url on delete

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ImageBlockEditor/ImageBlockEditor.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockEditor/ImageBlockEditor.tsx
@@ -42,7 +42,10 @@ export function ImageBlockEditor({
   }
 
   const handleImageDelete = async (): Promise<void> => {
-    if (onDelete != null) await onDelete()
+    if (onDelete != null) {
+      await onDelete()
+      formik.resetForm({ values: { src: '' } })
+    }
   }
 
   const formik = useFormik({


### PR DESCRIPTION
# Description

URL now gets cleared when the cover image is deleted

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/26787371/todos/4752777424)

# How should this PR be QA Tested?

- [x] When cover image block is deleted, the text field should be cleared

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
