### PR TITLE
fix: image tab stays open when background image is deleted

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useEffect, useState, MouseEvent } from 'react'
+import { ReactElement, useState, MouseEvent } from 'react'
 import Box from '@mui/material/Box'
 import { ToggleButton, ToggleButtonGroup, Stack, styled } from '@mui/material'
 import { Image as ImageIcon, Videocam } from '@mui/icons-material'
@@ -28,9 +28,6 @@ export function BackgroundMedia(): ReactElement {
   const [blockType, setBlockType] = useState(
     coverBlock?.__typename.toString() ?? 'VideoBlock'
   )
-  useEffect(() => {
-    setBlockType(coverBlock?.__typename.toString() ?? 'VideoBlock')
-  }, [setBlockType, coverBlock])
 
   const handleTypeChange = (
     event: MouseEvent<HTMLElement>,


### PR DESCRIPTION
# Description

Removed useEffect to let the image tab stay open when the background image is deleted

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/26787371/todos/4752765438)

# How should this PR be QA Tested?

- [x] When deleting a background image, the image tab should stay open
- [x] Drawer should display background image properties when selected.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
