### PR TITLE
fix: flakey navigateToBlockAction spec

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToBlockAction/NavigateToBlockAction.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToBlockAction/NavigateToBlockAction.spec.tsx
@@ -36,7 +36,7 @@ describe('NavigateToBlockAction', () => {
           id: selectedBlock.id,
           journeyId: 'journeyId',
           gtmEventName: 'gtmEventName',
-          blockId: 'step2.id'
+          blockId: 'step0.id'
         }
       }
     }))
@@ -50,7 +50,7 @@ describe('NavigateToBlockAction', () => {
                 id: selectedBlock.id,
                 journeyId: 'journeyId',
                 input: {
-                  blockId: 'step2.id'
+                  blockId: 'step0.id'
                 }
               }
             },
@@ -74,12 +74,12 @@ describe('NavigateToBlockAction', () => {
         </JourneyProvider>
       </MockedProvider>
     )
-    fireEvent.click(getByTestId('preview-step2.id'))
+    fireEvent.click(getByTestId('preview-step0.id'))
     await waitFor(() => expect(result).toHaveBeenCalled())
 
     expect(cache.extract()['ButtonBlock:button1.id']?.action).toEqual({
       gtmEventName: 'gtmEventName',
-      blockId: 'step2.id'
+      blockId: 'step0.id'
     })
   })
 })


### PR DESCRIPTION
# Description
Test was sometimes failing, on github. Think the problem is the card was not clickable as the machine running it did not have enough screen width to click the card specified in the test. Updated so that the action is tested for the first card. 

Hard to test if this issue is actually resolved, so keep an eye on it for the future

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/26787371/todos/4761555684)

# How should this PR be QA Tested?

- [x] Spec updated only, no QA needed

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
