### PR TITLE
feat: fix link action

### DIFF
--- a/libs/journeys/ui/src/libs/action/handleAction.spec.ts
+++ b/libs/journeys/ui/src/libs/action/handleAction.spec.ts
@@ -63,4 +63,14 @@ describe('handleAction', () => {
     })
     expect(nextActiveBlock).toHaveBeenCalledWith()
   })
+
+  it('should handle LinkAction', () => {
+    handleAction(router, {
+      __typename: 'LinkAction',
+      parentBlockId: 'parent-id',
+      gtmEventName: null,
+      url: 'http://www.google.com'
+    })
+    expect(router.push).toHaveBeenCalledWith('http://www.google.com')
+  })
 })

--- a/libs/journeys/ui/src/libs/action/handleAction.ts
+++ b/libs/journeys/ui/src/libs/action/handleAction.ts
@@ -19,5 +19,8 @@ export function handleAction(
     case 'NavigateAction':
       nextActiveBlock()
       break
+    case 'LinkAction':
+      void router.push(action.url)
+      break
   }
 }


### PR DESCRIPTION
# Description

Link action was not working. Added Link Action to handle action, so links are handled now

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/26787371/todos/4752644386)

# How should this PR be QA Tested?
- [x] Button with action of Link Action should redirect to the link

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
