### PR TITLE
chore: update base image to typescript-node 16-bullseye

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # Update the VARIANT arg in docker-compose.yml to pick a Node version
 ARG VARIANT=16
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:dev-${VARIANT}-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:${VARIANT}-bullseye
 
 # Update args in docker-compose.yaml to set the UID/GID of the "node" user.
 ARG USER_UID=1000


### PR DESCRIPTION
change default base image to `typescript-node:${VARIANT}-bullseye`