### PR TITLE
refactor: edit redirect link

### DIFF
--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/JourneyCardMenu.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/JourneyCardMenu.spec.tsx
@@ -48,7 +48,7 @@ describe('JourneyCardMenu', () => {
     fireEvent.click(getByRole('button'))
     expect(getByRole('menuitem', { name: 'Edit' })).toHaveAttribute(
       'href',
-      '/journeys/published-journey/edit'
+      '/journeys/published-journey'
     )
   })
   it('should handle preview', () => {

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/JourneyCardMenu.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/JourneyCardMenu.tsx
@@ -56,7 +56,7 @@ export function JourneyCardMenu({
           'aria-labelledby': 'journey-actions'
         }}
       >
-        <Link href={`/journeys/${slug}/edit`} passHref>
+        <Link href={`/journeys/${slug}`} passHref>
           <MenuItem sx={{ pl: 7, pr: 17, pt: 4, pb: 4 }}>
             <ListItemIcon>
               <EditIcon color="secondary" />


### PR DESCRIPTION
# Description

Currently clicking on the edit button redirects you to JourneyEdit where it should be redirected to the SingleJourney page. As when you click Edit you're not technically editing a card but you're editing the journey

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/26787371/todos/4757380004)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Clicking on the Edit button in the JourneyView page should redirect you to the SingleJourney page.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
