### PR TITLE
fix: revert arango to 3.8.6

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     environment:
       KUBECONFIG: /workspaces/core/.kube/config
   arangodb:
-    image: arangodb/arangodb
+    image: arangodb/arangodb:3.8.6
     volumes:
       - arango-data:/var/lib/arangodb3
     environment:


### PR DESCRIPTION
https://github.com/arangodb/arangodb/issues/15742

Arango 3.9.0 crashes on M1 macs. This drops back to 3.8.6 until we can get a better arm64 container for arango.