### PR TITLE
feat: link new card to previous card

### DIFF
--- a/apps/journeys-admin/__generated__/StepBlockNextBlockIdUpdate.ts
+++ b/apps/journeys-admin/__generated__/StepBlockNextBlockIdUpdate.ts
@@ -1,0 +1,32 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { StepBlockUpdateInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: StepBlockNextBlockIdUpdate
+// ====================================================
+
+export interface StepBlockNextBlockIdUpdate_stepBlockUpdate {
+  __typename: "StepBlock";
+  id: string;
+  /**
+   * nextBlockId contains the preferred block to navigate to when a
+   * NavigateAction occurs or if the user manually tries to advance to the next
+   * step. If no nextBlockId is set it can be assumed that this step represents
+   * the end of the current journey.
+   */
+  nextBlockId: string | null;
+}
+
+export interface StepBlockNextBlockIdUpdate {
+  stepBlockUpdate: StepBlockNextBlockIdUpdate_stepBlockUpdate;
+}
+
+export interface StepBlockNextBlockIdUpdateVariables {
+  id: string;
+  journeyId: string;
+  input: StepBlockUpdateInput;
+}

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.spec.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.spec.tsx
@@ -209,7 +209,6 @@ describe('CardPreview', () => {
         { __ref: 'CardBlock:cardId' }
       ])
     })
-    console.log(cache.extract()['Journey:journeyId'])
   })
 
   it('should set the nextBlockId for the previous step when a new card is created', async () => {

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
@@ -123,9 +123,10 @@ export function CardPreview({
     }
 
     const lastStep = last(steps)
-    const nextBlockExsists =
+    // this check is required as nextBlockId is not updated when the corrseponding block is deleted
+    const validNextBlockId =
       steps.find(({ id }) => id === lastStep?.nextBlockId) != null
-    if (!nextBlockExsists && lastStep != null) {
+    if (!validNextBlockId && lastStep != null) {
       await stepBlockNextBlockIdUpdate({
         variables: {
           id: lastStep.id,

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
@@ -124,8 +124,8 @@ export function CardPreview({
 
     const lastStep = last(steps)
     const nextBlockExsists =
-      steps.find(({ id }) => id === lastStep.nextBlockId) != null
-    if (!nextBlockExsists) {
+      steps.find(({ id }) => id === lastStep?.nextBlockId) != null
+    if (!nextBlockExsists && lastStep != null) {
       await stepBlockNextBlockIdUpdate({
         variables: {
           id: lastStep.id,


### PR DESCRIPTION
# Description

The user having to manually connect the blocks up using next block id when creating a new card, is both confusing and unintuitive. This PR makes it so that when a new card is created, the card immediately before the created card (if it isn't already connected to a card) will get its nextBlockId set as the id of the newly created card.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/26787371/todos/4752753075)

# How should this PR be QA Tested?

- [ ] When creating a new card from a card that has no next connected card, connects the card with the newly created card
- [ ] When creating a card from a card that is already connected to another card, the connection should stay the same

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
