### PR TITLE
fix: disable link action in editor

### DIFF
--- a/libs/journeys/ui/src/components/Button/Button.spec.tsx
+++ b/libs/journeys/ui/src/components/Button/Button.spec.tsx
@@ -133,6 +133,7 @@ describe('Button', () => {
       expect.objectContaining({
         push: expect.any(Function)
       }),
+      false,
       {
         __typename: 'NavigateToBlockAction',
         parentBlockId: block.id,

--- a/libs/journeys/ui/src/components/Button/Button.tsx
+++ b/libs/journeys/ui/src/components/Button/Button.tsx
@@ -2,7 +2,7 @@ import { ReactElement } from 'react'
 import { useRouter } from 'next/router'
 import MuiButton from '@mui/material/Button'
 import Box from '@mui/material/Box'
-import { handleAction, TreeBlock } from '../..'
+import { handleAction, TreeBlock, useEditor } from '../..'
 import { ButtonVariant } from '../../../__generated__/globalTypes'
 import { IconFields } from '../Icon/__generated__/IconFields'
 import { Icon } from '../Icon'
@@ -31,9 +31,12 @@ export function Button({
     | TreeBlock<IconFields>
     | undefined
 
+  const { state } = useEditor()
+  const editorMode = state.selectedBlock != null
+
   const router = useRouter()
   const handleClick = (): void => {
-    handleAction(router, action)
+    handleAction(router, editorMode, action)
   }
 
   return (

--- a/libs/journeys/ui/src/components/RadioQuestion/RadioOption/RadioOption.spec.tsx
+++ b/libs/journeys/ui/src/components/RadioQuestion/RadioOption/RadioOption.spec.tsx
@@ -52,6 +52,7 @@ describe('RadioOption', () => {
       expect.objectContaining({
         push: expect.any(Function)
       }),
+      false,
       {
         __typename: 'NavigateToBlockAction',
         parentBlockId: 'radioOption1.id',

--- a/libs/journeys/ui/src/components/RadioQuestion/RadioOption/RadioOption.tsx
+++ b/libs/journeys/ui/src/components/RadioQuestion/RadioOption/RadioOption.tsx
@@ -4,7 +4,7 @@ import Button, { ButtonProps } from '@mui/material/Button'
 import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import { useRouter } from 'next/router'
-import { TreeBlock, handleAction } from '../../..'
+import { TreeBlock, handleAction, useEditor } from '../../..'
 import { RadioOptionFields } from './__generated__/RadioOptionFields'
 
 export interface RadioOptionProps extends TreeBlock<RadioOptionFields> {
@@ -37,9 +37,11 @@ export function RadioOption({
   editableLabel
 }: RadioOptionProps): ReactElement {
   const router = useRouter()
+  const { state } = useEditor()
+  const editorMode = state.selectedBlock != null
 
   const handleClick = (): void => {
-    handleAction(router, action)
+    handleAction(router, editorMode, action)
     onClick?.(id)
   }
 

--- a/libs/journeys/ui/src/components/SignUp/SignUp.spec.tsx
+++ b/libs/journeys/ui/src/components/SignUp/SignUp.spec.tsx
@@ -152,6 +152,7 @@ describe('SignUp', () => {
         {
           push: expect.any(Function)
         },
+        false,
         {
           __typename: 'LinkAction',
           parentBlockId: 'signUp0.id',

--- a/libs/journeys/ui/src/components/SignUp/SignUp.tsx
+++ b/libs/journeys/ui/src/components/SignUp/SignUp.tsx
@@ -92,6 +92,7 @@ export const SignUp = ({
   const {
     state: { selectedBlock }
   } = useEditor()
+  const editorMode = selectedBlock != null
 
   return (
     <Box sx={{ mb: 4 }}>
@@ -104,7 +105,7 @@ export const SignUp = ({
           if (selectedBlock === undefined) {
             // TODO: Handle server error responses when available
             void onSubmitHandler(values).then(() => {
-              handleAction(router, action)
+              handleAction(router, editorMode, action)
             })
           }
         }}

--- a/libs/journeys/ui/src/components/Video/VideoTrigger/VideoTrigger.tsx
+++ b/libs/journeys/ui/src/components/Video/VideoTrigger/VideoTrigger.tsx
@@ -1,7 +1,7 @@
 import videojs from 'video.js'
 import { useRouter } from 'next/router'
 import { ReactElement, useEffect, useState } from 'react'
-import { TreeBlock, handleAction } from '../../..'
+import { TreeBlock, handleAction, useEditor } from '../../..'
 import { VideoTriggerFields } from './__generated__/VideoTriggerFields'
 
 export interface VideoTriggerProps extends TreeBlock<VideoTriggerFields> {
@@ -15,6 +15,8 @@ export function VideoTrigger({
 }: VideoTriggerProps): ReactElement {
   const router = useRouter()
   const [triggered, setTriggered] = useState(false)
+  const { state } = useEditor()
+  const editorMode = state.selectedBlock != null
 
   useEffect(() => {
     if (player != null && !triggered) {
@@ -24,16 +26,19 @@ export function VideoTrigger({
           player.pause()
           if (player.isFullscreen()) {
             player.exitFullscreen()
-            setTimeout(() => handleAction(router, triggerAction), 1000)
+            setTimeout(
+              () => handleAction(router, editorMode, triggerAction),
+              1000
+            )
           } else {
-            handleAction(router, triggerAction)
+            handleAction(router, editorMode, triggerAction)
           }
         }
       }
       player.on('timeupdate', timeUpdate)
       return () => player.off('timeupdate', timeUpdate)
     }
-  }, [player, triggerStart, router, triggerAction, triggered])
+  }, [player, triggerStart, router, triggerAction, triggered, editorMode])
 
   return <></>
 }

--- a/libs/journeys/ui/src/libs/action/handleAction.spec.ts
+++ b/libs/journeys/ui/src/libs/action/handleAction.spec.ts
@@ -12,13 +12,17 @@ jest.mock('../useBlocks/blocks', () => {
 })
 
 describe('handleAction', () => {
-  const router = {
-    push: jest.fn()
-  } as unknown as NextRouter
+  let router: NextRouter
+  beforeEach(() => {
+    router = {
+      push: jest.fn()
+    } as unknown as NextRouter
+  })
 
   const editorMode = false
 
   it('should handle empty action', () => {
+    const editorMode = false
     expect(() => handleAction(router, editorMode)).not.toThrowError()
   })
 
@@ -71,8 +75,29 @@ describe('handleAction', () => {
       __typename: 'LinkAction',
       parentBlockId: 'parent-id',
       gtmEventName: null,
-      url: 'http://www.google.com'
+      url: 'https://www.google.com'
     })
-    expect(router.push).toHaveBeenCalledWith('http://www.google.com')
+    expect(router.push).toHaveBeenCalledWith('https://www.google.com')
+  })
+
+  it('should not handle Link Action, when in editor mode', () => {
+    const editorMode = true
+    handleAction(router, editorMode, {
+      __typename: 'LinkAction',
+      parentBlockId: 'parent-id',
+      gtmEventName: null,
+      url: 'https://www.google.com'
+    })
+    expect(router.push).not.toHaveBeenCalled()
+  })
+
+  it('should not handle Navigate to Journey Action, when in editor mode', () => {
+    const editorMode = true
+    handleAction(router, editorMode, {
+      __typename: 'NavigateAction',
+      parentBlockId: 'parent-id',
+      gtmEventName: null
+    })
+    expect(router.push).not.toHaveBeenCalled()
   })
 })

--- a/libs/journeys/ui/src/libs/action/handleAction.spec.ts
+++ b/libs/journeys/ui/src/libs/action/handleAction.spec.ts
@@ -22,7 +22,6 @@ describe('handleAction', () => {
   const editorMode = false
 
   it('should handle empty action', () => {
-    const editorMode = false
     expect(() => handleAction(router, editorMode)).not.toThrowError()
   })
 

--- a/libs/journeys/ui/src/libs/action/handleAction.spec.ts
+++ b/libs/journeys/ui/src/libs/action/handleAction.spec.ts
@@ -16,12 +16,14 @@ describe('handleAction', () => {
     push: jest.fn()
   } as unknown as NextRouter
 
+  const editorMode = false
+
   it('should handle empty action', () => {
-    expect(() => handleAction(router)).not.toThrowError()
+    expect(() => handleAction(router, editorMode)).not.toThrowError()
   })
 
   it('should handle NavigateToBlockAction', () => {
-    handleAction(router, {
+    handleAction(router, editorMode, {
       __typename: 'NavigateToBlockAction',
       parentBlockId: 'parent-id',
       blockId: 'block-id',
@@ -31,7 +33,7 @@ describe('handleAction', () => {
   })
 
   it('should handle NavigateToJourneyAction', () => {
-    handleAction(router, {
+    handleAction(router, editorMode, {
       __typename: 'NavigateToJourneyAction',
       parentBlockId: 'parent-id',
       journey: {
@@ -46,7 +48,7 @@ describe('handleAction', () => {
 
   it('should handle NavigateToJourneyAction when journey is null', () => {
     expect(() =>
-      handleAction(router, {
+      handleAction(router, editorMode, {
         __typename: 'NavigateToJourneyAction',
         parentBlockId: 'parent-id',
         journey: null,
@@ -56,7 +58,7 @@ describe('handleAction', () => {
   })
 
   it('should handle NavigateAction', () => {
-    handleAction(router, {
+    handleAction(router, editorMode, {
       __typename: 'NavigateAction',
       parentBlockId: 'parent-id',
       gtmEventName: null
@@ -65,7 +67,7 @@ describe('handleAction', () => {
   })
 
   it('should handle LinkAction', () => {
-    handleAction(router, {
+    handleAction(router, editorMode, {
       __typename: 'LinkAction',
       parentBlockId: 'parent-id',
       gtmEventName: null,

--- a/libs/journeys/ui/src/libs/action/handleAction.ts
+++ b/libs/journeys/ui/src/libs/action/handleAction.ts
@@ -4,6 +4,7 @@ import { ActionFields } from './__generated__/ActionFields'
 
 export function handleAction(
   router: NextRouter,
+  editorMode: boolean,
   action?: ActionFields | null
 ): void {
   if (action == null) return
@@ -12,7 +13,7 @@ export function handleAction(
       nextActiveBlock({ id: action.blockId })
       break
     case 'NavigateToJourneyAction':
-      if (action.journey?.slug != null) {
+      if (action.journey?.slug != null && !editorMode) {
         void router.push(`/${action.journey.slug}`)
       }
       break
@@ -20,7 +21,9 @@ export function handleAction(
       nextActiveBlock()
       break
     case 'LinkAction':
-      void router.push(action.url)
+      if (!editorMode) {
+        void router.push(action.url)
+      }
       break
   }
 }


### PR DESCRIPTION
# Description

LinkAction and NavigateToJourneyAction, should not be handled when in editor mode. This PR fixes this by checking if there is a selectedBlock and sending through a boolean prop to handleAction

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/26787371/todos/4810871664)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] When in editor button that has link action to URL should not redirect to link
- [x] When in editor button that has Navigate to Journey Action should not redirect to Journey
- [x] Button actions works as expected when not in editor

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
