### PR TITLE
fix: button/radioOption/sign up link actions triggering onClick in admin

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioQuestionEdit/RadioQuestionEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioQuestionEdit/RadioQuestionEdit.tsx
@@ -34,7 +34,7 @@ export function RadioQuestionEdit({
 
   const journey = useJourney()
   const [labelValue, setLabel] = useState(label)
-  const [descriptionValue, setDescription] = useState(description)
+  const [descriptionValue, setDescription] = useState(description ?? '')
 
   async function handleSaveBlock(): Promise<void> {
     const label = labelValue.trimStart().trimEnd()
@@ -95,6 +95,7 @@ export function RadioQuestionEdit({
       description={description}
       editableLabel={labelInput}
       editableDescription={descriptionInput}
+      wrappers={{ Wrapper: ({ children }) => children }}
     />
   )
 }

--- a/apps/journeys-admin/src/components/Editor/Canvas/SelectableWrapper/SelectableWrapper.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/SelectableWrapper/SelectableWrapper.spec.tsx
@@ -1,3 +1,4 @@
+import { NextRouter, useRouter } from 'next/router'
 import { render, fireEvent } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
 import {
@@ -20,7 +21,17 @@ import { TypographyVariant } from '../../../../../__generated__/globalTypes'
 import { TypographyFields } from '../../../../../__generated__/TypographyFields'
 import { SelectableWrapper } from '.'
 
+jest.mock('next/router', () => ({
+  __esModule: true,
+  useRouter: jest.fn()
+}))
+
+const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
+
 describe('SelectableWrapper', () => {
+  const push = jest.fn()
+  mockUseRouter.mockReturnValue({ push } as unknown as NextRouter)
+
   const typographyBlock: TreeBlock<TypographyFields> = {
     __typename: 'TypographyBlock',
     id: 'typography.id',
@@ -35,7 +46,7 @@ describe('SelectableWrapper', () => {
 
   const buttonBlock: TreeBlock<ButtonFields> = {
     __typename: 'ButtonBlock',
-    id: 'button',
+    id: 'button.id',
     parentBlockId: 'parent.id',
     parentOrder: 0,
     label: 'button label',
@@ -44,7 +55,12 @@ describe('SelectableWrapper', () => {
     size: null,
     startIconId: null,
     endIconId: null,
-    action: null,
+    action: {
+      __typename: 'LinkAction',
+      parentBlockId: 'button.id',
+      gtmEventName: 'gtmEventName',
+      url: 'https://www.google.com'
+    },
     children: []
   }
 
@@ -175,6 +191,8 @@ describe('SelectableWrapper', () => {
       outline: '3px solid #C52D3A',
       zIndex: '1'
     })
+
+    expect(push).not.toHaveBeenCalled()
   })
 
   it('should select radio question on radio option click', async () => {
@@ -228,6 +246,7 @@ describe('SelectableWrapper', () => {
       outline: '3px solid #C52D3A',
       zIndex: '1'
     })
+    expect(push).not.toHaveBeenCalled()
   })
 
   it('should select radio option on click when sibling option selected', async () => {
@@ -255,5 +274,6 @@ describe('SelectableWrapper', () => {
       outline: '3px solid #C52D3A',
       zIndex: '1'
     })
+    expect(push).not.toHaveBeenCalled()
   })
 })

--- a/apps/journeys-admin/src/components/Editor/Canvas/SelectableWrapper/SelectableWrapper.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/SelectableWrapper/SelectableWrapper.tsx
@@ -2,6 +2,7 @@ import { ReactElement, MouseEvent } from 'react'
 import {
   ActiveTab,
   ActiveFab,
+  TreeBlock,
   WrapperProps,
   useEditor
 } from '@core/journeys/ui'
@@ -29,41 +30,55 @@ export function SelectableWrapper({
     block.__typename !== 'GridContainerBlock' &&
     block.__typename !== 'GridItemBlock'
 
+  const selectBlock = (block: TreeBlock): void => {
+    dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Edit })
+    dispatch({
+      type: 'SetActiveTabAction',
+      activeTab: ActiveTab.Properties
+    })
+    dispatch({ type: 'SetSelectedBlockAction', block })
+    dispatch({ type: 'SetSelectedAttributeIdAction', id: undefined })
+  }
+
+  const editBlock = (): void => {
+    dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Save })
+  }
+
   // TODO: Test dispatch via E2E
   const handleSelectBlock = (e: MouseEvent<HTMLElement>): void => {
-    if (block.__typename === 'RadioOptionBlock') {
+    // Allow RadioQuestion select event to be overridden by RadioOption select/edit events (no e.stopPropogation)
+    if (block.__typename === 'RadioQuestionBlock') {
+      if (selectedBlock?.id === block.id) {
+        editBlock()
+      } else {
+        selectBlock(block)
+      }
+    } else if (block.__typename === 'RadioOptionBlock') {
+      e.stopPropagation()
       const parentSelected = selectedBlock?.id === block.parentBlockId
       const siblingSelected =
         selectedBlock?.parentBlockId === block.parentBlockId
 
       if (selectedBlock?.id === block.id) {
-        e.stopPropagation()
-        dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Save })
-      } else if (parentSelected || siblingSelected) {
-        e.stopPropagation()
-        dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Edit })
-        dispatch({
-          type: 'SetActiveTabAction',
-          activeTab: ActiveTab.Properties
-        })
+        // Must override RadioQuestionBlock selected during event capture
         dispatch({ type: 'SetSelectedBlockAction', block })
-        dispatch({ type: 'SetSelectedAttributeIdAction', id: undefined })
+        editBlock()
+      } else if (parentSelected || siblingSelected) {
+        selectBlock(block)
       }
     } else {
+      e.stopPropagation()
       if (selectedBlock?.id === block.id && isInlineEditable) {
-        e.stopPropagation()
-        dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Save })
+        editBlock()
       } else {
-        e.stopPropagation()
-        dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Edit })
-        dispatch({
-          type: 'SetActiveTabAction',
-          activeTab: ActiveTab.Properties
-        })
-        dispatch({ type: 'SetSelectedBlockAction', block })
-        dispatch({ type: 'SetSelectedAttributeIdAction', id: undefined })
+        selectBlock(block)
       }
     }
+  }
+
+  // Container Blocks (RadioQuestion, Grid) don't stop propogation on ClickCapture, stop onClick so child events still occur.
+  const blockNonSelectionEvents = (e: MouseEvent<HTMLElement>): void => {
+    e.stopPropagation()
   }
 
   return isSelectable ? (
@@ -87,6 +102,7 @@ export function SelectableWrapper({
         zIndex: selectedBlock?.id === block.id ? 1 : 0
       }}
       onClickCapture={handleSelectBlock}
+      onClick={blockNonSelectionEvents}
     >
       {children}
     </Box>

--- a/apps/journeys-admin/src/components/Editor/Canvas/SelectableWrapper/SelectableWrapper.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/SelectableWrapper/SelectableWrapper.tsx
@@ -86,7 +86,7 @@ export function SelectableWrapper({
         outlineOffset: '5px',
         zIndex: selectedBlock?.id === block.id ? 1 : 0
       }}
-      onClick={handleSelectBlock}
+      onClickCapture={handleSelectBlock}
     >
       {children}
     </Box>


### PR DESCRIPTION
# Description

Actions on buttons / sign up / radio option were still triggering on admin mode as stopPropogation on the SelectableWrapper didn't trigger before they are fired due to event bubbling.

This PR stops the propagation on event capture - before they are fired and reworks the logic so child blocks (RadioOption) still get selected/edited when container blocks (RadioQuestion) are clicked.

https://dev.to/eladtzemach/event-capturing-and-bubbling-in-react-2ffg

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/26787371/todos/4810871664)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] PR checks
- [x] Manually check the blocks can be selected and edited without triggering actions.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
