### PR TITLE
fix: watch admin api

### DIFF
--- a/apps/watch-admin/.env.production
+++ b/apps/watch-admin/.env.production
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_GATEWAY_URL=https://graphql.jesusfilm.org/

--- a/apps/watch-admin/pages/api/login.tsx
+++ b/apps/watch-admin/pages/api/login.tsx
@@ -1,0 +1,17 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { setAuthCookies } from 'next-firebase-auth'
+import { initAuth } from '../../src/libs/firebaseClient/initAuth'
+
+initAuth()
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  try {
+    await setAuthCookies(req, res)
+    res.status(200).json({ success: true })
+  } catch (e) {
+    res.status(500).json({ error: 'Unexpected error.' })
+  }
+}

--- a/apps/watch-admin/pages/api/logout.tsx
+++ b/apps/watch-admin/pages/api/logout.tsx
@@ -1,0 +1,17 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { unsetAuthCookies } from 'next-firebase-auth'
+import { initAuth } from '../../src/libs/firebaseClient/initAuth'
+
+initAuth()
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  try {
+    await unsetAuthCookies(req, res)
+    res.status(200).json({ success: true })
+  } catch (e) {
+    res.status(500).json({ error: 'Unexpected error.' })
+  }
+}

--- a/apps/watch-admin/public/site.webmanifest
+++ b/apps/watch-admin/public/site.webmanifest
@@ -1,0 +1,19 @@
+{
+  "name": "WatchAdmin",
+  "short_name": "WatchAdmin",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}

--- a/apps/watch-admin/setupTests.tsx
+++ b/apps/watch-admin/setupTests.tsx
@@ -1,5 +1,8 @@
 import '@testing-library/jest-dom'
 import './test/createMatchMedia'
+import { configure } from '@testing-library/react'
+
+configure({ asyncUtilTimeout: 2500 })
 
 jest.mock('next/image', () => ({
   __esModule: true,

--- a/apps/watch-admin/src/libs/apolloClient/cache.ts
+++ b/apps/watch-admin/src/libs/apolloClient/cache.ts
@@ -8,27 +8,5 @@ export const cache = (): InMemoryCache =>
      these relationships, we need to pass a possibleTypes option when
      initializing InMemoryCache.
    */
-    possibleTypes: {
-      Action: [
-        'NavigateAction',
-        'NavigateToBlockAction',
-        'NavigateToJourneyAction',
-        'LinkAction'
-      ],
-      Block: [
-        'ButtonBlock',
-        'CardBlock',
-        'GridContainerBlock',
-        'GridItemBlock',
-        'IconBlock',
-        'ImageBlock',
-        'RadioQuestionBlock',
-        'RadioOptionBlock',
-        'SignUpBlock',
-        'StepBlock',
-        'TypographyBlock',
-        'VideoBlock',
-        'VideoTriggerBlock'
-      ]
-    }
+    possibleTypes: {}
   })

--- a/apps/watch-admin/tsconfig.json
+++ b/apps/watch-admin/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "jsx": "preserve",
+    "jsxImportSource": "@emotion/react",
     "allowJs": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
# Description

This fixes the missing watch-admin api pages for proper sign-in/out

# How should this PR be QA Tested?


- [ ] Start watch-admin
- [ ] login

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
