### PR TITLE
fix: stop admin video playing

### DIFF
--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
@@ -479,6 +479,137 @@ const steps: Array<TreeBlock<StepBlock>> = [
         ]
       }
     ]
+  },
+  {
+    id: 'step5.id',
+    __typename: 'StepBlock',
+    parentBlockId: null,
+    parentOrder: 4,
+    locked: false,
+    nextBlockId: null,
+    children: [
+      {
+        id: 'card5.id',
+        __typename: 'CardBlock',
+        parentBlockId: 'step5.id',
+        coverBlockId: 'video5.id',
+        parentOrder: 0,
+        backgroundColor: null,
+        themeMode: null,
+        themeName: null,
+        fullscreen: false,
+        children: [
+          {
+            id: 'typographyBlockId51',
+            __typename: 'TypographyBlock',
+            parentBlockId: 'card5.id',
+            parentOrder: 1,
+            align: null,
+            color: null,
+            content: 'Card with Video Background',
+            variant: TypographyVariant.h1,
+            children: []
+          },
+          {
+            id: 'video5.id',
+            __typename: 'VideoBlock',
+            parentBlockId: 'card5.id',
+            parentOrder: 0,
+            autoplay: false,
+            muted: true,
+            videoId: '2_0-FallingPlates',
+            videoVariantLanguageId: '529',
+            video: {
+              __typename: 'Video',
+              id: '2_0-FallingPlates',
+              variant: {
+                __typename: 'VideoVariant',
+                id: '2_0-FallingPlates-529',
+                hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
+              }
+            },
+            startAt: null,
+            endAt: null,
+            posterBlockId: 'image5.id',
+            fullsize: null,
+            children: [
+              {
+                id: 'image5.id',
+                __typename: 'ImageBlock',
+                src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
+                width: 1920,
+                height: 1080,
+                alt: 'random image from unsplash',
+                parentBlockId: 'video5.id',
+                parentOrder: 0,
+                children: [],
+                blurhash: 'LFALX]%g4Tf+?^jEMxo#00Mx%gjZ'
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'step6.id',
+    __typename: 'StepBlock',
+    parentBlockId: null,
+    parentOrder: 4,
+    locked: false,
+    nextBlockId: null,
+    children: [
+      {
+        id: 'card6.id',
+        __typename: 'CardBlock',
+        parentBlockId: 'step6.id',
+        coverBlockId: null,
+        parentOrder: 0,
+        backgroundColor: null,
+        themeMode: null,
+        themeName: null,
+        fullscreen: true,
+        children: [
+          {
+            id: 'video6.id',
+            __typename: 'VideoBlock',
+            parentBlockId: 'card6.id',
+            parentOrder: 0,
+            autoplay: false,
+            muted: true,
+            videoId: '2_0-FallingPlates',
+            videoVariantLanguageId: '529',
+            video: {
+              __typename: 'Video',
+              id: '2_0-FallingPlates',
+              variant: {
+                __typename: 'VideoVariant',
+                id: '2_0-FallingPlates-529',
+                hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
+              }
+            },
+            startAt: null,
+            endAt: null,
+            posterBlockId: 'image6.id',
+            fullsize: null,
+            children: [
+              {
+                id: 'image6.id',
+                __typename: 'ImageBlock',
+                src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
+                width: 1920,
+                height: 1080,
+                alt: 'random image from unsplash',
+                parentBlockId: 'video6.id',
+                parentOrder: 0,
+                children: [],
+                blurhash: 'LFALX]%g4Tf+?^jEMxo#00Mx%gjZ'
+              }
+            ]
+          }
+        ]
+      }
+    ]
   }
 ]
 

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
@@ -387,7 +387,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
     parentBlockId: null,
     parentOrder: 4,
     locked: false,
-    nextBlockId: null,
+    nextBlockId: 'step5.id',
     children: [
       {
         id: 'card4.id',
@@ -500,17 +500,6 @@ const steps: Array<TreeBlock<StepBlock>> = [
         fullscreen: false,
         children: [
           {
-            id: 'typographyBlockId51',
-            __typename: 'TypographyBlock',
-            parentBlockId: 'card5.id',
-            parentOrder: 1,
-            align: null,
-            color: null,
-            content: 'Card with Video Background',
-            variant: TypographyVariant.h1,
-            children: []
-          },
-          {
             id: 'video5.id',
             __typename: 'VideoBlock',
             parentBlockId: 'card5.id',
@@ -546,6 +535,17 @@ const steps: Array<TreeBlock<StepBlock>> = [
                 blurhash: 'LFALX]%g4Tf+?^jEMxo#00Mx%gjZ'
               }
             ]
+          },
+          {
+            id: 'typographyBlockId51',
+            __typename: 'TypographyBlock',
+            parentBlockId: 'card5.id',
+            parentOrder: 1,
+            align: null,
+            color: null,
+            content: 'Card with Video Background',
+            variant: TypographyVariant.h1,
+            children: []
           }
         ]
       }

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
@@ -20,6 +20,8 @@ import { FramePortal } from '../FramePortal'
 import { GetJourney_journey_blocks_StepBlock as StepBlock } from '../../../__generated__/GetJourney'
 import { HorizontalSelect } from '../HorizontalSelect'
 import { useJourney } from '../../libs/context'
+import { VideoWrapper } from '../Editor/Canvas/VideoWrapper'
+import { CardWrapper } from '../Editor/Canvas/CardWrapper'
 
 export interface CardPreviewProps {
   onSelect?: (step: TreeBlock<StepBlock>) => void
@@ -195,7 +197,13 @@ export function CardPreview({
             <FramePortal width={380} height={560}>
               <ThemeProvider themeName={themeName} themeMode={themeMode}>
                 <Box sx={{ p: 4, height: '100%' }}>
-                  <BlockRenderer block={step} />
+                  <BlockRenderer
+                    block={step}
+                    wrappers={{
+                      VideoWrapper,
+                      CardWrapper
+                    }}
+                  />
                 </Box>
               </ThemeProvider>
             </FramePortal>

--- a/apps/journeys-admin/src/components/Editor/Canvas/Canvas.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/Canvas.tsx
@@ -17,6 +17,8 @@ import 'swiper/swiper.min.css'
 import { useJourney } from '../../../libs/context'
 import { InlineEditWrapper } from './InlineEditWrapper'
 import { SelectableWrapper } from './SelectableWrapper'
+import { VideoWrapper } from './VideoWrapper'
+import { CardWrapper } from './CardWrapper'
 
 const EDGE_SLIDE_WIDTH = 24
 const MIN_SPACE_BETWEEN = 16
@@ -142,7 +144,9 @@ export function Canvas(): ReactElement {
                         ButtonWrapper: InlineEditWrapper,
                         RadioQuestionWrapper: InlineEditWrapper,
                         RadioOptionWrapper: InlineEditWrapper,
-                        SignUpWrapper: InlineEditWrapper
+                        SignUpWrapper: InlineEditWrapper,
+                        VideoWrapper,
+                        CardWrapper
                       }}
                     />
                   </Box>

--- a/apps/journeys-admin/src/components/Editor/Canvas/CardWrapper/CardWrapper.test.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/CardWrapper/CardWrapper.test.tsx
@@ -1,0 +1,333 @@
+import { ReactElement } from 'react'
+import { render } from '@testing-library/react'
+import type { TreeBlock } from '@core/journeys/ui'
+import { Card } from '@core/journeys/ui'
+import { CardWrapper } from '.'
+
+jest.mock('@core/journeys/ui', () => ({
+  __esModule: true,
+  Card: jest.fn(() => <></>)
+}))
+
+describe('CardWrapper', () => {
+  it('should set variant hls in video cover block to null', () => {
+    const Container = (_props: {
+      wrappers: Record<string, never>
+    }): ReactElement => <></>
+    const block: TreeBlock = {
+      id: 'card5.id',
+      __typename: 'CardBlock',
+      parentBlockId: 'step5.id',
+      coverBlockId: 'video5.id',
+      parentOrder: 0,
+      backgroundColor: null,
+      themeMode: null,
+      themeName: null,
+      fullscreen: false,
+      children: [
+        {
+          id: 'video5.id',
+          __typename: 'VideoBlock',
+          parentBlockId: 'card5.id',
+          parentOrder: 0,
+          autoplay: false,
+          muted: true,
+          videoId: '2_0-FallingPlates',
+          videoVariantLanguageId: '529',
+          video: {
+            __typename: 'Video',
+            id: '2_0-FallingPlates',
+            variant: {
+              __typename: 'VideoVariant',
+              id: '2_0-FallingPlates-529',
+              hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
+            }
+          },
+          startAt: null,
+          endAt: null,
+          posterBlockId: 'image5.id',
+          fullsize: null,
+          children: [
+            {
+              id: 'image5.id',
+              __typename: 'ImageBlock',
+              src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
+              width: 1920,
+              height: 1080,
+              alt: 'random image from unsplash',
+              parentBlockId: 'video5.id',
+              parentOrder: 0,
+              children: [],
+              blurhash: 'LFALX]%g4Tf+?^jEMxo#00Mx%gjZ'
+            }
+          ]
+        }
+      ]
+    }
+    render(
+      <CardWrapper block={block}>
+        <Container wrappers={{}} />
+      </CardWrapper>
+    )
+    expect(Card).toHaveBeenCalledWith(
+      {
+        __typename: 'CardBlock',
+        backgroundColor: null,
+        children: [
+          {
+            __typename: 'VideoBlock',
+            autoplay: false,
+            children: [
+              {
+                __typename: 'ImageBlock',
+                alt: 'random image from unsplash',
+                blurhash: 'LFALX]%g4Tf+?^jEMxo#00Mx%gjZ',
+                children: [],
+                height: 1080,
+                id: 'image5.id',
+                parentBlockId: 'video5.id',
+                parentOrder: 0,
+                src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
+                width: 1920
+              }
+            ],
+            endAt: null,
+            fullsize: null,
+            id: 'video5.id',
+            muted: true,
+            parentBlockId: 'card5.id',
+            parentOrder: 0,
+            posterBlockId: 'image5.id',
+            startAt: null,
+            video: {
+              __typename: 'Video',
+              id: '2_0-FallingPlates',
+              variant: {
+                __typename: 'VideoVariant',
+                hls: null,
+                id: '2_0-FallingPlates-529'
+              }
+            },
+            videoId: '2_0-FallingPlates',
+            videoVariantLanguageId: '529'
+          }
+        ],
+        coverBlockId: 'video5.id',
+        fullscreen: false,
+        id: 'card5.id',
+        parentBlockId: 'step5.id',
+        parentOrder: 0,
+        themeMode: null,
+        themeName: null,
+        wrappers: {}
+      },
+      {}
+    )
+  })
+
+  it('should handle where video is not set', () => {
+    const Container = (_props: {
+      wrappers: Record<string, never>
+    }): ReactElement => <></>
+    const block: TreeBlock = {
+      id: 'card5.id',
+      __typename: 'CardBlock',
+      parentBlockId: 'step5.id',
+      coverBlockId: 'video5.id',
+      parentOrder: 0,
+      backgroundColor: null,
+      themeMode: null,
+      themeName: null,
+      fullscreen: false,
+      children: [
+        {
+          id: 'video5.id',
+          __typename: 'VideoBlock',
+          parentBlockId: 'card5.id',
+          parentOrder: 0,
+          autoplay: false,
+          muted: true,
+          videoId: '2_0-FallingPlates',
+          videoVariantLanguageId: '529',
+          video: null,
+          startAt: null,
+          endAt: null,
+          posterBlockId: 'image5.id',
+          fullsize: null,
+          children: [
+            {
+              id: 'image5.id',
+              __typename: 'ImageBlock',
+              src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
+              width: 1920,
+              height: 1080,
+              alt: 'random image from unsplash',
+              parentBlockId: 'video5.id',
+              parentOrder: 0,
+              children: [],
+              blurhash: 'LFALX]%g4Tf+?^jEMxo#00Mx%gjZ'
+            }
+          ]
+        }
+      ]
+    }
+    render(
+      <CardWrapper block={block}>
+        <Container wrappers={{}} />
+      </CardWrapper>
+    )
+    expect(Card).toHaveBeenCalledWith(
+      {
+        __typename: 'CardBlock',
+        backgroundColor: null,
+        children: [
+          {
+            __typename: 'VideoBlock',
+            autoplay: false,
+            children: [
+              {
+                __typename: 'ImageBlock',
+                alt: 'random image from unsplash',
+                blurhash: 'LFALX]%g4Tf+?^jEMxo#00Mx%gjZ',
+                children: [],
+                height: 1080,
+                id: 'image5.id',
+                parentBlockId: 'video5.id',
+                parentOrder: 0,
+                src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
+                width: 1920
+              }
+            ],
+            endAt: null,
+            fullsize: null,
+            id: 'video5.id',
+            muted: true,
+            parentBlockId: 'card5.id',
+            parentOrder: 0,
+            posterBlockId: 'image5.id',
+            startAt: null,
+            video: null,
+            videoId: '2_0-FallingPlates',
+            videoVariantLanguageId: '529'
+          }
+        ],
+        coverBlockId: 'video5.id',
+        fullscreen: false,
+        id: 'card5.id',
+        parentBlockId: 'step5.id',
+        parentOrder: 0,
+        themeMode: null,
+        themeName: null,
+        wrappers: {}
+      },
+      {}
+    )
+  })
+
+  it('should handle where video variant is not set', () => {
+    const Container = (_props: {
+      wrappers: Record<string, never>
+    }): ReactElement => <></>
+    const block: TreeBlock = {
+      id: 'card5.id',
+      __typename: 'CardBlock',
+      parentBlockId: 'step5.id',
+      coverBlockId: 'video5.id',
+      parentOrder: 0,
+      backgroundColor: null,
+      themeMode: null,
+      themeName: null,
+      fullscreen: false,
+      children: [
+        {
+          id: 'video5.id',
+          __typename: 'VideoBlock',
+          parentBlockId: 'card5.id',
+          parentOrder: 0,
+          autoplay: false,
+          muted: true,
+          videoId: '2_0-FallingPlates',
+          videoVariantLanguageId: '529',
+          video: {
+            __typename: 'Video',
+            id: '2_0-FallingPlates',
+            variant: null
+          },
+          startAt: null,
+          endAt: null,
+          posterBlockId: 'image5.id',
+          fullsize: null,
+          children: [
+            {
+              id: 'image5.id',
+              __typename: 'ImageBlock',
+              src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
+              width: 1920,
+              height: 1080,
+              alt: 'random image from unsplash',
+              parentBlockId: 'video5.id',
+              parentOrder: 0,
+              children: [],
+              blurhash: 'LFALX]%g4Tf+?^jEMxo#00Mx%gjZ'
+            }
+          ]
+        }
+      ]
+    }
+    render(
+      <CardWrapper block={block}>
+        <Container wrappers={{}} />
+      </CardWrapper>
+    )
+    expect(Card).toHaveBeenCalledWith(
+      {
+        __typename: 'CardBlock',
+        backgroundColor: null,
+        children: [
+          {
+            __typename: 'VideoBlock',
+            autoplay: false,
+            children: [
+              {
+                __typename: 'ImageBlock',
+                alt: 'random image from unsplash',
+                blurhash: 'LFALX]%g4Tf+?^jEMxo#00Mx%gjZ',
+                children: [],
+                height: 1080,
+                id: 'image5.id',
+                parentBlockId: 'video5.id',
+                parentOrder: 0,
+                src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
+                width: 1920
+              }
+            ],
+            endAt: null,
+            fullsize: null,
+            id: 'video5.id',
+            muted: true,
+            parentBlockId: 'card5.id',
+            parentOrder: 0,
+            posterBlockId: 'image5.id',
+            startAt: null,
+            video: {
+              __typename: 'Video',
+              id: '2_0-FallingPlates',
+              variant: null
+            },
+            videoId: '2_0-FallingPlates',
+            videoVariantLanguageId: '529'
+          }
+        ],
+        coverBlockId: 'video5.id',
+        fullscreen: false,
+        id: 'card5.id',
+        parentBlockId: 'step5.id',
+        parentOrder: 0,
+        themeMode: null,
+        themeName: null,
+        wrappers: {}
+      },
+      {}
+    )
+  })
+})

--- a/apps/journeys-admin/src/components/Editor/Canvas/CardWrapper/CardWrapper.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/CardWrapper/CardWrapper.tsx
@@ -1,0 +1,33 @@
+import { ReactElement } from 'react'
+import { Card } from '@core/journeys/ui'
+import type { WrapperProps } from '@core/journeys/ui'
+
+export function CardWrapper({ block, children }: WrapperProps): ReactElement {
+  if (block.__typename === 'CardBlock') {
+    const blocks = block.children.map((child) => {
+      if (
+        child.id === block.coverBlockId &&
+        child.__typename === 'VideoBlock'
+      ) {
+        if (child.video?.variant?.hls == null) {
+          return child
+        }
+        return {
+          ...child,
+          video: {
+            ...child.video,
+            variant: { ...child.video.variant, hls: null }
+          }
+        }
+      }
+      return child
+    })
+    return (
+      <Card
+        {...{ ...block, children: blocks }}
+        wrappers={children.props.wrappers}
+      />
+    )
+  }
+  return <></>
+}

--- a/apps/journeys-admin/src/components/Editor/Canvas/CardWrapper/index.ts
+++ b/apps/journeys-admin/src/components/Editor/Canvas/CardWrapper/index.ts
@@ -1,0 +1,1 @@
+export { CardWrapper } from './CardWrapper'

--- a/apps/journeys-admin/src/components/Editor/Canvas/VideoWrapper/VideoWrapper.test.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/VideoWrapper/VideoWrapper.test.tsx
@@ -1,0 +1,242 @@
+import { render } from '@testing-library/react'
+import type { TreeBlock } from '@core/journeys/ui'
+import { Video } from '@core/journeys/ui'
+import { VideoWrapper } from '.'
+
+jest.mock('@core/journeys/ui', () => ({
+  __esModule: true,
+  Video: jest.fn(() => <></>)
+}))
+
+describe('VideoWrapper', () => {
+  it('should set variant hls in video cover block to null', () => {
+    const block: TreeBlock = {
+      id: 'video5.id',
+      __typename: 'VideoBlock',
+      parentBlockId: 'card5.id',
+      parentOrder: 0,
+      autoplay: false,
+      muted: true,
+      videoId: '2_0-FallingPlates',
+      videoVariantLanguageId: '529',
+      video: {
+        __typename: 'Video',
+        id: '2_0-FallingPlates',
+        variant: {
+          __typename: 'VideoVariant',
+          id: '2_0-FallingPlates-529',
+          hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
+        }
+      },
+      startAt: null,
+      endAt: null,
+      posterBlockId: 'image5.id',
+      fullsize: null,
+      children: [
+        {
+          id: 'image5.id',
+          __typename: 'ImageBlock',
+          src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
+          width: 1920,
+          height: 1080,
+          alt: 'random image from unsplash',
+          parentBlockId: 'video5.id',
+          parentOrder: 0,
+          children: [],
+          blurhash: 'LFALX]%g4Tf+?^jEMxo#00Mx%gjZ'
+        }
+      ]
+    }
+    render(
+      <VideoWrapper block={block}>
+        <></>
+      </VideoWrapper>
+    )
+    expect(Video).toHaveBeenCalledWith(
+      {
+        __typename: 'VideoBlock',
+        autoplay: false,
+        children: [
+          {
+            __typename: 'ImageBlock',
+            alt: 'random image from unsplash',
+            blurhash: 'LFALX]%g4Tf+?^jEMxo#00Mx%gjZ',
+            children: [],
+            height: 1080,
+            id: 'image5.id',
+            parentBlockId: 'video5.id',
+            parentOrder: 0,
+            src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
+            width: 1920
+          }
+        ],
+        endAt: null,
+        fullsize: null,
+        id: 'video5.id',
+        muted: true,
+        parentBlockId: 'card5.id',
+        parentOrder: 0,
+        posterBlockId: 'image5.id',
+        startAt: null,
+        video: {
+          __typename: 'Video',
+          id: '2_0-FallingPlates',
+          variant: {
+            __typename: 'VideoVariant',
+            hls: null,
+            id: '2_0-FallingPlates-529'
+          }
+        },
+        videoId: '2_0-FallingPlates',
+        videoVariantLanguageId: '529'
+      },
+      {}
+    )
+  })
+
+  it('should handle where video is not set', () => {
+    const block: TreeBlock = {
+      id: 'video5.id',
+      __typename: 'VideoBlock',
+      parentBlockId: 'card5.id',
+      parentOrder: 0,
+      autoplay: false,
+      muted: true,
+      videoId: '2_0-FallingPlates',
+      videoVariantLanguageId: '529',
+      video: null,
+      startAt: null,
+      endAt: null,
+      posterBlockId: 'image5.id',
+      fullsize: null,
+      children: [
+        {
+          id: 'image5.id',
+          __typename: 'ImageBlock',
+          src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
+          width: 1920,
+          height: 1080,
+          alt: 'random image from unsplash',
+          parentBlockId: 'video5.id',
+          parentOrder: 0,
+          children: [],
+          blurhash: 'LFALX]%g4Tf+?^jEMxo#00Mx%gjZ'
+        }
+      ]
+    }
+    render(
+      <VideoWrapper block={block}>
+        <></>
+      </VideoWrapper>
+    )
+    expect(Video).toHaveBeenCalledWith(
+      {
+        __typename: 'VideoBlock',
+        autoplay: false,
+        children: [
+          {
+            __typename: 'ImageBlock',
+            alt: 'random image from unsplash',
+            blurhash: 'LFALX]%g4Tf+?^jEMxo#00Mx%gjZ',
+            children: [],
+            height: 1080,
+            id: 'image5.id',
+            parentBlockId: 'video5.id',
+            parentOrder: 0,
+            src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
+            width: 1920
+          }
+        ],
+        endAt: null,
+        fullsize: null,
+        id: 'video5.id',
+        muted: true,
+        parentBlockId: 'card5.id',
+        parentOrder: 0,
+        posterBlockId: 'image5.id',
+        startAt: null,
+        video: null,
+        videoId: '2_0-FallingPlates',
+        videoVariantLanguageId: '529'
+      },
+      {}
+    )
+  })
+
+  it('should handle where video variant is not set', () => {
+    const block: TreeBlock = {
+      id: 'video5.id',
+      __typename: 'VideoBlock',
+      parentBlockId: 'card5.id',
+      parentOrder: 0,
+      autoplay: false,
+      muted: true,
+      videoId: '2_0-FallingPlates',
+      videoVariantLanguageId: '529',
+      video: {
+        __typename: 'Video',
+        id: '2_0-FallingPlates',
+        variant: null
+      },
+      startAt: null,
+      endAt: null,
+      posterBlockId: 'image5.id',
+      fullsize: null,
+      children: [
+        {
+          id: 'image5.id',
+          __typename: 'ImageBlock',
+          src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
+          width: 1920,
+          height: 1080,
+          alt: 'random image from unsplash',
+          parentBlockId: 'video5.id',
+          parentOrder: 0,
+          children: [],
+          blurhash: 'LFALX]%g4Tf+?^jEMxo#00Mx%gjZ'
+        }
+      ]
+    }
+    render(
+      <VideoWrapper block={block}>
+        <></>
+      </VideoWrapper>
+    )
+    expect(Video).toHaveBeenCalledWith(
+      {
+        __typename: 'VideoBlock',
+        autoplay: false,
+        children: [
+          {
+            __typename: 'ImageBlock',
+            alt: 'random image from unsplash',
+            blurhash: 'LFALX]%g4Tf+?^jEMxo#00Mx%gjZ',
+            children: [],
+            height: 1080,
+            id: 'image5.id',
+            parentBlockId: 'video5.id',
+            parentOrder: 0,
+            src: 'https://images.unsplash.com/photo-1601142634808-38923eb7c560?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
+            width: 1920
+          }
+        ],
+        endAt: null,
+        fullsize: null,
+        id: 'video5.id',
+        muted: true,
+        parentBlockId: 'card5.id',
+        parentOrder: 0,
+        posterBlockId: 'image5.id',
+        startAt: null,
+        video: {
+          __typename: 'Video',
+          id: '2_0-FallingPlates',
+          variant: null
+        },
+        videoId: '2_0-FallingPlates',
+        videoVariantLanguageId: '529'
+      },
+      {}
+    )
+  })
+})

--- a/apps/journeys-admin/src/components/Editor/Canvas/VideoWrapper/VideoWrapper.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/VideoWrapper/VideoWrapper.tsx
@@ -1,0 +1,25 @@
+import { ReactElement } from 'react'
+import { Video } from '@core/journeys/ui'
+import type { WrapperProps } from '@core/journeys/ui'
+
+export function VideoWrapper({ block }: WrapperProps): ReactElement {
+  return block.__typename === 'VideoBlock' ? (
+    <Video
+      {...{
+        ...block,
+        video:
+          block.video != null
+            ? {
+                ...block.video,
+                variant:
+                  block.video.variant != null
+                    ? { ...block.video.variant, hls: null }
+                    : null
+              }
+            : null
+      }}
+    />
+  ) : (
+    <></>
+  )
+}

--- a/apps/journeys-admin/src/components/Editor/Canvas/VideoWrapper/index.ts
+++ b/apps/journeys-admin/src/components/Editor/Canvas/VideoWrapper/index.ts
@@ -1,0 +1,1 @@
+export { VideoWrapper } from './VideoWrapper'

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
@@ -107,6 +107,7 @@ const getVideoMock = {
           }
         ],
         variant: {
+          id: 'variantA',
           duration: 144,
           hls: 'https://arc.gt/opsgn'
         }

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.spec.tsx
@@ -93,6 +93,7 @@ describe('VideoOptions', () => {
                     }
                   ],
                   variant: {
+                    id: 'variantA',
                     duration: 144,
                     hls: 'https://arc.gt/opsgn'
                   }

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.stories.tsx
@@ -95,6 +95,7 @@ export const Default: Story = () => (
                 }
               ],
               variant: {
+                id: 'variantA',
                 duration: 144,
                 hls: 'https://arc.gt/opsgn'
               }

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Source/Source.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Source/Source.spec.tsx
@@ -62,6 +62,7 @@ describe('Source', () => {
                     }
                   ],
                   variant: {
+                    id: 'variantA',
                     duration: 144,
                     hls: 'https://arc.gt/opsgn'
                   }

--- a/libs/journeys/ui/src/components/Card/Cover/Cover.tsx
+++ b/libs/journeys/ui/src/components/Card/Cover/Cover.tsx
@@ -80,6 +80,10 @@ export function Cover({
         <Box
           sx={{
             flexGrow: 1,
+            backgroundSize: 'cover',
+            backgroundPosition: 'center center',
+            backgroundImage:
+              imageBlock?.src != null ? `url(${imageBlock.src})` : undefined,
             '> .video-js': {
               width: '100%',
               height: '100%',
@@ -90,14 +94,19 @@ export function Cover({
           }}
           data-testid="CardVideoCover"
         >
-          <video ref={videoRef} className="video-js" playsInline>
-            {videoBlock.video?.variant?.hls != null && (
+          {videoBlock.video?.variant?.hls != null && (
+            <video
+              ref={videoRef}
+              className="video-js"
+              playsInline
+              poster={imageBlock?.src ?? undefined}
+            >
               <source
                 src={videoBlock.video.variant.hls}
                 type="application/x-mpegURL"
               />
-            )}
-          </video>
+            </video>
+          )}
         </Box>
       ) : (
         imageBlock?.src != null && (

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -92,8 +92,7 @@ export function Video({
           }
         },
         responsive: true,
-        muted: muted === true,
-        poster: posterBlock?.src != null ? posterBlock.src : undefined
+        muted: muted === true
       })
       playerRef.current.on('ready', () => {
         playerRef.current?.currentTime(startAt ?? 0)
@@ -169,6 +168,7 @@ export function Video({
             className="video-js vjs-big-play-centered"
             style={{ display: 'flex', alignSelf: 'center', height: '100%' }}
             playsInline
+            poster={posterBlock?.src ?? undefined}
           >
             <source src={video.variant.hls} type="application/x-mpegURL" />
           </video>
@@ -188,7 +188,11 @@ export function Video({
               alignItems: 'center',
               justifyContent: 'center',
               width: '100%',
-              fontSize: 100
+              fontSize: 100,
+              backgroundSize: 'cover',
+              backgroundPosition: 'center center',
+              backgroundImage:
+                posterBlock?.src != null ? `url(${posterBlock.src})` : undefined
             }}
             elevation={0}
             variant="outlined"


### PR DESCRIPTION
# Description

Stop playing video in canvas and card preview components on admin. This should also fix background display of poster image on video blocks and video backgrounds for cards. Bug was also addressed where variant id was not set.

- https://3.basecamp.com/3105655/buckets/26787371/todos/4752783621
- https://3.basecamp.com/3105655/buckets/26787371/todos/4757471362
- https://3.basecamp.com/3105655/buckets/26787371/todos/4752784571

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] video in card preview on admin should not play but display cover image with video icon
- [x] video as background to card in card preview on admin should not play but display cover image
- [x] video in canvas on admin should not play but display cover image with video icon
- [x] video as background to card in canvas on admin should not play but display cover image

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
