### PR TITLE
feat: loading screens

### DIFF
--- a/apps/journeys-admin/pages/index.tsx
+++ b/apps/journeys-admin/pages/index.tsx
@@ -46,7 +46,7 @@ function IndexPage(): ReactElement {
     <>
       <NextSeo title="Journeys" />
       <PageWrapper title="Journeys" AuthUser={AuthUser}>
-        {data?.journeys != null && <JourneyList journeys={data.journeys} />}
+        {<JourneyList journeys={data?.journeys} />}
       </PageWrapper>
     </>
   )
@@ -58,10 +58,9 @@ export const getServerSideProps = withAuthUserTokenSSR({
   const apolloClient = initializeApollo({
     token: (await AuthUser.getIdToken()) ?? ''
   })
-  await apolloClient.query({
-    query: GET_JOURNEYS
-  })
-
+  // await apolloClient.query({
+  //   query: GET_JOURNEYS
+  // })
   return addApolloState(apolloClient, {
     props: {}
   })

--- a/apps/journeys-admin/pages/index.tsx
+++ b/apps/journeys-admin/pages/index.tsx
@@ -7,7 +7,6 @@ import {
   withAuthUserTokenSSR
 } from 'next-firebase-auth'
 import { NextSeo } from 'next-seo'
-import { addApolloState, initializeApollo } from '../src/libs/apolloClient'
 import { GetJourneys } from '../__generated__/GetJourneys'
 import { JourneyList } from '../src/components/JourneyList'
 import { PageWrapper } from '../src/components/PageWrapper'
@@ -46,7 +45,7 @@ function IndexPage(): ReactElement {
     <>
       <NextSeo title="Journeys" />
       <PageWrapper title="Journeys" AuthUser={AuthUser}>
-        {<JourneyList journeys={data?.journeys} />}
+        <JourneyList journeys={data?.journeys} />
       </PageWrapper>
     </>
   )
@@ -54,16 +53,10 @@ function IndexPage(): ReactElement {
 
 export const getServerSideProps = withAuthUserTokenSSR({
   whenUnauthed: AuthAction.REDIRECT_TO_LOGIN
-})(async ({ AuthUser }) => {
-  const apolloClient = initializeApollo({
-    token: (await AuthUser.getIdToken()) ?? ''
-  })
-  // await apolloClient.query({
-  //   query: GET_JOURNEYS
-  // })
-  return addApolloState(apolloClient, {
+})(async () => {
+  return {
     props: {}
-  })
+  }
 })
 
 export default withAuthUser({

--- a/apps/journeys-admin/pages/journeys/[journeySlug].tsx
+++ b/apps/journeys-admin/pages/journeys/[journeySlug].tsx
@@ -13,7 +13,6 @@ import { JourneyInvite } from '../../src/components/JourneyInvite/JourneyInvite'
 import { GetJourney } from '../../__generated__/GetJourney'
 import { JourneyProvider } from '../../src/libs/context'
 import { JourneyView } from '../../src/components/JourneyView'
-import { addApolloState, initializeApollo } from '../../src/libs/apolloClient'
 import { PageWrapper } from '../../src/components/PageWrapper'
 import { Menu } from '../../src/components/JourneyView/Menu'
 
@@ -59,13 +58,13 @@ function JourneySlugPage(): ReactElement {
 
   return (
     <>
-      {data?.journey != null && (
+      {error == null && (
         <>
           <NextSeo
-            title={data.journey.title}
-            description={data.journey.description ?? undefined}
+            title={data?.journey?.title ?? 'Journey'}
+            description={data?.journey?.description ?? undefined}
           />
-          <JourneyProvider value={data.journey}>
+          <JourneyProvider value={data?.journey ?? undefined}>
             <PageWrapper
               title="Journey Details"
               showDrawer
@@ -100,30 +99,10 @@ function JourneySlugPage(): ReactElement {
 
 export const getServerSideProps = withAuthUserTokenSSR({
   whenUnauthed: AuthAction.REDIRECT_TO_LOGIN
-})(async ({ AuthUser, query }) => {
-  const apolloClient = initializeApollo({
-    token: (await AuthUser.getIdToken()) ?? ''
-  })
-
-  try {
-    await apolloClient.query({
-      query: GET_JOURNEY,
-      variables: {
-        id: query.journeySlug
-      }
-    })
-  } catch (error) {
-    if (error.graphQLErrors[0].extensions.code === 'FORBIDDEN') {
-      return addApolloState(apolloClient, {
-        props: {}
-      })
-    }
-    throw error
-  }
-
-  return addApolloState(apolloClient, {
+})(async () => {
+  return {
     props: {}
-  })
+  }
 })
 
 export default withAuthUser({

--- a/apps/journeys-admin/src/components/AccessAvatars/AccessAvatars.spec.tsx
+++ b/apps/journeys-admin/src/components/AccessAvatars/AccessAvatars.spec.tsx
@@ -104,7 +104,7 @@ describe('AccessAvatars', () => {
         </MockedProvider>
       </SnackbarProvider>
     )
-    fireEvent.click(getByRole('Button'))
+    fireEvent.click(getByRole('button'))
     expect(queryByText('Invite Other Editors')).toBeInTheDocument()
     fireEvent.click(getByTestId('dialog-close-button'))
     await waitFor(() =>

--- a/apps/journeys-admin/src/components/AccessAvatars/AccessAvatars.stories.tsx
+++ b/apps/journeys-admin/src/components/AccessAvatars/AccessAvatars.stories.tsx
@@ -138,4 +138,10 @@ NoImage.args = {
   ]
 }
 
+export const Loading: Story<AccessAvatarsProps> = Template.bind({})
+Loading.args = {
+  journeySlug: undefined,
+  userJourneys: undefined
+}
+
 export default AccessAvatarsDemo as Meta

--- a/apps/journeys-admin/src/components/AccessAvatars/AccessAvatars.tsx
+++ b/apps/journeys-admin/src/components/AccessAvatars/AccessAvatars.tsx
@@ -51,12 +51,6 @@ export function AccessAvatars({
   const [open, setOpen] = useState(false)
   const children = userJourneys?.map(
     ({ user }) => user != null && <AccessAvatar user={user} key={user.id} />
-  ) ?? (
-    <>
-      <Avatar />
-      <Avatar />
-      <Avatar />
-    </>
   )
   // small default sizes
   let diameter: number
@@ -79,57 +73,78 @@ export function AccessAvatars({
 
   return (
     <>
-      <Box
-        onClick={() => journeySlug != null && setOpen(true)}
-        sx={{
-          cursor: journeySlug != null ? 'pointer' : undefined,
-          height: diameter
-        }}
-        role="Button"
-      >
-        <AvatarGroup
-          max={xsMax}
-          sx={{
-            display: { xs: 'inline-flex', sm: 'none' },
-            '> .MuiAvatar-root': {
-              width: diameter,
-              height: diameter,
-              fontSize,
-              borderWidth,
-              borderColor: '#FFF'
-            },
-            '> .MuiAvatarGroup-avatar': {
-              backgroundColor: 'primary.main'
-            }
-          }}
-        >
-          {children}
-        </AvatarGroup>
-        <AvatarGroup
-          max={smMax}
-          sx={{
-            display: { xs: 'none', sm: 'inline-flex' },
-            '> .MuiAvatar-root': {
-              width: diameter,
-              height: diameter,
-              fontSize,
-              borderWidth,
-              borderColor: '#FFF'
-            },
-            '> .MuiAvatarGroup-avatar': {
-              backgroundColor: 'primary.main'
-            }
-          }}
-        >
-          {children}
-        </AvatarGroup>
-      </Box>
-      {journeySlug != null && (
-        <AccessDialog
-          journeySlug={journeySlug}
-          open={open}
-          onClose={() => setOpen(false)}
-        />
+      {journeySlug != null ? (
+        <>
+          <Box
+            onClick={() => setOpen(true)}
+            sx={{
+              cursor: 'pointer',
+              height: diameter
+            }}
+            role="button"
+          >
+            <AvatarGroup
+              max={xsMax}
+              sx={{
+                display: { xs: 'inline-flex', sm: 'none' },
+                '> .MuiAvatar-root': {
+                  width: diameter,
+                  height: diameter,
+                  fontSize,
+                  borderWidth,
+                  borderColor: '#FFF'
+                },
+                '> .MuiAvatarGroup-avatar': {
+                  backgroundColor: 'primary.main'
+                }
+              }}
+            >
+              {children}
+            </AvatarGroup>
+            <AvatarGroup
+              max={smMax}
+              sx={{
+                display: { xs: 'none', sm: 'inline-flex' },
+                '> .MuiAvatar-root': {
+                  width: diameter,
+                  height: diameter,
+                  fontSize,
+                  borderWidth,
+                  borderColor: '#FFF'
+                },
+                '> .MuiAvatarGroup-avatar': {
+                  backgroundColor: 'primary.main'
+                }
+              }}
+            >
+              {children}
+            </AvatarGroup>
+          </Box>
+          <AccessDialog
+            journeySlug={journeySlug}
+            open={open}
+            onClose={() => setOpen(false)}
+          />
+        </>
+      ) : (
+        <Box>
+          <AvatarGroup
+            sx={{
+              display: 'inline-flex',
+              '> .MuiAvatar-root': {
+                width: diameter,
+                height: diameter,
+                fontSize,
+                borderWidth,
+                borderColor: '#FFF'
+              }
+            }}
+          >
+            <Avatar />
+            <Avatar />
+            <Avatar />
+          </AvatarGroup>
+        </Box>
       )}
     </>
   )

--- a/apps/journeys-admin/src/components/AccessAvatars/AccessAvatars.tsx
+++ b/apps/journeys-admin/src/components/AccessAvatars/AccessAvatars.tsx
@@ -34,8 +34,8 @@ interface UserJourney {
 }
 
 export interface AccessAvatarsProps {
-  journeySlug: string
-  userJourneys: UserJourney[]
+  journeySlug?: string
+  userJourneys?: UserJourney[]
   size?: 'small' | 'medium' | 'large'
   xsMax?: number
   smMax?: number
@@ -49,10 +49,15 @@ export function AccessAvatars({
   smMax = 5
 }: AccessAvatarsProps): ReactElement {
   const [open, setOpen] = useState(false)
-  const children = userJourneys.map(
+  const children = userJourneys?.map(
     ({ user }) => user != null && <AccessAvatar user={user} key={user.id} />
+  ) ?? (
+    <>
+      <Avatar />
+      <Avatar />
+      <Avatar />
+    </>
   )
-
   // small default sizes
   let diameter: number
   let fontSize: number | undefined
@@ -75,8 +80,11 @@ export function AccessAvatars({
   return (
     <>
       <Box
-        onClick={() => setOpen(true)}
-        sx={{ cursor: 'pointer' }}
+        onClick={() => journeySlug != null && setOpen(true)}
+        sx={{
+          cursor: journeySlug != null ? 'pointer' : undefined,
+          height: diameter
+        }}
         role="Button"
       >
         <AvatarGroup
@@ -116,11 +124,13 @@ export function AccessAvatars({
           {children}
         </AvatarGroup>
       </Box>
-      <AccessDialog
-        journeySlug={journeySlug}
-        open={open}
-        onClose={() => setOpen(false)}
-      />
+      {journeySlug != null && (
+        <AccessDialog
+          journeySlug={journeySlug}
+          open={open}
+          onClose={() => setOpen(false)}
+        />
+      )}
     </>
   )
 }

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
@@ -614,7 +614,10 @@ const steps: Array<TreeBlock<StepBlock>> = [
 ]
 
 const Template: Story = ({ ...args }) => {
-  const [selected, setSelectedStep] = useState<TreeBlock<StepBlock>>(steps[0])
+  const [selected, setSelectedStep] = useState<TreeBlock<StepBlock>>(
+    args.steps?.[0]
+  )
+
   return (
     <MockedProvider>
       <JourneyProvider
@@ -629,7 +632,7 @@ const Template: Story = ({ ...args }) => {
         <CardPreview
           onSelect={(step) => setSelectedStep(step)}
           selected={selected}
-          steps={args.steps ?? steps}
+          steps={args.steps}
           showAddButton={args.showAddButton}
         />
       </JourneyProvider>
@@ -638,10 +641,19 @@ const Template: Story = ({ ...args }) => {
 }
 
 export const Default = Template.bind({})
+Default.args = {
+  steps
+}
 
 export const AddButton = Template.bind({})
 AddButton.args = {
+  steps,
   showAddButton: true
+}
+
+export const Loading = Template.bind({})
+Loading.args = {
+  steps: undefined
 }
 
 export default CardPreviewStory as Meta

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
@@ -11,6 +11,8 @@ import { ThemeProvider } from '@core/shared/ui'
 import AddIcon from '@mui/icons-material/Add'
 import Card from '@mui/material/Card'
 import CardActionArea from '@mui/material/CardActionArea'
+import Skeleton from '@mui/material/Skeleton'
+import Stack from '@mui/material/Stack'
 import { v4 as uuidv4 } from 'uuid'
 import { useMutation, gql } from '@apollo/client'
 import last from 'lodash/last'
@@ -27,7 +29,7 @@ import { CardWrapper } from '../Editor/Canvas/CardWrapper'
 export interface CardPreviewProps {
   onSelect?: (step: TreeBlock<StepBlock>) => void
   selected?: TreeBlock<StepBlock>
-  steps: Array<TreeBlock<StepBlock>>
+  steps?: Array<TreeBlock<StepBlock>>
   showAddButton?: boolean
 }
 
@@ -74,12 +76,14 @@ export function CardPreview({
   const journey = useJourney()
 
   const handleChange = (selectedId: string): void => {
+    if (steps == null) return
+
     const selectedStep = steps.find(({ id }) => id === selectedId)
     selectedStep != null && onSelect?.(selectedStep)
   }
 
   const handleClick = async (): Promise<void> => {
-    if (journey == null) return
+    if (journey == null || steps == null) return
 
     const stepId = uuidv4()
     const cardId = uuidv4()
@@ -152,70 +156,122 @@ export function CardPreview({
   }
 
   return (
-    <HorizontalSelect
-      onChange={handleChange}
-      id={selected?.id}
-      footer={
-        showAddButton === true && (
-          <Card
-            id="CardPreviewAddButton"
-            variant="outlined"
-            sx={{
-              display: 'flex',
-              width: 87,
-              height: 132,
-              m: 1
-            }}
-          >
-            <CardActionArea
+    <>
+      {steps != null ? (
+        <HorizontalSelect
+          onChange={handleChange}
+          id={selected?.id}
+          footer={
+            showAddButton === true && (
+              <Card
+                id="CardPreviewAddButton"
+                variant="outlined"
+                sx={{
+                  display: 'flex',
+                  width: 87,
+                  height: 132,
+                  m: 1
+                }}
+              >
+                <CardActionArea
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'center',
+                    alignItems: 'center'
+                  }}
+                  onClick={handleClick}
+                >
+                  <AddIcon color="primary" />
+                </CardActionArea>
+              </Card>
+            )
+          }
+        >
+          {steps.map((step) => (
+            <Box
+              id={step.id}
+              key={step.id}
+              data-testid={`preview-${step.id}`}
               sx={{
-                display: 'flex',
-                justifyContent: 'center',
-                alignItems: 'center'
+                width: 95,
+                height: 140
               }}
-              onClick={handleClick}
             >
-              <AddIcon color="primary" />
-            </CardActionArea>
-          </Card>
-        )
-      }
-    >
-      {steps.map((step) => (
-        <Box
-          id={step.id}
-          key={step.id}
-          data-testid={`preview-${step.id}`}
+              <Box
+                sx={{
+                  transform: 'scale(0.25)',
+                  transformOrigin: 'top left'
+                }}
+              >
+                <FramePortal width={380} height={560}>
+                  <ThemeProvider
+                    themeName={journey?.themeName ?? ThemeName.base}
+                    themeMode={journey?.themeMode ?? ThemeMode.light}
+                  >
+                    <Box sx={{ p: 4, height: '100%' }}>
+                      <BlockRenderer
+                        block={step}
+                        wrappers={{
+                          VideoWrapper,
+                          CardWrapper
+                        }}
+                      />
+                    </Box>
+                  </ThemeProvider>
+                </FramePortal>
+              </Box>
+            </Box>
+          ))}
+        </HorizontalSelect>
+      ) : (
+        <Stack
+          direction="row"
+          spacing={1}
           sx={{
-            width: 95,
-            height: 140
+            overflowX: 'auto',
+            overflowY: 'hidden',
+            py: 5,
+            px: 6
           }}
         >
           <Box
             sx={{
-              transform: 'scale(0.25)',
-              transformOrigin: 'top left'
+              border: '3px solid transparent'
             }}
           >
-            <FramePortal width={380} height={560}>
-              <ThemeProvider
-                themeName={journey?.themeName ?? ThemeName.base}
-                themeMode={journey?.themeMode ?? ThemeMode.light}
-              >
-                <Box sx={{ p: 4, height: '100%' }}>
-                  <BlockRenderer
-                    block={step}
-                    wrappers={{
-                      VideoWrapper,
-                      CardWrapper
-                    }}
-                  />
-                </Box>
-              </ThemeProvider>
-            </FramePortal>
+            <Skeleton
+              variant="rectangular"
+              width={87}
+              height={132}
+              sx={{ m: 1, borderRadius: 1 }}
+            />
           </Box>
-        </Box>
-      ))}
-    </HorizontalSelect>
+          <Box
+            sx={{
+              border: '3px solid transparent'
+            }}
+          >
+            <Skeleton
+              variant="rectangular"
+              width={87}
+              height={132}
+              sx={{ m: 1, borderRadius: 1 }}
+            />
+          </Box>
+          <Box
+            sx={{
+              border: '3px solid transparent'
+            }}
+          >
+            <Skeleton
+              variant="rectangular"
+              width={87}
+              height={132}
+              sx={{ m: 1, borderRadius: 1 }}
+            />
+          </Box>
+        </Stack>
+      )}
+    </>
   )
 }

--- a/apps/journeys-admin/src/components/Editor/Canvas/Canvas.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/Canvas.tsx
@@ -15,6 +15,7 @@ import { FramePortal } from '../../FramePortal'
 import { DRAWER_WIDTH } from '../Drawer'
 import 'swiper/swiper.min.css'
 import { useJourney } from '../../../libs/context'
+import { ThemeName, ThemeMode } from '../../../../__generated__/globalTypes'
 import { InlineEditWrapper } from './InlineEditWrapper'
 import { SelectableWrapper } from './SelectableWrapper'
 import { VideoWrapper } from './VideoWrapper'
@@ -32,7 +33,7 @@ export function Canvas(): ReactElement {
     state: { steps, selectedStep, selectedBlock },
     dispatch
   } = useEditor()
-  const { themeMode, themeName } = useJourney()
+  const journey = useJourney()
 
   useEffect(() => {
     if (swiper != null && selectedStep != null) {
@@ -134,7 +135,10 @@ export function Canvas(): ReactElement {
                 }}
               />
               <FramePortal width={356} height={536}>
-                <ThemeProvider themeName={themeName} themeMode={themeMode}>
+                <ThemeProvider
+                  themeName={journey?.themeName ?? ThemeName.base}
+                  themeMode={journey?.themeMode ?? ThemeMode.light}
+                >
                   <Box sx={{ p: 1, height: '100%' }}>
                     <BlockRenderer
                       block={step}

--- a/apps/journeys-admin/src/components/Editor/Canvas/Canvas.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/Canvas.tsx
@@ -1,4 +1,5 @@
 import Box from '@mui/material/Box'
+import Skeleton from '@mui/material/Skeleton'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import { Theme } from '@mui/material/styles'
 import { ReactElement, useEffect, useState } from 'react'
@@ -36,7 +37,7 @@ export function Canvas(): ReactElement {
   const journey = useJourney()
 
   useEffect(() => {
-    if (swiper != null && selectedStep != null) {
+    if (swiper != null && selectedStep != null && steps != null) {
       swiper.slideTo(steps.findIndex(({ id }) => id === selectedStep.id))
     }
   }, [steps, swiper, selectedStep])
@@ -93,72 +94,101 @@ export function Canvas(): ReactElement {
         spaceBetween={spaceBetween}
         centeredSlides={true}
         shortSwipes={false}
-        slideToClickedSlide
+        slideToClickedSlide={steps != null}
         onSwiper={(swiper) => setSwiper(swiper)}
-        onSlideChange={(swiper) =>
+        onSlideChange={(swiper) => {
+          if (steps == null) return
+
           dispatch({
             type: 'SetSelectedStepAction',
             step: steps[swiper.activeIndex]
           })
-        }
+        }}
       >
-        {steps.map((step) => (
-          <SwiperSlide key={step.id} style={{ width: 362 }}>
-            <Box
-              data-testid={`step-${step.id}`}
-              sx={{
-                borderRadius: 5,
-                transition: '0.2s all ease-out 0.1s',
-                position: 'relative',
-                overflow: 'hidden',
-                border: (theme) =>
-                  step.id === selectedBlock?.id
-                    ? `2px solid ${theme.palette.primary.main}`
-                    : `2px solid ${theme.palette.background.default}`,
-                transform:
-                  step.id === selectedStep?.id ? 'scaleY(1)' : 'scaleY(0.9)',
-                height: 536
-              }}
-            >
+        {steps != null ? (
+          steps.map((step) => (
+            <SwiperSlide key={step.id} style={{ width: 362 }}>
               <Box
+                data-testid={`step-${step.id}`}
                 sx={{
-                  position: 'absolute',
-                  top: 0,
-                  right: 0,
-                  bottom: 0,
-                  left: 0,
-                  zIndex: 1,
-                  transition: '0.2s opacity ease-out 0.1s',
-                  backgroundColor: (theme) => theme.palette.background.default,
-                  opacity: step.id === selectedStep?.id ? 0 : 1,
-                  pointerEvents: step.id === selectedStep?.id ? 'none' : 'auto'
+                  borderRadius: 5,
+                  transition: '0.2s all ease-out 0.1s',
+                  position: 'relative',
+                  overflow: 'hidden',
+                  border: (theme) =>
+                    step.id === selectedBlock?.id
+                      ? `2px solid ${theme.palette.primary.main}`
+                      : `2px solid ${theme.palette.background.default}`,
+                  transform:
+                    step.id === selectedStep?.id ? 'scaleY(1)' : 'scaleY(0.9)',
+                  height: 536
+                }}
+              >
+                <Box
+                  sx={{
+                    position: 'absolute',
+                    top: 0,
+                    right: 0,
+                    bottom: 0,
+                    left: 0,
+                    zIndex: 1,
+                    transition: '0.2s opacity ease-out 0.1s',
+                    backgroundColor: (theme) =>
+                      theme.palette.background.default,
+                    opacity: step.id === selectedStep?.id ? 0 : 1,
+                    pointerEvents:
+                      step.id === selectedStep?.id ? 'none' : 'auto'
+                  }}
+                />
+                <FramePortal width={356} height={536}>
+                  <ThemeProvider
+                    themeName={journey?.themeName ?? ThemeName.base}
+                    themeMode={journey?.themeMode ?? ThemeMode.light}
+                  >
+                    <Box sx={{ p: 1, height: '100%' }}>
+                      <BlockRenderer
+                        block={step}
+                        wrappers={{
+                          Wrapper: SelectableWrapper,
+                          TypographyWrapper: InlineEditWrapper,
+                          ButtonWrapper: InlineEditWrapper,
+                          RadioQuestionWrapper: InlineEditWrapper,
+                          RadioOptionWrapper: InlineEditWrapper,
+                          SignUpWrapper: InlineEditWrapper,
+                          VideoWrapper,
+                          CardWrapper
+                        }}
+                      />
+                    </Box>
+                  </ThemeProvider>
+                </FramePortal>
+              </Box>
+            </SwiperSlide>
+          ))
+        ) : (
+          <>
+            <SwiperSlide style={{ width: 362 }}>
+              <Skeleton
+                variant="rectangular"
+                width={362}
+                height={536}
+                sx={{ borderRadius: 5 }}
+              />
+            </SwiperSlide>
+            <SwiperSlide style={{ width: 362 }}>
+              <Skeleton
+                variant="rectangular"
+                width={362}
+                height={536}
+                sx={{
+                  borderRadius: 5,
+
+                  transform: 'scaleY(0.9)'
                 }}
               />
-              <FramePortal width={356} height={536}>
-                <ThemeProvider
-                  themeName={journey?.themeName ?? ThemeName.base}
-                  themeMode={journey?.themeMode ?? ThemeMode.light}
-                >
-                  <Box sx={{ p: 1, height: '100%' }}>
-                    <BlockRenderer
-                      block={step}
-                      wrappers={{
-                        Wrapper: SelectableWrapper,
-                        TypographyWrapper: InlineEditWrapper,
-                        ButtonWrapper: InlineEditWrapper,
-                        RadioQuestionWrapper: InlineEditWrapper,
-                        RadioOptionWrapper: InlineEditWrapper,
-                        SignUpWrapper: InlineEditWrapper,
-                        VideoWrapper,
-                        CardWrapper
-                      }}
-                    />
-                  </Box>
-                </ThemeProvider>
-              </FramePortal>
-            </Box>
-          </SwiperSlide>
-        ))}
+            </SwiperSlide>
+          </>
+        )}
       </Swiper>
     </Box>
   )

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.tsx
@@ -34,6 +34,8 @@ export function ButtonEdit({
   const [value, setValue] = useState(label)
 
   async function handleSaveBlock(): Promise<void> {
+    if (journey == null) return
+
     const label = value.trim().replace(/\n/g, '')
     await buttonBlockUpdate({
       variables: {

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditWrapper.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditWrapper.tsx
@@ -38,6 +38,8 @@ export function InlineEditWrapper({
   const journey = useJourney()
 
   const handleDeleteBlock = async (): Promise<void> => {
+    if (journey == null) return
+
     await blockDelete({
       variables: {
         id: block.id,

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.tsx
@@ -32,6 +32,8 @@ export function RadioOptionEdit({
   const [value, setValue] = useState(label)
 
   async function handleSaveBlock(): Promise<void> {
+    if (journey == null) return
+    
     const label = value.trim().replace(/\n/g, '')
     await radioOptionBlockUpdate({
       variables: {

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.tsx
@@ -33,7 +33,7 @@ export function RadioOptionEdit({
 
   async function handleSaveBlock(): Promise<void> {
     if (journey == null) return
-    
+
     const label = value.trim().replace(/\n/g, '')
     await radioOptionBlockUpdate({
       variables: {

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioQuestionEdit/RadioQuestionEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioQuestionEdit/RadioQuestionEdit.tsx
@@ -60,6 +60,8 @@ export function RadioQuestionEdit({
   const [descriptionValue, setDescription] = useState(description ?? '')
 
   async function handleUpdateBlock(): Promise<void> {
+    if (journey == null) return
+
     const label = labelValue.trimStart().trimEnd()
     const description = descriptionValue?.trimStart().trimEnd() ?? ''
 
@@ -85,6 +87,8 @@ export function RadioQuestionEdit({
   }
 
   const handleCreateOption = async (): Promise<void> => {
+    if (journey == null) return
+
     await radioOptionBlockCreate({
       variables: {
         input: {

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/SignUpEdit/SignUpEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/SignUpEdit/SignUpEdit.tsx
@@ -33,6 +33,8 @@ export function SignUpEdit({
   const [value, setValue] = useState(submitLabel ?? '')
 
   async function handleSaveBlock(): Promise<void> {
+    if (journey == null) return
+
     const submitLabel = value.trim().replace(/\n/g, '')
     await signUpBlockUpdate({
       variables: {

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.tsx
@@ -39,6 +39,8 @@ export function TypographyEdit({
   const [value, setValue] = useState(content)
 
   async function handleSaveBlock(): Promise<void> {
+    if (journey == null) return
+
     const content = value.trimStart().trimEnd()
 
     if (content === '') {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.tsx
@@ -85,7 +85,11 @@ export function Action(): ReactElement {
   const [action, setAction] = useState(selectedAction?.value ?? 'none')
 
   async function navigateAction(): Promise<void> {
-    if (selectedBlock != null && state.selectedStep?.nextBlockId != null) {
+    if (
+      selectedBlock != null &&
+      state.selectedStep?.nextBlockId != null &&
+      journey != null
+    ) {
       const { id, __typename: typeName } = selectedBlock
       await navigateActionUpdate({
         variables: {
@@ -111,7 +115,7 @@ export function Action(): ReactElement {
   }
 
   async function removeAction(): Promise<void> {
-    if (selectedBlock != null) {
+    if (selectedBlock != null && journey != null) {
       const { id, __typename: typeName } = selectedBlock
       await actionDelete({
         variables: {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/LinkAction/LinkAction.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/LinkAction/LinkAction.tsx
@@ -51,7 +51,7 @@ export function LinkAction(): ReactElement {
 
   async function handleSubmit(e: React.FocusEvent): Promise<void> {
     const target = e.target as HTMLInputElement
-    if (selectedBlock != null) {
+    if (selectedBlock != null && journey != null) {
       const { id, __typename: typeName } = selectedBlock
       await linkActionUpdate({
         variables: {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateAction/NavigateAction.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateAction/NavigateAction.tsx
@@ -7,11 +7,11 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import { CardPreview } from '../../../../../CardPreview'
 
 export function NavigateAction(): ReactElement {
-  const { state } = useEditor()
+  const {
+    state: { steps, selectedStep }
+  } = useEditor()
 
-  const nextStep = state.steps.find(
-    (step) => step.id === state.selectedStep?.nextBlockId
-  )
+  const nextStep = steps?.find((step) => step.id === selectedStep?.nextBlockId)
 
   return (
     <>
@@ -23,7 +23,7 @@ export function NavigateAction(): ReactElement {
         }}
         data-testid="cards-disabled-view"
       >
-        <CardPreview selected={nextStep} steps={state.steps} />
+        <CardPreview selected={nextStep} steps={steps} />
       </Box>
       <Stack
         direction={'row'}

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToBlockAction/NavigateToBlockAction.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToBlockAction/NavigateToBlockAction.tsx
@@ -44,7 +44,7 @@ export function NavigateToBlockAction(): ReactElement {
     ) ?? undefined
 
   async function handleSelectStep(step: TreeBlock<StepBlock>): Promise<void> {
-    if (selectedBlock != null) {
+    if (selectedBlock != null && journey != null) {
       const { id, __typename: typeName } = selectedBlock
       await navigateToBlockActionUpdate({
         variables: {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToBlockAction/NavigateToBlockAction.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToBlockAction/NavigateToBlockAction.tsx
@@ -27,9 +27,11 @@ export const NAVIGATE_TO_BLOCK_ACTION_UPDATE = gql`
 `
 
 export function NavigateToBlockAction(): ReactElement {
-  const { state } = useEditor()
+  const {
+    state: { steps, selectedBlock }
+  } = useEditor()
   const journey = useJourney()
-  const selectedBlock = state.selectedBlock as
+  const selectedButtonBlock = selectedBlock as
     | TreeBlock<ButtonBlock>
     | undefined
 
@@ -37,15 +39,15 @@ export function NavigateToBlockAction(): ReactElement {
     useMutation<NavigateToBlockActionUpdate>(NAVIGATE_TO_BLOCK_ACTION_UPDATE)
 
   const currentActionStep =
-    state.steps.find(
+    steps?.find(
       ({ id }) =>
-        selectedBlock?.action?.__typename === 'NavigateToBlockAction' &&
-        id === selectedBlock?.action?.blockId
+        selectedButtonBlock?.action?.__typename === 'NavigateToBlockAction' &&
+        id === selectedButtonBlock?.action?.blockId
     ) ?? undefined
 
   async function handleSelectStep(step: TreeBlock<StepBlock>): Promise<void> {
-    if (selectedBlock != null && journey != null) {
-      const { id, __typename: typeName } = selectedBlock
+    if (selectedButtonBlock != null && journey != null) {
+      const { id, __typename: typeName } = selectedButtonBlock
       await navigateToBlockActionUpdate({
         variables: {
           id,
@@ -72,7 +74,7 @@ export function NavigateToBlockAction(): ReactElement {
   return (
     <CardPreview
       selected={currentActionStep}
-      steps={state.steps}
+      steps={steps}
       onSelect={handleSelectStep}
     />
   )

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.tsx
@@ -61,7 +61,7 @@ export function NavigateToJourneyAction(): ReactElement {
     )?.id ?? ''
 
   async function handleChange(event: SelectChangeEvent): Promise<void> {
-    if (selectedBlock != null) {
+    if (selectedBlock != null && journey != null) {
       const { id, __typename: typeName } = selectedBlock
       await navigateToJourneyActionUpdate({
         variables: {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Attributes.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Attributes.tsx
@@ -95,7 +95,7 @@ export function Attributes({ selected, step }: AttributesProps): ReactElement {
       type: 'SetDrawerPropsAction',
       title: 'Social Share Appearance',
       mobileOpen: false,
-      children: <SocialShareAppearance id={selected.id} />
+      children: <SocialShareAppearance />
     })
   }, [selected.id, dispatch])
   return (

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Icon/Color/Color.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Icon/Color/Color.tsx
@@ -30,7 +30,7 @@ export function Color({ id, iconColor }: ColorProps): ReactElement {
   const journey = useJourney()
 
   async function handleChange(color: IconColor): Promise<void> {
-    if (color !== iconColor && color != null) {
+    if (color !== iconColor && color != null && journey != null) {
       await iconBlockColorUpdate({
         variables: {
           id,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Icon/Icon.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Icon/Icon.tsx
@@ -138,6 +138,8 @@ export function Icon({ id }: IconProps): ReactElement {
   const iconName = iconBlock?.iconName ?? ''
 
   async function iconUpdate(name: IconName | null): Promise<void> {
+    if (journey == null) return
+
     await iconBlockNameUpdate({
       variables: {
         id,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/MoveBlockButtons/MoveBlockButtons.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/MoveBlockButtons/MoveBlockButtons.tsx
@@ -70,7 +70,7 @@ export function MoveBlockButtons({
 
   const handleMove = (move: 'up' | 'down'): (() => Promise<void>) => {
     return async () => {
-      if (selectedBlock?.parentOrder != null) {
+      if (selectedBlock?.parentOrder != null && journey != null) {
         const moveBy = move === 'up' ? -1 : 1
 
         await blockOrderUpdate({

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Button/Color/Color.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Button/Color/Color.tsx
@@ -32,7 +32,7 @@ export function Color(): ReactElement {
     | undefined
 
   async function handleChange(color: ButtonColor): Promise<void> {
-    if (selectedBlock != null && color != null) {
+    if (selectedBlock != null && color != null && journey != null) {
       await buttonBlockUpdate({
         variables: {
           id: selectedBlock.id,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Button/Size/Size.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Button/Size/Size.tsx
@@ -31,7 +31,7 @@ export function Size(): ReactElement {
     | undefined
 
   async function handleChange(size: ButtonSize): Promise<void> {
-    if (selectedBlock != null && size != null) {
+    if (selectedBlock != null && size != null && journey != null) {
       await buttonBlockUpdate({
         variables: {
           id: selectedBlock.id,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Button/Variant/Variant.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Button/Variant/Variant.tsx
@@ -31,7 +31,7 @@ export function Variant(): ReactElement {
     | undefined
 
   async function handleChange(variant: ButtonVariant): Promise<void> {
-    if (selectedBlock != null && variant != null) {
+    if (selectedBlock != null && variant != null && journey != null) {
       await buttonBlockUpdate({
         variables: {
           id: selectedBlock.id,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundColor/BackgroundColor.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundColor/BackgroundColor.tsx
@@ -56,7 +56,7 @@ export function BackgroundColor(): ReactElement {
           (child) => child.__typename === 'CardBlock'
         )
   ) as TreeBlock<CardBlock> | undefined
-  const { id: journeyId } = useJourney()
+  const journey = useJourney()
 
   const [tabValue, setTabValue] = useState(0)
   const smUp = useMediaQuery((theme: Theme) => theme.breakpoints.up('sm'))
@@ -68,11 +68,13 @@ export function BackgroundColor(): ReactElement {
   }
 
   const handleColorChange = async (color: string): Promise<void> => {
+    if (journey == null) return
+
     if (cardBlock != null) {
       await cardBlockUpdate({
         variables: {
           id: cardBlock.id,
-          journeyId: journeyId,
+          journeyId: journey.id,
           input: {
             backgroundColor: color === 'null' ? null : color
           }

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.tsx
@@ -97,21 +97,23 @@ export function BackgroundMediaImage({
     useMutation<BlockDeleteForBackgroundImage>(
       BLOCK_DELETE_FOR_BACKGROUND_IMAGE
     )
-  const { id: journeyId } = useJourney()
+  const journey = useJourney()
 
   const handleImageDelete = async (): Promise<void> => {
     await deleteCoverBlock()
   }
 
   const deleteCoverBlock = async (): Promise<boolean> => {
+    if (journey == null) return false
+
     await blockDelete({
       variables: {
         id: coverBlock.id,
         parentBlockId: cardBlock.parentBlockId,
-        journeyId: journeyId
+        journeyId: journey.id
       },
       update(cache, { data }) {
-        blockDeleteUpdate(coverBlock, data?.blockDelete, cache, journeyId)
+        blockDeleteUpdate(coverBlock, data?.blockDelete, cache, journey.id)
       }
     })
 
@@ -120,7 +122,7 @@ export function BackgroundMediaImage({
     await cardBlockUpdate({
       variables: {
         id: cardBlock.id,
-        journeyId: journeyId,
+        journeyId: journey.id,
         input: {
           coverBlockId: null
         }
@@ -137,10 +139,12 @@ export function BackgroundMediaImage({
   }
 
   const createImageBlock = async (block): Promise<boolean> => {
+    if (journey == null) return false
+
     const { data } = await imageBlockCreate({
       variables: {
         input: {
-          journeyId: journeyId,
+          journeyId: journey.id,
           parentBlockId: cardBlock.id,
           src: block.src,
           alt: block.alt
@@ -149,7 +153,7 @@ export function BackgroundMediaImage({
       update(cache, { data }) {
         if (data?.imageBlockCreate != null) {
           cache.modify({
-            id: cache.identify({ __typename: 'Journey', id: journeyId }),
+            id: cache.identify({ __typename: 'Journey', id: journey.id }),
             fields: {
               blocks(existingBlockRefs = []) {
                 const newBlockRef = cache.writeFragment({
@@ -173,7 +177,7 @@ export function BackgroundMediaImage({
     await cardBlockUpdate({
       variables: {
         id: cardBlock.id,
-        journeyId: journeyId,
+        journeyId: journey.id,
         input: {
           coverBlockId: data?.imageBlockCreate.id ?? null
         }
@@ -190,10 +194,12 @@ export function BackgroundMediaImage({
   }
 
   const updateImageBlock = async (block: ImageBlock): Promise<boolean> => {
+    if (journey == null) return false
+
     await imageBlockUpdate({
       variables: {
         id: coverBlock.id,
-        journeyId: journeyId,
+        journeyId: journey.id,
         input: {
           src: block.src,
           alt: block.alt

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.tsx
@@ -87,24 +87,26 @@ export function BackgroundMediaVideo({
   const [blockDelete] = useMutation<BlockDeleteForBackgroundVideo>(
     BLOCK_DELETE_FOR_BACKGROUND_VIDEO
   )
-  const { id: journeyId } = useJourney()
+  const journey = useJourney()
   const videoBlock = coverBlock?.__typename === 'VideoBlock' ? coverBlock : null
 
   const deleteCoverBlock = async (): Promise<void> => {
+    if (journey == null) return
+
     await blockDelete({
       variables: {
         id: coverBlock.id,
         parentBlockId: coverBlock.parentBlockId,
-        journeyId: journeyId
+        journeyId: journey.id
       },
       update(cache, { data }) {
-        blockDeleteUpdate(coverBlock, data?.blockDelete, cache, journeyId)
+        blockDeleteUpdate(coverBlock, data?.blockDelete, cache, journey.id)
       }
     })
     await cardBlockUpdate({
       variables: {
         id: cardBlock.id,
-        journeyId: journeyId,
+        journeyId: journey.id,
         input: {
           coverBlockId: null
         }
@@ -122,10 +124,12 @@ export function BackgroundMediaVideo({
   const createVideoBlock = async (
     input: VideoBlockUpdateInput
   ): Promise<void> => {
+    if (journey == null) return
+
     const { data } = await videoBlockCreate({
       variables: {
         input: {
-          journeyId: journeyId,
+          journeyId: journey.id,
           parentBlockId: cardBlock.id,
           ...input
         }
@@ -133,7 +137,7 @@ export function BackgroundMediaVideo({
       update(cache, { data }) {
         if (data?.videoBlockCreate != null) {
           cache.modify({
-            id: cache.identify({ __typename: 'Journey', id: journeyId }),
+            id: cache.identify({ __typename: 'Journey', id: journey.id }),
             fields: {
               blocks(existingBlockRefs = []) {
                 const newBlockRef = cache.writeFragment({
@@ -155,7 +159,7 @@ export function BackgroundMediaVideo({
     await cardBlockUpdate({
       variables: {
         id: cardBlock.id,
-        journeyId: journeyId,
+        journeyId: journey.id,
         input: {
           coverBlockId: data?.videoBlockCreate?.id ?? null
         }
@@ -173,10 +177,12 @@ export function BackgroundMediaVideo({
   const updateVideoBlock = async (
     input: VideoBlockUpdateInput
   ): Promise<void> => {
+    if (journey == null) return
+
     await videoBlockUpdate({
       variables: {
         id: coverBlock.id,
-        journeyId: journeyId,
+        journeyId: journey.id,
         input
       }
     })

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardLayout/CardLayout.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardLayout/CardLayout.tsx
@@ -43,13 +43,13 @@ export function CardLayout(): ReactElement {
   const [cardBlockUpdate] = useMutation<CardBlockLayoutUpdate>(
     CARD_BLOCK_LAYOUT_UPDATE
   )
-  const { id: journeyId } = useJourney()
+  const journey = useJourney()
   const handleLayoutChange = async (selected: boolean): Promise<void> => {
-    if (cardBlock != null) {
+    if (journey != null && cardBlock != null) {
       await cardBlockUpdate({
         variables: {
           id: cardBlock.id,
-          journeyId: journeyId,
+          journeyId: journey.id,
           input: {
             fullscreen: selected
           }

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardStyling/CardStyling.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardStyling/CardStyling.tsx
@@ -44,14 +44,14 @@ export function CardStyling(): ReactElement {
   const [cardBlockUpdate] = useMutation<CardBlockThemeModeUpdate>(
     CARD_BLOCK_THEME_MODE_UPDATE
   )
-  const { id: journeyId } = useJourney()
+  const journey = useJourney()
 
   const handleChange = async (themeMode: ThemeMode): Promise<void> => {
-    if (cardBlock != null) {
+    if (journey != null && cardBlock != null) {
       await cardBlockUpdate({
         variables: {
           id: cardBlock.id,
-          journeyId,
+          journeyId: journey.id,
           input: {
             themeMode
           }

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Image/Options/ImageOptions.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Image/Options/ImageOptions.tsx
@@ -30,15 +30,17 @@ export function ImageOptions(): ReactElement {
   const {
     state: { selectedBlock }
   } = useEditor()
-  const { id: journeyId } = useJourney()
+  const journey = useJourney()
   const [imageBlockUpdate] = useMutation<ImageBlockUpdate>(IMAGE_BLOCK_UPDATE)
   const imageBlock = selectedBlock as TreeBlock<ImageBlock>
 
   const updateImageBlock = async (block: ImageBlock): Promise<void> => {
+    if (journey == null) return
+
     await imageBlockUpdate({
       variables: {
         id: imageBlock.id,
-        journeyId: journeyId,
+        journeyId: journey.id,
         input: {
           src: block.src,
           alt: block.alt

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/Cards.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/Cards.tsx
@@ -33,7 +33,7 @@ export function Cards(): ReactElement {
   const theme = useTheme()
   const { id, nextBlockId } = selectedBlock as TreeBlock<StepFields>
 
-  const nextStep: TreeBlock<StepFields> | undefined = steps.find(
+  const nextStep: TreeBlock<StepFields> | undefined = steps?.find(
     ({ id }) => nextBlockId === id
   )
 

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/Cards.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/Cards.tsx
@@ -38,6 +38,8 @@ export function Cards(): ReactElement {
   )
 
   async function handleSelectStep(step: TreeBlock<StepFields>): Promise<void> {
+    if (journey == null) return
+
     await stepBlockNextBlockUpdate({
       variables: {
         id,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Conditions/Conditions.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Conditions/Conditions.tsx
@@ -36,6 +36,8 @@ export function Conditions(): ReactElement {
   const block = selectedBlock as TreeBlock<StepFields>
 
   async function handleChange(): Promise<void> {
+    if (journey == null) return
+
     await stepBlockLockUpdate({
       variables: {
         id: block.id,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/SelectedCard.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/SelectedCard.tsx
@@ -11,6 +11,10 @@ import { useEditor, TreeBlock, BlockRenderer } from '@core/journeys/ui'
 import { useJourney } from '../../../../../../../../libs/context'
 import { StepFields } from '../../../../../../../../../__generated__/StepFields'
 import { StepBlockNextBlockUpdate } from '../../../../../../../../../__generated__/StepBlockNextBlockUpdate'
+import {
+  ThemeMode,
+  ThemeName
+} from '../../../../../../../../../__generated__/globalTypes'
 import { FramePortal } from '../../../../../../../FramePortal'
 
 export const STEP_BLOCK_DEFAULT_NEXT_BLOCK_UPDATE = gql`
@@ -44,6 +48,8 @@ export function SelectedCard(): ReactElement {
 
   // TODO: Set as block itself for now, still need to manually set next block
   async function handleRemoveCustomNextStep(): Promise<void> {
+    if (journey == null) return
+
     await stepBlockDefaultNextBlockUpdate({
       variables: {
         id,
@@ -87,8 +93,8 @@ export function SelectedCard(): ReactElement {
           >
             <FramePortal width={380} height={560}>
               <ThemeProvider
-                themeName={journey.themeName}
-                themeMode={journey.themeMode}
+                themeName={journey?.themeName ?? ThemeName.base}
+                themeMode={journey?.themeMode ?? ThemeMode.light}
               >
                 <Box sx={{ p: 4, height: '100%' }}>
                   <BlockRenderer

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/SelectedCard.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/SelectedCard.tsx
@@ -39,11 +39,11 @@ export function SelectedCard(): ReactElement {
   const journey = useJourney()
   const { id, nextBlockId, locked } = selectedBlock as TreeBlock<StepFields>
   const [nextStep, setNextStep] = useState(
-    steps.find((step) => nextBlockId === step.id)
+    steps?.find((step) => nextBlockId === step.id)
   )
 
   useEffect(() => {
-    setNextStep(steps.find((step) => nextBlockId === step.id))
+    setNextStep(steps?.find((step) => nextBlockId === step.id))
   }, [steps, nextBlockId])
 
   // TODO: Set as block itself for now, still need to manually set next block

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.tsx
@@ -23,7 +23,7 @@ export function Step({
     state: { steps },
     dispatch
   } = useEditor()
-  const nextBlock = steps.find(({ id }) => id === nextBlockId)
+  const nextBlock = steps?.find(({ id }) => id === nextBlockId)
   const nextBlockDescendants = flatten(nextBlock?.children ?? [])
   const nextBlockHeading = nextBlockDescendants.find(
     (block) => block.__typename === 'TypographyBlock'

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Align/Align.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Align/Align.tsx
@@ -52,7 +52,7 @@ export function Align(): ReactElement {
   ]
 
   async function handleChange(align: TypographyAlign): Promise<void> {
-    if (selectedBlock != null && align != null) {
+    if (selectedBlock != null && align != null && journey != null) {
       await typographyBlockUpdate({
         variables: {
           id: selectedBlock.id,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Color/Color.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Color/Color.tsx
@@ -33,7 +33,7 @@ export function Color(): ReactElement {
     | undefined
 
   async function handleChange(color: TypographyColor): Promise<void> {
-    if (selectedBlock != null && color != null) {
+    if (selectedBlock != null && color != null && journey != null) {
       await typographyBlockUpdate({
         variables: {
           id: selectedBlock.id,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Variant/Variant.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Variant/Variant.tsx
@@ -107,7 +107,7 @@ export function Variant(): ReactElement {
   ]
 
   async function handleChange(variant: TypographyVariant): Promise<void> {
-    if (selectedBlock != null && variant != null) {
+    if (selectedBlock != null && variant != null && journey != null) {
       await typographyBlockUpdate({
         variables: {
           id: selectedBlock.id,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.tsx
@@ -23,16 +23,16 @@ export function VideoOptions(): ReactElement {
   const {
     state: { selectedBlock }
   } = useEditor()
-  const { id: journeyId } = useJourney()
+  const journey = useJourney()
   const [videoBlockUpdate] = useMutation<VideoBlockUpdate>(VIDEO_BLOCK_UPDATE)
 
   const handleChange = async (input: VideoBlockUpdateInput): Promise<void> => {
-    if (selectedBlock == null) return
+    if (selectedBlock == null || journey == null) return
 
     await videoBlockUpdate({
       variables: {
         id: selectedBlock.id,
-        journeyId: journeyId,
+        journeyId: journey.id,
         input
       }
     })

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewButtonButton/NewButtonButton.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewButtonButton/NewButtonButton.tsx
@@ -48,7 +48,7 @@ export const BUTTON_BLOCK_CREATE = gql`
 export function NewButtonButton(): ReactElement {
   const [buttonBlockCreate] =
     useMutation<ButtonBlockCreate>(BUTTON_BLOCK_CREATE)
-  const { id: journeyId } = useJourney()
+  const journey = useJourney()
   const {
     state: { selectedStep },
     dispatch
@@ -61,12 +61,12 @@ export function NewButtonButton(): ReactElement {
     const card = selectedStep?.children.find(
       (block) => block.__typename === 'CardBlock'
     ) as TreeBlock<CardBlock> | undefined
-    if (card != null) {
+    if (card != null && journey != null) {
       const { data } = await buttonBlockCreate({
         variables: {
           input: {
             id,
-            journeyId,
+            journeyId: journey.id,
             parentBlockId: card.id,
             label: 'Edit Text...',
             variant: ButtonVariant.contained,
@@ -75,18 +75,18 @@ export function NewButtonButton(): ReactElement {
           },
           iconBlockCreateInput1: {
             id: startId,
-            journeyId,
+            journeyId: journey.id,
             parentBlockId: id,
             name: null
           },
           iconBlockCreateInput2: {
             id: endId,
-            journeyId,
+            journeyId: journey.id,
             parentBlockId: id,
             name: null
           },
           id,
-          journeyId,
+          journeyId: journey.id,
           updateInput: {
             startIconId: startId,
             endIconId: endId
@@ -95,7 +95,7 @@ export function NewButtonButton(): ReactElement {
         update(cache, { data }) {
           if (data?.buttonBlockUpdate != null) {
             cache.modify({
-              id: cache.identify({ __typename: 'Journey', id: journeyId }),
+              id: cache.identify({ __typename: 'Journey', id: journey.id }),
               fields: {
                 blocks(existingBlockRefs = []) {
                   const newStartIconBlockRef = cache.writeFragment({

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewImageButton/NewImageButton.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewImageButton/NewImageButton.tsx
@@ -26,7 +26,7 @@ export const IMAGE_BLOCK_CREATE = gql`
 
 export function NewImageButton(): ReactElement {
   const [imageBlockCreate] = useMutation<ImageBlockCreate>(IMAGE_BLOCK_CREATE)
-  const { id: journeyId } = useJourney()
+  const journey = useJourney()
   const {
     state: { selectedStep },
     dispatch
@@ -36,11 +36,11 @@ export function NewImageButton(): ReactElement {
     const card = selectedStep?.children.find(
       (block) => block.__typename === 'CardBlock'
     ) as TreeBlock<CardBlock> | undefined
-    if (card != null) {
+    if (card != null && journey != null) {
       const { data } = await imageBlockCreate({
         variables: {
           input: {
-            journeyId,
+            journeyId: journey.id,
             parentBlockId: card.id,
             src: null,
             alt: 'Default Image Icon'
@@ -49,7 +49,7 @@ export function NewImageButton(): ReactElement {
         update(cache, { data }) {
           if (data?.imageBlockCreate != null) {
             cache.modify({
-              id: cache.identify({ __typename: 'Journey', id: journeyId }),
+              id: cache.identify({ __typename: 'Journey', id: journey.id }),
               fields: {
                 blocks(existingBlockRefs = []) {
                   const newBlockRef = cache.writeFragment({

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewRadioQuestionButton/NewRadioQuestionButton.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewRadioQuestionButton/NewRadioQuestionButton.tsx
@@ -47,7 +47,7 @@ export function NewRadioQuestionButton(): ReactElement {
   const [radioQuestionBlockCreate] = useMutation<RadioQuestionBlockCreate>(
     RADIO_QUESTION_BLOCK_CREATE
   )
-  const { id: journeyId } = useJourney()
+  const journey = useJourney()
   const {
     state: { selectedStep },
     dispatch
@@ -59,22 +59,22 @@ export function NewRadioQuestionButton(): ReactElement {
       (block) => block.__typename === 'CardBlock'
     ) as TreeBlock<CardBlock> | undefined
 
-    if (card != null) {
+    if (card != null && journey != null) {
       const { data } = await radioQuestionBlockCreate({
         variables: {
           input: {
-            journeyId,
+            journeyId: journey.id,
             id,
             parentBlockId: card.id,
             label: 'Your Question Here?'
           },
           radioOptionBlockCreateInput1: {
-            journeyId,
+            journeyId: journey.id,
             parentBlockId: id,
             label: 'Option 1'
           },
           radioOptionBlockCreateInput2: {
-            journeyId,
+            journeyId: journey.id,
             parentBlockId: id,
             label: 'Option 2'
           }
@@ -82,7 +82,7 @@ export function NewRadioQuestionButton(): ReactElement {
         update(cache, { data }) {
           if (data?.radioQuestionBlockCreate != null) {
             cache.modify({
-              id: cache.identify({ __typename: 'Journey', id: journeyId }),
+              id: cache.identify({ __typename: 'Journey', id: journey.id }),
               fields: {
                 blocks(existingBlockRefs = []) {
                   const newBlockRef = cache.writeFragment({

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewSignUpButton/NewSignUpButton.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewSignUpButton/NewSignUpButton.tsx
@@ -41,7 +41,7 @@ export const SIGN_UP_BLOCK_CREATE = gql`
 export function NewSignUpButton(): ReactElement {
   const [signUpBlockCreate] =
     useMutation<SignUpBlockCreate>(SIGN_UP_BLOCK_CREATE)
-  const { id: journeyId } = useJourney()
+  const journey = useJourney()
   const {
     state: { selectedStep },
     dispatch
@@ -53,23 +53,23 @@ export function NewSignUpButton(): ReactElement {
     const card = selectedStep?.children.find(
       (block) => block.__typename === 'CardBlock'
     ) as TreeBlock<CardBlock> | undefined
-    if (card != null) {
+    if (card != null && journey != null) {
       const { data } = await signUpBlockCreate({
         variables: {
           input: {
             id,
-            journeyId,
+            journeyId: journey.id,
             parentBlockId: card.id,
             submitLabel: 'Submit'
           },
           iconBlockCreateInput: {
             id: submitId,
-            journeyId,
+            journeyId: journey.id,
             parentBlockId: id,
             name: null
           },
           id,
-          journeyId,
+          journeyId: journey.id,
           updateInput: {
             submitIconId: submitId
           }
@@ -77,7 +77,7 @@ export function NewSignUpButton(): ReactElement {
         update(cache, { data }) {
           if (data?.signUpBlockUpdate != null) {
             cache.modify({
-              id: cache.identify({ __typename: 'Journey', id: journeyId }),
+              id: cache.identify({ __typename: 'Journey', id: journey.id }),
               fields: {
                 blocks(existingBlockRefs = []) {
                   const newSubmitIconBlockRef = cache.writeFragment({

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewTypographyButton/NewTypographyButton.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewTypographyButton/NewTypographyButton.tsx
@@ -27,7 +27,7 @@ export function NewTypographyButton(): ReactElement {
   const [typographyBlockCreate] = useMutation<TypographyBlockCreate>(
     TYPOGRAPHY_BLOCK_CREATE
   )
-  const { id: journeyId } = useJourney()
+  const journey = useJourney()
   const {
     state: { selectedStep },
     dispatch
@@ -40,11 +40,11 @@ export function NewTypographyButton(): ReactElement {
     const checkTypography = card?.children.map((block) =>
       block.children.find((child) => child.__typename === 'TypographyBlock')
     )
-    if (card != null && checkTypography !== undefined) {
+    if (card != null && checkTypography !== undefined && journey != null) {
       const { data } = await typographyBlockCreate({
         variables: {
           input: {
-            journeyId,
+            journeyId: journey.id,
             parentBlockId: card.id,
             content: 'Add your text here...',
             variant: checkTypography.length > 0 ? 'body2' : 'h1'
@@ -53,7 +53,7 @@ export function NewTypographyButton(): ReactElement {
         update(cache, { data }) {
           if (data?.typographyBlockCreate != null) {
             cache.modify({
-              id: cache.identify({ __typename: 'Journey', id: journeyId }),
+              id: cache.identify({ __typename: 'Journey', id: journey.id }),
               fields: {
                 blocks(existingBlockRefs = []) {
                   const newBlockRef = cache.writeFragment({

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewVideoButton/NewVideoButton.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewVideoButton/NewVideoButton.tsx
@@ -23,7 +23,7 @@ export const VIDEO_BLOCK_CREATE = gql`
 
 export function NewVideoButton(): ReactElement {
   const [videoBlockCreate] = useMutation<VideoBlockCreate>(VIDEO_BLOCK_CREATE)
-  const { id: journeyId } = useJourney()
+  const journey = useJourney()
   const {
     state: { selectedStep },
     dispatch
@@ -33,11 +33,11 @@ export function NewVideoButton(): ReactElement {
     const card = selectedStep?.children.find(
       (block) => block.__typename === 'CardBlock'
     ) as TreeBlock<CardBlock> | undefined
-    if (card != null) {
+    if (card != null && journey != null) {
       const { data } = await videoBlockCreate({
         variables: {
           input: {
-            journeyId,
+            journeyId: journey.id,
             parentBlockId: card.id,
             autoplay: true,
             muted: false,
@@ -47,7 +47,7 @@ export function NewVideoButton(): ReactElement {
         update(cache, { data }) {
           if (data?.videoBlockCreate != null) {
             cache.modify({
-              id: cache.identify({ __typename: 'Journey', id: journeyId }),
+              id: cache.identify({ __typename: 'Journey', id: journey.id }),
               fields: {
                 blocks(existingBlockRefs = []) {
                   const newBlockRef = cache.writeFragment({

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ColorDisplayIcon/ColorDisplayIcon.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ColorDisplayIcon/ColorDisplayIcon.tsx
@@ -43,8 +43,8 @@ export function ColorDisplayIcon({
       }}
     >
       <ThemeProvider
-        themeName={card?.themeName ?? journey.themeName ?? ThemeName.base}
-        themeMode={card?.themeMode ?? journey.themeMode ?? ThemeMode.dark}
+        themeName={card?.themeName ?? journey?.themeName ?? ThemeName.base}
+        themeMode={card?.themeMode ?? journey?.themeMode ?? ThemeMode.dark}
         nested
       >
         <Box

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.stories.tsx
@@ -578,7 +578,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
   }
 ]
 
-const Template: Story = () => {
+const Template: Story = (args) => {
   return (
     <MockedProvider>
       <JourneyProvider
@@ -592,7 +592,7 @@ const Template: Story = () => {
       >
         <EditorProvider
           initialState={{
-            steps
+            steps: args.steps
           }}
         >
           <Box sx={{ mt: '80px' }}>
@@ -605,5 +605,13 @@ const Template: Story = () => {
 }
 
 export const Default = Template.bind({})
+Default.args = {
+  steps
+}
+
+export const Loading = Template.bind({})
+Loading.args = {
+  steps: undefined
+}
 
 export default ControlPanelStory as Meta

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.tsx
@@ -39,6 +39,7 @@ export function ControlPanel(): ReactElement {
         <Fab
           visible={activeTab !== ActiveTab.Blocks}
           onAddClick={handleAddFabClick}
+          disabled={steps == null}
         />
       </Box>
       <Box
@@ -62,12 +63,13 @@ export function ControlPanel(): ReactElement {
             label="Properties"
             {...tabA11yProps('control-panel', 1)}
             sx={{ flexGrow: 1 }}
-            disabled={selectedBlock == null}
+            disabled={steps == null || selectedBlock == null}
           />
           <Tab
             label="Blocks"
             {...tabA11yProps('control-panel', 2)}
             sx={{ flexGrow: 1 }}
+            disabled={steps == null}
           />
         </Tabs>
       </Box>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Fab/Fab.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Fab/Fab.tsx
@@ -9,9 +9,10 @@ import { useEditor, ActiveFab } from '@core/journeys/ui'
 interface FabProp {
   visible?: boolean
   onAddClick: () => void
+  disabled?: boolean
 }
 
-export function Fab({ visible, onAddClick }: FabProp): ReactElement {
+export function Fab({ visible, onAddClick, disabled }: FabProp): ReactElement {
   const {
     state: { activeFab },
     dispatch
@@ -33,6 +34,7 @@ export function Fab({ visible, onAddClick }: FabProp): ReactElement {
           size="large"
           color="primary"
           onClick={onAddClick}
+          disabled={disabled}
         >
           <AddRounded sx={{ mr: 3 }} />
           Add
@@ -43,6 +45,7 @@ export function Fab({ visible, onAddClick }: FabProp): ReactElement {
           size="large"
           color="primary"
           onClick={handleEditFab}
+          disabled={disabled}
         >
           <EditRounded sx={{ mr: 3 }} />
           Edit
@@ -53,6 +56,7 @@ export function Fab({ visible, onAddClick }: FabProp): ReactElement {
           size="large"
           color="primary"
           onClick={handleSaveFab}
+          disabled={disabled}
         >
           <CheckCircleRounded sx={{ mr: 3 }} />
           Done

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.spec.tsx
@@ -3,7 +3,7 @@ import { SocialShareAppearance } from '.'
 
 describe('SocialShareAppearance', () => {
   it('should render SocialShareAppearance', () => {
-    const { getByText } = render(<SocialShareAppearance id="journeyId" />)
+    const { getByText } = render(<SocialShareAppearance />)
     expect(getByText('Social Image')).toBeInTheDocument()
   })
 })

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.tsx
@@ -1,13 +1,7 @@
 import Box from '@mui/material/Box'
 import { ReactElement } from 'react'
 
-interface SocialShareAppearanceProps {
-  id: string
-}
-
-export function SocialShareAppearance({
-  id
-}: SocialShareAppearanceProps): ReactElement {
+export function SocialShareAppearance(): ReactElement {
   return (
     <>
       <Box sx={{ px: 6, py: 4 }}>Social Image</Box>

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/DeleteBlock.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/DeleteBlock.tsx
@@ -50,7 +50,7 @@ export function DeleteBlock({
   }
 
   const handleDeleteBlock = async (): Promise<void> => {
-    if (selectedBlock == null || journey == null) return
+    if (selectedBlock == null || journey == null || steps == null) return
 
     const deletedBlockParentOrder = selectedBlock.parentOrder
     const deletedBlockType = selectedBlock.__typename

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/DeleteBlock.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/DeleteBlock.tsx
@@ -35,7 +35,7 @@ export function DeleteBlock({
   const [blockDelete] = useMutation<BlockDelete>(BLOCK_DELETE)
   const { enqueueSnackbar } = useSnackbar()
 
-  const { id: journeyId } = useJourney()
+  const journey = useJourney()
   const {
     state: { selectedBlock, selectedStep, steps },
     dispatch
@@ -50,7 +50,7 @@ export function DeleteBlock({
   }
 
   const handleDeleteBlock = async (): Promise<void> => {
-    if (selectedBlock == null) return
+    if (selectedBlock == null || journey == null) return
 
     const deletedBlockParentOrder = selectedBlock.parentOrder
     const deletedBlockType = selectedBlock.__typename
@@ -60,11 +60,11 @@ export function DeleteBlock({
     const { data } = await blockDelete({
       variables: {
         id: selectedBlock.id,
-        journeyId,
+        journeyId: journey.id,
         parentBlockId: selectedBlock.parentBlockId
       },
       update(cache, { data }) {
-        blockDeleteUpdate(selectedBlock, data?.blockDelete, cache, journeyId)
+        blockDeleteUpdate(selectedBlock, data?.blockDelete, cache, journey.id)
       }
     })
 

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.tsx
@@ -60,6 +60,7 @@ export function Menu(): ReactElement {
         aria-haspopup="true"
         aria-expanded={anchorEl != null ? 'true' : undefined}
         onClick={handleShowMenu}
+        disabled={journey == null}
       >
         <MoreVert />
       </IconButton>

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.tsx
@@ -36,7 +36,10 @@ export function Menu(): ReactElement {
       <>
         <DeleteBlock variant="list-item" closeMenu={handleCloseMenu} />
         <Divider />
-        <NextLink href={`/journeys/${journey.slug}`} passHref>
+        <NextLink
+          href={journey != null ? `/journeys/${journey.slug}` : ''}
+          passHref
+        >
           <MenuItem>
             <ListItemIcon>
               <SettingsIcon />

--- a/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
@@ -512,28 +512,11 @@ const blocks: GetJourney_journey_blocks[] = [
   }
 ]
 
-const Template: Story = () => (
+const Template: Story = (args) => (
   <MockedProvider>
-    <Editor
-      journey={{
-        __typename: 'Journey',
-        id: 'journeyId',
-        themeName: ThemeName.base,
-        themeMode: ThemeMode.light,
-        title: 'NUA Journey: Ep.3 – Decision',
-        slug: 'nua-journey-ep-3-decision',
-        description: 'my cool journey',
-        locale: 'en-US',
-        status: JourneyStatus.draft,
-        createdAt: '2021-11-19T12:34:56.647Z',
-        publishedAt: null,
-        primaryImageBlock: null,
-        userJourneys: [],
-        blocks
-      }}
-    >
+    <Editor journey={args.journey}>
       <PageWrapper
-        title="NUA Journey: Ep.3 – Decision"
+        title="NUA Journey: Ep.3 - Decision"
         showDrawer
         Menu={<EditToolbar />}
         backHref="/journeys/nua-journey-ep-3-decision"
@@ -545,5 +528,28 @@ const Template: Story = () => (
 )
 
 export const Default = Template.bind({})
+Default.args = {
+  journey: {
+    __typename: 'Journey',
+    id: 'journeyId',
+    themeName: ThemeName.base,
+    themeMode: ThemeMode.light,
+    title: 'NUA Journey: Ep.3 – Decision',
+    slug: 'nua-journey-ep-3-decision',
+    description: 'my cool journey',
+    locale: 'en-US',
+    status: JourneyStatus.draft,
+    createdAt: '2021-11-19T12:34:56.647Z',
+    publishedAt: null,
+    primaryImageBlock: null,
+    userJourneys: [],
+    blocks
+  }
+}
+
+export const Loading = Template.bind({})
+Loading.args = {
+  journey: undefined
+}
 
 export default EditorStory as Meta

--- a/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
@@ -516,7 +516,7 @@ const Template: Story = (args) => (
   <MockedProvider>
     <Editor journey={args.journey}>
       <PageWrapper
-        title="NUA Journey: Ep.3 - Decision"
+        title={args.journey?.title ?? 'Edit Journey'}
         showDrawer
         Menu={<EditToolbar />}
         backHref="/journeys/nua-journey-ep-3-decision"

--- a/apps/journeys-admin/src/components/Editor/Editor.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.tsx
@@ -16,11 +16,12 @@ export function Editor({
   selectedStepId,
   children
 }: EditorProps): ReactElement {
-  const steps = transformer(journey?.blocks ?? []) as Array<
-    TreeBlock<StepBlock>
-  >
+  const steps =
+    journey != null
+      ? (transformer(journey.blocks ?? []) as Array<TreeBlock<StepBlock>>)
+      : undefined
   const selectedStep =
-    selectedStepId != null
+    selectedStepId != null && steps != null
       ? steps.find(({ id }) => id === selectedStepId)
       : undefined
 

--- a/apps/journeys-admin/src/components/Editor/Editor.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.tsx
@@ -6,7 +6,7 @@ import { JourneyProvider } from '../../libs/context'
 import { SocialShareAppearance } from './Drawer/SocialShareAppearance'
 
 interface EditorProps {
-  journey: Journey
+  journey?: Journey
   selectedStepId?: string
   children: ReactNode
 }
@@ -16,7 +16,9 @@ export function Editor({
   selectedStepId,
   children
 }: EditorProps): ReactElement {
-  const steps = transformer(journey.blocks ?? []) as Array<TreeBlock<StepBlock>>
+  const steps = transformer(journey?.blocks ?? []) as Array<
+    TreeBlock<StepBlock>
+  >
   const selectedStep =
     selectedStepId != null
       ? steps.find(({ id }) => id === selectedStepId)
@@ -29,7 +31,7 @@ export function Editor({
           steps,
           selectedStep,
           drawerTitle: 'Social Share Appearance',
-          drawerChildren: <SocialShareAppearance id={journey.id} />
+          drawerChildren: <SocialShareAppearance />
         }}
       >
         {children}

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Dialog/VideoBlockEditorSettingsPosterDialog.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Dialog/VideoBlockEditorSettingsPosterDialog.tsx
@@ -82,7 +82,7 @@ export function VideoBlockEditorSettingsPosterDialog({
   open,
   onClose
 }: VideoBlockEditorSettingsPosterDialogProps): ReactElement {
-  const { id: journeyId } = useJourney()
+  const journey = useJourney()
   const [blockDelete, { error: blockDeleteError }] =
     useMutation<BlockDeleteForPosterImage>(BLOCK_DELETE_FOR_POSTER_IMAGE)
   const [videoBlockUpdate, { error: videoBlockUpdateError }] =
@@ -93,16 +93,17 @@ export function VideoBlockEditorSettingsPosterDialog({
     useMutation<PosterImageBlockUpdate>(POSTER_IMAGE_BLOCK_UPDATE)
 
   const deleteCoverBlock = async (): Promise<void> => {
-    if (selectedBlock == null || parentBlockId == null) return
+    if (selectedBlock == null || parentBlockId == null || journey == null)
+      return
 
     await blockDelete({
       variables: {
         id: selectedBlock.id,
         parentBlockId: selectedBlock.parentBlockId,
-        journeyId: journeyId
+        journeyId: journey.id
       },
       update(cache, { data }) {
-        blockDeleteUpdate(selectedBlock, data?.blockDelete, cache, journeyId)
+        blockDeleteUpdate(selectedBlock, data?.blockDelete, cache, journey.id)
       }
     })
     if (blockDeleteError != null) return
@@ -110,7 +111,7 @@ export function VideoBlockEditorSettingsPosterDialog({
     await videoBlockUpdate({
       variables: {
         id: parentBlockId,
-        journeyId: journeyId,
+        journeyId: journey.id,
         input: {
           posterBlockId: null
         }
@@ -126,12 +127,12 @@ export function VideoBlockEditorSettingsPosterDialog({
   }
 
   const createImageBlock = async (block): Promise<boolean> => {
-    if (parentBlockId == null) return false
+    if (parentBlockId == null || journey == null) return false
 
     const { data } = await imageBlockCreate({
       variables: {
         input: {
-          journeyId: journeyId,
+          journeyId: journey.id,
           parentBlockId: parentBlockId,
           src: block.src,
           alt: block.alt
@@ -140,7 +141,7 @@ export function VideoBlockEditorSettingsPosterDialog({
       update(cache, { data }) {
         if (data?.imageBlockCreate != null) {
           cache.modify({
-            id: cache.identify({ __typename: 'Journey', id: journeyId }),
+            id: cache.identify({ __typename: 'Journey', id: journey.id }),
             fields: {
               blocks(existingBlockRefs = []) {
                 const newBlockRef = cache.writeFragment({
@@ -164,7 +165,7 @@ export function VideoBlockEditorSettingsPosterDialog({
     await videoBlockUpdate({
       variables: {
         id: parentBlockId,
-        journeyId: journeyId,
+        journeyId: journey.id,
         input: {
           posterBlockId: data?.imageBlockCreate.id ?? null
         }
@@ -181,12 +182,12 @@ export function VideoBlockEditorSettingsPosterDialog({
   }
 
   const updateImageBlock = async (block: ImageBlock): Promise<boolean> => {
-    if (selectedBlock == null) return false
+    if (selectedBlock == null || journey == null) return false
 
     await imageBlockUpdate({
       variables: {
         id: selectedBlock.id,
-        journeyId: journeyId,
+        journeyId: journey.id,
         input: {
           src: block.src,
           alt: block.alt

--- a/apps/journeys-admin/src/components/JourneyList/AddJourneyButton/AddJourneyButton.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/AddJourneyButton/AddJourneyButton.spec.tsx
@@ -127,7 +127,9 @@ describe('AddJourneyButton', () => {
     ])
     await waitFor(() =>
       expect(push).toHaveBeenCalledWith(
-        `/journeys/${resultData.journeyCreate.slug}/edit`
+        `/journeys/${resultData.journeyCreate.slug}/edit`,
+        undefined,
+        { shallow: true }
       )
     )
   })
@@ -188,7 +190,9 @@ describe('AddJourneyButton', () => {
     ])
     await waitFor(() =>
       expect(push).toHaveBeenCalledWith(
-        `/journeys/${resultData.journeyCreate.slug}/edit`
+        `/journeys/${resultData.journeyCreate.slug}/edit`,
+        undefined,
+        { shallow: true }
       )
     )
   })

--- a/apps/journeys-admin/src/components/JourneyList/AddJourneyButton/AddJourneyButton.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/AddJourneyButton/AddJourneyButton.tsx
@@ -6,6 +6,7 @@ import AddIcon from '@mui/icons-material/Add'
 import { gql, useMutation } from '@apollo/client'
 import { v4 as uuidv4 } from 'uuid'
 import { useRouter } from 'next/router'
+import CircularProgress from '@mui/material/CircularProgress'
 import { JourneyCreate } from '../../../../__generated__/JourneyCreate'
 
 export const JOURNEY_CREATE = gql`
@@ -114,7 +115,8 @@ interface AddJourneyFabProps {
 export function AddJourneyButton({
   variant
 }: AddJourneyFabProps): ReactElement {
-  const [journeyCreate] = useMutation<JourneyCreate>(JOURNEY_CREATE)
+  const [journeyCreate, { loading }] =
+    useMutation<JourneyCreate>(JOURNEY_CREATE)
   const router = useRouter()
 
   const handleClick = async (): Promise<void> => {
@@ -158,7 +160,9 @@ export function AddJourneyButton({
       }
     })
     if (data?.journeyCreate != null) {
-      void router.push(`/journeys/${data.journeyCreate.slug}/edit`)
+      void router.push(`/journeys/${data.journeyCreate.slug}/edit`, undefined, {
+        shallow: true
+      })
     }
   }
 
@@ -185,8 +189,13 @@ export function AddJourneyButton({
       color="primary"
       onClick={handleClick}
       sx={{ position: 'fixed', bottom: 16, right: 16, zIndex: 1 }}
+      disabled={loading}
     >
-      <AddRounded sx={{ mr: 3 }} />
+      {loading ? (
+        <CircularProgress size={24} sx={{ mr: 3 }} />
+      ) : (
+        <AddRounded sx={{ mr: 3 }} />
+      )}
       Add
     </Fab>
   )

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCard.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCard.stories.tsx
@@ -22,7 +22,9 @@ const Template: Story = ({ ...args }) => (
 )
 
 export const Default = Template.bind({})
-Default.args = { journey: defaultJourney }
+Default.args = {
+  journey: defaultJourney
+}
 
 export const Published = Template.bind({})
 Published.args = {
@@ -33,9 +35,15 @@ export const ExcessContent = Template.bind({})
 ExcessContent.args = {
   journey: descriptiveJourney
 }
+
 export const PreYear = Template.bind({})
 PreYear.args = {
   journey: oldJourney
+}
+
+export const Loading = Template.bind({})
+Loading.args = {
+  journey: undefined
 }
 
 export default TestStory as Meta

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCard.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCard.tsx
@@ -1,31 +1,27 @@
 import { ReactElement } from 'react'
 import { parseISO, isThisYear, intlFormat } from 'date-fns'
 import Card from '@mui/material/Card'
-import Typography from '@mui/material/Typography'
 import Grid from '@mui/material/Grid'
 import CardActionArea from '@mui/material/CardActionArea'
 import CardContent from '@mui/material/CardContent'
 import CardActions from '@mui/material/CardActions'
+import IconButton from '@mui/material/IconButton'
+import Typography from '@mui/material/Typography'
+import Skeleton from '@mui/material/Skeleton'
 import Link from 'next/link'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import EditIcon from '@mui/icons-material/Edit'
 import TranslateIcon from '@mui/icons-material/Translate'
+import MoreVertIcon from '@mui/icons-material/MoreVert'
 import { GetJourneys_journeys as Journey } from '../../../../__generated__/GetJourneys'
 import { AccessAvatars } from '../../AccessAvatars'
 import { JourneyCardMenu } from './JourneyCardMenu'
 
 interface JourneyCardProps {
-  journey: Journey
+  journey?: Journey
 }
 
 export function JourneyCard({ journey }: JourneyCardProps): ReactElement {
-  const date = parseISO(journey.createdAt)
-  const formattedDate = intlFormat(date, {
-    day: 'numeric',
-    month: 'long',
-    year: isThisYear(date) ? undefined : 'numeric'
-  })
-
   return (
     <Card
       aria-label="journey-card"
@@ -46,86 +42,160 @@ export function JourneyCard({ journey }: JourneyCardProps): ReactElement {
         }
       }}
     >
-      <Link href={`/journeys/${journey.slug}`} passHref>
-        <CardActionArea>
-          <CardContent
+      {journey != null ? (
+        <>
+          <Link href={`/journeys/${journey.slug}`} passHref>
+            <CardActionArea>
+              <CardContent
+                sx={{
+                  px: 6,
+                  py: 4
+                }}
+              >
+                <Typography
+                  variant="subtitle1"
+                  component="div"
+                  noWrap
+                  gutterBottom
+                  sx={{ color: 'secondary.main' }}
+                >
+                  {journey.title}
+                </Typography>
+                <Typography
+                  variant="caption"
+                  noWrap
+                  sx={{
+                    display: 'block',
+                    color: 'secondary.main'
+                  }}
+                >
+                  {intlFormat(parseISO(journey.createdAt), {
+                    day: 'numeric',
+                    month: 'long',
+                    year: isThisYear(parseISO(journey.createdAt))
+                      ? undefined
+                      : 'numeric'
+                  })}
+                  {journey.description !== null && ` - ${journey.description}`}
+                </Typography>
+              </CardContent>
+            </CardActionArea>
+          </Link>
+          <CardActions
             sx={{
               px: 6,
-              py: 4
+              pt: 0,
+              pb: 4
             }}
           >
-            <Typography
-              variant="subtitle1"
-              component="div"
-              noWrap
-              gutterBottom
-              sx={{ color: 'secondary.main' }}
-            >
-              {journey.title}
-            </Typography>
-            <Typography
-              variant="caption"
-              noWrap
+            <Grid container spacing={2} display="flex" alignItems="center">
+              <Grid item>
+                {journey.userJourneys != null && (
+                  <AccessAvatars
+                    journeySlug={journey.slug}
+                    userJourneys={journey.userJourneys}
+                  />
+                )}
+              </Grid>
+              {journey.status === 'draft' ? (
+                <>
+                  <Grid item display="flex" alignItems="center">
+                    <EditIcon color="warning" sx={{ fontSize: 13 }} />
+                  </Grid>
+                  <Grid item>
+                    <Typography variant="caption" sx={{ pr: 2 }}>
+                      Draft
+                    </Typography>
+                  </Grid>
+                </>
+              ) : (
+                <>
+                  <Grid item display="flex" alignItems="center">
+                    <CheckCircleIcon color="success" sx={{ fontSize: 13 }} />
+                  </Grid>
+                  <Grid item>
+                    <Typography variant="caption" sx={{ pr: 2 }}>
+                      Published
+                    </Typography>
+                  </Grid>
+                </>
+              )}
+              <Grid item display="flex" alignItems="center">
+                <TranslateIcon sx={{ fontSize: 13 }} />
+              </Grid>
+              <Grid item>
+                <Typography variant="caption">{journey.locale}</Typography>
+              </Grid>
+            </Grid>
+            <JourneyCardMenu status={journey.status} slug={journey.slug} />
+          </CardActions>
+        </>
+      ) : (
+        <>
+          <CardActionArea>
+            <CardContent
               sx={{
-                display: 'block',
-                color: 'secondary.main'
+                px: 6,
+                py: 4
               }}
             >
-              {formattedDate}
-              {journey.description !== null && ` - ${journey.description}`}
-            </Typography>
-          </CardContent>
-        </CardActionArea>
-      </Link>
-      <CardActions
-        sx={{
-          px: 6,
-          pt: 0,
-          pb: 4
-        }}
-      >
-        <Grid container spacing={2} display="flex" alignItems="center">
-          <Grid item>
-            {journey.userJourneys != null && (
-              <AccessAvatars
-                journeySlug={journey.slug}
-                userJourneys={journey.userJourneys}
-              />
-            )}
-          </Grid>
-
-          {journey.status === 'draft' ? (
-            <>
-              <Grid item display="flex" alignItems="center">
-                <EditIcon color="warning" sx={{ fontSize: 13 }} />
-              </Grid>
+              <Typography
+                variant="subtitle1"
+                component="div"
+                noWrap
+                gutterBottom
+                sx={{ color: 'secondary.main' }}
+              >
+                <Skeleton variant="text" width="60%" />
+              </Typography>
+              <Typography
+                variant="caption"
+                noWrap
+                sx={{
+                  display: 'block',
+                  color: 'secondary.main'
+                }}
+              >
+                <Skeleton variant="text" width="80%" />
+              </Typography>
+            </CardContent>
+          </CardActionArea>
+          <CardActions
+            sx={{
+              px: 6,
+              pt: 0,
+              pb: 4
+            }}
+          >
+            <Grid container spacing={2} display="flex" alignItems="center">
               <Grid item>
-                <Typography variant="caption" sx={{ pr: 2 }}>
-                  Draft
+                <Skeleton variant="circular" width={33} height={33} />
+              </Grid>
+              <>
+                <Grid item display="flex" alignItems="center">
+                  <EditIcon sx={{ fontSize: 13 }} />
+                </Grid>
+                <Grid item display="flex" alignItems="center">
+                  <Typography variant="caption" sx={{ pr: 2 }}>
+                    <Skeleton variant="text" width={40} />
+                  </Typography>
+                </Grid>
+              </>
+              <Grid item display="flex" alignItems="center">
+                <TranslateIcon sx={{ fontSize: 13 }} />
+              </Grid>
+              <Grid item display="flex" alignItems="center">
+                <Typography variant="caption">
+                  <Skeleton variant="text" width={40} />
                 </Typography>
               </Grid>
-            </>
-          ) : (
-            <>
-              <Grid item display="flex" alignItems="center">
-                <CheckCircleIcon color="success" sx={{ fontSize: 13 }} />
-              </Grid>
-              <Grid item>
-                <Typography variant="caption" sx={{ pr: 2 }}>
-                  Published
-                </Typography>
-              </Grid>
-            </>
-          )}
-          <Grid item display="flex" alignItems="center">
-            <TranslateIcon sx={{ fontSize: 13 }} />
-          </Grid>
-          <Grid item>
-            <Typography variant="caption">{journey.locale}</Typography>
-          </Grid>
-        </Grid>
-        <JourneyCardMenu status={journey.status} slug={journey.slug} />
-      </CardActions>
+            </Grid>
+            <IconButton disabled>
+              <MoreVertIcon />
+            </IconButton>
+          </CardActions>
+        </>
+      )}
     </Card>
   )
 }

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCard.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCard.tsx
@@ -42,96 +42,11 @@ export function JourneyCard({ journey }: JourneyCardProps): ReactElement {
         }
       }}
     >
-      {journey != null ? (
-        <>
-          <Link href={`/journeys/${journey.slug}`} passHref>
-            <CardActionArea>
-              <CardContent
-                sx={{
-                  px: 6,
-                  py: 4
-                }}
-              >
-                <Typography
-                  variant="subtitle1"
-                  component="div"
-                  noWrap
-                  gutterBottom
-                  sx={{ color: 'secondary.main' }}
-                >
-                  {journey.title}
-                </Typography>
-                <Typography
-                  variant="caption"
-                  noWrap
-                  sx={{
-                    display: 'block',
-                    color: 'secondary.main'
-                  }}
-                >
-                  {intlFormat(parseISO(journey.createdAt), {
-                    day: 'numeric',
-                    month: 'long',
-                    year: isThisYear(parseISO(journey.createdAt))
-                      ? undefined
-                      : 'numeric'
-                  })}
-                  {journey.description !== null && ` - ${journey.description}`}
-                </Typography>
-              </CardContent>
-            </CardActionArea>
-          </Link>
-          <CardActions
-            sx={{
-              px: 6,
-              pt: 0,
-              pb: 4
-            }}
-          >
-            <Grid container spacing={2} display="flex" alignItems="center">
-              <Grid item>
-                {journey.userJourneys != null && (
-                  <AccessAvatars
-                    journeySlug={journey.slug}
-                    userJourneys={journey.userJourneys}
-                  />
-                )}
-              </Grid>
-              {journey.status === 'draft' ? (
-                <>
-                  <Grid item display="flex" alignItems="center">
-                    <EditIcon color="warning" sx={{ fontSize: 13 }} />
-                  </Grid>
-                  <Grid item>
-                    <Typography variant="caption" sx={{ pr: 2 }}>
-                      Draft
-                    </Typography>
-                  </Grid>
-                </>
-              ) : (
-                <>
-                  <Grid item display="flex" alignItems="center">
-                    <CheckCircleIcon color="success" sx={{ fontSize: 13 }} />
-                  </Grid>
-                  <Grid item>
-                    <Typography variant="caption" sx={{ pr: 2 }}>
-                      Published
-                    </Typography>
-                  </Grid>
-                </>
-              )}
-              <Grid item display="flex" alignItems="center">
-                <TranslateIcon sx={{ fontSize: 13 }} />
-              </Grid>
-              <Grid item>
-                <Typography variant="caption">{journey.locale}</Typography>
-              </Grid>
-            </Grid>
-            <JourneyCardMenu status={journey.status} slug={journey.slug} />
-          </CardActions>
-        </>
-      ) : (
-        <>
+      <>
+        <Link
+          href={journey != null ? `/journeys/${journey.slug}` : ''}
+          passHref
+        >
           <CardActionArea>
             <CardContent
               sx={{
@@ -146,7 +61,11 @@ export function JourneyCard({ journey }: JourneyCardProps): ReactElement {
                 gutterBottom
                 sx={{ color: 'secondary.main' }}
               >
-                <Skeleton variant="text" width="60%" />
+                {journey != null ? (
+                  journey.title
+                ) : (
+                  <Skeleton variant="text" width={200} />
+                )}
               </Typography>
               <Typography
                 variant="caption"
@@ -156,46 +75,90 @@ export function JourneyCard({ journey }: JourneyCardProps): ReactElement {
                   color: 'secondary.main'
                 }}
               >
-                <Skeleton variant="text" width="80%" />
+                {journey != null ? (
+                  intlFormat(parseISO(journey.createdAt), {
+                    day: 'numeric',
+                    month: 'long',
+                    year: isThisYear(parseISO(journey.createdAt))
+                      ? undefined
+                      : 'numeric'
+                  })
+                ) : (
+                  <Skeleton variant="text" width={120} />
+                )}
+                {journey?.description != null && ` - ${journey.description}`}
               </Typography>
             </CardContent>
           </CardActionArea>
-          <CardActions
-            sx={{
-              px: 6,
-              pt: 0,
-              pb: 4
-            }}
-          >
-            <Grid container spacing={2} display="flex" alignItems="center">
-              <Grid item>
-                <Skeleton variant="circular" width={33} height={33} />
-              </Grid>
+        </Link>
+        <CardActions
+          sx={{
+            px: 6,
+            pt: 0,
+            pb: 4
+          }}
+        >
+          <Grid container spacing={2} display="flex" alignItems="center">
+            <Grid item>
+              <AccessAvatars
+                journeySlug={journey?.slug}
+                userJourneys={journey?.userJourneys ?? undefined}
+              />
+            </Grid>
+            {journey != null ? (
+              journey.status === 'draft' ? (
+                <>
+                  <Grid item>
+                    <EditIcon color="warning" sx={{ fontSize: 13 }} />
+                  </Grid>
+                  <Grid item sx={{ pr: 2 }}>
+                    <Typography variant="caption">Draft</Typography>
+                  </Grid>
+                </>
+              ) : (
+                <>
+                  <Grid item>
+                    <CheckCircleIcon color="success" sx={{ fontSize: 13 }} />
+                  </Grid>
+                  <Grid item sx={{ pr: 2 }}>
+                    <Typography variant="caption">Published</Typography>
+                  </Grid>
+                </>
+              )
+            ) : (
               <>
-                <Grid item display="flex" alignItems="center">
+                <Grid item>
                   <EditIcon sx={{ fontSize: 13 }} />
                 </Grid>
-                <Grid item display="flex" alignItems="center">
-                  <Typography variant="caption" sx={{ pr: 2 }}>
-                    <Skeleton variant="text" width={40} />
+                <Grid item sx={{ pr: 2 }}>
+                  <Typography variant="caption">
+                    <Skeleton variant="text" width={30} />
                   </Typography>
                 </Grid>
               </>
-              <Grid item display="flex" alignItems="center">
-                <TranslateIcon sx={{ fontSize: 13 }} />
-              </Grid>
-              <Grid item display="flex" alignItems="center">
-                <Typography variant="caption">
-                  <Skeleton variant="text" width={40} />
-                </Typography>
-              </Grid>
+            )}
+            <Grid item>
+              <TranslateIcon sx={{ fontSize: 13 }} />
             </Grid>
+            <Grid item>
+              <Typography variant="caption">
+                {journey != null ? (
+                  journey.locale
+                ) : (
+                  <Skeleton variant="text" width={40} />
+                )}
+              </Typography>
+            </Grid>
+          </Grid>
+          {journey != null ? (
+            <JourneyCardMenu status={journey.status} slug={journey.slug} />
+          ) : (
             <IconButton disabled>
               <MoreVertIcon />
             </IconButton>
-          </CardActions>
-        </>
-      )}
+          )}
+        </CardActions>
+      </>
     </Card>
   )
 }

--- a/apps/journeys-admin/src/components/JourneyList/JourneyList.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyList.stories.tsx
@@ -35,6 +35,11 @@ Default.args = {
   journeys: [defaultJourney, publishedJourney, oldJourney, descriptiveJourney]
 }
 
+export const Loading = Template.bind({})
+Loading.args = {
+  journeys: undefined
+}
+
 export const Empty = Template.bind({})
 Empty.args = {
   journeys: []

--- a/apps/journeys-admin/src/components/JourneyList/JourneyList.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyList.tsx
@@ -11,7 +11,7 @@ import { JourneySort, SortOrder } from './JourneySort'
 import { JourneyCard } from './JourneyCard'
 
 export interface JourneysListProps {
-  journeys: Journey[]
+  journeys?: Journey[]
 }
 
 export function JourneyList({ journeys }: JourneysListProps): ReactElement {
@@ -26,7 +26,9 @@ export function JourneyList({ journeys }: JourneysListProps): ReactElement {
 
   return (
     <Container sx={{ px: { xs: 0, sm: 8 } }}>
-      {journeys.length > 0 && <AddJourneyButton variant="fab" />}
+      {journeys != null && journeys.length > 0 && (
+        <AddJourneyButton variant="fab" />
+      )}
       <Stack
         direction={{ xs: 'column', sm: 'row' }}
         spacing={2}
@@ -43,28 +45,39 @@ export function JourneyList({ journeys }: JourneysListProps): ReactElement {
         </Box>
       </Stack>
       <Box sx={{ mb: { xs: 4, sm: 5 } }} data-testid="journey-list">
-        {sortedJourneys.map((journey) => (
-          <JourneyCard key={journey.id} journey={journey} />
-        ))}
-        {sortedJourneys.length === 0 && (
-          <Card
-            variant="outlined"
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              pt: 20,
-              pb: 16,
-              borderRadius: { xs: 0, sm: 3 }
-            }}
-          >
-            <Typography variant="subtitle1" align="center" gutterBottom>
-              No journeys to display.
-            </Typography>
-            <Typography variant="caption" align="center" gutterBottom>
-              Create a journey, then find it here.
-            </Typography>
-            <AddJourneyButton variant="button" />
-          </Card>
+        {journeys != null ? (
+          <>
+            {sortedJourneys.map((journey) => (
+              <JourneyCard key={journey.id} journey={journey} />
+            ))}
+            {sortedJourneys.length === 0 && (
+              <Card
+                variant="outlined"
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  pt: 20,
+                  pb: 16,
+                  borderRadius: { xs: 0, sm: 3 }
+                }}
+              >
+                <Typography variant="subtitle1" align="center" gutterBottom>
+                  No journeys to display.
+                </Typography>
+                <Typography variant="caption" align="center" gutterBottom>
+                  Create a journey, then find it here.
+                </Typography>
+                <AddJourneyButton variant="button" />
+              </Card>
+            )}
+          </>
+        ) : (
+          <>
+            <JourneyCard />
+            <JourneyCard />
+            <JourneyCard />
+            <JourneyCard />
+          </>
         )}
       </Box>
     </Container>

--- a/apps/journeys-admin/src/components/JourneyView/CardView/CardView.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/CardView/CardView.spec.tsx
@@ -65,10 +65,11 @@ describe('JourneyView/CardView', () => {
     )
     fireEvent.click(getByTestId('preview-step0.id'))
     await waitFor(() =>
-      expect(push).toHaveBeenCalledWith({
-        pathname: '/journeys/[slug]/edit',
-        query: { slug: 'my-journey', stepId: 'step0.id' }
-      })
+      expect(push).toHaveBeenCalledWith(
+        '/journeys/my-journey/edit?stepId=step0.id',
+        undefined,
+        { shallow: true }
+      )
     )
   })
 })

--- a/apps/journeys-admin/src/components/JourneyView/CardView/CardView.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/CardView/CardView.stories.tsx
@@ -44,4 +44,9 @@ ManyCards.args = {
   blocks: steps.concat(steps).concat(steps)
 }
 
+export const Loading = Template.bind({})
+Loading.args = {
+  blocks: undefined
+}
+
 export default CardViewStory as Meta

--- a/apps/journeys-admin/src/components/JourneyView/CardView/CardView.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/CardView/CardView.tsx
@@ -1,5 +1,7 @@
 import { ReactElement } from 'react'
 import Typography from '@mui/material/Typography'
+import Skeleton from '@mui/material/Skeleton'
+import Box from '@mui/material/Box'
 import { TreeBlock } from '@core/journeys/ui'
 import { useBreakpoints } from '@core/shared/ui'
 import { useRouter } from 'next/router'
@@ -7,8 +9,8 @@ import { BlockFields_StepBlock as StepBlock } from '../../../../__generated__/Bl
 import { CardPreview } from '../../CardPreview'
 
 export interface CardViewProps {
-  slug: string
-  blocks: Array<TreeBlock<StepBlock>>
+  slug?: string
+  blocks?: Array<TreeBlock<StepBlock>>
 }
 
 export function CardView({ slug, blocks }: CardViewProps): ReactElement {
@@ -16,6 +18,8 @@ export function CardView({ slug, blocks }: CardViewProps): ReactElement {
   const router = useRouter()
 
   const handleSelect = (step: { id: string }): void => {
+    if (slug == null) return
+
     void router.push({
       pathname: '/journeys/[slug]/edit',
       query: { slug, stepId: step.id }
@@ -33,13 +37,23 @@ export function CardView({ slug, blocks }: CardViewProps): ReactElement {
   return (
     <>
       <CardPreview onSelect={handleSelect} steps={blocks} showAddButton />
-      <Typography variant="body1" sx={{ pt: 2, textAlign: 'center' }}>
-        {stepBlockLength > 0
-          ? breakpoints.md
-            ? `${cardNumber} in this journey`
-            : `${cardNumber}`
-          : 'Select Empty Card to add'}
-      </Typography>
+      <Box sx={{ pt: 2, display: 'flex', justifyContent: 'center' }}>
+        <Typography variant="body1">
+          {blocks != null ? (
+            stepBlockLength > 0 ? (
+              breakpoints.md ? (
+                `${cardNumber} in this journey`
+              ) : (
+                `${cardNumber}`
+              )
+            ) : (
+              'Select Empty Card to add'
+            )
+          ) : (
+            <Skeleton variant="text" width={200} />
+          )}
+        </Typography>
+      </Box>
     </>
   )
 }

--- a/apps/journeys-admin/src/components/JourneyView/CardView/CardView.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/CardView/CardView.tsx
@@ -20,9 +20,8 @@ export function CardView({ slug, blocks }: CardViewProps): ReactElement {
   const handleSelect = (step: { id: string }): void => {
     if (slug == null) return
 
-    void router.push({
-      pathname: '/journeys/[slug]/edit',
-      query: { slug, stepId: step.id }
+    void router.push(`/journeys/${slug}/edit?stepId=${step.id}`, undefined, {
+      shallow: true
     })
   }
 

--- a/apps/journeys-admin/src/components/JourneyView/JourneyView.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyView.spec.tsx
@@ -5,6 +5,11 @@ import { JourneyProvider } from '../../libs/context'
 import { GetJourney_journey as Journey } from '../../../__generated__/GetJourney'
 import { JourneyView } from '.'
 
+jest.mock('@mui/material/useMediaQuery', () => ({
+  __esModule: true,
+  default: () => true
+}))
+
 describe('JourneyView', () => {
   it('should have edit button', () => {
     const { getByRole } = render(

--- a/apps/journeys-admin/src/components/JourneyView/JourneyView.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyView.stories.tsx
@@ -37,4 +37,9 @@ Default.args = {
   journey: publishedJourney
 }
 
+export const Loading = Template.bind({})
+Loading.args = {
+  journey: undefined
+}
+
 export default JourneyViewStory as Meta

--- a/apps/journeys-admin/src/components/JourneyView/JourneyView.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyView.tsx
@@ -13,7 +13,10 @@ import { CardView } from './CardView'
 
 export function JourneyView(): ReactElement {
   const journey = useJourney()
-  const blocks = journey?.blocks != null ? transformer(journey.blocks) : []
+  const blocks =
+    journey?.blocks != null
+      ? (transformer(journey.blocks) as Array<TreeBlock<StepBlock>>)
+      : undefined
 
   return (
     <Box sx={{ mr: { sm: '328px' }, mb: '80px' }}>
@@ -35,29 +38,11 @@ export function JourneyView(): ReactElement {
       </Box>
       <Properties />
       <>
-        {journey != null ? (
-          <>
-            <CardView
-              slug={journey.slug}
-              blocks={blocks as Array<TreeBlock<StepBlock>>}
-            />
-            <NextLink href={`/journeys/${journey.slug}/edit`} passHref>
-              <Fab
-                variant="extended"
-                size="large"
-                sx={{
-                  position: 'fixed',
-                  bottom: 16,
-                  right: { xs: 20, sm: 348 }
-                }}
-                color="primary"
-              >
-                <EditIcon sx={{ mr: 3 }} />
-                Edit
-              </Fab>
-            </NextLink>
-          </>
-        ) : (
+        <CardView slug={journey?.slug} blocks={blocks} />
+        <NextLink
+          href={journey != null ? `/journeys/${journey.slug}/edit` : ''}
+          passHref
+        >
           <Fab
             variant="extended"
             size="large"
@@ -67,12 +52,12 @@ export function JourneyView(): ReactElement {
               right: { xs: 20, sm: 348 }
             }}
             color="primary"
-            disabled
+            disabled={journey == null}
           >
             <EditIcon sx={{ mr: 3 }} />
             Edit
           </Fab>
-        )}
+        </NextLink>
       </>
     </Box>
   )

--- a/apps/journeys-admin/src/components/JourneyView/JourneyView.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyView.tsx
@@ -4,6 +4,7 @@ import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import EditIcon from '@mui/icons-material/Edit'
 import Fab from '@mui/material/Fab'
+import Skeleton from '@mui/material/Skeleton'
 import NextLink from 'next/link'
 import { BlockFields_StepBlock as StepBlock } from '../../../__generated__/BlockFields'
 import { useJourney } from '../../libs/context'
@@ -12,34 +13,67 @@ import { CardView } from './CardView'
 
 export function JourneyView(): ReactElement {
   const journey = useJourney()
-  const blocks = journey.blocks != null ? transformer(journey.blocks) : []
+  const blocks = journey?.blocks != null ? transformer(journey.blocks) : []
 
   return (
     <Box sx={{ mr: { sm: '328px' }, mb: '80px' }}>
       <Box sx={{ p: { xs: 6, sm: 8 }, backgroundColor: 'background.paper' }}>
-        <Typography variant="h4">{journey.title}</Typography>
-        <Typography variant="body1">{journey.description}</Typography>
+        <Typography variant="h4">
+          {journey != null ? (
+            journey.title
+          ) : (
+            <Skeleton variant="text" width="60%" />
+          )}
+        </Typography>
+        <Typography variant="body1">
+          {journey != null ? (
+            journey.description
+          ) : (
+            <Skeleton variant="text" width="80%" />
+          )}
+        </Typography>
       </Box>
       <Properties />
-      <CardView
-        slug={journey.slug}
-        blocks={blocks as Array<TreeBlock<StepBlock>>}
-      />
-      <NextLink href={`/journeys/${journey.slug}/edit`} passHref>
-        <Fab
-          variant="extended"
-          size="large"
-          sx={{
-            position: 'fixed',
-            bottom: 16,
-            right: { xs: 20, sm: 348 }
-          }}
-          color="primary"
-        >
-          <EditIcon sx={{ mr: 3 }} />
-          Edit
-        </Fab>
-      </NextLink>
+      <>
+        {journey != null ? (
+          <>
+            <CardView
+              slug={journey.slug}
+              blocks={blocks as Array<TreeBlock<StepBlock>>}
+            />
+            <NextLink href={`/journeys/${journey.slug}/edit`} passHref>
+              <Fab
+                variant="extended"
+                size="large"
+                sx={{
+                  position: 'fixed',
+                  bottom: 16,
+                  right: { xs: 20, sm: 348 }
+                }}
+                color="primary"
+              >
+                <EditIcon sx={{ mr: 3 }} />
+                Edit
+              </Fab>
+            </NextLink>
+          </>
+        ) : (
+          <Fab
+            variant="extended"
+            size="large"
+            sx={{
+              position: 'fixed',
+              bottom: 16,
+              right: { xs: 20, sm: 348 }
+            }}
+            color="primary"
+            disabled
+          >
+            <EditIcon sx={{ mr: 3 }} />
+            Edit
+          </Fab>
+        )}
+      </>
     </Box>
   )
 }

--- a/apps/journeys-admin/src/components/JourneyView/Menu/DescriptionDialog/DescriptionDialog.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/DescriptionDialog/DescriptionDialog.tsx
@@ -35,6 +35,8 @@ export function DescriptionDialog({
   )
 
   const handleSubmit = async (): Promise<void> => {
+    if (journey == null) return
+
     const updatedJourney = { description: value }
 
     try {

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.stories.tsx
@@ -48,4 +48,7 @@ Published.args = {
   forceOpen: true
 }
 
+export const Loading = Template.bind({})
+Loading.args = { journey: undefined }
+
 export default MenuStory as Meta

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
@@ -52,7 +52,7 @@ export function Menu({ forceOpen }: MenuProps): ReactElement {
 
   const handlePublish = async (): Promise<void> => {
     if (journey == null) return
-    
+
     await journeyPublish({
       variables: { id: journey?.id },
       optimisticResponse: {

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
@@ -51,8 +51,10 @@ export function Menu({ forceOpen }: MenuProps): ReactElement {
   }
 
   const handlePublish = async (): Promise<void> => {
+    if (journey == null) return
+    
     await journeyPublish({
-      variables: { id: journey.id },
+      variables: { id: journey?.id },
       optimisticResponse: {
         journeyPublish: { id: journey.id, __typename: 'Journey' }
       }
@@ -70,94 +72,102 @@ export function Menu({ forceOpen }: MenuProps): ReactElement {
   }
 
   const handleCopyLink = async (): Promise<void> => {
-    await navigator.clipboard.writeText(`your.nextstep.is/${journey.slug}`)
+    await navigator.clipboard.writeText(
+      `your.nextstep.is/${journey?.slug ?? ''}`
+    )
     setShowLinkAlert(true)
   }
 
   return (
     <>
-      <IconButton
-        id="single-journey-actions"
-        edge="end"
-        aria-controls="single-journey-actions"
-        aria-haspopup="true"
-        aria-expanded={openMenu ? 'true' : undefined}
-        onClick={handleShowMenu}
-      >
-        <MoreVert />
-      </IconButton>
-
-      <MuiMenu
-        id="single-journey-actions"
-        anchorEl={anchorEl}
-        open={openMenu}
-        onClose={handleCloseMenu}
-        MenuListProps={{
-          'aria-labelledby': 'journey-actions'
-        }}
-      >
-        <MenuItem
-          disabled={journey.status === JourneyStatus.draft}
-          component="a"
-          href={`http://your.nextstep.is/${journey.slug}`}
-        >
-          <ListItemIcon>
-            <AssignmentTurnedInIcon />
-          </ListItemIcon>
-          <ListItemText>Preview</ListItemText>
-        </MenuItem>
-        <MenuItem
-          disabled={journey.status === JourneyStatus.published}
-          onClick={handlePublish}
-        >
-          <ListItemIcon>
-            <VisibilityIcon />
-          </ListItemIcon>
-          <ListItemText>Publish</ListItemText>
-        </MenuItem>
-        <MenuItem onClick={handleUpdateTitle}>
-          <ListItemIcon>
-            <EditIcon />
-          </ListItemIcon>
-          <ListItemText>Title</ListItemText>
-        </MenuItem>
-        <MenuItem onClick={handleUpdateDescription}>
-          <ListItemIcon>
-            <DescriptionIcon />
-          </ListItemIcon>
-          <ListItemText>Description</ListItemText>
-        </MenuItem>
-        <Divider />
-        <NextLink href={`/journeys/${journey.slug}/edit`} passHref>
-          <MenuItem>
-            <ListItemIcon>
-              <ViewCarouselIcon />
-            </ListItemIcon>
-            <ListItemText>Edit Cards</ListItemText>
-          </MenuItem>
-        </NextLink>
-        <Divider />
-        <MenuItem onClick={handleCopyLink}>
-          <ListItemIcon>
-            <ContentCopyIcon />
-          </ListItemIcon>
-          <ListItemText>Copy Link</ListItemText>
-        </MenuItem>
-      </MuiMenu>
-
-      <TitleDialog
-        open={showTitleDialog}
-        onClose={() => setShowTitleDialog(false)}
-      />
-      <DescriptionDialog
-        open={showDescriptionDialog}
-        onClose={() => setShowDescriptionDialog(false)}
-      />
-      <Alert
-        open={showLinkAlert}
-        setOpen={setShowLinkAlert}
-        message="Link Copied"
-      />
+      {journey != null ? (
+        <>
+          <IconButton
+            id="single-journey-actions"
+            edge="end"
+            aria-controls="single-journey-actions"
+            aria-haspopup="true"
+            aria-expanded={openMenu ? 'true' : undefined}
+            onClick={handleShowMenu}
+          >
+            <MoreVert />
+          </IconButton>
+          <MuiMenu
+            id="single-journey-actions"
+            anchorEl={anchorEl}
+            open={openMenu}
+            onClose={handleCloseMenu}
+            MenuListProps={{
+              'aria-labelledby': 'journey-actions'
+            }}
+          >
+            <MenuItem
+              disabled={journey.status === JourneyStatus.draft}
+              component="a"
+              href={`http://your.nextstep.is/${journey.slug}`}
+            >
+              <ListItemIcon>
+                <AssignmentTurnedInIcon />
+              </ListItemIcon>
+              <ListItemText>Preview</ListItemText>
+            </MenuItem>
+            <MenuItem
+              disabled={journey.status === JourneyStatus.published}
+              onClick={handlePublish}
+            >
+              <ListItemIcon>
+                <VisibilityIcon />
+              </ListItemIcon>
+              <ListItemText>Publish</ListItemText>
+            </MenuItem>
+            <MenuItem onClick={handleUpdateTitle}>
+              <ListItemIcon>
+                <EditIcon />
+              </ListItemIcon>
+              <ListItemText>Title</ListItemText>
+            </MenuItem>
+            <MenuItem onClick={handleUpdateDescription}>
+              <ListItemIcon>
+                <DescriptionIcon />
+              </ListItemIcon>
+              <ListItemText>Description</ListItemText>
+            </MenuItem>
+            <Divider />
+            <NextLink href={`/journeys/${journey.slug}/edit`} passHref>
+              <MenuItem>
+                <ListItemIcon>
+                  <ViewCarouselIcon />
+                </ListItemIcon>
+                <ListItemText>Edit Cards</ListItemText>
+              </MenuItem>
+            </NextLink>
+            <Divider />
+            <MenuItem onClick={handleCopyLink}>
+              <ListItemIcon>
+                <ContentCopyIcon />
+              </ListItemIcon>
+              <ListItemText>Copy Link</ListItemText>
+            </MenuItem>
+          </MuiMenu>
+          <TitleDialog
+            open={showTitleDialog}
+            onClose={() => setShowTitleDialog(false)}
+          />
+          <DescriptionDialog
+            open={showDescriptionDialog}
+            onClose={() => setShowDescriptionDialog(false)}
+          />
+          <Alert
+            open={showLinkAlert}
+            setOpen={setShowLinkAlert}
+            message="Link Copied"
+          />
+        </>
+      ) : (
+        <IconButton disabled>
+          <MoreVert />
+        </IconButton>
+      )}
     </>
   )
 }

--- a/apps/journeys-admin/src/components/JourneyView/Menu/TitleDialog/TitleDialog.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/TitleDialog/TitleDialog.tsx
@@ -30,6 +30,8 @@ export function TitleDialog({ open, onClose }: TitleDialogProps): ReactElement {
   const [value, setValue] = useState(journey?.title ?? '')
 
   const handleSubmit = async (): Promise<void> => {
+    if (journey == null) return
+
     const updatedJourney = { title: value }
 
     try {

--- a/apps/journeys-admin/src/components/JourneyView/Properties/JourneyDetails/JourneyDetails.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Properties/JourneyDetails/JourneyDetails.stories.tsx
@@ -37,4 +37,9 @@ PreviousYear.args = {
   }
 }
 
+export const Loading = Template.bind({})
+Loading.args = {
+  journey: undefined
+}
+
 export default JourneyDetailsStory as Meta

--- a/apps/journeys-admin/src/components/JourneyView/Properties/JourneyDetails/JourneyDetails.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Properties/JourneyDetails/JourneyDetails.tsx
@@ -1,6 +1,7 @@
 import { isThisYear, parseISO, intlFormat } from 'date-fns'
 import { ReactElement } from 'react'
 import Box from '@mui/material/Box'
+import Skeleton from '@mui/material/Skeleton'
 import Typography from '@mui/material/Typography'
 import CheckCircleRounded from '@mui/icons-material/CheckCircleRounded'
 import EditRounded from '@mui/icons-material/EditRounded'
@@ -12,23 +13,30 @@ import { useJourney } from '../../../../libs/context'
 export function JourneyDetails(): ReactElement {
   const journey = useJourney()
 
-  const date = parseISO(journey.createdAt)
-  const formattedDate = intlFormat(date, {
-    day: 'numeric',
-    month: 'long',
-    year: isThisYear(date) ? undefined : 'numeric'
-  })
-
   return (
     <>
       <Box sx={{ display: 'flex', flexDirection: 'row' }}>
-        {journey.status === JourneyStatus.published ? (
-          <CheckCircleRounded color="success" fontSize="small" />
+        {journey != null ? (
+          <>
+            {journey.status === JourneyStatus.published ? (
+              <CheckCircleRounded color="success" fontSize="small" />
+            ) : (
+              <EditRounded color="warning" fontSize="small" />
+            )}
+          </>
         ) : (
-          <EditRounded color="warning" fontSize="small" />
+          <EditRounded fontSize="small" />
         )}
         <Typography variant="body2" data-testid="status" sx={{ ml: 2 }}>
-          {journey.status === JourneyStatus.published ? 'Published' : 'Draft'}
+          {journey != null ? (
+            journey.status === JourneyStatus.published ? (
+              'Published'
+            ) : (
+              'Draft'
+            )
+          ) : (
+            <Skeleton variant="text" width={30} />
+          )}
         </Typography>
       </Box>
       <Box sx={{ display: 'flex', flexDirection: 'row', mt: 2 }}>
@@ -38,13 +46,27 @@ export function JourneyDetails(): ReactElement {
           data-testid="created-at-date"
           sx={{ ml: 2 }}
         >
-          {formattedDate}
+          {journey != null ? (
+            intlFormat(parseISO(journey.createdAt), {
+              day: 'numeric',
+              month: 'long',
+              year: isThisYear(parseISO(journey.createdAt))
+                ? undefined
+                : 'numeric'
+            })
+          ) : (
+            <Skeleton variant="text" width={120} />
+          )}
         </Typography>
       </Box>
       <Box sx={{ display: 'flex', flexDirection: 'row', mt: 2 }}>
         <TranslateRounded fontSize="small" />
         <Typography variant="body2" data-testid="locale" sx={{ ml: 2 }}>
-          {journey.locale}
+          {journey != null ? (
+            journey.locale
+          ) : (
+            <Skeleton variant="text" width={40} />
+          )}
         </Typography>
       </Box>
     </>

--- a/apps/journeys-admin/src/components/JourneyView/Properties/Properties.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Properties/Properties.stories.tsx
@@ -17,12 +17,20 @@ const PropertiesStory = {
 
 const Template: Story = ({ ...args }) => (
   <MockedProvider mocks={[]}>
-    <JourneyProvider value={defaultJourney}>
+    <JourneyProvider value={args.journey}>
       <Properties {...args} />
     </JourneyProvider>
   </MockedProvider>
 )
 
 export const Default = Template.bind({})
+Default.args = {
+  journey: defaultJourney
+}
+
+export const Loading = Template.bind({})
+Loading.args = {
+  journey: undefined
+}
 
 export default PropertiesStory as Meta

--- a/apps/journeys-admin/src/components/JourneyView/Properties/Properties.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Properties/Properties.tsx
@@ -11,7 +11,7 @@ import { AccessAvatars } from '../../AccessAvatars'
 import { JourneyDetails } from './JourneyDetails'
 
 export function Properties(): ReactElement {
-  const { slug, userJourneys } = useJourney()
+  const journey = useJourney()
 
   return (
     <>
@@ -35,24 +35,28 @@ export function Properties(): ReactElement {
           <Box sx={{ px: 6 }}>
             <JourneyDetails />
           </Box>
-          {userJourneys != null && (
-            <Box sx={{ px: 6 }}>
-              <Typography variant="subtitle2" gutterBottom>
-                Access Control
-              </Typography>
-              <AccessAvatars
-                journeySlug={slug}
-                userJourneys={userJourneys}
-                size="medium"
-                xsMax={5}
-              />
-            </Box>
-          )}
+          <Box sx={{ px: 6 }}>
+            <Typography variant="subtitle2" gutterBottom>
+              Access Control
+            </Typography>
+            <AccessAvatars
+              journeySlug={journey?.slug}
+              userJourneys={journey?.userJourneys ?? undefined}
+              size="medium"
+              xsMax={5}
+            />
+          </Box>
           <Box sx={{ px: 6 }}>
             <Typography variant="subtitle2" gutterBottom>
               Journey URL
             </Typography>
-            <CopyTextField value={`https://your.nextstep.is/${slug}`} />
+            <CopyTextField
+              value={
+                journey?.slug != null
+                  ? `https://your.nextstep.is/${journey.slug}`
+                  : undefined
+              }
+            />
           </Box>
         </Stack>
       </Drawer>
@@ -67,22 +71,24 @@ export function Properties(): ReactElement {
         }}
         spacing={6}
       >
-        {userJourneys != null && (
-          <Divider>
-            <AccessAvatars
-              journeySlug={slug}
-              userJourneys={userJourneys}
-              size="medium"
-            />
-          </Divider>
-        )}
+        <Divider>
+          <AccessAvatars
+            journeySlug={journey?.slug}
+            userJourneys={journey?.userJourneys ?? undefined}
+            size="medium"
+          />
+        </Divider>
         <Box sx={{ px: 6 }}>
           <JourneyDetails />
         </Box>
         <Divider />
         <Box sx={{ px: 6 }}>
           <CopyTextField
-            value={`https://your.nextstep.is/${slug}`}
+            value={
+              journey?.slug != null
+                ? `https://your.nextstep.is/${journey.slug}`
+                : undefined
+            }
             label="Journey URL"
           />
         </Box>

--- a/apps/journeys-admin/src/libs/context/JourneyContext.tsx
+++ b/apps/journeys-admin/src/libs/context/JourneyContext.tsx
@@ -3,19 +3,17 @@ import { GetJourney_journey as Journey } from '../../../__generated__/GetJourney
 
 // Must set initial context for useContext, but it will always be a journey
 // Else JourneyView page will not load
-const JourneyContext = createContext({} as unknown as Journey)
+const JourneyContext = createContext({} as unknown as Journey | undefined)
 
-export function useJourney(): Journey {
+export function useJourney(): Journey | undefined {
   const context = useContext(JourneyContext)
-  if (context === undefined) {
-    throw new Error('useJourney must be used within a JourneyProvider')
-  }
+
   return context
 }
 
 interface JourneyProviderProps {
   children: ReactNode
-  value: Journey
+  value?: Journey
 }
 
 export function JourneyProvider({

--- a/libs/journeys/ui/src/libs/context/EditorContext.tsx
+++ b/libs/journeys/ui/src/libs/context/EditorContext.tsx
@@ -24,7 +24,7 @@ export enum ActiveFab {
 }
 
 export interface EditorState {
-  steps: Array<TreeBlock<StepBlock>>
+  steps?: Array<TreeBlock<StepBlock>>
   selectedStep?: TreeBlock<StepBlock>
   selectedBlock?: TreeBlock
   selectedAttributeId?: string
@@ -106,7 +106,9 @@ export const reducer = (
       return {
         ...state,
         selectedBlock:
-          action.id != null ? searchBlocks(state.steps, action.id) : undefined
+          action.id != null
+            ? searchBlocks(state.steps ?? [], action.id)
+            : undefined
       }
     case 'SetSelectedAttributeIdAction':
       return { ...state, selectedAttributeId: action.id }

--- a/libs/shared/ui/src/components/CopyTextField/CopyTextField.stories.tsx
+++ b/libs/shared/ui/src/components/CopyTextField/CopyTextField.stories.tsx
@@ -22,6 +22,11 @@ Default.args = {
   value: 'https://your.nextstep.is'
 }
 
+export const Loading = Template.bind({})
+Default.args = {
+  value: undefined
+}
+
 export const Custom = Template.bind({})
 Custom.args = {
   label: 'Editor Invite URL',

--- a/libs/shared/ui/src/components/CopyTextField/CopyTextField.tsx
+++ b/libs/shared/ui/src/components/CopyTextField/CopyTextField.tsx
@@ -47,6 +47,7 @@ export function CopyTextField({
       label={label}
       defaultValue={value}
       inputRef={inputRef}
+      disabled={value == null}
       inputProps={{ onFocus: handleFocus }}
       InputProps={{
         startAdornment: (
@@ -56,7 +57,11 @@ export function CopyTextField({
         ),
         endAdornment: (
           <InputAdornment position="end">
-            <IconButton onClick={handleCopyClick} aria-label="Copy">
+            <IconButton
+              onClick={handleCopyClick}
+              aria-label="Copy"
+              disabled={value == null}
+            >
               <ContentCopyRoundedIcon />
             </IconButton>
           </InputAdornment>


### PR DESCRIPTION
# Description

No more SSR for journey editor. Instead, we'll client-side load everything and put skeletons in place to make it feel more responsive. Everything here should be tested via VR testing since they are purely visual changes.

The bigger part of this PR is that journey is now nullable in journey provider and steps is now nullable in editor provider. These two changes alone make for significant null check additions across the app.

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/26787371/todos/4757422949)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] load journeys list
- [ ] load journey view
- [ ] load journey edit

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
