### PR TITLE
feat: show video title

### DIFF
--- a/apps/journeys-admin/__generated__/BlockFields.ts
+++ b/apps/journeys-admin/__generated__/BlockFields.ts
@@ -266,6 +266,11 @@ export interface BlockFields_TypographyBlock {
   variant: TypographyVariant | null;
 }
 
+export interface BlockFields_VideoBlock_video_title {
+  __typename: "Translation";
+  value: string;
+}
+
 export interface BlockFields_VideoBlock_video_variant {
   __typename: "VideoVariant";
   id: string;
@@ -275,6 +280,7 @@ export interface BlockFields_VideoBlock_video_variant {
 export interface BlockFields_VideoBlock_video {
   __typename: "Video";
   id: string;
+  title: BlockFields_VideoBlock_video_title[];
   variant: BlockFields_VideoBlock_video_variant | null;
 }
 

--- a/apps/journeys-admin/__generated__/CardBlockVideoBlockCreate.ts
+++ b/apps/journeys-admin/__generated__/CardBlockVideoBlockCreate.ts
@@ -9,6 +9,11 @@ import { VideoBlockCreateInput } from "./globalTypes";
 // GraphQL mutation operation: CardBlockVideoBlockCreate
 // ====================================================
 
+export interface CardBlockVideoBlockCreate_videoBlockCreate_video_title {
+  __typename: "Translation";
+  value: string;
+}
+
 export interface CardBlockVideoBlockCreate_videoBlockCreate_video_variant {
   __typename: "VideoVariant";
   id: string;
@@ -18,6 +23,7 @@ export interface CardBlockVideoBlockCreate_videoBlockCreate_video_variant {
 export interface CardBlockVideoBlockCreate_videoBlockCreate_video {
   __typename: "Video";
   id: string;
+  title: CardBlockVideoBlockCreate_videoBlockCreate_video_title[];
   variant: CardBlockVideoBlockCreate_videoBlockCreate_video_variant | null;
 }
 

--- a/apps/journeys-admin/__generated__/CardBlockVideoBlockUpdate.ts
+++ b/apps/journeys-admin/__generated__/CardBlockVideoBlockUpdate.ts
@@ -9,6 +9,11 @@ import { VideoBlockUpdateInput } from "./globalTypes";
 // GraphQL mutation operation: CardBlockVideoBlockUpdate
 // ====================================================
 
+export interface CardBlockVideoBlockUpdate_videoBlockUpdate_video_title {
+  __typename: "Translation";
+  value: string;
+}
+
 export interface CardBlockVideoBlockUpdate_videoBlockUpdate_video_variant {
   __typename: "VideoVariant";
   id: string;
@@ -18,6 +23,7 @@ export interface CardBlockVideoBlockUpdate_videoBlockUpdate_video_variant {
 export interface CardBlockVideoBlockUpdate_videoBlockUpdate_video {
   __typename: "Video";
   id: string;
+  title: CardBlockVideoBlockUpdate_videoBlockUpdate_video_title[];
   variant: CardBlockVideoBlockUpdate_videoBlockUpdate_video_variant | null;
 }
 

--- a/apps/journeys-admin/__generated__/GetJourney.ts
+++ b/apps/journeys-admin/__generated__/GetJourney.ts
@@ -266,6 +266,11 @@ export interface GetJourney_journey_blocks_TypographyBlock {
   variant: TypographyVariant | null;
 }
 
+export interface GetJourney_journey_blocks_VideoBlock_video_title {
+  __typename: "Translation";
+  value: string;
+}
+
 export interface GetJourney_journey_blocks_VideoBlock_video_variant {
   __typename: "VideoVariant";
   id: string;
@@ -275,6 +280,7 @@ export interface GetJourney_journey_blocks_VideoBlock_video_variant {
 export interface GetJourney_journey_blocks_VideoBlock_video {
   __typename: "Video";
   id: string;
+  title: GetJourney_journey_blocks_VideoBlock_video_title[];
   variant: GetJourney_journey_blocks_VideoBlock_video_variant | null;
 }
 

--- a/apps/journeys-admin/__generated__/VideoBlockCreate.ts
+++ b/apps/journeys-admin/__generated__/VideoBlockCreate.ts
@@ -9,6 +9,11 @@ import { VideoBlockCreateInput } from "./globalTypes";
 // GraphQL mutation operation: VideoBlockCreate
 // ====================================================
 
+export interface VideoBlockCreate_videoBlockCreate_video_title {
+  __typename: "Translation";
+  value: string;
+}
+
 export interface VideoBlockCreate_videoBlockCreate_video_variant {
   __typename: "VideoVariant";
   id: string;
@@ -18,6 +23,7 @@ export interface VideoBlockCreate_videoBlockCreate_video_variant {
 export interface VideoBlockCreate_videoBlockCreate_video {
   __typename: "Video";
   id: string;
+  title: VideoBlockCreate_videoBlockCreate_video_title[];
   variant: VideoBlockCreate_videoBlockCreate_video_variant | null;
 }
 

--- a/apps/journeys-admin/__generated__/VideoBlockUpdate.ts
+++ b/apps/journeys-admin/__generated__/VideoBlockUpdate.ts
@@ -9,6 +9,11 @@ import { VideoBlockUpdateInput } from "./globalTypes";
 // GraphQL mutation operation: VideoBlockUpdate
 // ====================================================
 
+export interface VideoBlockUpdate_videoBlockUpdate_video_title {
+  __typename: "Translation";
+  value: string;
+}
+
 export interface VideoBlockUpdate_videoBlockUpdate_video_variant {
   __typename: "VideoVariant";
   id: string;
@@ -18,6 +23,7 @@ export interface VideoBlockUpdate_videoBlockUpdate_video_variant {
 export interface VideoBlockUpdate_videoBlockUpdate_video {
   __typename: "Video";
   id: string;
+  title: VideoBlockUpdate_videoBlockUpdate_video_title[];
   variant: VideoBlockUpdate_videoBlockUpdate_video_variant | null;
 }
 

--- a/apps/journeys-admin/__generated__/VideoFields.ts
+++ b/apps/journeys-admin/__generated__/VideoFields.ts
@@ -7,6 +7,11 @@
 // GraphQL fragment: VideoFields
 // ====================================================
 
+export interface VideoFields_video_title {
+  __typename: "Translation";
+  value: string;
+}
+
 export interface VideoFields_video_variant {
   __typename: "VideoVariant";
   id: string;
@@ -16,6 +21,7 @@ export interface VideoFields_video_variant {
 export interface VideoFields_video {
   __typename: "Video";
   id: string;
+  title: VideoFields_video_title[];
   variant: VideoFields_video_variant | null;
 }
 

--- a/apps/journeys-admin/setupTests.tsx
+++ b/apps/journeys-admin/setupTests.tsx
@@ -12,4 +12,6 @@ jest.mock('next/image', () => ({
   )
 }))
 
+jest.setTimeout(10000)
+
 Element.prototype.scrollIntoView = jest.fn()

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
@@ -511,6 +511,12 @@ const steps: Array<TreeBlock<StepBlock>> = [
             video: {
               __typename: 'Video',
               id: '2_0-FallingPlates',
+              title: [
+                {
+                  __typename: 'Translation',
+                  value: 'FallingPlates'
+                }
+              ],
               variant: {
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
@@ -582,6 +588,12 @@ const steps: Array<TreeBlock<StepBlock>> = [
             video: {
               __typename: 'Video',
               id: '2_0-FallingPlates',
+              title: [
+                {
+                  __typename: 'Translation',
+                  value: 'FallingPlates'
+                }
+              ],
               variant: {
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',

--- a/apps/journeys-admin/src/components/Editor/Canvas/Canvas.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/Canvas.stories.tsx
@@ -411,6 +411,12 @@ const steps: Array<TreeBlock<StepBlock>> = [
             video: {
               __typename: 'Video',
               id: '2_0-FallingPlates',
+              title: [
+                {
+                  __typename: 'Translation',
+                  value: 'FallingPlates'
+                }
+              ],
               variant: {
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',

--- a/apps/journeys-admin/src/components/Editor/Canvas/CardWrapper/CardWrapper.test.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/CardWrapper/CardWrapper.test.tsx
@@ -260,15 +260,15 @@ describe('CardWrapper', () => {
           muted: true,
           videoId: '2_0-FallingPlates',
           videoVariantLanguageId: '529',
-          title: [
-            {
-              __typename: 'Translation',
-              value: 'FallingPlates'
-            }
-          ],
           video: {
             __typename: 'Video',
             id: '2_0-FallingPlates',
+            title: [
+              {
+                __typename: 'Translation',
+                value: 'FallingPlates'
+              }
+            ],
             variant: null
           },
           startAt: null,
@@ -330,6 +330,12 @@ describe('CardWrapper', () => {
             video: {
               __typename: 'Video',
               id: '2_0-FallingPlates',
+              title: [
+                {
+                  __typename: 'Translation',
+                  value: 'FallingPlates'
+                }
+              ],
               variant: null
             },
             videoId: '2_0-FallingPlates',

--- a/apps/journeys-admin/src/components/Editor/Canvas/CardWrapper/CardWrapper.test.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/CardWrapper/CardWrapper.test.tsx
@@ -37,6 +37,12 @@ describe('CardWrapper', () => {
           video: {
             __typename: 'Video',
             id: '2_0-FallingPlates',
+            title: [
+              {
+                __typename: 'Translation',
+                value: 'FallingPlates'
+              }
+            ],
             variant: {
               __typename: 'VideoVariant',
               id: '2_0-FallingPlates-529',
@@ -102,6 +108,12 @@ describe('CardWrapper', () => {
             video: {
               __typename: 'Video',
               id: '2_0-FallingPlates',
+              title: [
+                {
+                  __typename: 'Translation',
+                  value: 'FallingPlates'
+                }
+              ],
               variant: {
                 __typename: 'VideoVariant',
                 hls: null,
@@ -248,6 +260,12 @@ describe('CardWrapper', () => {
           muted: true,
           videoId: '2_0-FallingPlates',
           videoVariantLanguageId: '529',
+          title: [
+            {
+              __typename: 'Translation',
+              value: 'FallingPlates'
+            }
+          ],
           video: {
             __typename: 'Video',
             id: '2_0-FallingPlates',

--- a/apps/journeys-admin/src/components/Editor/Canvas/VideoWrapper/VideoWrapper.test.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/VideoWrapper/VideoWrapper.test.tsx
@@ -185,15 +185,15 @@ describe('VideoWrapper', () => {
       muted: true,
       videoId: '2_0-FallingPlates',
       videoVariantLanguageId: '529',
-      title: [
-        {
-          __typename: 'Translation',
-          value: 'FallingPlates'
-        }
-      ],
       video: {
         __typename: 'Video',
         id: '2_0-FallingPlates',
+        title: [
+          {
+            __typename: 'Translation',
+            value: 'FallingPlates'
+          }
+        ],
         variant: null
       },
       startAt: null,
@@ -249,6 +249,12 @@ describe('VideoWrapper', () => {
         video: {
           __typename: 'Video',
           id: '2_0-FallingPlates',
+          title: [
+            {
+              __typename: 'Translation',
+              value: 'FallingPlates'
+            }
+          ],
           variant: null
         },
         videoId: '2_0-FallingPlates',

--- a/apps/journeys-admin/src/components/Editor/Canvas/VideoWrapper/VideoWrapper.test.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/VideoWrapper/VideoWrapper.test.tsx
@@ -22,6 +22,12 @@ describe('VideoWrapper', () => {
       video: {
         __typename: 'Video',
         id: '2_0-FallingPlates',
+        title: [
+          {
+            __typename: 'Translation',
+            value: 'FallingPlates'
+          }
+        ],
         variant: {
           __typename: 'VideoVariant',
           id: '2_0-FallingPlates-529',
@@ -81,6 +87,12 @@ describe('VideoWrapper', () => {
         video: {
           __typename: 'Video',
           id: '2_0-FallingPlates',
+          title: [
+            {
+              __typename: 'Translation',
+              value: 'FallingPlates'
+            }
+          ],
           variant: {
             __typename: 'VideoVariant',
             hls: null,
@@ -173,6 +185,12 @@ describe('VideoWrapper', () => {
       muted: true,
       videoId: '2_0-FallingPlates',
       videoVariantLanguageId: '529',
+      title: [
+        {
+          __typename: 'Translation',
+          value: 'FallingPlates'
+        }
+      ],
       video: {
         __typename: 'Video',
         id: '2_0-FallingPlates',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Attributes.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Attributes.spec.tsx
@@ -73,6 +73,12 @@ describe('Attributes', () => {
     video: {
       __typename: 'Video',
       id: '2_0-FallingPlates',
+      title: [
+        {
+          __typename: 'Translation',
+          value: 'FallingPlates'
+        }
+      ],
       variant: {
         __typename: 'VideoVariant',
         id: '2_0-FallingPlates-529',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.spec.tsx
@@ -84,6 +84,12 @@ describe('BackgroundMedia', () => {
       video: {
         __typename: 'Video',
         id: '2_0-FallingPlates',
+        title: [
+          {
+            __typename: 'Translation',
+            value: 'FallingPlates'
+          }
+        ],
         variant: {
           __typename: 'VideoVariant',
           id: '2_0-FallingPlates-529',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.stories.tsx
@@ -74,6 +74,12 @@ const video: TreeBlock<VideoBlock> = {
   video: {
     __typename: 'Video',
     id: '2_0-FallingPlates',
+    title: [
+      {
+        __typename: 'Translation',
+        value: 'FallingPlates'
+      }
+    ],
     variant: {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
@@ -168,6 +168,12 @@ describe('BackgroundMediaImage', () => {
       video: {
         __typename: 'Video',
         id: '2_0-FallingPlates',
+        title: [
+          {
+            __typename: 'Translation',
+            value: 'FallingPlates'
+          }
+        ],
         variant: {
           __typename: 'VideoVariant',
           id: '2_0-FallingPlates-529',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
@@ -51,6 +51,12 @@ const video: TreeBlock<VideoBlock> = {
   video: {
     __typename: 'Video',
     id: '5_0-NUA0201-0-0',
+    title: [
+      {
+        __typename: 'Translation',
+        value: 'FallingPlates'
+      }
+    ],
     variant: {
       __typename: 'VideoVariant',
       id: '5_0-NUA0201-0-0-529',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.tsx
@@ -233,7 +233,9 @@ export function BackgroundMediaVideo({
 
   return (
     <VideoBlockEditor
-      selectedBlock={videoBlock}
+      selectedBlock={
+        videoBlock != null ? { ...videoBlock, parentOrder: null } : videoBlock
+      }
       onChange={handleChange}
       onDelete={handleDelete}
     />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/Card.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/Card.spec.tsx
@@ -139,6 +139,12 @@ describe('Card', () => {
             video: {
               __typename: 'Video',
               id: '2_0-FallingPlates',
+              title: [
+                {
+                  __typename: 'Translation',
+                  value: 'FallingPlates'
+                }
+              ],
               variant: {
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
@@ -193,6 +199,12 @@ describe('Card', () => {
             video: {
               __typename: 'Video',
               id: '2_0-FallingPlates',
+              title: [
+                {
+                  __typename: 'Translation',
+                  value: 'FallingPlates'
+                }
+              ],
               variant: {
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.spec.tsx
@@ -28,6 +28,12 @@ const video: TreeBlock<VideoBlock> = {
   video: {
     __typename: 'Video',
     id: '2_0-FallingPlates',
+    title: [
+      {
+        __typename: 'Translation',
+        value: 'FallingPlates'
+      }
+    ],
     variant: {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.stories.tsx
@@ -36,6 +36,12 @@ const video: TreeBlock<VideoBlock> = {
   video: {
     __typename: 'Video',
     id: '2_0-FallingPlates',
+    title: [
+      {
+        __typename: 'Translation',
+        value: 'FallingPlates'
+      }
+    ],
     variant: {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Video.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Video.spec.tsx
@@ -21,6 +21,12 @@ describe('Video', () => {
       video: {
         __typename: 'Video',
         id: '2_0-FallingPlates',
+        title: [
+          {
+            __typename: 'Translation',
+            value: 'FallingPlates'
+          }
+        ],
         variant: {
           __typename: 'VideoVariant',
           id: '2_0-FallingPlates-529',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Video.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Video.stories.tsx
@@ -60,6 +60,12 @@ export const Filled: Story = () => {
     video: {
       __typename: 'Video',
       id: '2_0-FallingPlates',
+      title: [
+        {
+          __typename: 'Translation',
+          value: 'FallingPlates'
+        }
+      ],
       variant: {
         __typename: 'VideoVariant',
         id: '2_0-FallingPlates-529',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.stories.tsx
@@ -416,6 +416,12 @@ const steps: Array<TreeBlock<StepBlock>> = [
             video: {
               __typename: 'Video',
               id: '2_0-FallingPlates',
+              title: [
+                {
+                  __typename: 'Translation',
+                  value: 'FallingPlates'
+                }
+              ],
               variant: {
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',

--- a/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
@@ -363,6 +363,12 @@ const blocks: GetJourney_journey_blocks[] = [
     video: {
       __typename: 'Video',
       id: '2_0-FallingPlates',
+      title: [
+        {
+          __typename: 'Translation',
+          value: 'FallingPlates'
+        }
+      ],
       variant: {
         __typename: 'VideoVariant',
         id: '2_0-FallingPlates-529',

--- a/apps/journeys-admin/src/components/Editor/ImageBlockHeader/ImageBlockHeader.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockHeader/ImageBlockHeader.stories.tsx
@@ -71,7 +71,7 @@ export const Image = Template.bind({})
 Image.args = {
   selectedBlock: image,
   header: image.alt,
-  caption: '300x200px',
+  caption: 'Very long caption. So long in fact that it goes over the edge.',
   showDelete: true
 }
 

--- a/apps/journeys-admin/src/components/Editor/ImageBlockHeader/ImageBlockHeader.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockHeader/ImageBlockHeader.tsx
@@ -50,7 +50,14 @@ export function ImageBlockHeader({
               {header}
             </Typography>
           )}
-          <Typography variant="caption">
+          <Typography
+            variant="caption"
+            sx={{
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden'
+            }}
+          >
             {caption}
             &nbsp;
           </Typography>

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Dialog/VideoBlockEditorSettingsPosterDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Dialog/VideoBlockEditorSettingsPosterDialog.spec.tsx
@@ -55,6 +55,12 @@ const video: TreeBlock<VideoBlock> = {
   video: {
     __typename: 'Video',
     id: '2_0-FallingPlates',
+    title: [
+      {
+        __typename: 'Translation',
+        value: 'FallingPlates'
+      }
+    ],
     variant: {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/VideoBlockEditorSettingsPoster.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/VideoBlockEditorSettingsPoster.spec.tsx
@@ -23,6 +23,12 @@ const video: VideoBlock = {
   video: {
     __typename: 'Video',
     id: '2_0-FallingPlates',
+    title: [
+      {
+        __typename: 'Translation',
+        value: 'FallingPlates'
+      }
+    ],
     variant: {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.spec.tsx
@@ -19,6 +19,12 @@ const video: TreeBlock = {
   video: {
     __typename: 'Video',
     id: '2_0-FallingPlates',
+    title: [
+      {
+        __typename: 'Translation',
+        value: 'FallingPlates'
+      }
+    ],
     variant: {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.spec.tsx
@@ -21,6 +21,12 @@ const video: TreeBlock<VideoBlock> = {
   video: {
     __typename: 'Video',
     id: '2_0-FallingPlates',
+    title: [
+      {
+        __typename: 'Translation',
+        value: 'FallingPlates'
+      }
+    ],
     variant: {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
@@ -31,9 +37,6 @@ const video: TreeBlock<VideoBlock> = {
   children: []
 }
 
-const onChange = jest.fn()
-const onDelete = jest.fn()
-
 describe('VideoBlockEditor', () => {
   describe('no existing block', () => {
     it('shows placeholders on null', () => {
@@ -42,8 +45,8 @@ describe('VideoBlockEditor', () => {
           <MockedProvider>
             <VideoBlockEditor
               selectedBlock={null}
-              onChange={onChange}
-              onDelete={onDelete}
+              onChange={jest.fn()}
+              onDelete={jest.fn()}
             />
           </MockedProvider>
         </ThemeProvider>
@@ -53,13 +56,32 @@ describe('VideoBlockEditor', () => {
   })
 
   describe('existing block', () => {
+    it('shows title and hls link', async () => {
+      const { getByText } = render(
+        <ThemeProvider>
+          <MockedProvider>
+            <VideoBlockEditor
+              selectedBlock={video}
+              onChange={jest.fn()}
+              onDelete={jest.fn()}
+            />
+          </MockedProvider>
+        </ThemeProvider>
+      )
+      expect(getByText('FallingPlates')).toBeInTheDocument()
+      expect(
+        getByText('https://arc.gt/hls/2_0-FallingPlates/529')
+      ).toBeInTheDocument()
+    })
+
     it('calls onDelete', async () => {
+      const onDelete = jest.fn()
       const { getByTestId } = render(
         <ThemeProvider>
           <MockedProvider>
             <VideoBlockEditor
               selectedBlock={video}
-              onChange={onChange}
+              onChange={jest.fn()}
               onDelete={onDelete}
             />
           </MockedProvider>
@@ -76,8 +98,8 @@ describe('VideoBlockEditor', () => {
           <MockedProvider>
             <VideoBlockEditor
               selectedBlock={video}
-              onChange={onChange}
-              onDelete={onDelete}
+              onChange={jest.fn()}
+              onDelete={jest.fn()}
             />
           </MockedProvider>
         </ThemeProvider>

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.stories.tsx
@@ -54,6 +54,12 @@ const video: TreeBlock<VideoBlock> = {
   video: {
     __typename: 'Video',
     id: '2_0-FallingPlates',
+    title: [
+      {
+        __typename: 'Translation',
+        value: 'FallingPlates'
+      }
+    ],
     variant: {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.tsx
@@ -38,10 +38,11 @@ export function VideoBlockEditor({
         <ImageBlockHeader
           selectedBlock={posterBlock}
           header={
-            selectedBlock?.video?.variant?.hls == null
+            selectedBlock?.video?.title?.[0]?.value == null
               ? 'Select Video File'
-              : selectedBlock.video.variant.hls
+              : selectedBlock.video.title[0].value
           }
+          caption={selectedBlock?.video?.variant?.hls ?? undefined}
           showDelete={showDelete && selectedBlock?.video != null}
           onDelete={handleVideoDelete}
         />

--- a/apps/journeys-admin/src/libs/blockDeleteUpdate/blockDeleteUpdate.spec.ts
+++ b/apps/journeys-admin/src/libs/blockDeleteUpdate/blockDeleteUpdate.spec.ts
@@ -28,6 +28,12 @@ const video: TreeBlock<VideoBlock> = {
   video: {
     __typename: 'Video',
     id: '2_0-FallingPlates',
+    title: [
+      {
+        __typename: 'Translation',
+        value: 'FallingPlates'
+      }
+    ],
     variant: {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',

--- a/apps/journeys/__generated__/BlockFields.ts
+++ b/apps/journeys/__generated__/BlockFields.ts
@@ -266,6 +266,11 @@ export interface BlockFields_TypographyBlock {
   variant: TypographyVariant | null;
 }
 
+export interface BlockFields_VideoBlock_video_title {
+  __typename: "Translation";
+  value: string;
+}
+
 export interface BlockFields_VideoBlock_video_variant {
   __typename: "VideoVariant";
   id: string;
@@ -275,6 +280,7 @@ export interface BlockFields_VideoBlock_video_variant {
 export interface BlockFields_VideoBlock_video {
   __typename: "Video";
   id: string;
+  title: BlockFields_VideoBlock_video_title[];
   variant: BlockFields_VideoBlock_video_variant | null;
 }
 

--- a/apps/journeys/__generated__/GetJourney.ts
+++ b/apps/journeys/__generated__/GetJourney.ts
@@ -271,6 +271,11 @@ export interface GetJourney_journey_blocks_TypographyBlock {
   variant: TypographyVariant | null;
 }
 
+export interface GetJourney_journey_blocks_VideoBlock_video_title {
+  __typename: "Translation";
+  value: string;
+}
+
 export interface GetJourney_journey_blocks_VideoBlock_video_variant {
   __typename: "VideoVariant";
   id: string;
@@ -280,6 +285,7 @@ export interface GetJourney_journey_blocks_VideoBlock_video_variant {
 export interface GetJourney_journey_blocks_VideoBlock_video {
   __typename: "Video";
   id: string;
+  title: GetJourney_journey_blocks_VideoBlock_video_title[];
   variant: GetJourney_journey_blocks_VideoBlock_video_variant | null;
 }
 

--- a/apps/journeys/__generated__/VideoFields.ts
+++ b/apps/journeys/__generated__/VideoFields.ts
@@ -7,6 +7,11 @@
 // GraphQL fragment: VideoFields
 // ====================================================
 
+export interface VideoFields_video_title {
+  __typename: "Translation";
+  value: string;
+}
+
 export interface VideoFields_video_variant {
   __typename: "VideoVariant";
   id: string;
@@ -16,6 +21,7 @@ export interface VideoFields_video_variant {
 export interface VideoFields_video {
   __typename: "Video";
   id: string;
+  title: VideoFields_video_title[];
   variant: VideoFields_video_variant | null;
 }
 

--- a/apps/journeys/src/components/Conductor/Conductor.stories.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.stories.tsx
@@ -834,6 +834,12 @@ const videoBlocks: TreeBlock[] = [
             video: {
               __typename: 'Video',
               id: '2_0-FallingPlates',
+              title: [
+                {
+                  __typename: 'Translation',
+                  value: 'FallingPlates'
+                }
+              ],
               variant: {
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
@@ -958,6 +964,12 @@ const videoBlocks: TreeBlock[] = [
             video: {
               __typename: 'Video',
               id: '2_0-FallingPlates',
+              title: [
+                {
+                  __typename: 'Translation',
+                  value: 'FallingPlates'
+                }
+              ],
               variant: {
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
@@ -1018,6 +1030,12 @@ const videoBlocks: TreeBlock[] = [
             video: {
               __typename: 'Video',
               id: '2_0-FallingPlates',
+              title: [
+                {
+                  __typename: 'Translation',
+                  value: 'FallingPlates'
+                }
+              ],
               variant: {
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',

--- a/apps/watch-admin/__generated__/BlockFields.ts
+++ b/apps/watch-admin/__generated__/BlockFields.ts
@@ -266,6 +266,11 @@ export interface BlockFields_TypographyBlock {
   variant: TypographyVariant | null;
 }
 
+export interface BlockFields_VideoBlock_video_title {
+  __typename: "Translation";
+  value: string;
+}
+
 export interface BlockFields_VideoBlock_video_variant {
   __typename: "VideoVariant";
   id: string;
@@ -275,6 +280,7 @@ export interface BlockFields_VideoBlock_video_variant {
 export interface BlockFields_VideoBlock_video {
   __typename: "Video";
   id: string;
+  title: BlockFields_VideoBlock_video_title[];
   variant: BlockFields_VideoBlock_video_variant | null;
 }
 

--- a/apps/watch-admin/__generated__/VideoFields.ts
+++ b/apps/watch-admin/__generated__/VideoFields.ts
@@ -7,6 +7,11 @@
 // GraphQL fragment: VideoFields
 // ====================================================
 
+export interface VideoFields_video_title {
+  __typename: "Translation";
+  value: string;
+}
+
 export interface VideoFields_video_variant {
   __typename: "VideoVariant";
   id: string;
@@ -16,6 +21,7 @@ export interface VideoFields_video_variant {
 export interface VideoFields_video {
   __typename: "Video";
   id: string;
+  title: VideoFields_video_title[];
   variant: VideoFields_video_variant | null;
 }
 

--- a/apps/watch/__generated__/BlockFields.ts
+++ b/apps/watch/__generated__/BlockFields.ts
@@ -266,6 +266,11 @@ export interface BlockFields_TypographyBlock {
   variant: TypographyVariant | null;
 }
 
+export interface BlockFields_VideoBlock_video_title {
+  __typename: "Translation";
+  value: string;
+}
+
 export interface BlockFields_VideoBlock_video_variant {
   __typename: "VideoVariant";
   id: string;
@@ -275,6 +280,7 @@ export interface BlockFields_VideoBlock_video_variant {
 export interface BlockFields_VideoBlock_video {
   __typename: "Video";
   id: string;
+  title: BlockFields_VideoBlock_video_title[];
   variant: BlockFields_VideoBlock_video_variant | null;
 }
 

--- a/apps/watch/__generated__/VideoFields.ts
+++ b/apps/watch/__generated__/VideoFields.ts
@@ -7,6 +7,11 @@
 // GraphQL fragment: VideoFields
 // ====================================================
 
+export interface VideoFields_video_title {
+  __typename: "Translation";
+  value: string;
+}
+
 export interface VideoFields_video_variant {
   __typename: "VideoVariant";
   id: string;
@@ -16,6 +21,7 @@ export interface VideoFields_video_variant {
 export interface VideoFields_video {
   __typename: "Video";
   id: string;
+  title: VideoFields_video_title[];
   variant: VideoFields_video_variant | null;
 }
 

--- a/libs/journeys/ui/src/components/BlockRenderer/BlockRenderer.spec.tsx
+++ b/libs/journeys/ui/src/components/BlockRenderer/BlockRenderer.spec.tsx
@@ -500,6 +500,12 @@ describe('BlockRenderer', () => {
       video: {
         __typename: 'Video',
         id: '2_0-FallingPlates',
+        title: [
+          {
+            __typename: 'Translation',
+            value: 'FallingPlates'
+          }
+        ],
         variant: {
           __typename: 'VideoVariant',
           id: '2_0-FallingPlates-529',
@@ -533,6 +539,12 @@ describe('BlockRenderer', () => {
       video: {
         __typename: 'Video',
         id: '2_0-FallingPlates',
+        title: [
+          {
+            __typename: 'Translation',
+            value: 'FallingPlates'
+          }
+        ],
         variant: {
           __typename: 'VideoVariant',
           id: '2_0-FallingPlates-529',

--- a/libs/journeys/ui/src/components/Card/Card.spec.tsx
+++ b/libs/journeys/ui/src/components/Card/Card.spec.tsx
@@ -111,6 +111,12 @@ describe('CardBlock', () => {
               video: {
                 __typename: 'Video',
                 id: '2_0-FallingPlates',
+                title: [
+                  {
+                    __typename: 'Translation',
+                    value: 'FallingPlates'
+                  }
+                ],
                 variant: {
                   __typename: 'VideoVariant',
                   id: '2_0-FallingPlates-529',

--- a/libs/journeys/ui/src/components/Card/Card.stories.tsx
+++ b/libs/journeys/ui/src/components/Card/Card.stories.tsx
@@ -214,6 +214,12 @@ VideoCover.args = {
       video: {
         __typename: 'Video',
         id: '2_0-FallingPlates',
+        title: [
+          {
+            __typename: 'Translation',
+            value: 'FallingPlates'
+          }
+        ],
         variant: {
           __typename: 'VideoVariant',
           id: '2_0-FallingPlates-529',
@@ -258,6 +264,12 @@ VideoContent.args = {
       video: {
         __typename: 'Video',
         id: '2_0-FallingPlates',
+        title: [
+          {
+            __typename: 'Translation',
+            value: 'FallingPlates'
+          }
+        ],
         variant: {
           __typename: 'VideoVariant',
           id: '2_0-FallingPlates-529',

--- a/libs/journeys/ui/src/components/Video/Video.spec.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.spec.tsx
@@ -21,6 +21,12 @@ const block: TreeBlock<VideoFields> = {
   video: {
     __typename: 'Video',
     id: '2_0-FallingPlates',
+    title: [
+      {
+        __typename: 'Translation',
+        value: 'FallingPlates'
+      }
+    ],
     variant: {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',

--- a/libs/journeys/ui/src/components/Video/Video.stories.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.stories.tsx
@@ -30,6 +30,12 @@ const videoBlock: TreeBlock<VideoFields> = {
   video: {
     __typename: 'Video',
     id: '2_0-FallingPlates',
+    title: [
+      {
+        __typename: 'Translation',
+        value: 'FallingPlates'
+      }
+    ],
     variant: {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',

--- a/libs/journeys/ui/src/components/Video/__generated__/VideoFields.ts
+++ b/libs/journeys/ui/src/components/Video/__generated__/VideoFields.ts
@@ -7,6 +7,11 @@
 // GraphQL fragment: VideoFields
 // ====================================================
 
+export interface VideoFields_video_title {
+  __typename: "Translation";
+  value: string;
+}
+
 export interface VideoFields_video_variant {
   __typename: "VideoVariant";
   id: string;
@@ -16,6 +21,7 @@ export interface VideoFields_video_variant {
 export interface VideoFields_video {
   __typename: "Video";
   id: string;
+  title: VideoFields_video_title[];
   variant: VideoFields_video_variant | null;
 }
 

--- a/libs/journeys/ui/src/components/Video/videoFields.ts
+++ b/libs/journeys/ui/src/components/Video/videoFields.ts
@@ -15,6 +15,9 @@ export const VIDEO_FIELDS = gql`
     videoVariantLanguageId
     video {
       id
+      title(primary: true) {
+        value
+      }
       variant {
         id
         hls

--- a/libs/journeys/ui/src/libs/transformer/__generated__/BlockFields.ts
+++ b/libs/journeys/ui/src/libs/transformer/__generated__/BlockFields.ts
@@ -266,6 +266,11 @@ export interface BlockFields_TypographyBlock {
   variant: TypographyVariant | null;
 }
 
+export interface BlockFields_VideoBlock_video_title {
+  __typename: "Translation";
+  value: string;
+}
+
 export interface BlockFields_VideoBlock_video_variant {
   __typename: "VideoVariant";
   id: string;
@@ -275,6 +280,7 @@ export interface BlockFields_VideoBlock_video_variant {
 export interface BlockFields_VideoBlock_video {
   __typename: "Video";
   id: string;
+  title: BlockFields_VideoBlock_video_title[];
   variant: BlockFields_VideoBlock_video_variant | null;
 }
 


### PR DESCRIPTION
# Description

Show title and hls link when video selected. Most of the changes are just adding title to videoBlock fields.

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/26787371/todos/4840250786)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] select video on video block, should show title and hls link
- [ ] select video on card background media, should show title and hls link

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
