### PR TITLE
fix: restrain card hight on mobile landscape

### DIFF
--- a/apps/journeys/src/components/Conductor/Conductor.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.tsx
@@ -133,7 +133,6 @@ export function Conductor({ blocks }: ConductorProps): ReactElement {
               >
                 <Box
                   sx={{
-                    display: 'grid',
                     px: `${gapBetweenSlides / 2}px`,
                     height: `calc(100% - ${theme.spacing(6)})`,
                     [theme.breakpoints.up('lg')]: {
@@ -146,26 +145,23 @@ export function Conductor({ blocks }: ConductorProps): ReactElement {
                     backgroundColor={theme.palette.primary.light}
                     themeMode={null}
                     themeName={null}
-                    sx={{ gridColumn: 1, gridRow: 1, boxShadow: 'none' }}
                   >
-                    <></>
-                  </CardWrapper>
-                  <Fade
-                    in={activeBlock?.id === block.id}
-                    mountOnEnter
-                    unmountOnExit
-                  >
-                    <Box
-                      sx={{
-                        width: '100%',
-                        height: '100%',
-                        gridColumn: 1,
-                        gridRow: 1
-                      }}
+                    <Fade
+                      in={activeBlock?.id === block.id}
+                      mountOnEnter
+                      unmountOnExit
                     >
-                      <BlockRenderer block={block} />
-                    </Box>
-                  </Fade>
+                      <Box
+                        sx={{
+                          position: 'absolute',
+                          width: '100%',
+                          height: '100%'
+                        }}
+                      >
+                        <BlockRenderer block={block} />
+                      </Box>
+                    </Fade>
+                  </CardWrapper>
                 </Box>
               </SwiperSlide>
             ))}


### PR DESCRIPTION
# Description

When content on mobile landscape is too much, the card height isn't being constrained.

<img width="698" alt="image" src="https://user-images.githubusercontent.com/10802634/163291991-6ad56dd4-96b4-44b1-8da9-c800576b07b2.png">

Fix so it scrolls again
<img width="698" alt="image" src="https://user-images.githubusercontent.com/10802634/163292014-1f75eb24-a764-486c-a7c7-e47b4183d08b.png">

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] PR checks pass

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
