### PR TITLE
fix: blurImage returns undefiend when creating new imageBlock

### DIFF
--- a/libs/journeys/ui/src/libs/blurImage/blurImage.spec.ts
+++ b/libs/journeys/ui/src/libs/blurImage/blurImage.spec.ts
@@ -41,4 +41,10 @@ describe('blurImage', () => {
       blurImage(image.width, image.height, image.blurhash, '#00000088')
     ).toBe(undefined)
   })
+
+  it('returns undefined if blurhash is empty string', () => {
+    expect(blurImage(image.width, image.height, '', '#00000088')).toBe(
+      undefined
+    )
+  })
 })

--- a/libs/journeys/ui/src/libs/blurImage/blurImage.ts
+++ b/libs/journeys/ui/src/libs/blurImage/blurImage.ts
@@ -9,6 +9,8 @@ export const blurImage = (
   blurhash: string,
   hexBackground: string
 ): string | undefined => {
+  if (blurhash === '') return undefined
+
   const divisor = greatestCommonDivisor(imageWidth, imageHeight)
   const width = imageWidth / divisor
   const height = imageHeight / divisor


### PR DESCRIPTION
# Description
BlurImage requires blurHash, but newly created imageBlocks do not have this. Added a check so blurImage returns undefined, if blurhash is empty string.

- Link to Basecamp Todo

# How should this PR be QA Tested?
- [x] Can create an image block without crashing

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
