### PR TITLE
fix: apollo reload client on token change

### DIFF
--- a/apps/journeys-admin/pages/_app.tsx
+++ b/apps/journeys-admin/pages/_app.tsx
@@ -12,12 +12,11 @@ import { initAuth } from '../src/libs/firebaseClient/initAuth'
 initAuth()
 
 function JourneysAdminApp({ Component, pageProps }: AppProps): ReactElement {
-  const apolloClient = useApollo(
-    pageProps.AuthUserSerialized != null
-      ? JSON.parse(pageProps.AuthUserSerialized)._token
-      : '',
-    pageProps
-  )
+  const token =
+    (pageProps.AuthUserSerialized != null
+      ? (JSON.parse(pageProps.AuthUserSerialized)._token as string | null)
+      : '') ?? ''
+  const apolloClient = useApollo(token)
 
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_GTM_ID != null)

--- a/apps/journeys-admin/src/libs/apolloClient/apolloClient.ts
+++ b/apps/journeys-admin/src/libs/apolloClient/apolloClient.ts
@@ -4,17 +4,10 @@ import {
   NormalizedCacheObject
 } from '@apollo/client'
 import { setContext } from '@apollo/client/link/context'
-import merge from 'deepmerge'
-import { isEqual } from 'lodash'
-import { AppProps } from 'next/app'
 import { useMemo } from 'react'
 import { cache } from './cache'
 
-export const APOLLO_STATE_PROP_NAME = '__APOLLO_STATE__'
-
-let apolloClient: ApolloClient<NormalizedCacheObject> | undefined
-
-export function createApolloClient(
+function createApolloClient(
   token: string
 ): ApolloClient<NormalizedCacheObject> {
   const httpLink = createHttpLink({
@@ -37,63 +30,6 @@ export function createApolloClient(
   })
 }
 
-export function initializeApollo({
-  initialState,
-  token
-}: {
-  initialState?: NormalizedCacheObject
-  token: string
-}): ApolloClient<NormalizedCacheObject> {
-  const _apolloClient = apolloClient ?? createApolloClient(token)
-
-  // If your page has Next.js data fetching methods that use Apollo Client,
-  // the initial state gets hydrated here
-  if (initialState != null) {
-    // Get existing cache, loaded during client side data fetching
-    const existingCache = _apolloClient.extract()
-
-    // Merge the existing cache into data passed from getStaticProps/getServerSideProps
-    const data = merge(initialState, existingCache, {
-      // combine arrays using object equality (like in sets)
-      arrayMerge: (destinationArray, sourceArray) => [
-        ...sourceArray,
-        ...destinationArray.filter((d) =>
-          sourceArray.every((s) => !isEqual(d, s))
-        )
-      ]
-    })
-
-    // Restore the cache with the merged data
-    _apolloClient.cache.restore(data)
-  }
-  // For SSG and SSR always create a new Apollo Client
-  if (typeof window === 'undefined') return _apolloClient
-
-  // Create the Apollo Client once in the client
-  if (apolloClient == null) apolloClient = _apolloClient
-
-  return _apolloClient
-}
-
-export function addApolloState(
-  client: ApolloClient<NormalizedCacheObject>,
-  pageProps: AppProps['pageProps']
-): AppProps['pageProps'] {
-  if (pageProps?.props != null) {
-    pageProps.props[APOLLO_STATE_PROP_NAME] = client.cache.extract()
-  }
-
-  return pageProps
-}
-
-export function useApollo(
-  token: string,
-  pageProps: AppProps['pageProps']
-): ApolloClient<NormalizedCacheObject> {
-  const initialState = pageProps[APOLLO_STATE_PROP_NAME]
-  const store = useMemo(
-    () => initializeApollo({ token, initialState }),
-    [token, initialState]
-  )
-  return store
+export function useApollo(token: string): ApolloClient<NormalizedCacheObject> {
+  return useMemo(() => createApolloClient(token), [token])
 }

--- a/apps/journeys-admin/src/libs/apolloClient/index.ts
+++ b/apps/journeys-admin/src/libs/apolloClient/index.ts
@@ -1,6 +1,1 @@
-export {
-  createApolloClient,
-  initializeApollo,
-  addApolloState,
-  useApollo
-} from './apolloClient'
+export { useApollo } from './apolloClient'


### PR DESCRIPTION
# Description

Remove SSR from journeys-admin. Recreate apollo client whenever firebase token changes.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] logging in should no longer result in an endless loading cycle.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
