### PR TITLE
refactor: journey language field

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -302,7 +302,7 @@ type Journey
   createdAt: DateTime! @join__field(graph: JOURNEYS)
   description: String @join__field(graph: JOURNEYS)
   id: ID! @join__field(graph: JOURNEYS)
-  locale: String! @join__field(graph: JOURNEYS)
+  language: Language! @join__field(graph: JOURNEYS)
   primaryImageBlock: ImageBlock @join__field(graph: JOURNEYS)
   publishedAt: DateTime @join__field(graph: JOURNEYS)
   seoDescription: String @join__field(graph: JOURNEYS)
@@ -323,7 +323,7 @@ input JourneyCreateInput {
   (Provided for optimistic mutation result matching)
   """
   id: ID
-  locale: String
+  languageId: String!
 
   """
   Slug should be unique amongst all journeys
@@ -345,7 +345,7 @@ enum JourneyStatus {
 
 input JourneyUpdateInput {
   description: String
-  locale: String
+  languageId: String
   primaryImageBlockId: ID
   seoDescription: String
   seoTitle: String
@@ -358,6 +358,7 @@ input JourneyUpdateInput {
 type Language
   @join__owner(graph: LANGUAGES)
   @join__type(graph: LANGUAGES, key: "id")
+  @join__type(graph: JOURNEYS, key: "id")
   @join__type(graph: VIDEOS, key: "id")
 {
   bcp47: String @join__field(graph: LANGUAGES)

--- a/apps/api-journeys/db/seeds/nua1.ts
+++ b/apps/api-journeys/db/seeds/nua1.ts
@@ -24,7 +24,7 @@ export async function nua1(): Promise<void> {
   const journey = await db.collection('journeys').save({
     _key: '1',
     title: 'Fact or Fiction',
-    locale: 'en-US',
+    languageId: '529',
     themeMode: ThemeMode.light,
     themeName: ThemeName.base,
     slug: 'fact-or-fiction',

--- a/apps/api-journeys/db/seeds/nua2.ts
+++ b/apps/api-journeys/db/seeds/nua2.ts
@@ -24,7 +24,7 @@ export async function nua2(): Promise<void> {
   const journey = await db.collection('journeys').save({
     _key: '2',
     title: 'What About The Resurrection?',
-    locale: 'en-US',
+    languageId: '529',
     themeMode: ThemeMode.light,
     themeName: ThemeName.base,
     slug: slug,

--- a/apps/api-journeys/db/seeds/nua8.ts
+++ b/apps/api-journeys/db/seeds/nua8.ts
@@ -24,7 +24,7 @@ export async function nua8(): Promise<void> {
   const journey = await db.collection('journeys').save({
     _key: '3',
     title: "What's Jesus Got to Do With Me",
-    locale: 'en-US',
+    languageId: '529',
     themeMode: ThemeMode.light,
     themeName: ThemeName.base,
     slug: slug,

--- a/apps/api-journeys/db/seeds/nua9.ts
+++ b/apps/api-journeys/db/seeds/nua9.ts
@@ -25,7 +25,7 @@ export async function nua9(): Promise<void> {
   const journey = await db.collection('journeys').save({
     _key: '4',
     title: 'Decision',
-    locale: 'en-US',
+    languageId: '529',
     themeMode: ThemeMode.light,
     themeName: ThemeName.base,
     slug: slug,

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -76,7 +76,7 @@ type Journey @key(fields: "id") {
   primaryImageBlock: ImageBlock
   id: ID!
   title: String!
-  locale: String!
+  language: Language!
   themeMode: ThemeMode!
   themeName: ThemeName!
   description: String
@@ -614,7 +614,7 @@ input JourneyCreateInput {
   """
   id: ID
   title: String!
-  locale: String
+  languageId: String!
   themeMode: ThemeMode
   themeName: ThemeName
   description: String
@@ -631,7 +631,7 @@ input JourneyCreateInput {
 
 input JourneyUpdateInput {
   title: String
-  locale: String
+  languageId: String
   themeMode: ThemeMode
   themeName: ThemeName
   description: String
@@ -764,6 +764,10 @@ extend type Mutation {
 extend type Video @key(fields: "id primaryLanguageId") {
   id: ID! @external
   primaryLanguageId: ID! @external
+}
+
+extend type Language @key(fields: "id") {
+  id: ID! @external
 }
 
 extend type Query {

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -325,7 +325,7 @@ export class VideoBlockUpdateInput {
 export class JourneyCreateInput {
     id?: Nullable<string>;
     title: string;
-    locale?: Nullable<string>;
+    languageId: string;
     themeMode?: Nullable<ThemeMode>;
     themeName?: Nullable<ThemeName>;
     description?: Nullable<string>;
@@ -334,7 +334,7 @@ export class JourneyCreateInput {
 
 export class JourneyUpdateInput {
     title?: Nullable<string>;
-    locale?: Nullable<string>;
+    languageId?: Nullable<string>;
     themeMode?: Nullable<ThemeMode>;
     themeName?: Nullable<ThemeName>;
     description?: Nullable<string>;
@@ -416,7 +416,6 @@ export class Journey {
     primaryImageBlock?: Nullable<ImageBlock>;
     id: string;
     title: string;
-    locale: string;
     themeMode: ThemeMode;
     themeName: ThemeName;
     description?: Nullable<string>;

--- a/apps/api-journeys/src/app/modules/action/navigateToJourney/navigateToJourney.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/action/navigateToJourney/navigateToJourney.resolver.spec.ts
@@ -33,7 +33,7 @@ describe('NavigateToJourneyActionResolver', () => {
     id: '4',
     title: 'Fact or Fiction',
     status: JourneyStatus.published,
-    locale: 'en-US',
+    languageId: '529',
     themeMode: 'light',
     themeName: 'base',
     slug: 'fact-or-fiction'

--- a/apps/api-journeys/src/app/modules/block/block.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/block.service.spec.ts
@@ -44,7 +44,7 @@ describe('BlockService', () => {
     title: 'published',
     createdAt: '1234',
     status: JourneyStatus.published,
-    locale: 'en-US',
+    languageId: '529',
     themeMode: ThemeMode.light,
     themeName: ThemeName.base,
     description: null,

--- a/apps/api-journeys/src/app/modules/journey/journey.graphql
+++ b/apps/api-journeys/src/app/modules/journey/journey.graphql
@@ -1,7 +1,11 @@
+extend type Language @key(fields: "id") {
+  id: ID! @external
+}
+
 type Journey @key(fields: "id") {
   id: ID!
   title: String!
-  locale: String!
+  language: Language!
   themeMode: ThemeMode!
   themeName: ThemeName!
   description: String
@@ -37,7 +41,7 @@ input JourneyCreateInput {
   """
   id: ID
   title: String!
-  locale: String
+  languageId: String!
   themeMode: ThemeMode
   themeName: ThemeName
   description: String
@@ -53,7 +57,7 @@ input JourneyCreateInput {
 
 input JourneyUpdateInput {
   title: String
-  locale: String
+  languageId: String
   themeMode: ThemeMode
   themeName: ThemeName
   description: String

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -41,7 +41,7 @@ describe('JourneyResolver', () => {
     slug: 'journey-slug',
     title: 'published',
     status: JourneyStatus.published,
-    locale: 'en-US',
+    languageId: '529',
     themeMode: ThemeMode.light,
     themeName: ThemeName.base,
     description: null,
@@ -64,7 +64,7 @@ describe('JourneyResolver', () => {
 
   const journeyUpdate = {
     title: 'published',
-    locale: 'en-US',
+    languageId: '529',
     themeMode: ThemeMode.light,
     themeName: ThemeName.base,
     description: null,
@@ -254,13 +254,16 @@ describe('JourneyResolver', () => {
     it('creates a Journey', async () => {
       mockUuidv4.mockReturnValueOnce('journeyId')
       expect(
-        await resolver.journeyCreate({ title: 'Untitled Journey' }, 'userId')
+        await resolver.journeyCreate(
+          { title: 'Untitled Journey', languageId: '529' },
+          'userId'
+        )
       ).toEqual({
         id: 'journeyId',
         themeName: ThemeName.base,
         themeMode: ThemeMode.light,
         createdAt: new Date().toISOString(),
-        locale: 'en-US',
+        languageId: '529',
         status: JourneyStatus.draft,
         slug: 'untitled-journey',
         title: 'Untitled Journey'
@@ -269,7 +272,10 @@ describe('JourneyResolver', () => {
 
     it('creates a UserJourney', async () => {
       mockUuidv4.mockReturnValueOnce('journeyId')
-      await resolver.journeyCreate({ title: 'Untitled Journey' }, 'userId')
+      await resolver.journeyCreate(
+        { title: 'Untitled Journey', languageId: '529' },
+        'userId'
+      )
       expect(ujService.save).toHaveBeenCalledWith({
         userId: 'userId',
         journeyId: 'journeyId',
@@ -282,13 +288,16 @@ describe('JourneyResolver', () => {
       mockSave.mockRejectedValueOnce({ errorNum: 1210 })
       mockUuidv4.mockReturnValueOnce('journeyId')
       expect(
-        await resolver.journeyCreate({ title: 'Untitled Journey' }, 'userId')
+        await resolver.journeyCreate(
+          { title: 'Untitled Journey', languageId: '529' },
+          'userId'
+        )
       ).toEqual({
         id: 'journeyId',
         themeName: ThemeName.base,
         themeMode: ThemeMode.light,
         createdAt: new Date().toISOString(),
-        locale: 'en-US',
+        languageId: '529',
         status: JourneyStatus.draft,
         slug: 'untitled-journey-journeyId',
         title: 'Untitled Journey'
@@ -299,7 +308,10 @@ describe('JourneyResolver', () => {
       const mockSave = service.save as jest.MockedFunction<typeof service.save>
       mockSave.mockRejectedValueOnce(new Error('database error'))
       await expect(
-        resolver.journeyCreate({ title: 'Untitled Journey' }, 'userId')
+        resolver.journeyCreate(
+          { title: 'Untitled Journey', languageId: '529' },
+          'userId'
+        )
       ).rejects.toThrow('database error')
     })
   })
@@ -366,6 +378,15 @@ describe('JourneyResolver', () => {
 
     it('should return published', async () => {
       expect(resolver.status(journey)).toEqual(JourneyStatus.published)
+    })
+  })
+
+  describe('language', () => {
+    it('returns object for federation', async () => {
+      expect(await resolver.language({ languageId: 'languageId' })).toEqual({
+        __typename: 'Language',
+        id: 'languageId'
+      })
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -389,4 +389,11 @@ describe('JourneyResolver', () => {
       })
     })
   })
+
+  it('when no languageId returns object for federation with default', async () => {
+    expect(await resolver.language({})).toEqual({
+      __typename: 'Language',
+      id: '529'
+    })
+  })
 })

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -107,7 +107,6 @@ export class JourneyResolver {
           themeName: ThemeName.base,
           themeMode: ThemeMode.light,
           createdAt: new Date().toISOString(),
-          locale: 'en-US',
           status: JourneyStatus.draft,
           ...input
         })
@@ -181,5 +180,12 @@ export class JourneyResolver {
   @ResolveField()
   status(@Parent() { publishedAt }: Journey): JourneyStatus {
     return publishedAt == null ? JourneyStatus.draft : JourneyStatus.published
+  }
+
+  @ResolveField('language')
+  async language(
+    @Parent() journey
+  ): Promise<{ __typename: 'Language'; id: string }> {
+    return { __typename: 'Language', id: journey.languageId }
   }
 }

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -186,6 +186,7 @@ export class JourneyResolver {
   async language(
     @Parent() journey
   ): Promise<{ __typename: 'Language'; id: string }> {
-    return { __typename: 'Language', id: journey.languageId }
+    // 529 (english) is default if not set
+    return { __typename: 'Language', id: journey.languageId ?? '529' }
   }
 }

--- a/apps/api-journeys/src/app/modules/journey/journey.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.service.spec.ts
@@ -40,7 +40,7 @@ describe('JourneyService', () => {
     _key: '1',
     title: 'published',
     status: JourneyStatus.published,
-    locale: 'en-US',
+    languageId: '529',
     themeMode: ThemeMode.light,
     themeName: ThemeName.base,
     description: null,

--- a/apps/api-journeys/src/app/modules/userJourney/userJourney.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/userJourney/userJourney.resolver.spec.ts
@@ -42,7 +42,7 @@ describe('UserJourneyResolver', () => {
     id: '1',
     title: 'published',
     status: JourneyStatus.published,
-    locale: 'en-US',
+    languageId: '529',
     themeMode: ThemeMode.light,
     themeName: ThemeName.base,
     description: null,

--- a/apps/api-journeys/src/app/modules/userJourney/userJourney.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/userJourney/userJourney.service.spec.ts
@@ -50,7 +50,7 @@ describe('UserJourneyService', () => {
   const journey = {
     id: '1',
     title: 'published',
-    locale: 'en-US',
+    languageId: '529',
     themeMode: ThemeMode.light,
     themeName: ThemeName.base,
     description: null,

--- a/apps/journeys-admin/__generated__/GetJourney.ts
+++ b/apps/journeys-admin/__generated__/GetJourney.ts
@@ -9,6 +9,18 @@ import { JourneyStatus, ThemeName, ThemeMode, ButtonVariant, ButtonColor, Button
 // GraphQL query operation: GetJourney
 // ====================================================
 
+export interface GetJourney_journey_language_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface GetJourney_journey_language {
+  __typename: "Language";
+  id: string;
+  name: GetJourney_journey_language_name[];
+}
+
 export interface GetJourney_journey_blocks_ButtonBlock_action_NavigateAction {
   __typename: "NavigateAction";
   parentBlockId: string;
@@ -405,7 +417,7 @@ export interface GetJourney_journey {
   title: string;
   description: string | null;
   status: JourneyStatus;
-  locale: string;
+  language: GetJourney_journey_language;
   createdAt: any;
   publishedAt: any | null;
   themeName: ThemeName;

--- a/apps/journeys-admin/__generated__/GetJourneys.ts
+++ b/apps/journeys-admin/__generated__/GetJourneys.ts
@@ -9,6 +9,18 @@ import { ThemeName, ThemeMode, JourneyStatus } from "./globalTypes";
 // GraphQL query operation: GetJourneys
 // ====================================================
 
+export interface GetJourneys_journeys_language_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface GetJourneys_journeys_language {
+  __typename: "Language";
+  id: string;
+  name: GetJourneys_journeys_language_name[];
+}
+
 export interface GetJourneys_journeys_userJourneys_user {
   __typename: "User";
   id: string;
@@ -33,7 +45,7 @@ export interface GetJourneys_journeys {
   slug: string;
   themeName: ThemeName;
   themeMode: ThemeMode;
-  locale: string;
+  language: GetJourneys_journeys_language;
   status: JourneyStatus;
   userJourneys: GetJourneys_journeys_userJourneys[] | null;
 }

--- a/apps/journeys-admin/__generated__/JourneyCreate.ts
+++ b/apps/journeys-admin/__generated__/JourneyCreate.ts
@@ -9,6 +9,18 @@ import { ThemeName, ThemeMode, JourneyStatus } from "./globalTypes";
 // GraphQL mutation operation: JourneyCreate
 // ====================================================
 
+export interface JourneyCreate_journeyCreate_language_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface JourneyCreate_journeyCreate_language {
+  __typename: "Language";
+  id: string;
+  name: JourneyCreate_journeyCreate_language_name[];
+}
+
 export interface JourneyCreate_journeyCreate_userJourneys_user {
   __typename: "User";
   id: string;
@@ -33,7 +45,7 @@ export interface JourneyCreate_journeyCreate {
   slug: string;
   themeName: ThemeName;
   themeMode: ThemeMode;
-  locale: string;
+  language: JourneyCreate_journeyCreate_language;
   status: JourneyStatus;
   userJourneys: JourneyCreate_journeyCreate_userJourneys[] | null;
 }

--- a/apps/journeys-admin/__generated__/globalTypes.ts
+++ b/apps/journeys-admin/__generated__/globalTypes.ts
@@ -203,7 +203,7 @@ export interface ImageBlockUpdateInput {
 
 export interface JourneyUpdateInput {
   description?: string | null;
-  locale?: string | null;
+  languageId?: string | null;
   primaryImageBlockId?: string | null;
   seoDescription?: string | null;
   seoTitle?: string | null;

--- a/apps/journeys-admin/pages/index.tsx
+++ b/apps/journeys-admin/pages/index.tsx
@@ -22,7 +22,13 @@ const GET_JOURNEYS = gql`
       slug
       themeName
       themeMode
-      locale
+      language {
+        id
+        name(primary: true) {
+          value
+          primary
+        }
+      }
       status
       userJourneys {
         id

--- a/apps/journeys-admin/pages/journeys/[journeySlug].tsx
+++ b/apps/journeys-admin/pages/journeys/[journeySlug].tsx
@@ -26,7 +26,13 @@ export const GET_JOURNEY = gql`
       title
       description
       status
-      locale
+      language {
+        id
+        name {
+          value
+          primary
+        }
+      }
       createdAt
       publishedAt
       themeName

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.stories.tsx
@@ -28,7 +28,17 @@ const journey: Journey = {
   themeMode: ThemeMode.light,
   title: 'my journey',
   slug: 'my-journey',
-  locale: 'en-US',
+  language: {
+    __typename: 'Language',
+    id: '529',
+    name: [
+      {
+        __typename: 'Translation',
+        value: 'English',
+        primary: true
+      }
+    ]
+  },
   description: 'my cool journey',
   status: JourneyStatus.draft,
   createdAt: '2021-11-19T12:34:56.647Z',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.spec.tsx
@@ -24,7 +24,17 @@ describe('NavigateToJourneyAction', () => {
     themeMode: ThemeMode.light,
     title: 'my journey',
     slug: 'my-journey',
-    locale: 'en-US',
+    language: {
+      __typename: 'Language',
+      id: '529',
+      name: [
+        {
+          __typename: 'Translation',
+          value: 'English',
+          primary: true
+        }
+      ]
+    },
     description: 'my cool journey',
     status: JourneyStatus.draft,
     createdAt: '2021-11-19T12:34:56.647Z',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.stories.tsx
@@ -28,7 +28,17 @@ const journey: Journey = {
   themeMode: ThemeMode.light,
   title: 'my journey',
   slug: 'my-journey',
-  locale: 'en-US',
+  language: {
+    __typename: 'Language',
+    id: '529',
+    name: [
+      {
+        __typename: 'Translation',
+        value: 'English',
+        primary: true
+      }
+    ]
+  },
   description: 'my cool journey',
   status: JourneyStatus.draft,
   createdAt: '2021-11-19T12:34:56.647Z',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundColor/BackgroundColor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundColor/BackgroundColor.spec.tsx
@@ -25,7 +25,17 @@ const journey: Journey = {
   themeMode: ThemeMode.light,
   title: 'my journey',
   slug: 'my-journey',
-  locale: 'en-US',
+  language: {
+    __typename: 'Language',
+    id: '529',
+    name: [
+      {
+        __typename: 'Translation',
+        value: 'English',
+        primary: true
+      }
+    ]
+  },
   description: 'my cool journey',
   status: JourneyStatus.draft,
   createdAt: '2021-11-19T12:34:56.647Z',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.spec.tsx
@@ -26,7 +26,17 @@ const journey: Journey = {
   themeMode: ThemeMode.light,
   title: 'my journey',
   slug: 'my-journey',
-  locale: 'en-US',
+  language: {
+    __typename: 'Language',
+    id: '529',
+    name: [
+      {
+        __typename: 'Translation',
+        value: 'English',
+        primary: true
+      }
+    ]
+  },
   description: 'my cool journey',
   status: JourneyStatus.draft,
   createdAt: '2021-11-19T12:34:56.647Z',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.stories.tsx
@@ -36,7 +36,17 @@ const journey: Journey = {
   themeMode: ThemeMode.light,
   title: 'my journey',
   slug: 'my-journey',
-  locale: 'en-US',
+  language: {
+    __typename: 'Language',
+    id: '529',
+    name: [
+      {
+        __typename: 'Translation',
+        value: 'English',
+        primary: true
+      }
+    ]
+  },
   description: 'my cool journey',
   status: JourneyStatus.draft,
   createdAt: '2021-11-19T12:34:56.647Z',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
@@ -30,7 +30,17 @@ const journey: Journey = {
   themeMode: ThemeMode.light,
   title: 'my journey',
   slug: 'my-journey',
-  locale: 'en-US',
+  language: {
+    __typename: 'Language',
+    id: '529',
+    name: [
+      {
+        __typename: 'Translation',
+        value: 'English',
+        primary: true
+      }
+    ]
+  },
   description: 'my cool journey',
   status: JourneyStatus.draft,
   createdAt: '2021-11-19T12:34:56.647Z',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/Card.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/Card.spec.tsx
@@ -60,7 +60,17 @@ describe('Card', () => {
       themeMode: ThemeMode.dark,
       title: 'my journey',
       slug: 'my-journey',
-      locale: 'en-US',
+      language: {
+        __typename: 'Language',
+        id: '529',
+        name: [
+          {
+            __typename: 'Translation',
+            value: 'English',
+            primary: true
+          }
+        ]
+      },
       description: 'my cool journey',
       status: JourneyStatus.draft,
       createdAt: '2021-11-19T12:34:56.647Z',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardLayout/CardLayout.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardLayout/CardLayout.spec.tsx
@@ -23,7 +23,17 @@ const journey: Journey = {
   themeMode: ThemeMode.light,
   title: 'my journey',
   slug: 'my-journey',
-  locale: 'en-US',
+  language: {
+    __typename: 'Language',
+    id: '529',
+    name: [
+      {
+        __typename: 'Translation',
+        value: 'English',
+        primary: true
+      }
+    ]
+  },
   description: 'my cool journey',
   status: JourneyStatus.draft,
   createdAt: '2021-11-19T12:34:56.647Z',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardLayout/CardLayout.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardLayout/CardLayout.stories.tsx
@@ -33,7 +33,17 @@ const journey: Journey = {
   themeMode: ThemeMode.light,
   title: 'my journey',
   slug: 'my-journey',
-  locale: 'en-US',
+  language: {
+    __typename: 'Language',
+    id: '529',
+    name: [
+      {
+        __typename: 'Translation',
+        value: 'English',
+        primary: true
+      }
+    ]
+  },
   description: 'my cool journey',
   status: JourneyStatus.draft,
   createdAt: '2021-11-19T12:34:56.647Z',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardStyling/CardStyling.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardStyling/CardStyling.spec.tsx
@@ -35,7 +35,17 @@ const journey: Journey = {
   themeMode: ThemeMode.light,
   title: 'my journey',
   slug: 'my-journey',
-  locale: 'en-US',
+  language: {
+    __typename: 'Language',
+    id: '529',
+    name: [
+      {
+        __typename: 'Translation',
+        value: 'English',
+        primary: true
+      }
+    ]
+  },
   description: 'my cool journey',
   status: JourneyStatus.draft,
   createdAt: '2021-11-19T12:34:56.647Z',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardStyling/CardStyling.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardStyling/CardStyling.stories.tsx
@@ -33,7 +33,17 @@ const journey: Journey = {
   themeMode: ThemeMode.light,
   title: 'my journey',
   slug: 'my-journey',
-  locale: 'en-US',
+  language: {
+    __typename: 'Language',
+    id: '529',
+    name: [
+      {
+        __typename: 'Translation',
+        value: 'English',
+        primary: true
+      }
+    ]
+  },
   description: 'my cool journey',
   status: JourneyStatus.draft,
   createdAt: '2021-11-19T12:34:56.647Z',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Image/Options/ImageOptions.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Image/Options/ImageOptions.spec.tsx
@@ -21,7 +21,17 @@ const journey: Journey = {
   themeMode: ThemeMode.light,
   title: 'my journey',
   slug: 'my-journey',
-  locale: 'en-US',
+  language: {
+    __typename: 'Language',
+    id: '529',
+    name: [
+      {
+        __typename: 'Translation',
+        value: 'English',
+        primary: true
+      }
+    ]
+  },
   description: 'my cool journey',
   status: JourneyStatus.draft,
   createdAt: '2021-11-19T12:34:56.647Z',

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.stories.tsx
@@ -29,7 +29,17 @@ const journey: Journey = {
   themeMode: ThemeMode.light,
   title: 'my journey',
   slug: 'my-journey',
-  locale: 'en-US',
+  language: {
+    __typename: 'Language',
+    id: '529',
+    name: [
+      {
+        __typename: 'Translation',
+        value: 'English',
+        primary: true
+      }
+    ]
+  },
   description: null,
   status: JourneyStatus.draft,
   createdAt: '2021-11-19T12:34:56.647Z',

--- a/apps/journeys-admin/src/components/Editor/Editor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.spec.tsx
@@ -19,7 +19,17 @@ describe('Editor', () => {
     themeMode: ThemeMode.light,
     title: 'my journey',
     slug: 'my-journey',
-    locale: 'en-US',
+    language: {
+      __typename: 'Language',
+      id: '529',
+      name: [
+        {
+          __typename: 'Translation',
+          value: 'English',
+          primary: true
+        }
+      ]
+    },
     description: 'my cool journey',
     status: JourneyStatus.draft,
     createdAt: '2021-11-19T12:34:56.647Z',

--- a/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
@@ -545,7 +545,7 @@ Default.args = {
     title: 'NUA Journey: Ep.3 – Decision',
     slug: 'nua-journey-ep-3-decision',
     description: 'my cool journey',
-    locale: 'en-US',
+    languageId: '529',
     status: JourneyStatus.draft,
     createdAt: '2021-11-19T12:34:56.647Z',
     publishedAt: null,

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Dialog/VideoBlockEditorSettingsPosterDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Dialog/VideoBlockEditorSettingsPosterDialog.spec.tsx
@@ -30,7 +30,17 @@ const journey: Journey = {
   themeMode: ThemeMode.light,
   title: 'my journey',
   slug: 'my-journey',
-  locale: 'en-US',
+  language: {
+    __typename: 'Language',
+    id: '529',
+    name: [
+      {
+        __typename: 'Translation',
+        value: 'English',
+        primary: true
+      }
+    ]
+  },
   description: 'my cool journey',
   status: JourneyStatus.draft,
   createdAt: '2021-11-19T12:34:56.647Z',

--- a/apps/journeys-admin/src/components/JourneyList/AddJourneyButton/AddJourneyButton.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/AddJourneyButton/AddJourneyButton.spec.tsx
@@ -26,7 +26,7 @@ describe('AddJourneyButton', () => {
       description:
         'Use journey description for notes about the audience, topic, traffic source, etc. Only you and other editors can see it.',
       id: 'journeyId',
-      locale: 'en-US',
+      languageId: '529',
       publishedAt: null,
       slug: 'untitled-journey-journeyId',
       status: 'draft',

--- a/apps/journeys-admin/src/components/JourneyList/AddJourneyButton/AddJourneyButton.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/AddJourneyButton/AddJourneyButton.stories.tsx
@@ -37,7 +37,7 @@ const Template: Story = ({ variant }) => (
               description:
                 'Use journey description for notes about the audience, topic, traffic source, etc. Only you and other editors can see it.',
               id: 'journeyId',
-              locale: 'en-US',
+              languageId: '529',
               publishedAt: null,
               slug: 'untitled-journey-journeyId',
               status: 'draft',

--- a/apps/journeys-admin/src/components/JourneyList/AddJourneyButton/AddJourneyButton.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/AddJourneyButton/AddJourneyButton.tsx
@@ -27,6 +27,7 @@ export const JOURNEY_CREATE = gql`
         id: $journeyId
         title: $title
         description: $description
+        languageId: "529"
         themeMode: dark
       }
     ) {
@@ -38,7 +39,13 @@ export const JOURNEY_CREATE = gql`
       slug
       themeName
       themeMode
-      locale
+      language {
+        id
+        name(primary: true) {
+          value
+          primary
+        }
+      }
       status
       userJourneys {
         id

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCard.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCard.spec.tsx
@@ -49,7 +49,7 @@ describe('JourneyCard', () => {
     expect(getByText('January 1 - a published journey')).toBeInTheDocument()
   })
 
-  it('should render the locale captialized', () => {
+  it('should render the language name', () => {
     const { getByText } = render(
       <SnackbarProvider>
         <MockedProvider>
@@ -59,7 +59,7 @@ describe('JourneyCard', () => {
         </MockedProvider>
       </SnackbarProvider>
     )
-    expect(getByText('en-US')).toBeInTheDocument()
+    expect(getByText('English')).toBeInTheDocument()
   })
 
   it('should render the formated date with year if journey is created before the current year', () => {

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCard.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCard.tsx
@@ -143,7 +143,7 @@ export function JourneyCard({ journey }: JourneyCardProps): ReactElement {
             <Grid item>
               <Typography variant="caption">
                 {journey != null ? (
-                  journey.locale
+                  journey.language.name.find(({ primary }) => primary)?.value
                 ) : (
                   <Skeleton variant="text" width={40} />
                 )}

--- a/apps/journeys-admin/src/components/JourneyList/journeyListData.ts
+++ b/apps/journeys-admin/src/components/JourneyList/journeyListData.ts
@@ -15,7 +15,17 @@ export const defaultJourney: Journey = {
   themeName: ThemeName.base,
   themeMode: ThemeMode.light,
   slug: 'default',
-  locale: 'en-US',
+  language: {
+    __typename: 'Language',
+    id: '529',
+    name: [
+      {
+        __typename: 'Translation',
+        value: 'English',
+        primary: true
+      }
+    ]
+  },
   createdAt: formatISO(startOfYear(new Date())),
   publishedAt: null,
   status: JourneyStatus.draft,
@@ -82,5 +92,20 @@ export const descriptiveJourney: Journey = {
     'This heading is very long so that we can test out the wrapping of the title on the card, by default this should be no longer than 2 lines on the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur nisi magna, tincidunt ut ornare a, hendrerit quis nunc. Ut sapien enim, elementum ut elit commodo, egestas dapibus magna. Proin mattis magna id tellus pellentesque ultricies. Donec nibh lorem, ultrices quis neque nec, porttitor molestie mi. Fusce mollis, sem sit amet finibus tempor, metus nunc congue elit, sed pulvinar tellus turpis id felis. Sed facilisis vulputate tortor, et suscipit diam. Suspendisse sem orci, facilisis et justo ac, laoreet ultricies erat. Nunc venenatis, leo ac ultricies pellentesque, enim purus accumsan dui, id facilisis nisl ipsum nec justo. Phasellus accumsan magna sit amet nisl hendrerit pharetra sit amet nec felis. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. In dapibus nulla ut est feugiat, at accumsan massa eleifend. Suspendisse suscipit id ligula ultricies mollis. In lobortis, dolor sed consequat suscipit, lorem eros molestie neque, at malesuada erat tellus nec felis. Curabitur cursus facilisis mauris id aliquet. Nulla malesuada eu erat quis iaculis.',
   description:
     'This description is also very very long for the purpose of testing out text wrapping which also should restricted to 2 lines on the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur nisi magna, tincidunt ut ornare a, hendrerit quis nunc. Ut sapien enim, elementum ut elit commodo, egestas dapibus magna. Proin mattis magna id tellus pellentesque ultricies. Donec nibh lorem, ultrices quis neque nec, porttitor molestie mi. Fusce mollis, sem sit amet finibus tempor, metus nunc congue elit, sed pulvinar tellus turpis id felis. Sed facilisis vulputate tortor, et suscipit diam. Suspendisse sem orci, facilisis et justo ac, laoreet ultricies erat. Nunc venenatis, leo ac ultricies pellentesque, enim purus accumsan dui, id facilisis nisl ipsum nec justo. Phasellus accumsan magna sit amet nisl hendrerit pharetra sit amet nec felis. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. In dapibus nulla ut est feugiat, at accumsan massa eleifend. Suspendisse suscipit id ligula ultricies mollis. In lobortis, dolor sed consequat suscipit, lorem eros molestie neque, at malesuada erat tellus nec felis. Curabitur cursus facilisis mauris id aliquet. Nulla malesuada eu erat quis iaculis.',
-  locale: 'zh-Hans'
+  language: {
+    __typename: 'Language',
+    id: '20615',
+    name: [
+      {
+        __typename: 'Translation',
+        value: '普通話',
+        primary: true
+      },
+      {
+        __typename: 'Translation',
+        value: 'Chinese, Mandarin',
+        primary: false
+      }
+    ]
+  }
 }

--- a/apps/journeys-admin/src/components/JourneyView/JourneyView.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyView.spec.tsx
@@ -3,6 +3,11 @@ import { MockedProvider } from '@apollo/client/testing'
 import { SnackbarProvider } from 'notistack'
 import { JourneyProvider } from '../../libs/context'
 import { GetJourney_journey as Journey } from '../../../__generated__/GetJourney'
+import {
+  JourneyStatus,
+  ThemeName,
+  ThemeMode
+} from '../../../__generated__/globalTypes'
 import { JourneyView } from '.'
 
 jest.mock('@mui/material/useMediaQuery', () => ({
@@ -12,21 +17,38 @@ jest.mock('@mui/material/useMediaQuery', () => ({
 
 describe('JourneyView', () => {
   it('should have edit button', () => {
+    const journey: Journey = {
+      __typename: 'Journey',
+      id: 'journeyId',
+      slug: 'my-journey',
+      title: 'title',
+      description: 'description',
+      createdAt: '2021-11-19T12:34:56.647Z',
+      blocks: [],
+      language: {
+        __typename: 'Language',
+        id: '529',
+        name: [
+          {
+            __typename: 'Translation',
+            value: 'English',
+            primary: true
+          }
+        ]
+      },
+      publishedAt: null,
+      status: JourneyStatus.draft,
+      themeName: ThemeName.base,
+      themeMode: ThemeMode.light,
+      seoTitle: null,
+      seoDescription: null,
+      primaryImageBlock: null,
+      userJourneys: []
+    }
     const { getByRole } = render(
       <MockedProvider>
         <SnackbarProvider>
-          <JourneyProvider
-            value={
-              {
-                id: 'journeyId',
-                slug: 'my-journey',
-                title: 'title',
-                description: 'description',
-                createdAt: '2021-11-19T12:34:56.647Z',
-                blocks: []
-              } as unknown as Journey
-            }
-          >
+          <JourneyProvider value={journey}>
             <JourneyView />
           </JourneyProvider>
         </SnackbarProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Properties/JourneyDetails/JourneyDetails.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Properties/JourneyDetails/JourneyDetails.tsx
@@ -61,9 +61,9 @@ export function JourneyDetails(): ReactElement {
       </Box>
       <Box sx={{ display: 'flex', flexDirection: 'row', mt: 2 }}>
         <TranslateRounded fontSize="small" />
-        <Typography variant="body2" data-testid="locale" sx={{ ml: 2 }}>
+        <Typography variant="body2" sx={{ ml: 2 }}>
           {journey != null ? (
-            journey.locale
+            journey.language.name.find(({ primary }) => primary)?.value
           ) : (
             <Skeleton variant="text" width={40} />
           )}

--- a/apps/journeys-admin/src/components/JourneyView/data.ts
+++ b/apps/journeys-admin/src/components/JourneyView/data.ts
@@ -17,7 +17,17 @@ export const defaultJourney: Journey = {
   title: 'Journey Heading',
   description: 'Description',
   slug: 'default',
-  locale: 'en-US',
+  language: {
+    __typename: 'Language',
+    id: '529',
+    name: [
+      {
+        __typename: 'Translation',
+        value: 'English',
+        primary: true
+      }
+    ]
+  },
   status: JourneyStatus.draft,
   createdAt: '2021-11-19T12:34:56.647Z',
   publishedAt: null,

--- a/apps/journeys-admin/src/libs/blockDeleteUpdate/blockDeleteUpdate.spec.ts
+++ b/apps/journeys-admin/src/libs/blockDeleteUpdate/blockDeleteUpdate.spec.ts
@@ -66,7 +66,17 @@ const journey: Journey = {
   themeMode: ThemeMode.light,
   title: 'my journey',
   slug: 'my-journey',
-  locale: 'en-US',
+  language: {
+    __typename: 'Language',
+    id: '529',
+    name: [
+      {
+        __typename: 'Translation',
+        value: 'English',
+        primary: true
+      }
+    ]
+  },
   description: 'my cool journey',
   status: JourneyStatus.draft,
   createdAt: '2021-11-19T12:34:56.647Z',

--- a/apps/journeys-admin/src/libs/context/JourneyContext.spec.tsx
+++ b/apps/journeys-admin/src/libs/context/JourneyContext.spec.tsx
@@ -25,7 +25,17 @@ const journey: Journey = {
   themeMode: ThemeMode.light,
   title: 'my journey',
   slug: 'my-journey',
-  locale: 'en-US',
+  language: {
+    __typename: 'Language',
+    id: '529',
+    name: [
+      {
+        __typename: 'Translation',
+        value: 'English',
+        primary: true
+      }
+    ]
+  },
   description: 'my cool journey',
   status: JourneyStatus.draft,
   createdAt: '2021-11-19T12:34:56.647Z',
@@ -62,7 +72,7 @@ describe('JourneyContext', () => {
       themeMode: ThemeMode.light,
       title: 'my journey',
       slug: 'my-journey',
-      locale: 'en-US',
+      languageId: '529',
       description: 'my cool journey',
       status: JourneyStatus.draft,
       createdAt: '2021-11-19T12:34:56.647Z',

--- a/apps/journeys-admin/src/libs/context/JourneyContext.spec.tsx
+++ b/apps/journeys-admin/src/libs/context/JourneyContext.spec.tsx
@@ -72,7 +72,17 @@ describe('JourneyContext', () => {
       themeMode: ThemeMode.light,
       title: 'my journey',
       slug: 'my-journey',
-      languageId: '529',
+      language: {
+        __typename: 'Language',
+        id: '529',
+        name: [
+          {
+            __typename: 'Translation',
+            value: 'English',
+            primary: true
+          }
+        ]
+      },
       description: 'my cool journey',
       status: JourneyStatus.draft,
       createdAt: '2021-11-19T12:34:56.647Z',


### PR DESCRIPTION
# Description

Change to Journeys to use languageId instead of locale. Defaults to 529 if no languageId set.

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/26787371/todos/4752622705) backend pr to allow this to work

# How should this PR be QA Tested?

No QA required as will be tested in a future PR.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
