### PR TITLE
fix: value in copy text field

### DIFF
--- a/libs/shared/ui/src/components/CopyTextField/CopyTextField.spec.tsx
+++ b/libs/shared/ui/src/components/CopyTextField/CopyTextField.spec.tsx
@@ -55,7 +55,9 @@ describe('AccessDialog', () => {
         />
       </SnackbarProvider>
     )
-    expect(getByRole('textbox', { name: 'Journey URL' })).toBeInTheDocument()
+    expect(getByRole('textbox', { name: 'Journey URL' })).toHaveValue(
+      'http://localhost/journeys/journeySlug'
+    )
     expect(getByText('this is custom helper text')).toBeInTheDocument()
     fireEvent.click(getByRole('button', { name: 'Copy' }))
     await waitFor(() =>

--- a/libs/shared/ui/src/components/CopyTextField/CopyTextField.tsx
+++ b/libs/shared/ui/src/components/CopyTextField/CopyTextField.tsx
@@ -45,10 +45,9 @@ export function CopyTextField({
       }}
       hiddenLabel={label == null}
       label={label}
-      defaultValue={value}
       inputRef={inputRef}
       disabled={value == null}
-      inputProps={{ onFocus: handleFocus }}
+      inputProps={{ onFocus: handleFocus, value }}
       InputProps={{
         startAdornment: (
           <InputAdornment position="start">


### PR DESCRIPTION
# Description

Makes journey link visible in copy link text.

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/26787371/todos/4856873151)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] go to journey view page. Should show link in url.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
