### PR TITLE
fix: social share

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/DescriptionEdit/DescriptionEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/DescriptionEdit/DescriptionEdit.tsx
@@ -46,7 +46,7 @@ export function DescriptionEdit(): ReactElement {
   const initialValues =
     journey != null
       ? {
-          seoDescription: journey?.seoDescription ?? journey?.description ?? ''
+          seoDescription: journey.seoDescription ?? journey.description ?? ''
         }
       : null
 

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/DescriptionEdit/DescriptionEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/DescriptionEdit/DescriptionEdit.tsx
@@ -43,50 +43,69 @@ export function DescriptionEdit(): ReactElement {
     })
   }
 
-  const initialValues = {
-    seoDescription: journey?.seoDescription ?? journey?.description ?? ''
-  }
+  const initialValues =
+    journey != null
+      ? {
+          seoDescription: journey?.seoDescription ?? journey?.description ?? ''
+        }
+      : null
+
   const seoDescriptionSchema = object().shape({
     seoDescription: string().max(180, 'Character limit reached') // 180 characters just a few more words than 18 on average
   })
 
   return (
-    <Formik
-      initialValues={initialValues}
-      validationSchema={seoDescriptionSchema}
-      onSubmit={noop}
-    >
-      {({ values, touched, errors, handleChange, handleBlur }) => (
-        <Form>
-          <TextField
-            disabled={journey == null}
-            id="seoDescription"
-            name="seoDescription"
-            variant="filled"
-            label="Description"
-            fullWidth
-            multiline
-            maxRows={5}
-            value={values.seoDescription}
-            error={
-              touched.seoDescription === true && Boolean(errors.seoDescription)
-            }
-            helperText={
-              errors.seoDescription != null
-                ? errors.seoDescription
-                : 'Recommended length: up to 18 words'
-            }
-            onChange={handleChange}
-            onBlur={(e) => {
-              handleBlur(e)
-              errors.seoDescription == null && handleSubmit(e)
-            }}
-            sx={{
-              pb: 6
-            }}
-          />
-        </Form>
+    <>
+      {initialValues != null ? (
+        <Formik
+          initialValues={initialValues}
+          validationSchema={seoDescriptionSchema}
+          onSubmit={noop}
+        >
+          {({ values, touched, errors, handleChange, handleBlur }) => (
+            <Form>
+              <TextField
+                id="seoDescription"
+                name="seoDescription"
+                variant="filled"
+                label="Description"
+                fullWidth
+                multiline
+                maxRows={5}
+                value={values.seoDescription}
+                error={
+                  touched.seoDescription === true &&
+                  Boolean(errors.seoDescription)
+                }
+                helperText={
+                  errors.seoDescription != null
+                    ? errors.seoDescription
+                    : 'Recommended length: up to 18 words'
+                }
+                onChange={handleChange}
+                onBlur={(e) => {
+                  handleBlur(e)
+                  errors.seoDescription == null && handleSubmit(e)
+                }}
+                sx={{
+                  pb: 6
+                }}
+              />
+            </Form>
+          )}
+        </Formik>
+      ) : (
+        <TextField
+          variant="filled"
+          label="Description"
+          fullWidth
+          disabled
+          helperText="Recommended length: up to 18 words"
+          sx={{
+            pb: 6
+          }}
+        />
       )}
-    </Formik>
+    </>
   )
 }

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/TitleEdit/TitleEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/TitleEdit/TitleEdit.tsx
@@ -43,48 +43,66 @@ export function TitleEdit(): ReactElement {
     })
   }
 
-  const initialValues = {
-    seoTitle: journey?.seoTitle ?? journey?.title ?? ''
-  }
+  const initialValues =
+    journey != null
+      ? {
+          seoTitle: journey?.seoTitle ?? journey?.title ?? ''
+        }
+      : null
+
   const seoTitleSchema = object().shape({
     seoTitle: string().max(50, 'Character limit reached')
   })
 
   return (
-    <Formik
-      initialValues={initialValues}
-      validationSchema={seoTitleSchema}
-      onSubmit={noop}
-    >
-      {({ values, touched, errors, handleChange, handleBlur }) => (
-        <Form>
-          <TextField
-            disabled={journey == null}
-            id="seoTitle"
-            name="seoTitle"
-            variant="filled"
-            label="Title"
-            fullWidth
-            multiline
-            maxRows={2}
-            value={values.seoTitle}
-            error={touched.seoTitle === true && Boolean(errors.seoTitle)}
-            helperText={
-              errors.seoTitle != null
-                ? errors.seoTitle
-                : 'Recommended length: 5 words'
-            }
-            onChange={handleChange}
-            onBlur={(e) => {
-              handleBlur(e)
-              errors.seoTitle == null && handleSubmit(e)
-            }}
-            sx={{
-              pb: 4
-            }}
-          />
-        </Form>
+    <>
+      {initialValues != null ? (
+        <Formik
+          initialValues={initialValues}
+          validationSchema={seoTitleSchema}
+          onSubmit={noop}
+        >
+          {({ values, touched, errors, handleChange, handleBlur }) => (
+            <Form>
+              <TextField
+                id="seoTitle"
+                name="seoTitle"
+                variant="filled"
+                label="Title"
+                fullWidth
+                multiline
+                maxRows={2}
+                value={values.seoTitle}
+                error={touched.seoTitle === true && Boolean(errors.seoTitle)}
+                helperText={
+                  errors.seoTitle != null
+                    ? errors.seoTitle
+                    : 'Recommended length: 5 words'
+                }
+                onChange={handleChange}
+                onBlur={(e) => {
+                  handleBlur(e)
+                  errors.seoTitle == null && handleSubmit(e)
+                }}
+                sx={{
+                  pb: 4
+                }}
+              />
+            </Form>
+          )}
+        </Formik>
+      ) : (
+        <TextField
+          variant="filled"
+          label="Title"
+          fullWidth
+          disabled
+          helperText="Recommended length: 5 words"
+          sx={{
+            pb: 4
+          }}
+        />
       )}
-    </Formik>
+    </>
   )
 }

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/TitleEdit/TitleEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/TitleEdit/TitleEdit.tsx
@@ -46,7 +46,7 @@ export function TitleEdit(): ReactElement {
   const initialValues =
     journey != null
       ? {
-          seoTitle: journey?.seoTitle ?? journey?.title ?? ''
+          seoTitle: journey.seoTitle ?? journey.title
         }
       : null
 

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.spec.tsx
@@ -4,6 +4,10 @@ import { SnackbarProvider } from 'notistack'
 import { EditToolbar } from '.'
 
 describe('Edit Toolbar', () => {
+  jest.mock('@mui/material/useMediaQuery', () => ({
+    __esModule: true,
+    default: () => true
+  }))
   it('should render Toolbar', () => {
     const { getAllByRole, getByTestId } = render(
       <SnackbarProvider>

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.spec.tsx
@@ -3,11 +3,11 @@ import { render } from '@testing-library/react'
 import { SnackbarProvider } from 'notistack'
 import { EditToolbar } from '.'
 
+jest.mock('@mui/material/useMediaQuery', () => ({
+  __esModule: true,
+  default: () => true
+}))
 describe('Edit Toolbar', () => {
-  jest.mock('@mui/material/useMediaQuery', () => ({
-    __esModule: true,
-    default: () => true
-  }))
   it('should render Toolbar', () => {
     const { getAllByRole, getByTestId } = render(
       <SnackbarProvider>

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.spec.tsx
@@ -18,105 +18,115 @@ jest.mock('@mui/material/useMediaQuery', () => ({
 }))
 
 describe('EditToolbar Menu', () => {
-  it('should open the block menu on icon click', () => {
-    const selectedBlock: TreeBlock<TypographyBlock> = {
-      id: 'typography0.id',
-      __typename: 'TypographyBlock',
-      parentBlockId: 'card1.id',
-      parentOrder: 0,
-      content: 'Title',
-      variant: null,
-      color: null,
-      align: null,
-      children: []
-    }
-
-    const { getByRole, getByTestId } = render(
-      <SnackbarProvider>
-        <MockedProvider>
-          <EditorProvider initialState={{ selectedBlock }}>
-            <Menu />
-          </EditorProvider>
-        </MockedProvider>
-      </SnackbarProvider>
+  describe('desktop', () => {
+    beforeEach(() =>
+      (useMediaQuery as jest.Mock).mockImplementation(() => true)
     )
-    expect(getByRole('button')).toContainElement(getByTestId('MoreVertIcon'))
-    fireEvent.click(getByRole('button'))
-    expect(getByRole('menu')).toBeInTheDocument()
-    expect(getByRole('menuitem', { name: 'Delete Block' })).toBeInTheDocument()
-  })
 
-  it('should open the card menu on icon click', () => {
-    const selectedBlock: TreeBlock<StepBlock> = {
-      __typename: 'StepBlock',
-      id: 'stepId',
-      parentBlockId: 'journeyId',
-      parentOrder: 0,
-      locked: true,
-      nextBlockId: null,
-      children: []
-    }
+    it('should open the block menu on icon click', () => {
+      const selectedBlock: TreeBlock<TypographyBlock> = {
+        id: 'typography0.id',
+        __typename: 'TypographyBlock',
+        parentBlockId: 'card1.id',
+        parentOrder: 0,
+        content: 'Title',
+        variant: null,
+        color: null,
+        align: null,
+        children: []
+      }
 
-    const { getByRole, getByTestId, queryByRole } = render(
-      <SnackbarProvider>
-        <MockedProvider>
-          <EditorProvider initialState={{ selectedBlock }}>
-            <Menu />
-          </EditorProvider>
-        </MockedProvider>
-      </SnackbarProvider>
-    )
-    expect(getByRole('button')).toContainElement(getByTestId('MoreVertIcon'))
-    fireEvent.click(getByRole('button'))
-    expect(getByRole('menu')).toBeInTheDocument()
-    expect(getByRole('menuitem', { name: 'Delete Card' })).toBeInTheDocument()
-    expect(
-      queryByRole('menuitem', { name: 'Social Settings' })
-    ).not.toBeInTheDocument()
-  })
-
-  it('should link back to journey on click', () => {
-    const selectedBlock: TreeBlock<StepBlock> = {
-      __typename: 'StepBlock',
-      id: 'stepId',
-      parentBlockId: 'journeyId',
-      parentOrder: 0,
-      locked: true,
-      nextBlockId: null,
-      children: []
-    }
-
-    const { getByRole } = render(
-      <SnackbarProvider>
-        <MockedProvider>
-          <JourneyProvider
-            value={
-              {
-                id: 'journeyId',
-                slug: 'my-journey'
-              } as unknown as Journey
-            }
-          >
+      const { getByRole, getByTestId, queryByRole } = render(
+        <SnackbarProvider>
+          <MockedProvider>
             <EditorProvider initialState={{ selectedBlock }}>
               <Menu />
             </EditorProvider>
-          </JourneyProvider>
-        </MockedProvider>
-      </SnackbarProvider>
-    )
+          </MockedProvider>
+        </SnackbarProvider>
+      )
+      expect(getByRole('button')).toContainElement(getByTestId('MoreVertIcon'))
+      fireEvent.click(getByRole('button'))
+      expect(getByRole('menu')).toBeInTheDocument()
+      expect(
+        getByRole('menuitem', { name: 'Delete Block' })
+      ).toBeInTheDocument()
 
-    fireEvent.click(getByRole('button'))
-    expect(getByRole('menuitem', { name: 'Journey Settings' })).toHaveAttribute(
-      'href',
-      '/journeys/my-journey'
-    )
+      expect(
+        queryByRole('menuitem', { name: 'Social Settings' })
+      ).not.toBeInTheDocument()
+    })
+
+    it('should open the card menu on icon click', () => {
+      const selectedBlock: TreeBlock<StepBlock> = {
+        __typename: 'StepBlock',
+        id: 'stepId',
+        parentBlockId: 'journeyId',
+        parentOrder: 0,
+        locked: true,
+        nextBlockId: null,
+        children: []
+      }
+
+      const { getByRole, getByTestId, queryByRole } = render(
+        <SnackbarProvider>
+          <MockedProvider>
+            <EditorProvider initialState={{ selectedBlock }}>
+              <Menu />
+            </EditorProvider>
+          </MockedProvider>
+        </SnackbarProvider>
+      )
+      expect(getByRole('button')).toContainElement(getByTestId('MoreVertIcon'))
+      fireEvent.click(getByRole('button'))
+      expect(getByRole('menu')).toBeInTheDocument()
+      expect(getByRole('menuitem', { name: 'Delete Card' })).toBeInTheDocument()
+      expect(
+        queryByRole('menuitem', { name: 'Social Settings' })
+      ).not.toBeInTheDocument()
+    })
+    it('should link back to journey on click', () => {
+      const selectedBlock: TreeBlock<StepBlock> = {
+        __typename: 'StepBlock',
+        id: 'stepId',
+        parentBlockId: 'journeyId',
+        parentOrder: 0,
+        locked: true,
+        nextBlockId: null,
+        children: []
+      }
+
+      const { getByRole } = render(
+        <SnackbarProvider>
+          <MockedProvider>
+            <JourneyProvider
+              value={
+                {
+                  id: 'journeyId',
+                  slug: 'my-journey'
+                } as unknown as Journey
+              }
+            >
+              <EditorProvider initialState={{ selectedBlock }}>
+                <Menu />
+              </EditorProvider>
+            </JourneyProvider>
+          </MockedProvider>
+        </SnackbarProvider>
+      )
+
+      fireEvent.click(getByRole('button'))
+      expect(
+        getByRole('menuitem', { name: 'Journey Settings' })
+      ).toHaveAttribute('href', '/journeys/my-journey')
+    })
   })
 
-  describe('social settings', () => {
+  describe('mobile', () => {
     beforeEach(() =>
       (useMediaQuery as jest.Mock).mockImplementation(() => false)
     )
-    it('should display on mobile and opens social share drawer when card is selected', () => {
+    it('should display opens social share drawer when card is selected', () => {
       const selectedBlock: TreeBlock<StepBlock> = {
         __typename: 'StepBlock',
         id: 'stepId',
@@ -147,7 +157,7 @@ describe('EditToolbar Menu', () => {
       expect(getByText('Social Settings')).toBeInTheDocument()
     })
 
-    it('should display on mobile and opens social share drawer when block is selected', () => {
+    it('should display and opens social share drawer when block is selected', () => {
       const selectedBlock: TreeBlock<TypographyBlock> = {
         id: 'typography0.id',
         __typename: 'TypographyBlock',

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.spec.tsx
@@ -2,6 +2,8 @@ import { MockedProvider } from '@apollo/client/testing'
 import { render, fireEvent } from '@testing-library/react'
 import { SnackbarProvider } from 'notistack'
 import { EditorProvider, TreeBlock } from '@core/journeys/ui'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import { ThemeProvider } from '../../../ThemeProvider'
 import {
   GetJourney_journey_blocks_TypographyBlock as TypographyBlock,
   GetJourney_journey_blocks_StepBlock as StepBlock,
@@ -9,6 +11,11 @@ import {
 } from '../../../../../__generated__/GetJourney'
 import { JourneyProvider } from '../../../../libs/context'
 import { Menu } from '.'
+
+jest.mock('@mui/material/useMediaQuery', () => ({
+  __esModule: true,
+  default: jest.fn()
+}))
 
 describe('EditToolbar Menu', () => {
   it('should open the block menu on icon click', () => {
@@ -50,7 +57,7 @@ describe('EditToolbar Menu', () => {
       children: []
     }
 
-    const { getByRole, getByTestId } = render(
+    const { getByRole, getByTestId, queryByRole } = render(
       <SnackbarProvider>
         <MockedProvider>
           <EditorProvider initialState={{ selectedBlock }}>
@@ -63,6 +70,9 @@ describe('EditToolbar Menu', () => {
     fireEvent.click(getByRole('button'))
     expect(getByRole('menu')).toBeInTheDocument()
     expect(getByRole('menuitem', { name: 'Delete Card' })).toBeInTheDocument()
+    expect(
+      queryByRole('menuitem', { name: 'Social Settings' })
+    ).not.toBeInTheDocument()
   })
 
   it('should link back to journey on click', () => {
@@ -100,5 +110,74 @@ describe('EditToolbar Menu', () => {
       'href',
       '/journeys/my-journey'
     )
+  })
+
+  describe('social settings', () => {
+    beforeEach(() =>
+      (useMediaQuery as jest.Mock).mockImplementation(() => false)
+    )
+    it('should display on mobile and opens social share drawer when card is selected', () => {
+      const selectedBlock: TreeBlock<StepBlock> = {
+        __typename: 'StepBlock',
+        id: 'stepId',
+        parentBlockId: 'journeyId',
+        parentOrder: 0,
+        locked: true,
+        nextBlockId: null,
+        children: []
+      }
+
+      const { getByRole, getByText } = render(
+        <SnackbarProvider>
+          <MockedProvider>
+            <EditorProvider initialState={{ selectedBlock }}>
+              <ThemeProvider>
+                <Menu />
+              </ThemeProvider>
+            </EditorProvider>
+          </MockedProvider>
+        </SnackbarProvider>
+      )
+      fireEvent.click(getByRole('button'))
+      expect(
+        getByRole('menuitem', { name: 'Social Settings' })
+      ).toBeInTheDocument()
+
+      fireEvent.click(getByRole('menuitem', { name: 'Social Settings' }))
+      expect(getByText('Social Settings')).toBeInTheDocument()
+    })
+
+    it('should display on mobile and opens social share drawer when block is selected', () => {
+      const selectedBlock: TreeBlock<TypographyBlock> = {
+        id: 'typography0.id',
+        __typename: 'TypographyBlock',
+        parentBlockId: 'card1.id',
+        parentOrder: 0,
+        content: 'Title',
+        variant: null,
+        color: null,
+        align: null,
+        children: []
+      }
+
+      const { getByRole, getByText } = render(
+        <SnackbarProvider>
+          <MockedProvider>
+            <EditorProvider initialState={{ selectedBlock }}>
+              <ThemeProvider>
+                <Menu />
+              </ThemeProvider>
+            </EditorProvider>
+          </MockedProvider>
+        </SnackbarProvider>
+      )
+      fireEvent.click(getByRole('button'))
+      expect(
+        getByRole('menuitem', { name: 'Social Settings' })
+      ).toBeInTheDocument()
+
+      fireEvent.click(getByRole('menuitem', { name: 'Social Settings' }))
+      expect(getByText('Social Settings')).toBeInTheDocument()
+    })
   })
 })

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.stories.tsx
@@ -2,11 +2,11 @@ import { Story, Meta } from '@storybook/react'
 import { MockedProvider } from '@apollo/client/testing'
 import { screen, userEvent } from '@storybook/testing-library'
 import { EditorProvider } from '@core/journeys/ui'
-import { simpleComponentConfig } from '../../../../libs/storybook'
+import { journeysAdminConfig } from '../../../../libs/storybook'
 import { Menu } from '.'
 
 const MenuStory = {
-  ...simpleComponentConfig,
+  ...journeysAdminConfig,
   component: Menu,
   title: 'Journeys-Admin/Editor/EditToolbar/Menu'
 }

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.tsx
@@ -7,17 +7,22 @@ import ListItemText from '@mui/material/ListItemText'
 import ListItemIcon from '@mui/material/ListItemIcon'
 import Divider from '@mui/material/Divider'
 import { useEditor } from '@core/journeys/ui'
+import { Theme } from '@mui/material/styles'
 import SettingsIcon from '@mui/icons-material/Settings'
 import NextLink from 'next/link'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import ShareRoundedIcon from '@mui/icons-material/ShareRounded'
 import { DeleteBlock } from '../DeleteBlock'
 import { useJourney } from '../../../../libs/context'
 
 export function Menu(): ReactElement {
   const {
-    state: { selectedBlock }
+    state: { selectedBlock },
+    dispatch
   } = useEditor()
 
   const journey = useJourney()
+  const smUp = useMediaQuery((theme: Theme) => theme.breakpoints.up('sm'))
 
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
   const handleShowMenu = (event: React.MouseEvent<HTMLButtonElement>): void => {
@@ -27,14 +32,35 @@ export function Menu(): ReactElement {
     setAnchorEl(null)
   }
 
+  function SocialSettings(): ReactElement {
+    return (
+      <>
+        {!smUp && (
+          <MenuItem onClick={handleOpenSocial}>
+            <ListItemIcon>
+              <ShareRoundedIcon />
+            </ListItemIcon>
+            <ListItemText>Social Settings</ListItemText>
+          </MenuItem>
+        )}
+      </>
+    )
+  }
+
   function BlockMenu(): ReactElement {
-    return <DeleteBlock variant="list-item" />
+    return (
+      <>
+        <DeleteBlock variant="list-item" />
+        <SocialSettings />
+      </>
+    )
   }
 
   function CardMenu(): ReactElement {
     return (
       <>
         <DeleteBlock variant="list-item" closeMenu={handleCloseMenu} />
+        <SocialSettings />
         <Divider />
         <NextLink
           href={journey != null ? `/journeys/${journey.slug}` : ''}
@@ -49,6 +75,14 @@ export function Menu(): ReactElement {
         </NextLink>
       </>
     )
+  }
+
+  function handleOpenSocial(): void {
+    dispatch({
+      type: 'SetDrawerMobileOpenAction',
+      mobileOpen: true
+    })
+    handleCloseMenu()
   }
 
   return (

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.tsx
@@ -32,9 +32,10 @@ export function Menu(): ReactElement {
     setAnchorEl(null)
   }
 
-  function SocialSettings(): ReactElement {
+  function BlockMenu(): ReactElement {
     return (
       <>
+        <DeleteBlock variant="list-item" />
         {!smUp && (
           <MenuItem onClick={handleOpenSocial}>
             <ListItemIcon>
@@ -47,20 +48,18 @@ export function Menu(): ReactElement {
     )
   }
 
-  function BlockMenu(): ReactElement {
-    return (
-      <>
-        <DeleteBlock variant="list-item" />
-        <SocialSettings />
-      </>
-    )
-  }
-
   function CardMenu(): ReactElement {
     return (
       <>
         <DeleteBlock variant="list-item" closeMenu={handleCloseMenu} />
-        <SocialSettings />
+        {!smUp && (
+          <MenuItem onClick={handleOpenSocial}>
+            <ListItemIcon>
+              <ShareRoundedIcon />
+            </ListItemIcon>
+            <ListItemText>Social Settings</ListItemText>
+          </MenuItem>
+        )}
         <Divider />
         <NextLink
           href={journey != null ? `/journeys/${journey.slug}` : ''}

--- a/apps/journeys/.env.example
+++ b/apps/journeys/.env.example
@@ -10,3 +10,8 @@ NEXT_PUBLIC_FIREBASE_CONFIG_JSON=
 # 1. Create a new workspace on Google Tag Manager
 # 2. Copy and paste the ID with the format GTM-XXXXXXX
 NEXT_PUBLIC_GTM_ID=
+# Facebook app_id
+# https://developers.facebook.com/apps/redirect/dashboard
+# 1. Create a new facebook app
+# 2. Copy and paste App ID in quotes below e.g NEXT_PUBLIC_FACEBOOK_APP_ID='1234567891234567'
+NEXT_FACEBOOK_APP_ID=

--- a/apps/journeys/.env.example
+++ b/apps/journeys/.env.example
@@ -13,5 +13,5 @@ NEXT_PUBLIC_GTM_ID=
 # Facebook app_id
 # https://developers.facebook.com/apps/redirect/dashboard
 # 1. Create a new facebook app
-# 2. Copy and paste App ID in quotes below e.g NEXT_PUBLIC_FACEBOOK_APP_ID='1234567891234567'
+# 2. Copy and paste App ID below e.g NEXT_PUBLIC_FACEBOOK_APP_ID=1234567891234567
 NEXT_FACEBOOK_APP_ID=

--- a/apps/journeys/__generated__/GetJourney.ts
+++ b/apps/journeys/__generated__/GetJourney.ts
@@ -391,6 +391,7 @@ export interface GetJourney_journey {
   themeMode: ThemeMode;
   title: string;
   description: string | null;
+  slug: string;
   seoTitle: string | null;
   seoDescription: string | null;
   primaryImageBlock: GetJourney_journey_primaryImageBlock | null;

--- a/apps/journeys/pages/[journeySlug].tsx
+++ b/apps/journeys/pages/[journeySlug].tsx
@@ -16,6 +16,8 @@ interface JourneyPageProps {
   journey: Journey
 }
 
+const fbAppId = process.env.NEXT_FACEBOOK_APP_ID
+
 function JourneyPage({ journey }: JourneyPageProps): ReactElement {
   return (
     <>
@@ -23,7 +25,9 @@ function JourneyPage({ journey }: JourneyPageProps): ReactElement {
         title={journey.title}
         description={journey.description ?? undefined}
         openGraph={{
+          type: 'website',
           title: journey.seoTitle ?? journey.title,
+          url: `https://wwww.your.nextstep.is/${journey.slug}`,
           description:
             journey.seoDescription ?? journey.description ?? undefined,
           images:
@@ -39,6 +43,13 @@ function JourneyPage({ journey }: JourneyPageProps): ReactElement {
                 ]
               : []
         }}
+        facebook={
+          fbAppId != null
+            ? {
+                appId: fbAppId
+              }
+            : undefined
+        }
         twitter={{
           site: '@YourNextStepIs',
           cardType: 'summary_large_image'
@@ -70,6 +81,7 @@ export const getStaticProps: GetStaticProps<JourneyPageProps> = async ({
           themeMode
           title
           description
+          slug
           seoTitle
           seoDescription
           primaryImageBlock {

--- a/apps/journeys/pages/[journeySlug].tsx
+++ b/apps/journeys/pages/[journeySlug].tsx
@@ -16,8 +16,6 @@ interface JourneyPageProps {
   journey: Journey
 }
 
-const fbAppId = process.env.NEXT_FACEBOOK_APP_ID
-
 function JourneyPage({ journey }: JourneyPageProps): ReactElement {
   return (
     <>
@@ -44,9 +42,9 @@ function JourneyPage({ journey }: JourneyPageProps): ReactElement {
               : []
         }}
         facebook={
-          fbAppId != null
+          process.env.NEXT_PUBLIC_FACEBOOK_APP_ID != null
             ? {
-                appId: fbAppId
+                appId: process.env.NEXT_PUBLIC_FACEBOOK_APP_ID
               }
             : undefined
         }

--- a/apps/journeys/pages/[journeySlug].tsx
+++ b/apps/journeys/pages/[journeySlug].tsx
@@ -40,7 +40,7 @@ function JourneyPage({ journey }: JourneyPageProps): ReactElement {
               : []
         }}
         twitter={{
-          site: '@JesusFilm',
+          site: '@YourNextStepIs',
           cardType: 'summary_large_image'
         }}
       />


### PR DESCRIPTION
# Description
This PR is a collection of fixes for social share component:
- Added button to top bar menu do display social drawer on mobile
- Fixed a bug where initial values was not correctly getting loaded in
- SEO: Linked twitter account to [@YourNextStepIs](https://twitter.com/YourNextStepIs)
- SEO: Created a FB app id + instructions for developers to create their own

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/26787371/todos/4752672406)

# How should this PR be QA Tested?
- [ ] Social settings should not appear in menu when in desktop
- [ ] Social settings should be included in the menu and open social drawer on mobile
- [ ] Title field should be filled with social share title if set, and journey title 
- [ ] Description field should be filled with social share description, if not set should use journey description. If both aren't set, should be empty.
- [ ] Paste journey URL in Twitter share [validator](https://cards-dev.twitter.com/validator) should pass
- [ ] Past journey URL in Facebook share [validator](https://developers.facebook.com/tools/debug/) should pass

# Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
