### PR TITLE
fix: cover should allow for missing image block

### DIFF
--- a/libs/journeys/ui/src/components/Card/Card.tsx
+++ b/libs/journeys/ui/src/components/Card/Card.tsx
@@ -67,7 +67,7 @@ export function Card({
                   (block) =>
                     block.id === coverBlock.posterBlockId &&
                     block.__typename === 'ImageBlock'
-                ) as TreeBlock<ImageFields>
+                ) as TreeBlock<ImageFields> | undefined
               }
             >
               {renderedChildren}

--- a/libs/journeys/ui/src/components/Card/Cover/Cover.tsx
+++ b/libs/journeys/ui/src/components/Card/Cover/Cover.tsx
@@ -12,7 +12,7 @@ import 'video.js/dist/video-js.css'
 
 interface CoverProps {
   children: ReactNode
-  imageBlock: TreeBlock<ImageFields>
+  imageBlock?: TreeBlock<ImageFields>
   videoBlock?: TreeBlock<VideoFields>
 }
 
@@ -26,15 +26,15 @@ export function Cover({
   const theme = useTheme()
   const [loading, setLoading] = useState(true)
 
-  const blurBackground = blurImage(
-    imageBlock.width,
-    imageBlock.height,
-    imageBlock.blurhash,
-    theme.palette.background.paper
-  )
-
-  const imageBackground =
-    imageBlock?.src != null ? imageBlock.src : blurBackground
+  const blurBackground =
+    imageBlock != null
+      ? blurImage(
+          imageBlock.width,
+          imageBlock.height,
+          imageBlock.blurhash,
+          theme.palette.background.paper
+        )
+      : undefined
 
   useEffect(() => {
     if (videoRef.current != null) {
@@ -92,12 +92,12 @@ export function Cover({
             />
           </video>
         )}
-        {loading && imageBackground != null && (
+        {loading && imageBlock != null && blurBackground != null && (
           <NextImage
             data-testid={
               videoBlock != null ? 'VideoPosterCover' : 'CardImageCover'
             }
-            src={imageBackground}
+            src={imageBlock?.src ?? blurBackground}
             alt={imageBlock.alt}
             placeholder="blur"
             blurDataURL={blurBackground}


### PR DESCRIPTION
# Description

![Screen Shot 2022-04-21 at 2 56 02 PM](https://user-images.githubusercontent.com/802117/164362548-bd416846-41e0-45a2-bb4e-2dc36e7b2e42.png)

Fixes error where cover was receiving no cover image for video.

# How should this PR be QA Tested?

- [ ] create background video with no cover image. Should still display.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
