### PR TITLE
fix: move blocks update all api

### DIFF
--- a/apps/api-journeys/src/app/modules/block/block.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/block.resolver.ts
@@ -1,13 +1,6 @@
 // Block resolver tests are in individual block type spec files
 
-import {
-  Args,
-  Query,
-  ResolveField,
-  Resolver,
-  Mutation,
-  Parent
-} from '@nestjs/graphql'
+import { Args, Query, ResolveField, Resolver, Mutation } from '@nestjs/graphql'
 import { UseGuards } from '@nestjs/common'
 import { Block, UserJourneyRole } from '../../__generated__/graphql'
 import { RoleGuard } from '../../lib/roleGuard/roleGuard'
@@ -43,22 +36,7 @@ export class BlockResolver {
     @Args('journeyId') journeyId: string,
     @Args('parentOrder') parentOrder: number
   ): Promise<Block[]> {
-    const selectedBlock: Block = await this.blockService.get(id)
-
-    if (
-      selectedBlock.journeyId === journeyId &&
-      selectedBlock.parentOrder != null
-    ) {
-      const siblings = await this.blockService.getSiblings(
-        journeyId,
-        selectedBlock.parentBlockId
-      )
-      siblings.splice(selectedBlock.parentOrder, 1)
-      siblings.splice(parentOrder, 0, selectedBlock)
-
-      return await this.blockService.reorderSiblings(siblings)
-    }
-    return []
+    return await this.blockService.reorderBlock(id, journeyId, parentOrder)
   }
 
   @Mutation()
@@ -75,19 +53,5 @@ export class BlockResolver {
       journeyId,
       parentBlockId
     )
-  }
-
-  async siblings(@Parent() block: Block): Promise<Block[]> {
-    return await this.blockService.getSiblings(
-      block.journeyId,
-      block.parentBlockId
-    )
-  }
-
-  async updateOrder(
-    @Args('id') id: string,
-    @Args('parentOrder') parentOrder: number
-  ): Promise<Block> {
-    return await this.blockService.update(id, { parentOrder })
   }
 }


### PR DESCRIPTION
# Description

updateAll baseService doesn't properly update with objects with ids, only objects with keys. Currently the array we send from block.resolver have ids.

Refactored move logic to block.service. As Mike said "the KeyAsId/IdAsKey transformations are now handled in the services, instead of the resolvers. Keeping id in resolver and key in service."

-[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/26787371/todos/4786305141)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Manually testing move works
- [x] Deleting a block with children still works

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
