### PR TITLE
feat: featured journeys

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -301,6 +301,7 @@ type Journey
   blocks: [Block!] @join__field(graph: JOURNEYS)
   createdAt: DateTime! @join__field(graph: JOURNEYS)
   description: String @join__field(graph: JOURNEYS)
+  featuredAt: DateTime @join__field(graph: JOURNEYS)
   id: ID! @join__field(graph: JOURNEYS)
   language: Language! @join__field(graph: JOURNEYS)
   primaryImageBlock: ImageBlock @join__field(graph: JOURNEYS)
@@ -336,6 +337,10 @@ input JourneyCreateInput {
   themeMode: ThemeMode
   themeName: ThemeName
   title: String!
+}
+
+input JourneysFilter {
+  featured: Boolean
 }
 
 enum JourneyStatus {
@@ -461,7 +466,7 @@ type Query {
   adminJourney(id: ID!, idType: IdType): Journey @join__field(graph: JOURNEYS)
   adminJourneys: [Journey!]! @join__field(graph: JOURNEYS)
   journey(id: ID!, idType: IdType): Journey @join__field(graph: JOURNEYS)
-  journeys: [Journey!]! @join__field(graph: JOURNEYS)
+  journeys(where: JourneysFilter): [Journey!]! @join__field(graph: JOURNEYS)
   language(id: ID!): Language @join__field(graph: LANGUAGES)
   languages(limit: Int, offset: Int): [Language!]! @join__field(graph: LANGUAGES)
   me: User @join__field(graph: USERS)

--- a/apps/api-journeys/db/seeds/nua1.ts
+++ b/apps/api-journeys/db/seeds/nua1.ts
@@ -27,10 +27,11 @@ export async function nua1(): Promise<void> {
     languageId: '529',
     themeMode: ThemeMode.light,
     themeName: ThemeName.base,
-    slug: 'fact-or-fiction',
+    slug,
     status: JourneyStatus.published,
-    createdAt: new Date('2031-12-25T12:34:56.647Z'),
-    publishedAt: new Date('2031-12-25T12:34:56.647Z')
+    createdAt: new Date(),
+    publishedAt: new Date(),
+    featuredAt: new Date()
   })
 
   // first step

--- a/apps/api-journeys/db/seeds/nua2.ts
+++ b/apps/api-journeys/db/seeds/nua2.ts
@@ -27,10 +27,11 @@ export async function nua2(): Promise<void> {
     languageId: '529',
     themeMode: ThemeMode.light,
     themeName: ThemeName.base,
-    slug: slug,
+    slug,
     status: JourneyStatus.published,
-    createdAt: new Date('2031-12-25T12:34:56.647Z'),
-    publishedAt: new Date('2031-12-25T12:34:56.647Z')
+    createdAt: new Date(),
+    publishedAt: new Date(),
+    featuredAt: new Date()
   })
 
   // first step

--- a/apps/api-journeys/db/seeds/nua8.ts
+++ b/apps/api-journeys/db/seeds/nua8.ts
@@ -27,10 +27,11 @@ export async function nua8(): Promise<void> {
     languageId: '529',
     themeMode: ThemeMode.light,
     themeName: ThemeName.base,
-    slug: slug,
+    slug,
     status: JourneyStatus.published,
-    createdAt: new Date('2031-12-25T12:34:56.647Z'),
-    publishedAt: new Date('2031-12-25T12:34:56.647Z')
+    createdAt: new Date(),
+    publishedAt: new Date(),
+    featuredAt: new Date()
   })
 
   // first step

--- a/apps/api-journeys/db/seeds/nua9.ts
+++ b/apps/api-journeys/db/seeds/nua9.ts
@@ -10,7 +10,7 @@ import { ArangoDB } from '../db'
 const db = ArangoDB()
 
 export async function nua9(): Promise<void> {
-  const slug = 'descision'
+  const slug = 'decision'
   await db.query(aql`
         FOR journey in journeys
             FILTER journey.slug == ${slug}
@@ -28,10 +28,11 @@ export async function nua9(): Promise<void> {
     languageId: '529',
     themeMode: ThemeMode.light,
     themeName: ThemeName.base,
-    slug: slug,
+    slug,
     status: JourneyStatus.published,
-    createdAt: new Date('2031-12-25T12:34:56.647Z'),
-    publishedAt: new Date('2031-12-25T12:34:56.647Z')
+    createdAt: new Date(),
+    publishedAt: new Date(),
+    featuredAt: new Date()
   })
 
   //   first step

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -82,6 +82,7 @@ type Journey @key(fields: "id") {
   description: String
   slug: String!
   publishedAt: DateTime
+  featuredAt: DateTime
   createdAt: DateTime!
   status: JourneyStatus!
   seoTitle: String
@@ -607,6 +608,10 @@ enum JourneyStatus {
   published
 }
 
+input JourneysFilter {
+  featured: Boolean
+}
+
 input JourneyCreateInput {
   """
   ID should be unique Response UUID
@@ -773,7 +778,7 @@ extend type Language @key(fields: "id") {
 extend type Query {
   adminJourneys: [Journey!]!
   adminJourney(id: ID!, idType: IdType): Journey
-  journeys: [Journey!]!
+  journeys(where: JourneysFilter): [Journey!]!
   journey(id: ID!, idType: IdType): Journey
 }
 

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -426,6 +426,7 @@ export class Journey {
     description?: Nullable<string>;
     slug: string;
     publishedAt?: Nullable<DateTime>;
+    featuredAt?: Nullable<DateTime>;
     createdAt: DateTime;
     status: JourneyStatus;
     seoTitle?: Nullable<string>;

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -322,6 +322,10 @@ export class VideoBlockUpdateInput {
     fullsize?: Nullable<boolean>;
 }
 
+export class JourneysFilter {
+    featured?: Nullable<boolean>;
+}
+
 export class JourneyCreateInput {
     id?: Nullable<string>;
     title: string;
@@ -710,7 +714,7 @@ export abstract class IQuery {
 
     abstract adminJourney(id: string, idType?: Nullable<IdType>): Nullable<Journey> | Promise<Nullable<Journey>>;
 
-    abstract journeys(): Journey[] | Promise<Journey[]>;
+    abstract journeys(where?: Nullable<JourneysFilter>): Journey[] | Promise<Journey[]>;
 
     abstract journey(id: string, idType?: Nullable<IdType>): Nullable<Journey> | Promise<Nullable<Journey>>;
 }

--- a/apps/api-journeys/src/app/modules/journey/journey.graphql
+++ b/apps/api-journeys/src/app/modules/journey/journey.graphql
@@ -27,10 +27,14 @@ enum JourneyStatus {
   published
 }
 
+input JourneysFilter {
+  featured: Boolean
+}
+
 extend type Query {
   adminJourneys: [Journey!]!
   adminJourney(id: ID!, idType: IdType): Journey
-  journeys: [Journey!]!
+  journeys(where: JourneysFilter): [Journey!]!
   journey(id: ID!, idType: IdType): Journey
 }
 

--- a/apps/api-journeys/src/app/modules/journey/journey.graphql
+++ b/apps/api-journeys/src/app/modules/journey/journey.graphql
@@ -11,6 +11,7 @@ type Journey @key(fields: "id") {
   description: String
   slug: String!
   publishedAt: DateTime
+  featuredAt: DateTime
   createdAt: DateTime!
   status: JourneyStatus!
   seoTitle: String

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -147,7 +147,17 @@ describe('JourneyResolver', () => {
   describe('journeys', () => {
     it('should get published journeys', async () => {
       expect(await resolver.journeys()).toEqual([journey, journey])
-      expect(service.getAllPublishedJourneys).toHaveBeenCalledWith()
+      expect(service.getAllPublishedJourneys).toHaveBeenCalledWith(undefined)
+    })
+
+    it('should get published and featured journeys', async () => {
+      expect(await resolver.journeys({ featured: true })).toEqual([
+        journey,
+        journey
+      ])
+      expect(service.getAllPublishedJourneys).toHaveBeenCalledWith({
+        featured: true
+      })
     })
   })
 

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -25,7 +25,8 @@ import {
   ThemeMode,
   ThemeName,
   UserJourney,
-  UserJourneyRole
+  UserJourneyRole,
+  JourneysFilter
 } from '../../__generated__/graphql'
 import { UserJourneyService } from '../userJourney/userJourney.service'
 import { RoleGuard } from '../../lib/roleGuard/roleGuard'
@@ -72,8 +73,8 @@ export class JourneyResolver {
   }
 
   @Query()
-  async journeys(): Promise<Journey[]> {
-    return await this.journeyService.getAllPublishedJourneys()
+  async journeys(@Args('where') where?: JourneysFilter): Promise<Journey[]> {
+    return await this.journeyService.getAllPublishedJourneys(where)
   }
 
   @Query()

--- a/apps/api-journeys/src/app/modules/journey/journey.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing'
-import { Database } from 'arangojs'
+import { Database, aql } from 'arangojs'
 import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
 import {
   mockCollectionSaveResult,
@@ -7,7 +7,7 @@ import {
 } from '@core/nest/database'
 import { DocumentCollection } from 'arangojs/collection'
 import { keyAsId } from '@core/nest/decorators'
-
+import { AqlQuery } from 'arangojs/aql'
 import {
   JourneyStatus,
   ThemeMode,
@@ -16,15 +16,16 @@ import {
 import { JourneyService } from './journey.service'
 
 describe('JourneyService', () => {
-  let service: JourneyService
+  let service: JourneyService, db: DeepMockProxy<Database>
 
   beforeEach(async () => {
+    db = mockDeep<Database>()
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         JourneyService,
         {
           provide: 'DATABASE',
-          useFactory: () => mockDeep<Database>()
+          useFactory: () => db
         }
       ]
     }).compile()
@@ -52,9 +53,7 @@ describe('JourneyService', () => {
 
   describe('getAll', () => {
     beforeEach(() => {
-      ;(service.db as DeepMockProxy<Database>).query.mockReturnValue(
-        mockDbQueryResult(service.db, [journey, journey])
-      )
+      db.query.mockReturnValueOnce(mockDbQueryResult(db, [journey, journey]))
     })
 
     it('should return an array of journeys', async () => {
@@ -64,9 +63,7 @@ describe('JourneyService', () => {
 
   describe('get', () => {
     beforeEach(() => {
-      ;(service.db as DeepMockProxy<Database>).query.mockReturnValue(
-        mockDbQueryResult(service.db, [journey])
-      )
+      db.query.mockReturnValueOnce(mockDbQueryResult(db, [journey]))
     })
 
     it('should return a journey', async () => {
@@ -76,9 +73,7 @@ describe('JourneyService', () => {
 
   describe('getBySlug', () => {
     beforeEach(() => {
-      ;(service.db as DeepMockProxy<Database>).query.mockReturnValue(
-        mockDbQueryResult(service.db, [journey])
-      )
+      db.query.mockReturnValueOnce(mockDbQueryResult(db, [journey]))
     })
 
     it('should return a journey', async () => {
@@ -87,22 +82,53 @@ describe('JourneyService', () => {
   })
 
   describe('getAllPublishedJourneys', () => {
-    beforeEach(() => {
-      ;(service.db as DeepMockProxy<Database>).query.mockReturnValue(
-        mockDbQueryResult(service.db, [journey])
-      )
+    it('should return published journeys', async () => {
+      db.query.mockReturnValueOnce(mockDbQueryResult(db, [journey]))
+      expect(await service.getAllPublishedJourneys()).toEqual([journeyWithId])
     })
 
-    it('should return published journeys', async () => {
-      expect(await service.getAllPublishedJourneys()).toEqual([journeyWithId])
+    it('should filter by featured', async () => {
+      db.query.mockImplementationOnce(async (q) => {
+        const { query, bindVars } = q as unknown as AqlQuery
+        expect(query).toEqual(
+          aql`
+          FOR journey IN undefined
+            FILTER journey.status == @value0
+              AND journey.featuredAt != null
+            RETURN journey
+        `.query
+        )
+        expect(bindVars).toEqual({
+          value0: 'published'
+        })
+        return await mockDbQueryResult(db, [journey])
+      })
+      await service.getAllPublishedJourneys({ featured: true })
+    })
+
+    it('should filter by not featured', async () => {
+      db.query.mockImplementationOnce(async (q) => {
+        const { query, bindVars } = q as unknown as AqlQuery
+        expect(query).toEqual(
+          aql`
+          FOR journey IN undefined
+            FILTER journey.status == @value0
+              AND journey.featuredAt == null
+            RETURN journey
+        `.query
+        )
+        expect(bindVars).toEqual({
+          value0: 'published'
+        })
+        return await mockDbQueryResult(db, [journey])
+      })
+      await service.getAllPublishedJourneys({ featured: false })
     })
   })
 
   describe('getAllByOwnerEditor', () => {
     beforeEach(() => {
-      ;(service.db as DeepMockProxy<Database>).query.mockReturnValue(
-        mockDbQueryResult(service.db, [journey])
-      )
+      db.query.mockReturnValueOnce(mockDbQueryResult(db, [journey]))
     })
 
     it('should return all for user', async () => {

--- a/apps/api-journeys/src/app/modules/journey/journey.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.service.spec.ts
@@ -104,6 +104,7 @@ describe('JourneyService', () => {
         return await mockDbQueryResult(db, [journey])
       })
       await service.getAllPublishedJourneys({ featured: true })
+      expect(db.query).toHaveBeenCalled()
     })
 
     it('should filter by not featured', async () => {
@@ -123,6 +124,7 @@ describe('JourneyService', () => {
         return await mockDbQueryResult(db, [journey])
       })
       await service.getAllPublishedJourneys({ featured: false })
+      expect(db.query).toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
# Description

Adds a featured journey filter to journeys graphql query. This is a relatively pointless PR. It is designed to retrigger journeys seeds which are being reset today.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
