### PR TITLE
fix: cache blurImage url

### DIFF
--- a/libs/journeys/ui/src/components/Card/Card.tsx
+++ b/libs/journeys/ui/src/components/Card/Card.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, ReactNode } from 'react'
+import { ReactElement, ReactNode, useMemo } from 'react'
 import { ThemeProvider, NextImage } from '@core/shared/ui'
 import { useTheme } from '@mui/material/styles'
 import Paper from '@mui/material/Paper'
@@ -31,8 +31,8 @@ export function Card({
     | TreeBlock<ImageFields | VideoFields>
     | undefined
 
-  const blurUrl =
-    coverBlock?.__typename === 'ImageBlock'
+  const blurUrl = useMemo(() => {
+    return coverBlock?.__typename === 'ImageBlock'
       ? blurImage(
           coverBlock.width,
           coverBlock.height,
@@ -40,6 +40,7 @@ export function Card({
           theme.palette.background.paper
         )
       : undefined
+  }, [coverBlock, theme])
 
   const renderedChildren = children
     .filter(({ id }) => id !== coverBlockId)

--- a/libs/journeys/ui/src/components/Card/Cover/Cover.tsx
+++ b/libs/journeys/ui/src/components/Card/Cover/Cover.tsx
@@ -1,4 +1,11 @@
-import { ReactElement, ReactNode, useEffect, useRef, useState } from 'react'
+import {
+  ReactElement,
+  ReactNode,
+  useEffect,
+  useRef,
+  useState,
+  useMemo
+} from 'react'
 import videojs from 'video.js'
 import { NextImage } from '@core/shared/ui'
 import { useTheme } from '@mui/material/styles'
@@ -26,8 +33,8 @@ export function Cover({
   const theme = useTheme()
   const [loading, setLoading] = useState(true)
 
-  const blurBackground =
-    imageBlock != null
+  const blurBackground = useMemo(() => {
+    return imageBlock != null
       ? blurImage(
           imageBlock.width,
           imageBlock.height,
@@ -35,6 +42,7 @@ export function Cover({
           theme.palette.background.paper
         )
       : undefined
+  }, [imageBlock, theme])
 
   useEffect(() => {
     if (videoRef.current != null) {

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -1,5 +1,12 @@
 import videojs from 'video.js'
-import { ReactElement, useEffect, useRef, useCallback, useState } from 'react'
+import {
+  ReactElement,
+  useEffect,
+  useRef,
+  useCallback,
+  useState,
+  useMemo
+} from 'react'
 import { useMutation, gql } from '@apollo/client'
 import { NextImage } from '@core/shared/ui'
 import Box from '@mui/material/Box'
@@ -50,8 +57,8 @@ export function Video({
     (block) => block.id === posterBlockId && block.__typename === 'ImageBlock'
   ) as TreeBlock<ImageFields> | undefined
 
-  const blurBackground =
-    posterBlock != null
+  const blurBackground = useMemo(() => {
+    return posterBlock != null
       ? blurImage(
           posterBlock.width,
           posterBlock.height,
@@ -59,6 +66,7 @@ export function Video({
           theme.palette.background.paper
         )
       : undefined
+  }, [posterBlock, theme])
 
   const handleVideoResponse = useCallback(
     (videoState: VideoResponseStateEnum, videoPosition?: number): void => {


### PR DESCRIPTION
# Description

useMemo to cache blurImage results so don't need to rerun the calculation on every render. Fixes the performance issues.

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Running admin locally is faster

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
