### PR TITLE
fix: create card background as cover

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
@@ -138,7 +138,8 @@ describe('BackgroundMediaImage', () => {
                   journeyId: journey.id,
                   parentBlockId: card.id,
                   src: image.src,
-                  alt: image.alt
+                  alt: image.alt,
+                  isCover: true
                 }
               }
             },
@@ -213,7 +214,8 @@ describe('BackgroundMediaImage', () => {
                   journeyId: journey.id,
                   parentBlockId: card.id,
                   src: image.src,
-                  alt: image.alt
+                  alt: image.alt,
+                  isCover: true
                 }
               }
             },

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.tsx
@@ -158,7 +158,8 @@ export function BackgroundMediaImage({
           journeyId: journey.id,
           parentBlockId: cardBlock.id,
           src: block.src,
-          alt: block.alt
+          alt: block.alt,
+          isCover: true
         }
       },
       update(cache, { data }) {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
@@ -168,7 +168,8 @@ describe('BackgroundMediaVideo', () => {
                   journeyId: 'journeyId',
                   parentBlockId: 'cardId',
                   videoId: '2_0-Brand_Video',
-                  videoVariantLanguageId: '529'
+                  videoVariantLanguageId: '529',
+                  isCover: true
                 }
               }
             },
@@ -238,7 +239,8 @@ describe('BackgroundMediaVideo', () => {
                   journeyId: 'journeyId',
                   parentBlockId: 'cardId',
                   videoId: '2_0-Brand_Video',
-                  videoVariantLanguageId: '529'
+                  videoVariantLanguageId: '529',
+                  isCover: true
                 }
               }
             },

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.tsx
@@ -133,6 +133,7 @@ export function BackgroundMediaVideo({
         input: {
           journeyId: journey.id,
           parentBlockId: cardBlock.id,
+          isCover: true,
           ...input
         }
       },


### PR DESCRIPTION
# Description

Card media backgrounds weren't being created as covers with the updated api. Added the `isCover` prop to the api call now.

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/27244374/todos/4874291271#__recording_4874598010)

# How should this PR be QA Tested?

- [x] Cards should create cover media images / videos that persist on refresh

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
