### PR TITLE
fix: add fonts to iframe preview vr update

### DIFF
--- a/apps/journeys-admin/src/components/FramePortal/FramePortal.tsx
+++ b/apps/journeys-admin/src/components/FramePortal/FramePortal.tsx
@@ -32,6 +32,9 @@ function Content({ children, document }: ContentProps): ReactElement {
 
   useEffect(() => {
     document.body.style.backgroundColor = 'transparent'
+    document.head.innerHTML =
+      document.head.innerHTML +
+      '<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600;800&family=Open+Sans&display=swap" rel="stylesheet" />'
   }, [document])
 
   return <CacheProvider value={cache}>{children}</CacheProvider>

--- a/apps/journeys-admin/src/components/FramePortal/FramePortal.tsx
+++ b/apps/journeys-admin/src/components/FramePortal/FramePortal.tsx
@@ -20,21 +20,19 @@ interface ContentProps {
 }
 
 function Content({ children, document }: ContentProps): ReactElement {
-  const cache = useMemo(
-    () =>
-      createCache({
-        key: 'iframe',
-        container: document.head,
-        prepend: true
-      }),
-    [document]
-  )
-
-  useEffect(() => {
-    document.body.style.backgroundColor = 'transparent'
+  const cache = useMemo(() => {
     document.head.innerHTML =
       document.head.innerHTML +
       '<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600;800&family=Open+Sans&display=swap" rel="stylesheet" />'
+    return createCache({
+      key: 'iframe',
+      container: document.head,
+      prepend: true
+    })
+  }, [document])
+
+  useEffect(() => {
+    document.body.style.backgroundColor = 'transparent'
   }, [document])
 
   return <CacheProvider value={cache}>{children}</CacheProvider>

--- a/apps/journeys-admin/src/components/FramePortal/FramePortal.tsx
+++ b/apps/journeys-admin/src/components/FramePortal/FramePortal.tsx
@@ -33,9 +33,6 @@ function Content({ children, document }: ContentProps): ReactElement {
 
   useEffect(() => {
     document.body.style.backgroundColor = 'transparent'
-    document.head.innerHTML =
-      document.head.innerHTML +
-      '<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600;800&family=Open+Sans&display=swap" rel="stylesheet" />'
   }, [document])
 
   return <CacheProvider value={cache}>{children}</CacheProvider>


### PR DESCRIPTION
# Description

VR was not correctly adding the link to the iframe dom. This should fix that.

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] add h1 font should still work.
- [ ] vr should be working again.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
