### PR TITLE
fix: card background cover display

### DIFF
--- a/libs/journeys/ui/src/components/BlockRenderer/BlockRenderer.tsx
+++ b/libs/journeys/ui/src/components/BlockRenderer/BlockRenderer.tsx
@@ -74,6 +74,10 @@ export function BlockRenderer({
   const TypographyWrapper = wrappers?.TypographyWrapper ?? DefaultWrapper
   const VideoWrapper = wrappers?.VideoWrapper ?? DefaultWrapper
 
+  if (block.parentOrder === null) {
+    return <></>
+  }
+
   switch (block.__typename) {
     case 'ButtonBlock':
       return (

--- a/libs/journeys/ui/src/components/Card/Card.stories.tsx
+++ b/libs/journeys/ui/src/components/Card/Card.stories.tsx
@@ -4,7 +4,6 @@ import Box from '@mui/material/Box'
 import { MockedProvider } from '@apollo/client/testing'
 import { journeyUiConfig, TreeBlock } from '../..'
 import {
-  TypographyColor,
   TypographyVariant,
   ButtonVariant,
   ButtonColor,
@@ -12,6 +11,8 @@ import {
   IconName,
   IconSize
 } from '../../../__generated__/globalTypes'
+import { ImageFields } from '../Image/__generated__/ImageFields'
+import { VideoFields } from '../Video/__generated__/VideoFields'
 import { CardFields } from './__generated__/CardFields'
 import { Card } from './Card'
 
@@ -44,7 +45,7 @@ const Template: Story<TreeBlock<CardFields>> = ({ ...props }) => {
   )
 }
 
-const children: TreeBlock[] = [
+const content: TreeBlock[] = [
   {
     id: 'typographyBlockId1',
     __typename: 'TypographyBlock',
@@ -95,249 +96,107 @@ const children: TreeBlock[] = [
   }
 ]
 
+const image: TreeBlock<ImageFields> = {
+  id: 'imageBlockId1',
+  __typename: 'ImageBlock',
+  src: 'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920',
+  width: 1920,
+  height: 1080,
+  alt: 'random image from unsplash',
+  parentBlockId: 'Image1',
+  parentOrder: 3,
+  children: [],
+  blurhash: 'L9AS}j^-0dVC4Tq[=~PATeXSV?aL'
+}
+
+const video: TreeBlock<VideoFields> = {
+  __typename: 'VideoBlock',
+  id: 'videoBlockId1',
+  parentBlockId: null,
+  parentOrder: null,
+  muted: true,
+  autoplay: true,
+  startAt: null,
+  endAt: null,
+  posterBlockId: null,
+  videoId: '2_0-FallingPlates',
+  videoVariantLanguageId: '529',
+  video: {
+    __typename: 'Video',
+    id: '2_0-FallingPlates',
+    title: [
+      {
+        __typename: 'Translation',
+        value: 'FallingPlates'
+      }
+    ],
+    image:
+      'https://d1wl257kev7hsz.cloudfront.net/cinematics/2_0-FallingPlates.mobileCinematicHigh.jpg',
+    variant: {
+      __typename: 'VideoVariant',
+      id: '2_0-FallingPlates-529',
+      hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
+    }
+  },
+  fullsize: null,
+  children: []
+}
+
 export const Default: Story<TreeBlock<CardFields>> = Template.bind({})
 Default.args = {
   themeMode: null,
   themeName: null,
-  children
+  children: content
 }
 
-export const CustomColor: Story<TreeBlock<CardFields>> = Template.bind({})
-CustomColor.args = {
+export const Custom: Story<TreeBlock<CardFields>> = Template.bind({})
+Custom.args = {
   backgroundColor: '#F1A025',
-  children
+  children: content
+}
+
+export const ImageBlur: Story<TreeBlock<CardFields>> = Template.bind({})
+ImageBlur.args = {
+  coverBlockId: image.id,
+  children: [...content, image],
+  fullscreen: true
 }
 
 export const ImageCover: Story<TreeBlock<CardFields>> = Template.bind({})
 ImageCover.args = {
-  coverBlockId: 'imageBlockId1',
-  children: [
-    {
-      id: 'typographyBlockId1',
-      __typename: 'TypographyBlock',
-      parentBlockId: null,
-      parentOrder: 0,
-      align: null,
-      color: TypographyColor.secondary,
-      content: 'It s Ok To Get Angry',
-      variant: TypographyVariant.overline,
-      children: []
-    },
-    {
-      id: 'typographyBlockId2',
-      __typename: 'TypographyBlock',
-      parentBlockId: null,
-      parentOrder: 1,
-      align: null,
-      color: null,
-      content:
-        'Christianity isn’t about looking nice and religious; it’s diving into the deep end, a life fully immersed in following after Jesus.',
-      variant: TypographyVariant.subtitle1,
-      children: []
-    },
-    {
-      id: 'typographyBlockId3',
-      __typename: 'TypographyBlock',
-      parentBlockId: null,
-      parentOrder: 2,
-      align: null,
-      color: null,
-      content: 'Bible, 1 Corinthians 15:3-4',
-      variant: TypographyVariant.body2,
-      children: []
-    },
-    {
-      id: 'imageBlockId1',
-      __typename: 'ImageBlock',
-      src: 'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920',
-      width: 1920,
-      height: 1080,
-      alt: 'random image from unsplash',
-      parentBlockId: 'Image1',
-      parentOrder: 3,
-      children: [],
-      blurhash: 'L9AS}j^-0dVC4Tq[=~PATeXSV?aL'
-    }
-  ]
+  coverBlockId: image.id,
+  children: [...content, image]
 }
 
-export const VideoCover: Story<TreeBlock<CardFields>> = Template.bind({})
-VideoCover.args = {
-  coverBlockId: 'videoBlockId1',
+export const VideoCoverDefault: Story<TreeBlock<CardFields>> = Template.bind({})
+VideoCoverDefault.args = {
+  coverBlockId: video.id,
+  children: [...content, video]
+}
+
+export const VideoCoverCustom: Story<TreeBlock<CardFields>> = Template.bind({})
+VideoCoverCustom.args = {
+  backgroundColor: '#F1A025',
+  coverBlockId: video.id,
+  children: [...content, video]
+}
+
+export const VideoCoverPoster: Story<TreeBlock<CardFields>> = Template.bind({})
+VideoCoverPoster.args = {
+  coverBlockId: video.id,
   children: [
+    ...content,
     {
-      id: 'typographyBlockId1',
-      __typename: 'TypographyBlock',
-      parentBlockId: null,
-      parentOrder: 0,
-      align: null,
-      color: TypographyColor.secondary,
-      content: 'It s Ok To Get Angry',
-      variant: TypographyVariant.overline,
-      children: []
-    },
-    {
-      id: 'typographyBlockId2',
-      __typename: 'TypographyBlock',
-      parentBlockId: null,
-      parentOrder: 1,
-      align: null,
-      color: null,
-      content:
-        'Christianity isn’t about looking nice and religious; it’s diving into the deep end, a life fully immersed in following after Jesus.',
-      variant: TypographyVariant.subtitle1,
-      children: []
-    },
-    {
-      id: 'typographyBlockId3',
-      __typename: 'TypographyBlock',
-      parentBlockId: null,
-      parentOrder: 2,
-      align: null,
-      color: null,
-      content: 'Bible, 1 Corinthians 15:3-4',
-      variant: TypographyVariant.body2,
-      children: []
-    },
-    {
-      __typename: 'VideoBlock',
-      id: 'videoBlockId1',
-      parentBlockId: null,
-      parentOrder: 3,
-      muted: true,
-      autoplay: true,
-      startAt: null,
-      endAt: null,
-      posterBlockId: 'posterBlockId',
-      videoId: '2_0-FallingPlates',
-      videoVariantLanguageId: '529',
-      video: {
-        __typename: 'Video',
-        id: '2_0-FallingPlates',
-        title: [
-          {
-            __typename: 'Translation',
-            value: 'FallingPlates'
-          }
-        ],
-        image:
-          'https://d1wl257kev7hsz.cloudfront.net/cinematics/2_0-FallingPlates.mobileCinematicHigh.jpg',
-        variant: {
-          __typename: 'VideoVariant',
-          id: '2_0-FallingPlates-529',
-          hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-        }
-      },
-      fullsize: null,
-      children: [
-        {
-          id: 'posterBlockId',
-          __typename: 'ImageBlock',
-          src: 'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920',
-          alt: 'random image from unsplash',
-          width: 1600,
-          height: 1067,
-          blurhash: 'L9AS}j^-0dVC4Tq[=~PATeXSV?aL',
-          parentBlockId: 'videoBlockId',
-          parentOrder: 0,
-          children: []
-        }
-      ]
+      ...video,
+      posterBlockId: image.id,
+      children: [image]
     }
   ]
 }
 
 export const VideoContent: Story<TreeBlock<CardFields>> = Template.bind({})
 VideoContent.args = {
-  coverBlockId: 'videoBlockId1',
-  children: [
-    {
-      __typename: 'VideoBlock',
-      id: 'video1.id',
-      parentBlockId: null,
-      parentOrder: 0,
-      autoplay: false,
-      muted: true,
-      videoId: '2_0-FallingPlates',
-      videoVariantLanguageId: '529',
-      video: {
-        __typename: 'Video',
-        id: '2_0-FallingPlates',
-        title: [
-          {
-            __typename: 'Translation',
-            value: 'FallingPlates'
-          }
-        ],
-        image:
-          'https://d1wl257kev7hsz.cloudfront.net/cinematics/2_0-FallingPlates.mobileCinematicHigh.jpg',
-        variant: {
-          __typename: 'VideoVariant',
-          id: '2_0-FallingPlates-529',
-          hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-        }
-      },
-      startAt: null,
-      endAt: null,
-      posterBlockId: null,
-      fullsize: true,
-      children: []
-    }
-  ]
-}
-
-export const ImageBlur: Story<TreeBlock<CardFields>> = Template.bind({})
-ImageBlur.args = {
-  coverBlockId: 'imageBlockId1',
-  children: [
-    {
-      id: 'typographyBlockId1',
-      __typename: 'TypographyBlock',
-      parentBlockId: null,
-      parentOrder: 0,
-      align: null,
-      color: null,
-      content: 'Bible Quote',
-      variant: TypographyVariant.overline,
-      children: []
-    },
-    {
-      id: 'typographyBlockId2',
-      __typename: 'TypographyBlock',
-      parentBlockId: null,
-      parentOrder: 1,
-      align: null,
-      color: null,
-      content:
-        'For what I received I passed on to you as of first importance: that Christ died for our sins according to the Scriptures, that he was buried, that he was raised on the third day...',
-      variant: TypographyVariant.subtitle1,
-      children: []
-    },
-    {
-      id: 'typographyBlockId3',
-      __typename: 'TypographyBlock',
-      parentBlockId: null,
-      parentOrder: 2,
-      align: null,
-      color: null,
-      content: 'Bible, 1 Corinthians 15:3-4',
-      variant: TypographyVariant.body2,
-      children: []
-    },
-    {
-      id: 'imageBlockId1',
-      __typename: 'ImageBlock',
-      src: 'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920',
-      width: 1920,
-      height: 1080,
-      alt: 'random image from unsplash',
-      parentBlockId: 'Image1',
-      parentOrder: 3,
-      children: [],
-      blurhash: 'L9AS}j^-0dVC4Tq[=~PATeXSV?aL'
-    }
-  ],
-  fullscreen: true
+  children: [{ ...video, autoplay: false, parentOrder: 0 }]
 }
 
 export default Demo as Meta

--- a/libs/journeys/ui/src/components/Card/Card.tsx
+++ b/libs/journeys/ui/src/components/Card/Card.tsx
@@ -48,6 +48,9 @@ export function Card({
       <BlockRenderer block={block} wrappers={wrappers} key={block.id} />
     ))
 
+  const cardColor =
+    backgroundColor != null ? backgroundColor : 'background.paper'
+
   return (
     <CardWrapper
       id={id}
@@ -58,10 +61,13 @@ export function Card({
       {coverBlock != null && (fullscreen == null || !fullscreen) ? (
         <>
           {coverBlock.__typename === 'ImageBlock' && (
-            <CardCover imageBlock={coverBlock}>{renderedChildren}</CardCover>
+            <CardCover backgroundColor={cardColor} imageBlock={coverBlock}>
+              {renderedChildren}
+            </CardCover>
           )}
           {coverBlock.__typename === 'VideoBlock' && (
             <CardCover
+              backgroundColor={cardColor}
               videoBlock={coverBlock}
               imageBlock={
                 coverBlock.children.find(

--- a/libs/journeys/ui/src/components/Card/Cover/ContentOverlay/ContentOverlay.tsx
+++ b/libs/journeys/ui/src/components/Card/Cover/ContentOverlay/ContentOverlay.tsx
@@ -24,6 +24,7 @@ export function ContentOverlay({
             xs: 'polygon(0 6vw, 100% 0, 100% 100%, 0 100%)',
             sm: 'polygon(6vh 0, 100% 0, 100% 100%, 0 100%)'
           },
+          backgroundColor: 'background.paper',
           marginTop: { xs: '-6vw', sm: 0 },
           marginLeft: { xs: 0, sm: '-6vh' },
           paddingLeft: { sm: `6vh` },

--- a/libs/journeys/ui/src/components/Card/Cover/ContentOverlay/ContentOverlay.tsx
+++ b/libs/journeys/ui/src/components/Card/Cover/ContentOverlay/ContentOverlay.tsx
@@ -24,7 +24,6 @@ export function ContentOverlay({
             xs: 'polygon(0 6vw, 100% 0, 100% 100%, 0 100%)',
             sm: 'polygon(6vh 0, 100% 0, 100% 100%, 0 100%)'
           },
-          backgroundColor: 'background.paper',
           marginTop: { xs: '-6vw', sm: 0 },
           marginLeft: { xs: 0, sm: '-6vh' },
           paddingLeft: { sm: `6vh` },
@@ -66,6 +65,7 @@ export function ContentOverlay({
             zIndex: -1,
             transform: 'scaleY(-1)',
             backgroundBlendMode: 'hard-light',
+            backgroundColor: 'background.paper',
             backgroundImage:
               backgroundSrc != null
                 ? `url(${backgroundSrc}), url(${backgroundSrc})`
@@ -134,6 +134,7 @@ export function ContentOverlay({
                   backgroundRepeat: 'no-repeat',
                   backgroundSize: '100% 100%',
                   backgroundPosition: '0% 0%',
+                  backgroundColor: 'background.paper',
                   backgroundImage:
                     backgroundSrc != null
                       ? `url(${backgroundSrc}), url(${backgroundSrc})`

--- a/libs/journeys/ui/src/components/Card/Cover/ContentOverlay/ContentOverlay.tsx
+++ b/libs/journeys/ui/src/components/Card/Cover/ContentOverlay/ContentOverlay.tsx
@@ -4,11 +4,13 @@ import Box from '@mui/material/Box'
 
 interface ContentOverlayProps {
   children: ReactNode
+  backgroundColor: string
   backgroundSrc?: string
 }
 
 export function ContentOverlay({
   children,
+  backgroundColor,
   backgroundSrc
 }: ContentOverlayProps): ReactElement {
   const theme = useTheme()
@@ -65,7 +67,8 @@ export function ContentOverlay({
             zIndex: -1,
             transform: 'scaleY(-1)',
             backgroundBlendMode: 'hard-light',
-            backgroundColor: 'background.paper',
+            backgroundColor:
+              backgroundSrc == null ? backgroundColor : undefined,
             backgroundImage:
               backgroundSrc != null
                 ? `url(${backgroundSrc}), url(${backgroundSrc})`
@@ -134,7 +137,8 @@ export function ContentOverlay({
                   backgroundRepeat: 'no-repeat',
                   backgroundSize: '100% 100%',
                   backgroundPosition: '0% 0%',
-                  backgroundColor: 'background.paper',
+                  backgroundColor:
+                    backgroundSrc == null ? backgroundColor : undefined,
                   backgroundImage:
                     backgroundSrc != null
                       ? `url(${backgroundSrc}), url(${backgroundSrc})`

--- a/libs/journeys/ui/src/components/Card/Cover/Cover.tsx
+++ b/libs/journeys/ui/src/components/Card/Cover/Cover.tsx
@@ -19,12 +19,14 @@ import 'video.js/dist/video-js.css'
 
 interface CoverProps {
   children: ReactNode
+  backgroundColor: string
   imageBlock?: TreeBlock<ImageFields>
   videoBlock?: TreeBlock<VideoFields>
 }
 
 export function Cover({
   children,
+  backgroundColor,
   imageBlock,
   videoBlock
 }: CoverProps): ReactElement {
@@ -114,7 +116,12 @@ export function Cover({
           />
         )}
       </Box>
-      <ContentOverlay backgroundSrc={blurBackground}>{children}</ContentOverlay>
+      <ContentOverlay
+        backgroundColor={backgroundColor}
+        backgroundSrc={blurBackground}
+      >
+        {children}
+      </ContentOverlay>
     </>
   )
 }


### PR DESCRIPTION
# Description

Problem 1:
<img width="486" alt="image" src="https://user-images.githubusercontent.com/10802634/165637182-205276c5-c6e1-4ba5-be6f-d9105b09b52c.png">
When you have an existing cover background (eg image), and replace this with another cover of different type (eg video). The old cover is removed as a background but now appears as a regular block (with null parentOrder). This will disappear when you refresh the page. But we want to hide `parentOrder: null` blocks.

[Basecamp](https://3.basecamp.com/3105655/buckets/27244374/todos/4879140066) 

Problem 2: 
<img width="486" alt="image" src="https://user-images.githubusercontent.com/10802634/165637515-c574539b-8010-4389-a9ce-f7c8d89ee361.png">
Cards with video backgrounds but no poster image don't display the content box correctly. This is now fixed.
<img width="486" alt="image" src="https://user-images.githubusercontent.com/10802634/165637710-68eb0942-83c0-4bed-9f1a-95f3e1eeb011.png">

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Manually tested

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
