### PR TITLE
fix: where headers were set after sent to client

### DIFF
--- a/apps/journeys-admin/pages/api/preview.ts
+++ b/apps/journeys-admin/pages/api/preview.ts
@@ -1,4 +1,4 @@
-import type { NextApiHandler } from 'next'
+import type { NextApiRequest, NextApiResponse } from 'next'
 import { verifyIdToken } from 'next-firebase-auth'
 import fetch from 'node-fetch'
 import { initAuth } from '../../src/libs/firebaseClient/initAuth'
@@ -11,7 +11,10 @@ async function sleep(ms): Promise<void> {
   })
 }
 
-const handler: NextApiHandler = async (req, res) => {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
   if (req.cookies['journeys-admin.AuthUser'] == null) {
     return res.status(400).json({ error: 'Missing Authorization header value' })
   }
@@ -47,7 +50,5 @@ const handler: NextApiHandler = async (req, res) => {
   // 300ms required to invalidate edge caches
   await sleep(300)
 
-  return res.redirect(307, `${process.env.JOURNEYS_URL}/${slug}`).json({})
+  res.redirect(307, `${process.env.JOURNEYS_URL}/${slug}`)
 }
-
-export default handler


### PR DESCRIPTION
# Description

Fixes error attached below.

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] preview link should work

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main

```
{
	"id": "AQAAAYBtlEpk_Enp8AAAAABBWUJ0bEZQZkFBQzViM096emxXZEN3QUE",
	"content": {
		"timestamp": "2022-04-28T00:31:16.580Z",
		"tags": [
			"source:vercel"
		],
		"host": "journeys-admin-esoo36ph2-jesusfilm.vercel.app",
		"service": "admin.nextstep.is",
		"message": "START RequestId: 674dab71-d49e-49aa-83a9-f08cc5bd45fc Version: $LATEST\n2022-04-28T00:31:17.356Z\t674dab71-d49e-49aa-83a9-f08cc5bd45fc\tERROR\tError [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client\n    at new NodeError (internal/errors.js:322:7)\n    at ServerResponse.setHeader (_http_outgoing.js:561:11)\n    at sendJson (/var/task/node_modules/next/dist/server/api-utils/node.js:314:9)\n    at ServerResponse.apiRes.json (/var/task/node_modules/next/dist/server/api-utils/node.js:166:31)\n    at handler (/var/task/dist/apps/journeys-admin/.next/server/pages/api/preview.js:82:69)\n    at async Object.apiResolver (/var/task/node_modules/next/dist/server/api-utils/node.js:184:9)\n    at async NextNodeServer.runApi (/var/task/node_modules/next/dist/server/next-server.js:395:9)\n    at async Object.fn (/var/task/node_modules/next/dist/server/base-server.js:477:37)\n    at async Router.execute (/var/task/node_modules/next/dist/server/router.js:243:32)\n    at async NextNodeServer.run (/var/task/node_modules/next/dist/server/base-server.js:594:29) {\n  code: 'ERR_HTTP_HEADERS_SENT'\n}\n2022-04-28T00:31:17.356Z\t674dab71-d49e-49aa-83a9-f08cc5bd45fc\tERROR\tError [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client\n    at new NodeError (internal/errors.js:322:7)\n    at ServerResponse.setHeader (_http_outgoing.js:561:11)\n    at sendJson (/var/task/node_modules/next/dist/server/api-utils/node.js:314:9)\n    at ServerResponse.apiRes.json (/var/task/node_modules/next/dist/server/api-utils/node.js:166:31)\n    at handler (/var/task/dist/apps/journeys-admin/.next/server/pages/api/preview.js:82:69)\n    at async Object.apiResolver (/var/task/node_modules/next/dist/server/api-utils/node.js:184:9)\n    at async NextNodeServer.runApi (/var/task/node_modules/next/dist/server/next-server.js:395:9)\n    at async Object.fn (/var/task/node_modules/next/dist/server/base-server.js:477:37)\n    at async Router.execute (/var/task/node_modules/next/dist/server/router.js:243:32)\n    at async NextNodeServer.run (/var/task/node_modules/next/dist/server/base-server.js:594:29) {\n  code: 'ERR_HTTP_HEADERS_SENT'\n}\nEND RequestId: 674dab71-d49e-49aa-83a9-f08cc5bd45fc\nREPORT RequestId: 674dab71-d49e-49aa-83a9-f08cc5bd45fc\tDuration: 675.99 ms\tBilled Duration: 676 ms\tMemory Size: 1024 MB\tMax Memory Used: 75 MB\t\nRequestId: 674dab71-d49e-49aa-83a9-f08cc5bd45fc Error: Runtime exited with error: exit status 1\nRuntime.ExitError",
		"attributes": {
			"http": {
				"status_category": "Error"
			},
			"network": {
				"client": {
					"geoip": {
						"city": {
							"name": "Nelson"
						},
						"subdivision": {
							"name": "Nelson"
						},
						"country": {
							"iso_code": "NZ",
							"name": "New Zealand"
						},
						"as": {
							"route": "203.86.192.0/21",
							"type": "isp",
							"number": "AS23655",
							"domain": "2degrees.nz",
							"name": "2degrees Networks Limited"
						},
						"location": {
							"latitude": -41.285,
							"longitude": 173.2749
						},
						"timezone": "Pacific/Auckland",
						"ipAddress": "203.86.193.21",
						"continent": {
							"code": "OC",
							"name": "Oceania"
						}
					}
				}
			},
			"projectId": "prj_ZsU1kFm8Fp8ysQVJlEXB3k2sy6Gq",
			"source": "lambda",
			"deploymentId": "dpl_GJQcSd5wKwRLy35e8Ec77qqBfRpj",
			"url_host": "journeys-admin-esoo36ph2-jesusfilm.vercel.app",
			"proxy": {
				"timestamp": 1651105876580,
				"region": "syd1",
				"errorCode": "FUNCTION_INVOCATION_FAILED",
				"cacheId": "-",
				"host": "admin.nextstep.is",
				"referer": "https://admin.nextstep.is/journeys/untitled-journey-70bbd55a-5648-4040-9eb6-34722ce9c042/edit?stepId=62f04698-de51-4e25-9f59-5513f3324d1d",
				"userAgent": [
					"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36"
				],
				"path": "/api/preview?slug=untitled-journey-70bbd55a-5648-4040-9eb6-34722ce9c042",
				"clientIp": "203.86.193.21",
				"scheme": "https",
				"method": "GET",
				"statusCode": 500
			},
			"timestamp": 1651105876582,
			"path": "api/preview",
			"statusCode": -1,
			"id": "1651105876582833959897216582",
			"requestId": "syd1:syd1::rsxpf-1651105876580-f60cd76a3db0"
		}
	}
}
```