### PR TITLE
fix: update preview icons and href, update tests

### DIFF
--- a/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.spec.tsx
@@ -41,6 +41,7 @@ describe('Edit Toolbar', () => {
     const button = getAllByRole('link', { name: 'Preview' })[0]
     expect(button).toContainElement(getByTestId('VisibilityIcon'))
     expect(button).toHaveAttribute('href', '/api/preview?slug=untitled-journey')
+    expect(button).toHaveAttribute('target', '_blank')
     expect(button).not.toBeDisabled()
   })
 })

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.spec.tsx
@@ -39,7 +39,7 @@ describe('Edit Toolbar', () => {
       </SnackbarProvider>
     )
     const button = getAllByRole('link', { name: 'Preview' })[0]
-    expect(button).toContainElement(getByTestId('PreviewRoundedIcon'))
+    expect(button).toContainElement(getByTestId('VisibilityIcon'))
     expect(button).toHaveAttribute('href', '/api/preview?slug=untitled-journey')
     expect(button).not.toBeDisabled()
   })

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react'
 import IconButton from '@mui/material/IconButton'
-import PreviewRoundedIcon from '@mui/icons-material/PreviewRounded'
+import VisibilityIcon from '@mui/icons-material/Visibility'
 import { useJourney } from '../../../libs/context'
 import { DeleteBlock } from './DeleteBlock'
 import { Menu } from './Menu'
@@ -16,7 +16,7 @@ export function EditToolbar(): ReactElement {
         target="_blank"
         disabled={journey == null}
       >
-        <PreviewRoundedIcon />
+        <VisibilityIcon />
       </IconButton>
       <DeleteBlock variant="button" />
       <Menu />

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.spec.tsx
@@ -48,10 +48,10 @@ describe('EditToolbar Menu', () => {
       expect(getByRole('button')).toContainElement(getByTestId('MoreVertIcon'))
       fireEvent.click(getByRole('button'))
       expect(getByRole('menu')).toBeInTheDocument()
+      expect(getByRole('menuitem', { name: 'Preview' })).toBeInTheDocument()
       expect(
         getByRole('menuitem', { name: 'Delete Block' })
       ).toBeInTheDocument()
-
       expect(
         queryByRole('menuitem', { name: 'Social Settings' })
       ).not.toBeInTheDocument()
@@ -80,6 +80,7 @@ describe('EditToolbar Menu', () => {
       expect(getByRole('button')).toContainElement(getByTestId('MoreVertIcon'))
       fireEvent.click(getByRole('button'))
       expect(getByRole('menu')).toBeInTheDocument()
+      expect(getByRole('menuitem', { name: 'Preview' })).toBeInTheDocument()
       expect(getByRole('menuitem', { name: 'Delete Card' })).toBeInTheDocument()
       expect(
         queryByRole('menuitem', { name: 'Social Settings' })

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.tsx
@@ -5,6 +5,7 @@ import MuiMenu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import ListItemText from '@mui/material/ListItemText'
 import ListItemIcon from '@mui/material/ListItemIcon'
+import VisibilityIcon from '@mui/icons-material/Visibility'
 import Divider from '@mui/material/Divider'
 import { useEditor } from '@core/journeys/ui'
 import { Theme } from '@mui/material/styles'
@@ -14,6 +15,7 @@ import useMediaQuery from '@mui/material/useMediaQuery'
 import ShareRoundedIcon from '@mui/icons-material/ShareRounded'
 import { DeleteBlock } from '../DeleteBlock'
 import { useJourney } from '../../../../libs/context'
+import { JourneyStatus } from '../../../../../__generated__/globalTypes'
 
 export function Menu(): ReactElement {
   const {
@@ -35,6 +37,19 @@ export function Menu(): ReactElement {
   function BlockMenu(): ReactElement {
     return (
       <>
+        <MenuItem
+          disabled={journey?.status === JourneyStatus.draft}
+          component="a"
+          href={`/api/preview?slug=${journey?.slug ?? ''}`}
+          target="_blank"
+          rel="noopener"
+          onClick={handleCloseMenu}
+        >
+          <ListItemIcon>
+            <VisibilityIcon />
+          </ListItemIcon>
+          <ListItemText>Preview</ListItemText>
+        </MenuItem>
         <DeleteBlock variant="list-item" />
         {!smUp && (
           <MenuItem onClick={handleOpenSocial}>
@@ -51,6 +66,19 @@ export function Menu(): ReactElement {
   function CardMenu(): ReactElement {
     return (
       <>
+        <MenuItem
+          disabled={journey?.status === JourneyStatus.draft}
+          component="a"
+          href={`/api/preview?slug=${journey?.slug ?? ''}`}
+          target="_blank"
+          rel="noopener"
+          onClick={handleCloseMenu}
+        >
+          <ListItemIcon>
+            <VisibilityIcon />
+          </ListItemIcon>
+          <ListItemText>Preview</ListItemText>
+        </MenuItem>
         <DeleteBlock variant="list-item" closeMenu={handleCloseMenu} />
         {!smUp && (
           <MenuItem onClick={handleOpenSocial}>

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/JourneyCardMenu.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/JourneyCardMenu.spec.tsx
@@ -69,6 +69,10 @@ describe('JourneyCardMenu', () => {
       'href',
       '/api/preview?slug=published-journey'
     )
+    expect(getByRole('menuitem', { name: 'Preview' })).toHaveAttribute(
+      'target',
+      '_blank'
+    )
   })
 
   it('should have a disabled preview button is journey is draft', () => {

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/JourneyCardMenu.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/JourneyCardMenu.spec.tsx
@@ -67,7 +67,7 @@ describe('JourneyCardMenu', () => {
     fireEvent.click(getByRole('button'))
     expect(getByRole('menuitem', { name: 'Preview' })).toHaveAttribute(
       'href',
-      'https://your.nextstep.is/published-journey'
+      '/api/preview?slug=published-journey'
     )
   })
 

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/JourneyCardMenu.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/JourneyCardMenu.tsx
@@ -95,7 +95,7 @@ export function JourneyCardMenu({
             </ListItemText>
           </MenuItem>
         ) : (
-          <Link href={`https://your.nextstep.is/${slug}`} passHref>
+          <Link href={`/api/preview?slug=${slug}`} passHref>
             <MenuItem sx={{ pl: 7, pr: 17, pt: 4, pb: 4 }}>
               <ListItemIcon>
                 <VisibilityIcon color="secondary" />

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/JourneyCardMenu.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/JourneyCardMenu.tsx
@@ -83,31 +83,23 @@ export function JourneyCardMenu({
           </ListItemText>
         </MenuItem>
 
-        {status === JourneyStatus.draft ? (
-          <MenuItem disabled sx={{ pl: 7, pr: 17, pt: 4, pb: 4 }}>
-            <ListItemIcon>
-              <VisibilityIcon color="secondary" />
-            </ListItemIcon>
-            <ListItemText>
-              <Typography variant="body1" sx={{ pl: 2 }}>
-                Preview
-              </Typography>
-            </ListItemText>
-          </MenuItem>
-        ) : (
-          <Link href={`/api/preview?slug=${slug}`} passHref>
-            <MenuItem sx={{ pl: 7, pr: 17, pt: 4, pb: 4 }}>
-              <ListItemIcon>
-                <VisibilityIcon color="secondary" />
-              </ListItemIcon>
-              <ListItemText>
-                <Typography variant="body1" sx={{ pl: 2 }}>
-                  Preview
-                </Typography>
-              </ListItemText>
-            </MenuItem>
-          </Link>
-        )}
+        <MenuItem
+          sx={{ pl: 7, pr: 17, pt: 4, pb: 4 }}
+          disabled={status === JourneyStatus.draft}
+          component="a"
+          href={`/api/preview?slug=${slug}`}
+          target="_blank"
+          rel="noopener"
+        >
+          <ListItemIcon>
+            <VisibilityIcon color="secondary" />
+          </ListItemIcon>
+          <ListItemText>
+            <Typography variant="body1" sx={{ pl: 2 }}>
+              Preview
+            </Typography>
+          </ListItemText>
+        </MenuItem>
       </Menu>
 
       <AccessDialog

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.spec.tsx
@@ -63,6 +63,10 @@ describe('JourneyView/Menu', () => {
       'href',
       `/api/preview?slug=${publishedJourney.slug}`
     )
+    expect(getByRole('menuitem', { name: 'Preview' })).toHaveAttribute(
+      'target',
+      '_blank'
+    )
   })
 
   it('should publish when clicked', async () => {

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.spec.tsx
@@ -61,7 +61,7 @@ describe('JourneyView/Menu', () => {
     fireEvent.click(getByRole('button'))
     expect(getByRole('menuitem', { name: 'Preview' })).toHaveAttribute(
       'href',
-      `https://your.nextstep.is/${publishedJourney.slug}`
+      `/api/preview?slug=${publishedJourney.slug}`
     )
   })
 

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
@@ -7,7 +7,7 @@ import MenuItem from '@mui/material/MenuItem'
 import ListItemText from '@mui/material/ListItemText'
 import ListItemIcon from '@mui/material/ListItemIcon'
 import MoreVert from '@mui/icons-material/MoreVert'
-import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn'
+import BeenHereRoundedIcon from '@mui/icons-material/BeenhereRounded'
 import VisibilityIcon from '@mui/icons-material/Visibility'
 import EditIcon from '@mui/icons-material/Edit'
 import DescriptionIcon from '@mui/icons-material/Description'
@@ -116,13 +116,13 @@ export function Menu({ forceOpen }: MenuProps): ReactElement {
             <MenuItem
               disabled={journey.status === JourneyStatus.draft}
               component="a"
-              href={`https://your.nextstep.is/${journey.slug}`}
+              href={`/api/preview?slug=${journey.slug}`}
               target="_blank"
               rel="noopener"
               onClick={handleCloseMenu}
             >
               <ListItemIcon>
-                <AssignmentTurnedInIcon />
+                <VisibilityIcon />
               </ListItemIcon>
               <ListItemText>Preview</ListItemText>
             </MenuItem>
@@ -131,7 +131,7 @@ export function Menu({ forceOpen }: MenuProps): ReactElement {
               onClick={handlePublish}
             >
               <ListItemIcon>
-                <VisibilityIcon />
+                <BeenHereRoundedIcon />
               </ListItemIcon>
               <ListItemText>Publish</ListItemText>
             </MenuItem>


### PR DESCRIPTION
# Description

All Preview icons should be consistent and point to the newly created endpoint for viewing journeys while in admin.

- [Link to Basecamp Todo
](https://3.basecamp.com/3105655/buckets/27244374/todos/4883549626)
# How should this PR be QA Tested?

Setup described in https://github.com/JesusFilm/core/pull/535

- [x] Manually test all preview buttons (JourneyList in dropdown, JourneyDetails in dropdown in toolbar up top, Editor in toolbar) take you to a working preview.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
