### PR TITLE
fix: card preview spacing

### DIFF
--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
@@ -168,9 +168,8 @@ export function CardPreview({
                 variant="outlined"
                 sx={{
                   display: 'flex',
-                  width: 87,
-                  height: 132,
-                  m: 1
+                  width: 89,
+                  height: 134
                 }}
               >
                 <CardActionArea
@@ -194,7 +193,8 @@ export function CardPreview({
               data-testid={`preview-${step.id}`}
               sx={{
                 width: 95,
-                height: 140
+                height: 140,
+                margin: '-3px'
               }}
             >
               <Box

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundColor/BackgroundColor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundColor/BackgroundColor.spec.tsx
@@ -81,7 +81,7 @@ describe('BackgroundColor', () => {
 
     // Palette picker
     expect(getAllByTestId('#FEFEFE')[0].parentElement).toHaveStyle({
-      outline: '2px solid #C52D3A'
+      border: '2px solid #C52D3A'
     })
     expect(getAllByTestId('#FEFEFE')[0]).toHaveStyle({
       backgroundColor: '#FEFEFE'

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.tsx
@@ -73,7 +73,12 @@ export function ControlPanel(): ReactElement {
           />
         </Tabs>
       </Box>
-      <TabPanel name="control-panel" value={activeTab} index={0}>
+      <TabPanel
+        sx={{ height: 186 }}
+        name="control-panel"
+        value={activeTab}
+        index={0}
+      >
         <CardPreview
           selected={selectedStep}
           onSelect={handleSelectStepPreview}
@@ -81,12 +86,22 @@ export function ControlPanel(): ReactElement {
           showAddButton
         />
       </TabPanel>
-      <TabPanel name="control-panel" value={activeTab} index={1}>
+      <TabPanel
+        sx={{ height: 186 }}
+        name="control-panel"
+        value={activeTab}
+        index={1}
+      >
         {selectedBlock !== undefined && selectedStep !== undefined && (
           <Attributes selected={selectedBlock} step={selectedStep} />
         )}
       </TabPanel>
-      <TabPanel name="control-panel" value={activeTab} index={2}>
+      <TabPanel
+        sx={{ height: 186 }}
+        name="control-panel"
+        value={activeTab}
+        index={2}
+      >
         <BlocksTab />
       </TabPanel>
     </Box>

--- a/apps/journeys-admin/src/components/Editor/Editor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.spec.tsx
@@ -83,8 +83,8 @@ describe('Editor', () => {
         </ThemeProvider>
       </MockedProvider>
     )
-    expect(getByTestId('preview-step1.id').parentElement).toHaveStyle(
-      'outline: 2px solid #C52D3A'
-    )
+    expect(getByTestId('preview-step1.id').parentElement).toHaveStyle({
+      border: '2px solid #C52D3A'
+    })
   })
 })

--- a/apps/journeys-admin/src/components/HorizontalSelect/HorizontalSelect.spec.tsx
+++ b/apps/journeys-admin/src/components/HorizontalSelect/HorizontalSelect.spec.tsx
@@ -22,9 +22,9 @@ describe('HorizontalSelect', () => {
         <Box id="step2.id">Option 2</Box>
       </HorizontalSelect>
     )
-    expect(getByText('Option 1').parentElement).toHaveStyle(
-      'outline: 2px solid #1976d2'
-    )
+    expect(getByText('Option 1').parentElement).toHaveStyle({
+      border: '2px solid #1976d2'
+    })
   })
 
   it('should display footer', () => {

--- a/apps/journeys-admin/src/components/HorizontalSelect/HorizontalSelect.tsx
+++ b/apps/journeys-admin/src/components/HorizontalSelect/HorizontalSelect.tsx
@@ -62,7 +62,8 @@ export function HorizontalSelect({
                   id === child.props.id
                     ? `2px solid ${theme.palette.primary.main} `
                     : '2px solid transparent',
-                cursor: 'pointer'
+                cursor: 'pointer',
+                margin: '1px'
               }}
               onClick={() => onChange?.(child.props.id)}
             >

--- a/apps/journeys-admin/src/components/HorizontalSelect/HorizontalSelect.tsx
+++ b/apps/journeys-admin/src/components/HorizontalSelect/HorizontalSelect.tsx
@@ -57,11 +57,11 @@ export function HorizontalSelect({
                 borderRadius: 2,
                 transition: '0.2s border-color ease-out',
                 position: 'relative',
-                outline: (theme) =>
+                padding: '3px',
+                border: (theme) =>
                   id === child.props.id
                     ? `2px solid ${theme.palette.primary.main} `
                     : '2px solid transparent',
-                border: '3px solid transparent',
                 cursor: 'pointer'
               }}
               onClick={() => onChange?.(child.props.id)}
@@ -83,7 +83,8 @@ export function HorizontalSelect({
       {footer != null && (
         <Box
           sx={{
-            border: '3px solid transparent'
+            padding: '3px',
+            border: '2px solid transparent'
           }}
         >
           {footer}

--- a/libs/shared/ui/src/components/TabPanel/TabPanel.tsx
+++ b/libs/shared/ui/src/components/TabPanel/TabPanel.tsx
@@ -1,28 +1,31 @@
 import { ReactElement, ReactNode } from 'react'
+import Box from '@mui/material/Box'
+import { SxProps } from '@mui/system/styleFunctionSx'
 
 interface TabPanelProps {
   name: string
   children?: ReactNode
   value: number
   index: number
+  sx?: SxProps
 }
 export function TabPanel({
   name,
   children,
   value,
   index,
-  ...other
+  sx
 }: TabPanelProps): ReactElement {
   return (
-    <div
+    <Box
       role="tabpanel"
       hidden={value !== index}
       id={`${name}-tabpanel-${index}`}
       aria-labelledby={`${name}-tab-${index}`}
-      {...other}
+      sx={sx}
     >
       {children}
-    </div>
+    </Box>
   )
 }
 


### PR DESCRIPTION
# Description

Border on card preview is too large. Also outline border-radius does not work on safari or in VR.

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] VR should match figma for card preview.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
