### PR TITLE
fix: video playing in next card properties

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/SelectedCard.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/SelectedCard.tsx
@@ -16,6 +16,8 @@ import {
   ThemeName
 } from '../../../../../../../../../__generated__/globalTypes'
 import { FramePortal } from '../../../../../../../FramePortal'
+import { VideoWrapper } from '../../../../../../Canvas/VideoWrapper'
+import { CardWrapper } from '../../../../../../Canvas/CardWrapper'
 
 export const STEP_BLOCK_DEFAULT_NEXT_BLOCK_UPDATE = gql`
   mutation StepBlockDefaultNextBlockUpdate(
@@ -103,6 +105,10 @@ export function SelectedCard(): ReactElement {
                         ? nextStep
                         : (selectedBlock as TreeBlock<StepFields>)
                     }
+                    wrappers={{
+                      VideoWrapper,
+                      CardWrapper
+                    }}
                   />
                 </Box>
               </ThemeProvider>


### PR DESCRIPTION
# Description

Video player not displayed correctly on next card properties

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/27244374/todos/4883168152)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] In the Editor, click on a card and click on the next card button. Videos shouldn't be playing in the Next Card Properties drawer
- [ ] In the Editor, click on a card and click on the next card button. Background videos shouldn't be playing in the Next Card Properties drawer

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
