### PR TITLE
fix: journey progress at bottom on desktop

### DIFF
--- a/apps/journeys/src/components/Conductor/Conductor.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.tsx
@@ -92,10 +92,10 @@ export function Conductor({ blocks }: ConductorProps): ReactElement {
   return (
     <Div100vh>
       <Stack
-        direction={breakpoints.lg ? 'column-reverse' : 'column'}
         sx={{
           justifyContent: 'center',
-          height: '100%'
+          height: '100%',
+          flexDirection: { lg: 'column-reverse' }
         }}
       >
         <Box


### PR DESCRIPTION
# Description

conductor journey progress was in the wrong place on lg resolutions because under SSR the styles were set incorrectly. This defers to CSS to position this correctly. 

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] go to journey on desktop. journey progress bar should be at the bottom of page before load.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
