### PR TITLE
fix: add emotion cache

### DIFF
--- a/apps/journeys-admin/pages/_app.tsx
+++ b/apps/journeys-admin/pages/_app.tsx
@@ -16,7 +16,7 @@ import { initAuth } from '../src/libs/firebaseClient/initAuth'
 initAuth()
 const clientSideEmotionCache = createEmotionCache()
 
-function JourneysAdminApp({
+export default function JourneysAdminApp({
   Component,
   pageProps,
   emotionCache = clientSideEmotionCache
@@ -81,5 +81,3 @@ function JourneysAdminApp({
     </CacheProvider>
   )
 }
-
-export default JourneysAdminApp

--- a/apps/journeys-admin/pages/_app.tsx
+++ b/apps/journeys-admin/pages/_app.tsx
@@ -6,13 +6,21 @@ import { SnackbarProvider } from 'notistack'
 import { DefaultSeo } from 'next-seo'
 import TagManager from 'react-gtm-module'
 import { datadogRum } from '@datadog/browser-rum'
+import { CacheProvider } from '@emotion/react'
+import type { EmotionCache } from '@emotion/cache'
+import { createEmotionCache } from '@core/shared/ui'
 import { useApollo } from '../src/libs/apolloClient'
 import { ThemeProvider } from '../src/components/ThemeProvider'
 import { initAuth } from '../src/libs/firebaseClient/initAuth'
 
 initAuth()
+const clientSideEmotionCache = createEmotionCache()
 
-function JourneysAdminApp({ Component, pageProps }: AppProps): ReactElement {
+function JourneysAdminApp({
+  Component,
+  pageProps,
+  emotionCache = clientSideEmotionCache
+}: AppProps & { emotionCache?: EmotionCache }): ReactElement {
   const token =
     (pageProps.AuthUserSerialized != null
       ? (JSON.parse(pageProps.AuthUserSerialized)._token as string | null)
@@ -47,7 +55,7 @@ function JourneysAdminApp({ Component, pageProps }: AppProps): ReactElement {
   }, [])
 
   return (
-    <>
+    <CacheProvider value={emotionCache}>
       <DefaultSeo
         titleTemplate="%s | Next Steps"
         defaultTitle="Admin | Next Steps"
@@ -70,7 +78,7 @@ function JourneysAdminApp({ Component, pageProps }: AppProps): ReactElement {
           </SnackbarProvider>
         </ApolloProvider>
       </ThemeProvider>
-    </>
+    </CacheProvider>
   )
 }
 

--- a/apps/journeys-admin/pages/_document.tsx
+++ b/apps/journeys-admin/pages/_document.tsx
@@ -1,8 +1,13 @@
-import { Children, ReactElement } from 'react'
+import { ReactElement, FunctionComponent } from 'react'
 import Document, { Html, Head, Main, NextScript } from 'next/document'
-import ServerStyleSheets from '@mui/styles/ServerStyleSheets'
+import createEmotionServer from '@emotion/server/create-instance'
+import type { EmotionCache } from '@emotion/cache'
+import type { Enhancer, AppType } from 'next/dist/shared/lib/utils'
+import { createEmotionCache } from '@core/shared/ui'
 
-export default class MyDocument extends Document {
+export default class MyDocument extends Document<{
+  emotionStyleTags: ReactElement[]
+}> {
   render(): ReactElement {
     return (
       <Html lang="en">
@@ -41,7 +46,7 @@ export default class MyDocument extends Document {
 }
 
 // `getInitialProps` belongs to `_document` (instead of `_app`),
-// it's compatible with server-side generation (SSG).
+// it's compatible with static-site generation (SSG).
 MyDocument.getInitialProps = async (ctx) => {
   // Resolution order
   //
@@ -65,20 +70,37 @@ MyDocument.getInitialProps = async (ctx) => {
   // 3. app.render
   // 4. page.render
 
-  // Render app and page and get the context of the page with collected side effects.
-  const sheets = new ServerStyleSheets()
   const originalRenderPage = ctx.renderPage
+
+  // You can consider sharing the same emotion cache between all the SSR requests to speed up performance.
+  // However, be aware that it can have global side effects.
+  const cache = createEmotionCache()
+  const { extractCriticalToChunks } = createEmotionServer(cache)
 
   ctx.renderPage = () =>
     originalRenderPage({
-      enhanceApp: (App) => (props) => sheets.collect(<App {...props} />)
+      enhanceApp: ((App: FunctionComponent<{ emotionCache: EmotionCache }>) => {
+        return function EnhanceApp(props) {
+          return <App emotionCache={cache} {...props} />
+        }
+      }) as unknown as Enhancer<AppType>
     })
 
   const initialProps = await Document.getInitialProps(ctx)
+  // This is important. It prevents emotion to render invalid HTML.
+  // See https://github.com/mui/material-ui/issues/26561#issuecomment-855286153
+  const emotionStyles = extractCriticalToChunks(initialProps.html)
+  const emotionStyleTags = emotionStyles.styles.map((style) => (
+    <style
+      data-emotion={`${style.key} ${style.ids.join(' ')}`}
+      key={style.key}
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: style.css }}
+    />
+  ))
 
   return {
     ...initialProps,
-    // Styles fragment is rendered after the app and page rendering finish.
-    styles: [...Children.toArray(initialProps.styles), sheets.getStyleElement()]
+    emotionStyleTags
   }
 }

--- a/apps/journeys/pages/_app.tsx
+++ b/apps/journeys/pages/_app.tsx
@@ -15,7 +15,7 @@ import { firebaseClient } from '../src/libs/firebaseClient'
 
 const clientSideEmotionCache = createEmotionCache()
 
-function CustomApp({
+export default function JourneysApp({
   Component,
   pageProps,
   emotionCache = clientSideEmotionCache
@@ -76,5 +76,3 @@ function CustomApp({
     </CacheProvider>
   )
 }
-
-export default CustomApp

--- a/apps/journeys/pages/_app.tsx
+++ b/apps/journeys/pages/_app.tsx
@@ -7,10 +7,19 @@ import { getAuth, signInAnonymously } from 'firebase/auth'
 import { DefaultSeo } from 'next-seo'
 import TagManager from 'react-gtm-module'
 import { datadogRum } from '@datadog/browser-rum'
+import { CacheProvider } from '@emotion/react'
+import type { EmotionCache } from '@emotion/cache'
+import { createEmotionCache } from '@core/shared/ui'
 import { createApolloClient } from '../src/libs/client'
 import { firebaseClient } from '../src/libs/firebaseClient'
 
-function CustomApp({ Component, pageProps }: AppProps): ReactElement {
+const clientSideEmotionCache = createEmotionCache()
+
+function CustomApp({
+  Component,
+  pageProps,
+  emotionCache = clientSideEmotionCache
+}: AppProps & { emotionCache?: EmotionCache }): ReactElement {
   const auth = getAuth(firebaseClient)
   const [user] = useAuthState(auth)
   const client = createApolloClient(user?.accessToken)
@@ -50,7 +59,7 @@ function CustomApp({ Component, pageProps }: AppProps): ReactElement {
   }, [])
 
   return (
-    <>
+    <CacheProvider value={emotionCache}>
       <DefaultSeo
         titleTemplate="%s | Next Steps"
         defaultTitle="Next Steps | Helping you find the next best step on your spiritual journey"
@@ -64,7 +73,7 @@ function CustomApp({ Component, pageProps }: AppProps): ReactElement {
       <ApolloProvider client={client}>
         <Component {...pageProps} />
       </ApolloProvider>
-    </>
+    </CacheProvider>
   )
 }
 

--- a/apps/watch-admin/pages/_app.tsx
+++ b/apps/watch-admin/pages/_app.tsx
@@ -14,7 +14,7 @@ import { initAuth } from '../src/libs/firebaseClient/initAuth'
 initAuth()
 const clientSideEmotionCache = createEmotionCache()
 
-function CustomApp({
+export default function WatchAdminApp({
   Component,
   pageProps,
   emotionCache = clientSideEmotionCache
@@ -61,5 +61,3 @@ function CustomApp({
     </CacheProvider>
   )
 }
-
-export default JourneysAdminApp

--- a/apps/watch-admin/pages/_app.tsx
+++ b/apps/watch-admin/pages/_app.tsx
@@ -4,13 +4,21 @@ import Head from 'next/head'
 import { ApolloProvider } from '@apollo/client'
 import { SnackbarProvider } from 'notistack'
 import { DefaultSeo } from 'next-seo'
+import { CacheProvider } from '@emotion/react'
+import type { EmotionCache } from '@emotion/cache'
+import { createEmotionCache } from '@core/shared/ui'
 import { useApollo } from '../src/libs/apolloClient'
 import { ThemeProvider } from '../src/components/ThemeProvider'
 import { initAuth } from '../src/libs/firebaseClient/initAuth'
 
 initAuth()
+const clientSideEmotionCache = createEmotionCache()
 
-function JourneysAdminApp({ Component, pageProps }: AppProps): ReactElement {
+function CustomApp({
+  Component,
+  pageProps,
+  emotionCache = clientSideEmotionCache
+}: AppProps & { emotionCache?: EmotionCache }): ReactElement {
   const apolloClient = useApollo(
     pageProps.AuthUserSerialized != null
       ? JSON.parse(pageProps.AuthUserSerialized)._token
@@ -27,7 +35,7 @@ function JourneysAdminApp({ Component, pageProps }: AppProps): ReactElement {
   }, [])
 
   return (
-    <>
+    <CacheProvider value={emotionCache}>
       <DefaultSeo
         titleTemplate="%s | Next Steps"
         defaultTitle="Admin | Next Steps"
@@ -50,7 +58,7 @@ function JourneysAdminApp({ Component, pageProps }: AppProps): ReactElement {
           </SnackbarProvider>
         </ApolloProvider>
       </ThemeProvider>
-    </>
+    </CacheProvider>
   )
 }
 

--- a/apps/watch-admin/pages/_document.tsx
+++ b/apps/watch-admin/pages/_document.tsx
@@ -1,6 +1,9 @@
-import { Children, ReactElement } from 'react'
+import { ReactElement, FunctionComponent } from 'react'
 import Document, { Html, Head, Main, NextScript } from 'next/document'
-import ServerStyleSheets from '@mui/styles/ServerStyleSheets'
+import createEmotionServer from '@emotion/server/create-instance'
+import type { EmotionCache } from '@emotion/cache'
+import type { Enhancer, AppType } from 'next/dist/shared/lib/utils'
+import { createEmotionCache } from '@core/shared/ui'
 
 export default class MyDocument extends Document {
   render(): ReactElement {
@@ -36,7 +39,7 @@ export default class MyDocument extends Document {
 }
 
 // `getInitialProps` belongs to `_document` (instead of `_app`),
-// it's compatible with server-side generation (SSG).
+// it's compatible with static-site generation (SSG).
 MyDocument.getInitialProps = async (ctx) => {
   // Resolution order
   //
@@ -60,20 +63,37 @@ MyDocument.getInitialProps = async (ctx) => {
   // 3. app.render
   // 4. page.render
 
-  // Render app and page and get the context of the page with collected side effects.
-  const sheets = new ServerStyleSheets()
   const originalRenderPage = ctx.renderPage
+
+  // You can consider sharing the same emotion cache between all the SSR requests to speed up performance.
+  // However, be aware that it can have global side effects.
+  const cache = createEmotionCache()
+  const { extractCriticalToChunks } = createEmotionServer(cache)
 
   ctx.renderPage = () =>
     originalRenderPage({
-      enhanceApp: (App) => (props) => sheets.collect(<App {...props} />)
+      enhanceApp: ((App: FunctionComponent<{ emotionCache: EmotionCache }>) => {
+        return function EnhanceApp(props) {
+          return <App emotionCache={cache} {...props} />
+        }
+      }) as unknown as Enhancer<AppType>
     })
 
   const initialProps = await Document.getInitialProps(ctx)
+  // This is important. It prevents emotion to render invalid HTML.
+  // See https://github.com/mui/material-ui/issues/26561#issuecomment-855286153
+  const emotionStyles = extractCriticalToChunks(initialProps.html)
+  const emotionStyleTags = emotionStyles.styles.map((style) => (
+    <style
+      data-emotion={`${style.key} ${style.ids.join(' ')}`}
+      key={style.key}
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: style.css }}
+    />
+  ))
 
   return {
     ...initialProps,
-    // Styles fragment is rendered after the app and page rendering finish.
-    styles: [...Children.toArray(initialProps.styles), sheets.getStyleElement()]
+    emotionStyleTags
   }
 }

--- a/apps/watch/pages/_app.tsx
+++ b/apps/watch/pages/_app.tsx
@@ -5,10 +5,19 @@ import { ApolloProvider } from '@apollo/client'
 import { useAuthState } from 'react-firebase-hooks/auth'
 import { getAuth, signInAnonymously } from 'firebase/auth'
 import { DefaultSeo } from 'next-seo'
-import { createApolloClient } from '../src/libs/client'
+import { CacheProvider } from '@emotion/react'
+import type { EmotionCache } from '@emotion/cache'
+import { createEmotionCache } from '@core/shared/ui'
 import { firebaseClient } from '../src/libs/firebaseClient'
+import { createApolloClient } from '../src/libs/client'
 
-function CustomApp({ Component, pageProps }: AppProps): ReactElement {
+const clientSideEmotionCache = createEmotionCache()
+
+function CustomApp({
+  Component,
+  pageProps,
+  emotionCache = clientSideEmotionCache
+}: AppProps & { emotionCache?: EmotionCache }): ReactElement {
   const auth = getAuth(firebaseClient)
   const [user] = useAuthState(auth)
   const client = createApolloClient(user?.accessToken)
@@ -29,7 +38,7 @@ function CustomApp({ Component, pageProps }: AppProps): ReactElement {
   }, [])
 
   return (
-    <>
+    <CacheProvider value={emotionCache}>
       <DefaultSeo
         titleTemplate="%s | Next Steps"
         defaultTitle="Next Steps | Helping you find the next best step on your spiritual journey"
@@ -43,7 +52,7 @@ function CustomApp({ Component, pageProps }: AppProps): ReactElement {
       <ApolloProvider client={client}>
         <Component {...pageProps} />
       </ApolloProvider>
-    </>
+    </CacheProvider>
   )
 }
 

--- a/apps/watch/pages/_app.tsx
+++ b/apps/watch/pages/_app.tsx
@@ -13,7 +13,7 @@ import { createApolloClient } from '../src/libs/client'
 
 const clientSideEmotionCache = createEmotionCache()
 
-function CustomApp({
+export default function WatchApp({
   Component,
   pageProps,
   emotionCache = clientSideEmotionCache
@@ -55,5 +55,3 @@ function CustomApp({
     </CacheProvider>
   )
 }
-
-export default CustomApp

--- a/apps/watch/pages/_document.tsx
+++ b/apps/watch/pages/_document.tsx
@@ -1,6 +1,9 @@
-import { Children, ReactElement } from 'react'
+import { ReactElement, FunctionComponent } from 'react'
 import Document, { Html, Head, Main, NextScript } from 'next/document'
-import { ServerStyleSheets } from '@mui/styles'
+import createEmotionServer from '@emotion/server/create-instance'
+import type { EmotionCache } from '@emotion/cache'
+import type { Enhancer, AppType } from 'next/dist/shared/lib/utils'
+import { createEmotionCache } from '@core/shared/ui'
 
 export default class MyDocument extends Document {
   render(): ReactElement {
@@ -36,7 +39,7 @@ export default class MyDocument extends Document {
 }
 
 // `getInitialProps` belongs to `_document` (instead of `_app`),
-// it's compatible with server-side generation (SSG).
+// it's compatible with static-site generation (SSG).
 MyDocument.getInitialProps = async (ctx) => {
   // Resolution order
   //
@@ -60,20 +63,37 @@ MyDocument.getInitialProps = async (ctx) => {
   // 3. app.render
   // 4. page.render
 
-  // Render app and page and get the context of the page with collected side effects.
-  const sheets = new ServerStyleSheets()
   const originalRenderPage = ctx.renderPage
+
+  // You can consider sharing the same emotion cache between all the SSR requests to speed up performance.
+  // However, be aware that it can have global side effects.
+  const cache = createEmotionCache()
+  const { extractCriticalToChunks } = createEmotionServer(cache)
 
   ctx.renderPage = () =>
     originalRenderPage({
-      enhanceApp: (App) => (props) => sheets.collect(<App {...props} />)
+      enhanceApp: ((App: FunctionComponent<{ emotionCache: EmotionCache }>) => {
+        return function EnhanceApp(props) {
+          return <App emotionCache={cache} {...props} />
+        }
+      }) as unknown as Enhancer<AppType>
     })
 
   const initialProps = await Document.getInitialProps(ctx)
+  // This is important. It prevents emotion to render invalid HTML.
+  // See https://github.com/mui/material-ui/issues/26561#issuecomment-855286153
+  const emotionStyles = extractCriticalToChunks(initialProps.html)
+  const emotionStyleTags = emotionStyles.styles.map((style) => (
+    <style
+      data-emotion={`${style.key} ${style.ids.join(' ')}`}
+      key={style.key}
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: style.css }}
+    />
+  ))
 
   return {
     ...initialProps,
-    // Styles fragment is rendered after the app and page rendering finish.
-    styles: [...Children.toArray(initialProps.styles), sheets.getStyleElement()]
+    emotionStyleTags
   }
 }

--- a/libs/shared/ui/src/index.ts
+++ b/libs/shared/ui/src/index.ts
@@ -5,6 +5,7 @@ export { TabPanel, tabA11yProps } from './components/TabPanel'
 export { sharedUiConfig, simpleComponentConfig } from './libs/storybook/config'
 export { themes } from './libs/themes'
 export { useBreakpoints } from './libs/useBreakpoints'
+export { createEmotionCache } from './libs/emotion/cache'
 export {
   secondsToTimeFormat,
   timeFormatToSeconds,

--- a/libs/shared/ui/src/libs/emotion/cache.ts
+++ b/libs/shared/ui/src/libs/emotion/cache.ts
@@ -1,0 +1,7 @@
+import createCache, { EmotionCache } from '@emotion/cache'
+
+// prepend: true moves MUI styles to the top of the <head> so they're loaded first.
+// It allows developers to easily override MUI styles with other styling solutions, like CSS modules.
+export function createEmotionCache(): EmotionCache {
+  return createCache({ key: 'css', prepend: true })
+}


### PR DESCRIPTION
# Description

This is causing a render reload on the frontend for SSR pages. This should stop that from happening as SSR rendered emotion css classes should now match the frontend.

https://github.com/mui/material-ui/blob/master/examples/nextjs/pages/_document.js

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] no error on journeys page saying 'class mismatch'

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
