### PR TITLE
fix: initial card background image parentOrder

### DIFF
--- a/apps/journeys-admin/src/components/JourneyList/AddJourneyButton/AddJourneyButton.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/AddJourneyButton/AddJourneyButton.spec.tsx
@@ -26,7 +26,13 @@ describe('AddJourneyButton', () => {
       description:
         'Use journey description for notes about the audience, topic, traffic source, etc. Only you and other editors can see it.',
       id: 'journeyId',
-      languageId: '529',
+      language: {
+        id: '529',
+        name: {
+          value: 'English',
+          primary: true
+        }
+      },
       publishedAt: null,
       slug: 'untitled-journey-journeyId',
       status: 'draft',

--- a/apps/journeys-admin/src/components/JourneyList/AddJourneyButton/AddJourneyButton.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/AddJourneyButton/AddJourneyButton.tsx
@@ -61,12 +61,7 @@ export const JOURNEY_CREATE = gql`
       id
     }
     cardBlockCreate(
-      input: {
-        id: $cardId
-        parentBlockId: $stepId
-        journeyId: $journeyId
-        coverBlockId: $imageId
-      }
+      input: { id: $cardId, parentBlockId: $stepId, journeyId: $journeyId }
     ) {
       id
     }
@@ -78,6 +73,7 @@ export const JOURNEY_CREATE = gql`
         src: "https://images.unsplash.com/photo-1524414287096-c7fb74ab3ba0?w=854&q=50"
         alt: $alt
         blurhash: "LgFiG+59PC=s|AE3XT$gnjngs7Ne"
+        isCover: true
       }
     ) {
       id


### PR DESCRIPTION
# Description

Default Journey creates a card with background image incorrectly. Fix this so it's a cover with parentOrder: null

[- Link to Basecamp Todo
](https://3.basecamp.com/3105655/buckets/27244374/todos/4879140066)
# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Swap images after creating a default journey, it should switch as expected without a standalone image being generated.

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
