### PR TITLE
fix: deprecate heading and description in radioquestionblock

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -437,7 +437,7 @@ type Mutation {
   radioOptionBlockCreate(input: RadioOptionBlockCreateInput!): RadioOptionBlock! @join__field(graph: JOURNEYS)
   radioOptionBlockUpdate(id: ID!, input: RadioOptionBlockUpdateInput!, journeyId: ID!): RadioOptionBlock! @join__field(graph: JOURNEYS)
   radioQuestionBlockCreate(input: RadioQuestionBlockCreateInput!): RadioQuestionBlock! @join__field(graph: JOURNEYS)
-  radioQuestionBlockUpdate(id: ID!, input: RadioQuestionBlockUpdateInput!, journeyId: ID!): RadioQuestionBlock! @join__field(graph: JOURNEYS)
+  radioQuestionBlockUpdate(id: ID!, journeyId: ID!, parentBlockId: ID!): RadioQuestionBlock! @join__field(graph: JOURNEYS)
   radioQuestionResponseCreate(input: RadioQuestionResponseCreateInput!): RadioQuestionResponse! @join__field(graph: JOURNEYS)
   radioQuestionSubmissionEventCreate(input: RadioQuestionSubmissionEventCreateInput!): RadioQuestionSubmissionEvent! @join__field(graph: JOURNEYS)
   signUpBlockCreate(input: SignUpBlockCreateInput!): SignUpBlock! @join__field(graph: JOURNEYS)
@@ -535,10 +535,8 @@ input RadioOptionBlockUpdateInput {
 }
 
 type RadioQuestionBlock implements Block {
-  description: String
   id: ID!
   journeyId: ID!
-  label: String!
   parentBlockId: ID
   parentOrder: Int
 }
@@ -546,14 +544,7 @@ type RadioQuestionBlock implements Block {
 input RadioQuestionBlockCreateInput {
   id: ID
   journeyId: ID!
-  label: String!
   parentBlockId: ID!
-}
-
-input RadioQuestionBlockUpdateInput {
-  description: String
-  label: String
-  parentBlockId: ID
 }
 
 type RadioQuestionResponse implements Response {

--- a/apps/api-journeys/db/seeds/nua1.ts
+++ b/apps/api-journeys/db/seeds/nua1.ts
@@ -252,7 +252,6 @@ export async function nua1(): Promise<void> {
     journeyId: journey._key,
     __typename: 'RadioQuestionBlock',
     parentBlockId: card3._key,
-    label: '',
     parentOrder: 2
   })
 
@@ -485,7 +484,6 @@ export async function nua1(): Promise<void> {
     journeyId: journey._key,
     __typename: 'RadioQuestionBlock',
     parentBlockId: card6._key,
-    label: '',
     parentOrder: 2
   })
 

--- a/apps/api-journeys/db/seeds/nua2.ts
+++ b/apps/api-journeys/db/seeds/nua2.ts
@@ -249,7 +249,6 @@ export async function nua2(): Promise<void> {
     journeyId: journey._key,
     __typename: 'RadioQuestionBlock',
     parentBlockId: card3._key,
-    label: '',
     parentOrder: 2
   })
 
@@ -536,11 +535,6 @@ export async function nua2(): Promise<void> {
     journeyId: journey._key,
     __typename: 'RadioQuestionBlock',
     parentBlockId: card7._key,
-    label: '',
-    action: {
-      gtmEventName: 'click',
-      journeyId: '3'
-    },
     parentOrder: 2
   })
 

--- a/apps/api-journeys/db/seeds/nua8.ts
+++ b/apps/api-journeys/db/seeds/nua8.ts
@@ -248,7 +248,6 @@ export async function nua8(): Promise<void> {
     journeyId: journey._key,
     __typename: 'RadioQuestionBlock',
     parentBlockId: card3._key,
-    label: '',
     parentOrder: 2
   })
 
@@ -525,7 +524,6 @@ export async function nua8(): Promise<void> {
     journeyId: journey._key,
     __typename: 'RadioQuestionBlock',
     parentBlockId: card7._key,
-    label: '',
     parentOrder: 2
   })
 

--- a/apps/api-journeys/db/seeds/nua9.ts
+++ b/apps/api-journeys/db/seeds/nua9.ts
@@ -243,7 +243,6 @@ export async function nua9(): Promise<void> {
     journeyId: journey._key,
     __typename: 'RadioQuestionBlock',
     parentBlockId: card2._key,
-    label: '',
     parentOrder: 2
   })
 

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -357,8 +357,6 @@ type RadioQuestionBlock implements Block {
   journeyId: ID!
   parentBlockId: ID
   parentOrder: Int
-  label: String!
-  description: String
 }
 
 input RadioOptionBlockCreateInput {
@@ -372,18 +370,11 @@ input RadioQuestionBlockCreateInput {
   id: ID
   journeyId: ID!
   parentBlockId: ID!
-  label: String!
 }
 
 input RadioOptionBlockUpdateInput {
   parentBlockId: ID
   label: String
-}
-
-input RadioQuestionBlockUpdateInput {
-  parentBlockId: ID
-  label: String
-  description: String
 }
 
 type SignUpBlock implements Block {
@@ -849,7 +840,7 @@ extend type Mutation {
   radioOptionBlockCreate(input: RadioOptionBlockCreateInput!): RadioOptionBlock!
   radioQuestionBlockCreate(input: RadioQuestionBlockCreateInput!): RadioQuestionBlock!
   radioOptionBlockUpdate(id: ID!, journeyId: ID!, input: RadioOptionBlockUpdateInput!): RadioOptionBlock!
-  radioQuestionBlockUpdate(id: ID!, journeyId: ID!, input: RadioQuestionBlockUpdateInput!): RadioQuestionBlock!
+  radioQuestionBlockUpdate(id: ID!, journeyId: ID!, parentBlockId: ID!): RadioQuestionBlock!
   signUpBlockCreate(input: SignUpBlockCreateInput!): SignUpBlock!
   signUpBlockUpdate(id: ID!, journeyId: ID!, input: SignUpBlockUpdateInput!): SignUpBlock
   stepBlockCreate(input: StepBlockCreateInput!): StepBlock!

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -246,18 +246,11 @@ export class RadioQuestionBlockCreateInput {
     id?: Nullable<string>;
     journeyId: string;
     parentBlockId: string;
-    label: string;
 }
 
 export class RadioOptionBlockUpdateInput {
     parentBlockId?: Nullable<string>;
     label?: Nullable<string>;
-}
-
-export class RadioQuestionBlockUpdateInput {
-    parentBlockId?: Nullable<string>;
-    label?: Nullable<string>;
-    description?: Nullable<string>;
 }
 
 export class SignUpBlockCreateInput {
@@ -568,8 +561,6 @@ export class RadioQuestionBlock implements Block {
     journeyId: string;
     parentBlockId?: Nullable<string>;
     parentOrder?: Nullable<number>;
-    label: string;
-    description?: Nullable<string>;
 }
 
 export class SignUpBlock implements Block {
@@ -746,7 +737,7 @@ export abstract class IMutation {
 
     abstract radioOptionBlockUpdate(id: string, journeyId: string, input: RadioOptionBlockUpdateInput): RadioOptionBlock | Promise<RadioOptionBlock>;
 
-    abstract radioQuestionBlockUpdate(id: string, journeyId: string, input: RadioQuestionBlockUpdateInput): RadioQuestionBlock | Promise<RadioQuestionBlock>;
+    abstract radioQuestionBlockUpdate(id: string, journeyId: string, parentBlockId: string): RadioQuestionBlock | Promise<RadioQuestionBlock>;
 
     abstract signUpBlockCreate(input: SignUpBlockCreateInput): SignUpBlock | Promise<SignUpBlock>;
 

--- a/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.graphql
+++ b/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.graphql
@@ -12,8 +12,6 @@ type RadioQuestionBlock implements Block {
   journeyId: ID!
   parentBlockId: ID
   parentOrder: Int
-  label: String!
-  description: String
 }
 
 input RadioOptionBlockCreateInput {
@@ -27,18 +25,11 @@ input RadioQuestionBlockCreateInput {
   id: ID
   journeyId: ID!
   parentBlockId: ID!
-  label: String!
 }
 
 input RadioOptionBlockUpdateInput {
   parentBlockId: ID
   label: String
-}
-
-input RadioQuestionBlockUpdateInput {
-  parentBlockId: ID
-  label: String
-  description: String
 }
 
 extend type Mutation {
@@ -54,6 +45,6 @@ extend type Mutation {
   radioQuestionBlockUpdate(
     id: ID!
     journeyId: ID!
-    input: RadioQuestionBlockUpdateInput!
+    parentBlockId: ID!
   ): RadioQuestionBlock!
 }

--- a/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.spec.ts
@@ -24,7 +24,6 @@ describe('RadioQuestionBlockResolver', () => {
     parentBlockId: '3',
     parentOrder: 3,
     label: 'label',
-    description: 'description',
     action: {
       gtmEventName: 'gtmEventName',
       blockId: '4'
@@ -60,8 +59,7 @@ describe('RadioQuestionBlockResolver', () => {
     __typename: 'RadioQuestionBlock',
     parentBlockId: '2',
     parentOrder: 2,
-    journeyId: '2',
-    label: 'label'
+    journeyId: '2'
   }
 
   const blockService = {
@@ -154,9 +152,9 @@ describe('RadioQuestionBlockResolver', () => {
       await resolver.radioQuestionBlockUpdate(
         block.id,
         block.journeyId,
-        radioQuestionInput
+        block.parentBlockId
       )
-      expect(service.update).toHaveBeenCalledWith(block.id, radioQuestionInput)
+      expect(service.update).toHaveBeenCalledWith(block.id, block.parentBlockId)
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.ts
@@ -7,8 +7,7 @@ import {
   RadioOptionBlockCreateInput,
   RadioQuestionBlockCreateInput,
   UserJourneyRole,
-  RadioOptionBlockUpdateInput,
-  RadioQuestionBlockUpdateInput
+  RadioOptionBlockUpdateInput
 } from '../../../__generated__/graphql'
 import { BlockService } from '../block.service'
 import { RoleGuard } from '../../../lib/roleGuard/roleGuard'
@@ -92,8 +91,8 @@ export class RadioQuestionBlockResolver {
   async radioQuestionBlockUpdate(
     @Args('id') id: string,
     @Args('journeyId') journeyId: string,
-    @Args('input') input: RadioQuestionBlockUpdateInput
+    @Args('parentBlockId') parentBlockId: string
   ): Promise<RadioQuestionBlock> {
-    return await this.blockService.update(id, input)
+    return await this.blockService.update(id, parentBlockId)
   }
 }

--- a/apps/journeys-admin/__generated__/BlockFields.ts
+++ b/apps/journeys-admin/__generated__/BlockFields.ts
@@ -187,8 +187,6 @@ export interface BlockFields_RadioQuestionBlock {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  label: string;
-  description: string | null;
 }
 
 export interface BlockFields_SignUpBlock_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/BlockFields.ts
+++ b/apps/journeys-admin/__generated__/BlockFields.ts
@@ -187,6 +187,8 @@ export interface BlockFields_RadioQuestionBlock {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
+  label: string;
+  description: string | null;
 }
 
 export interface BlockFields_SignUpBlock_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/GetJourney.ts
+++ b/apps/journeys-admin/__generated__/GetJourney.ts
@@ -199,6 +199,8 @@ export interface GetJourney_journey_blocks_RadioQuestionBlock {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
+  label: string;
+  description: string | null;
 }
 
 export interface GetJourney_journey_blocks_SignUpBlock_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/GetJourney.ts
+++ b/apps/journeys-admin/__generated__/GetJourney.ts
@@ -199,8 +199,6 @@ export interface GetJourney_journey_blocks_RadioQuestionBlock {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  label: string;
-  description: string | null;
 }
 
 export interface GetJourney_journey_blocks_SignUpBlock_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/RadioQuestionBlockCreate.ts
+++ b/apps/journeys-admin/__generated__/RadioQuestionBlockCreate.ts
@@ -14,6 +14,8 @@ export interface RadioQuestionBlockCreate_radioQuestionBlockCreate {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
+  label: string;
+  description: string | null;
 }
 
 export interface RadioQuestionBlockCreate_radioOption1_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/RadioQuestionBlockCreate.ts
+++ b/apps/journeys-admin/__generated__/RadioQuestionBlockCreate.ts
@@ -14,8 +14,6 @@ export interface RadioQuestionBlockCreate_radioQuestionBlockCreate {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  label: string;
-  description: string | null;
 }
 
 export interface RadioQuestionBlockCreate_radioOption1_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/RadioQuestionFields.ts
+++ b/apps/journeys-admin/__generated__/RadioQuestionFields.ts
@@ -12,4 +12,6 @@ export interface RadioQuestionFields {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
+  label: string;
+  description: string | null;
 }

--- a/apps/journeys-admin/__generated__/RadioQuestionFields.ts
+++ b/apps/journeys-admin/__generated__/RadioQuestionFields.ts
@@ -12,6 +12,4 @@ export interface RadioQuestionFields {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  label: string;
-  description: string | null;
 }

--- a/apps/journeys-admin/__generated__/globalTypes.ts
+++ b/apps/journeys-admin/__generated__/globalTypes.ts
@@ -249,7 +249,6 @@ export interface RadioOptionBlockUpdateInput {
 export interface RadioQuestionBlockCreateInput {
   id?: string | null;
   journeyId: string;
-  label: string;
   parentBlockId: string;
 }
 

--- a/apps/journeys-admin/__generated__/globalTypes.ts
+++ b/apps/journeys-admin/__generated__/globalTypes.ts
@@ -249,6 +249,7 @@ export interface RadioOptionBlockUpdateInput {
 export interface RadioQuestionBlockCreateInput {
   id?: string | null;
   journeyId: string;
+  label: string;
   parentBlockId: string;
 }
 

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
@@ -262,8 +262,6 @@ const steps: Array<TreeBlock<StepBlock>> = [
             __typename: 'RadioQuestionBlock',
             parentBlockId: 'card2.id',
             parentOrder: 2,
-            label: '',
-            description: '',
             children: [
               {
                 id: 'radioOption1.id',
@@ -368,8 +366,6 @@ const steps: Array<TreeBlock<StepBlock>> = [
             __typename: 'RadioQuestionBlock',
             parentBlockId: 'card3.id',
             parentOrder: 2,
-            label: '',
-            description: '',
             children: [
               {
                 id: 'radioOption1.id',

--- a/apps/journeys-admin/src/components/Editor/Canvas/Canvas.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/Canvas.stories.tsx
@@ -250,8 +250,6 @@ const steps: Array<TreeBlock<StepBlock>> = [
             __typename: 'RadioQuestionBlock',
             parentOrder: 2,
             parentBlockId: 'card2.id',
-            label: 'What is Christianity to you?',
-            description: '',
             children: [
               {
                 id: 'radioOption1.id',
@@ -345,8 +343,6 @@ const steps: Array<TreeBlock<StepBlock>> = [
             __typename: 'RadioQuestionBlock',
             parentBlockId: 'card3.id',
             parentOrder: 2,
-            label: 'Do you need to change to be good enough for God?',
-            description: '',
             children: [
               {
                 id: 'radioOption1.id',

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditWrapper.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditWrapper.spec.tsx
@@ -187,8 +187,6 @@ describe('InlineEditWrapper', () => {
       parentBlockId: 'card.id',
       parentOrder: 0,
       id: 'radioQuestion.id',
-      label: 'heading',
-      description: 'description',
       children: [option]
     }
 

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.stories.tsx
@@ -35,8 +35,6 @@ const option1: TreeBlock<RadioOptionFields> = {
 const block: TreeBlock<RadioQuestionFields> = {
   __typename: 'RadioQuestionBlock',
   id: 'RadioQuestion1',
-  label: 'Label',
-  description: 'Description',
   parentBlockId: 'RadioQuestion1',
   parentOrder: 0,
   children: [

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioQuestionEdit/RadioQuestionEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioQuestionEdit/RadioQuestionEdit.spec.tsx
@@ -19,8 +19,6 @@ describe('RadioQuestionEdit', () => {
       parentBlockId: 'card.id',
       parentOrder: 0,
       id: 'radioQuestion.id',
-      label: 'heading',
-      description: 'description',
       children: children ?? []
     }
   }

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioQuestionEdit/RadioQuestionEdit.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioQuestionEdit/RadioQuestionEdit.stories.tsx
@@ -51,8 +51,6 @@ const block: TreeBlock<RadioQuestionFields> = {
   __typename: 'RadioQuestionBlock',
   parentBlockId: 'card0.id',
   parentOrder: 2,
-  label: '',
-  description: null,
   children: [
     {
       __typename: 'RadioOptionBlock',

--- a/apps/journeys-admin/src/components/Editor/Canvas/SelectableWrapper/SelectableWrapper.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/SelectableWrapper/SelectableWrapper.spec.tsx
@@ -90,8 +90,6 @@ describe('SelectableWrapper', () => {
   const radioQuestionBlock: TreeBlock<RadioQuestionFields> = {
     __typename: 'RadioQuestionBlock',
     id: 'RadioQuestion1',
-    label: 'Label',
-    description: 'Description',
     parentBlockId: 'parent.id',
     parentOrder: 0,
     children: [

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/data.ts
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/data.ts
@@ -223,8 +223,6 @@ export const steps: Array<TreeBlock<StepBlock>> = [
             __typename: 'RadioQuestionBlock',
             parentBlockId: 'card2.id',
             parentOrder: 2,
-            label: '',
-            description: '',
             children: [
               {
                 id: 'radioOption1.id',
@@ -347,8 +345,6 @@ export const steps: Array<TreeBlock<StepBlock>> = [
             __typename: 'RadioQuestionBlock',
             parentBlockId: 'card3.id',
             parentOrder: 3,
-            label: '',
-            description: '',
             children: [
               {
                 id: 'radioOption1.id',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Attributes.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Attributes.spec.tsx
@@ -180,8 +180,6 @@ describe('Attributes', () => {
     const block: TreeBlock = {
       __typename: 'RadioQuestionBlock',
       id: 'RadioQuestion1',
-      label: 'Label',
-      description: 'Description',
       parentBlockId: 'RadioQuestion1',
       parentOrder: 0,
       children: []

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.spec.tsx
@@ -340,7 +340,7 @@ describe('ControlPanel', () => {
           id: 'uuid',
           parentBlockId: 'cardId',
           parentOrder: 2,
-          journeyId: 'journeyId',
+          journeyId: 'journeyId'
         },
         radioOption1: {
           __typename: 'RadioOptionBlock',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.spec.tsx
@@ -341,8 +341,6 @@ describe('ControlPanel', () => {
           parentBlockId: 'cardId',
           parentOrder: 2,
           journeyId: 'journeyId',
-          label: '',
-          description: null
         },
         radioOption1: {
           __typename: 'RadioOptionBlock',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.stories.tsx
@@ -266,8 +266,6 @@ const steps: Array<TreeBlock<StepBlock>> = [
             __typename: 'RadioQuestionBlock',
             parentOrder: 2,
             parentBlockId: 'card2.id',
-            label: '',
-            description: '',
             children: [
               {
                 id: 'radioOption1.id',
@@ -372,8 +370,6 @@ const steps: Array<TreeBlock<StepBlock>> = [
             __typename: 'RadioQuestionBlock',
             parentBlockId: 'card3.id',
             parentOrder: 2,
-            label: '',
-            description: '',
             children: [
               {
                 id: 'radioOption1.id',

--- a/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
@@ -262,7 +262,7 @@ const blocks: GetJourney_journey_blocks[] = [
     id: 'radioQuestion1.id',
     __typename: 'RadioQuestionBlock',
     parentBlockId: 'card2.id',
-    parentOrder: 2,
+    parentOrder: 2
   },
   {
     id: 'radioOption1.id',
@@ -354,7 +354,7 @@ const blocks: GetJourney_journey_blocks[] = [
     id: 'radioQuestion2.id',
     __typename: 'RadioQuestionBlock',
     parentBlockId: 'card3.id',
-    parentOrder: 2,
+    parentOrder: 2
   },
   {
     id: 'radioOption4.id',

--- a/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
@@ -263,8 +263,6 @@ const blocks: GetJourney_journey_blocks[] = [
     __typename: 'RadioQuestionBlock',
     parentBlockId: 'card2.id',
     parentOrder: 2,
-    label: '',
-    description: ''
   },
   {
     id: 'radioOption1.id',
@@ -357,8 +355,6 @@ const blocks: GetJourney_journey_blocks[] = [
     __typename: 'RadioQuestionBlock',
     parentBlockId: 'card3.id',
     parentOrder: 2,
-    label: '',
-    description: ''
   },
   {
     id: 'radioOption4.id',

--- a/apps/journeys-admin/src/components/JourneyView/CardView/data.ts
+++ b/apps/journeys-admin/src/components/JourneyView/CardView/data.ts
@@ -331,8 +331,6 @@ export const steps: Array<TreeBlock<StepBlock>> = [
             __typename: 'RadioQuestionBlock',
             parentBlockId: 'card2.id',
             parentOrder: 2,
-            label: '',
-            description: '',
             children: [
               {
                 id: 'radioOption1.id',
@@ -437,8 +435,6 @@ export const steps: Array<TreeBlock<StepBlock>> = [
             __typename: 'RadioQuestionBlock',
             parentBlockId: 'card3.id',
             parentOrder: 2,
-            label: '',
-            description: '',
             children: [
               {
                 id: 'radioOption1.id',

--- a/apps/journeys/__generated__/BlockFields.ts
+++ b/apps/journeys/__generated__/BlockFields.ts
@@ -187,8 +187,6 @@ export interface BlockFields_RadioQuestionBlock {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  label: string;
-  description: string | null;
 }
 
 export interface BlockFields_SignUpBlock_action_NavigateAction {

--- a/apps/journeys/__generated__/BlockFields.ts
+++ b/apps/journeys/__generated__/BlockFields.ts
@@ -187,6 +187,8 @@ export interface BlockFields_RadioQuestionBlock {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
+  label: string;
+  description: string | null;
 }
 
 export interface BlockFields_SignUpBlock_action_NavigateAction {

--- a/apps/journeys/__generated__/GetJourney.ts
+++ b/apps/journeys/__generated__/GetJourney.ts
@@ -203,6 +203,8 @@ export interface GetJourney_journey_blocks_RadioQuestionBlock {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
+  label: string;
+  description: string | null;
 }
 
 export interface GetJourney_journey_blocks_SignUpBlock_action_NavigateAction {

--- a/apps/journeys/__generated__/GetJourney.ts
+++ b/apps/journeys/__generated__/GetJourney.ts
@@ -203,8 +203,6 @@ export interface GetJourney_journey_blocks_RadioQuestionBlock {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  label: string;
-  description: string | null;
 }
 
 export interface GetJourney_journey_blocks_SignUpBlock_action_NavigateAction {

--- a/apps/journeys/__generated__/RadioQuestionFields.ts
+++ b/apps/journeys/__generated__/RadioQuestionFields.ts
@@ -12,4 +12,6 @@ export interface RadioQuestionFields {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
+  label: string;
+  description: string | null;
 }

--- a/apps/journeys/__generated__/RadioQuestionFields.ts
+++ b/apps/journeys/__generated__/RadioQuestionFields.ts
@@ -12,6 +12,4 @@ export interface RadioQuestionFields {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  label: string;
-  description: string | null;
 }

--- a/apps/journeys/src/components/Conductor/Conductor.spec.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.spec.tsx
@@ -47,8 +47,6 @@ describe('Conductor', () => {
                 __typename: 'RadioQuestionBlock',
                 parentBlockId: 'card1.id',
                 parentOrder: 0,
-                label: 'Step 1',
-                description: 'Start',
                 children: [
                   {
                     id: 'radioOption2.id',
@@ -122,8 +120,6 @@ describe('Conductor', () => {
                 __typename: 'RadioQuestionBlock',
                 parentBlockId: 'card2.id',
                 parentOrder: 0,
-                label: 'Step 2',
-                description: 'Locked',
                 children: [
                   {
                     id: 'radioOption1.id',
@@ -197,8 +193,6 @@ describe('Conductor', () => {
                 __typename: 'RadioQuestionBlock',
                 parentBlockId: 'card3.id',
                 parentOrder: 0,
-                label: 'Step 3',
-                description: 'No nextBlockId',
                 children: [
                   {
                     id: 'radioOption1.id',
@@ -272,8 +266,6 @@ describe('Conductor', () => {
                 __typename: 'RadioQuestionBlock',
                 parentBlockId: 'card4.id',
                 parentOrder: 0,
-                label: 'Step 4',
-                description: 'End',
                 children: [
                   {
                     id: 'radioOption1.id',
@@ -385,8 +377,6 @@ describe('Conductor', () => {
                 __typename: 'RadioQuestionBlock',
                 parentBlockId: 'card1.id',
                 parentOrder: 0,
-                label: 'Step 1',
-                description: 'Start',
                 children: [
                   {
                     id: 'radioOption2.id',
@@ -531,8 +521,6 @@ describe('Conductor', () => {
                 __typename: 'RadioQuestionBlock',
                 parentBlockId: 'card3.id',
                 parentOrder: 0,
-                label: 'Step 3',
-                description: 'No nextBlockId',
                 children: [
                   {
                     id: 'radioOption1.id',

--- a/apps/journeys/src/components/Conductor/Conductor.stories.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.stories.tsx
@@ -59,8 +59,6 @@ const basic: TreeBlock[] = [
             __typename: 'RadioQuestionBlock',
             parentBlockId: 'card1.id',
             parentOrder: 2,
-            label: '',
-            description: null,
             children: [
               {
                 id: 'radioOption2.id',
@@ -168,8 +166,6 @@ const basic: TreeBlock[] = [
             __typename: 'RadioQuestionBlock',
             parentBlockId: 'card2.id',
             parentOrder: 2,
-            label: '',
-            description: null,
             children: [
               {
                 id: 'radioOption1.id',
@@ -265,8 +261,6 @@ const basic: TreeBlock[] = [
             __typename: 'RadioQuestionBlock',
             parentBlockId: 'card3.id',
             parentOrder: 2,
-            label: 'Step 3',
-            description: 'No nextBlockId',
             children: [
               {
                 id: 'radioOption1.id',
@@ -362,8 +356,6 @@ const basic: TreeBlock[] = [
             __typename: 'RadioQuestionBlock',
             parentBlockId: 'card4.id',
             parentOrder: 2,
-            label: 'Step 4',
-            description: 'End',
             children: [
               {
                 id: 'radioOption1.id',
@@ -635,8 +627,6 @@ const imageBlocks: TreeBlock[] = [
             __typename: 'RadioQuestionBlock',
             parentBlockId: 'step2.id',
             parentOrder: 2,
-            label: '',
-            description: '',
             children: [
               {
                 id: 'radioOption1.id',
@@ -741,8 +731,6 @@ const imageBlocks: TreeBlock[] = [
             __typename: 'RadioQuestionBlock',
             parentBlockId: 'step2.id',
             parentOrder: 2,
-            label: '',
-            description: '',
             children: [
               {
                 id: 'radioOption1.id',
@@ -1020,8 +1008,6 @@ const videoBlocks: TreeBlock[] = [
             __typename: 'RadioQuestionBlock',
             parentBlockId: 'card2.id',
             parentOrder: 2,
-            label: '',
-            description: null,
             children: [
               {
                 id: 'radioOption1.id',

--- a/apps/watch-admin/__generated__/BlockFields.ts
+++ b/apps/watch-admin/__generated__/BlockFields.ts
@@ -187,8 +187,6 @@ export interface BlockFields_RadioQuestionBlock {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  label: string;
-  description: string | null;
 }
 
 export interface BlockFields_SignUpBlock_action_NavigateAction {

--- a/apps/watch-admin/__generated__/RadioQuestionFields.ts
+++ b/apps/watch-admin/__generated__/RadioQuestionFields.ts
@@ -12,6 +12,4 @@ export interface RadioQuestionFields {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  label: string;
-  description: string | null;
 }

--- a/apps/watch/__generated__/BlockFields.ts
+++ b/apps/watch/__generated__/BlockFields.ts
@@ -187,8 +187,6 @@ export interface BlockFields_RadioQuestionBlock {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  label: string;
-  description: string | null;
 }
 
 export interface BlockFields_SignUpBlock_action_NavigateAction {

--- a/apps/watch/__generated__/RadioQuestionFields.ts
+++ b/apps/watch/__generated__/RadioQuestionFields.ts
@@ -12,6 +12,4 @@ export interface RadioQuestionFields {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  label: string;
-  description: string | null;
 }

--- a/libs/journeys/ui/src/components/BlockRenderer/BlockRenderer.spec.tsx
+++ b/libs/journeys/ui/src/components/BlockRenderer/BlockRenderer.spec.tsx
@@ -268,8 +268,6 @@ describe('BlockRenderer', () => {
       id: 'main',
       parentBlockId: null,
       parentOrder: 0,
-      label: '',
-      description: null,
       children: [option, { ...option, label: 'radio option 2' }]
     }
     const { getByText } = render(
@@ -287,8 +285,6 @@ describe('BlockRenderer', () => {
       id: 'main',
       parentBlockId: null,
       parentOrder: 0,
-      label: '',
-      description: null,
       children: []
     }
     const { getByTestId, getByRole } = render(

--- a/libs/journeys/ui/src/components/RadioQuestion/RadioQuestion.spec.tsx
+++ b/libs/journeys/ui/src/components/RadioQuestion/RadioQuestion.spec.tsx
@@ -16,8 +16,6 @@ jest.mock('../../libs/action', () => {
 const block: TreeBlock<RadioQuestionFields> = {
   __typename: 'RadioQuestionBlock',
   id: 'RadioQuestion1',
-  label: 'Label',
-  description: 'Description',
   parentBlockId: 'RadioQuestion1',
   parentOrder: 0,
   children: [

--- a/libs/journeys/ui/src/components/RadioQuestion/RadioQuestion.stories.tsx
+++ b/libs/journeys/ui/src/components/RadioQuestion/RadioQuestion.stories.tsx
@@ -140,7 +140,6 @@ export const Default: Story<TreeBlock<RadioQuestionFields>> =
   DefaultTemplate.bind({})
 Default.args = {
   id: 'Default',
-  label: 'How can we help you know more about Jesus?',
   children,
   parentOrder: 1,
   parentBlockId: 'Step1'
@@ -151,8 +150,6 @@ export const Long: Story<TreeBlock<RadioQuestionFields>> = DefaultTemplate.bind(
 )
 Long.args = {
   id: 'Long',
-  label: 'Have you accepted Jesus in your life?',
-  description: '',
   children: longLabel,
   parentOrder: 2
 }

--- a/libs/journeys/ui/src/components/RadioQuestion/__generated__/RadioQuestionFields.ts
+++ b/libs/journeys/ui/src/components/RadioQuestion/__generated__/RadioQuestionFields.ts
@@ -12,4 +12,6 @@ export interface RadioQuestionFields {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
+  label: string;
+  description: string | null;
 }

--- a/libs/journeys/ui/src/components/RadioQuestion/__generated__/RadioQuestionFields.ts
+++ b/libs/journeys/ui/src/components/RadioQuestion/__generated__/RadioQuestionFields.ts
@@ -12,6 +12,4 @@ export interface RadioQuestionFields {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  label: string;
-  description: string | null;
 }

--- a/libs/journeys/ui/src/components/RadioQuestion/radioQuestionFields.ts
+++ b/libs/journeys/ui/src/components/RadioQuestion/radioQuestionFields.ts
@@ -5,7 +5,5 @@ export const RADIO_QUESTION_FIELDS = gql`
     id
     parentBlockId
     parentOrder
-    label
-    description
   }
 `

--- a/libs/journeys/ui/src/libs/searchBlocks/searchBlocks.spec.ts
+++ b/libs/journeys/ui/src/libs/searchBlocks/searchBlocks.spec.ts
@@ -29,8 +29,6 @@ describe('searchBlocks', () => {
           {
             __typename: 'RadioQuestionBlock',
             id: 'RadioQuestion1',
-            label: 'Label',
-            description: 'Description',
             parentBlockId: 'RadioQuestion1',
             parentOrder: 1,
             children: [

--- a/libs/journeys/ui/src/libs/transformer/__generated__/BlockFields.ts
+++ b/libs/journeys/ui/src/libs/transformer/__generated__/BlockFields.ts
@@ -187,8 +187,6 @@ export interface BlockFields_RadioQuestionBlock {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
-  label: string;
-  description: string | null;
 }
 
 export interface BlockFields_SignUpBlock_action_NavigateAction {

--- a/libs/journeys/ui/src/libs/transformer/__generated__/BlockFields.ts
+++ b/libs/journeys/ui/src/libs/transformer/__generated__/BlockFields.ts
@@ -187,6 +187,8 @@ export interface BlockFields_RadioQuestionBlock {
   id: string;
   parentBlockId: string | null;
   parentOrder: number | null;
+  label: string;
+  description: string | null;
 }
 
 export interface BlockFields_SignUpBlock_action_NavigateAction {

--- a/libs/journeys/ui/src/libs/transformer/transformer.spec.ts
+++ b/libs/journeys/ui/src/libs/transformer/transformer.spec.ts
@@ -24,9 +24,7 @@ describe('transformer', () => {
           __typename: 'RadioQuestionBlock',
           id: 'Question1',
           parentBlockId: 'Root1',
-          parentOrder: 0,
-          label: 'Question 1',
-          description: 'Question 1 description'
+          parentOrder: 0
         },
         {
           __typename: 'RadioOptionBlock',
@@ -64,9 +62,7 @@ describe('transformer', () => {
           __typename: 'RadioQuestionBlock',
           id: 'Question2',
           parentBlockId: 'Root2',
-          parentOrder: 1,
-          label: 'Question 2',
-          description: 'Question 2 description'
+          parentOrder: 1
         }
       ])
     ).toEqual([
@@ -96,9 +92,7 @@ describe('transformer', () => {
             __typename: 'RadioQuestionBlock',
             id: 'Question1',
             parentBlockId: 'Root1',
-            parentOrder: 0,
-            label: 'Question 1',
-            description: 'Question 1 description'
+            parentOrder: 0
           }
         ],
         id: 'Root1',
@@ -134,9 +128,7 @@ describe('transformer', () => {
             __typename: 'RadioQuestionBlock',
             id: 'Question2',
             parentBlockId: 'Root2',
-            parentOrder: 1,
-            label: 'Question 2',
-            description: 'Question 2 description'
+            parentOrder: 1
           }
         ],
         id: 'Root2',


### PR DESCRIPTION
# Description

Deprecate heading and description properties on RadioQuestion block in backend

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/27244374/todos/4888072623)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Label and description shouldn't be in RadioQuestionBlock

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
