### PR TITLE
refactor: deprecate coverblockid field on card mutations

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -117,7 +117,6 @@ type CardBlock implements Block {
 
 input CardBlockCreateInput {
   backgroundColor: String
-  coverBlockId: ID
   fullscreen: Boolean
   id: ID
   journeyId: ID!
@@ -128,7 +127,6 @@ input CardBlockCreateInput {
 
 input CardBlockUpdateInput {
   backgroundColor: String
-  coverBlockId: ID
   fullscreen: Boolean
   parentBlockId: ID
   themeMode: ThemeMode

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -183,7 +183,6 @@ input CardBlockCreateInput {
   journeyId: ID!
   parentBlockId: ID!
   backgroundColor: String
-  coverBlockId: ID @deprecated(reason: "coverBlockId will be updated on Image and Video Cover block creation")
   fullscreen: Boolean
   themeMode: ThemeMode
   themeName: ThemeName
@@ -192,7 +191,6 @@ input CardBlockCreateInput {
 input CardBlockUpdateInput {
   parentBlockId: ID
   backgroundColor: String
-  coverBlockId: ID @deprecated(reason: "coverBlockId will be updated on Image and Video Cover block creation")
   fullscreen: Boolean
   themeMode: ThemeMode
   themeName: ThemeName

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -189,7 +189,6 @@ export class CardBlockCreateInput {
     journeyId: string;
     parentBlockId: string;
     backgroundColor?: Nullable<string>;
-    coverBlockId?: Nullable<string>;
     fullscreen?: Nullable<boolean>;
     themeMode?: Nullable<ThemeMode>;
     themeName?: Nullable<ThemeName>;
@@ -198,7 +197,6 @@ export class CardBlockCreateInput {
 export class CardBlockUpdateInput {
     parentBlockId?: Nullable<string>;
     backgroundColor?: Nullable<string>;
-    coverBlockId?: Nullable<string>;
     fullscreen?: Nullable<boolean>;
     themeMode?: Nullable<ThemeMode>;
     themeName?: Nullable<ThemeName>;

--- a/apps/api-journeys/src/app/modules/block/card/card.graphql
+++ b/apps/api-journeys/src/app/modules/block/card/card.graphql
@@ -36,10 +36,6 @@ input CardBlockCreateInput {
   journeyId: ID!
   parentBlockId: ID!
   backgroundColor: String
-  coverBlockId: ID
-    @deprecated(
-      reason: "coverBlockId will be updated on Image and Video Cover block creation"
-    )
   fullscreen: Boolean
   themeMode: ThemeMode
   themeName: ThemeName
@@ -48,10 +44,6 @@ input CardBlockCreateInput {
 input CardBlockUpdateInput {
   parentBlockId: ID
   backgroundColor: String
-  coverBlockId: ID
-    @deprecated(
-      reason: "coverBlockId will be updated on Image and Video Cover block creation"
-    )
   fullscreen: Boolean
   themeMode: ThemeMode
   themeName: ThemeName

--- a/apps/journeys-admin/__generated__/globalTypes.ts
+++ b/apps/journeys-admin/__generated__/globalTypes.ts
@@ -164,7 +164,6 @@ export interface ButtonBlockUpdateInput {
 
 export interface CardBlockUpdateInput {
   backgroundColor?: string | null;
-  coverBlockId?: string | null;
   fullscreen?: boolean | null;
   parentBlockId?: string | null;
   themeMode?: ThemeMode | null;


### PR DESCRIPTION
# Description

We should no longer allow coverBlockId to be set by cardBlockUpdate and cardBlockCreate mutations. Rather, coverBlockId is set on cover ImageCreate or VideoCreate

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/27244374/todos/4888071920)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] CoverBlockId field should no longer be in cardBlockCreate and cardBlockUpdate mutations

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
