### PR TITLE
feat: add admin to journey provider

### DIFF
--- a/apps/journeys-admin/pages/journeys/[journeySlug].tsx
+++ b/apps/journeys-admin/pages/journeys/[journeySlug].tsx
@@ -40,11 +40,7 @@ function JourneySlugPage(): ReactElement {
             description={data?.journey?.description ?? undefined}
           />
           <JourneyProvider
-            value={
-              data?.journey == null
-                ? { journey: data?.journey ?? undefined, admin: true }
-                : undefined
-            }
+            value={{ journey: data?.journey ?? undefined, admin: true }}
           >
             <PageWrapper
               title="Journey Details"

--- a/apps/journeys-admin/pages/journeys/[journeySlug].tsx
+++ b/apps/journeys-admin/pages/journeys/[journeySlug].tsx
@@ -39,7 +39,13 @@ function JourneySlugPage(): ReactElement {
             title={data?.journey?.title ?? 'Journey'}
             description={data?.journey?.description ?? undefined}
           />
-          <JourneyProvider value={data?.journey ?? undefined}>
+          <JourneyProvider
+            value={
+              data?.journey == null
+                ? { journey: data?.journey ?? undefined, admin: true }
+                : undefined
+            }
+          >
             <PageWrapper
               title="Journey Details"
               showDrawer

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.spec.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.spec.tsx
@@ -36,13 +36,13 @@ describe('CardPreview', () => {
     const { getByTestId } = render(
       <MockedProvider>
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
             } as unknown as Journey
-          }
+          }}
         >
           <CardPreview onSelect={onSelect} steps={[step]} />
         </JourneyProvider>
@@ -96,13 +96,13 @@ describe('CardPreview', () => {
         ]}
       >
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
             } as unknown as Journey
-          }
+          }}
         >
           <CardPreview steps={[]} onSelect={onSelect} showAddButton />
         </JourneyProvider>
@@ -189,13 +189,13 @@ describe('CardPreview', () => {
         ]}
       >
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
             } as unknown as Journey
-          }
+          }}
         >
           <CardPreview steps={[]} onSelect={onSelect} showAddButton />
         </JourneyProvider>
@@ -288,13 +288,13 @@ describe('CardPreview', () => {
         ]}
       >
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
             } as unknown as Journey
-          }
+          }}
         >
           <CardPreview steps={[step]} onSelect={onSelect} showAddButton />
         </JourneyProvider>
@@ -383,13 +383,13 @@ describe('CardPreview', () => {
         ]}
       >
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
             } as unknown as Journey
-          }
+          }}
         >
           <CardPreview steps={[step]} onSelect={onSelect} showAddButton />
         </JourneyProvider>

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.spec.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.spec.tsx
@@ -41,7 +41,8 @@ describe('CardPreview', () => {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <CardPreview onSelect={onSelect} steps={[step]} />
@@ -101,7 +102,8 @@ describe('CardPreview', () => {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <CardPreview steps={[]} onSelect={onSelect} showAddButton />
@@ -194,7 +196,8 @@ describe('CardPreview', () => {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <CardPreview steps={[]} onSelect={onSelect} showAddButton />
@@ -293,7 +296,8 @@ describe('CardPreview', () => {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <CardPreview steps={[step]} onSelect={onSelect} showAddButton />
@@ -388,7 +392,8 @@ describe('CardPreview', () => {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <CardPreview steps={[step]} onSelect={onSelect} showAddButton />

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
@@ -665,7 +665,8 @@ const Template: Story = ({ ...args }) => {
             id: 'journeyId',
             themeMode: ThemeMode.light,
             themeName: ThemeName.base
-          } as unknown as Journey
+          } as unknown as Journey,
+          admin: true
         }}
       >
         <CardPreview

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
@@ -660,13 +660,13 @@ const Template: Story = ({ ...args }) => {
   return (
     <MockedProvider>
       <JourneyProvider
-        value={
-          {
+        value={{
+          journey: {
             id: 'journeyId',
             themeMode: ThemeMode.light,
             themeName: ThemeName.base
           } as unknown as Journey
-        }
+        }}
       >
         <CardPreview
           onSelect={(step) => setSelectedStep(step)}

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
@@ -74,8 +74,6 @@ export function CardPreview({
     STEP_BLOCK_NEXTBLOCKID_UPDATE
   )
   const { journey } = useJourney()
-  // const value = useJourney()
-  // console.log('value:', value)
 
   const handleChange = (selectedId: string): void => {
     if (steps == null) return

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
@@ -73,7 +73,9 @@ export function CardPreview({
   const [stepBlockNextBlockIdUpdate] = useMutation<StepBlockNextBlockIdUpdate>(
     STEP_BLOCK_NEXTBLOCKID_UPDATE
   )
-  const journey = useJourney()
+  const { journey } = useJourney()
+  // const value = useJourney()
+  // console.log('value:', value)
 
   const handleChange = (selectedId: string): void => {
     if (steps == null) return

--- a/apps/journeys-admin/src/components/Editor/Canvas/Canvas.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/Canvas.spec.tsx
@@ -36,7 +36,8 @@ describe('Canvas', () => {
               id: 'journeyId',
               themeMode: ThemeMode.dark,
               themeName: ThemeName.base
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <EditorProvider

--- a/apps/journeys-admin/src/components/Editor/Canvas/Canvas.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/Canvas.spec.tsx
@@ -31,13 +31,13 @@ describe('Canvas', () => {
     const { getByTestId } = render(
       <ThemeProvider>
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journeyId',
               themeMode: ThemeMode.dark,
               themeName: ThemeName.base
             } as unknown as Journey
-          }
+          }}
         >
           <EditorProvider
             initialState={{

--- a/apps/journeys-admin/src/components/Editor/Canvas/Canvas.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/Canvas.stories.tsx
@@ -585,13 +585,13 @@ const Template: Story = () => {
   return (
     <MockedProvider>
       <JourneyProvider
-        value={
-          {
+        value={{
+          journey: {
             id: 'journeyId',
             themeMode: ThemeMode.light,
             themeName: ThemeName.base
           } as unknown as Journey
-        }
+        }}
       >
         <EditorProvider initialState={{ steps: steps }}>
           <Canvas />

--- a/apps/journeys-admin/src/components/Editor/Canvas/Canvas.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/Canvas.stories.tsx
@@ -590,7 +590,8 @@ const Template: Story = () => {
             id: 'journeyId',
             themeMode: ThemeMode.light,
             themeName: ThemeName.base
-          } as unknown as Journey
+          } as unknown as Journey,
+          admin: true
         }}
       >
         <EditorProvider initialState={{ steps: steps }}>

--- a/apps/journeys-admin/src/components/Editor/Canvas/Canvas.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/Canvas.tsx
@@ -33,7 +33,7 @@ export function Canvas(): ReactElement {
     state: { steps, selectedStep, selectedBlock },
     dispatch
   } = useEditor()
-  const journey = useJourney()
+  const { journey } = useJourney()
 
   useEffect(() => {
     if (swiper != null && selectedStep != null && steps != null) {

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.spec.tsx
@@ -63,7 +63,9 @@ describe('ButtonEdit', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <EditorProvider>
             <ButtonEdit {...props} />
           </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.spec.tsx
@@ -64,7 +64,10 @@ describe('ButtonEdit', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <EditorProvider>
             <ButtonEdit {...props} />

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.stories.tsx
@@ -143,7 +143,8 @@ const Template: Story = ({ ...args }) => {
             id: 'journeyId',
             themeMode: ThemeMode.light,
             themeName: ThemeName.base
-          } as unknown as Journey
+          } as unknown as Journey,
+          admin: true
         }}
       >
         <EditorProvider

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.stories.tsx
@@ -138,13 +138,13 @@ const Template: Story = ({ ...args }) => {
   return (
     <MockedProvider>
       <JourneyProvider
-        value={
-          {
+        value={{
+          journey: {
             id: 'journeyId',
             themeMode: ThemeMode.light,
             themeName: ThemeName.base
           } as unknown as Journey
-        }
+        }}
       >
         <EditorProvider
           initialState={{

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.tsx
@@ -29,7 +29,7 @@ export function ButtonEdit({
   const [buttonBlockUpdate] = useMutation<ButtonBlockUpdateContent>(
     BUTTON_BLOCK_UPDATE_CONTENT
   )
-  const journey = useJourney()
+  const { journey } = useJourney()
   const [value, setValue] = useState(label)
 
   async function handleSaveBlock(): Promise<void> {

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditWrapper.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditWrapper.tsx
@@ -39,7 +39,7 @@ export function InlineEditWrapper({
     state: { selectedBlock, activeFab, selectedStep },
     dispatch
   } = useEditor()
-  const journey = useJourney()
+  const { journey } = useJourney()
 
   const showEditable =
     (activeFab === ActiveFab.Save && selectedBlock?.id === block.id) ||

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.spec.tsx
@@ -59,7 +59,9 @@ describe('RadioOptionEdit', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <EditorProvider>
             <RadioOptionEdit {...props} />
           </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.spec.tsx
@@ -60,7 +60,10 @@ describe('RadioOptionEdit', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <EditorProvider>
             <RadioOptionEdit {...props} />

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.stories.tsx
@@ -122,13 +122,13 @@ const Template: Story = ({ ...args }) => {
   return (
     <MockedProvider>
       <JourneyProvider
-        value={
-          {
+        value={{
+          journey: {
             id: 'journeyId',
             themeMode: ThemeMode.light,
             themeName: ThemeName.base
           } as unknown as Journey
-        }
+        }}
       >
         <EditorProvider
           initialState={{

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.stories.tsx
@@ -127,7 +127,8 @@ const Template: Story = ({ ...args }) => {
             id: 'journeyId',
             themeMode: ThemeMode.light,
             themeName: ThemeName.base
-          } as unknown as Journey
+          } as unknown as Journey,
+          admin: true
         }}
       >
         <EditorProvider

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.tsx
@@ -27,7 +27,7 @@ export function RadioOptionEdit({
   const [radioOptionBlockUpdate] = useMutation<RadioOptionBlockUpdateContent>(
     RADIO_OPTION_BLOCK_UPDATE_CONTENT
   )
-  const journey = useJourney()
+  const { journey } = useJourney()
   const [value, setValue] = useState(label)
 
   async function handleSaveBlock(): Promise<void> {

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioQuestionEdit/RadioQuestionEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioQuestionEdit/RadioQuestionEdit.spec.tsx
@@ -65,7 +65,9 @@ describe('RadioQuestionEdit', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <EditorProvider>
             <RadioQuestionEdit
               {...props([
@@ -98,7 +100,9 @@ describe('RadioQuestionEdit', () => {
   it('hides add option button if over 11 options', async () => {
     const { getAllByRole } = render(
       <MockedProvider mocks={[]}>
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <EditorProvider>
             <RadioQuestionEdit
               {...props([

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioQuestionEdit/RadioQuestionEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioQuestionEdit/RadioQuestionEdit.spec.tsx
@@ -66,7 +66,10 @@ describe('RadioQuestionEdit', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <EditorProvider>
             <RadioQuestionEdit
@@ -101,7 +104,10 @@ describe('RadioQuestionEdit', () => {
     const { getAllByRole } = render(
       <MockedProvider mocks={[]}>
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <EditorProvider>
             <RadioQuestionEdit

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioQuestionEdit/RadioQuestionEdit.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioQuestionEdit/RadioQuestionEdit.stories.tsx
@@ -124,13 +124,13 @@ const Template: Story = ({ ...args }) => {
   return (
     <MockedProvider>
       <JourneyProvider
-        value={
-          {
+        value={{
+          journey: {
             id: 'journeyId',
             themeMode: ThemeMode.light,
             themeName: ThemeName.base
           } as unknown as Journey
-        }
+        }}
       >
         <EditorProvider
           initialState={{

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioQuestionEdit/RadioQuestionEdit.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioQuestionEdit/RadioQuestionEdit.stories.tsx
@@ -129,7 +129,8 @@ const Template: Story = ({ ...args }) => {
             id: 'journeyId',
             themeMode: ThemeMode.light,
             themeName: ThemeName.base
-          } as unknown as Journey
+          } as unknown as Journey,
+          admin: true
         }}
       >
         <EditorProvider

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioQuestionEdit/RadioQuestionEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioQuestionEdit/RadioQuestionEdit.tsx
@@ -38,7 +38,7 @@ export function RadioQuestionEdit({
   const [radioOptionBlockCreate] = useMutation<RadioOptionBlockCreate>(
     RADIO_OPTION_BLOCK_CREATE
   )
-  const journey = useJourney()
+  const { journey } = useJourney()
 
   const handleCreateOption = async (): Promise<void> => {
     if (journey == null) return

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/SignUpEdit/SignUpEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/SignUpEdit/SignUpEdit.spec.tsx
@@ -58,7 +58,9 @@ describe('SignUpEdit', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <EditorProvider>
             <SignUpEdit {...props} />
           </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/SignUpEdit/SignUpEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/SignUpEdit/SignUpEdit.spec.tsx
@@ -59,7 +59,10 @@ describe('SignUpEdit', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <EditorProvider>
             <SignUpEdit {...props} />

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/SignUpEdit/SignUpEdit.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/SignUpEdit/SignUpEdit.stories.tsx
@@ -78,13 +78,13 @@ const Template: Story = ({ ...args }) => {
   return (
     <MockedProvider>
       <JourneyProvider
-        value={
-          {
+        value={{
+          journey: {
             id: 'journeyId',
             themeMode: ThemeMode.light,
             themeName: ThemeName.base
           } as unknown as Journey
-        }
+        }}
       >
         <EditorProvider
           initialState={{

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/SignUpEdit/SignUpEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/SignUpEdit/SignUpEdit.tsx
@@ -28,7 +28,7 @@ export function SignUpEdit({
     SIGN_UP_BLOCK_UPDATE_CONTENT
   )
 
-  const journey = useJourney()
+  const { journey } = useJourney()
   const [value, setValue] = useState(submitLabel ?? '')
 
   async function handleSaveBlock(): Promise<void> {

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.spec.tsx
@@ -66,7 +66,10 @@ describe('TypographyEdit', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <EditorProvider>
             <TypographyEdit {...props} />

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.spec.tsx
@@ -65,7 +65,9 @@ describe('TypographyEdit', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <EditorProvider>
             <TypographyEdit {...props} />
           </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.spec.tsx
@@ -88,7 +88,14 @@ describe('TypographyEdit', () => {
   it('calls onDelete when text content deleted', async () => {
     const { getByRole } = render(
       <MockedProvider>
-        <TypographyEdit {...props} />
+        <JourneyProvider
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
+        >
+          <TypographyEdit {...props} />
+        </JourneyProvider>
       </MockedProvider>
     )
     const input = getByRole('textbox')

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.stories.tsx
@@ -109,13 +109,13 @@ const Template: Story = ({ ...args }) => {
   return (
     <MockedProvider>
       <JourneyProvider
-        value={
-          {
+        value={{
+          journey: {
             id: 'journeyId',
             themeMode: ThemeMode.light,
             themeName: ThemeName.base
           } as unknown as Journey
-        }
+        }}
       >
         <EditorProvider
           initialState={{

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.stories.tsx
@@ -114,7 +114,8 @@ const Template: Story = ({ ...args }) => {
             id: 'journeyId',
             themeMode: ThemeMode.light,
             themeName: ThemeName.base
-          } as unknown as Journey
+          } as unknown as Journey,
+          admin: true
         }}
       >
         <EditorProvider

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.tsx
@@ -34,7 +34,7 @@ export function TypographyEdit({
     TYPOGRAPHY_BLOCK_UPDATE_CONTENT
   )
 
-  const journey = useJourney()
+  const { journey } = useJourney()
   const [value, setValue] = useState(content)
 
   async function handleSaveBlock(): Promise<void> {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.spec.tsx
@@ -179,7 +179,8 @@ describe('Action', () => {
             request: {
               query: ACTION_DELETE,
               variables: {
-                id: selectedBlock?.id
+                id: selectedBlock?.id,
+                journeyId: 'journeyId'
               }
             },
             result
@@ -187,9 +188,16 @@ describe('Action', () => {
         ]}
         cache={cache}
       >
-        <EditorProvider initialState={{ selectedBlock }}>
-          <Action />
-        </EditorProvider>
+        <JourneyProvider
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
+        >
+          <EditorProvider initialState={{ selectedBlock }}>
+            <Action />
+          </EditorProvider>
+        </JourneyProvider>
       </MockedProvider>
     )
     expect(getByText('URL/Website')).toBeInTheDocument()

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.spec.tsx
@@ -82,13 +82,13 @@ describe('Action', () => {
         cache={cache}
       >
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
             } as unknown as Journey
-          }
+          }}
         >
           <EditorProvider initialState={{ steps, selectedBlock, selectedStep }}>
             <Action />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.spec.tsx
@@ -87,7 +87,8 @@ describe('Action', () => {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <EditorProvider initialState={{ steps, selectedBlock, selectedStep }}>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.stories.tsx
@@ -83,7 +83,7 @@ const Template: Story = ({ ...args }) => {
         }
       ]}
     >
-      <JourneyProvider value={journey}>
+      <JourneyProvider value={{ journey }}>
         <EditorProvider
           initialState={{
             ...args,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.stories.tsx
@@ -83,7 +83,7 @@ const Template: Story = ({ ...args }) => {
         }
       ]}
     >
-      <JourneyProvider value={{ journey }}>
+      <JourneyProvider value={{ journey, admin: true }}>
         <EditorProvider
           initialState={{
             ...args,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.tsx
@@ -65,7 +65,7 @@ export const actions = [
 
 export function Action(): ReactElement {
   const { state } = useEditor()
-  const journey = useJourney()
+  const { journey } = useJourney()
 
   // Add addtional types here to use this component for that block
   const selectedBlock = state.selectedBlock as

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/LinkAction/LinkAction.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/LinkAction/LinkAction.spec.tsx
@@ -1,8 +1,9 @@
 import { MockedProvider } from '@apollo/client/testing'
 import { render, waitFor, fireEvent } from '@testing-library/react'
-import { EditorProvider } from '@core/journeys/ui'
+import { EditorProvider, JourneyProvider } from '@core/journeys/ui'
 import { InMemoryCache } from '@apollo/client'
 import { steps } from '../data'
+import { GetJourney_journey as Journey } from '../../../../../../../__generated__/GetJourney'
 import { LinkAction, LINK_ACTION_UPDATE } from './LinkAction'
 
 describe('LinkAction', () => {
@@ -43,7 +44,7 @@ describe('LinkAction', () => {
     const result = jest.fn(() => ({
       data: {
         blockUpdateLinkAction: {
-          id: 'journeyId',
+          id: selectedBlock.id,
           gtmEventName: 'gtmEventName',
           url: 'https://www.github.com'
         }
@@ -58,6 +59,7 @@ describe('LinkAction', () => {
               query: LINK_ACTION_UPDATE,
               variables: {
                 id: selectedBlock.id,
+                journeyId: 'journeyId',
                 input: {
                   url: 'https://www.github.com'
                 }
@@ -68,9 +70,16 @@ describe('LinkAction', () => {
         ]}
         cache={cache}
       >
-        <EditorProvider initialState={{ selectedBlock }}>
-          <LinkAction />
-        </EditorProvider>
+        <JourneyProvider
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
+        >
+          <EditorProvider initialState={{ selectedBlock }}>
+            <LinkAction />
+          </EditorProvider>
+        </JourneyProvider>
       </MockedProvider>
     )
     fireEvent.change(getByRole('textbox'), {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/LinkAction/LinkAction.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/LinkAction/LinkAction.tsx
@@ -30,7 +30,7 @@ interface LinkActionFormValues {
 
 export function LinkAction(): ReactElement {
   const { state } = useEditor()
-  const journey = useJourney()
+  const { journey } = useJourney()
   const selectedBlock = state.selectedBlock as
     | TreeBlock<ButtonBlock>
     | undefined

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateAction/NavigateAction.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateAction/NavigateAction.spec.tsx
@@ -21,7 +21,8 @@ describe('NavigateAction', () => {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <EditorProvider initialState={{ steps, selectedStep }}>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateAction/NavigateAction.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateAction/NavigateAction.spec.tsx
@@ -16,13 +16,13 @@ describe('NavigateAction', () => {
     const { getByTestId, getByText } = render(
       <MockedProvider>
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
             } as unknown as Journey
-          }
+          }}
         >
           <EditorProvider initialState={{ steps, selectedStep }}>
             <NavigateAction />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateAction/NavigateAction.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateAction/NavigateAction.stories.tsx
@@ -34,7 +34,7 @@ export const Navigate: Story = () => {
       <Box>
         <Typography>Default</Typography>
         <MockedProvider>
-          <JourneyProvider value={journeyTheme}>
+          <JourneyProvider value={{ journey: journeyTheme }}>
             <EditorProvider
               initialState={{
                 steps,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateAction/NavigateAction.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateAction/NavigateAction.stories.tsx
@@ -34,7 +34,7 @@ export const Navigate: Story = () => {
       <Box>
         <Typography>Default</Typography>
         <MockedProvider>
-          <JourneyProvider value={{ journey: journeyTheme }}>
+          <JourneyProvider value={{ journey: journeyTheme, admin: true }}>
             <EditorProvider
               initialState={{
                 steps,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToBlockAction/NavigateToBlockAction.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToBlockAction/NavigateToBlockAction.spec.tsx
@@ -59,13 +59,13 @@ describe('NavigateToBlockAction', () => {
         cache={cache}
       >
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
             } as unknown as Journey
-          }
+          }}
         >
           <EditorProvider initialState={{ steps, selectedBlock }}>
             <NavigateToBlockAction />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToBlockAction/NavigateToBlockAction.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToBlockAction/NavigateToBlockAction.spec.tsx
@@ -64,7 +64,8 @@ describe('NavigateToBlockAction', () => {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <EditorProvider initialState={{ steps, selectedBlock }}>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToBlockAction/NavigateToBlockAction.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToBlockAction/NavigateToBlockAction.stories.tsx
@@ -33,7 +33,7 @@ export const NavigateToBlock: Story = () => {
       <Box>
         <Typography>Default</Typography>
         <MockedProvider>
-          <JourneyProvider value={journeyTheme}>
+          <JourneyProvider value={{ journey: journeyTheme }}>
             <EditorProvider initialState={{ steps }}>
               <NavigateToBlockAction />
             </EditorProvider>
@@ -44,7 +44,7 @@ export const NavigateToBlock: Story = () => {
       <Box>
         <Typography>Selected card</Typography>
         <MockedProvider>
-          <JourneyProvider value={journeyTheme}>
+          <JourneyProvider value={{ journey: journeyTheme }}>
             <EditorProvider initialState={{ selectedBlock, steps }}>
               <NavigateToBlockAction />
             </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToBlockAction/NavigateToBlockAction.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToBlockAction/NavigateToBlockAction.stories.tsx
@@ -33,7 +33,7 @@ export const NavigateToBlock: Story = () => {
       <Box>
         <Typography>Default</Typography>
         <MockedProvider>
-          <JourneyProvider value={{ journey: journeyTheme }}>
+          <JourneyProvider value={{ journey: journeyTheme, admin: true }}>
             <EditorProvider initialState={{ steps }}>
               <NavigateToBlockAction />
             </EditorProvider>
@@ -44,7 +44,7 @@ export const NavigateToBlock: Story = () => {
       <Box>
         <Typography>Selected card</Typography>
         <MockedProvider>
-          <JourneyProvider value={{ journey: journeyTheme }}>
+          <JourneyProvider value={{ journey: journeyTheme, admin: true }}>
             <EditorProvider initialState={{ selectedBlock, steps }}>
               <NavigateToBlockAction />
             </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToBlockAction/NavigateToBlockAction.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToBlockAction/NavigateToBlockAction.tsx
@@ -30,7 +30,7 @@ export function NavigateToBlockAction(): ReactElement {
   const {
     state: { steps, selectedBlock }
   } = useEditor()
-  const journey = useJourney()
+  const { journey } = useJourney()
   const currentBlock = selectedBlock as
     | TreeBlock<ButtonBlock>
     | TreeBlock<VideoBlock>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.spec.tsx
@@ -77,7 +77,7 @@ describe('NavigateToJourneyAction', () => {
           }
         ]}
       >
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <EditorProvider initialState={{ selectedBlock }}>
             <NavigateToJourneyAction />
           </EditorProvider>
@@ -151,7 +151,7 @@ describe('NavigateToJourneyAction', () => {
         ]}
         cache={cache}
       >
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <EditorProvider initialState={{ selectedBlock }}>
             <NavigateToJourneyAction />
           </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.spec.tsx
@@ -77,7 +77,7 @@ describe('NavigateToJourneyAction', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <EditorProvider initialState={{ selectedBlock }}>
             <NavigateToJourneyAction />
           </EditorProvider>
@@ -151,7 +151,7 @@ describe('NavigateToJourneyAction', () => {
         ]}
         cache={cache}
       >
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <EditorProvider initialState={{ selectedBlock }}>
             <NavigateToJourneyAction />
           </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.stories.tsx
@@ -76,7 +76,7 @@ export const NavigateToJourney: Story = () => {
             }
           ]}
         >
-          <JourneyProvider value={{ journey }}>
+          <JourneyProvider value={{ journey, admin: true }}>
             <EditorProvider initialState={{ selectedBlock }}>
               <NavigateToJourneyAction />
             </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.stories.tsx
@@ -76,7 +76,7 @@ export const NavigateToJourney: Story = () => {
             }
           ]}
         >
-          <JourneyProvider value={journey}>
+          <JourneyProvider value={{ journey }}>
             <EditorProvider initialState={{ selectedBlock }}>
               <NavigateToJourneyAction />
             </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.tsx
@@ -40,7 +40,7 @@ export const NAVIGATE_TO_JOURNEY_ACTION_UPDATE = gql`
 
 export function NavigateToJourneyAction(): ReactElement {
   const { state } = useEditor()
-  const journey = useJourney()
+  const { journey } = useJourney()
   const selectedBlock = state.selectedBlock as
     | TreeBlock<ButtonBlock>
     | undefined

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Icon/Color/Color.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Icon/Color/Color.tsx
@@ -26,7 +26,7 @@ export function Color({ id, iconColor }: ColorProps): ReactElement {
   const [iconBlockColorUpdate] = useMutation<IconBlockColorUpdate>(
     ICON_BLOCK_COLOR_UPDATE
   )
-  const journey = useJourney()
+  const { journey } = useJourney()
 
   async function handleChange(color: IconColor): Promise<void> {
     if (color !== iconColor && color != null && journey != null) {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Icon/Icon.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Icon/Icon.spec.tsx
@@ -1,9 +1,12 @@
 import { render, fireEvent, waitFor } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
-import { EditorProvider, TreeBlock } from '@core/journeys/ui'
+import { EditorProvider, TreeBlock, JourneyProvider } from '@core/journeys/ui'
 import { IconName } from '../../../../../../__generated__/globalTypes'
 import { IconFields } from '../../../../../../__generated__/IconFields'
-import { GetJourney_journey_blocks_ButtonBlock as ButtonBlock } from '../../../../../../__generated__/GetJourney'
+import {
+  GetJourney_journey_blocks_ButtonBlock as ButtonBlock,
+  GetJourney_journey as Journey
+} from '../../../../../../__generated__/GetJourney'
 import { ICON_BLOCK_NAME_UPDATE } from './Icon'
 import { Icon } from '.'
 
@@ -98,6 +101,7 @@ describe('Icon', () => {
               query: ICON_BLOCK_NAME_UPDATE,
               variables: {
                 id: icon.id,
+                journeyId: 'journeyId',
                 input: {
                   name: IconName.ArrowForwardRounded
                 }
@@ -107,9 +111,16 @@ describe('Icon', () => {
           }
         ]}
       >
-        <EditorProvider initialState={{ selectedBlock: testSelectedBlock }}>
-          <Icon id={testIcon.id} />
-        </EditorProvider>
+        <JourneyProvider
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
+        >
+          <EditorProvider initialState={{ selectedBlock: testSelectedBlock }}>
+            <Icon id={testIcon.id} />
+          </EditorProvider>
+        </JourneyProvider>
       </MockedProvider>
     )
 
@@ -140,6 +151,7 @@ describe('Icon', () => {
               query: ICON_BLOCK_NAME_UPDATE,
               variables: {
                 id: icon.id,
+                journeyId: 'journeyId',
                 input: {
                   name: null
                 }
@@ -149,9 +161,16 @@ describe('Icon', () => {
           }
         ]}
       >
-        <EditorProvider initialState={{ selectedBlock }}>
-          <Icon id={icon.id} />
-        </EditorProvider>
+        <JourneyProvider
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
+        >
+          <EditorProvider initialState={{ selectedBlock }}>
+            <Icon id={icon.id} />
+          </EditorProvider>
+        </JourneyProvider>
       </MockedProvider>
     )
     fireEvent.mouseDown(getByRole('button', { name: 'icon-name' }))
@@ -181,6 +200,7 @@ describe('Icon', () => {
               query: ICON_BLOCK_NAME_UPDATE,
               variables: {
                 id: icon.id,
+                journeyId: 'journeyId',
                 input: {
                   name: IconName.BeenhereRounded
                 }
@@ -190,9 +210,16 @@ describe('Icon', () => {
           }
         ]}
       >
-        <EditorProvider initialState={{ selectedBlock }}>
-          <Icon id={icon.id} />
-        </EditorProvider>
+        <JourneyProvider
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
+        >
+          <EditorProvider initialState={{ selectedBlock }}>
+            <Icon id={icon.id} />
+          </EditorProvider>
+        </JourneyProvider>
       </MockedProvider>
     )
     fireEvent.mouseDown(getByRole('button', { name: 'icon-name' }))

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Icon/Icon.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Icon/Icon.tsx
@@ -126,7 +126,7 @@ export function Icon({ id }: IconProps): ReactElement {
   const [iconBlockNameUpdate] = useMutation<IconBlockNameUpdate>(
     ICON_BLOCK_NAME_UPDATE
   )
-  const journey = useJourney()
+  const { journey } = useJourney()
   const { state } = useEditor()
   const selectedBlock = state.selectedBlock as IconParentBlock
 

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/MoveBlockButtons/MoveBlockButtons.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/MoveBlockButtons/MoveBlockButtons.spec.tsx
@@ -87,7 +87,10 @@ describe('MoveBlockButton', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <EditorProvider>
             <MoveBlockButtons selectedBlock={block2} selectedStep={step} />
@@ -117,7 +120,10 @@ describe('MoveBlockButton', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <EditorProvider>
             <MoveBlockButtons selectedBlock={block1} selectedStep={step} />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/MoveBlockButtons/MoveBlockButtons.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/MoveBlockButtons/MoveBlockButtons.spec.tsx
@@ -86,7 +86,9 @@ describe('MoveBlockButton', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <EditorProvider>
             <MoveBlockButtons selectedBlock={block2} selectedStep={step} />
           </EditorProvider>
@@ -114,7 +116,9 @@ describe('MoveBlockButton', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <EditorProvider>
             <MoveBlockButtons selectedBlock={block1} selectedStep={step} />
           </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/MoveBlockButtons/MoveBlockButtons.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/MoveBlockButtons/MoveBlockButtons.tsx
@@ -60,7 +60,7 @@ export function MoveBlockButtons({
   selectedStep
 }: MoveBlockButtonsProps): ReactElement {
   const [blockOrderUpdate] = useMutation<BlockOrderUpdate>(BLOCK_ORDER_UPDATE)
-  const journey = useJourney()
+  const { journey } = useJourney()
 
   const parentBlock =
     selectedBlock.parentBlockId != null

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Button/Color/Color.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Button/Color/Color.tsx
@@ -24,7 +24,7 @@ export function Color(): ReactElement {
   const [buttonBlockUpdate] =
     useMutation<ButtonBlockUpdateColor>(BUTTON_BLOCK_UPDATE)
 
-  const journey = useJourney()
+  const { journey } = useJourney()
   const { state } = useEditor()
   const selectedBlock = state.selectedBlock as
     | TreeBlock<ButtonBlock>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Button/Size/Size.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Button/Size/Size.tsx
@@ -23,7 +23,7 @@ export function Size(): ReactElement {
   const [buttonBlockUpdate] =
     useMutation<ButtonBlockUpdateSize>(BUTTON_BLOCK_UPDATE)
 
-  const journey = useJourney()
+  const { journey } = useJourney()
   const { state } = useEditor()
   const selectedBlock = state.selectedBlock as
     | TreeBlock<ButtonBlock>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Button/Variant/Variant.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Button/Variant/Variant.tsx
@@ -23,7 +23,7 @@ export function Variant(): ReactElement {
   const [buttonBlockUpdate] =
     useMutation<ButtonBlockUpdateVariant>(BUTTON_BLOCK_UPDATE)
 
-  const journey = useJourney()
+  const { journey } = useJourney()
   const { state } = useEditor()
   const selectedBlock = state.selectedBlock as
     | TreeBlock<ButtonBlock>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundColor/BackgroundColor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundColor/BackgroundColor.spec.tsx
@@ -64,7 +64,7 @@ describe('BackgroundColor', () => {
     const { getByTestId, getByRole, getAllByTestId } = render(
       <MockedProvider>
         <ThemeProvider>
-          <JourneyProvider value={journey}>
+          <JourneyProvider value={{ journey }}>
             <EditorProvider initialState={{ selectedBlock: card }}>
               <BackgroundColor />
             </EditorProvider>
@@ -125,7 +125,7 @@ describe('BackgroundColor', () => {
         ]}
       >
         <ThemeProvider>
-          <JourneyProvider value={journey}>
+          <JourneyProvider value={{ journey }}>
             <EditorProvider initialState={{ selectedBlock: card }}>
               <BackgroundColor />
             </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundColor/BackgroundColor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundColor/BackgroundColor.spec.tsx
@@ -64,7 +64,7 @@ describe('BackgroundColor', () => {
     const { getByTestId, getByRole, getAllByTestId } = render(
       <MockedProvider>
         <ThemeProvider>
-          <JourneyProvider value={{ journey }}>
+          <JourneyProvider value={{ journey, admin: true }}>
             <EditorProvider initialState={{ selectedBlock: card }}>
               <BackgroundColor />
             </EditorProvider>
@@ -125,7 +125,7 @@ describe('BackgroundColor', () => {
         ]}
       >
         <ThemeProvider>
-          <JourneyProvider value={{ journey }}>
+          <JourneyProvider value={{ journey, admin: true }}>
             <EditorProvider initialState={{ selectedBlock: card }}>
               <BackgroundColor />
             </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundColor/BackgroundColor.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundColor/BackgroundColor.tsx
@@ -66,7 +66,7 @@ export function BackgroundColor(): ReactElement {
         )
   ) as TreeBlock<CardFields> | undefined
 
-  const journey = useJourney()
+  const { journey } = useJourney()
 
   const cardTheme =
     themes[cardBlock?.themeName ?? journey?.themeName ?? 'base'][

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.spec.tsx
@@ -64,7 +64,7 @@ describe('BackgroundMedia', () => {
     const { getByTestId } = render(
       <MockedProvider>
         <ThemeProvider>
-          <JourneyProvider value={{ journey }}>
+          <JourneyProvider value={{ journey, admin: true }}>
             <EditorProvider initialState={{ selectedBlock: card }}>
               <SnackbarProvider>
                 <BackgroundMedia />
@@ -128,7 +128,7 @@ describe('BackgroundMedia', () => {
     const { getByTestId } = render(
       <MockedProvider>
         <ThemeProvider>
-          <JourneyProvider value={{ journey }}>
+          <JourneyProvider value={{ journey, admin: true }}>
             <EditorProvider initialState={{ selectedBlock: card }}>
               <SnackbarProvider>
                 <BackgroundMedia />
@@ -180,7 +180,7 @@ describe('BackgroundMedia', () => {
     const { getByTestId } = render(
       <MockedProvider>
         <ThemeProvider>
-          <JourneyProvider value={{ journey }}>
+          <JourneyProvider value={{ journey, admin: true }}>
             <EditorProvider initialState={{ selectedBlock: step }}>
               <SnackbarProvider>
                 <BackgroundMedia />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.spec.tsx
@@ -64,7 +64,7 @@ describe('BackgroundMedia', () => {
     const { getByTestId } = render(
       <MockedProvider>
         <ThemeProvider>
-          <JourneyProvider value={journey}>
+          <JourneyProvider value={{ journey }}>
             <EditorProvider initialState={{ selectedBlock: card }}>
               <SnackbarProvider>
                 <BackgroundMedia />
@@ -128,7 +128,7 @@ describe('BackgroundMedia', () => {
     const { getByTestId } = render(
       <MockedProvider>
         <ThemeProvider>
-          <JourneyProvider value={journey}>
+          <JourneyProvider value={{ journey }}>
             <EditorProvider initialState={{ selectedBlock: card }}>
               <SnackbarProvider>
                 <BackgroundMedia />
@@ -180,7 +180,7 @@ describe('BackgroundMedia', () => {
     const { getByTestId } = render(
       <MockedProvider>
         <ThemeProvider>
-          <JourneyProvider value={journey}>
+          <JourneyProvider value={{ journey }}>
             <EditorProvider initialState={{ selectedBlock: step }}>
               <SnackbarProvider>
                 <BackgroundMedia />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.stories.tsx
@@ -133,7 +133,7 @@ const image: TreeBlock<ImageBlock> = {
 const Template: Story = ({ ...args }) => (
   <MockedProvider>
     <ThemeProvider>
-      <JourneyProvider value={{ journey }}>
+      <JourneyProvider value={{ journey, admin: true }}>
         <EditorProvider
           initialState={{
             ...args,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.stories.tsx
@@ -133,7 +133,7 @@ const image: TreeBlock<ImageBlock> = {
 const Template: Story = ({ ...args }) => (
   <MockedProvider>
     <ThemeProvider>
-      <JourneyProvider value={journey}>
+      <JourneyProvider value={{ journey }}>
         <EditorProvider
           initialState={{
             ...args,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
@@ -147,7 +147,7 @@ describe('BackgroundMediaImage', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <SnackbarProvider>
             <BackgroundMediaImage cardBlock={card} />
           </SnackbarProvider>
@@ -223,7 +223,7 @@ describe('BackgroundMediaImage', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <SnackbarProvider>
             <BackgroundMediaImage cardBlock={videoCard} />
           </SnackbarProvider>
@@ -306,7 +306,7 @@ describe('BackgroundMediaImage', () => {
             }
           ]}
         >
-          <JourneyProvider value={{ journey }}>
+          <JourneyProvider value={{ journey, admin: true }}>
             <SnackbarProvider>
               <BackgroundMediaImage cardBlock={existingCoverBlock} />
             </SnackbarProvider>
@@ -329,7 +329,7 @@ describe('BackgroundMediaImage', () => {
     it('shows loading icon', async () => {
       const { getByRole } = render(
         <MockedProvider mocks={[]}>
-          <JourneyProvider value={{ journey }}>
+          <JourneyProvider value={{ journey, admin: true }}>
             <SnackbarProvider>
               <BackgroundMediaImage cardBlock={existingCoverBlock} />
             </SnackbarProvider>
@@ -401,7 +401,7 @@ describe('BackgroundMediaImage', () => {
             }
           ]}
         >
-          <JourneyProvider value={{ journey }}>
+          <JourneyProvider value={{ journey, admin: true }}>
             <SnackbarProvider>
               <BackgroundMediaImage cardBlock={existingCoverBlock} />
             </SnackbarProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
@@ -147,7 +147,7 @@ describe('BackgroundMediaImage', () => {
           }
         ]}
       >
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <SnackbarProvider>
             <BackgroundMediaImage cardBlock={card} />
           </SnackbarProvider>
@@ -223,7 +223,7 @@ describe('BackgroundMediaImage', () => {
           }
         ]}
       >
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <SnackbarProvider>
             <BackgroundMediaImage cardBlock={videoCard} />
           </SnackbarProvider>
@@ -306,7 +306,7 @@ describe('BackgroundMediaImage', () => {
             }
           ]}
         >
-          <JourneyProvider value={journey}>
+          <JourneyProvider value={{ journey }}>
             <SnackbarProvider>
               <BackgroundMediaImage cardBlock={existingCoverBlock} />
             </SnackbarProvider>
@@ -329,7 +329,7 @@ describe('BackgroundMediaImage', () => {
     it('shows loading icon', async () => {
       const { getByRole } = render(
         <MockedProvider mocks={[]}>
-          <JourneyProvider value={journey}>
+          <JourneyProvider value={{ journey }}>
             <SnackbarProvider>
               <BackgroundMediaImage cardBlock={existingCoverBlock} />
             </SnackbarProvider>
@@ -401,7 +401,7 @@ describe('BackgroundMediaImage', () => {
             }
           ]}
         >
-          <JourneyProvider value={journey}>
+          <JourneyProvider value={{ journey }}>
             <SnackbarProvider>
               <BackgroundMediaImage cardBlock={existingCoverBlock} />
             </SnackbarProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.tsx
@@ -96,7 +96,7 @@ export function BackgroundMediaImage({
   const [blockDelete] = useMutation<BlockDeleteForBackgroundImage>(
     BLOCK_DELETE_FOR_BACKGROUND_IMAGE
   )
-  const journey = useJourney()
+  const { journey } = useJourney()
   const { enqueueSnackbar } = useSnackbar()
 
   const handleImageDelete = async (): Promise<void> => {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
@@ -179,7 +179,9 @@ describe('BackgroundMediaVideo', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <ThemeProvider>
             <SnackbarProvider>
               <BackgroundMediaVideo cardBlock={card} />
@@ -252,7 +254,9 @@ describe('BackgroundMediaVideo', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <ThemeProvider>
             <SnackbarProvider>
               <BackgroundMediaVideo cardBlock={imageCard} />
@@ -325,7 +329,9 @@ describe('BackgroundMediaVideo', () => {
             }
           ]}
         >
-          <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+          <JourneyProvider
+            value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          >
             <ThemeProvider>
               <SnackbarProvider>
                 <BackgroundMediaVideo cardBlock={existingCoverBlock} />
@@ -406,7 +412,9 @@ describe('BackgroundMediaVideo', () => {
           ]}
         >
           <ThemeProvider>
-            <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+            <JourneyProvider
+              value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+            >
               <SnackbarProvider>
                 <BackgroundMediaVideo cardBlock={existingCoverBlock} />
               </SnackbarProvider>
@@ -428,7 +436,9 @@ describe('BackgroundMediaVideo', () => {
       it('shows settings', async () => {
         const { getAllByRole } = render(
           <MockedProvider>
-            <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+            <JourneyProvider
+              value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+            >
               <ThemeProvider>
                 <SnackbarProvider>
                   <BackgroundMediaVideo cardBlock={existingCoverBlock} />
@@ -489,7 +499,9 @@ describe('BackgroundMediaVideo', () => {
               }
             ]}
           >
-            <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+            <JourneyProvider
+              value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+            >
               <ThemeProvider>
                 <SnackbarProvider>
                   <BackgroundMediaVideo cardBlock={existingCoverBlock} />
@@ -543,7 +555,9 @@ describe('BackgroundMediaVideo', () => {
             }
           ]}
         >
-          <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+          <JourneyProvider
+            value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          >
             <ThemeProvider>
               <SnackbarProvider>
                 <BackgroundMediaVideo cardBlock={existingCoverBlock} />
@@ -596,7 +610,9 @@ describe('BackgroundMediaVideo', () => {
             }
           ]}
         >
-          <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+          <JourneyProvider
+            value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          >
             <ThemeProvider>
               <SnackbarProvider>
                 <BackgroundMediaVideo cardBlock={existingCoverBlock} />
@@ -651,7 +667,9 @@ describe('BackgroundMediaVideo', () => {
           ]}
         >
           <ThemeProvider>
-            <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+            <JourneyProvider
+              value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+            >
               <SnackbarProvider>
                 <BackgroundMediaVideo cardBlock={existingCoverBlock} />
               </SnackbarProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
@@ -180,7 +180,10 @@ describe('BackgroundMediaVideo', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <ThemeProvider>
             <SnackbarProvider>
@@ -255,7 +258,10 @@ describe('BackgroundMediaVideo', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <ThemeProvider>
             <SnackbarProvider>
@@ -330,7 +336,10 @@ describe('BackgroundMediaVideo', () => {
           ]}
         >
           <JourneyProvider
-            value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+            value={{
+              journey: { id: 'journeyId' } as unknown as Journey,
+              admin: true
+            }}
           >
             <ThemeProvider>
               <SnackbarProvider>
@@ -413,7 +422,10 @@ describe('BackgroundMediaVideo', () => {
         >
           <ThemeProvider>
             <JourneyProvider
-              value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+              value={{
+                journey: { id: 'journeyId' } as unknown as Journey,
+                admin: true
+              }}
             >
               <SnackbarProvider>
                 <BackgroundMediaVideo cardBlock={existingCoverBlock} />
@@ -437,7 +449,10 @@ describe('BackgroundMediaVideo', () => {
         const { getAllByRole } = render(
           <MockedProvider>
             <JourneyProvider
-              value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+              value={{
+                journey: { id: 'journeyId' } as unknown as Journey,
+                admin: true
+              }}
             >
               <ThemeProvider>
                 <SnackbarProvider>
@@ -500,7 +515,10 @@ describe('BackgroundMediaVideo', () => {
             ]}
           >
             <JourneyProvider
-              value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+              value={{
+                journey: { id: 'journeyId' } as unknown as Journey,
+                admin: true
+              }}
             >
               <ThemeProvider>
                 <SnackbarProvider>
@@ -556,7 +574,10 @@ describe('BackgroundMediaVideo', () => {
           ]}
         >
           <JourneyProvider
-            value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+            value={{
+              journey: { id: 'journeyId' } as unknown as Journey,
+              admin: true
+            }}
           >
             <ThemeProvider>
               <SnackbarProvider>
@@ -611,7 +632,10 @@ describe('BackgroundMediaVideo', () => {
           ]}
         >
           <JourneyProvider
-            value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+            value={{
+              journey: { id: 'journeyId' } as unknown as Journey,
+              admin: true
+            }}
           >
             <ThemeProvider>
               <SnackbarProvider>
@@ -668,7 +692,10 @@ describe('BackgroundMediaVideo', () => {
         >
           <ThemeProvider>
             <JourneyProvider
-              value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+              value={{
+                journey: { id: 'journeyId' } as unknown as Journey,
+                admin: true
+              }}
             >
               <SnackbarProvider>
                 <BackgroundMediaVideo cardBlock={existingCoverBlock} />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.tsx
@@ -87,7 +87,7 @@ export function BackgroundMediaVideo({
   const [blockDelete] = useMutation<BlockDeleteForBackgroundVideo>(
     BLOCK_DELETE_FOR_BACKGROUND_VIDEO
   )
-  const journey = useJourney()
+  const { journey } = useJourney()
   const { enqueueSnackbar } = useSnackbar()
   const videoBlock = coverBlock?.__typename === 'VideoBlock' ? coverBlock : null
 

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/Card.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/Card.spec.tsx
@@ -82,7 +82,7 @@ describe('Card', () => {
     }
     it('shows background color from prop', () => {
       const { getByRole } = render(
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <Card {...card} backgroundColor="#00FFCC" />
         </JourneyProvider>
       )
@@ -92,7 +92,7 @@ describe('Card', () => {
 
     it('shows background color from card theme', () => {
       const { getByRole } = render(
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <Card
             {...card}
             themeName={ThemeName.base}
@@ -106,7 +106,7 @@ describe('Card', () => {
 
     it('shows background color from journey theme', () => {
       const { getByRole } = render(
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <Card {...card} />
         </JourneyProvider>
       )
@@ -118,7 +118,7 @@ describe('Card', () => {
       const { getByText } = render(
         <MockedProvider>
           <ThemeProvider>
-            <JourneyProvider value={{ journey }}>
+            <JourneyProvider value={{ journey, admin: true }}>
               <EditorProvider>
                 <Drawer />
                 <Card {...card} backgroundColor="#00FFCC" />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/Card.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/Card.spec.tsx
@@ -82,7 +82,7 @@ describe('Card', () => {
     }
     it('shows background color from prop', () => {
       const { getByRole } = render(
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <Card {...card} backgroundColor="#00FFCC" />
         </JourneyProvider>
       )
@@ -92,7 +92,7 @@ describe('Card', () => {
 
     it('shows background color from card theme', () => {
       const { getByRole } = render(
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <Card
             {...card}
             themeName={ThemeName.base}
@@ -106,7 +106,7 @@ describe('Card', () => {
 
     it('shows background color from journey theme', () => {
       const { getByRole } = render(
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <Card {...card} />
         </JourneyProvider>
       )
@@ -118,7 +118,7 @@ describe('Card', () => {
       const { getByText } = render(
         <MockedProvider>
           <ThemeProvider>
-            <JourneyProvider value={journey}>
+            <JourneyProvider value={{ journey }}>
               <EditorProvider>
                 <Drawer />
                 <Card {...card} backgroundColor="#00FFCC" />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/Card.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/Card.tsx
@@ -29,7 +29,7 @@ export function Card({
   children
 }: TreeBlock<CardBlock>): ReactElement {
   const { dispatch } = useEditor()
-  const journey = useJourney()
+  const { journey } = useJourney()
 
   const coverBlock = children.find((block) => block.id === coverBlockId) as
     | TreeBlock<ImageBlock | VideoBlock>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardLayout/CardLayout.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardLayout/CardLayout.spec.tsx
@@ -60,7 +60,7 @@ describe('CardLayout', () => {
     }
     const { getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <EditorProvider initialState={{ selectedBlock: card }}>
             <CardLayout />
           </EditorProvider>
@@ -85,7 +85,7 @@ describe('CardLayout', () => {
     }
     const { getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <EditorProvider initialState={{ selectedBlock: card }}>
             <CardLayout />
           </EditorProvider>
@@ -119,7 +119,7 @@ describe('CardLayout', () => {
     }
     const { getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <EditorProvider initialState={{ selectedBlock: step }}>
             <CardLayout />
           </EditorProvider>
@@ -174,7 +174,7 @@ describe('CardLayout', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <EditorProvider initialState={{ selectedBlock: card }}>
             <CardLayout />
           </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardLayout/CardLayout.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardLayout/CardLayout.spec.tsx
@@ -60,7 +60,7 @@ describe('CardLayout', () => {
     }
     const { getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <EditorProvider initialState={{ selectedBlock: card }}>
             <CardLayout />
           </EditorProvider>
@@ -85,7 +85,7 @@ describe('CardLayout', () => {
     }
     const { getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <EditorProvider initialState={{ selectedBlock: card }}>
             <CardLayout />
           </EditorProvider>
@@ -119,7 +119,7 @@ describe('CardLayout', () => {
     }
     const { getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <EditorProvider initialState={{ selectedBlock: step }}>
             <CardLayout />
           </EditorProvider>
@@ -174,7 +174,7 @@ describe('CardLayout', () => {
           }
         ]}
       >
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <EditorProvider initialState={{ selectedBlock: card }}>
             <CardLayout />
           </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardLayout/CardLayout.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardLayout/CardLayout.stories.tsx
@@ -70,7 +70,7 @@ export const Default: Story = () => {
 
   return (
     <MockedProvider>
-      <JourneyProvider value={journey}>
+      <JourneyProvider value={{ journey }}>
         <EditorProvider
           initialState={{
             selectedBlock: block,
@@ -102,7 +102,7 @@ export const FullScreen: Story = () => {
 
   return (
     <MockedProvider>
-      <JourneyProvider value={journey}>
+      <JourneyProvider value={{ journey }}>
         <EditorProvider
           initialState={{
             selectedBlock: block,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardLayout/CardLayout.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardLayout/CardLayout.stories.tsx
@@ -70,7 +70,7 @@ export const Default: Story = () => {
 
   return (
     <MockedProvider>
-      <JourneyProvider value={{ journey }}>
+      <JourneyProvider value={{ journey, admin: true }}>
         <EditorProvider
           initialState={{
             selectedBlock: block,
@@ -102,7 +102,7 @@ export const FullScreen: Story = () => {
 
   return (
     <MockedProvider>
-      <JourneyProvider value={{ journey }}>
+      <JourneyProvider value={{ journey, admin: true }}>
         <EditorProvider
           initialState={{
             selectedBlock: block,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardLayout/CardLayout.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardLayout/CardLayout.tsx
@@ -42,7 +42,7 @@ export function CardLayout(): ReactElement {
   const [cardBlockUpdate] = useMutation<CardBlockLayoutUpdate>(
     CARD_BLOCK_LAYOUT_UPDATE
   )
-  const journey = useJourney()
+  const { journey } = useJourney()
   const handleLayoutChange = async (selected: boolean): Promise<void> => {
     if (journey != null && cardBlock != null) {
       await cardBlockUpdate({

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardStyling/CardStyling.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardStyling/CardStyling.spec.tsx
@@ -60,7 +60,7 @@ describe('CardStyling', () => {
   it('shows default ', () => {
     const { getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <EditorProvider initialState={{ selectedBlock: initialBlock }}>
             <CardStyling />
           </EditorProvider>
@@ -85,7 +85,7 @@ describe('CardStyling', () => {
     }
     const { getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <EditorProvider initialState={{ selectedBlock: card }}>
             <CardStyling />
           </EditorProvider>
@@ -119,7 +119,7 @@ describe('CardStyling', () => {
     }
     const { getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <EditorProvider initialState={{ selectedBlock: step }}>
             <CardStyling />
           </EditorProvider>
@@ -144,7 +144,7 @@ describe('CardStyling', () => {
     }
     const { getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <EditorProvider initialState={{ selectedBlock: card }}>
             <CardStyling />
           </EditorProvider>
@@ -193,7 +193,7 @@ describe('CardStyling', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <EditorProvider initialState={{ selectedBlock: initialBlock }}>
             <CardStyling />
           </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardStyling/CardStyling.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardStyling/CardStyling.spec.tsx
@@ -60,7 +60,7 @@ describe('CardStyling', () => {
   it('shows default ', () => {
     const { getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <EditorProvider initialState={{ selectedBlock: initialBlock }}>
             <CardStyling />
           </EditorProvider>
@@ -85,7 +85,7 @@ describe('CardStyling', () => {
     }
     const { getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <EditorProvider initialState={{ selectedBlock: card }}>
             <CardStyling />
           </EditorProvider>
@@ -119,7 +119,7 @@ describe('CardStyling', () => {
     }
     const { getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <EditorProvider initialState={{ selectedBlock: step }}>
             <CardStyling />
           </EditorProvider>
@@ -144,7 +144,7 @@ describe('CardStyling', () => {
     }
     const { getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <EditorProvider initialState={{ selectedBlock: card }}>
             <CardStyling />
           </EditorProvider>
@@ -193,7 +193,7 @@ describe('CardStyling', () => {
           }
         ]}
       >
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <EditorProvider initialState={{ selectedBlock: initialBlock }}>
             <CardStyling />
           </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardStyling/CardStyling.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardStyling/CardStyling.stories.tsx
@@ -70,7 +70,7 @@ export const Default: Story = () => {
 
   return (
     <MockedProvider>
-      <JourneyProvider value={{ journey }}>
+      <JourneyProvider value={{ journey, admin: true }}>
         <EditorProvider
           initialState={{
             selectedBlock: block,
@@ -102,7 +102,7 @@ export const Light: Story = () => {
 
   return (
     <MockedProvider>
-      <JourneyProvider value={{ journey }}>
+      <JourneyProvider value={{ journey, admin: true }}>
         <EditorProvider
           initialState={{
             selectedBlock: block,
@@ -134,7 +134,7 @@ export const Dark: Story = () => {
 
   return (
     <MockedProvider>
-      <JourneyProvider value={{ journey }}>
+      <JourneyProvider value={{ journey, admin: true }}>
         <EditorProvider
           initialState={{
             selectedBlock: block,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardStyling/CardStyling.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardStyling/CardStyling.stories.tsx
@@ -70,7 +70,7 @@ export const Default: Story = () => {
 
   return (
     <MockedProvider>
-      <JourneyProvider value={journey}>
+      <JourneyProvider value={{ journey }}>
         <EditorProvider
           initialState={{
             selectedBlock: block,
@@ -102,7 +102,7 @@ export const Light: Story = () => {
 
   return (
     <MockedProvider>
-      <JourneyProvider value={journey}>
+      <JourneyProvider value={{ journey }}>
         <EditorProvider
           initialState={{
             selectedBlock: block,
@@ -134,7 +134,7 @@ export const Dark: Story = () => {
 
   return (
     <MockedProvider>
-      <JourneyProvider value={journey}>
+      <JourneyProvider value={{ journey }}>
         <EditorProvider
           initialState={{
             selectedBlock: block,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardStyling/CardStyling.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardStyling/CardStyling.tsx
@@ -47,7 +47,7 @@ export function CardStyling(): ReactElement {
   const [cardBlockUpdate] = useMutation<CardBlockThemeModeUpdate>(
     CARD_BLOCK_THEME_MODE_UPDATE
   )
-  const journey = useJourney()
+  const { journey } = useJourney()
 
   const handleChange = async (themeMode: ThemeMode): Promise<void> => {
     if (journey != null && cardBlock != null) {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Image/Options/ImageOptions.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Image/Options/ImageOptions.spec.tsx
@@ -91,7 +91,7 @@ describe('ImageOptions', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <SnackbarProvider>
             <EditorProvider
               initialState={{
@@ -118,7 +118,7 @@ describe('ImageOptions', () => {
   it('shows loading icon', async () => {
     const { getByRole } = render(
       <MockedProvider mocks={[]}>
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <SnackbarProvider>
             <EditorProvider
               initialState={{

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Image/Options/ImageOptions.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Image/Options/ImageOptions.spec.tsx
@@ -91,7 +91,7 @@ describe('ImageOptions', () => {
           }
         ]}
       >
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <SnackbarProvider>
             <EditorProvider
               initialState={{
@@ -118,7 +118,7 @@ describe('ImageOptions', () => {
   it('shows loading icon', async () => {
     const { getByRole } = render(
       <MockedProvider mocks={[]}>
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <SnackbarProvider>
             <EditorProvider
               initialState={{

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Image/Options/ImageOptions.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Image/Options/ImageOptions.tsx
@@ -29,7 +29,7 @@ export function ImageOptions(): ReactElement {
   const {
     state: { selectedBlock }
   } = useEditor()
-  const journey = useJourney()
+  const { journey } = useJourney()
   const { enqueueSnackbar } = useSnackbar()
   const [imageBlockUpdate, { loading }] =
     useMutation<ImageBlockUpdate>(IMAGE_BLOCK_UPDATE)

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/Cards.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/Cards.spec.tsx
@@ -63,13 +63,13 @@ describe('Cards', () => {
         ]}
       >
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
             } as unknown as Journey
-          }
+          }}
         >
           <EditorProvider initialState={{ steps, selectedBlock }}>
             <Cards />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/Cards.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/Cards.spec.tsx
@@ -68,7 +68,8 @@ describe('Cards', () => {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <EditorProvider initialState={{ steps, selectedBlock }}>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/Cards.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Cards/Cards.tsx
@@ -28,7 +28,7 @@ export function Cards(): ReactElement {
   const {
     state: { steps, selectedBlock }
   } = useEditor()
-  const journey = useJourney()
+  const { journey } = useJourney()
   const theme = useTheme()
   const { id, nextBlockId } = selectedBlock as TreeBlock<StepFields>
 

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Conditions/Conditions.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Conditions/Conditions.spec.tsx
@@ -46,7 +46,9 @@ describe('Conditions', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <EditorProvider initialState={{ selectedBlock }}>
             <Conditions />
           </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Conditions/Conditions.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Conditions/Conditions.spec.tsx
@@ -47,7 +47,10 @@ describe('Conditions', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <EditorProvider initialState={{ selectedBlock }}>
             <Conditions />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Conditions/Conditions.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/Conditions/Conditions.tsx
@@ -30,7 +30,7 @@ export function Conditions(): ReactElement {
   const {
     state: { selectedBlock }
   } = useEditor()
-  const journey = useJourney()
+  const { journey } = useJourney()
   const theme = useTheme()
   const block = selectedBlock as TreeBlock<StepFields>
 

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/NextCard.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/NextCard.spec.tsx
@@ -31,7 +31,8 @@ describe('NextCard', () => {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <EditorProvider initialState={{ selectedBlock }}>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/NextCard.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/NextCard.spec.tsx
@@ -26,13 +26,13 @@ describe('NextCard', () => {
     const { getByRole } = render(
       <MockedProvider>
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
             } as unknown as Journey
-          }
+          }}
         >
           <EditorProvider initialState={{ selectedBlock }}>
             <NextCard />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/NextCard.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/NextCard.stories.tsx
@@ -99,7 +99,7 @@ const journeyTheme = {
 const Template: Story = ({ ...args }) => {
   return (
     <MockedProvider>
-      <JourneyProvider value={journeyTheme}>
+      <JourneyProvider value={{ journey: journeyTheme }}>
         <EditorProvider
           initialState={{
             ...args,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/NextCard.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/NextCard.stories.tsx
@@ -99,7 +99,7 @@ const journeyTheme = {
 const Template: Story = ({ ...args }) => {
   return (
     <MockedProvider>
-      <JourneyProvider value={{ journey: journeyTheme }}>
+      <JourneyProvider value={{ journey: journeyTheme, admin: true }}>
         <EditorProvider
           initialState={{
             ...args,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/SelectedCard.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/SelectedCard.spec.tsx
@@ -70,7 +70,8 @@ describe('Selected Card', () => {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <EditorProvider initialState={{ steps, selectedBlock }}>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/SelectedCard.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/SelectedCard.spec.tsx
@@ -65,13 +65,13 @@ describe('Selected Card', () => {
         ]}
       >
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journeyId',
               themeMode: ThemeMode.light,
               themeName: ThemeName.base
             } as unknown as Journey
-          }
+          }}
         >
           <EditorProvider initialState={{ steps, selectedBlock }}>
             <SelectedCard />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/SelectedCard.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/SelectedCard.tsx
@@ -42,7 +42,7 @@ export function SelectedCard(): ReactElement {
   const {
     state: { steps, selectedBlock }
   } = useEditor()
-  const journey = useJourney()
+  const { journey } = useJourney()
   const { id, nextBlockId, locked } = selectedBlock as TreeBlock<StepFields>
   const [nextStep, setNextStep] = useState(
     steps?.find((step) => nextBlockId === step.id)

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.spec.tsx
@@ -49,7 +49,8 @@ describe('Step', () => {
                   id: 'journeyId',
                   themeMode: ThemeMode.light,
                   themeName: ThemeName.base
-                } as unknown as Journey
+                } as unknown as Journey,
+                admin: true
               }}
             >
               <EditorProvider initialState={{ selectedBlock: step }}>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.spec.tsx
@@ -44,13 +44,13 @@ describe('Step', () => {
         <MockedProvider>
           <ThemeProvider>
             <JourneyProvider
-              value={
-                {
+              value={{
+                journey: {
                   id: 'journeyId',
                   themeMode: ThemeMode.light,
                   themeName: ThemeName.base
                 } as unknown as Journey
-              }
+              }}
             >
               <EditorProvider initialState={{ selectedBlock: step }}>
                 <Drawer />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Align/Align.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Align/Align.spec.tsx
@@ -1,8 +1,11 @@
 import { render, fireEvent, waitFor } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
-import { EditorProvider, TreeBlock } from '@core/journeys/ui'
+import { EditorProvider, TreeBlock, JourneyProvider } from '@core/journeys/ui'
 import { TypographyAlign } from '../../../../../../../../__generated__/globalTypes'
-import { GetJourney_journey_blocks_TypographyBlock as TypographyBlock } from '../../../../../../../../__generated__/GetJourney'
+import {
+  GetJourney_journey_blocks_TypographyBlock as TypographyBlock,
+  GetJourney_journey as Journey
+} from '../../../../../../../../__generated__/GetJourney'
 import { TYPOGRAPHY_BLOCK_UPDATE_ALIGN } from './Align'
 import { Align } from '.'
 
@@ -47,6 +50,7 @@ describe('Typography align selector', () => {
       data: {
         typographyBlockUpdate: {
           id: 'id',
+          journeyId: 'journeyId',
           align: TypographyAlign.right
         }
       }
@@ -59,7 +63,7 @@ describe('Typography align selector', () => {
               query: TYPOGRAPHY_BLOCK_UPDATE_ALIGN,
               variables: {
                 id: 'id',
-                journeyId: undefined,
+                journeyId: 'journeyId',
                 input: {
                   align: TypographyAlign.right
                 }
@@ -69,9 +73,16 @@ describe('Typography align selector', () => {
           }
         ]}
       >
-        <EditorProvider initialState={{ selectedBlock }}>
-          <Align />
-        </EditorProvider>
+        <JourneyProvider
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
+        >
+          <EditorProvider initialState={{ selectedBlock }}>
+            <Align />
+          </EditorProvider>
+        </JourneyProvider>
       </MockedProvider>
     )
 

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Align/Align.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Align/Align.tsx
@@ -26,7 +26,7 @@ export function Align(): ReactElement {
   const [typographyBlockUpdate] = useMutation<TypographyBlockUpdateAlign>(
     TYPOGRAPHY_BLOCK_UPDATE_ALIGN
   )
-  const journey = useJourney()
+  const { journey } = useJourney()
   const { state } = useEditor()
   const selectedBlock = state.selectedBlock as
     | TreeBlock<TypographyBlock>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Color/Color.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Color/Color.spec.tsx
@@ -1,7 +1,10 @@
 import { render, fireEvent, waitFor } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
-import { EditorProvider, TreeBlock } from '@core/journeys/ui'
-import { GetJourney_journey_blocks_TypographyBlock as TypographyBlock } from '../../../../../../../../__generated__/GetJourney'
+import { EditorProvider, TreeBlock, JourneyProvider } from '@core/journeys/ui'
+import {
+  GetJourney_journey_blocks_TypographyBlock as TypographyBlock,
+  GetJourney_journey as Journey
+} from '../../../../../../../../__generated__/GetJourney'
 import { TypographyColor } from '../../../../../../../../__generated__/globalTypes'
 import { TYPOGRAPHY_BLOCK_UPDATE_COLOR } from './Color'
 import { Color } from '.'
@@ -59,7 +62,7 @@ describe('Typography color selector', () => {
               query: TYPOGRAPHY_BLOCK_UPDATE_COLOR,
               variables: {
                 id: 'id',
-                journeyId: undefined,
+                journeyId: 'journeyId',
                 input: {
                   color: TypographyColor.secondary
                 }
@@ -69,9 +72,16 @@ describe('Typography color selector', () => {
           }
         ]}
       >
-        <EditorProvider initialState={{ selectedBlock }}>
-          <Color />
-        </EditorProvider>
+        <JourneyProvider
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
+        >
+          <EditorProvider initialState={{ selectedBlock }}>
+            <Color />
+          </EditorProvider>
+        </JourneyProvider>
       </MockedProvider>
     )
     expect(getByRole('button', { name: 'Error' })).toHaveClass('Mui-selected')

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Color/Color.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Color/Color.tsx
@@ -25,7 +25,7 @@ export function Color(): ReactElement {
     TYPOGRAPHY_BLOCK_UPDATE_COLOR
   )
 
-  const journey = useJourney()
+  const { journey } = useJourney()
   const { state } = useEditor()
   const selectedBlock = state.selectedBlock as
     | TreeBlock<TypographyBlock>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Variant/Variant.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Variant/Variant.spec.tsx
@@ -1,7 +1,10 @@
 import { render, fireEvent, waitFor } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
-import { EditorProvider, TreeBlock } from '@core/journeys/ui'
-import { GetJourney_journey_blocks_TypographyBlock as TypographyBlock } from '../../../../../../../../__generated__/GetJourney'
+import { EditorProvider, TreeBlock, JourneyProvider } from '@core/journeys/ui'
+import {
+  GetJourney_journey_blocks_TypographyBlock as TypographyBlock,
+  GetJourney_journey as Journey
+} from '../../../../../../../../__generated__/GetJourney'
 import { TypographyVariant } from '../../../../../../../../__generated__/globalTypes'
 import { TYPOGRAPHY_BLOCK_UPDATE_VARIANT } from './Variant'
 import { Variant } from '.'
@@ -68,7 +71,7 @@ describe('Typography variant selector', () => {
               query: TYPOGRAPHY_BLOCK_UPDATE_VARIANT,
               variables: {
                 id: 'id',
-                journeyId: undefined,
+                journeyId: 'journeyId',
                 input: {
                   variant: TypographyVariant.overline
                 }
@@ -78,9 +81,16 @@ describe('Typography variant selector', () => {
           }
         ]}
       >
-        <EditorProvider initialState={{ selectedBlock }}>
-          <Variant />
-        </EditorProvider>
+        <JourneyProvider
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
+        >
+          <EditorProvider initialState={{ selectedBlock }}>
+            <Variant />
+          </EditorProvider>
+        </JourneyProvider>
       </MockedProvider>
     )
     expect(getByRole('button', { name: 'Header 1' })).toHaveClass(

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Variant/Variant.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Variant/Variant.tsx
@@ -25,7 +25,7 @@ export function Variant(): ReactElement {
   const [typographyBlockUpdate] = useMutation<TypographyBlockUpdateVariant>(
     TYPOGRAPHY_BLOCK_UPDATE_VARIANT
   )
-  const journey = useJourney()
+  const { journey } = useJourney()
   const { state } = useEditor()
   const selectedBlock = state.selectedBlock as
     | TreeBlock<TypographyBlock>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.spec.tsx
@@ -128,7 +128,9 @@ describe('VideoOptions', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <ThemeProvider>
             <EditorProvider
               initialState={{

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.spec.tsx
@@ -129,7 +129,10 @@ describe('VideoOptions', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <ThemeProvider>
             <EditorProvider

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.tsx
@@ -23,7 +23,7 @@ export function VideoOptions(): ReactElement {
   const {
     state: { selectedBlock }
   } = useEditor()
-  const journey = useJourney()
+  const { journey } = useJourney()
   const [videoBlockUpdate] = useMutation<VideoBlockUpdate>(VIDEO_BLOCK_UPDATE)
   const { enqueueSnackbar } = useSnackbar()
 

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/BlocksTab.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/BlocksTab.stories.tsx
@@ -19,7 +19,10 @@ export const Default: Story = () => {
   return (
     <MockedProvider mocks={[]}>
       <JourneyProvider
-        value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        value={{
+          journey: { id: 'journeyId' } as unknown as Journey,
+          admin: true
+        }}
       >
         <EditorProvider
           initialState={{

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/BlocksTab.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/BlocksTab.stories.tsx
@@ -18,7 +18,9 @@ const BlocksTabStory = {
 export const Default: Story = () => {
   return (
     <MockedProvider mocks={[]}>
-      <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+      <JourneyProvider
+        value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+      >
         <EditorProvider
           initialState={{
             selectedStep: {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewButtonButton/NewButtonButton.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewButtonButton/NewButtonButton.spec.tsx
@@ -127,7 +127,9 @@ describe('Button', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <EditorProvider initialState={{ selectedStep }}>
             <NewButtonButton />
           </EditorProvider>
@@ -234,7 +236,9 @@ describe('Button', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <EditorProvider initialState={{ selectedStep }}>
             <NewButtonButton />
           </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewButtonButton/NewButtonButton.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewButtonButton/NewButtonButton.spec.tsx
@@ -128,7 +128,10 @@ describe('Button', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <EditorProvider initialState={{ selectedStep }}>
             <NewButtonButton />
@@ -237,7 +240,10 @@ describe('Button', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <EditorProvider initialState={{ selectedStep }}>
             <NewButtonButton />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewButtonButton/NewButtonButton.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewButtonButton/NewButtonButton.stories.tsx
@@ -97,7 +97,9 @@ export const Default: Story = () => {
         }
       ]}
     >
-      <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+      <JourneyProvider
+        value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+      >
         <EditorProvider
           initialState={{
             selectedStep: {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewButtonButton/NewButtonButton.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewButtonButton/NewButtonButton.stories.tsx
@@ -98,7 +98,10 @@ export const Default: Story = () => {
       ]}
     >
       <JourneyProvider
-        value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        value={{
+          journey: { id: 'journeyId' } as unknown as Journey,
+          admin: true
+        }}
       >
         <EditorProvider
           initialState={{

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewButtonButton/NewButtonButton.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewButtonButton/NewButtonButton.tsx
@@ -48,7 +48,7 @@ export const BUTTON_BLOCK_CREATE = gql`
 export function NewButtonButton(): ReactElement {
   const [buttonBlockCreate] =
     useMutation<ButtonBlockCreate>(BUTTON_BLOCK_CREATE)
-  const journey = useJourney()
+  const { journey } = useJourney()
   const {
     state: { selectedStep },
     dispatch

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewImageButton/NewImageButton.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewImageButton/NewImageButton.spec.tsx
@@ -65,7 +65,10 @@ describe('Image', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <EditorProvider initialState={{ selectedStep }}>
             <NewImageButton />
@@ -123,7 +126,10 @@ describe('Image', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <EditorProvider initialState={{ selectedStep }}>
             <NewImageButton />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewImageButton/NewImageButton.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewImageButton/NewImageButton.spec.tsx
@@ -64,7 +64,9 @@ describe('Image', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <EditorProvider initialState={{ selectedStep }}>
             <NewImageButton />
           </EditorProvider>
@@ -120,7 +122,9 @@ describe('Image', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <EditorProvider initialState={{ selectedStep }}>
             <NewImageButton />
           </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewImageButton/NewImageButton.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewImageButton/NewImageButton.stories.tsx
@@ -46,7 +46,10 @@ export const Default: Story = () => {
       ]}
     >
       <JourneyProvider
-        value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        value={{
+          journey: { id: 'journeyId' } as unknown as Journey,
+          admin: true
+        }}
       >
         <EditorProvider
           initialState={{

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewImageButton/NewImageButton.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewImageButton/NewImageButton.stories.tsx
@@ -45,7 +45,9 @@ export const Default: Story = () => {
         }
       ]}
     >
-      <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+      <JourneyProvider
+        value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+      >
         <EditorProvider
           initialState={{
             selectedStep: {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewImageButton/NewImageButton.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewImageButton/NewImageButton.tsx
@@ -26,7 +26,7 @@ export const IMAGE_BLOCK_CREATE = gql`
 
 export function NewImageButton(): ReactElement {
   const [imageBlockCreate] = useMutation<ImageBlockCreate>(IMAGE_BLOCK_CREATE)
-  const journey = useJourney()
+  const { journey } = useJourney()
   const {
     state: { selectedStep },
     dispatch

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewRadioQuestionButton/NewRadioQuestion.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewRadioQuestionButton/NewRadioQuestion.stories.tsx
@@ -78,7 +78,9 @@ export const Default: Story = () => {
       ]}
       addTypename={false}
     >
-      <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+      <JourneyProvider
+        value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+      >
         <EditorProvider
           initialState={{
             selectedStep: {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewRadioQuestionButton/NewRadioQuestion.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewRadioQuestionButton/NewRadioQuestion.stories.tsx
@@ -79,7 +79,10 @@ export const Default: Story = () => {
       addTypename={false}
     >
       <JourneyProvider
-        value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        value={{
+          journey: { id: 'journeyId' } as unknown as Journey,
+          admin: true
+        }}
       >
         <EditorProvider
           initialState={{

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewRadioQuestionButton/NewRadioQuestionButton.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewRadioQuestionButton/NewRadioQuestionButton.spec.tsx
@@ -164,7 +164,10 @@ describe('RadioQuestion', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <EditorProvider initialState={{ selectedStep }}>
             <NewRadioQuestionButton />
@@ -316,7 +319,10 @@ describe('RadioQuestion', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <EditorProvider initialState={{ selectedStep }}>
             <NewRadioQuestionButton />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewRadioQuestionButton/NewRadioQuestionButton.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewRadioQuestionButton/NewRadioQuestionButton.spec.tsx
@@ -163,7 +163,9 @@ describe('RadioQuestion', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <EditorProvider initialState={{ selectedStep }}>
             <NewRadioQuestionButton />
           </EditorProvider>
@@ -313,7 +315,9 @@ describe('RadioQuestion', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <EditorProvider initialState={{ selectedStep }}>
             <NewRadioQuestionButton />
           </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewRadioQuestionButton/NewRadioQuestionButton.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewRadioQuestionButton/NewRadioQuestionButton.tsx
@@ -52,7 +52,7 @@ export function NewRadioQuestionButton(): ReactElement {
   const [typographyBlockCreate] = useMutation<TypographyBlockCreate>(
     TYPOGRAPHY_BLOCK_CREATE
   )
-  const journey = useJourney()
+  const { journey } = useJourney()
   const {
     state: { selectedStep },
     dispatch

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewSignUpButton/NewSignUpButton.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewSignUpButton/NewSignUpButton.spec.tsx
@@ -99,7 +99,10 @@ describe('SignUp', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <EditorProvider initialState={{ selectedStep }}>
             <NewSignUpButton />
@@ -187,7 +190,10 @@ describe('SignUp', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <EditorProvider initialState={{ selectedStep }}>
             <NewSignUpButton />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewSignUpButton/NewSignUpButton.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewSignUpButton/NewSignUpButton.spec.tsx
@@ -98,7 +98,9 @@ describe('SignUp', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <EditorProvider initialState={{ selectedStep }}>
             <NewSignUpButton />
           </EditorProvider>
@@ -184,7 +186,9 @@ describe('SignUp', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <EditorProvider initialState={{ selectedStep }}>
             <NewSignUpButton />
           </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewSignUpButton/NewSignUpButton.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewSignUpButton/NewSignUpButton.stories.tsx
@@ -76,7 +76,10 @@ export const Default: Story = () => {
       addTypename={false}
     >
       <JourneyProvider
-        value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        value={{
+          journey: { id: 'journeyId' } as unknown as Journey,
+          admin: true
+        }}
       >
         <EditorProvider
           initialState={{

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewSignUpButton/NewSignUpButton.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewSignUpButton/NewSignUpButton.stories.tsx
@@ -75,7 +75,9 @@ export const Default: Story = () => {
       ]}
       addTypename={false}
     >
-      <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+      <JourneyProvider
+        value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+      >
         <EditorProvider
           initialState={{
             selectedStep: {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewSignUpButton/NewSignUpButton.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewSignUpButton/NewSignUpButton.tsx
@@ -41,7 +41,7 @@ export const SIGN_UP_BLOCK_CREATE = gql`
 export function NewSignUpButton(): ReactElement {
   const [signUpBlockCreate] =
     useMutation<SignUpBlockCreate>(SIGN_UP_BLOCK_CREATE)
-  const journey = useJourney()
+  const { journey } = useJourney()
   const {
     state: { selectedStep },
     dispatch

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewTypographyButton/NewTypographyButton.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewTypographyButton/NewTypographyButton.spec.tsx
@@ -63,7 +63,9 @@ describe('Typography', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <EditorProvider initialState={{ selectedStep }}>
             <NewTypographyButton />
           </EditorProvider>
@@ -118,7 +120,9 @@ describe('Typography', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <EditorProvider initialState={{ selectedStep }}>
             <NewTypographyButton />
           </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewTypographyButton/NewTypographyButton.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewTypographyButton/NewTypographyButton.spec.tsx
@@ -64,7 +64,10 @@ describe('Typography', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <EditorProvider initialState={{ selectedStep }}>
             <NewTypographyButton />
@@ -121,7 +124,10 @@ describe('Typography', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <EditorProvider initialState={{ selectedStep }}>
             <NewTypographyButton />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewTypographyButton/NewTypographyButton.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewTypographyButton/NewTypographyButton.stories.tsx
@@ -44,7 +44,9 @@ export const Default: Story = () => {
       ]}
       addTypename={false}
     >
-      <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+      <JourneyProvider
+        value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+      >
         <EditorProvider
           initialState={{
             selectedStep: {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewTypographyButton/NewTypographyButton.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewTypographyButton/NewTypographyButton.stories.tsx
@@ -45,7 +45,10 @@ export const Default: Story = () => {
       addTypename={false}
     >
       <JourneyProvider
-        value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        value={{
+          journey: { id: 'journeyId' } as unknown as Journey,
+          admin: true
+        }}
       >
         <EditorProvider
           initialState={{

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewTypographyButton/NewTypographyButton.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewTypographyButton/NewTypographyButton.tsx
@@ -27,7 +27,7 @@ export function NewTypographyButton(): ReactElement {
   const [typographyBlockCreate] = useMutation<TypographyBlockCreate>(
     TYPOGRAPHY_BLOCK_CREATE
   )
-  const journey = useJourney()
+  const { journey } = useJourney()
   const {
     state: { selectedStep },
     dispatch

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewVideoButton/NewVideoButton.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewVideoButton/NewVideoButton.spec.tsx
@@ -69,7 +69,10 @@ describe('Video', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <EditorProvider initialState={{ selectedStep }}>
             <NewVideoButton />
@@ -131,7 +134,10 @@ describe('Video', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <EditorProvider initialState={{ selectedStep }}>
             <NewVideoButton />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewVideoButton/NewVideoButton.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewVideoButton/NewVideoButton.spec.tsx
@@ -68,7 +68,9 @@ describe('Video', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <EditorProvider initialState={{ selectedStep }}>
             <NewVideoButton />
           </EditorProvider>
@@ -128,7 +130,9 @@ describe('Video', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <EditorProvider initialState={{ selectedStep }}>
             <NewVideoButton />
           </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewVideoButton/NewVideoButton.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewVideoButton/NewVideoButton.stories.tsx
@@ -47,7 +47,9 @@ export const Default: Story = () => {
       ]}
       addTypename={false}
     >
-      <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+      <JourneyProvider
+        value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+      >
         <EditorProvider
           initialState={{
             selectedStep: {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewVideoButton/NewVideoButton.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewVideoButton/NewVideoButton.stories.tsx
@@ -48,7 +48,10 @@ export const Default: Story = () => {
       addTypename={false}
     >
       <JourneyProvider
-        value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        value={{
+          journey: { id: 'journeyId' } as unknown as Journey,
+          admin: true
+        }}
       >
         <EditorProvider
           initialState={{

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewVideoButton/NewVideoButton.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/BlocksTab/NewVideoButton/NewVideoButton.tsx
@@ -23,7 +23,7 @@ export const VIDEO_BLOCK_CREATE = gql`
 
 export function NewVideoButton(): ReactElement {
   const [videoBlockCreate] = useMutation<VideoBlockCreate>(VIDEO_BLOCK_CREATE)
-  const journey = useJourney()
+  const { journey } = useJourney()
   const {
     state: { selectedStep },
     dispatch

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ColorDisplayIcon/ColorDisplayIcon.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ColorDisplayIcon/ColorDisplayIcon.tsx
@@ -26,7 +26,7 @@ enum DisplayColor {
 export function ColorDisplayIcon({
   color
 }: ColorDisplayIconProps): ReactElement {
-  const journey = useJourney()
+  const { journey } = useJourney()
   const {
     state: { selectedStep }
   } = useEditor()

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.spec.tsx
@@ -71,13 +71,13 @@ describe('ControlPanel', () => {
     const { getByTestId, getByText, getByRole } = render(
       <MockedProvider>
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journeyId',
               themeMode: ThemeMode.dark,
               themeName: ThemeName.base
             } as unknown as Journey
-          }
+          }}
         >
           <EditorProvider initialState={{ steps: [step1, step2] }}>
             <ControlPanel />
@@ -99,13 +99,13 @@ describe('ControlPanel', () => {
     const { getByRole, queryByRole } = render(
       <MockedProvider>
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journeyId',
               themeMode: ThemeMode.dark,
               themeName: ThemeName.base
             } as unknown as Journey
-          }
+          }}
         >
           <EditorProvider initialState={{ steps: [step1, step2] }}>
             <ControlPanel />
@@ -125,13 +125,13 @@ describe('ControlPanel', () => {
     const { getByRole } = render(
       <MockedProvider>
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journeyId',
               themeMode: ThemeMode.dark,
               themeName: ThemeName.base
             } as unknown as Journey
-          }
+          }}
         >
           <EditorProvider initialState={{ steps: [step1, step2] }}>
             <ControlPanel />
@@ -182,13 +182,13 @@ describe('ControlPanel', () => {
         ]}
       >
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journeyId',
               themeMode: ThemeMode.dark,
               themeName: ThemeName.base
             } as unknown as Journey
-          }
+          }}
         >
           <EditorProvider initialState={{ steps: [step1, step2, step3] }}>
             <ControlPanel />
@@ -273,13 +273,13 @@ describe('ControlPanel', () => {
         ]}
       >
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journeyId',
               themeMode: ThemeMode.dark,
               themeName: ThemeName.base
             } as unknown as Journey
-          }
+          }}
         >
           <EditorProvider initialState={{ steps: [step1, step2, step3] }}>
             <ControlPanel />
@@ -430,13 +430,13 @@ describe('ControlPanel', () => {
         ]}
       >
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journeyId',
               themeMode: ThemeMode.dark,
               themeName: ThemeName.base
             } as unknown as Journey
-          }
+          }}
         >
           <EditorProvider initialState={{ steps: [step1, step2, step3] }}>
             <ControlPanel />
@@ -494,13 +494,13 @@ describe('ControlPanel', () => {
         ]}
       >
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journeyId',
               themeMode: ThemeMode.dark,
               themeName: ThemeName.base
             } as unknown as Journey
-          }
+          }}
         >
           <EditorProvider initialState={{ steps: [step1, step2, step3] }}>
             <ControlPanel />
@@ -561,13 +561,13 @@ describe('ControlPanel', () => {
         ]}
       >
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journeyId',
               themeMode: ThemeMode.dark,
               themeName: ThemeName.base
             } as unknown as Journey
-          }
+          }}
         >
           <EditorProvider initialState={{ steps: [step1, step2, step3] }}>
             <ControlPanel />
@@ -670,13 +670,13 @@ describe('ControlPanel', () => {
         ]}
       >
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journeyId',
               themeMode: ThemeMode.dark,
               themeName: ThemeName.base
             } as unknown as Journey
-          }
+          }}
         >
           <EditorProvider initialState={{ steps: [step1, step2, step3] }}>
             <ControlPanel />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.spec.tsx
@@ -76,7 +76,8 @@ describe('ControlPanel', () => {
               id: 'journeyId',
               themeMode: ThemeMode.dark,
               themeName: ThemeName.base
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <EditorProvider initialState={{ steps: [step1, step2] }}>
@@ -104,7 +105,8 @@ describe('ControlPanel', () => {
               id: 'journeyId',
               themeMode: ThemeMode.dark,
               themeName: ThemeName.base
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <EditorProvider initialState={{ steps: [step1, step2] }}>
@@ -130,7 +132,8 @@ describe('ControlPanel', () => {
               id: 'journeyId',
               themeMode: ThemeMode.dark,
               themeName: ThemeName.base
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <EditorProvider initialState={{ steps: [step1, step2] }}>
@@ -187,7 +190,8 @@ describe('ControlPanel', () => {
               id: 'journeyId',
               themeMode: ThemeMode.dark,
               themeName: ThemeName.base
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <EditorProvider initialState={{ steps: [step1, step2, step3] }}>
@@ -278,7 +282,8 @@ describe('ControlPanel', () => {
               id: 'journeyId',
               themeMode: ThemeMode.dark,
               themeName: ThemeName.base
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <EditorProvider initialState={{ steps: [step1, step2, step3] }}>
@@ -435,7 +440,8 @@ describe('ControlPanel', () => {
               id: 'journeyId',
               themeMode: ThemeMode.dark,
               themeName: ThemeName.base
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <EditorProvider initialState={{ steps: [step1, step2, step3] }}>
@@ -499,7 +505,8 @@ describe('ControlPanel', () => {
               id: 'journeyId',
               themeMode: ThemeMode.dark,
               themeName: ThemeName.base
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <EditorProvider initialState={{ steps: [step1, step2, step3] }}>
@@ -566,7 +573,8 @@ describe('ControlPanel', () => {
               id: 'journeyId',
               themeMode: ThemeMode.dark,
               themeName: ThemeName.base
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <EditorProvider initialState={{ steps: [step1, step2, step3] }}>
@@ -675,7 +683,8 @@ describe('ControlPanel', () => {
               id: 'journeyId',
               themeMode: ThemeMode.dark,
               themeName: ThemeName.base
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <EditorProvider initialState={{ steps: [step1, step2, step3] }}>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.stories.tsx
@@ -612,13 +612,13 @@ const Template: Story = (args) => {
   return (
     <MockedProvider>
       <JourneyProvider
-        value={
-          {
+        value={{
+          journey: {
             id: 'journeyId',
             themeMode: ThemeMode.dark,
             themeName: ThemeName.base
           } as unknown as Journey
-        }
+        }}
       >
         <EditorProvider
           initialState={{

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.stories.tsx
@@ -617,7 +617,8 @@ const Template: Story = (args) => {
             id: 'journeyId',
             themeMode: ThemeMode.dark,
             themeName: ThemeName.base
-          } as unknown as Journey
+          } as unknown as Journey,
+          admin: true
         }}
       >
         <EditorProvider

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/DescriptionEdit/DescriptionEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/DescriptionEdit/DescriptionEdit.spec.tsx
@@ -24,7 +24,8 @@ describe('DescriptionEdit', () => {
             journey: {
               description: 'journey description',
               seoDescription: 'social description'
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <DescriptionEdit />
@@ -41,7 +42,8 @@ describe('DescriptionEdit', () => {
             journey: {
               description: 'journey description',
               seoDescription: null
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <DescriptionEdit />
@@ -58,7 +60,8 @@ describe('DescriptionEdit', () => {
             journey: {
               description: null,
               seoDescription: null
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <DescriptionEdit />
@@ -96,7 +99,10 @@ describe('DescriptionEdit', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journey.id' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journey.id' } as unknown as Journey,
+            admin: true
+          }}
         >
           <DescriptionEdit />
         </JourneyProvider>
@@ -116,7 +122,10 @@ describe('DescriptionEdit', () => {
     const { getByRole, getByText } = render(
       <MockedProvider>
         <JourneyProvider
-          value={{ journey: { id: 'journey.id' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journey.id' } as unknown as Journey,
+            admin: true
+          }}
         >
           <DescriptionEdit />
         </JourneyProvider>

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/DescriptionEdit/DescriptionEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/DescriptionEdit/DescriptionEdit.spec.tsx
@@ -20,12 +20,12 @@ describe('DescriptionEdit', () => {
     const { getByText } = render(
       <MockedProvider>
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               description: 'journey description',
               seoDescription: 'social description'
             } as unknown as Journey
-          }
+          }}
         >
           <DescriptionEdit />
         </JourneyProvider>
@@ -37,12 +37,12 @@ describe('DescriptionEdit', () => {
     const { getByText } = render(
       <MockedProvider>
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               description: 'journey description',
               seoDescription: null
             } as unknown as Journey
-          }
+          }}
         >
           <DescriptionEdit />
         </JourneyProvider>
@@ -54,12 +54,12 @@ describe('DescriptionEdit', () => {
     const { getByRole } = render(
       <MockedProvider>
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               description: null,
               seoDescription: null
             } as unknown as Journey
-          }
+          }}
         >
           <DescriptionEdit />
         </JourneyProvider>
@@ -95,7 +95,9 @@ describe('DescriptionEdit', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journey.id' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journey.id' } as unknown as Journey }}
+        >
           <DescriptionEdit />
         </JourneyProvider>
       </MockedProvider>
@@ -113,7 +115,9 @@ describe('DescriptionEdit', () => {
 
     const { getByRole, getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={{ id: 'journey.id' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journey.id' } as unknown as Journey }}
+        >
           <DescriptionEdit />
         </JourneyProvider>
       </MockedProvider>

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/DescriptionEdit/DescriptionEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/DescriptionEdit/DescriptionEdit.tsx
@@ -21,7 +21,7 @@ export function DescriptionEdit(): ReactElement {
     JOURNEY_SEO_DESCRIPTION_UPDATE
   )
 
-  const journey = useJourney()
+  const { journey } = useJourney()
 
   async function handleSubmit(e: React.FocusEvent): Promise<void> {
     if (journey == null) return

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/ImageEdit/ImageEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/ImageEdit/ImageEdit.spec.tsx
@@ -45,7 +45,8 @@ describe('ImageEdit', () => {
                 src: 'img.src',
                 alt: 'image.alt'
               }
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <ImageEdit />
@@ -126,7 +127,10 @@ describe('ImageEdit', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journey.id' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journey.id' } as unknown as Journey,
+            admin: true
+          }}
         >
           <ImageEdit />
         </JourneyProvider>
@@ -201,7 +205,8 @@ describe('ImageEdit', () => {
             journey: {
               id: 'journey.id',
               primaryImageBlock: { ...image }
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <ImageEdit />
@@ -293,7 +298,8 @@ describe('ImageEdit', () => {
             journey: {
               id: 'journey.id',
               primaryImageBlock: { ...image }
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <ImageEdit />

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/ImageEdit/ImageEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/ImageEdit/ImageEdit.spec.tsx
@@ -29,7 +29,14 @@ describe('ImageEdit', () => {
   it('should disaply placeholder icon when no image set', () => {
     const { getAllByTestId } = render(
       <MockedProvider>
-        <ImageEdit />
+        <JourneyProvider
+          value={{
+            journey: { primaryImageBlockId: null } as unknown as Journey,
+            admin: true
+          }}
+        >
+          <ImageEdit />
+        </JourneyProvider>
       </MockedProvider>
     )
     expect(getAllByTestId('ImageIcon')).toHaveLength(2)

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/ImageEdit/ImageEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/ImageEdit/ImageEdit.spec.tsx
@@ -39,14 +39,14 @@ describe('ImageEdit', () => {
     const { getByRole } = render(
       <MockedProvider>
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               primaryImageBlock: {
                 src: 'img.src',
                 alt: 'image.alt'
               }
             } as unknown as Journey
-          }
+          }}
         >
           <ImageEdit />
         </JourneyProvider>
@@ -125,7 +125,9 @@ describe('ImageEdit', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journey.id' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journey.id' } as unknown as Journey }}
+        >
           <ImageEdit />
         </JourneyProvider>
       </MockedProvider>
@@ -195,12 +197,12 @@ describe('ImageEdit', () => {
         ]}
       >
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journey.id',
               primaryImageBlock: { ...image }
             } as unknown as Journey
-          }
+          }}
         >
           <ImageEdit />
         </JourneyProvider>
@@ -287,12 +289,12 @@ describe('ImageEdit', () => {
         ]}
       >
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               id: 'journey.id',
               primaryImageBlock: { ...image }
             } as unknown as Journey
-          }
+          }}
         >
           <ImageEdit />
         </JourneyProvider>

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/ImageEdit/ImageEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/ImageEdit/ImageEdit.tsx
@@ -73,7 +73,7 @@ export function ImageEdit(): ReactElement {
     JOURNEY_PRIMARY_IMAGE_UPDATE
   )
 
-  const journey = useJourney()
+  const { journey } = useJourney()
   const [open, setOpen] = useState(false)
 
   function handleOpen(): void {

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.spec.tsx
@@ -1,6 +1,7 @@
 import { render, fireEvent, waitFor } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
 import { JourneyProvider } from '@core/journeys/ui'
+import { JourneyStatus } from '../../../../../__generated__/globalTypes'
 import { GetJourney_journey as Journey } from '../../../../../__generated__/GetJourney'
 import { SocialShareAppearance } from '.'
 
@@ -9,7 +10,14 @@ describe('SocialShareAppearance', () => {
   it('should render SocialShareAppearance', () => {
     const { getByText, getByTestId, getByRole } = render(
       <MockedProvider>
-        <SocialShareAppearance />
+        <JourneyProvider
+          value={{
+            journey: { status: JourneyStatus.published } as unknown as Journey,
+            admin: true
+          }}
+        >
+          <SocialShareAppearance />
+        </JourneyProvider>
       </MockedProvider>
     )
     expect(getByText('Social Image')).toBeInTheDocument()

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.spec.tsx
@@ -25,7 +25,7 @@ describe('SocialShareAppearance', () => {
 
     const { getByRole } = render(
       <MockedProvider>
-        <JourneyProvider value={{ slug } as unknown as Journey}>
+        <JourneyProvider value={{ journey: { slug } as unknown as Journey }}>
           <SocialShareAppearance />
         </JourneyProvider>
       </MockedProvider>
@@ -46,7 +46,7 @@ describe('SocialShareAppearance', () => {
 
     const { getByRole } = render(
       <MockedProvider>
-        <JourneyProvider value={{ slug } as unknown as Journey}>
+        <JourneyProvider value={{ journey: { slug } as unknown as Journey }}>
           <SocialShareAppearance />
         </JourneyProvider>
       </MockedProvider>
@@ -65,7 +65,9 @@ describe('SocialShareAppearance', () => {
   it('should disable share buttons  and show tool tip if journey is not published', async () => {
     const { getByRole, getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={{ publishedAt: null } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { publishedAt: null } as unknown as Journey }}
+        >
           <SocialShareAppearance />
         </JourneyProvider>
       </MockedProvider>

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.spec.tsx
@@ -25,7 +25,9 @@ describe('SocialShareAppearance', () => {
 
     const { getByRole } = render(
       <MockedProvider>
-        <JourneyProvider value={{ journey: { slug } as unknown as Journey }}>
+        <JourneyProvider
+          value={{ journey: { slug } as unknown as Journey, admin: true }}
+        >
           <SocialShareAppearance />
         </JourneyProvider>
       </MockedProvider>
@@ -46,7 +48,9 @@ describe('SocialShareAppearance', () => {
 
     const { getByRole } = render(
       <MockedProvider>
-        <JourneyProvider value={{ journey: { slug } as unknown as Journey }}>
+        <JourneyProvider
+          value={{ journey: { slug } as unknown as Journey, admin: true }}
+        >
           <SocialShareAppearance />
         </JourneyProvider>
       </MockedProvider>
@@ -66,7 +70,10 @@ describe('SocialShareAppearance', () => {
     const { getByRole, getByText } = render(
       <MockedProvider>
         <JourneyProvider
-          value={{ journey: { publishedAt: null } as unknown as Journey }}
+          value={{
+            journey: { publishedAt: null } as unknown as Journey,
+            admin: true
+          }}
         >
           <SocialShareAppearance />
         </JourneyProvider>

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.stories.tsx
@@ -65,7 +65,7 @@ const image: ImageBlock = {
 const Template: Story = ({ ...args }) => {
   return (
     <MockedProvider>
-      <JourneyProvider value={{ journey: args.journey }}>
+      <JourneyProvider value={{ journey: args.journey, admin: true }}>
         <EditorProvider
           initialState={{
             drawerTitle: 'Social Share Appearance',

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.stories.tsx
@@ -65,7 +65,7 @@ const image: ImageBlock = {
 const Template: Story = ({ ...args }) => {
   return (
     <MockedProvider>
-      <JourneyProvider value={args.journey}>
+      <JourneyProvider value={{ journey: args.journey }}>
         <EditorProvider
           initialState={{
             drawerTitle: 'Social Share Appearance',

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.tsx
@@ -12,7 +12,7 @@ import { TitleEdit } from './TitleEdit/TitleEdit'
 import { DescriptionEdit } from './DescriptionEdit/DescriptionEdit'
 
 export function SocialShareAppearance(): ReactElement {
-  const journey = useJourney()
+  const { journey } = useJourney()
   const isPublished = journey?.status === 'published'
 
   return (

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/TitleEdit/TitleEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/TitleEdit/TitleEdit.spec.tsx
@@ -17,12 +17,12 @@ describe('TitleEdit', () => {
     const { getByText } = render(
       <MockedProvider>
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               title: 'journey title',
               seoTitle: 'Social share title'
             } as unknown as Journey
-          }
+          }}
         >
           <TitleEdit />
         </JourneyProvider>
@@ -35,12 +35,12 @@ describe('TitleEdit', () => {
     const { getByText } = render(
       <MockedProvider>
         <JourneyProvider
-          value={
-            {
+          value={{
+            journey: {
               title: 'journey title',
               seoTitle: null
             } as unknown as Journey
-          }
+          }}
         >
           <TitleEdit />
         </JourneyProvider>
@@ -77,7 +77,9 @@ describe('TitleEdit', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journey.id' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journey.id' } as unknown as Journey }}
+        >
           <TitleEdit />
         </JourneyProvider>
       </MockedProvider>
@@ -94,7 +96,9 @@ describe('TitleEdit', () => {
 
     const { getByRole, getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={{ id: 'journey.id' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journey.id' } as unknown as Journey }}
+        >
           <TitleEdit />
         </JourneyProvider>
       </MockedProvider>

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/TitleEdit/TitleEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/TitleEdit/TitleEdit.spec.tsx
@@ -21,7 +21,8 @@ describe('TitleEdit', () => {
             journey: {
               title: 'journey title',
               seoTitle: 'Social share title'
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <TitleEdit />
@@ -39,7 +40,8 @@ describe('TitleEdit', () => {
             journey: {
               title: 'journey title',
               seoTitle: null
-            } as unknown as Journey
+            } as unknown as Journey,
+            admin: true
           }}
         >
           <TitleEdit />
@@ -78,7 +80,10 @@ describe('TitleEdit', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journey.id' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journey.id' } as unknown as Journey,
+            admin: true
+          }}
         >
           <TitleEdit />
         </JourneyProvider>
@@ -97,7 +102,10 @@ describe('TitleEdit', () => {
     const { getByRole, getByText } = render(
       <MockedProvider>
         <JourneyProvider
-          value={{ journey: { id: 'journey.id' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journey.id' } as unknown as Journey,
+            admin: true
+          }}
         >
           <TitleEdit />
         </JourneyProvider>

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/TitleEdit/TitleEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/TitleEdit/TitleEdit.tsx
@@ -21,7 +21,7 @@ export function TitleEdit(): ReactElement {
     JOURNEY_SEO_TITLE_UPDATE
   )
 
-  const journey = useJourney()
+  const { journey } = useJourney()
 
   async function handleSubmit(e: React.FocusEvent): Promise<void> {
     if (journey == null) return

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/DeleteBlock.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/DeleteBlock.spec.tsx
@@ -110,7 +110,10 @@ describe('DeleteBlock', () => {
           ]}
         >
           <JourneyProvider
-            value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+            value={{
+              journey: { id: 'journeyId' } as unknown as Journey,
+              admin: true
+            }}
           >
             <EditorProvider initialState={{ selectedBlock, selectedStep }}>
               <DeleteBlock variant="button" />
@@ -178,7 +181,10 @@ describe('DeleteBlock', () => {
           ]}
         >
           <JourneyProvider
-            value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+            value={{
+              journey: { id: 'journeyId' } as unknown as Journey,
+              admin: true
+            }}
           >
             <EditorProvider initialState={{ selectedBlock, selectedStep }}>
               <DeleteBlock variant="list-item" />
@@ -244,7 +250,10 @@ describe('DeleteBlock', () => {
           ]}
         >
           <JourneyProvider
-            value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+            value={{
+              journey: { id: 'journeyId' } as unknown as Journey,
+              admin: true
+            }}
           >
             <EditorProvider initialState={{ selectedBlock }}>
               <DeleteBlock variant="button" />
@@ -316,7 +325,10 @@ describe('DeleteBlock', () => {
           ]}
         >
           <JourneyProvider
-            value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+            value={{
+              journey: { id: 'journeyId' } as unknown as Journey,
+              admin: true
+            }}
           >
             <EditorProvider initialState={{ selectedBlock }}>
               <DeleteBlock variant="list-item" />

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/DeleteBlock.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/DeleteBlock.spec.tsx
@@ -109,7 +109,9 @@ describe('DeleteBlock', () => {
             }
           ]}
         >
-          <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+          <JourneyProvider
+            value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          >
             <EditorProvider initialState={{ selectedBlock, selectedStep }}>
               <DeleteBlock variant="button" />
             </EditorProvider>
@@ -175,7 +177,9 @@ describe('DeleteBlock', () => {
             }
           ]}
         >
-          <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+          <JourneyProvider
+            value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          >
             <EditorProvider initialState={{ selectedBlock, selectedStep }}>
               <DeleteBlock variant="list-item" />
             </EditorProvider>
@@ -239,7 +243,9 @@ describe('DeleteBlock', () => {
             }
           ]}
         >
-          <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+          <JourneyProvider
+            value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          >
             <EditorProvider initialState={{ selectedBlock }}>
               <DeleteBlock variant="button" />
             </EditorProvider>
@@ -309,7 +315,9 @@ describe('DeleteBlock', () => {
             }
           ]}
         >
-          <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+          <JourneyProvider
+            value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          >
             <EditorProvider initialState={{ selectedBlock }}>
               <DeleteBlock variant="list-item" />
             </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/DeleteBlock.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/DeleteBlock.stories.tsx
@@ -1,13 +1,15 @@
 import { Story, Meta } from '@storybook/react'
-import { EditorProvider, TreeBlock } from '@core/journeys/ui'
+import { EditorProvider, TreeBlock, JourneyProvider } from '@core/journeys/ui'
 import { MockedProvider } from '@apollo/client/testing'
 import { SnackbarProvider } from 'notistack'
 import { screen, userEvent } from '@storybook/testing-library'
 import { simpleComponentConfig } from '../../../../libs/storybook'
 import {
   GetJourney_journey_blocks_TypographyBlock as TypographyBlock,
-  GetJourney_journey_blocks_StepBlock as StepBlock
+  GetJourney_journey_blocks_StepBlock as StepBlock,
+  GetJourney_journey as Journey
 } from '../../../../../__generated__/GetJourney'
+import { JourneyStatus } from '../../../../../__generated__/globalTypes'
 import { DeleteBlock, BLOCK_DELETE } from './DeleteBlock'
 
 const DeleteBlockStory = {
@@ -53,7 +55,8 @@ const selectedStep: TreeBlock<StepBlock> = {
 
 const Template: Story = ({ ...args }) => {
   const {
-    state: { selectedBlock }
+    state: { selectedBlock },
+    status
   } = args
 
   return (
@@ -82,9 +85,11 @@ const Template: Story = ({ ...args }) => {
           }
         ]}
       >
-        <EditorProvider initialState={args.state}>
-          <DeleteBlock variant={args.variant} />
-        </EditorProvider>
+        <JourneyProvider value={{ journey: { status } as unkown as Journey }}>
+          <EditorProvider initialState={args.state}>
+            <DeleteBlock variant={args.variant} />
+          </EditorProvider>
+        </JourneyProvider>
       </MockedProvider>
     </SnackbarProvider>
   )
@@ -97,7 +102,8 @@ Button.args = {
     selectedBlock,
     selectedStep,
     steps: [selectedStep]
-  }
+  },
+  status: JourneyStatus.published
 }
 Button.play = () => {
   const button = screen.getByRole('button')
@@ -107,7 +113,8 @@ Button.play = () => {
 export const MenuItem = Template.bind({})
 MenuItem.args = {
   variant: 'list-item',
-  state: { selectedBlock, selectedStep, steps: [selectedStep] }
+  state: { selectedBlock, selectedStep, steps: [selectedStep] },
+  status: JourneyStatus.published
 }
 MenuItem.play = () => {
   const button = screen.getByRole('menuitem')
@@ -117,12 +124,14 @@ MenuItem.play = () => {
 export const disabledButton = Template.bind({})
 disabledButton.args = {
   variant: 'button',
-  state: {}
+  state: {},
+  status: JourneyStatus.draft
 }
 export const disabledMenuItem = Template.bind({})
 disabledMenuItem.args = {
   variant: 'list-item',
-  state: {}
+  state: {},
+  status: JourneyStatus.draft
 }
 
 export default DeleteBlockStory as Meta

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/DeleteBlock.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/DeleteBlock.stories.tsx
@@ -85,7 +85,7 @@ const Template: Story = ({ ...args }) => {
           }
         ]}
       >
-        <JourneyProvider value={{ journey: { status } as unkown as Journey }}>
+        <JourneyProvider value={{ journey: { status } as unknown as Journey }}>
           <EditorProvider initialState={args.state}>
             <DeleteBlock variant={args.variant} />
           </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/DeleteBlock.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/DeleteBlock.tsx
@@ -34,7 +34,7 @@ export function DeleteBlock({
   const [blockDelete] = useMutation<BlockDelete>(BLOCK_DELETE)
   const { enqueueSnackbar } = useSnackbar()
 
-  const journey = useJourney()
+  const { journey } = useJourney()
   const {
     state: { selectedBlock, selectedStep, steps },
     dispatch

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.spec.tsx
@@ -32,7 +32,9 @@ describe('Edit Toolbar', () => {
       <SnackbarProvider>
         <MockedProvider>
           <JourneyProvider
-            value={{ slug: 'untitled-journey' } as unknown as Journey}
+            value={{
+              journey: { slug: 'untitled-journey' } as unknown as Journey
+            }}
           >
             <EditToolbar />
           </JourneyProvider>
@@ -51,12 +53,12 @@ describe('Edit Toolbar', () => {
       <SnackbarProvider>
         <MockedProvider>
           <JourneyProvider
-            value={
-              {
+            value={{
+              journey: {
                 slug: 'untitled-journey',
                 status: JourneyStatus.draft
               } as unknown as Journey
-            }
+            }}
           >
             <EditToolbar />
           </JourneyProvider>

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.spec.tsx
@@ -33,7 +33,8 @@ describe('Edit Toolbar', () => {
         <MockedProvider>
           <JourneyProvider
             value={{
-              journey: { slug: 'untitled-journey' } as unknown as Journey
+              journey: { slug: 'untitled-journey' } as unknown as Journey,
+              admin: true
             }}
           >
             <EditToolbar />
@@ -57,7 +58,8 @@ describe('Edit Toolbar', () => {
               journey: {
                 slug: 'untitled-journey',
                 status: JourneyStatus.draft
-              } as unknown as Journey
+              } as unknown as Journey,
+              admin: true
             }}
           >
             <EditToolbar />

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.stories.tsx
@@ -1,8 +1,12 @@
 import { Story, Meta } from '@storybook/react'
 import { MockedProvider } from '@apollo/client/testing'
-import { EditorProvider, TreeBlock } from '@core/journeys/ui'
+import { EditorProvider, TreeBlock, JourneyProvider } from '@core/journeys/ui'
 import { simpleComponentConfig } from '../../../libs/storybook'
-import { GetJourney_journey_blocks_TypographyBlock as TypographyBlock } from '../../../../__generated__/GetJourney'
+import {
+  GetJourney_journey_blocks_TypographyBlock as TypographyBlock,
+  GetJourney_journey as Journey
+} from '../../../../__generated__/GetJourney'
+import { JourneyStatus } from '../../../../__generated__/globalTypes'
 import { EditToolbar } from '.'
 
 const EditToolbarStory = {
@@ -26,9 +30,15 @@ export const Default: Story = () => {
 
   return (
     <MockedProvider>
-      <EditorProvider initialState={{ selectedBlock }}>
-        <EditToolbar />
-      </EditorProvider>
+      <JourneyProvider
+        value={{
+          journey: { status: JourneyStatus.published } as unknown as Journey
+        }}
+      >
+        <EditorProvider initialState={{ selectedBlock }}>
+          <EditToolbar />
+        </EditorProvider>
+      </JourneyProvider>
     </MockedProvider>
   )
 }

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.tsx
@@ -7,7 +7,7 @@ import { DeleteBlock } from './DeleteBlock'
 import { Menu } from './Menu'
 
 export function EditToolbar(): ReactElement {
-  const journey = useJourney()
+  const { journey } = useJourney()
 
   return (
     <>

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.spec.tsx
@@ -100,12 +100,12 @@ describe('EditToolbar Menu', () => {
         <SnackbarProvider>
           <MockedProvider>
             <JourneyProvider
-              value={
-                {
+              value={{
+                journey: {
                   id: 'journeyId',
                   slug: 'my-journey'
                 } as unknown as Journey
-              }
+              }}
             >
               <EditorProvider initialState={{ selectedBlock }}>
                 <Menu />

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.spec.tsx
@@ -9,6 +9,7 @@ import {
   GetJourney_journey_blocks_StepBlock as StepBlock,
   GetJourney_journey as Journey
 } from '../../../../../__generated__/GetJourney'
+import { JourneyStatus } from '../../../../../__generated__/globalTypes'
 import { Menu } from '.'
 
 jest.mock('@mui/material/useMediaQuery', () => ({
@@ -38,9 +39,18 @@ describe('EditToolbar Menu', () => {
       const { getByRole, getByTestId, queryByRole } = render(
         <SnackbarProvider>
           <MockedProvider>
-            <EditorProvider initialState={{ selectedBlock }}>
-              <Menu />
-            </EditorProvider>
+            <JourneyProvider
+              value={{
+                journey: {
+                  status: JourneyStatus.draft
+                } as unknown as Journey,
+                admin: true
+              }}
+            >
+              <EditorProvider initialState={{ selectedBlock }}>
+                <Menu />
+              </EditorProvider>
+            </JourneyProvider>
           </MockedProvider>
         </SnackbarProvider>
       )
@@ -70,9 +80,18 @@ describe('EditToolbar Menu', () => {
       const { getByRole, getByTestId, queryByRole } = render(
         <SnackbarProvider>
           <MockedProvider>
-            <EditorProvider initialState={{ selectedBlock }}>
-              <Menu />
-            </EditorProvider>
+            <JourneyProvider
+              value={{
+                journey: {
+                  status: JourneyStatus.draft
+                } as unknown as Journey,
+                admin: true
+              }}
+            >
+              <EditorProvider initialState={{ selectedBlock }}>
+                <Menu />
+              </EditorProvider>
+            </JourneyProvider>
           </MockedProvider>
         </SnackbarProvider>
       )
@@ -141,11 +160,20 @@ describe('EditToolbar Menu', () => {
       const { getByRole, getByText } = render(
         <SnackbarProvider>
           <MockedProvider>
-            <EditorProvider initialState={{ selectedBlock }}>
-              <ThemeProvider>
-                <Menu />
-              </ThemeProvider>
-            </EditorProvider>
+            <JourneyProvider
+              value={{
+                journey: {
+                  status: JourneyStatus.draft
+                } as unknown as Journey,
+                admin: true
+              }}
+            >
+              <EditorProvider initialState={{ selectedBlock }}>
+                <ThemeProvider>
+                  <Menu />
+                </ThemeProvider>
+              </EditorProvider>
+            </JourneyProvider>
           </MockedProvider>
         </SnackbarProvider>
       )
@@ -174,11 +202,20 @@ describe('EditToolbar Menu', () => {
       const { getByRole, getByText } = render(
         <SnackbarProvider>
           <MockedProvider>
-            <EditorProvider initialState={{ selectedBlock }}>
-              <ThemeProvider>
-                <Menu />
-              </ThemeProvider>
-            </EditorProvider>
+            <JourneyProvider
+              value={{
+                journey: {
+                  status: JourneyStatus.draft
+                } as unknown as Journey,
+                admin: true
+              }}
+            >
+              <EditorProvider initialState={{ selectedBlock }}>
+                <ThemeProvider>
+                  <Menu />
+                </ThemeProvider>
+              </EditorProvider>
+            </JourneyProvider>
           </MockedProvider>
         </SnackbarProvider>
       )

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.spec.tsx
@@ -104,7 +104,8 @@ describe('EditToolbar Menu', () => {
                 journey: {
                   id: 'journeyId',
                   slug: 'my-journey'
-                } as unknown as Journey
+                } as unknown as Journey,
+                admin: true
               }}
             >
               <EditorProvider initialState={{ selectedBlock }}>

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.stories.tsx
@@ -1,8 +1,10 @@
 import { Story, Meta } from '@storybook/react'
 import { MockedProvider } from '@apollo/client/testing'
 import { screen, userEvent } from '@storybook/testing-library'
-import { EditorProvider } from '@core/journeys/ui'
+import { EditorProvider, JourneyProvider } from '@core/journeys/ui'
+import { JourneyStatus } from '../../../../../__generated__/globalTypes'
 import { journeysAdminConfig } from '../../../../libs/storybook'
+import { GetJourney_journey as Journey } from '../../../../../__generated__/GetJourney'
 import { Menu } from '.'
 
 const MenuStory = {
@@ -14,9 +16,16 @@ const MenuStory = {
 const Template: Story = ({ ...args }) => {
   return (
     <MockedProvider>
-      <EditorProvider initialState={{ ...args }}>
-        <Menu />
-      </EditorProvider>
+      <JourneyProvider
+        value={{
+          journey: { status: JourneyStatus.draft } as unknown as Journey,
+          admin: true
+        }}
+      >
+        <EditorProvider initialState={{ ...args }}>
+          <Menu />
+        </EditorProvider>
+      </JourneyProvider>
     </MockedProvider>
   )
 }

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.tsx
@@ -22,7 +22,7 @@ export function Menu(): ReactElement {
     dispatch
   } = useEditor()
 
-  const journey = useJourney()
+  const { journey } = useJourney()
   const smUp = useMediaQuery((theme: Theme) => theme.breakpoints.up('sm'))
 
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)

--- a/apps/journeys-admin/src/components/Editor/Editor.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.tsx
@@ -30,7 +30,7 @@ export function Editor({
       : undefined
 
   return (
-    <JourneyProvider value={journey}>
+    <JourneyProvider value={{ journey }}>
       <EditorProvider
         initialState={{
           steps,

--- a/apps/journeys-admin/src/components/Editor/Editor.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.tsx
@@ -30,7 +30,7 @@ export function Editor({
       : undefined
 
   return (
-    <JourneyProvider value={{ journey }}>
+    <JourneyProvider value={{ journey, admin: true }}>
       <EditorProvider
         initialState={{
           steps,

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Dialog/VideoBlockEditorSettingsPosterDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Dialog/VideoBlockEditorSettingsPosterDialog.spec.tsx
@@ -167,7 +167,7 @@ describe('VideoBlockEditorSettingsPosterDialog', () => {
             }
           ]}
         >
-          <JourneyProvider value={journey}>
+          <JourneyProvider value={{ journey }}>
             <VideoBlockEditorSettingsPosterDialog
               selectedBlock={null}
               parentBlockId={video.id}
@@ -245,7 +245,7 @@ describe('VideoBlockEditorSettingsPosterDialog', () => {
             }
           ]}
         >
-          <JourneyProvider value={journey}>
+          <JourneyProvider value={{ journey }}>
             <VideoBlockEditorSettingsPosterDialog
               selectedBlock={existingImageBlock}
               parentBlockId={video.id}
@@ -324,7 +324,7 @@ describe('VideoBlockEditorSettingsPosterDialog', () => {
             }
           ]}
         >
-          <JourneyProvider value={journey}>
+          <JourneyProvider value={{ journey }}>
             <VideoBlockEditorSettingsPosterDialog
               selectedBlock={image}
               parentBlockId={video.id}

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Dialog/VideoBlockEditorSettingsPosterDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Dialog/VideoBlockEditorSettingsPosterDialog.spec.tsx
@@ -167,7 +167,7 @@ describe('VideoBlockEditorSettingsPosterDialog', () => {
             }
           ]}
         >
-          <JourneyProvider value={{ journey }}>
+          <JourneyProvider value={{ journey, admin: true }}>
             <VideoBlockEditorSettingsPosterDialog
               selectedBlock={null}
               parentBlockId={video.id}
@@ -245,7 +245,7 @@ describe('VideoBlockEditorSettingsPosterDialog', () => {
             }
           ]}
         >
-          <JourneyProvider value={{ journey }}>
+          <JourneyProvider value={{ journey, admin: true }}>
             <VideoBlockEditorSettingsPosterDialog
               selectedBlock={existingImageBlock}
               parentBlockId={video.id}
@@ -324,7 +324,7 @@ describe('VideoBlockEditorSettingsPosterDialog', () => {
             }
           ]}
         >
-          <JourneyProvider value={{ journey }}>
+          <JourneyProvider value={{ journey, admin: true }}>
             <VideoBlockEditorSettingsPosterDialog
               selectedBlock={image}
               parentBlockId={video.id}

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Dialog/VideoBlockEditorSettingsPosterDialog.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Dialog/VideoBlockEditorSettingsPosterDialog.tsx
@@ -86,7 +86,7 @@ export function VideoBlockEditorSettingsPosterDialog({
   onLoading,
   onLoad
 }: VideoBlockEditorSettingsPosterDialogProps): ReactElement {
-  const journey = useJourney()
+  const { journey } = useJourney()
 
   const [blockDelete, { error: blockDeleteError }] =
     useMutation<BlockDeleteForPosterImage>(BLOCK_DELETE_FOR_POSTER_IMAGE)

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/VideoBlockEditorSettingsPoster.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/VideoBlockEditorSettingsPoster.spec.tsx
@@ -120,7 +120,9 @@ describe('VideoBlockEditorSettingsPoster', () => {
           }
         ]}
       >
-        <JourneyProvider value={{ id: 'journeyId' } as unknown as Journey}>
+        <JourneyProvider
+          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+        >
           <ThemeProvider>
             <VideoBlockEditorSettingsPoster
               selectedBlock={image}

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/VideoBlockEditorSettingsPoster.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/VideoBlockEditorSettingsPoster.spec.tsx
@@ -121,7 +121,10 @@ describe('VideoBlockEditorSettingsPoster', () => {
         ]}
       >
         <JourneyProvider
-          value={{ journey: { id: 'journeyId' } as unknown as Journey }}
+          value={{
+            journey: { id: 'journeyId' } as unknown as Journey,
+            admin: true
+          }}
         >
           <ThemeProvider>
             <VideoBlockEditorSettingsPoster

--- a/apps/journeys-admin/src/components/JourneyView/CardView/CardView.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/CardView/CardView.spec.tsx
@@ -24,7 +24,7 @@ describe('JourneyView/CardView', () => {
   it('should render cards', () => {
     const { getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <CardView slug="my-journey" blocks={steps} />
         </JourneyProvider>
       </MockedProvider>
@@ -34,7 +34,7 @@ describe('JourneyView/CardView', () => {
   it('should render description for 1 card', () => {
     const { getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <CardView slug="my-journey" blocks={oneStep} />
         </JourneyProvider>
       </MockedProvider>
@@ -45,7 +45,7 @@ describe('JourneyView/CardView', () => {
   it('should render description when no cards are present', () => {
     const { getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <CardView slug="my-journey" blocks={[]} />
         </JourneyProvider>
       </MockedProvider>
@@ -58,7 +58,7 @@ describe('JourneyView/CardView', () => {
     mockUseRouter.mockReturnValue({ push } as unknown as NextRouter)
     const { getByTestId } = render(
       <MockedProvider>
-        <JourneyProvider value={{ journey }}>
+        <JourneyProvider value={{ journey, admin: true }}>
           <CardView slug="my-journey" blocks={steps} />
         </JourneyProvider>
       </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyView/CardView/CardView.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/CardView/CardView.spec.tsx
@@ -24,7 +24,7 @@ describe('JourneyView/CardView', () => {
   it('should render cards', () => {
     const { getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <CardView slug="my-journey" blocks={steps} />
         </JourneyProvider>
       </MockedProvider>
@@ -34,7 +34,7 @@ describe('JourneyView/CardView', () => {
   it('should render description for 1 card', () => {
     const { getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <CardView slug="my-journey" blocks={oneStep} />
         </JourneyProvider>
       </MockedProvider>
@@ -45,7 +45,7 @@ describe('JourneyView/CardView', () => {
   it('should render description when no cards are present', () => {
     const { getByText } = render(
       <MockedProvider>
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <CardView slug="my-journey" blocks={[]} />
         </JourneyProvider>
       </MockedProvider>
@@ -58,7 +58,7 @@ describe('JourneyView/CardView', () => {
     mockUseRouter.mockReturnValue({ push } as unknown as NextRouter)
     const { getByTestId } = render(
       <MockedProvider>
-        <JourneyProvider value={journey}>
+        <JourneyProvider value={{ journey }}>
           <CardView slug="my-journey" blocks={steps} />
         </JourneyProvider>
       </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyView/CardView/CardView.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/CardView/CardView.stories.tsx
@@ -21,7 +21,8 @@ const Template: Story<Omit<CardViewProps, 'slug'>> = ({ ...args }) => (
           id: 'journeyId',
           themeMode: ThemeMode.dark,
           themeName: ThemeName.base
-        } as unknown as Journey
+        } as unknown as Journey,
+        admin: true
       }}
     >
       <CardView slug="my-journey" {...args} />

--- a/apps/journeys-admin/src/components/JourneyView/CardView/CardView.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/CardView/CardView.stories.tsx
@@ -16,13 +16,13 @@ const CardViewStory = {
 const Template: Story<Omit<CardViewProps, 'slug'>> = ({ ...args }) => (
   <MockedProvider>
     <JourneyProvider
-      value={
-        {
+      value={{
+        journey: {
           id: 'journeyId',
           themeMode: ThemeMode.dark,
           themeName: ThemeName.base
         } as unknown as Journey
-      }
+      }}
     >
       <CardView slug="my-journey" {...args} />
     </JourneyProvider>

--- a/apps/journeys-admin/src/components/JourneyView/JourneyView.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyView.spec.tsx
@@ -48,7 +48,7 @@ describe('JourneyView', () => {
     const { getByRole } = render(
       <MockedProvider>
         <SnackbarProvider>
-          <JourneyProvider value={journey}>
+          <JourneyProvider value={{ journey }}>
             <JourneyView />
           </JourneyProvider>
         </SnackbarProvider>

--- a/apps/journeys-admin/src/components/JourneyView/JourneyView.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyView.spec.tsx
@@ -48,7 +48,7 @@ describe('JourneyView', () => {
     const { getByRole } = render(
       <MockedProvider>
         <SnackbarProvider>
-          <JourneyProvider value={{ journey }}>
+          <JourneyProvider value={{ journey, admin: true }}>
             <JourneyView />
           </JourneyProvider>
         </SnackbarProvider>

--- a/apps/journeys-admin/src/components/JourneyView/JourneyView.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyView.stories.tsx
@@ -19,7 +19,7 @@ const JourneyViewStory = {
 
 const Template: Story = ({ ...args }) => (
   <MockedProvider>
-    <JourneyProvider value={args.journey}>
+    <JourneyProvider value={{ journey: args.journey }}>
       <PageWrapper
         title="Journey Details"
         showDrawer

--- a/apps/journeys-admin/src/components/JourneyView/JourneyView.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyView.tsx
@@ -11,7 +11,7 @@ import { Properties } from './Properties'
 import { CardView } from './CardView'
 
 export function JourneyView(): ReactElement {
-  const journey = useJourney()
+  const { journey } = useJourney()
   const blocks =
     journey?.blocks != null
       ? (transformer(journey.blocks) as Array<TreeBlock<StepBlock>>)

--- a/apps/journeys-admin/src/components/JourneyView/Menu/DescriptionDialog/DescriptionDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/DescriptionDialog/DescriptionDialog.spec.tsx
@@ -12,7 +12,7 @@ describe('JourneyView/Menu/DescriptionDialog', () => {
     const { getByRole } = render(
       <MockedProvider mocks={[]}>
         <SnackbarProvider>
-          <JourneyProvider value={{ journey: defaultJourney }}>
+          <JourneyProvider value={{ journey: defaultJourney, admin: true }}>
             <DescriptionDialog open onClose={onClose} />
           </JourneyProvider>
         </SnackbarProvider>
@@ -58,7 +58,7 @@ describe('JourneyView/Menu/DescriptionDialog', () => {
         ]}
       >
         <SnackbarProvider>
-          <JourneyProvider value={{ journey: defaultJourney }}>
+          <JourneyProvider value={{ journey: defaultJourney, admin: true }}>
             <DescriptionDialog open onClose={onClose} />
           </JourneyProvider>
         </SnackbarProvider>
@@ -93,7 +93,7 @@ describe('JourneyView/Menu/DescriptionDialog', () => {
         ]}
       >
         <SnackbarProvider>
-          <JourneyProvider value={{ journey: defaultJourney }}>
+          <JourneyProvider value={{ journey: defaultJourney, admin: true }}>
             <DescriptionDialog open onClose={onClose} />
           </JourneyProvider>
         </SnackbarProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Menu/DescriptionDialog/DescriptionDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/DescriptionDialog/DescriptionDialog.spec.tsx
@@ -12,7 +12,7 @@ describe('JourneyView/Menu/DescriptionDialog', () => {
     const { getByRole } = render(
       <MockedProvider mocks={[]}>
         <SnackbarProvider>
-          <JourneyProvider value={defaultJourney}>
+          <JourneyProvider value={{ journey: defaultJourney }}>
             <DescriptionDialog open onClose={onClose} />
           </JourneyProvider>
         </SnackbarProvider>
@@ -58,7 +58,7 @@ describe('JourneyView/Menu/DescriptionDialog', () => {
         ]}
       >
         <SnackbarProvider>
-          <JourneyProvider value={defaultJourney}>
+          <JourneyProvider value={{ journey: defaultJourney }}>
             <DescriptionDialog open onClose={onClose} />
           </JourneyProvider>
         </SnackbarProvider>
@@ -93,7 +93,7 @@ describe('JourneyView/Menu/DescriptionDialog', () => {
         ]}
       >
         <SnackbarProvider>
-          <JourneyProvider value={defaultJourney}>
+          <JourneyProvider value={{ journey: defaultJourney }}>
             <DescriptionDialog open onClose={onClose} />
           </JourneyProvider>
         </SnackbarProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Menu/DescriptionDialog/DescriptionDialog.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/DescriptionDialog/DescriptionDialog.stories.tsx
@@ -22,7 +22,7 @@ const Template: Story = (args) => {
 
   return (
     <MockedProvider mocks={args.mocks}>
-      <JourneyProvider value={defaultJourney}>
+      <JourneyProvider value={{ journey: defaultJourney }}>
         <DescriptionDialog open={open} onClose={() => setOpen(false)} />
       </JourneyProvider>
     </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Menu/DescriptionDialog/DescriptionDialog.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/DescriptionDialog/DescriptionDialog.stories.tsx
@@ -22,7 +22,7 @@ const Template: Story = (args) => {
 
   return (
     <MockedProvider mocks={args.mocks}>
-      <JourneyProvider value={{ journey: defaultJourney }}>
+      <JourneyProvider value={{ journey: defaultJourney, admin: true }}>
         <DescriptionDialog open={open} onClose={() => setOpen(false)} />
       </JourneyProvider>
     </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Menu/DescriptionDialog/DescriptionDialog.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/DescriptionDialog/DescriptionDialog.tsx
@@ -26,7 +26,7 @@ export function DescriptionDialog({
   onClose
 }: DescriptionDialogProps): ReactElement {
   const [journeyUpdate] = useMutation<JourneyDescUpdate>(JOURNEY_DESC_UPDATE)
-  const journey = useJourney()
+  const { journey } = useJourney()
   const { enqueueSnackbar } = useSnackbar()
 
   const handleUpdateDescription = async (

--- a/apps/journeys-admin/src/components/JourneyView/Menu/LanguageDialog/LanguageDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/LanguageDialog/LanguageDialog.spec.tsx
@@ -72,7 +72,7 @@ describe('JourneyView/Menu/LanguageDialog', () => {
     const { getByRole } = render(
       <MockedProvider mocks={[getLanguagesMock]}>
         <SnackbarProvider>
-          <JourneyProvider value={defaultJourney}>
+          <JourneyProvider value={{ journey: defaultJourney }}>
             <LanguageDialog open onClose={onClose} />
           </JourneyProvider>
         </SnackbarProvider>
@@ -134,7 +134,7 @@ describe('JourneyView/Menu/LanguageDialog', () => {
         ]}
       >
         <SnackbarProvider>
-          <JourneyProvider value={defaultJourney}>
+          <JourneyProvider value={{ journey: defaultJourney }}>
             <LanguageDialog open onClose={onClose} />
           </JourneyProvider>
         </SnackbarProvider>
@@ -154,7 +154,7 @@ describe('JourneyView/Menu/LanguageDialog', () => {
     const { getByRole, getByText } = render(
       <MockedProvider mocks={[getLanguagesMock]}>
         <SnackbarProvider>
-          <JourneyProvider value={defaultJourney}>
+          <JourneyProvider value={{ journey: defaultJourney }}>
             <LanguageDialog open onClose={onClose} />
           </JourneyProvider>
         </SnackbarProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Menu/LanguageDialog/LanguageDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/LanguageDialog/LanguageDialog.spec.tsx
@@ -72,7 +72,7 @@ describe('JourneyView/Menu/LanguageDialog', () => {
     const { getByRole } = render(
       <MockedProvider mocks={[getLanguagesMock]}>
         <SnackbarProvider>
-          <JourneyProvider value={{ journey: defaultJourney }}>
+          <JourneyProvider value={{ journey: defaultJourney, admin: true }}>
             <LanguageDialog open onClose={onClose} />
           </JourneyProvider>
         </SnackbarProvider>
@@ -134,7 +134,7 @@ describe('JourneyView/Menu/LanguageDialog', () => {
         ]}
       >
         <SnackbarProvider>
-          <JourneyProvider value={{ journey: defaultJourney }}>
+          <JourneyProvider value={{ journey: defaultJourney, admin: true }}>
             <LanguageDialog open onClose={onClose} />
           </JourneyProvider>
         </SnackbarProvider>
@@ -154,7 +154,7 @@ describe('JourneyView/Menu/LanguageDialog', () => {
     const { getByRole, getByText } = render(
       <MockedProvider mocks={[getLanguagesMock]}>
         <SnackbarProvider>
-          <JourneyProvider value={{ journey: defaultJourney }}>
+          <JourneyProvider value={{ journey: defaultJourney, admin: true }}>
             <LanguageDialog open onClose={onClose} />
           </JourneyProvider>
         </SnackbarProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Menu/LanguageDialog/LanguageDialog.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/LanguageDialog/LanguageDialog.stories.tsx
@@ -115,7 +115,7 @@ const Template: Story = () => {
         }
       ]}
     >
-      <JourneyProvider value={defaultJourney}>
+      <JourneyProvider value={{ journey: defaultJourney }}>
         <LanguageDialog open={open} onClose={() => setOpen(false)} />
       </JourneyProvider>
     </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Menu/LanguageDialog/LanguageDialog.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/LanguageDialog/LanguageDialog.stories.tsx
@@ -115,7 +115,7 @@ const Template: Story = () => {
         }
       ]}
     >
-      <JourneyProvider value={{ journey: defaultJourney }}>
+      <JourneyProvider value={{ journey: defaultJourney, admin: true }}>
         <LanguageDialog open={open} onClose={() => setOpen(false)} />
       </JourneyProvider>
     </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Menu/LanguageDialog/LanguageDialog.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/LanguageDialog/LanguageDialog.tsx
@@ -34,7 +34,7 @@ export function LanguageDialog({
   const [journeyUpdate] = useMutation<JourneyLanguageUpdate>(
     JOURNEY_LANGUAGE_UPDATE
   )
-  const journey = useJourney()
+  const { journey } = useJourney()
   const { enqueueSnackbar } = useSnackbar()
 
   const handleSubmit = async (values: FormikValues): Promise<void> => {

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.spec.tsx
@@ -17,7 +17,7 @@ describe('JourneyView/Menu', () => {
     const { getByRole } = render(
       <SnackbarProvider>
         <MockedProvider mocks={[]}>
-          <JourneyProvider value={{ journey: defaultJourney }}>
+          <JourneyProvider value={{ journey: defaultJourney, admin: true }}>
             <Menu />
           </JourneyProvider>
         </MockedProvider>
@@ -33,7 +33,7 @@ describe('JourneyView/Menu', () => {
     const { getByRole } = render(
       <SnackbarProvider>
         <MockedProvider mocks={[]}>
-          <JourneyProvider value={{ journey: defaultJourney }}>
+          <JourneyProvider value={{ journey: defaultJourney, admin: true }}>
             <Menu />
           </JourneyProvider>
         </MockedProvider>
@@ -51,7 +51,7 @@ describe('JourneyView/Menu', () => {
     const { getByRole } = render(
       <SnackbarProvider>
         <MockedProvider mocks={[]}>
-          <JourneyProvider value={{ journey: publishedJourney }}>
+          <JourneyProvider value={{ journey: publishedJourney, admin: true }}>
             <Menu />
           </JourneyProvider>
         </MockedProvider>
@@ -93,7 +93,7 @@ describe('JourneyView/Menu', () => {
             }
           ]}
         >
-          <JourneyProvider value={{ journey: defaultJourney }}>
+          <JourneyProvider value={{ journey: defaultJourney, admin: true }}>
             <Menu />
           </JourneyProvider>
         </MockedProvider>
@@ -113,7 +113,7 @@ describe('JourneyView/Menu', () => {
     const { getByRole } = render(
       <SnackbarProvider>
         <MockedProvider mocks={[]}>
-          <JourneyProvider value={{ journey: publishedJourney }}>
+          <JourneyProvider value={{ journey: publishedJourney, admin: true }}>
             <Menu />
           </JourneyProvider>
         </MockedProvider>
@@ -131,7 +131,7 @@ describe('JourneyView/Menu', () => {
     const { getByRole } = render(
       <SnackbarProvider>
         <MockedProvider mocks={[]}>
-          <JourneyProvider value={{ journey: defaultJourney }}>
+          <JourneyProvider value={{ journey: defaultJourney, admin: true }}>
             <Menu />
           </JourneyProvider>
         </MockedProvider>
@@ -149,7 +149,7 @@ describe('JourneyView/Menu', () => {
     const { getByRole } = render(
       <SnackbarProvider>
         <MockedProvider mocks={[]}>
-          <JourneyProvider value={{ journey: defaultJourney }}>
+          <JourneyProvider value={{ journey: defaultJourney, admin: true }}>
             <Menu />
           </JourneyProvider>
         </MockedProvider>
@@ -167,7 +167,7 @@ describe('JourneyView/Menu', () => {
     const { getByRole, getByText } = render(
       <SnackbarProvider>
         <MockedProvider mocks={[]}>
-          <JourneyProvider value={{ journey: defaultJourney }}>
+          <JourneyProvider value={{ journey: defaultJourney, admin: true }}>
             <Menu />
           </JourneyProvider>
         </MockedProvider>
@@ -188,7 +188,7 @@ describe('JourneyView/Menu', () => {
     const { getByRole, getByText } = render(
       <SnackbarProvider>
         <MockedProvider mocks={[]}>
-          <JourneyProvider value={{ journey: defaultJourney }}>
+          <JourneyProvider value={{ journey: defaultJourney, admin: true }}>
             <Menu />
           </JourneyProvider>
         </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.spec.tsx
@@ -17,7 +17,7 @@ describe('JourneyView/Menu', () => {
     const { getByRole } = render(
       <SnackbarProvider>
         <MockedProvider mocks={[]}>
-          <JourneyProvider value={defaultJourney}>
+          <JourneyProvider value={{ journey: defaultJourney }}>
             <Menu />
           </JourneyProvider>
         </MockedProvider>
@@ -33,7 +33,7 @@ describe('JourneyView/Menu', () => {
     const { getByRole } = render(
       <SnackbarProvider>
         <MockedProvider mocks={[]}>
-          <JourneyProvider value={defaultJourney}>
+          <JourneyProvider value={{ journey: defaultJourney }}>
             <Menu />
           </JourneyProvider>
         </MockedProvider>
@@ -51,7 +51,7 @@ describe('JourneyView/Menu', () => {
     const { getByRole } = render(
       <SnackbarProvider>
         <MockedProvider mocks={[]}>
-          <JourneyProvider value={publishedJourney}>
+          <JourneyProvider value={{ journey: publishedJourney }}>
             <Menu />
           </JourneyProvider>
         </MockedProvider>
@@ -93,7 +93,7 @@ describe('JourneyView/Menu', () => {
             }
           ]}
         >
-          <JourneyProvider value={defaultJourney}>
+          <JourneyProvider value={{ journey: defaultJourney }}>
             <Menu />
           </JourneyProvider>
         </MockedProvider>
@@ -113,7 +113,7 @@ describe('JourneyView/Menu', () => {
     const { getByRole } = render(
       <SnackbarProvider>
         <MockedProvider mocks={[]}>
-          <JourneyProvider value={publishedJourney}>
+          <JourneyProvider value={{ journey: publishedJourney }}>
             <Menu />
           </JourneyProvider>
         </MockedProvider>
@@ -131,7 +131,7 @@ describe('JourneyView/Menu', () => {
     const { getByRole } = render(
       <SnackbarProvider>
         <MockedProvider mocks={[]}>
-          <JourneyProvider value={defaultJourney}>
+          <JourneyProvider value={{ journey: defaultJourney }}>
             <Menu />
           </JourneyProvider>
         </MockedProvider>
@@ -149,7 +149,7 @@ describe('JourneyView/Menu', () => {
     const { getByRole } = render(
       <SnackbarProvider>
         <MockedProvider mocks={[]}>
-          <JourneyProvider value={defaultJourney}>
+          <JourneyProvider value={{ journey: defaultJourney }}>
             <Menu />
           </JourneyProvider>
         </MockedProvider>
@@ -167,7 +167,7 @@ describe('JourneyView/Menu', () => {
     const { getByRole, getByText } = render(
       <SnackbarProvider>
         <MockedProvider mocks={[]}>
-          <JourneyProvider value={defaultJourney}>
+          <JourneyProvider value={{ journey: defaultJourney }}>
             <Menu />
           </JourneyProvider>
         </MockedProvider>
@@ -188,7 +188,7 @@ describe('JourneyView/Menu', () => {
     const { getByRole, getByText } = render(
       <SnackbarProvider>
         <MockedProvider mocks={[]}>
-          <JourneyProvider value={defaultJourney}>
+          <JourneyProvider value={{ journey: defaultJourney }}>
             <Menu />
           </JourneyProvider>
         </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.stories.tsx
@@ -90,7 +90,7 @@ const Template: Story = ({ ...args }) => (
       }
     ]}
   >
-    <JourneyProvider value={{ journey: args.journey }}>
+    <JourneyProvider value={{ journey: args.journey, admin: true }}>
       <Menu {...args} />
     </JourneyProvider>
   </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.stories.tsx
@@ -90,7 +90,7 @@ const Template: Story = ({ ...args }) => (
       }
     ]}
   >
-    <JourneyProvider value={args.journey}>
+    <JourneyProvider value={{ journey: args.journey }}>
       <Menu {...args} />
     </JourneyProvider>
   </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
@@ -37,7 +37,7 @@ interface MenuProps {
 }
 
 export function Menu({ forceOpen }: MenuProps): ReactElement {
-  const journey = useJourney()
+  const { journey } = useJourney()
   const [journeyPublish] = useMutation<JourneyPublish>(JOURNEY_PUBLISH)
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
   const [showTitleDialog, setShowTitleDialog] = useState(false)

--- a/apps/journeys-admin/src/components/JourneyView/Menu/TitleDialog/TitleDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/TitleDialog/TitleDialog.spec.tsx
@@ -12,7 +12,7 @@ describe('JourneyView/Menu/TitleDialog', () => {
     const { getByRole } = render(
       <MockedProvider mocks={[]}>
         <SnackbarProvider>
-          <JourneyProvider value={defaultJourney}>
+          <JourneyProvider value={{ journey: defaultJourney }}>
             <TitleDialog open onClose={onClose} />
           </JourneyProvider>
         </SnackbarProvider>
@@ -58,7 +58,7 @@ describe('JourneyView/Menu/TitleDialog', () => {
         ]}
       >
         <SnackbarProvider>
-          <JourneyProvider value={defaultJourney}>
+          <JourneyProvider value={{ journey: defaultJourney }}>
             <TitleDialog open onClose={onClose} />
           </JourneyProvider>
         </SnackbarProvider>
@@ -91,7 +91,7 @@ describe('JourneyView/Menu/TitleDialog', () => {
         ]}
       >
         <SnackbarProvider>
-          <JourneyProvider value={defaultJourney}>
+          <JourneyProvider value={{ journey: defaultJourney }}>
             <TitleDialog open onClose={onClose} />
           </JourneyProvider>
         </SnackbarProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Menu/TitleDialog/TitleDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/TitleDialog/TitleDialog.spec.tsx
@@ -12,7 +12,7 @@ describe('JourneyView/Menu/TitleDialog', () => {
     const { getByRole } = render(
       <MockedProvider mocks={[]}>
         <SnackbarProvider>
-          <JourneyProvider value={{ journey: defaultJourney }}>
+          <JourneyProvider value={{ journey: defaultJourney, admin: true }}>
             <TitleDialog open onClose={onClose} />
           </JourneyProvider>
         </SnackbarProvider>
@@ -58,7 +58,7 @@ describe('JourneyView/Menu/TitleDialog', () => {
         ]}
       >
         <SnackbarProvider>
-          <JourneyProvider value={{ journey: defaultJourney }}>
+          <JourneyProvider value={{ journey: defaultJourney, admin: true }}>
             <TitleDialog open onClose={onClose} />
           </JourneyProvider>
         </SnackbarProvider>
@@ -91,7 +91,7 @@ describe('JourneyView/Menu/TitleDialog', () => {
         ]}
       >
         <SnackbarProvider>
-          <JourneyProvider value={{ journey: defaultJourney }}>
+          <JourneyProvider value={{ journey: defaultJourney, admin: true }}>
             <TitleDialog open onClose={onClose} />
           </JourneyProvider>
         </SnackbarProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Menu/TitleDialog/TitleDialog.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/TitleDialog/TitleDialog.stories.tsx
@@ -22,7 +22,7 @@ const Template: Story = (args) => {
 
   return (
     <MockedProvider mocks={args.mocks}>
-      <JourneyProvider value={defaultJourney}>
+      <JourneyProvider value={{ journey: defaultJourney }}>
         <TitleDialog open={open} onClose={() => setOpen(false)} />
       </JourneyProvider>
     </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Menu/TitleDialog/TitleDialog.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/TitleDialog/TitleDialog.stories.tsx
@@ -22,7 +22,7 @@ const Template: Story = (args) => {
 
   return (
     <MockedProvider mocks={args.mocks}>
-      <JourneyProvider value={{ journey: defaultJourney }}>
+      <JourneyProvider value={{ journey: defaultJourney, admin: true }}>
         <TitleDialog open={open} onClose={() => setOpen(false)} />
       </JourneyProvider>
     </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Menu/TitleDialog/TitleDialog.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/TitleDialog/TitleDialog.tsx
@@ -23,7 +23,7 @@ interface TitleDialogProps {
 
 export function TitleDialog({ open, onClose }: TitleDialogProps): ReactElement {
   const [journeyUpdate] = useMutation<JourneyTitleUpdate>(JOURNEY_TITLE_UPDATE)
-  const journey = useJourney()
+  const { journey } = useJourney()
   const { enqueueSnackbar } = useSnackbar()
 
   const handleUpdateTitle = async (values: FormikValues): Promise<void> => {

--- a/apps/journeys-admin/src/components/JourneyView/Properties/JourneyDetails/JourneyDetails.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Properties/JourneyDetails/JourneyDetails.stories.tsx
@@ -13,7 +13,7 @@ const JourneyDetailsStory = {
 
 const Template: Story = ({ ...args }) => (
   <MockedProvider>
-    <JourneyProvider value={{ journey: args.journey }}>
+    <JourneyProvider value={{ journey: args.journey, admin: true }}>
       <JourneyDetails {...args} />
     </JourneyProvider>
   </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Properties/JourneyDetails/JourneyDetails.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Properties/JourneyDetails/JourneyDetails.stories.tsx
@@ -13,7 +13,7 @@ const JourneyDetailsStory = {
 
 const Template: Story = ({ ...args }) => (
   <MockedProvider>
-    <JourneyProvider value={args.journey}>
+    <JourneyProvider value={{ journey: args.journey }}>
       <JourneyDetails {...args} />
     </JourneyProvider>
   </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Properties/JourneyDetails/JourneyDetails.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Properties/JourneyDetails/JourneyDetails.tsx
@@ -11,7 +11,7 @@ import { useJourney } from '@core/journeys/ui'
 import { JourneyStatus } from '../../../../../__generated__/globalTypes'
 
 export function JourneyDetails(): ReactElement {
-  const journey = useJourney()
+  const { journey } = useJourney()
 
   return (
     <>

--- a/apps/journeys-admin/src/components/JourneyView/Properties/Properties.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Properties/Properties.stories.tsx
@@ -17,7 +17,7 @@ const PropertiesStory = {
 
 const Template: Story = ({ ...args }) => (
   <MockedProvider mocks={[]}>
-    <JourneyProvider value={{ journey: args.journey }}>
+    <JourneyProvider value={{ journey: args.journey, admin: true }}>
       <Properties {...args} />
     </JourneyProvider>
   </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Properties/Properties.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Properties/Properties.stories.tsx
@@ -17,7 +17,7 @@ const PropertiesStory = {
 
 const Template: Story = ({ ...args }) => (
   <MockedProvider mocks={[]}>
-    <JourneyProvider value={args.journey}>
+    <JourneyProvider value={{ journey: args.journey }}>
       <Properties {...args} />
     </JourneyProvider>
   </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Properties/Properties.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Properties/Properties.tsx
@@ -11,7 +11,7 @@ import { AccessAvatars } from '../../AccessAvatars'
 import { JourneyDetails } from './JourneyDetails'
 
 export function Properties(): ReactElement {
-  const journey = useJourney()
+  const { journey } = useJourney()
 
   return (
     <>

--- a/apps/journeys/pages/[journeySlug].tsx
+++ b/apps/journeys/pages/[journeySlug].tsx
@@ -55,7 +55,7 @@ function JourneyPage({ journey }: JourneyPageProps): ReactElement {
           cardType: 'summary_large_image'
         }}
       />
-      <JourneyProvider value={{ journey, admin: false }}>
+      <JourneyProvider value={{ journey }}>
         <ThemeProvider
           themeName={journey.themeName}
           themeMode={journey.themeMode}

--- a/apps/journeys/pages/[journeySlug].tsx
+++ b/apps/journeys/pages/[journeySlug].tsx
@@ -55,7 +55,7 @@ function JourneyPage({ journey }: JourneyPageProps): ReactElement {
           cardType: 'summary_large_image'
         }}
       />
-      <JourneyProvider value={journey}>
+      <JourneyProvider value={{ journey, admin: false }}>
         <ThemeProvider
           themeName={journey.themeName}
           themeMode={journey.themeMode}

--- a/apps/journeys/pages/[journeySlug].tsx
+++ b/apps/journeys/pages/[journeySlug].tsx
@@ -55,7 +55,7 @@ function JourneyPage({ journey }: JourneyPageProps): ReactElement {
           cardType: 'summary_large_image'
         }}
       />
-      <JourneyProvider value={{ journey }}>
+      <JourneyProvider value={{ journey, admin: false }}>
         <ThemeProvider
           themeName={journey.themeName}
           themeMode={journey.themeMode}

--- a/libs/journeys/ui/src/libs/context/JourneyContext.spec.tsx
+++ b/libs/journeys/ui/src/libs/context/JourneyContext.spec.tsx
@@ -58,7 +58,7 @@ const journey: Journey = {
 describe('JourneyContext', () => {
   it('should pass through the journey props', () => {
     const { getByRole } = render(
-      <JourneyProvider value={journey}>
+      <JourneyProvider value={{ journey }}>
         <TestComponent />
       </JourneyProvider>
     )

--- a/libs/journeys/ui/src/libs/context/JourneyContext.spec.tsx
+++ b/libs/journeys/ui/src/libs/context/JourneyContext.spec.tsx
@@ -13,7 +13,7 @@ import { JourneyProvider, useJourney } from '.'
 const checkJourney = jest.fn()
 
 const TestComponent = (): ReactElement => {
-  const journey = useJourney()
+  const { journey } = useJourney()
 
   return <Button onClick={checkJourney(journey)}>Test</Button>
 }

--- a/libs/journeys/ui/src/libs/context/JourneyContext.tsx
+++ b/libs/journeys/ui/src/libs/context/JourneyContext.tsx
@@ -8,11 +8,9 @@ interface UseJourneyProps {
 
 // Must set initial context for useContext, but it will always be a journey
 // Else JourneyView page will not load
-const JourneyContext = createContext(
-  {} as unknown as UseJourneyProps | undefined
-)
+const JourneyContext = createContext({} as unknown as Journey | undefined)
 
-export function useJourney(): UseJourneyProps | undefined {
+export function useJourney(): Journey | undefined {
   const context = useContext(JourneyContext)
 
   return context

--- a/libs/journeys/ui/src/libs/context/JourneyContext.tsx
+++ b/libs/journeys/ui/src/libs/context/JourneyContext.tsx
@@ -1,11 +1,18 @@
 import { createContext, ReactElement, ReactNode, useContext } from 'react'
 import { JourneyFields as Journey } from './__generated__/JourneyFields'
 
+interface UseJourneyProps {
+  journey?: Journey
+  admin?: boolean
+}
+
 // Must set initial context for useContext, but it will always be a journey
 // Else JourneyView page will not load
-const JourneyContext = createContext({} as unknown as Journey | undefined)
+const JourneyContext = createContext(
+  {} as unknown as UseJourneyProps | undefined
+)
 
-export function useJourney(): Journey | undefined {
+export function useJourney(): UseJourneyProps | undefined {
   const context = useContext(JourneyContext)
 
   return context
@@ -13,7 +20,7 @@ export function useJourney(): Journey | undefined {
 
 interface JourneyProviderProps {
   children: ReactNode
-  value?: Journey
+  value?: { journey?: Journey; admin?: boolean }
 }
 
 export function JourneyProvider({

--- a/libs/journeys/ui/src/libs/context/JourneyContext.tsx
+++ b/libs/journeys/ui/src/libs/context/JourneyContext.tsx
@@ -1,16 +1,14 @@
 import { createContext, ReactElement, ReactNode, useContext } from 'react'
 import { JourneyFields as Journey } from './__generated__/JourneyFields'
 
-interface UseJourneyProps {
+interface Context {
   journey?: Journey
   admin?: boolean
 }
 
-// Must set initial context for useContext, but it will always be a journey
-// Else JourneyView page will not load
-const JourneyContext = createContext({} as unknown as Journey | undefined)
+const JourneyContext = createContext<Context>({})
 
-export function useJourney(): Journey | undefined {
+export function useJourney(): Context {
   const context = useContext(JourneyContext)
 
   return context
@@ -18,7 +16,7 @@ export function useJourney(): Journey | undefined {
 
 interface JourneyProviderProps {
   children: ReactNode
-  value?: { journey?: Journey; admin?: boolean }
+  value: Context
 }
 
 export function JourneyProvider({


### PR DESCRIPTION
# Description

Extends the value object on journey context with a admin value so we can easily know if a journey is used within admin or visitor.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tests should pass

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
