### PR TITLE
fix: arangodb bigquery export secret

### DIFF
--- a/resources/kube/arangodb-bigquery-etl/arangodb-bigquery-etl-deployment.yaml
+++ b/resources/kube/arangodb-bigquery-etl/arangodb-bigquery-etl-deployment.yaml
@@ -22,5 +22,12 @@ spec:
           envFrom:
             - secretRef:
                 name: env-db-main
-            - secretRef:
-                name: env-gcloud
+          volumeMounts:
+            - name: gcloud
+              mountPath: '/etc/gcloud'
+              readOnly: true
+      volumes:
+        - name: gcloud
+          secret:
+            secretName: gcloud-json
+            optional: false

--- a/resources/kube/arangodb-bigquery-etl/bqexport.sh
+++ b/resources/kube/arangodb-bigquery-etl/bqexport.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export DATABASE_URL="http+tcp://arangodb:8529"
-echo $GCLOUD_JSON > /gcloud.json
+cp /etc/gcloud/gcloud /gcloud.json
 export GOOGLE_APPLICATION_CREDENTIALS="/gcloud.json"
 gcloud auth activate-service-account jfp-core@jfp-data-warehouse.iam.gserviceaccount.com --key-file="/gcloud.json" --project=jfp-data-warehouse
 


### PR DESCRIPTION
# Description

This fixes the issue that arose with a new version of google cloud cli. Instead of passing the secret as an environment variable, it now passes it as a mounted secret file. 

Already working and implemented in deployed image