### PR TITLE
fix video play event duplication

### DIFF
--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -13,7 +13,8 @@ import Box from '@mui/material/Box'
 import { useTheme } from '@mui/material/styles'
 import Paper from '@mui/material/Paper'
 import VideocamRounded from '@mui/icons-material/VideocamRounded'
-import { TreeBlock, useEditor, blurImage } from '../..'
+import { v4 as uuidv4 } from 'uuid'
+import { TreeBlock, useEditor, blurImage, useJourney } from '../..'
 import { VideoPlayEventStateEnum } from '../../../__generated__/globalTypes'
 import { ImageFields } from '../Image/__generated__/ImageFields'
 import { VideoPlayEventCreate } from './__generated__/VideoPlayEventCreate'
@@ -48,6 +49,7 @@ export function Video({
     VIDEO_PLAY_EVENT_CREATE
   )
   const [loading, setLoading] = useState(true)
+  const { admin } = useJourney()
   const theme = useTheme()
   const {
     state: { selectedBlock }
@@ -75,17 +77,21 @@ export function Video({
     (videoState: VideoPlayEventStateEnum, videoPosition?: number): void => {
       const position = videoPosition != null ? Math.floor(videoPosition) : 0
 
-      void videoPlayEventCreate({
-        variables: {
-          input: {
-            blockId,
-            state: videoState,
-            position
+      if (admin === false) {
+        const id = uuidv4()
+        void videoPlayEventCreate({
+          variables: {
+            input: {
+              id,
+              blockId,
+              state: videoState,
+              position
+            }
           }
-        }
-      })
+        })
+      }
     },
-    [blockId, videoPlayEventCreate]
+    [blockId, admin, videoPlayEventCreate]
   )
 
   useEffect(() => {

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -54,6 +54,7 @@ export function Video({
   } = useEditor()
   const videoRef = useRef<HTMLVideoElement>(null)
   const playerRef = useRef<videojs.Player>()
+  const eventRef = useRef(false)
 
   const posterBlock = children.find(
     (block) => block.id === posterBlockId && block.__typename === 'ImageBlock'
@@ -125,11 +126,15 @@ export function Video({
           if (autoplay === true) setLoading(false)
         })
         playerRef.current.on('playing', () => {
-          if (autoplay !== true) setLoading(false)
-          handleVideoPlayEvent(
-            VideoPlayEventStateEnum.PLAYING,
-            playerRef.current?.currentTime()
-          )
+          if (!eventRef.current) {
+            eventRef.current = true
+          } else {
+            if (autoplay !== true) setLoading(false)
+            handleVideoPlayEvent(
+              VideoPlayEventStateEnum.PLAYING,
+              playerRef.current?.currentTime()
+            )
+          }
         })
         playerRef.current.on('pause', () => {
           handleVideoPlayEvent(


### PR DESCRIPTION
# Description

- Fix video play event send double events when video first starts playing
- Added admin check for event create
- Add uuid for event create

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/26787374/todos/4816010650)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tests pass

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
