### PR TITLE
fix: endat to pause video when no action

### DIFF
--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -93,6 +93,17 @@ export function Video({
           if (playerRef?.current?.isFullscreen() === true)
             playerRef.current?.exitFullscreen()
         })
+        playerRef.current.on('timeupdate', () => {
+          if (playerRef.current != null) {
+            if (
+              action == null &&
+              endAt != null &&
+              playerRef.current.currentTime() >= endAt
+            ) {
+              playerRef.current.pause()
+            }
+          }
+        })
       }
     }
   }, [
@@ -100,6 +111,7 @@ export function Video({
     endAt,
     muted,
     autoplay,
+    action,
     blockId,
     posterBlock,
     selectedBlock,


### PR DESCRIPTION
# Description

Had to remake because of #604 cause of commit naming issues

EndAt should pause the video when there's no action that is selected

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/27244374/todos/4927627955)

# How should this PR be QA Tested?

- [ ]  If there's no action, video should pause at the EndAt value and do nothing
- [ ]  If action and endAt was set, videos should trigger to the next card or do its set action

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
