### PR TITLE
fix: canvas to only render current card

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Canvas/Canvas.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/Canvas.tsx
@@ -2,6 +2,7 @@ import Box from '@mui/material/Box'
 import Skeleton from '@mui/material/Skeleton'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import { Theme } from '@mui/material/styles'
+import Fade from '@mui/material/Fade'
 import { ReactElement, useEffect, useState } from 'react'
 import {
   BlockRenderer,
@@ -139,25 +140,32 @@ export function Canvas(): ReactElement {
                       step.id === selectedStep?.id ? 'none' : 'auto'
                   }}
                 />
+
                 <FramePortal width={356} height={536}>
                   <ThemeProvider
                     themeName={journey?.themeName ?? ThemeName.base}
                     themeMode={journey?.themeMode ?? ThemeMode.light}
                   >
-                    <Box sx={{ p: 1, height: '100%' }}>
-                      <BlockRenderer
-                        block={step}
-                        wrappers={{
-                          Wrapper: SelectableWrapper,
-                          TypographyWrapper: InlineEditWrapper,
-                          ButtonWrapper: InlineEditWrapper,
-                          RadioQuestionWrapper: InlineEditWrapper,
-                          RadioOptionWrapper: InlineEditWrapper,
-                          SignUpWrapper: InlineEditWrapper,
-                          VideoWrapper
-                        }}
-                      />
-                    </Box>
+                    <Fade
+                      in={selectedStep?.id === step.id}
+                      mountOnEnter
+                      unmountOnExit
+                    >
+                      <Box sx={{ p: 1, height: '100%' }}>
+                        <BlockRenderer
+                          block={step}
+                          wrappers={{
+                            Wrapper: SelectableWrapper,
+                            TypographyWrapper: InlineEditWrapper,
+                            ButtonWrapper: InlineEditWrapper,
+                            RadioQuestionWrapper: InlineEditWrapper,
+                            RadioOptionWrapper: InlineEditWrapper,
+                            SignUpWrapper: InlineEditWrapper,
+                            VideoWrapper
+                          }}
+                        />
+                      </Box>
+                    </Fade>
                   </ThemeProvider>
                 </FramePortal>
               </Box>


### PR DESCRIPTION
# Description

Editing a long journey (with like 10 cards), a noticeable delay occurs. Currently, there is about a 5-10 second delay between any action in the Editor. To help solve that issue we're only allowing the canvas to render one card

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/27244374/todos/4923485547)

# How should this PR be QA Tested?

- [ ] Adding a block should only take around 3-6 seconds (this is due to change depending on the size of the journey) instead of 5-10

A more detailed QA
- [ ] Please follow the steps
   1.  Open up google chrome
   2. Visit journeys admin and go on a journey with lots of cards and images or create one
   3. In the editor of journeys-admin right-click on the website and visit the performance tab
   4. Click on the record button
   5. In the editor, add a new block
   6. Once block is added, stop the recording
   7. Check the scripting information and see how long it took

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
