### PR TITLE
fix: set default video action

### DIFF
--- a/apps/journeys-admin/__generated__/UpdateVideoBlockNextStep.ts
+++ b/apps/journeys-admin/__generated__/UpdateVideoBlockNextStep.ts
@@ -1,0 +1,26 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { NavigateToBlockActionInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: UpdateVideoBlockNextStep
+// ====================================================
+
+export interface UpdateVideoBlockNextStep_blockUpdateNavigateToBlockAction {
+  __typename: "NavigateToBlockAction";
+  gtmEventName: string | null;
+  blockId: string;
+}
+
+export interface UpdateVideoBlockNextStep {
+  blockUpdateNavigateToBlockAction: UpdateVideoBlockNextStep_blockUpdateNavigateToBlockAction;
+}
+
+export interface UpdateVideoBlockNextStepVariables {
+  id: string;
+  journeyId: string;
+  input: NavigateToBlockActionInput;
+}

--- a/apps/journeys-admin/__generated__/VideoBlockSetDefaultAction.ts
+++ b/apps/journeys-admin/__generated__/VideoBlockSetDefaultAction.ts
@@ -1,0 +1,26 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { NavigateToBlockActionInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: VideoBlockSetDefaultAction
+// ====================================================
+
+export interface VideoBlockSetDefaultAction_blockUpdateNavigateToBlockAction {
+  __typename: "NavigateToBlockAction";
+  gtmEventName: string | null;
+  blockId: string;
+}
+
+export interface VideoBlockSetDefaultAction {
+  blockUpdateNavigateToBlockAction: VideoBlockSetDefaultAction_blockUpdateNavigateToBlockAction;
+}
+
+export interface VideoBlockSetDefaultActionVariables {
+  id: string;
+  journeyId: string;
+  input: NavigateToBlockActionInput;
+}

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.spec.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.spec.tsx
@@ -10,7 +10,8 @@ import {
 import { ThemeName, ThemeMode } from '../../../__generated__/globalTypes'
 import {
   STEP_AND_CARD_BLOCK_CREATE,
-  STEP_BLOCK_NEXTBLOCKID_UPDATE
+  STEP_BLOCK_NEXTBLOCKID_UPDATE,
+  VIDEO_BLOCK_SET_DEFAULT_ACTION
 } from './CardPreview'
 import { CardPreview } from '.'
 
@@ -22,6 +23,42 @@ jest.mock('uuid', () => ({
 const mockUuidv4 = uuidv4 as jest.MockedFunction<typeof uuidv4>
 
 describe('CardPreview', () => {
+  const mocks = [
+    {
+      request: {
+        query: STEP_AND_CARD_BLOCK_CREATE,
+        variables: {
+          journeyId: 'journeyId',
+          stepId: 'stepId',
+          cardId: 'cardId'
+        }
+      },
+      result: {
+        data: {
+          stepBlockCreate: {
+            id: 'stepId',
+            parentBlockId: null,
+            parentOrder: 0,
+            locked: false,
+            nextBlockId: null,
+            __typename: 'StepBlock'
+          },
+          cardBlockCreate: {
+            id: 'cardId',
+            parentBlockId: 'stepId',
+            parentOrder: 0,
+            backgroundColor: null,
+            coverBlockId: null,
+            themeMode: null,
+            themeName: null,
+            fullscreen: false,
+            __typename: 'CardBlock'
+          }
+        }
+      }
+    }
+  ]
+
   it('should call onSelect when step is clicked', () => {
     const onSelect = jest.fn()
     const step: TreeBlock<StepBlock> = {
@@ -59,43 +96,7 @@ describe('CardPreview', () => {
     const onSelect = jest.fn()
 
     const { getByRole } = render(
-      <MockedProvider
-        mocks={[
-          {
-            request: {
-              query: STEP_AND_CARD_BLOCK_CREATE,
-              variables: {
-                journeyId: 'journeyId',
-                stepId: 'stepId',
-                cardId: 'cardId'
-              }
-            },
-            result: {
-              data: {
-                stepBlockCreate: {
-                  id: 'stepId',
-                  parentBlockId: null,
-                  parentOrder: 0,
-                  locked: false,
-                  nextBlockId: null,
-                  __typename: 'StepBlock'
-                },
-                cardBlockCreate: {
-                  id: 'cardId',
-                  parentBlockId: 'stepId',
-                  parentOrder: 0,
-                  backgroundColor: null,
-                  coverBlockId: null,
-                  themeMode: null,
-                  themeName: null,
-                  fullscreen: false,
-                  __typename: 'CardBlock'
-                }
-              }
-            }
-          }
-        ]}
-      >
+      <MockedProvider mocks={mocks}>
         <JourneyProvider
           value={{
             journey: {
@@ -152,44 +153,7 @@ describe('CardPreview', () => {
     })
 
     const { getByRole } = render(
-      <MockedProvider
-        cache={cache}
-        mocks={[
-          {
-            request: {
-              query: STEP_AND_CARD_BLOCK_CREATE,
-              variables: {
-                journeyId: 'journeyId',
-                stepId: 'stepId',
-                cardId: 'cardId'
-              }
-            },
-            result: {
-              data: {
-                stepBlockCreate: {
-                  id: 'stepId',
-                  parentBlockId: null,
-                  parentOrder: 0,
-                  locked: false,
-                  nextBlockId: null,
-                  __typename: 'StepBlock'
-                },
-                cardBlockCreate: {
-                  id: 'cardId',
-                  parentBlockId: 'stepId',
-                  parentOrder: 0,
-                  backgroundColor: null,
-                  coverBlockId: null,
-                  themeMode: null,
-                  themeName: null,
-                  fullscreen: false,
-                  __typename: 'CardBlock'
-                }
-              }
-            }
-          }
-        ]}
-      >
+      <MockedProvider cache={cache} mocks={mocks}>
         <JourneyProvider
           value={{
             journey: {
@@ -242,39 +206,7 @@ describe('CardPreview', () => {
     const { getByRole } = render(
       <MockedProvider
         mocks={[
-          {
-            request: {
-              query: STEP_AND_CARD_BLOCK_CREATE,
-              variables: {
-                journeyId: 'journeyId',
-                stepId: 'stepId',
-                cardId: 'cardId'
-              }
-            },
-            result: {
-              data: {
-                stepBlockCreate: {
-                  id: 'stepId',
-                  parentBlockId: null,
-                  parentOrder: 0,
-                  locked: false,
-                  nextBlockId: null,
-                  __typename: 'StepBlock'
-                },
-                cardBlockCreate: {
-                  id: 'cardId',
-                  parentBlockId: 'stepId',
-                  parentOrder: 0,
-                  backgroundColor: null,
-                  coverBlockId: null,
-                  themeMode: null,
-                  themeName: null,
-                  fullscreen: false,
-                  __typename: 'CardBlock'
-                }
-              }
-            }
-          },
+          ...mocks,
           {
             request: {
               query: STEP_BLOCK_NEXTBLOCKID_UPDATE,
@@ -338,39 +270,7 @@ describe('CardPreview', () => {
     const { getByRole } = render(
       <MockedProvider
         mocks={[
-          {
-            request: {
-              query: STEP_AND_CARD_BLOCK_CREATE,
-              variables: {
-                journeyId: 'journeyId',
-                stepId: 'stepId',
-                cardId: 'cardId'
-              }
-            },
-            result: {
-              data: {
-                stepBlockCreate: {
-                  id: 'stepId',
-                  parentBlockId: null,
-                  parentOrder: 0,
-                  locked: false,
-                  nextBlockId: null,
-                  __typename: 'StepBlock'
-                },
-                cardBlockCreate: {
-                  id: 'cardId',
-                  parentBlockId: 'stepId',
-                  parentOrder: 0,
-                  backgroundColor: null,
-                  coverBlockId: null,
-                  themeMode: null,
-                  themeName: null,
-                  fullscreen: false,
-                  __typename: 'CardBlock'
-                }
-              }
-            }
-          },
+          ...mocks,
           {
             request: {
               query: STEP_BLOCK_NEXTBLOCKID_UPDATE,
@@ -403,5 +303,153 @@ describe('CardPreview', () => {
 
     fireEvent.click(getByRole('button'))
     await waitFor(() => expect(result).not.toHaveBeenCalled())
+  })
+
+  it('should set the action of the previous steps video block when a new card is created', async () => {
+    mockUuidv4.mockReturnValueOnce('stepId')
+    mockUuidv4.mockReturnValueOnce('cardId')
+    const onSelect = jest.fn()
+
+    const videoBlock: TreeBlock = {
+      __typename: 'VideoBlock',
+      id: 'videoId',
+      parentBlockId: 'cardId',
+      parentOrder: 0,
+      autoplay: false,
+      startAt: 10,
+      endAt: null,
+      muted: null,
+      posterBlockId: 'posterBlockId',
+      fullsize: null,
+      action: null,
+      videoId: '2_0-FallingPlates',
+      videoVariantLanguageId: '529',
+      video: {
+        __typename: 'Video',
+        id: '2_0-FallingPlates',
+        title: [
+          {
+            __typename: 'Translation',
+            value: 'FallingPlates'
+          }
+        ],
+        image:
+          'https://d1wl257kev7hsz.cloudfront.net/cinematics/2_0-FallingPlates.mobileCinematicHigh.jpg',
+        variant: {
+          __typename: 'VideoVariant',
+          id: '2_0-FallingPlates-529',
+          hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
+        }
+      },
+      children: []
+    }
+
+    const step: TreeBlock<StepBlock> = {
+      __typename: 'StepBlock',
+      id: 'lastStepId',
+      parentBlockId: null,
+      parentOrder: 0,
+      locked: false,
+      nextBlockId: 'someStepId',
+      children: [
+        {
+          id: 'cardId',
+          __typename: 'CardBlock',
+          parentBlockId: 'lastStepId.id',
+          parentOrder: 0,
+          coverBlockId: null,
+          backgroundColor: null,
+          themeMode: null,
+          themeName: null,
+          fullscreen: false,
+          children: [videoBlock]
+        }
+      ]
+    }
+
+    const cache = new InMemoryCache()
+    cache.restore({
+      'Journey:journeyId': {
+        id: 'journeyId',
+        __typename: 'Journey'
+      },
+      'VideoBlock:videoId': {
+        ...videoBlock
+      }
+    })
+
+    const result = jest.fn(() => ({
+      data: {
+        blockUpdateNavigateToBlockAction: {
+          id: videoBlock.id,
+          journeyId: 'journeyId',
+          gtmEventName: 'gtmEventName',
+          blockId: 'stepId'
+        }
+      }
+    }))
+
+    const { getByRole } = render(
+      <MockedProvider
+        cache={cache}
+        mocks={[
+          ...mocks,
+          {
+            request: {
+              query: STEP_BLOCK_NEXTBLOCKID_UPDATE,
+              variables: {
+                id: 'lastStepId',
+                journeyId: 'journeyId',
+                input: {
+                  nextBlockId: 'stepId'
+                }
+              }
+            },
+            result: {
+              data: {
+                stepBlockUpdate: {
+                  journeyId: 'journeyId',
+                  id: 'stepId',
+                  nextBlockId: 'nextBlockId'
+                }
+              }
+            }
+          },
+          {
+            request: {
+              query: VIDEO_BLOCK_SET_DEFAULT_ACTION,
+              variables: {
+                id: videoBlock.id,
+                journeyId: 'journeyId',
+                input: {
+                  blockId: 'stepId'
+                }
+              }
+            },
+            result
+          }
+        ]}
+      >
+        <JourneyProvider
+          value={{
+            journey: {
+              id: 'journeyId',
+              themeMode: ThemeMode.light,
+              themeName: ThemeName.base
+            } as unknown as Journey,
+            admin: true
+          }}
+        >
+          <CardPreview steps={[step]} onSelect={onSelect} showAddButton />
+        </JourneyProvider>
+      </MockedProvider>
+    )
+
+    fireEvent.click(getByRole('button'))
+    await waitFor(() => expect(result).toHaveBeenCalled())
+    expect(cache.extract()['VideoBlock:videoId']?.action).toEqual({
+      gtmEventName: 'gtmEventName',
+      blockId: 'stepId'
+    })
   })
 })

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
@@ -23,7 +23,7 @@ import { StepBlockNextBlockIdUpdate } from '../../../__generated__/StepBlockNext
 import { VideoBlockSetDefaultAction } from '../../../__generated__/VideoBlockSetDefaultAction'
 import {
   BlockFields_CardBlock as CardBlock,
-  BlockFields_VideoBlock as VideoBlock,
+  BlockFields_VideoBlock as VideoBlock
 } from '../../../__generated__/BlockFields'
 import { FramePortal } from '../FramePortal'
 import { GetJourney_journey_blocks_StepBlock as StepBlock } from '../../../__generated__/GetJourney'
@@ -186,13 +186,15 @@ export function CardPreview({
     const videoBlock = prevCard?.children.find(
       (block) => block.__typename === 'VideoBlock'
     ) as unknown as TreeBlock<VideoBlock>
-    // const validVideoNextBlockId =
-    //   videoBlock?.action != null ||
-    //   (videoBlock?.action?.__typename === 'NavigateToBlockAction' &&
-    //     steps?.find(({ id }) => id === videoBlock?.action?.blockId) != null)
+    const validVideoNextBlockId =
+      steps.find(
+        ({ id }) =>
+          videoBlock?.action?.__typename === 'NavigateToBlockAction' &&
+          videoBlock?.action?.blockId === id
+      ) != null
 
     if (
-      // validVideoNextBlockId &&
+      !validVideoNextBlockId &&
       prevCard != null &&
       videoBlock != null &&
       prevCard.coverBlockId !== videoBlock.id

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
@@ -20,6 +20,11 @@ import last from 'lodash/last'
 import { ThemeName, ThemeMode } from '../../../__generated__/globalTypes'
 import { StepAndCardBlockCreate } from '../../../__generated__/StepAndCardBlockCreate'
 import { StepBlockNextBlockIdUpdate } from '../../../__generated__/StepBlockNextBlockIdUpdate'
+import { VideoBlockSetDefaultAction } from '../../../__generated__/VideoBlockSetDefaultAction'
+import {
+  BlockFields_CardBlock as CardBlock,
+  BlockFields_VideoBlock as VideoBlock,
+} from '../../../__generated__/BlockFields'
 import { FramePortal } from '../FramePortal'
 import { GetJourney_journey_blocks_StepBlock as StepBlock } from '../../../__generated__/GetJourney'
 import { HorizontalSelect } from '../HorizontalSelect'
@@ -61,6 +66,23 @@ export const STEP_BLOCK_NEXTBLOCKID_UPDATE = gql`
   }
 `
 
+export const VIDEO_BLOCK_SET_DEFAULT_ACTION = gql`
+  mutation VideoBlockSetDefaultAction(
+    $id: ID!
+    $journeyId: ID!
+    $input: NavigateToBlockActionInput!
+  ) {
+    blockUpdateNavigateToBlockAction(
+      id: $id
+      journeyId: $journeyId
+      input: $input
+    ) {
+      gtmEventName
+      blockId
+    }
+  }
+`
+
 export function CardPreview({
   steps,
   selected,
@@ -72,6 +94,9 @@ export function CardPreview({
   )
   const [stepBlockNextBlockIdUpdate] = useMutation<StepBlockNextBlockIdUpdate>(
     STEP_BLOCK_NEXTBLOCKID_UPDATE
+  )
+  const [videoBlockSetDefaultAction] = useMutation<VideoBlockSetDefaultAction>(
+    VIDEO_BLOCK_SET_DEFAULT_ACTION
   )
   const { journey } = useJourney()
 
@@ -131,14 +156,14 @@ export function CardPreview({
       )
     }
 
-    const lastStep = last(steps)
+    const prevStep = last(steps)
     // this check is required as nextBlockId is not updated when the corrseponding block is deleted
     const validNextBlockId =
-      steps.find(({ id }) => id === lastStep?.nextBlockId) != null
-    if (!validNextBlockId && lastStep != null) {
+      steps.find(({ id }) => id === prevStep?.nextBlockId) != null
+    if (!validNextBlockId && prevStep != null) {
       await stepBlockNextBlockIdUpdate({
         variables: {
-          id: lastStep.id,
+          id: prevStep.id,
           journeyId: journey.id,
           input: {
             nextBlockId: stepId
@@ -147,8 +172,50 @@ export function CardPreview({
         optimisticResponse: {
           stepBlockUpdate: {
             __typename: 'StepBlock',
-            id: lastStep.id,
+            id: prevStep.id,
             nextBlockId: stepId
+          }
+        }
+      })
+    }
+
+    // this sets video block default action to navigate to the newly created step
+    const prevCard = prevStep?.children.find(
+      (block) => block.__typename === 'CardBlock'
+    ) as unknown as TreeBlock<CardBlock>
+    const videoBlock = prevCard?.children.find(
+      (block) => block.__typename === 'VideoBlock'
+    ) as unknown as TreeBlock<VideoBlock>
+    // const validVideoNextBlockId =
+    //   videoBlock?.action != null ||
+    //   (videoBlock?.action?.__typename === 'NavigateToBlockAction' &&
+    //     steps?.find(({ id }) => id === videoBlock?.action?.blockId) != null)
+
+    if (
+      // validVideoNextBlockId &&
+      prevCard != null &&
+      videoBlock != null &&
+      prevCard.coverBlockId !== videoBlock.id
+    ) {
+      await videoBlockSetDefaultAction({
+        variables: {
+          id: videoBlock.id,
+          journeyId: journey.id,
+          input: {
+            blockId: stepId
+          }
+        },
+        update(cache, { data }) {
+          if (data?.blockUpdateNavigateToBlockAction != null) {
+            cache.modify({
+              id: cache.identify({
+                __typename: 'VideoBlock',
+                id: videoBlock.id
+              }),
+              fields: {
+                action: () => data?.blockUpdateNavigateToBlockAction
+              }
+            })
           }
         }
       })

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.spec.tsx
@@ -2,15 +2,25 @@ import { MockedProvider } from '@apollo/client/testing'
 import { TreeBlock, EditorProvider, JourneyProvider } from '@core/journeys/ui'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { SnackbarProvider } from 'notistack'
+import { InMemoryCache } from '@apollo/client'
 import { GET_VIDEOS } from '../../../../../VideoLibrary/VideoList/VideoList'
 import { GET_VIDEO } from '../../../../../VideoLibrary/VideoDetails/VideoDetails'
 import { videos } from '../../../../../VideoLibrary/VideoList/VideoListData'
 import {
   GetJourney_journey as Journey,
-  GetJourney_journey_blocks_VideoBlock as VideoBlock
+  GetJourney_journey_blocks_VideoBlock as VideoBlock,
+  GetJourney_journey_blocks_StepBlock as StepBlock
 } from '../../../../../../../../__generated__/GetJourney'
+import {
+  ThemeMode,
+  ThemeName
+} from '../../../../../../../../__generated__/globalTypes'
 import { ThemeProvider } from '../../../../../../ThemeProvider'
-import { VideoOptions, VIDEO_BLOCK_UPDATE } from './VideoOptions'
+import {
+  VideoOptions,
+  VIDEO_BLOCK_UPDATE,
+  UPDATE_VIDEO_BLOCK_NEXT_STEP
+} from './VideoOptions'
 
 const video: TreeBlock<VideoBlock> = {
   id: 'video1.id',
@@ -47,6 +57,63 @@ const video: TreeBlock<VideoBlock> = {
 }
 
 describe('VideoOptions', () => {
+  const mocks = [
+    {
+      request: {
+        query: GET_VIDEOS,
+        variables: {
+          offset: 0,
+          limit: 5,
+          where: {
+            availableVariantLanguageIds: ['529'],
+            title: null
+          }
+        }
+      },
+      result: {
+        data: {
+          videos
+        }
+      }
+    },
+    {
+      request: {
+        query: GET_VIDEO,
+        variables: {
+          id: '2_0-Brand_Video'
+        }
+      },
+      result: {
+        data: {
+          video: {
+            id: '2_0-Brand_Video',
+            image:
+              'https://d1wl257kev7hsz.cloudfront.net/cinematics/2_Acts7302-0-0.mobileCinematicHigh.jpg',
+            primaryLanguageId: '529',
+            title: [
+              {
+                primary: true,
+                value: 'Jesus Taken Up Into Heaven'
+              }
+            ],
+            description: [
+              {
+                primary: true,
+                value:
+                  'Jesus promises the Holy Spirit; then ascends into the clouds.'
+              }
+            ],
+            variant: {
+              id: 'variantA',
+              duration: 144,
+              hls: 'https://arc.gt/opsgn'
+            }
+          }
+        }
+      }
+    }
+  ]
+
   it('updates video block', async () => {
     const videoBlockResult = jest.fn(() => ({
       data: {
@@ -56,60 +123,7 @@ describe('VideoOptions', () => {
     const { getByRole, getByText } = render(
       <MockedProvider
         mocks={[
-          {
-            request: {
-              query: GET_VIDEOS,
-              variables: {
-                offset: 0,
-                limit: 5,
-                where: {
-                  availableVariantLanguageIds: ['529'],
-                  title: null
-                }
-              }
-            },
-            result: {
-              data: {
-                videos
-              }
-            }
-          },
-          {
-            request: {
-              query: GET_VIDEO,
-              variables: {
-                id: '2_0-Brand_Video'
-              }
-            },
-            result: {
-              data: {
-                video: {
-                  id: '2_0-Brand_Video',
-                  image:
-                    'https://d1wl257kev7hsz.cloudfront.net/cinematics/2_Acts7302-0-0.mobileCinematicHigh.jpg',
-                  primaryLanguageId: '529',
-                  title: [
-                    {
-                      primary: true,
-                      value: 'Jesus Taken Up Into Heaven'
-                    }
-                  ],
-                  description: [
-                    {
-                      primary: true,
-                      value:
-                        'Jesus promises the Holy Spirit; then ascends into the clouds.'
-                    }
-                  ],
-                  variant: {
-                    id: 'variantA',
-                    duration: 144,
-                    hls: 'https://arc.gt/opsgn'
-                  }
-                }
-              }
-            }
-          },
+          ...mocks,
           {
             request: {
               query: VIDEO_BLOCK_UPDATE,
@@ -156,5 +170,128 @@ describe('VideoOptions', () => {
     )
     fireEvent.click(getByRole('button', { name: 'Select' }))
     await waitFor(() => expect(videoBlockResult).toHaveBeenCalledWith())
+  })
+
+  it('updates video nextBlockId to the next step by default', async () => {
+    const selectedStep: TreeBlock<StepBlock> = {
+      __typename: 'StepBlock',
+      id: 'prevCard.id',
+      parentBlockId: null,
+      parentOrder: 0,
+      locked: false,
+      nextBlockId: 'step1.id',
+      children: [
+        {
+          id: 'card1.id',
+          __typename: 'CardBlock',
+          parentBlockId: 'prevCard.id',
+          parentOrder: 0,
+          coverBlockId: null,
+          backgroundColor: null,
+          themeMode: null,
+          themeName: null,
+          fullscreen: false,
+          children: [video]
+        }
+      ]
+    }
+
+    const cache = new InMemoryCache()
+    cache.restore({
+      'Journey:journeyId': {
+        blocks: [{ __ref: 'VideoBlock:video1.id' }],
+        id: 'journeyId',
+        __typename: 'Journey'
+      },
+      'VideoBlock:video1.id': {
+        ...video
+      }
+    })
+
+    const result = jest.fn(() => ({
+      data: {
+        blockUpdateNavigateToBlockAction: {
+          id: video.id,
+          journeyId: 'journeyId',
+          gtmEventName: 'gtmEventName',
+          blockId: 'step1.id'
+        }
+      }
+    }))
+
+    const { getByText, getByRole } = render(
+      <MockedProvider
+        mocks={[
+          ...mocks,
+          {
+            request: {
+              query: VIDEO_BLOCK_UPDATE,
+              variables: {
+                id: video.id,
+                journeyId: 'journeyId',
+                input: {
+                  videoId: '2_0-Brand_Video',
+                  videoVariantLanguageId: '529',
+                  startAt: 0,
+                  endAt: 144
+                }
+              }
+            },
+            result: {
+              data: {
+                videoBlockUpdate: video
+              }
+            }
+          },
+          {
+            request: {
+              query: UPDATE_VIDEO_BLOCK_NEXT_STEP,
+              variables: {
+                id: video.id,
+                journeyId: 'journeyId',
+                input: {
+                  blockId: 'step1.id'
+                }
+              }
+            },
+            result
+          }
+        ]}
+        cache={cache}
+      >
+        <JourneyProvider
+          value={{
+            journey: {
+              id: 'journeyId',
+              themeMode: ThemeMode.light,
+              themeName: ThemeName.base
+            } as unknown as Journey,
+            admin: true
+          }}
+        >
+          <ThemeProvider>
+            <EditorProvider
+              initialState={{ selectedStep, selectedBlock: video }}
+            >
+              <SnackbarProvider>
+                <VideoOptions />
+              </SnackbarProvider>
+            </EditorProvider>
+          </ThemeProvider>
+        </JourneyProvider>
+      </MockedProvider>
+    )
+    fireEvent.click(getByRole('button', { name: 'Select a Video' }))
+    await waitFor(() => expect(getByText('Brand Video')).toBeInTheDocument())
+    fireEvent.click(getByText('Brand Video'))
+    await waitFor(() =>
+      expect(getByRole('button', { name: 'Select' })).toBeEnabled()
+    )
+    fireEvent.click(getByRole('button', { name: 'Select' }))
+    await waitFor(() => expect(result).toHaveBeenCalled())
+    expect(cache.extract()['VideoBlock:video1.id']?.action).toEqual({
+      gtmEventName: 'gtmEventName',
+      blockId: 'step1.id'
+    })
   })
 })

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.tsx
@@ -1,10 +1,17 @@
 import { ReactElement } from 'react'
-import { useEditor, VIDEO_FIELDS, useJourney } from '@core/journeys/ui'
+import {
+  useEditor,
+  VIDEO_FIELDS,
+  useJourney,
+  TreeBlock
+} from '@core/journeys/ui'
 import { gql, useMutation } from '@apollo/client'
 import { useSnackbar } from 'notistack'
 import { VideoBlockUpdateInput } from '../../../../../../../../__generated__/globalTypes'
 import { VideoBlockEditor } from '../../../../../VideoBlockEditor'
 import { VideoBlockUpdate } from '../../../../../../../../__generated__/VideoBlockUpdate'
+import { UpdateVideoBlockNextStep } from '../../../../../../../../__generated__/UpdateVideoBlockNextStep'
+import { BlockFields_VideoBlock as VideoBlock } from '../../../../../../../../__generated__/BlockFields'
 
 export const VIDEO_BLOCK_UPDATE = gql`
   ${VIDEO_FIELDS}
@@ -19,13 +26,62 @@ export const VIDEO_BLOCK_UPDATE = gql`
   }
 `
 
+export const UPDATE_VIDEO_BLOCK_NEXT_STEP = gql`
+  mutation UpdateVideoBlockNextStep(
+    $id: ID!
+    $journeyId: ID!
+    $input: NavigateToBlockActionInput!
+  ) {
+    blockUpdateNavigateToBlockAction(
+      id: $id
+      journeyId: $journeyId
+      input: $input
+    ) {
+      gtmEventName
+      blockId
+    }
+  }
+`
+
 export function VideoOptions(): ReactElement {
   const {
-    state: { selectedBlock }
+    state: { selectedStep, selectedBlock }
   } = useEditor()
   const { journey } = useJourney()
-  const [videoBlockUpdate] = useMutation<VideoBlockUpdate>(VIDEO_BLOCK_UPDATE)
   const { enqueueSnackbar } = useSnackbar()
+  const [videoBlockUpdate] = useMutation<VideoBlockUpdate>(VIDEO_BLOCK_UPDATE)
+  const [updateVideoBlockNextStep] = useMutation<UpdateVideoBlockNextStep>(
+    UPDATE_VIDEO_BLOCK_NEXT_STEP
+  )
+
+  const updateDefaultNextStep = async (): Promise<void> => {
+    const nextStepId = selectedStep?.nextBlockId
+    const currentBlock = selectedBlock as TreeBlock<VideoBlock> | undefined
+    if (nextStepId != null && currentBlock != null && journey != null) {
+      await updateVideoBlockNextStep({
+        variables: {
+          id: currentBlock.id,
+          journeyId: journey.id,
+          input: {
+            blockId: nextStepId
+          }
+        },
+        update(cache, { data }) {
+          if (data?.blockUpdateNavigateToBlockAction != null) {
+            cache.modify({
+              id: cache.identify({
+                __typename: 'VideoBlock',
+                id: currentBlock.id
+              }),
+              fields: {
+                action: () => data?.blockUpdateNavigateToBlockAction
+              }
+            })
+          }
+        }
+      })
+    }
+  }
 
   const handleChange = async (input: VideoBlockUpdateInput): Promise<void> => {
     if (selectedBlock == null || journey == null) return
@@ -38,6 +94,7 @@ export function VideoOptions(): ReactElement {
           input
         }
       })
+      await updateDefaultNextStep()
       enqueueSnackbar('Video Updated', {
         variant: 'success',
         preventDuplicate: true


### PR DESCRIPTION
# Description

Had to remake #606 because of commit naming errors 

On video create or after selecting a video from the video library. Set the default action of that video to go to the next step

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/27244374/todos/4924125766)

# How should this PR be QA Tested?
Card A - previous card of the newly created card
Card B - newly created card

- [ ] After creating Card B, it should set Card A's video block action to navigate to Card B 
- [ ] If both Card A and B already exist, but theres no video block on Card A. After adding a video block in Card A, it should set the default action to navigate to card B
- [ ] If there's no Card B, after adding a video block to Card A, it should not set anything within action

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
