### PR TITLE
fix: no blurhash in cardpreview

### DIFF
--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
@@ -24,6 +24,7 @@ import { FramePortal } from '../FramePortal'
 import { GetJourney_journey_blocks_StepBlock as StepBlock } from '../../../__generated__/GetJourney'
 import { HorizontalSelect } from '../HorizontalSelect'
 import { VideoWrapper } from '../Editor/Canvas/VideoWrapper'
+import { ImageWrapper } from '../Editor/Canvas/ImageWrapper'
 import { CardWrapper } from '../Editor/Canvas/CardWrapper'
 
 export interface CardPreviewProps {
@@ -213,6 +214,7 @@ export function CardPreview({
                         block={step}
                         wrappers={{
                           VideoWrapper,
+                          ImageWrapper,
                           CardWrapper
                         }}
                       />

--- a/apps/journeys-admin/src/components/Editor/Canvas/CardWrapper/CardWrapper.test.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/CardWrapper/CardWrapper.test.tsx
@@ -368,4 +368,134 @@ describe('CardWrapper', () => {
       {}
     )
   })
+
+  it('should set blurhash to an empty string', () => {
+    const Container = (_props: {
+      wrappers: Record<string, never>
+    }): ReactElement => <></>
+    const block: TreeBlock = {
+      id: 'card5.id',
+      __typename: 'CardBlock',
+      parentBlockId: 'step5.id',
+      coverBlockId: 'image.id',
+      parentOrder: 0,
+      backgroundColor: null,
+      themeMode: null,
+      themeName: null,
+      fullscreen: false,
+      children: [
+        {
+          __typename: 'ImageBlock',
+          parentBlockId: 'card5.id',
+          parentOrder: 0,
+          id: 'image.id',
+          src: 'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920',
+          alt: 'random image from unsplash',
+          width: 1600,
+          height: 1067,
+          blurhash: 'L9AS}j^-0dVC4Tq[=~PATeXSV?aL',
+          children: []
+        }
+      ]
+    }
+    render(
+      <CardWrapper block={block}>
+        <Container wrappers={{}} />
+      </CardWrapper>
+    )
+    expect(Card).toHaveBeenCalledWith(
+      {
+        id: 'card5.id',
+        __typename: 'CardBlock',
+        parentBlockId: 'step5.id',
+        coverBlockId: 'image.id',
+        parentOrder: 0,
+        backgroundColor: null,
+        themeMode: null,
+        themeName: null,
+        fullscreen: false,
+        children: [
+          {
+            __typename: 'ImageBlock',
+            parentBlockId: 'card5.id',
+            parentOrder: 0,
+            id: 'image.id',
+            src: 'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920',
+            alt: 'random image from unsplash',
+            width: 1600,
+            height: 1067,
+            blurhash: '',
+            children: []
+          }
+        ],
+        wrappers: {}
+      },
+      {}
+    )
+  })
+
+  it('should where blurhash is not set', () => {
+    const Container = (_props: {
+      wrappers: Record<string, never>
+    }): ReactElement => <></>
+    const block: TreeBlock = {
+      id: 'card5.id',
+      __typename: 'CardBlock',
+      parentBlockId: 'step5.id',
+      coverBlockId: 'image.id',
+      parentOrder: 0,
+      backgroundColor: null,
+      themeMode: null,
+      themeName: null,
+      fullscreen: false,
+      children: [
+        {
+          __typename: 'ImageBlock',
+          parentBlockId: 'card5.id',
+          parentOrder: 0,
+          id: 'image.id',
+          src: 'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920',
+          alt: 'random image from unsplash',
+          width: 1600,
+          height: 1067,
+          blurhash: '',
+          children: []
+        }
+      ]
+    }
+    render(
+      <CardWrapper block={block}>
+        <Container wrappers={{}} />
+      </CardWrapper>
+    )
+    expect(Card).toHaveBeenCalledWith(
+      {
+        id: 'card5.id',
+        __typename: 'CardBlock',
+        parentBlockId: 'step5.id',
+        coverBlockId: 'image.id',
+        parentOrder: 0,
+        backgroundColor: null,
+        themeMode: null,
+        themeName: null,
+        fullscreen: false,
+        children: [
+          {
+            __typename: 'ImageBlock',
+            parentBlockId: 'card5.id',
+            parentOrder: 0,
+            id: 'image.id',
+            src: 'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920',
+            alt: 'random image from unsplash',
+            width: 1600,
+            height: 1067,
+            blurhash: '',
+            children: []
+          }
+        ],
+        wrappers: {}
+      },
+      {}
+    )
+  })
 })

--- a/apps/journeys-admin/src/components/Editor/Canvas/CardWrapper/CardWrapper.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/CardWrapper/CardWrapper.tsx
@@ -29,7 +29,7 @@ export function CardWrapper({ block, children }: WrapperProps): ReactElement {
         }
         return {
           ...child,
-          blurhash: null
+          blurhash: ''
         }
       }
       return child

--- a/apps/journeys-admin/src/components/Editor/Canvas/CardWrapper/CardWrapper.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/CardWrapper/CardWrapper.tsx
@@ -20,8 +20,21 @@ export function CardWrapper({ block, children }: WrapperProps): ReactElement {
           }
         }
       }
+      if (
+        child.id === block.coverBlockId &&
+        child.__typename === 'ImageBlock'
+      ) {
+        if (child.blurhash == null) {
+          return child
+        }
+        return {
+          ...child,
+          blurhash: null
+        }
+      }
       return child
     })
+
     return (
       <Card
         {...{ ...block, children: blocks }}

--- a/apps/journeys-admin/src/components/Editor/Canvas/ImageWrapper/ImageWrapper.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/ImageWrapper/ImageWrapper.spec.tsx
@@ -1,0 +1,81 @@
+import { render } from '@testing-library/react'
+import type { TreeBlock } from '@core/journeys/ui'
+import { Image } from '@core/journeys/ui'
+import { ImageWrapper } from '.'
+
+jest.mock('@core/journeys/ui', () => ({
+  __esModule: true,
+  Image: jest.fn(() => <></>)
+}))
+
+describe('ImageWrapper', () => {
+  it('should set blurhash and alt text to empty string', () => {
+    const block: TreeBlock = {
+      __typename: 'ImageBlock',
+      parentBlockId: 'card5.id',
+      parentOrder: 0,
+      id: 'Image',
+      src: 'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920',
+      alt: 'random image from unsplash',
+      width: 1600,
+      height: 1067,
+      blurhash: 'L9AS}j^-0dVC4Tq[=~PATeXSV?aL',
+      children: []
+    }
+    render(
+      <ImageWrapper block={block}>
+        <></>
+      </ImageWrapper>
+    )
+    expect(Image).toHaveBeenCalledWith(
+      {
+        __typename: 'ImageBlock',
+        parentBlockId: 'card5.id',
+        parentOrder: 0,
+        id: 'Image',
+        src: 'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920',
+        alt: '',
+        width: 1600,
+        height: 1067,
+        blurhash: '',
+        children: []
+      },
+      {}
+    )
+  })
+
+  it('should handle where blurhash is not set', () => {
+    const block: TreeBlock = {
+      __typename: 'ImageBlock',
+      parentBlockId: 'card5.id',
+      parentOrder: 0,
+      id: 'Image',
+      src: 'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920',
+      alt: 'random image from unsplash',
+      width: 1600,
+      height: 1067,
+      blurhash: '',
+      children: []
+    }
+    render(
+      <ImageWrapper block={block}>
+        <></>
+      </ImageWrapper>
+    )
+    expect(Image).toHaveBeenCalledWith(
+      {
+        __typename: 'ImageBlock',
+        parentBlockId: 'card5.id',
+        parentOrder: 0,
+        id: 'Image',
+        src: 'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920',
+        alt: '',
+        width: 1600,
+        height: 1067,
+        blurhash: '',
+        children: []
+      },
+      {}
+    )
+  })
+})

--- a/apps/journeys-admin/src/components/Editor/Canvas/ImageWrapper/ImageWrapper.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/ImageWrapper/ImageWrapper.tsx
@@ -1,0 +1,17 @@
+import { ReactElement } from 'react'
+import { Image } from '@core/journeys/ui'
+import type { WrapperProps } from '@core/journeys/ui'
+
+export function ImageWrapper({ block }: WrapperProps): ReactElement {
+  return block.__typename === 'ImageBlock' ? (
+    <Image
+      {...{
+        ...block,
+        blurhash: '',
+        alt: ''
+      }}
+    />
+  ) : (
+    <></>
+  )
+}

--- a/apps/journeys-admin/src/components/Editor/Canvas/ImageWrapper/index.ts
+++ b/apps/journeys-admin/src/components/Editor/Canvas/ImageWrapper/index.ts
@@ -1,0 +1,1 @@
+export { ImageWrapper } from './ImageWrapper'

--- a/libs/journeys/ui/src/components/Card/Card.tsx
+++ b/libs/journeys/ui/src/components/Card/Card.tsx
@@ -61,7 +61,8 @@ export function Card({
       : theme.palette.background.paper
 
   const blurUrl = useMemo(() => {
-    return imageBlock?.blurhash != null
+    return imageBlock != null &&
+      (imageBlock.blurhash !== '' || videoBlock?.video?.variant?.hls != null)
       ? blurImage(
           imageBlock.width,
           imageBlock.height,
@@ -69,7 +70,7 @@ export function Card({
           cardColor
         )
       : undefined
-  }, [imageBlock, cardColor])
+  }, [imageBlock, cardColor, videoBlock?.video?.variant?.hls])
 
   const renderedChildren = children
     .filter(({ id }) => id !== coverBlockId)

--- a/libs/journeys/ui/src/components/Card/Card.tsx
+++ b/libs/journeys/ui/src/components/Card/Card.tsx
@@ -61,7 +61,7 @@ export function Card({
       : theme.palette.background.paper
 
   const blurUrl = useMemo(() => {
-    return imageBlock != null
+    return imageBlock?.blurhash != null
       ? blurImage(
           imageBlock.width,
           imageBlock.height,

--- a/libs/journeys/ui/src/components/Card/ContainedCover/ContainedCover.tsx
+++ b/libs/journeys/ui/src/components/Card/ContainedCover/ContainedCover.tsx
@@ -115,6 +115,19 @@ export function ContainedCover({
             objectFit="cover"
           />
         )}
+        {loading && imageBlock != null && (
+          <NextImage
+            data-testid={
+              videoBlock != null
+                ? 'VideoPosterCover'
+                : 'ContainedCardImageCover'
+            }
+            src={imageBlock.src}
+            alt={imageBlock.alt}
+            layout="fill"
+            objectFir="cover"
+          />
+        )}
       </Box>
       <ContentOverlay
         backgroundColor={backgroundColor}

--- a/libs/journeys/ui/src/components/Card/ContainedCover/ContainedCover.tsx
+++ b/libs/journeys/ui/src/components/Card/ContainedCover/ContainedCover.tsx
@@ -115,7 +115,7 @@ export function ContainedCover({
             objectFit="cover"
           />
         )}
-        {loading && imageBlock != null && (
+        {loading && imageBlock != null && imageBlock.src != null && (
           <NextImage
             data-testid={
               videoBlock != null
@@ -125,7 +125,7 @@ export function ContainedCover({
             src={imageBlock.src}
             alt={imageBlock.alt}
             layout="fill"
-            objectFir="cover"
+            objectFit="cover"
           />
         )}
       </Box>

--- a/libs/journeys/ui/src/components/Image/Image.tsx
+++ b/libs/journeys/ui/src/components/Image/Image.tsx
@@ -17,7 +17,9 @@ export function Image({
 }: TreeBlock<ImageFields>): ReactElement {
   const theme = useTheme()
   const placeholderSrc = useMemo(() => {
-    return blurImage(width, height, blurhash, theme.palette.background.paper)
+    return blurhash != null
+      ? blurImage(width, height, blurhash, theme.palette.background.paper)
+      : undefined
   }, [blurhash, width, height, theme])
 
   return (

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -39,7 +39,7 @@ export function Video({
   ) as TreeBlock<ImageFields> | undefined
 
   const blurBackground = useMemo(() => {
-    return posterBlock != null
+    return posterBlock != null && video?.variant?.hls != null
       ? blurImage(
           posterBlock.width,
           posterBlock.height,
@@ -47,7 +47,7 @@ export function Video({
           theme.palette.background.paper
         )
       : undefined
-  }, [posterBlock, theme])
+  }, [posterBlock, theme, video?.variant?.hls])
 
   useEffect(() => {
     if (videoRef.current != null) {


### PR DESCRIPTION
# Description

Editing a long journey (with like 10 cards), a noticeable delay occurs. Currently, there is about a 5-10 second delay between any action in the Editor. To help solve that issue we'll stop using blurhash in card preview

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/27244374/todos/4923485547)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Adding a block in a big journey should only take 1-2 seconds

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
