### PR TITLE
fix: blurimage calculation

### DIFF
--- a/libs/journeys/ui/src/components/Card/Card.spec.tsx
+++ b/libs/journeys/ui/src/components/Card/Card.spec.tsx
@@ -160,12 +160,7 @@ describe('CardBlock', () => {
       />
     )
 
-    expect(blurImage).toBeCalledWith(
-      imageBlock.width,
-      imageBlock.height,
-      imageBlock.blurhash,
-      '#fff'
-    )
+    expect(blurImage).toBeCalledWith(imageBlock.blurhash, '#fff')
     expect(getByTestId('ExpandedCover')).toBeInTheDocument()
     await waitFor(() =>
       expect(getByTestId('expandedBlurBackground')).toBeInTheDocument()
@@ -182,12 +177,7 @@ describe('CardBlock', () => {
     )
     const standaloneImageBlock = queryByTestId(`image-${imageBlock.id}`)
 
-    expect(blurImage).toBeCalledWith(
-      imageBlock.width,
-      imageBlock.height,
-      imageBlock.blurhash,
-      '#fff'
-    )
+    expect(blurImage).toBeCalledWith(imageBlock.blurhash, '#fff')
     expect(queryByTestId('ContainedCover')).toBeInTheDocument()
     expect(queryByTestId('ContainedCardImageCover')).toHaveAccessibleName(
       'random image from unsplash'
@@ -205,12 +195,7 @@ describe('CardBlock', () => {
     )
     const standaloneVideoBlock = queryByTestId(`video-${videoBlock.id}`)
 
-    expect(blurImage).toBeCalledWith(
-      imageBlock.width,
-      imageBlock.height,
-      imageBlock.blurhash,
-      '#fff'
-    )
+    expect(blurImage).toBeCalledWith(imageBlock.blurhash, '#fff')
     expect(queryByTestId('ContainedCover')).toBeInTheDocument()
     expect(queryByTestId('VideoPosterCover')).toHaveAccessibleName(
       'random image from unsplash - video'

--- a/libs/journeys/ui/src/components/Card/Card.tsx
+++ b/libs/journeys/ui/src/components/Card/Card.tsx
@@ -62,12 +62,7 @@ export function Card({
 
   const blurUrl = useMemo(() => {
     return imageBlock != null
-      ? blurImage(
-          imageBlock.width,
-          imageBlock.height,
-          imageBlock.blurhash,
-          cardColor
-        )
+      ? blurImage(imageBlock.blurhash, cardColor)
       : undefined
   }, [imageBlock, cardColor])
 

--- a/libs/journeys/ui/src/components/Image/Image.spec.tsx
+++ b/libs/journeys/ui/src/components/Image/Image.spec.tsx
@@ -36,12 +36,7 @@ describe('Image', () => {
       'random image from unsplash'
     )
 
-    expect(blurImage).toBeCalledWith(
-      block.width,
-      block.height,
-      block.blurhash,
-      '#fff'
-    )
+    expect(blurImage).toBeCalledWith(block.blurhash, '#fff')
   })
 
   it('should render the default image', () => {

--- a/libs/journeys/ui/src/components/Image/Image.tsx
+++ b/libs/journeys/ui/src/components/Image/Image.tsx
@@ -17,8 +17,8 @@ export function Image({
 }: TreeBlock<ImageFields>): ReactElement {
   const theme = useTheme()
   const placeholderSrc = useMemo(() => {
-    return blurImage(width, height, blurhash, theme.palette.background.paper)
-  }, [blurhash, width, height, theme])
+    return blurImage(blurhash, theme.palette.background.paper)
+  }, [blurhash, theme])
 
   return (
     <Box

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -40,12 +40,7 @@ export function Video({
 
   const blurBackground = useMemo(() => {
     return posterBlock != null
-      ? blurImage(
-          posterBlock.width,
-          posterBlock.height,
-          posterBlock.blurhash,
-          theme.palette.background.paper
-        )
+      ? blurImage(posterBlock.blurhash, theme.palette.background.paper)
       : undefined
   }, [posterBlock, theme])
 

--- a/libs/journeys/ui/src/libs/blurImage/blurImage.spec.ts
+++ b/libs/journeys/ui/src/libs/blurImage/blurImage.spec.ts
@@ -15,10 +15,8 @@ describe('blurImage', () => {
   }
 
   it('returns url of blurred image', () => {
-    expect(
-      blurImage(image.width, image.height, image.blurhash, '#000000')
-    ).toBe(
-      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAYAAAA7KqwyAAAABmJLR0QA/wD/AP+gvaeTAAABA0lEQVQokV2RMY4cQQwDi5S69x7hwP9/ngMfPDstOpiFAwcVECAqIPXz60fUxq9F7UWtRlUgmBzuuXnfF3+ui+/r4tcVcgumQIUFiHyA/7OTB0IRXgwk/2h7kEwBxVNWHpMIEMIQDskNOSjFdwQR3Q0YymCLspCFFAJYIAVxkN/IN9JCMr8R7W1k4/WhC7uQgIhocAq30Qh6gMNkCEPr1ciFeuG18VrUR6A55AhrEAdyCHBKdERJNHuBC9ZGe6NeqJoSaAZuM3pGJcNI1ARjpKKzFlTBWrAX6o26EcJzwEKEZPAcDDiDgNh0usFFqqEb1kJVjyB+XjgL1xvXwjMoNxKMzF9Ukn10nay9yQAAAABJRU5ErkJggg=='
+    expect(blurImage(image.blurhash, '#000000')).toBe(
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABmJLR0QA/wD/AP+gvaeTAAAD80lEQVRYhZWXXY4cNwyEv2K3gRzCD7n/CZPYw8oDSUk9O4bhXQgttNSsYvFHGv3913cj0BU17ou4Al39jBpIIAAwxk5yRr545YvX68XPHj9eL/57mX9e4ARSkEEZaXs1+/M//cG+3+39JYHffTjGZcDv773WYxbNc2NPQx8++kLEXusPIyeox4aXvcBcGHywPIkY4qtBLxLqTScpHXs28SdwgbOeW4Um4plDSDu/9Gb4q5enSufe53pgwuX95eTbqYK9wLEnBO5gvhn3JnUqIX/yviTfIwlnkzD3eD7aN4m7rKkMisPDmrznxSNHvNcD40cIdg4YkUAisndNKG61hQIvJU5ZB1HvyEOwEgkvEvOfXKpZAHe//Xe8b+NNwAhtBfRUY/WgFQPtJAKywRGbgIpEYC5VRiXiG+KHtgpPBQQ6Ol6B6wiD+FI1/V00+GcVghBcMmmTmFfn3CYQDaZ5noroIFYkhsokdLKbitUKKLHc4CKlJgTZuXErSlJ1iz7VIIRiwHvPkWrqzTFxmgzRDDeBJBVcYewCvyR+Ym6iJKaBFA12AHMospXvAj3XQ8girAeJCFVovJvThcmlAA32CxL17PwYFwWkl+7hRyLhllwhwhDR2/sTNYn74WV0NsUmQcRWo/OhulntcQoryBjPRy0RQyQKWI++USf0TRzMB1zRwLFJKY7ekK1vdwAnoSAVRARkYAWOWCKlWolHaYubiE68kTvgelNDrQLanXAdcG4igRyEC1gOxEV00sltnynrisPNddRhxMqDmvdtKGL3A1GAFiQojB2ky/scEr7q1hTVpOQTWt3mxd0NYIdggWuD95Ws8sBonWjGaRQFmg6kCyl7XF3O7vhvDSen7tU9Gozr9Fzoior/JGr3cnlOUAMXOJEv5Cz5ewRG6Y55bBLdASsHYHn9eA54HCpBnfvOXVckHtCMyhldaDyP7NP+re8XgeNlxJELz/mjNbvyQGwFlAZlVY4vlNnVZJTn4bbBrckBhFf5vakwc8U+DScE3ZRtV9U4UF5IryYSSC4I+/A+Vhe9d/eKJrHrfp0FMXkwCgyBugXgBF+QWftzEjFYNy3NXfNUAG53fT8q4JMSc2zSMWiJLTdQYgW7qjp0TrSuLAcB1Zl6oz7Zjpa8DDyeUwXdUjt5RdYvnmlWKwmnJc+VhYMAuHHv5VkDuQdvowDfFeizLRJSC3gTL2UeHRSWzQpBt0f3whclpiWPStOGj2PY7yqtptVE5kbcV78BLwX4HAKLbeRRu2/l1GGZUJ5JxtwhPK13iO/9sVZOjXQ2jfOjsf2+thXSCd7GlnLSYbt4xfliPDzcPJiJB9PH2icH+LD/3UH4H95u1e/6dl73AAAAAElFTkSuQmCC'
     )
   })
 
@@ -37,14 +35,10 @@ describe('blurImage', () => {
       return createElement(tagName)
     }
 
-    expect(
-      blurImage(image.width, image.height, image.blurhash, '#000000')
-    ).toBe(undefined)
+    expect(blurImage(image.blurhash, '#000000')).toBe(undefined)
   })
 
   it('returns undefined if blurhash is empty string', () => {
-    expect(blurImage(image.width, image.height, '', '#00000088')).toBe(
-      undefined
-    )
+    expect(blurImage('', '#00000088')).toBe(undefined)
   })
 })

--- a/libs/journeys/ui/src/libs/blurImage/blurImage.ts
+++ b/libs/journeys/ui/src/libs/blurImage/blurImage.ts
@@ -1,32 +1,24 @@
 import { decode } from 'blurhash'
 
-const greatestCommonDivisor = (a: number, b: number): number =>
-  b === 0 ? a : greatestCommonDivisor(b, a % b)
-
 export const blurImage = (
-  imageWidth: number,
-  imageHeight: number,
   blurhash: string,
   hexBackground: string
 ): string | undefined => {
   if (blurhash === '') return undefined
 
-  const divisor = greatestCommonDivisor(imageWidth, imageHeight)
-  const width = imageWidth / divisor
-  const height = imageHeight / divisor
-  const pixels = decode(blurhash, width, height, 1)
+  const pixels = decode(blurhash, 32, 32, 1)
 
   const canvas = document.createElement('canvas')
-  canvas.setAttribute('width', `${width}px`)
-  canvas.setAttribute('height', `${height}px`)
+  canvas.setAttribute('width', '32px')
+  canvas.setAttribute('height', '32px')
   const context = canvas.getContext('2d')
 
   if (context != null) {
-    const imageData = context.createImageData(width, height)
+    const imageData = context.createImageData(32, 32)
     imageData.data.set(pixels)
     context.putImageData(imageData, 0, 0)
     context.fillStyle = `${hexBackground}88`
-    context.fillRect(0, 0, width, height)
+    context.fillRect(0, 0, 32, 32)
     const blurUrl = canvas.toDataURL('image/webp')
 
     return blurUrl


### PR DESCRIPTION
# Description

Editing a long journey (with like 10 cards), a noticeable delay occurs. Currently, there is about a 5-10 second delay between any action in the Editor. To help solve that issue we lowered down the aspect ratio of the image so that the blurhash calculation is a lot faster

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/27244374/todos/4923485547)

# How should this PR be QA Tested?

- [ ] Adding or deleting blocks in a card should 1 second
- [ ] Creating a new card should take 1 second

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
- [ ] Vlad has approved of the blurhash changes