### PR TITLE
fix: add cors to gateway

### DIFF
--- a/apps/api-gateway/src/environments/environment.prod.ts
+++ b/apps/api-gateway/src/environments/environment.prod.ts
@@ -9,5 +9,21 @@ export const config: EnvironmentConfig = {
   listenOptions: {
     port: 4000,
     host: '0.0.0.0'
+  },
+  cors: {
+    origin: [
+      // apollo studio
+      'https://studio.apollographql.com',
+      // any project deployed on the jesusfilm vercel account
+      /-jesusfilm\.vercel\.app$/,
+      // journeys-admin
+      'https://journeys-admin.vercel.app',
+      'https://admin.nextstep.is',
+      // journeys
+      'https://journeys-phi.vercel.app',
+      'https://your.nextstep.is',
+      // watch
+      'https://watch-one.vercel.app'
+    ]
   }
 }

--- a/apps/api-gateway/src/environments/environment.ts
+++ b/apps/api-gateway/src/environments/environment.ts
@@ -9,5 +9,6 @@ export const config: EnvironmentConfig = {
   listenOptions: {
     port: 4000,
     host: '0.0.0.0'
-  }
+  },
+  cors: false
 }

--- a/apps/api-gateway/src/environments/types.ts
+++ b/apps/api-gateway/src/environments/types.ts
@@ -1,4 +1,5 @@
 import { GatewayConfig } from '@apollo/gateway'
+import { CorsOptions } from 'apollo-server'
 
 export interface EnvironmentConfig {
   production: boolean
@@ -13,4 +14,5 @@ export interface EnvironmentConfig {
     writableAll?: boolean
     ipv6Only?: boolean
   }
+  cors?: CorsOptions | boolean
 }

--- a/apps/api-gateway/src/main.ts
+++ b/apps/api-gateway/src/main.ts
@@ -33,6 +33,8 @@ export const gateway = new ApolloGateway({
 const server = new ApolloServer({
   gateway,
   plugins: [apolloWinstonLoggingPlugin({ level: process.env.LOGGING_LEVEL })],
+  csrfPrevention: true,
+  cors: config.cors,
   context: async ({ req }) => {
     const token = req.headers.authorization
     if (

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@nestjs/platform-express": "^8.3.1",
         "@nrwl/next": "13.2.2",
         "apollo-datasource": "^3.3.1",
-        "apollo-server": "^3.6.3",
+        "apollo-server": "^3.7.0",
         "arangojs": "^7.6.1",
         "aws-sdk": "^2.1062.0",
         "axios": "^0.26.1",
@@ -441,12 +441,21 @@
         "graphql": "^15.8.0 || ^16.0.0"
       }
     },
+    "node_modules/@apollo/utils.logger": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-1.0.0.tgz",
+      "integrity": "sha512-dx9XrjyisD2pOa+KsB5RcDbWIAdgC91gJfeyLCgy0ctJMjQe7yZK5kdWaWlaOoCeX0z6YI9iYlg7vMPyMpQF3Q=="
+    },
     "node_modules/@apollographql/apollo-tools": {
-      "version": "0.5.2",
-      "license": "MIT",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.5.4.tgz",
+      "integrity": "sha512-shM3q7rUbNyXVVRkQJQseXv6bnYM3BUma/eZhwXR4xsuM+bqWnJKvW7SAfRjP7LuSCocrexa5AXhjjawNHrIlw==",
       "engines": {
         "node": ">=8",
         "npm": ">=6"
+      },
+      "peerDependencies": {
+        "graphql": "^14.2.1 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@apollographql/graphql-playground-html": {
@@ -20783,18 +20792,20 @@
       }
     },
     "node_modules/apollo-reporting-protobuf": {
-      "version": "3.3.0",
-      "license": "MIT",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.3.1.tgz",
+      "integrity": "sha512-tyvj3Vj71TCh6c8PtdHOLgHHBSJ05DF/A/Po3q8yfHTBkOPcOJZE/GGN/PT/pwKg7HHxKcAeHDw7+xciVvGx0w==",
       "dependencies": {
         "@apollo/protobufjs": "1.2.2"
       }
     },
     "node_modules/apollo-server": {
-      "version": "3.6.3",
-      "license": "MIT",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-3.7.0.tgz",
+      "integrity": "sha512-sMD9V0cScsuXKtqtpLBpeU3s0eRyG12n3HtHGg9LNBanYkxS4/I1i0JozO0r0e2kO5yyJ1gc6UWim9+NDxUrnA==",
       "dependencies": {
-        "apollo-server-core": "^3.6.3",
-        "apollo-server-express": "^3.6.3",
+        "apollo-server-core": "^3.7.0",
+        "apollo-server-express": "^3.7.0",
         "express": "^4.17.1"
       },
       "peerDependencies": {
@@ -20812,21 +20823,23 @@
       }
     },
     "node_modules/apollo-server-core": {
-      "version": "3.6.3",
-      "license": "MIT",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.7.0.tgz",
+      "integrity": "sha512-xUCDjrBzPVbttbh/HenuQdivco/dcXE2oIDYwCU6FU2RBXqxWFmuCl2Xe7VPA/5Frw/4snJDLCyVte9PA5edww==",
       "dependencies": {
-        "@apollographql/apollo-tools": "^0.5.1",
+        "@apollo/utils.logger": "^1.0.0",
+        "@apollographql/apollo-tools": "^0.5.3",
         "@apollographql/graphql-playground-html": "1.6.29",
         "@graphql-tools/mock": "^8.1.2",
         "@graphql-tools/schema": "^8.0.0",
         "@josephg/resolvable": "^1.0.0",
         "apollo-datasource": "^3.3.1",
-        "apollo-reporting-protobuf": "^3.3.0",
+        "apollo-reporting-protobuf": "^3.3.1",
         "apollo-server-caching": "^3.3.0",
         "apollo-server-env": "^4.2.1",
         "apollo-server-errors": "^3.3.1",
-        "apollo-server-plugin-base": "^3.5.1",
-        "apollo-server-types": "^3.5.1",
+        "apollo-server-plugin-base": "^3.5.3",
+        "apollo-server-types": "^3.5.3",
         "async-retry": "^1.2.1",
         "fast-json-stable-stringify": "^2.1.0",
         "graphql-tag": "^2.11.0",
@@ -20834,13 +20847,22 @@
         "loglevel": "^1.6.8",
         "lru-cache": "^6.0.0",
         "sha.js": "^2.4.11",
-        "uuid": "^8.0.0"
+        "uuid": "^8.0.0",
+        "whatwg-mimetype": "^3.0.0"
       },
       "engines": {
         "node": ">=12.0"
       },
       "peerDependencies": {
         "graphql": "^15.3.0 || ^16.0.0"
+      }
+    },
+    "node_modules/apollo-server-core/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/apollo-server-env": {
@@ -20864,8 +20886,9 @@
       }
     },
     "node_modules/apollo-server-express": {
-      "version": "3.6.3",
-      "license": "MIT",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-3.7.0.tgz",
+      "integrity": "sha512-176LSK7YBxwfleurtbfr5SYMheNNJSHrQa2h4QuosLqhfFJkfTpI2iBW56N737U47QfyueCOvkjNZVq86e3n2g==",
       "dependencies": {
         "@types/accepts": "^1.3.5",
         "@types/body-parser": "1.19.2",
@@ -20873,8 +20896,8 @@
         "@types/express": "4.17.13",
         "@types/express-serve-static-core": "4.17.28",
         "accepts": "^1.3.5",
-        "apollo-server-core": "^3.6.3",
-        "apollo-server-types": "^3.5.1",
+        "apollo-server-core": "^3.7.0",
+        "apollo-server-types": "^3.5.3",
         "body-parser": "^1.19.0",
         "cors": "^2.8.5",
         "parseurl": "^1.3.3"
@@ -20898,10 +20921,11 @@
       }
     },
     "node_modules/apollo-server-plugin-base": {
-      "version": "3.5.1",
-      "license": "MIT",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.5.3.tgz",
+      "integrity": "sha512-zojm3qiUGYtM5k1PPrCJnLZSDNqvWvmIDvqBjCu3wI3iNZqNm3MOA86eYGFfaBi/WNu3qYIj6QE3T7w0XjRV1A==",
       "dependencies": {
-        "apollo-server-types": "^3.5.1"
+        "apollo-server-types": "^3.5.3"
       },
       "engines": {
         "node": ">=12.0"
@@ -20911,10 +20935,11 @@
       }
     },
     "node_modules/apollo-server-types": {
-      "version": "3.5.1",
-      "license": "MIT",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.5.3.tgz",
+      "integrity": "sha512-Qf5mMVTDyABEeyjGecwMsk0y0km4KuW8/j/UwBDQkAAW1QRy+w8nqi+wvSoA5hNXiYCdJN4U4nxTxm9+2eiT4w==",
       "dependencies": {
-        "apollo-reporting-protobuf": "^3.3.0",
+        "apollo-reporting-protobuf": "^3.3.1",
         "apollo-server-caching": "^3.3.0",
         "apollo-server-env": "^4.2.1"
       },
@@ -47427,8 +47452,16 @@
       "version": "0.3.1",
       "requires": {}
     },
+    "@apollo/utils.logger": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-1.0.0.tgz",
+      "integrity": "sha512-dx9XrjyisD2pOa+KsB5RcDbWIAdgC91gJfeyLCgy0ctJMjQe7yZK5kdWaWlaOoCeX0z6YI9iYlg7vMPyMpQF3Q=="
+    },
     "@apollographql/apollo-tools": {
-      "version": "0.5.2"
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.5.4.tgz",
+      "integrity": "sha512-shM3q7rUbNyXVVRkQJQseXv6bnYM3BUma/eZhwXR4xsuM+bqWnJKvW7SAfRjP7LuSCocrexa5AXhjjawNHrIlw==",
+      "requires": {}
     },
     "@apollographql/graphql-playground-html": {
       "version": "1.6.29",
@@ -61247,16 +61280,20 @@
       }
     },
     "apollo-reporting-protobuf": {
-      "version": "3.3.0",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.3.1.tgz",
+      "integrity": "sha512-tyvj3Vj71TCh6c8PtdHOLgHHBSJ05DF/A/Po3q8yfHTBkOPcOJZE/GGN/PT/pwKg7HHxKcAeHDw7+xciVvGx0w==",
       "requires": {
         "@apollo/protobufjs": "1.2.2"
       }
     },
     "apollo-server": {
-      "version": "3.6.3",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-3.7.0.tgz",
+      "integrity": "sha512-sMD9V0cScsuXKtqtpLBpeU3s0eRyG12n3HtHGg9LNBanYkxS4/I1i0JozO0r0e2kO5yyJ1gc6UWim9+NDxUrnA==",
       "requires": {
-        "apollo-server-core": "^3.6.3",
-        "apollo-server-express": "^3.6.3",
+        "apollo-server-core": "^3.7.0",
+        "apollo-server-express": "^3.7.0",
         "express": "^4.17.1"
       }
     },
@@ -61267,20 +61304,23 @@
       }
     },
     "apollo-server-core": {
-      "version": "3.6.3",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.7.0.tgz",
+      "integrity": "sha512-xUCDjrBzPVbttbh/HenuQdivco/dcXE2oIDYwCU6FU2RBXqxWFmuCl2Xe7VPA/5Frw/4snJDLCyVte9PA5edww==",
       "requires": {
-        "@apollographql/apollo-tools": "^0.5.1",
+        "@apollo/utils.logger": "^1.0.0",
+        "@apollographql/apollo-tools": "^0.5.3",
         "@apollographql/graphql-playground-html": "1.6.29",
         "@graphql-tools/mock": "^8.1.2",
         "@graphql-tools/schema": "^8.0.0",
         "@josephg/resolvable": "^1.0.0",
         "apollo-datasource": "^3.3.1",
-        "apollo-reporting-protobuf": "^3.3.0",
+        "apollo-reporting-protobuf": "^3.3.1",
         "apollo-server-caching": "^3.3.0",
         "apollo-server-env": "^4.2.1",
         "apollo-server-errors": "^3.3.1",
-        "apollo-server-plugin-base": "^3.5.1",
-        "apollo-server-types": "^3.5.1",
+        "apollo-server-plugin-base": "^3.5.3",
+        "apollo-server-types": "^3.5.3",
         "async-retry": "^1.2.1",
         "fast-json-stable-stringify": "^2.1.0",
         "graphql-tag": "^2.11.0",
@@ -61288,7 +61328,15 @@
         "loglevel": "^1.6.8",
         "lru-cache": "^6.0.0",
         "sha.js": "^2.4.11",
-        "uuid": "^8.0.0"
+        "uuid": "^8.0.0",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "dependencies": {
+        "whatwg-mimetype": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+          "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="
+        }
       }
     },
     "apollo-server-env": {
@@ -61302,7 +61350,9 @@
       "requires": {}
     },
     "apollo-server-express": {
-      "version": "3.6.3",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-3.7.0.tgz",
+      "integrity": "sha512-176LSK7YBxwfleurtbfr5SYMheNNJSHrQa2h4QuosLqhfFJkfTpI2iBW56N737U47QfyueCOvkjNZVq86e3n2g==",
       "requires": {
         "@types/accepts": "^1.3.5",
         "@types/body-parser": "1.19.2",
@@ -61310,8 +61360,8 @@
         "@types/express": "4.17.13",
         "@types/express-serve-static-core": "4.17.28",
         "accepts": "^1.3.5",
-        "apollo-server-core": "^3.6.3",
-        "apollo-server-types": "^3.5.1",
+        "apollo-server-core": "^3.7.0",
+        "apollo-server-types": "^3.5.3",
         "body-parser": "^1.19.0",
         "cors": "^2.8.5",
         "parseurl": "^1.3.3"
@@ -61329,15 +61379,19 @@
       }
     },
     "apollo-server-plugin-base": {
-      "version": "3.5.1",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.5.3.tgz",
+      "integrity": "sha512-zojm3qiUGYtM5k1PPrCJnLZSDNqvWvmIDvqBjCu3wI3iNZqNm3MOA86eYGFfaBi/WNu3qYIj6QE3T7w0XjRV1A==",
       "requires": {
-        "apollo-server-types": "^3.5.1"
+        "apollo-server-types": "^3.5.3"
       }
     },
     "apollo-server-types": {
-      "version": "3.5.1",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.5.3.tgz",
+      "integrity": "sha512-Qf5mMVTDyABEeyjGecwMsk0y0km4KuW8/j/UwBDQkAAW1QRy+w8nqi+wvSoA5hNXiYCdJN4U4nxTxm9+2eiT4w==",
       "requires": {
-        "apollo-reporting-protobuf": "^3.3.0",
+        "apollo-reporting-protobuf": "^3.3.1",
         "apollo-server-caching": "^3.3.0",
         "apollo-server-env": "^4.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@nestjs/platform-express": "^8.3.1",
     "@nrwl/next": "13.2.2",
     "apollo-datasource": "^3.3.1",
-    "apollo-server": "^3.6.3",
+    "apollo-server": "^3.7.0",
     "arangojs": "^7.6.1",
     "aws-sdk": "^2.1062.0",
     "axios": "^0.26.1",


### PR DESCRIPTION
# Description

This addresses a security concern that means that API requests from clients can only come from specific URLs under our control.

- update to apollo-server 3.7 to support csrfPrevention option in apollo server config.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
