### PR TITLE
feat: extend events api with name

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -65,6 +65,7 @@ input ButtonBlockUpdateInput {
 type ButtonClickEvent implements Event {
   block: ButtonBlock
   id: ID!
+  stepName: String!
   userId: ID!
 }
 
@@ -75,6 +76,7 @@ input ButtonClickEventCreateInput {
   ID should be unique Event UUID (Provided for optimistic mutation result matching)
   """
   id: ID
+  stepName: String!
 }
 
 enum ButtonColor {
@@ -405,6 +407,7 @@ input JourneyUpdateInput {
 type JourneyViewEvent implements Event {
   id: ID!
   journey: Journey
+  title: String!
   userId: ID!
 }
 
@@ -414,6 +417,7 @@ input JourneyViewEventCreateInput {
   """
   id: ID
   journeyId: ID!
+  title: String!
 }
 
 type Language
@@ -587,6 +591,7 @@ type RadioQuestionSubmissionEvent implements Event {
   block: RadioQuestionBlock
   id: ID!
   radioOptionBlockId: ID!
+  stepName: String!
   userId: ID!
 }
 
@@ -598,6 +603,7 @@ input RadioQuestionSubmissionEventCreateInput {
   """
   id: ID
   radioOptionBlockId: ID!
+  stepName: String!
 }
 
 type SignUpBlock implements Block {
@@ -628,6 +634,7 @@ type SignUpSubmissionEvent implements Event {
   email: String!
   id: ID!
   name: String!
+  stepName: String!
   userId: ID!
 }
 
@@ -640,6 +647,7 @@ input SignUpSubmissionEventCreateInput {
   """
   id: ID
   name: String!
+  stepName: String!
 }
 
 type StepBlock implements Block {
@@ -678,6 +686,7 @@ input StepBlockUpdateInput {
 type StepViewEvent implements Event {
   block: StepBlock
   id: ID!
+  stepName: String!
   userId: ID!
 }
 
@@ -688,6 +697,7 @@ input StepViewEventCreateInput {
   ID should be unique Event UUID (Provided for optimistic mutation result matching)
   """
   id: ID
+  stepName: String!
 }
 
 enum ThemeMode {

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -606,11 +606,13 @@ input ButtonClickEventCreateInput {
   """
   id: ID
   blockId: ID!
+  stepName: String!
 }
 
 type ButtonClickEvent implements Event {
   id: ID!
   userId: ID!
+  stepName: String!
   block: ButtonBlock
 }
 
@@ -625,11 +627,13 @@ input JourneyViewEventCreateInput {
   """
   id: ID
   journeyId: ID!
+  title: String!
 }
 
 type JourneyViewEvent implements Event {
   id: ID!
   userId: ID!
+  title: String!
   journey: Journey
 }
 
@@ -640,12 +644,14 @@ input RadioQuestionSubmissionEventCreateInput {
   id: ID
   blockId: ID!
   radioOptionBlockId: ID!
+  stepName: String!
 }
 
 type RadioQuestionSubmissionEvent implements Event {
   id: ID!
   userId: ID!
   radioOptionBlockId: ID!
+  stepName: String!
   block: RadioQuestionBlock
 }
 
@@ -657,6 +663,7 @@ input SignUpSubmissionEventCreateInput {
   blockId: ID!
   name: String!
   email: String!
+  stepName: String!
 }
 
 type SignUpSubmissionEvent implements Event {
@@ -664,6 +671,7 @@ type SignUpSubmissionEvent implements Event {
   userId: ID!
   name: String!
   email: String!
+  stepName: String!
   block: SignUpBlock
 }
 
@@ -673,11 +681,13 @@ input StepViewEventCreateInput {
   """
   id: ID
   blockId: ID!
+  stepName: String!
 }
 
 type StepViewEvent implements Event {
   id: ID!
   userId: ID!
+  stepName: String!
   block: StepBlock
 }
 

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -312,17 +312,20 @@ export class VideoBlockUpdateInput {
 export class ButtonClickEventCreateInput {
     id?: Nullable<string>;
     blockId: string;
+    stepName: string;
 }
 
 export class JourneyViewEventCreateInput {
     id?: Nullable<string>;
     journeyId: string;
+    title: string;
 }
 
 export class RadioQuestionSubmissionEventCreateInput {
     id?: Nullable<string>;
     blockId: string;
     radioOptionBlockId: string;
+    stepName: string;
 }
 
 export class SignUpSubmissionEventCreateInput {
@@ -330,11 +333,13 @@ export class SignUpSubmissionEventCreateInput {
     blockId: string;
     name: string;
     email: string;
+    stepName: string;
 }
 
 export class StepViewEventCreateInput {
     id?: Nullable<string>;
     blockId: string;
+    stepName: string;
 }
 
 export class VideoStartEventCreateInput {
@@ -630,6 +635,7 @@ export class ButtonClickEvent implements Event {
     __typename?: 'ButtonClickEvent';
     id: string;
     userId: string;
+    stepName: string;
     block?: Nullable<ButtonBlock>;
 }
 
@@ -637,6 +643,7 @@ export class JourneyViewEvent implements Event {
     __typename?: 'JourneyViewEvent';
     id: string;
     userId: string;
+    title: string;
     journey?: Nullable<Journey>;
 }
 
@@ -645,6 +652,7 @@ export class RadioQuestionSubmissionEvent implements Event {
     id: string;
     userId: string;
     radioOptionBlockId: string;
+    stepName: string;
     block?: Nullable<RadioQuestionBlock>;
 }
 
@@ -654,6 +662,7 @@ export class SignUpSubmissionEvent implements Event {
     userId: string;
     name: string;
     email: string;
+    stepName: string;
     block?: Nullable<SignUpBlock>;
 }
 
@@ -661,6 +670,7 @@ export class StepViewEvent implements Event {
     __typename?: 'StepViewEvent';
     id: string;
     userId: string;
+    stepName: string;
     block?: Nullable<StepBlock>;
 }
 

--- a/apps/api-journeys/src/app/modules/event/button/button.graphql
+++ b/apps/api-journeys/src/app/modules/event/button/button.graphql
@@ -4,11 +4,13 @@ input ButtonClickEventCreateInput {
   """
   id: ID
   blockId: ID!
+  stepName: String!
 }
 
 type ButtonClickEvent implements Event {
   id: ID!
   userId: ID!
+  stepName: String!
   block: ButtonBlock
 }
 

--- a/apps/api-journeys/src/app/modules/event/button/button.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/event/button/button.resolver.spec.ts
@@ -8,7 +8,8 @@ describe('ButtonClickEventResolver', () => {
 
   const input: ButtonClickEventCreateInput = {
     id: '1',
-    blockId: 'block.id'
+    blockId: 'block.id',
+    stepName: 'first step'
   }
 
   const eventService = {

--- a/apps/api-journeys/src/app/modules/event/journey/journey.graphql
+++ b/apps/api-journeys/src/app/modules/event/journey/journey.graphql
@@ -4,11 +4,13 @@ input JourneyViewEventCreateInput {
   """
   id: ID
   journeyId: ID!
+  title: String!
 }
 
 type JourneyViewEvent implements Event {
   id: ID!
   userId: ID!
+  title: String!
   journey: Journey
 }
 

--- a/apps/api-journeys/src/app/modules/event/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/event/journey/journey.resolver.spec.ts
@@ -8,7 +8,8 @@ describe('JourneyViewEventResolver', () => {
 
   const input: JourneyViewEventCreateInput = {
     id: '1',
-    journeyId: 'journey.id'
+    journeyId: 'journey.id',
+    title: 'journey title'
   }
 
   const eventService = {

--- a/apps/api-journeys/src/app/modules/event/radioQuestion/radioQuestion.graphql
+++ b/apps/api-journeys/src/app/modules/event/radioQuestion/radioQuestion.graphql
@@ -5,12 +5,14 @@ input RadioQuestionSubmissionEventCreateInput {
   id: ID
   blockId: ID!
   radioOptionBlockId: ID!
+  stepName: String!
 }
 
 type RadioQuestionSubmissionEvent implements Event {
   id: ID!
   userId: ID!
   radioOptionBlockId: ID!
+  stepName: String!
   block: RadioQuestionBlock
 }
 

--- a/apps/api-journeys/src/app/modules/event/radioQuestion/radioQuestion.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/event/radioQuestion/radioQuestion.resolver.spec.ts
@@ -8,7 +8,8 @@ describe('RadioQuestionSubmissionEventResolver', () => {
   const input = {
     id: '1',
     blockId: '2',
-    radioOptionBlockId: '4'
+    radioOptionBlockId: '4',
+    stepName: 'first step'
   }
 
   const eventService = {

--- a/apps/api-journeys/src/app/modules/event/signUp/signUp.graphql
+++ b/apps/api-journeys/src/app/modules/event/signUp/signUp.graphql
@@ -6,6 +6,7 @@ input SignUpSubmissionEventCreateInput {
   blockId: ID!
   name: String!
   email: String!
+  stepName: String!
 }
 
 type SignUpSubmissionEvent implements Event {
@@ -13,6 +14,7 @@ type SignUpSubmissionEvent implements Event {
   userId: ID!
   name: String!
   email: String!
+  stepName: String!
   block: SignUpBlock
 }
 

--- a/apps/api-journeys/src/app/modules/event/signUp/signUp.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/event/signUp/signUp.resolver.spec.ts
@@ -9,7 +9,8 @@ describe('SignUpEventResolver', () => {
     id: '1',
     blockId: '2',
     name: 'Robert Smith',
-    email: 'robert.smith@jesusfilm.org'
+    email: 'robert.smith@jesusfilm.org',
+    stepName: 'first step'
   }
 
   const eventService = {

--- a/apps/api-journeys/src/app/modules/event/step/step.graphql
+++ b/apps/api-journeys/src/app/modules/event/step/step.graphql
@@ -4,11 +4,13 @@ input StepViewEventCreateInput {
   """
   id: ID
   blockId: ID!
+  stepName: String!
 }
 
 type StepViewEvent implements Event {
   id: ID!
   userId: ID!
+  stepName: String!
   block: StepBlock
 }
 

--- a/apps/api-journeys/src/app/modules/event/step/step.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/event/step/step.resolver.spec.ts
@@ -9,7 +9,8 @@ describe('StepViewEventResolver', () => {
     id: '1',
     blockId: 'block.id',
     previousBlockId: 'previousBlock.id',
-    journeyId: 'journey.id'
+    journeyId: 'journey.id',
+    stepName: 'first step'
   }
 
   const eventService = {

--- a/apps/journeys-admin/__generated__/globalTypes.ts
+++ b/apps/journeys-admin/__generated__/globalTypes.ts
@@ -159,6 +159,7 @@ export interface ButtonBlockUpdateInput {
 export interface ButtonClickEventCreateInput {
   blockId: string;
   id?: string | null;
+  stepName: string;
 }
 
 export interface CardBlockUpdateInput {
@@ -254,6 +255,7 @@ export interface RadioQuestionSubmissionEventCreateInput {
   blockId: string;
   id?: string | null;
   radioOptionBlockId: string;
+  stepName: string;
 }
 
 export interface SignUpBlockCreateInput {
@@ -274,6 +276,7 @@ export interface SignUpSubmissionEventCreateInput {
   email: string;
   id?: string | null;
   name: string;
+  stepName: string;
 }
 
 export interface StepBlockUpdateInput {
@@ -284,6 +287,7 @@ export interface StepBlockUpdateInput {
 export interface StepViewEventCreateInput {
   blockId: string;
   id?: string | null;
+  stepName: string;
 }
 
 export interface TypographyBlockCreateInput {

--- a/apps/journeys/__generated__/globalTypes.ts
+++ b/apps/journeys/__generated__/globalTypes.ts
@@ -127,17 +127,20 @@ export enum TypographyVariant {
 export interface ButtonClickEventCreateInput {
   blockId: string;
   id?: string | null;
+  stepName: string;
 }
 
 export interface JourneyViewEventCreateInput {
   id?: string | null;
   journeyId: string;
+  title: string;
 }
 
 export interface RadioQuestionSubmissionEventCreateInput {
   blockId: string;
   id?: string | null;
   radioOptionBlockId: string;
+  stepName: string;
 }
 
 export interface SignUpSubmissionEventCreateInput {
@@ -145,11 +148,13 @@ export interface SignUpSubmissionEventCreateInput {
   email: string;
   id?: string | null;
   name: string;
+  stepName: string;
 }
 
 export interface StepViewEventCreateInput {
   blockId: string;
   id?: string | null;
+  stepName: string;
 }
 
 export interface VideoCollapseEventCreateInput {

--- a/apps/watch-admin/__generated__/globalTypes.ts
+++ b/apps/watch-admin/__generated__/globalTypes.ts
@@ -127,12 +127,14 @@ export enum TypographyVariant {
 export interface ButtonClickEventCreateInput {
   blockId: string;
   id?: string | null;
+  stepName: string;
 }
 
 export interface RadioQuestionSubmissionEventCreateInput {
   blockId: string;
   id?: string | null;
   radioOptionBlockId: string;
+  stepName: string;
 }
 
 export interface SignUpSubmissionEventCreateInput {
@@ -140,11 +142,13 @@ export interface SignUpSubmissionEventCreateInput {
   email: string;
   id?: string | null;
   name: string;
+  stepName: string;
 }
 
 export interface StepViewEventCreateInput {
   blockId: string;
   id?: string | null;
+  stepName: string;
 }
 
 export interface VideoCollapseEventCreateInput {

--- a/apps/watch/__generated__/globalTypes.ts
+++ b/apps/watch/__generated__/globalTypes.ts
@@ -133,12 +133,14 @@ export enum VideoType {
 export interface ButtonClickEventCreateInput {
   blockId: string;
   id?: string | null;
+  stepName: string;
 }
 
 export interface RadioQuestionSubmissionEventCreateInput {
   blockId: string;
   id?: string | null;
   radioOptionBlockId: string;
+  stepName: string;
 }
 
 export interface SignUpSubmissionEventCreateInput {
@@ -146,11 +148,13 @@ export interface SignUpSubmissionEventCreateInput {
   email: string;
   id?: string | null;
   name: string;
+  stepName: string;
 }
 
 export interface StepViewEventCreateInput {
   blockId: string;
   id?: string | null;
+  stepName: string;
 }
 
 export interface VideoCollapseEventCreateInput {

--- a/libs/journeys/ui/__generated__/globalTypes.ts
+++ b/libs/journeys/ui/__generated__/globalTypes.ts
@@ -127,12 +127,14 @@ export enum TypographyVariant {
 export interface ButtonClickEventCreateInput {
   blockId: string;
   id?: string | null;
+  stepName: string;
 }
 
 export interface RadioQuestionSubmissionEventCreateInput {
   blockId: string;
   id?: string | null;
   radioOptionBlockId: string;
+  stepName: string;
 }
 
 export interface SignUpSubmissionEventCreateInput {
@@ -140,11 +142,13 @@ export interface SignUpSubmissionEventCreateInput {
   email: string;
   id?: string | null;
   name: string;
+  stepName: string;
 }
 
 export interface StepViewEventCreateInput {
   blockId: string;
   id?: string | null;
+  stepName: string;
 }
 
 export interface VideoCollapseEventCreateInput {


### PR DESCRIPTION
# Description

Extend events API with journey name and step names

[- Journey](https://3.basecamp.com/3105655/buckets/27717553/todos/4960774270)
[- Step](https://3.basecamp.com/3105655/buckets/27717553/todos/4960773937)
[- Button, SignUp, RadioQuestion](https://3.basecamp.com/3105655/buckets/27717553/todos/4960775062)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Backend

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
