### PR TITLE
feat: prevent users from creating journeys unless invited

### DIFF
--- a/apps/journeys-admin/pages/index.tsx
+++ b/apps/journeys-admin/pages/index.tsx
@@ -53,7 +53,7 @@ function IndexPage(): ReactElement {
     <>
       <NextSeo title="Journeys" />
       <PageWrapper title="Journeys" authUser={AuthUser}>
-        <JourneyList journeys={data?.journeys} disableCreation={true} />
+        <JourneyList journeys={data?.journeys} disableCreation />
       </PageWrapper>
     </>
   )

--- a/apps/journeys-admin/pages/index.tsx
+++ b/apps/journeys-admin/pages/index.tsx
@@ -53,7 +53,7 @@ function IndexPage(): ReactElement {
     <>
       <NextSeo title="Journeys" />
       <PageWrapper title="Journeys" authUser={AuthUser}>
-        <JourneyList journeys={data?.journeys} />
+        <JourneyList journeys={data?.journeys} disableCreation={true} />
       </PageWrapper>
     </>
   )

--- a/apps/journeys-admin/src/components/JourneyList/JourneyList.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyList.spec.tsx
@@ -24,7 +24,7 @@ describe('JourneyList', () => {
   })
 
   it('should order journeys in alphabetical order', () => {
-    const { getAllByLabelText, getByRole } = render(
+    const { getAllByLabelText, getByRole, getByText } = render(
       <SnackbarProvider>
         <MockedProvider>
           <ThemeProvider>
@@ -33,6 +33,7 @@ describe('JourneyList', () => {
         </MockedProvider>
       </SnackbarProvider>
     )
+    expect(getByText('All Journeys')).toBeInTheDocument()
 
     const journeyCards = getAllByLabelText('journey-card')
 
@@ -44,7 +45,7 @@ describe('JourneyList', () => {
   })
 
   it('should render all journeys', () => {
-    const { getAllByLabelText } = render(
+    const { getAllByLabelText, getByText } = render(
       <SnackbarProvider>
         <MockedProvider>
           <ThemeProvider>
@@ -55,6 +56,7 @@ describe('JourneyList', () => {
         </MockedProvider>
       </SnackbarProvider>
     )
+    expect(getByText('All Journeys')).toBeInTheDocument()
     expect(getAllByLabelText('journey-card').length).toBe(3)
   })
 
@@ -68,7 +70,7 @@ describe('JourneyList', () => {
         </MockedProvider>
       </SnackbarProvider>
     )
-
+    expect(getByText('All Journeys')).toBeInTheDocument()
     expect(getByText('No journeys to display.')).toBeInTheDocument()
     expect(
       getByText('Create a journey, then find it here.')
@@ -79,16 +81,16 @@ describe('JourneyList', () => {
   })
 
   it('should prevent users from creating a journey unless invited', () => {
-    const { getByText, getByRole } = render(
+    const { getByText, getByRole, queryByText } = render(
       <SnackbarProvider>
         <MockedProvider>
           <ThemeProvider>
-            <JourneyList journeys={[]} disableCreation={true} />
+            <JourneyList journeys={[]} disableCreation />
           </ThemeProvider>
         </MockedProvider>
       </SnackbarProvider>
     )
-
+    expect(queryByText('All Journeys')).not.toBeInTheDocument()
     expect(
       getByText('You need to be invited to create the first journey')
     ).toBeInTheDocument()

--- a/apps/journeys-admin/src/components/JourneyList/JourneyList.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyList.spec.tsx
@@ -63,7 +63,7 @@ describe('JourneyList', () => {
       <SnackbarProvider>
         <MockedProvider>
           <ThemeProvider>
-            <JourneyList journeys={[]} />
+            <JourneyList journeys={[]} disableCreation={false} />
           </ThemeProvider>
         </MockedProvider>
       </SnackbarProvider>
@@ -76,5 +76,27 @@ describe('JourneyList', () => {
     expect(
       getByRole('button', { name: 'Create a Journey' })
     ).toBeInTheDocument()
+  })
+
+  it('should prevent users from creating a journey unless invited', () => {
+    const { getByText, getByRole } = render(
+      <SnackbarProvider>
+        <MockedProvider>
+          <ThemeProvider>
+            <JourneyList journeys={[]} disableCreation={true} />
+          </ThemeProvider>
+        </MockedProvider>
+      </SnackbarProvider>
+    )
+
+    expect(
+      getByText('You need to be invited to create the first journey')
+    ).toBeInTheDocument()
+    expect(
+      getByText(
+        'Someone with a full account should add you to their journey as an editor, after that you will have full access'
+      )
+    ).toBeInTheDocument()
+    expect(getByRole('button', { name: 'Contact Support' })).toBeInTheDocument()
   })
 })

--- a/apps/journeys-admin/src/components/JourneyList/JourneyList.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyList.stories.tsx
@@ -32,17 +32,26 @@ const Template: Story<JourneysListProps> = ({ ...args }) => (
 
 export const Default = Template.bind({})
 Default.args = {
-  journeys: [defaultJourney, publishedJourney, oldJourney, descriptiveJourney]
+  journeys: [defaultJourney, publishedJourney, oldJourney, descriptiveJourney],
+  disableCreation: true
 }
 
 export const Loading = Template.bind({})
 Loading.args = {
-  journeys: undefined
+  journeys: undefined,
+  disableCreation: true
 }
 
-export const Empty = Template.bind({})
-Empty.args = {
-  journeys: []
+export const Access = Template.bind({})
+Access.args = {
+  journeys: [],
+  disableCreation: true
+}
+
+export const CreateJourney = Template.bind({})
+CreateJourney.args = {
+  journeys: [],
+  disableCreation: false
 }
 
 export default JourneyListStory as Meta

--- a/apps/journeys-admin/src/components/JourneyList/JourneyList.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyList.tsx
@@ -28,15 +28,17 @@ export function JourneyList({
     sortOrder === SortOrder.TITLE
       ? sortBy(journeys, 'title')
       : sortBy(journeys, ({ createdAt }) =>
-        new Date(createdAt).getTime()
-      ).reverse()
+          new Date(createdAt).getTime()
+        ).reverse()
 
   return (
     <Container sx={{ px: { xs: 0, sm: 8 } }}>
       {journeys != null && journeys.length > 0 && (
         <AddJourneyButton variant="fab" />
       )}
-      {(journeys == null || journeys.length > 0 || disableCreation !== true) && (
+      {(journeys == null ||
+        journeys.length > 0 ||
+        disableCreation !== true) && (
         <Stack
           direction={{ xs: 'column', sm: 'row' }}
           spacing={2}

--- a/apps/journeys-admin/src/components/JourneyList/JourneyList.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyList.tsx
@@ -1,9 +1,12 @@
 import { ReactElement, useState } from 'react'
 import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
 import Card from '@mui/material/Card'
 import Typography from '@mui/material/Typography'
 import Stack from '@mui/material/Stack'
 import Container from '@mui/material/Container'
+import NewReleasesRounded from '@mui/icons-material/NewReleasesRounded'
+import ContactSupportRounded from '@mui/icons-material/ContactSupportRounded'
 import { sortBy } from 'lodash'
 import { GetJourneys_journeys as Journey } from '../../../__generated__/GetJourneys'
 import { AddJourneyButton } from './AddJourneyButton'
@@ -12,45 +15,51 @@ import { JourneyCard } from './JourneyCard'
 
 export interface JourneysListProps {
   journeys?: Journey[]
+  disableCreation?: boolean
 }
 
-export function JourneyList({ journeys }: JourneysListProps): ReactElement {
+export function JourneyList({
+  journeys,
+  disableCreation
+}: JourneysListProps): ReactElement {
   const [sortOrder, setSortOrder] = useState<SortOrder>()
 
   const sortedJourneys =
     sortOrder === SortOrder.TITLE
       ? sortBy(journeys, 'title')
       : sortBy(journeys, ({ createdAt }) =>
-          new Date(createdAt).getTime()
-        ).reverse()
+        new Date(createdAt).getTime()
+      ).reverse()
 
   return (
     <Container sx={{ px: { xs: 0, sm: 8 } }}>
       {journeys != null && journeys.length > 0 && (
         <AddJourneyButton variant="fab" />
       )}
-      <Stack
-        direction={{ xs: 'column', sm: 'row' }}
-        spacing={2}
-        justifyContent="space-between"
-        sx={{
-          mx: { xs: 6, sm: 0 },
-          mt: { xs: 5, sm: 10 },
-          mb: { xs: 4, sm: 5 }
-        }}
-      >
-        <Typography variant="h3">All Journeys</Typography>
-        <Box>
-          <JourneySort sortOrder={sortOrder} onChange={setSortOrder} />
-        </Box>
-      </Stack>
+      {(journeys == null || journeys.length > 0 || disableCreation !== true) && (
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={2}
+          justifyContent="space-between"
+          sx={{
+            mx: { xs: 6, sm: 0 },
+            mt: { xs: 5, sm: 10 },
+            mb: { xs: 4, sm: 5 }
+          }}
+        >
+          <Typography variant="h3">All Journeys</Typography>
+          <Box>
+            <JourneySort sortOrder={sortOrder} onChange={setSortOrder} />
+          </Box>
+        </Stack>
+      )}
       <Box sx={{ mb: { xs: 4, sm: 5 } }} data-testid="journey-list">
         {journeys != null ? (
           <>
             {sortedJourneys.map((journey) => (
               <JourneyCard key={journey.id} journey={journey} />
             ))}
-            {sortedJourneys.length === 0 && (
+            {sortedJourneys.length === 0 && disableCreation !== true && (
               <Card
                 variant="outlined"
                 sx={{
@@ -80,6 +89,32 @@ export function JourneyList({ journeys }: JourneysListProps): ReactElement {
           </>
         )}
       </Box>
+      {journeys != null && journeys.length === 0 && disableCreation && (
+        <Container maxWidth="sm" sx={{ mt: 20 }}>
+          <Stack direction="column" spacing={8} alignItems="center">
+            <NewReleasesRounded sx={{ fontSize: 60 }} />
+            <Typography variant="h1" align="center">
+              You need to be invited to create the first journey
+            </Typography>
+            <Typography variant="subtitle2" align="center">
+              Someone with a full account should add you to their journey as an
+              editor, after that you will have full access
+            </Typography>
+            <Box>
+              <Button
+                variant="contained"
+                startIcon={<ContactSupportRounded />}
+                size="medium"
+                onClick={() => {
+                  window.location.href = `mailto:support@nextstep.is?subject=Invite request for the NextStep builder`
+                }}
+              >
+                Contact Support
+              </Button>
+            </Box>
+          </Stack>
+        </Container>
+      )}
     </Container>
   )
 }


### PR DESCRIPTION
# Description

If a user doesn’t have any journey - don’t give them the permission/ability to make a new one.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/27717553/todos/4960677527#__recording_4963953270)

# How should this PR be QA Tested?

- [ ] If a user doesn't have any journey - they should be prompted to ask for a journey invite
- [ ] If a user does have a journey - they should see their journey

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
