### PR TITLE
feat: add step name to step event

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.tsx
@@ -16,7 +16,8 @@ export function Step({
     dispatch
   } = useEditor()
   const nextBlock = steps?.find(({ id }) => id === nextBlockId)
-  const heading = nextBlock != null ? getStepHeading(nextBlock) : 'None'
+  const heading =
+    nextBlock != null ? getStepHeading(nextBlock.children) : 'None'
 
   return (
     <Attribute

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.tsx
@@ -1,18 +1,10 @@
-import { TreeBlock, useEditor } from '@core/journeys/ui'
+import { TreeBlock, useEditor, getStepHeading } from '@core/journeys/ui'
 import { ReactElement } from 'react'
 import LockIcon from '@mui/icons-material/Lock'
 import LockOpenIcon from '@mui/icons-material/LockOpen'
 import { GetJourney_journey_blocks_StepBlock as StepBlock } from '../../../../../../../__generated__/GetJourney'
 import { Attribute } from '../..'
-import { BlockFields_TypographyBlock as TypographyBlock } from '../../../../../../../__generated__/BlockFields'
 import { NextCard } from './NextCard'
-
-function flatten(children: TreeBlock[]): TreeBlock[] {
-  return children.reduce(
-    (result, item) => [...result, item, ...flatten(item.children)],
-    []
-  )
-}
 
 export function Step({
   id,
@@ -24,19 +16,14 @@ export function Step({
     dispatch
   } = useEditor()
   const nextBlock = steps?.find(({ id }) => id === nextBlockId)
-  const nextBlockDescendants = flatten(nextBlock?.children ?? [])
-  const nextBlockHeading = nextBlockDescendants.find(
-    (block) => block.__typename === 'TypographyBlock'
-  ) as TreeBlock<TypographyBlock> | undefined
+  const heading = nextBlock != null ? getStepHeading(nextBlock) : 'None'
 
   return (
     <Attribute
       id={`${id}-next-block`}
       icon={locked ? <LockIcon /> : <LockOpenIcon />}
       name="Next Card"
-      value={
-        nextBlock != null ? nextBlockHeading?.content ?? 'Untitled' : 'None'
-      }
+      value={heading ?? 'Untitled'}
       description={locked ? 'Locked With Interaction' : 'Unlocked Card'}
       onClick={() => {
         dispatch({

--- a/libs/journeys/ui/src/components/Step/Step.spec.tsx
+++ b/libs/journeys/ui/src/components/Step/Step.spec.tsx
@@ -5,7 +5,7 @@ import TagManager from 'react-gtm-module'
 import { TreeBlock } from '../..'
 import { JourneyProvider } from '../../libs/context/JourneyContext'
 import { StepFields } from './__generated__/StepFields'
-import { STEP_VIEW_EVENT_CREATE } from './Step'
+import { STEP_VIEW_EVENT_CREATE, getHeading } from './Step'
 import { Step } from '.'
 
 jest.mock('uuid', () => ({
@@ -205,5 +205,110 @@ describe('Step', () => {
       </MockedProvider>
     )
     expect(baseElement).toContainHTML('<body><div /></body>')
+  })
+
+  describe('GetHeading', () => {
+    it('should return step heading if there is a typography block', () => {
+      const children: TreeBlock[] = [
+        {
+          __typename: 'CardBlock',
+          id: 'card.id',
+          parentBlockId: 'step.id',
+          parentOrder: null,
+          backgroundColor: null,
+          coverBlockId: null,
+          themeMode: null,
+          themeName: null,
+          fullscreen: false,
+          children: [
+            {
+              __typename: 'TypographyBlock',
+              id: 'typography1.id',
+              parentBlockId: 'card.id',
+              parentOrder: 0,
+              align: null,
+              color: null,
+              variant: null,
+              content: 'Heading',
+              children: []
+            }
+          ]
+        }
+      ]
+      const treeBlocks: TreeBlock[] = [
+        {
+          __typename: 'StepBlock',
+          id: 'step.id',
+          parentBlockId: null,
+          parentOrder: 0,
+          locked: false,
+          nextBlockId: null,
+          children
+        }
+      ]
+      expect(getHeading({ blockId: 'step.id', children, treeBlocks })).toEqual(
+        'Heading'
+      )
+    })
+    it('should return step number  if no typogrpahy block', () => {
+      const children: TreeBlock[] = [
+        {
+          __typename: 'CardBlock',
+          id: 'card.id',
+          parentBlockId: 'step.id',
+          parentOrder: null,
+          backgroundColor: null,
+          coverBlockId: null,
+          themeMode: null,
+          themeName: null,
+          fullscreen: false,
+          children: []
+        }
+      ]
+      const treeBlocks: TreeBlock[] = [
+        {
+          __typename: 'StepBlock',
+          id: 'step.id',
+          parentBlockId: null,
+          parentOrder: 0,
+          locked: false,
+          nextBlockId: null,
+          children
+        }
+      ]
+      expect(getHeading({ blockId: 'step.id', children, treeBlocks })).toEqual(
+        'Step 1'
+      )
+    })
+    it('should return Untitled if step is not found', () => {
+      const children: TreeBlock[] = [
+        {
+          __typename: 'CardBlock',
+          id: 'card.id',
+          parentBlockId: 'step.id',
+          parentOrder: null,
+          backgroundColor: null,
+          coverBlockId: null,
+          themeMode: null,
+          themeName: null,
+          fullscreen: false,
+          children: []
+        }
+      ]
+      const treeBlocks: TreeBlock[] = [
+        {
+          __typename: 'StepBlock',
+          id: 'step.id',
+          parentBlockId: null,
+          parentOrder: 0,
+          locked: false,
+          nextBlockId: null,
+          children
+        }
+      ]
+      expect(
+        getHeading({ blockId: 'anotherStep.id', children, treeBlocks })
+      ).toEqual('Untitled')
+    })
   })
 })

--- a/libs/journeys/ui/src/components/Step/Step.spec.tsx
+++ b/libs/journeys/ui/src/components/Step/Step.spec.tsx
@@ -139,7 +139,8 @@ describe('Step', () => {
         dataLayer: {
           event: 'step_view',
           eventId: 'uuid',
-          blockId: 'Step1'
+          blockId: 'Step1',
+          stepName: 'Untitled'
         }
       })
     )

--- a/libs/journeys/ui/src/components/Step/Step.tsx
+++ b/libs/journeys/ui/src/components/Step/Step.tsx
@@ -2,7 +2,8 @@ import { ReactElement, useEffect } from 'react'
 import { useMutation, gql } from '@apollo/client'
 import { v4 as uuidv4 } from 'uuid'
 import TagManager from 'react-gtm-module'
-import { TreeBlock, getStepHeading } from '../..'
+import findIndex from 'lodash/findIndex'
+import { TreeBlock, getStepHeading, useBlocks } from '../..'
 import { BlockRenderer, WrappersProps } from '../BlockRenderer'
 import { useJourney } from '../../libs/context/JourneyContext'
 import { StepFields } from './__generated__/StepFields'
@@ -30,7 +31,9 @@ export function Step({
   )
 
   const { admin } = useJourney()
-  const heading = getStepHeading(children)
+  const { treeBlocks } = useBlocks()
+
+  const heading = getHeading({ blockId, children, treeBlocks })
 
   useEffect(() => {
     if (!admin) {
@@ -43,7 +46,7 @@ export function Step({
           event: 'step_view',
           eventId: id,
           blockId,
-          stepName: heading ?? 'Untitled'
+          stepName: heading
         }
       })
     }
@@ -56,4 +59,28 @@ export function Step({
       ))}
     </>
   )
+}
+
+interface GetHeadingProps {
+  blockId: string
+  children: TreeBlock[]
+  treeBlocks: TreeBlock[]
+}
+
+export function getHeading({
+  blockId,
+  children,
+  treeBlocks
+}: GetHeadingProps): string {
+  const title = getStepHeading(children)
+  if (title != null) {
+    return title
+  } else {
+    const index = findIndex(treeBlocks, { id: blockId })
+    if (index === -1) {
+      return 'Untitled'
+    } else {
+      return `Step ${index + 1}`
+    }
+  }
 }

--- a/libs/journeys/ui/src/components/Step/Step.tsx
+++ b/libs/journeys/ui/src/components/Step/Step.tsx
@@ -2,7 +2,7 @@ import { ReactElement, useEffect } from 'react'
 import { useMutation, gql } from '@apollo/client'
 import { v4 as uuidv4 } from 'uuid'
 import TagManager from 'react-gtm-module'
-import { TreeBlock } from '../..'
+import { TreeBlock, getStepHeading } from '../..'
 import { BlockRenderer, WrappersProps } from '../BlockRenderer'
 import { useJourney } from '../../libs/context/JourneyContext'
 import { StepFields } from './__generated__/StepFields'
@@ -30,6 +30,7 @@ export function Step({
   )
 
   const { admin } = useJourney()
+  const heading = getStepHeading(children)
 
   useEffect(() => {
     if (!admin) {
@@ -41,11 +42,12 @@ export function Step({
         dataLayer: {
           event: 'step_view',
           eventId: id,
-          blockId
+          blockId,
+          stepName: heading ?? 'Untitled'
         }
       })
     }
-  }, [blockId, stepViewEventCreate, admin])
+  }, [blockId, stepViewEventCreate, admin, heading])
 
   return (
     <>

--- a/libs/journeys/ui/src/index.ts
+++ b/libs/journeys/ui/src/index.ts
@@ -50,7 +50,8 @@ export {
   treeBlocksVar,
   useJourney,
   JourneyProvider,
-  JOURNEY_FIELDS
+  JOURNEY_FIELDS,
+  getStepHeading
 } from './libs'
 export type {
   TreeBlock,

--- a/libs/journeys/ui/src/libs/getStepHeading/getStepHeading.spec.ts
+++ b/libs/journeys/ui/src/libs/getStepHeading/getStepHeading.spec.ts
@@ -1,0 +1,80 @@
+import { JourneyFields_blocks_StepBlock as StepBlock } from '../context/__generated__/JourneyFields'
+import { TreeBlock } from '..'
+import { getStepHeading } from '.'
+
+describe('getStepHeading', () => {
+  it('returns text of first typography block', () => {
+    const stepBlock: TreeBlock<StepBlock> = {
+      __typename: 'StepBlock',
+      id: 'step.id',
+      parentBlockId: null,
+      parentOrder: null,
+      locked: false,
+      nextBlockId: null,
+      children: [
+        {
+          __typename: 'CardBlock',
+          id: 'card.id',
+          parentBlockId: 'step.id',
+          parentOrder: null,
+          backgroundColor: null,
+          coverBlockId: null,
+          themeMode: null,
+          themeName: null,
+          fullscreen: false,
+          children: [
+            {
+              __typename: 'TypographyBlock',
+              id: 'typography1.id',
+              parentBlockId: 'card.id',
+              parentOrder: 0,
+              align: null,
+              color: null,
+              variant: null,
+              content: 'Heading',
+              children: []
+            },
+            {
+              __typename: 'TypographyBlock',
+              id: 'typograph2.id',
+              parentBlockId: 'card.id',
+              parentOrder: 1,
+              align: null,
+              color: null,
+              variant: null,
+              content: 'Description',
+              children: []
+            }
+          ]
+        }
+      ]
+    }
+    expect(getStepHeading(stepBlock)).toEqual('Heading')
+  })
+
+  it('returns undefined if there are no typography blocks', () => {
+    const stepBlock: TreeBlock<StepBlock> = {
+      __typename: 'StepBlock',
+      id: 'step.id',
+      parentBlockId: null,
+      parentOrder: null,
+      locked: false,
+      nextBlockId: null,
+      children: [
+        {
+          __typename: 'CardBlock',
+          id: 'card.id',
+          parentBlockId: 'step.id',
+          parentOrder: null,
+          backgroundColor: null,
+          coverBlockId: null,
+          themeMode: null,
+          themeName: null,
+          fullscreen: false,
+          children: []
+        }
+      ]
+    }
+    expect(getStepHeading(stepBlock)).toBeUndefined()
+  })
+})

--- a/libs/journeys/ui/src/libs/getStepHeading/getStepHeading.spec.ts
+++ b/libs/journeys/ui/src/libs/getStepHeading/getStepHeading.spec.ts
@@ -1,67 +1,51 @@
-import { JourneyFields_blocks_StepBlock as StepBlock } from '../context/__generated__/JourneyFields'
 import { TreeBlock } from '..'
 import { getStepHeading } from '.'
 
 describe('getStepHeading', () => {
   it('returns text of first typography block', () => {
-    const stepBlock: TreeBlock<StepBlock> = {
-      __typename: 'StepBlock',
-      id: 'step.id',
-      parentBlockId: null,
-      parentOrder: null,
-      locked: false,
-      nextBlockId: null,
-      children: [
-        {
-          __typename: 'CardBlock',
-          id: 'card.id',
-          parentBlockId: 'step.id',
-          parentOrder: null,
-          backgroundColor: null,
-          coverBlockId: null,
-          themeMode: null,
-          themeName: null,
-          fullscreen: false,
-          children: [
-            {
-              __typename: 'TypographyBlock',
-              id: 'typography1.id',
-              parentBlockId: 'card.id',
-              parentOrder: 0,
-              align: null,
-              color: null,
-              variant: null,
-              content: 'Heading',
-              children: []
-            },
-            {
-              __typename: 'TypographyBlock',
-              id: 'typograph2.id',
-              parentBlockId: 'card.id',
-              parentOrder: 1,
-              align: null,
-              color: null,
-              variant: null,
-              content: 'Description',
-              children: []
-            }
-          ]
-        }
-      ]
-    }
-    expect(getStepHeading(stepBlock)).toEqual('Heading')
+    const children: TreeBlock[] = [
+      {
+        __typename: 'CardBlock',
+        id: 'card.id',
+        parentBlockId: 'step.id',
+        parentOrder: null,
+        backgroundColor: null,
+        coverBlockId: null,
+        themeMode: null,
+        themeName: null,
+        fullscreen: false,
+        children: [
+          {
+            __typename: 'TypographyBlock',
+            id: 'typography1.id',
+            parentBlockId: 'card.id',
+            parentOrder: 0,
+            align: null,
+            color: null,
+            variant: null,
+            content: 'Heading',
+            children: []
+          },
+          {
+            __typename: 'TypographyBlock',
+            id: 'typograph2.id',
+            parentBlockId: 'card.id',
+            parentOrder: 1,
+            align: null,
+            color: null,
+            variant: null,
+            content: 'Description',
+            children: []
+          }
+        ]
+      }
+    ]
+
+    expect(getStepHeading(children)).toEqual('Heading')
   })
 
   it('returns undefined if there are no typography blocks', () => {
-    const stepBlock: TreeBlock<StepBlock> = {
-      __typename: 'StepBlock',
-      id: 'step.id',
-      parentBlockId: null,
-      parentOrder: null,
-      locked: false,
-      nextBlockId: null,
-      children: []
-    }
-    expect(getStepHeading(stepBlock)).toBeUndefined()
+    const children: TreeBlock[] = []
+    expect(getStepHeading(children)).toBeUndefined()
   })
 })

--- a/libs/journeys/ui/src/libs/getStepHeading/getStepHeading.spec.ts
+++ b/libs/journeys/ui/src/libs/getStepHeading/getStepHeading.spec.ts
@@ -60,20 +60,7 @@ describe('getStepHeading', () => {
       parentOrder: null,
       locked: false,
       nextBlockId: null,
-      children: [
-        {
-          __typename: 'CardBlock',
-          id: 'card.id',
-          parentBlockId: 'step.id',
-          parentOrder: null,
-          backgroundColor: null,
-          coverBlockId: null,
-          themeMode: null,
-          themeName: null,
-          fullscreen: false,
-          children: []
-        }
-      ]
+      children: []
     }
     expect(getStepHeading(stepBlock)).toBeUndefined()
   })

--- a/libs/journeys/ui/src/libs/getStepHeading/getStepHeading.ts
+++ b/libs/journeys/ui/src/libs/getStepHeading/getStepHeading.ts
@@ -12,7 +12,7 @@ function flatten(children: TreeBlock[]): TreeBlock[] {
 }
 
 export function getStepHeading(step: TreeBlock<StepBlock>): string | undefined {
-  const descendants = flatten(step?.children ?? [])
+  const descendants = flatten(step.children)
   const heading = descendants.find(
     (block) => block.__typename === 'TypographyBlock'
   ) as TreeBlock<TypographyBlock> | undefined

--- a/libs/journeys/ui/src/libs/getStepHeading/getStepHeading.ts
+++ b/libs/journeys/ui/src/libs/getStepHeading/getStepHeading.ts
@@ -1,7 +1,4 @@
-import {
-  JourneyFields_blocks_StepBlock as StepBlock,
-  JourneyFields_blocks_TypographyBlock as TypographyBlock
-} from '../context/__generated__/JourneyFields'
+import { JourneyFields_blocks_TypographyBlock as TypographyBlock } from '../context/__generated__/JourneyFields'
 import { TreeBlock } from '..'
 
 function flatten(children: TreeBlock[]): TreeBlock[] {
@@ -11,8 +8,8 @@ function flatten(children: TreeBlock[]): TreeBlock[] {
   )
 }
 
-export function getStepHeading(step: TreeBlock<StepBlock>): string | undefined {
-  const descendants = flatten(step.children)
+export function getStepHeading(children: TreeBlock[]): string | undefined {
+  const descendants = flatten(children)
   const heading = descendants.find(
     (block) => block.__typename === 'TypographyBlock'
   ) as TreeBlock<TypographyBlock> | undefined

--- a/libs/journeys/ui/src/libs/getStepHeading/getStepHeading.ts
+++ b/libs/journeys/ui/src/libs/getStepHeading/getStepHeading.ts
@@ -1,0 +1,21 @@
+import {
+  JourneyFields_blocks_StepBlock as StepBlock,
+  JourneyFields_blocks_TypographyBlock as TypographyBlock
+} from '../context/__generated__/JourneyFields'
+import { TreeBlock } from '..'
+
+function flatten(children: TreeBlock[]): TreeBlock[] {
+  return children.reduce<TreeBlock[]>(
+    (result, item) => [...result, item, ...flatten(item.children)],
+    []
+  )
+}
+
+export function getStepHeading(step: TreeBlock<StepBlock>): string | undefined {
+  const descendants = flatten(step?.children ?? [])
+  const heading = descendants.find(
+    (block) => block.__typename === 'TypographyBlock'
+  ) as TreeBlock<TypographyBlock> | undefined
+
+  return heading?.content
+}

--- a/libs/journeys/ui/src/libs/getStepHeading/index.ts
+++ b/libs/journeys/ui/src/libs/getStepHeading/index.ts
@@ -1,0 +1,1 @@
+export { getStepHeading } from './getStepHeading'

--- a/libs/journeys/ui/src/libs/index.ts
+++ b/libs/journeys/ui/src/libs/index.ts
@@ -42,3 +42,4 @@ export type {
   SetSelectedStepAction,
   SetSelectedBlockByIdAction
 } from './context'
+export { getStepHeading } from './getStepHeading'


### PR DESCRIPTION
# Description

- Extracted logic for getting stepHeading into own component
- Send step name with step view events to GA4.
- Test

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/27717553/todos/4960673373)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] GTM receives step name
- [ ] GA4 receives step name

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
