### PR TITLE
fix: admins build target

### DIFF
--- a/apps/journeys-admin/project.json
+++ b/apps/journeys-admin/project.json
@@ -36,7 +36,7 @@
     "serve": {
       "executor": "@nrwl/next:server",
       "options": {
-        "buildTarget": "journeys-admin:build",
+        "buildTarget": "journeys-admin:_build",
         "dev": true,
         "hostname": "0.0.0.0",
         "port": 4200


### PR DESCRIPTION
# Description

Fixed the admins build target when running `nx run journeys-admin:serve`

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] The command `nx run journeys-admin:serve` should work

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
