### PR TITLE
fix: change translation key naming and referencing

### DIFF
--- a/apps/journeys-admin/pages/_app.tsx
+++ b/apps/journeys-admin/pages/_app.tsx
@@ -25,7 +25,7 @@ function JourneysAdminApp({
   pageProps,
   emotionCache = clientSideEmotionCache
 }: AppProps & { emotionCache?: EmotionCache }): ReactElement {
-  const { t } = useTranslation('apps-journeys-admin')
+  const { t } = useTranslation('apps-journeys-admin', { keyPrefix: 'app' })
   const token =
     (pageProps.AuthUserSerialized != null
       ? (JSON.parse(pageProps.AuthUserSerialized)._token as string | null)
@@ -62,8 +62,8 @@ function JourneysAdminApp({
   return (
     <CacheProvider value={emotionCache}>
       <DefaultSeo
-        titleTemplate={t('%s | Next Steps')}
-        defaultTitle={t('Admin | Next Steps')}
+        titleTemplate={t('seoTemplate')}
+        defaultTitle={t('seoDefaultTitle')}
       />
       <Head>
         <meta

--- a/apps/journeys-admin/pages/index.tsx
+++ b/apps/journeys-admin/pages/index.tsx
@@ -49,14 +49,14 @@ const GET_JOURNEYS = gql`
 `
 
 function IndexPage(): ReactElement {
-  const { t } = useTranslation('apps-journeys-admin')
+  const { t } = useTranslation('apps-journeys-admin', { keyPrefix: 'app' })
   const { data } = useQuery<GetJourneys>(GET_JOURNEYS)
   const AuthUser = useAuthUser()
 
   return (
     <>
-      <NextSeo title={t('Journeys')} />
-      <PageWrapper title={t('Journeys')} authUser={AuthUser}>
+      <NextSeo title={t('title')} />
+      <PageWrapper title={t('title')} authUser={AuthUser}>
         <JourneyList journeys={data?.journeys} disableCreation />
       </PageWrapper>
     </>

--- a/apps/journeys-admin/pages/journeys/[journeySlug].tsx
+++ b/apps/journeys-admin/pages/journeys/[journeySlug].tsx
@@ -40,14 +40,14 @@ function JourneySlugPage(): ReactElement {
       {error == null && (
         <>
           <NextSeo
-            title={data?.journey?.title ?? t('Journey')}
+            title={data?.journey?.title ?? t('journeyDetailsPage.seoTitle')}
             description={data?.journey?.description ?? undefined}
           />
           <JourneyProvider
             value={{ journey: data?.journey ?? undefined, admin: true }}
           >
             <PageWrapper
-              title={t('Journey Details')}
+              title={t('journeyDetailsPage.title')}
               showDrawer
               backHref="/"
               menu={<Menu />}
@@ -61,13 +61,13 @@ function JourneySlugPage(): ReactElement {
       {error?.graphQLErrors[0].message ===
         'User has not received an invitation to edit this journey.' && (
         <>
-          <NextSeo title={t('Access Denied')} />
+          <NextSeo title={t('access.denied')} />
           <JourneyInvite journeySlug={router.query.journeySlug as string} />
         </>
       )}
       {error?.graphQLErrors[0].message === 'User invitation pending.' && (
         <>
-          <NextSeo title={t('Access Denied')} />
+          <NextSeo title={t('access.denied')} />
           <JourneyInvite
             journeySlug={router.query.journeySlug as string}
             requestReceived

--- a/apps/journeys-admin/pages/journeys/[journeySlug]/edit.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeySlug]/edit.tsx
@@ -34,8 +34,8 @@ function JourneyEditPage(): ReactElement {
           <NextSeo
             title={
               data?.journey?.title != null
-                ? t('Edit {{title}}', { title: data.journey.title })
-                : t('Edit Journey')
+                ? t('journeyEditPage.title', { title: data.journey.title })
+                : t('journeyEditPage.defaultTitle')
             }
             description={data?.journey?.description ?? undefined}
           />
@@ -44,7 +44,7 @@ function JourneyEditPage(): ReactElement {
             selectedStepId={router.query.stepId as string | undefined}
           >
             <PageWrapper
-              title={data?.journey?.title ?? t('Edit Journey')}
+              title={data?.journey?.title ?? t('journeyEditPage.defaultTitle')}
               showDrawer
               backHref={`/journeys/${router.query.journeySlug as string}`}
               menu={<EditToolbar />}
@@ -58,13 +58,13 @@ function JourneyEditPage(): ReactElement {
       {error?.graphQLErrors[0].message ===
         'User has not received an invitation to edit this journey.' && (
         <>
-          <NextSeo title={t('Access Denied')} />
+          <NextSeo title={t('access.denied')} />
           <JourneyInvite journeySlug={router.query.journeySlug as string} />
         </>
       )}
       {error?.graphQLErrors[0].message === 'User invitation pending.' && (
         <>
-          <NextSeo title={t('Access Denied')} />
+          <NextSeo title={t('access.denied')} />
           <JourneyInvite
             journeySlug={router.query.journeySlug as string}
             requestReceived

--- a/apps/journeys-admin/pages/users/sign-in.tsx
+++ b/apps/journeys-admin/pages/users/sign-in.tsx
@@ -14,7 +14,7 @@ function SignInPage(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   return (
     <>
-      <NextSeo title={t('Sign In')} />
+      <NextSeo title={t('signInPage.title')} />
       <SignIn />
     </>
   )

--- a/apps/journeys/pages/_app.tsx
+++ b/apps/journeys/pages/_app.tsx
@@ -23,7 +23,7 @@ function JourneysApp({
   pageProps,
   emotionCache = clientSideEmotionCache
 }: AppProps & { emotionCache?: EmotionCache }): ReactElement {
-  const { t } = useTranslation('apps-journeys')
+  const { t } = useTranslation('apps-journeys', { keyPrefix: 'app' })
   useEffect(() => {
     if (
       process.env.NEXT_PUBLIC_GTM_ID != null &&
@@ -67,10 +67,8 @@ function JourneysApp({
   return (
     <CacheProvider value={emotionCache}>
       <DefaultSeo
-        titleTemplate={t('%s | Next Steps')}
-        defaultTitle={t(
-          'Next Steps | Helping you find the next best step on your spiritual journey'
-        )}
+        titleTemplate={t('seoTemplate')}
+        defaultTitle={t('seoDefaultTitle')}
       />
       <Head>
         <meta

--- a/libs/journeys/ui/src/components/SignUp/SignUp.tsx
+++ b/libs/journeys/ui/src/components/SignUp/SignUp.tsx
@@ -58,7 +58,7 @@ export const SignUp = ({
   sx,
   ...props
 }: SignUpProps): ReactElement => {
-  const { t } = useTranslation('libs-journeys-ui')
+  const { t } = useTranslation('libs-journeys-ui', { keyPrefix: 'signUp' })
 
   const submitIcon = children.find((block) => block.id === submitIconId) as
     | TreeBlock<IconFields>
@@ -80,12 +80,10 @@ export const SignUp = ({
   const initialValues: SignUpFormValues = { name: '', email: '' }
   const signUpSchema = object().shape({
     name: string()
-      .min(2, t('Name must be 2 characters or more'))
-      .max(50, t('Name must be 50 characters or less'))
-      .required(t('Required')),
-    email: string()
-      .email(t('Please enter a valid email address'))
-      .required(t('Required'))
+      .min(2, t('minCharacters'))
+      .max(50, t('maxCharacters'))
+      .required(t('required')),
+    email: string().email(t('invalidEmail')).required(t('required'))
   })
 
   const onSubmitHandler = async (values: SignUpFormValues): Promise<void> => {
@@ -153,14 +151,14 @@ export const SignUp = ({
               {...formikProps}
               id="name"
               name="name"
-              label={t('Name')}
+              label={t('name')}
               disabled={selectedBlock !== undefined}
             />
             <TextField
               {...formikProps}
               id="email"
               name="email"
-              label={t('Email')}
+              label={t('email')}
               disabled={selectedBlock !== undefined}
             />
             <LoadingButton
@@ -176,7 +174,7 @@ export const SignUp = ({
                 mb: 0
               }}
             >
-              {editableSubmitLabel ?? submitLabel ?? t('Submit')}
+              {editableSubmitLabel ?? submitLabel ?? t('submit')}
             </LoadingButton>
           </Form>
         )}

--- a/libs/locales/en/apps-journeys-admin.json
+++ b/libs/locales/en/apps-journeys-admin.json
@@ -1,11 +1,21 @@
 {
-  "%s | Next Steps": "%s | Next Steps",
-  "Admin | Next Steps": "Admin | Next Steps",
-  "Journeys": "Journeys",
-  "Journey": "Journey",
-  "Journey Details": "Journey Details",
-  "Access Denied": "Access Denied",
-  "Edit {{title}}": "Edit {{title}}",
-  "Edit Journey": "Edit Journey",
-  "Sign In": "Sign In"
+  "app": {
+    "title": "Journeys", 
+    "seoTemplate":"%s | Next Steps", 
+    "seoDefaultTitle": "Admin | Next Steps"
+  },
+  "journeyDetailsPage": {
+    "title": "Journey Details",
+    "seoTitle": "Journey"
+  },
+  "journeyEditPage": {
+    "title": "Edit {{title}}",
+    "defaultTitle": "Edit Journey"
+  },
+  "signInPage": {
+    "title": "Sign In"
+  },
+  "access": {
+    "denied": "Access Denied"
+  }
 }

--- a/libs/locales/en/apps-journeys.json
+++ b/libs/locales/en/apps-journeys.json
@@ -1,4 +1,6 @@
 {
-  "%s | Next Steps": "%s | Next Steps",
-  "Next Steps | Helping you find the next best step on your spiritual journey": "Next Steps | Helping you find the next best step on your spiritual journey"
+  "app": {
+    "seoTemplate":"%s | Next Steps", 
+    "seoDefaultTitle": "Next Steps | Helping you find the next best step on your spiritual journey"
+  }
 }

--- a/libs/locales/en/libs-journeys-ui.json
+++ b/libs/locales/en/libs-journeys-ui.json
@@ -1,9 +1,11 @@
 {
-  "Name must be 2 characters or more": "Name must be 2 characters or more",
-  "Name must be 50 characters or less": "Name must be 50 characters or less",
-  "Required": "Required",
-  "Please enter a valid email address": "Please enter a valid email address",
-  "Name": "Name",
-  "Email": "Email",
-  "Submit": "Submit"
+  "signUp":{
+    "minCharacters": "Name must be 2 characters or more",
+    "maxCharacters": "Name must be 50 characters or less",
+    "required": "Required",
+    "invalidEmail": "Please enter a valid email address",
+    "name": "Name",
+    "email": "Email",
+    "submit": "Submit"
+  }
 }


### PR DESCRIPTION
# Description

Talked to Tatai about not using the value as the key name but basing them on namespaces. This would provide some structure to translations as the project grows. Errors would also be more apparent (eg `t(jounrey)` would translate to `jounrey` rather than `Journey`)

How does this kind of grouping look to others?

For more info / interesting reads:
https://lokalise.com/blog/translation-keys-naming-and-organizing/
https://dev.to/omaiboroda/three-ways-to-name-i18n-translation-keys-2fed
https://phrase.com/blog/posts/ruby-lessons-learned-naming-and-managing-rails-i18n-keys/

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
