### PR TITLE
fix: copy locales to journeys build

### DIFF
--- a/apps/journeys/next-i18next.config.js
+++ b/apps/journeys/next-i18next.config.js
@@ -7,7 +7,11 @@ const i18nConfig = {
   i18n: {
     defaultLocale: 'en',
     locales: ['en'],
-    localePath: path.resolve('./libs/locales')
+    localePath: path.resolve(
+      process.env.NEXT_PUBLIC_VERCEL_ENV == null || process.env.CI != null
+        ? './libs/locales'
+        : './public/locales'
+    )
   }
 }
 

--- a/apps/journeys/project.json
+++ b/apps/journeys/project.json
@@ -5,6 +5,24 @@
   "implicitDependencies": ["locales"],
   "targets": {
     "build": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "commands": [
+          "cp -r libs/locales apps/journeys/public",
+          "nx _build journeys"
+        ],
+        "parallel": false
+      },
+      "configurations": {
+        "production": {
+          "commands": [
+            "cp -r libs/locales apps/journeys/public",
+            "nx _build journeys --prod"
+          ]
+        }
+      }
+    },
+    "_build": {
       "executor": "@nrwl/next:build",
       "outputs": ["{options.outputPath}"],
       "options": {
@@ -18,7 +36,7 @@
     "serve": {
       "executor": "@nrwl/next:server",
       "options": {
-        "buildTarget": "journeys:build",
+        "buildTarget": "journeys:_build",
         "dev": true,
         "hostname": "0.0.0.0",
         "port": 4100


### PR DESCRIPTION
there are no locales present on the journey site. This means the api cannot refresh a page. See the datadog log error [here](https://app.datadoghq.com/logs?query=status%3Aerror&event=AQAAAYEdJd3KtL0OaQAAAABBWUVkSmZoaUFBQ0UwNzdSMUZicVZBQUE&index=%2A&from_ts=1654050575604&to_ts=1654051475604&live=true).

Two steps were taken:

- update build command for journeys
- update locales directory