### PR TITLE
fix: update step order on step delete

### DIFF
--- a/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/utils/getSelected.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/utils/getSelected.spec.tsx
@@ -140,7 +140,7 @@ describe('updatedSelected', () => {
   it('should select the step after the deleted step if deleted step is the first step', () => {
     const input = {
       parentOrder: 1,
-      siblings: [],
+      siblings: [step1, step2],
       type: 'StepBlock',
       steps,
       selectedStep: selectedStep

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/utils/getSelected.ts
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/utils/getSelected.ts
@@ -26,7 +26,7 @@ export default function getSelected({
   | SetSelectedStepAction
   | null {
   // BUG: siblings not returning correct data for blocks nested in a gridBlock - resolve this when we decide how grid will be used
-  if (siblings.length > 0) {
+  if (siblings.length > 0 && siblings[0].__typename !== 'StepBlock') {
     const blockToSelect =
       siblings.find((sibling) => sibling.parentOrder === parentOrder - 1) ??
       siblings[parentOrder]


### PR DESCRIPTION
# Description

Front end changes for updating step order on step delete

[- Link to Basecamp Todo - point 2](https://3.basecamp.com/3105655/buckets/27717553/todos/4985508524)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] When a card is deleted before the last card. Adding a new card should create it after the last card.

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
