### PR TITLE
chore: bump google gax from 2.28.1 to 2.30.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4426,8 +4426,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.4.4",
-      "license": "Apache-2.0",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.7.tgz",
+      "integrity": "sha512-eBM03pu9hd3VqDQG+kHahiG1x80RGkkqqRb1Pchcwqej/KkAH95gAvKs6laqaHCycYaPK+TKuNQnOz9UXYA8qw==",
       "dependencies": {
         "@grpc/proto-loader": "^0.6.4",
         "@types/node": ">=12.12.47"
@@ -4437,14 +4438,15 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.6.7",
-      "license": "Apache-2.0",
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
+      "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
       "dependencies": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^6.10.0",
-        "yargs": "^16.1.1"
+        "protobufjs": "^6.11.3",
+        "yargs": "^16.2.0"
       },
       "bin": {
         "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
@@ -30354,8 +30356,9 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "7.10.2",
-      "license": "Apache-2.0",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.14.1.tgz",
+      "integrity": "sha512-5Rk7iLNDFhFeBYc3s8l1CqzbEBcdhwR193RlD4vSNFajIcINKI8W8P0JLmBpwymHqqWbX34pJDQu39cSy/6RsA==",
       "optional": true,
       "dependencies": {
         "arrify": "^2.0.0",
@@ -30373,22 +30376,23 @@
       }
     },
     "node_modules/google-gax": {
-      "version": "2.28.1",
-      "license": "Apache-2.0",
+      "version": "2.30.5",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.30.5.tgz",
+      "integrity": "sha512-Jey13YrAN2hfpozHzbtrwEfEHdStJh1GwaQ2+Akh1k0Tv/EuNVSuBtHZoKSBm5wBMvNsxTsEIZ/152NrYyZgxQ==",
       "optional": true,
       "dependencies": {
-        "@grpc/grpc-js": "~1.4.0",
-        "@grpc/proto-loader": "^0.6.1",
+        "@grpc/grpc-js": "~1.6.0",
+        "@grpc/proto-loader": "^0.6.12",
         "@types/long": "^4.0.0",
         "abort-controller": "^3.0.0",
         "duplexify": "^4.0.0",
         "fast-text-encoding": "^1.0.3",
-        "google-auth-library": "^7.6.1",
+        "google-auth-library": "^7.14.0",
         "is-stream-ended": "^0.1.4",
         "node-fetch": "^2.6.1",
-        "object-hash": "^2.1.1",
-        "proto3-json-serializer": "^0.1.5",
-        "protobufjs": "6.11.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^0.1.8",
+        "protobufjs": "6.11.3",
         "retry-request": "^4.0.0"
       },
       "bin": {
@@ -30396,6 +30400,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/google-gax/node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "optional": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/google-p12-pem": {
@@ -40176,17 +40189,19 @@
       }
     },
     "node_modules/proto3-json-serializer": {
-      "version": "0.1.6",
-      "license": "Apache-2.0",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-0.1.9.tgz",
+      "integrity": "sha512-A60IisqvnuI45qNRygJjrnNjX2TMdQGMY+57tR3nul3ZgO2zXkR9OGR8AXxJhkqx84g0FTnrfi3D5fWMSdANdQ==",
       "optional": true,
       "dependencies": {
         "protobufjs": "^6.11.2"
       }
     },
     "node_modules/protobufjs": {
-      "version": "6.11.2",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -51470,20 +51485,24 @@
       "requires": {}
     },
     "@grpc/grpc-js": {
-      "version": "1.4.4",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.7.tgz",
+      "integrity": "sha512-eBM03pu9hd3VqDQG+kHahiG1x80RGkkqqRb1Pchcwqej/KkAH95gAvKs6laqaHCycYaPK+TKuNQnOz9UXYA8qw==",
       "requires": {
         "@grpc/proto-loader": "^0.6.4",
         "@types/node": ">=12.12.47"
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.6.7",
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
+      "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
       "requires": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^6.10.0",
-        "yargs": "^16.1.1"
+        "protobufjs": "^6.11.3",
+        "yargs": "^16.2.0"
       },
       "dependencies": {
         "yargs": {
@@ -69220,7 +69239,9 @@
       }
     },
     "google-auth-library": {
-      "version": "7.10.2",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.14.1.tgz",
+      "integrity": "sha512-5Rk7iLNDFhFeBYc3s8l1CqzbEBcdhwR193RlD4vSNFajIcINKI8W8P0JLmBpwymHqqWbX34pJDQu39cSy/6RsA==",
       "optional": true,
       "requires": {
         "arrify": "^2.0.0",
@@ -69235,22 +69256,32 @@
       }
     },
     "google-gax": {
-      "version": "2.28.1",
+      "version": "2.30.5",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.30.5.tgz",
+      "integrity": "sha512-Jey13YrAN2hfpozHzbtrwEfEHdStJh1GwaQ2+Akh1k0Tv/EuNVSuBtHZoKSBm5wBMvNsxTsEIZ/152NrYyZgxQ==",
       "optional": true,
       "requires": {
-        "@grpc/grpc-js": "~1.4.0",
-        "@grpc/proto-loader": "^0.6.1",
+        "@grpc/grpc-js": "~1.6.0",
+        "@grpc/proto-loader": "^0.6.12",
         "@types/long": "^4.0.0",
         "abort-controller": "^3.0.0",
         "duplexify": "^4.0.0",
         "fast-text-encoding": "^1.0.3",
-        "google-auth-library": "^7.6.1",
+        "google-auth-library": "^7.14.0",
         "is-stream-ended": "^0.1.4",
         "node-fetch": "^2.6.1",
-        "object-hash": "^2.1.1",
-        "proto3-json-serializer": "^0.1.5",
-        "protobufjs": "6.11.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^0.1.8",
+        "protobufjs": "6.11.3",
         "retry-request": "^4.0.0"
+      },
+      "dependencies": {
+        "object-hash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+          "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+          "optional": true
+        }
       }
     },
     "google-p12-pem": {
@@ -75763,14 +75794,18 @@
       }
     },
     "proto3-json-serializer": {
-      "version": "0.1.6",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-0.1.9.tgz",
+      "integrity": "sha512-A60IisqvnuI45qNRygJjrnNjX2TMdQGMY+57tR3nul3ZgO2zXkR9OGR8AXxJhkqx84g0FTnrfi3D5fWMSdANdQ==",
       "optional": true,
       "requires": {
         "protobufjs": "^6.11.2"
       }
     },
     "protobufjs": {
-      "version": "6.11.2",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",


### PR DESCRIPTION
The package protobufjs before 6.11.3 are vulnerable to Prototype Pollution which can allow an attacker to add/modify properties of the Object.prototype.

This vulnerability can occur in multiple ways:

by providing untrusted user input to util.setProperty or to ReflectionObject.setParsedOption functions
by parsing/loading .proto files

```
firebase-admin@9.12.0 requires protobufjs@6.11.2 via a transitive dependency on google-gax@2.28.1
next-firebase-auth@1.0.0-canary.5 requires protobufjs@6.11.2 via a transitive dependency on google-gax@2.28.1
```

This PR update google-gax v2.30.5:

Bug Fixes
- deps: update dependency protobufjs to v6.11.3 (https://github.com/googleapis/gax-nodejs/issues/1272) ([6492a2c](https://github.com/googleapis/gax-nodejs/commit/6492a2cc55086439518dcb20cb6001c28e1d2bda))
- deps: use protobufjs v6.11.3 (https://github.com/googleapis/gax-nodejs/issues/1271) ([d650c15](https://github.com/googleapis/gax-nodejs/commit/d650c1510cd98958fc32be03b890970f6f321595))