### PR TITLE
feat: embed power bi report and admin journeys report endpoint

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -385,6 +385,13 @@ input JourneysFilter {
   featured: Boolean
 }
 
+enum JourneysReportType {
+  multipleFull
+  multipleSummary
+  singleFull
+  singleSummary
+}
+
 enum JourneyStatus {
   draft
   published
@@ -532,9 +539,27 @@ input NavigateToJourneyActionInput {
   journeyId: String!
 }
 
+type PowerBiEmbed {
+  """The embed token"""
+  accessToken: String!
+
+  """The embed URL of the report"""
+  embedUrl: String!
+
+  """The date and time (UTC) of token expiration"""
+  expiration: String!
+
+  """The report ID"""
+  reportId: String!
+
+  """The name of the report"""
+  reportName: String!
+}
+
 type Query {
   adminJourney(id: ID!, idType: IdType): Journey @join__field(graph: JOURNEYS)
   adminJourneys: [Journey!]! @join__field(graph: JOURNEYS)
+  adminJourneysReport(reportType: JourneysReportType!): PowerBiEmbed @join__field(graph: JOURNEYS)
   countries: [Country!]! @join__field(graph: LANGUAGES)
   country(id: ID!, idType: IdType): Country! @join__field(graph: LANGUAGES)
   episodes(idType: IdType, limit: Int, offset: Int, playlistId: ID!, where: VideosFilter): [Video!]! @join__field(graph: VIDEOS)

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -812,6 +812,30 @@ input JourneysFilter {
   featured: Boolean
 }
 
+enum JourneysReportType {
+  multipleFull
+  multipleSummary
+  singleFull
+  singleSummary
+}
+
+type PowerBiEmbed {
+  """The report ID"""
+  reportId: String!
+
+  """The name of the report"""
+  reportName: String!
+
+  """The embed URL of the report"""
+  embedUrl: String!
+
+  """The embed token"""
+  accessToken: String!
+
+  """The date and time (UTC) of token expiration"""
+  expiration: String!
+}
+
 input JourneyCreateInput {
   """
   ID should be unique Response UUID
@@ -922,6 +946,7 @@ extend type Language @key(fields: "id") {
 }
 
 extend type Query {
+  adminJourneysReport(reportType: JourneysReportType!): PowerBiEmbed
   adminJourneys: [Journey!]!
   adminJourney(id: ID!, idType: IdType): Journey
   journeys(where: JourneysFilter): [Journey!]!

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -126,6 +126,13 @@ export enum JourneyStatus {
     published = "published"
 }
 
+export enum JourneysReportType {
+    multipleFull = "multipleFull",
+    multipleSummary = "multipleSummary",
+    singleFull = "singleFull",
+    singleSummary = "singleSummary"
+}
+
 export enum UserJourneyRole {
     inviteRequested = "inviteRequested",
     editor = "editor",
@@ -722,6 +729,15 @@ export class VideoProgressEvent implements Event {
     block?: Nullable<VideoBlock>;
 }
 
+export class PowerBiEmbed {
+    __typename?: 'PowerBiEmbed';
+    reportId: string;
+    reportName: string;
+    embedUrl: string;
+    accessToken: string;
+    expiration: string;
+}
+
 export class UserJourney {
     __typename?: 'UserJourney';
     journey?: Nullable<Journey>;
@@ -836,6 +852,8 @@ export class Language {
 }
 
 export abstract class IQuery {
+    abstract adminJourneysReport(reportType: JourneysReportType): Nullable<PowerBiEmbed> | Promise<Nullable<PowerBiEmbed>>;
+
     abstract adminJourneys(): Journey[] | Promise<Journey[]>;
 
     abstract adminJourney(id: string, idType?: Nullable<IdType>): Nullable<Journey> | Promise<Nullable<Journey>>;

--- a/apps/api-journeys/src/app/modules/journey/journey.graphql
+++ b/apps/api-journeys/src/app/modules/journey/journey.graphql
@@ -32,7 +32,38 @@ input JourneysFilter {
   featured: Boolean
 }
 
+enum JourneysReportType {
+  multipleFull
+  multipleSummary
+  singleFull
+  singleSummary
+}
+
+type PowerBiEmbed {
+  """
+  The report ID
+  """
+  reportId: String!
+  """
+  The name of the report
+  """
+  reportName: String!
+  """
+  The embed URL of the report
+  """
+  embedUrl: String!
+  """
+  The embed token
+  """
+  accessToken: String!
+  """
+  The date and time (UTC) of token expiration
+  """
+  expiration: String!
+}
+
 extend type Query {
+  adminJourneysReport(reportType: JourneysReportType!): PowerBiEmbed
   adminJourneys: [Journey!]!
   adminJourney(id: ID!, idType: IdType): Journey
   journeys(where: JourneysFilter): [Journey!]!

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -1,12 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { v4 as uuidv4 } from 'uuid'
+import { getPowerBiEmbed } from '@core/nest/powerBi/getPowerBiEmbed'
 import {
   IdType,
   Journey,
   JourneyStatus,
   ThemeMode,
   ThemeName,
-  UserJourneyRole
+  UserJourneyRole,
+  JourneysReportType
 } from '../../__generated__/graphql'
 import { BlockResolver } from '../block/block.resolver'
 import { BlockService } from '../block/block.service'
@@ -20,6 +22,15 @@ jest.mock('uuid', () => ({
 }))
 
 const mockUuidv4 = uuidv4 as jest.MockedFunction<typeof uuidv4>
+
+jest.mock('@core/nest/powerBi/getPowerBiEmbed', () => ({
+  __esModule: true,
+  getPowerBiEmbed: jest.fn()
+}))
+
+const mockGetPowerBiEmbed = getPowerBiEmbed as jest.MockedFunction<
+  typeof getPowerBiEmbed
+>
 
 describe('JourneyResolver', () => {
   beforeAll(() => {
@@ -135,6 +146,164 @@ describe('JourneyResolver', () => {
     resolver = module.get<JourneyResolver>(JourneyResolver)
     service = module.get<JourneyService>(JourneyService)
     ujService = module.get<UserJourneyService>(UserJourneyService)
+  })
+
+  describe('adminJourneysEmbed', () => {
+    it('should throw an error', async () => {
+      await expect(
+        resolver.adminJourneysReport('userId', JourneysReportType.multipleFull)
+      ).rejects.toThrow('server environment variables missing')
+    })
+
+    describe('with environment configuration', () => {
+      const OLD_ENV = process.env
+
+      beforeEach(() => {
+        jest.resetModules() // Most important - it clears the cache
+        process.env = { ...OLD_ENV } // Make a copy
+        process.env.POWER_BI_CLIENT_ID = 'POWER_BI_CLIENT_ID'
+        process.env.POWER_BI_CLIENT_SECRET = 'POWER_BI_CLIENT_SECRET'
+        process.env.POWER_BI_TENANT_ID = 'POWER_BI_TENANT_ID'
+        process.env.POWER_BI_WORKSPACE_ID = 'POWER_BI_WORKSPACE_ID'
+        process.env.POWER_BI_JOURNEYS_MULTIPLE_FULL_REPORT_ID =
+          'POWER_BI_JOURNEYS_MULTIPLE_FULL_REPORT_ID'
+        process.env.POWER_BI_JOURNEYS_MULTIPLE_SUMMARY_REPORT_ID =
+          'POWER_BI_JOURNEYS_MULTIPLE_SUMMARY_REPORT_ID'
+        process.env.POWER_BI_JOURNEYS_SINGLE_FULL_REPORT_ID =
+          'POWER_BI_JOURNEYS_SINGLE_FULL_REPORT_ID'
+        process.env.POWER_BI_JOURNEYS_SINGLE_SUMMARY_REPORT_ID =
+          'POWER_BI_JOURNEYS_SINGLE_SUMMARY_REPORT_ID'
+      })
+
+      afterAll(() => {
+        process.env = OLD_ENV // Restore old environment
+      })
+
+      it('should get power bi embed for multiple full', async () => {
+        mockGetPowerBiEmbed.mockResolvedValue({
+          reportId: 'reportId',
+          reportName: 'reportName',
+          embedUrl: 'embedUrl',
+          accessToken: 'accessToken',
+          expiration: '2hrs'
+        })
+        await expect(
+          resolver.adminJourneysReport(
+            'userId',
+            JourneysReportType.multipleFull
+          )
+        ).resolves.toEqual({
+          reportId: 'reportId',
+          reportName: 'reportName',
+          embedUrl: 'embedUrl',
+          accessToken: 'accessToken',
+          expiration: '2hrs'
+        })
+        expect(mockGetPowerBiEmbed).toHaveBeenCalledWith(
+          {
+            clientId: 'POWER_BI_CLIENT_ID',
+            clientSecret: 'POWER_BI_CLIENT_SECRET',
+            tenantId: 'POWER_BI_TENANT_ID',
+            workspaceId: 'POWER_BI_WORKSPACE_ID'
+          },
+          'POWER_BI_JOURNEYS_MULTIPLE_FULL_REPORT_ID',
+          'userId'
+        )
+      })
+
+      it('should get power bi embed for multiple summary', async () => {
+        mockGetPowerBiEmbed.mockResolvedValue({
+          reportId: 'reportId',
+          reportName: 'reportName',
+          embedUrl: 'embedUrl',
+          accessToken: 'accessToken',
+          expiration: '2hrs'
+        })
+        await expect(
+          resolver.adminJourneysReport(
+            'userId',
+            JourneysReportType.multipleSummary
+          )
+        ).resolves.toEqual({
+          reportId: 'reportId',
+          reportName: 'reportName',
+          embedUrl: 'embedUrl',
+          accessToken: 'accessToken',
+          expiration: '2hrs'
+        })
+        expect(mockGetPowerBiEmbed).toHaveBeenCalledWith(
+          {
+            clientId: 'POWER_BI_CLIENT_ID',
+            clientSecret: 'POWER_BI_CLIENT_SECRET',
+            tenantId: 'POWER_BI_TENANT_ID',
+            workspaceId: 'POWER_BI_WORKSPACE_ID'
+          },
+          'POWER_BI_JOURNEYS_MULTIPLE_SUMMARY_REPORT_ID',
+          'userId'
+        )
+      })
+
+      it('should get power bi embed for single full', async () => {
+        mockGetPowerBiEmbed.mockResolvedValue({
+          reportId: 'reportId',
+          reportName: 'reportName',
+          embedUrl: 'embedUrl',
+          accessToken: 'accessToken',
+          expiration: '2hrs'
+        })
+        await expect(
+          resolver.adminJourneysReport('userId', JourneysReportType.singleFull)
+        ).resolves.toEqual({
+          reportId: 'reportId',
+          reportName: 'reportName',
+          embedUrl: 'embedUrl',
+          accessToken: 'accessToken',
+          expiration: '2hrs'
+        })
+        expect(mockGetPowerBiEmbed).toHaveBeenCalledWith(
+          {
+            clientId: 'POWER_BI_CLIENT_ID',
+            clientSecret: 'POWER_BI_CLIENT_SECRET',
+            tenantId: 'POWER_BI_TENANT_ID',
+            workspaceId: 'POWER_BI_WORKSPACE_ID'
+          },
+          'POWER_BI_JOURNEYS_SINGLE_FULL_REPORT_ID',
+          'userId'
+        )
+      })
+
+      it('should get power bi embed for single summary', async () => {
+        mockGetPowerBiEmbed.mockResolvedValue({
+          reportId: 'reportId',
+          reportName: 'reportName',
+          embedUrl: 'embedUrl',
+          accessToken: 'accessToken',
+          expiration: '2hrs'
+        })
+        await expect(
+          resolver.adminJourneysReport(
+            'userId',
+            JourneysReportType.singleSummary
+          )
+        ).resolves.toEqual({
+          reportId: 'reportId',
+          reportName: 'reportName',
+          embedUrl: 'embedUrl',
+          accessToken: 'accessToken',
+          expiration: '2hrs'
+        })
+        expect(mockGetPowerBiEmbed).toHaveBeenCalledWith(
+          {
+            clientId: 'POWER_BI_CLIENT_ID',
+            clientSecret: 'POWER_BI_CLIENT_SECRET',
+            tenantId: 'POWER_BI_TENANT_ID',
+            workspaceId: 'POWER_BI_WORKSPACE_ID'
+          },
+          'POWER_BI_JOURNEYS_SINGLE_SUMMARY_REPORT_ID',
+          'userId'
+        )
+      })
+    })
   })
 
   describe('adminJourneys', () => {

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -9,8 +9,16 @@ import {
 import { CurrentUserId } from '@core/nest/decorators/CurrentUserId'
 import slugify from 'slugify'
 import { UseGuards } from '@nestjs/common'
+import {
+  getPowerBiEmbed,
+  PowerBiEmbed
+} from '@core/nest/powerBi/getPowerBiEmbed'
+import {
+  ApolloError,
+  ForbiddenError,
+  UserInputError
+} from 'apollo-server-errors'
 import { GqlAuthGuard } from '@core/nest/gqlAuthGuard/GqlAuthGuard'
-import { ForbiddenError, UserInputError } from 'apollo-server-errors'
 import { v4 as uuidv4 } from 'uuid'
 
 import { BlockService } from '../block/block.service'
@@ -26,7 +34,8 @@ import {
   ThemeName,
   UserJourney,
   UserJourneyRole,
-  JourneysFilter
+  JourneysFilter,
+  JourneysReportType
 } from '../../__generated__/graphql'
 import { UserJourneyService } from '../userJourney/userJourney.service'
 import { RoleGuard } from '../../lib/roleGuard/roleGuard'
@@ -41,6 +50,51 @@ export class JourneyResolver {
     private readonly blockService: BlockService,
     private readonly userJourneyService: UserJourneyService
   ) {}
+
+  @Query()
+  async adminJourneysReport(
+    @CurrentUserId() userId: string,
+    @Args('reportType') reportType: JourneysReportType
+  ): Promise<PowerBiEmbed> {
+    let reportId: string | undefined
+    switch (reportType) {
+      case JourneysReportType.multipleFull:
+        reportId = process.env.POWER_BI_JOURNEYS_MULTIPLE_FULL_REPORT_ID
+        break
+      case JourneysReportType.multipleSummary:
+        reportId = process.env.POWER_BI_JOURNEYS_MULTIPLE_SUMMARY_REPORT_ID
+        break
+      case JourneysReportType.singleFull:
+        reportId = process.env.POWER_BI_JOURNEYS_SINGLE_FULL_REPORT_ID
+        break
+      case JourneysReportType.singleSummary:
+        reportId = process.env.POWER_BI_JOURNEYS_SINGLE_SUMMARY_REPORT_ID
+        break
+    }
+
+    if (
+      process.env.POWER_BI_CLIENT_ID == null ||
+      process.env.POWER_BI_CLIENT_SECRET == null ||
+      process.env.POWER_BI_TENANT_ID == null ||
+      process.env.POWER_BI_WORKSPACE_ID == null ||
+      reportId == null
+    ) {
+      throw new ApolloError('server environment variables missing')
+    }
+
+    const config = {
+      clientId: process.env.POWER_BI_CLIENT_ID,
+      clientSecret: process.env.POWER_BI_CLIENT_SECRET,
+      tenantId: process.env.POWER_BI_TENANT_ID,
+      workspaceId: process.env.POWER_BI_WORKSPACE_ID
+    }
+
+    try {
+      return await getPowerBiEmbed(config, reportId, userId)
+    } catch (err) {
+      throw new ApolloError(err.message)
+    }
+  }
 
   @Query()
   async adminJourneys(@CurrentUserId() userId: string): Promise<Journey[]> {

--- a/libs/nest/powerBi/.babelrc
+++ b/libs/nest/powerBi/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/libs/nest/powerBi/.eslintrc.json
+++ b/libs/nest/powerBi/.eslintrc.json
@@ -1,0 +1,21 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["libs/nest/powerBi/tsconfig.*?.json"]
+      },
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/nest/powerBi/README.md
+++ b/libs/nest/powerBi/README.md
@@ -1,0 +1,7 @@
+# nest/powerBi
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test nest/powerBi` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/nest/powerBi/jest.config.js
+++ b/libs/nest/powerBi/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  displayName: 'nest/powerBi',
+  preset: '../../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json'
+    }
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest'
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../coverage/libs/nest/powerBi'
+}

--- a/libs/nest/powerBi/project.json
+++ b/libs/nest/powerBi/project.json
@@ -1,0 +1,23 @@
+{
+  "root": "libs/nest/powerBi",
+  "sourceRoot": "libs/nest/powerBi/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/nest/powerBi/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/libs/nest/powerBi"],
+      "options": {
+        "jestConfig": "libs/nest/powerBi/jest.config.js",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/nest/powerBi/src/lib/config.ts
+++ b/libs/nest/powerBi/src/lib/config.ts
@@ -1,0 +1,15 @@
+export interface PowerBiConfig {
+  apiUrl?: string
+  authorityUri?: string
+  clientId: string
+  clientSecret: string
+  scope?: string
+  tenantId: string
+  workspaceId: string
+}
+
+export const defaultPowerBiConfig = {
+  apiUrl: 'https://api.powerbi.com/',
+  authorityUri: 'https://login.microsoftonline.com/common/v2.0',
+  scope: 'https://analysis.windows.net/powerbi/api'
+}

--- a/libs/nest/powerBi/src/lib/getPowerBiAccessToken/getPowerBiAccessToken.spec.ts
+++ b/libs/nest/powerBi/src/lib/getPowerBiAccessToken/getPowerBiAccessToken.spec.ts
@@ -1,0 +1,99 @@
+import { AuthenticationContext } from 'adal-node'
+import { getPowerBiAccessToken } from '.'
+
+jest.mock('adal-node', () => {
+  return {
+    AuthenticationContext: jest.fn()
+  }
+})
+const mockAuthenticationContext = AuthenticationContext as jest.MockedClass<
+  typeof AuthenticationContext
+>
+
+describe('getPowerBiAccessToken', () => {
+  beforeEach(() => {
+    mockAuthenticationContext.mockClear()
+  })
+
+  describe('getPowerBiAccessToken', () => {
+    it('should return tokenResponse', async () => {
+      const acquireTokenWithClientCredentials = jest.fn(
+        (_scope, _clientId, _clientSecret, callback) => {
+          callback(undefined, { accessToken: 'accessToken' })
+        }
+      )
+      mockAuthenticationContext.mockImplementationOnce(
+        () =>
+          ({
+            acquireTokenWithClientCredentials
+          } as unknown as AuthenticationContext)
+      )
+      expect(
+        await getPowerBiAccessToken(
+          'https://login.microsoftonline.com/common/v2.0',
+          'clientId',
+          'clientSecret',
+          'https://analysis.windows.net/powerbi/api',
+          'tenantId'
+        )
+      ).toEqual({ accessToken: 'accessToken' })
+      expect(mockAuthenticationContext).toHaveBeenCalledWith(
+        'https://login.microsoftonline.com/tenantId/v2.0'
+      )
+      expect(acquireTokenWithClientCredentials).toHaveBeenCalledWith(
+        'https://analysis.windows.net/powerbi/api',
+        'clientId',
+        'clientSecret',
+        expect.any(Function)
+      )
+    })
+
+    it('should return error', async () => {
+      mockAuthenticationContext.mockImplementationOnce(() => {
+        return {
+          acquireTokenWithClientCredentials: (
+            _scope,
+            _clientId,
+            _clientSecret,
+            callback
+          ) => {
+            callback(new Error('error'), undefined)
+          }
+        } as unknown as AuthenticationContext
+      })
+      await expect(
+        getPowerBiAccessToken(
+          'https://login.microsoftonline.com/common/v2.0',
+          'clientId',
+          'clientSecret',
+          'https://analysis.windows.net/powerbi/api',
+          'tenantId'
+        )
+      ).rejects.toThrow('error')
+    })
+
+    it('should return error response', async () => {
+      mockAuthenticationContext.mockImplementationOnce(() => {
+        return {
+          acquireTokenWithClientCredentials: (
+            _scope,
+            _clientId,
+            _clientSecret,
+            callback
+          ) => {
+            callback(new Error('error'), new Error('tokenResponse error'))
+          }
+        } as unknown as AuthenticationContext
+      })
+      await expect(
+        getPowerBiAccessToken(
+          'https://login.microsoftonline.com/common/v2.0',
+          'clientId',
+          'clientSecret',
+          'https://analysis.windows.net/powerbi/api',
+          'tenantId'
+        )
+      ).rejects.toThrow('tokenResponse error')
+    })
+  })
+})

--- a/libs/nest/powerBi/src/lib/getPowerBiAccessToken/getPowerBiAccessToken.ts
+++ b/libs/nest/powerBi/src/lib/getPowerBiAccessToken/getPowerBiAccessToken.ts
@@ -1,0 +1,30 @@
+import { AuthenticationContext, TokenResponse } from 'adal-node'
+
+export async function getPowerBiAccessToken(
+  authorityUri: string,
+  clientId: string,
+  clientSecret: string,
+  scope: string,
+  tenantId: string
+): Promise<TokenResponse> {
+  const context = new AuthenticationContext(
+    authorityUri.replace('common', tenantId)
+  )
+
+  return await new Promise((resolve, reject) => {
+    context.acquireTokenWithClientCredentials(
+      scope,
+      clientId,
+      clientSecret,
+      (err, tokenResponse) => {
+        if (err == null) {
+          resolve(tokenResponse as TokenResponse)
+        } else {
+          // Function returns error object in tokenResponse
+          // Invalid Username will return empty tokenResponse, thus err is used
+          reject(tokenResponse == null ? err : tokenResponse)
+        }
+      }
+    )
+  })
+}

--- a/libs/nest/powerBi/src/lib/getPowerBiAccessToken/index.ts
+++ b/libs/nest/powerBi/src/lib/getPowerBiAccessToken/index.ts
@@ -1,0 +1,1 @@
+export { getPowerBiAccessToken } from './getPowerBiAccessToken'

--- a/libs/nest/powerBi/src/lib/getPowerBiEmbed/getPowerBiEmbed.spec.ts
+++ b/libs/nest/powerBi/src/lib/getPowerBiEmbed/getPowerBiEmbed.spec.ts
@@ -1,0 +1,277 @@
+import fetch, { Response, FetchError } from 'node-fetch'
+import { TokenResponse } from 'adal-node'
+import { getPowerBiAccessToken } from '../getPowerBiAccessToken'
+import { getPowerBiEmbed } from '.'
+
+jest.mock('node-fetch', () => {
+  const originalModule = jest.requireActual('node-fetch')
+  return {
+    __esModule: true,
+    ...originalModule,
+    default: jest.fn()
+  }
+})
+const mockFetch = fetch as jest.MockedFunction<typeof fetch>
+
+jest.mock('../getPowerBiAccessToken')
+const mockGetPowerBiAccessToken = getPowerBiAccessToken as jest.MockedFunction<
+  typeof getPowerBiAccessToken
+>
+
+describe('getPowerBiEmbed', () => {
+  beforeEach(() => {
+    mockFetch.mockClear()
+    mockGetPowerBiAccessToken.mockClear()
+  })
+
+  describe('getPowerBiEmbed', () => {
+    it('should return embedInfo', async () => {
+      const accessToken = 'accessToken'
+      const tokenRequest = mockGetPowerBiAccessToken.mockResolvedValueOnce({
+        accessToken
+      } as unknown as TokenResponse)
+      const reportRequest = mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          await Promise.resolve({
+            id: 'reportId',
+            name: 'reportName',
+            embedUrl: 'embedUrl',
+            datasetId: 'datasetId'
+          })
+      } as unknown as Response)
+      const embedTokenRequest = mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          await Promise.resolve({
+            token: accessToken,
+            expiration: '2hr'
+          })
+      } as unknown as Response)
+      await expect(
+        getPowerBiEmbed(
+          {
+            clientId: 'clientId',
+            clientSecret: 'clientSecret',
+            tenantId: 'tenantId',
+            workspaceId: 'workspaceId'
+          },
+          'reportId',
+          'userId'
+        )
+      ).resolves.toEqual({
+        reportId: 'reportId',
+        reportName: 'reportName',
+        embedUrl: 'embedUrl',
+        accessToken,
+        expiration: '2hr'
+      })
+      expect(tokenRequest).toHaveBeenCalledWith(
+        'https://login.microsoftonline.com/common/v2.0',
+        'clientId',
+        'clientSecret',
+        'https://analysis.windows.net/powerbi/api',
+        'tenantId'
+      )
+      expect(reportRequest).toHaveBeenCalledWith(
+        'https://api.powerbi.com/v1.0/myorg/groups/workspaceId/reports/reportId',
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json'
+          },
+          method: 'GET'
+        }
+      )
+      expect(embedTokenRequest).toHaveBeenCalledWith(
+        'https://api.powerbi.com/v1.0/myorg/GenerateToken',
+        {
+          body: JSON.stringify({
+            reports: [{ id: 'reportId' }],
+            datasets: [{ id: 'datasetId' }],
+            targetWorkspaces: [{ id: 'workspaceId' }],
+            identities: [
+              {
+                username: 'userId',
+                roles: ['Equipment Team'],
+                datasets: ['datasetId']
+              }
+            ]
+          }),
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json'
+          },
+          method: 'POST'
+        }
+      )
+    })
+
+    it('should return handle tokenRequest ErrorResponse error', async () => {
+      const tokenRequest = mockGetPowerBiAccessToken.mockRejectedValueOnce({
+        error: 'error',
+        errorDescription: 'errorDescription'
+      })
+      await expect(
+        getPowerBiEmbed(
+          {
+            clientId: 'clientId',
+            clientSecret: 'clientSecret',
+            tenantId: 'tenantId',
+            workspaceId: 'workspaceId'
+          },
+          'reportId',
+          'userId'
+        )
+      ).rejects.toThrow('errorDescription')
+      expect(tokenRequest).toHaveBeenCalledWith(
+        'https://login.microsoftonline.com/common/v2.0',
+        'clientId',
+        'clientSecret',
+        'https://analysis.windows.net/powerbi/api',
+        'tenantId'
+      )
+    })
+
+    it('should return handle tokenRequest error', async () => {
+      const tokenRequest = mockGetPowerBiAccessToken.mockRejectedValueOnce(
+        new Error('error')
+      )
+      await expect(
+        getPowerBiEmbed(
+          {
+            clientId: 'clientId',
+            clientSecret: 'clientSecret',
+            tenantId: 'tenantId',
+            workspaceId: 'workspaceId'
+          },
+          'reportId',
+          'userId'
+        )
+      ).rejects.toThrow('error')
+      expect(tokenRequest).toHaveBeenCalledWith(
+        'https://login.microsoftonline.com/common/v2.0',
+        'clientId',
+        'clientSecret',
+        'https://analysis.windows.net/powerbi/api',
+        'tenantId'
+      )
+    })
+
+    it('should return handle reportRequest error', async () => {
+      const accessToken = 'accessToken'
+      const tokenRequest = mockGetPowerBiAccessToken.mockResolvedValueOnce({
+        accessToken
+      } as unknown as TokenResponse)
+      const reportRequest = mockFetch.mockRejectedValueOnce(
+        new FetchError(
+          'uri requested responds with an invalid redirect URL',
+          'invalid-redirect'
+        )
+      )
+      await expect(
+        getPowerBiEmbed(
+          {
+            clientId: 'clientId',
+            clientSecret: 'clientSecret',
+            tenantId: 'tenantId',
+            workspaceId: 'workspaceId'
+          },
+          'reportId',
+          'userId'
+        )
+      ).rejects.toThrow('uri requested responds with an invalid redirect URL')
+      expect(tokenRequest).toHaveBeenCalledWith(
+        'https://login.microsoftonline.com/common/v2.0',
+        'clientId',
+        'clientSecret',
+        'https://analysis.windows.net/powerbi/api',
+        'tenantId'
+      )
+      expect(reportRequest).toHaveBeenCalledWith(
+        'https://api.powerbi.com/v1.0/myorg/groups/workspaceId/reports/reportId',
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json'
+          },
+          method: 'GET'
+        }
+      )
+    })
+
+    it('should return handle embedTokenRequest error', async () => {
+      const accessToken = 'accessToken'
+      const tokenRequest = mockGetPowerBiAccessToken.mockResolvedValueOnce({
+        accessToken
+      } as unknown as TokenResponse)
+      const reportRequest = mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          await Promise.resolve({
+            id: 'reportId',
+            name: 'reportName',
+            embedUrl: 'embedUrl',
+            datasetId: 'datasetId'
+          })
+      } as unknown as Response)
+      const embedTokenRequest = mockFetch.mockRejectedValueOnce(
+        new FetchError(
+          'uri requested responds with an invalid redirect URL',
+          'invalid-redirect'
+        )
+      )
+      await expect(
+        getPowerBiEmbed(
+          {
+            clientId: 'clientId',
+            clientSecret: 'clientSecret',
+            tenantId: 'tenantId',
+            workspaceId: 'workspaceId'
+          },
+          'reportId',
+          'userId'
+        )
+      ).rejects.toThrow('uri requested responds with an invalid redirect URL')
+      expect(tokenRequest).toHaveBeenCalledWith(
+        'https://login.microsoftonline.com/common/v2.0',
+        'clientId',
+        'clientSecret',
+        'https://analysis.windows.net/powerbi/api',
+        'tenantId'
+      )
+      expect(reportRequest).toHaveBeenCalledWith(
+        'https://api.powerbi.com/v1.0/myorg/groups/workspaceId/reports/reportId',
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json'
+          },
+          method: 'GET'
+        }
+      )
+      expect(embedTokenRequest).toHaveBeenCalledWith(
+        'https://api.powerbi.com/v1.0/myorg/GenerateToken',
+        {
+          body: JSON.stringify({
+            reports: [{ id: 'reportId' }],
+            datasets: [{ id: 'datasetId' }],
+            targetWorkspaces: [{ id: 'workspaceId' }],
+            identities: [
+              {
+                username: 'userId',
+                roles: ['Equipment Team'],
+                datasets: ['datasetId']
+              }
+            ]
+          }),
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json'
+          },
+          method: 'POST'
+        }
+      )
+    })
+  })
+})

--- a/libs/nest/powerBi/src/lib/getPowerBiEmbed/getPowerBiEmbed.ts
+++ b/libs/nest/powerBi/src/lib/getPowerBiEmbed/getPowerBiEmbed.ts
@@ -1,0 +1,175 @@
+import fetch, { FetchError } from 'node-fetch'
+import { getPowerBiAccessToken } from '../getPowerBiAccessToken'
+import { PowerBiConfig, defaultPowerBiConfig } from '../config'
+
+export interface PowerBiEmbed {
+  /**
+   * The report ID
+   */
+  reportId: string
+  /**
+   * The name of the report
+   */
+  reportName: string
+  /**
+   * The embed URL of the report
+   */
+  embedUrl: string
+  /**
+   * The embed token
+   */
+  accessToken: string
+  /**
+   * The date and time (UTC) of token expiration
+   */
+  expiration: string
+}
+
+/**
+ * Generate embed token and embed urls for reports
+ * @return Details like Embed URL, Access token and Expiry
+ */
+export async function getPowerBiEmbed(
+  config: PowerBiConfig,
+  reportId: string,
+  userId: string
+): Promise<PowerBiEmbed> {
+  const {
+    apiUrl,
+    workspaceId,
+    authorityUri,
+    clientId,
+    clientSecret,
+    scope,
+    tenantId
+  } = {
+    ...defaultPowerBiConfig,
+    ...config
+  }
+  try {
+    const headers = await getRequestHeaders(
+      authorityUri,
+      clientId,
+      clientSecret,
+      scope,
+      tenantId
+    )
+    return await getEmbedParamsForSingleReport(
+      apiUrl,
+      workspaceId,
+      reportId,
+      userId,
+      headers
+    )
+  } catch (err) {
+    if (
+      Object.prototype.hasOwnProperty.call(err, 'errorDescription') === true &&
+      Object.prototype.hasOwnProperty.call(err, 'error') === true
+    ) {
+      throw new Error(err.errorDescription)
+    } else if (err instanceof FetchError) {
+      throw new Error(err.message)
+    } else {
+      throw new Error(err.toString())
+    }
+  }
+}
+
+/**
+ * Get embed params for a single report for a single workspace
+ */
+async function getEmbedParamsForSingleReport(
+  apiUrl: string,
+  workspaceId: string,
+  reportId: string,
+  userId: string,
+  headers: RequestHeaders
+): Promise<PowerBiEmbed> {
+  const result = await fetch(
+    `${apiUrl}v1.0/myorg/groups/${workspaceId}/reports/${reportId}`,
+    {
+      method: 'GET',
+      headers
+    }
+  )
+
+  const { id, name, embedUrl, datasetId } = await result.json()
+
+  return {
+    reportId: id as string,
+    reportName: name as string,
+    embedUrl: embedUrl as string,
+    ...(await getEmbedTokenForSingleReportSingleWorkspace(
+      apiUrl,
+      reportId,
+      userId,
+      [datasetId],
+      workspaceId,
+      headers
+    ))
+  }
+}
+
+/**
+ * Get Embed token for single report, multiple datasets, and an optional target workspace
+ */
+async function getEmbedTokenForSingleReportSingleWorkspace(
+  apiUrl: string,
+  reportId: string,
+  userId: string,
+  datasetIds: string[],
+  workspaceId: string,
+  headers: RequestHeaders
+): Promise<{ accessToken: string; expiration: string }> {
+  const result = await fetch(`${apiUrl}v1.0/myorg/GenerateToken`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      reports: [{ id: reportId }],
+      datasets: datasetIds.map((datasetId) => ({
+        id: datasetId
+      })),
+      targetWorkspaces: [{ id: workspaceId }],
+      identities: [
+        {
+          username: userId,
+          roles: ['Equipment Team'],
+          datasets: datasetIds
+        }
+      ]
+    })
+  })
+
+  const { token, expiration } = await result.json()
+
+  return { accessToken: token, expiration }
+}
+
+interface RequestHeaders {
+  'Content-Type': 'application/json'
+  Authorization: string
+  [key: string]: string
+}
+
+/**
+ * Get Request headers
+ */
+async function getRequestHeaders(
+  authorityUri: string,
+  clientId: string,
+  clientSecret: string,
+  scope: string,
+  tenantId: string
+): Promise<RequestHeaders> {
+  const tokenResponse = await getPowerBiAccessToken(
+    authorityUri,
+    clientId,
+    clientSecret,
+    scope,
+    tenantId
+  )
+  return {
+    'Content-Type': 'application/json',
+    Authorization: 'Bearer '.concat(tokenResponse.accessToken)
+  }
+}

--- a/libs/nest/powerBi/src/lib/getPowerBiEmbed/index.ts
+++ b/libs/nest/powerBi/src/lib/getPowerBiEmbed/index.ts
@@ -1,0 +1,2 @@
+export { getPowerBiEmbed } from './getPowerBiEmbed'
+export type { PowerBiEmbed } from './getPowerBiEmbed'

--- a/libs/nest/powerBi/tsconfig.json
+++ b/libs/nest/powerBi/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/nest/powerBi/tsconfig.lib.json
+++ b/libs/nest/powerBi/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["**/*.spec.ts", "**/*.test.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/nest/powerBi/tsconfig.spec.json
+++ b/libs/nest/powerBi/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@nestjs/graphql": "^10.0.4",
         "@nestjs/platform-express": "^8.3.1",
         "@nrwl/next": "13.2.2",
+        "adal-node": "^0.2.3",
         "apollo-datasource": "^3.3.1",
         "apollo-server": "^3.7.0",
         "arangojs": "^7.6.1",
@@ -19997,6 +19998,68 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/adal-node": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.3.tgz",
+      "integrity": "sha512-gMKr8RuYEYvsj7jyfCv/4BfKToQThz20SP71N3AtFn3ia3yAR8Qt2T3aVQhuJzunWs2b38ZsQV0qsZPdwZr7VQ==",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.7.0",
+        "async": "^2.6.3",
+        "axios": "^0.21.1",
+        "date-utils": "*",
+        "jws": "3.x.x",
+        "underscore": ">= 1.3.1",
+        "uuid": "^3.1.0",
+        "xpath.js": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.6.15"
+      }
+    },
+    "node_modules/adal-node/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/adal-node/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
+    "node_modules/adal-node/node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/adal-node/node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/adal-node/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/address": {
       "version": "1.1.2",
       "dev": true,
@@ -26057,6 +26120,14 @@
       "version": "0.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/date-utils": {
+      "version": "1.2.21",
+      "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
+      "integrity": "sha512-wJMBjqlwXR0Iv0wUo/lFbhSQ7MmG1hl36iuxuE91kW+5b5sWbase73manEqNH9sOLFAMG83B4ffNKq9/Iq0FVA==",
+      "engines": {
+        "node": ">0.4.0"
+      }
     },
     "node_modules/dayjs": {
       "version": "1.10.7",
@@ -46172,6 +46243,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/underscore": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
+      "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
+    },
     "node_modules/underscore.string": {
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.6.tgz",
@@ -48449,6 +48525,14 @@
       "version": "2.2.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xpath.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
+      "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/xregexp": {
       "version": "2.0.0",
@@ -62156,6 +62240,63 @@
       "version": "7.2.0",
       "dev": true
     },
+    "adal-node": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.3.tgz",
+      "integrity": "sha512-gMKr8RuYEYvsj7jyfCv/4BfKToQThz20SP71N3AtFn3ia3yAR8Qt2T3aVQhuJzunWs2b38ZsQV0qsZPdwZr7VQ==",
+      "requires": {
+        "@xmldom/xmldom": "^0.7.0",
+        "async": "^2.6.3",
+        "axios": "^0.21.1",
+        "date-utils": "*",
+        "jws": "3.x.x",
+        "underscore": ">= 1.3.1",
+        "uuid": "^3.1.0",
+        "xpath.js": "~1.1.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "axios": {
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        },
+        "jwa": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+          "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+          "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "ecdsa-sig-formatter": "1.0.11",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jws": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+          "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+          "requires": {
+            "jwa": "^1.4.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
+      }
+    },
     "address": {
       "version": "1.1.2",
       "dev": true
@@ -66367,6 +66508,11 @@
     "date-format": {
       "version": "0.0.2",
       "dev": true
+    },
+    "date-utils": {
+      "version": "1.2.21",
+      "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
+      "integrity": "sha512-wJMBjqlwXR0Iv0wUo/lFbhSQ7MmG1hl36iuxuE91kW+5b5sWbase73manEqNH9sOLFAMG83B4ffNKq9/Iq0FVA=="
     },
     "dayjs": {
       "version": "1.10.7",
@@ -79868,6 +80014,11 @@
       "version": "0.1.2",
       "dev": true
     },
+    "underscore": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
+      "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
+    },
     "underscore.string": {
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.6.tgz",
@@ -81428,6 +81579,11 @@
     "xmlchars": {
       "version": "2.2.0",
       "dev": true
+    },
+    "xpath.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
+      "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
     },
     "xregexp": {
       "version": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@nestjs/graphql": "^10.0.4",
     "@nestjs/platform-express": "^8.3.1",
     "@nrwl/next": "13.2.2",
+    "adal-node": "^0.2.3",
     "apollo-datasource": "^3.3.1",
     "apollo-server": "^3.7.0",
     "arangojs": "^7.6.1",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,6 +24,7 @@
       "@core/nest/database/*": ["libs/nest/database/src/lib/*"],
       "@core/nest/decorators/*": ["libs/nest/decorators/src/lib/*"],
       "@core/nest/gqlAuthGuard/*": ["libs/nest/gqlAuthGuard/src/lib/*"],
+      "@core/nest/powerBi/*": ["libs/nest/powerBi/src/lib/*"],
       // "@core/shared/storybook": [],
       "@core/shared/ui/*": [
         "libs/shared/ui/src/components/*",

--- a/workspace.json
+++ b/workspace.json
@@ -22,6 +22,7 @@
     "nest-database": "libs/nest/database",
     "nest-decorators": "libs/nest/decorators",
     "nest/gqlAuthGuard": "libs/nest/gqlAuthGuard",
+    "nest/powerBi": "libs/nest/powerBi",
     "shared-storybook": "libs/shared/storybook",
     "shared-ui": "libs/shared/ui",
     "watch": "apps/watch",


### PR DESCRIPTION
# Description

Much of this work is based on the [NodeJS example app](https://github.com/microsoft/PowerBI-Developer-Samples/tree/master/NodeJS) from Microsoft.

- add new nest-specific library for creating embed tokens from power bi
- add new adminJourneysReport endpoint on api-journeys
- add necessary environment variables to doppler
- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/27931561/todos/5008366837)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration. @csiyang to carry out this work in his branch.

- [x] Generate token for multiple summary journey report and embed into journeys page
- [x] Generate token for multiple full journey report and embed into journeys analytics page
- [x] Generate token for single summary journey report and embed into journey analytics page
- [x] Generate token for single full journey report and embed into journey analytics page

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
