### PR TITLE
fix: More accurately type getSiblingsInternal return type

### DIFF
--- a/apps/api-journeys/src/app/modules/block/block.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/block.service.spec.ts
@@ -156,16 +156,16 @@ describe('BlockService', () => {
       ])
       expect(
         await service.reorderSiblings([
-          { _key: block._key, parentOrder: 2 },
-          { _key: block._key, parentOrder: 3 }
+          { ...block, id: block._key, parentOrder: 2 },
+          { ...block, id: block._key, parentOrder: 3 }
         ])
       ).toEqual([
         { ...block, parentOrder: 0 },
         { ...block, parentOrder: 1 }
       ])
       expect(service.updateAll).toHaveBeenCalledWith([
-        { _key: block._key, parentOrder: 0 },
-        { _key: block._key, parentOrder: 1 }
+        { ...block, id: block._key, parentOrder: 0 },
+        { ...block, id: block._key, parentOrder: 1 }
       ])
     })
   })
@@ -267,7 +267,10 @@ describe('BlockService', () => {
           { _key: block._key, new: block }
         ])
       )
-      const siblings = [blockWithId, blockWithId] as Block[]
+      const siblings = [
+        { ...block, id: block._key },
+        { ...block, id: block._key }
+      ]
 
       service.getSiblingsInternal = jest.fn(
         async () => await Promise.resolve(siblings)

--- a/apps/api-journeys/src/app/modules/block/block.service.ts
+++ b/apps/api-journeys/src/app/modules/block/block.service.ts
@@ -32,7 +32,7 @@ export class BlockService extends BaseService {
   async getSiblingsInternal(
     journeyId: string,
     parentBlockId?: string | null
-  ): Promise<Block[]> {
+  ): Promise<Array<Block & { _key: string }>> {
     // Only StepBlocks should not have parentBlockId
     const res =
       parentBlockId != null
@@ -56,7 +56,7 @@ export class BlockService extends BaseService {
   }
 
   async reorderSiblings(
-    siblings: Block[] | Array<{ _key: string; parentOrder: number }>
+    siblings: Array<Block & { _key: string }>
   ): Promise<Block[]> {
     const updatedSiblings = siblings.map((block, index) => ({
       ...block,
@@ -71,7 +71,7 @@ export class BlockService extends BaseService {
     journeyId: string,
     parentOrder: number
   ): Promise<Block[]> {
-    const block = idAsKey(await this.get(id)) as Block
+    const block = idAsKey(await this.get(id)) as Block & { _key: string }
 
     if (block.journeyId === journeyId && block.parentOrder != null) {
       const siblings = await this.getSiblingsInternal(


### PR DESCRIPTION
# Description

As I write tests for the blockDuplicate, I've discovered we incorrectly type the return object for `getSiblingsInternal`. This matters I need to know when the `_key` property is present or not (arrango allows us to use a user defined `_key` to specify the `_id` - we cannot directly set `_id`). This is important for the duplication api since I'm generating id's for each block.

More accurately we get something like when we call `getSiblingsInternal`
<img width="420" alt="image" src="https://user-images.githubusercontent.com/10802634/174195662-c004af24-2f47-4226-bc30-e5218ef5971d.png">

# How should this PR be QA Tested?

- [x] Manually tested move blocks and delete blocks still works
- [x] Unit tests pass

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
