### PR TITLE
feat: add saveAll in base service

### DIFF
--- a/apps/api-journeys/db/seeds/nua1.ts
+++ b/apps/api-journeys/db/seeds/nua1.ts
@@ -420,8 +420,7 @@ export async function nua1(): Promise<void> {
     __typename: 'IconBlock',
     parentBlockId: button2._key,
     name: 'ContactSupportRounded',
-    size: 'md',
-    parentOrder: 4
+    size: 'md'
   })
   const icon2b = await db.collection('blocks').save({
     journeyId: journey._key,

--- a/apps/api-journeys/src/app/modules/block/block.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/block.service.spec.ts
@@ -4,6 +4,7 @@ import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
 import {
   mockCollectionRemoveResult,
   mockCollectionSaveResult,
+  mockCollectionSaveAllResult,
   mockCollectionUpdateAllResult,
   mockDbQueryResult
 } from '@core/nest/database'
@@ -131,6 +132,23 @@ describe('BlockService', () => {
 
     it('should return a saved block', async () => {
       expect(await service.save(block)).toEqual(blockWithId)
+    })
+  })
+
+  describe('saveAll', () => {
+    beforeEach(() => {
+      ;(
+        service.collection as DeepMockProxy<DocumentCollection>
+      ).saveAll.mockReturnValue(
+        mockCollectionSaveAllResult(service.collection, [block, block])
+      )
+    })
+
+    it('should return saved blocks', async () => {
+      expect(await service.saveAll([block, block])).toEqual([
+        blockWithId,
+        blockWithId
+      ])
     })
   })
 

--- a/libs/nest/database/src/lib/base.service.ts
+++ b/libs/nest/database/src/lib/base.service.ts
@@ -66,6 +66,14 @@ export abstract class BaseService {
     return result.new
   }
 
+  @IdAsKey()
+  async saveAll<T>(arr: T[]): Promise<T[]> {
+    const result = await this.collection.saveAll(arr, {
+      returnNew: true
+    })
+    return result.map((item) => item.new)
+  }
+
   @KeyAsId()
   async remove<T>(_key: string): Promise<T> {
     const result = await this.collection.remove(_key, { returnOld: true })

--- a/libs/nest/database/src/lib/dbMock.ts
+++ b/libs/nest/database/src/lib/dbMock.ts
@@ -33,6 +33,19 @@ export const mockCollectionSaveResult = async <T>(
     new: result
   })
 
+export const mockCollectionSaveAllResult = async <T>(
+  collection: DocumentCollection,
+  results: Array<T & { _key: string }>
+): Promise<Array<DocumentMetadata & { new?: Document }>> =>
+  await Promise.resolve(
+    results.map((result) => ({
+      _key: result._key,
+      _id: `${collection.name}/${result._key}`,
+      _rev: '1',
+      new: result
+    }))
+  )
+
 export const mockCollectionRemoveResult = async <T>(
   collection: DocumentCollection,
   result: T & { _key: string }


### PR DESCRIPTION
# Description

Allows us to use saveAll to create multiple blocks at once. Used for the duplication cycle 5 project.

The unit test, dbMock and function itself is very similar to `updateAll` and `save`.

# How should this PR be QA Tested?

- [ ] Unit tests pass
- [ ] Tested it works to save multiple blocks with duplication code branch

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
