### PR TITLE
feat: card reordering

### DIFF
--- a/apps/journeys-admin/__generated__/StepsOrderUpdate.ts
+++ b/apps/journeys-admin/__generated__/StepsOrderUpdate.ts
@@ -1,0 +1,24 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL mutation operation: StepsOrderUpdate
+// ====================================================
+
+export interface StepsOrderUpdate_blockOrderUpdate {
+  __typename: "ButtonBlock" | "CardBlock" | "GridContainerBlock" | "GridItemBlock" | "IconBlock" | "ImageBlock" | "RadioOptionBlock" | "RadioQuestionBlock" | "SignUpBlock" | "StepBlock" | "TypographyBlock" | "VideoBlock" | "VideoTriggerBlock";
+  id: string;
+  parentOrder: number | null;
+}
+
+export interface StepsOrderUpdate {
+  blockOrderUpdate: StepsOrderUpdate_blockOrderUpdate[];
+}
+
+export interface StepsOrderUpdateVariables {
+  id: string;
+  journeyId: string;
+  parentOrder: number;
+}

--- a/apps/journeys-admin/src/components/CardPreview/CardList/CardList.spec.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardList/CardList.spec.tsx
@@ -1,0 +1,231 @@
+import { render, fireEvent } from '@testing-library/react'
+import { TreeBlock } from '@core/journeys/ui'
+import { MockedProvider } from '@apollo/client/testing'
+import { DragDropContext } from 'react-beautiful-dnd'
+import { BlockFields_StepBlock as StepBlock } from '../../../../__generated__/BlockFields'
+import { CardList } from '.'
+
+jest.mock('react-beautiful-dnd', () => ({
+  Droppable: ({ children }) =>
+    children(
+      {
+        draggableProps: {
+          style: {}
+        },
+        innerRef: jest.fn()
+      },
+      {}
+    ),
+  Draggable: ({ children }) =>
+    children(
+      {
+        draggableProps: {
+          style: {}
+        },
+        innerRef: jest.fn()
+      },
+      {}
+    ),
+  DragDropContext: ({ children }) => children
+}))
+
+describe('CardList', () => {
+  const selected: TreeBlock<StepBlock> = {
+    id: 'step2.id',
+    __typename: 'StepBlock',
+    parentBlockId: null,
+    parentOrder: 0,
+    locked: false,
+    nextBlockId: 'step3.id',
+    children: [
+      {
+        id: 'card2.id',
+        __typename: 'CardBlock',
+        parentBlockId: 'step2.id',
+        coverBlockId: null,
+        parentOrder: 0,
+        backgroundColor: null,
+        themeMode: null,
+        themeName: null,
+        fullscreen: false,
+        children: [
+          {
+            id: 'video1.id',
+            __typename: 'VideoBlock',
+            parentBlockId: 'card2.id',
+            parentOrder: 0,
+            autoplay: true,
+            muted: true,
+            videoId: '2_0-FallingPlates',
+            videoVariantLanguageId: '529',
+            video: {
+              __typename: 'Video',
+              id: '2_0-FallingPlates',
+              title: [
+                {
+                  __typename: 'Translation',
+                  value: 'FallingPlates'
+                }
+              ],
+              image:
+                'https://d1wl257kev7hsz.cloudfront.net/cinematics/2_0-FallingPlates.mobileCinematicHigh.jpg',
+              variant: {
+                __typename: 'VideoVariant',
+                id: '2_0-FallingPlates-529',
+                hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
+              }
+            },
+            endAt: null,
+            startAt: null,
+            posterBlockId: null,
+            fullsize: true,
+            action: null,
+            children: [
+              {
+                id: 'trigger.id',
+                __typename: 'VideoTriggerBlock',
+                parentBlockId: 'video1.id',
+                parentOrder: 0,
+                triggerStart: 20,
+                triggerAction: {
+                  __typename: 'NavigateToBlockAction',
+                  parentBlockId: 'trigger.id',
+                  gtmEventName: 'gtmEventName',
+                  blockId: 'step3.id'
+                },
+                children: []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+
+  const droppableProvided = {
+    draggableProps: {
+      style: {}
+    },
+    innerRef: jest.fn()
+  }
+
+  const steps: Array<TreeBlock<StepBlock>> = [
+    {
+      id: 'step1.id',
+      __typename: 'StepBlock',
+      parentBlockId: null,
+      parentOrder: 0,
+      locked: false,
+      nextBlockId: 'step2.id',
+      children: [
+        {
+          id: 'card1.id',
+          __typename: 'CardBlock',
+          parentBlockId: 'step1.id',
+          coverBlockId: 'null',
+          parentOrder: 0,
+          backgroundColor: null,
+          themeMode: null,
+          themeName: null,
+          fullscreen: false,
+          children: [
+            {
+              id: 'radioQuestion1.id',
+              __typename: 'RadioQuestionBlock',
+              parentBlockId: 'card1.id',
+              parentOrder: 0,
+              children: [
+                {
+                  id: 'radioOption2.id',
+                  __typename: 'RadioOptionBlock',
+                  parentBlockId: 'radioQuestion1.id',
+                  parentOrder: 0,
+                  label: '1. Step 2 (Locked)',
+                  action: {
+                    __typename: 'NavigateToBlockAction',
+                    parentBlockId: 'radioOption2.id',
+                    gtmEventName: 'gtmEventName',
+                    blockId: 'step2.id'
+                  },
+                  children: []
+                },
+                {
+                  id: 'radioOption3.id',
+                  __typename: 'RadioOptionBlock',
+                  parentBlockId: 'radioQuestion1.id',
+                  parentOrder: 1,
+                  label: '1. Step 3 (No nextBlockId)',
+                  action: {
+                    __typename: 'NavigateToBlockAction',
+                    parentBlockId: 'radioOption3.id',
+                    gtmEventName: 'gtmEventName',
+                    blockId: 'step3.id'
+                  },
+                  children: []
+                },
+                {
+                  id: 'radioOption4.id',
+                  __typename: 'RadioOptionBlock',
+                  parentBlockId: 'radioQuestion1.id',
+                  parentOrder: 2,
+                  label: '1. Step 4 (End)',
+                  action: {
+                    __typename: 'NavigateToBlockAction',
+                    parentBlockId: 'radioOption4.id',
+                    gtmEventName: 'gtmEventName',
+                    blockId: 'step4.id'
+                  },
+                  children: []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    selected
+  ]
+
+  it('should call handleClick on addCard click', () => {
+    const handleClick = jest.fn()
+    const { getByRole } = render(
+      <MockedProvider>
+        <CardList
+          steps={steps}
+          selected={selected}
+          showAddButton={true}
+          handleClick={handleClick}
+        />
+      </MockedProvider>
+    )
+    expect(getByRole('button')).toBeInTheDocument()
+    fireEvent.click(getByRole('button'))
+    expect(handleClick).toHaveBeenCalled()
+  })
+
+  it('should render without the drag handle', () => {
+    const { queryByRole } = render(
+      <MockedProvider>
+        <CardList steps={steps} selected={selected} showAddButton={true} />
+      </MockedProvider>
+    )
+    expect(queryByRole('DragHandleRoundedIcon')).not.toBeInTheDocument()
+  })
+
+  it('should prompt users that a card is draggable', () => {
+    const { getAllByTestId } = render(
+      <MockedProvider>
+        <DragDropContext>
+          <CardList
+            steps={steps}
+            selected={selected}
+            showAddButton={true}
+            droppableProvided={droppableProvided}
+          />
+        </DragDropContext>
+      </MockedProvider>
+    )
+    const dragHandle = getAllByTestId('DragHandleRoundedIcon')
+    expect(dragHandle[0]).toHaveClass('MuiSvgIcon-root')
+  })
+})

--- a/apps/journeys-admin/src/components/CardPreview/CardList/CardList.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardList/CardList.tsx
@@ -1,0 +1,179 @@
+import { ReactElement } from 'react'
+import Box from '@mui/material/Box'
+import { BlockRenderer, TreeBlock, useJourney } from '@core/journeys/ui'
+import { ThemeProvider } from '@core/shared/ui'
+import AddIcon from '@mui/icons-material/Add'
+import Card from '@mui/material/Card'
+import CardActionArea from '@mui/material/CardActionArea'
+import DragHandleRounded from '@mui/icons-material/DragHandleRounded'
+import {
+  Draggable,
+  DroppableProvided,
+  DraggableProvided,
+  DraggableStateSnapshot
+} from 'react-beautiful-dnd'
+import { FramePortal } from '../../FramePortal'
+import { ThemeName, ThemeMode } from '../../../../__generated__/globalTypes'
+import { HorizontalSelect } from '../../HorizontalSelect'
+import { VideoWrapper } from '../../Editor/Canvas/VideoWrapper'
+import { CardWrapper } from '../../Editor/Canvas/CardWrapper'
+import { BlockFields_StepBlock as StepBlock } from '../../../../__generated__/BlockFields'
+
+interface CardListProps {
+  steps: Array<TreeBlock<StepBlock>>
+  selected?: TreeBlock<StepBlock>
+  showAddButton?: boolean
+  droppableProvided?: DroppableProvided
+  handleClick?: () => void
+  handleChange?: (selectedId: string) => void
+  isDragging?: boolean
+}
+
+export function CardList({
+  steps,
+  selected,
+  showAddButton,
+  droppableProvided,
+  handleClick,
+  handleChange,
+  isDragging
+}: CardListProps): ReactElement {
+  const AddCardSlide = (): ReactElement => (
+    <Card
+      id="CardPreviewAddButton"
+      variant="outlined"
+      sx={{
+        display: 'flex',
+        width: 87,
+        height: 132,
+        m: 1
+      }}
+    >
+      <CardActionArea
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center'
+        }}
+        onClick={handleClick}
+      >
+        <AddIcon color="primary" />
+      </CardActionArea>
+    </Card>
+  )
+  return (
+    <HorizontalSelect
+      onChange={handleChange}
+      id={selected?.id}
+      isDragging={isDragging}
+      insert={showAddButton === true && <AddCardSlide />}
+      insertPosition={steps.findIndex(({ id }) => id === selected?.id)}
+    >
+      {droppableProvided != null &&
+        steps.map((step, index) => (
+          <Draggable
+            key={step.id}
+            id={step.id}
+            draggableId={step.id}
+            index={index}
+          >
+            {(provided, snapshot) => (
+              <CardItem
+                key={step.id}
+                id={step.id}
+                provided={provided}
+                step={step}
+                snapshot={snapshot}
+              />
+            )}
+          </Draggable>
+        ))}
+      {droppableProvided == null &&
+        steps.map((step) => (
+          <CardItem key={step.id} id={step.id} step={step} />
+        ))}
+      {droppableProvided != null ? droppableProvided.placeholder : null}
+    </HorizontalSelect>
+  )
+}
+
+interface CardItemProps {
+  step: TreeBlock<StepBlock>
+  id: string
+  provided?: DraggableProvided
+  snapshot?: DraggableStateSnapshot
+}
+
+const CardItem = ({
+  step,
+  id,
+  provided,
+  snapshot
+}: CardItemProps): ReactElement => {
+  const { journey } = useJourney()
+
+  return (
+    <Box
+      ref={provided != null ? provided.innerRef : null}
+      id={id}
+      key={id}
+      data-testid={`preview-${id}`}
+      sx={{
+        width: 95,
+        height: 140,
+        position: 'relative',
+        top: provided != null ? -24 : undefined
+      }}
+      {...(provided != null ? provided.draggableProps : {})}
+    >
+      {provided != null && snapshot != null && (
+        <Box
+          {...(provided != null ? provided.dragHandleProps : {})}
+          sx={{
+            display: 'flex',
+            justifyContent: 'center'
+          }}
+        >
+          <DragHandleRounded
+            sx={{
+              opacity: snapshot.isDragging === true ? 1 : 0.5
+            }}
+          />
+        </Box>
+      )}
+      <Box
+        sx={{
+          transform: 'scale(0.25)',
+          transformOrigin: 'top left'
+        }}
+      >
+        <Box
+          sx={{
+            position: 'absolute',
+            display: 'block',
+            width: 380,
+            height: 560,
+            zIndex: 2,
+            cursor: 'pointer'
+          }}
+        />
+        <FramePortal width={380} height={560}>
+          <ThemeProvider
+            themeName={journey?.themeName ?? ThemeName.base}
+            themeMode={journey?.themeMode ?? ThemeMode.light}
+          >
+            <Box sx={{ p: 4, height: '100%' }}>
+              <BlockRenderer
+                block={step}
+                wrappers={{
+                  VideoWrapper,
+                  CardWrapper
+                }}
+              />
+            </Box>
+          </ThemeProvider>
+        </FramePortal>
+      </Box>
+    </Box>
+  )
+}

--- a/apps/journeys-admin/src/components/CardPreview/CardList/index.ts
+++ b/apps/journeys-admin/src/components/CardPreview/CardList/index.ts
@@ -1,0 +1,1 @@
+export { CardList } from './CardList'

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
@@ -2,6 +2,7 @@ import { Story, Meta } from '@storybook/react'
 import { useState } from 'react'
 import { TreeBlock, JourneyProvider } from '@core/journeys/ui'
 import { MockedProvider } from '@apollo/client/testing'
+import { DragDropContext } from 'react-beautiful-dnd'
 import {
   GetJourney_journey_blocks_StepBlock as StepBlock,
   GetJourney_journey as Journey
@@ -669,12 +670,15 @@ const Template: Story = ({ ...args }) => {
           admin: true
         }}
       >
-        <CardPreview
-          onSelect={(step) => setSelectedStep(step)}
-          selected={selected}
-          steps={args.steps}
-          showAddButton={args.showAddButton}
-        />
+        <DragDropContext>
+          <CardPreview
+            onSelect={(step) => setSelectedStep(step)}
+            selected={selected}
+            steps={args.steps}
+            showAddButton={args.showAddButton}
+            isDraggable
+          />
+        </DragDropContext>
       </JourneyProvider>
     </MockedProvider>
   )

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
@@ -1,34 +1,28 @@
 import Box from '@mui/material/Box'
-import { ReactElement } from 'react'
+import { ReactElement, useState } from 'react'
 import {
-  BlockRenderer,
   CARD_FIELDS,
   STEP_FIELDS,
   TreeBlock,
   transformer,
   useJourney
 } from '@core/journeys/ui'
-import { ThemeProvider } from '@core/shared/ui'
-import AddIcon from '@mui/icons-material/Add'
-import Card from '@mui/material/Card'
-import CardActionArea from '@mui/material/CardActionArea'
 import Skeleton from '@mui/material/Skeleton'
 import Stack from '@mui/material/Stack'
 import { v4 as uuidv4 } from 'uuid'
 import { useMutation, gql } from '@apollo/client'
-import { ThemeName, ThemeMode } from '../../../__generated__/globalTypes'
+import { DragDropContext, Droppable } from 'react-beautiful-dnd'
+import { StepsOrderUpdate } from '../../../__generated__/StepsOrderUpdate'
 import { StepAndCardBlockCreate } from '../../../__generated__/StepAndCardBlockCreate'
-import { FramePortal } from '../FramePortal'
 import { GetJourney_journey_blocks_StepBlock as StepBlock } from '../../../__generated__/GetJourney'
-import { HorizontalSelect } from '../HorizontalSelect'
-import { VideoWrapper } from '../Editor/Canvas/VideoWrapper'
-import { CardWrapper } from '../Editor/Canvas/CardWrapper'
+import { CardList } from './CardList'
 
 export interface CardPreviewProps {
   onSelect?: (step: TreeBlock<StepBlock>) => void
   selected?: TreeBlock<StepBlock>
   steps?: Array<TreeBlock<StepBlock>>
   showAddButton?: boolean
+  isDraggable?: boolean
 }
 
 export const STEP_AND_CARD_BLOCK_CREATE = gql`
@@ -53,15 +47,31 @@ export const STEP_AND_CARD_BLOCK_CREATE = gql`
   }
 `
 
+export const STEPS_ORDER_UPDATE = gql`
+  mutation StepsOrderUpdate($id: ID!, $journeyId: ID!, $parentOrder: Int!) {
+    blockOrderUpdate(
+      id: $id
+      journeyId: $journeyId
+      parentOrder: $parentOrder
+    ) {
+      id
+      parentOrder
+    }
+  }
+`
+
 export function CardPreview({
   steps,
   selected,
   onSelect,
-  showAddButton
+  showAddButton,
+  isDraggable
 }: CardPreviewProps): ReactElement {
+  const [isDragging, setIsDragging] = useState(false)
   const [stepAndCardBlockCreate] = useMutation<StepAndCardBlockCreate>(
     STEP_AND_CARD_BLOCK_CREATE
   )
+  const [stepsOrderUpdate] = useMutation<StepsOrderUpdate>(STEPS_ORDER_UPDATE)
   const { journey } = useJourney()
 
   const handleChange = (selectedId: string): void => {
@@ -157,74 +167,80 @@ export function CardPreview({
     }
   }
 
-  const AddCardSlide = (): ReactElement => (
-    <Card
-      id="CardPreviewAddButton"
-      variant="outlined"
-      sx={{
-        display: 'flex',
-        width: 87,
-        height: 132,
-        m: 1
-      }}
-    >
-      <CardActionArea
-        sx={{
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center'
-        }}
-        onClick={handleClick}
-      >
-        <AddIcon color="primary" />
-      </CardActionArea>
-    </Card>
-  )
+  const onBeforeCapture = (): void => {
+    setIsDragging(true)
+  }
+
+  const onDragEnd = async ({ destination, source }): Promise<void> => {
+    setIsDragging(false)
+    if (steps == null) return
+    if (journey == null) return
+    if (destination == null) return
+
+    const cardDragging = steps[source.index]
+    const destIndex: number = destination.index
+
+    if (
+      destination.droppableId === source.droppableId &&
+      destIndex === source.index
+    )
+      return
+
+    if (cardDragging.parentOrder != null) {
+      const parentOrder = cardDragging.parentOrder + destIndex - source.index
+
+      await stepsOrderUpdate({
+        variables: {
+          id: cardDragging.id,
+          journeyId: journey.id,
+          parentOrder
+        },
+        optimisticResponse: {
+          blockOrderUpdate: [
+            {
+              __typename: 'StepBlock',
+              id: cardDragging.id,
+              parentOrder
+            }
+          ]
+        }
+      })
+    }
+  }
+
   return (
     <>
       {steps != null ? (
-        <HorizontalSelect
-          onChange={handleChange}
-          id={selected?.id}
-          insert={showAddButton === true && <AddCardSlide />}
-          insertPosition={steps.findIndex(({ id }) => id === selected?.id)}
-        >
-          {steps.map((step) => (
-            <Box
-              id={step.id}
-              key={step.id}
-              data-testid={`preview-${step.id}`}
-              sx={{
-                width: 95,
-                height: 140
-              }}
-            >
-              <Box
-                sx={{
-                  transform: 'scale(0.25)',
-                  transformOrigin: 'top left'
-                }}
-              >
-                <FramePortal width={380} height={560}>
-                  <ThemeProvider
-                    themeName={journey?.themeName ?? ThemeName.base}
-                    themeMode={journey?.themeMode ?? ThemeMode.light}
-                  >
-                    <Box sx={{ p: 4, height: '100%' }}>
-                      <BlockRenderer
-                        block={step}
-                        wrappers={{
-                          VideoWrapper,
-                          CardWrapper
-                        }}
-                      />
-                    </Box>
-                  </ThemeProvider>
-                </FramePortal>
-              </Box>
-            </Box>
-          ))}
-        </HorizontalSelect>
+        isDraggable === true ? (
+          <DragDropContext
+            onBeforeCapture={onBeforeCapture}
+            onDragEnd={onDragEnd}
+          >
+            <Droppable droppableId="steps" direction="horizontal">
+              {(provided) => (
+                <Box ref={provided.innerRef} {...provided.droppableProps}>
+                  <CardList
+                    steps={steps}
+                    selected={selected}
+                    showAddButton={showAddButton}
+                    droppableProvided={provided}
+                    handleClick={handleClick}
+                    handleChange={handleChange}
+                    isDragging={isDragging}
+                  />
+                </Box>
+              )}
+            </Droppable>
+          </DragDropContext>
+        ) : (
+          <CardList
+            steps={steps}
+            selected={selected}
+            handleClick={handleClick}
+            handleChange={handleChange}
+            showAddButton={showAddButton}
+          />
+        )
       ) : (
         <Stack
           direction="row"

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.tsx
@@ -79,6 +79,7 @@ export function ControlPanel(): ReactElement {
           onSelect={handleSelectStepPreview}
           steps={steps}
           showAddButton
+          isDraggable
         />
       </TabPanel>
       <TabPanel name="control-panel" value={activeTab} index={1}>

--- a/apps/journeys-admin/src/components/HorizontalSelect/HorizontalSelect.tsx
+++ b/apps/journeys-admin/src/components/HorizontalSelect/HorizontalSelect.tsx
@@ -17,6 +17,7 @@ export interface HorizontalSelectProps {
   children: ReactNode
   sx?: SxProps<Theme>
   footer?: ReactNode
+  isDragging?: boolean
   insert?: ReactNode
   insertPosition?: number
 }
@@ -27,6 +28,7 @@ export function HorizontalSelect({
   onChange,
   sx,
   footer,
+  isDragging,
   insert,
   insertPosition
 }: HorizontalSelectProps): ReactElement {
@@ -63,7 +65,7 @@ export function HorizontalSelect({
                 transition: '0.2s border-color ease-out',
                 position: 'relative',
                 outline: (theme) =>
-                  id === child.props.id
+                  id === child.props.id && isDragging !== true
                     ? `2px solid ${theme.palette.primary.main} `
                     : '2px solid transparent',
                 border: '3px solid transparent',
@@ -73,7 +75,6 @@ export function HorizontalSelect({
             >
               <Box
                 sx={{
-                  position: 'absolute',
                   top: 0,
                   right: 0,
                   bottom: 0,
@@ -85,7 +86,11 @@ export function HorizontalSelect({
             </Box>
           )
         }
-        if (insertPosition === index && isValidElement(insert)) {
+        if (
+          insertPosition === index &&
+          isDragging !== true &&
+          isValidElement(insert)
+        ) {
           result.push(
             <Box
               sx={{

--- a/apps/journeys-admin/src/components/JourneyView/CardView/CardView.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/CardView/CardView.tsx
@@ -35,7 +35,12 @@ export function CardView({ slug, blocks }: CardViewProps): ReactElement {
 
   return (
     <>
-      <CardPreview onSelect={handleSelect} steps={blocks} showAddButton />
+      <CardPreview
+        onSelect={handleSelect}
+        steps={blocks}
+        showAddButton
+        isDraggable={false}
+      />
       <Box sx={{ pt: 2, display: 'flex', justifyContent: 'center' }}>
         <Typography variant="body1">
           {blocks != null ? (

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "next-seo": "^5.0.0",
         "notistack": "^2.0.3",
         "react": "17.0.2",
+        "react-beautiful-dnd": "^13.1.0",
         "react-colorful": "^5.5.1",
         "react-div-100vh": "^0.6.0",
         "react-dom": "17.0.2",
@@ -19078,6 +19079,17 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.24",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.24.tgz",
+      "integrity": "sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
+      }
+    },
     "node_modules/@types/react-router": {
       "version": "5.1.17",
       "dev": true,
@@ -25233,6 +25245,14 @@
         "inherits": "^2.0.4",
         "source-map": "^0.6.1",
         "source-map-resolve": "^0.6.0"
+      }
+    },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "node_modules/css-declaration-sorter": {
@@ -36199,6 +36219,11 @@
         "@octokit/rest": "^16.43.0 || ^17.11.0 || ^18.12.0"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
     "node_modules/memoizerific": {
       "version": "1.11.3",
       "dev": true,
@@ -40469,6 +40494,11 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
+    },
     "node_modules/ramda": {
       "version": "0.27.1",
       "license": "MIT"
@@ -40607,6 +40637,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-beautiful-dnd": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.0.tgz",
+      "integrity": "sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2",
+        "css-box-model": "^1.2.0",
+        "memoize-one": "^5.1.1",
+        "raf-schd": "^4.0.2",
+        "react-redux": "^7.2.0",
+        "redux": "^4.0.4",
+        "use-memo-one": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.5 || ^17.0.0",
+        "react-dom": "^16.8.5 || ^17.0.0"
       }
     },
     "node_modules/react-colorful": {
@@ -40872,6 +40920,30 @@
       "version": "3.2.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "7.2.8",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.8.tgz",
+      "integrity": "sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.10.0",
@@ -41320,6 +41392,14 @@
       "license": "MIT",
       "dependencies": {
         "esprima": "~4.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/reflect-metadata": {
@@ -46698,6 +46778,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-memo-one": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
+      "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -61411,6 +61499,17 @@
         "@types/react": "*"
       }
     },
+    "@types/react-redux": {
+      "version": "7.1.24",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.24.tgz",
+      "integrity": "sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
+      }
+    },
     "@types/react-router": {
       "version": "5.1.17",
       "dev": true,
@@ -65729,6 +65828,14 @@
           "version": "0.6.1",
           "dev": true
         }
+      }
+    },
+    "css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "requires": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "css-declaration-sorter": {
@@ -73220,6 +73327,11 @@
         "@octokit/rest": "^16.43.0 || ^17.11.0 || ^18.12.0"
       }
     },
+    "memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
     "memoizerific": {
       "version": "1.11.3",
       "dev": true,
@@ -75989,6 +76101,11 @@
         }
       }
     },
+    "raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
+    },
     "ramda": {
       "version": "0.27.1"
     },
@@ -76078,6 +76195,20 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
+      }
+    },
+    "react-beautiful-dnd": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.0.tgz",
+      "integrity": "sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==",
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "css-box-model": "^1.2.0",
+        "memoize-one": "^5.1.1",
+        "raf-schd": "^4.0.2",
+        "react-redux": "^7.2.0",
+        "redux": "^4.0.4",
+        "use-memo-one": "^1.1.1"
       }
     },
     "react-colorful": {
@@ -76254,6 +76385,19 @@
         "@babel/runtime": "^7.12.5",
         "@popperjs/core": "^2.5.4",
         "react-popper": "^2.2.4"
+      }
+    },
+    "react-redux": {
+      "version": "7.2.8",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.8.tgz",
+      "integrity": "sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
       }
     },
     "react-refresh": {
@@ -76567,6 +76711,14 @@
       "dev": true,
       "requires": {
         "esprima": "~4.0.0"
+      }
+    },
+    "redux": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "reflect-metadata": {
@@ -80105,6 +80257,12 @@
       "requires": {
         "use-isomorphic-layout-effect": "^1.0.0"
       }
+    },
+    "use-memo-one": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
+      "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==",
+      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2"

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "next-seo": "^5.0.0",
     "notistack": "^2.0.3",
     "react": "17.0.2",
+    "react-beautiful-dnd": "^13.1.0",
     "react-colorful": "^5.5.1",
     "react-div-100vh": "^0.6.0",
     "react-dom": "17.0.2",


### PR DESCRIPTION
# Description

**Depends on #698 #695 and the upcoming Move API and conductor changes**

Enables user to drag and drop their cards within CardPreview. This gives the users the ability to reorder the cards within their journey

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/27930061/todos/5008117987)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Users should be able to drag and drop cards under CardPreview and reorder the cards to their desired place
- [ ] Reordered cards should work as expected in their journeys

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
