### PR TITLE
fix: only check branch name on pr

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,7 @@ jobs:
       - name: lint commit messages
         run: npx commitlint --from 5364963 # earliest good commit to main
       - name: lint branch name
+        if: ${{ github.event_name == 'pull_request' }}
         run: npx validate-branch-name -t $GITHUB_HEAD_REF
       - name: Check for file changes due to codegen
         run: ./tools/scripts/check-git-status.sh


### PR DESCRIPTION
# Description

github action should only check branch name when in a PR. This check is not necessary on main branch.

![Screen Shot 2022-06-27 at 3 13 33 PM](https://user-images.githubusercontent.com/802117/175853133-bfa62e0c-2cf2-4213-85c9-476e41c33528.png)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
