### PR TITLE
fix: prevent card tab switching

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.spec.tsx
@@ -69,7 +69,7 @@ describe('ControlPanel', () => {
     ]
   }
 
-  it('should render the element', () => {
+  it('should render tabs and tab panels', () => {
     const { getByTestId, getByText, getByRole } = render(
       <MockedProvider>
         <JourneyProvider
@@ -88,14 +88,18 @@ describe('ControlPanel', () => {
         </JourneyProvider>
       </MockedProvider>
     )
+    // Default start on Cards
     expect(getByRole('tabpanel', { name: 'Cards' })).toBeInTheDocument()
-    fireEvent.click(getByTestId('preview-step1.id'))
+    fireEvent.click(getByRole('tab', { name: 'Properties' }))
     expect(getByRole('tabpanel', { name: 'Properties' })).toBeInTheDocument()
-    expect(getByRole('tab', { name: 'Properties' })).not.toBeDisabled()
     expect(getByText('Unlocked Card')).toBeInTheDocument()
     fireEvent.click(getByRole('tab', { name: 'Cards' }))
+    expect(getByRole('tabpanel', { name: 'Cards' })).toBeInTheDocument()
     fireEvent.click(getByTestId('preview-step2.id'))
     expect(getByText('Locked With Interaction')).toBeInTheDocument()
+    fireEvent.click(getByRole('tab', { name: 'Blocks' }))
+    expect(getByRole('tabpanel', { name: 'Blocks' })).toBeInTheDocument()
+    expect(getByRole('button', { name: 'Text' }))
   })
 
   it('should hide add button when clicking blocks tab', async () => {
@@ -117,9 +121,7 @@ describe('ControlPanel', () => {
         </JourneyProvider>
       </MockedProvider>
     )
-    expect(getByRole('tabpanel', { name: 'Cards' })).toBeInTheDocument()
     fireEvent.click(getByRole('tab', { name: 'Blocks' }))
-    expect(getByRole('tabpanel', { name: 'Blocks' })).toBeInTheDocument()
     await waitFor(() =>
       expect(queryByRole('button', { name: 'Add' })).not.toBeInTheDocument()
     )
@@ -144,7 +146,6 @@ describe('ControlPanel', () => {
         </JourneyProvider>
       </MockedProvider>
     )
-    expect(getByRole('tabpanel', { name: 'Cards' })).toBeInTheDocument()
     fireEvent.click(getByRole('button', { name: 'Add' }))
     expect(getByRole('tabpanel', { name: 'Blocks' })).toBeInTheDocument()
     // TODO: Flakey expectation passes locally, fails remotely
@@ -202,9 +203,7 @@ describe('ControlPanel', () => {
         </JourneyProvider>
       </MockedProvider>
     )
-    expect(getByRole('tab', { name: 'Cards' })).toBeInTheDocument()
     fireEvent.click(getByTestId('preview-step3.id'))
-    expect(getByRole('tabpanel', { name: 'Properties' })).toBeInTheDocument()
     fireEvent.click(getByRole('button', { name: 'Add' }))
     expect(getByRole('tabpanel', { name: 'Blocks' })).toBeInTheDocument()
     fireEvent.click(getByRole('button', { name: 'Text' }))
@@ -294,9 +293,7 @@ describe('ControlPanel', () => {
         </JourneyProvider>
       </MockedProvider>
     )
-    expect(getByRole('tab', { name: 'Cards' })).toBeInTheDocument()
     fireEvent.click(getByTestId('preview-step3.id'))
-    expect(getByRole('tabpanel', { name: 'Properties' })).toBeInTheDocument()
     fireEvent.click(getByRole('button', { name: 'Add' }))
     expect(getByRole('tabpanel', { name: 'Blocks' })).toBeInTheDocument()
     fireEvent.click(getByRole('button', { name: 'Subscribe' }))
@@ -449,9 +446,7 @@ describe('ControlPanel', () => {
         </JourneyProvider>
       </MockedProvider>
     )
-    expect(getByRole('tab', { name: 'Cards' })).toBeInTheDocument()
     fireEvent.click(getByTestId('preview-step3.id'))
-    expect(getByRole('tabpanel', { name: 'Properties' })).toBeInTheDocument()
     fireEvent.click(getByRole('button', { name: 'Add' }))
     expect(getByRole('tabpanel', { name: 'Blocks' })).toBeInTheDocument()
     fireEvent.click(getByRole('button', { name: 'Poll' }))
@@ -514,9 +509,7 @@ describe('ControlPanel', () => {
         </JourneyProvider>
       </MockedProvider>
     )
-    expect(getByRole('tab', { name: 'Cards' })).toBeInTheDocument()
     fireEvent.click(getByTestId('preview-step3.id'))
-    expect(getByRole('tabpanel', { name: 'Properties' })).toBeInTheDocument()
     fireEvent.click(getByRole('button', { name: 'Add' }))
     expect(getByRole('tabpanel', { name: 'Blocks' })).toBeInTheDocument()
     fireEvent.click(getByRole('button', { name: 'Image' }))
@@ -582,9 +575,7 @@ describe('ControlPanel', () => {
         </JourneyProvider>
       </MockedProvider>
     )
-    expect(getByRole('tab', { name: 'Cards' })).toBeInTheDocument()
     fireEvent.click(getByTestId('preview-step3.id'))
-    expect(getByRole('tabpanel', { name: 'Properties' })).toBeInTheDocument()
     fireEvent.click(getByRole('button', { name: 'Add' }))
     expect(getByRole('tabpanel', { name: 'Blocks' })).toBeInTheDocument()
     fireEvent.click(getByRole('button', { name: 'Video' }))
@@ -692,9 +683,7 @@ describe('ControlPanel', () => {
         </JourneyProvider>
       </MockedProvider>
     )
-    expect(getByRole('tab', { name: 'Cards' })).toBeInTheDocument()
     fireEvent.click(getByTestId('preview-step3.id'))
-    expect(getByRole('tabpanel', { name: 'Properties' })).toBeInTheDocument()
     fireEvent.click(getByRole('button', { name: 'Add' }))
     expect(getByRole('tabpanel', { name: 'Blocks' })).toBeInTheDocument()
     fireEvent.click(getByRole('button', { name: 'Button' }))

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.tsx
@@ -31,7 +31,6 @@ export function ControlPanel(): ReactElement {
   const handleSelectStepPreview = (step: TreeBlock<StepBlock>): void => {
     dispatch({ type: 'SetSelectedStepAction', step })
     dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Add })
-    dispatch({ type: 'SetActiveTabAction', activeTab: ActiveTab.Properties })
   }
 
   const handleAddFabClick = (): void => {


### PR DESCRIPTION
# Description

Removed the dispatch to change tab when selecting a card.

[Basecamp](https://3.basecamp.com/3105655/buckets/28141725/todos/5056136130)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Click another card in the control panel, it should select the card but the control panel should stay on "Cards"

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
