### PR TITLE
fix: allow dependabot branch name

### DIFF
--- a/validate-branch-name.config.js
+++ b/validate-branch-name.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   pattern:
-    '^[0-9]{2}-[0-9]{2}-[A-Z]{2}-(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)-[a-z0-9-]+[a-z0-9]$',
+    '^(dependabot/.*)|([0-9]{2}-[0-9]{2}-[A-Z]{2}-(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)-[a-z0-9-]+[a-z0-9])$',
   errorMsg:
     'Your branch does not match the naming convention (https://github.com/JesusFilm/core/wiki/Repository-Best-Practice#naming-your-branch)'
 }


### PR DESCRIPTION
allow @dependabot branch names like dependabot/npm_and_yarn/sharp-0.30.7