### PR TITLE
fix: journey button to go to id instead of slug

### DIFF
--- a/apps/journeys-admin/src/components/JourneyList/AddJourneyButton/AddJourneyButton.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/AddJourneyButton/AddJourneyButton.spec.tsx
@@ -133,7 +133,7 @@ describe('AddJourneyButton', () => {
     ])
     await waitFor(() =>
       expect(push).toHaveBeenCalledWith(
-        `/journeys/${resultData.journeyCreate.slug}/edit`,
+        `/journeys/${resultData.journeyCreate.id}/edit`,
         undefined,
         { shallow: true }
       )
@@ -196,7 +196,7 @@ describe('AddJourneyButton', () => {
     ])
     await waitFor(() =>
       expect(push).toHaveBeenCalledWith(
-        `/journeys/${resultData.journeyCreate.slug}/edit`,
+        `/journeys/${resultData.journeyCreate.id}/edit`,
         undefined,
         { shallow: true }
       )

--- a/apps/journeys-admin/src/components/JourneyList/AddJourneyButton/AddJourneyButton.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/AddJourneyButton/AddJourneyButton.tsx
@@ -163,7 +163,7 @@ export function AddJourneyButton({
       }
     })
     if (data?.journeyCreate != null) {
-      void router.push(`/journeys/${data.journeyCreate.slug}/edit`, undefined, {
+      void router.push(`/journeys/${data.journeyCreate.id}/edit`, undefined, {
         shallow: true
       })
     }


### PR DESCRIPTION
# Description

This was a bug introduced with https://github.com/JesusFilm/core/pull/725. The add button was routing users to the journeys/[slug]/edit route which has since been updated to journeys/[id]/edit. This PR fixes that!

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] clicking on journey add button should create the journey then navigate to the edit page

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
