### PR TITLE
fix: add css to head tag on ssr

### DIFF
--- a/apps/journeys-admin/pages/_document.tsx
+++ b/apps/journeys-admin/pages/_document.tsx
@@ -35,6 +35,8 @@ export default class MyDocument extends Document<{
             href="/favicon-16x16.png"
           />
           <link rel="manifest" href="/site.webmanifest" />
+          {/* Inject MUI styles first to match with the prepend: true configuration. */}
+          {this.props.emotionStyleTags}
         </Head>
         <body>
           <Main />

--- a/apps/watch-admin/pages/_document.tsx
+++ b/apps/watch-admin/pages/_document.tsx
@@ -5,7 +5,9 @@ import type { EmotionCache } from '@emotion/cache'
 import type { Enhancer, AppType } from 'next/dist/shared/lib/utils'
 import { createEmotionCache } from '@core/shared/ui/createEmotionCache'
 
-export default class MyDocument extends Document {
+export default class MyDocument extends Document<{
+  emotionStyleTags: ReactElement[]
+}> {
   render(): ReactElement {
     return (
       <Html lang="en">
@@ -28,6 +30,8 @@ export default class MyDocument extends Document {
             href="/favicon-16x16.png"
           />
           <link rel="manifest" href="/site.webmanifest" />
+          {/* Inject MUI styles first to match with the prepend: true configuration. */}
+          {this.props.emotionStyleTags}
         </Head>
         <body>
           <Main />

--- a/apps/watch/pages/_document.tsx
+++ b/apps/watch/pages/_document.tsx
@@ -5,7 +5,9 @@ import type { EmotionCache } from '@emotion/cache'
 import type { Enhancer, AppType } from 'next/dist/shared/lib/utils'
 import { createEmotionCache } from '@core/shared/ui/createEmotionCache'
 
-export default class MyDocument extends Document {
+export default class MyDocument extends Document<{
+  emotionStyleTags: ReactElement[]
+}> {
   render(): ReactElement {
     return (
       <Html lang="en">
@@ -28,6 +30,8 @@ export default class MyDocument extends Document {
             href="/favicon-16x16.png"
           />
           <link rel="manifest" href="/site.webmanifest" />
+          {/* Inject MUI styles first to match with the prepend: true configuration. */}
+          {this.props.emotionStyleTags}
         </Head>
         <body style={{ margin: 0 }}>
           <Main />


### PR DESCRIPTION
# Description

Sever-side Rendering was not injecting the emotion style tags. This was resulting in a flash of unstyled elements that were visible to the user before hydrating the page.

The reference code was provided by [material UI](https://github.com/mui/material-ui/blob/931facf2684f952b31d8c8ae163219a738260401/examples/nextjs-with-typescript/pages/_document.tsx#L20).

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] loading a page should not result in a flash of unstyled content

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
