### PR TITLE
fix: remove apollo client cache ssr

### DIFF
--- a/apps/journeys/pages/[journeySlug].tsx
+++ b/apps/journeys/pages/[journeySlug].tsx
@@ -8,7 +8,7 @@ import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { NextSeo } from 'next-seo'
 import { Conductor } from '../src/components/Conductor'
-import { apolloClient } from '../src/libs/apolloClient'
+import { createApolloClient } from '../src/libs/apolloClient'
 import {
   GetJourney,
   GetJourney_journey as Journey
@@ -76,6 +76,7 @@ function JourneyPage({ journey }: JourneyPageProps): ReactElement {
 export const getStaticProps: GetStaticProps<JourneyPageProps> = async (
   context
 ) => {
+  const apolloClient = createApolloClient()
   const { data } = await apolloClient.query<GetJourney>({
     query: gql`
       ${JOURNEY_FIELDS}
@@ -118,6 +119,7 @@ export const getStaticProps: GetStaticProps<JourneyPageProps> = async (
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {
+  const apolloClient = createApolloClient()
   const { data } = await apolloClient.query<GetJourneySlugs>({
     query: gql`
       query GetJourneySlugs {

--- a/apps/journeys/pages/_app.tsx
+++ b/apps/journeys/pages/_app.tsx
@@ -12,7 +12,7 @@ import { SnackbarProvider } from 'notistack'
 import { getAuth, onAuthStateChanged } from 'firebase/auth'
 import { appWithTranslation } from 'next-i18next'
 import { useTranslation } from 'react-i18next'
-import { apolloClient } from '../src/libs/apolloClient'
+import { useApollo } from '../src/libs/apolloClient'
 import { firebaseClient } from '../src/libs/firebaseClient'
 import i18nConfig from '../next-i18next.config'
 
@@ -63,6 +63,7 @@ function JourneysApp({
       }
     })
   }, [])
+  const apolloClient = useApollo()
 
   return (
     <CacheProvider value={emotionCache}>

--- a/apps/journeys/pages/index.tsx
+++ b/apps/journeys/pages/index.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link'
 import { GetStaticProps } from 'next'
 import { gql } from '@apollo/client'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import { apolloClient } from '../src/libs/apolloClient'
+import { createApolloClient } from '../src/libs/apolloClient'
 import {
   GetJourneys,
   GetJourneys_journeys as Journey
@@ -40,6 +40,7 @@ function JourneysPage({ journeys }: JourneysPageProps): ReactElement {
 export const getStaticProps: GetStaticProps<JourneysPageProps> = async (
   context
 ) => {
+  const apolloClient = createApolloClient()
   const { data } = await apolloClient.query<GetJourneys>({
     query: gql`
       query GetJourneys {

--- a/apps/journeys/project.json
+++ b/apps/journeys/project.json
@@ -43,7 +43,7 @@
       },
       "configurations": {
         "production": {
-          "buildTarget": "journeys:build:production",
+          "buildTarget": "journeys:_build:production",
           "dev": false
         }
       }

--- a/apps/journeys/src/libs/apolloClient/apolloClient.ts
+++ b/apps/journeys/src/libs/apolloClient/apolloClient.ts
@@ -1,6 +1,11 @@
-import { ApolloClient, createHttpLink } from '@apollo/client'
+import {
+  ApolloClient,
+  createHttpLink,
+  NormalizedCacheObject
+} from '@apollo/client'
 import { setContext } from '@apollo/client/link/context'
 import { getAuth, signInAnonymously } from 'firebase/auth'
+import { useMemo } from 'react'
 import { firebaseClient } from '../firebaseClient'
 import { cache } from './cache'
 
@@ -21,7 +26,14 @@ const authLink = setContext(async (_, { headers }) => {
   }
 })
 
-export const apolloClient = new ApolloClient({
-  link: typeof window === 'undefined' ? httpLink : authLink.concat(httpLink),
-  cache: cache()
-})
+export function createApolloClient(): ApolloClient<NormalizedCacheObject> {
+  return new ApolloClient({
+    ssrMode: typeof window === 'undefined',
+    link: typeof window === 'undefined' ? httpLink : authLink.concat(httpLink),
+    cache: cache()
+  })
+}
+
+export function useApollo(): ApolloClient<NormalizedCacheObject> {
+  return useMemo(() => createApolloClient(), [])
+}

--- a/apps/journeys/src/libs/apolloClient/index.ts
+++ b/apps/journeys/src/libs/apolloClient/index.ts
@@ -1,1 +1,1 @@
-export { apolloClient } from './apolloClient'
+export { useApollo, createApolloClient } from './apolloClient'


### PR DESCRIPTION
# Description

This should fix revalidating pages (clicking the preview button). The issue is that the SSR functions were using a shared apollo cache. This make is so that all journeys project usage of graphql is fresh on every SSR invocation.'

The changes in journeys mimics the apollo client in journeys-admin.

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Deploy this branch on stage. Go to journeys-admin on stage. Go to a journey. Make a change. Then click preview. Changes should be immediately apparent.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
