### PR TITLE
chore: use env for journeys url on journeys-admin

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.tsx
@@ -44,7 +44,10 @@ export function SocialShareAppearance(): ReactElement {
               disabled={journey == null || !isPublished}
               href={
                 journey?.slug != null
-                  ? `https://www.facebook.com/sharer/sharer.php?u=https://your.nextstep.is/${journey.slug}`
+                  ? `https://www.facebook.com/sharer/sharer.php?u=${
+                      process.env.NEXT_PUBLIC_JOURNEYS_URL ??
+                      'https://your.nextstep.is'
+                    }/${journey.slug}`
                   : ''
               }
               target="_blank"
@@ -71,7 +74,10 @@ export function SocialShareAppearance(): ReactElement {
               disabled={journey == null || !isPublished}
               href={
                 journey?.slug != null
-                  ? `https://twitter.com/intent/tweet?url=https://your.nextstep.is/${journey.slug}`
+                  ? `https://twitter.com/intent/tweet?url=${
+                      process.env.NEXT_PUBLIC_JOURNEYS_URL ??
+                      'https://your.nextstep.is'
+                    }/${journey.slug}`
                   : ''
               }
               target="_blank"

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
@@ -91,7 +91,9 @@ export function Menu({ forceOpen }: MenuProps): ReactElement {
     if (journey == null) return
 
     await navigator.clipboard.writeText(
-      `https://your.nextstep.is/${journey.slug}`
+      `${process.env.NEXT_PUBLIC_JOURNEYS_URL ?? 'https://your.nextstep.is'}/${
+        journey.slug
+      }`
     )
     setAnchorEl(null)
     enqueueSnackbar('Link Copied', {

--- a/apps/journeys-admin/src/components/JourneyView/Properties/Properties.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Properties/Properties.tsx
@@ -59,7 +59,10 @@ export function Properties(): ReactElement {
             <CopyTextField
               value={
                 journey?.slug != null
-                  ? `https://your.nextstep.is/${journey.slug}`
+                  ? `${
+                      process.env.NEXT_PUBLIC_JOURNEYS_URL ??
+                      'https://your.nextstep.is'
+                    }/${journey.slug}`
                   : undefined
               }
             />
@@ -102,7 +105,10 @@ export function Properties(): ReactElement {
           <CopyTextField
             value={
               journey?.slug != null
-                ? `https://your.nextstep.is/${journey.slug}`
+                ? `${
+                    process.env.NEXT_PUBLIC_JOURNEYS_URL ??
+                    'https://your.nextstep.is'
+                  }/${journey.slug}`
                 : undefined
             }
             label={t('Journey URL')}


### PR DESCRIPTION
# Description

Instead of hardcoding https://your.nextstep.is this PR checks NEXT_PUBLIC_JOURNEYS_URL env first. This should allow staging environments to show staging links to journeys instead.

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] FB button, social share appearance on admin. should link to your-stage.nextstep.is
- [x] Twitter button, social share appearance on admin. should link to your-stage.nextstep.is
- [x] journey view three dot menu should copy link to clipboard with your-stage.nextstep.is as base url
- [x] journey view copy link text field should show link with your-stage.nextstep.is as base URL on mobile
- [x] journey view copy link text field should show link with your-stage.nextstep.is as base URL on desktop

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
