### PR TITLE
fix: duplicate journey title, find difference between titles

### DIFF
--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -602,10 +602,6 @@ describe('JourneyResolver', () => {
           ...journey,
           title: `${journey.title} copy 2`
         },
-        {
-          ...journey,
-          title: `${journey.title} copy 4`
-        },
         // Unique journeys with same base title - returns 0
         {
           ...journey,
@@ -629,7 +625,26 @@ describe('JourneyResolver', () => {
         array,
         journey.title
       )
-      expect(duplicateNumbers).toEqual([0, 1, 2, 4, 0, 0, 0, 1])
+      expect(duplicateNumbers).toEqual([0, 1, 2, 0, 0, 0, 1])
+      const arrayCopy = [
+        {
+          ...journey,
+          title: `journey copy`
+        },
+        {
+          ...journey,
+          title: `journey copy copy`
+        },
+        {
+          ...journey,
+          title: `journey copy copy 2`
+        }
+      ]
+      const duplicateNumbersCopy = resolver.getJourneyDuplicateNumbers(
+        arrayCopy,
+        'journey copy'
+      )
+      expect(duplicateNumbersCopy).toEqual([0, 1, 2])
     })
   })
 

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -633,6 +633,10 @@ describe('JourneyResolver', () => {
         },
         {
           ...journey,
+          title: `journey copy 1`
+        },
+        {
+          ...journey,
           title: `journey copy copy`
         },
         {
@@ -644,7 +648,7 @@ describe('JourneyResolver', () => {
         arrayCopy,
         'journey copy'
       )
-      expect(duplicateNumbersCopy).toEqual([0, 1, 2])
+      expect(duplicateNumbersCopy).toEqual([0, 0, 1, 2])
     })
   })
 

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -201,13 +201,14 @@ export class JourneyResolver {
     @Args('title') title: string
   ): number[] {
     return journeys.map((journey, i) => {
-      const splitTitle = journey.title.split(' copy')
-      if (journey.title === title || splitTitle.length > 2) {
+      if (journey.title === title) {
         return 0
       } else if (journey.title === `${title} copy`) {
         return 1
       } else {
-        const duplicate = splitTitle[splitTitle.length - 1]?.trim() ?? ''
+        // Find the difference between duplicated journey and journey in list titles, remove the "copy" to find duplicate number
+        const modifier = journey.title.split(title)[1]?.split(' copy')
+        const duplicate = modifier[1]?.trim() ?? ''
         const numbers = duplicate.match(/^\d+$/)
         // If no duplicate number found, it's a unique journey. Return 0
         return numbers != null ? parseInt(numbers[0]) : 0


### PR DESCRIPTION
# Description

Previously duplicating "Journey copy" would result in ""Journey copy copy" , "Journey copy copy" ... aka it wouldn't increment if the title ended with "copy" this PR fixes that.

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Use journeys-admin vercel [link](https://journeys-admin-git-22-05-jg-feat-duplicate-jou-22c866-jesusfilm.vercel.app/) to check duplicating "Journey copy" multiple times correctly increments the title

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
