### PR TITLE
fix: firefox cardlist margin

### DIFF
--- a/apps/journeys-admin/src/components/CardPreview/CardList/CardList.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardList/CardList.tsx
@@ -123,7 +123,8 @@ const CardItem = ({
         width: 95,
         height: 140,
         position: 'relative',
-        top: provided != null ? -24 : undefined
+        // top: provided != null ? -24 : undefined,
+        overflow: 'hidden'
       }}
       {...(provided != null ? provided.draggableProps : {})}
     >

--- a/apps/journeys-admin/src/components/CardPreview/CardList/CardList.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardList/CardList.tsx
@@ -140,11 +140,11 @@ const CardItem = ({
       data-testid={`preview-${id}`}
       sx={{
         width: 95,
-        height: 160,
+        height: provided != null ? 160 : 140,
         position: 'relative',
         top: provided != null ? -24 : undefined,
         mb: provided != null ? -24 : undefined,
-        overflow: 'hidden'
+        overflow: provided != null ? 'hidden' : undefined
       }}
       {...(provided != null ? provided.draggableProps : {})}
     >

--- a/apps/journeys-admin/src/components/CardPreview/CardList/CardList.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardList/CardList.tsx
@@ -29,6 +29,7 @@ interface CardListProps {
   handleClick?: () => void
   handleChange?: (selectedId: string) => void
   isDragging?: boolean
+  isDraggable?: boolean
 }
 
 export function CardList({
@@ -38,7 +39,8 @@ export function CardList({
   droppableProvided,
   handleClick,
   handleChange,
-  isDragging
+  isDragging,
+  isDraggable
 }: CardListProps): ReactElement {
   const AddCardSlide = (): ReactElement => (
     <Card
@@ -85,6 +87,7 @@ export function CardList({
                 provided={provided}
                 step={step}
                 snapshot={snapshot}
+                isDraggable={isDraggable}
               />
             )}
           </Draggable>
@@ -103,13 +106,15 @@ interface CardItemProps {
   id: string
   provided?: DraggableProvided
   snapshot?: DraggableStateSnapshot
+  isDraggable?: boolean
 }
 
 const CardItem = ({
   step,
   id,
   provided,
-  snapshot
+  snapshot,
+  isDraggable
 }: CardItemProps): ReactElement => {
   const { journey } = useJourney()
 
@@ -121,11 +126,11 @@ const CardItem = ({
       data-testid={`preview-${id}`}
       sx={{
         width: 95,
-        height: provided != null ? 160 : 140,
         position: 'relative',
-        top: provided != null ? -24 : undefined,
-        mb: provided != null ? -24 : undefined,
-        overflow: provided != null ? 'hidden' : undefined
+        height: isDraggable === true ? 160 : 140,
+        top: isDraggable === true ? '-24px' : undefined,
+        mb: isDraggable === true ? '-24px' : undefined,
+        overflow: isDraggable === true ? 'hidden' : undefined
       }}
       {...(provided != null ? provided.draggableProps : {})}
     >

--- a/apps/journeys-admin/src/components/CardPreview/CardList/CardList.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardList/CardList.tsx
@@ -78,34 +78,15 @@ export function CardList({
             draggableId={step.id}
             index={index}
           >
-            {(provided, snapshot) => {
-              return (
-                <>
-                  {/* {provided != null && snapshot != null && (
-                    <Box
-                      {...(provided != null ? provided.dragHandleProps : {})}
-                      sx={{
-                        display: 'flex',
-                        justifyContent: 'center'
-                      }}
-                    >
-                      <DragHandleRounded
-                        sx={{
-                          opacity: snapshot.isDragging === true ? 1 : 0.5
-                        }}
-                      />
-                    </Box>
-                  )} */}
-                  <CardItem
-                    key={step.id}
-                    id={step.id}
-                    provided={provided}
-                    step={step}
-                    snapshot={snapshot}
-                  />
-                </>
-              )
-            }}
+            {(provided, snapshot) => (
+              <CardItem
+                key={step.id}
+                id={step.id}
+                provided={provided}
+                step={step}
+                snapshot={snapshot}
+              />
+            )}
           </Draggable>
         ))}
       {droppableProvided == null &&

--- a/apps/journeys-admin/src/components/CardPreview/CardList/CardList.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardList/CardList.tsx
@@ -78,15 +78,34 @@ export function CardList({
             draggableId={step.id}
             index={index}
           >
-            {(provided, snapshot) => (
-              <CardItem
-                key={step.id}
-                id={step.id}
-                provided={provided}
-                step={step}
-                snapshot={snapshot}
-              />
-            )}
+            {(provided, snapshot) => {
+              return (
+                <>
+                  {/* {provided != null && snapshot != null && (
+                    <Box
+                      {...(provided != null ? provided.dragHandleProps : {})}
+                      sx={{
+                        display: 'flex',
+                        justifyContent: 'center'
+                      }}
+                    >
+                      <DragHandleRounded
+                        sx={{
+                          opacity: snapshot.isDragging === true ? 1 : 0.5
+                        }}
+                      />
+                    </Box>
+                  )} */}
+                  <CardItem
+                    key={step.id}
+                    id={step.id}
+                    provided={provided}
+                    step={step}
+                    snapshot={snapshot}
+                  />
+                </>
+              )
+            }}
           </Draggable>
         ))}
       {droppableProvided == null &&
@@ -121,9 +140,10 @@ const CardItem = ({
       data-testid={`preview-${id}`}
       sx={{
         width: 95,
-        height: 140,
+        height: 160,
         position: 'relative',
-        // top: provided != null ? -24 : undefined,
+        top: provided != null ? -24 : undefined,
+        mb: provided != null ? -24 : undefined,
         overflow: 'hidden'
       }}
       {...(provided != null ? provided.draggableProps : {})}

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
@@ -673,7 +673,7 @@ const Template: Story = ({ ...args }) => {
             selected={selected}
             steps={args.steps}
             showAddButton={args.showAddButton}
-            isDraggable
+            isDraggable={args.isDraggable}
           />
         </DragDropContext>
       </JourneyProvider>
@@ -684,6 +684,12 @@ const Template: Story = ({ ...args }) => {
 export const Default = Template.bind({})
 Default.args = {
   steps
+}
+
+export const Draggable = Template.bind({})
+Draggable.args = {
+  steps,
+  isDraggable: true
 }
 
 export const AddButton = Template.bind({})

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
@@ -182,6 +182,7 @@ export function CardPreview({
                     handleClick={handleClick}
                     handleChange={handleChange}
                     isDragging={isDragging}
+                    isDraggable={isDraggable}
                   />
                 </Box>
               )}


### PR DESCRIPTION
# Description

Found that Firefox wasn't correctly scaling the iframes in card list, which then left the full height of the card on the y axis, then an overflow: hidden was positioning the cards so that any spacing on top of the card is lost.  The solution was to add an additional overflow: hidden so the full height is not passed to horizontal select.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/28141725/todos/5055669888)

# How should this PR be QA Tested?

**This solution uses negative margins, so should thoroughly QA'd to ensure it is still working as intended**

- [ ] Drag should show and work, cards should have correct outline when selected:
> - [ ] on Chrome web view
> - [ ] on Chrome mobile view
> - [ ] on Firefox web view
> - [ ] on Firefox mobile view
> - [ ] on Safari web view
> - [ ] on Safari mobile view

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
