### PR TITLE
fix: batch events broken by conflict resolution

### DIFF
--- a/apps/journeys-admin/src/components/JourneyList/JourneyList.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyList.spec.tsx
@@ -28,6 +28,7 @@ describe('JourneyList', () => {
             <ThemeProvider>
               <JourneyList
                 journeys={[defaultJourney, publishedJourney, oldJourney]}
+                event=""
               />
             </ThemeProvider>
           </FlagsProvider>
@@ -43,7 +44,7 @@ describe('JourneyList', () => {
         <MockedProvider>
           <FlagsProvider>
             <ThemeProvider>
-              <JourneyList journeys={[]} />
+              <JourneyList journeys={[]} event="" />
             </ThemeProvider>
           </FlagsProvider>
         </MockedProvider>
@@ -69,6 +70,7 @@ describe('JourneyList', () => {
             <ThemeProvider>
               <JourneyList
                 journeys={[defaultJourney, publishedJourney, oldJourney]}
+                event=""
               />
             </ThemeProvider>
           </FlagsProvider>
@@ -88,6 +90,7 @@ describe('JourneyList', () => {
             <ThemeProvider>
               <JourneyList
                 journeys={[defaultJourney, publishedJourney, oldJourney]}
+                event=""
               />
             </ThemeProvider>
           </FlagsProvider>
@@ -105,7 +108,7 @@ describe('JourneyList', () => {
         <MockedProvider>
           <FlagsProvider flags={{ reports: true }}>
             <ThemeProvider>
-              <JourneyList journeys={[]} />
+              <JourneyList journeys={[]} event="" />
             </ThemeProvider>
           </FlagsProvider>
         </MockedProvider>
@@ -124,6 +127,7 @@ describe('JourneyList', () => {
             <ThemeProvider>
               <JourneyList
                 journeys={[defaultJourney, publishedJourney, oldJourney]}
+                event=""
               />
             </ThemeProvider>
           </FlagsProvider>
@@ -143,6 +147,7 @@ describe('JourneyList', () => {
               <JourneyList
                 journeys={[defaultJourney, publishedJourney, oldJourney]}
                 router={router}
+                event=""
               />
             </ThemeProvider>
           </FlagsProvider>
@@ -161,6 +166,7 @@ describe('JourneyList', () => {
             <ThemeProvider>
               <JourneyList
                 journeys={[defaultJourney, publishedJourney, oldJourney]}
+                event=""
                 router={router}
               />
             </ThemeProvider>
@@ -181,6 +187,7 @@ describe('JourneyList', () => {
               <JourneyList
                 journeys={[defaultJourney, publishedJourney, oldJourney]}
                 router={router}
+                event=""
               />
             </ThemeProvider>
           </FlagsProvider>

--- a/apps/journeys-admin/src/components/JourneyList/JourneyList.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyList.stories.tsx
@@ -53,7 +53,13 @@ const Template: Story = ({ ...args }) => (
 export const Default = Template.bind({})
 Default.args = {
   props: {
-    journeys: [defaultJourney, publishedJourney, oldJourney, descriptiveJourney]
+    journeys: [
+      defaultJourney,
+      publishedJourney,
+      oldJourney,
+      descriptiveJourney
+    ],
+    event: ''
   },
   reports: true
 }
@@ -61,14 +67,20 @@ Default.args = {
 export const Reports = Template.bind({})
 Reports.args = {
   props: {
-    journeys: [defaultJourney, publishedJourney, oldJourney, descriptiveJourney]
+    journeys: [
+      defaultJourney,
+      publishedJourney,
+      oldJourney,
+      descriptiveJourney
+    ],
+    event: ''
   },
   reports: true
 }
 
 export const Access = Template.bind({})
 Access.args = {
-  props: { journeys: [] },
+  props: { journeys: [], event: '' },
   reports: true
 }
 

--- a/apps/journeys-admin/src/components/JourneyList/JourneyList.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyList.tsx
@@ -17,14 +17,14 @@ import { StatusTabPanel } from './StatusTabPanel'
 export interface JourneysListProps {
   journeys?: Journey[]
   router?: NextRouter
-  event?: string | undefined
+  event: string | undefined
   authUser?: AuthUser
 }
 
 export function JourneyList({
   journeys,
   router,
-  event = '',
+  event,
   authUser
 }: JourneysListProps): ReactElement {
   const { reports } = useFlags()
@@ -36,7 +36,7 @@ export function JourneyList({
       )}
       <Container sx={{ px: { xs: 0, sm: 8 } }}>
         {(journeys == null || journeys.length > 0) && (
-          <StatusTabPanel router={router} />
+          <StatusTabPanel router={router} event={event} authUser={authUser} />
         )}
         {journeys != null &&
           (journeys.length > 0 ? (

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/ActiveStatusTab.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/ActiveStatusTab.spec.tsx
@@ -43,7 +43,7 @@ describe('ActiveStatusTab', () => {
       <MockedProvider mocks={[activeJourneysMock]}>
         <ThemeProvider>
           <SnackbarProvider>
-            <ActiveStatusTab onLoad={noop} />
+            <ActiveStatusTab onLoad={noop} event="" />
           </SnackbarProvider>
         </ThemeProvider>
       </MockedProvider>
@@ -64,7 +64,11 @@ describe('ActiveStatusTab', () => {
       <MockedProvider mocks={[activeJourneysMock]}>
         <ThemeProvider>
           <SnackbarProvider>
-            <ActiveStatusTab onLoad={noop} sortOrder={SortOrder.TITLE} />
+            <ActiveStatusTab
+              onLoad={noop}
+              sortOrder={SortOrder.TITLE}
+              event=""
+            />
           </SnackbarProvider>
         </ThemeProvider>
       </MockedProvider>
@@ -85,7 +89,7 @@ describe('ActiveStatusTab', () => {
       <MockedProvider mocks={[noJourneysMock]}>
         <ThemeProvider>
           <SnackbarProvider>
-            <ActiveStatusTab onLoad={noop} />
+            <ActiveStatusTab onLoad={noop} event="" />
           </SnackbarProvider>
         </ThemeProvider>
       </MockedProvider>
@@ -104,7 +108,7 @@ describe('ActiveStatusTab', () => {
       <MockedProvider mocks={[]}>
         <ThemeProvider>
           <SnackbarProvider>
-            <ActiveStatusTab onLoad={noop} />
+            <ActiveStatusTab onLoad={noop} event="" />
           </SnackbarProvider>
         </ThemeProvider>
       </MockedProvider>
@@ -120,7 +124,7 @@ describe('ActiveStatusTab', () => {
       <MockedProvider mocks={[noJourneysMock]}>
         <ThemeProvider>
           <SnackbarProvider>
-            <ActiveStatusTab onLoad={onLoad} />
+            <ActiveStatusTab onLoad={onLoad} event="" />
           </SnackbarProvider>
         </ThemeProvider>
       </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/ActiveStatusTab.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/ActiveStatusTab.stories.tsx
@@ -30,7 +30,8 @@ const Template: Story = ({ ...args }) => (
 export const Default = Template.bind({})
 Default.args = {
   props: {
-    onLoad: noop
+    onLoad: noop,
+    event: ''
   },
   mocks: [
     {
@@ -54,7 +55,8 @@ Default.args = {
 export const NoJourneys = Template.bind({})
 NoJourneys.args = {
   props: {
-    onLoad: noop
+    onLoad: noop,
+    event: ''
   },
   mocks: [
     {
@@ -73,7 +75,8 @@ NoJourneys.args = {
 export const Loading = Template.bind({})
 Loading.args = {
   props: {
-    onLoad: noop
+    onLoad: noop,
+    event: ''
   },
   mocks: []
 }

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/ActiveStatusTab.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/ActiveStatusTab.tsx
@@ -68,14 +68,14 @@ export const TRASH_ACTIVE_JOURNEYS = gql`
 interface ActiveStatusTabProps {
   onLoad: () => void
   sortOrder?: SortOrder
-  event?: string | undefined
+  event: string | undefined
   authUser?: AuthUser
 }
 
 export function ActiveStatusTab({
   onLoad,
   sortOrder,
-  event = '',
+  event,
   authUser
 }: ActiveStatusTabProps): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ArchivedStatusTab/ArchivedStatusTab.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ArchivedStatusTab/ArchivedStatusTab.spec.tsx
@@ -65,7 +65,11 @@ describe('ArchivedStatusTab', () => {
       <MockedProvider mocks={[archivedJourneysMock]}>
         <ThemeProvider>
           <SnackbarProvider>
-            <ArchivedStatusTab onLoad={noop} sortOrder={SortOrder.TITLE} />
+            <ArchivedStatusTab
+              onLoad={noop}
+              sortOrder={SortOrder.TITLE}
+              event=""
+            />
           </SnackbarProvider>
         </ThemeProvider>
       </MockedProvider>
@@ -86,7 +90,7 @@ describe('ArchivedStatusTab', () => {
       <MockedProvider mocks={[]}>
         <ThemeProvider>
           <SnackbarProvider>
-            <ArchivedStatusTab onLoad={noop} />
+            <ArchivedStatusTab onLoad={noop} event="" />
           </SnackbarProvider>
         </ThemeProvider>
       </MockedProvider>
@@ -102,7 +106,7 @@ describe('ArchivedStatusTab', () => {
       <MockedProvider mocks={[noJourneysMock]}>
         <ThemeProvider>
           <SnackbarProvider>
-            <ArchivedStatusTab onLoad={onLoad} />
+            <ArchivedStatusTab onLoad={onLoad} event="" />
           </SnackbarProvider>
         </ThemeProvider>
       </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ArchivedStatusTab/ArchivedStatusTab.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ArchivedStatusTab/ArchivedStatusTab.stories.tsx
@@ -30,7 +30,8 @@ const Template: Story = ({ ...args }) => (
 export const Default = Template.bind({})
 Default.args = {
   props: {
-    onLoad: noop
+    onLoad: noop,
+    event: ''
   },
   mocks: [
     {
@@ -54,7 +55,8 @@ Default.args = {
 export const NoJourneys = Template.bind({})
 NoJourneys.args = {
   props: {
-    onLoad: noop
+    onLoad: noop,
+    event: ''
   },
   mocks: [
     {
@@ -73,7 +75,8 @@ NoJourneys.args = {
 export const Loading = Template.bind({})
 Loading.args = {
   props: {
-    onLoad: noop
+    onLoad: noop,
+    event: ''
   },
   mocks: []
 }

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ArchivedStatusTab/ArchivedStatusTab.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ArchivedStatusTab/ArchivedStatusTab.tsx
@@ -68,14 +68,14 @@ export const TRASH_ARCHIVED_JOURNEYS = gql`
 interface ArchivedStatusTabProps {
   onLoad: () => void
   sortOrder?: SortOrder
-  event?: string | undefined
+  event: string | undefined
   authUser?: AuthUser
 }
 
 export function ArchivedStatusTab({
   onLoad,
   sortOrder,
-  event = '',
+  event,
   authUser
 }: ArchivedStatusTabProps): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/StatusTabPanel.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/StatusTabPanel.spec.tsx
@@ -43,7 +43,7 @@ describe('StatusTabPanel', () => {
       >
         <ThemeProvider>
           <SnackbarProvider>
-            <StatusTabPanel />
+            <StatusTabPanel event="" />
           </SnackbarProvider>
         </ThemeProvider>
       </MockedProvider>
@@ -58,7 +58,7 @@ describe('StatusTabPanel', () => {
       <MockedProvider>
         <ThemeProvider>
           <SnackbarProvider>
-            <StatusTabPanel />
+            <StatusTabPanel event="" />
           </SnackbarProvider>
         </ThemeProvider>
       </MockedProvider>
@@ -84,7 +84,7 @@ describe('StatusTabPanel', () => {
       >
         <ThemeProvider>
           <SnackbarProvider>
-            <StatusTabPanel />
+            <StatusTabPanel event="" />
           </SnackbarProvider>
         </ThemeProvider>
       </MockedProvider>
@@ -124,7 +124,7 @@ describe('StatusTabPanel', () => {
       >
         <ThemeProvider>
           <SnackbarProvider>
-            <StatusTabPanel router={router} />
+            <StatusTabPanel router={router} event="" />
           </SnackbarProvider>
         </ThemeProvider>
       </MockedProvider>
@@ -159,7 +159,7 @@ describe('StatusTabPanel', () => {
           ]}
         >
           <ThemeProvider>
-            <StatusTabPanel router={router} />
+            <StatusTabPanel router={router} event="" />
           </ThemeProvider>
         </MockedProvider>
       </SnackbarProvider>

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/StatusTabPanel.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/StatusTabPanel.stories.tsx
@@ -23,7 +23,7 @@ const StatusTabPanelStory = {
 
 const Template: Story = ({ ...args }) => (
   <MockedProvider mocks={args.mocks}>
-    <StatusTabPanel />
+    <StatusTabPanel event="" />
   </MockedProvider>
 )
 

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/StatusTabPanel.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/StatusTabPanel.tsx
@@ -15,7 +15,7 @@ import { TrashedStatusTab } from './TrashedStatusTab'
 
 export interface StatusTabPanelProps {
   router?: NextRouter
-  event?: string | undefined
+  event: string | undefined
   authUser?: AuthUser | undefined
 }
 
@@ -27,7 +27,7 @@ interface StatusOptions {
 
 export function StatusTabPanel({
   router,
-  event = '',
+  event,
   authUser
 }: StatusTabPanelProps): ReactElement {
   const journeyStatusTabs: StatusOptions[] = [

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/TrashedStatusTab/TrashedStatusTab.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/TrashedStatusTab/TrashedStatusTab.spec.tsx
@@ -51,7 +51,7 @@ describe('TrashedStatusTab', () => {
       <MockedProvider mocks={[trashedJourneysMock]}>
         <ThemeProvider>
           <SnackbarProvider>
-            <TrashedStatusTab onLoad={noop} />
+            <TrashedStatusTab onLoad={noop} event="" />
           </SnackbarProvider>
         </ThemeProvider>
       </MockedProvider>
@@ -72,7 +72,11 @@ describe('TrashedStatusTab', () => {
       <MockedProvider mocks={[trashedJourneysMock]}>
         <ThemeProvider>
           <SnackbarProvider>
-            <TrashedStatusTab onLoad={noop} sortOrder={SortOrder.TITLE} />
+            <TrashedStatusTab
+              onLoad={noop}
+              sortOrder={SortOrder.TITLE}
+              event=""
+            />
           </SnackbarProvider>
         </ThemeProvider>
       </MockedProvider>
@@ -109,7 +113,11 @@ describe('TrashedStatusTab', () => {
       >
         <ThemeProvider>
           <SnackbarProvider>
-            <TrashedStatusTab onLoad={noop} sortOrder={SortOrder.TITLE} />
+            <TrashedStatusTab
+              onLoad={noop}
+              sortOrder={SortOrder.TITLE}
+              event=""
+            />
           </SnackbarProvider>
         </ThemeProvider>
       </MockedProvider>
@@ -128,7 +136,7 @@ describe('TrashedStatusTab', () => {
       <MockedProvider mocks={[]}>
         <ThemeProvider>
           <SnackbarProvider>
-            <TrashedStatusTab onLoad={noop} />
+            <TrashedStatusTab onLoad={noop} event="" />
           </SnackbarProvider>
         </ThemeProvider>
       </MockedProvider>
@@ -144,7 +152,7 @@ describe('TrashedStatusTab', () => {
       <MockedProvider mocks={[noJourneysMock]}>
         <ThemeProvider>
           <SnackbarProvider>
-            <TrashedStatusTab onLoad={onLoad} />
+            <TrashedStatusTab onLoad={onLoad} event="" />
           </SnackbarProvider>
         </ThemeProvider>
       </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/TrashedStatusTab/TrashedStatusTab.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/TrashedStatusTab/TrashedStatusTab.stories.tsx
@@ -31,7 +31,7 @@ export const Default = Template.bind({})
 Default.args = {
   props: {
     onLoad: noop,
-    event:''
+    event: ''
   },
   mocks: [
     {

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/TrashedStatusTab/TrashedStatusTab.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/TrashedStatusTab/TrashedStatusTab.stories.tsx
@@ -30,7 +30,8 @@ const Template: Story = ({ ...args }) => (
 export const Default = Template.bind({})
 Default.args = {
   props: {
-    onLoad: noop
+    onLoad: noop,
+    event:''
   },
   mocks: [
     {
@@ -54,7 +55,8 @@ Default.args = {
 export const NoJourneys = Template.bind({})
 NoJourneys.args = {
   props: {
-    onLoad: noop
+    onLoad: noop,
+    event: ''
   },
   mocks: [
     {
@@ -73,7 +75,8 @@ NoJourneys.args = {
 export const Loading = Template.bind({})
 Loading.args = {
   props: {
-    onLoad: noop
+    onLoad: noop,
+    event: ''
   },
   mocks: []
 }

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/TrashedStatusTab/TrashedStatusTab.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/TrashedStatusTab/TrashedStatusTab.tsx
@@ -69,14 +69,14 @@ export const DELETE_TRASHED_JOURNEYS = gql`
 interface TrashedStatusTabProps {
   onLoad: (journeys: string[] | undefined) => void
   sortOrder?: SortOrder
-  event?: string | undefined
+  event: string | undefined
   authUser?: AuthUser
 }
 
 export function TrashedStatusTab({
   onLoad,
   sortOrder,
-  event = '',
+  event,
   authUser
 }: TrashedStatusTabProps): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')


### PR DESCRIPTION
# Description

There was a conflict resolution with the PowerBI branch that caused batch actions on journeys to fail. Prop now required to prevent accidental deletion later

# How should this PR be QA Tested?

Batch actions create a modal again

- [ ] Test A
- [ ] Test B

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
