### PR TITLE
fix: video thumbnail

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ImageBlockThumbnail/ImageBlockThumbnail.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockThumbnail/ImageBlockThumbnail.tsx
@@ -1,7 +1,6 @@
 import { ReactElement } from 'react'
 import CircularProgress from '@mui/material/CircularProgress'
 import ImageIcon from '@mui/icons-material/Image'
-import Image from 'next/image'
 import Box from '@mui/material/Box'
 
 interface ImageBlockThumbnailProps {
@@ -30,11 +29,15 @@ export function ImageBlockThumbnail({
       {loading === true ? (
         <CircularProgress size={20} />
       ) : selectedBlock?.src != null ? (
-        <Image
+        <Box
+          component="img"
           src={selectedBlock.src}
           alt={selectedBlock.alt}
-          layout="fill"
-          objectFit="cover"
+          sx={{
+            width: 55,
+            height: 55,
+            objectFit: 'cover'
+          }}
         />
       ) : (
         <ImageIcon data-testid="imageBlockThumbnailPlaceholder" />


### PR DESCRIPTION
# Description

Video thumbnail wasn't showing up, because the img src was not in our next/image config. But since we cannot control those images and their sources, it was opted to refactor from using the next/image component to a regular img component.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/28141725/todos/5097279310)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Video thumbnail should show picture

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
