### PR TITLE
fix: selected step in editor context

### DIFF
--- a/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
+++ b/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
@@ -185,7 +185,21 @@ export function EditorProvider({
   useEffect(() => {
     if (initialState?.steps != null)
       dispatch({ type: 'SetStepsAction', steps: initialState.steps })
-  }, [initialState?.steps])
+    if (initialState?.selectedStep != null)
+      dispatch({
+        type: 'SetSelectedStepAction',
+        step: initialState.selectedStep
+      })
+    if (initialState?.selectedBlock != null)
+      dispatch({
+        type: 'SetSelectedBlockAction',
+        block: initialState.selectedBlock
+      })
+  }, [
+    initialState?.steps,
+    initialState?.selectedStep,
+    initialState?.selectedBlock
+  ])
 
   return (
     <EditorContext.Provider value={{ state, dispatch }}>


### PR DESCRIPTION
# Description

This PR fixes the selection of selected block when it is included in the querystring

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/28141725/todos/5055629370)

# How should this PR be QA Tested?

- [ ] Select journey in admin
- [ ] Select a step from the cards
- [ ] ensure selected step is open in editor

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
