### PR TITLE
fix: reorder typography properties

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Typography.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Typography.spec.tsx
@@ -22,10 +22,10 @@ describe('Typography properties', () => {
       children: []
     }
     const { getByRole } = render(<Typography {...block} />)
-    expect(getByRole('button', { name: 'Color Primary' })).toBeInTheDocument()
     expect(
       getByRole('button', { name: 'Text Variant Body 2' })
     ).toBeInTheDocument()
+    expect(getByRole('button', { name: 'Color Primary' })).toBeInTheDocument()
     expect(
       getByRole('button', { name: 'Text Alignment Left' })
     ).toBeInTheDocument()
@@ -44,10 +44,10 @@ describe('Typography properties', () => {
       children: []
     }
     const { getByRole } = render(<Typography {...block} />)
-    expect(getByRole('button', { name: 'Color Secondary' })).toBeInTheDocument()
     expect(
       getByRole('button', { name: 'Text Variant Header 2' })
     ).toBeInTheDocument()
+    expect(getByRole('button', { name: 'Color Secondary' })).toBeInTheDocument()
     expect(
       getByRole('button', { name: 'Text Alignment Center' })
     ).toBeInTheDocument()

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Typography.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Typography.tsx
@@ -20,22 +20,6 @@ export function Typography(block: TreeBlock<TypographyBlock>): ReactElement {
   return (
     <>
       <Attribute
-        id={`${id}-typography-color`}
-        icon={<ColorDisplayIcon color={color} />}
-        name="Color"
-        value={capitalize(color?.toString() ?? 'primary')}
-        description="Text Color"
-        onClick={() => {
-          dispatch({
-            type: 'SetDrawerPropsAction',
-            title: 'Text Color',
-            mobileOpen: true,
-            children: <Color />
-          })
-        }}
-      />
-
-      <Attribute
         id={`${id}-typography-variant`}
         icon={<TextFieldsRoundedIcon />}
         name="Text Variant"
@@ -49,6 +33,22 @@ export function Typography(block: TreeBlock<TypographyBlock>): ReactElement {
             title: 'Text Variant',
             mobileOpen: true,
             children: <Variant />
+          })
+        }}
+      />
+
+      <Attribute
+        id={`${id}-typography-color`}
+        icon={<ColorDisplayIcon color={color} />}
+        name="Color"
+        value={capitalize(color?.toString() ?? 'primary')}
+        description="Text Color"
+        onClick={() => {
+          dispatch({
+            type: 'SetDrawerPropsAction',
+            title: 'Text Color',
+            mobileOpen: true,
+            children: <Color />
           })
         }}
       />


### PR DESCRIPTION
# Description

Reorder the typography properties from Color, Variant, and Alignment to Variant, Color, and Alignment

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/28141725/todos/5056195152)

# How should this PR be QA Tested?

- [ ] Typography properties should be in this order: Variant | Color | Alignment


# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
