### PR TITLE
fix: journey sort order

### DIFF
--- a/apps/journeys-admin/src/components/JourneyList/JourneySort/utils/sortJourneys.spec.ts
+++ b/apps/journeys-admin/src/components/JourneyList/JourneySort/utils/sortJourneys.spec.ts
@@ -1,6 +1,6 @@
 import { defaultJourney, oldJourney } from '../../journeyListData'
 import { SortOrder } from '../JourneySort'
-import { GetActiveJourneys_journeys as ActiveJourneys } from '../../../../../__generated__/GetActiveJourneys'
+import { GetActiveJourneys_journeys as ActiveJourney } from '../../../../../__generated__/GetActiveJourneys'
 import { sortJourneys } from './sortJourneys'
 
 describe('sortJourneys', () => {
@@ -21,26 +21,26 @@ describe('sortJourneys', () => {
     const journeys = [
       {
         title: 'Z'
-      } as unknown as ActiveJourneys,
+      } as unknown as ActiveJourney,
       {
-        title: 'aB'
-      } as unknown as ActiveJourneys,
+        title: 'aA'
+      } as unknown as ActiveJourney,
       {
         title: 'AB'
-      } as unknown as ActiveJourneys
+      } as unknown as ActiveJourney
     ]
 
     const sorted = sortJourneys(journeys, SortOrder.TITLE)
     expect(sorted).toEqual([
       {
         title: 'AB'
-      } as unknown as ActiveJourneys,
+      } as unknown as ActiveJourney,
       {
-        title: 'aB'
-      } as unknown as ActiveJourneys,
+        title: 'aA'
+      } as unknown as ActiveJourney,
       {
         title: 'Z'
-      } as unknown as ActiveJourneys
+      } as unknown as ActiveJourney
     ])
   })
 })

--- a/apps/journeys-admin/src/components/JourneyList/JourneySort/utils/sortJourneys.spec.ts
+++ b/apps/journeys-admin/src/components/JourneyList/JourneySort/utils/sortJourneys.spec.ts
@@ -1,0 +1,46 @@
+import { defaultJourney, oldJourney } from '../../journeyListData'
+import { SortOrder } from '../JourneySort'
+import { GetActiveJourneys_journeys as ActiveJourneys } from '../../../../../__generated__/GetActiveJourneys'
+import { sortJourneys } from './sortJourneys'
+
+describe('sortJourneys', () => {
+  it('should return journeys sorted by creation date by default', () => {
+    const sorted = sortJourneys([oldJourney, defaultJourney])
+    expect(sorted).toEqual([defaultJourney, oldJourney])
+  })
+
+  it('should return journeys sorted by creation date', () => {
+    const sorted = sortJourneys(
+      [oldJourney, defaultJourney],
+      SortOrder.CREATED_AT
+    )
+    expect(sorted).toEqual([defaultJourney, oldJourney])
+  })
+
+  it('should return journeys sorted by alphabetical order', () => {
+    const journeys = [
+      {
+        title: 'Z'
+      } as unknown as ActiveJourneys,
+      {
+        title: 'aB'
+      } as unknown as ActiveJourneys,
+      {
+        title: 'AB'
+      } as unknown as ActiveJourneys
+    ]
+
+    const sorted = sortJourneys(journeys, SortOrder.TITLE)
+    expect(sorted).toEqual([
+      {
+        title: 'AB'
+      } as unknown as ActiveJourneys,
+      {
+        title: 'aB'
+      } as unknown as ActiveJourneys,
+      {
+        title: 'Z'
+      } as unknown as ActiveJourneys
+    ])
+  })
+})

--- a/apps/journeys-admin/src/components/JourneyList/JourneySort/utils/sortJourneys.ts
+++ b/apps/journeys-admin/src/components/JourneyList/JourneySort/utils/sortJourneys.ts
@@ -1,0 +1,23 @@
+import orderBy from 'lodash/orderBy'
+import { SortOrder } from '../JourneySort'
+import { GetActiveJourneys_journeys as ActiveJourneys } from '../../../../../__generated__/GetActiveJourneys'
+import { GetArchivedJourneys_journeys as ArchivedJourneys } from '../../../../../__generated__/GetArchivedJourneys'
+import { GetTrashedJourneys_journeys as TrashedJourneys } from '../../../../../__generated__/GetTrashedJourneys'
+
+export function sortJourneys(
+  journeys: Array<ActiveJourneys | ArchivedJourneys | TrashedJourneys>,
+  sortOrder?: SortOrder
+): Array<ActiveJourneys | ArchivedJourneys | TrashedJourneys> {
+  const sortedJourneys =
+    sortOrder === SortOrder.TITLE
+      ? orderBy(
+          journeys,
+          [({ title }) => title.toLowerCase()[0], ({ title }) => title],
+          ['asc', 'asc']
+        )
+      : orderBy(journeys, ({ createdAt }) =>
+          new Date(createdAt).getTime()
+        ).reverse()
+
+  return sortedJourneys
+}

--- a/apps/journeys-admin/src/components/JourneyList/JourneySort/utils/sortJourneys.ts
+++ b/apps/journeys-admin/src/components/JourneyList/JourneySort/utils/sortJourneys.ts
@@ -1,13 +1,13 @@
 import orderBy from 'lodash/orderBy'
 import { SortOrder } from '../JourneySort'
-import { GetActiveJourneys_journeys as ActiveJourneys } from '../../../../../__generated__/GetActiveJourneys'
-import { GetArchivedJourneys_journeys as ArchivedJourneys } from '../../../../../__generated__/GetArchivedJourneys'
-import { GetTrashedJourneys_journeys as TrashedJourneys } from '../../../../../__generated__/GetTrashedJourneys'
+import { GetActiveJourneys_journeys as ActiveJourney } from '../../../../../__generated__/GetActiveJourneys'
+import { GetArchivedJourneys_journeys as ArchivedJourney } from '../../../../../__generated__/GetArchivedJourneys'
+import { GetTrashedJourneys_journeys as TrashedJourney } from '../../../../../__generated__/GetTrashedJourneys'
 
 export function sortJourneys(
-  journeys: Array<ActiveJourneys | ArchivedJourneys | TrashedJourneys>,
+  journeys: Array<ActiveJourney | ArchivedJourney | TrashedJourney>,
   sortOrder?: SortOrder
-): Array<ActiveJourneys | ArchivedJourneys | TrashedJourneys> {
+): Array<ActiveJourney | ArchivedJourney | TrashedJourney> {
   const sortedJourneys =
     sortOrder === SortOrder.TITLE
       ? orderBy(

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/ActiveStatusTab.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/ActiveStatusTab.spec.tsx
@@ -60,8 +60,26 @@ describe('ActiveStatusTab', () => {
   })
 
   it('should order journeys in alphabetical order', async () => {
+    const lowerCaseJourneyTitle = {
+      ...defaultJourney,
+      title: 'a lower case title'
+    }
+
     const { getAllByLabelText } = render(
-      <MockedProvider mocks={[activeJourneysMock]}>
+      <MockedProvider
+        mocks={[
+          {
+            request: {
+              query: GET_ACTIVE_JOURNEYS
+            },
+            result: {
+              data: {
+                journeys: [lowerCaseJourneyTitle, oldJourney]
+              }
+            }
+          }
+        ]}
+      >
         <ThemeProvider>
           <SnackbarProvider>
             <ActiveStatusTab
@@ -80,7 +98,7 @@ describe('ActiveStatusTab', () => {
       )
     )
     expect(getAllByLabelText('journey-card')[1].textContent).toContain(
-      'Default Journey Heading'
+      'a lower case title'
     )
   })
 

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/ActiveStatusTab.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/ActiveStatusTab.tsx
@@ -2,7 +2,6 @@ import { ReactElement, useEffect, useState } from 'react'
 import Card from '@mui/material/Card'
 import { gql, useMutation, useQuery } from '@apollo/client'
 import Typography from '@mui/material/Typography'
-import { sortBy } from 'lodash'
 import { useTranslation } from 'react-i18next'
 import { AuthUser } from 'next-firebase-auth'
 import { useSnackbar } from 'notistack'
@@ -11,6 +10,7 @@ import { JourneyCard } from '../../JourneyCard'
 import { AddJourneyButton } from '../../AddJourneyButton'
 import { SortOrder } from '../../JourneySort'
 import { Dialog } from '../../../Dialog'
+import { sortJourneys } from '../../JourneySort/utils/sortJourneys'
 
 export const GET_ACTIVE_JOURNEYS = gql`
   query GetActiveJourneys {
@@ -180,17 +180,12 @@ export function ActiveStatusTab({
     }
   }, [event, refetch])
 
-  // orders of the first characters ascii value
   const sortedJourneys =
-    sortOrder === SortOrder.TITLE
-      ? sortBy(journeys, 'title')
-      : sortBy(journeys, ({ createdAt }) =>
-          new Date(createdAt).getTime()
-        ).reverse()
+    journeys != null ? sortJourneys(journeys, sortOrder) : undefined
 
   return (
     <>
-      {journeys != null ? (
+      {journeys != null && sortedJourneys != null ? (
         <>
           {sortedJourneys.map((journey) => (
             <JourneyCard key={journey.id} journey={journey} refetch={refetch} />

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ArchivedStatusTab/ArchivedStatusTab.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ArchivedStatusTab/ArchivedStatusTab.spec.tsx
@@ -61,8 +61,25 @@ describe('ArchivedStatusTab', () => {
   })
 
   it('should order journeys in alphabetical order', async () => {
+    const lowerCaseJourneyTitle = {
+      ...defaultJourney,
+      title: 'a lower case title'
+    }
     const { getAllByLabelText } = render(
-      <MockedProvider mocks={[archivedJourneysMock]}>
+      <MockedProvider
+        mocks={[
+          {
+            request: {
+              query: GET_ARCHIVED_JOURNEYS
+            },
+            result: {
+              data: {
+                journeys: [lowerCaseJourneyTitle, oldJourney]
+              }
+            }
+          }
+        ]}
+      >
         <ThemeProvider>
           <SnackbarProvider>
             <ArchivedStatusTab
@@ -81,7 +98,7 @@ describe('ArchivedStatusTab', () => {
       )
     )
     expect(getAllByLabelText('journey-card')[1].textContent).toContain(
-      'Default Journey Heading'
+      'a lower case title'
     )
   })
 

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ArchivedStatusTab/ArchivedStatusTab.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ArchivedStatusTab/ArchivedStatusTab.tsx
@@ -3,7 +3,6 @@ import Box from '@mui/material/Box'
 import Card from '@mui/material/Card'
 import { gql, useMutation, useQuery } from '@apollo/client'
 import Typography from '@mui/material/Typography'
-import { sortBy } from 'lodash'
 import { useTranslation } from 'react-i18next'
 import { useSnackbar } from 'notistack'
 import { AuthUser } from 'next-firebase-auth'
@@ -11,6 +10,7 @@ import { GetArchivedJourneys } from '../../../../../__generated__/GetArchivedJou
 import { JourneyCard } from '../../JourneyCard'
 import { SortOrder } from '../../JourneySort'
 import { Dialog } from '../../../Dialog'
+import { sortJourneys } from '../../JourneySort/utils/sortJourneys'
 
 export const GET_ARCHIVED_JOURNEYS = gql`
   query GetArchivedJourneys {
@@ -180,17 +180,12 @@ export function ArchivedStatusTab({
     }
   }, [event, refetch])
 
-  // orders of the first characters ascii value
   const sortedJourneys =
-    sortOrder === SortOrder.TITLE
-      ? sortBy(journeys, 'title')
-      : sortBy(journeys, ({ createdAt }) =>
-          new Date(createdAt).getTime()
-        ).reverse()
+    journeys != null ? sortJourneys(journeys, sortOrder) : undefined
 
   return (
     <>
-      {journeys != null ? (
+      {journeys != null && sortedJourneys != null ? (
         <>
           {sortedJourneys.map((journey) => (
             <JourneyCard key={journey.id} journey={journey} refetch={refetch} />

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/TrashedStatusTab/TrashedStatusTab.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/TrashedStatusTab/TrashedStatusTab.spec.tsx
@@ -68,8 +68,30 @@ describe('TrashedStatusTab', () => {
   })
 
   it('should order journeys in alphabetical order', async () => {
+    const trashedLowerCaseJourneyTitle = {
+      ...defaultJourney,
+      title: 'a lower case title',
+      trashedAt: '2021-12-07T03:22:41.135Z'
+    }
+    const trashedOldJourney = {
+      ...oldJourney,
+      trashedAt: '2021-12-07T03:22:41.135Z'
+    }
     const { getAllByLabelText } = render(
-      <MockedProvider mocks={[trashedJourneysMock]}>
+      <MockedProvider
+        mocks={[
+          {
+            request: {
+              query: GET_TRASHED_JOURNEYS
+            },
+            result: {
+              data: {
+                journeys: [trashedLowerCaseJourneyTitle, trashedOldJourney]
+              }
+            }
+          }
+        ]}
+      >
         <ThemeProvider>
           <SnackbarProvider>
             <TrashedStatusTab
@@ -88,7 +110,7 @@ describe('TrashedStatusTab', () => {
       )
     )
     expect(getAllByLabelText('journey-card')[1].textContent).toContain(
-      'Default Journey Heading'
+      'a lower case title'
     )
   })
 

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/TrashedStatusTab/TrashedStatusTab.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/TrashedStatusTab/TrashedStatusTab.tsx
@@ -8,7 +8,7 @@ import { useSnackbar } from 'notistack'
 import { AuthUser } from 'next-firebase-auth'
 import {
   GetTrashedJourneys,
-  GetTrashedJourneys_journeys as TrashedJourneys
+  GetTrashedJourneys_journeys as TrashedJourney
 } from '../../../../../__generated__/GetTrashedJourneys'
 import { JourneyCard } from '../../JourneyCard'
 import { SortOrder } from '../../JourneySort'
@@ -189,7 +189,7 @@ export function TrashedStatusTab({
 
   const sortedJourneys =
     journeys != null
-      ? (sortJourneys(journeys, sortOrder) as TrashedJourneys[])
+      ? (sortJourneys(journeys, sortOrder) as TrashedJourney[])
       : undefined
 
   // calculate 40 days ago. may later be replaced by cron job

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/TrashedStatusTab/TrashedStatusTab.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/TrashedStatusTab/TrashedStatusTab.tsx
@@ -3,14 +3,17 @@ import Box from '@mui/material/Box'
 import Card from '@mui/material/Card'
 import { gql, useMutation, useQuery } from '@apollo/client'
 import Typography from '@mui/material/Typography'
-import { sortBy } from 'lodash'
 import { useTranslation } from 'react-i18next'
 import { useSnackbar } from 'notistack'
 import { AuthUser } from 'next-firebase-auth'
-import { GetTrashedJourneys } from '../../../../../__generated__/GetTrashedJourneys'
+import {
+  GetTrashedJourneys,
+  GetTrashedJourneys_journeys as TrashedJourneys
+} from '../../../../../__generated__/GetTrashedJourneys'
 import { JourneyCard } from '../../JourneyCard'
 import { SortOrder } from '../../JourneySort'
 import { Dialog } from '../../../Dialog'
+import { sortJourneys } from '../../JourneySort/utils/sortJourneys'
 
 export const GET_TRASHED_JOURNEYS = gql`
   query GetTrashedJourneys {
@@ -184,13 +187,10 @@ export function TrashedStatusTab({
     }
   }, [event, refetch])
 
-  // orders of the first characters ascii value
   const sortedJourneys =
-    sortOrder === SortOrder.TITLE
-      ? sortBy(journeys, 'title')
-      : sortBy(journeys, ({ createdAt }) =>
-          new Date(createdAt).getTime()
-        ).reverse()
+    journeys != null
+      ? (sortJourneys(journeys, sortOrder) as TrashedJourneys[])
+      : undefined
 
   // calculate 40 days ago. may later be replaced by cron job
   const daysAgo = new Date()
@@ -198,7 +198,7 @@ export function TrashedStatusTab({
 
   return (
     <>
-      {journeys != null ? (
+      {journeys != null && sortedJourneys != null ? (
         <>
           {sortedJourneys
             .filter((journey) => new Date(journey.trashedAt) > daysAgo)


### PR DESCRIPTION
# Description

Default sortBy from lodash is sorted by ASCII value, which meant that "a" comes after "Z". This PR fixes that by adding additional options to orderBy and extracting it as util function.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/28141725/todos/5094342591)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Create some journeys, when sorting by name journeys should be ordered as alphabetical, then casing.  (Eg: A, a, B, f, Z)

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
