### PR TITLE
fix: card reselection on change

### DIFF
--- a/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
+++ b/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
@@ -185,21 +185,7 @@ export function EditorProvider({
   useEffect(() => {
     if (initialState?.steps != null)
       dispatch({ type: 'SetStepsAction', steps: initialState.steps })
-    if (initialState?.selectedStep != null)
-      dispatch({
-        type: 'SetSelectedStepAction',
-        step: initialState.selectedStep
-      })
-    if (initialState?.selectedBlock != null)
-      dispatch({
-        type: 'SetSelectedBlockAction',
-        block: initialState.selectedBlock
-      })
-  }, [
-    initialState?.steps,
-    initialState?.selectedStep,
-    initialState?.selectedBlock
-  ])
+  }, [initialState?.steps])
 
   return (
     <EditorContext.Provider value={{ state, dispatch }}>


### PR DESCRIPTION
# Description

Revert changes from https://github.com/JesusFilm/core/pull/768. It unintentionally dispatched a card reselect after properties or blocks on a card change.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/28141725/todos/5120221158)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Changing properties on a card should not select the initially selected card (the stepId from URL)
- [x] Creating a radioOption button should still show after creating an option
- [x] On journeyView, no matter what card you click on to get into the editor, the first card should be selected. (This is the reverted functionality)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
