### PR TITLE
fix: selected step from journey view

### DIFF
--- a/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
+++ b/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
@@ -199,7 +199,6 @@ export function EditorProvider({
       })
       stepRef.current = true
 
-      // only used to instantiate tests
       if (initialState?.selectedBlock != null)
         dispatch({
           type: 'SetSelectedBlockAction',

--- a/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
+++ b/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
@@ -185,7 +185,21 @@ export function EditorProvider({
   useEffect(() => {
     if (initialState?.steps != null)
       dispatch({ type: 'SetStepsAction', steps: initialState.steps })
-  }, [initialState?.steps])
+    if (initialState?.selectedStep != null)
+      dispatch({
+        type: 'SetSelectedStepAction',
+        step: initialState.selectedStep
+      })
+    if (initialState?.selectedBlock != null)
+      dispatch({
+        type: 'SetSelectedBlockAction',
+        block: initialState.selectedBlock
+      })
+  }, [
+    initialState?.steps,
+    initialState?.selectedStep,
+    initialState?.selectedBlock
+  ])
 
   return (
     <EditorContext.Provider value={{ state, dispatch }}>

--- a/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
+++ b/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
@@ -198,21 +198,15 @@ export function EditorProvider({
         step: initialState.selectedStep
       })
       stepRef.current = true
-    }
-  }, [initialState?.selectedStep])
 
-  // only run once
-  const blockRef = useRef(false)
-  useEffect(() => {
-    if (blockRef.current) return
-    if (initialState?.selectedBlock != null) {
-      dispatch({
-        type: 'SetSelectedBlockAction',
-        block: initialState.selectedBlock
-      })
-      blockRef.current = true
+      // only used to instantiate tests
+      if (initialState?.selectedBlock != null)
+        dispatch({
+          type: 'SetSelectedBlockAction',
+          block: initialState.selectedBlock
+        })
     }
-  }, [initialState?.selectedBlock])
+  }, [initialState?.selectedStep, initialState?.selectedBlock])
 
   return (
     <EditorContext.Provider value={{ state, dispatch }}>

--- a/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
+++ b/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
@@ -5,7 +5,8 @@ import {
   ReactNode,
   useEffect,
   useContext,
-  useReducer
+  useReducer,
+  useRef
 } from 'react'
 import { searchBlocks } from '../searchBlocks'
 import type { TreeBlock } from '../block'
@@ -185,21 +186,20 @@ export function EditorProvider({
   useEffect(() => {
     if (initialState?.steps != null)
       dispatch({ type: 'SetStepsAction', steps: initialState.steps })
-    if (initialState?.selectedStep != null)
+  }, [initialState?.steps])
+
+  // only run once
+  const stepRef = useRef(false)
+  useEffect(() => {
+    if (stepRef.current) return
+    if (initialState?.selectedStep != null) {
       dispatch({
         type: 'SetSelectedStepAction',
         step: initialState.selectedStep
       })
-    if (initialState?.selectedBlock != null)
-      dispatch({
-        type: 'SetSelectedBlockAction',
-        block: initialState.selectedBlock
-      })
-  }, [
-    initialState?.steps,
-    initialState?.selectedStep,
-    initialState?.selectedBlock
-  ])
+      stepRef.current = true
+    }
+  }, [initialState?.selectedStep])
 
   return (
     <EditorContext.Provider value={{ state, dispatch }}>

--- a/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
+++ b/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
@@ -201,6 +201,19 @@ export function EditorProvider({
     }
   }, [initialState?.selectedStep])
 
+  // only run once
+  const blockRef = useRef(false)
+  useEffect(() => {
+    if (blockRef.current) return
+    if (initialState?.selectedBlock != null) {
+      dispatch({
+        type: 'SetSelectedBlockAction',
+        block: initialState.selectedBlock
+      })
+      blockRef.current = true
+    }
+  }, [initialState?.selectedBlock])
+
   return (
     <EditorContext.Provider value={{ state, dispatch }}>
       {children}


### PR DESCRIPTION
# Description

This resolves the issue of the url selected step loading again after block creation, while allowing the selected block to be selected from journey overview

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/28141725/todos/5055629370)

# How should this PR be QA Tested?

- [ ] Select a card from journey overview, ensure correct step is displayed
- [ ] Create a block on another card, ensure it does not return to previously selected step

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
