### PR TITLE
fix: link tests using env failing on development

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.spec.tsx
@@ -7,6 +7,8 @@ import { SocialShareAppearance } from '.'
 
 describe('SocialShareAppearance', () => {
   const slug = 'untitiled-journey'
+  const originalEnv = process.env
+
   it('should render SocialShareAppearance', () => {
     const { getByText, getByTestId, getByRole } = render(
       <MockedProvider>
@@ -28,7 +30,44 @@ describe('SocialShareAppearance', () => {
     expect(getByRole('button', { name: 'Twitter' })).toBeInTheDocument()
   })
 
-  it('should open facebook share in new window', () => {
+  it('should open facebook share in new window in development', () => {
+    jest.resetModules()
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_JOURNEYS_URL: 'http://localhost:4100'
+    }
+
+    const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${process.env.NEXT_PUBLIC_JOURNEYS_URL}/${slug}`
+
+    const { getByRole } = render(
+      <MockedProvider>
+        <JourneyProvider
+          value={{ journey: { slug } as unknown as Journey, admin: true }}
+        >
+          <SocialShareAppearance />
+        </JourneyProvider>
+      </MockedProvider>
+    )
+
+    expect(getByRole('link', { name: 'Facebook' })).toHaveAttribute(
+      'href',
+      facebookUrl
+    )
+    expect(getByRole('link', { name: 'Facebook' })).toHaveAttribute(
+      'target',
+      '_blank'
+    )
+
+    process.env = originalEnv
+  })
+
+  it('should open facebook share in new window in production', () => {
+    jest.resetModules()
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_JOURNEYS_URL: undefined
+    }
+
     const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=https://your.nextstep.is/${slug}`
 
     const { getByRole } = render(
@@ -49,9 +88,48 @@ describe('SocialShareAppearance', () => {
       'target',
       '_blank'
     )
+
+    process.env = originalEnv
   })
 
-  it('should open twitter share in new window', () => {
+  it('should open twitter share in new window in development', () => {
+    jest.resetModules()
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_JOURNEYS_URL: 'http://localhost:4100'
+    }
+
+    const twitterUrl = `https://twitter.com/intent/tweet?url=${process.env.NEXT_PUBLIC_JOURNEYS_URL}/${slug}`
+
+    const { getByRole } = render(
+      <MockedProvider>
+        <JourneyProvider
+          value={{ journey: { slug } as unknown as Journey, admin: true }}
+        >
+          <SocialShareAppearance />
+        </JourneyProvider>
+      </MockedProvider>
+    )
+
+    expect(getByRole('link', { name: 'Twitter' })).toHaveAttribute(
+      'href',
+      twitterUrl
+    )
+    expect(getByRole('link', { name: 'Twitter' })).toHaveAttribute(
+      'target',
+      '_blank'
+    )
+
+    process.env = originalEnv
+  })
+
+  it('should open twitter share in new window in production', () => {
+    jest.resetModules()
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_JOURNEYS_URL: undefined
+    }
+
     const twitterUrl = `https://twitter.com/intent/tweet?url=https://your.nextstep.is/${slug}`
 
     const { getByRole } = render(
@@ -72,6 +150,8 @@ describe('SocialShareAppearance', () => {
       'target',
       '_blank'
     )
+
+    process.env = originalEnv
   })
 
   it('should disable share buttons  and show tool tip if journey is not published', async () => {

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.spec.tsx
@@ -37,7 +37,9 @@ describe('SocialShareAppearance', () => {
       NEXT_PUBLIC_JOURNEYS_URL: 'http://localhost:4100'
     }
 
-    const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${process.env.NEXT_PUBLIC_JOURNEYS_URL}/${slug}`
+    const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${
+      process.env.NEXT_PUBLIC_JOURNEYS_URL as string
+    }/${slug}`
 
     const { getByRole } = render(
       <MockedProvider>
@@ -99,7 +101,9 @@ describe('SocialShareAppearance', () => {
       NEXT_PUBLIC_JOURNEYS_URL: 'http://localhost:4100'
     }
 
-    const twitterUrl = `https://twitter.com/intent/tweet?url=${process.env.NEXT_PUBLIC_JOURNEYS_URL}/${slug}`
+    const twitterUrl = `https://twitter.com/intent/tweet?url=${
+      process.env.NEXT_PUBLIC_JOURNEYS_URL as string
+    }/${slug}`
 
     const { getByRole } = render(
       <MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.spec.tsx
@@ -15,16 +15,6 @@ Object.assign(navigator, {
 
 describe('JourneyView/Menu', () => {
   const originalEnv = process.env
-  // beforeEach(() => {
-  //   jest.resetModules()
-  //   process.env = {
-  //     ...originalEnv,
-  //     NEXT_PUBLIC_JOURNEYS_URL: 'http://localhost:4100'
-  //   }
-  // })
-  // afterEach(() => {
-  //   process.env = originalEnv
-  // })
 
   it('should open menu on click', () => {
     const { getByRole } = render(


### PR DESCRIPTION
# Description

A recent change allowing links to use a localhost URL broke some tests when running `nx test journeys-admin`, this PR ensures the tests have the correct env keys

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/28141725/todos/5097086540)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Git hub actions should pass
- [x] You should pull this branch and run `nx test journeys-admin` locally and it should all pass

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
