### PR TITLE
fix: scrolls to the duplicated journey

### DIFF
--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCard.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCard.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react'
+import { ReactElement, useRef, useEffect } from 'react'
 import { parseISO, isThisYear, intlFormat } from 'date-fns'
 import Card from '@mui/material/Card'
 import Grid from '@mui/material/Grid'
@@ -23,6 +23,7 @@ import { StatusChip } from './StatusChip'
 
 interface JourneyCardProps {
   journey?: Journey
+  duplicatedJourneyId?: string
   refetch?: () => Promise<
     ApolloQueryResult<
       GetActiveJourneys | GetArchivedJourneys | GetTrashedJourneys
@@ -32,10 +33,24 @@ interface JourneyCardProps {
 
 export function JourneyCard({
   journey,
+  duplicatedJourneyId,
   refetch
 }: JourneyCardProps): ReactElement {
+  const duplicatedJourneyRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (duplicatedJourneyId != null && duplicatedJourneyRef.current != null) {
+      duplicatedJourneyRef.current.scrollIntoView({
+        behavior: 'smooth'
+      })
+    }
+  }, [duplicatedJourneyId, journey])
+
   return (
     <Card
+      ref={
+        journey?.id === duplicatedJourneyId ? duplicatedJourneyRef : undefined
+      }
       aria-label="journey-card"
       variant="outlined"
       sx={{

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCard.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCard.tsx
@@ -41,7 +41,8 @@ export function JourneyCard({
   useEffect(() => {
     if (duplicatedJourneyId != null && duplicatedJourneyRef.current != null) {
       duplicatedJourneyRef.current.scrollIntoView({
-        behavior: 'smooth'
+        behavior: 'smooth',
+        block: 'center'
       })
     }
   }, [duplicatedJourneyId, journey])

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem.tsx/DuplicateJourneyMenuItem.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem.tsx/DuplicateJourneyMenuItem.tsx
@@ -60,6 +60,7 @@ export function DuplicateJourneyMenuItem({
       variant: 'success',
       preventDuplicate: true
     })
+    window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
   return (

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem.tsx/DuplicateJourneyMenuItem.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem.tsx/DuplicateJourneyMenuItem.tsx
@@ -60,7 +60,6 @@ export function DuplicateJourneyMenuItem({
       variant: 'success',
       preventDuplicate: true
     })
-    window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
   return (

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/ActiveStatusTab.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/ActiveStatusTab.tsx
@@ -5,12 +5,16 @@ import Typography from '@mui/material/Typography'
 import { useTranslation } from 'react-i18next'
 import { AuthUser } from 'next-firebase-auth'
 import { useSnackbar } from 'notistack'
-import { GetActiveJourneys } from '../../../../../__generated__/GetActiveJourneys'
+import {
+  GetActiveJourneys,
+  GetActiveJourneys_journeys as Journeys
+} from '../../../../../__generated__/GetActiveJourneys'
 import { JourneyCard } from '../../JourneyCard'
 import { AddJourneyButton } from '../../AddJourneyButton'
 import { SortOrder } from '../../JourneySort'
 import { Dialog } from '../../../Dialog'
 import { sortJourneys } from '../../JourneySort/utils/sortJourneys'
+import { getDuplicatedJourney } from './utils/getDuplicatedJourney'
 
 export const GET_ACTIVE_JOURNEYS = gql`
   query GetActiveJourneys {
@@ -85,20 +89,15 @@ export function ActiveStatusTab({
 
   const journeys = data?.journeys
 
-  const [oldJourneys, setOldJourneys] = useState(data?.journeys)
+  const [oldJourneys, setOldJourneys] = useState<Journeys[]>()
+  const [newJourneys, setNewJourneys] = useState<Journeys[]>()
 
   useEffect(() => {
-    if (data != null) {
-      setOldJourneys(data.journeys)
-    }
-  }, [data])
+    setOldJourneys(newJourneys)
+    setNewJourneys(journeys)
+  }, [data, journeys, newJourneys, oldJourneys])
 
-  let duplicatedJourneyId: string | undefined
-  if (oldJourneys !== journeys && oldJourneys != null) {
-    duplicatedJourneyId = journeys?.find(
-      (journey, i) => journey !== oldJourneys[i]
-    )?.id
-  }
+  const duplicatedJourneyId = getDuplicatedJourney(oldJourneys, newJourneys)
 
   const [archiveActive] = useMutation(ARCHIVE_ACTIVE_JOURNEYS, {
     variables: {

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/ActiveStatusTab.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/ActiveStatusTab.tsx
@@ -87,17 +87,15 @@ export function ActiveStatusTab({
   const { data, loading, error, refetch } =
     useQuery<GetActiveJourneys>(GET_ACTIVE_JOURNEYS)
 
-  const journeys = data?.journeys
-
   const [oldJourneys, setOldJourneys] = useState<Journeys[]>()
-  const [newJourneys, setNewJourneys] = useState<Journeys[]>()
+  const [journeys, setJourneys] = useState<Journeys[]>()
 
   useEffect(() => {
-    setOldJourneys(newJourneys)
-    setNewJourneys(journeys)
-  }, [data, journeys, newJourneys, oldJourneys])
+    setOldJourneys(journeys)
+    setJourneys(data?.journeys)
+  }, [data, journeys, oldJourneys])
 
-  const duplicatedJourneyId = getDuplicatedJourney(oldJourneys, newJourneys)
+  const duplicatedJourneyId = getDuplicatedJourney(oldJourneys, journeys)
 
   const [archiveActive] = useMutation(ARCHIVE_ACTIVE_JOURNEYS, {
     variables: {

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/ActiveStatusTab.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/ActiveStatusTab.tsx
@@ -85,6 +85,21 @@ export function ActiveStatusTab({
 
   const journeys = data?.journeys
 
+  const [oldJourneys, setOldJourneys] = useState(data?.journeys)
+
+  useEffect(() => {
+    if (data != null) {
+      setOldJourneys(data.journeys)
+    }
+  }, [data])
+
+  let duplicatedJourneyId: string | undefined
+  if (oldJourneys !== journeys && oldJourneys != null) {
+    duplicatedJourneyId = journeys?.find(
+      (journey, i) => journey !== oldJourneys[i]
+    )?.id
+  }
+
   const [archiveActive] = useMutation(ARCHIVE_ACTIVE_JOURNEYS, {
     variables: {
       ids: journeys
@@ -188,7 +203,12 @@ export function ActiveStatusTab({
       {journeys != null && sortedJourneys != null ? (
         <>
           {sortedJourneys.map((journey) => (
-            <JourneyCard key={journey.id} journey={journey} refetch={refetch} />
+            <JourneyCard
+              key={journey.id}
+              journey={journey}
+              refetch={refetch}
+              duplicatedJourneyId={duplicatedJourneyId}
+            />
           ))}
           {journeys.length === 0 && (
             <Card

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/utils/getDuplicated.spec.ts
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/utils/getDuplicated.spec.ts
@@ -1,0 +1,84 @@
+import { formatISO, startOfYear } from 'date-fns'
+import {
+  ThemeName,
+  ThemeMode,
+  JourneyStatus,
+  UserJourneyRole
+} from '../../../../../../__generated__/globalTypes'
+import { getDuplicatedJourney } from './getDuplicatedJourney'
+
+describe('getDuplicatedJourney', () => {
+  const defaultJourney = {
+    __typename: 'Journey',
+    id: 'journey-id',
+    title: 'Default Journey Heading',
+    description: null,
+    themeName: ThemeName.base,
+    themeMode: ThemeMode.light,
+    slug: 'default',
+    language: {
+      __typename: 'Language',
+      id: '529',
+      name: [
+        {
+          __typename: 'Translation',
+          value: 'English',
+          primary: true
+        }
+      ]
+    },
+    createdAt: formatISO(startOfYear(new Date())),
+    publishedAt: null,
+    status: JourneyStatus.published,
+    seoTitle: null,
+    seoDescription: null,
+    userJourneys: {
+      __typename: 'UserJourney',
+      id: 'user-journey-id',
+      role: UserJourneyRole.owner,
+      user: {
+        __typename: 'User',
+        id: 'user-id1',
+        firstName: 'Amin',
+        lastName: 'One',
+        imageUrl: 'https://bit.ly/3Gth4Yf'
+      }
+    }
+  }
+
+  const journey1 = {
+    ...defaultJourney,
+    id: 'published-journey-id',
+    title: 'Published Journey Heading',
+    description: 'a published journey',
+    publishedAt: formatISO(startOfYear(new Date()))
+  }
+  const journey2 = {
+    id: 'published-journey2-id',
+    title: 'Published Journey2 Heading',
+    description: 'a published journey2',
+    publishedAt: formatISO(startOfYear(new Date()))
+  }
+  const duplicatedJourney = {
+    id: 'duplicated-journey-id',
+    title: 'Duplicated Journey Heading',
+    description: 'a duplicated journey',
+    publishedAt: formatISO(startOfYear(new Date()))
+  }
+
+  const oldJourneys = [journey1, journey2]
+  const newJourneys = [journey1, journey2, duplicatedJourney]
+
+  it('should return the duplicated journeys id', () => {
+    const duplicatedJourneyId = getDuplicatedJourney(oldJourneys, newJourneys)
+    expect(duplicatedJourneyId).toEqual('duplicated-journey-id')
+  })
+
+  it('should not return the duplicated journey id if journey length is the same', () => {
+    const duplicatedJourneyId = getDuplicatedJourney(
+      [...oldJourneys, journey1],
+      newJourneys
+    )
+    expect(duplicatedJourneyId).not.toEqual('duplicated-journey-id')
+  })
+})

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/utils/getDuplicated.spec.ts
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/utils/getDuplicated.spec.ts
@@ -67,18 +67,20 @@ describe('getDuplicatedJourney', () => {
   }
 
   const oldJourneys = [journey1, journey2]
-  const newJourneys = [journey1, journey2, duplicatedJourney]
+  const journeys = [journey1, journey2, duplicatedJourney]
 
   it('should return the duplicated journeys id', () => {
-    const duplicatedJourneyId = getDuplicatedJourney(oldJourneys, newJourneys)
+    const duplicatedJourneyId = getDuplicatedJourney(oldJourneys, journeys)
     expect(duplicatedJourneyId).toEqual('duplicated-journey-id')
   })
 
-  it('should not return the duplicated journey id if journey length is the same', () => {
-    const duplicatedJourneyId = getDuplicatedJourney(
+  it('should return undefined if journey length is not 1 more than old journeys', () => {
+    const lowerBoundResult = getDuplicatedJourney([journey1], journeys)
+    const upperBoundResult = getDuplicatedJourney(
       [...oldJourneys, journey1],
-      newJourneys
+      journeys
     )
-    expect(duplicatedJourneyId).not.toEqual('duplicated-journey-id')
+    expect(lowerBoundResult).toBeUndefined()
+    expect(upperBoundResult).toBeUndefined()
   })
 })

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/utils/getDuplicatedJourney.ts
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/utils/getDuplicatedJourney.ts
@@ -1,8 +1,11 @@
 export const getDuplicatedJourney = (
   oldJourneys,
-  newJourneys
+  journeys
 ): string | undefined => {
-  if ((oldJourneys.length as number) + 1 === newJourneys.length) {
-    return newJourneys?.find((journey, i) => journey !== oldJourneys[i])?.id
+  if (
+    oldJourneys != null &&
+    (oldJourneys.length as number) + 1 === journeys.length
+  ) {
+    return journeys?.find((journey, i) => journey !== oldJourneys[i])?.id
   }
 }

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/utils/getDuplicatedJourney.ts
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/ActiveStatusTab/utils/getDuplicatedJourney.ts
@@ -1,0 +1,8 @@
+export const getDuplicatedJourney = (
+  oldJourneys,
+  newJourneys
+): string | undefined => {
+  if ((oldJourneys.length as number) + 1 === newJourneys.length) {
+    return newJourneys?.find((journey, i) => journey !== oldJourneys[i])?.id
+  }
+}


### PR DESCRIPTION
# Description

If our users have a lot of journeys and they've decided to duplicate a journey at the very bottom of the list. Some of them might not be aware that they'll have to scroll to the duplicated journey. I've added the ability to automatically scroll to the duplicated journey

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] After duplicating a journey it should scroll to the duplicated journey regardless of how it is currently sorted

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
