### PR TITLE
fix: unwanted report re renders

### DIFF
--- a/apps/journeys-admin/pages/journeys/[journeyId]/reports.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/reports.tsx
@@ -13,7 +13,7 @@ import Box from '@mui/material/Box'
 import { useRouter } from 'next/router'
 import { PageWrapper } from '../../../src/components/PageWrapper'
 import i18nConfig from '../../../next-i18next.config'
-import { DynamicPowerBiReport } from '../../../src/components/DynamicPowerBiReport'
+import { MemoizedDynamicReport } from '../../../src/components/DynamicPowerBiReport'
 import { JourneysReportType } from '../../../__generated__/globalTypes'
 
 function JourneyReportsPage(): ReactElement {
@@ -30,7 +30,7 @@ function JourneyReportsPage(): ReactElement {
         backHref={`/journeys/${router.query.journeyId as string}`}
       >
         <Box sx={{ height: 'calc(100vh - 48px)' }}>
-          <DynamicPowerBiReport reportType={JourneysReportType.singleFull} />
+          <MemoizedDynamicReport reportType={JourneysReportType.singleFull} />
         </Box>
       </PageWrapper>
     </>

--- a/apps/journeys-admin/pages/reports.tsx
+++ b/apps/journeys-admin/pages/reports.tsx
@@ -12,7 +12,7 @@ import { getLaunchDarklyClient } from '@core/shared/ui/getLaunchDarklyClient'
 import Box from '@mui/material/Box'
 import { PageWrapper } from '../src/components/PageWrapper'
 import i18nConfig from '../next-i18next.config'
-import { DynamicPowerBiReport } from '../src/components/DynamicPowerBiReport'
+import { MemoizedDynamicReport } from '../src/components/DynamicPowerBiReport'
 import { JourneysReportType } from '../__generated__/globalTypes'
 
 function ReportsPage(): ReactElement {
@@ -24,7 +24,7 @@ function ReportsPage(): ReactElement {
       <NextSeo title={t('Reports')} />
       <PageWrapper title={t('Reports')} authUser={AuthUser}>
         <Box sx={{ height: 'calc(100vh - 48px)' }}>
-          <DynamicPowerBiReport reportType={JourneysReportType.multipleFull} />
+          <MemoizedDynamicReport reportType={JourneysReportType.multipleFull} />
         </Box>
       </PageWrapper>
     </>

--- a/apps/journeys-admin/src/components/DynamicPowerBiReport/DyanmicPowerBiReport.spec.tsx
+++ b/apps/journeys-admin/src/components/DynamicPowerBiReport/DyanmicPowerBiReport.spec.tsx
@@ -3,7 +3,7 @@ import { render, waitFor } from '@testing-library/react'
 import { SnackbarProvider } from 'notistack'
 import { JourneysReportType } from '../../../__generated__/globalTypes'
 import { GET_ADMIN_JOURNEYS_REPORT } from './Report/Report'
-import { DynamicPowerBiReport } from '.'
+import { MemoizedDynamicReport } from '.'
 
 describe('DynamicPowerBiReport', () => {
   it('should render the report', async () => {
@@ -28,7 +28,7 @@ describe('DynamicPowerBiReport', () => {
         ]}
       >
         <SnackbarProvider>
-          <DynamicPowerBiReport reportType={JourneysReportType.multipleFull} />
+          <MemoizedDynamicReport reportType={JourneysReportType.multipleFull} />
         </SnackbarProvider>
       </MockedProvider>
     )

--- a/apps/journeys-admin/src/components/DynamicPowerBiReport/DynamicPowerBiReport.tsx
+++ b/apps/journeys-admin/src/components/DynamicPowerBiReport/DynamicPowerBiReport.tsx
@@ -1,8 +1,8 @@
-import { ReactElement } from 'react'
+import { ReactElement, memo } from 'react'
 import dynamic from 'next/dynamic'
 import { ReportProps } from './Report/Report'
 
-export function DynamicPowerBiReport(props: ReportProps): ReactElement {
+function DynamicPowerBiReport(props: ReportProps): ReactElement {
   // PowerBI needs dynamic import
   // See issue: https://github.com/microsoft/powerbi-client-react/issues/65
   const Report = dynamic<ReportProps>(
@@ -16,3 +16,5 @@ export function DynamicPowerBiReport(props: ReportProps): ReactElement {
 
   return <Report {...props} />
 }
+
+export const MemoizedDynamicReport = memo(DynamicPowerBiReport)

--- a/apps/journeys-admin/src/components/DynamicPowerBiReport/index.ts
+++ b/apps/journeys-admin/src/components/DynamicPowerBiReport/index.ts
@@ -1,1 +1,1 @@
-export { DynamicPowerBiReport } from './DynamicPowerBiReport'
+export { MemoizedDynamicReport } from './DynamicPowerBiReport'

--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/StatusTabPanel.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/StatusTabPanel.tsx
@@ -82,7 +82,6 @@ export function StatusTabPanel({
     newValue: number
   ): void => {
     if (newValue != null && router != null) {
-      // handle change can't be tested until more tabs are added
       setActiveTab(newValue)
       // ensure tab data is refreshed on change
       switch (newValue) {
@@ -102,10 +101,14 @@ export function StatusTabPanel({
       const tabParam =
         journeyStatusTabs.find((status) => status.tabIndex === newValue)
           ?.queryParam ?? journeyStatusTabs[0].queryParam
-      void router.push({
-        href: '/',
-        query: { tab: tabParam }
-      })
+      void router.push(
+        {
+          href: '/',
+          query: { tab: tabParam }
+        },
+        undefined,
+        { shallow: true }
+      )
     }
   }
 

--- a/apps/journeys-admin/src/components/JourneyView/JourneyView.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyView.tsx
@@ -15,7 +15,7 @@ import { useTranslation } from 'react-i18next'
 import { useFlags } from '@core/shared/ui/FlagsProvider'
 import { JourneysReportType } from '../../../__generated__/globalTypes'
 import { BlockFields_StepBlock as StepBlock } from '../../../__generated__/BlockFields'
-import { DynamicPowerBiReport } from '../DynamicPowerBiReport'
+import { MemoizedDynamicReport } from '../DynamicPowerBiReport'
 import { Properties } from './Properties'
 import { CardView } from './CardView'
 import { SlugDialog } from './Properties/SlugDialog'
@@ -58,7 +58,7 @@ export function JourneyView(): ReactElement {
             sx={{ height: '213px', pb: 6, mx: 6 }}
             data-testid="power-bi-report"
           >
-            <DynamicPowerBiReport
+            <MemoizedDynamicReport
               reportType={JourneysReportType.singleSummary}
             />
           </Box>

--- a/apps/journeys-admin/src/components/MultipleSummaryReport/MultipleSummaryReport.tsx
+++ b/apps/journeys-admin/src/components/MultipleSummaryReport/MultipleSummaryReport.tsx
@@ -7,7 +7,7 @@ import Button from '@mui/material/Button'
 import ArrowForwardIosRoundedIcon from '@mui/icons-material/ArrowForwardIosRounded'
 import Link from 'next/link'
 import { JourneysReportType } from '../../../__generated__/globalTypes'
-import { DynamicPowerBiReport } from '../DynamicPowerBiReport'
+import { MemoizedDynamicReport } from '../DynamicPowerBiReport'
 
 export function MultipleSummaryReport(): ReactElement {
   return (
@@ -33,7 +33,7 @@ export function MultipleSummaryReport(): ReactElement {
           </Link>
         </Stack>
         <Box sx={{ height: '160px', pb: 8 }}>
-          <DynamicPowerBiReport
+          <MemoizedDynamicReport
             reportType={JourneysReportType.multipleSummary}
           />
         </Box>


### PR DESCRIPTION
# Description

Reports were re rendering each time a state changed on the page.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/28141725/todos/5094429522)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Changing tabs shouldn't cause multiple summary report to re render.
- [x] Updating journey details shouldn't cause single summary report to re render

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
