### PR TITLE
refactor: layout calculations from js to css

### DIFF
--- a/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/StatusTabPanel.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/StatusTabPanel/StatusTabPanel.tsx
@@ -115,15 +115,13 @@ export function StatusTabPanel({
   return (
     <>
       <>
-        {!smUp && (
-          <Box sx={{ my: 4, ml: 6 }}>
-            <JourneySort
-              sortOrder={sortOrder}
-              onChange={setSortOrder}
-              disabled={!tabsLoaded}
-            />
-          </Box>
-        )}
+        <Box sx={{ my: 4, ml: 6, display: smUp ? 'none' : 'block' }}>
+          <JourneySort
+            sortOrder={sortOrder}
+            onChange={setSortOrder}
+            disabled={!tabsLoaded}
+          />
+        </Box>
 
         <Card
           variant="outlined"
@@ -168,22 +166,21 @@ export function StatusTabPanel({
               disabled={!tabsLoaded}
             />
 
-            {smUp && (
-              <Box
-                sx={{
-                  mr: 6,
-                  ml: 'auto',
-                  mt: 3,
-                  mb: 2
-                }}
-              >
-                <JourneySort
-                  sortOrder={sortOrder}
-                  onChange={setSortOrder}
-                  disabled={!tabsLoaded}
-                />
-              </Box>
-            )}
+            <Box
+              sx={{
+                mr: 6,
+                ml: 'auto',
+                mt: 3,
+                mb: 2,
+                display: !smUp ? 'none' : 'block'
+              }}
+            >
+              <JourneySort
+                sortOrder={sortOrder}
+                onChange={setSortOrder}
+                disabled={!tabsLoaded}
+              />
+            </Box>
           </Tabs>
         </Card>
 

--- a/apps/journeys-admin/src/components/PageWrapper/PageWrapper.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/PageWrapper.tsx
@@ -57,11 +57,12 @@ export function PageWrapper({
           }
         }}
       >
-        {!smUp && showAppBarMobile ? (
+        {showAppBarMobile ? (
           <Toolbar
             sx={{
               backgroundColor: 'secondary.dark',
-              justifyContent: 'center'
+              justifyContent: 'center',
+              display: smUp ? 'none' : 'flex'
             }}
           >
             <IconButton


### PR DESCRIPTION
# Description

Nav bar and sort chip elements layout was being calculated by javascript, this caused the element to appear before it gets hidden.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/28141725/todos/5128964737)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] When visiting journey list and journey view, when page loads the top nav bar should not appear on desktop
- [x] On journey list, the status chip should not appear above the tab panel on desktop
- [x] Note: after many refreshes, the page gets cached and it can be hard to see this.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main