### PR TITLE
fix: next card property title and remove action

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/SelectedCard.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/SelectedCard.spec.tsx
@@ -47,12 +47,12 @@ describe('Selected Card', () => {
 
   const steps = [selectedBlock, nextBlock, noNextBlockId, lastBlock]
 
-  it('updates nextBlockId to the step itself on remove button click', async () => {
+  it('removes nextBlockId on remove button click', async () => {
     const result = jest.fn(() => ({
       data: {
         stepBlockUpdate: {
           id: 'step0.id',
-          nextBlockId: 'step0.id'
+          nextBlockId: null
         }
       }
     }))
@@ -67,7 +67,7 @@ describe('Selected Card', () => {
                 id: selectedBlock.id,
                 journeyId: 'journeyId',
                 input: {
-                  nextBlockId: selectedBlock.id
+                  nextBlockId: null
                 }
               }
             },

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/SelectedCard.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/SelectedCard/SelectedCard.tsx
@@ -62,7 +62,6 @@ export function SelectedCard(): ReactElement {
     }
   }, [steps, nextBlockId, selectedBlock, lastStep, parentOrder])
 
-  // TODO: Set as block itself for now, still need to manually set next block
   async function handleRemoveCustomNextStep(): Promise<void> {
     if (journey == null) return
 
@@ -71,14 +70,14 @@ export function SelectedCard(): ReactElement {
         id,
         journeyId: journey.id,
         input: {
-          nextBlockId: id
+          nextBlockId: null
         }
       },
       optimisticResponse: {
         stepBlockUpdate: {
           id,
           __typename: 'StepBlock',
-          nextBlockId: id
+          nextBlockId: null
         }
       }
     })

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.spec.tsx
@@ -97,7 +97,7 @@ describe('Step', () => {
         parentBlockId: null,
         parentOrder: 0,
         locked: false,
-        nextBlockId: 'step2.id',
+        nextBlockId: null,
         children: []
       }
       const step2: TreeBlock<StepBlock> = {
@@ -121,6 +121,72 @@ describe('Step', () => {
       expect(getByText('Step {{number}}')).toBeInTheDocument()
     })
 
+    it('shows custom next step title', () => {
+      const step1: TreeBlock<StepBlock> = {
+        id: 'step1.id',
+        __typename: 'StepBlock',
+        parentBlockId: null,
+        parentOrder: 0,
+        locked: false,
+        nextBlockId: 'step5.id',
+        children: []
+      }
+      const step2: TreeBlock<StepBlock> = {
+        id: 'step2.id',
+        __typename: 'StepBlock',
+        parentBlockId: null,
+        parentOrder: 1,
+        locked: false,
+        nextBlockId: null,
+        children: []
+      }
+      const step5: TreeBlock<StepBlock> = {
+        id: 'step5.id',
+        __typename: 'StepBlock',
+        parentBlockId: null,
+        parentOrder: 4,
+        locked: false,
+        nextBlockId: null,
+        children: [
+          {
+            __typename: 'CardBlock',
+            id: 'card1.id',
+            parentBlockId: 'step2.id',
+            coverBlockId: null,
+            parentOrder: 0,
+            backgroundColor: null,
+            themeMode: null,
+            themeName: null,
+            fullscreen: false,
+            children: [
+              {
+                __typename: 'TypographyBlock',
+                id: 'typography',
+                content: 'my Title',
+                parentBlockId: 'card1.id',
+                parentOrder: 0,
+                align: null,
+                color: null,
+                variant: null,
+                children: []
+              }
+            ]
+          }
+        ]
+      }
+
+      const { getByText } = render(
+        <EditorProvider
+          initialState={{
+            steps: [step1, step2, step5]
+          }}
+        >
+          <Step {...step1} />
+        </EditorProvider>
+      )
+      expect(getByText('my Title')).toBeInTheDocument()
+    })
+
     it('shows first typography text', () => {
       const step1: TreeBlock<StepBlock> = {
         id: 'step1.id',
@@ -128,7 +194,7 @@ describe('Step', () => {
         parentBlockId: null,
         parentOrder: 0,
         locked: false,
-        nextBlockId: 'step2.id',
+        nextBlockId: null,
         children: []
       }
       const step2: TreeBlock<StepBlock> = {
@@ -175,6 +241,37 @@ describe('Step', () => {
         </EditorProvider>
       )
       expect(getByText('my Title')).toBeInTheDocument()
+    })
+
+    it('should show none', () => {
+      const step1: TreeBlock<StepBlock> = {
+        id: 'step1.id',
+        __typename: 'StepBlock',
+        parentBlockId: null,
+        parentOrder: 0,
+        locked: false,
+        nextBlockId: null,
+        children: []
+      }
+      const step2: TreeBlock<StepBlock> = {
+        id: 'step2.id',
+        __typename: 'StepBlock',
+        parentBlockId: null,
+        parentOrder: 1,
+        locked: false,
+        nextBlockId: null,
+        children: []
+      }
+      const { getByText } = render(
+        <EditorProvider
+          initialState={{
+            steps: [step1, step2]
+          }}
+        >
+          <Step {...step2} />
+        </EditorProvider>
+      )
+      expect(getByText('None')).toBeInTheDocument()
     })
   })
 })

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.tsx
@@ -12,6 +12,7 @@ import { NextCard } from './NextCard'
 export function Step({
   id,
   nextBlockId,
+  parentOrder,
   locked
 }: TreeBlock<StepBlock>): ReactElement {
   const {
@@ -19,10 +20,17 @@ export function Step({
     dispatch
   } = useEditor()
   const { t } = useTranslation('apps-journeys-admin')
-  const nextBlock = steps?.find(({ id }) => id === nextBlockId)
+
+  let nextStep: TreeBlock<StepBlock> | undefined
+  if (nextBlockId != null) {
+    nextStep = steps?.find((step) => nextBlockId === step.id)
+  } else if (parentOrder != null) {
+    nextStep = steps?.find((step) => parentOrder + 1 === step.parentOrder)
+  }
+
   const heading =
-    nextBlockId != null && nextBlock != null && steps != null
-      ? getStepHeading(nextBlockId, nextBlock.children, steps, t)
+    nextStep != null && steps != null
+      ? getStepHeading(nextStep.id, nextStep.children, steps, t)
       : 'None'
 
   return (


### PR DESCRIPTION
# Description

How the default next card is calculated got refactored in a previous [PR](https://github.com/JesusFilm/core/commit/b1470484769e13acddbfe94bdaa7119999ad4c3a). This PR makes the same fix for the `NextCard` button in card properties. Also updated the remove action, so nextBlockId is removed instead of selecting itself.


- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] NextCard button should display the title of the next card (or its step number) on default nextBlock
- [ ] NextCard button should display the title of the next card (or its step number) on custom nextBlock
- [ ] Removing nextBlockId (from drawer) should change back to default nextBlock

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
