### PR TITLE
fix: make drafts previewable

### DIFF
--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -143,7 +143,6 @@ export class JourneyResolver {
       idType === IdType.slug
         ? await this.journeyService.getBySlug(id)
         : await this.journeyService.get(id)
-    if (result?.publishedAt == null) return null
     return result
   }
 


### PR DESCRIPTION
# Description

Enable journeys that have a status of drafts to be previewable. This is so that templates can be previewed even when their status is currently on draft. This change is only on the backend. On the frontend, if they're on a journey and have a status of draft, users still can't click on the preview button. 

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/28496234/todos/5168859103)

# How should this PR be QA Tested?

- [ ] API only

Manual Checks
- removing the check on the front end for disabling the preview button. Then create a new journey and preview it.
- previewing a published journey and changing its status on the database to draft. The same link should still be working as intended

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
