### PR TITLE
fix: journeys language overflow

### DIFF
--- a/apps/journeys-admin/__generated__/BlockFields.ts
+++ b/apps/journeys-admin/__generated__/BlockFields.ts
@@ -275,25 +275,12 @@ export interface BlockFields_VideoBlock_video_variant {
   hls: string | null;
 }
 
-export interface BlockFields_VideoBlock_video_variantLanguages_name {
-  __typename: "Translation";
-  value: string;
-  primary: boolean;
-}
-
-export interface BlockFields_VideoBlock_video_variantLanguages {
-  __typename: "Language";
-  id: string;
-  name: BlockFields_VideoBlock_video_variantLanguages_name[];
-}
-
 export interface BlockFields_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: BlockFields_VideoBlock_video_title[];
   image: string | null;
   variant: BlockFields_VideoBlock_video_variant | null;
-  variantLanguages: BlockFields_VideoBlock_video_variantLanguages[];
 }
 
 export interface BlockFields_VideoBlock_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/CardBlockVideoBlockCreate.ts
+++ b/apps/journeys-admin/__generated__/CardBlockVideoBlockCreate.ts
@@ -20,25 +20,12 @@ export interface CardBlockVideoBlockCreate_videoBlockCreate_video_variant {
   hls: string | null;
 }
 
-export interface CardBlockVideoBlockCreate_videoBlockCreate_video_variantLanguages_name {
-  __typename: "Translation";
-  value: string;
-  primary: boolean;
-}
-
-export interface CardBlockVideoBlockCreate_videoBlockCreate_video_variantLanguages {
-  __typename: "Language";
-  id: string;
-  name: CardBlockVideoBlockCreate_videoBlockCreate_video_variantLanguages_name[];
-}
-
 export interface CardBlockVideoBlockCreate_videoBlockCreate_video {
   __typename: "Video";
   id: string;
   title: CardBlockVideoBlockCreate_videoBlockCreate_video_title[];
   image: string | null;
   variant: CardBlockVideoBlockCreate_videoBlockCreate_video_variant | null;
-  variantLanguages: CardBlockVideoBlockCreate_videoBlockCreate_video_variantLanguages[];
 }
 
 export interface CardBlockVideoBlockCreate_videoBlockCreate_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/CardBlockVideoBlockUpdate.ts
+++ b/apps/journeys-admin/__generated__/CardBlockVideoBlockUpdate.ts
@@ -20,25 +20,12 @@ export interface CardBlockVideoBlockUpdate_videoBlockUpdate_video_variant {
   hls: string | null;
 }
 
-export interface CardBlockVideoBlockUpdate_videoBlockUpdate_video_variantLanguages_name {
-  __typename: "Translation";
-  value: string;
-  primary: boolean;
-}
-
-export interface CardBlockVideoBlockUpdate_videoBlockUpdate_video_variantLanguages {
-  __typename: "Language";
-  id: string;
-  name: CardBlockVideoBlockUpdate_videoBlockUpdate_video_variantLanguages_name[];
-}
-
 export interface CardBlockVideoBlockUpdate_videoBlockUpdate_video {
   __typename: "Video";
   id: string;
   title: CardBlockVideoBlockUpdate_videoBlockUpdate_video_title[];
   image: string | null;
   variant: CardBlockVideoBlockUpdate_videoBlockUpdate_video_variant | null;
-  variantLanguages: CardBlockVideoBlockUpdate_videoBlockUpdate_video_variantLanguages[];
 }
 
 export interface CardBlockVideoBlockUpdate_videoBlockUpdate_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/GetJourney.ts
+++ b/apps/journeys-admin/__generated__/GetJourney.ts
@@ -287,25 +287,12 @@ export interface GetJourney_journey_blocks_VideoBlock_video_variant {
   hls: string | null;
 }
 
-export interface GetJourney_journey_blocks_VideoBlock_video_variantLanguages_name {
-  __typename: "Translation";
-  value: string;
-  primary: boolean;
-}
-
-export interface GetJourney_journey_blocks_VideoBlock_video_variantLanguages {
-  __typename: "Language";
-  id: string;
-  name: GetJourney_journey_blocks_VideoBlock_video_variantLanguages_name[];
-}
-
 export interface GetJourney_journey_blocks_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: GetJourney_journey_blocks_VideoBlock_video_title[];
   image: string | null;
   variant: GetJourney_journey_blocks_VideoBlock_video_variant | null;
-  variantLanguages: GetJourney_journey_blocks_VideoBlock_video_variantLanguages[];
 }
 
 export interface GetJourney_journey_blocks_VideoBlock_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/GetVideoVariantLanguages.ts
+++ b/apps/journeys-admin/__generated__/GetVideoVariantLanguages.ts
@@ -1,0 +1,34 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: GetVideoVariantLanguages
+// ====================================================
+
+export interface GetVideoVariantLanguages_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface GetVideoVariantLanguages_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: GetVideoVariantLanguages_video_variantLanguages_name[];
+}
+
+export interface GetVideoVariantLanguages_video {
+  __typename: "Video";
+  id: string;
+  variantLanguages: GetVideoVariantLanguages_video_variantLanguages[];
+}
+
+export interface GetVideoVariantLanguages {
+  video: GetVideoVariantLanguages_video;
+}
+
+export interface GetVideoVariantLanguagesVariables {
+  id: string;
+}

--- a/apps/journeys-admin/__generated__/JourneyFields.ts
+++ b/apps/journeys-admin/__generated__/JourneyFields.ts
@@ -287,25 +287,12 @@ export interface JourneyFields_blocks_VideoBlock_video_variant {
   hls: string | null;
 }
 
-export interface JourneyFields_blocks_VideoBlock_video_variantLanguages_name {
-  __typename: "Translation";
-  value: string;
-  primary: boolean;
-}
-
-export interface JourneyFields_blocks_VideoBlock_video_variantLanguages {
-  __typename: "Language";
-  id: string;
-  name: JourneyFields_blocks_VideoBlock_video_variantLanguages_name[];
-}
-
 export interface JourneyFields_blocks_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: JourneyFields_blocks_VideoBlock_video_title[];
   image: string | null;
   variant: JourneyFields_blocks_VideoBlock_video_variant | null;
-  variantLanguages: JourneyFields_blocks_VideoBlock_video_variantLanguages[];
 }
 
 export interface JourneyFields_blocks_VideoBlock_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/VideoBlockCreate.ts
+++ b/apps/journeys-admin/__generated__/VideoBlockCreate.ts
@@ -20,25 +20,12 @@ export interface VideoBlockCreate_videoBlockCreate_video_variant {
   hls: string | null;
 }
 
-export interface VideoBlockCreate_videoBlockCreate_video_variantLanguages_name {
-  __typename: "Translation";
-  value: string;
-  primary: boolean;
-}
-
-export interface VideoBlockCreate_videoBlockCreate_video_variantLanguages {
-  __typename: "Language";
-  id: string;
-  name: VideoBlockCreate_videoBlockCreate_video_variantLanguages_name[];
-}
-
 export interface VideoBlockCreate_videoBlockCreate_video {
   __typename: "Video";
   id: string;
   title: VideoBlockCreate_videoBlockCreate_video_title[];
   image: string | null;
   variant: VideoBlockCreate_videoBlockCreate_video_variant | null;
-  variantLanguages: VideoBlockCreate_videoBlockCreate_video_variantLanguages[];
 }
 
 export interface VideoBlockCreate_videoBlockCreate_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/VideoBlockUpdate.ts
+++ b/apps/journeys-admin/__generated__/VideoBlockUpdate.ts
@@ -20,25 +20,12 @@ export interface VideoBlockUpdate_videoBlockUpdate_video_variant {
   hls: string | null;
 }
 
-export interface VideoBlockUpdate_videoBlockUpdate_video_variantLanguages_name {
-  __typename: "Translation";
-  value: string;
-  primary: boolean;
-}
-
-export interface VideoBlockUpdate_videoBlockUpdate_video_variantLanguages {
-  __typename: "Language";
-  id: string;
-  name: VideoBlockUpdate_videoBlockUpdate_video_variantLanguages_name[];
-}
-
 export interface VideoBlockUpdate_videoBlockUpdate_video {
   __typename: "Video";
   id: string;
   title: VideoBlockUpdate_videoBlockUpdate_video_title[];
   image: string | null;
   variant: VideoBlockUpdate_videoBlockUpdate_video_variant | null;
-  variantLanguages: VideoBlockUpdate_videoBlockUpdate_video_variantLanguages[];
 }
 
 export interface VideoBlockUpdate_videoBlockUpdate_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/VideoFields.ts
+++ b/apps/journeys-admin/__generated__/VideoFields.ts
@@ -18,25 +18,12 @@ export interface VideoFields_video_variant {
   hls: string | null;
 }
 
-export interface VideoFields_video_variantLanguages_name {
-  __typename: "Translation";
-  value: string;
-  primary: boolean;
-}
-
-export interface VideoFields_video_variantLanguages {
-  __typename: "Language";
-  id: string;
-  name: VideoFields_video_variantLanguages_name[];
-}
-
 export interface VideoFields_video {
   __typename: "Video";
   id: string;
   title: VideoFields_video_title[];
   image: string | null;
   variant: VideoFields_video_variant | null;
-  variantLanguages: VideoFields_video_variantLanguages[];
 }
 
 export interface VideoFields_action_NavigateAction {

--- a/apps/journeys-admin/src/components/CardPreview/CardList/CardList.spec.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardList/CardList.spec.tsx
@@ -73,20 +73,7 @@ describe('CardList', () => {
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
                 hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-              },
-              variantLanguages: [
-                {
-                  __typename: 'Language',
-                  id: '529',
-                  name: [
-                    {
-                      __typename: 'Translation',
-                      value: 'English',
-                      primary: true
-                    }
-                  ]
-                }
-              ]
+              }
             },
             endAt: null,
             startAt: null,

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
@@ -542,20 +542,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
                 hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-              },
-              variantLanguages: [
-                {
-                  __typename: 'Language',
-                  id: '529',
-                  name: [
-                    {
-                      __typename: 'Translation',
-                      value: 'English',
-                      primary: true
-                    }
-                  ]
-                }
-              ]
+              }
             },
             startAt: null,
             endAt: null,
@@ -635,20 +622,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
                 hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-              },
-              variantLanguages: [
-                {
-                  __typename: 'Language',
-                  id: '529',
-                  name: [
-                    {
-                      __typename: 'Translation',
-                      value: 'English',
-                      primary: true
-                    }
-                  ]
-                }
-              ]
+              }
             },
             startAt: null,
             endAt: null,

--- a/apps/journeys-admin/src/components/Editor/Canvas/Canvas.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/Canvas.stories.tsx
@@ -420,20 +420,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
                 hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-              },
-              variantLanguages: [
-                {
-                  __typename: 'Language',
-                  id: '529',
-                  name: [
-                    {
-                      __typename: 'Translation',
-                      value: 'English',
-                      primary: true
-                    }
-                  ]
-                }
-              ]
+              }
             },
             startAt: null,
             endAt: null,

--- a/apps/journeys-admin/src/components/Editor/Canvas/CardWrapper/CardWrapper.test.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/CardWrapper/CardWrapper.test.tsx
@@ -49,20 +49,7 @@ describe('CardWrapper', () => {
               __typename: 'VideoVariant',
               id: '2_0-FallingPlates-529',
               hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-            },
-            variantLanguages: [
-              {
-                __typename: 'Language',
-                id: '529',
-                name: [
-                  {
-                    __typename: 'Translation',
-                    value: 'English',
-                    primary: true
-                  }
-                ]
-              }
-            ]
+            }
           },
           startAt: null,
           endAt: null,
@@ -137,20 +124,7 @@ describe('CardWrapper', () => {
                 __typename: 'VideoVariant',
                 hls: null,
                 id: '2_0-FallingPlates-529'
-              },
-              variantLanguages: [
-                {
-                  __typename: 'Language',
-                  id: '529',
-                  name: [
-                    {
-                      __typename: 'Translation',
-                      value: 'English',
-                      primary: true
-                    }
-                  ]
-                }
-              ]
+              }
             },
             videoId: '2_0-FallingPlates',
             videoVariantLanguageId: '529'
@@ -305,20 +279,7 @@ describe('CardWrapper', () => {
             ],
             image:
               'https://d1wl257kev7hsz.cloudfront.net/cinematics/2_0-FallingPlates.mobileCinematicHigh.jpg',
-            variant: null,
-            variantLanguages: [
-              {
-                __typename: 'Language',
-                id: '529',
-                name: [
-                  {
-                    __typename: 'Translation',
-                    value: 'English',
-                    primary: true
-                  }
-                ]
-              }
-            ]
+            variant: null
           },
           startAt: null,
           endAt: null,
@@ -389,20 +350,7 @@ describe('CardWrapper', () => {
               ],
               image:
                 'https://d1wl257kev7hsz.cloudfront.net/cinematics/2_0-FallingPlates.mobileCinematicHigh.jpg',
-              variant: null,
-              variantLanguages: [
-                {
-                  __typename: 'Language',
-                  id: '529',
-                  name: [
-                    {
-                      __typename: 'Translation',
-                      value: 'English',
-                      primary: true
-                    }
-                  ]
-                }
-              ]
+              variant: null
             },
             videoId: '2_0-FallingPlates',
             videoVariantLanguageId: '529'

--- a/apps/journeys-admin/src/components/Editor/Canvas/VideoWrapper/VideoWrapper.test.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/VideoWrapper/VideoWrapper.test.tsx
@@ -34,20 +34,7 @@ describe('VideoWrapper', () => {
           __typename: 'VideoVariant',
           id: '2_0-FallingPlates-529',
           hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-        },
-        variantLanguages: [
-          {
-            __typename: 'Language',
-            id: '529',
-            name: [
-              {
-                __typename: 'Translation',
-                value: 'English',
-                primary: true
-              }
-            ]
-          }
-        ]
+        }
       },
       startAt: null,
       endAt: null,
@@ -116,20 +103,7 @@ describe('VideoWrapper', () => {
             __typename: 'VideoVariant',
             hls: null,
             id: '2_0-FallingPlates-529'
-          },
-          variantLanguages: [
-            {
-              __typename: 'Language',
-              id: '529',
-              name: [
-                {
-                  __typename: 'Translation',
-                  value: 'English',
-                  primary: true
-                }
-              ]
-            }
-          ]
+          }
         },
         videoId: '2_0-FallingPlates',
         videoVariantLanguageId: '529'
@@ -230,20 +204,7 @@ describe('VideoWrapper', () => {
         ],
         image:
           'https://d1wl257kev7hsz.cloudfront.net/cinematics/2_0-FallingPlates.mobileCinematicHigh.jpg',
-        variant: null,
-        variantLanguages: [
-          {
-            __typename: 'Language',
-            id: '529',
-            name: [
-              {
-                __typename: 'Translation',
-                value: 'English',
-                primary: true
-              }
-            ]
-          }
-        ]
+        variant: null
       },
       startAt: null,
       endAt: null,
@@ -308,20 +269,7 @@ describe('VideoWrapper', () => {
           ],
           image:
             'https://d1wl257kev7hsz.cloudfront.net/cinematics/2_0-FallingPlates.mobileCinematicHigh.jpg',
-          variant: null,
-          variantLanguages: [
-            {
-              __typename: 'Language',
-              id: '529',
-              name: [
-                {
-                  __typename: 'Translation',
-                  value: 'English',
-                  primary: true
-                }
-              ]
-            }
-          ]
+          variant: null
         },
         videoId: '2_0-FallingPlates',
         videoVariantLanguageId: '529'

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Attributes.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Attributes.spec.tsx
@@ -87,20 +87,7 @@ describe('Attributes', () => {
         __typename: 'VideoVariant',
         id: '2_0-FallingPlates-529',
         hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-      },
-      variantLanguages: [
-        {
-          __typename: 'Language',
-          id: '529',
-          name: [
-            {
-              __typename: 'Translation',
-              value: 'English',
-              primary: true
-            }
-          ]
-        }
-      ]
+      }
     },
     children: []
   }

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.spec.tsx
@@ -110,20 +110,7 @@ describe('BackgroundMedia', () => {
           __typename: 'VideoVariant',
           id: '2_0-FallingPlates-529',
           hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-        },
-        variantLanguages: [
-          {
-            __typename: 'Language',
-            id: '529',
-            name: [
-              {
-                __typename: 'Translation',
-                value: 'English',
-                primary: true
-              }
-            ]
-          }
-        ]
+        }
       },
       posterBlockId: 'poster1.id',
       children: []

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.stories.tsx
@@ -100,20 +100,7 @@ const video: TreeBlock<VideoBlock> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    },
-    variantLanguages: [
-      {
-        __typename: 'Language',
-        id: '529',
-        name: [
-          {
-            __typename: 'Translation',
-            value: 'English',
-            primary: true
-          }
-        ]
-      }
-    ]
+    }
   },
   posterBlockId: 'poster1.id',
   children: []

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.stories.tsx
@@ -18,6 +18,8 @@ import {
 } from '../../../../../../../../__generated__/globalTypes'
 import { ThemeProvider } from '../../../../../../ThemeProvider'
 import { Drawer } from '../../../../../Drawer'
+import { GetVideoVariantLanguages_video } from '../../../../../../../../__generated__/GetVideoVariantLanguages'
+import { GET_VIDEO_VARIANT_LANGUAGES } from '../../../../../VideoBlockEditor/VideoBlockEditor'
 import { BackgroundMedia } from '.'
 
 const BackgroundMediaStory = {
@@ -132,8 +134,42 @@ const image: TreeBlock<ImageBlock> = {
   children: []
 }
 
+const videoLanguages: GetVideoVariantLanguages_video = {
+  __typename: 'Video',
+  id: '2_0-FallingPlates',
+  variantLanguages: [
+    {
+      __typename: 'Language',
+      id: '529',
+      name: [
+        {
+          __typename: 'Translation',
+          value: 'English',
+          primary: true
+        }
+      ]
+    }
+  ]
+}
+
 const Template: Story = ({ ...args }) => (
-  <MockedProvider>
+  <MockedProvider
+    mocks={[
+      {
+        request: {
+          query: GET_VIDEO_VARIANT_LANGUAGES,
+          variables: {
+            id: videoLanguages.id
+          }
+        },
+        result: {
+          data: {
+            video: videoLanguages
+          }
+        }
+      }
+    ]}
+  >
     <ThemeProvider>
       <JourneyProvider value={{ journey, admin: true }}>
         <EditorProvider

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
@@ -105,20 +105,7 @@ const video: TreeBlock<VideoBlock> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    },
-    variantLanguages: [
-      {
-        __typename: 'Language',
-        id: '529',
-        name: [
-          {
-            __typename: 'Translation',
-            value: 'English',
-            primary: true
-          }
-        ]
-      }
-    ]
+    }
   },
   posterBlockId: null,
   children: []

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
@@ -64,20 +64,7 @@ const video: TreeBlock<VideoBlock> = {
       __typename: 'VideoVariant',
       id: '5_0-NUA0201-0-0-529',
       hls: 'https://arc.gt/hls/5_0-NUA0201-0-0/529'
-    },
-    variantLanguages: [
-      {
-        __typename: 'Language',
-        id: '529',
-        name: [
-          {
-            __typename: 'Translation',
-            value: 'English',
-            primary: true
-          }
-        ]
-      }
-    ]
+    }
   },
   posterBlockId: null,
   children: []

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/Card.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/Card.spec.tsx
@@ -209,20 +209,7 @@ describe('Card', () => {
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
                 hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-              },
-              variantLanguages: [
-                {
-                  __typename: 'Language',
-                  id: '529',
-                  name: [
-                    {
-                      __typename: 'Translation',
-                      value: 'English',
-                      primary: true
-                    }
-                  ]
-                }
-              ]
+              }
             },
             posterBlockId: null,
             muted: true,
@@ -285,20 +272,7 @@ describe('Card', () => {
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
                 hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-              },
-              variantLanguages: [
-                {
-                  __typename: 'Language',
-                  id: '529',
-                  name: [
-                    {
-                      __typename: 'Translation',
-                      value: 'English',
-                      primary: true
-                    }
-                  ]
-                }
-              ]
+              }
             },
             posterBlockId: null,
             muted: true,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.spec.tsx
@@ -52,20 +52,7 @@ const video: TreeBlock<VideoBlock> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    },
-    variantLanguages: [
-      {
-        __typename: 'Language',
-        id: '529',
-        name: [
-          {
-            __typename: 'Translation',
-            value: 'English',
-            primary: true
-          }
-        ]
-      }
-    ]
+    }
   },
   posterBlockId: null,
   children: []
@@ -123,20 +110,7 @@ describe('VideoOptions', () => {
               id: 'variantA',
               duration: 144,
               hls: 'https://arc.gt/opsgn'
-            },
-            variantLanguages: [
-              {
-                __typename: 'Language',
-                id: '529',
-                name: [
-                  {
-                    value: 'English',
-                    primary: true,
-                    __typename: 'Translation'
-                  }
-                ]
-              }
-            ]
+            }
           }
         }
       }

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.stories.tsx
@@ -10,6 +10,8 @@ import { ThemeProvider } from '../../../../../../ThemeProvider'
 import { GET_VIDEOS } from '../../../../../VideoLibrary/VideoList/VideoList'
 import { GET_VIDEO } from '../../../../../VideoLibrary/VideoDetails/VideoDetails'
 import { videos } from '../../../../../VideoLibrary/VideoList/VideoListData'
+import { GetVideoVariantLanguages_video } from '../../../../../../../../__generated__/GetVideoVariantLanguages'
+import { GET_VIDEO_VARIANT_LANGUAGES } from '../../../../../VideoBlockEditor/VideoBlockEditor'
 import { VideoOptions } from './VideoOptions'
 
 const VideoOptionsStory = {
@@ -54,6 +56,24 @@ const video: TreeBlock<VideoBlock> = {
   },
   posterBlockId: 'poster1.id',
   children: []
+}
+
+const videoLanguages: GetVideoVariantLanguages_video = {
+  __typename: 'Video',
+  id: '2_0-FallingPlates',
+  variantLanguages: [
+    {
+      __typename: 'Language',
+      id: '529',
+      name: [
+        {
+          __typename: 'Translation',
+          value: 'English',
+          primary: true
+        }
+      ]
+    }
+  ]
 }
 
 export const Default: Story = () => (
@@ -110,6 +130,19 @@ export const Default: Story = () => (
                 hls: 'https://arc.gt/opsgn'
               }
             }
+          }
+        }
+      },
+      {
+        request: {
+          query: GET_VIDEO_VARIANT_LANGUAGES,
+          variables: {
+            id: videoLanguages.id
+          }
+        },
+        result: {
+          data: {
+            video: videoLanguages
           }
         }
       }

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.stories.tsx
@@ -50,20 +50,7 @@ const video: TreeBlock<VideoBlock> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    },
-    variantLanguages: [
-      {
-        __typename: 'Language',
-        id: '529',
-        name: [
-          {
-            __typename: 'Translation',
-            value: 'English',
-            primary: true
-          }
-        ]
-      }
-    ]
+    }
   },
   posterBlockId: 'poster1.id',
   children: []

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Video.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Video.spec.tsx
@@ -34,20 +34,7 @@ describe('Video', () => {
           __typename: 'VideoVariant',
           id: '2_0-FallingPlates-529',
           hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-        },
-        variantLanguages: [
-          {
-            __typename: 'Language',
-            id: '529',
-            name: [
-              {
-                __typename: 'Translation',
-                value: 'English',
-                primary: true
-              }
-            ]
-          }
-        ]
+        }
       },
       posterBlockId: null,
       children: []

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Video.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Video.stories.tsx
@@ -74,20 +74,7 @@ export const Filled: Story = () => {
         __typename: 'VideoVariant',
         id: '2_0-FallingPlates-529',
         hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-      },
-      variantLanguages: [
-        {
-          __typename: 'Language',
-          id: '529',
-          name: [
-            {
-              __typename: 'Translation',
-              value: 'English',
-              primary: true
-            }
-          ]
-        }
-      ]
+      }
     },
     posterBlockId: null,
     children: []

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.stories.tsx
@@ -447,20 +447,7 @@ const steps: Array<TreeBlock<StepBlock>> = [
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
                 hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-              },
-              variantLanguages: [
-                {
-                  __typename: 'Language',
-                  id: '529',
-                  name: [
-                    {
-                      __typename: 'Translation',
-                      value: 'English',
-                      primary: true
-                    }
-                  ]
-                }
-              ]
+              }
             },
             startAt: null,
             endAt: null,

--- a/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
@@ -124,20 +124,7 @@ const blocks: GetJourney_journey_blocks[] = [
         __typename: 'VideoVariant',
         id: '2_0-FallingPlates-529',
         hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-      },
-      variantLanguages: [
-        {
-          __typename: 'Language',
-          id: '529',
-          name: [
-            {
-              __typename: 'Translation',
-              value: 'English',
-              primary: true
-            }
-          ]
-        }
-      ]
+      }
     },
     startAt: null,
     endAt: null,
@@ -437,20 +424,7 @@ const blocks: GetJourney_journey_blocks[] = [
         __typename: 'VideoVariant',
         id: '2_0-FallingPlates-529',
         hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-      },
-      variantLanguages: [
-        {
-          __typename: 'Language',
-          id: '529',
-          name: [
-            {
-              __typename: 'Translation',
-              value: 'English',
-              primary: true
-            }
-          ]
-        }
-      ]
+      }
     },
     startAt: null,
     endAt: null,

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Dialog/VideoBlockEditorSettingsPosterDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Dialog/VideoBlockEditorSettingsPosterDialog.spec.tsx
@@ -80,20 +80,7 @@ const video: TreeBlock<VideoBlock> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    },
-    variantLanguages: [
-      {
-        __typename: 'Language',
-        id: '529',
-        name: [
-          {
-            __typename: 'Translation',
-            value: 'English',
-            primary: true
-          }
-        ]
-      }
-    ]
+    }
   },
   posterBlockId: null,
   children: []

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/VideoBlockEditorSettingsPoster.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/VideoBlockEditorSettingsPoster.spec.tsx
@@ -39,20 +39,7 @@ const video: VideoBlock = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    },
-    variantLanguages: [
-      {
-        __typename: 'Language',
-        id: '529',
-        name: [
-          {
-            __typename: 'Translation',
-            value: 'English',
-            primary: true
-          }
-        ]
-      }
-    ]
+    }
   },
   posterBlockId: null
 }

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.spec.tsx
@@ -32,20 +32,7 @@ const video: TreeBlock = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    },
-    variantLanguages: [
-      {
-        __typename: 'Language',
-        id: '529',
-        name: [
-          {
-            __typename: 'Translation',
-            value: 'English',
-            primary: true
-          }
-        ]
-      }
-    ]
+    }
   },
   posterBlockId: null,
   children: []

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Source/Source.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Source/Source.spec.tsx
@@ -66,20 +66,7 @@ describe('Source', () => {
                     id: 'variantA',
                     duration: 144,
                     hls: 'https://arc.gt/opsgn'
-                  },
-                  variantLanguages: [
-                    {
-                      __typename: 'Language',
-                      id: '529',
-                      name: [
-                        {
-                          value: 'English',
-                          primary: true,
-                          __typename: 'Translation'
-                        }
-                      ]
-                    }
-                  ]
+                  },                  
                 }
               }
             }

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Source/Source.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Source/Source.spec.tsx
@@ -66,7 +66,7 @@ describe('Source', () => {
                     id: 'variantA',
                     duration: 144,
                     hls: 'https://arc.gt/opsgn'
-                  },                  
+                  }
                 }
               }
             }

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.spec.tsx
@@ -65,7 +65,7 @@ const mocks = [
     request: {
       query: GET_VIDEO_VARIANT_LANGUAGES,
       variables: {
-        id: '2_0-FallingPlates'
+        id: videoLanguages.id
       }
     },
     result: {
@@ -151,7 +151,7 @@ describe('VideoBlockEditor', () => {
           request: {
             query: GET_VIDEO_VARIANT_LANGUAGES,
             variables: {
-              id: '2_0-FallingPlates'
+              id: videoLanguages.id
             }
           },
           result: {

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.spec.tsx
@@ -65,7 +65,7 @@ const mocks = [
     request: {
       query: GET_VIDEO_VARIANT_LANGUAGES,
       variables: {
-        id: video.id
+        id: '2_0-FallingPlates'
       }
     },
     result: {
@@ -151,7 +151,7 @@ describe('VideoBlockEditor', () => {
           request: {
             query: GET_VIDEO_VARIANT_LANGUAGES,
             variables: {
-              id: video.id
+              id: '2_0-FallingPlates'
             }
           },
           result: {

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.stories.tsx
@@ -136,7 +136,7 @@ const Template: Story = ({ ...args }) => (
         request: {
           query: GET_VIDEO_VARIANT_LANGUAGES,
           variables: {
-            id: video.id
+            id: '2_0-FallingPlates'
           }
         },
         result: {

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.stories.tsx
@@ -136,7 +136,7 @@ const Template: Story = ({ ...args }) => (
         request: {
           query: GET_VIDEO_VARIANT_LANGUAGES,
           variables: {
-            id: '2_0-FallingPlates'
+            id: videoLanguages.id
           }
         },
         result: {

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.stories.tsx
@@ -9,12 +9,16 @@ import {
   GetJourney_journey_blocks_VideoBlock as VideoBlock,
   GetJourney_journey_blocks_ImageBlock as ImageBlock
 } from '../../../../__generated__/GetJourney'
+import { GetVideoVariantLanguages_video } from '../../../../__generated__/GetVideoVariantLanguages'
 import { journeysAdminConfig } from '../../../libs/storybook'
 import { ThemeMode } from '../../../../__generated__/globalTypes'
 import { ThemeProvider } from '../../ThemeProvider'
 import { videos } from '../VideoLibrary/VideoList/VideoListData'
 import { GET_VIDEOS } from '../VideoLibrary/VideoList/VideoList'
-import { VideoBlockEditor } from './VideoBlockEditor'
+import {
+  GET_VIDEO_VARIANT_LANGUAGES,
+  VideoBlockEditor
+} from './VideoBlockEditor'
 
 const BackgroundMediaStory = {
   ...journeysAdminConfig,
@@ -67,20 +71,7 @@ const video: TreeBlock<VideoBlock> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    },
-    variantLanguages: [
-      {
-        __typename: 'Language',
-        id: '529',
-        name: [
-          {
-            __typename: 'Translation',
-            value: 'English',
-            primary: true
-          }
-        ]
-      }
-    ]
+    }
   },
   posterBlockId: 'poster1.id',
   children: []
@@ -102,6 +93,24 @@ const poster: TreeBlock<ImageBlock> = {
 const onChange = async (): Promise<void> => await Promise.resolve()
 const onDelete = async (): Promise<void> => await Promise.resolve()
 
+const videoLanguages: GetVideoVariantLanguages_video = {
+  __typename: 'Video',
+  id: '2_0-FallingPlates',
+  variantLanguages: [
+    {
+      __typename: 'Language',
+      id: '529',
+      name: [
+        {
+          __typename: 'Translation',
+          value: 'English',
+          primary: true
+        }
+      ]
+    }
+  ]
+}
+
 const Template: Story = ({ ...args }) => (
   <MockedProvider
     mocks={[
@@ -120,6 +129,19 @@ const Template: Story = ({ ...args }) => (
         result: {
           data: {
             videos
+          }
+        }
+      },
+      {
+        request: {
+          query: GET_VIDEO_VARIANT_LANGUAGES,
+          variables: {
+            id: video.id
+          }
+        },
+        result: {
+          data: {
+            video: videoLanguages
           }
         }
       }

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.tsx
@@ -53,7 +53,7 @@ export function VideoBlockEditor({
     GET_VIDEO_VARIANT_LANGUAGES,
     {
       variables: {
-        id: selectedBlock?.id
+        id: selectedBlock?.video?.id
       },
       skip: selectedBlock?.video?.id == null
     }
@@ -76,6 +76,7 @@ export function VideoBlockEditor({
       language = `${language} (${nativeLanguage})`
     setLanguage(language)
   }, [data?.video?.variantLanguages, selectedBlock?.videoVariantLanguageId])
+
   return (
     <>
       <Box sx={{ px: 6, pt: 4 }}>

--- a/apps/journeys-admin/src/libs/blockDeleteUpdate/blockDeleteUpdate.spec.ts
+++ b/apps/journeys-admin/src/libs/blockDeleteUpdate/blockDeleteUpdate.spec.ts
@@ -41,8 +41,7 @@ const video: TreeBlock<VideoBlock> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    },
-    variantLanguages: []
+    }
   },
   posterBlockId: null,
   children: []

--- a/apps/journeys/__generated__/BlockFields.ts
+++ b/apps/journeys/__generated__/BlockFields.ts
@@ -275,25 +275,12 @@ export interface BlockFields_VideoBlock_video_variant {
   hls: string | null;
 }
 
-export interface BlockFields_VideoBlock_video_variantLanguages_name {
-  __typename: "Translation";
-  value: string;
-  primary: boolean;
-}
-
-export interface BlockFields_VideoBlock_video_variantLanguages {
-  __typename: "Language";
-  id: string;
-  name: BlockFields_VideoBlock_video_variantLanguages_name[];
-}
-
 export interface BlockFields_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: BlockFields_VideoBlock_video_title[];
   image: string | null;
   variant: BlockFields_VideoBlock_video_variant | null;
-  variantLanguages: BlockFields_VideoBlock_video_variantLanguages[];
 }
 
 export interface BlockFields_VideoBlock_action_NavigateAction {

--- a/apps/journeys/__generated__/GetJourney.ts
+++ b/apps/journeys/__generated__/GetJourney.ts
@@ -287,25 +287,12 @@ export interface GetJourney_journey_blocks_VideoBlock_video_variant {
   hls: string | null;
 }
 
-export interface GetJourney_journey_blocks_VideoBlock_video_variantLanguages_name {
-  __typename: "Translation";
-  value: string;
-  primary: boolean;
-}
-
-export interface GetJourney_journey_blocks_VideoBlock_video_variantLanguages {
-  __typename: "Language";
-  id: string;
-  name: GetJourney_journey_blocks_VideoBlock_video_variantLanguages_name[];
-}
-
 export interface GetJourney_journey_blocks_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: GetJourney_journey_blocks_VideoBlock_video_title[];
   image: string | null;
   variant: GetJourney_journey_blocks_VideoBlock_video_variant | null;
-  variantLanguages: GetJourney_journey_blocks_VideoBlock_video_variantLanguages[];
 }
 
 export interface GetJourney_journey_blocks_VideoBlock_action_NavigateAction {

--- a/apps/journeys/__generated__/JourneyFields.ts
+++ b/apps/journeys/__generated__/JourneyFields.ts
@@ -287,25 +287,12 @@ export interface JourneyFields_blocks_VideoBlock_video_variant {
   hls: string | null;
 }
 
-export interface JourneyFields_blocks_VideoBlock_video_variantLanguages_name {
-  __typename: "Translation";
-  value: string;
-  primary: boolean;
-}
-
-export interface JourneyFields_blocks_VideoBlock_video_variantLanguages {
-  __typename: "Language";
-  id: string;
-  name: JourneyFields_blocks_VideoBlock_video_variantLanguages_name[];
-}
-
 export interface JourneyFields_blocks_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: JourneyFields_blocks_VideoBlock_video_title[];
   image: string | null;
   variant: JourneyFields_blocks_VideoBlock_video_variant | null;
-  variantLanguages: JourneyFields_blocks_VideoBlock_video_variantLanguages[];
 }
 
 export interface JourneyFields_blocks_VideoBlock_action_NavigateAction {

--- a/apps/journeys/__generated__/VideoFields.ts
+++ b/apps/journeys/__generated__/VideoFields.ts
@@ -18,25 +18,12 @@ export interface VideoFields_video_variant {
   hls: string | null;
 }
 
-export interface VideoFields_video_variantLanguages_name {
-  __typename: "Translation";
-  value: string;
-  primary: boolean;
-}
-
-export interface VideoFields_video_variantLanguages {
-  __typename: "Language";
-  id: string;
-  name: VideoFields_video_variantLanguages_name[];
-}
-
 export interface VideoFields_video {
   __typename: "Video";
   id: string;
   title: VideoFields_video_title[];
   image: string | null;
   variant: VideoFields_video_variant | null;
-  variantLanguages: VideoFields_video_variantLanguages[];
 }
 
 export interface VideoFields_action_NavigateAction {

--- a/apps/journeys/src/components/Conductor/Conductor.stories.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.stories.tsx
@@ -922,20 +922,7 @@ const videoBlocks: TreeBlock[] = [
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
                 hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-              },
-              variantLanguages: [
-                {
-                  __typename: 'Language',
-                  id: '529',
-                  name: [
-                    {
-                      __typename: 'Translation',
-                      value: 'English',
-                      primary: true
-                    }
-                  ]
-                }
-              ]
+              }
             },
             endAt: null,
             startAt: null,
@@ -1100,20 +1087,7 @@ const videoBlocks: TreeBlock[] = [
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
                 hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-              },
-              variantLanguages: [
-                {
-                  __typename: 'Language',
-                  id: '529',
-                  name: [
-                    {
-                      __typename: 'Translation',
-                      value: 'English',
-                      primary: true
-                    }
-                  ]
-                }
-              ]
+              }
             },
             endAt: null,
             startAt: null,
@@ -1182,20 +1156,7 @@ const videoBlocks: TreeBlock[] = [
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
                 hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-              },
-              variantLanguages: [
-                {
-                  __typename: 'Language',
-                  id: '529',
-                  name: [
-                    {
-                      __typename: 'Translation',
-                      value: 'English',
-                      primary: true
-                    }
-                  ]
-                }
-              ]
+              }
             },
             endAt: null,
             startAt: 10,
@@ -1305,20 +1266,7 @@ const VideoLoop: TreeBlock[] = [
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
                 hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-              },
-              variantLanguages: [
-                {
-                  __typename: 'Language',
-                  id: '529',
-                  name: [
-                    {
-                      __typename: 'Translation',
-                      value: 'English',
-                      primary: true
-                    }
-                  ]
-                }
-              ]
+              }
             },
             startAt: 10,
             endAt: 30,
@@ -1387,20 +1335,7 @@ const VideoLoop: TreeBlock[] = [
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
                 hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-              },
-              variantLanguages: [
-                {
-                  __typename: 'Language',
-                  id: '529',
-                  name: [
-                    {
-                      __typename: 'Translation',
-                      value: 'English',
-                      primary: true
-                    }
-                  ]
-                }
-              ]
+              }
             },
             startAt: 10,
             endAt: 30,
@@ -1474,20 +1409,7 @@ const VideoLoop: TreeBlock[] = [
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
                 hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-              },
-              variantLanguages: [
-                {
-                  __typename: 'Language',
-                  id: '529',
-                  name: [
-                    {
-                      __typename: 'Translation',
-                      value: 'English',
-                      primary: true
-                    }
-                  ]
-                }
-              ]
+              }
             },
             startAt: 10,
             endAt: 30,

--- a/apps/watch-admin/__generated__/BlockFields.ts
+++ b/apps/watch-admin/__generated__/BlockFields.ts
@@ -275,25 +275,12 @@ export interface BlockFields_VideoBlock_video_variant {
   hls: string | null;
 }
 
-export interface BlockFields_VideoBlock_video_variantLanguages_name {
-  __typename: "Translation";
-  value: string;
-  primary: boolean;
-}
-
-export interface BlockFields_VideoBlock_video_variantLanguages {
-  __typename: "Language";
-  id: string;
-  name: BlockFields_VideoBlock_video_variantLanguages_name[];
-}
-
 export interface BlockFields_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: BlockFields_VideoBlock_video_title[];
   image: string | null;
   variant: BlockFields_VideoBlock_video_variant | null;
-  variantLanguages: BlockFields_VideoBlock_video_variantLanguages[];
 }
 
 export interface BlockFields_VideoBlock_action_NavigateAction {

--- a/apps/watch-admin/__generated__/JourneyFields.ts
+++ b/apps/watch-admin/__generated__/JourneyFields.ts
@@ -287,25 +287,12 @@ export interface JourneyFields_blocks_VideoBlock_video_variant {
   hls: string | null;
 }
 
-export interface JourneyFields_blocks_VideoBlock_video_variantLanguages_name {
-  __typename: "Translation";
-  value: string;
-  primary: boolean;
-}
-
-export interface JourneyFields_blocks_VideoBlock_video_variantLanguages {
-  __typename: "Language";
-  id: string;
-  name: JourneyFields_blocks_VideoBlock_video_variantLanguages_name[];
-}
-
 export interface JourneyFields_blocks_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: JourneyFields_blocks_VideoBlock_video_title[];
   image: string | null;
   variant: JourneyFields_blocks_VideoBlock_video_variant | null;
-  variantLanguages: JourneyFields_blocks_VideoBlock_video_variantLanguages[];
 }
 
 export interface JourneyFields_blocks_VideoBlock_action_NavigateAction {

--- a/apps/watch-admin/__generated__/VideoFields.ts
+++ b/apps/watch-admin/__generated__/VideoFields.ts
@@ -18,25 +18,12 @@ export interface VideoFields_video_variant {
   hls: string | null;
 }
 
-export interface VideoFields_video_variantLanguages_name {
-  __typename: "Translation";
-  value: string;
-  primary: boolean;
-}
-
-export interface VideoFields_video_variantLanguages {
-  __typename: "Language";
-  id: string;
-  name: VideoFields_video_variantLanguages_name[];
-}
-
 export interface VideoFields_video {
   __typename: "Video";
   id: string;
   title: VideoFields_video_title[];
   image: string | null;
   variant: VideoFields_video_variant | null;
-  variantLanguages: VideoFields_video_variantLanguages[];
 }
 
 export interface VideoFields_action_NavigateAction {

--- a/apps/watch/__generated__/BlockFields.ts
+++ b/apps/watch/__generated__/BlockFields.ts
@@ -275,25 +275,12 @@ export interface BlockFields_VideoBlock_video_variant {
   hls: string | null;
 }
 
-export interface BlockFields_VideoBlock_video_variantLanguages_name {
-  __typename: "Translation";
-  value: string;
-  primary: boolean;
-}
-
-export interface BlockFields_VideoBlock_video_variantLanguages {
-  __typename: "Language";
-  id: string;
-  name: BlockFields_VideoBlock_video_variantLanguages_name[];
-}
-
 export interface BlockFields_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: BlockFields_VideoBlock_video_title[];
   image: string | null;
   variant: BlockFields_VideoBlock_video_variant | null;
-  variantLanguages: BlockFields_VideoBlock_video_variantLanguages[];
 }
 
 export interface BlockFields_VideoBlock_action_NavigateAction {

--- a/apps/watch/__generated__/JourneyFields.ts
+++ b/apps/watch/__generated__/JourneyFields.ts
@@ -287,25 +287,12 @@ export interface JourneyFields_blocks_VideoBlock_video_variant {
   hls: string | null;
 }
 
-export interface JourneyFields_blocks_VideoBlock_video_variantLanguages_name {
-  __typename: "Translation";
-  value: string;
-  primary: boolean;
-}
-
-export interface JourneyFields_blocks_VideoBlock_video_variantLanguages {
-  __typename: "Language";
-  id: string;
-  name: JourneyFields_blocks_VideoBlock_video_variantLanguages_name[];
-}
-
 export interface JourneyFields_blocks_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: JourneyFields_blocks_VideoBlock_video_title[];
   image: string | null;
   variant: JourneyFields_blocks_VideoBlock_video_variant | null;
-  variantLanguages: JourneyFields_blocks_VideoBlock_video_variantLanguages[];
 }
 
 export interface JourneyFields_blocks_VideoBlock_action_NavigateAction {

--- a/apps/watch/__generated__/VideoFields.ts
+++ b/apps/watch/__generated__/VideoFields.ts
@@ -18,25 +18,12 @@ export interface VideoFields_video_variant {
   hls: string | null;
 }
 
-export interface VideoFields_video_variantLanguages_name {
-  __typename: "Translation";
-  value: string;
-  primary: boolean;
-}
-
-export interface VideoFields_video_variantLanguages {
-  __typename: "Language";
-  id: string;
-  name: VideoFields_video_variantLanguages_name[];
-}
-
 export interface VideoFields_video {
   __typename: "Video";
   id: string;
   title: VideoFields_video_title[];
   image: string | null;
   variant: VideoFields_video_variant | null;
-  variantLanguages: VideoFields_video_variantLanguages[];
 }
 
 export interface VideoFields_action_NavigateAction {

--- a/libs/journeys/ui/src/components/BlockRenderer/BlockRenderer.spec.tsx
+++ b/libs/journeys/ui/src/components/BlockRenderer/BlockRenderer.spec.tsx
@@ -544,20 +544,7 @@ describe('BlockRenderer', () => {
           __typename: 'VideoVariant',
           id: '2_0-FallingPlates-529',
           hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-        },
-        variantLanguages: [
-          {
-            __typename: 'Language',
-            id: '529',
-            name: [
-              {
-                __typename: 'Translation',
-                value: 'English',
-                primary: true
-              }
-            ]
-          }
-        ]
+        }
       },
       autoplay: false,
       muted: false,
@@ -599,20 +586,7 @@ describe('BlockRenderer', () => {
           __typename: 'VideoVariant',
           id: '2_0-FallingPlates-529',
           hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-        },
-        variantLanguages: [
-          {
-            __typename: 'Language',
-            id: '529',
-            name: [
-              {
-                __typename: 'Translation',
-                value: 'English',
-                primary: true
-              }
-            ]
-          }
-        ]
+        }
       },
       autoplay: false,
       muted: false,

--- a/libs/journeys/ui/src/components/Card/Card.spec.tsx
+++ b/libs/journeys/ui/src/components/Card/Card.spec.tsx
@@ -87,20 +87,7 @@ describe('CardBlock', () => {
         __typename: 'VideoVariant',
         id: '2_0-FallingPlates-529',
         hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-      },
-      variantLanguages: [
-        {
-          __typename: 'Language',
-          id: '529',
-          name: [
-            {
-              __typename: 'Translation',
-              value: 'English',
-              primary: true
-            }
-          ]
-        }
-      ]
+      }
     },
     children: [
       {

--- a/libs/journeys/ui/src/components/Card/Card.stories.tsx
+++ b/libs/journeys/ui/src/components/Card/Card.stories.tsx
@@ -137,20 +137,7 @@ const video: TreeBlock<VideoFields> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    },
-    variantLanguages: [
-      {
-        __typename: 'Language',
-        id: '529',
-        name: [
-          {
-            __typename: 'Translation',
-            value: 'English',
-            primary: true
-          }
-        ]
-      }
-    ]
+    }
   },
   action: null,
   fullsize: null,

--- a/libs/journeys/ui/src/components/Card/ContainedCover/ContainedCover.spec.tsx
+++ b/libs/journeys/ui/src/components/Card/ContainedCover/ContainedCover.spec.tsx
@@ -52,20 +52,7 @@ describe('ContainedCover', () => {
         __typename: 'VideoVariant',
         id: '2_0-FallingPlates-529',
         hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-      },
-      variantLanguages: [
-        {
-          __typename: 'Language',
-          id: '529',
-          name: [
-            {
-              __typename: 'Translation',
-              value: 'English',
-              primary: true
-            }
-          ]
-        }
-      ]
+      }
     },
     children: []
   }

--- a/libs/journeys/ui/src/components/Video/Video.spec.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.spec.tsx
@@ -34,20 +34,7 @@ const block: TreeBlock<VideoFields> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    },
-    variantLanguages: [
-      {
-        __typename: 'Language',
-        id: '529',
-        name: [
-          {
-            __typename: 'Translation',
-            value: 'English',
-            primary: true
-          }
-        ]
-      }
-    ]
+    }
   },
   children: [
     {

--- a/libs/journeys/ui/src/components/Video/Video.stories.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.stories.tsx
@@ -44,20 +44,7 @@ const videoBlock: TreeBlock<VideoFields> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    },
-    variantLanguages: [
-      {
-        __typename: 'Language',
-        id: '529',
-        name: [
-          {
-            __typename: 'Translation',
-            value: 'English',
-            primary: true
-          }
-        ]
-      }
-    ]
+    }
   },
   startAt: null,
   endAt: null,

--- a/libs/journeys/ui/src/components/Video/__generated__/VideoFields.ts
+++ b/libs/journeys/ui/src/components/Video/__generated__/VideoFields.ts
@@ -18,25 +18,12 @@ export interface VideoFields_video_variant {
   hls: string | null;
 }
 
-export interface VideoFields_video_variantLanguages_name {
-  __typename: "Translation";
-  value: string;
-  primary: boolean;
-}
-
-export interface VideoFields_video_variantLanguages {
-  __typename: "Language";
-  id: string;
-  name: VideoFields_video_variantLanguages_name[];
-}
-
 export interface VideoFields_video {
   __typename: "Video";
   id: string;
   title: VideoFields_video_title[];
   image: string | null;
   variant: VideoFields_video_variant | null;
-  variantLanguages: VideoFields_video_variantLanguages[];
 }
 
 export interface VideoFields_action_NavigateAction {

--- a/libs/journeys/ui/src/components/Video/videoFields.ts
+++ b/libs/journeys/ui/src/components/Video/videoFields.ts
@@ -25,13 +25,6 @@ export const VIDEO_FIELDS = gql`
         id
         hls
       }
-      variantLanguages {
-        id
-        name(languageId: "529", primary: true) {
-          value
-          primary
-        }
-      }
     }
     action {
       ...ActionFields

--- a/libs/journeys/ui/src/libs/JourneyProvider/__generated__/JourneyFields.ts
+++ b/libs/journeys/ui/src/libs/JourneyProvider/__generated__/JourneyFields.ts
@@ -287,25 +287,12 @@ export interface JourneyFields_blocks_VideoBlock_video_variant {
   hls: string | null;
 }
 
-export interface JourneyFields_blocks_VideoBlock_video_variantLanguages_name {
-  __typename: "Translation";
-  value: string;
-  primary: boolean;
-}
-
-export interface JourneyFields_blocks_VideoBlock_video_variantLanguages {
-  __typename: "Language";
-  id: string;
-  name: JourneyFields_blocks_VideoBlock_video_variantLanguages_name[];
-}
-
 export interface JourneyFields_blocks_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: JourneyFields_blocks_VideoBlock_video_title[];
   image: string | null;
   variant: JourneyFields_blocks_VideoBlock_video_variant | null;
-  variantLanguages: JourneyFields_blocks_VideoBlock_video_variantLanguages[];
 }
 
 export interface JourneyFields_blocks_VideoBlock_action_NavigateAction {

--- a/libs/journeys/ui/src/libs/block/__generated__/BlockFields.ts
+++ b/libs/journeys/ui/src/libs/block/__generated__/BlockFields.ts
@@ -275,25 +275,12 @@ export interface BlockFields_VideoBlock_video_variant {
   hls: string | null;
 }
 
-export interface BlockFields_VideoBlock_video_variantLanguages_name {
-  __typename: "Translation";
-  value: string;
-  primary: boolean;
-}
-
-export interface BlockFields_VideoBlock_video_variantLanguages {
-  __typename: "Language";
-  id: string;
-  name: BlockFields_VideoBlock_video_variantLanguages_name[];
-}
-
 export interface BlockFields_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: BlockFields_VideoBlock_video_title[];
   image: string | null;
   variant: BlockFields_VideoBlock_video_variant | null;
-  variantLanguages: BlockFields_VideoBlock_video_variantLanguages[];
 }
 
 export interface BlockFields_VideoBlock_action_NavigateAction {


### PR DESCRIPTION
# Description

Currently, journeys are pulling variant language for each video block. In the case of The Jesus Film, this is 1900 per block. This is likely affecting performance. I have moved the variant call to the relevant admin section and made it non-blocking.

This is a likely unintended side effect of https://github.com/JesusFilm/core/pull/769

The majority of the changes in this PR are just removing the variantLanguages from specs and generated files.

# How should this PR be QA Tested?

- [ ] Ensure language is still present in video block properties

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
