### PR TITLE
fix: handling blockId duplication

### DIFF
--- a/apps/api-journeys/src/app/modules/block/block.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/block.service.spec.ts
@@ -95,7 +95,9 @@ describe('BlockService', () => {
     id: cardBlock.coverBlockId,
     journeyId: journey.id,
     parentBlockId: cardBlock.id,
-    posterBlockId: 'image'
+    posterBlockId: 'image',
+    videoId: 'videoId',
+    videoVariantLanguageId: 'videoVariantLanguageId'
   }
   const imageBlock = {
     __typename: 'ImageBlock',

--- a/apps/api-journeys/src/app/modules/block/block.service.ts
+++ b/apps/api-journeys/src/app/modules/block/block.service.ts
@@ -198,7 +198,9 @@ export class BlockService extends BaseService {
           duplicateStepIds != null && block[key] != null
             ? duplicateStepIds.get(block[key])
             : null
-      } else if (key.includes('Id')) {
+        // All ids that link to child blocks should include BlockId in the key name.
+        // TODO: startIconId and endIconId should be renamed as IconBlockId's
+      } else if (key.includes('BlockId') || key.includes('IconId')) {
         updatedBlockProps[key] = childIds.get(block[key]) ?? null
       }
       if (key === 'action') {


### PR DESCRIPTION
# Description

videoId and videoVariantLanguageId were incorrectly set, fix this.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] BackgroundVideos now duplicate properly
- [x] VideoBlocks now duplicate properly

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
