### PR TITLE
feat: add seed for userRoles

### DIFF
--- a/apps/api-journeys/db/seed.ts
+++ b/apps/api-journeys/db/seed.ts
@@ -3,6 +3,7 @@ import { nua1 } from './seeds/nua1'
 import { nua2 } from './seeds/nua2'
 import { nua8 } from './seeds/nua8'
 import { nua9 } from './seeds/nua9'
+import { createUserRolesCollection } from './seeds/createUserRolesCollection'
 
 const db = ArangoDB()
 
@@ -25,10 +26,7 @@ async function main(): Promise<void> {
       keyOptions: { type: 'uuid' }
     })
 
-  if (!(await db.collection('userRoles').exists()))
-    await db.createCollection('userRoles', {
-      keyOptions: { type: 'uuid' }
-    })
+  await createUserRolesCollection()
 
   await db.collection('journeys').ensureIndex({
     type: 'persistent',

--- a/apps/api-journeys/db/seeds/createUserRolesCollection.ts
+++ b/apps/api-journeys/db/seeds/createUserRolesCollection.ts
@@ -1,0 +1,28 @@
+import { aql } from 'arangojs'
+import { ArangoDB } from '../db'
+
+const db = ArangoDB()
+
+export async function createUserRolesCollection(): Promise<void> {
+  await db.collection('userRoles').drop()
+  await db.createCollection('userRoles', {
+    keyOptions: { type: 'uuid' }
+  })
+
+  const users = await db.query(aql`
+    FOR user IN users
+          return user
+  `)
+
+  async function generateEmptyUserRoles(): Promise<void> {
+    while (users.hasNext) {
+      const u = await users.next()
+      await db.collection('userRoles').save({
+        userId: u.userId,
+        roles: []
+      })
+    }
+  }
+
+  await generateEmptyUserRoles()
+}


### PR DESCRIPTION
# Description

userRoles table was added into production, but no data was seeded for it. Now that we are relying on data from userRoles, anything that uses userRoles is broken in production (eg adminJourneys mutation)

This PR contains the script to generate the seed data for userRoles.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
