### PR TITLE
fix: publisher templates fetch

### DIFF
--- a/apps/api-journeys/src/app/modules/journey/journey.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.service.spec.ts
@@ -167,9 +167,9 @@ describe('JourneyService', () => {
           FOR journey in undefined
             FILTER userJourney.journeyId == journey._key && userJourney.userId == @value0
               && (userJourney.role == @value1 || userJourney.role == @value2)
-        && journey.status IN @value3
-          RETURN journey
-    `.query
+          && journey.status IN @value3
+            RETURN journey
+      `.query
         )
         expect(bindVars).toEqual({
           value0: 'user.id',
@@ -192,9 +192,9 @@ describe('JourneyService', () => {
         expect(query).toEqual(
           aql`FOR journey in undefined
               FILTER journey.template == true
-        && true
-          RETURN journey
-    `.query
+          && true
+            RETURN journey
+      `.query
         )
         return await mockDbQueryResult(db, [journey])
       })

--- a/apps/api-journeys/src/app/modules/journey/journey.service.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.service.ts
@@ -96,19 +96,24 @@ export class JourneyService extends BaseService {
       status != null ? aql`&& journey.status IN ${status}` : aql`&& true`
 
     const roleFilter =
-      template === true && includes(user.roles, Role.publisher)
-        ? aql`FOR journey in ${this.collection}
+      template === true
+        ? includes(user.roles, Role.publisher) &&
+          aql`FOR journey in ${this.collection}
               FILTER journey.template == true`
         : aql`FOR userJourney in userJourneys
           FOR journey in ${this.collection}
             FILTER userJourney.journeyId == journey._key && userJourney.userId == ${user.userId}
               && (userJourney.role == ${UserJourneyRole.owner} || userJourney.role == ${UserJourneyRole.editor})`
 
-    const result = await this.db.query(aql`${roleFilter}
-        ${statusFilter}
-          RETURN journey
-    `)
-    return await result.all()
+    if (roleFilter !== false) {
+      const result = await this.db.query(aql`${roleFilter}
+          ${statusFilter}
+            RETURN journey
+      `)
+      return await result.all()
+    } else {
+      return []
+    }
   }
 
   collection: DocumentCollection = this.db.collection('journeys')


### PR DESCRIPTION
# Description

When fetch with `template: true` and user not a `publisher`, the query returns a list of journeys owned by the user. But it should not return anything 

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Tested you can still fetch journeys locally
- [x] Tested you can still fetch templates locally
- [x] Tested the described use case is fixed

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
