### PR TITLE
fix: editor journey settings link

### DIFF
--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.spec.tsx
@@ -140,7 +140,7 @@ describe('EditToolbar Menu', () => {
       fireEvent.click(getByRole('button'))
       expect(
         getByRole('menuitem', { name: 'Journey Settings' })
-      ).toHaveAttribute('href', '/journeys/my-journey')
+      ).toHaveAttribute('href', '/journeys/journeyId')
     })
   })
 

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.tsx
@@ -93,7 +93,7 @@ export function Menu(): ReactElement {
         )}
         <Divider />
         <NextLink
-          href={journey != null ? `/journeys/${journey.slug}` : ''}
+          href={journey != null ? `/journeys/${journey.id}` : ''}
           passHref
         >
           <MenuItem>


### PR DESCRIPTION
# Description

Awhile back we updated the editor pages to use journeyId instead of journeySlug. This link was still yet to be updated to use id.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/28980303/todos/5269917082)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Clicking on `Journey Settings` from editor will take to the journey details page

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
