### PR TITLE
fix: redirect url of create template

### DIFF
--- a/apps/journeys-admin/src/components/JourneyView/Menu/CreateTemplateMenuItem/CreateTemplateMenuItem.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/CreateTemplateMenuItem/CreateTemplateMenuItem.spec.tsx
@@ -91,7 +91,7 @@ describe('CreateTemplateMenuItem', () => {
     fireEvent.click(getByRole('menuitem', { name: 'Create Template' }))
     await waitFor(() => expect(result).toHaveBeenCalled())
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith('/templates/templateId', undefined, {
+      expect(push).toHaveBeenCalledWith('/publisher/templateId', undefined, {
         shallow: true
       })
     })

--- a/apps/journeys-admin/src/components/JourneyView/Menu/CreateTemplateMenuItem/CreateTemplateMenuItem.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/CreateTemplateMenuItem/CreateTemplateMenuItem.tsx
@@ -109,7 +109,7 @@ export function CreateTemplateMenuItem(): ReactElement {
         })
 
         void router.push(
-          `/templates/${templateData.journeyTemplate.id}`,
+          `/publisher/${templateData.journeyTemplate.id}`,
           undefined,
           { shallow: true }
         )


### PR DESCRIPTION
# Description

With the recent changes of the pages going from `/library` and `/templates` to `/templates` and `/publisher`. With the key changes of /publisher is now the new admin page/URL path. This updates the url that users get redirected to on create template click

Follow the discussions
[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/29147486/todos/5289546952#__recording_5301672806)

# How should this PR be QA Tested?

- [ ] On create template click, publishers should be redirected to /publisher/[journeyid]

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
