### PR TITLE
fix: remove user id and user journey check

### DIFF
--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -194,7 +194,7 @@ describe('JourneyResolver', () => {
         return null
       }),
       getAllPublishedJourneys: jest.fn(() => [journey, journey]),
-      getAllByIds: jest.fn((userId, ids) => {
+      getAllByIds: jest.fn((ids) => {
         switch (ids[0]) {
           case archivedJourney.id:
             return [archivedJourney]
@@ -869,7 +869,7 @@ describe('JourneyResolver', () => {
     it('archives an array of Journeys', async () => {
       const date = '2021-12-07T03:22:41.135Z'
       jest.useFakeTimers().setSystemTime(new Date(date).getTime())
-      await resolver.journeysArchive('1', [journey.id, draftJourney.id])
+      await resolver.journeysArchive([journey.id, draftJourney.id])
       expect(service.updateAll).toHaveBeenCalledWith([
         {
           _key: journey.id,
@@ -889,7 +889,7 @@ describe('JourneyResolver', () => {
     it('trashes an array of Journeys', async () => {
       const date = '2021-12-07T03:22:41.135Z'
       jest.useFakeTimers().setSystemTime(new Date(date).getTime())
-      await resolver.journeysTrash('1', [journey.id, draftJourney.id])
+      await resolver.journeysTrash([journey.id, draftJourney.id])
       expect(service.updateAll).toHaveBeenCalledWith([
         {
           _key: journey.id,
@@ -909,7 +909,7 @@ describe('JourneyResolver', () => {
     it('deletes an array of Journeys', async () => {
       const date = '2021-12-07T03:22:41.135Z'
       jest.useFakeTimers().setSystemTime(new Date(date).getTime())
-      await resolver.journeysDelete('1', [journey.id, draftJourney.id])
+      await resolver.journeysDelete([journey.id, draftJourney.id])
       expect(service.updateAll).toHaveBeenCalledWith([
         {
           _key: journey.id,
@@ -927,7 +927,7 @@ describe('JourneyResolver', () => {
 
   describe('journeysRestore', () => {
     it('resores a published Journey', async () => {
-      await resolver.journeysRestore('1', [trashedJourney.id])
+      await resolver.journeysRestore([trashedJourney.id])
       expect(service.updateAll).toHaveBeenCalledWith([
         {
           _key: trashedJourney.id,
@@ -937,7 +937,7 @@ describe('JourneyResolver', () => {
     })
 
     it('restores an draft Journey', async () => {
-      await resolver.journeysRestore('1', [trashedDraftJourney.id])
+      await resolver.journeysRestore([trashedDraftJourney.id])
       expect(service.updateAll).toHaveBeenCalledWith([
         {
           _key: trashedDraftJourney.id,

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -367,11 +367,8 @@ export class JourneyResolver {
       { role: Role.publisher, attributes: { template: true } }
     ])
   )
-  async journeysArchive(
-    @CurrentUserId() userId: string,
-    @Args('ids') ids: string[]
-  ): Promise<Journey[]> {
-    const results = (await this.journeyService.getAllByIds(userId, ids)).map(
+  async journeysArchive(@Args('ids') ids: string[]): Promise<Journey[]> {
+    const results = (await this.journeyService.getAllByIds(ids)).map(
       (journey) => ({
         _key: journey.id,
         status: JourneyStatus.archived,
@@ -391,11 +388,8 @@ export class JourneyResolver {
       { role: Role.publisher, attributes: { template: true } }
     ])
   )
-  async journeysDelete(
-    @CurrentUserId() userId: string,
-    @Args('ids') ids: string[]
-  ): Promise<Journey[]> {
-    const results = (await this.journeyService.getAllByIds(userId, ids)).map(
+  async journeysDelete(@Args('ids') ids: string[]): Promise<Journey[]> {
+    const results = (await this.journeyService.getAllByIds(ids)).map(
       (journey) => ({
         _key: journey.id,
         status: JourneyStatus.deleted,
@@ -414,11 +408,8 @@ export class JourneyResolver {
       { role: Role.publisher, attributes: { template: true } }
     ])
   )
-  async journeysTrash(
-    @CurrentUserId() userId: string,
-    @Args('ids') ids: string[]
-  ): Promise<Journey[]> {
-    const results = (await this.journeyService.getAllByIds(userId, ids)).map(
+  async journeysTrash(@Args('ids') ids: string[]): Promise<Journey[]> {
+    const results = (await this.journeyService.getAllByIds(ids)).map(
       (journey) => ({
         _key: journey.id,
         status: JourneyStatus.trashed,
@@ -438,11 +429,8 @@ export class JourneyResolver {
       { role: Role.publisher, attributes: { template: true } }
     ])
   )
-  async journeysRestore(
-    @CurrentUserId() userId: string,
-    @Args('ids') ids: string[]
-  ): Promise<Journey[]> {
-    const results = (await this.journeyService.getAllByIds(userId, ids)).map(
+  async journeysRestore(@Args('ids') ids: string[]): Promise<Journey[]> {
+    const results = (await this.journeyService.getAllByIds(ids)).map(
       (journey) => ({
         _key: journey.id,
         status:

--- a/apps/api-journeys/src/app/modules/journey/journey.service.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.service.ts
@@ -74,13 +74,10 @@ export class JourneyService extends BaseService {
   }
 
   @KeyAsId()
-  async getAllByIds(userId: string, ids: string[]): Promise<Journey[]> {
+  async getAllByIds(ids: string[]): Promise<Journey[]> {
     const result = await this.db.query(aql`
-    FOR userJourney in userJourneys
       FOR journey in ${this.collection}
-          FILTER userJourney.journeyId == journey._key && userJourney.userId == ${userId}
-           && userJourney.role == ${UserJourneyRole.owner}
-           && journey._key IN ${ids}
+          FILTER journey._key IN ${ids}
           RETURN journey
     `)
     return await result.all()


### PR DESCRIPTION
# Description

Removed userId and userJourney check for getAllByIds. Templates archive, trash, delete restore was failing because of the userJourney check. Since the addition to roleGuard, this check is also now not needed.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/29147486/todos/5301698079)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] API

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
