### PR TITLE
fix: redirect issues

### DIFF
--- a/apps/journeys-admin/pages/publisher/[journeyId]/edit.tsx
+++ b/apps/journeys-admin/pages/publisher/[journeyId]/edit.tsx
@@ -43,7 +43,7 @@ function TemplateEditPage(): ReactElement {
         <PageWrapper
           title={data?.publisherTemplate?.title ?? t('Edit Template')}
           showDrawer
-          backHref={`/templates/${router.query.journeyId as string}`}
+          backHref={`/publisher/${router.query.journeyId as string}`}
           authUser={AuthUser}
         >
           <JourneyEdit />

--- a/apps/journeys-admin/src/components/JourneyView/CardView/CardView.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/CardView/CardView.spec.tsx
@@ -53,7 +53,7 @@ describe('JourneyView/CardView', () => {
     expect(getByText('Select Empty Card to add')).toBeInTheDocument()
   })
 
-  it('should navigate to edit page when adding new card', async () => {
+  it('should navigate to journey edit page when adding new card', async () => {
     const push = jest.fn()
     mockUseRouter.mockReturnValue({ push } as unknown as NextRouter)
     const { getByTestId } = render(
@@ -67,6 +67,28 @@ describe('JourneyView/CardView', () => {
     await waitFor(() =>
       expect(push).toHaveBeenCalledWith(
         '/journeys/journeyId/edit?stepId=step0.id',
+        undefined,
+        { shallow: true }
+      )
+    )
+  })
+
+  it('should navigate to publisher edit page when adding new card', async () => {
+    const push = jest.fn()
+    mockUseRouter.mockReturnValue({ push } as unknown as NextRouter)
+    const { getByTestId } = render(
+      <MockedProvider>
+        <JourneyProvider
+          value={{ journey: { ...journey, template: true }, admin: true }}
+        >
+          <CardView id="journeyId" blocks={steps} isPublisher />
+        </JourneyProvider>
+      </MockedProvider>
+    )
+    fireEvent.click(getByTestId('preview-step0.id'))
+    await waitFor(() =>
+      expect(push).toHaveBeenCalledWith(
+        '/publisher/journeyId/edit?stepId=step0.id',
         undefined,
         { shallow: true }
       )

--- a/apps/journeys-admin/src/components/JourneyView/CardView/CardView.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/CardView/CardView.tsx
@@ -12,9 +12,14 @@ import { CardPreview } from '../../CardPreview'
 export interface CardViewProps {
   id?: string
   blocks?: Array<TreeBlock<StepBlock>>
+  isPublisher?: boolean
 }
 
-export function CardView({ id, blocks }: CardViewProps): ReactElement {
+export function CardView({
+  id,
+  blocks,
+  isPublisher
+}: CardViewProps): ReactElement {
   const { journey } = useJourney()
   const breakpoints = useBreakpoints()
   const router = useRouter()
@@ -22,9 +27,17 @@ export function CardView({ id, blocks }: CardViewProps): ReactElement {
   const handleSelect = (step: { id: string }): void => {
     if (id == null) return
 
-    void router.push(`/journeys/${id}/edit?stepId=${step.id}`, undefined, {
-      shallow: true
-    })
+    if (journey?.template !== true) {
+      void router.push(`/journeys/${id}/edit?stepId=${step.id}`, undefined, {
+        shallow: true
+      })
+    }
+
+    if (journey?.template === true && isPublisher === true) {
+      void router.push(`/publisher/${id}/edit?stepId=${step.id}`, undefined, {
+        shallow: true
+      })
+    }
   }
 
   const stepBlockLength =
@@ -40,7 +53,7 @@ export function CardView({ id, blocks }: CardViewProps): ReactElement {
       <CardPreview
         onSelect={handleSelect}
         steps={blocks}
-        showAddButton={journey?.template !== true}
+        showAddButton={journey?.template !== true || isPublisher}
         isDraggable={false}
       />
       <Box sx={{ pt: 2, display: 'flex', justifyContent: 'center' }}>

--- a/apps/journeys-admin/src/components/JourneyView/JourneyView.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyView.tsx
@@ -117,7 +117,7 @@ export function JourneyView({ journeyType }: JourneyViewProps): ReactElement {
       )}
 
       <>
-        <CardView id={journey?.id} blocks={blocks} />
+        <CardView id={journey?.id} blocks={blocks} isPublisher={isPublisher} />
         <JourneyViewFab isPublisher={isPublisher} />
       </>
 


### PR DESCRIPTION
# Description

Fix redirect issues when clicking on card view and clicking back on back href from the edit page

- Link to Basecamp Todo

# How should this PR be QA Tested?

Journeys 
- [ ] Users with access should be able to click on a card view and be redirected to /journeys/[journeyid]/edit.

Templates
- [ ] Users shouldn't be able to click on card view and be redirected to /publishers/[journeyid]/edit

Publisher
- [ ] Publishers should be able to click on card view and be redirected to /publishers/[journeyid]/edit
- [ ] Publishers should be able to click on the plus card button and create a new card. Then be redirected to /publishers/[journeyid]/edit

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
