### PR TITLE
fix: template redirect and access issues

### DIFF
--- a/apps/journeys-admin/pages/journeys/[journeyId]/edit.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/edit.tsx
@@ -59,11 +59,11 @@ function JourneyEditPage(): ReactElement {
       )}
       {error?.graphQLErrors[0].message ===
         'User has not received an invitation to edit this journey.' && (
-          <>
-            <NextSeo title={t('Access Denied')} />
-            <JourneyInvite journeyId={router.query.journeyId as string} />
-          </>
-        )}
+        <>
+          <NextSeo title={t('Access Denied')} />
+          <JourneyInvite journeyId={router.query.journeyId as string} />
+        </>
+      )}
       {error?.graphQLErrors[0].message === 'User invitation pending.' && (
         <>
           <NextSeo title={t('Access Denied')} />

--- a/apps/journeys-admin/pages/publisher/[journeyId].tsx
+++ b/apps/journeys-admin/pages/publisher/[journeyId].tsx
@@ -78,7 +78,7 @@ function TemplateDetailsAdmin(): ReactElement {
           </JourneyProvider>
         </>
       )}
-      {isPublisher !== true && (
+      {data?.publisherTemplate != null && isPublisher !== true && (
         <>
           <NextSeo title={t('Access Denied')} />
           <PublisherInvite />

--- a/apps/journeys-admin/pages/publisher/[journeyId]/edit.tsx
+++ b/apps/journeys-admin/pages/publisher/[journeyId]/edit.tsx
@@ -64,7 +64,7 @@ function TemplateEditPage(): ReactElement {
           </Editor>
         </>
       )}
-      {isPublisher !== true && (
+      {data?.publisherTemplate != null && isPublisher !== true && (
         <>
           <NextSeo title={t('Access Denied')} />
           <PublisherInvite />

--- a/apps/journeys-admin/src/libs/apolloClient/apolloClient.ts
+++ b/apps/journeys-admin/src/libs/apolloClient/apolloClient.ts
@@ -7,7 +7,7 @@ import { setContext } from '@apollo/client/link/context'
 import { useMemo } from 'react'
 import { cache } from './cache'
 
-function createApolloClient(
+export function createApolloClient(
   token: string
 ): ApolloClient<NormalizedCacheObject> {
   const httpLink = createHttpLink({

--- a/apps/journeys-admin/src/libs/apolloClient/index.ts
+++ b/apps/journeys-admin/src/libs/apolloClient/index.ts
@@ -1,1 +1,1 @@
-export { useApollo } from './apolloClient'
+export { useApollo, createApolloClient } from './apolloClient'


### PR DESCRIPTION
# Description

We found an issue where anyone can access `/journey/[journeyId]/edit` of a journey that is a template.
Users when visiting the edit page of a template but through the journeys URL, `/journey/[journeyId]/edit`, users should always be redirected to `/publisher/[journeyId]/edit`

This would allow the `/publisher/[journeyId]/edit` to handle permissions,
and not allow a template to be edited on `/journey/[journeyId]/edit`

Publishers are currently seeing the access denied componet for a short amount of time while the page is loading. Publishers don't need to see this component

- Link to Basecamp Todo

# How should this PR be QA Tested?

- [ ] Publishers visiting the [jouneyid] and edit page shouldn't be able to see the AccessDenied component while the page is loading

- [ ] If the journey is a template. And users have visited the edit page, `/journey/[journeyId]/edit`. Users should get redirected to `/publisher/[journeyid]/edit`.
- [ ] And upon visiting the said page above. Users without the publishers access should see the AccessDenied component

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
