### PR TITLE
ci: remove dependency on test for vr

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,6 @@ jobs:
           targets: generate,test
           args: --ci
   visual-test:
-    needs: [lint, build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,7 @@ jobs:
           targets: generate,test
           args: --ci
   visual-test:
-    needs: [lint, build, test]
+    needs: [lint, build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
# Description

Unit tests and VR are isolated tests. We ran VR last to reduce snapshots taken unnecessarily, this is no longer needed with TurboSnap. We're currently under our snapshot limit - 45/80k with the month ending Sept 29th

# How should this PR be QA Tested?

- [ ] VR in parallel to other checks
<img width="350" alt="image" src="https://user-images.githubusercontent.com/10802634/190044831-83f14ae1-7b5d-49af-9163-d7c5167e1589.png">

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
