### PR TITLE
feat: video source and youtube values

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -961,6 +961,13 @@ type VideoBlock implements Block {
   endAt: Int
   fullsize: Boolean
   id: ID!
+
+  """
+  internal source videos: this field is not populated and instead only present
+  in the video field
+  For other sources this is automatically populated.
+  """
+  image: String
   journeyId: ID!
   muted: Boolean
   parentBlockId: ID

--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -942,6 +942,21 @@ type VideoBlock implements Block {
   action: Action
   autoplay: Boolean
 
+  """
+  internal source videos: this field is not populated and instead only present
+  in the video field
+  For other sources this is automatically populated.
+  """
+  description: String
+
+  """
+  internal source videos: this field is not populated and instead only present
+  in the video field
+  For other sources this is automatically populated.
+  duration in seconds.
+  """
+  duration: Int
+
   """endAt dictates at which point of time the video should end"""
   endAt: Int
   fullsize: Boolean
@@ -958,30 +973,39 @@ type VideoBlock implements Block {
   """
   posterBlockId: ID
 
+  """
+  internal source: videoId, videoVariantLanguageId, and video present
+  youTube source: videoId, title, description, and duration present
+  """
+  source: VideoBlockSource!
+
   """startAt dictates at which point of time the video should start playing"""
   startAt: Int
 
   """
-  video is only populated when videoID and videoVariant LanguageId are present.
-  Relates to videos from the Jesus Film Project video library.
+  internal source videos: this field is not populated and instead only present
+  in the video field.
+  For other sources this is automatically populated.
+  """
+  title: String
+
+  """
+  internal source videos: video is only populated when videoID and
+  videoVariantLanguageId are present
   """
   video: Video
 
   """
-  videoId and videoVariantLanguageId both need to be set to select a video.
-  Relates to videos from the Jesus Film Project video library.
+  internal source videos: videoId and videoVariantLanguageId both need to be set
+  to select a video.
+  For other sources only videoId needs to be set.
   """
   videoId: ID
 
   """
-  videoUrl is used when embedding a video from a third-party provider.
-  e.g YouTube, Vimeo etc.
-  """
-  videoUrl: String
-
-  """
-  videoId and videoVariantLanguageId both need to be set to select a video
-  Relates to videos from the Jesus Film Project video library.
+  internal source videos: videoId and videoVariantLanguageId both need to be set
+  to select a video.
+  For other sources only videoId needs to be set.
   """
   videoVariantLanguageId: ID
 }
@@ -1010,26 +1034,33 @@ input VideoBlockCreateInput {
   """
   posterBlockId: ID
 
+  """
+  internal source: videoId and videoVariantLanguageId required
+  youTube source: videoId required
+  """
+  source: VideoBlockSource
+
   """startAt dictates at which point of time the video should start playing"""
   startAt: Int
 
   """
-  videoId and videoVariantLanguageId both need to be set to select a video.
-  Relates to videos from the Jesus Film Project video library.
+  internal source videos: videoId and videoVariantLanguageId both need to be set
+  to select a video.
+  For other sources only videoId needs to be set.
   """
   videoId: ID
 
   """
-  videoUrl is used when embedding a video from a third-party provider.
-  e.g YouTube, Vimeo etc.
-  """
-  videoUrl: String
-
-  """
-  videoId and videoVariantLanguageId both need to be set to select a video
-  Relates to videos from the Jesus Film Project video library.
+  internal source videos: videoId and videoVariantLanguageId both need to be set
+  to select a video.
+  For other sources only videoId needs to be set.
   """
   videoVariantLanguageId: ID
+}
+
+enum VideoBlockSource {
+  internal
+  youTube
 }
 
 input VideoBlockUpdateInput {
@@ -1047,24 +1078,26 @@ input VideoBlockUpdateInput {
   """
   posterBlockId: ID
 
+  """
+  internal source: videoId and videoVariantLanguageId required
+  youTube source: videoId required
+  """
+  source: VideoBlockSource
+
   """startAt dictates at which point of time the video should start playing"""
   startAt: Int
 
   """
-  videoId and videoVariantLanguageId both need to be set to select a video.
-  Relates to videos from the Jesus Film Project video library.
+  internal source videos: videoId and videoVariantLanguageId both need to be set
+  to select a video.
+  For other sources only videoId needs to be set.
   """
   videoId: ID
 
   """
-  videoUrl is used when embedding a video from a third-party provider.
-  e.g YouTube, Vimeo etc.
-  """
-  videoUrl: String
-
-  """
-  videoId and videoVariantLanguageId both need to be set to select a video
-  Relates to videos from the Jesus Film Project video library.
+  internal source videos: videoId and videoVariantLanguageId both need to be set
+  to select a video.
+  For other sources only videoId needs to be set.
   """
   videoVariantLanguageId: ID
 }

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -491,6 +491,11 @@ input TypographyBlockUpdateInput {
   align: TypographyAlign
 }
 
+enum VideoBlockSource {
+  internal
+  youTube
+}
+
 type VideoBlock implements Block {
   id: ID!
   journeyId: ID!
@@ -514,28 +519,52 @@ type VideoBlock implements Block {
   fullsize: Boolean
 
   """
-  video is only populated when videoID and videoVariant LanguageId are present.
-  Relates to videos from the Jesus Film Project video library.
+  internal source videos: video is only populated when videoID and
+  videoVariantLanguageId are present
   """
   video: Video
 
   """
-  videoId and videoVariantLanguageId both need to be set to select a video.
-  Relates to videos from the Jesus Film Project video library.
+  internal source videos: videoId and videoVariantLanguageId both need to be set
+  to select a video.
+  For other sources only videoId needs to be set.
   """
   videoId: ID
 
   """
-  videoId and videoVariantLanguageId both need to be set to select a video
-  Relates to videos from the Jesus Film Project video library.
+  internal source videos: videoId and videoVariantLanguageId both need to be set
+  to select a video.
+  For other sources only videoId needs to be set.
   """
   videoVariantLanguageId: ID
 
   """
-  videoUrl is used when embedding a video from a third-party provider.
-  e.g YouTube, Vimeo etc.
+  internal source: videoId, videoVariantLanguageId, and video present
+  youTube source: videoId, title, description, and duration present
   """
-  videoUrl: String
+  source: VideoBlockSource!
+
+  """
+  internal source videos: this field is not populated and instead only present
+  in the video field.
+  For other sources this is automatically populated.
+  """
+  title: String
+
+  """
+  internal source videos: this field is not populated and instead only present
+  in the video field
+  For other sources this is automatically populated.
+  """
+  description: String
+
+  """
+  internal source videos: this field is not populated and instead only present
+  in the video field
+  For other sources this is automatically populated.
+  duration in seconds.
+  """
+  duration: Int
 
   """action that should be performed when the video ends"""
   action: Action
@@ -556,22 +585,24 @@ input VideoBlockCreateInput {
   autoplay: Boolean
 
   """
-  videoId and videoVariantLanguageId both need to be set to select a video.
-  Relates to videos from the Jesus Film Project video library.
+  internal source videos: videoId and videoVariantLanguageId both need to be set
+  to select a video.
+  For other sources only videoId needs to be set.
   """
   videoId: ID
 
   """
-  videoId and videoVariantLanguageId both need to be set to select a video
-  Relates to videos from the Jesus Film Project video library.
+  internal source videos: videoId and videoVariantLanguageId both need to be set
+  to select a video.
+  For other sources only videoId needs to be set.
   """
   videoVariantLanguageId: ID
 
   """
-  videoUrl is used when embedding a video from a third-party provider.
-  e.g YouTube, Vimeo etc.
+  internal source: videoId and videoVariantLanguageId required
+  youTube source: videoId required
   """
-  videoUrl: String
+  source: VideoBlockSource
 
   """
   posterBlockId is present if a child block should be used as a poster.
@@ -597,22 +628,24 @@ input VideoBlockUpdateInput {
   autoplay: Boolean
 
   """
-  videoId and videoVariantLanguageId both need to be set to select a video.
-  Relates to videos from the Jesus Film Project video library.
+  internal source videos: videoId and videoVariantLanguageId both need to be set
+  to select a video.
+  For other sources only videoId needs to be set.
   """
   videoId: ID
 
   """
-  videoId and videoVariantLanguageId both need to be set to select a video
-  Relates to videos from the Jesus Film Project video library.
+  internal source videos: videoId and videoVariantLanguageId both need to be set
+  to select a video.
+  For other sources only videoId needs to be set.
   """
   videoVariantLanguageId: ID
 
   """
-  videoUrl is used when embedding a video from a third-party provider.
-  e.g YouTube, Vimeo etc.
+  internal source: videoId and videoVariantLanguageId required
+  youTube source: videoId required
   """
-  videoUrl: String
+  source: VideoBlockSource
 
   """
   posterBlockId is present if a child block should be used as a poster.

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -562,6 +562,13 @@ type VideoBlock implements Block {
   internal source videos: this field is not populated and instead only present
   in the video field
   For other sources this is automatically populated.
+  """
+  image: String
+
+  """
+  internal source videos: this field is not populated and instead only present
+  in the video field
+  For other sources this is automatically populated.
   duration in seconds.
   """
   duration: Int

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -654,6 +654,7 @@ export class VideoBlock implements Block {
     source: VideoBlockSource;
     title?: Nullable<string>;
     description?: Nullable<string>;
+    image?: Nullable<string>;
     duration?: Nullable<number>;
     action?: Nullable<Action>;
 }

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -116,6 +116,11 @@ export enum TypographyAlign {
     right = "right"
 }
 
+export enum VideoBlockSource {
+    internal = "internal",
+    youTube = "youTube"
+}
+
 export enum IdType {
     databaseId = "databaseId",
     slug = "slug"
@@ -307,7 +312,7 @@ export class VideoBlockCreateInput {
     autoplay?: Nullable<boolean>;
     videoId?: Nullable<string>;
     videoVariantLanguageId?: Nullable<string>;
-    videoUrl?: Nullable<string>;
+    source?: Nullable<VideoBlockSource>;
     posterBlockId?: Nullable<string>;
     fullsize?: Nullable<boolean>;
     isCover?: Nullable<boolean>;
@@ -320,7 +325,7 @@ export class VideoBlockUpdateInput {
     autoplay?: Nullable<boolean>;
     videoId?: Nullable<string>;
     videoVariantLanguageId?: Nullable<string>;
-    videoUrl?: Nullable<string>;
+    source?: Nullable<VideoBlockSource>;
     posterBlockId?: Nullable<string>;
     fullsize?: Nullable<boolean>;
 }
@@ -646,7 +651,10 @@ export class VideoBlock implements Block {
     video?: Nullable<Video>;
     videoId?: Nullable<string>;
     videoVariantLanguageId?: Nullable<string>;
-    videoUrl?: Nullable<string>;
+    source: VideoBlockSource;
+    title?: Nullable<string>;
+    description?: Nullable<string>;
+    duration?: Nullable<number>;
     action?: Nullable<Action>;
 }
 

--- a/apps/api-journeys/src/app/modules/block/video/video.graphql
+++ b/apps/api-journeys/src/app/modules/block/video/video.graphql
@@ -68,6 +68,12 @@ type VideoBlock implements Block {
   internal source videos: this field is not populated and instead only present
   in the video field
   For other sources this is automatically populated.
+  """
+  image: String
+  """
+  internal source videos: this field is not populated and instead only present
+  in the video field
+  For other sources this is automatically populated.
   duration in seconds.
   """
   duration: Int

--- a/apps/api-journeys/src/app/modules/block/video/video.graphql
+++ b/apps/api-journeys/src/app/modules/block/video/video.graphql
@@ -3,6 +3,11 @@ extend type Video @key(fields: "id primaryLanguageId") {
   primaryLanguageId: ID! @external
 }
 
+enum VideoBlockSource {
+  internal
+  youTube
+}
+
 type VideoBlock implements Block {
   id: ID!
   journeyId: ID!
@@ -26,25 +31,46 @@ type VideoBlock implements Block {
   posterBlockId: ID
   fullsize: Boolean
   """
-  video is only populated when videoID and videoVariant LanguageId are present.
-  Relates to videos from the Jesus Film Project video library.
+  internal source videos: video is only populated when videoID and
+  videoVariantLanguageId are present
   """
   video: Video
   """
-  videoId and videoVariantLanguageId both need to be set to select a video.
-  Relates to videos from the Jesus Film Project video library.
+  internal source videos: videoId and videoVariantLanguageId both need to be set
+  to select a video.
+  For other sources only videoId needs to be set.
   """
   videoId: ID
   """
-  videoId and videoVariantLanguageId both need to be set to select a video
-  Relates to videos from the Jesus Film Project video library.
+  internal source videos: videoId and videoVariantLanguageId both need to be set
+  to select a video.
+  For other sources only videoId needs to be set.
   """
   videoVariantLanguageId: ID
   """
-  videoUrl is used when embedding a video from a third-party provider.
-  e.g YouTube, Vimeo etc.
+  internal source: videoId, videoVariantLanguageId, and video present
+  youTube source: videoId, title, description, and duration present
   """
-  videoUrl: String
+  source: VideoBlockSource!
+  """
+  internal source videos: this field is not populated and instead only present
+  in the video field.
+  For other sources this is automatically populated.
+  """
+  title: String
+  """
+  internal source videos: this field is not populated and instead only present
+  in the video field
+  For other sources this is automatically populated.
+  """
+  description: String
+  """
+  internal source videos: this field is not populated and instead only present
+  in the video field
+  For other sources this is automatically populated.
+  duration in seconds.
+  """
+  duration: Int
   """
   action that should be performed when the video ends
   """
@@ -67,20 +93,22 @@ input VideoBlockCreateInput {
   muted: Boolean
   autoplay: Boolean
   """
-  videoId and videoVariantLanguageId both need to be set to select a video.
-  Relates to videos from the Jesus Film Project video library.
+  internal source videos: videoId and videoVariantLanguageId both need to be set
+  to select a video.
+  For other sources only videoId needs to be set.
   """
   videoId: ID
   """
-  videoId and videoVariantLanguageId both need to be set to select a video
-  Relates to videos from the Jesus Film Project video library.
+  internal source videos: videoId and videoVariantLanguageId both need to be set
+  to select a video.
+  For other sources only videoId needs to be set.
   """
   videoVariantLanguageId: ID
   """
-  videoUrl is used when embedding a video from a third-party provider.
-  e.g YouTube, Vimeo etc.
+  internal source: videoId and videoVariantLanguageId required
+  youTube source: videoId required
   """
-  videoUrl: String
+  source: VideoBlockSource
   """
   posterBlockId is present if a child block should be used as a poster.
   This child block should not be rendered normally, instead it should be used
@@ -106,20 +134,22 @@ input VideoBlockUpdateInput {
   muted: Boolean
   autoplay: Boolean
   """
-  videoId and videoVariantLanguageId both need to be set to select a video.
-  Relates to videos from the Jesus Film Project video library.
+  internal source videos: videoId and videoVariantLanguageId both need to be set
+  to select a video.
+  For other sources only videoId needs to be set.
   """
   videoId: ID
   """
-  videoId and videoVariantLanguageId both need to be set to select a video
-  Relates to videos from the Jesus Film Project video library.
+  internal source videos: videoId and videoVariantLanguageId both need to be set
+  to select a video.
+  For other sources only videoId needs to be set.
   """
   videoVariantLanguageId: ID
   """
-  videoUrl is used when embedding a video from a third-party provider.
-  e.g YouTube, Vimeo etc.
+  internal source: videoId and videoVariantLanguageId required
+  youTube source: videoId required
   """
-  videoUrl: String
+  source: VideoBlockSource
   """
   posterBlockId is present if a child block should be used as a poster.
   This child block should not be rendered normally, instead it should be used

--- a/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
@@ -5,6 +5,7 @@ import {
   CardBlock,
   VideoBlock,
   VideoBlockCreateInput,
+  VideoBlockSource,
   VideoBlockUpdateInput
 } from '../../../__generated__/graphql'
 import { JourneyService } from '../../journey/journey.service'
@@ -72,7 +73,8 @@ describe('VideoBlockResolver', () => {
     muted: true,
     autoplay: true,
     fullsize: true,
-    action: navigateAction
+    action: navigateAction,
+    source: VideoBlockSource.internal
   }
 
   const parentBlock: CardBlock = {
@@ -108,7 +110,8 @@ describe('VideoBlockResolver', () => {
     muted: true,
     autoplay: true,
     posterBlockId: 'posterBlockId',
-    fullsize: true
+    fullsize: true,
+    source: VideoBlockSource.internal
   }
 
   beforeEach(async () => {
@@ -176,38 +179,30 @@ describe('VideoBlockResolver', () => {
       })
     })
 
-    it('throws validation when invalid URL', async () => {
+    it('throws error when invalid YouTube videoId', async () => {
       await expect(
         async () =>
           await resolver.videoBlockCreate({
             journeyId: 'journeyId',
             parentBlockId: 'parentBlockId',
-            videoUrl: 'test'
+            videoId: 'test',
+            source: VideoBlockSource.youTube
           })
-      ).rejects.toThrow('videoUrl must be a valid YouTube URL')
+      ).rejects.toThrow('videoId must be a valid YouTube videoId')
     })
 
-    it('throws validation when URL not from YouTube', async () => {
-      await expect(
-        async () =>
-          await resolver.videoBlockCreate({
-            journeyId: 'journeyId',
-            parentBlockId: 'parentBlockId',
-            videoUrl: 'https://google.com'
-          })
-      ).rejects.toThrow('videoUrl must be a valid YouTube URL')
-    })
-
-    it('creates a VideoBlock when URL from YouTube', async () => {
+    it('creates a VideoBlock when videoId from YouTube', async () => {
       expect(
         await resolver.videoBlockCreate({
           journeyId: 'journeyId',
           parentBlockId: 'parentBlockId',
-          videoUrl: 'https://www.youtube.com/watch?v=ak06MSETeo4'
+          videoId: 'ak06MSETeo4',
+          source: VideoBlockSource.youTube
         })
       ).toEqual({
         ...createdBlock,
-        videoUrl: 'https://www.youtube.com/watch?v=ak06MSETeo4'
+        videoId: 'ak06MSETeo4',
+        source: VideoBlockSource.youTube
       })
     })
   })
@@ -219,32 +214,26 @@ describe('VideoBlockResolver', () => {
       ).toEqual(updatedBlock)
     })
 
-    it('throws validation when invalid URL', async () => {
+    it('throws error when invalid YouTube videoId', async () => {
       await expect(
         async () =>
           await resolver.videoBlockUpdate('blockId', 'journeyId', {
-            videoUrl: 'test'
+            videoId: 'test',
+            source: VideoBlockSource.youTube
           })
-      ).rejects.toThrow('videoUrl must be a valid YouTube URL')
+      ).rejects.toThrow('videoId must be a valid YouTube videoId')
     })
 
-    it('throws validation when URL not from YouTube', async () => {
-      await expect(
-        async () =>
-          await resolver.videoBlockUpdate('blockId', 'journeyId', {
-            videoUrl: 'https://google.com'
-          })
-      ).rejects.toThrow('videoUrl must be a valid YouTube URL')
-    })
-
-    it('updates a VideoBlock when URL from YouTube', async () => {
+    it('updates a VideoBlock when videoId from YouTube', async () => {
       expect(
         await resolver.videoBlockUpdate('blockId', 'journeyId', {
-          videoUrl: 'https://www.youtube.com/watch?v=ak06MSETeo4'
+          videoId: 'ak06MSETeo4',
+          source: VideoBlockSource.youTube
         })
       ).toEqual({
         ...updatedBlock,
-        videoUrl: 'https://www.youtube.com/watch?v=ak06MSETeo4'
+        videoId: 'ak06MSETeo4',
+        source: VideoBlockSource.youTube
       })
     })
   })

--- a/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
@@ -179,30 +179,75 @@ describe('VideoBlockResolver', () => {
       })
     })
 
-    it('throws error when invalid YouTube videoId', async () => {
-      await expect(
-        async () =>
+    describe('Internal Source', () => {
+      it('throws error when no videoVariantLanguageId', async () => {
+        await expect(
+          async () =>
+            await resolver.videoBlockCreate({
+              journeyId: 'journeyId',
+              parentBlockId: 'parentBlockId',
+              videoId: 'videoId',
+              source: VideoBlockSource.internal
+            })
+        ).rejects.toThrow('videoVariantLanguageId is a required field')
+      })
+
+      it('throws error when no videoId', async () => {
+        await expect(
+          async () =>
+            await resolver.videoBlockCreate({
+              journeyId: 'journeyId',
+              parentBlockId: 'parentBlockId',
+              videoVariantLanguageId: 'videoVariantLanguageId',
+              source: VideoBlockSource.internal
+            })
+        ).rejects.toThrow('videoId is a required field')
+      })
+
+      it('creates a VideoBlock', async () => {
+        expect(
           await resolver.videoBlockCreate({
             journeyId: 'journeyId',
             parentBlockId: 'parentBlockId',
-            videoId: 'test',
-            source: VideoBlockSource.youTube
+            videoId: 'videoId',
+            videoVariantLanguageId: 'videoVariantLanguageId',
+            source: VideoBlockSource.internal
           })
-      ).rejects.toThrow('videoId must be a valid YouTube videoId')
+        ).toEqual({
+          ...createdBlock,
+          videoId: 'videoId',
+          videoVariantLanguageId: 'videoVariantLanguageId',
+          source: VideoBlockSource.internal
+        })
+      })
     })
 
-    it('creates a VideoBlock when videoId from YouTube', async () => {
-      expect(
-        await resolver.videoBlockCreate({
-          journeyId: 'journeyId',
-          parentBlockId: 'parentBlockId',
+    describe('YouTube Source', () => {
+      it('throws error when invalid videoId', async () => {
+        await expect(
+          async () =>
+            await resolver.videoBlockCreate({
+              journeyId: 'journeyId',
+              parentBlockId: 'parentBlockId',
+              videoId: 'test',
+              source: VideoBlockSource.youTube
+            })
+        ).rejects.toThrow('videoId must be a valid YouTube videoId')
+      })
+
+      it('creates a VideoBlock', async () => {
+        expect(
+          await resolver.videoBlockCreate({
+            journeyId: 'journeyId',
+            parentBlockId: 'parentBlockId',
+            videoId: 'ak06MSETeo4',
+            source: VideoBlockSource.youTube
+          })
+        ).toEqual({
+          ...createdBlock,
           videoId: 'ak06MSETeo4',
           source: VideoBlockSource.youTube
         })
-      ).toEqual({
-        ...createdBlock,
-        videoId: 'ak06MSETeo4',
-        source: VideoBlockSource.youTube
       })
     })
   })
@@ -214,26 +259,65 @@ describe('VideoBlockResolver', () => {
       ).toEqual(updatedBlock)
     })
 
-    it('throws error when invalid YouTube videoId', async () => {
-      await expect(
-        async () =>
+    describe('Internal Source', () => {
+      it('throws error when no videoVariantLanguageId', async () => {
+        await expect(
+          async () =>
+            await resolver.videoBlockUpdate('blockId', 'journeyId', {
+              videoId: 'videoId',
+              source: VideoBlockSource.internal
+            })
+        ).rejects.toThrow('videoVariantLanguageId is a required field')
+      })
+
+      it('throws error when no videoId', async () => {
+        await expect(
+          async () =>
+            await resolver.videoBlockUpdate('blockId', 'journeyId', {
+              videoVariantLanguageId: 'videoVariantLanguageId',
+              source: VideoBlockSource.internal
+            })
+        ).rejects.toThrow('videoId is a required field')
+      })
+
+      it('updates a VideoBlock', async () => {
+        expect(
           await resolver.videoBlockUpdate('blockId', 'journeyId', {
-            videoId: 'test',
-            source: VideoBlockSource.youTube
+            videoId: 'videoId',
+            videoVariantLanguageId: 'videoVariantLanguageId',
+            source: VideoBlockSource.internal
           })
-      ).rejects.toThrow('videoId must be a valid YouTube videoId')
+        ).toEqual({
+          ...updatedBlock,
+          videoId: 'videoId',
+          videoVariantLanguageId: 'videoVariantLanguageId',
+          source: VideoBlockSource.internal
+        })
+      })
     })
 
-    it('updates a VideoBlock when videoId from YouTube', async () => {
-      expect(
-        await resolver.videoBlockUpdate('blockId', 'journeyId', {
+    describe('YouTube Source', () => {
+      it('throws error when invalid videoId', async () => {
+        await expect(
+          async () =>
+            await resolver.videoBlockUpdate('blockId', 'journeyId', {
+              videoId: 'test',
+              source: VideoBlockSource.youTube
+            })
+        ).rejects.toThrow('videoId must be a valid YouTube videoId')
+      })
+
+      it('updates a VideoBlock', async () => {
+        expect(
+          await resolver.videoBlockUpdate('blockId', 'journeyId', {
+            videoId: 'ak06MSETeo4',
+            source: VideoBlockSource.youTube
+          })
+        ).toEqual({
+          ...updatedBlock,
           videoId: 'ak06MSETeo4',
           source: VideoBlockSource.youTube
         })
-      ).toEqual({
-        ...updatedBlock,
-        videoId: 'ak06MSETeo4',
-        source: VideoBlockSource.youTube
       })
     })
   })

--- a/apps/api-journeys/src/app/modules/block/video/video.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/video/video.resolver.ts
@@ -1,6 +1,8 @@
 import { Args, Mutation, Parent, ResolveField, Resolver } from '@nestjs/graphql'
 import { UseGuards } from '@nestjs/common'
 import { object, string } from 'yup'
+import fetch from 'node-fetch'
+import { UserInputError } from 'apollo-server'
 import { BlockService } from '../block.service'
 import {
   Action,
@@ -23,6 +25,36 @@ const videoBlockInternalSchema = object().shape({
   videoId: string().required(),
   videoVariantLanguageId: string().required()
 })
+
+export interface YoutubeVideosData {
+  items: Array<{
+    id: string
+    snippet: {
+      title: string
+      description: string
+      thumbnails: { default: { url: string } }
+    }
+    contentDetails: {
+      duration: string
+    }
+  }>
+}
+
+function parseISO8601Duration(duration: string): number {
+  const match = duration.match(/P(\d+Y)?(\d+W)?(\d+D)?T(\d+H)?(\d+M)?(\d+S)?/)
+
+  if (match == null) {
+    console.error(`Invalid duration: ${duration}`)
+    return 0
+  }
+  const [years, weeks, days, hours, minutes, seconds] = match
+    .slice(1)
+    .map((period) => (period != null ? parseInt(period.replace(/\D/, '')) : 0))
+  return (
+    (((years * 365 + weeks * 7 + days) * 24 + hours) * 60 + minutes) * 60 +
+    seconds
+  )
+}
 
 @Resolver('VideoBlock')
 export class VideoBlockResolver {
@@ -51,6 +83,10 @@ export class VideoBlockResolver {
     switch (input.source) {
       case VideoBlockSource.youTube:
         await videoBlockYouTubeSchema.validate(input)
+        input = {
+          ...input,
+          ...(await this.fetchFieldsFromYouTube(input.videoId as string))
+        }
         break
       case VideoBlockSource.internal:
         await videoBlockInternalSchema.validate(input)
@@ -117,6 +153,10 @@ export class VideoBlockResolver {
     switch (input.source ?? block.source) {
       case VideoBlockSource.youTube:
         await videoBlockYouTubeSchema.validate({ ...block, ...input })
+        input = {
+          ...input,
+          ...(await this.fetchFieldsFromYouTube(input.videoId as string))
+        }
         break
       case VideoBlockSource.internal:
         await videoBlockInternalSchema.validate({ ...block, ...input })
@@ -154,5 +194,31 @@ export class VideoBlockResolver {
     block: VideoBlock
   ): VideoBlockSource {
     return block.source ?? VideoBlockSource.internal
+  }
+
+  private async fetchFieldsFromYouTube(
+    videoId: string
+  ): Promise<Pick<VideoBlock, 'title' | 'description' | 'image' | 'duration'>> {
+    const query = new URLSearchParams({
+      part: 'snippet,contentDetails',
+      key: process.env.FIREBASE_API_KEY ?? '',
+      id: videoId
+    }).toString()
+    const videosData: YoutubeVideosData = await (
+      await fetch(`https://www.googleapis.com/youtube/v3/videos?${query}`)
+    ).json()
+    if (videosData.items[0] == null) {
+      throw new UserInputError('videoId cannot be found on YouTube', {
+        videoId: ['videoId cannot be found on YouTube']
+      })
+    }
+    return {
+      title: videosData.items[0].snippet.title,
+      description: videosData.items[0].snippet.description,
+      image: videosData.items[0].snippet.thumbnails.default.url,
+      duration: parseISO8601Duration(
+        videosData.items[0].contentDetails.duration
+      )
+    }
   }
 }

--- a/apps/journeys-admin/__generated__/BlockFields.ts
+++ b/apps/journeys-admin/__generated__/BlockFields.ts
@@ -341,18 +341,20 @@ export interface BlockFields_VideoBlock {
   posterBlockId: string | null;
   fullsize: boolean | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoId: string | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoVariantLanguageId: string | null;
   /**
-   * video is only populated when videoID and videoVariant LanguageId are present.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: video is only populated when videoID and
+   * videoVariantLanguageId are present
    */
   video: BlockFields_VideoBlock_video | null;
   /**

--- a/apps/journeys-admin/__generated__/CardBlockVideoBlockCreate.ts
+++ b/apps/journeys-admin/__generated__/CardBlockVideoBlockCreate.ts
@@ -86,18 +86,20 @@ export interface CardBlockVideoBlockCreate_videoBlockCreate {
   posterBlockId: string | null;
   fullsize: boolean | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoId: string | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoVariantLanguageId: string | null;
   /**
-   * video is only populated when videoID and videoVariant LanguageId are present.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: video is only populated when videoID and
+   * videoVariantLanguageId are present
    */
   video: CardBlockVideoBlockCreate_videoBlockCreate_video | null;
   /**

--- a/apps/journeys-admin/__generated__/CardBlockVideoBlockUpdate.ts
+++ b/apps/journeys-admin/__generated__/CardBlockVideoBlockUpdate.ts
@@ -86,18 +86,20 @@ export interface CardBlockVideoBlockUpdate_videoBlockUpdate {
   posterBlockId: string | null;
   fullsize: boolean | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoId: string | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoVariantLanguageId: string | null;
   /**
-   * video is only populated when videoID and videoVariant LanguageId are present.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: video is only populated when videoID and
+   * videoVariantLanguageId are present
    */
   video: CardBlockVideoBlockUpdate_videoBlockUpdate_video | null;
   /**

--- a/apps/journeys-admin/__generated__/GetJourney.ts
+++ b/apps/journeys-admin/__generated__/GetJourney.ts
@@ -353,18 +353,20 @@ export interface GetJourney_journey_blocks_VideoBlock {
   posterBlockId: string | null;
   fullsize: boolean | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoId: string | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoVariantLanguageId: string | null;
   /**
-   * video is only populated when videoID and videoVariant LanguageId are present.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: video is only populated when videoID and
+   * videoVariantLanguageId are present
    */
   video: GetJourney_journey_blocks_VideoBlock_video | null;
   /**

--- a/apps/journeys-admin/__generated__/JourneyFields.ts
+++ b/apps/journeys-admin/__generated__/JourneyFields.ts
@@ -353,18 +353,20 @@ export interface JourneyFields_blocks_VideoBlock {
   posterBlockId: string | null;
   fullsize: boolean | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoId: string | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoVariantLanguageId: string | null;
   /**
-   * video is only populated when videoID and videoVariant LanguageId are present.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: video is only populated when videoID and
+   * videoVariantLanguageId are present
    */
   video: JourneyFields_blocks_VideoBlock_video | null;
   /**

--- a/apps/journeys-admin/__generated__/VideoBlockCreate.ts
+++ b/apps/journeys-admin/__generated__/VideoBlockCreate.ts
@@ -86,18 +86,20 @@ export interface VideoBlockCreate_videoBlockCreate {
   posterBlockId: string | null;
   fullsize: boolean | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoId: string | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoVariantLanguageId: string | null;
   /**
-   * video is only populated when videoID and videoVariant LanguageId are present.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: video is only populated when videoID and
+   * videoVariantLanguageId are present
    */
   video: VideoBlockCreate_videoBlockCreate_video | null;
   /**

--- a/apps/journeys-admin/__generated__/VideoBlockUpdate.ts
+++ b/apps/journeys-admin/__generated__/VideoBlockUpdate.ts
@@ -86,18 +86,20 @@ export interface VideoBlockUpdate_videoBlockUpdate {
   posterBlockId: string | null;
   fullsize: boolean | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoId: string | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoVariantLanguageId: string | null;
   /**
-   * video is only populated when videoID and videoVariant LanguageId are present.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: video is only populated when videoID and
+   * videoVariantLanguageId are present
    */
   video: VideoBlockUpdate_videoBlockUpdate_video | null;
   /**

--- a/apps/journeys-admin/__generated__/VideoFields.ts
+++ b/apps/journeys-admin/__generated__/VideoFields.ts
@@ -84,18 +84,20 @@ export interface VideoFields {
   posterBlockId: string | null;
   fullsize: boolean | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoId: string | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoVariantLanguageId: string | null;
   /**
-   * video is only populated when videoID and videoVariant LanguageId are present.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: video is only populated when videoID and
+   * videoVariantLanguageId are present
    */
   video: VideoFields_video | null;
   /**

--- a/apps/journeys-admin/__generated__/globalTypes.ts
+++ b/apps/journeys-admin/__generated__/globalTypes.ts
@@ -144,6 +144,11 @@ export enum UserJourneyRole {
   owner = "owner",
 }
 
+export enum VideoBlockSource {
+  internal = "internal",
+  youTube = "youTube",
+}
+
 export enum VideoType {
   episode = "episode",
   playlist = "playlist",
@@ -333,9 +338,9 @@ export interface VideoBlockCreateInput {
   muted?: boolean | null;
   parentBlockId: string;
   posterBlockId?: string | null;
+  source?: VideoBlockSource | null;
   startAt?: number | null;
   videoId?: string | null;
-  videoUrl?: string | null;
   videoVariantLanguageId?: string | null;
 }
 
@@ -345,9 +350,9 @@ export interface VideoBlockUpdateInput {
   fullsize?: boolean | null;
   muted?: boolean | null;
   posterBlockId?: string | null;
+  source?: VideoBlockSource | null;
   startAt?: number | null;
   videoId?: string | null;
-  videoUrl?: string | null;
   videoVariantLanguageId?: string | null;
 }
 

--- a/apps/journeys/__generated__/BlockFields.ts
+++ b/apps/journeys/__generated__/BlockFields.ts
@@ -341,18 +341,20 @@ export interface BlockFields_VideoBlock {
   posterBlockId: string | null;
   fullsize: boolean | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoId: string | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoVariantLanguageId: string | null;
   /**
-   * video is only populated when videoID and videoVariant LanguageId are present.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: video is only populated when videoID and
+   * videoVariantLanguageId are present
    */
   video: BlockFields_VideoBlock_video | null;
   /**

--- a/apps/journeys/__generated__/GetJourney.ts
+++ b/apps/journeys/__generated__/GetJourney.ts
@@ -353,18 +353,20 @@ export interface GetJourney_journey_blocks_VideoBlock {
   posterBlockId: string | null;
   fullsize: boolean | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoId: string | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoVariantLanguageId: string | null;
   /**
-   * video is only populated when videoID and videoVariant LanguageId are present.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: video is only populated when videoID and
+   * videoVariantLanguageId are present
    */
   video: GetJourney_journey_blocks_VideoBlock_video | null;
   /**

--- a/apps/journeys/__generated__/JourneyFields.ts
+++ b/apps/journeys/__generated__/JourneyFields.ts
@@ -353,18 +353,20 @@ export interface JourneyFields_blocks_VideoBlock {
   posterBlockId: string | null;
   fullsize: boolean | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoId: string | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoVariantLanguageId: string | null;
   /**
-   * video is only populated when videoID and videoVariant LanguageId are present.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: video is only populated when videoID and
+   * videoVariantLanguageId are present
    */
   video: JourneyFields_blocks_VideoBlock_video | null;
   /**

--- a/apps/journeys/__generated__/VideoFields.ts
+++ b/apps/journeys/__generated__/VideoFields.ts
@@ -84,18 +84,20 @@ export interface VideoFields {
   posterBlockId: string | null;
   fullsize: boolean | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoId: string | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoVariantLanguageId: string | null;
   /**
-   * video is only populated when videoID and videoVariant LanguageId are present.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: video is only populated when videoID and
+   * videoVariantLanguageId are present
    */
   video: VideoFields_video | null;
   /**

--- a/apps/watch-admin/__generated__/BlockFields.ts
+++ b/apps/watch-admin/__generated__/BlockFields.ts
@@ -341,18 +341,20 @@ export interface BlockFields_VideoBlock {
   posterBlockId: string | null;
   fullsize: boolean | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoId: string | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoVariantLanguageId: string | null;
   /**
-   * video is only populated when videoID and videoVariant LanguageId are present.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: video is only populated when videoID and
+   * videoVariantLanguageId are present
    */
   video: BlockFields_VideoBlock_video | null;
   /**

--- a/apps/watch-admin/__generated__/JourneyFields.ts
+++ b/apps/watch-admin/__generated__/JourneyFields.ts
@@ -353,18 +353,20 @@ export interface JourneyFields_blocks_VideoBlock {
   posterBlockId: string | null;
   fullsize: boolean | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoId: string | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoVariantLanguageId: string | null;
   /**
-   * video is only populated when videoID and videoVariant LanguageId are present.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: video is only populated when videoID and
+   * videoVariantLanguageId are present
    */
   video: JourneyFields_blocks_VideoBlock_video | null;
   /**

--- a/apps/watch-admin/__generated__/VideoFields.ts
+++ b/apps/watch-admin/__generated__/VideoFields.ts
@@ -84,18 +84,20 @@ export interface VideoFields {
   posterBlockId: string | null;
   fullsize: boolean | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoId: string | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoVariantLanguageId: string | null;
   /**
-   * video is only populated when videoID and videoVariant LanguageId are present.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: video is only populated when videoID and
+   * videoVariantLanguageId are present
    */
   video: VideoFields_video | null;
   /**

--- a/apps/watch/__generated__/BlockFields.ts
+++ b/apps/watch/__generated__/BlockFields.ts
@@ -341,18 +341,20 @@ export interface BlockFields_VideoBlock {
   posterBlockId: string | null;
   fullsize: boolean | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoId: string | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoVariantLanguageId: string | null;
   /**
-   * video is only populated when videoID and videoVariant LanguageId are present.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: video is only populated when videoID and
+   * videoVariantLanguageId are present
    */
   video: BlockFields_VideoBlock_video | null;
   /**

--- a/apps/watch/__generated__/JourneyFields.ts
+++ b/apps/watch/__generated__/JourneyFields.ts
@@ -353,18 +353,20 @@ export interface JourneyFields_blocks_VideoBlock {
   posterBlockId: string | null;
   fullsize: boolean | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoId: string | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoVariantLanguageId: string | null;
   /**
-   * video is only populated when videoID and videoVariant LanguageId are present.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: video is only populated when videoID and
+   * videoVariantLanguageId are present
    */
   video: JourneyFields_blocks_VideoBlock_video | null;
   /**

--- a/apps/watch/__generated__/VideoFields.ts
+++ b/apps/watch/__generated__/VideoFields.ts
@@ -84,18 +84,20 @@ export interface VideoFields {
   posterBlockId: string | null;
   fullsize: boolean | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoId: string | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoVariantLanguageId: string | null;
   /**
-   * video is only populated when videoID and videoVariant LanguageId are present.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: video is only populated when videoID and
+   * videoVariantLanguageId are present
    */
   video: VideoFields_video | null;
   /**

--- a/libs/journeys/ui/src/components/Video/__generated__/VideoFields.ts
+++ b/libs/journeys/ui/src/components/Video/__generated__/VideoFields.ts
@@ -84,18 +84,20 @@ export interface VideoFields {
   posterBlockId: string | null;
   fullsize: boolean | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoId: string | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoVariantLanguageId: string | null;
   /**
-   * video is only populated when videoID and videoVariant LanguageId are present.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: video is only populated when videoID and
+   * videoVariantLanguageId are present
    */
   video: VideoFields_video | null;
   /**

--- a/libs/journeys/ui/src/libs/JourneyProvider/__generated__/JourneyFields.ts
+++ b/libs/journeys/ui/src/libs/JourneyProvider/__generated__/JourneyFields.ts
@@ -353,18 +353,20 @@ export interface JourneyFields_blocks_VideoBlock {
   posterBlockId: string | null;
   fullsize: boolean | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoId: string | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoVariantLanguageId: string | null;
   /**
-   * video is only populated when videoID and videoVariant LanguageId are present.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: video is only populated when videoID and
+   * videoVariantLanguageId are present
    */
   video: JourneyFields_blocks_VideoBlock_video | null;
   /**

--- a/libs/journeys/ui/src/libs/block/__generated__/BlockFields.ts
+++ b/libs/journeys/ui/src/libs/block/__generated__/BlockFields.ts
@@ -341,18 +341,20 @@ export interface BlockFields_VideoBlock {
   posterBlockId: string | null;
   fullsize: boolean | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoId: string | null;
   /**
-   * videoId and videoVariantLanguageId both need to be set to select a video
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: videoId and videoVariantLanguageId both need to be set
+   * to select a video.
+   * For other sources only videoId needs to be set.
    */
   videoVariantLanguageId: string | null;
   /**
-   * video is only populated when videoID and videoVariant LanguageId are present.
-   * Relates to videos from the Jesus Film Project video library.
+   * internal source videos: video is only populated when videoID and
+   * videoVariantLanguageId are present
    */
   video: BlockFields_VideoBlock_video | null;
   /**


### PR DESCRIPTION
# Description

Please include a summary of the change and which todo is completed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- pull youtube video data into video block
- removes video URL from video block
- validate internal and youtube source video blocks
- don't break current functionality
- all future video blocks should use source set to internal

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

You will need to run `nx fetch-secrets api-journeys` before trying to QA this

 - [x] create YT video block update with 'ak06MSETeo4' videoId and source set to youTube, should create block including title, description, duration and image fields
 - [x] update YT video block create with 'ak06MSETeo4' videoId and source set to youTube, should update block including title, description, duration and image fields
 - [x] create internal video block update with videoId, videoLanguageId and source set to internal, should create block
 - [x] update internal video block create with videoId, videoLanguageId and source set to internal, should update block
 - [x] create internal video block update with videoId, videoLanguageId and no source, should create block
 - [x] update internal video block create with videoId, videoLanguageId and no source, should update block
 - [x] create invalid YT video block with 'test' videoId field and should throw error
 - [x] create invalid YT video block with 'ak06MSETeoz' videoId field and should throw error

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
