### PR TITLE
ci: prevent VR on dependabot branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,6 +150,7 @@ jobs:
         uses: chromaui/action@v1
         # Options required for Chromatic's GitHub Action
         # https://www.chromatic.com/docs/github-actions#available-options
+        # https://github.com/chromaui/chromatic-cli/blob/main/action.yml
         with:
           #👇 Chromatic projectToken, see https://storybook.js.org/tutorials/intro-to-storybook/react/en/deploy/ to obtain it
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
@@ -158,3 +159,6 @@ jobs:
           exitOnceUploaded: true,
           autoAcceptChanges: 'main'
           onlyChanged: true
+          skip: 'dependabot/**'
+          untraced: 'package.json,yarn.lock'
+          traceChanged: 'expanded'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,5 +160,4 @@ jobs:
           autoAcceptChanges: 'main'
           onlyChanged: true
           skip: 'dependabot/**'
-          untraced: 'package.json,yarn.lock'
           traceChanged: 'expanded'

--- a/libs/shared/ui/src/libs/themes/base/theme.stories.tsx
+++ b/libs/shared/ui/src/libs/themes/base/theme.stories.tsx
@@ -66,7 +66,7 @@ const ColorTokens = ({
         sx={{
           bgcolor: theme.palette.background.paper,
           color: theme.palette.text.primary,
-          mb: theme.spacing(6),
+          mb: theme.spacing(7),
           p: theme.spacing(3),
           boxShadow: theme.shadows[1]
         }}

--- a/libs/shared/ui/src/libs/themes/base/theme.stories.tsx
+++ b/libs/shared/ui/src/libs/themes/base/theme.stories.tsx
@@ -66,7 +66,7 @@ const ColorTokens = ({
         sx={{
           bgcolor: theme.palette.background.paper,
           color: theme.palette.text.primary,
-          mb: theme.spacing(7),
+          mb: theme.spacing(6),
           p: theme.spacing(3),
           boxShadow: theme.shadows[1]
         }}


### PR DESCRIPTION
# Description

We've used up 9k snapshots just from duplicate dependancy bot changes.

I'm going to:
- Ignore VR on dependabot branches. Turbosnap configured to always run full build on main so it has always has latest changes (as recommended).

# How should this PR be QA Tested?

- [x] Build is skipped 
<img width="870" alt="image" src="https://user-images.githubusercontent.com/10802634/191604542-e94ac61b-6ac1-4c1d-93ff-80eeaf4ac10d.png">

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
