### PR TITLE
fix: back link on template view pages

### DIFF
--- a/apps/journeys-admin/pages/publisher/[journeyId].tsx
+++ b/apps/journeys-admin/pages/publisher/[journeyId].tsx
@@ -70,7 +70,7 @@ function TemplateDetailsAdmin(): ReactElement {
               title={t('Template Details')}
               authUser={AuthUser}
               showDrawer
-              backHref="/"
+              backHref="/publisher"
               menu={<Menu />}
             >
               <JourneyView journeyType="Template" />

--- a/apps/journeys-admin/pages/templates/[journeyId].tsx
+++ b/apps/journeys-admin/pages/templates/[journeyId].tsx
@@ -48,7 +48,7 @@ function TemplateDetails(): ReactElement {
           title={t('Journey Template')}
           authUser={AuthUser}
           showDrawer
-          backHref="/"
+          backHref="/templates"
           menu={<Menu />}
         >
           <JourneyView journeyType="Template" />


### PR DESCRIPTION
# Description

fix back links

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/29147486/todos/5355289714)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Clicking on the back button from Journey Template should take you to Journey Templates
- [ ] Clicking on the back button from Template Details should take you to Templates Admin

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
