### PR TITLE
fix: templates edit seo title

### DIFF
--- a/apps/journeys-admin/pages/publisher/[journeyId]/edit.tsx
+++ b/apps/journeys-admin/pages/publisher/[journeyId]/edit.tsx
@@ -42,7 +42,9 @@ function TemplateEditPage(): ReactElement {
             title={
               data?.publisherTemplate?.title != null
                 ? t('Edit {{title}}', {
-                    title: data.publisherTemplate.template
+                    title:
+                      data.publisherTemplate.seoTitle ??
+                      data.publisherTemplate.title
                   })
                 : t('Edit Template')
             }

--- a/apps/journeys-admin/pages/publisher/[journeyId]/edit.tsx
+++ b/apps/journeys-admin/pages/publisher/[journeyId]/edit.tsx
@@ -42,9 +42,7 @@ function TemplateEditPage(): ReactElement {
             title={
               data?.publisherTemplate?.title != null
                 ? t('Edit {{title}}', {
-                    title:
-                      data.publisherTemplate.seoTitle ??
-                      data.publisherTemplate.title
+                    title: data.publisherTemplate.title
                   })
                 : t('Edit Template')
             }


### PR DESCRIPTION
# Description

Update seo title

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/29147486/todos/5297226886)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Templates edit page should show template title instead of "Edit true"
<img width="375" alt="image" src="https://user-images.githubusercontent.com/10802634/192427990-bf3d1b8b-e053-4b6b-809e-acfb4fd1f13a.png">


# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
