### PR TITLE
fix: seo title templates edit page

### DIFF
--- a/apps/journeys-admin/pages/publisher/[journeyId]/edit.tsx
+++ b/apps/journeys-admin/pages/publisher/[journeyId]/edit.tsx
@@ -31,7 +31,11 @@ function TemplateEditPage(): ReactElement {
       <NextSeo
         title={
           data?.publisherTemplate?.title != null
-            ? t('Edit {{title}}', { title: data.publisherTemplate.template })
+            ? t('Edit {{title}}', {
+                title:
+                  data.publisherTemplate.seoTitle ??
+                  data.publisherTemplate.title
+              })
             : t('Edit Template')
         }
         description={data?.publisherTemplate?.description ?? undefined}

--- a/apps/journeys-admin/src/components/JourneyView/DatePreview/DatePreview.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/DatePreview/DatePreview.spec.tsx
@@ -1,0 +1,40 @@
+import { render, fireEvent, waitFor } from '@testing-library/react'
+import { MockedProvider } from '@apollo/client/testing'
+import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
+import { NextRouter, useRouter } from 'next/router'
+import { publishedJourney } from '../data'
+import { DatePreview } from './DatePreview'
+
+jest.mock('next/router', () => ({
+  __esModule: true,
+  useRouter: jest.fn()
+}))
+
+const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
+
+describe('DatePreview', () => {
+  it('should have template date and the preview button', async () => {
+    const push = jest.fn()
+    mockUseRouter.mockReturnValue({ push } as unknown as NextRouter)
+    const { getByText, getByRole } = render(
+      <MockedProvider>
+        <JourneyProvider
+          value={{
+            journey: {
+              ...publishedJourney,
+              slug: 'template-slug',
+              template: true
+            }
+          }}
+        >
+          <DatePreview />
+        </JourneyProvider>
+      </MockedProvider>
+    )
+    expect(getByText('November 19, 2021')).toBeInTheDocument()
+    fireEvent.click(getByRole('button', { name: 'Preview' }))
+    await waitFor(() => {
+      expect(push).toHaveBeenCalledWith('/api/preview?slug=template-slug')
+    })
+  })
+})

--- a/apps/journeys-admin/src/components/JourneyView/DatePreview/DatePreview.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/DatePreview/DatePreview.stories.tsx
@@ -1,0 +1,24 @@
+import { Story, Meta } from '@storybook/react'
+import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
+import { simpleComponentConfig } from '../../../libs/storybook'
+import { defaultJourney } from '../data'
+import { DatePreview } from './DatePreview'
+
+const DatePreviewStory = {
+  ...simpleComponentConfig,
+  component: DatePreview,
+  title: 'Journeys-Admin/JourneyView/DatePreview'
+}
+
+const Template: Story = ({ ...args }) => (
+  <JourneyProvider value={{ journey: args.journey }}>
+    <DatePreview />
+  </JourneyProvider>
+)
+
+export const Default = Template.bind({})
+Default.args = {
+  journey: defaultJourney
+}
+
+export default DatePreviewStory as Meta

--- a/apps/journeys-admin/src/components/JourneyView/DatePreview/DatePreview.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/DatePreview/DatePreview.tsx
@@ -1,0 +1,49 @@
+import { ReactElement } from 'react'
+import { parseISO, intlFormat } from 'date-fns'
+import { useJourney } from '@core/journeys/ui/JourneyProvider'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import Button from '@mui/material/Button'
+import VisibilityIcon from '@mui/icons-material/Visibility'
+import Skeleton from '@mui/material/Skeleton'
+import { useRouter } from 'next/router'
+
+export function DatePreview(): ReactElement {
+  const { journey } = useJourney()
+  const router = useRouter()
+
+  return (
+    <Stack
+      direction="row"
+      justifyContent="space-between"
+      sx={{ alignItems: 'center' }}
+    >
+      <Typography variant="overline" sx={{ color: 'secondary.light' }}>
+        {journey != null ? (
+          intlFormat(parseISO(journey.createdAt), {
+            month: 'long',
+            day: 'numeric',
+            year: 'numeric'
+          })
+        ) : (
+          <Skeleton variant="text" width="100px" />
+        )}
+      </Typography>
+      <Button
+        startIcon={<VisibilityIcon />}
+        variant="outlined"
+        size="small"
+        color="secondary"
+        disabled={journey == null}
+        style={{ borderRadius: 8 }}
+        onClick={async () =>
+          await router.push(
+            journey != null ? `/api/preview?slug=${journey.slug}` : ''
+          )
+        }
+      >
+        Preview
+      </Button>
+    </Stack>
+  )
+}

--- a/apps/journeys-admin/src/components/JourneyView/DatePreview/index.ts
+++ b/apps/journeys-admin/src/components/JourneyView/DatePreview/index.ts
@@ -1,0 +1,1 @@
+export { DatePreview } from './DatePreview'

--- a/apps/journeys-admin/src/components/JourneyView/JourneyView.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyView.stories.tsx
@@ -116,4 +116,9 @@ PublisherTemplate.args = {
   ]
 }
 
+export const LoadingTemplate = JourneyTemplate.bind({})
+LoadingTemplate.args = {
+  journey: null
+}
+
 export default JourneyViewStory as Meta

--- a/apps/journeys-admin/src/components/JourneyView/JourneyView.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyView.tsx
@@ -17,6 +17,7 @@ import { CardView } from './CardView'
 import { SlugDialog } from './JourneyLink/SlugDialog'
 import { EmbedJourneyDialog } from './JourneyLink/EmbedJourneyDialog'
 import { TitleDescription } from './TitleDescription'
+import { DatePreview } from './DatePreview'
 import { JourneyLink } from './JourneyLink'
 
 export const GET_USER_ROLE = gql`
@@ -65,7 +66,7 @@ export function JourneyView({ journeyType }: JourneyViewProps): ReactElement {
       >
         {/* if template: SocialImage */}
         <Stack direction="column" spacing={6} sx={{ width: '100%' }}>
-          {/* if template: DatePreview */}
+          {journeyType === 'Template' && <DatePreview />}
           <TitleDescription isPublisher={isPublisher} />
         </Stack>
       </Box>

--- a/apps/journeys-admin/src/components/JourneyView/TitleDescription/TitleDescription.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/TitleDescription/TitleDescription.tsx
@@ -1,5 +1,4 @@
 import { ReactElement, useState } from 'react'
-import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import Skeleton from '@mui/material/Skeleton'
 import Stack from '@mui/material/Stack'
@@ -26,7 +25,7 @@ export function TitleDescription({
 
   return (
     <>
-      <Box sx={{ backgroundColor: 'background.paper' }}>
+      <Stack direction="column" spacing={4}>
         <Stack
           direction="row"
           sx={{
@@ -58,7 +57,7 @@ export function TitleDescription({
             <Skeleton variant="text" width="80%" />
           )}
         </Typography>
-      </Box>
+      </Stack>
       <TitleDescriptionDialog
         open={showTitleDescriptionDialog}
         onClose={() => setShowTitleDescriptionDialog(false)}


### PR DESCRIPTION
# Description

Update seo title

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/29147486/todos/5297226886)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Templates edit page should show template title instead of "Edit true"
<img width="375" alt="image" src="https://user-images.githubusercontent.com/10802634/192427990-bf3d1b8b-e053-4b6b-809e-acfb4fd1f13a.png">


# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
