### PR TITLE
fix: remove template duplicate from template card

### DIFF
--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DefaultMenu/DefaultMenu.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DefaultMenu/DefaultMenu.spec.tsx
@@ -6,7 +6,7 @@ import { JourneyStatus } from '../../../../../../__generated__/globalTypes'
 import { DefaultMenu } from '.'
 
 describe('DefaultMenu', () => {
-  it('should render menu items', () => {
+  it('should render menu for journey', () => {
     const { getByRole } = render(
       <MockedProvider>
         <SnackbarProvider>
@@ -26,8 +26,37 @@ describe('DefaultMenu', () => {
     expect(getByRole('menuitem', { name: 'Edit' })).toBeInTheDocument()
     expect(getByRole('menuitem', { name: 'Access' })).toBeInTheDocument()
     expect(getByRole('menuitem', { name: 'Preview' })).toBeInTheDocument()
+    expect(getByRole('menuitem', { name: 'Duplicate' })).toBeInTheDocument()
     expect(getByRole('menuitem', { name: 'Archive' })).toBeInTheDocument()
     expect(getByRole('menuitem', { name: 'Trash' })).toBeInTheDocument()
+  })
+
+  it('should render menu for templates', () => {
+    const { queryByRole, getByRole } = render(
+      <MockedProvider>
+        <SnackbarProvider>
+          <DefaultMenu
+            id="template-id"
+            slug="template-slug"
+            status={JourneyStatus.published}
+            journeyId="template-id"
+            published
+            setOpenAccessDialog={noop}
+            handleCloseMenu={noop}
+            template
+            setOpenTrashDialog={noop}
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    )
+    expect(getByRole('menuitem', { name: 'Edit' })).toBeInTheDocument()
+    expect(getByRole('menuitem', { name: 'Preview' })).toBeInTheDocument()
+    expect(getByRole('menuitem', { name: 'Archive' })).toBeInTheDocument()
+    expect(getByRole('menuitem', { name: 'Trash' })).toBeInTheDocument()
+    expect(queryByRole('menuitem', { name: 'Access' })).not.toBeInTheDocument()
+    expect(
+      queryByRole('menuitem', { name: 'Duplicate' })
+    ).not.toBeInTheDocument()
   })
 
   it('should call correct functions on Access click', () => {
@@ -131,30 +160,5 @@ describe('DefaultMenu', () => {
     fireEvent.click(getByRole('menuitem', { name: 'Trash' }))
     expect(setOpenTrashDialog).toHaveBeenCalled()
     expect(handleCloseMenu).toHaveBeenCalled()
-  })
-
-  it('should show menu for templates', () => {
-    const { queryByRole, getByRole } = render(
-      <MockedProvider>
-        <SnackbarProvider>
-          <DefaultMenu
-            id="template-id"
-            slug="template-slug"
-            status={JourneyStatus.published}
-            journeyId="template-id"
-            published
-            setOpenAccessDialog={noop}
-            handleCloseMenu={noop}
-            template
-            setOpenTrashDialog={noop}
-          />
-        </SnackbarProvider>
-      </MockedProvider>
-    )
-    expect(getByRole('menuitem', { name: 'Edit' })).toBeInTheDocument()
-    expect(getByRole('menuitem', { name: 'Preview' })).toBeInTheDocument()
-    expect(getByRole('menuitem', { name: 'Archive' })).toBeInTheDocument()
-    expect(getByRole('menuitem', { name: 'Trash' })).toBeInTheDocument()
-    expect(queryByRole('menuitem', { name: 'Access' })).not.toBeInTheDocument()
   })
 })

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DefaultMenu/DefaultMenu.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DefaultMenu/DefaultMenu.tsx
@@ -75,7 +75,9 @@ export function DefaultMenu({
         />
       </NextLink>
 
-      <DuplicateJourneyMenuItem id={id} handleCloseMenu={handleCloseMenu} />
+      {template !== true && (
+        <DuplicateJourneyMenuItem id={id} handleCloseMenu={handleCloseMenu} />
+      )}
 
       <Divider />
 


### PR DESCRIPTION
# Description

Should not be able to duplicate templates from template list 

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/29147486/todos/5289546900)

# How should this PR be QA Tested?

- [ ] Remove Duplicate action
<img width="803" alt="image" src="https://user-images.githubusercontent.com/10802634/192431387-790f44fb-360d-454c-8777-9fb9fe9daeee.png">

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
