### PR TITLE
fix: video block update without video id

### DIFF
--- a/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
@@ -382,7 +382,7 @@ describe('VideoBlockResolver', () => {
         ).rejects.toThrow('videoId cannot be found on YouTube')
       })
 
-      it('updates a VideoBlock', async () => {
+      it('updates videoId', async () => {
         mockFetch.mockResolvedValueOnce({
           ok: true,
           json: async () =>
@@ -421,6 +421,19 @@ describe('VideoBlockResolver', () => {
           duration: 1167,
           image: 'https://i.ytimg.com/vi/7RoqnGcEjcs/hqdefault.jpg',
           title: 'What is the Bible?'
+        })
+      })
+
+      it('updates a VideoBlock', async () => {
+        expect(
+          await resolver.videoBlockUpdate('blockId', 'journeyId', {
+            autoplay: true,
+            source: VideoBlockSource.youTube
+          })
+        ).toEqual({
+          ...updatedBlock,
+          autoplay: true,
+          source: VideoBlockSource.youTube
         })
       })
     })

--- a/apps/api-journeys/src/app/modules/block/video/video.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/video/video.resolver.ts
@@ -159,9 +159,11 @@ export class VideoBlockResolver {
     switch (input.source ?? block.source) {
       case VideoBlockSource.youTube:
         await videoBlockYouTubeSchema.validate({ ...block, ...input })
-        input = {
-          ...input,
-          ...(await this.fetchFieldsFromYouTube(input.videoId as string))
+        if (input.videoId != null) {
+          input = {
+            ...input,
+            ...(await this.fetchFieldsFromYouTube(input.videoId))
+          }
         }
         break
       case VideoBlockSource.internal:

--- a/libs/journeys/ui/src/components/VideoTrigger/VideoTrigger.tsx
+++ b/libs/journeys/ui/src/components/VideoTrigger/VideoTrigger.tsx
@@ -23,7 +23,7 @@ export function VideoTrigger({
   useEffect(() => {
     if (player != null && !triggered) {
       const timeUpdate = (): void => {
-        if (player.currentTime() >= triggerStart && !player.seeking()) {
+        if (player.currentTime() >= triggerStart - 1 && !player.seeking()) {
           setTriggered(true)
           player.pause()
           if (player.isFullscreen()) {


### PR DESCRIPTION
# Description

Superceeds https://github.com/JesusFilm/core/pull/925

Please include a summary of the change and which todo is completed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- [Updating youtube fields error](https://3.basecamp.com/3105655/buckets/29494894/todos/5377889516)
- [EndAt sometimes doesn't work](https://3.basecamp.com/3105655/buckets/29494894/todos/5378769580)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Updating StartAt on Admin
- [ ] Updating EndAt on Admin
- [ ] Updating Autoplay on Admin 
- [ ] Updating Muted on Admin
- [ ] Videos to jump to the next video on EndAt value

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
