### PR TITLE
fix: refresh form when changing blocks

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useState } from 'react'
+import { ReactElement, useState, useEffect } from 'react'
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import { useEditor } from '@core/journeys/ui/EditorProvider'
 import type { TreeBlock } from '@core/journeys/ui/block'
@@ -42,7 +42,6 @@ export const ACTION_DELETE = gql`
     }
   }
 `
-
 export const actions = [
   {
     value: 'none',
@@ -88,6 +87,12 @@ export function Action(): ReactElement {
   )
 
   const [action, setAction] = useState(selectedAction?.value ?? 'none')
+
+  useEffect(() => {
+    if (selectedAction != null) {
+      setAction(selectedAction.value)
+    }
+  }, [selectedBlock, selectedAction])
 
   async function navigateAction(): Promise<void> {
     if (

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.tsx
@@ -91,6 +91,8 @@ export function Action(): ReactElement {
   useEffect(() => {
     if (selectedAction != null) {
       setAction(selectedAction.value)
+    } else {
+    	setAction('none')
     }
   }, [selectedBlock, selectedAction])
 

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.tsx
@@ -92,7 +92,7 @@ export function Action(): ReactElement {
     if (selectedAction != null) {
       setAction(selectedAction.value)
     } else {
-    	setAction('none')
+      setAction('none')
     }
   }, [selectedBlock, selectedAction])
 

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/LinkAction/LinkAction.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/LinkAction/LinkAction.tsx
@@ -83,6 +83,7 @@ export function LinkAction(): ReactElement {
         initialValues={initialValues}
         validationSchema={linkActionSchema}
         onSubmit={noop}
+        enableReinitialize
       >
         {({ values, touched, errors, handleChange, handleBlur }) => (
           <Form>


### PR DESCRIPTION
# Description

The action link property field wasn't changing as you clicked between button blocks on admin.

[Basecamp Todo](https://3.basecamp.com/3105655/buckets/29494894/todos/5382588092)

# How should this PR be QA Tested?

Minimal to solve the issue:
- [x] Make the 2 buttons with links navigate to different Urls
- [x] Clicking between all the buttons should show the correct action property
- [x] The buttons navigate to the correct place

Extra checks:
- [x] Create multiple button blocks, 1 of each action type and 2 link actions
- [x] Clicking between all the buttons should show the correct action property
- [x] Repeat for at least 1 other block type (RadioOption, TextResponse etc)

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
