### PR TITLE
fix: video update mutation

### DIFF
--- a/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
@@ -349,7 +349,11 @@ describe('VideoBlockResolver', () => {
           ...updatedBlock,
           videoId: 'videoId',
           videoVariantLanguageId: 'videoVariantLanguageId',
-          source: VideoBlockSource.internal
+          source: VideoBlockSource.internal,
+          title: null,
+          description: null,
+          image: null,
+          duration: null
         })
       })
     })

--- a/apps/api-journeys/src/app/modules/block/video/video.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/video/video.resolver.ts
@@ -167,6 +167,15 @@ export class VideoBlockResolver {
         }
         break
       case VideoBlockSource.internal:
+        input = {
+          ...input,
+          ...{
+            title: null,
+            description: null,
+            image: null,
+            duration: null
+          }
+        }
         await videoBlockInternalSchema.validate({ ...block, ...input })
         break
     }


### PR DESCRIPTION
# Description

Data from YouTube is still being stored in the same block after changing providers from YouTube to Internal. Which can cause a problem depending on how we use the data. 

- Link to Basecamp Todo

# How should this PR be QA Tested?

- [ ] API only
- [ ] Test to pass

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
