### PR TITLE
fix: card reordering issue

### DIFF
--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
@@ -162,8 +162,8 @@ export function CardPreview({
               ]
             }
           })
+          setIsDragging(false)
         }
-        setIsDragging(false)
       },
     [steps, journey, stepsOrderUpdate]
   )

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
@@ -146,7 +146,7 @@ export function CardPreview({
           const parentOrder =
             cardDragging.parentOrder + destIndex - source.index
 
-          await stepsOrderUpdate({
+          const { data } = await stepsOrderUpdate({
             variables: {
               id: cardDragging.id,
               journeyId: journey.id,
@@ -162,7 +162,9 @@ export function CardPreview({
               ]
             }
           })
-          setIsDragging(false)
+          if (data?.blockOrderUpdate != null) {
+            setIsDragging(false)
+          }
         }
       },
     [steps, journey, stepsOrderUpdate]

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Attributes.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Attributes.spec.tsx
@@ -304,46 +304,4 @@ describe('Attributes', () => {
       children: <SocialShareAppearance />
     })
   })
-
-  it('should not open social share if active tab is not Cards', () => {
-    const dispatch = jest.fn()
-    mockUseEditor.mockReturnValue({
-      state: { ...state, activeTab: ActiveTab.Properties },
-      dispatch
-    })
-    render(<Attributes selected={card} step={step} />)
-    expect(dispatch).not.toHaveBeenCalledWith({
-      type: 'SetDrawerPropsAction',
-      title: 'Social Share Appearance',
-      children: <SocialShareAppearance />
-    })
-  })
-
-  it('should not open social share if selectedBlock is not StepBlock', () => {
-    const dispatch = jest.fn()
-    mockUseEditor.mockReturnValue({
-      state: { ...state, activeTab: ActiveTab.Properties },
-      dispatch
-    })
-    const block: TreeBlock = {
-      id: 'signup.id',
-      __typename: 'SignUpBlock',
-      parentBlockId: null,
-      parentOrder: 0,
-      submitLabel: null,
-      action: null,
-      submitIconId: null,
-      children: []
-    }
-    render(
-      <MockedProvider>
-        <Attributes selected={block} step={{ ...card, children: [block] }} />
-      </MockedProvider>
-    )
-    expect(dispatch).not.toHaveBeenCalledWith({
-      type: 'SetDrawerPropsAction',
-      title: 'Social Share Appearance',
-      children: <SocialShareAppearance />
-    })
-  })
 })

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Attributes.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Attributes.spec.tsx
@@ -277,14 +277,42 @@ describe('Attributes', () => {
     expect(getByRole('button', { name: 'Action None' })).toBeInTheDocument()
   })
 
-  it('should open social share appearance drawer', () => {
+  it('should open social share if active tab is Cards', () => {
     const dispatch = jest.fn()
     mockUseEditor.mockReturnValue({
       state,
       dispatch
     })
-    render(<Attributes selected={card} step={card} />)
+    render(<Attributes selected={card} step={step} />)
     expect(dispatch).toHaveBeenCalledWith({
+      type: 'SetDrawerPropsAction',
+      title: 'Social Share Appearance',
+      children: <SocialShareAppearance />
+    })
+  })
+
+  it('should open social share if selectedBlock is a StepBlock', () => {
+    const dispatch = jest.fn()
+    mockUseEditor.mockReturnValue({
+      state: { ...state, activeTab: ActiveTab.Properties },
+      dispatch
+    })
+    render(<Attributes selected={step} step={step} />)
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'SetDrawerPropsAction',
+      title: 'Social Share Appearance',
+      children: <SocialShareAppearance />
+    })
+  })
+
+  it('should not open social share if active tab is not Cards or selectedBlock not StepBlock', () => {
+    const dispatch = jest.fn()
+    mockUseEditor.mockReturnValue({
+      state: { ...state, activeTab: ActiveTab.Properties },
+      dispatch
+    })
+    render(<Attributes selected={card} step={step} />)
+    expect(dispatch).not.toHaveBeenCalledWith({
       type: 'SetDrawerPropsAction',
       title: 'Social Share Appearance',
       children: <SocialShareAppearance />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Attributes.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Attributes.spec.tsx
@@ -2,6 +2,12 @@ import { MockedProvider } from '@apollo/client/testing'
 import { render } from '@testing-library/react'
 import type { TreeBlock } from '@core/journeys/ui/block'
 import {
+  ActiveFab,
+  ActiveTab,
+  EditorState,
+  useEditor
+} from '@core/journeys/ui/EditorProvider'
+import {
   GetJourney_journey_blocks_CardBlock as CardBlock,
   GetJourney_journey_blocks_StepBlock as StepBlock
 } from '../../../../../__generated__/GetJourney'
@@ -10,9 +16,35 @@ import {
   ThemeMode,
   VideoBlockSource
 } from '../../../../../__generated__/globalTypes'
+import { SocialShareAppearance } from '../../Drawer/SocialShareAppearance'
 import { Attributes } from '.'
 
+jest.mock('@core/journeys/ui/EditorProvider', () => {
+  const originalModule = jest.requireActual('@core/journeys/ui/EditorProvider')
+  return {
+    __esModule: true,
+    ...originalModule,
+    useEditor: jest.fn()
+  }
+})
+
+const mockUseEditor = useEditor as jest.MockedFunction<typeof useEditor>
+
 describe('Attributes', () => {
+  const state: EditorState = {
+    steps: [],
+    drawerMobileOpen: false,
+    activeTab: ActiveTab.Cards,
+    activeFab: ActiveFab.Add
+  }
+
+  beforeEach(() => {
+    mockUseEditor.mockReturnValue({
+      state,
+      dispatch: jest.fn()
+    })
+  })
+
   const card: TreeBlock<CardBlock> = {
     id: 'card0.id',
     __typename: 'CardBlock',
@@ -243,5 +275,19 @@ describe('Attributes', () => {
 
     expect(getByTestId('move-block-buttons')).toBeInTheDocument()
     expect(getByRole('button', { name: 'Action None' })).toBeInTheDocument()
+  })
+
+  it('should open social share appearance drawer', () => {
+    const dispatch = jest.fn()
+    mockUseEditor.mockReturnValue({
+      state,
+      dispatch
+    })
+    render(<Attributes selected={card} step={card} />)
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'SetDrawerPropsAction',
+      title: 'Social Share Appearance',
+      children: <SocialShareAppearance />
+    })
   })
 })

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Attributes.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Attributes.spec.tsx
@@ -305,13 +305,41 @@ describe('Attributes', () => {
     })
   })
 
-  it('should not open social share if active tab is not Cards or selectedBlock not StepBlock', () => {
+  it('should not open social share if active tab is not Cards', () => {
     const dispatch = jest.fn()
     mockUseEditor.mockReturnValue({
       state: { ...state, activeTab: ActiveTab.Properties },
       dispatch
     })
     render(<Attributes selected={card} step={step} />)
+    expect(dispatch).not.toHaveBeenCalledWith({
+      type: 'SetDrawerPropsAction',
+      title: 'Social Share Appearance',
+      children: <SocialShareAppearance />
+    })
+  })
+
+  it('should not open social share if selectedBlock is not StepBlock', () => {
+    const dispatch = jest.fn()
+    mockUseEditor.mockReturnValue({
+      state: { ...state, activeTab: ActiveTab.Properties },
+      dispatch
+    })
+    const block: TreeBlock = {
+      id: 'signup.id',
+      __typename: 'SignUpBlock',
+      parentBlockId: null,
+      parentOrder: 0,
+      submitLabel: null,
+      action: null,
+      submitIconId: null,
+      children: []
+    }
+    render(
+      <MockedProvider>
+        <Attributes selected={block} step={{ ...card, children: [block] }} />
+      </MockedProvider>
+    )
     expect(dispatch).not.toHaveBeenCalledWith({
       type: 'SetDrawerPropsAction',
       title: 'Social Share Appearance',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Attributes.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Attributes.tsx
@@ -102,14 +102,14 @@ export function Attributes({ selected, step }: AttributesProps): ReactElement {
   } = useEditor()
 
   useEffect(() => {
-    if (activeTab === ActiveTab.Cards) {
+    if (activeTab === ActiveTab.Cards || selected?.__typename === 'StepBlock') {
       dispatch({
         type: 'SetDrawerPropsAction',
         title: 'Social Share Appearance',
         children: <SocialShareAppearance />
       })
     }
-  }, [activeTab, dispatch])
+  }, [activeTab, dispatch, selected])
 
   // Map typename to labels when we have translation keys
   const blockLabel =

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.spec.tsx
@@ -1,14 +1,7 @@
-import {
-  ActiveFab,
-  ActiveTab,
-  useEditor,
-  EditorProvider,
-  EditorState
-} from '@core/journeys/ui/EditorProvider'
+import { EditorProvider } from '@core/journeys/ui/EditorProvider'
 import type { TreeBlock } from '@core/journeys/ui/block'
 import { render } from '@testing-library/react'
 import { GetJourney_journey_blocks_StepBlock as StepBlock } from '../../../../../../../__generated__/GetJourney'
-import { NextCard } from './NextCard'
 import { Step } from '.'
 
 jest.mock('react-i18next', () => ({
@@ -20,33 +13,7 @@ jest.mock('react-i18next', () => ({
   }
 }))
 
-jest.mock('@core/journeys/ui/EditorProvider', () => {
-  const originalModule = jest.requireActual('@core/journeys/ui/EditorProvider')
-  return {
-    __esModule: true,
-    ...originalModule,
-    useEditor: jest.fn()
-  }
-})
-
-const mockUseEditor = useEditor as jest.MockedFunction<typeof useEditor>
-
 describe('Step', () => {
-  const dispatch = jest.fn()
-
-  const state: EditorState = {
-    steps: [],
-    drawerMobileOpen: false,
-    activeTab: ActiveTab.Cards,
-    activeFab: ActiveFab.Add
-  }
-
-  beforeEach(() => {
-    mockUseEditor.mockReturnValue({
-      state,
-      dispatch: jest.fn()
-    })
-  })
   it('shows default messages', () => {
     const step: TreeBlock<StepBlock> = {
       id: 'step1.id',
@@ -96,15 +63,6 @@ describe('Step', () => {
         nextBlockId: null,
         children: []
       }
-      mockUseEditor.mockReturnValue({
-        state: {
-          steps: [step1, step2],
-          drawerMobileOpen: false,
-          activeTab: ActiveTab.Cards,
-          activeFab: ActiveFab.Add
-        },
-        dispatch
-      })
       const { getByText } = render(
         <EditorProvider
           initialState={{
@@ -170,15 +128,6 @@ describe('Step', () => {
           }
         ]
       }
-      mockUseEditor.mockReturnValue({
-        state: {
-          steps: [step1, step2, step5],
-          drawerMobileOpen: false,
-          activeTab: ActiveTab.Cards,
-          activeFab: ActiveFab.Add
-        },
-        dispatch
-      })
       const { getByText } = render(
         <EditorProvider
           initialState={{
@@ -235,15 +184,6 @@ describe('Step', () => {
           }
         ]
       }
-      mockUseEditor.mockReturnValue({
-        state: {
-          steps: [step1, step2],
-          drawerMobileOpen: false,
-          activeTab: ActiveTab.Cards,
-          activeFab: ActiveFab.Add
-        },
-        dispatch
-      })
       const { getByText } = render(
         <EditorProvider
           initialState={{
@@ -285,36 +225,6 @@ describe('Step', () => {
         </EditorProvider>
       )
       expect(getByText('None')).toBeInTheDocument()
-    })
-  })
-  it('should open property drawr for variant', () => {
-    const step: TreeBlock<StepBlock> = {
-      id: 'step1.id',
-      __typename: 'StepBlock',
-      parentBlockId: 'step1.id',
-      parentOrder: 0,
-      locked: true,
-      nextBlockId: null,
-      children: []
-    }
-    const dispatch = jest.fn()
-    mockUseEditor.mockReturnValue({
-      state,
-      dispatch
-    })
-    render(<Step {...step} />)
-    expect(dispatch).toHaveBeenCalledWith({
-      type: 'SetActiveTabAction',
-      activeTab: ActiveTab.Properties
-    })
-    expect(dispatch).toHaveBeenCalledWith({
-      type: 'SetSelectedAttributeIdAction',
-      id: 'step1.id-next-block'
-    })
-    expect(dispatch).toHaveBeenCalledWith({
-      type: 'SetDrawerPropsAction',
-      title: 'Next Card Properties',
-      children: <NextCard />
     })
   })
 })

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/Step.tsx
@@ -1,7 +1,7 @@
-import { ActiveTab, useEditor } from '@core/journeys/ui/EditorProvider'
+import { useEditor } from '@core/journeys/ui/EditorProvider'
 import type { TreeBlock } from '@core/journeys/ui/block'
 import { getStepHeading } from '@core/journeys/ui/getStepHeading'
-import { ReactElement, useEffect } from 'react'
+import { ReactElement } from 'react'
 import LockIcon from '@mui/icons-material/Lock'
 import LockOpenIcon from '@mui/icons-material/LockOpen'
 import { useTranslation } from 'react-i18next'
@@ -32,22 +32,6 @@ export function Step({
     nextStep != null && steps != null
       ? getStepHeading(nextStep.id, nextStep.children, steps, t)
       : 'None'
-
-  useEffect(() => {
-    dispatch({
-      type: 'SetActiveTabAction',
-      activeTab: ActiveTab.Properties
-    })
-    dispatch({
-      type: 'SetSelectedAttributeIdAction',
-      id: `${id}-next-block`
-    })
-    dispatch({
-      type: 'SetDrawerPropsAction',
-      title: 'Next Card Properties',
-      children: <NextCard />
-    })
-  }, [dispatch, id])
 
   return (
     <Attribute

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.spec.tsx
@@ -88,7 +88,9 @@ describe('ControlPanel', () => {
         </JourneyProvider>
       </MockedProvider>
     )
-    // Default start on Properties
+    // Default start on Cards
+    expect(getByRole('tabpanel', { name: 'Cards' })).toBeInTheDocument()
+    fireEvent.click(getByRole('tab', { name: 'Properties' }))
     expect(getByRole('tabpanel', { name: 'Properties' })).toBeInTheDocument()
     expect(getByText('Unlocked Card')).toBeInTheDocument()
     fireEvent.click(getByRole('tab', { name: 'Cards' }))


### PR DESCRIPTION
# Description

Cards cannot be reordered. Or more precisely it stops being draggable after a few reordering attempts. Have also put in the fix for removing selecting Card's first property. Instead it should just display social share appearance 

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/29494894/todos/5382574651)

# How should this PR be QA Tested?

- [ ] Cards to always be draggable and no more reordering issue
- [ ] Clicking on a Card block doesn't open it's first property drawer

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
