### PR TITLE
fix: card delete causing crash

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/NextCard.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/NextCard.tsx
@@ -17,6 +17,8 @@ export function NextCard(): ReactElement {
     setTabValue(newValue)
   }
 
+  console.log('pls deploy')
+
   return (
     <>
       <SelectedCard />

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/NextCard.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/NextCard.tsx
@@ -17,8 +17,6 @@ export function NextCard(): ReactElement {
     setTabValue(newValue)
   }
 
-  pls('im getting despreate to get this to deploy')
-
   return (
     <>
       <SelectedCard />
@@ -55,8 +53,4 @@ export function NextCard(): ReactElement {
       </Box>
     </>
   )
-}
-
-function pls(text: string): any {
-  console.log(text)
 }

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/NextCard.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Step/NextCard/NextCard.tsx
@@ -17,7 +17,7 @@ export function NextCard(): ReactElement {
     setTabValue(newValue)
   }
 
-  console.log('pls deploy')
+  pls('im getting despreate to get this to deploy')
 
   return (
     <>
@@ -55,4 +55,8 @@ export function NextCard(): ReactElement {
       </Box>
     </>
   )
+}
+
+function pls(text: string): any {
+  console.log(text)
 }

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/DeleteBlock.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/DeleteBlock.tsx
@@ -55,27 +55,27 @@ export function DeleteBlock({
     const stepsBeforeDelete = steps
     const stepBeforeDelete = selectedStep
 
-    const { data } = await blockDelete({
+    await blockDelete({
       variables: {
         id: selectedBlock.id,
         journeyId: journey.id,
         parentBlockId: selectedBlock.parentBlockId
       },
       update(cache, { data }) {
+        if (data?.blockDelete != null && deletedBlockParentOrder != null) {
+          const selected = getSelected({
+            parentOrder: deletedBlockParentOrder,
+            siblings: data.blockDelete,
+            type: deletedBlockType,
+            steps: stepsBeforeDelete,
+            selectedStep: stepBeforeDelete
+          })
+          selected != null && dispatch(selected)
+        }
+
         blockDeleteUpdate(selectedBlock, data?.blockDelete, cache, journey.id)
       }
     })
-
-    if (data?.blockDelete != null && deletedBlockParentOrder != null) {
-      const selected = getSelected({
-        parentOrder: deletedBlockParentOrder,
-        siblings: data.blockDelete,
-        type: deletedBlockType,
-        steps: stepsBeforeDelete,
-        selectedStep: stepBeforeDelete
-      })
-      selected != null && dispatch(selected)
-    }
 
     handleCloseDialog()
 


### PR DESCRIPTION
# Description

https://github.com/JesusFilm/core/pull/903 made a change where the card properties is getting selected as soon as a card is selected. This caused a crash when  a card is deleted with `Next Card` properties is open. Updating the selectedBlock before updating cache allows the `Next Card` properties have the correct id for the correct block before the old one is removed

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/29494894/todos/5393397254)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Deleting card with `Next Card` properties open should select the previous card, and not crash

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
