### PR TITLE
fix: image covering video when playing

### DIFF
--- a/libs/journeys/ui/src/components/Card/ContainedCover/ContainedCover.tsx
+++ b/libs/journeys/ui/src/components/Card/ContainedCover/ContainedCover.tsx
@@ -125,7 +125,7 @@ export function ContainedCover({
           </video>
         )}
         {/* video image */}
-        {videoImage != null && (
+        {videoImage != null && loading && (
           <NextImage
             src={videoImage}
             alt="card video image"

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -260,7 +260,7 @@ export function Video({
         </>
       )}
       {/* Video Image  */}
-      {videoImage != null && posterBlock?.src == null && (
+      {videoImage != null && posterBlock?.src == null && loading && (
         <NextImage
           src={videoImage}
           alt="video image"


### PR DESCRIPTION
# Description

Image covering video when playing on journeys. Default images of internal and youtube videos are covering videos when they're playing on Journeys. 

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/29494894/todos/5398088483)

# How should this PR be QA Tested?

Create a journey that has videos - including an internal and youtube video. And background videos - including an internal and youtube video. Then publish the journey and visit that journey

- [x] Custom image shouldn't cover videos while its playing
- [x] Custom image shouldn't cover background videos while its playing
- [x] Default image shouldn't cover videos while its playing
- [x] Default image shouldn't cover background videos while its playing

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
