### PR TITLE
feat: rtl language check

### DIFF
--- a/libs/shared/ui/src/libs/rtl/index.ts
+++ b/libs/shared/ui/src/libs/rtl/index.ts
@@ -1,0 +1,1 @@
+export { isRtl } from './rtl'

--- a/libs/shared/ui/src/libs/rtl/rtl.spec.tsx
+++ b/libs/shared/ui/src/libs/rtl/rtl.spec.tsx
@@ -1,0 +1,34 @@
+import { isRtl } from '.'
+
+describe('isRtl', () => {
+  it('should return true for rtl locales', () => {
+    expect(isRtl('ar')).toBe(true)
+    expect(isRtl('ar-aao')).toBe(true)
+    expect(isRtl('AR')).toBe(true)
+    expect(isRtl('AR-AAO')).toBe(true)
+
+    expect(isRtl('arc')).toBe(true)
+    expect(isRtl('dv')).toBe(true)
+    expect(isRtl('fa')).toBe(true)
+    expect(isRtl('ha')).toBe(true)
+    expect(isRtl('he')).toBe(true)
+    expect(isRtl('ar')).toBe(true)
+    expect(isRtl('khw')).toBe(true)
+    expect(isRtl('ks')).toBe(true)
+    expect(isRtl('ku')).toBe(true)
+    expect(isRtl('ps')).toBe(true)
+    expect(isRtl('ur')).toBe(true)
+    expect(isRtl('yi')).toBe(true)
+  })
+
+  it('should return false by default', () => {
+    expect(isRtl('en')).toBe(false)
+    expect(isRtl('EN')).toBe(false)
+    expect(isRtl('en-us')).toBe(false)
+    expect(isRtl('123')).toBe(false)
+    expect(isRtl('aao-ar')).toBe(false)
+    expect(isRtl('ar_')).toBe(false)
+    expect(isRtl('arr')).toBe(false)
+    expect(isRtl('')).toBe(false)
+  })
+})

--- a/libs/shared/ui/src/libs/rtl/rtl.ts
+++ b/libs/shared/ui/src/libs/rtl/rtl.ts
@@ -1,0 +1,22 @@
+export function isRtl(locale: string): boolean {
+  // locale should be bcp47, else iso3
+  const formattedLocale = locale.split('-')[0].toLowerCase()
+
+  switch (formattedLocale) {
+    case 'ar':
+    case 'arc':
+    case 'dv':
+    case 'fa':
+    case 'ha':
+    case 'he':
+    case 'khw':
+    case 'ks':
+    case 'ku':
+    case 'ps':
+    case 'ur':
+    case 'yi':
+      return true
+    default:
+      return false
+  }
+}


### PR DESCRIPTION
# Description

Helper function to check that a locale is RTL.

[Basecamp Todo](https://3.basecamp.com/3105655/buckets/29688713/todos/5413370739)

# How should this PR be QA Tested?

See unit tests but in general:

- [x] it should be false for non-rtl locale
- [x] it should be false for numeric string
- [x] it should be false for empty string
- [x] it should be false for string which includes rtl locale substring (not separated by "-" separator)
- [x] it should be true for any of the codes above
- [x] it should be true for any of the code above in uppercase
- [x] it should be true for any of the codes above with suffix of "-" 

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
