### PR TITLE
fix: add journey rtl check

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.stories.tsx
@@ -33,7 +33,7 @@ const journey: Journey = {
     __typename: 'Language',
     id: '529',
     bcp47: 'en',
-    iso3: 'en',
+    iso3: 'eng',
     name: [
       {
         __typename: 'Translation',

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.stories.tsx
@@ -33,7 +33,7 @@ const journey: Journey = {
     __typename: 'Language',
     id: '529',
     bcp47: 'en',
-    iso3: 'en',
+    iso3: 'eng',
     name: [
       {
         __typename: 'Translation',

--- a/libs/journeys/ui/src/libs/rtl/index.ts
+++ b/libs/journeys/ui/src/libs/rtl/index.ts
@@ -1,0 +1,1 @@
+export { getJourneyRtl } from './rtl'

--- a/libs/journeys/ui/src/libs/rtl/rtl.spec.tsx
+++ b/libs/journeys/ui/src/libs/rtl/rtl.spec.tsx
@@ -62,4 +62,8 @@ describe('getJourneyRtl', () => {
       })
     ).toBe(false)
   })
+
+  it('should return false for undefined journey', () => {
+    expect(getJourneyRtl(undefined)).toBe(false)
+  })
 })

--- a/libs/journeys/ui/src/libs/rtl/rtl.spec.tsx
+++ b/libs/journeys/ui/src/libs/rtl/rtl.spec.tsx
@@ -1,0 +1,65 @@
+import {
+  JourneyFields as Journey,
+  JourneyFields_language as Language
+} from '../JourneyProvider/__generated__/JourneyFields'
+import {
+  JourneyStatus,
+  ThemeMode,
+  ThemeName
+} from '../../../__generated__/globalTypes'
+import { getJourneyRtl } from '.'
+
+const language: Language = {
+  __typename: 'Language',
+  id: '529',
+  bcp47: 'ar',
+  iso3: 'arb',
+  name: [
+    {
+      __typename: 'Translation',
+      value: 'Arabic, Modern Standard',
+      primary: false
+    }
+  ]
+}
+
+const journey: Journey = {
+  __typename: 'Journey',
+  id: 'journeyId',
+  themeName: ThemeName.base,
+  themeMode: ThemeMode.light,
+  title: 'my journey',
+  slug: 'my-journey',
+  language,
+  description: 'my cool journey',
+  status: JourneyStatus.draft,
+  createdAt: '2021-11-19T12:34:56.647Z',
+  publishedAt: null,
+  blocks: [],
+  primaryImageBlock: null,
+  userJourneys: [],
+  template: null,
+  seoTitle: null,
+  seoDescription: null
+}
+
+describe('getJourneyRtl', () => {
+  it('should return true for journey with rtl bcp47 and iso3', () => {
+    expect(getJourneyRtl(journey)).toBe(true)
+  })
+
+  it('should return false for journey with rtl iso3 only', () => {
+    expect(
+      getJourneyRtl({ ...journey, language: { ...language, bcp47: null } })
+    ).toBe(false)
+  })
+
+  it('should return false for journey with no locale codes', () => {
+    expect(
+      getJourneyRtl({
+        ...journey,
+        language: { ...language, bcp47: null, iso3: null }
+      })
+    ).toBe(false)
+  })
+})

--- a/libs/journeys/ui/src/libs/rtl/rtl.ts
+++ b/libs/journeys/ui/src/libs/rtl/rtl.ts
@@ -1,0 +1,9 @@
+import { isRtl } from '../../../../../shared/ui/src/libs/rtl'
+import { JourneyFields as Journey } from '../JourneyProvider/__generated__/JourneyFields'
+
+export function getJourneyRtl(journey: Journey): boolean {
+  // Currently just check for bcp47 codes
+  const locale = journey.language.bcp47 ?? ''
+
+  return isRtl(locale)
+}

--- a/libs/journeys/ui/src/libs/rtl/rtl.ts
+++ b/libs/journeys/ui/src/libs/rtl/rtl.ts
@@ -1,9 +1,9 @@
 import { isRtl } from '../../../../../shared/ui/src/libs/rtl'
 import { JourneyFields as Journey } from '../JourneyProvider/__generated__/JourneyFields'
 
-export function getJourneyRtl(journey: Journey): boolean {
+export function getJourneyRtl(journey: Journey | undefined): boolean {
   // Currently just check for bcp47 codes
-  const locale = journey.language.bcp47 ?? ''
+  const locale = journey?.language.bcp47 ?? ''
 
   return isRtl(locale)
 }

--- a/libs/journeys/ui/src/libs/rtl/rtl.ts
+++ b/libs/journeys/ui/src/libs/rtl/rtl.ts
@@ -1,4 +1,4 @@
-import { isRtl } from '../../../../../shared/ui/src/libs/rtl'
+import { isRtl } from '@core/shared/ui/rtl'
 import { JourneyFields as Journey } from '../JourneyProvider/__generated__/JourneyFields'
 
 export function getJourneyRtl(journey: Journey | undefined): boolean {


### PR DESCRIPTION
# Description

Helper function to use with journeys apps (journeys, journeys-admin). We can't use iso3 to retrieve locales (not on supported list), it's a pain to maintain if every dev needs to remember this - `getJourneyRtl` can be the single point for controlling this logic if it changes in the future.

<img width="1540" alt="image" src="https://user-images.githubusercontent.com/10802634/194801541-6ed71d69-361e-4743-b3fc-ae00d1f67ce3.png">

[Basecamp Todo
](https://3.basecamp.com/3105655/buckets/29688713/todos/5413370739)

# How should this PR be QA Tested?

- [x] it should be false if journey does not have bcp37 locale code

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
