### PR TITLE
fix: launch darkly to run identify every time

### DIFF
--- a/libs/shared/ui/src/libs/getLaunchDarklyClient/getLaunchDarklyClient.ts
+++ b/libs/shared/ui/src/libs/getLaunchDarklyClient/getLaunchDarklyClient.ts
@@ -7,9 +7,10 @@ let launchDarklyClient: LDClient
  * @returns a LaunchDarkly server-side client as a singleton.
  */
 export async function getLaunchDarklyClient(user?: LDUser): Promise<LDClient> {
-  if (launchDarklyClient != null) return launchDarklyClient
+  if (launchDarklyClient == null) {
+    launchDarklyClient = init(process.env.LAUNCH_DARKLY_SDK_KEY ?? '')
+  }
 
-  launchDarklyClient = init(process.env.LAUNCH_DARKLY_SDK_KEY ?? '')
   await launchDarklyClient.waitForInitialization()
 
   if (user != null) launchDarklyClient.identify(user)


### PR DESCRIPTION
# Description

LaunchDarkly was not calling identify function when LaunchDarkly was already initialized. This meant within a single lambda function multiple users were only being identified

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Identify should be called on Launch Darkly every time the page loads across multiple users

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
