### PR TITLE
fix: youtube videos not playing

### DIFF
--- a/libs/journeys/ui/src/components/Card/ContainedCover/ContainedCover.tsx
+++ b/libs/journeys/ui/src/components/Card/ContainedCover/ContainedCover.tsx
@@ -32,17 +32,19 @@ export function ContainedCover({
   const theme = useTheme()
   const [loading, setLoading] = useState(true)
 
+  const isYouTube = videoBlock?.source === VideoBlockSource.youTube
+
   useEffect(() => {
     if (videoRef.current != null) {
       playerRef.current = videojs(videoRef.current, {
-        autoplay: true,
+        autoplay: !isYouTube,
         controls: false,
         preload: 'metadata',
         userActions: {
           hotkeys: false,
           doubleClick: false
         },
-        muted: true,
+        muted: !isYouTube,
         loop: true,
         poster: backgroundBlur
       })
@@ -71,7 +73,7 @@ export function ContainedCover({
         }
       })
     }
-  }, [imageBlock, theme, videoBlock, backgroundBlur])
+  }, [imageBlock, theme, videoBlock, backgroundBlur, isYouTube])
 
   const videoImage =
     videoBlock?.source === VideoBlockSource.internal
@@ -102,7 +104,7 @@ export function ContainedCover({
           }
         }}
       >
-        {videoBlock?.videoId != null && (
+        {videoBlock?.videoId != null && !isYouTube && (
           <video
             ref={videoRef}
             className="video-js"

--- a/libs/journeys/ui/src/components/Card/ContainedCover/ContainedCover.tsx
+++ b/libs/journeys/ui/src/components/Card/ContainedCover/ContainedCover.tsx
@@ -33,19 +33,20 @@ export function ContainedCover({
   const [loading, setLoading] = useState(true)
 
   const isYouTube = videoBlock?.source === VideoBlockSource.youTube
-  const iosMobile = /iPhone|iPad|iPod/i.test(navigator.userAgent)
 
   useEffect(() => {
     if (videoRef.current != null) {
       playerRef.current = videojs(videoRef.current, {
-        autoplay: !(isYouTube && iosMobile),
+        autoplay: !(
+          isYouTube && /iPhone|iPad|iPod/i.test(navigator?.userAgent)
+        ),
         controls: false,
         preload: 'metadata',
         userActions: {
           hotkeys: false,
           doubleClick: false
         },
-        muted: !(isYouTube && iosMobile),
+        muted: !(isYouTube && /iPhone|iPad|iPod/i.test(navigator?.userAgent)),
         loop: true,
         poster: backgroundBlur
       })
@@ -74,7 +75,7 @@ export function ContainedCover({
         }
       })
     }
-  }, [imageBlock, theme, videoBlock, backgroundBlur, isYouTube, iosMobile])
+  }, [imageBlock, theme, videoBlock, backgroundBlur, isYouTube])
 
   const videoImage =
     videoBlock?.source === VideoBlockSource.internal
@@ -98,7 +99,7 @@ export function ContainedCover({
             },
             '> .vjs-loading-spinner': {
               zIndex: 1,
-              display: isYouTube && iosMobile ? 'none' : 'block'
+              display: isYouTube ? 'none' : 'block'
             },
             '> .vjs-poster': {
               backgroundSize: 'cover'

--- a/libs/journeys/ui/src/components/Card/ContainedCover/ContainedCover.tsx
+++ b/libs/journeys/ui/src/components/Card/ContainedCover/ContainedCover.tsx
@@ -33,18 +33,19 @@ export function ContainedCover({
   const [loading, setLoading] = useState(true)
 
   const isYouTube = videoBlock?.source === VideoBlockSource.youTube
+  const iosMobile = /iPhone|iPad|iPod/i.test(navigator.userAgent)
 
   useEffect(() => {
     if (videoRef.current != null) {
       playerRef.current = videojs(videoRef.current, {
-        autoplay: !isYouTube,
+        autoplay: !(isYouTube && iosMobile),
         controls: false,
         preload: 'metadata',
         userActions: {
           hotkeys: false,
           doubleClick: false
         },
-        muted: !isYouTube,
+        muted: !(isYouTube && iosMobile),
         loop: true,
         poster: backgroundBlur
       })
@@ -73,7 +74,7 @@ export function ContainedCover({
         }
       })
     }
-  }, [imageBlock, theme, videoBlock, backgroundBlur, isYouTube])
+  }, [imageBlock, theme, videoBlock, backgroundBlur, isYouTube, iosMobile])
 
   const videoImage =
     videoBlock?.source === VideoBlockSource.internal
@@ -96,7 +97,8 @@ export function ContainedCover({
               objectFit: 'cover'
             },
             '> .vjs-loading-spinner': {
-              zIndex: 1
+              zIndex: 1,
+              display: isYouTube && iosMobile ? 'none' : 'block'
             },
             '> .vjs-poster': {
               backgroundSize: 'cover'
@@ -104,7 +106,7 @@ export function ContainedCover({
           }
         }}
       >
-        {videoBlock?.videoId != null && !isYouTube && (
+        {videoBlock?.videoId != null && (
           <video
             ref={videoRef}
             className="video-js"

--- a/libs/journeys/ui/src/components/Card/ContainedCover/ContainedCover.tsx
+++ b/libs/journeys/ui/src/components/Card/ContainedCover/ContainedCover.tsx
@@ -36,17 +36,18 @@ export function ContainedCover({
 
   useEffect(() => {
     if (videoRef.current != null) {
+      // autoplay when video is YouTube on iOS does not work. We should disable autoplay in that case.
+      const isYouTubeAndiOS =
+        isYouTube && /iPhone|iPad|iPod/i.test(navigator?.userAgent)
       playerRef.current = videojs(videoRef.current, {
-        autoplay: !(
-          isYouTube && /iPhone|iPad|iPod/i.test(navigator?.userAgent)
-        ),
+        autoplay: !isYouTubeAndiOS,
         controls: false,
         preload: 'metadata',
         userActions: {
           hotkeys: false,
           doubleClick: false
         },
-        muted: !(isYouTube && /iPhone|iPad|iPod/i.test(navigator?.userAgent)),
+        muted: true,
         loop: true,
         poster: backgroundBlur
       })

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -52,8 +52,6 @@ export function Video({
       : undefined
   }, [posterBlock, theme])
 
-  const iosMobile = /iPhone|iPad|iPod/i.test(navigator.userAgent)
-
   useEffect(() => {
     if (videoRef.current != null) {
       playerRef.current = videojs(videoRef.current, {
@@ -164,14 +162,7 @@ export function Video({
           },
           '> .vjs-loading-spinner': {
             zIndex: 1,
-            display:
-              autoplay !== true && source === VideoBlockSource.youTube
-                ? 'none'
-                : autoplay === true &&
-                  source === VideoBlockSource.youTube &&
-                  iosMobile
-                ? 'none'
-                : 'block'
+            display: source === VideoBlockSource.youTube ? 'none' : 'block'
           },
           '> .vjs-big-play-button': {
             zIndex: 1

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -181,7 +181,7 @@ export function Video({
             color: VIDEO_FOREGROUND_COLOR
           }
         },
-        // renders big play button for youtube videos on IOS devices
+        // renders big play button for youtube videos on iOS devices
         'video::-webkit-media-controls-start-playback-button': {
           display: 'none'
         },
@@ -218,7 +218,7 @@ export function Video({
               )}
             {source === VideoBlockSource.youTube && (
               <source
-                src={`https://www.youtube.com/embed/watch?v=${videoId}`}
+                src={`https://www.youtube.com/watch?v=${videoId}`}
                 type="video/youtube"
               />
             )}

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -52,7 +52,7 @@ export function Video({
       : undefined
   }, [posterBlock, theme])
 
-  const mobile = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent)
+  const mobile = /iPhone|iPad|iPod/i.test(navigator.userAgent)
 
   useEffect(() => {
     if (videoRef.current != null) {

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -52,7 +52,7 @@ export function Video({
       : undefined
   }, [posterBlock, theme])
 
-  const mobile = /iPhone|iPad|iPod/i.test(navigator.userAgent)
+  const iosMobile = /iPhone|iPad|iPod/i.test(navigator.userAgent)
 
   useEffect(() => {
     if (videoRef.current != null) {
@@ -167,7 +167,11 @@ export function Video({
             display:
               autoplay !== true && source === VideoBlockSource.youTube
                 ? 'none'
-                : null
+                : autoplay === true &&
+                  source === VideoBlockSource.youTube &&
+                  iosMobile
+                ? 'none'
+                : 'block'
           },
           '> .vjs-big-play-button': {
             zIndex: 1
@@ -185,6 +189,16 @@ export function Video({
           '&:hover': {
             color: VIDEO_FOREGROUND_COLOR
           }
+        },
+        // renders big play button for youtube videos on IOS devices
+        'video::-webkit-media-controls-start-playback-button': {
+          display: 'none'
+        },
+        '> .video-js.vjs-controls-enabled .vjs-big-play-button': {
+          display: 'none'
+        },
+        '> .video-js.vjs-controls-enabled.vjs-paused .vjs-big-play-button': {
+          display: 'block'
         }
       }}
     >
@@ -262,8 +276,7 @@ export function Video({
         </>
       )}
       {/* Video Image  */}
-      {/* Issues with video image covering controls */}
-      {videoImage != null && posterBlock?.src == null && !mobile && loading && (
+      {videoImage != null && posterBlock?.src == null && loading && (
         <NextImage
           src={videoImage}
           alt="video image"

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -52,6 +52,8 @@ export function Video({
       : undefined
   }, [posterBlock, theme])
 
+  const mobile = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent)
+
   useEffect(() => {
     if (videoRef.current != null) {
       playerRef.current = videojs(videoRef.current, {
@@ -211,7 +213,7 @@ export function Video({
               )}
             {source === VideoBlockSource.youTube && (
               <source
-                src={`https://www.youtube.com/watch?v=${videoId}`}
+                src={`https://www.youtube.com/embed/watch?v=${videoId}`}
                 type="video/youtube"
               />
             )}
@@ -260,7 +262,8 @@ export function Video({
         </>
       )}
       {/* Video Image  */}
-      {videoImage != null && posterBlock?.src == null && loading && (
+      {/* Issues with video image covering controls */}
+      {videoImage != null && posterBlock?.src == null && !mobile && loading && (
         <NextImage
           src={videoImage}
           alt="video image"


### PR DESCRIPTION
# Description

Youtube videos are not loading on journeys, and cannot be played. This happens on both iPhone and iPad, for both regular video blocks and background videos. The card will either display an infinite spinning animation or just display the thumbnail image.

**The current fix is temporary** and will further look into it during this cycle's (Cycle 8) cooldown. The current fix is to disable autoplay for youtube videos and card background videos on iOS devices. On a card background, an image should be rendered instead of a video. 

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/29689605/todos/5431672006)

# How should this PR be QA Tested?

1. View the [Video QA Journey](https://journeys-git-22-08-jg-fix-youtube-autoplay-jesusfilm.vercel.app/video-qa)
2. Run through each step and check off relevant tasks

## Background Video
### Internal
### CoverBlock

- [x] autoplays on iOS
- [ ] autoplays on Android
- [x] autoplays on Web

## Background Video
### internal
### No CoverBlock

- [x] autoplays on iOS
- [x] autoplays on Android
- [x] autoplays on Web

## Background Video
### YouTube
### CoverBlock

- [x] show cover block image on iOS
- [x] autoplays on Android
- [x] autoplays on Web

## Background Video
### YouTube
### No CoverBlock

- [x] show youtube poster image on iOS
- [x] autoplays on Android
- [x] autoplays on Web

## VideoBlock
### Internal
### Autoplay
### CoverBlock

- [x] autoplays on iOS
- [x] autoplays on Android
- [x] autoplays on Web

## VideoBlock
### Internal
### Autoplay
### No CoverBlock

- [x] autoplays on iOS
- [x] autoplays on Android
- [x] autoplays on Web

## VideoBlock
### Internal
### Manual
### CoverBlock

- [x] plays on iOS
- [x] plays on Android
- [x] plays on Web

## VideoBlock
### Internal
### Manual
### No CoverBlock

- [x] plays on iOS
- [x] plays on Android
- [x] plays on Web

## VideoBlock
### YouTube
### Autoplay
### CoverBlock

- [x] plays on iOS (no autoplay)
- [x] autoplays on Android
- [x] autoplays on Web

## VideoBlock
### YouTube
### Autoplay
### No CoverBlock

- [x] plays on iOS (no autoplay)
- [x] autoplays on Android
- [x] autoplays on Web

## VideoBlock
### YouTube
### Manual
### CoverBlock

- [x] plays on iOS
- [x] plays on Android
- [x] plays on Web

## VideoBlock
### YouTube
### Manual
### No CoverBlock

- [x] plays on iOS
- [x] plays on Android
- [x] plays on Web

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
