### PR TITLE
fix: set key on seed for visitors and members

### DIFF
--- a/apps/api-journeys/db/seeds/jfpTeam.ts
+++ b/apps/api-journeys/db/seeds/jfpTeam.ts
@@ -27,6 +27,7 @@ export async function jfpTeam(): Promise<void> {
   await db.query(aql`
     FOR userJourney IN userJourneys
       INSERT {
+        _key: CONCAT(userJourney.userId, ":", ${team._key}),
         teamId: ${team._key}, 
         userId: userJourney.userId, 
         createdAt: DATE_ISO8601(DATE_NOW())
@@ -38,8 +39,9 @@ export async function jfpTeam(): Promise<void> {
   await db.query(aql`
     FOR event IN events
       INSERT {
+        _key: CONCAT(event.userId, ":", ${team._key}),
         teamId: ${team._key}, 
-        userId: event.userId, 
+        userId: event.userId,
         createdAt: DATE_ISO8601(DATE_NOW())
       }
       IN visitors OPTIONS { ignoreErrors: true }


### PR DESCRIPTION
# Description

Please include a summary of the change and which todo is completed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] run `nx seed api-journeys`
- [x] visitors table should have _key field set to userId:teamId
- [x] members table should have _key field set to userId:teamId

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
