### PR TITLE
fix: use _key instead of id on member service

### DIFF
--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -658,7 +658,7 @@ describe('JourneyResolver', () => {
       )
       expect(mService.save).toHaveBeenCalledWith(
         {
-          id: 'userId:jfp-team',
+          _key: 'userId:jfp-team',
           userId: 'userId',
           teamId: 'jfp-team'
         },

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -196,7 +196,7 @@ export class JourneyResolver {
         })
         await this.memberService.save(
           {
-            id: `${userId}:${team.id}`,
+            _key: `${userId}:${team.id}`,
             userId,
             teamId: team.id
           },

--- a/apps/api-journeys/src/app/modules/userJourney/userJourney.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/userJourney/userJourney.resolver.spec.ts
@@ -158,7 +158,7 @@ describe('UserJourneyResolver', () => {
       await resolver.userJourneyApprove(userJourney.id, actorUserJourney.userId)
       expect(mService.save).toHaveBeenCalledWith(
         {
-          id: '2:jfp-team',
+          _key: '2:jfp-team',
           userId: '2',
           teamId: 'jfp-team'
         },

--- a/apps/api-journeys/src/app/modules/userJourney/userJourney.resolver.ts
+++ b/apps/api-journeys/src/app/modules/userJourney/userJourney.resolver.ts
@@ -92,7 +92,7 @@ export class UserJourneyResolver {
 
     await this.memberService.save(
       {
-        id: `${userId}:${journey.teamId}`,
+        _key: `${userId}:${journey.teamId}`,
         userId,
         teamId: journey.teamId
       },


### PR DESCRIPTION
# Description

Please include a summary of the change and which todo is completed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- Create a member document when creating new journey
- Create a member document when approving a request to edit a journey

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Create a new user and request an invite to an existing journey. Approve journey edit request on a different account. Check member table for new record with key from `jfp-team:userId`

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
