### PR TITLE
ci: vr test ignore full rebuilds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,7 +158,7 @@ jobs:
           storybookBuildDir: 'dist/storybook/shared-storybook'
           exitOnceUploaded: true,
           autoAcceptChanges: 'main'
-          onlyChanged: '@(!main)'
+          onlyChanged: '!(main)'
           skip: '@(dependabot/**|00-00-CI-chore-update-translations)'
           untraced: 'package.json,package-lock.json,main.js,preview.js'
           traceChanged: 'expanded'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,5 +160,5 @@ jobs:
           autoAcceptChanges: 'main'
           onlyChanged: '!(main)'
           skip: '@(dependabot/**|00-00-CI-chore-update-translations)'
-          untraced: 'package.json,package-lock.json,main.js,preview.js'
+          untraced: 'package.json,package-lock.json,main.js,preview.js, preview-head.html,.storybook/static/*.js, manager.js'
           traceChanged: 'expanded'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,5 +160,5 @@ jobs:
           autoAcceptChanges: 'main'
           onlyChanged: '!(main)'
           skip: '@(dependabot/**|00-00-CI-chore-update-translations)'
-          untraced: 'package.json,package-lock.json,main.js,preview.js, preview-head.html,.storybook/static/*.js, manager.js'
+          untraced: 'package.json,package-lock.json,.storybook/*.@(js|html),.storybook/**/*.@(js|svg)'
           traceChanged: 'expanded'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,6 +158,7 @@ jobs:
           storybookBuildDir: 'dist/storybook/shared-storybook'
           exitOnceUploaded: true,
           autoAcceptChanges: 'main'
-          onlyChanged: true
+          onlyChanged: '@(!main)'
           skip: '@(dependabot/**|00-00-CI-chore-update-translations)'
+          untraced: 'package.json,package-lock.json,main.js,preview.js'
           traceChanged: 'expanded'

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -53,6 +53,9 @@ module.exports = {
     '@storybook/addon-interactions',
     '@storybook/addon-a11y'
   ],
+  features: {
+    interactionsDebugger: true
+  },
   core: {
     builder: 'webpack5'
   },


### PR DESCRIPTION
# Description

Full rebuilds are chewing through our Chromatic usage

See issue here:
https://jfp-digital.slack.com/archives/C041QM21FDL/p1667327141049819

# How should this PR be QA Tested?

- [x] TurboSnap should not run full rebuild on UI tests even though `main.js` is changed
https://www.chromatic.com/build?appId=612c2a83fdc2b2003a5c2eb7&number=3324
- [ ] TurboSnap should run full rebuild in main once this PR is merged in.

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
