### PR TITLE
refactor: use onClose instead of handleClose

### DIFF
--- a/apps/journeys-admin/src/components/AccessDialog/AccessDialog.tsx
+++ b/apps/journeys-admin/src/components/AccessDialog/AccessDialog.tsx
@@ -86,7 +86,7 @@ export function AccessDialog({
   return (
     <Dialog
       open={open ?? false}
-      handleClose={onClose}
+      onClose={onClose}
       dialogTitle={{
         title: 'Invite Other Editors',
         closeButton: true

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/ImageEdit/ImageEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/ImageEdit/ImageEdit.tsx
@@ -268,7 +268,7 @@ export function ImageEdit(): ReactElement {
 
       <Dialog
         open={open}
-        handleClose={handleClose}
+        onClose={handleClose}
         dialogTitle={{ title: 'Social media image', closeButton: true }}
       >
         <ImageBlockEditor

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/DeleteBlock.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/DeleteBlock/DeleteBlock.tsx
@@ -94,7 +94,7 @@ export function DeleteBlock({
     <>
       <Dialog
         open={openDialog}
-        handleClose={handleCloseDialog}
+        onClose={handleCloseDialog}
         dialogTitle={{ title: 'Delete Card?' }}
         dialogAction={{
           onSubmit: handleDeleteBlock,

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Dialog/VideoBlockEditorSettingsPosterDialog.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Dialog/VideoBlockEditorSettingsPosterDialog.tsx
@@ -228,7 +228,7 @@ export function VideoBlockEditorSettingsPosterDialog({
   return (
     <Dialog
       open={open}
-      handleClose={onClose}
+      onClose={onClose}
       dialogTitle={{
         title: 'Cover Image',
         closeButton: true

--- a/apps/journeys-admin/src/components/JourneyList/ActiveJourneyList/ActiveJourneyList.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/ActiveJourneyList/ActiveJourneyList.tsx
@@ -240,7 +240,7 @@ export function ActiveJourneyList({
       )}
       <Dialog
         open={openArchiveAll ?? false}
-        handleClose={handleClose}
+        onClose={handleClose}
         dialogTitle={{
           title: t('Archive Journeys'),
           closeButton: true
@@ -259,7 +259,7 @@ export function ActiveJourneyList({
       </Dialog>
       <Dialog
         open={openTrashAll ?? false}
-        handleClose={handleClose}
+        onClose={handleClose}
         dialogTitle={{
           title: t('Trash Journeys'),
           closeButton: true

--- a/apps/journeys-admin/src/components/JourneyList/ArchivedJourneyList/ArchivedJourneyList.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/ArchivedJourneyList/ArchivedJourneyList.tsx
@@ -238,7 +238,7 @@ export function ArchivedJourneyList({
       )}
       <Dialog
         open={openRestoreAll ?? false}
-        handleClose={handleClose}
+        onClose={handleClose}
         dialogTitle={{
           title: t('Unarchive Journeys'),
           closeButton: true
@@ -257,7 +257,7 @@ export function ArchivedJourneyList({
       </Dialog>
       <Dialog
         open={openTrashAll ?? false}
-        handleClose={handleClose}
+        onClose={handleClose}
         dialogTitle={{
           title: t('Trash Journeys'),
           closeButton: true

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DeleteJourneyDialog/DeleteJourneyDialog.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DeleteJourneyDialog/DeleteJourneyDialog.tsx
@@ -72,7 +72,7 @@ export function DeleteJourneyDialog({
   return (
     <Dialog
       open={open}
-      handleClose={handleClose}
+      onClose={handleClose}
       dialogTitle={{ title: 'Delete Forever?', closeButton: true }}
       dialogAction={{
         onSubmit: handleDelete,

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/RestoreJourneyDialog/RestoreJourneyDialog.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/RestoreJourneyDialog/RestoreJourneyDialog.tsx
@@ -78,7 +78,7 @@ export function RestoreJourneyDialog({
   return (
     <Dialog
       open={open}
-      handleClose={handleClose}
+      onClose={handleClose}
       dialogTitle={{ title: 'Restore Journey?', closeButton: true }}
       dialogAction={{
         onSubmit: handleRestore,

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/TrashJourneyDialog/TrashJourneyDialog.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/TrashJourneyDialog/TrashJourneyDialog.tsx
@@ -72,7 +72,7 @@ export function TrashJourneyDialog({
   return (
     <Dialog
       open={open}
-      handleClose={handleClose}
+      onClose={handleClose}
       dialogTitle={{ title: 'Trash Journey?', closeButton: true }}
       dialogAction={{
         onSubmit: handleTrash,

--- a/apps/journeys-admin/src/components/JourneyList/TrashedJourneyList/TrashedJourneyList.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/TrashedJourneyList/TrashedJourneyList.tsx
@@ -243,7 +243,7 @@ export function TrashedJourneyList({
       )}
       <Dialog
         open={openRestoreAll ?? false}
-        handleClose={handleClose}
+        onClose={handleClose}
         dialogTitle={{
           title: t('Restore Journeys'),
           closeButton: true
@@ -262,7 +262,7 @@ export function TrashedJourneyList({
       </Dialog>
       <Dialog
         open={openDeleteAll ?? false}
-        handleClose={handleClose}
+        onClose={handleClose}
         dialogTitle={{
           title: t('Delete Journeys Forever'),
           closeButton: true

--- a/apps/journeys-admin/src/components/JourneyView/JourneyLink/EmbedJourneyDialog/EmbedJourneyDialog.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyLink/EmbedJourneyDialog/EmbedJourneyDialog.tsx
@@ -56,7 +56,7 @@ iframe.style.zIndex="auto"
   return (
     <Dialog
       open={open}
-      handleClose={onClose}
+      onClose={onClose}
       dialogTitle={{
         title: 'Embed journey'
       }}

--- a/apps/journeys-admin/src/components/JourneyView/JourneyLink/SlugDialog/SlugDialog.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyLink/SlugDialog/SlugDialog.tsx
@@ -78,7 +78,7 @@ export function SlugDialog({ open, onClose }: SlugDialogProps): ReactElement {
           {({ values, handleChange, handleSubmit, resetForm }) => (
             <Dialog
               open={open}
-              handleClose={handleClose(resetForm)}
+              onClose={handleClose(resetForm)}
               dialogTitle={{ title: t('Edit URL') }}
               dialogAction={{
                 onSubmit: handleSubmit,

--- a/apps/journeys-admin/src/components/JourneyView/Menu/DescriptionDialog/DescriptionDialog.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/DescriptionDialog/DescriptionDialog.tsx
@@ -89,7 +89,7 @@ export function DescriptionDialog({
           {({ values, handleChange, handleSubmit, resetForm }) => (
             <Dialog
               open={open}
-              handleClose={handleClose(resetForm)}
+              onClose={handleClose(resetForm)}
               dialogTitle={{ title: 'Edit Description' }}
               dialogAction={{
                 onSubmit: handleSubmit,

--- a/apps/journeys-admin/src/components/JourneyView/Menu/LanguageDialog/LanguageDialog.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/LanguageDialog/LanguageDialog.tsx
@@ -122,7 +122,7 @@ export function LanguageDialog({
           {({ values, handleSubmit, resetForm, setFieldValue }) => (
             <Dialog
               open={open}
-              handleClose={handleClose(resetForm)}
+              onClose={handleClose(resetForm)}
               dialogTitle={{ title: 'Edit Language' }}
               dialogAction={{
                 onSubmit: handleSubmit,

--- a/apps/journeys-admin/src/components/JourneyView/Menu/TitleDialog/TitleDialog.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/TitleDialog/TitleDialog.tsx
@@ -79,7 +79,7 @@ export function TitleDialog({ open, onClose }: TitleDialogProps): ReactElement {
           {({ values, handleChange, handleSubmit, resetForm }) => (
             <Dialog
               open={open}
-              handleClose={handleClose(resetForm)}
+              onClose={handleClose(resetForm)}
               dialogTitle={{ title: 'Edit Title' }}
               dialogAction={{
                 onSubmit: handleSubmit,

--- a/apps/journeys-admin/src/components/JourneyView/TitleDescription/TitleDescriptionDialog/TitleDescriptionDialog.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/TitleDescription/TitleDescriptionDialog/TitleDescriptionDialog.tsx
@@ -98,7 +98,7 @@ export function TitleDescriptionDialog({
           {({ values, handleChange, handleSubmit, resetForm }) => (
             <Dialog
               open={open}
-              handleClose={handleClose(resetForm)}
+              onClose={handleClose(resetForm)}
               dialogTitle={{ title: 'Edit Title and Description' }}
               dialogAction={{
                 onSubmit: handleSubmit,

--- a/apps/journeys-admin/src/components/TemplateList/ActiveTemplates/ActiveTemplates.tsx
+++ b/apps/journeys-admin/src/components/TemplateList/ActiveTemplates/ActiveTemplates.tsx
@@ -220,7 +220,7 @@ export function ActiveTemplates({
 
       <Dialog
         open={openArchiveAll ?? false}
-        handleClose={handleClose}
+        onClose={handleClose}
         dialogTitle={{
           title: 'Archive Templates',
           closeButton: true
@@ -239,7 +239,7 @@ export function ActiveTemplates({
       </Dialog>
       <Dialog
         open={openTrashAll ?? false}
-        handleClose={handleClose}
+        onClose={handleClose}
         dialogTitle={{
           title: t('Trash Templates'),
           closeButton: true

--- a/apps/journeys-admin/src/components/TemplateList/ArchivedTemplates/ArchivedTemplates.tsx
+++ b/apps/journeys-admin/src/components/TemplateList/ArchivedTemplates/ArchivedTemplates.tsx
@@ -231,7 +231,7 @@ export function ArchivedTemplates({
 
       <Dialog
         open={openRestoreAll ?? false}
-        handleClose={handleClose}
+        onClose={handleClose}
         dialogTitle={{
           title: t('Unarchive Templates'),
           closeButton: true
@@ -250,7 +250,7 @@ export function ArchivedTemplates({
       </Dialog>
       <Dialog
         open={openTrashAll ?? false}
-        handleClose={handleClose}
+        onClose={handleClose}
         dialogTitle={{
           title: t('Trash Templates'),
           closeButton: true

--- a/apps/journeys-admin/src/components/TemplateList/TrashedTemplates/TrashedTemplates.tsx
+++ b/apps/journeys-admin/src/components/TemplateList/TrashedTemplates/TrashedTemplates.tsx
@@ -225,7 +225,7 @@ export function TrashedTemplates({
 
       <Dialog
         open={openRestoreAll ?? false}
-        handleClose={handleClose}
+        onClose={handleClose}
         dialogTitle={{
           title: t('Restore Templates'),
           closeButton: true
@@ -244,7 +244,7 @@ export function TrashedTemplates({
       </Dialog>
       <Dialog
         open={openDeleteAll ?? false}
-        handleClose={handleClose}
+        onClose={handleClose}
         dialogTitle={{
           title: t('Delete Templates Forever'),
           closeButton: true

--- a/libs/shared/ui/src/components/Dialog/Dialog.spec.tsx
+++ b/libs/shared/ui/src/components/Dialog/Dialog.spec.tsx
@@ -6,7 +6,7 @@ import { Dialog } from './Dialog'
 describe('Dialog', () => {
   const dialogProps: Parameters<typeof Dialog>[0] = {
     open: true,
-    handleClose: jest.fn(),
+    onClose: jest.fn(),
     dialogTitle: {
       title: 'Title',
       closeButton: true
@@ -26,7 +26,7 @@ describe('Dialog', () => {
   it('should close the dialog when the close button is clicked', () => {
     const { getByTestId } = render(<Dialog {...dialogProps} />)
     fireEvent.click(getByTestId('CloseRoundedIcon'))
-    expect(dialogProps.handleClose).toHaveBeenCalled()
+    expect(dialogProps.onClose).toHaveBeenCalled()
   })
 
   it('should show the custom labels for buttons', () => {
@@ -53,7 +53,7 @@ describe('Dialog', () => {
     }
     const { getByRole } = render(<Dialog {...input} />)
     fireEvent.click(getByRole('button', { name: 'Cancel' }))
-    expect(dialogProps.handleClose).toHaveBeenCalled()
+    expect(dialogProps.onClose).toHaveBeenCalled()
   })
 
   it('should call the submit function', () => {

--- a/libs/shared/ui/src/components/Dialog/Dialog.stories.tsx
+++ b/libs/shared/ui/src/components/Dialog/Dialog.stories.tsx
@@ -25,7 +25,7 @@ const Template: ComponentStory<typeof Dialog> = ({ ...args }) => {
 export const Basic = Template.bind({})
 Basic.args = {
   open: true,
-  handleClose: noop,
+  onClose: noop,
   dialogTitle: { title: 'Simple Dialog' },
   dialogAction: {
     onSubmit: noop,
@@ -37,7 +37,7 @@ Basic.args = {
 export const Form = Template.bind({})
 Form.args = {
   open: true,
-  handleClose: noop,
+  onClose: noop,
   dialogTitle: {
     title: 'Edit Form',
     closeButton: true
@@ -53,7 +53,7 @@ Form.args = {
 export const MinHeight = Template.bind({})
 MinHeight.args = {
   open: true,
-  handleClose: noop,
+  onClose: noop,
   dialogTitle: {
     title: 'Minimum Height Dialog',
     closeButton: true
@@ -64,7 +64,7 @@ MinHeight.args = {
 export const Info = Template.bind({})
 Info.args = {
   open: true,
-  handleClose: noop,
+  onClose: noop,
   dialogTitle: {
     title: 'Info Dialog',
     closeButton: true
@@ -98,7 +98,7 @@ Info.args = {
 export const ExcessText = Template.bind({})
 ExcessText.args = {
   open: true,
-  handleClose: noop,
+  onClose: noop,
   dialogTitle: {
     title: 'Excess text',
     closeButton: true
@@ -149,7 +149,7 @@ ExcessText.args = {
 export const FullScreen = Template.bind({})
 FullScreen.args = {
   open: true,
-  handleClose: noop,
+  onClose: noop,
   dialogTitle: {
     title: 'Full Screen Dialog',
     closeButton: true

--- a/libs/shared/ui/src/components/Dialog/Dialog.tsx
+++ b/libs/shared/ui/src/components/Dialog/Dialog.tsx
@@ -10,7 +10,7 @@ import CloseRoundedIcon from '@mui/icons-material/CloseRounded'
 
 interface DialogProps {
   open: boolean
-  handleClose: () => void
+  onClose: () => void
   dialogTitle?: DialogTitle
   dialogAction?: DialogAction
   divider?: boolean
@@ -64,7 +64,7 @@ const StyledDialog = styled(MuiDialog)({
 
 export function Dialog({
   open,
-  handleClose,
+  onClose,
   dialogTitle,
   dialogAction,
   divider,
@@ -77,7 +77,7 @@ export function Dialog({
       fullScreen={fullscreen}
       maxWidth="sm"
       fullWidth
-      onClose={handleClose}
+      onClose={onClose}
     >
       {dialogTitle != null && (
         <MuiDialogTitle>
@@ -85,7 +85,7 @@ export function Dialog({
           {dialogTitle.closeButton != null && dialogTitle.closeButton && (
             <IconButton
               size="medium"
-              onClick={handleClose}
+              onClick={onClose}
               data-testid="dialog-close-button"
             >
               <CloseRoundedIcon />
@@ -97,7 +97,7 @@ export function Dialog({
       {dialogAction != null && (
         <DialogActions>
           {dialogAction.closeLabel != null && (
-            <Button onClick={handleClose}>{dialogAction.closeLabel}</Button>
+            <Button onClick={onClose}>{dialogAction.closeLabel}</Button>
           )}
           <Button onClick={dialogAction?.onSubmit}>
             {dialogAction.submitLabel ?? 'Save'}


### PR DESCRIPTION
# Description

We use on_ as prop names on components. handle_ are internal functions

# How should this PR be QA Tested?

- [x] Checks are green

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
