### PR TITLE
fix: simple hero

### DIFF
--- a/apps/watch/src/components/Hero/SimpleHero/SimpleHero.spec.tsx
+++ b/apps/watch/src/components/Hero/SimpleHero/SimpleHero.spec.tsx
@@ -2,83 +2,87 @@ import { render } from '@testing-library/react'
 import { VideoType } from '../../../../__generated__/globalTypes'
 import { SimpleHero } from '.'
 
-const episode = {
-  id: '1_fj_1-0-0',
-  __typename: 'Video',
-  type: VideoType.standalone,
-  image:
-    'https://d1wl257kev7hsz.cloudfront.net/cinematics/1_fj_1-0-0.mobileCinematicHigh.jpg',
-  imageAlt: [
-    {
-      value: 'image',
-      __typename: 'Translation'
-    }
-  ],
-  snippet: [
-    {
-      value:
-        "A few men in the village walk and talk. The JESUS film has been shown in their village and it's made an impression. One man keeps remembering how Jesus brought the daughter of Jairus from death to life.",
-      __typename: 'Translation'
-    }
-  ],
-  title: [
-    {
-      value: 'Who is God',
-      __typename: 'Translation'
-    }
-  ],
-  variant: {
-    duration: 1079,
-    __typename: 'VideoVariant',
-    hls: 'https://arc.gt/qjqeh'
-  },
-  episodeIds: [''],
-  slug: [
-    {
-      value: 'who-is-god',
-      __typename: 'Translation'
-    }
-  ]
-}
-
-const video = {
-  id: '1_fj-0-0',
-  type: VideoType.playlist,
-  image:
-    'https://d1wl257kev7hsz.cloudfront.net/cinematics/1_cl-0-0.mobileCinematicHigh.jpg',
-  title: [
-    {
-      value: 'Following Jesus (India)',
-      __typename: 'Translation'
-    }
-  ],
-  variant: { duration: 0, __typename: 'VideoVariant', hls: null },
-  __typename: 'Video',
-  slug: [
-    {
-      value: 'following-jesus-india',
-      __typename: 'Translation'
-    }
-  ],
-  description: [
-    {
-      value: 'description',
-      __typename: 'Translation'
-    }
-  ],
-  episodes: [episode, episode, episode],
-  variantLanguages: [
-    {
-      __typename: 'Language',
-      id: '1171',
-      name: [{ __typename: 'Translation', value: 'Assamese' }]
-    }
-  ]
-}
-
 describe('SimpleHero', () => {
   it('should render SimpleHero', () => {
-    const { getByRole } = render(<SimpleHero video={video} loading={false} />)
+    const { getByRole } = render(
+      <SimpleHero
+        video={{
+          id: '1_fj-0-0',
+          type: VideoType.playlist,
+          image:
+            'https://d1wl257kev7hsz.cloudfront.net/cinematics/1_cl-0-0.mobileCinematicHigh.jpg',
+          title: [
+            {
+              value: 'Following Jesus (India)',
+              __typename: 'Translation'
+            }
+          ],
+          variant: { duration: 0, __typename: 'VideoVariant', hls: null },
+          __typename: 'Video',
+          slug: [
+            {
+              value: 'following-jesus-india',
+              __typename: 'Translation'
+            }
+          ],
+          description: [
+            {
+              value: 'description',
+              __typename: 'Translation'
+            }
+          ],
+          episodes: [
+            {
+              id: '1_fj_1-0-0',
+              __typename: 'Video',
+              type: VideoType.standalone,
+              image:
+                'https://d1wl257kev7hsz.cloudfront.net/cinematics/1_fj_1-0-0.mobileCinematicHigh.jpg',
+              imageAlt: [
+                {
+                  value: 'image',
+                  __typename: 'Translation'
+                }
+              ],
+              snippet: [
+                {
+                  value:
+                    "A few men in the village walk and talk. The JESUS film has been shown in their village and it's made an impression. One man keeps remembering how Jesus brought the daughter of Jairus from death to life.",
+                  __typename: 'Translation'
+                }
+              ],
+              title: [
+                {
+                  value: 'Who is God',
+                  __typename: 'Translation'
+                }
+              ],
+              variant: {
+                duration: 1079,
+                __typename: 'VideoVariant',
+                hls: 'https://arc.gt/qjqeh'
+              },
+              episodeIds: [''],
+              slug: [
+                {
+                  value: 'who-is-god',
+                  __typename: 'Translation'
+                }
+              ]
+            }
+          ],
+          variantLanguages: [
+            {
+              __typename: 'Language',
+              id: '1171',
+              name: [{ __typename: 'Translation', value: 'Assamese' }]
+            }
+          ]
+        }}
+        loading={false}
+      />
+    )
+
     expect(getByRole('img')).toHaveAttribute(
       'src',
       'https://d1wl257kev7hsz.cloudfront.net/cinematics/1_fj_1-0-0.mobileCinematicHigh.jpg'

--- a/apps/watch/src/components/Hero/SimpleHero/SimpleHero.spec.tsx
+++ b/apps/watch/src/components/Hero/SimpleHero/SimpleHero.spec.tsx
@@ -1,0 +1,87 @@
+import { render } from '@testing-library/react'
+import { VideoType } from '../../../../__generated__/globalTypes'
+import { SimpleHero } from '.'
+
+const episode = {
+  id: '1_fj_1-0-0',
+  __typename: 'Video',
+  type: VideoType.standalone,
+  image:
+    'https://d1wl257kev7hsz.cloudfront.net/cinematics/1_fj_1-0-0.mobileCinematicHigh.jpg',
+  imageAlt: [
+    {
+      value: 'image',
+      __typename: 'Translation'
+    }
+  ],
+  snippet: [
+    {
+      value:
+        "A few men in the village walk and talk. The JESUS film has been shown in their village and it's made an impression. One man keeps remembering how Jesus brought the daughter of Jairus from death to life.",
+      __typename: 'Translation'
+    }
+  ],
+  title: [
+    {
+      value: 'Who is God',
+      __typename: 'Translation'
+    }
+  ],
+  variant: {
+    duration: 1079,
+    __typename: 'VideoVariant',
+    hls: 'https://arc.gt/qjqeh'
+  },
+  episodeIds: [''],
+  slug: [
+    {
+      value: 'who-is-god',
+      __typename: 'Translation'
+    }
+  ]
+}
+
+const video = {
+  id: '1_fj-0-0',
+  type: VideoType.playlist,
+  image:
+    'https://d1wl257kev7hsz.cloudfront.net/cinematics/1_cl-0-0.mobileCinematicHigh.jpg',
+  title: [
+    {
+      value: 'Following Jesus (India)',
+      __typename: 'Translation'
+    }
+  ],
+  variant: { duration: 0, __typename: 'VideoVariant', hls: null },
+  __typename: 'Video',
+  slug: [
+    {
+      value: 'following-jesus-india',
+      __typename: 'Translation'
+    }
+  ],
+  description: [
+    {
+      value: 'description',
+      __typename: 'Translation'
+    }
+  ],
+  episodes: [episode, episode, episode],
+  variantLanguages: [
+    {
+      __typename: 'Language',
+      id: '1171',
+      name: [{ __typename: 'Translation', value: 'Assamese' }]
+    }
+  ]
+}
+
+describe('SimpleHero', () => {
+  it('should render SimpleHero', () => {
+    const { getByRole } = render(<SimpleHero video={video} loading={false} />)
+    expect(getByRole('img')).toHaveAttribute(
+      'src',
+      'https://d1wl257kev7hsz.cloudfront.net/cinematics/1_fj_1-0-0.mobileCinematicHigh.jpg'
+    )
+  })
+})

--- a/apps/watch/src/components/Hero/SimpleHero/SimpleHero.stories.tsx
+++ b/apps/watch/src/components/Hero/SimpleHero/SimpleHero.stories.tsx
@@ -1,0 +1,94 @@
+import { Meta, Story } from '@storybook/react'
+import { watchConfig } from '../../../libs/storybook'
+import { VideoType } from '../../../../__generated__/globalTypes'
+import { SimpleHero } from './SimpleHero'
+
+const SimpleHeroStory = {
+  ...watchConfig,
+  component: SimpleHero,
+  title: 'Watch/Hero/SimpleHero'
+}
+
+const episode = {
+  id: '1_fj_1-0-0',
+  type: VideoType.standalone,
+  image:
+    'https://d1wl257kev7hsz.cloudfront.net/cinematics/1_fj_1-0-0.mobileCinematicHigh.jpg',
+  imageAlt: [
+    {
+      value: 'image',
+      __typename: 'Translation'
+    }
+  ],
+  snippet: [
+    {
+      value:
+        "A few men in the village walk and talk. The JESUS film has been shown in their village and it's made an impression. One man keeps remembering how Jesus brought the daughter of Jairus from death to life.",
+      __typename: 'Translation'
+    }
+  ],
+  title: [
+    {
+      value: 'Who is God',
+      __typename: 'Translation'
+    }
+  ],
+  variant: {
+    duration: 1079,
+    __typename: 'VideoVariant',
+    hls: 'https://arc.gt/qjqeh'
+  },
+  __typename: 'Video',
+  episodeIds: [],
+  slug: [
+    {
+      value: 'who-is-god',
+      __typename: 'Translation'
+    }
+  ]
+}
+
+const Template: Story = ({ ...args }) => (
+  <SimpleHero video={args.video} loading={args.loading} />
+)
+
+export const Default = Template.bind({})
+Default.args = {
+  video: {
+    id: '1_fj-0-0',
+    type: VideoType.playlist,
+    image:
+      'https://d1wl257kev7hsz.cloudfront.net/cinematics/1_cl-0-0.mobileCinematicHigh.jpg',
+    title: [
+      {
+        value: 'Following Jesus (India)',
+        __typename: 'Translation'
+      }
+    ],
+    variant: { duration: 0, __typename: 'VideoVariant', hls: null },
+    __typename: 'Video',
+    slug: [
+      {
+        value: 'following-jesus-india',
+        __typename: 'Translation'
+      }
+    ],
+    description: [
+      {
+        value: 'description',
+        __typename: 'Translation'
+      }
+    ],
+    episodes: [episode, episode, episode],
+    variantLanguages: [
+      {
+        __typename: 'language',
+        id: 1171,
+        name: [{ __typename: 'Translation', value: 'Assamese' }]
+      }
+    ]
+  },
+  loading: false
+}
+
+export default SimpleHeroStory as Meta

--- a/apps/watch/src/components/Hero/SimpleHero/SimpleHero.tsx
+++ b/apps/watch/src/components/Hero/SimpleHero/SimpleHero.tsx
@@ -3,6 +3,8 @@ import Box from '@mui/material/Box'
 import CircularProgress from '@mui/material/CircularProgress'
 import Container from '@mui/material/Container'
 import Typography from '@mui/material/Typography'
+import Stack from '@mui/material/Stack'
+import Image from 'next/image'
 
 import { GetVideo_video as Video } from '../../../../__generated__/GetVideo'
 
@@ -12,38 +14,58 @@ interface SimpleHeroProps {
 }
 
 export function SimpleHero({ loading, video }: SimpleHeroProps): ReactElement {
+  const image = video.episodes[0].image as string
+
   return (
-    <>
+    <Box
+      sx={{
+        height: 340,
+        width: '100%',
+        display: 'flex',
+        alignItems: 'end',
+        position: 'relative'
+      }}
+    >
       {loading && <CircularProgress />}
+      <Image
+        src={image}
+        alt={video?.title[0].value}
+        layout="fill"
+        objectFit="cover"
+        style={{
+          zIndex: -1
+        }}
+      />
       <Box
-        sx={{
-          backgroundImage: `url(${video.image as string})`,
-          backgroundSize: 'cover',
-          backgroundPosition: 'center',
-          height: 776
+        style={{
+          zIndex: 0,
+          position: 'absolute',
+          height: '100%',
+          width: '100%',
+          backgroundColor: 'rgba(0,0,0,0.6)'
+        }}
+      />
+      <Container
+        maxWidth="xl"
+        style={{
+          zIndex: 1
         }}
       >
-        <Container
-          maxWidth="xl"
-          style={{
-            position: 'absolute',
-            top: 350,
-            paddingLeft: 100,
-            margin: 0,
-            textShadow: '0px 3px 4px rgba(0, 0, 0, 0.25)'
-          }}
+        {/* render video type */}
+        <Stack
+          direction={{ xs: 'column', sm: 'column', md: 'column', lg: 'row' }}
+          alignItems={{ xs: 'start', lg: 'end' }}
+          justifyContent="space-between"
+          pb={10}
         >
-          <Typography
-            variant="h2"
-            sx={{
-              maxWidth: '600px',
-              color: 'text.primary'
-            }}
-          >
+          <Typography variant="h1" color="secondary.contrastText">
             {video.title[0]?.value}
           </Typography>
-        </Container>
-      </Box>
-    </>
+          <Typography variant="overline1" color="secondary.contrastText">
+            {video.episodes.length} Episodes
+          </Typography>
+        </Stack>
+      </Container>
+    </Box>
   )
 }

--- a/apps/watch/src/components/Hero/SimpleHero/SimpleHero.tsx
+++ b/apps/watch/src/components/Hero/SimpleHero/SimpleHero.tsx
@@ -7,6 +7,7 @@ import Stack from '@mui/material/Stack'
 import Image from 'next/image'
 
 import { GetVideo_video as Video } from '../../../../__generated__/GetVideo'
+import { VideoType } from '../../../../__generated__/globalTypes'
 
 interface SimpleHeroProps {
   loading: boolean
@@ -50,17 +51,29 @@ export function SimpleHero({ loading, video }: SimpleHeroProps): ReactElement {
           zIndex: 2
         }}
       >
-        {/* render video type */}
+        {video.type === VideoType.playlist && (
+          <Typography
+            variant="overline1"
+            color="secondary.contrastText"
+            sx={{ opacity: 0.7 }}
+          >
+            Series
+          </Typography>
+        )}
         <Stack
           direction={{ xs: 'column', lg: 'row' }}
           alignItems={{ xs: 'start', lg: 'end' }}
           justifyContent="space-between"
-          pb={10}
+          pb={15}
         >
           <Typography variant="h1" color="secondary.contrastText">
             {video.title[0]?.value}
           </Typography>
-          <Typography variant="overline1" color="secondary.contrastText">
+          <Typography
+            variant="overline1"
+            color="secondary.contrastText"
+            sx={{ opacity: 0.7 }}
+          >
             {video.episodes.length} Episodes
           </Typography>
         </Stack>

--- a/apps/watch/src/components/Hero/SimpleHero/SimpleHero.tsx
+++ b/apps/watch/src/components/Hero/SimpleHero/SimpleHero.tsx
@@ -14,12 +14,12 @@ interface SimpleHeroProps {
 }
 
 export function SimpleHero({ loading, video }: SimpleHeroProps): ReactElement {
-  const image = video.episodes[0].image as string
+  const firstEpisodeImage = video.episodes[0]?.image
 
   return (
     <Box
       sx={{
-        height: 340,
+        height: { xs: 280, lg: 340 },
         width: '100%',
         display: 'flex',
         alignItems: 'end',
@@ -27,33 +27,32 @@ export function SimpleHero({ loading, video }: SimpleHeroProps): ReactElement {
       }}
     >
       {loading && <CircularProgress />}
-      <Image
-        src={image}
-        alt={video?.title[0].value}
-        layout="fill"
-        objectFit="cover"
-        style={{
-          zIndex: -1
-        }}
-      />
+      {firstEpisodeImage != null && (
+        <Image
+          src={firstEpisodeImage}
+          alt={video?.title[0].value}
+          layout="fill"
+          objectFit="cover"
+        />
+      )}
       <Box
         style={{
-          zIndex: 0,
+          zIndex: 1,
           position: 'absolute',
           height: '100%',
           width: '100%',
-          backgroundColor: 'rgba(0,0,0,0.6)'
+          backgroundColor: 'rgba(0,0,0,0.5)'
         }}
       />
       <Container
         maxWidth="xl"
         style={{
-          zIndex: 1
+          zIndex: 2
         }}
       >
         {/* render video type */}
         <Stack
-          direction={{ xs: 'column', sm: 'column', md: 'column', lg: 'row' }}
+          direction={{ xs: 'column', lg: 'row' }}
           alignItems={{ xs: 'start', lg: 'end' }}
           justifyContent="space-between"
           pb={10}

--- a/apps/watch/src/components/Hero/SimpleHero/index.ts
+++ b/apps/watch/src/components/Hero/SimpleHero/index.ts
@@ -1,0 +1,1 @@
+export { SimpleHero } from './SimpleHero'

--- a/apps/watch/src/components/Hero/index.ts
+++ b/apps/watch/src/components/Hero/index.ts
@@ -1,3 +1,3 @@
 export { HomeHero } from './HomeHero'
-export { SimpleHero } from './SimpleHero/SimpleHero'
+export { SimpleHero } from './SimpleHero'
 export { VideoHero } from './VideoHero/VideoHero'


### PR DESCRIPTION
# Description

Fix the simple hero to be rendering the right text and background image. It should also display properly on mobile

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/29906873/todos/5472572886)

# How should this PR be QA Tested?

- [ ] it should render the thumbnail image of the first video in the series
- [ ] it should render the series name
- [ ] it should render the video type
- [ ] it should render how many episodes are there in the series

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
