### PR TITLE
ci: use turbosnap on main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,8 +145,8 @@ jobs:
         with:
           files: 'dist/storybook/shared-storybook'
         #👇 Adds Chromatic as a step in the workflow
-      - name: Run VR tests on main
-        if: ${{ steps.check_files.outputs.files_exists == 'true' && github.ref == 'refs/heads/main' }}
+      - name: Run VR tests
+        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
         uses: chromaui/action@v1
         # Options required for Chromatic's GitHub Action
         # https://www.chromatic.com/docs/github-actions#available-options
@@ -160,15 +160,5 @@ jobs:
           autoAcceptChanges: 'main'
           onlyChanged: 'true'
           skip: '@(dependabot/**|00-00-CI-chore-update-translations)'
-          traceChanged: 'expanded'
-      - name: Run VR tests
-        if: ${{ steps.check_files.outputs.files_exists == 'true' && github.ref != 'refs/heads/main' }}
-        uses: chromaui/action@v1
-        with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          storybookBuildDir: 'dist/storybook/shared-storybook'
-          exitOnceUploaded: true,
-          onlyChanged: 'true'
-          untraced: 'package.json,package-lock.json,.storybook/main.js,.storybook/preview.js,.storybook/preview-head.html,.storybook/static/*.js',
+          untraced: ${{ github.ref != 'refs/heads/main' && 'package.json,package-lock.json,.storybook/main.js,.storybook/preview.js,.storybook/preview-head.html,.storybook/static/*.js' }},
           traceChanged: 'expanded'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,8 +145,8 @@ jobs:
         with:
           files: 'dist/storybook/shared-storybook'
         #👇 Adds Chromatic as a step in the workflow
-      - name: Run VR tests
-        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
+      - name: Run VR tests on main
+        if: ${{ steps.check_files.outputs.files_exists == 'true' && github.ref == 'refs/heads/main' }}
         uses: chromaui/action@v1
         # Options required for Chromatic's GitHub Action
         # https://www.chromatic.com/docs/github-actions#available-options
@@ -158,7 +158,17 @@ jobs:
           storybookBuildDir: 'dist/storybook/shared-storybook'
           exitOnceUploaded: true,
           autoAcceptChanges: 'main'
-          onlyChanged: '!(main)'
+          onlyChanged: 'true'
           skip: '@(dependabot/**|00-00-CI-chore-update-translations)'
-          untraced: 'package.json,package-lock.json,.storybook/main.js,.storybook/preview.js,.storybook/preview-head.html,.storybook/static/*.js'
+          traceChanged: 'expanded'
+      - name: Run VR tests
+        if: ${{ steps.check_files.outputs.files_exists == 'true' && github.ref != 'refs/heads/main' }}
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          storybookBuildDir: 'dist/storybook/shared-storybook'
+          exitOnceUploaded: true,
+          onlyChanged: 'true'
+          untraced: 'package.json,package-lock.json,.storybook/main.js,.storybook/preview.js,.storybook/preview-head.html,.storybook/static/*.js',
           traceChanged: 'expanded'


### PR DESCRIPTION
# Description

Original main and all other branches used TurboSnap and triggered rebuilds on all config files. We later (in this current build) made all TurboSnap branches skip rebuilds on the config files so removed main from using TurboSnap.

This branch turns TurboSnap on main but runs a seperate VR step for non-main branches so they will not rebuild on storybook config files.

I'm not sure if there was a simpler way to toggle `untraced` to be on or off based on which branch we're on...

Adding in this change to slightly decrease the number of snapshots we chew through

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Main branches should no longer run full rebuilds if not necessary

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
