### PR TITLE
ci: fix chromatic untraced

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,7 +163,7 @@ jobs:
           autoAcceptChanges: 'main'
           onlyChanged: 'true'
           skip: '@(dependabot/**|00-00-CI-chore-update-translations)'
+          traceChanged: 'expanded'
           untraced: |
           - '**/package*.json'
           - '**/.storybook/**'
-          traceChanged: 'expanded'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,9 +158,12 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
           storybookBuildDir: 'dist/storybook/shared-storybook'
+          dryRun: true,
           exitOnceUploaded: true,
           autoAcceptChanges: 'main'
           onlyChanged: 'true'
           skip: '@(dependabot/**|00-00-CI-chore-update-translations)'
-          untraced: 'package.json,package-lock.json,.storybook/main.js,.storybook/preview.js,.storybook/preview-head.html,.storybook/static/*.js'
+          untraced: |
+          - '**/package*.json'
+          - '**/.storybook/**'
           traceChanged: 'expanded'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,5 +162,5 @@ jobs:
           autoAcceptChanges: 'main'
           onlyChanged: 'true'
           skip: '@(dependabot/**|00-00-CI-chore-update-translations)'
-          untraced: ${{ github.ref != 'refs/heads/main' && 'package.json,package-lock.json,.storybook/main.js,.storybook/preview.js,.storybook/preview-head.html,.storybook/static/*.js' }}
+          untraced: 'package.json,package-lock.json,.storybook/main.js,.storybook/preview.js,.storybook/preview-head.html,.storybook/static/*.js'
           traceChanged: 'expanded'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,5 +162,5 @@ jobs:
           autoAcceptChanges: 'main'
           onlyChanged: 'true'
           skip: '@(dependabot/**|00-00-CI-chore-update-translations)'
-          untraced: 'package.json,package-lock.json,.storybook/main.js,.storybook/preview.js,.storybook/preview-head.html,.storybook/static/*.js',
+          untraced: ${{ github.ref != 'refs/heads/main' && 'package.json,package-lock.json,.storybook/main.js,.storybook/preview.js,.storybook/preview-head.html,.storybook/static/*.js' }}
           traceChanged: 'expanded'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,6 +161,7 @@ jobs:
           exitOnceUploaded: 'true'
           autoAcceptChanges: 'main'
           onlyChanged: 'true'
+          forceRebuild: 'true'
           skip: '@(dependabot/**|00-00-CI-chore-update-translations)'
           untraced: |
             - '**/package*.json'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -159,11 +159,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           storybookBuildDir: 'dist/storybook/shared-storybook'
           dryRun: 'true'
-          exitOnceUploaded: true,
+          exitOnceUploaded: 'true'
           autoAcceptChanges: 'main'
           onlyChanged: 'true'
           skip: '@(dependabot/**|00-00-CI-chore-update-translations)'
-          traceChanged: 'expanded'
           untraced: |
-          - '**/package*.json'
-          - '**/.storybook/**'
+            - '**/package*.json'
+            - '**/.storybook/**'
+          traceChanged: 'expanded'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,7 +158,7 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
           storybookBuildDir: 'dist/storybook/shared-storybook'
-          dryRun: true,
+          dryRun: 'true'
           exitOnceUploaded: true,
           autoAcceptChanges: 'main'
           onlyChanged: 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,7 +158,6 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
           storybookBuildDir: 'dist/storybook/shared-storybook'
-          dryRun: 'true'
           exitOnceUploaded: 'true'
           autoAcceptChanges: 'main'
           onlyChanged: 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,5 +162,5 @@ jobs:
           autoAcceptChanges: 'main'
           onlyChanged: 'true'
           skip: '@(dependabot/**|00-00-CI-chore-update-translations)'
-          untraced: ${{ github.ref != 'refs/heads/main' && 'package.json,package-lock.json,.storybook/main.js,.storybook/preview.js,.storybook/preview-head.html,.storybook/static/*.js' }},
+          untraced: 'package.json,package-lock.json,.storybook/main.js,.storybook/preview.js,.storybook/preview-head.html,.storybook/static/*.js',
           traceChanged: 'expanded'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,7 +161,7 @@ jobs:
           exitOnceUploaded: 'true'
           autoAcceptChanges: 'main'
           onlyChanged: 'true'
-          forceRebuild: 'true'
+          forceRebuild: 'main'
           skip: '@(dependabot/**|00-00-CI-chore-update-translations)'
           untraced: |
             - '**/package*.json'

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -73,7 +73,7 @@ module.exports = {
       ? config.resolve.plugins.push(tsPaths)
       : (config.resolve.plugins = [tsPaths])
 
-    // TODO: Remove once Storybook supports Emotion 11
+    // TODO: Remove once Storybook supports Emotion 11.
     config.resolve.alias = {
       ...config.resolve.alias,
       '@emotion/styled': require.resolve('@emotion/styled'),

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -73,7 +73,7 @@ module.exports = {
       ? config.resolve.plugins.push(tsPaths)
       : (config.resolve.plugins = [tsPaths])
 
-    // TODO: Remove once Storybook supports Emotion 11.
+    // TODO: Remove once Storybook supports Emotion 11
     config.resolve.alias = {
       ...config.resolve.alias,
       '@emotion/styled': require.resolve('@emotion/styled'),


### PR DESCRIPTION
# Description

Untraced configuration was set incorrectly and there were bugs with older versions of Chromatic so we were still getting full rebuilds for storybook

# How should this PR be QA Tested?

- [ ] Turbosnap ignores `untraced` files
For commit https://github.com/JesusFilm/core/pull/1068/commits/37e7d42ac1a87834018e5663ffdf2a93cf1dac77
We changed `storybook/main.js` and `main.yml` files. Only yml files detected
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/10802634/202533549-815600da-f8db-4273-8e91-7daa64e4aedc.png">

- [ ] Turbosnap disabled when `forceRebuild` is true , then make sure is `forceRebuild: 'main'` 
For commit https://github.com/JesusFilm/core/pull/1068/commits/c49cffcc67cf11b878f6b7fa052b06f410ef53c9
The same change to `storybook/main.js` and `main.yml` triggered Turbosnap to be disabled. 
<img width="1051" alt="image" src="https://user-images.githubusercontent.com/10802634/202532886-5a47b48d-1366-4e6f-a95c-41da7826f619.png">

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
