### PR TITLE
ci: try a fetch depth of zero

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,7 @@ jobs:
           fetch-depth: 0
       - name: Fetch other branches
         if: ${{ github.event_name == 'pull_request' }}
-        run: git fetch --no-tags --prune --depth=300 origin $GITHUB_BASE_REF
+        run: git fetch --no-tags --prune --depth=0 origin $GITHUB_BASE_REF
       - name: Check branch up to date with base
         run: ./tools/scripts/check-git-diff.sh
       - uses: actions/setup-node@v2


### PR DESCRIPTION
# Description

Turbosnap is registering package.json changes even when the file should not be counted on non-main branches.
A chromatic dev has reccomended:

<img width="376" alt="image" src="https://user-images.githubusercontent.com/10802634/202562415-ac17b83b-2e81-406c-a3b6-5427465cf309.png">

This is update after #1071 

# How should this PR be QA Tested?

Test after merging
- [ ] PRs that merge latest main (which also include package.json changes in main), should have Turbosnap enabled

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
