### PR TITLE
ci: build only affected libraries so full rebuilds have less impact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,8 +150,6 @@ jobs:
           exitOnceUploaded: 'true'
           autoAcceptChanges: 'main'
           onlyChanged: 'true'
-          # Uncomment forceRebuild if you're making a package and storybook config change which you expect to change stories. Recomment after the visual regression build is done.
-          # forceRebuild: 'main'
           skip: '@(dependabot/**|00-00-CI-chore-update-translations)'
           untraced: |
             - '**/package*.json'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,30 +133,11 @@ jobs:
         run: npm install --silent
       - name: nx Install
         run: npm install -g nx --silent
-      - name: Get affected apps (PR only)
-        id: affected-apps
-        if: ${{ github.event_name == 'pull_request' }}
-        run: echo "::set-output name=apps::$(nx affected:apps --plain --base=origin/main --head=HEAD)"
-      - name: Get affected libs (PR only)
-        id: affected-libs
-        if: ${{ github.event_name == 'pull_request' }}
-        run: echo "::set-output name=libs::$(nx affected:libs --plain --base=origin/main --head=HEAD)"
       - name: Build Stories
         id: build-storybook
-        env:
-          NX_AFFECTED_APPS: ${{ steps.affected-apps.outputs.apps }}
-          NX_AFFECTED_LIBS: ${{ steps.affected-libs.outputs.libs }}
-        uses: mansagroup/nrwl-nx-action@v2
-        with:
-          targets: build-storybook
-      - name: Check for frontend changes
-        id: check_files
-        uses: andstor/file-existence-action@v1
-        with:
-          files: 'dist/storybook/shared-storybook'
+        run: nx build-storybook shared-storybook --webpack-stats-json
         #👇 Adds Chromatic as a step in the workflow
       - name: Run VR tests
-        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
         uses: chromaui/action@v1
         # Options required for Chromatic's GitHub Action
         # https://www.chromatic.com/docs/github-actions#available-options
@@ -169,7 +150,8 @@ jobs:
           exitOnceUploaded: 'true'
           autoAcceptChanges: 'main'
           onlyChanged: 'true'
-          forceRebuild: 'main'
+          # Uncomment forceRebuild if you're making a package and storybook config change which you expect to change stories. Recomment after the visual regression build is done.
+          # forceRebuild: 'main'
           skip: '@(dependabot/**|00-00-CI-chore-update-translations)'
           untraced: |
             - '**/package*.json'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,6 +150,8 @@ jobs:
           exitOnceUploaded: 'true'
           autoAcceptChanges: 'main'
           onlyChanged: 'true'
+          # Uncomment forceRebuild if you're making a package and storybook config change which you expect to change stories. Recomment after the visual regression build is done.
+          # forceRebuild: 'main'
           skip: '@(dependabot/**|00-00-CI-chore-update-translations)'
           untraced: |
             - '**/package*.json'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,7 +150,6 @@ jobs:
           exitOnceUploaded: 'true'
           autoAcceptChanges: 'main'
           onlyChanged: 'true'
-          forceRebuild: 'main'
           skip: '@(dependabot/**|00-00-CI-chore-update-translations)'
           untraced: |
             - '**/package*.json'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,11 +133,30 @@ jobs:
         run: npm install --silent
       - name: nx Install
         run: npm install -g nx --silent
+      - name: Get affected apps (PR only)
+        id: affected-apps
+        if: ${{ github.event_name == 'pull_request' }}
+        run: echo "::set-output name=apps::$(nx affected:apps --plain --base=origin/main --head=HEAD)"
+      - name: Get affected libs (PR only)
+        id: affected-libs
+        if: ${{ github.event_name == 'pull_request' }}
+        run: echo "::set-output name=libs::$(nx affected:libs --plain --base=origin/main --head=HEAD)"
       - name: Build Stories
         id: build-storybook
-        run: nx build-storybook shared-storybook --webpack-stats-json
+        env:
+          NX_AFFECTED_APPS: ${{ steps.affected-apps.outputs.apps }}
+          NX_AFFECTED_LIBS: ${{ steps.affected-libs.outputs.libs }}
+        uses: mansagroup/nrwl-nx-action@v2
+        with:
+          targets: build-storybook
+      - name: Check for frontend changes
+        id: check_files
+        uses: andstor/file-existence-action@v1
+        with:
+          files: 'dist/storybook/shared-storybook'
         #👇 Adds Chromatic as a step in the workflow
       - name: Run VR tests
+        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
         uses: chromaui/action@v1
         # Options required for Chromatic's GitHub Action
         # https://www.chromatic.com/docs/github-actions#available-options
@@ -150,8 +169,7 @@ jobs:
           exitOnceUploaded: 'true'
           autoAcceptChanges: 'main'
           onlyChanged: 'true'
-          # Uncomment forceRebuild if you're making a package and storybook config change which you expect to change stories. Recomment after the visual regression build is done.
-          # forceRebuild: 'main'
+          forceRebuild: 'main'
           skip: '@(dependabot/**|00-00-CI-chore-update-translations)'
           untraced: |
             - '**/package*.json'

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -42,33 +42,12 @@ const allStories = [
   ...storiesForProject['shared-ui']
 ]
 
-const affectedStories = () => {
-  const affectedApps = process.env.NX_AFFECTED_APPS ?? ''
-  const affectedLibs = process.env.NX_AFFECTED_LIBS ?? ''
-  const affectedProjects = [
-    ...affectedApps.split(' '),
-    ...affectedLibs.split(' ')
-  ]
-
-  const stories = affectedProjects
-    .map((project) => {
-      if (project === '') return []
-      return storiesForProject[project] ?? []
-    })
-    .flat()
-
-  return stories.length > 0 ? stories : undefined
-}
-
 module.exports = {
   staticDirs: [
     './static',
     { from: '../apps/watch/public/fonts', to: '/fonts' }
   ],
-  stories:
-    affectedStories() ||
-    storiesForProject[process.env.NX_TASK_TARGET_PROJECT] ||
-    allStories,
+  stories: allStories,
   addons: [
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -42,12 +42,33 @@ const allStories = [
   ...storiesForProject['shared-ui']
 ]
 
+const affectedStories = () => {
+  const affectedApps = process.env.NX_AFFECTED_APPS ?? ''
+  const affectedLibs = process.env.NX_AFFECTED_LIBS ?? ''
+  const affectedProjects = [
+    ...affectedApps.split(' '),
+    ...affectedLibs.split(' ')
+  ]
+
+  const stories = affectedProjects
+    .map((project) => {
+      if (project === '') return []
+      return storiesForProject[project] ?? []
+    })
+    .flat()
+
+  return stories.length > 0 ? stories : undefined
+}
+
 module.exports = {
   staticDirs: [
     './static',
     { from: '../apps/watch/public/fonts', to: '/fonts' }
   ],
-  stories: allStories,
+  stories:
+    affectedStories() ||
+    storiesForProject[process.env.NX_TASK_TARGET_PROJECT] ||
+    allStories,
   addons: [
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',


### PR DESCRIPTION
# Description

Turbosnap continues to pick up package.json changes from main. Always ignore these changes by default and manually rebuild the entire project when we expect it (or storybook config changes) to cause a story update.

I have exhausted all other options on our end that we know could possibly be causing the issue... fixing git history errors (via incorrect branch fetching), incorrect configurations...
#1071 #1072 #1068 

<img width="1159" alt="image" src="https://user-images.githubusercontent.com/10802634/202575805-86e1d9d0-4802-48d7-8b02-828ae634afc6.png">

Tatai has suggested building only the affected libraries. I've added back the previous logic + steps we used in #856 

But first we're testing that untraced works in all circumstances (even when merging in latest main + package.json changes)

# How should this PR be QA Tested?

To test after merged in.
- [ ] PRs which have this change + package.json changes merged in from latest main don't trigger full rebuild

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
