### PR TITLE
fix: cover media delete

### DIFF
--- a/apps/api-journeys/src/app/modules/block/image/image.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/image/image.resolver.spec.ts
@@ -129,13 +129,12 @@ describe('ImageBlockResolver', () => {
   })
 
   describe('imageBlockCreate', () => {
+    mockedAxios.get.mockResolvedValue({
+      data: {
+        mockData: 'mockData' // this kinda doesnt matter since sharp returns the data we need, but still need to mock so it doesnt run the API
+      }
+    })
     it('creates an ImageBlock', async () => {
-      mockedAxios.get.mockResolvedValue({
-        data: {
-          mockData: 'mockData' // this kinda doesnt matter since sharp returns the data we need, but still need to mock so it doesnt run the API
-        }
-      })
-
       await resolver.imageBlockCreate(blockCreate)
 
       expect(service.getSiblings).toHaveBeenCalledWith(
@@ -154,10 +153,6 @@ describe('ImageBlockResolver', () => {
         isCover: true,
         parentOrder: null
       })
-      expect(service.removeBlockAndChildren).toHaveBeenCalledWith(
-        parentBlock.coverBlockId,
-        parentBlock.journeyId
-      )
       expect(service.update).toHaveBeenCalledWith(parentBlock.id, {
         coverBlockId: createdBlock.id
       })

--- a/apps/api-journeys/src/app/modules/block/image/image.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/image/image.resolver.ts
@@ -88,13 +88,6 @@ export class ImageBlockResolver {
       await this.blockService.update(parentBlock.id, {
         coverBlockId: coverBlock.id
       })
-      // Delete old coverBlock
-      if (parentBlock.coverBlockId != null) {
-        await this.blockService.removeBlockAndChildren(
-          parentBlock.coverBlockId,
-          parentBlock.journeyId
-        )
-      }
 
       return coverBlock
     }

--- a/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
@@ -168,7 +168,6 @@ describe('VideoBlockResolver', () => {
         __typename: 'VideoBlock',
         parentOrder: 0
       })
-      // expect(service.update).toHaveBeenCalledWith(createdBlock.id, createdBlock)
     })
 
     it('creates a cover VideoBlock', async () => {

--- a/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
@@ -168,7 +168,7 @@ describe('VideoBlockResolver', () => {
         __typename: 'VideoBlock',
         parentOrder: 0
       })
-      expect(service.update).toHaveBeenCalledWith(createdBlock.id, createdBlock)
+      // expect(service.update).toHaveBeenCalledWith(createdBlock.id, createdBlock)
     })
 
     it('creates a cover VideoBlock', async () => {
@@ -180,10 +180,6 @@ describe('VideoBlockResolver', () => {
         isCover: true,
         parentOrder: null
       })
-      expect(service.removeBlockAndChildren).toHaveBeenCalledWith(
-        parentBlock.coverBlockId,
-        parentBlock.journeyId
-      )
       expect(service.update).toHaveBeenCalledWith(parentBlock.id, {
         coverBlockId: createdBlock.id
       })

--- a/apps/api-journeys/src/app/modules/block/video/video.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/video/video.resolver.ts
@@ -6,7 +6,6 @@ import { UserInputError } from 'apollo-server'
 import { BlockService } from '../block.service'
 import {
   Action,
-  CardBlock,
   Role,
   UserJourneyRole,
   VideoBlock,
@@ -101,20 +100,10 @@ export class VideoBlockResolver {
         __typename: 'VideoBlock',
         parentOrder: null
       })
-      const parentBlock: CardBlock = await this.blockService.get(
-        input.parentBlockId
-      )
 
       await this.blockService.update(input.parentBlockId, {
         coverBlockId: coverBlock.id
       })
-
-      if (parentBlock.coverBlockId != null) {
-        await this.blockService.removeBlockAndChildren(
-          parentBlock.coverBlockId,
-          input.journeyId
-        )
-      }
 
       return coverBlock
     }


### PR DESCRIPTION
# Description

https://github.com/JesusFilm/core/pull/518 made changes that the front end should handle any card block updates when any cover media is deleted. This PR removes card block update in the resolver.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/29689605/todos/5529209266)

# How should this PR be QA Tested?

Preconditions: create a card with a cover image, then delete the cover image.

- [ ] Cover image should show success snackbar and delete the cover image

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
