### PR TITLE
fix: update cypress request dependency 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3498,9 +3498,10 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "2.88.8",
+      "version": "2.88.10",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.10.tgz",
+      "integrity": "sha512-Zp7F+R93N0yZyG34GutyTNr+okam7s/Fzc1+i3kcqOP8vk6OuajuE9qZJ6Rs+10/1JFtXFYMdyarnU1rZuJesg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -57984,7 +57985,9 @@
       }
     },
     "@cypress/request": {
-      "version": "2.88.8",
+      "version": "2.88.10",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.10.tgz",
+      "integrity": "sha512-Zp7F+R93N0yZyG34GutyTNr+okam7s/Fzc1+i3kcqOP8vk6OuajuE9qZJ6Rs+10/1JFtXFYMdyarnU1rZuJesg==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",


### PR DESCRIPTION
# Description

Update the dependency for cypress that was causing npm to fail

Dependency update, no qa

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
