### PR TITLE
feat: style mui autocomplete & other textfields

### DIFF
--- a/libs/shared/ui/src/libs/themes/website/tokens/components.stories.tsx
+++ b/libs/shared/ui/src/libs/themes/website/tokens/components.stories.tsx
@@ -131,7 +131,13 @@ const Template: Story<ComponentProps<typeof Button>> = (args) => {
         disablePortal
         fullWidth
         options={audioLanguages}
-        renderInput={(params) => <TextField {...params} label="Audio" />}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label="Audio"
+            helperText="6 options available"
+          />
+        )}
       />
       {/* TABS */}
       <Tabs value={value} onChange={handleChange} aria-label="tabs example">

--- a/libs/shared/ui/src/libs/themes/website/tokens/components.stories.tsx
+++ b/libs/shared/ui/src/libs/themes/website/tokens/components.stories.tsx
@@ -1,5 +1,6 @@
 import { useState, SyntheticEvent, ComponentProps } from 'react'
 import { Story, Meta } from '@storybook/react'
+import Autocomplete from '@mui/material/Autocomplete'
 import Button from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
 import Stack from '@mui/material/Stack'
@@ -32,6 +33,15 @@ const Template: Story<ComponentProps<typeof Button>> = (args) => {
   const handleChange = (e: SyntheticEvent, newValue: number): void => {
     setValue(newValue)
   }
+
+  const audioLanguages = [
+    { label: 'English', value: 'en' },
+    { label: 'Spanish', value: 'es' },
+    { label: 'French', value: 'fr' },
+    { label: 'Chinese - Simplified', value: 'zh-hans' },
+    { label: 'Chinese - Traditional', value: 'zh-hant' },
+    { label: 'Arabic', value: 'ar' }
+  ]
 
   return (
     <Stack spacing={8} alignItems="flex-start">
@@ -116,6 +126,13 @@ const Template: Story<ComponentProps<typeof Button>> = (args) => {
         <MenuItem value="high">High (59.83 MB)</MenuItem>
         <MenuItem value="low">Low (12 MB)</MenuItem>
       </TextField>
+      {/* AUTOCOMPLETE */}
+      <Autocomplete
+        disablePortal
+        fullWidth
+        options={audioLanguages}
+        renderInput={(params) => <TextField {...params} label="Audio" />}
+      />
       {/* TABS */}
       <Tabs value={value} onChange={handleChange} aria-label="tabs example">
         <Tab label="Description" {...tabA11yProps('description', 0)} />
@@ -127,21 +144,6 @@ const Template: Story<ComponentProps<typeof Button>> = (args) => {
       <TabPanel name="discussion" value={value} index={1}>
         Discussion
       </TabPanel>
-      {/* DIALOG */}
-      {/* TODO: Move Dialog to shared-ui */}
-      {/* <FormControl>
-        <InputLabel htmlFor="search">Keyword, Country or Language</InputLabel>
-        <FilledInput
-          id="search"
-          endAdornment={
-            <InputAdornment position="end">
-              <IconButton>
-                <SearchIcon />
-              </IconButton>
-            </InputAdornment>
-          }
-        />
-      </FormControl> */}
     </Stack>
   )
 }

--- a/libs/shared/ui/src/libs/themes/website/tokens/components.tsx
+++ b/libs/shared/ui/src/libs/themes/website/tokens/components.tsx
@@ -68,6 +68,11 @@ export const websiteComponents: Required<Pick<ThemeOptions, 'components'>> = {
         IconComponent: KeyboardArrowDownIcon
       }
     },
+    MuiAutocomplete: {
+      defaultProps: {
+        popupIcon: <KeyboardArrowDownIcon />
+      }
+    },
     MuiTabs: {
       styleOverrides: {
         root: {

--- a/libs/shared/ui/src/libs/themes/website/tokens/components.tsx
+++ b/libs/shared/ui/src/libs/themes/website/tokens/components.tsx
@@ -63,6 +63,31 @@ export const websiteComponents: Required<Pick<ThemeOptions, 'components'>> = {
         }
       ]
     },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        notchedOutline: {
+          top: 0,
+          '> legend': {
+            display: 'none'
+          }
+        },
+        input: {
+          ':not([readonly])': {
+            transform: `translate(0px, 9px) scale(1)`,
+            transition: `color 200ms cubic-bezier(0.0,0,0.2,1) 0ms,transform 200ms cubic-bezier(0.0,0,0.2,1) 0ms,max-width 200ms cubic-bezier(0.0,0,0.2,1) 0ms`
+          }
+        }
+      }
+    },
+    MuiInputLabel: {
+      styleOverrides: {
+        outlined: {
+          '&.MuiInputLabel-shrink': {
+            transform: `translate(14px, 9px) scale(0.75)`
+          }
+        }
+      }
+    },
     MuiSelect: {
       defaultProps: {
         IconComponent: KeyboardArrowDownIcon


### PR DESCRIPTION
# Description

Styling the default MuiAutocomplete and TextFields so they display like the designs

Default MuiAutocomplete
<img width="340" alt="image" src="https://user-images.githubusercontent.com/10802634/203866159-2823a844-950b-43f5-ad61-7e4d2f035aa7.png">
<img width="348" alt="image" src="https://user-images.githubusercontent.com/10802634/203866190-859e4251-74aa-4826-8c0a-ef0198fd3387.png">

Designs
<img width="375" alt="image" src="https://user-images.githubusercontent.com/10802634/203866021-a09c4473-5403-4210-b8fc-43c4cccef0ae.png">
<img width="375" alt="image" src="https://user-images.githubusercontent.com/10802634/203866069-31d47c51-010f-46f6-a23d-e6722952aab9.png">
<img width="700" alt="image" src="https://user-images.githubusercontent.com/10802634/203866112-b7b57c57-4af0-4f04-82d6-359667ba48bb.png">

[Basecamp Todo](https://3.basecamp.com/3105655/buckets/30317529/todos/5570931464)
# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Components are approved by UX
- [ ] TextField values shift downwards to make space for label
- [ ] Read only text fields not expected to have labels, values are centered
- [ ] Checks are green

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
