### PR TITLE
fix: share dialog content

### DIFF
--- a/apps/watch/src/components/ShareDialog/ShareDialog.tsx
+++ b/apps/watch/src/components/ShareDialog/ShareDialog.tsx
@@ -154,12 +154,7 @@ export function ShareDialog({
             <Typography variant="subtitle2" sx={{ mb: 1 }}>
               {video.title[0].value}
             </Typography>
-            <Typography>
-              {`${video.description[0].value
-                .split(' ')
-                .slice(0, 18)
-                .join(' ')}...`}
-            </Typography>
+            <Typography>{video.snippet[0].value}</Typography>
           </Stack>
         </Stack>
         <>


### PR DESCRIPTION
# Description

Updated the share dialog to display the snippet instead of the description with ellipses.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/30300130/todos/5570693924)

# How should this PR be QA Tested?

**Requirements:**

Click on a video and click the share button.

- [ ] it should show the description without the ellipses

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
