### PR TITLE
fix: breakpoints on sm

### DIFF
--- a/libs/shared/ui/src/libs/themes/base/theme.stories.tsx
+++ b/libs/shared/ui/src/libs/themes/base/theme.stories.tsx
@@ -24,7 +24,7 @@ const ThemeDemo = {
   title: 'Default Theme',
   parameters: {
     ...simpleComponentConfig.parameters,
-    theme: 'dark'
+    theme: 'all'
   }
 }
 
@@ -185,9 +185,6 @@ Colors.args = {
   mainColor: ['light', 'main', 'dark'],
   overrideColors: ['primary', 'secondary', 'error']
 }
-Colors.parameters = {
-  theme: 'all'
-}
 
 // Make sure this is consistent with palette in colors.ts
 const palette: Record<string, string> = {
@@ -292,8 +289,8 @@ const ViewportTemplate: Story<ThemeStoryProps> = (args) => {
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'center',
-        height: '600px',
-        m: '20%'
+        height: '100%',
+        px: '20%'
       }}
     >
       <Typography
@@ -410,7 +407,8 @@ Viewport.parameters = {
       breakpoints.values.xxl - 1,
       breakpoints.values.xxl
     ]
-  }
+  },
+  theme: 'dark'
 }
 
 const StyledButton = styled(Button)(({ theme }) => ({

--- a/libs/shared/ui/src/libs/themes/base/tokens/breakpoints.ts
+++ b/libs/shared/ui/src/libs/themes/base/tokens/breakpoints.ts
@@ -67,7 +67,7 @@ const only = (key: Breakpoint): string => {
   // Use max-height over orientation for storybook / chromatic checks
   const overlappingMobileCheck =
     key === 'sm'
-      ? `(min-width: ${minWidths.md}px) and (max-width: 961px) and (max-height: ${minHeights.md}px), `
+      ? `(min-width: ${minWidths.md}px) and (max-width: 9999px) and (max-height: ${minHeights.md}px), `
       : ''
 
   return `@media ${overlappingMobileCheck}${defaultBreakpointCheck}`


### PR DESCRIPTION
# Description

Really wide screens with height < 600px render as `sm`

Adding this fix now since it affects watch page layout.

# How should this PR be QA Tested?

- [x] We no longer get this issue in storybook
<img width="1727" alt="image" src="https://user-images.githubusercontent.com/10802634/204909000-58f3bba8-7583-411f-903b-f66e32be9fae.png">

Now looks like 
<img width="1727" alt="image" src="https://user-images.githubusercontent.com/10802634/204909057-6a6594d9-c9f4-4674-a3cf-11e67f19ea00.png">

- [x] Green checks

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
