### PR TITLE
fix: icon in shared dialog

### DIFF
--- a/libs/shared/ui/src/components/Dialog/Dialog.spec.tsx
+++ b/libs/shared/ui/src/components/Dialog/Dialog.spec.tsx
@@ -20,7 +20,9 @@ describe('Dialog', () => {
     children: <Typography>Children</Typography>
   }
   it('should display the content', () => {
-    const { getByText, getByRole, getByTestId } = render(<Dialog {...dialogProps} />)
+    const { getByText, getByRole, getByTestId } = render(
+      <Dialog {...dialogProps} />
+    )
     expect(getByTestId('LanguageIcon')).toBeInTheDocument()
     expect(getByText('Title')).toBeInTheDocument()
     expect(getByText('Children')).toBeInTheDocument()

--- a/libs/shared/ui/src/components/Dialog/Dialog.spec.tsx
+++ b/libs/shared/ui/src/components/Dialog/Dialog.spec.tsx
@@ -1,5 +1,6 @@
 import { ComponentProps } from 'react'
 import Typography from '@mui/material/Typography'
+import Language from '@mui/icons-material/Language'
 import { fireEvent } from '@storybook/testing-library'
 import { render } from '@testing-library/react'
 import { Dialog } from './Dialog'
@@ -9,6 +10,7 @@ describe('Dialog', () => {
     open: true,
     onClose: jest.fn(),
     dialogTitle: {
+      icon: <Language />,
       title: 'Title',
       closeButton: true
     },
@@ -18,7 +20,8 @@ describe('Dialog', () => {
     children: <Typography>Children</Typography>
   }
   it('should display the content', () => {
-    const { getByText, getByRole } = render(<Dialog {...dialogProps} />)
+    const { getByText, getByRole, getByTestId } = render(<Dialog {...dialogProps} />)
+    expect(getByTestId('LanguageIcon')).toBeInTheDocument()
     expect(getByText('Title')).toBeInTheDocument()
     expect(getByText('Children')).toBeInTheDocument()
     expect(getByRole('button', { name: 'Save' })).toBeInTheDocument()

--- a/libs/shared/ui/src/components/Dialog/Dialog.stories.tsx
+++ b/libs/shared/ui/src/components/Dialog/Dialog.stories.tsx
@@ -7,6 +7,7 @@ import MuiListItem from '@mui/material/ListItem'
 import ListItemAvatar from '@mui/material/ListItemAvatar'
 import Skeleton from '@mui/material/Skeleton'
 import ListItemText from '@mui/material/ListItemText'
+import Language from '@mui/icons-material/Language'
 import { sharedUiConfig } from '../../libs/sharedUiConfig'
 import { Dialog } from './Dialog'
 
@@ -32,6 +33,14 @@ Basic.args = {
     onSubmit: noop,
     submitLabel: 'Ok'
   },
+  children: <Typography>This is the content</Typography>
+}
+
+export const IconTitle = Template.bind({})
+IconTitle.args = {
+  open: true,
+  onClose: noop,
+  dialogTitle: { icon: <Language sx={{ mr: 3 }} />, title: 'Simple Dialog' },
   children: <Typography>This is the content</Typography>
 }
 

--- a/libs/shared/ui/src/components/Dialog/Dialog.tsx
+++ b/libs/shared/ui/src/components/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react'
+import { ReactElement, ReactNode } from 'react'
 import { styled } from '@mui/material/styles'
 import MuiDialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
@@ -25,6 +25,7 @@ interface DialogAction {
 }
 
 interface DialogTitle {
+  icon?: ReactNode
   title: string
   closeButton?: boolean
 }
@@ -81,6 +82,7 @@ export function Dialog({
     >
       {dialogTitle != null && (
         <MuiDialogTitle>
+          {dialogTitle.icon != null && dialogTitle.icon}
           {dialogTitle.title}
           {dialogTitle.closeButton != null && dialogTitle.closeButton && (
             <IconButton


### PR DESCRIPTION
# Description

Added the ability to add icon in shared dialog

- Link to Basecamp Todo

# How should this PR be QA Tested?

**Requirements**
Visit [Storybook](https://612c2a83fdc2b2003a5c2eb7-egaratpisu.chromatic.com/?path=/story/shared-ui-dialog--icon-title)

- [ ] it should render an Icon before the Title

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
