### PR TITLE
fix: oom children search

### DIFF
--- a/apps/api-videos/src/app/modules/video/video.service.spec.ts
+++ b/apps/api-videos/src/app/modules/video/video.service.spec.ts
@@ -37,7 +37,7 @@ const DEFAULT_QUERY = aql`
     `.query
 
 const VIDEO_EPISODES_QUERY = aql`
-    FOR item IN 
+    FOR item IN undefined
       FILTER item._key IN @value0
       RETURN {
         _key: item._key,

--- a/apps/api-videos/src/app/modules/video/video.service.ts
+++ b/apps/api-videos/src/app/modules/video/video.service.ts
@@ -211,9 +211,8 @@ export class VideoService extends BaseService {
     keys: string[],
     variantLanguageId?: string
   ): Promise<T[]> {
-    const videosView = this.db.view('videosView')
     const res = await this.db.query(aql`
-    FOR item IN ${videosView}
+    FOR item IN ${this.collection}
       FILTER item._key IN ${keys}
       RETURN {
         _key: item._key,


### PR DESCRIPTION
# Description

This PR addresses the out of memory issue when searching for large sets of child data in videos

# How should this PR be QA Tested?

- [x] children no longer cause oom memory issues

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
