### PR TITLE
feat: create video context

### DIFF
--- a/apps/watch/pages/[part1]/[part2].tsx
+++ b/apps/watch/pages/[part1]/[part2].tsx
@@ -7,6 +7,7 @@ import { createApolloClient } from '../../src/libs/client'
 import { VideoContentPage } from '../../src/components/VideoContentPage'
 import { VideoContainerPage } from '../../src/components/VideoContainerPage/VideoContainerPage'
 import { LanguageProvider } from '../../src/libs/languageContext/LanguageContext'
+import { VideoProvider } from '../../src/libs/videoContext'
 import { VIDEO_CONTENT_FIELDS } from '../../src/libs/videoContentFields'
 
 export const GET_VIDEO_CONTENT = gql`
@@ -25,11 +26,13 @@ interface Part2PageProps {
 export default function Part2Page({ content }: Part2PageProps): ReactElement {
   return (
     <LanguageProvider>
-      {content.variant?.hls != null ? (
-        <VideoContentPage content={content} />
-      ) : (
-        <VideoContainerPage content={content} />
-      )}
+      <VideoProvider value={{ content }}>
+        {content.variant?.hls != null ? (
+          <VideoContentPage />
+        ) : (
+          <VideoContainerPage content={content} />
+        )}
+      </VideoProvider>
     </LanguageProvider>
   )
 }

--- a/apps/watch/pages/[part1]/[part2]/[part3].tsx
+++ b/apps/watch/pages/[part1]/[part2]/[part3].tsx
@@ -6,6 +6,7 @@ import { VideoContentPage } from '../../../src/components/VideoContentPage'
 import { createApolloClient } from '../../../src/libs/client'
 import { GetVideoContainerAndVideoContent } from '../../../__generated__/GetVideoContainerAndVideoContent'
 import { LanguageProvider } from '../../../src/libs/languageContext/LanguageContext'
+import { VideoProvider } from '../../../src/libs/videoContext'
 import { VIDEO_CONTENT_FIELDS } from '../../../src/libs/videoContentFields'
 
 export const GET_VIDEO_CONTAINER_AND_VIDEO_CONTENT = gql`
@@ -35,7 +36,9 @@ export default function Part3Page({
 }: Part3PageProps): ReactElement {
   return (
     <LanguageProvider>
-      <VideoContentPage container={container} content={content} />
+      <VideoProvider value={{ content, container }}>
+        <VideoContentPage />
+      </VideoProvider>
     </LanguageProvider>
   )
 }

--- a/apps/watch/src/components/Hero/VideoHero/VideoHero.tsx
+++ b/apps/watch/src/components/Hero/VideoHero/VideoHero.tsx
@@ -10,15 +10,15 @@ import PlayArrow from '@mui/icons-material/PlayArrow'
 import AccessTime from '@mui/icons-material/AccessTime'
 import Circle from '@mui/icons-material/Circle'
 import videojs from 'video.js'
-import { VideoContentFields } from '../../../../__generated__/VideoContentFields'
 import 'video.js/dist/video-js.css'
+import { useVideo } from '../../../libs/videoContext'
 
 interface VideoHeroProps {
   loading?: boolean
-  video: VideoContentFields
 }
 
-export function VideoHero({ loading, video }: VideoHeroProps): ReactElement {
+export function VideoHero({ loading }: VideoHeroProps): ReactElement {
+  const { variant, title, image, children } = useVideo()
   const videoRef = useRef<HTMLVideoElement>(null)
   const playerRef = useRef<videojs.Player>()
   const [isPlaying, setIsPlaying] = useState(false)
@@ -46,7 +46,7 @@ export function VideoHero({ loading, video }: VideoHeroProps): ReactElement {
           }
         },
         responsive: true,
-        poster: video?.image ?? undefined
+        poster: image ?? undefined
       })
       playerRef.current.on('pause', pauseVideo)
       playerRef.current.on('play', playVideo)
@@ -68,13 +68,13 @@ export function VideoHero({ loading, video }: VideoHeroProps): ReactElement {
       <>
         <Box
           sx={{
-            backgroundImage: `url(${video.image as string})`,
+            backgroundImage: `url(${image as string})`,
             backgroundSize: 'cover',
             backgroundPosition: 'center',
             height: 776
           }}
         >
-          {video.variant?.hls != null && (
+          {variant?.hls != null && (
             <video
               ref={videoRef}
               className="vjs-jfp video-js vjs-fill"
@@ -83,7 +83,7 @@ export function VideoHero({ loading, video }: VideoHeroProps): ReactElement {
               }}
               playsInline
             >
-              <source src={video.variant.hls} type="application/x-mpegURL" />
+              <source src={variant.hls} type="application/x-mpegURL" />
             </video>
           )}
           {!isPlaying && (
@@ -105,7 +105,7 @@ export function VideoHero({ loading, video }: VideoHeroProps): ReactElement {
                     color: 'text.primary'
                   }}
                 >
-                  {video.title[0]?.value}
+                  {title[0]?.value}
                 </Typography>
               </Container>
               <Box
@@ -123,12 +123,12 @@ export function VideoHero({ loading, video }: VideoHeroProps): ReactElement {
                   sx={{ color: 'text.primary' }}
                 >
                   <Stack direction="row" spacing="20px">
-                    {video.children.length > 0 && (
+                    {children.length > 0 && (
                       <Typography variant="subtitle1">
-                        {video.children.length} episodes
+                        {children.length} episodes
                       </Typography>
                     )}
-                    {video.children.length === 0 && (
+                    {children.length === 0 && (
                       <>
                         <Button
                           size="large"
@@ -139,14 +139,14 @@ export function VideoHero({ loading, video }: VideoHeroProps): ReactElement {
                           <PlayArrow />
                           &nbsp; Play Video
                         </Button>
-                        {video.variant !== null && (
+                        {variant !== null && (
                           <Stack height="71px" direction="row">
                             <AccessTime sx={{ paddingTop: '23px' }} />
                             <Typography
                               variant="body2"
                               sx={{ lineHeight: '71px', paddingLeft: '10px' }}
                             >
-                              {secondsToMinutes(video.variant.duration)} min
+                              {secondsToMinutes(variant.duration)} min
                             </Typography>
                           </Stack>
                         )}

--- a/apps/watch/src/components/ShareDialog/ShareDialog.spec.tsx
+++ b/apps/watch/src/components/ShareDialog/ShareDialog.spec.tsx
@@ -4,6 +4,7 @@ import {
   VideoContentFields,
   VideoContentFields_children
 } from '../../../__generated__/VideoContentFields'
+import { VideoProvider } from '../../libs/videoContext'
 
 import { videos } from '../Videos/testData'
 import { ShareDialog } from './ShareDialog'
@@ -51,7 +52,9 @@ describe('ShareDialog', () => {
   it('closes the modal on cancel icon click', () => {
     const { getByTestId } = render(
       <SnackbarProvider>
-        <ShareDialog video={video} open routes={routes} onClose={onClose} />
+        <VideoProvider value={{ content: video }}>
+          <ShareDialog open routes={routes} onClose={onClose} />
+        </VideoProvider>
       </SnackbarProvider>
     )
     fireEvent.click(getByTestId('dialog-close-button'))
@@ -61,15 +64,18 @@ describe('ShareDialog', () => {
   it('only shows share link on playlist video', () => {
     const { getByRole, queryAllByRole } = render(
       <SnackbarProvider>
-        <ShareDialog
-          video={{
-            ...video,
-            children: [{ id: '1' }] as unknown as VideoContentFields_children[]
+        <VideoProvider
+          value={{
+            content: {
+              ...video,
+              children: [
+                { id: '1' }
+              ] as unknown as VideoContentFields_children[]
+            }
           }}
-          routes={routes}
-          open
-          onClose={onClose}
-        />
+        >
+          <ShareDialog routes={routes} open onClose={onClose} />
+        </VideoProvider>
       </SnackbarProvider>
     )
 
@@ -100,7 +106,9 @@ describe('ShareDialog', () => {
 
       const { getByRole } = render(
         <SnackbarProvider>
-          <ShareDialog video={video} routes={routes} open onClose={onClose} />
+          <VideoProvider value={{ content: video }}>
+            <ShareDialog routes={routes} open onClose={onClose} />
+          </VideoProvider>
         </SnackbarProvider>
       )
 
@@ -121,7 +129,9 @@ describe('ShareDialog', () => {
 
       const { getByRole } = render(
         <SnackbarProvider>
-          <ShareDialog video={video} routes={routes} open onClose={onClose} />
+          <VideoProvider value={{ content: video }}>
+            <ShareDialog routes={routes} open onClose={onClose} />
+          </VideoProvider>
         </SnackbarProvider>
       )
 
@@ -153,7 +163,9 @@ describe('ShareDialog', () => {
 
       const { getByRole } = render(
         <SnackbarProvider>
-          <ShareDialog video={video} routes={routes} open onClose={onClose} />
+          <VideoProvider value={{ content: video }}>
+            <ShareDialog routes={routes} open onClose={onClose} />
+          </VideoProvider>
         </SnackbarProvider>
       )
 
@@ -172,7 +184,9 @@ describe('ShareDialog', () => {
 
       const { getByRole } = render(
         <SnackbarProvider>
-          <ShareDialog video={video} routes={routes} open onClose={onClose} />
+          <VideoProvider value={{ content: video }}>
+            <ShareDialog routes={routes} open onClose={onClose} />
+          </VideoProvider>
         </SnackbarProvider>
       )
 
@@ -214,7 +228,9 @@ describe('ShareDialog', () => {
         'https://watch-jesusfilm.vercel.app/the-story-of-jesus-for-children'
       const { getByRole, getByText } = render(
         <SnackbarProvider>
-          <ShareDialog video={video} routes={routes} open onClose={onClose} />
+          <VideoProvider value={{ content: video }}>
+            <ShareDialog routes={routes} open onClose={onClose} />
+          </VideoProvider>
         </SnackbarProvider>
       )
       expect(getByRole('textbox')).toHaveValue(link)
@@ -232,7 +248,9 @@ describe('ShareDialog', () => {
 
       const { getByRole, getByText } = render(
         <SnackbarProvider>
-          <ShareDialog video={video} routes={routes} open onClose={onClose} />
+          <VideoProvider value={{ content: video }}>
+            <ShareDialog routes={routes} open onClose={onClose} />
+          </VideoProvider>
         </SnackbarProvider>
       )
 

--- a/apps/watch/src/components/ShareDialog/ShareDialog.stories.tsx
+++ b/apps/watch/src/components/ShareDialog/ShareDialog.stories.tsx
@@ -7,6 +7,7 @@ import {
   VideoContentFields_children
 } from '../../../__generated__/VideoContentFields'
 import { watchConfig } from '../../libs/storybook'
+import { VideoProvider } from '../../libs/videoContext'
 import { videos } from '../Videos/testData'
 import { ShareDialog } from './ShareDialog'
 
@@ -45,8 +46,14 @@ const video: VideoContentFields = {
 
 const routes = ['the-story-of-jesus-for-children']
 
-const Template: Story<ComponentProps<typeof ShareDialog>> = ({ ...args }) => {
-  return <ShareDialog {...args} />
+const Template: Story<
+  ComponentProps<typeof ShareDialog> & { video: VideoContentFields }
+> = ({ ...args }) => {
+  return (
+    <VideoProvider value={{ content: args.video }}>
+      <ShareDialog {...args} />
+    </VideoProvider>
+  )
 }
 
 export const Basic = Template.bind({})

--- a/apps/watch/src/components/ShareDialog/ShareDialog.tsx
+++ b/apps/watch/src/components/ShareDialog/ShareDialog.tsx
@@ -14,20 +14,19 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import { createSvgIcon } from '@mui/material/utils'
 import { useTheme } from '@mui/material/styles'
 import { TabPanel, tabA11yProps } from '@core/shared/ui/TabPanel'
-import { VideoContentFields } from '../../../__generated__/VideoContentFields'
+import { useVideo } from '../../libs/videoContext'
 
 interface ShareDialogProps
   extends Pick<ComponentProps<typeof Dialog>, 'open' | 'onClose'> {
-  video: VideoContentFields
   routes: string[]
 }
 
 export function ShareDialog({
-  video,
   routes,
   ...dialogProps
 }: ShareDialogProps): ReactElement {
   const { enqueueSnackbar } = useSnackbar()
+  const { description, snippet, id, image, title, children } = useVideo()
   const [value, setValue] = useState(0)
   const theme = useTheme()
 
@@ -36,10 +35,10 @@ export function ShareDialog({
   }
 
   const shareDescription =
-    video.description != null && video.description.length > 0
-      ? video.description[0].value
-      : video.snippet != null && video.snippet.length > 0
-      ? video.snippet[0].value
+    description != null && description.length > 0
+      ? description[0].value
+      : snippet != null && snippet.length > 0
+      ? snippet[0].value
       : ''
 
   const shareLink =
@@ -59,9 +58,7 @@ export function ShareDialog({
   }
 
   const getRefId = (): string =>
-    video.id.split('_').length === 1
-      ? `529-${video.id}`
-      : video.id.replace('_', '_529-')
+    id.split('_').length === 1 ? `529-${id}` : id.replace('_', '_529-')
 
   const getEmbedCode = (): string =>
     `<div class="arc-cont"><iframe src="https://api.arclight.org/videoPlayerUrl?refId=${getRefId()}&playerStyle=default" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe><style>.arc-cont{position:relative;display:block;margin:10px auto;width:100%}.arc-cont:after{padding-top:59%;display:block;content:""}.arc-cont>iframe{position:absolute;top:0;bottom:0;right:0;left:0;width:98%;height:98%;border:0}</style></div>`
@@ -143,11 +140,11 @@ export function ShareDialog({
           alignItems="flex-start"
           sx={{ mb: 4 }}
         >
-          {video.image != null && (
+          {image != null && (
             <Box sx={{ display: { xs: 'none', sm: 'flex' } }}>
               <Image
-                src={video.image}
-                alt={video.title[0].value}
+                src={image}
+                alt={title[0].value}
                 width={240}
                 height={115}
                 objectFit="cover"
@@ -157,7 +154,7 @@ export function ShareDialog({
           )}
           <Stack sx={{ maxWidth: { sm: '272px' } }}>
             <Typography variant="subtitle2" sx={{ mb: 1 }}>
-              {video.title[0].value}
+              {title[0].value}
             </Typography>
             <Typography>
               {`${shareDescription.split(' ').slice(0, 18).join(' ')}...`}
@@ -183,7 +180,7 @@ export function ShareDialog({
               <TwitterIcon sx={{ fontSize: 46 }} />
             </IconButton>
           </Stack>
-          {video.children.length > 0 ? (
+          {children.length > 0 ? (
             <ShareLink />
           ) : (
             <>

--- a/apps/watch/src/components/VideoContainerPage/VideoContainerPage.spec.tsx
+++ b/apps/watch/src/components/VideoContainerPage/VideoContainerPage.spec.tsx
@@ -5,6 +5,7 @@ import {
   VideoContentFields,
   VideoContentFields_children
 } from '../../../__generated__/VideoContentFields'
+import { VideoProvider } from '../../libs/videoContext'
 import { VideoContainerPage } from '.'
 
 const video = {
@@ -24,7 +25,9 @@ describe('VideoContainerPage', () => {
   it('should render ContainerHero', () => {
     const { getByText } = render(
       <SnackbarProvider>
-        <VideoContainerPage content={video} />
+        <VideoProvider value={{ content: video }}>
+          <VideoContainerPage content={video} />
+        </VideoProvider>
       </SnackbarProvider>
     )
     expect(getByText('video title')).toBeInTheDocument()
@@ -33,7 +36,9 @@ describe('VideoContainerPage', () => {
   it('should render snippet', () => {
     const { getByText } = render(
       <SnackbarProvider>
-        <VideoContainerPage content={video} />
+        <VideoProvider value={{ content: video }}>
+          <VideoContainerPage content={video} />
+        </VideoProvider>
       </SnackbarProvider>
     )
     expect(getByText('video description')).toBeInTheDocument()
@@ -42,7 +47,9 @@ describe('VideoContainerPage', () => {
   it('should render share button', () => {
     const { getByRole } = render(
       <SnackbarProvider>
-        <VideoContainerPage content={video} />
+        <VideoProvider value={{ content: video }}>
+          <VideoContainerPage content={video} />
+        </VideoProvider>
       </SnackbarProvider>
     )
     expect(getByRole('button', { name: 'Share' })).toBeInTheDocument()
@@ -55,7 +62,9 @@ describe('VideoContainerPage', () => {
   xit('should render videos', () => {
     const { getByTestId } = render(
       <SnackbarProvider>
-        <VideoContainerPage content={video} />
+        <VideoProvider value={{ content: video }}>
+          <VideoContainerPage content={video} />
+        </VideoProvider>
       </SnackbarProvider>
     )
 

--- a/apps/watch/src/components/VideoContainerPage/VideoContainerPage.stories.tsx
+++ b/apps/watch/src/components/VideoContainerPage/VideoContainerPage.stories.tsx
@@ -1,6 +1,7 @@
 import { ComponentProps } from 'react'
 import { Story, Meta } from '@storybook/react'
 import { watchConfig } from '../../libs/storybook'
+import { VideoProvider } from '../../libs/videoContext'
 import { videos } from '../Videos/testData'
 import { VideoContainerPage } from '.'
 
@@ -16,7 +17,11 @@ const VideoContainerPageStory = {
 
 const Template: Story<ComponentProps<typeof VideoContainerPage>> = ({
   ...args
-}) => <VideoContainerPage {...args} />
+}) => (
+  <VideoProvider value={{ content: videos[0] }}>
+    <VideoContainerPage {...args} />
+  </VideoProvider>
+)
 
 export const Default = Template.bind({})
 Default.args = {

--- a/apps/watch/src/components/VideoContainerPage/VideoContainerPage.tsx
+++ b/apps/watch/src/components/VideoContainerPage/VideoContainerPage.tsx
@@ -48,7 +48,6 @@ export function VideoContainerPage({
           </Stack>
           <ShareDialog
             open={openShare}
-            video={content}
             routes={[]}
             onClose={() => setOpenShare(false)}
           />

--- a/apps/watch/src/components/VideoContentPage/VideoContentPage.spec.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoContentPage.spec.tsx
@@ -5,6 +5,7 @@ import {
   VideoContentFields,
   VideoContentFields_children
 } from '../../../__generated__/VideoContentFields'
+import { VideoProvider } from '../../libs/videoContext'
 import { VideoContentPage } from '.'
 
 const video = {
@@ -29,7 +30,9 @@ describe('VideoContentPage', () => {
   it('should render VideoHero', () => {
     const { getAllByRole } = render(
       <SnackbarProvider>
-        <VideoContentPage content={video} />
+        <VideoProvider value={{ content: video }}>
+          <VideoContentPage />
+        </VideoProvider>
       </SnackbarProvider>
     )
 
@@ -39,7 +42,9 @@ describe('VideoContentPage', () => {
   it('should render description', () => {
     const { getByText } = render(
       <SnackbarProvider>
-        <VideoContentPage content={video} />
+        <VideoProvider value={{ content: video }}>
+          <VideoContentPage />
+        </VideoProvider>
       </SnackbarProvider>
     )
     expect(getByText('video description')).toBeInTheDocument()
@@ -48,7 +53,9 @@ describe('VideoContentPage', () => {
   it('should render related videos', () => {
     const { getByTestId } = render(
       <SnackbarProvider>
-        <VideoContentPage content={video} />
+        <VideoProvider value={{ content: video }}>
+          <VideoContentPage />
+        </VideoProvider>
       </SnackbarProvider>
     )
 
@@ -58,7 +65,9 @@ describe('VideoContentPage', () => {
   it('should render share button', () => {
     const { getByRole } = render(
       <SnackbarProvider>
-        <VideoContentPage content={video} />
+        <VideoProvider value={{ content: video }}>
+          <VideoContentPage />
+        </VideoProvider>
       </SnackbarProvider>
     )
     expect(getByRole('button', { name: 'Share' })).toBeInTheDocument()

--- a/apps/watch/src/components/VideoContentPage/VideoContentPage.stories.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoContentPage.stories.tsx
@@ -1,6 +1,7 @@
 import { ComponentProps } from 'react'
 import { Story, Meta } from '@storybook/react'
 import { watchConfig } from '../../libs/storybook'
+import { VideoProvider } from '../../libs/videoContext'
 import { videos } from '../Videos/testData'
 import { VideoContentPage } from '.'
 
@@ -16,11 +17,12 @@ const VideoContentPageStory = {
 
 const Template: Story<ComponentProps<typeof VideoContentPage>> = ({
   ...args
-}) => <VideoContentPage {...args} />
+}) => (
+  <VideoProvider value={{ content: videos[0] }}>
+    <VideoContentPage {...args} />
+  </VideoProvider>
+)
 
 export const Default = Template.bind({})
-Default.args = {
-  content: videos[0]
-}
 
 export default VideoContentPageStory as Meta

--- a/apps/watch/src/components/VideoContentPage/VideoContentPage.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoContentPage.tsx
@@ -14,7 +14,6 @@ import { ThemeProvider } from '@core/shared/ui/ThemeProvider'
 import { ThemeMode, ThemeName } from '@core/shared/ui/themes'
 import 'video.js/dist/video-js.css'
 
-import { LanguageProvider } from '../../libs/languageContext/LanguageContext'
 import { VideoHero } from '../Hero'
 import { PageWrapper } from '../PageWrapper'
 import { VideosCarousel } from '../Videos/VideosCarousel/VideosCarousel'
@@ -31,86 +30,82 @@ export function VideoContentPage(): ReactElement {
   }
 
   return (
-    <LanguageProvider>
-      <PageWrapper hero={<VideoHero />}>
-        <>
-          <ThemeProvider
-            themeName={ThemeName.website}
-            themeMode={ThemeMode.dark}
-            nested
+    <PageWrapper hero={<VideoHero />}>
+      <>
+        <ThemeProvider
+          themeName={ThemeName.website}
+          themeMode={ThemeMode.dark}
+          nested
+        >
+          <Paper elevation={0} square sx={{ pt: '20px' }}>
+            <Container maxWidth="xxl">
+              {/* TODO: combine content and container children? */}
+              {children.length > 0 && (
+                <VideosCarousel
+                  videos={children}
+                  routePrefix={slug}
+                  routeSuffix={variant?.slug.split('/')[1]}
+                />
+              )}
+              {container != null && container.children.length > 0 && (
+                <VideosCarousel
+                  videos={container.children}
+                  routePrefix={container.slug}
+                  routeSuffix={container.variant?.slug.split('/')[1]}
+                />
+              )}
+            </Container>
+          </Paper>
+        </ThemeProvider>
+        <Container maxWidth="xxl">
+          <Stack
+            direction="row"
+            spacing="100px"
+            sx={{
+              mx: 0,
+              mt: 20,
+              mb: 80,
+              maxWidth: '100%'
+            }}
           >
-            <Paper elevation={0} square sx={{ pt: '20px' }}>
-              <Container maxWidth="xxl">
-                {/* TODO: combine content and container children? */}
-                {children.length > 0 && (
-                  <VideosCarousel
-                    videos={children}
-                    routePrefix={slug}
-                    routeSuffix={variant?.slug.split('/')[1]}
-                  />
-                )}
-                {container != null && container.children.length > 0 && (
-                  <VideosCarousel
-                    videos={container.children}
-                    routePrefix={container.slug}
-                    routeSuffix={container.variant?.slug.split('/')[1]}
-                  />
-                )}
-              </Container>
-            </Paper>
-          </ThemeProvider>
-          <Container maxWidth="xxl">
-            <Stack
-              direction="row"
-              spacing="100px"
-              sx={{
-                mx: 0,
-                mt: 20,
-                mb: 80,
-                maxWidth: '100%'
-              }}
-            >
-              <Box width="100%">
-                <Tabs
-                  value={tabValue}
-                  onChange={handleTabChange}
-                  aria-label="background tabs"
-                  variant="fullWidth"
-                  centered
-                  sx={{ marginBottom: '40px' }}
-                >
-                  <Tab
-                    label="Description"
-                    {...tabA11yProps('video-description', 0)}
-                  />
-                </Tabs>
-                <TabPanel name="video-description" value={tabValue} index={0}>
-                  <Typography variant="body1">
-                    {description[0]?.value}
-                  </Typography>
-                </TabPanel>
-              </Box>
-              <Box width="336px">
-                <Stack direction="row" spacing="20px" mb="40px">
-                  <Button variant="outlined">
-                    <SaveAlt />
-                    &nbsp; Download
-                  </Button>
-                  <Button variant="outlined" onClick={() => setOpenShare(true)}>
-                    <Share />
-                    &nbsp; Share
-                  </Button>
-                </Stack>
-              </Box>
-            </Stack>
-            <ShareDialog
-              open={openShare}
-              routes={[]}
-              onClose={() => setOpenShare(false)}
-            />
-          </Container>
-        </>
-      </PageWrapper>
-    </LanguageProvider>
+            <Box width="100%">
+              <Tabs
+                value={tabValue}
+                onChange={handleTabChange}
+                aria-label="background tabs"
+                variant="fullWidth"
+                centered
+                sx={{ marginBottom: '40px' }}
+              >
+                <Tab
+                  label="Description"
+                  {...tabA11yProps('video-description', 0)}
+                />
+              </Tabs>
+              <TabPanel name="video-description" value={tabValue} index={0}>
+                <Typography variant="body1">{description[0]?.value}</Typography>
+              </TabPanel>
+            </Box>
+            <Box width="336px">
+              <Stack direction="row" spacing="20px" mb="40px">
+                <Button variant="outlined">
+                  <SaveAlt />
+                  &nbsp; Download
+                </Button>
+                <Button variant="outlined" onClick={() => setOpenShare(true)}>
+                  <Share />
+                  &nbsp; Share
+                </Button>
+              </Stack>
+            </Box>
+          </Stack>
+          <ShareDialog
+            open={openShare}
+            routes={[]}
+            onClose={() => setOpenShare(false)}
+          />
+        </Container>
+      </>
+    </PageWrapper>
   )
 }

--- a/apps/watch/src/components/VideoContentPage/VideoContentPage.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoContentPage.tsx
@@ -14,23 +14,16 @@ import { ThemeProvider } from '@core/shared/ui/ThemeProvider'
 import { ThemeMode, ThemeName } from '@core/shared/ui/themes'
 import 'video.js/dist/video-js.css'
 
-import { VideoContentFields } from '../../../__generated__/VideoContentFields'
 import { LanguageProvider } from '../../libs/languageContext/LanguageContext'
 import { VideoHero } from '../Hero'
 import { PageWrapper } from '../PageWrapper'
 import { VideosCarousel } from '../Videos/VideosCarousel/VideosCarousel'
 import { ShareDialog } from '../ShareDialog'
-
-interface VideoContentPageProps {
-  container?: VideoContentFields
-  content: VideoContentFields
-}
+import { useVideo } from '../../libs/videoContext'
 
 // Usually FeatureFilm, ShortFilm, Episode or Segment Videos
-export function VideoContentPage({
-  container,
-  content
-}: VideoContentPageProps): ReactElement {
+export function VideoContentPage(): ReactElement {
+  const { container, children, slug, variant, description } = useVideo()
   const [tabValue, setTabValue] = useState(0)
   const [openShare, setOpenShare] = useState(false)
   const handleTabChange = (_event, newValue): void => {
@@ -39,90 +32,84 @@ export function VideoContentPage({
 
   return (
     <LanguageProvider>
-      <PageWrapper hero={<VideoHero video={content} />}>
-        {content != null && (
-          <>
-            <ThemeProvider
-              themeName={ThemeName.website}
-              themeMode={ThemeMode.dark}
-              nested
+      <PageWrapper hero={<VideoHero />}>
+        <>
+          <ThemeProvider
+            themeName={ThemeName.website}
+            themeMode={ThemeMode.dark}
+            nested
+          >
+            <Paper elevation={0} square sx={{ pt: '20px' }}>
+              <Container maxWidth="xxl">
+                {/* TODO: combine content and container children? */}
+                {children.length > 0 && (
+                  <VideosCarousel
+                    videos={children}
+                    routePrefix={slug}
+                    routeSuffix={variant?.slug.split('/')[1]}
+                  />
+                )}
+                {container != null && container.children.length > 0 && (
+                  <VideosCarousel
+                    videos={container.children}
+                    routePrefix={container.slug}
+                    routeSuffix={container.variant?.slug.split('/')[1]}
+                  />
+                )}
+              </Container>
+            </Paper>
+          </ThemeProvider>
+          <Container maxWidth="xxl">
+            <Stack
+              direction="row"
+              spacing="100px"
+              sx={{
+                mx: 0,
+                mt: 20,
+                mb: 80,
+                maxWidth: '100%'
+              }}
             >
-              <Paper elevation={0} square sx={{ pt: '20px' }}>
-                <Container maxWidth="xxl">
-                  {/* TODO: combine content and container children? */}
-                  {content?.children.length > 0 && (
-                    <VideosCarousel
-                      videos={content.children}
-                      routePrefix={content.slug}
-                      routeSuffix={content.variant?.slug.split('/')[1]}
-                    />
-                  )}
-                  {container != null && container.children.length > 0 && (
-                    <VideosCarousel
-                      videos={container.children}
-                      routePrefix={container.slug}
-                      routeSuffix={container.variant?.slug.split('/')[1]}
-                    />
-                  )}
-                </Container>
-              </Paper>
-            </ThemeProvider>
-            <Container maxWidth="xxl">
-              <Stack
-                direction="row"
-                spacing="100px"
-                sx={{
-                  mx: 0,
-                  mt: 20,
-                  mb: 80,
-                  maxWidth: '100%'
-                }}
-              >
-                <Box width="100%">
-                  <Tabs
-                    value={tabValue}
-                    onChange={handleTabChange}
-                    aria-label="background tabs"
-                    variant="fullWidth"
-                    centered
-                    sx={{ marginBottom: '40px' }}
-                  >
-                    <Tab
-                      label="Description"
-                      {...tabA11yProps('video-description', 0)}
-                    />
-                  </Tabs>
-                  <TabPanel name="video-description" value={tabValue} index={0}>
-                    <Typography variant="body1">
-                      {content.description[0]?.value}
-                    </Typography>
-                  </TabPanel>
-                </Box>
-                <Box width="336px">
-                  <Stack direction="row" spacing="20px" mb="40px">
-                    <Button variant="outlined">
-                      <SaveAlt />
-                      &nbsp; Download
-                    </Button>
-                    <Button
-                      variant="outlined"
-                      onClick={() => setOpenShare(true)}
-                    >
-                      <Share />
-                      &nbsp; Share
-                    </Button>
-                  </Stack>
-                </Box>
-              </Stack>
-              <ShareDialog
-                open={openShare}
-                video={content}
-                routes={[]}
-                onClose={() => setOpenShare(false)}
-              />
-            </Container>
-          </>
-        )}
+              <Box width="100%">
+                <Tabs
+                  value={tabValue}
+                  onChange={handleTabChange}
+                  aria-label="background tabs"
+                  variant="fullWidth"
+                  centered
+                  sx={{ marginBottom: '40px' }}
+                >
+                  <Tab
+                    label="Description"
+                    {...tabA11yProps('video-description', 0)}
+                  />
+                </Tabs>
+                <TabPanel name="video-description" value={tabValue} index={0}>
+                  <Typography variant="body1">
+                    {description[0]?.value}
+                  </Typography>
+                </TabPanel>
+              </Box>
+              <Box width="336px">
+                <Stack direction="row" spacing="20px" mb="40px">
+                  <Button variant="outlined">
+                    <SaveAlt />
+                    &nbsp; Download
+                  </Button>
+                  <Button variant="outlined" onClick={() => setOpenShare(true)}>
+                    <Share />
+                    &nbsp; Share
+                  </Button>
+                </Stack>
+              </Box>
+            </Stack>
+            <ShareDialog
+              open={openShare}
+              routes={[]}
+              onClose={() => setOpenShare(false)}
+            />
+          </Container>
+        </>
       </PageWrapper>
     </LanguageProvider>
   )

--- a/apps/watch/src/libs/videoContext/VideoContext.spec.tsx
+++ b/apps/watch/src/libs/videoContext/VideoContext.spec.tsx
@@ -76,8 +76,7 @@ describe('VideoContext', () => {
 
     expect(handleClick).toHaveBeenCalledWith({
       ...chapter1,
-      container: videos[0],
-      isPlaying: false
+      container: videos[0]
     })
   })
 })

--- a/apps/watch/src/libs/videoContext/VideoContext.spec.tsx
+++ b/apps/watch/src/libs/videoContext/VideoContext.spec.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render } from '@testing-library/react'
+import { ReactElement } from 'react'
+
+import { VideoContentFields } from '../../../__generated__/VideoContentFields'
+import { VideoLabel } from '../../../__generated__/globalTypes'
+import { videos } from '../../components/Videos/testData'
+import { VideoProvider, useVideo } from './VideoContext'
+
+const chapter1: VideoContentFields = {
+  __typename: 'Video',
+  id: '1_jf6101-0-0',
+  label: VideoLabel.segment,
+  image:
+    'https://d1wl257kev7hsz.cloudfront.net/cinematics/1_jf6101-0-0.mobileCinematicHigh.jpg',
+  imageAlt: [{ __typename: 'Translation', value: 'The Beginning' }],
+  snippet: [
+    {
+      __typename: 'Translation',
+      value:
+        'The story of Jesus fits within the larger story of the Judeo Christian tradition. The purpose of everything since creation has been to point to the life of Jesus.'
+    }
+  ],
+  description: [
+    {
+      __typename: 'Translation',
+      value:
+        'The story of Jesus fits within the larger story of the Judeo Christian tradition. The purpose of everything since creation has been to point to the life of Jesus.\n\nAll of creation speaks of the majesty of God. As God created man and woman he intended them to live in peace with him forever. But because of their disobedience mankind was separated from God. But God still loved mankind so throughout the Scriptures God reveals his plan to save the world.'
+    }
+  ],
+  studyQuestions: [],
+  title: [{ __typename: 'Translation', value: 'The Beginning' }],
+  variant: {
+    __typename: 'VideoVariant',
+    id: '1_529-jf6101-0-0',
+    duration: 488,
+    hls: 'https://arc.gt/pm6g1',
+    language: {
+      __typename: 'Language',
+      id: '529',
+      name: [{ __typename: 'Translation', value: 'English' }]
+    },
+    slug: 'the-beginning/english'
+  },
+  slug: 'the-beginning',
+  children: []
+}
+
+const handleClick = jest.fn()
+
+const TestComponent = (): ReactElement => {
+  const video = useVideo()
+
+  return (
+    <button
+      onClick={() => {
+        handleClick(video)
+      }}
+    />
+  )
+}
+
+describe('VideoContext', () => {
+  it('should pass the video data', () => {
+    const { getByRole } = render(
+      <VideoProvider
+        value={{
+          content: chapter1,
+          container: videos[0]
+        }}
+      >
+        <TestComponent />
+      </VideoProvider>
+    )
+
+    fireEvent.click(getByRole('button'))
+
+    expect(handleClick).toHaveBeenCalledWith({
+      ...chapter1,
+      container: videos[0],
+      isPlaying: false
+    })
+  })
+})

--- a/apps/watch/src/libs/videoContext/VideoContext.tsx
+++ b/apps/watch/src/libs/videoContext/VideoContext.tsx
@@ -8,7 +8,6 @@ interface VideoPageProps {
 
 interface Context extends Omit<VideoContentFields, '__typename'> {
   container?: VideoContentFields
-  isPlaying?: boolean
 }
 
 const VideoContext = createContext<Context | undefined>(undefined)
@@ -34,7 +33,7 @@ export function VideoProvider({
 }: VideoProviderProps): ReactElement {
   return (
     <VideoContext.Provider
-      value={{ ...value.content, container: value.container, isPlaying: false }}
+      value={{ ...value.content, container: value.container }}
     >
       {children}
     </VideoContext.Provider>

--- a/apps/watch/src/libs/videoContext/VideoContext.tsx
+++ b/apps/watch/src/libs/videoContext/VideoContext.tsx
@@ -1,0 +1,42 @@
+import { createContext, ReactElement, ReactNode, useContext } from 'react'
+import { VideoContentFields } from '../../../__generated__/VideoContentFields'
+
+interface VideoPageProps {
+  content: VideoContentFields
+  container?: VideoContentFields
+}
+
+interface Context extends Omit<VideoContentFields, '__typename'> {
+  container?: VideoContentFields
+  isPlaying: boolean
+}
+
+const VideoContext = createContext<Context | undefined>(undefined)
+
+export function useVideo(): Context {
+  const context = useContext(VideoContext)
+
+  if (context === undefined) {
+    throw new Error('useVideos must be used within a VideoProvider')
+  }
+
+  return context
+}
+
+interface VideoProviderProps {
+  children: ReactNode
+  value: VideoPageProps
+}
+
+export function VideoProvider({
+  children,
+  value
+}: VideoProviderProps): ReactElement {
+  return (
+    <VideoContext.Provider
+      value={{ ...value.content, container: value.container, isPlaying: false }}
+    >
+      {children}
+    </VideoContext.Provider>
+  )
+}

--- a/apps/watch/src/libs/videoContext/VideoContext.tsx
+++ b/apps/watch/src/libs/videoContext/VideoContext.tsx
@@ -8,7 +8,7 @@ interface VideoPageProps {
 
 interface Context extends Omit<VideoContentFields, '__typename'> {
   container?: VideoContentFields
-  isPlaying: boolean
+  isPlaying?: boolean
 }
 
 const VideoContext = createContext<Context | undefined>(undefined)

--- a/apps/watch/src/libs/videoContext/index.ts
+++ b/apps/watch/src/libs/videoContext/index.ts
@@ -1,0 +1,1 @@
+export { VideoProvider, useVideo } from './VideoContext'


### PR DESCRIPTION
# Description

Use VideoProvider to get values of video content and video container instead of prop drilling. Using render props pattern here would make each page too large so not appropriate here.

[Basecamp Todo](https://3.basecamp.com/3105655/buckets/30300130/todos/5616332686)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] All part2 and part3 pages render correctly

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
