### PR TITLE
fix: change the copy of journey-delete-dialog message

### DIFF
--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/TrashJourneyDialog/TrashJourneyDialog.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/TrashJourneyDialog/TrashJourneyDialog.tsx
@@ -81,7 +81,9 @@ export function TrashJourneyDialog({
       }}
     >
       <Typography>
-        By selecting “delete”, this journey will be moved to the trash. It will remain there for 40 days, before being automatically and permanently deleted.
+        By selecting “delete”, this journey will be moved to the trash. It will
+        remain there for 40 days, before being automatically and permanently
+        deleted.
       </Typography>
     </Dialog>
   )

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/TrashJourneyDialog/TrashJourneyDialog.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/TrashJourneyDialog/TrashJourneyDialog.tsx
@@ -81,8 +81,7 @@ export function TrashJourneyDialog({
       }}
     >
       <Typography>
-        Journey will be moved to trash. You can find this journey under the
-        Trash tab for 40 days, until it is premanently deleted.
+        By selecting “delete”, this journey will be moved to the trash. It will remain there for 40 days, before being automatically and permanently deleted.
       </Typography>
     </Dialog>
   )


### PR DESCRIPTION
# Description

Change the journey-delete-dialog message box text 

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/29689605/todos/5533245318)

# How should this PR be QA Tested?

Going to the Journey-admin panel, click on the journey`s card option button at the right bottom corner, click on trash menu option, 

- [ ] Check the "journey-delete-dialog-message" dialog message box content 

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
