### PR TITLE
fix: difficulties editing text

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.tsx
@@ -21,7 +21,7 @@ export const BUTTON_BLOCK_UPDATE_CONTENT = gql`
   }
 `
 interface ButtonEditProps extends TreeBlock<ButtonFields> {
-  visibleCaret
+  visibleCaret?: boolean
 }
 
 export function ButtonEdit({
@@ -72,7 +72,7 @@ export function ButtonEdit({
         setValue(e.currentTarget.value)
       }}
       onClick={(e) => e.stopPropagation()}
-      sx={visibleCaret===false? {caretColor: 'transparent'}: {}}
+      sx={visibleCaret ?? true ? {} : { caretColor: 'transparent' }}
     />
   )
 

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.tsx
@@ -20,13 +20,16 @@ export const BUTTON_BLOCK_UPDATE_CONTENT = gql`
     }
   }
 `
-interface ButtonEditProps extends TreeBlock<ButtonFields> {}
+interface ButtonEditProps extends TreeBlock<ButtonFields> {
+  visibleCaret
+}
 
 export function ButtonEdit({
   id,
   buttonVariant,
   buttonColor,
   label,
+  visibleCaret,
   ...buttonProps
 }: ButtonEditProps): ReactElement {
   const [buttonBlockUpdate] = useMutation<ButtonBlockUpdateContent>(
@@ -69,6 +72,7 @@ export function ButtonEdit({
         setValue(e.currentTarget.value)
       }}
       onClick={(e) => e.stopPropagation()}
+      sx={visibleCaret===false? {caretColor: 'transparent'}: {}}
     />
   )
 

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditInput/InlineEditInput.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditInput/InlineEditInput.tsx
@@ -1,11 +1,12 @@
-import { styled, SimplePaletteColorOptions } from '@mui/material/styles'
+// import { styled, SimplePaletteColorOptions } from '@mui/material/styles'
+import { styled } from '@mui/material/styles'
 import InputBase, { InputBaseProps } from '@mui/material/InputBase'
-import { adminTheme } from '../../../../ThemeProvider/admin/theme'
+// import { adminTheme } from '../../../../ThemeProvider/admin/theme'
 
 interface StyledInputProps extends InputBaseProps {}
 
-const adminPrimaryColor = adminTheme.palette
-  .primary as SimplePaletteColorOptions
+// const adminPrimaryColor = adminTheme.palette
+//   .primary as SimplePaletteColorOptions
 
 export const InlineEditInput = styled(InputBase)<StyledInputProps>(() => ({
   '& .MuiInputBase-input': {
@@ -20,4 +21,5 @@ export const InlineEditInput = styled(InputBase)<StyledInputProps>(() => ({
   letterSpacing: 'inherit',
   padding: '0px',
   // caretColor: adminPrimaryColor.contrastText
+  caretColor: 'white'
 }))

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditInput/InlineEditInput.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditInput/InlineEditInput.tsx
@@ -19,5 +19,5 @@ export const InlineEditInput = styled(InputBase)<StyledInputProps>(() => ({
   lineHeight: 'inherit',
   letterSpacing: 'inherit',
   padding: '0px',
-  caretColor: adminPrimaryColor.main
+  // caretColor: adminPrimaryColor.contrastText
 }))

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditInput/InlineEditInput.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditInput/InlineEditInput.tsx
@@ -1,12 +1,11 @@
-// import { styled, SimplePaletteColorOptions } from '@mui/material/styles'
-import { styled } from '@mui/material/styles'
+import { styled, SimplePaletteColorOptions } from '@mui/material/styles'
 import InputBase, { InputBaseProps } from '@mui/material/InputBase'
-// import { adminTheme } from '../../../../ThemeProvider/admin/theme'
+import { adminTheme } from '../../../../ThemeProvider/admin/theme'
 
 interface StyledInputProps extends InputBaseProps {}
 
-// const adminPrimaryColor = adminTheme.palette
-//   .primary as SimplePaletteColorOptions
+const adminPrimaryColor = adminTheme.palette
+  .primary as SimplePaletteColorOptions
 
 export const InlineEditInput = styled(InputBase)<StyledInputProps>(() => ({
   '& .MuiInputBase-input': {
@@ -20,6 +19,5 @@ export const InlineEditInput = styled(InputBase)<StyledInputProps>(() => ({
   lineHeight: 'inherit',
   letterSpacing: 'inherit',
   padding: '0px',
-  // caretColor: adminPrimaryColor.contrastText
-  caretColor: 'white'
+  caretColor: adminPrimaryColor.main
 }))

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditWrapper.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditWrapper.tsx
@@ -85,5 +85,5 @@ export function InlineEditWrapper({
       children
     )
 
-  return EditComponent
+  return showEditable? EditComponent: children
 }

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditWrapper.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditWrapper.tsx
@@ -70,20 +70,27 @@ export function InlineEditWrapper({
 
   const EditComponent =
     block.__typename === 'TypographyBlock' ? (
-      <TypographyEdit {...block} deleteSelf={handleDeleteBlock} visibleCaret={showEditable} />
+      <TypographyEdit
+        {...block}
+        deleteSelf={handleDeleteBlock}
+        visibleCaret={showEditable}
+      />
     ) : block.__typename === 'ButtonBlock' ? (
-      <ButtonEdit {...block} visibleCaret={showEditable}/>
+      <ButtonEdit {...block} visibleCaret={showEditable} />
     ) : block.__typename === 'RadioOptionBlock' ? (
-      <RadioOptionEdit {...block} visibleCaret={showEditable}/>
+      <RadioOptionEdit {...block} visibleCaret={showEditable} />
     ) : block.__typename === 'RadioQuestionBlock' ? (
-      <RadioQuestionEdit {...block} wrappers={children.props.wrappers} />
+      showEditable ? (
+        <RadioQuestionEdit {...block} wrappers={children.props.wrappers} />
+      ) : (
+        children
+      )
     ) : block.__typename === 'TextResponseBlock' ? (
-      <TextResponseEdit {...block} visibleCaret={showEditable}/>
+      <TextResponseEdit {...block} visibleCaret={showEditable} />
     ) : block.__typename === 'SignUpBlock' ? (
       <SignUpEdit {...block} />
     ) : (
       children
     )
-
-  return showEditable? EditComponent: children
+  return EditComponent
 }

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditWrapper.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/InlineEditWrapper.tsx
@@ -70,20 +70,20 @@ export function InlineEditWrapper({
 
   const EditComponent =
     block.__typename === 'TypographyBlock' ? (
-      <TypographyEdit {...block} deleteSelf={handleDeleteBlock} />
+      <TypographyEdit {...block} deleteSelf={handleDeleteBlock} visibleCaret={showEditable} />
     ) : block.__typename === 'ButtonBlock' ? (
-      <ButtonEdit {...block} />
+      <ButtonEdit {...block} visibleCaret={showEditable}/>
     ) : block.__typename === 'RadioOptionBlock' ? (
-      <RadioOptionEdit {...block} />
+      <RadioOptionEdit {...block} visibleCaret={showEditable}/>
     ) : block.__typename === 'RadioQuestionBlock' ? (
       <RadioQuestionEdit {...block} wrappers={children.props.wrappers} />
     ) : block.__typename === 'TextResponseBlock' ? (
-      <TextResponseEdit {...block} />
+      <TextResponseEdit {...block} visibleCaret={showEditable}/>
     ) : block.__typename === 'SignUpBlock' ? (
       <SignUpEdit {...block} />
     ) : (
       children
     )
 
-  return showEditable ? EditComponent : children
+  return EditComponent
 }

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.tsx
@@ -71,7 +71,7 @@ export function RadioOptionEdit({
         setValue(e.currentTarget.value)
       }}
       onClick={(e) => e.stopPropagation()}
-      sx={(visibleCaret ?? true) ? {} : { caretColor: 'transparent' }}
+      sx={visibleCaret ?? true ? {} : { caretColor: 'transparent' }}
     />
   )
 

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.tsx
@@ -20,11 +20,14 @@ export const RADIO_OPTION_BLOCK_UPDATE_CONTENT = gql`
     }
   }
 `
-interface RadioOptionEditProps extends TreeBlock<RadioOptionFields> {}
+interface RadioOptionEditProps extends TreeBlock<RadioOptionFields> {
+  visibleCaret
+}
 
 export function RadioOptionEdit({
   id,
   label,
+  visibleCaret,
   ...radioOptionProps
 }: RadioOptionEditProps): ReactElement {
   const [radioOptionBlockUpdate] = useMutation<RadioOptionBlockUpdateContent>(
@@ -68,6 +71,7 @@ export function RadioOptionEdit({
         setValue(e.currentTarget.value)
       }}
       onClick={(e) => e.stopPropagation()}
+      sx={visibleCaret===false? {caretColor: 'transparent'}: {}}
     />
   )
 

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/RadioOptionEdit/RadioOptionEdit.tsx
@@ -21,7 +21,7 @@ export const RADIO_OPTION_BLOCK_UPDATE_CONTENT = gql`
   }
 `
 interface RadioOptionEditProps extends TreeBlock<RadioOptionFields> {
-  visibleCaret
+  visibleCaret?: boolean
 }
 
 export function RadioOptionEdit({
@@ -71,7 +71,7 @@ export function RadioOptionEdit({
         setValue(e.currentTarget.value)
       }}
       onClick={(e) => e.stopPropagation()}
-      sx={visibleCaret===false? {caretColor: 'transparent'}: {}}
+      sx={(visibleCaret ?? true) ? {} : { caretColor: 'transparent' }}
     />
   )
 

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TextResponseEdit/TextResponseEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TextResponseEdit/TextResponseEdit.tsx
@@ -20,11 +20,14 @@ export const TEXT_RESPONSE_BLOCK_UPDATE_CONTENT = gql`
     }
   }
 `
-interface TextResponseEditProps extends TreeBlock<TextResponseFields> {}
+interface TextResponseEditProps extends TreeBlock<TextResponseFields> {
+  visibleCaret
+}
 
 export function TextResponseEdit({
   id,
   submitLabel,
+  visibleCaret,
   ...textResponseProps
 }: TextResponseEditProps): ReactElement {
   const [textResponseBlockUpdate] = useMutation<TextResponseBlockUpdateContent>(
@@ -68,6 +71,7 @@ export function TextResponseEdit({
         setValue(e.currentTarget.value)
       }}
       onClick={(e) => e.stopPropagation()}
+      sx={visibleCaret===false? {caretColor: 'transparent'}: {}}
     />
   )
 

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TextResponseEdit/TextResponseEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TextResponseEdit/TextResponseEdit.tsx
@@ -21,7 +21,7 @@ export const TEXT_RESPONSE_BLOCK_UPDATE_CONTENT = gql`
   }
 `
 interface TextResponseEditProps extends TreeBlock<TextResponseFields> {
-  visibleCaret
+  visibleCaret?: boolean
 }
 
 export function TextResponseEdit({
@@ -71,7 +71,7 @@ export function TextResponseEdit({
         setValue(e.currentTarget.value)
       }}
       onClick={(e) => e.stopPropagation()}
-      sx={visibleCaret===false? {caretColor: 'transparent'}: {}}
+      sx={visibleCaret ?? true ? {} : { caretColor: 'transparent' }}
     />
   )
 

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.spec.tsx
@@ -19,6 +19,7 @@ describe('TypographyEdit', () => {
     align: null,
     color: null,
     children: [],
+    visibleCaret: true,
     deleteSelf: onDelete
   }
   it('selects the input on click', () => {

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.tsx
@@ -22,6 +22,7 @@ export const TYPOGRAPHY_BLOCK_UPDATE_CONTENT = gql`
 `
 interface TypographyEditProps extends TreeBlock<TypographyFields> {
   deleteSelf: () => void
+  visibleCaret
 }
 
 export function TypographyEdit({
@@ -31,6 +32,7 @@ export function TypographyEdit({
   color,
   content,
   deleteSelf,
+  visibleCaret=true,
   ...props
 }: TypographyEditProps): ReactElement {
   const [typographyBlockUpdate] = useMutation<TypographyBlockUpdateContent>(
@@ -80,6 +82,7 @@ export function TypographyEdit({
         setValue(e.currentTarget.value)
       }}
       onClick={(e) => e.stopPropagation()}
+      sx={visibleCaret===false? {caretColor: 'transparent'}: {}}
     />
   )
 

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.tsx
@@ -82,7 +82,7 @@ export function TypographyEdit({
         setValue(e.currentTarget.value)
       }}
       onClick={(e) => e.stopPropagation()}
-      sx={(visibleCaret ?? true) ? {} : { caretColor: 'transparent' }}
+      sx={visibleCaret ?? true ? {} : { caretColor: 'transparent' }}
     />
   )
 

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.tsx
@@ -22,7 +22,7 @@ export const TYPOGRAPHY_BLOCK_UPDATE_CONTENT = gql`
 `
 interface TypographyEditProps extends TreeBlock<TypographyFields> {
   deleteSelf: () => void
-  visibleCaret
+  visibleCaret?: boolean
 }
 
 export function TypographyEdit({
@@ -32,7 +32,7 @@ export function TypographyEdit({
   color,
   content,
   deleteSelf,
-  visibleCaret=true,
+  visibleCaret,
   ...props
 }: TypographyEditProps): ReactElement {
   const [typographyBlockUpdate] = useMutation<TypographyBlockUpdateContent>(
@@ -82,7 +82,7 @@ export function TypographyEdit({
         setValue(e.currentTarget.value)
       }}
       onClick={(e) => e.stopPropagation()}
-      sx={visibleCaret===false? {caretColor: 'transparent'}: {}}
+      sx={(visibleCaret ?? true) ? {} : { caretColor: 'transparent' }}
     />
   )
 


### PR DESCRIPTION
# Description

Fix difficulties to edit text field by wrapping input fields by editing-wrapper of its specific block component and disabling input-caret (hiding caret|cursor) whenever the block component is not selected for editing.

Change the color of inline-edit-input to white

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/29689605/todos/5529134774)

# How should this PR be QA Tested?

Go to journeys-admin panel, create new or select a journey, create or select a card, add new block or select a block on the card.  

- [x] Check if the text field cursor is not appearing at the beginning when it clicked 
- [x] Check if the text field cursor color is white when the field is clicked

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
