### PR TITLE
fix: only show seo title and description

### DIFF
--- a/apps/journeys/pages/[journeySlug].tsx
+++ b/apps/journeys/pages/[journeySlug].tsx
@@ -32,16 +32,15 @@ function JourneyPage({ journey }: JourneyPageProps): ReactElement {
   return (
     <>
       <NextSeo
-        title={journey.title}
-        description={journey.description ?? undefined}
+        title={journey.seoTitle ?? undefined}
+        description={journey.seoDescription ?? undefined}
         openGraph={{
           type: 'website',
-          title: journey.seoTitle ?? journey.title,
+          title: journey.seoTitle ?? undefined,
           url: `https://${
             process.env.NEXT_PUBLIC_VERCEL_URL ?? 'your.nextstep.is'
           }/${journey.slug}`,
-          description:
-            journey.seoDescription ?? journey.description ?? undefined,
+          description: journey.seoDescription ?? undefined,
           images:
             journey.primaryImageBlock?.src != null
               ? [


### PR DESCRIPTION
# Description

Should only ever show SEO Title and Description

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] SEO title and description shows on published journey when shared
- [ ] when SEO title and description is blank, journey title and description should never show

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
