### PR TITLE
fix: home grid to match designs

### DIFF
--- a/apps/watch/next.config.js
+++ b/apps/watch/next.config.js
@@ -7,12 +7,7 @@ const withImages = require('next-images')
  **/
 const nextConfig = {
   images: {
-    domains: [
-      'images.unsplash.com',
-      'localhost',
-      'unsplash.com',
-      'd1wl257kev7hsz.cloudfront.net'
-    ],
+    domains: ['localhost', 'd1wl257kev7hsz.cloudfront.net'],
     disableStaticImages: true
   },
   nx: {

--- a/apps/watch/pages/_app.tsx
+++ b/apps/watch/pages/_app.tsx
@@ -49,8 +49,8 @@ export default function WatchApp({
   return (
     <CacheProvider value={emotionCache}>
       <DefaultSeo
-        titleTemplate="%s | Next Steps"
-        defaultTitle="Next Steps | Helping you find the next best step on your spiritual journey"
+        titleTemplate="%s | Jesus Film Project"
+        defaultTitle="Watch | Jesus Film Project"
       />
       <Head>
         <meta

--- a/apps/watch/pages/index.tsx
+++ b/apps/watch/pages/index.tsx
@@ -52,8 +52,6 @@ function HomePage({ videos }: HomePageProps): ReactElement {
 
 export const getStaticProps: GetStaticProps<HomePageProps> = async () => {
   const apolloClient = createApolloClient()
-  // unfortunately we have to grab videos individually. Getting them in batch causes out of memory issues
-  // TODO: replace once we migrate off arangodb
   const { data } = await apolloClient.query<GetHomeVideos>({
     query: GET_HOME_VIDEOS,
     variables: {

--- a/apps/watch/public/fonts/fonts.css
+++ b/apps/watch/public/fonts/fonts.css
@@ -7,6 +7,7 @@
     url('/fonts/apercu_bold.svg') format('svg'), url('/fonts/ApercuBold.otf');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -17,4 +18,5 @@
     url('/fonts/apercu_regular.svg') format('svg'), url('/fonts/ApercuBold.otf');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }

--- a/apps/watch/src/components/Header/Header.tsx
+++ b/apps/watch/src/components/Header/Header.tsx
@@ -47,13 +47,15 @@ export function Header(): ReactElement {
       >
         <Toolbar sx={{ justifyContent: 'space-between' }}>
           <NextLink href="/" passHref>
-            <Image
-              src={logo}
-              width="160"
-              height="40"
-              alt="Watch Logo"
-              style={{ cursor: 'pointer' }}
-            />
+            <a>
+              <Image
+                src={logo}
+                width="160"
+                height="40"
+                alt="Watch Logo"
+                style={{ cursor: 'pointer' }}
+              />
+            </a>
           </NextLink>
           <Stack spacing={0.5} direction="row">
             <IconButton

--- a/apps/watch/src/components/Header/HeaderMenuPanel/HeaderMenuPanel.tsx
+++ b/apps/watch/src/components/Header/HeaderMenuPanel/HeaderMenuPanel.tsx
@@ -54,13 +54,15 @@ export function HeaderMenuPanel({
     <Paper elevation={0}>
       <Stack spacing={0.5} direction="row" justifyContent="space-between" p={8}>
         <NextLink href="/" passHref>
-          <Image
-            src={logo}
-            width="160"
-            height="40"
-            alt="Watch Logo"
-            style={{ cursor: 'pointer' }}
-          />
+          <a>
+            <Image
+              src={logo}
+              width="160"
+              height="40"
+              alt="Watch Logo"
+              style={{ cursor: 'pointer' }}
+            />
+          </a>
         </NextLink>
         <IconButton
           color="inherit"

--- a/apps/watch/src/components/HomePage/HomeVideos/Card/HomeVideoCard.spec.tsx
+++ b/apps/watch/src/components/HomePage/HomeVideos/Card/HomeVideoCard.spec.tsx
@@ -2,7 +2,7 @@ import { ThemeProvider } from '@core/shared/ui/ThemeProvider'
 import { ThemeName, ThemeMode } from '@core/shared/ui/themes'
 import { render } from '@testing-library/react'
 import { videos } from '../../../Videos/testData'
-import { HomeVideoCard, FilmType } from '.'
+import { HomeVideoCard } from '.'
 
 describe('HomeVideoCard', () => {
   describe('card', () => {
@@ -13,7 +13,7 @@ describe('HomeVideoCard', () => {
         </ThemeProvider>
       )
       expect(getByText(videos[0].title[0].value)).toBeInTheDocument()
-      expect(getByText(FilmType[videos[0].label])).toBeInTheDocument()
+      expect(getByText('61 chapters')).toBeInTheDocument()
     })
     it('should link to video url', async () => {
       const { getByRole } = render(<HomeVideoCard video={videos[0]} />)

--- a/apps/watch/src/components/HomePage/HomeVideos/Card/HomeVideoCard.tsx
+++ b/apps/watch/src/components/HomePage/HomeVideos/Card/HomeVideoCard.tsx
@@ -1,41 +1,23 @@
 import { ReactElement } from 'react'
 import Typography from '@mui/material/Typography'
-import PlayArrow from '@mui/icons-material/PlayArrow'
+import PlayArrow from '@mui/icons-material/PlayArrowRounded'
 import { secondsToTimeFormat } from '@core/shared/ui/timeFormat'
 import Link from 'next/link'
 import Stack from '@mui/material/Stack'
 import { styled } from '@mui/material/styles'
 import ButtonBase from '@mui/material/ButtonBase'
+import NextImage from 'next/image'
+import Box from '@mui/material/Box'
+import { VideoLabel } from '../../../../../__generated__/globalTypes'
 import { VideoChildFields } from '../../../../../__generated__/VideoChildFields'
-
-export enum FilmType {
-  collection = 'Collection',
-  episode = 'Episode',
-  featureFilm = 'Feature Film',
-  segment = 'Segment',
-  series = 'Series',
-  shortFilm = 'Short Film'
-}
-
-const designationColors = {
-  collection: '#FF9E00',
-  episode: '#7283BE',
-  segment: '#7283BE',
-  featureFilm: '#FF9E00',
-  series: '#3AA74A',
-  shortFilm: '#FF9E00'
-}
 
 interface VideoListCardProps {
   video?: VideoChildFields
 }
 
 const ImageButton = styled(ButtonBase)(({ theme }) => ({
+  borderRadius: 8,
   width: '100%',
-  minWidth: 266,
-  maxWidth: 338,
-  minHeight: 136,
-  maxHeight: 160,
   position: 'relative',
   '&:hover, &.Mui-focusVisible': {
     zIndex: 1,
@@ -48,61 +30,92 @@ const ImageButton = styled(ButtonBase)(({ theme }) => ({
   }
 }))
 
-const ImageSpan = styled('span')(({ theme }) => ({
-  position: 'absolute',
-  objectFit: 'cover',
-  left: 0,
-  right: 0,
-  top: 0,
-  bottom: 0,
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  color: theme.palette.common.white
-}))
-
-const ImageSrc = styled('span')({
+const Layer = styled(Box)({
   position: 'absolute',
   left: 0,
   right: 0,
   top: 0,
   bottom: 0,
-  backgroundSize: 'cover',
-  backgroundPosition: 'center 40%',
-  borderRadius: '8px'
+  borderRadius: 8,
+  overflow: 'hidden'
 })
 
-const ImageBackdrop = styled('span')(({ theme }) => ({
-  position: 'absolute',
-  left: 0,
-  right: 0,
-  top: 0,
-  bottom: 0,
-  backgroundColor: theme.palette.common.black,
-  opacity: 0.4,
-  transition: theme.transitions.create('opacity'),
-  borderRadius: '8px',
-  border: '1px solid rgba(255, 255, 255, 0.18)'
-}))
-
 export function HomeVideoCard({ video }: VideoListCardProps): ReactElement {
+  let label = 'Item'
+  let color = '#FFF'
+  let childLabel = 'items'
+
+  switch (video?.label) {
+    case VideoLabel.collection:
+      label = 'Collection'
+      color = '#FF9E00'
+      break
+    case VideoLabel.episode:
+      label = 'Episode'
+      color = '#7283BE'
+      break
+    case VideoLabel.featureFilm:
+      label = 'Feature Film'
+      color = '#FF9E00'
+      childLabel = 'chapters'
+      break
+    case VideoLabel.segment:
+      label = 'Segment'
+      color = '#7283BE'
+      break
+    case VideoLabel.series:
+      label = 'Series'
+      color = '#3AA74A'
+      childLabel = 'episodes'
+      break
+    case VideoLabel.shortFilm:
+      label = 'Short Film'
+      color = '#FF9E00'
+      break
+  }
+
   return (
     <Link href={`/${video?.variant?.slug ?? ''}`} passHref>
-      <ImageButton focusRipple>
-        <ImageSrc
-          style={{
-            backgroundImage: `url(${video?.image ?? ''})`
+      <ImageButton
+        focusRipple
+        sx={{
+          height: {
+            xs: 166,
+            md: 136,
+            xl: 146
+          }
+        }}
+      >
+        {video?.image != null && (
+          <Layer>
+            <NextImage
+              src={video?.image}
+              layout="fill"
+              objectFit="cover"
+              objectPosition="left top"
+            />
+          </Layer>
+        )}
+        <Layer
+          sx={{
+            background:
+              'linear-gradient(180deg, rgba(0, 0, 0, 0) 37.81%, rgba(0, 0, 0, 0.8) 100%)',
+            transition: (theme) => theme.transitions.create('opacity'),
+            boxShadow: 'inset 0px 0px 0px 1px rgba(255, 255, 255, 0.12)'
           }}
+          className="MuiImageBackdrop-root"
         />
-        <ImageBackdrop className="MuiImageBackdrop-root" />
-        <ImageSpan>
+        <Layer
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'flex-end',
+            p: 4
+          }}
+        >
           <Typography
             variant="h6"
             sx={{
-              position: 'absolute',
-              left: 14,
-              bottom: 42,
-              padding: 0,
               textShadow:
                 '0px 4px 4px rgba(0, 0, 0, 0.25), 0px 2px 3px rgba(0, 0, 0, 0.45)'
             }}
@@ -113,46 +126,50 @@ export function HomeVideoCard({ video }: VideoListCardProps): ReactElement {
             direction="row"
             justifyContent="space-between"
             alignItems="center"
-            p={0}
-            position="absolute"
-            left={14}
-            bottom={12}
-            right={14}
+            sx={{ minWidth: 0 }}
           >
             <Typography
               variant="overline2"
-              color={designationColors[video?.label ?? ''] ?? ''}
-              p={0}
+              color={color}
+              sx={{
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden'
+              }}
             >
-              {FilmType[video?.label ?? '']}
+              {label}
             </Typography>
             <Stack
               direction="row"
               alignItems="center"
-              px="4px"
-              py="8px"
-              gap="2px"
-              borderRadius="8px"
-              height={29}
-              color="primary.contrastText"
-              bgcolor="rgba(0, 0, 0, 0.5)"
+              spacing={1}
+              sx={{
+                p: 2,
+                borderRadius: 2,
+                height: 29,
+                color: 'primary.contrastText',
+                backgroundColor: 'rgba(0, 0, 0, 0.5)',
+                flexShrink: 0
+              }}
             >
               {video?.children.length === 0 && (
-                <Stack direction="row">
+                <>
                   <PlayArrow sx={{ fontSize: '1rem' }} />
                   <Typography variant="body1" sx={{ lineHeight: '16px' }}>
-                    {secondsToTimeFormat(video?.variant?.duration ?? 0)}
+                    {secondsToTimeFormat(video?.variant?.duration ?? 0, {
+                      trimZeroes: true
+                    })}
                   </Typography>
-                </Stack>
+                </>
               )}
               {(video?.children.length ?? 0) > 0 && (
                 <Typography variant="body1">
-                  {video?.children.length} episodes
+                  {video?.children.length} {childLabel}
                 </Typography>
               )}
             </Stack>
           </Stack>
-        </ImageSpan>
+        </Layer>
       </ImageButton>
     </Link>
   )

--- a/apps/watch/src/components/HomePage/HomeVideos/Card/index.ts
+++ b/apps/watch/src/components/HomePage/HomeVideos/Card/index.ts
@@ -1,1 +1,1 @@
-export { FilmType, HomeVideoCard } from './HomeVideoCard'
+export { HomeVideoCard } from './HomeVideoCard'

--- a/apps/watch/src/components/HomePage/HomeVideos/HomeVideos.tsx
+++ b/apps/watch/src/components/HomePage/HomeVideos/HomeVideos.tsx
@@ -11,41 +11,10 @@ interface VideoListGridProps {
 
 export function HomeVideos({ data }: VideoListGridProps): ReactElement {
   return (
-    <Grid
-      container
-      spacing="14px"
-      data-testid="video-list-grid"
-      justifyContent="center"
-      mb={0}
-      mr={0}
-      pt={0}
-      px="76px"
-    >
+    <Grid container spacing="14px" data-testid="video-list-grid">
       {(data?.length ?? 0) > 0 &&
         data?.map((item, index) => (
-          <Grid
-            item
-            key={index}
-            pt={0}
-            xl={3}
-            lg={4}
-            md={6}
-            sm={12}
-            xs={12}
-            minWidth={266}
-            maxWidth={338}
-            minHeight={136}
-            maxHeight={160}
-            sx={{
-              display: {
-                xs: index > 5 ? 'none' : '',
-                sm: index > 5 ? 'none' : '',
-                md: 'inherit',
-                lg: 'inherit',
-                xl: 'inherit'
-              }
-            }}
-          >
+          <Grid item key={index} xs={12} md={4} xl={3}>
             <HomeVideoCard video={item} />
           </Grid>
         ))}

--- a/libs/shared/ui/src/libs/timeFormat/timeFormat.ts
+++ b/libs/shared/ui/src/libs/timeFormat/timeFormat.ts
@@ -1,6 +1,11 @@
-export const secondsToTimeFormat = (seconds: number): string => {
+export const secondsToTimeFormat = (
+  seconds: number,
+  options?: { trimZeroes: boolean }
+): string => {
   const date = new Date(seconds * 1000)
-  return date.toISOString().substring(11, 19)
+  return options?.trimZeroes === true
+    ? date.toISOString().substring(11, 19).replace(/^00:/, '').replace(/^0/, '')
+    : date.toISOString().substring(11, 19)
 }
 
 export const secondsToMinutes = (seconds: number): number => {


### PR DESCRIPTION
# Description

- increase performance by using next image
- handle all widths with varying heights
- use ellipses where possible to enable small presentation of boxes
- use full width of container
- border of card should now take into consideration gradient

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] watch home page grid should match designs

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
