### PR TITLE
fix: home background, header and description

### DIFF
--- a/apps/watch/src/components/Header/Header.tsx
+++ b/apps/watch/src/components/Header/Header.tsx
@@ -3,6 +3,7 @@ import Container from '@mui/material/Container'
 import SwipeableDrawer from '@mui/material/SwipeableDrawer'
 import IconButton from '@mui/material/IconButton'
 import MenuIcon from '@mui/icons-material/Menu'
+import Box from '@mui/material/Box'
 import Stack from '@mui/material/Stack'
 import AppBar from '@mui/material/AppBar'
 import Toolbar from '@mui/material/Toolbar'
@@ -34,49 +35,45 @@ export function Header(): ReactElement {
     }
 
   return (
-    <Container
-      sx={{
-        position: 'absolute'
-      }}
-      maxWidth={false}
-      disableGutters
-    >
-      <AppBar
-        position="absolute"
-        sx={{ background: 'transparent', boxShadow: 'none', p: 4 }}
-      >
-        <Toolbar sx={{ justifyContent: 'space-between' }}>
-          <NextLink href="/" passHref>
-            <a>
-              <Image
-                src={logo}
-                width="160"
-                height="40"
-                alt="Watch Logo"
-                style={{ cursor: 'pointer' }}
-              />
-            </a>
-          </NextLink>
-          <Stack spacing={0.5} direction="row">
-            <IconButton
-              color="inherit"
-              aria-label="open header menu"
-              edge="start"
-              onClick={toggleDrawer('top', true)}
-            >
-              <MenuIcon />
-            </IconButton>
-          </Stack>
-        </Toolbar>
-      </AppBar>
-      <SwipeableDrawer
-        anchor="top"
-        open={state.top}
-        onClose={toggleDrawer('top', false)}
-        onOpen={toggleDrawer('top', true)}
-      >
-        <HeaderMenuPanel toggleDrawer={toggleDrawer} />
-      </SwipeableDrawer>
-    </Container>
+    <Box position="relative">
+      <Container maxWidth="xxl" disableGutters>
+        <AppBar
+          sx={{ background: 'transparent', boxShadow: 'none', p: 4 }}
+          position="static"
+        >
+          <Toolbar sx={{ justifyContent: 'space-between' }}>
+            <NextLink href="/" passHref>
+              <a>
+                <Image
+                  src={logo}
+                  width="160"
+                  height="40"
+                  alt="Watch Logo"
+                  style={{ cursor: 'pointer' }}
+                />
+              </a>
+            </NextLink>
+            <Stack spacing={0.5} direction="row">
+              <IconButton
+                color="inherit"
+                aria-label="open header menu"
+                edge="start"
+                onClick={toggleDrawer('top', true)}
+              >
+                <MenuIcon />
+              </IconButton>
+            </Stack>
+          </Toolbar>
+        </AppBar>
+        <SwipeableDrawer
+          anchor="top"
+          open={state.top}
+          onClose={toggleDrawer('top', false)}
+          onOpen={toggleDrawer('top', true)}
+        >
+          <HeaderMenuPanel toggleDrawer={toggleDrawer} />
+        </SwipeableDrawer>
+      </Container>
+    </Box>
   )
 }

--- a/apps/watch/src/components/Header/Header.tsx
+++ b/apps/watch/src/components/Header/Header.tsx
@@ -35,7 +35,7 @@ export function Header(): ReactElement {
     }
 
   return (
-    <Box position="relative">
+    <Box sx={{ position: 'absolute', top: 0, left: 0, right: 0, zIndex: 2 }}>
       <Container maxWidth="xxl" disableGutters>
         <AppBar
           sx={{ background: 'transparent', boxShadow: 'none', p: 4 }}

--- a/apps/watch/src/components/Header/HeaderMenuPanel/HeaderMenuPanel.tsx
+++ b/apps/watch/src/components/Header/HeaderMenuPanel/HeaderMenuPanel.tsx
@@ -1,5 +1,6 @@
 import { ReactElement, KeyboardEvent, MouseEvent } from 'react'
 import Paper from '@mui/material/Paper'
+import Container from '@mui/material/Container'
 import Button from '@mui/material/Button'
 import FavoriteIcon from '@mui/icons-material/Favorite'
 import IconButton from '@mui/material/IconButton'
@@ -52,57 +53,66 @@ export function HeaderMenuPanel({
 
   return (
     <Paper elevation={0}>
-      <Stack spacing={0.5} direction="row" justifyContent="space-between" p={8}>
-        <NextLink href="/" passHref>
-          <a>
-            <Image
-              src={logo}
-              width="160"
-              height="40"
-              alt="Watch Logo"
-              style={{ cursor: 'pointer' }}
-            />
-          </a>
-        </NextLink>
-        <IconButton
-          color="inherit"
-          aria-label="open drawer"
-          edge="start"
-          onClick={toggleDrawer('top', false)}
-        >
-          <CloseIcon />
-        </IconButton>
-      </Stack>
-      <Divider />
-      <Stack
-        direction={{ xs: 'column', sm: 'row' }}
-        justifyContent="space-between"
-        p={8}
-      >
+      <Container maxWidth="xxl" disableGutters>
         <Stack
+          spacing={0.5}
+          direction="row"
           justifyContent="space-between"
-          alignItems={{ sm: 'center' }}
-          spacing={{ xs: 3, sm: 3, md: 8 }}
-          direction={{ xs: 'column', sm: 'row' }}
+          p={8}
         >
-          <HeaderLink url="https://www.jesusfilm.org/about" label="About" />
-          <HeaderLink url="https://www.jesusfilm.org/give" label="Give" />
-          <HeaderLink
-            url="https://www.jesusfilm.org/partners"
-            label="Partner"
-          />
-          <HeaderLink url="https://www.jesusfilm.org/tools" label="Tools" />
-          <HeaderLink url="https://www.jesusfilm.org/blog" label="Blog" />
+          <NextLink href="/" passHref>
+            <a>
+              <Image
+                src={logo}
+                width="160"
+                height="40"
+                alt="Watch Logo"
+                style={{ cursor: 'pointer' }}
+              />
+            </a>
+          </NextLink>
+          <IconButton
+            color="inherit"
+            aria-label="open drawer"
+            edge="start"
+            onClick={toggleDrawer('top', false)}
+          >
+            <CloseIcon />
+          </IconButton>
         </Stack>
-        <Button
-          startIcon={<FavoriteIcon />}
-          href="https://www.jesusfilm.org/how-to-help/ways-to-donate/give-now-2/?amount=&frequency=single&campaign-code=NXWJPO&designation-number=2592320&thankYouRedirect=https%3A%2F%2Fwww.jesusfilm.org%2Fcontent%2Fjf%2Fus%2Fdevelopment%2Fspecial%2Fthank-you-refer%2Fsocial-share.html"
-          target="_blank"
-          rel="noopener"
+      </Container>
+      <Divider />
+      <Container maxWidth="xxl" disableGutters>
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          justifyContent="space-between"
+          p={8}
         >
-          <Typography variant="overline2">Give Now</Typography>
-        </Button>
-      </Stack>
+          <Stack
+            justifyContent="space-between"
+            alignItems={{ sm: 'center' }}
+            spacing={{ xs: 3, sm: 3, md: 8 }}
+            direction={{ xs: 'column', sm: 'row' }}
+          >
+            <HeaderLink url="https://www.jesusfilm.org/about" label="About" />
+            <HeaderLink url="https://www.jesusfilm.org/give" label="Give" />
+            <HeaderLink
+              url="https://www.jesusfilm.org/partners"
+              label="Partner"
+            />
+            <HeaderLink url="https://www.jesusfilm.org/tools" label="Tools" />
+            <HeaderLink url="https://www.jesusfilm.org/blog" label="Blog" />
+          </Stack>
+          <Button
+            startIcon={<FavoriteIcon />}
+            href="https://www.jesusfilm.org/how-to-help/ways-to-donate/give-now-2/?amount=&frequency=single&campaign-code=NXWJPO&designation-number=2592320&thankYouRedirect=https%3A%2F%2Fwww.jesusfilm.org%2Fcontent%2Fjf%2Fus%2Fdevelopment%2Fspecial%2Fthank-you-refer%2Fsocial-share.html"
+            target="_blank"
+            rel="noopener"
+          >
+            <Typography variant="overline2">Give Now</Typography>
+          </Button>
+        </Stack>
+      </Container>
     </Paper>
   )
 }

--- a/apps/watch/src/components/HomePage/HomeHero/HomeHero.tsx
+++ b/apps/watch/src/components/HomePage/HomeHero/HomeHero.tsx
@@ -14,7 +14,8 @@ export function HomeHero(): ReactElement {
         width: '100%',
         display: 'flex',
         alignItems: 'center',
-        position: 'relative'
+        position: 'relative',
+        backgroundColor: 'background.default'
       }}
     >
       <Image

--- a/apps/watch/src/components/VideoContainerPage/ContainerDescription/ContainerDescription.tsx
+++ b/apps/watch/src/components/VideoContainerPage/ContainerDescription/ContainerDescription.tsx
@@ -20,7 +20,11 @@ export function ContainerDescription({
       alignItems="flex-start"
       spacing={4}
     >
-      <Typography variant="subtitle1" color="text.primary">
+      <Typography
+        variant="subtitle1"
+        color="text.primary"
+        sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+      >
         {value}
       </Typography>
       <Button

--- a/apps/watch/src/components/VideoContentPage/VideoContent/VideoContent.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoContent/VideoContent.tsx
@@ -87,7 +87,7 @@ export function VideoContent(): ReactElement {
         <Typography
           variant="body1"
           color="text.secondary"
-          sx={{ whiteSpace: 'pre-wrap' }}
+          sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
         >
           {description[0]?.value}
         </Typography>


### PR DESCRIPTION
# Description

- center header
- descriptions should now break urls into multiple lines
- background home page should be black on header

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] No white flash on home page
- [x] /lumo-the-gospel-of-luke/english/ description text should now wrap when on super small resolutions
- [x] heading should be contained on all pages

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
