### PR TITLE
fix: video card hide slug link when video is series

### DIFF
--- a/apps/watch/src/components/VideoCard/VideoCard.spec.tsx
+++ b/apps/watch/src/components/VideoCard/VideoCard.spec.tsx
@@ -51,6 +51,20 @@ describe('VideoCard', () => {
       )
     })
 
+    it('sets link to video url without container slug when series', () => {
+      const { getByRole } = render(
+        <VideoCard
+          video={videos[5]}
+          variant="contained"
+          containerSlug="jesus"
+        />
+      )
+      expect(getByRole('link')).toHaveAttribute(
+        'href',
+        `/${videos[5].variant?.slug as string}`
+      )
+    })
+
     it('displays feature film', () => {
       const { getByText } = render(
         <VideoCard video={videos[0]} variant="contained" />

--- a/apps/watch/src/components/VideoCard/VideoCard.tsx
+++ b/apps/watch/src/components/VideoCard/VideoCard.tsx
@@ -50,7 +50,9 @@ export function VideoCard({
   return (
     <NextLink
       href={`/${
-        containerSlug != null && video?.label !== VideoLabel.collection
+        containerSlug != null &&
+        video?.label != null &&
+        ![VideoLabel.collection, VideoLabel.series].includes(video.label)
           ? `${containerSlug}/`
           : ''
       }${video?.variant?.slug ?? ''}`}


### PR DESCRIPTION
# Description

series should hide video container slug on video card

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] video card showing series on a collection page should link to just the series page without current collection

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
