### PR TITLE
fix: audio dialog language null check

### DIFF
--- a/apps/watch/src/components/AudioDialog/AudioLanguageDialog.tsx
+++ b/apps/watch/src/components/AudioDialog/AudioLanguageDialog.tsx
@@ -1,13 +1,11 @@
 import { ComponentProps, ReactElement } from 'react'
 import { Dialog } from '@core/shared/ui/Dialog'
-import {
-  Language,
-  LanguageAutocomplete
-} from '@core/shared/ui/LanguageAutocomplete'
+import { LanguageAutocomplete } from '@core/shared/ui/LanguageAutocomplete'
 import { Formik, Form, FormikValues } from 'formik'
 import TextField from '@mui/material/TextField'
 import LanguageIcon from '@mui/icons-material/Language'
 import { useRouter } from 'next/router'
+import { compact } from 'lodash'
 import { useVideo } from '../../libs/videoContext'
 
 interface AudioLanguageDialogProps
@@ -20,9 +18,9 @@ export function AudioLanguageDialog({
   const { variant, variantLanguagesWithSlug } = useVideo()
   const router = useRouter()
 
-  const languages = variantLanguagesWithSlug?.map(
-    ({ language }) => language
-  ) as unknown as Language[]
+  const languages = compact(
+    variantLanguagesWithSlug?.map(({ language }) => language)
+  )
 
   function handleSubmit(value: FormikValues): void {
     const selectedLanguageSlug = variantLanguagesWithSlug?.find(

--- a/apps/watch/src/components/VideoContentPage/AudioLanguageButton/AudioLanguageButton.tsx
+++ b/apps/watch/src/components/VideoContentPage/AudioLanguageButton/AudioLanguageButton.tsx
@@ -8,6 +8,7 @@ import Button from '@mui/material/Button'
 import Typography from '@mui/material/Typography'
 import IconButton from '@mui/material/IconButton'
 import LanguageRounded from '@mui/icons-material/LanguageRounded'
+import { compact } from 'lodash'
 import { useVideo } from '../../../libs/videoContext'
 import { AudioLanguageDialog } from '../../AudioDialog'
 
@@ -20,6 +21,10 @@ export function AudioLanguageButton({
 }: AudioLanguageButtonProps): ReactElement {
   const { variant, variantLanguagesWithSlug } = useVideo()
   const [openAudioLanguage, setOpenAudioLanguage] = useState(false)
+
+  const languages = compact(
+    variantLanguagesWithSlug?.map(({ language }) => language)
+  )
 
   const nativeName = variant?.language?.name.find(
     ({ primary }) => !primary
@@ -48,7 +53,7 @@ export function AudioLanguageButton({
           <Typography variant="subtitle1">{localName ?? nativeName}</Typography>
           <AddOutlined fontSize="small" />
           <Typography variant="subtitle1">
-            {variantLanguagesWithSlug.length - 1} Languages
+            {languages.length - 1} Languages
           </Typography>
           <KeyboardArrowDownOutlined fontSize="small" />
         </Button>


### PR DESCRIPTION
# Description

Updated language null check for audio dialog

- Link to Basecamp Todo

# How should this PR be QA Tested?

- [ ] clicking on audio language button opens audio language dialog
- [ ] clicking on audio language icon opens audio language dialog

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
