### PR TITLE
fix: controls on android and loading icon

### DIFF
--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoHero.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoHero.tsx
@@ -7,7 +7,6 @@ import { useVideo } from '../../../libs/videoContext'
 import { Header } from '../../Header'
 import { VideoControls } from './VideoControls'
 import { VideoHeroOverlay } from './VideoHeroOverlay'
-import 'video.js/dist/video-js.css'
 
 const VIDEO_HERO_BOTTOM_SPACING = 150
 interface VideoHeroProps {
@@ -77,9 +76,22 @@ export function VideoHero({ onPlay }: VideoHeroProps): ReactElement {
           paddingBottom: isFullscreen ? 0 : VIDEO_HERO_BOTTOM_SPACING
         }}
       >
-        <Box sx={{ position: 'relative', height: '100%', width: '100%' }}>
+        <Box
+          sx={{
+            background: 'black',
+            position: 'relative',
+            height: '100%',
+            width: '100%',
+            '.vjs-hidden': { display: 'none' },
+            '.vjs-loading-spinner': { display: 'none' },
+            '.vjs, .vjs-tech': {
+              height: '100%',
+              width: '100%'
+            }
+          }}
+        >
           {variant?.hls != null && (
-            <video className="video-js vjs-fill" ref={videoRef} playsInline />
+            <video className="vjs" ref={videoRef} playsInline />
           )}
           {playerRef.current != null && isPlaying && (
             <VideoControls


### PR DESCRIPTION
# Description

Controls on android fullscreen are currently not showing. And we've stopped using VideoJS loading icon and created our own instead. This allows us not to import the video js CSS file. 

- Link to Basecamp Todo

# How should this PR be QA Tested?

**Requirements**
- Play any video and click on fullscreen (for android testing)
- Throttle the webpage to use slow3G (general testing)

---------------------

- [ ] it should render controls on android fullscreen
- [ ] it should render MUI circular progress when video is loading
- [ ] it should keep the controls and header while video is loading

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
