### PR TITLE
feat: overlay buttons

### DIFF
--- a/apps/watch/src/components/VideoContentPage/AudioLanguageButton/AudioLanguageButton.spec.tsx
+++ b/apps/watch/src/components/VideoContentPage/AudioLanguageButton/AudioLanguageButton.spec.tsx
@@ -5,13 +5,22 @@ import { AudioLanguageButton } from '.'
 
 describe('AudioLanguageButton', () => {
   it('renders audio language as a button', async () => {
-    const { getByRole, getByText } = render(
+    const { getByRole, getAllByText } = render(
       <VideoProvider value={{ content: videos[0] }}>
-        <AudioLanguageButton />
+        <AudioLanguageButton componentVariant="button" />
       </VideoProvider>
     )
     await waitFor(() => fireEvent.click(getByRole('button')))
 
-    expect(getByText('3 Languages Available')).toBeInTheDocument()
+    expect(getAllByText('3 Languages Available')[0]).toBeInTheDocument()
+  })
+  it('renders audio language as an icon', async () => {
+    const { getByTestId, getAllByText } = render(
+      <VideoProvider value={{ content: videos[0] }}>
+        <AudioLanguageButton componentVariant="icon" />
+      </VideoProvider>
+    )
+    await waitFor(() => fireEvent.click(getByTestId('LanguageOutlinedIcon')))
+    expect(getAllByText('3 Languages Available')[0]).toBeInTheDocument()
   })
 })

--- a/apps/watch/src/components/VideoContentPage/AudioLanguageButton/AudioLanguageButton.spec.tsx
+++ b/apps/watch/src/components/VideoContentPage/AudioLanguageButton/AudioLanguageButton.spec.tsx
@@ -5,22 +5,22 @@ import { AudioLanguageButton } from '.'
 
 describe('AudioLanguageButton', () => {
   it('renders audio language as a button', async () => {
-    const { getByRole, getAllByText } = render(
+    const { getByRole, getByText } = render(
       <VideoProvider value={{ content: videos[0] }}>
         <AudioLanguageButton componentVariant="button" />
       </VideoProvider>
     )
     await waitFor(() => fireEvent.click(getByRole('button')))
 
-    expect(getAllByText('3 Languages Available')[0]).toBeInTheDocument()
+    expect(getByText('3 Languages Available')).toBeInTheDocument()
   })
   it('renders audio language as an icon', async () => {
-    const { getByTestId, getAllByText } = render(
+    const { getByTestId, getByText } = render(
       <VideoProvider value={{ content: videos[0] }}>
         <AudioLanguageButton componentVariant="icon" />
       </VideoProvider>
     )
     await waitFor(() => fireEvent.click(getByTestId('LanguageOutlinedIcon')))
-    expect(getAllByText('3 Languages Available')[0]).toBeInTheDocument()
+    expect(getByText('3 Languages Available')).toBeInTheDocument()
   })
 })

--- a/apps/watch/src/components/VideoContentPage/AudioLanguageButton/AudioLanguageButton.spec.tsx
+++ b/apps/watch/src/components/VideoContentPage/AudioLanguageButton/AudioLanguageButton.spec.tsx
@@ -7,20 +7,11 @@ describe('AudioLanguageButton', () => {
   it('renders audio language as a button', async () => {
     const { getByRole, getByText } = render(
       <VideoProvider value={{ content: videos[0] }}>
-        <AudioLanguageButton componentVariant="button" />
+        <AudioLanguageButton />
       </VideoProvider>
     )
     await waitFor(() => fireEvent.click(getByRole('button')))
-    expect(getByText('3 Languages Available')).toBeInTheDocument()
-  })
 
-  it('renders audio language as an icon', async () => {
-    const { getByTestId, getByText } = render(
-      <VideoProvider value={{ content: videos[0] }}>
-        <AudioLanguageButton componentVariant="icon" />
-      </VideoProvider>
-    )
-    await waitFor(() => fireEvent.click(getByTestId('LanguageRoundedIcon')))
     expect(getByText('3 Languages Available')).toBeInTheDocument()
   })
 })

--- a/apps/watch/src/components/VideoContentPage/AudioLanguageButton/AudioLanguageButton.tsx
+++ b/apps/watch/src/components/VideoContentPage/AudioLanguageButton/AudioLanguageButton.tsx
@@ -8,10 +8,17 @@ import Button from '@mui/material/Button'
 import Typography from '@mui/material/Typography'
 import { compact } from 'lodash'
 import Box from '@mui/material/Box'
+import IconButton from '@mui/material/IconButton'
 import { useVideo } from '../../../libs/videoContext'
 import { AudioLanguageDialog } from '../../AudioDialog'
 
-export function AudioLanguageButton(): ReactElement {
+interface AudioLanguageButtonProps {
+  componentVariant: 'button' | 'icon'
+}
+
+export function AudioLanguageButton({
+  componentVariant
+}: AudioLanguageButtonProps): ReactElement {
   const { variant, variantLanguagesWithSlug } = useVideo()
   const [openAudioLanguage, setOpenAudioLanguage] = useState(false)
 
@@ -28,7 +35,7 @@ export function AudioLanguageButton(): ReactElement {
 
   return (
     <ThemeProvider themeName={ThemeName.website} themeMode={ThemeMode.light}>
-      <>
+      {componentVariant === 'button' ? (
         <Button
           size="small"
           onClick={() => setOpenAudioLanguage(true)}
@@ -69,11 +76,19 @@ export function AudioLanguageButton(): ReactElement {
           </Box>
           <KeyboardArrowDownOutlined fontSize="small" />
         </Button>
-        <AudioLanguageDialog
-          open={openAudioLanguage}
-          onClose={() => setOpenAudioLanguage(false)}
-        />
-      </>
+      ) : (
+        <IconButton onClick={() => setOpenAudioLanguage(true)}>
+          <LanguageOutlined sx={{ color: '#ffffff' }} />
+        </IconButton>
+      )}
+      <AudioLanguageDialog
+        open={openAudioLanguage}
+        onClose={() => setOpenAudioLanguage(false)}
+      />
+      <AudioLanguageDialog
+        open={openAudioLanguage}
+        onClose={() => setOpenAudioLanguage(false)}
+      />
     </ThemeProvider>
   )
 }

--- a/apps/watch/src/components/VideoContentPage/AudioLanguageButton/AudioLanguageButton.tsx
+++ b/apps/watch/src/components/VideoContentPage/AudioLanguageButton/AudioLanguageButton.tsx
@@ -9,6 +9,7 @@ import Typography from '@mui/material/Typography'
 import IconButton from '@mui/material/IconButton'
 import LanguageRounded from '@mui/icons-material/LanguageRounded'
 import { compact } from 'lodash'
+import Box from '@mui/material/Box'
 import { useVideo } from '../../../libs/videoContext'
 import { AudioLanguageDialog } from '../../AudioDialog'
 
@@ -43,6 +44,7 @@ export function AudioLanguageButton({
             gap: 1,
             display: 'flex',
             alignItem: 'center',
+            justifyContent: 'flex-end',
             color: 'background.paper',
             '&:hover': {
               backgroundColor: 'transparent'
@@ -50,11 +52,28 @@ export function AudioLanguageButton({
           }}
         >
           <LanguageOutlined fontSize="small" />
-          <Typography variant="subtitle1">{localName ?? nativeName}</Typography>
-          <AddOutlined fontSize="small" />
-          <Typography variant="subtitle1">
-            {languages.length - 1} Languages
+          <Typography
+            variant="subtitle1"
+            sx={{
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden'
+            }}
+          >
+            {localName ?? nativeName}
           </Typography>
+          <Box
+            sx={{
+              display: { xs: 'none', lg: 'flex' },
+              alignItems: 'center',
+              gap: 1
+            }}
+          >
+            <AddOutlined fontSize="small" />
+            <Typography variant="subtitle1" sx={{ whiteSpace: 'nowrap' }}>
+              {languages.length - 1} Languages
+            </Typography>
+          </Box>
           <KeyboardArrowDownOutlined fontSize="small" />
         </Button>
       ) : (

--- a/apps/watch/src/components/VideoContentPage/AudioLanguageButton/AudioLanguageButton.tsx
+++ b/apps/watch/src/components/VideoContentPage/AudioLanguageButton/AudioLanguageButton.tsx
@@ -85,10 +85,6 @@ export function AudioLanguageButton({
         open={openAudioLanguage}
         onClose={() => setOpenAudioLanguage(false)}
       />
-      <AudioLanguageDialog
-        open={openAudioLanguage}
-        onClose={() => setOpenAudioLanguage(false)}
-      />
     </ThemeProvider>
   )
 }

--- a/apps/watch/src/components/VideoContentPage/AudioLanguageButton/AudioLanguageButton.tsx
+++ b/apps/watch/src/components/VideoContentPage/AudioLanguageButton/AudioLanguageButton.tsx
@@ -6,20 +6,12 @@ import AddOutlined from '@mui/icons-material/AddOutlined'
 import KeyboardArrowDownOutlined from '@mui/icons-material/KeyboardArrowDownOutlined'
 import Button from '@mui/material/Button'
 import Typography from '@mui/material/Typography'
-import IconButton from '@mui/material/IconButton'
-import LanguageRounded from '@mui/icons-material/LanguageRounded'
 import { compact } from 'lodash'
 import Box from '@mui/material/Box'
 import { useVideo } from '../../../libs/videoContext'
 import { AudioLanguageDialog } from '../../AudioDialog'
 
-interface AudioLanguageButtonProps {
-  componentVariant: 'button' | 'icon'
-}
-
-export function AudioLanguageButton({
-  componentVariant
-}: AudioLanguageButtonProps): ReactElement {
+export function AudioLanguageButton(): ReactElement {
   const { variant, variantLanguagesWithSlug } = useVideo()
   const [openAudioLanguage, setOpenAudioLanguage] = useState(false)
 
@@ -36,7 +28,7 @@ export function AudioLanguageButton({
 
   return (
     <ThemeProvider themeName={ThemeName.website} themeMode={ThemeMode.light}>
-      {componentVariant === 'button' ? (
+      <>
         <Button
           size="small"
           onClick={() => setOpenAudioLanguage(true)}
@@ -45,6 +37,7 @@ export function AudioLanguageButton({
             display: 'flex',
             alignItem: 'center',
             justifyContent: 'flex-end',
+            width: 'inherit',
             color: 'background.paper',
             '&:hover': {
               backgroundColor: 'transparent'
@@ -76,15 +69,11 @@ export function AudioLanguageButton({
           </Box>
           <KeyboardArrowDownOutlined fontSize="small" />
         </Button>
-      ) : (
-        <IconButton onClick={() => setOpenAudioLanguage(true)}>
-          <LanguageRounded sx={{ color: '#ffffff' }} />
-        </IconButton>
-      )}
-      <AudioLanguageDialog
-        open={openAudioLanguage}
-        onClose={() => setOpenAudioLanguage(false)}
-      />
+        <AudioLanguageDialog
+          open={openAudioLanguage}
+          onClose={() => setOpenAudioLanguage(false)}
+        />
+      </>
     </ThemeProvider>
   )
 }

--- a/apps/watch/src/components/VideoContentPage/VideoContentPage.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoContentPage.tsx
@@ -82,9 +82,9 @@ export function VideoContentPage(): ReactElement {
                   videos={container.children}
                   renderItem={(props: Parameters<typeof CarouselItem>[0]) => {
                     return <CarouselItem {...props} />
-                }}
+                  }}
                 />
-              )}   */}
+              )} */}
             </Paper>
           </ThemeProvider>
           <Container maxWidth="xxl">

--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoControls/VideoControls.spec.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoControls/VideoControls.spec.tsx
@@ -101,7 +101,7 @@ describe('VideoControls', () => {
         <VideoControls player={player} />
       </VideoProvider>
     )
-    fireEvent.click(getByTestId('LanguageRoundedIcon'))
+    fireEvent.click(getByTestId('LanguageOutlinedIcon'))
     expect(getByRole('textbox')).toHaveValue('English')
   })
 

--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoHero.spec.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoHero.spec.tsx
@@ -1,4 +1,5 @@
 import { render, fireEvent } from '@testing-library/react'
+import { SnackbarProvider } from 'notistack'
 import { VideoProvider } from '../../../libs/videoContext'
 import { videos } from '../../Videos/testData'
 import { VideoHero } from './VideoHero'
@@ -6,9 +7,11 @@ import { VideoHero } from './VideoHero'
 describe('VideoHero', () => {
   it('should render the video hero', () => {
     const { getByText, queryByText, getByRole, getByTestId } = render(
-      <VideoProvider value={{ content: videos[0] }}>
-        <VideoHero />
-      </VideoProvider>
+      <SnackbarProvider>
+        <VideoProvider value={{ content: videos[0] }}>
+          <VideoHero />
+        </VideoProvider>
+      </SnackbarProvider>
     )
     expect(getByText('JESUS')).toBeInTheDocument()
     fireEvent.click(getByRole('button', { name: 'Play Video' }))

--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoHeroOverlay/VideoHeroOverlay.spec.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoHeroOverlay/VideoHeroOverlay.spec.tsx
@@ -1,4 +1,5 @@
 import { render, fireEvent } from '@testing-library/react'
+import { SnackbarProvider } from 'notistack'
 import { VideoContentFields } from '../../../../../__generated__/VideoContentFields'
 import {
   VideoLabel,
@@ -114,9 +115,11 @@ describe('VideoHeroOverlay', () => {
 
   it('should render the Video Hero Overlay', () => {
     const { getByRole, getByText, getByTestId } = render(
-      <VideoProvider value={{ content: video }}>
-        <VideoHeroOverlay />
-      </VideoProvider>
+      <SnackbarProvider>
+        <VideoProvider value={{ content: video }}>
+          <VideoHeroOverlay />
+        </VideoProvider>
+      </SnackbarProvider>
     )
     expect(getByText('The Story of Jesus for Children')).toBeInTheDocument()
     expect(getByText('61 min')).toBeInTheDocument()
@@ -129,9 +132,11 @@ describe('VideoHeroOverlay', () => {
   it('should play video on the Play Video button click', () => {
     const handlePlay = jest.fn()
     const { getByRole } = render(
-      <VideoProvider value={{ content: video }}>
-        <VideoHeroOverlay handlePlay={handlePlay} />
-      </VideoProvider>
+      <SnackbarProvider>
+        <VideoProvider value={{ content: video }}>
+          <VideoHeroOverlay handlePlay={handlePlay} />
+        </VideoProvider>
+      </SnackbarProvider>
     )
     fireEvent.click(getByRole('button', { name: 'Play Video' }))
     expect(handlePlay).toHaveBeenCalled()
@@ -140,9 +145,11 @@ describe('VideoHeroOverlay', () => {
   it('should play video on the Mute Icon click', () => {
     const handlePlay = jest.fn()
     const { getByTestId } = render(
-      <VideoProvider value={{ content: video }}>
-        <VideoHeroOverlay handlePlay={handlePlay} />
-      </VideoProvider>
+      <SnackbarProvider>
+        <VideoProvider value={{ content: video }}>
+          <VideoHeroOverlay handlePlay={handlePlay} />
+        </VideoProvider>
+      </SnackbarProvider>
     )
     fireEvent.click(getByTestId('VolumeOffOutlinedIcon'))
     expect(handlePlay).toHaveBeenCalled()

--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoHeroOverlay/VideoHeroOverlay.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoHeroOverlay/VideoHeroOverlay.tsx
@@ -100,11 +100,7 @@ export function VideoHeroOverlay({
           >
             <Stack
               direction={{ xs: 'column-reverse', md: 'row' }}
-              aria-label="fejfiejfieifji"
-              sx={{
-                width: '100%',
-                gap: 8
-              }}
+              sx={{ width: { xs: '100%', md: 'unset' }, gap: 8 }}
             >
               <Box
                 sx={{
@@ -112,7 +108,7 @@ export function VideoHeroOverlay({
                   justifyContent: 'space-between'
                 }}
               >
-                <AudioLanguageButton componentVariant="button" />
+                <AudioLanguageButton />
                 <Stack direction="row" spacing={5}>
                   <ShareButton
                     variant="icon"
@@ -141,6 +137,7 @@ export function VideoHeroOverlay({
                 size="small"
                 variant="contained"
                 onClick={handlePlay}
+                fullWidth
                 sx={{
                   display: { xs: 'flex', md: 'none' },
                   backgroundColor: 'primary.main'
@@ -168,10 +165,12 @@ export function VideoHeroOverlay({
             </Stack>
             <Box
               sx={{
-                display: { xs: 'none', md: 'flex' }
+                display: { xs: 'none', md: 'flex' },
+                overflow: 'hidden',
+                ml: 10
               }}
             >
-              <AudioLanguageButton componentVariant="button" />
+              <AudioLanguageButton />
             </Box>
           </Stack>
         </Stack>

--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoHeroOverlay/VideoHeroOverlay.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoHeroOverlay/VideoHeroOverlay.tsx
@@ -108,7 +108,7 @@ export function VideoHeroOverlay({
                   justifyContent: 'space-between'
                 }}
               >
-                <AudioLanguageButton />
+                <AudioLanguageButton componentVariant="button" />
                 <Stack direction="row" spacing={5}>
                   <ShareButton
                     variant="icon"
@@ -170,7 +170,7 @@ export function VideoHeroOverlay({
                 ml: 10
               }}
             >
-              <AudioLanguageButton />
+              <AudioLanguageButton componentVariant="button" />
             </Box>
           </Stack>
         </Stack>

--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoHeroOverlay/VideoHeroOverlay.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoHeroOverlay/VideoHeroOverlay.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react'
+import { ReactElement, useState } from 'react'
 import { secondsToMinutes } from '@core/shared/ui/timeFormat'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
@@ -13,6 +13,10 @@ import Image from 'next/image'
 import { useVideo } from '../../../../libs/videoContext'
 import { HeroOverlay } from '../../../HeroOverlay'
 import { AudioLanguageButton } from '../../AudioLanguageButton'
+import { ShareButton } from '../../../ShareButton'
+import { DownloadButton } from '../../DownloadButton'
+import { DownloadDialog } from '../../../DownloadDialog'
+import { ShareDialog } from '../../../ShareDialog'
 
 interface VideoHeroOverlayProps {
   handlePlay?: () => void
@@ -22,6 +26,8 @@ export function VideoHeroOverlay({
   handlePlay
 }: VideoHeroOverlayProps): ReactElement {
   const { image, imageAlt, title, variant } = useVideo()
+  const [openShare, setOpenShare] = useState(false)
+  const [openDownload, setOpenDownload] = useState(false)
 
   return (
     <Box
@@ -98,6 +104,24 @@ export function VideoHeroOverlay({
                 width: '100%'
               }}
             >
+              <Box
+                sx={{
+                  display: { xs: 'flex', md: 'none' },
+                  justifyContent: 'space-between'
+                }}
+              >
+                <AudioLanguageButton componentVariant="icon" />
+                <Stack direction="row" spacing={5}>
+                  <ShareButton
+                    variant="icon"
+                    onClick={() => setOpenShare(true)}
+                  />
+                  <DownloadButton
+                    variant="icon"
+                    onClick={() => setOpenDownload(true)}
+                  />
+                </Stack>
+              </Box>
               <Button
                 size="large"
                 variant="contained"
@@ -152,6 +176,15 @@ export function VideoHeroOverlay({
             </Box>
           </Stack>
         </Stack>
+        {variant != null && variant.downloads.length > 0 && (
+          <DownloadDialog
+            open={openDownload}
+            onClose={() => {
+              setOpenDownload(false)
+            }}
+          />
+        )}
+        <ShareDialog open={openShare} onClose={() => setOpenShare(false)} />
       </Container>
     </Box>
   )

--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoHeroOverlay/VideoHeroOverlay.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoHeroOverlay/VideoHeroOverlay.tsx
@@ -94,14 +94,16 @@ export function VideoHeroOverlay({
             direction="row"
             justifyContent="space-between"
             sx={{
-              pt: { xs: 0, md: 15 }
+              pt: { xs: 0, md: 15 },
+              width: '100%'
             }}
           >
             <Stack
-              spacing={8}
               direction={{ xs: 'column-reverse', md: 'row' }}
+              aria-label="fejfiejfieifji"
               sx={{
-                width: '100%'
+                width: '100%',
+                gap: 8
               }}
             >
               <Box
@@ -110,7 +112,7 @@ export function VideoHeroOverlay({
                   justifyContent: 'space-between'
                 }}
               >
-                <AudioLanguageButton componentVariant="icon" />
+                <AudioLanguageButton componentVariant="button" />
                 <Stack direction="row" spacing={5}>
                   <ShareButton
                     variant="icon"
@@ -158,7 +160,7 @@ export function VideoHeroOverlay({
               >
                 <AccessTime sx={{ width: 17, height: 17 }} />
                 {variant !== null && (
-                  <Typography variant="body1">
+                  <Typography variant="body1" sx={{ whiteSpace: 'nowrap' }}>
                     {secondsToMinutes(variant.duration)} min
                   </Typography>
                 )}
@@ -166,10 +168,7 @@ export function VideoHeroOverlay({
             </Stack>
             <Box
               sx={{
-                display: { xs: 'none', md: 'flex' },
-                width: '100%',
-                justifyContent: 'end',
-                alignItems: 'center'
+                display: { xs: 'none', md: 'flex' }
               }}
             >
               <AudioLanguageButton componentVariant="button" />


### PR DESCRIPTION
# Description

Adds video overlay share / download buttons on mobile website. Languages dropdown button clips using ellipsis for longer language names

- Link to Basecamp Todo

# How should this PR be QA Tested?

- [ ] Should render both red share and download buttons on mobile breakpoints
- [ ] Languages button / icon should resize depending on screen size, particularly for longer language names

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
