### PR TITLE
chore: add source maps to prod watch

### DIFF
--- a/apps/watch/next.config.js
+++ b/apps/watch/next.config.js
@@ -30,6 +30,7 @@ const nextConfig = {
     defaultLocale: 'en',
     localeDetection: false
   },
-  trailingSlash: true
+  trailingSlash: true,
+  productionBrowserSourceMaps: true
 }
 module.exports = withPlugins([[withBundleAnalyzer], [withNx]], nextConfig)


### PR DESCRIPTION
# Description

Add source maps to prod watch to allow lighthouse to reveal optimization opportunities.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
