### PR TITLE
fix: render title only on feature films

### DIFF
--- a/apps/watch/src/components/VideoContentPage/VideoContentPage.spec.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoContentPage.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, getByTestId, render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import { SnackbarProvider } from 'notistack'
 import { videos } from '../Videos/testData'
 import { VideoProvider } from '../../libs/videoContext'

--- a/apps/watch/src/components/VideoContentPage/VideoContentPage.spec.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoContentPage.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react'
+import { fireEvent, getByTestId, render } from '@testing-library/react'
 import { SnackbarProvider } from 'notistack'
 import { videos } from '../Videos/testData'
 import { VideoProvider } from '../../libs/videoContext'
@@ -38,6 +38,30 @@ describe('VideoContentPage', () => {
     )
 
     expect(getByTestId('videos-carousel')).toBeInTheDocument()
+  })
+
+  it('should render title on feature films', () => {
+    const { getByTestId } = render(
+      <SnackbarProvider>
+        <VideoProvider value={{ content: videos[0] }}>
+          <VideoContentPage />
+        </VideoProvider>
+      </SnackbarProvider>
+    )
+
+    expect(getByTestId('title')).toBeInTheDocument()
+  })
+
+  it('should not render title if item is not a feature film', () => {
+    const { queryByTestId } = render(
+      <SnackbarProvider>
+        <VideoProvider value={{ content: videos[2] }}>
+          <VideoContentPage />
+        </VideoProvider>
+      </SnackbarProvider>
+    )
+
+    expect(queryByTestId('title')).toBeNull()
   })
 
   it('should render share button', () => {

--- a/apps/watch/src/components/VideoContentPage/VideoContentPage.spec.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoContentPage.spec.tsx
@@ -41,7 +41,7 @@ describe('VideoContentPage', () => {
   })
 
   it('should render title on feature films', () => {
-    const { getAllByRole } = render(
+    const { getByRole } = render(
       <SnackbarProvider>
         <VideoProvider value={{ content: videos[0] }}>
           <VideoContentPage />
@@ -49,7 +49,7 @@ describe('VideoContentPage', () => {
       </SnackbarProvider>
     )
 
-    expect(getAllByRole('heading', { name: 'JESUS Scenes' })).toHaveLength(1)
+    expect(getByRole('heading', { name: 'JESUS Scenes' })).toBeInTheDocument()
   })
 
   it('should render share button', () => {

--- a/apps/watch/src/components/VideoContentPage/VideoContentPage.spec.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoContentPage.spec.tsx
@@ -41,7 +41,7 @@ describe('VideoContentPage', () => {
   })
 
   it('should render title on feature films', () => {
-    const { getByTestId } = render(
+    const { getAllByRole } = render(
       <SnackbarProvider>
         <VideoProvider value={{ content: videos[0] }}>
           <VideoContentPage />
@@ -49,19 +49,7 @@ describe('VideoContentPage', () => {
       </SnackbarProvider>
     )
 
-    expect(getByTestId('title')).toBeInTheDocument()
-  })
-
-  it('should not render title if item is not a feature film', () => {
-    const { queryByTestId } = render(
-      <SnackbarProvider>
-        <VideoProvider value={{ content: videos[2] }}>
-          <VideoContentPage />
-        </VideoProvider>
-      </SnackbarProvider>
-    )
-
-    expect(queryByTestId('title')).toBeNull()
+    expect(getAllByRole('heading', { name: 'JESUS Scenes' })).toHaveLength(1)
   })
 
   it('should render share button', () => {

--- a/apps/watch/src/components/VideoContentPage/VideoContentPage.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoContentPage.tsx
@@ -127,12 +127,7 @@ export function VideoContentPage(): ReactElement {
           {container == null && label === VideoLabel.featureFilm && (
             <Stack sx={{ mb: 14 }}>
               <Container maxWidth="xxl">
-                <Typography
-                  variant="h4"
-                  gutterBottom
-                  sx={{ mb: 6 }}
-                  data-testid="title"
-                >
+                <Typography variant="h4" gutterBottom sx={{ mb: 6 }}>
                   {title[0].value} Scenes
                 </Typography>
               </Container>

--- a/apps/watch/src/components/VideoContentPage/VideoContentPage.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoContentPage.tsx
@@ -127,7 +127,12 @@ export function VideoContentPage(): ReactElement {
           {container == null && label === VideoLabel.featureFilm && (
             <Stack sx={{ mb: 14 }}>
               <Container maxWidth="xxl">
-                <Typography variant="h4" gutterBottom sx={{ mb: 6 }}>
+                <Typography
+                  variant="h4"
+                  gutterBottom
+                  sx={{ mb: 6 }}
+                  data-testid="title"
+                >
                   {title[0].value} Scenes
                 </Typography>
               </Container>

--- a/apps/watch/src/components/VideoContentPage/VideoContentPage.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoContentPage.tsx
@@ -7,6 +7,7 @@ import { NextSeo } from 'next-seo'
 
 import 'video.js/dist/video-js.css'
 
+import { VideoLabel } from '../../../__generated__/globalTypes'
 import { useVideo } from '../../libs/videoContext'
 import { PageWrapper } from '../PageWrapper'
 import { ShareDialog } from '../ShareDialog'
@@ -30,7 +31,8 @@ export function VideoContentPage(): ReactElement {
     slug,
     variant,
     children,
-    container
+    container,
+    label
   } = useVideo()
   const [hasPlayed, setHasPlayed] = useState(false)
   const [openShare, setOpenShare] = useState(false)
@@ -122,7 +124,7 @@ export function VideoContentPage(): ReactElement {
             <ShareDialog open={openShare} onClose={() => setOpenShare(false)} />
           </Container>
           {/* TODO: Replace with proper related video components */}
-          {container == null && (
+          {container == null && label === VideoLabel.featureFilm && (
             <Stack sx={{ mb: 14 }}>
               <Container maxWidth="xxl">
                 <Typography variant="h4" gutterBottom sx={{ mb: 6 }}>


### PR DESCRIPTION
# Description

Please include a summary of the change and which todo is completed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/30278084/todos/5706315181)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] On the page for the feature film "JESUS", the text "JESUS scenes" and a carousel is displayed at the bottom of the page.
- [x] On the page for the chapter "Jesus calms the storm", no title or carousel is displayed at the bottom of the page.
- [x] On the page for the series "Reflections of Hope", no title or carousel is displayed at the bottom of the page.
- [x] On the page for the episode "Day 6: Jesus Died for Me", no title or carousel is displayed at the bottom of the page.
- [x] On the page for the collection "LUMO", no title or carousel is displayed at the bottom of the page.
- [x] On the page for the short film "Chosen Witness", no title or carousel is displayed at the bottom of the page.
- [x] One unit test has been added to src/components/VideoContentPage/VideoContentPage.stories.tsx.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
