### PR TITLE
fix: refactor to use one apollo provider

### DIFF
--- a/apps/watch/pages/_app.tsx
+++ b/apps/watch/pages/_app.tsx
@@ -3,6 +3,7 @@ import { AppProps as NextJsAppProps } from 'next/app'
 import Head from 'next/head'
 import { ThemeProvider } from '@core/shared/ui/ThemeProvider'
 import { ThemeMode, ThemeName } from '@core/shared/ui/themes'
+import { ApolloProvider, NormalizedCacheObject } from '@apollo/client'
 import { DefaultSeo } from 'next-seo'
 import { CacheProvider } from '@emotion/react'
 import type { EmotionCache } from '@emotion/cache'
@@ -11,6 +12,7 @@ import { createEmotionCache } from '@core/shared/ui/createEmotionCache'
 import 'swiper/swiper.min.css'
 import '../public/fonts/fonts.css'
 import '../public/styles/swiper-js.css'
+import { useApolloClient } from '../src/libs/apolloClient'
 
 const clientSideEmotionCache = createEmotionCache({ prepend: false })
 
@@ -23,22 +25,34 @@ export default function WatchApp({
   pageProps,
   emotionCache = clientSideEmotionCache
 }: WatchAppProps): ReactElement {
+  const initialPageProps = pageProps as {
+    initialApolloState?: NormalizedCacheObject
+  }
+  const client = useApolloClient({
+    initialState: initialPageProps.initialApolloState
+  })
+
   return (
-    <CacheProvider value={emotionCache}>
-      <DefaultSeo
-        titleTemplate="%s | Jesus Film Project"
-        defaultTitle="Watch | Jesus Film Project"
-        description="Free Gospel Video Streaming Library. Watch, learn and share the gospel in over 2000 languages."
-      />
-      <Head>
-        <meta
-          name="viewport"
-          content="minimum-scale=1, initial-scale=1, width=device-width"
+    <ApolloProvider client={client}>
+      <CacheProvider value={emotionCache}>
+        <DefaultSeo
+          titleTemplate="%s | Jesus Film Project"
+          defaultTitle="Watch | Jesus Film Project"
+          description="Free Gospel Video Streaming Library. Watch, learn and share the gospel in over 2000 languages."
         />
-      </Head>
-      <ThemeProvider themeName={ThemeName.website} themeMode={ThemeMode.light}>
-        <Component {...pageProps} />
-      </ThemeProvider>
-    </CacheProvider>
+        <Head>
+          <meta
+            name="viewport"
+            content="minimum-scale=1, initial-scale=1, width=device-width"
+          />
+        </Head>
+        <ThemeProvider
+          themeName={ThemeName.website}
+          themeMode={ThemeMode.light}
+        >
+          <Component {...pageProps} />
+        </ThemeProvider>
+      </CacheProvider>
+    </ApolloProvider>
   )
 }

--- a/apps/watch/pages/videos.tsx
+++ b/apps/watch/pages/videos.tsx
@@ -1,4 +1,4 @@
-import { ApolloProvider, NormalizedCacheObject } from '@apollo/client'
+import { NormalizedCacheObject } from '@apollo/client'
 import { GetStaticProps } from 'next'
 import { ReactElement } from 'react'
 import { Videos } from '../src/components/VideosPage'
@@ -7,19 +7,13 @@ import {
   GET_VIDEOS,
   limit
 } from '../src/components/VideosPage/VideosPage'
-import { createApolloClient, useApolloClient } from '../src/libs/apolloClient'
+import { createApolloClient } from '../src/libs/apolloClient'
 
 interface VideosPageProps {
   initialApolloState: NormalizedCacheObject
 }
-function VideosPage({ initialApolloState }: VideosPageProps): ReactElement {
-  const client = useApolloClient({ initialState: initialApolloState })
-
-  return (
-    <ApolloProvider client={client}>
-      <Videos />
-    </ApolloProvider>
-  )
+function VideosPage(): ReactElement {
+  return <Videos />
 }
 
 export const getStaticProps: GetStaticProps<VideosPageProps> = async () => {


### PR DESCRIPTION
# Description

Dependency for John, Jian wei and Nick to allow them to reference the same apollo client cache

[John's PR](https://3.basecamp.com/3105655/buckets/30278084/todos/5711053621)
[Nick's PR](https://3.basecamp.com/3105655/buckets/30278084/todos/5711054440)
[Jian Wei's PR](https://3.basecamp.com/3105655/buckets/30278084/todos/5711232308)

# How should this PR be QA Tested?

- [ ] All existing pages still render correctly
- [ ] Rest is tested in the PRs above.

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
