### PR TITLE
feat: add user invite api

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -791,6 +791,9 @@ type Mutation
 
   """Updates template"""
   journeyTemplate(id: ID!, input: JourneyTemplateInput!): Journey! @join__field(graph: JOURNEYS)
+  userInviteCreate(journeyId: ID!, input: UserInviteCreateInput): UserInvite! @join__field(graph: JOURNEYS)
+  userInviteRemove(id: ID!, journeyId: ID!): UserInvite! @join__field(graph: JOURNEYS)
+  userInviteAcceptAll: [UserInvite!]! @join__field(graph: JOURNEYS)
   userJourneyApprove(id: ID!): UserJourney! @join__field(graph: JOURNEYS)
   userJourneyPromote(id: ID!): UserJourney! @join__field(graph: JOURNEYS)
   userJourneyRemove(id: ID!): UserJourney! @join__field(graph: JOURNEYS)
@@ -908,6 +911,7 @@ type Query
   adminJourney(id: ID!, idType: IdType): Journey @join__field(graph: JOURNEYS)
   journeys(where: JourneysFilter): [Journey!]! @join__field(graph: JOURNEYS)
   journey(id: ID!, idType: IdType): Journey @join__field(graph: JOURNEYS)
+  userInvites(journeyId: ID!): [UserInvite!] @join__field(graph: JOURNEYS)
   getUserRole: UserRole @join__field(graph: JOURNEYS)
 
   """A list of visitors that are connected with a specific team."""
@@ -1395,6 +1399,23 @@ type UserAgent
   browser: Browser!
   device: Device!
   os: OperatingSystem!
+}
+
+type UserInvite
+  @join__type(graph: JOURNEYS, key: "id")
+{
+  id: ID!
+  journeyId: ID!
+  senderId: ID!
+  email: String!
+  acceptedAt: DateTime
+  removedAt: DateTime
+}
+
+input UserInviteCreateInput
+  @join__type(graph: JOURNEYS)
+{
+  email: String!
 }
 
 type UserJourney

--- a/apps/api-journeys/db/seed.ts
+++ b/apps/api-journeys/db/seed.ts
@@ -41,6 +41,18 @@ async function main(): Promise<void> {
     unique: true
   })
 
+  if (!(await db.collection('userInvites').exists()))
+    await db.createCollection('userInvites', {
+      keyOptions: { type: 'uuid' }
+    })
+
+  await db.collection('userInvites').ensureIndex({
+    type: 'persistent',
+    fields: ['journeyId', 'email'],
+    name: 'journeyIdAndEmail',
+    unique: true
+  })
+
   if (!(await db.collection('teams').exists()))
     await db.createCollection('teams', {
       keyOptions: { type: 'uuid' }

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -156,6 +156,9 @@ extend type Mutation {
 
   """Updates template"""
   journeyTemplate(id: ID!, input: JourneyTemplateInput!): Journey!
+  userInviteCreate(journeyId: ID!, input: UserInviteCreateInput): UserInvite!
+  userInviteRemove(id: ID!, journeyId: ID!): UserInvite!
+  userInviteAcceptAll: [UserInvite!]!
   userJourneyApprove(id: ID!): UserJourney!
   userJourneyPromote(id: ID!): UserJourney!
   userJourneyRemove(id: ID!): UserJourney!
@@ -1513,6 +1516,7 @@ extend type Query {
   adminJourney(id: ID!, idType: IdType): Journey
   journeys(where: JourneysFilter): [Journey!]!
   journey(id: ID!, idType: IdType): Journey
+  userInvites(journeyId: ID!): [UserInvite!]
   getUserRole: UserRole
 
   """A list of visitors that are connected with a specific team."""
@@ -1581,6 +1585,21 @@ type UserJourney
 
 input JourneyTemplateInput {
   template: Boolean
+}
+
+type UserInvite
+  @key(fields: "id")
+{
+  id: ID!
+  journeyId: ID!
+  senderId: ID!
+  email: String!
+  acceptedAt: DateTime
+  removedAt: DateTime
+}
+
+input UserInviteCreateInput {
+  email: String!
 }
 
 enum UserJourneyRole {
@@ -1806,4 +1825,4 @@ type _Service {
   sdl: String
 }
 
-union _Entity = Journey | Language | User | UserJourney | UserRole | Video | Visitor
+union _Entity = Journey | Language | User | UserInvite | UserJourney | UserRole | Video | Visitor

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -549,6 +549,10 @@ export class JourneyTemplateInput {
     template?: Nullable<boolean>;
 }
 
+export class UserInviteCreateInput {
+    email: string;
+}
+
 export class VisitorUpdateInput {
     email?: Nullable<string>;
     messagePlatformId?: Nullable<string>;
@@ -980,6 +984,8 @@ export abstract class IQuery {
 
     abstract journey(id: string, idType?: Nullable<IdType>): Nullable<Journey> | Promise<Nullable<Journey>>;
 
+    abstract userInvites(journeyId: string): Nullable<UserInvite[]> | Promise<Nullable<UserInvite[]>>;
+
     abstract getUserRole(): Nullable<UserRole> | Promise<Nullable<UserRole>>;
 
     abstract visitorsConnection(teamId: string, first?: Nullable<number>, after?: Nullable<string>): VisitorsConnection | Promise<VisitorsConnection>;
@@ -996,6 +1002,16 @@ export class UserJourney {
     role: UserJourneyRole;
     user?: Nullable<User>;
     openedAt?: Nullable<DateTime>;
+}
+
+export class UserInvite {
+    __typename?: 'UserInvite';
+    id: string;
+    journeyId: string;
+    senderId: string;
+    email: string;
+    acceptedAt?: Nullable<DateTime>;
+    removedAt?: Nullable<DateTime>;
 }
 
 export class UserRole {
@@ -1174,6 +1190,12 @@ export abstract class IMutation {
     abstract journeysRestore(ids: string[]): Nullable<Nullable<Journey>[]> | Promise<Nullable<Nullable<Journey>[]>>;
 
     abstract journeyTemplate(id: string, input: JourneyTemplateInput): Journey | Promise<Journey>;
+
+    abstract userInviteCreate(journeyId: string, input?: Nullable<UserInviteCreateInput>): UserInvite | Promise<UserInvite>;
+
+    abstract userInviteRemove(id: string, journeyId: string): UserInvite | Promise<UserInvite>;
+
+    abstract userInviteAcceptAll(): UserInvite[] | Promise<UserInvite[]>;
 
     abstract userJourneyApprove(id: string): UserJourney | Promise<UserJourney>;
 

--- a/apps/api-journeys/src/app/app.module.ts
+++ b/apps/api-journeys/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { JourneyModule } from './modules/journey/journey.module'
 import { EventModule } from './modules/event/event.module'
 import { UserJourneyModule } from './modules/userJourney/userJourney.module'
 import { UserRoleModule } from './modules/userRole/userRole.module'
+import { UserInviteModule } from './modules/userInvite/userInvite.module'
 import { VisitorModule } from './modules/visitor/visitor.module'
 import { MemberModule } from './modules/member/member.module'
 import { TeamModule } from './modules/team/team.module'
@@ -26,6 +27,7 @@ import { TeamModule } from './modules/team/team.module'
     MemberModule,
     TeamModule,
     UserJourneyModule,
+    UserInviteModule,
     UserRoleModule,
     VisitorModule,
     GraphQLModule.forRoot<ApolloFederationDriverConfig>({

--- a/apps/api-journeys/src/app/modules/userInvite/userInvite.graphql
+++ b/apps/api-journeys/src/app/modules/userInvite/userInvite.graphql
@@ -1,0 +1,22 @@
+type UserInvite @key(fields: "id") {
+  id: ID!
+  journeyId: ID!
+  senderId: ID!
+  email: String!
+  acceptedAt: DateTime
+  removedAt: DateTime
+}
+
+extend type Query {
+  userInvites(journeyId: ID!): [UserInvite!]
+}
+
+input UserInviteCreateInput {
+  email: String!
+}
+
+extend type Mutation {
+  userInviteCreate(journeyId: ID!, input: UserInviteCreateInput): UserInvite!
+  userInviteRemove(id: ID!, journeyId: ID!): UserInvite!
+  userInviteAcceptAll: [UserInvite!]!
+}

--- a/apps/api-journeys/src/app/modules/userInvite/userInvite.module.ts
+++ b/apps/api-journeys/src/app/modules/userInvite/userInvite.module.ts
@@ -1,0 +1,19 @@
+import { Global, Module } from '@nestjs/common'
+import { DatabaseModule } from '@core/nest/database/DatabaseModule'
+import { UserJourneyResolver } from '../userJourney/userJourney.resolver'
+import { JourneyService } from '../journey/journey.service'
+import { UserInviteService } from './userInvite.service'
+import { UserInviteResolver } from './userInvite.resolver'
+
+@Global()
+@Module({
+  imports: [DatabaseModule],
+  providers: [
+    UserInviteService,
+    UserInviteResolver,
+    UserJourneyResolver,
+    JourneyService
+  ],
+  exports: [UserInviteService]
+})
+export class UserInviteModule {}

--- a/apps/api-journeys/src/app/modules/userInvite/userInvite.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/userInvite/userInvite.resolver.spec.ts
@@ -1,0 +1,273 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { Role, UserJourneyRole } from '../../__generated__/graphql'
+import { JourneyService } from '../journey/journey.service'
+import { UserJourneyResolver } from '../userJourney/userJourney.resolver'
+import { UserJourneyService } from '../userJourney/userJourney.service'
+import { UserRoleService } from '../userRole/userRole.service'
+
+import { UserInviteResolver } from './userInvite.resolver'
+import { UserInviteService } from './userInvite.service'
+
+describe('UserInviteResolver', () => {
+  let resolver: UserInviteResolver,
+    service: UserInviteService,
+    ujResolver: UserJourneyResolver
+
+  const createInput = {
+    email: 'test@email.com'
+  }
+
+  const userInvite = {
+    id: '1',
+    journeyId: 'journeyId',
+    senderId: 'senderId',
+    email: 'test@email.com',
+    acceptedAt: null,
+    removedAt: null
+  }
+
+  const acceptedInvite = {
+    ...userInvite,
+    id: '2',
+    journeyId: 'acceptedJourneyId',
+    acceptedAt: '2021-02-18T00:00:00.000Z'
+  }
+
+  const removedInvite = {
+    ...userInvite,
+    id: '3',
+    journeyId: 'removedJourneyId',
+    removedAt: '2021-02-18T00:00:00.000Z'
+  }
+
+  const userInviteService = {
+    provide: UserInviteService,
+    useFactory: () => ({
+      save: jest.fn((input) => {
+        return { ...input, acceptedAt: null, removedAt: null }
+      }),
+      update: jest.fn((id, input) => {
+        return { ...userInvite, ...input }
+      }),
+      remove: jest.fn((id) => userInvite),
+      getAllUserInvitesByEmail: jest.fn((email) => {
+        if (email === userInvite.email) {
+          return [userInvite, acceptedInvite, removedInvite]
+        }
+        return []
+      }),
+      getAllUserInvitesByJourney: jest.fn((journeyId) => {
+        return [{ ...userInvite, journeyId }]
+      }),
+      getUserInviteByJourneyAndEmail: jest.fn((journeyId, email) => {
+        if (
+          journeyId === removedInvite.journeyId &&
+          email === removedInvite.email
+        ) {
+          return removedInvite
+        } else if (
+          journeyId === acceptedInvite.journeyId &&
+          email === acceptedInvite.email
+        ) {
+          return acceptedInvite
+        }
+        return null
+      })
+    })
+  }
+
+  const userJourney = {
+    id: 'userJourneyId',
+    userId: 'userId',
+    journeyId: 'journeyId',
+    role: UserJourneyRole.editor
+  }
+
+  const userJourneyResolver = {
+    provide: UserJourneyResolver,
+    useFactory: () => ({
+      userJourneyRequest: jest.fn((journeyId, idType, userId) => {
+        return { ...userJourney, journeyId, userId, role: 'inviteRequested' }
+      }),
+      userJourneyApprove: jest.fn((id, userId) => {
+        return userJourney
+      })
+    })
+  }
+
+  const userJourneyService = {
+    provide: UserJourneyService,
+    useFactory: () => ({ get: jest.fn((key) => userJourney) })
+  }
+
+  const userRole = {
+    id: 'userRoleId',
+    userId: 'userId',
+    roles: [Role.publisher]
+  }
+
+  const userRoleService = {
+    provide: UserRoleService,
+    useFactory: () => ({
+      getUserRoleById: jest.fn(() => userRole)
+    })
+  }
+
+  const journeyService = {
+    provide: JourneyService,
+    useFactory: () => ({
+      get: jest.fn((id) => ({ id }))
+    })
+  }
+
+  const user = {
+    id: 'userId',
+    email: 'test@email.com',
+    firstName: 'Test'
+  }
+
+  beforeAll(() => {
+    jest.useFakeTimers('modern')
+    jest.setSystemTime(new Date('2021-02-18'))
+  })
+
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserInviteResolver,
+        userInviteService,
+        userJourneyResolver,
+        userJourneyService,
+        userRoleService,
+        journeyService
+      ]
+    }).compile()
+    resolver = module.get(UserInviteResolver)
+    service = await module.resolve(UserInviteService)
+    ujResolver = await module.resolve(UserJourneyResolver)
+  })
+
+  describe('userInvites', () => {
+    it('should return all user invites sent for a journey', async () => {
+      await resolver.userInvites('journeyId')
+
+      expect(service.getAllUserInvitesByJourney).toHaveBeenCalledWith(
+        'journeyId'
+      )
+    })
+  })
+
+  describe('userInviteCreate', () => {
+    it('should create user invite if does not exist', async () => {
+      const invite = await resolver.userInviteCreate(
+        'senderId',
+        'newJourneyId',
+        createInput
+      )
+
+      expect(service.save).toHaveBeenCalledWith({
+        journeyId: 'newJourneyId',
+        senderId: 'senderId',
+        email: createInput.email
+      })
+      expect(service.update).not.toHaveBeenCalled()
+      expect(invite).toEqual({
+        journeyId: 'newJourneyId',
+        senderId: 'senderId',
+        email: createInput.email,
+        acceptedAt: null,
+        removedAt: null
+      })
+    })
+
+    it('should re-activate existing user invite if not accepted', async () => {
+      await resolver.userInviteCreate(
+        'senderId',
+        'removedJourneyId',
+        createInput
+      )
+
+      expect(service.save).not.toHaveBeenCalled()
+      expect(service.update).toHaveBeenCalledWith(removedInvite.id, {
+        senderId: removedInvite.senderId,
+        removedAt: null
+      })
+    })
+
+    it('should ignore accepted user invite', async () => {
+      const invite = await resolver.userInviteCreate(
+        'senderId',
+        'acceptedJourneyId',
+        createInput
+      )
+
+      expect(service.save).not.toHaveBeenCalled()
+      expect(service.update).not.toHaveBeenCalled()
+      expect(invite).toEqual(acceptedInvite)
+    })
+
+    it('throws UserInputError when journey does not exist', async () => {
+      await resolver
+        .userInviteCreate('senderId', 'randomJourneyId', createInput)
+        .catch((error) => {
+          expect(error.message).toEqual('journey does not exist')
+        })
+    })
+  })
+
+  describe('userInviteRemove', () => {
+    it('should remove user invite', async () => {
+      const invite = await resolver.userInviteRemove('1', 'journeyId')
+
+      expect(service.update).toHaveBeenCalledWith('1', {
+        removedAt: '2021-02-18T00:00:00.000Z'
+      })
+      expect(invite).toEqual({
+        ...userInvite,
+        removedAt: '2021-02-18T00:00:00.000Z'
+      })
+    })
+  })
+
+  describe('userInviteAcceptAll', () => {
+    it('should accept unredeemed valid user invites', async () => {
+      const invites = await resolver.userInviteAcceptAll(user)
+
+      expect(ujResolver.userJourneyRequest).toHaveBeenCalledTimes(1)
+      expect(ujResolver.userJourneyRequest).toHaveBeenCalledWith(
+        'journeyId',
+        'databaseId',
+        'userId'
+      )
+      expect(ujResolver.userJourneyApprove).toHaveBeenCalledTimes(1)
+      expect(ujResolver.userJourneyApprove).toHaveBeenCalledWith(
+        'userJourneyId',
+        'senderId'
+      )
+
+      expect(await invites[0]).toEqual({
+        ...userInvite,
+        acceptedAt: '2021-02-18T00:00:00.000Z'
+      })
+      // Accepted and expired invites unchanged
+      expect(await invites[1]).toEqual(acceptedInvite)
+      expect(await invites[2]).toEqual(removedInvite)
+    })
+
+    it('should show no invites if email does not match', async () => {
+      const rejectedInvite = await resolver.userInviteAcceptAll({
+        ...user,
+        email: 'doesnotexist@email.com'
+      })
+
+      expect(ujResolver.userJourneyRequest).not.toHaveBeenCalled()
+      expect(ujResolver.userJourneyApprove).not.toHaveBeenCalled()
+      expect(service.update).not.toHaveBeenCalled()
+      expect(rejectedInvite).toEqual([])
+    })
+  })
+})

--- a/apps/api-journeys/src/app/modules/userInvite/userInvite.resolver.ts
+++ b/apps/api-journeys/src/app/modules/userInvite/userInvite.resolver.ts
@@ -1,0 +1,139 @@
+import { Resolver, Query, Mutation, Args } from '@nestjs/graphql'
+import { UseGuards } from '@nestjs/common'
+import { CurrentUserId } from '@core/nest/decorators/CurrentUserId'
+import { CurrentUser } from '@core/nest/decorators/CurrentUser'
+import { GqlAuthGuard } from '@core/nest/gqlAuthGuard/GqlAuthGuard'
+import { UserInputError } from 'apollo-server-errors'
+import { User } from '@core/nest/common/firebaseClient'
+
+import {
+  IdType,
+  Journey,
+  UserInvite,
+  UserInviteCreateInput,
+  UserJourneyRole
+} from '../../__generated__/graphql'
+import { UserJourneyResolver } from '../userJourney/userJourney.resolver'
+import { RoleGuard } from '../../lib/roleGuard/roleGuard'
+import { JourneyService } from '../journey/journey.service'
+import { UserInviteService } from './userInvite.service'
+
+@Resolver('UserInvite')
+export class UserInviteResolver {
+  constructor(
+    private readonly userInviteService: UserInviteService,
+    private readonly userJourneyResolver: UserJourneyResolver,
+    private readonly journeyService: JourneyService
+  ) {}
+
+  @Query()
+  @UseGuards(
+    GqlAuthGuard,
+    RoleGuard('journeyId', [UserJourneyRole.owner, UserJourneyRole.editor])
+  )
+  async userInvites(
+    @Args('journeyId') journeyId: string
+  ): Promise<UserInvite[]> {
+    return await this.userInviteService.getAllUserInvitesByJourney(journeyId)
+  }
+
+  @Mutation()
+  @UseGuards(
+    GqlAuthGuard,
+    RoleGuard('journeyId', [UserJourneyRole.owner, UserJourneyRole.editor])
+  )
+  async userInviteCreate(
+    @CurrentUserId() senderId: string,
+    @Args('journeyId') journeyId: string,
+    @Args('input') input: UserInviteCreateInput
+  ): Promise<UserInvite> {
+    const userInvite: UserInvite =
+      await this.userInviteService.getUserInviteByJourneyAndEmail(
+        journeyId,
+        input.email
+      )
+
+    // Create invite if doesn't exist else re-activate removed invite
+    if (userInvite == null) {
+      const journey = await this.journeyService.get<Journey>(journeyId)
+
+      if (journey == null) throw new UserInputError('journey does not exist')
+
+      return await this.userInviteService.save({
+        journeyId: journey.id,
+        senderId,
+        email: input.email
+      })
+    }
+
+    if (userInvite.acceptedAt == null) {
+      return await this.userInviteService.update(userInvite.id, {
+        senderId,
+        removedAt: null
+      })
+    }
+
+    return userInvite
+  }
+
+  @Mutation()
+  @UseGuards(
+    GqlAuthGuard,
+    RoleGuard('journeyId', [UserJourneyRole.owner, UserJourneyRole.editor])
+  )
+  async userInviteRemove(
+    @Args('id') id: string,
+    @Args('journeyId') journeyId: string
+  ): Promise<UserInvite> {
+    return await this.userInviteService.update(id, {
+      removedAt: new Date().toISOString()
+    })
+  }
+
+  async redeemInvite(
+    userInvite: UserInvite,
+    userId: string
+  ): Promise<UserInvite> {
+    if (userInvite.acceptedAt == null && userInvite.removedAt == null) {
+      const userJourney = await this.userJourneyResolver.userJourneyRequest(
+        userInvite.journeyId,
+        IdType.databaseId,
+        userId
+      )
+
+      await this.userJourneyResolver.userJourneyApprove(
+        userJourney.id,
+        userInvite.senderId
+      )
+
+      const updatedInvite: UserInvite = await this.userInviteService.update(
+        userInvite.id,
+        {
+          acceptedAt: new Date().toISOString()
+        }
+      )
+
+      return updatedInvite
+    }
+
+    return userInvite
+  }
+
+  @Mutation()
+  @UseGuards(GqlAuthGuard)
+  async userInviteAcceptAll(
+    @CurrentUser() user: User
+  ): Promise<Array<Promise<UserInvite>>> {
+    const userInvites = await this.userInviteService.getAllUserInvitesByEmail(
+      user.email
+    )
+
+    if (userInvites.length === 0) return []
+
+    const invites = userInvites.map(
+      async (userInvite) => await this.redeemInvite(userInvite, user.id)
+    )
+
+    return invites
+  }
+}

--- a/apps/api-journeys/src/app/modules/userInvite/userInvite.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/userInvite/userInvite.service.spec.ts
@@ -1,0 +1,77 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { Database } from 'arangojs'
+import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
+import { mockDbQueryResult } from '@core/nest/database/mock'
+import { DocumentCollection } from 'arangojs/collection'
+import { keyAsId } from '@core/nest/decorators/KeyAsId'
+
+import { UserInviteService } from './userInvite.service'
+
+describe('userInviteService', () => {
+  let service: UserInviteService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserInviteService,
+        {
+          provide: 'DATABASE',
+          useFactory: () => mockDeep<Database>()
+        }
+      ]
+    }).compile()
+
+    service = module.get<UserInviteService>(UserInviteService)
+    service.collection = mockDeep<DocumentCollection>()
+  })
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
+
+  const userInvite = {
+    _key: '1',
+    journeyId: 'journeyId',
+    name: 'username',
+    email: 'email@test.com',
+    accepted: false,
+    expireAt: 'UTCDateTimeString'
+  }
+
+  const userInviteWithId = keyAsId(userInvite)
+
+  describe('getUserInviteByJourneyAndEmail', () => {
+    it('should return a userInvite if exists', async () => {
+      ;(service.db as DeepMockProxy<Database>).query.mockReturnValue(
+        mockDbQueryResult(service.db, [userInvite])
+      )
+      expect(
+        await service.getUserInviteByJourneyAndEmail(
+          'journeyId',
+          'email@test.com'
+        )
+      ).toEqual(userInviteWithId)
+    })
+  })
+
+  describe('getAllUserInvitesByEmail', () => {
+    it('should return a userInvite array', async () => {
+      ;(service.db as DeepMockProxy<Database>).query.mockReturnValue(
+        mockDbQueryResult(service.db, [userInvite])
+      )
+      expect(await service.getAllUserInvitesByEmail('email@test.com')).toEqual([
+        userInviteWithId
+      ])
+    })
+  })
+
+  describe('getAllUserInvitesByJourney', () => {
+    it('should return a userInvite array', async () => {
+      ;(service.db as DeepMockProxy<Database>).query.mockReturnValue(
+        mockDbQueryResult(service.db, [userInvite])
+      )
+      expect(await service.getAllUserInvitesByJourney('journeyId')).toEqual([
+        userInviteWithId
+      ])
+    })
+  })
+})

--- a/apps/api-journeys/src/app/modules/userInvite/userInvite.service.ts
+++ b/apps/api-journeys/src/app/modules/userInvite/userInvite.service.ts
@@ -1,0 +1,48 @@
+import { BaseService } from '@core/nest/database/BaseService'
+import { KeyAsId } from '@core/nest/decorators/KeyAsId'
+import { Injectable } from '@nestjs/common'
+import { aql } from 'arangojs'
+import { DocumentCollection } from 'arangojs/collection'
+import { UserInvite } from '../../__generated__/graphql'
+
+@Injectable()
+export class UserInviteService extends BaseService {
+  collection: DocumentCollection = this.db.collection('userInvites')
+
+  @KeyAsId()
+  async getUserInviteByJourneyAndEmail(
+    journeyId: string,
+    email: string
+  ): Promise<UserInvite> {
+    const res = await this.db.query(aql`
+      FOR userInvite in ${this.collection}
+        FILTER userInvite.journeyId == ${journeyId} && userInvite.email == ${email}
+        LIMIT 1
+        RETURN userInvite
+    `)
+
+    return await res.next()
+  }
+
+  @KeyAsId()
+  async getAllUserInvitesByEmail(email: string): Promise<UserInvite[]> {
+    const res = await this.db.query(aql`
+      FOR userInvite in ${this.collection}
+        FILTER userInvite.email == ${email}
+        RETURN userInvite
+    `)
+
+    return await res.all()
+  }
+
+  @KeyAsId()
+  async getAllUserInvitesByJourney(journeyId: string): Promise<UserInvite[]> {
+    const res = await this.db.query(aql`
+      FOR userInvite in ${this.collection}
+        FILTER userInvite.journeyId == ${journeyId}
+        RETURN userInvite
+    `)
+
+    return await res.all()
+  }
+}

--- a/libs/nest/common/src/lib/firebaseClient/index.ts
+++ b/libs/nest/common/src/lib/firebaseClient/index.ts
@@ -1,1 +1,6 @@
-export { firebaseClient, contextToUserId } from './firebaseClient'
+export {
+  firebaseClient,
+  contextToUserId,
+  contextToUser,
+  User
+} from './firebaseClient'

--- a/libs/nest/decorators/src/lib/CurrentUser/CurrentUser.ts
+++ b/libs/nest/decorators/src/lib/CurrentUser/CurrentUser.ts
@@ -1,0 +1,11 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common'
+import { AuthenticationError } from 'apollo-server-errors'
+import { contextToUser } from '@core/nest/common/firebaseClient'
+
+export const CurrentUser = createParamDecorator(
+  async (_data, context: ExecutionContext) => {
+    const user = await contextToUser(context)
+    if (user == null) throw new AuthenticationError('Token is invalid')
+    return user
+  }
+)

--- a/libs/nest/decorators/src/lib/CurrentUser/index.ts
+++ b/libs/nest/decorators/src/lib/CurrentUser/index.ts
@@ -1,0 +1,1 @@
+export { CurrentUser } from './CurrentUser'


### PR DESCRIPTION
# Description

Creates and updates a userInvite to set journey permissions

[Basecamp Todo](https://3.basecamp.com/3105655/buckets/31245893/todos/5763468706)

# How should this PR be QA Tested?

Stage graphql correctly returns expected data
- [x] userInviteCreate - returns new userInvite
- [x] userInvites - returns all user invites for a particular journey
- [x] userInviteRemove - removes invite by id
- [x] userInviteAcceptAll - returns updated userInvite (only allows changing `accepted` value for now), userJourney also created in database (side effect)

<img width="1677" alt="image" src="https://user-images.githubusercontent.com/10802634/215878515-a34aa4a3-7220-40af-b63a-c35c3ca6af50.png">
<img width="1223" alt="image" src="https://user-images.githubusercontent.com/10802634/215878785-be0e7245-1ad4-4630-8ffd-817b83c93015.png">



# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
