### PR TITLE
fix: graphql generation and cors vercel error with router

### DIFF
--- a/apps/api-gateway/project.json
+++ b/apps/api-gateway/project.json
@@ -27,7 +27,7 @@
       "options": {
         "commands": [
           {
-            "command": "rover supergraph compose --config apps/api-gateway/supergraph.yml > apps/api-gateway/schema.graphql"
+            "command": "rover supergraph compose --config apps/api-gateway/supergraph.yml --elv2-license=accept > apps/api-gateway/schema.graphql"
           }
         ]
       }

--- a/apps/api-gateway/router.prod.yaml
+++ b/apps/api-gateway/router.prod.yaml
@@ -19,7 +19,7 @@ cors:
     - https://watch.jesusfilm.org
   match_origins:
     # any project deployed on the jesusfilm vercel account
-    - '^https://([a-z0-9]+[.])*-jesusfilm[.]vercel[.]app$'
+    - '^https://([a-z0-9-]+)-jesusfilm[.]vercel[.]app$'
 headers:
   all:
     request:


### PR DESCRIPTION
# Description

Two router bugs resolved:
- cannot generate graphql without accepting license
- vercel previews cannot connect to API

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] generate-graphql works when first generating a dev container
- [ ] previews can connect to stage

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
