### PR TITLE
feat: approve invited user on journey related pages

### DIFF
--- a/apps/journeys-admin/__generated__/UserInviteAcceptAll.ts
+++ b/apps/journeys-admin/__generated__/UserInviteAcceptAll.ts
@@ -1,0 +1,18 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL mutation operation: UserInviteAcceptAll
+// ====================================================
+
+export interface UserInviteAcceptAll_userInviteAcceptAll {
+  __typename: "UserInvite";
+  id: string;
+  acceptedAt: any | null;
+}
+
+export interface UserInviteAcceptAll {
+  userInviteAcceptAll: UserInviteAcceptAll_userInviteAcceptAll[];
+}

--- a/apps/journeys-admin/pages/index.tsx
+++ b/apps/journeys-admin/pages/index.tsx
@@ -12,8 +12,10 @@ import { useTranslation } from 'react-i18next'
 import { useRouter } from 'next/router'
 import { getLaunchDarklyClient } from '@core/shared/ui/getLaunchDarklyClient'
 import { GetJourneys } from '../__generated__/GetJourneys'
+import { UserInviteAcceptAll } from '../__generated__/UserInviteAcceptAll'
 import { JourneyList } from '../src/components/JourneyList'
 import { PageWrapper } from '../src/components/PageWrapper'
+import { createApolloClient } from '../src/libs/apolloClient'
 import i18nConfig from '../next-i18next.config'
 import JourneyListMenu from '../src/components/JourneyList/JourneyListMenu/JourneyListMenu'
 
@@ -48,6 +50,15 @@ export const GET_JOURNEYS = gql`
           imageUrl
         }
       }
+    }
+  }
+`
+
+export const ACCEPT_USER_INVITE = gql`
+  mutation UserInviteAcceptAll {
+    userInviteAcceptAll {
+      id
+      acceptedAt
     }
   }
 `
@@ -106,6 +117,14 @@ export const getServerSideProps = withAuthUserTokenSSR({
   const flags = (await launchDarklyClient.allFlagsState(ldUser)).toJSON() as {
     [key: string]: boolean | undefined
   }
+
+  const token = await AuthUser.getIdToken()
+  const apolloClient = createApolloClient(token != null ? token : '')
+
+  await apolloClient.mutate<UserInviteAcceptAll>({
+    mutation: ACCEPT_USER_INVITE
+  })
+
   return {
     props: {
       flags,

--- a/apps/journeys-admin/pages/journeys/[journeyId].tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId].tsx
@@ -14,11 +14,14 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'react-i18next'
 import { getLaunchDarklyClient } from '@core/shared/ui/getLaunchDarklyClient'
 import { JourneyInvite } from '../../src/components/JourneyInvite/JourneyInvite'
+import { createApolloClient } from '../../src/libs/apolloClient'
 import { GetJourney } from '../../__generated__/GetJourney'
+import { UserInviteAcceptAll } from '../../__generated__/UserInviteAcceptAll'
 import { JourneyView } from '../../src/components/JourneyView'
 import { PageWrapper } from '../../src/components/PageWrapper'
 import { Menu } from '../../src/components/JourneyView/Menu'
 import i18nConfig from '../../next-i18next.config'
+import { ACCEPT_USER_INVITE } from '..'
 
 export const GET_JOURNEY = gql`
   ${JOURNEY_FIELDS}
@@ -93,6 +96,14 @@ export const getServerSideProps = withAuthUserTokenSSR({
   const flags = (await launchDarklyClient.allFlagsState(ldUser)).toJSON() as {
     [key: string]: boolean | undefined
   }
+
+  const token = await AuthUser.getIdToken()
+  const apolloClient = createApolloClient(token != null ? token : '')
+
+  await apolloClient.mutate<UserInviteAcceptAll>({
+    mutation: ACCEPT_USER_INVITE
+  })
+
   return {
     props: {
       flags,

--- a/apps/journeys-admin/pages/journeys/[journeyId]/edit.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/edit.tsx
@@ -12,6 +12,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'react-i18next'
 import { getLaunchDarklyClient } from '@core/shared/ui/getLaunchDarklyClient'
 import { GetJourney } from '../../../__generated__/GetJourney'
+import { UserInviteAcceptAll } from '../../../__generated__/UserInviteAcceptAll'
 import { Editor } from '../../../src/components/Editor'
 import { PageWrapper } from '../../../src/components/PageWrapper'
 import { GET_JOURNEY } from '../[journeyId]'
@@ -20,6 +21,7 @@ import { EditToolbar } from '../../../src/components/Editor/EditToolbar'
 import { JourneyInvite } from '../../../src/components/JourneyInvite/JourneyInvite'
 import { createApolloClient } from '../../../src/libs/apolloClient'
 import i18nConfig from '../../../next-i18next.config'
+import { ACCEPT_USER_INVITE } from '../..'
 
 function JourneyEditPage(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
@@ -93,6 +95,10 @@ export const getServerSideProps = withAuthUserTokenSSR({
 
   const token = await AuthUser.getIdToken()
   const apolloClient = createApolloClient(token != null ? token : '')
+
+  await apolloClient.mutate<UserInviteAcceptAll>({
+    mutation: ACCEPT_USER_INVITE
+  })
 
   const { data } = await apolloClient.query<GetJourney>({
     query: GET_JOURNEY,

--- a/apps/journeys-admin/pages/journeys/[journeyId]/reports.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/reports.tsx
@@ -12,9 +12,12 @@ import { getLaunchDarklyClient } from '@core/shared/ui/getLaunchDarklyClient'
 import Box from '@mui/material/Box'
 import { useRouter } from 'next/router'
 import { PageWrapper } from '../../../src/components/PageWrapper'
+import { UserInviteAcceptAll } from '../../../__generated__/UserInviteAcceptAll'
 import i18nConfig from '../../../next-i18next.config'
 import { MemoizedDynamicReport } from '../../../src/components/DynamicPowerBiReport'
+import { createApolloClient } from '../../../src/libs/apolloClient'
 import { JourneysReportType } from '../../../__generated__/globalTypes'
+import { ACCEPT_USER_INVITE } from '../..'
 
 function JourneyReportsPage(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
@@ -55,6 +58,14 @@ export const getServerSideProps = withAuthUserTokenSSR({
   const flags = (await launchDarklyClient.allFlagsState(ldUser)).toJSON() as {
     [key: string]: boolean | undefined
   }
+
+  const token = await AuthUser.getIdToken()
+  const apolloClient = createApolloClient(token != null ? token : '')
+
+  await apolloClient.mutate<UserInviteAcceptAll>({
+    mutation: ACCEPT_USER_INVITE
+  })
+
   return {
     props: {
       flags,


### PR DESCRIPTION
# Description

Visiting any of the journey list, detail, edit or report pages after you get invited should let you see the page after refresh.

[Basecamp Todo](https://3.basecamp.com/3105655/buckets/31245893/todos/5763488517)

# How should this PR be QA Tested?

Create a user invite using apollo or localhost:4000
<img width="1705" alt="image" src="https://user-images.githubusercontent.com/10802634/215933972-1759adbc-0349-49b1-afcd-1a7164579c4b.png">

Or create via adding directly to arrango
{
  "journeyId": "dcd0c068-de99-4c45-8775-f4328d042832",
  "senderId": "SMNiOX5sL9OwbLFsLznsoMkVn603",
  "email": "another@email.com",
  "accepted": true,
  "expireAt": "2023-03-04T03:42:25.712Z",
  "acceptedAt": "2023-02-06T19:47:01.553Z"
}

Log in or sign up using the email in the invite - you should be able to see the journey or journeys you've been invited 
to.
- [ ] Shows journeys when you navigate to journey list page / landing page immediately after getting an invite
- [ ] Shows journeys when you navigate to journey details page immediately after getting an invite
- [ ] Shows journeys when you navigate to journey edit page immediately after getting an invite
- [ ] Shows journeys when you navigate to journey reports page immediately after getting an invite

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
