### PR TITLE
feat: add journeyProfile table

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -796,6 +796,7 @@ type Mutation
 
   """Updates template"""
   journeyTemplate(id: ID!, input: JourneyTemplateInput!): Journey!
+  journeyProfileCreate: JourneyProfile!
   userJourneyApprove(id: ID!): UserJourney!
   userJourneyPromote(id: ID!): UserJourney!
   userJourneyRemove(id: ID!): UserJourney!

--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -547,6 +547,14 @@ input JourneyCreateInput
   slug: String
 }
 
+type JourneyProfile
+  @join__type(graph: JOURNEYS, key: "id")
+{
+  id: ID!
+  userId: ID!
+  acceptedTermsAt: DateTime
+}
+
 input JourneysFilter
   @join__type(graph: JOURNEYS)
 {
@@ -903,6 +911,7 @@ type Query
   adminJourney(id: ID!, idType: IdType): Journey @join__field(graph: JOURNEYS)
   journeys(where: JourneysFilter): [Journey!]! @join__field(graph: JOURNEYS)
   journey(id: ID!, idType: IdType): Journey @join__field(graph: JOURNEYS)
+  getJourneyProfile: JourneyProfile @join__field(graph: JOURNEYS)
   getUserRole: UserRole @join__field(graph: JOURNEYS)
 
   """A list of visitors that are connected with a specific team."""

--- a/apps/api-journeys/db/seed.ts
+++ b/apps/api-journeys/db/seed.ts
@@ -65,6 +65,18 @@ async function main(): Promise<void> {
     unique: true
   })
 
+  if (!(await db.collection('journeyProfiles').exists()))
+    await db.createCollection('journeyProfiles', {
+      keyOptions: { type: 'uuid' }
+    })
+
+  await db.collection('journeyProfiles').ensureIndex({
+    type: 'persistent',
+    fields: ['userId'],
+    name: 'userId',
+    unique: true
+  })
+
   if (!(await db.collection('userRoles').exists()))
     await db.createCollection('userRoles', {
       keyOptions: { type: 'uuid' }

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -156,6 +156,7 @@ extend type Mutation {
 
   """Updates template"""
   journeyTemplate(id: ID!, input: JourneyTemplateInput!): Journey!
+  journeyProfileCreate: JourneyProfile!
   userJourneyApprove(id: ID!): UserJourney!
   userJourneyPromote(id: ID!): UserJourney!
   userJourneyRemove(id: ID!): UserJourney!

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -1512,6 +1512,7 @@ extend type Query {
   adminJourney(id: ID!, idType: IdType): Journey
   journeys(where: JourneysFilter): [Journey!]!
   journey(id: ID!, idType: IdType): Journey
+  getJourneyProfile: JourneyProfile
   getUserRole: UserRole
 
   """A list of visitors that are connected with a specific team."""
@@ -1577,6 +1578,14 @@ type UserJourney
 
 input JourneyTemplateInput {
   template: Boolean
+}
+
+type JourneyProfile
+  @key(fields: "id")
+{
+  id: ID!
+  userId: ID!
+  acceptedTermsAt: DateTime
 }
 
 enum UserJourneyRole {
@@ -1802,4 +1811,4 @@ type _Service {
   sdl: String
 }
 
-union _Entity = Journey | Language | User | UserJourney | UserRole | Video | Visitor
+union _Entity = Journey | JourneyProfile | Language | User | UserJourney | UserRole | Video | Visitor

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -1184,6 +1184,8 @@ export abstract class IMutation {
 
     abstract journeyTemplate(id: string, input: JourneyTemplateInput): Journey | Promise<Journey>;
 
+    abstract journeyProfileCreate(): JourneyProfile | Promise<JourneyProfile>;
+
     abstract userJourneyApprove(id: string): UserJourney | Promise<UserJourney>;
 
     abstract userJourneyPromote(id: string): UserJourney | Promise<UserJourney>;

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -980,6 +980,8 @@ export abstract class IQuery {
 
     abstract journey(id: string, idType?: Nullable<IdType>): Nullable<Journey> | Promise<Nullable<Journey>>;
 
+    abstract getJourneyProfile(): Nullable<JourneyProfile> | Promise<Nullable<JourneyProfile>>;
+
     abstract getUserRole(): Nullable<UserRole> | Promise<Nullable<UserRole>>;
 
     abstract visitorsConnection(teamId: string, first?: Nullable<number>, after?: Nullable<string>): VisitorsConnection | Promise<VisitorsConnection>;
@@ -995,6 +997,13 @@ export class UserJourney {
     journeyId: string;
     role: UserJourneyRole;
     user?: Nullable<User>;
+}
+
+export class JourneyProfile {
+    __typename?: 'JourneyProfile';
+    id: string;
+    userId: string;
+    acceptedTermsAt?: Nullable<DateTime>;
 }
 
 export class UserRole {

--- a/apps/api-journeys/src/app/app.module.ts
+++ b/apps/api-journeys/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { BlockModule } from './modules/block/block.module'
 import { JourneyModule } from './modules/journey/journey.module'
 import { EventModule } from './modules/event/event.module'
 import { UserJourneyModule } from './modules/userJourney/userJourney.module'
+import { JourneyProfileModule } from './modules/journeyProfile/journeyProfile.module'
 import { UserRoleModule } from './modules/userRole/userRole.module'
 import { VisitorModule } from './modules/visitor/visitor.module'
 import { MemberModule } from './modules/member/member.module'
@@ -27,6 +28,7 @@ import { TeamModule } from './modules/team/team.module'
     TeamModule,
     UserJourneyModule,
     UserRoleModule,
+    JourneyProfileModule,
     VisitorModule,
     GraphQLModule.forRoot<ApolloFederationDriverConfig>({
       driver: ApolloFederationDriver,

--- a/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.graphql
+++ b/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.graphql
@@ -1,0 +1,9 @@
+type JourneyProfile @key(fields: "id") {
+  id: ID!
+  userId: ID!
+  acceptedTermsAt: DateTime
+}
+
+extend type Query {
+  getJourneyProfile: JourneyProfile
+}

--- a/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.graphql
+++ b/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.graphql
@@ -7,3 +7,7 @@ type JourneyProfile @key(fields: "id") {
 extend type Query {
   getJourneyProfile: JourneyProfile
 }
+
+extend type Mutation {
+  journeyProfileCreate: JourneyProfile!
+}

--- a/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.module.ts
+++ b/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.module.ts
@@ -1,0 +1,12 @@
+import { Global, Module } from '@nestjs/common'
+import { DatabaseModule } from '@core/nest/database/DatabaseModule'
+import { JourneyProfileService } from './journeyProfile.service'
+import { JourneyProfileResolver } from './journeyProfile.resolver'
+
+@Global()
+@Module({
+  imports: [DatabaseModule],
+  providers: [JourneyProfileService, JourneyProfileResolver],
+  exports: [JourneyProfileService]
+})
+export class JourneyProfileModule {}

--- a/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.resolver.spec.ts
@@ -16,7 +16,7 @@ describe('JourneyProfileResolver', () => {
     const journeyProfileService = {
       provide: JourneyProfileService,
       useFactory: () => ({
-        getJourneyProfileById: jest.fn(() => user)
+        getJourneyProfileByUserId: jest.fn(() => user)
       })
     }
 

--- a/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.resolver.spec.ts
@@ -6,25 +6,53 @@ import { JourneyProfileService } from './journeyProfile.service'
 describe('JourneyProfileResolver', () => {
   let resolver: JourneyProfileResolver
 
-  it('should return user profile', async () => {
-    const user = {
-      id: '1',
-      userId: 'userId',
-      acceptedTermsAt: '2021-11-19T12:34:56.647Z'
-    }
+  const profile = {
+    id: '1',
+    userId: 'userId',
+    acceptedTermsAt: null
+  }
 
-    const journeyProfileService = {
-      provide: JourneyProfileService,
-      useFactory: () => ({
-        getJourneyProfileByUserId: jest.fn(() => user)
+  const journeyProfileService = {
+    provide: JourneyProfileService,
+    useFactory: () => ({
+      getJourneyProfileByUserId: jest.fn((userId) =>
+        userId === profile.userId ? profile : null
+      ),
+      save: jest.fn((input) => {
+        return { ...profile, ...input }
       })
-    }
+    })
+  }
 
+  beforeAll(() => {
+    jest.useFakeTimers('modern')
+    jest.setSystemTime(new Date('2021-02-18'))
+  })
+
+  beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [JourneyProfileResolver, journeyProfileService]
     }).compile()
     resolver = module.get<JourneyProfileResolver>(JourneyProfileResolver)
+  })
 
-    expect(await resolver.getJourneyProfile('userId')).toEqual(user)
+  describe('getJourneyProfile', () => {
+    it('should return user profile', async () => {
+      expect(await resolver.getJourneyProfile('userId')).toEqual(profile)
+    })
+  })
+
+  describe('journeyProfileCreate', () => {
+    it('should create user profile', async () => {
+      expect(await resolver.journeyProfileCreate('newUserId')).toEqual({
+        ...profile,
+        userId: 'newUserId',
+        acceptedTermsAt: '2021-02-18T00:00:00.000Z'
+      })
+    })
+
+    it('should return existing profile', async () => {
+      expect(await resolver.journeyProfileCreate('userId')).toEqual(profile)
+    })
   })
 })

--- a/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.resolver.spec.ts
@@ -1,0 +1,30 @@
+import { Test, TestingModule } from '@nestjs/testing'
+
+import { JourneyProfileResolver } from './journeyProfile.resolver'
+import { JourneyProfileService } from './journeyProfile.service'
+
+describe('JourneyProfileResolver', () => {
+  let resolver: JourneyProfileResolver
+
+  it('should return user profile', async () => {
+    const user = {
+      id: '1',
+      userId: 'userId',
+      acceptedTermsAt: '2021-11-19T12:34:56.647Z'
+    }
+
+    const journeyProfileService = {
+      provide: JourneyProfileService,
+      useFactory: () => ({
+        getJourneyProfileById: jest.fn(() => user)
+      })
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [JourneyProfileResolver, journeyProfileService]
+    }).compile()
+    resolver = module.get<JourneyProfileResolver>(JourneyProfileResolver)
+
+    expect(await resolver.getJourneyProfile('userId')).toEqual(user)
+  })
+})

--- a/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.resolver.ts
@@ -1,4 +1,4 @@
-import { Resolver, Query } from '@nestjs/graphql'
+import { Resolver, Query, Mutation } from '@nestjs/graphql'
 import { CurrentUserId } from '@core/nest/decorators/CurrentUserId'
 import { UseGuards } from '@nestjs/common'
 import { GqlAuthGuard } from '@core/nest/gqlAuthGuard/GqlAuthGuard'
@@ -15,5 +15,23 @@ export class JourneyProfileResolver {
     @CurrentUserId() userId: string
   ): Promise<JourneyProfile> {
     return await this.journeyProfileService.getJourneyProfileByUserId(userId)
+  }
+
+  @Mutation()
+  @UseGuards(GqlAuthGuard)
+  async journeyProfileCreate(
+    @CurrentUserId() userId: string
+  ): Promise<JourneyProfile> {
+    const profile = await this.getJourneyProfile(userId)
+
+    // Create profile after accepting terms of service
+    if (profile == null) {
+      return await this.journeyProfileService.save({
+        userId,
+        acceptedTermsAt: new Date().toISOString()
+      })
+    }
+
+    return profile
   }
 }

--- a/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.resolver.ts
@@ -1,0 +1,19 @@
+import { Resolver, Query } from '@nestjs/graphql'
+import { CurrentUserId } from '@core/nest/decorators/CurrentUserId'
+import { UseGuards } from '@nestjs/common'
+import { GqlAuthGuard } from '@core/nest/gqlAuthGuard/GqlAuthGuard'
+import { JourneyProfile } from '../../__generated__/graphql'
+import { JourneyProfileService } from './journeyProfile.service'
+
+@Resolver('JourneyProfile')
+export class JourneyProfileResolver {
+  constructor(private readonly journeyProfileService: JourneyProfileService) {}
+
+  @Query()
+  @UseGuards(GqlAuthGuard)
+  async getJourneyProfile(
+    @CurrentUserId() userId: string
+  ): Promise<JourneyProfile> {
+    return await this.journeyProfileService.getJourneyProfileByUserId(userId)
+  }
+}

--- a/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.service.spec.ts
@@ -1,10 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { Database } from 'arangojs'
 import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
-import {
-  mockCollectionSaveResult,
-  mockDbQueryResult
-} from '@core/nest/database/mock'
+import { mockDbQueryResult } from '@core/nest/database/mock'
 import { DocumentCollection, EdgeCollection } from 'arangojs/collection'
 import { keyAsId } from '@core/nest/decorators/KeyAsId'
 
@@ -51,23 +48,12 @@ describe('journeyProfileService', () => {
       expect(await service.getJourneyProfileByUserId('1')).toEqual(userWithId)
     })
 
-    it('should return a newly created user role', async () => {
-      const user2 = {
-        _key: '2',
-        userId: 'userId2',
-        acceptedTermsAt: null
-      }
-
+    it('should return null if user role does not exist', async () => {
       ;(service.db as DeepMockProxy<Database>).query.mockReturnValue(
         mockDbQueryResult(service.db, [])
       )
-      collectionMock.save.mockReturnValue(
-        mockCollectionSaveResult(service.collection, user2)
-      )
 
-      expect(await service.getJourneyProfileByUserId('2')).toEqual(
-        keyAsId(user2)
-      )
+      expect(await service.getJourneyProfileByUserId('2')).toEqual(null)
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.service.spec.ts
@@ -5,27 +5,31 @@ import {
   mockCollectionSaveResult,
   mockDbQueryResult
 } from '@core/nest/database/mock'
-import { DocumentCollection } from 'arangojs/collection'
+import { DocumentCollection, EdgeCollection } from 'arangojs/collection'
 import { keyAsId } from '@core/nest/decorators/KeyAsId'
 
 import { JourneyProfileService } from './journeyProfile.service'
 
 describe('journeyProfileService', () => {
-  let service: JourneyProfileService
+  let service: JourneyProfileService,
+    db: DeepMockProxy<Database>,
+    collectionMock: DeepMockProxy<DocumentCollection & EdgeCollection>
 
   beforeEach(async () => {
+    db = mockDeep()
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         JourneyProfileService,
         {
           provide: 'DATABASE',
-          useFactory: () => mockDeep<Database>()
+          useFactory: () => db
         }
       ]
     }).compile()
 
     service = module.get<JourneyProfileService>(JourneyProfileService)
-    service.collection = mockDeep<DocumentCollection>()
+    collectionMock = mockDeep()
+    service.collection = collectionMock
   })
   afterAll(() => {
     jest.resetAllMocks()
@@ -57,9 +61,7 @@ describe('journeyProfileService', () => {
       ;(service.db as DeepMockProxy<Database>).query.mockReturnValue(
         mockDbQueryResult(service.db, [])
       )
-      ;(
-        service.collection as DeepMockProxy<DocumentCollection>
-      ).save.mockReturnValue(
+      collectionMock.save.mockReturnValue(
         mockCollectionSaveResult(service.collection, user2)
       )
 

--- a/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.service.spec.ts
@@ -1,0 +1,71 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { Database } from 'arangojs'
+import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
+import {
+  mockCollectionSaveResult,
+  mockDbQueryResult
+} from '@core/nest/database/mock'
+import { DocumentCollection } from 'arangojs/collection'
+import { keyAsId } from '@core/nest/decorators/KeyAsId'
+
+import { JourneyProfileService } from './journeyProfile.service'
+
+describe('journeyProfileService', () => {
+  let service: JourneyProfileService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        JourneyProfileService,
+        {
+          provide: 'DATABASE',
+          useFactory: () => mockDeep<Database>()
+        }
+      ]
+    }).compile()
+
+    service = module.get<JourneyProfileService>(JourneyProfileService)
+    service.collection = mockDeep<DocumentCollection>()
+  })
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
+
+  const user = {
+    _key: '1',
+    userId: 'userId',
+    acceptedTermsAt: '2021-11-19T12:34:56.647Z'
+  }
+
+  const userWithId = keyAsId(user)
+
+  describe('getJourneyProfileByUserId', () => {
+    it('should return a user role if exists', async () => {
+      ;(service.db as DeepMockProxy<Database>).query.mockReturnValue(
+        mockDbQueryResult(service.db, [user])
+      )
+      expect(await service.getJourneyProfileByUserId('1')).toEqual(userWithId)
+    })
+
+    it('should return a newly created user role', async () => {
+      const user2 = {
+        _key: '2',
+        userId: 'userId2',
+        acceptedTermsAt: null
+      }
+
+      ;(service.db as DeepMockProxy<Database>).query.mockReturnValue(
+        mockDbQueryResult(service.db, [])
+      )
+      ;(
+        service.collection as DeepMockProxy<DocumentCollection>
+      ).save.mockReturnValue(
+        mockCollectionSaveResult(service.collection, user2)
+      )
+
+      expect(await service.getJourneyProfileByUserId('2')).toEqual(
+        keyAsId(user2)
+      )
+    })
+  })
+})

--- a/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.service.ts
+++ b/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.service.ts
@@ -1,0 +1,25 @@
+import { BaseService } from '@core/nest/database/BaseService'
+import { KeyAsId } from '@core/nest/decorators/KeyAsId'
+import { Injectable } from '@nestjs/common'
+import { aql } from 'arangojs'
+import { DocumentCollection } from 'arangojs/collection'
+import { JourneyProfile } from '../../__generated__/graphql'
+
+@Injectable()
+export class JourneyProfileService extends BaseService {
+  collection: DocumentCollection = this.db.collection('journeyProfiles')
+
+  @KeyAsId()
+  async getJourneyProfileByUserId(userId: string): Promise<JourneyProfile> {
+    const response = await this.db.query(aql`
+      FOR user in ${this.collection}
+        FILTER user.userId == ${userId}
+        LIMIT 1
+        RETURN user
+    `)
+
+    return response.hasNext
+      ? await response.next()
+      : await this.save({ userId, acceptedTermsAt: null })
+  }
+}

--- a/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.service.ts
+++ b/apps/api-journeys/src/app/modules/journeyProfile/journeyProfile.service.ts
@@ -17,8 +17,6 @@ export class JourneyProfileService extends BaseService {
         RETURN user
     `)
 
-    return response.hasNext
-      ? await response.next()
-      : await this.save({ userId, acceptedTermsAt: null })
+    return response.hasNext ? await response.next() : null
   }
 }


### PR DESCRIPTION
# Description

Add a user profile table for api-journeys. 

[Basecamp Todo](https://3.basecamp.com/3105655/buckets/31245893/todos/5783931883)

# How should this PR be QA Tested?

- Would need to run locally and comment out "AuthGuard", and manually pass userId (instead of useCurrentUserId) to test.
- Run seed.
- [ ] Able to make a user profile for userId without profile with `journeyProfileCreate`
- [ ] Able to retrieve a user profile via the userId with `getJourneyProfile`

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
