### PR TITLE
feat: preview url field

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -455,6 +455,12 @@ type ImageBlock implements Block
   alt: String!
 
   """
+  previewUrl refers to a feature that allows a user to view a preview
+  or a sample representation of an image before actually utilizing it.
+  """
+  previewUrl: String
+
+  """
   blurhash is a compact representation of a placeholder for an image.
   Find a frontend implementation at https://github.com/woltapp/blurhash
   """

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -425,6 +425,12 @@ type ImageBlock implements Block {
   alt: String!
 
   """
+  previewUrl refers to a feature that allows a user to view a preview
+  or a sample representation of an image before actually utilizing it.
+  """
+  previewUrl: String
+
+  """
   blurhash is a compact representation of a placeholder for an image.
   Find a frontend implementation at https://github.com/woltapp/blurhash
   """

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -703,6 +703,7 @@ export class ImageBlock implements Block {
     width: number;
     height: number;
     alt: string;
+    previewUrl?: Nullable<string>;
     blurhash: string;
 }
 

--- a/apps/api-journeys/src/app/modules/block/image/image.graphql
+++ b/apps/api-journeys/src/app/modules/block/image/image.graphql
@@ -8,6 +8,11 @@ type ImageBlock implements Block {
   height: Int!
   alt: String!
   """
+  previewUrl refers to a feature that allows a user to view a preview
+  or a sample representation of an image before actually utilizing it.
+  """
+  previewUrl: String
+  """
   blurhash is a compact representation of a placeholder for an image.
   Find a frontend implementation at https://github.com/woltapp/blurhash
   """


### PR DESCRIPTION
# Description

Added a new field to the image block, previewUrl. This field should enable us to give a preview or a sample representation of an image before using it

- Link to Basecamp Todo

# How should this PR be QA Tested?

- [ ] API only

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
