### PR TITLE
chore: add data loaders

### DIFF
--- a/apps/api-journeys/src/app/lib/roleGuard/roleGuard.spec.ts
+++ b/apps/api-journeys/src/app/lib/roleGuard/roleGuard.spec.ts
@@ -8,11 +8,13 @@ import {
   Role,
   ThemeMode,
   ThemeName,
-  UserJourney,
   UserJourneyRole,
   UserRole
 } from '../../__generated__/graphql'
-import { UserJourneyService } from '../../modules/userJourney/userJourney.service'
+import {
+  UserJourneyRecord,
+  UserJourneyService
+} from '../../modules/userJourney/userJourney.service'
 import { UserRoleService } from '../../modules/userRole/userRole.service'
 import { JourneyService } from '../../modules/journey/journey.service'
 import { RoleGuard } from './roleGuard'
@@ -27,7 +29,7 @@ const mockContextToUserId = contextToUserId as jest.MockedFunction<
 >
 
 describe('RoleGuard', () => {
-  const userJourney: UserJourney = {
+  const userJourney: UserJourneyRecord = {
     id: '1',
     userId: '1',
     journeyId: '2',
@@ -84,7 +86,7 @@ describe('RoleGuard', () => {
     _userJourneyService: UserJourneyService,
     _journeyId: string,
     _userId: string
-  ): Promise<UserJourney> => {
+  ): Promise<UserJourneyRecord | undefined> => {
     return userJourney
   }
 

--- a/apps/api-journeys/src/app/lib/roleGuard/roleGuard.ts
+++ b/apps/api-journeys/src/app/lib/roleGuard/roleGuard.ts
@@ -9,11 +9,13 @@ import {
 import { get, includes, reduce } from 'lodash'
 import { AuthenticationError } from 'apollo-server-errors'
 import { contextToUserId } from '@core/nest/common/firebaseClient'
-import { UserJourneyService } from '../../modules/userJourney/userJourney.service'
+import {
+  UserJourneyRecord,
+  UserJourneyService
+} from '../../modules/userJourney/userJourney.service'
 import {
   Journey,
   Role,
-  UserJourney,
   UserJourneyRole,
   UserRole
 } from '../../__generated__/graphql'
@@ -25,7 +27,7 @@ export const fetchUserJourney = async (
   userJourneyService: UserJourneyService,
   journeyId: string,
   userId: string
-): Promise<UserJourney> => {
+): Promise<UserJourneyRecord | undefined> => {
   return await userJourneyService.forJourneyUser(journeyId, userId)
 }
 
@@ -73,7 +75,8 @@ export const RoleGuard = (
     ) {}
 
     checkAttributes(journey: Journey, attributes?: Partial<Journey>): boolean {
-      if (attributes == null || attributes === {}) return true
+      if (attributes == null || Object.keys(attributes).length === 0)
+        return true
       return Object.keys(attributes).every(
         (key: string) => attributes[key] === journey[key]
       )
@@ -83,7 +86,10 @@ export const RoleGuard = (
       return permission === 'public'
     }
 
-    userJourneyRole(permission: Permission, userJourney: UserJourney): boolean {
+    userJourneyRole(
+      permission: Permission,
+      userJourney: UserJourneyRecord
+    ): boolean {
       return (
         permission !== UserJourneyRole.inviteRequested &&
         permission === userJourney.role
@@ -97,7 +103,7 @@ export const RoleGuard = (
     checkAllowedAccess(
       permissions: Permission[],
       journey: Journey,
-      userJourney: UserJourney,
+      userJourney: UserJourneyRecord | undefined,
       userRole: UserRole,
       attributes?: Partial<Journey>
     ): boolean {

--- a/apps/api-journeys/src/app/modules/action/action.resolver.ts
+++ b/apps/api-journeys/src/app/modules/action/action.resolver.ts
@@ -35,9 +35,9 @@ export class ActionResolver {
     @Args('id') id: string,
     @Args('journeyId') journeyId: string
   ): Promise<Block> {
-    const block = await this.blockService.get<Block & { __typename: string }>(
-      id
-    )
+    const block = (await this.blockService.get(id)) as Block & {
+      __typename: string
+    }
 
     if (
       !includes(

--- a/apps/api-journeys/src/app/modules/action/linkAction/linkAction.resolver.ts
+++ b/apps/api-journeys/src/app/modules/action/linkAction/linkAction.resolver.ts
@@ -30,9 +30,9 @@ export class LinkActionResolver {
     @Args('journeyId') journeyId: string,
     @Args('input') input: LinkActionInput
   ): Promise<Action> {
-    const block = await this.blockService.get<Block & { __typename: string }>(
-      id
-    )
+    const block = (await this.blockService.get(id)) as Block & {
+      __typename: string
+    }
 
     if (
       !includes(

--- a/apps/api-journeys/src/app/modules/action/navigateAction/navigateAction.resolver.ts
+++ b/apps/api-journeys/src/app/modules/action/navigateAction/navigateAction.resolver.ts
@@ -30,11 +30,9 @@ export class NavigateActionResolver {
     @Args('journeyId') journeyId: string,
     @Args('input') input: NavigateActionInput
   ): Promise<Action> {
-    const block = await this.blockService.get<
-      Block & {
-        __typename: string
-      }
-    >(id)
+    const block = (await this.blockService.get(id)) as Block & {
+      __typename: string
+    }
 
     if (
       !includes(

--- a/apps/api-journeys/src/app/modules/action/navigateToBlockAction/navigateToBlockAction.resolver.ts
+++ b/apps/api-journeys/src/app/modules/action/navigateToBlockAction/navigateToBlockAction.resolver.ts
@@ -30,11 +30,9 @@ export class NavigateToBlockActionResolver {
     @Args('journeyId') journeyId: string,
     @Args('input') input: NavigateToBlockActionInput
   ): Promise<Action> {
-    const block = await this.blockService.get<
-      Block & {
-        __typename: string
-      }
-    >(id)
+    const block = (await this.blockService.get(id)) as Block & {
+      __typename: string
+    }
 
     if (
       !includes(

--- a/apps/api-journeys/src/app/modules/action/navigateToJourney/navigateToJourney.resolver.ts
+++ b/apps/api-journeys/src/app/modules/action/navigateToJourney/navigateToJourney.resolver.ts
@@ -41,11 +41,9 @@ export class NavigateToJourneyActionResolver {
     @Args('journeyId') journeyId: string,
     @Args('input') input: NavigateToJourneyActionInput
   ): Promise<Action> {
-    const block = await this.blockService.get<
-      Block & {
-        __typename: string
-      }
-    >(id)
+    const block = (await this.blockService.get(id)) as Block & {
+      __typename: string
+    }
 
     if (
       !includes(

--- a/apps/api-journeys/src/app/modules/block/block.service.ts
+++ b/apps/api-journeys/src/app/modules/block/block.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common'
 import { v4 as uuidv4 } from 'uuid'
 import { aql } from 'arangojs'
 import { BaseService } from '@core/nest/database/BaseService'
-import { DocumentCollection } from 'arangojs/collection'
 import { KeyAsId, keyAsId } from '@core/nest/decorators/KeyAsId'
 import { idAsKey } from '@core/nest/decorators/IdAsKey'
 import {
@@ -302,5 +301,5 @@ export class BlockService extends BaseService {
     return block != null ? block[type] === value : false
   }
 
-  collection: DocumentCollection = this.db.collection('blocks')
+  collection = this.db.collection('blocks')
 }

--- a/apps/api-journeys/src/app/modules/block/card/card.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/card/card.resolver.spec.ts
@@ -92,9 +92,7 @@ describe('CardBlockResolver', () => {
 
   describe('cardBlockCreate', () => {
     it('creates a CardBlock', async () => {
-      await resolver
-        .cardBlockCreate(blockUpdate)
-        .catch((err) => console.log(err))
+      await resolver.cardBlockCreate(blockUpdate)
       expect(service.getSiblings).toHaveBeenCalledWith(
         blockUpdate.journeyId,
         blockUpdate.parentBlockId
@@ -105,9 +103,7 @@ describe('CardBlockResolver', () => {
 
   describe('cardBlockUpdate', () => {
     it('updates a CardBlock', async () => {
-      resolver
-        .cardBlockUpdate(block.id, block.journeyId, blockUpdate)
-        .catch((err) => console.log(err))
+      await resolver.cardBlockUpdate(block.id, block.journeyId, blockUpdate)
       expect(service.update).toHaveBeenCalledWith(block.id, blockUpdate)
     })
   })

--- a/apps/api-journeys/src/app/modules/block/image/image.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/image/image.resolver.ts
@@ -3,8 +3,7 @@ import { Args, Mutation, Resolver } from '@nestjs/graphql'
 import { UserInputError } from 'apollo-server-errors'
 import { encode } from 'blurhash'
 import axios from 'axios'
-// eslint-disable-next-line import/no-namespace
-import * as sharp from 'sharp'
+import sharp from 'sharp'
 
 import { BlockService } from '../block.service'
 import {

--- a/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.spec.ts
@@ -158,7 +158,9 @@ describe('RadioQuestionBlockResolver', () => {
         block.journeyId,
         block.parentBlockId
       )
-      expect(service.update).toHaveBeenCalledWith(block.id, block.parentBlockId)
+      expect(service.update).toHaveBeenCalledWith(block.id, {
+        parentBlockId: block.parentBlockId
+      })
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/radioQuestion/radioQuestion.resolver.ts
@@ -104,6 +104,6 @@ export class RadioQuestionBlockResolver {
     @Args('journeyId') journeyId: string,
     @Args('parentBlockId') parentBlockId: string
   ): Promise<RadioQuestionBlock> {
-    return await this.blockService.update(id, parentBlockId)
+    return await this.blockService.update(id, { parentBlockId })
   }
 }

--- a/apps/api-journeys/src/app/modules/block/step/step.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/step/step.resolver.spec.ts
@@ -74,9 +74,7 @@ describe('StepBlockResolver', () => {
   describe('stepBlockCreate', () => {
     it('creates a StepBlock', async () => {
       expect(
-        await resolver
-          .stepBlockCreate(omit(block, ['id', 'parentOrder']))
-          .catch((err) => console.log(err))
+        await resolver.stepBlockCreate(omit(block, ['id', 'parentOrder']))
       ).toEqual(blockCreateResponse)
       expect(service.getSiblings).toHaveBeenCalledWith(block.journeyId)
       expect(service.save).toHaveBeenCalledWith({
@@ -88,9 +86,7 @@ describe('StepBlockResolver', () => {
 
   describe('stepBlockUpdate', () => {
     it('updates a StepBlock', async () => {
-      resolver
-        .stepBlockUpdate(block.id, block.journeyId, blockUpdate)
-        .catch((err) => console.log(err))
+      await resolver.stepBlockUpdate(block.id, block.journeyId, blockUpdate)
       expect(service.update).toHaveBeenCalledWith(block.id, blockUpdate)
     })
   })

--- a/apps/api-journeys/src/app/modules/block/video/video.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/video/video.resolver.ts
@@ -156,7 +156,7 @@ export class VideoBlockResolver {
     @Args('journeyId') journeyId: string,
     @Args('input') input: VideoBlockUpdateInput
   ): Promise<VideoBlock> {
-    const block = await this.blockService.get<VideoBlock>(id)
+    const block = await this.blockService.get(id)
     switch (input.source ?? block.source) {
       case VideoBlockSource.youTube:
         await videoBlockYouTubeSchema.validate({ ...block, ...input })

--- a/apps/api-journeys/src/app/modules/event/button/button.resolver.ts
+++ b/apps/api-journeys/src/app/modules/event/button/button.resolver.ts
@@ -61,7 +61,7 @@ export class ChatOpenEventResolver {
 
     if (visitor.messagePlatform == null) {
       void this.visitorService.update(visitor.id, {
-        messagePlatform: input.value
+        messagePlatform: input.value ?? undefined
       })
     }
 

--- a/apps/api-journeys/src/app/modules/event/event.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/event/event.service.spec.ts
@@ -2,14 +2,16 @@ import { Test, TestingModule } from '@nestjs/testing'
 import { Database } from 'arangojs'
 import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
 import { mockDbQueryResult } from '@core/nest/database/mock'
-import { DocumentCollection } from 'arangojs/collection'
+import { DocumentCollection, EdgeCollection } from 'arangojs/collection'
 import { AqlQuery } from 'arangojs/aql'
 import { BlockService } from '../block/block.service'
 import { VisitorService } from '../visitor/visitor.service'
 import { EventService } from './event.service'
 
 describe('EventService', () => {
-  let service: EventService, db: DeepMockProxy<Database>
+  let service: EventService,
+    db: DeepMockProxy<Database>,
+    collectionMock: DeepMockProxy<DocumentCollection & EdgeCollection>
 
   const blockService = {
     provide: BlockService,
@@ -59,7 +61,7 @@ describe('EventService', () => {
   }
 
   beforeEach(async () => {
-    db = mockDeep<Database>()
+    db = mockDeep()
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         EventService,
@@ -73,7 +75,8 @@ describe('EventService', () => {
     }).compile()
 
     service = module.get<EventService>(EventService)
-    service.collection = mockDeep<DocumentCollection>()
+    collectionMock = mockDeep()
+    service.collection = collectionMock
   })
   afterAll(() => {
     jest.resetAllMocks()

--- a/apps/api-journeys/src/app/modules/event/event.service.ts
+++ b/apps/api-journeys/src/app/modules/event/event.service.ts
@@ -1,12 +1,11 @@
 import { Injectable, Inject } from '@nestjs/common'
 import { BaseService } from '@core/nest/database/BaseService'
-import { DocumentCollection } from 'arangojs/collection'
 import { UserInputError } from 'apollo-server-errors'
 import { aql } from 'arangojs'
 import { KeyAsId } from '@core/nest/decorators/KeyAsId'
 import { BlockService } from '../block/block.service'
-import { VisitorService } from '../visitor/visitor.service'
-import { Visitor, Event } from '../../__generated__/graphql'
+import { VisitorRecord, VisitorService } from '../visitor/visitor.service'
+import { Event } from '../../__generated__/graphql'
 
 @Injectable()
 export class EventService extends BaseService {
@@ -16,14 +15,14 @@ export class EventService extends BaseService {
   @Inject(VisitorService)
   private readonly visitorService: VisitorService
 
-  collection: DocumentCollection = this.db.collection('events')
+  collection = this.db.collection('events')
 
   async validateBlockEvent(
     userId: string,
     blockId: string,
     stepId: string | null = null
   ): Promise<{
-    visitor: Visitor
+    visitor: VisitorRecord
     journeyId: string
   }> {
     const block: { journeyId: string; _key: string } | undefined =

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -190,6 +190,7 @@ export class JourneyResolver {
           ...input
         })
         await this.userJourneyService.save({
+          id: uuidv4(),
           userId,
           journeyId: journey.id,
           role: UserJourneyRole.owner
@@ -314,6 +315,7 @@ export class JourneyResolver {
         const journey: Journey = await this.journeyService.save(input)
         await this.blockService.saveAll(duplicateBlocks)
         await this.userJourneyService.save({
+          id: uuidv4(),
           userId,
           journeyId: journey.id,
           role: UserJourneyRole.owner

--- a/apps/api-journeys/src/app/modules/journey/journey.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.service.spec.ts
@@ -5,7 +5,7 @@ import {
   mockCollectionSaveResult,
   mockDbQueryResult
 } from '@core/nest/database/mock'
-import { DocumentCollection } from 'arangojs/collection'
+import { DocumentCollection, EdgeCollection } from 'arangojs/collection'
 import { keyAsId } from '@core/nest/decorators/KeyAsId'
 import { AqlQuery } from 'arangojs/aql'
 import {
@@ -18,10 +18,12 @@ import {
 import { JourneyService } from './journey.service'
 
 describe('JourneyService', () => {
-  let service: JourneyService, db: DeepMockProxy<Database>
+  let service: JourneyService,
+    db: DeepMockProxy<Database>,
+    collectionMock: DeepMockProxy<DocumentCollection & EdgeCollection>
 
   beforeEach(async () => {
-    db = mockDeep<Database>()
+    db = mockDeep()
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         JourneyService,
@@ -33,7 +35,8 @@ describe('JourneyService', () => {
     }).compile()
 
     service = module.get<JourneyService>(JourneyService)
-    service.collection = mockDeep<DocumentCollection>()
+    collectionMock = mockDeep()
+    service.collection = collectionMock
   })
   afterAll(() => {
     jest.resetAllMocks()
@@ -208,9 +211,7 @@ describe('JourneyService', () => {
 
   describe('save', () => {
     beforeEach(() => {
-      ;(
-        service.collection as DeepMockProxy<DocumentCollection>
-      ).save.mockReturnValue(
+      collectionMock.save.mockReturnValue(
         mockCollectionSaveResult(service.collection, journey)
       )
     })
@@ -222,9 +223,7 @@ describe('JourneyService', () => {
 
   describe('update', () => {
     beforeEach(() => {
-      ;(
-        service.collection as DeepMockProxy<DocumentCollection>
-      ).update.mockReturnValue(
+      collectionMock.update.mockReturnValue(
         mockCollectionSaveResult(service.collection, journey)
       )
     })

--- a/apps/api-journeys/src/app/modules/journey/journey.service.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common'
 import { aql } from 'arangojs'
 import { BaseService } from '@core/nest/database/BaseService'
-import { DocumentCollection } from 'arangojs/collection'
 import { KeyAsId } from '@core/nest/decorators/KeyAsId'
 import { includes } from 'lodash'
 import { AqlQuery } from 'arangojs/aql'
@@ -110,5 +109,5 @@ export class JourneyService extends BaseService {
     return await result.all()
   }
 
-  collection: DocumentCollection = this.db.collection('journeys')
+  collection = this.db.collection('journeys')
 }

--- a/apps/api-journeys/src/app/modules/member/member.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/member/member.service.spec.ts
@@ -2,29 +2,32 @@ import { Test, TestingModule } from '@nestjs/testing'
 import { Database } from 'arangojs'
 import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
 import { mockDbQueryResult } from '@core/nest/database/mock'
-import { DocumentCollection } from 'arangojs/collection'
+import { DocumentCollection, EdgeCollection } from 'arangojs/collection'
 import { keyAsId } from '@core/nest/decorators/KeyAsId'
 
 import { AqlQuery } from 'arangojs/aql'
 import { MemberService } from './member.service'
 
 describe('memberService', () => {
-  let service: MemberService, db: DeepMockProxy<Database>
+  let service: MemberService,
+    db: DeepMockProxy<Database>,
+    collectionMock: DeepMockProxy<DocumentCollection & EdgeCollection>
 
   beforeEach(async () => {
+    db = mockDeep()
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         MemberService,
         {
           provide: 'DATABASE',
-          useFactory: () => mockDeep<Database>()
+          useFactory: () => db
         }
       ]
     }).compile()
 
     service = module.get<MemberService>(MemberService)
-    db = service.db as DeepMockProxy<Database>
-    service.collection = mockDeep<DocumentCollection>()
+    collectionMock = mockDeep()
+    service.collection = collectionMock
   })
   afterAll(() => {
     jest.resetAllMocks()

--- a/apps/api-journeys/src/app/modules/member/member.service.ts
+++ b/apps/api-journeys/src/app/modules/member/member.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common'
 import { BaseService } from '@core/nest/database/BaseService'
-import { DocumentCollection } from 'arangojs/collection'
 import { aql } from 'arangojs'
 import { ArrayCursor } from 'arangojs/cursor'
 import { KeyAsId } from '@core/nest/decorators/KeyAsId'
@@ -12,7 +11,7 @@ interface Member {
 }
 @Injectable()
 export class MemberService extends BaseService {
-  collection: DocumentCollection = this.db.collection('members')
+  collection = this.db.collection('members')
 
   @KeyAsId()
   async getMemberByTeamId(

--- a/apps/api-journeys/src/app/modules/team/team.service.ts
+++ b/apps/api-journeys/src/app/modules/team/team.service.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@nestjs/common'
 import { BaseService } from '@core/nest/database/BaseService'
-import { DocumentCollection } from 'arangojs/collection'
 
 @Injectable()
 export class TeamService extends BaseService {
-  collection: DocumentCollection = this.db.collection('teams')
+  collection = this.db.collection('teams')
 }

--- a/apps/api-journeys/src/app/modules/userInvite/userInvite.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/userInvite/userInvite.resolver.spec.ts
@@ -269,5 +269,16 @@ describe('UserInviteResolver', () => {
       expect(service.update).not.toHaveBeenCalled()
       expect(rejectedInvite).toEqual([])
     })
+
+    it('should throw an error when no user journey', async () => {
+      const mockUserJourneyRequest =
+        ujResolver.userJourneyRequest as jest.MockedFunction<
+          typeof ujResolver.userJourneyRequest
+        >
+      mockUserJourneyRequest.mockResolvedValueOnce(undefined)
+      await expect(
+        async () => await resolver.redeemInvite(userInvite, user.id)
+      ).rejects.toThrow('userJourney does not exist')
+    })
   })
 })

--- a/apps/api-journeys/src/app/modules/userInvite/userInvite.resolver.ts
+++ b/apps/api-journeys/src/app/modules/userInvite/userInvite.resolver.ts
@@ -55,7 +55,7 @@ export class UserInviteResolver {
 
     // Create invite if doesn't exist else re-activate removed invite
     if (userInvite == null) {
-      const journey = await this.journeyService.get<Journey>(journeyId)
+      const journey: Journey = await this.journeyService.get(journeyId)
 
       if (journey == null) throw new UserInputError('journey does not exist')
 
@@ -100,6 +100,9 @@ export class UserInviteResolver {
         IdType.databaseId,
         userId
       )
+
+      if (userJourney == null)
+        throw new UserInputError('userJourney does not exist')
 
       await this.userJourneyResolver.userJourneyApprove(
         userJourney.id,

--- a/apps/api-journeys/src/app/modules/userInvite/userInvite.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/userInvite/userInvite.service.spec.ts
@@ -2,27 +2,31 @@ import { Test, TestingModule } from '@nestjs/testing'
 import { Database } from 'arangojs'
 import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
 import { mockDbQueryResult } from '@core/nest/database/mock'
-import { DocumentCollection } from 'arangojs/collection'
+import { DocumentCollection, EdgeCollection } from 'arangojs/collection'
 import { keyAsId } from '@core/nest/decorators/KeyAsId'
 
 import { UserInviteService } from './userInvite.service'
 
 describe('userInviteService', () => {
-  let service: UserInviteService
+  let service: UserInviteService,
+    db: DeepMockProxy<Database>,
+    collectionMock: DeepMockProxy<DocumentCollection & EdgeCollection>
 
   beforeEach(async () => {
+    db = mockDeep()
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UserInviteService,
         {
           provide: 'DATABASE',
-          useFactory: () => mockDeep<Database>()
+          useFactory: () => db
         }
       ]
     }).compile()
 
     service = module.get<UserInviteService>(UserInviteService)
-    service.collection = mockDeep<DocumentCollection>()
+    collectionMock = mockDeep()
+    service.collection = collectionMock
   })
   afterAll(() => {
     jest.resetAllMocks()

--- a/apps/api-journeys/src/app/modules/userInvite/userInvite.service.ts
+++ b/apps/api-journeys/src/app/modules/userInvite/userInvite.service.ts
@@ -2,12 +2,11 @@ import { BaseService } from '@core/nest/database/BaseService'
 import { KeyAsId } from '@core/nest/decorators/KeyAsId'
 import { Injectable } from '@nestjs/common'
 import { aql } from 'arangojs'
-import { DocumentCollection } from 'arangojs/collection'
 import { UserInvite } from '../../__generated__/graphql'
 
 @Injectable()
 export class UserInviteService extends BaseService {
-  collection: DocumentCollection = this.db.collection('userInvites')
+  collection = this.db.collection('userInvites')
 
   @KeyAsId()
   async getUserInviteByJourneyAndEmail(

--- a/apps/api-journeys/src/app/modules/userJourney/userJourney.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/userJourney/userJourney.service.spec.ts
@@ -6,7 +6,7 @@ import {
   mockCollectionSaveResult,
   mockDbQueryResult
 } from '@core/nest/database/mock'
-import { DocumentCollection } from 'arangojs/collection'
+import { DocumentCollection, EdgeCollection } from 'arangojs/collection'
 import { keyAsId } from '@core/nest/decorators/KeyAsId'
 
 import {
@@ -16,31 +16,35 @@ import {
   ThemeName,
   UserJourneyRole
 } from '../../__generated__/graphql'
-import { UserJourneyService } from './userJourney.service'
+import { UserJourneyRecord, UserJourneyService } from './userJourney.service'
 
 describe('UserJourneyService', () => {
-  let service: UserJourneyService
+  let service: UserJourneyService,
+    db: DeepMockProxy<Database>,
+    collectionMock: DeepMockProxy<DocumentCollection & EdgeCollection>
 
   beforeEach(async () => {
+    db = mockDeep()
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UserJourneyService,
         {
           provide: 'DATABASE',
-          useFactory: () => mockDeep<Database>()
+          useFactory: () => db
         }
       ]
     }).compile()
 
     service = module.get<UserJourneyService>(UserJourneyService)
-    service.collection = mockDeep<DocumentCollection>()
+    collectionMock = mockDeep()
+    service.collection = collectionMock
   })
   afterAll(() => {
     jest.resetAllMocks()
   })
 
-  const userJourney = {
-    _key: '1',
+  const userJourney: UserJourneyRecord = {
+    id: '1',
     userId: '1',
     journeyId: '2',
     role: UserJourneyRole.editor
@@ -63,7 +67,7 @@ describe('UserJourneyService', () => {
 
   describe('forJourney', () => {
     beforeEach(() => {
-      ;(service.db as DeepMockProxy<Database>).query.mockReturnValue(
+      db.query.mockReturnValue(
         mockDbQueryResult(service.db, [userJourney, userJourney])
       )
     })
@@ -78,9 +82,7 @@ describe('UserJourneyService', () => {
 
   describe('forUserJourney', () => {
     beforeEach(() => {
-      ;(service.db as DeepMockProxy<Database>).query.mockReturnValue(
-        mockDbQueryResult(service.db, [userJourney])
-      )
+      db.query.mockReturnValue(mockDbQueryResult(service.db, [userJourney]))
     })
 
     it('should return a userjourney', async () => {
@@ -90,10 +92,11 @@ describe('UserJourneyService', () => {
 
   describe('remove', () => {
     beforeEach(() => {
-      ;(
-        service.collection as DeepMockProxy<DocumentCollection>
-      ).remove.mockReturnValue(
-        mockCollectionRemoveResult(service.collection, userJourney)
+      collectionMock.remove.mockReturnValue(
+        mockCollectionRemoveResult(service.collection, {
+          ...userJourney,
+          _key: userJourney.id
+        })
       )
     })
 
@@ -104,10 +107,11 @@ describe('UserJourneyService', () => {
 
   describe('save', () => {
     beforeEach(() => {
-      ;(
-        service.collection as DeepMockProxy<DocumentCollection>
-      ).save.mockReturnValue(
-        mockCollectionSaveResult(service.collection, userJourney)
+      collectionMock.save.mockReturnValue(
+        mockCollectionSaveResult(service.collection, {
+          ...userJourney,
+          _key: userJourney.id
+        })
       )
     })
 
@@ -118,10 +122,11 @@ describe('UserJourneyService', () => {
 
   describe('update', () => {
     beforeEach(() => {
-      ;(
-        service.collection as DeepMockProxy<DocumentCollection>
-      ).update.mockReturnValue(
-        mockCollectionSaveResult(service.collection, userJourney)
+      collectionMock.update.mockReturnValue(
+        mockCollectionSaveResult(service.collection, {
+          ...userJourney,
+          _key: userJourney.id
+        })
       )
     })
 

--- a/apps/api-journeys/src/app/modules/userRole/userRole.service.ts
+++ b/apps/api-journeys/src/app/modules/userRole/userRole.service.ts
@@ -2,12 +2,11 @@ import { BaseService } from '@core/nest/database/BaseService'
 import { KeyAsId } from '@core/nest/decorators/KeyAsId'
 import { Injectable } from '@nestjs/common'
 import { aql } from 'arangojs'
-import { DocumentCollection } from 'arangojs/collection'
 import { UserRole } from '../../__generated__/graphql'
 
 @Injectable()
 export class UserRoleService extends BaseService {
-  collection: DocumentCollection = this.db.collection('userRoles')
+  collection = this.db.collection('userRoles')
 
   @KeyAsId()
   async getUserRoleById(userId: string): Promise<UserRole> {

--- a/apps/api-journeys/src/app/modules/visitor/visitor.resolver.ts
+++ b/apps/api-journeys/src/app/modules/visitor/visitor.resolver.ts
@@ -9,10 +9,10 @@ import {
 } from '@nestjs/graphql'
 import { ForbiddenError, UserInputError } from 'apollo-server-errors'
 import { IResult, UAParser } from 'ua-parser-js'
-import { Event, Visitor, VisitorsConnection } from '../../__generated__/graphql'
+import { Event, VisitorsConnection } from '../../__generated__/graphql'
 import { EventService } from '../event/event.service'
 import { MemberService } from '../member/member.service'
-import { VisitorService } from './visitor.service'
+import { VisitorService, VisitorRecord } from './visitor.service'
 
 @Resolver('Visitor')
 export class VisitorResolver {
@@ -48,10 +48,8 @@ export class VisitorResolver {
   async visitor(
     @CurrentUserId() userId: string,
     @Args('id') id: string
-  ): Promise<Visitor> {
-    const visitor = await this.visitorService.get<
-      ({ teamId: string } & Visitor) | undefined
-    >(id)
+  ): Promise<VisitorRecord> {
+    const visitor = await this.visitorService.get(id)
 
     if (visitor == null)
       throw new UserInputError(`Visitor with ID "${id}" does not exist`)
@@ -74,10 +72,8 @@ export class VisitorResolver {
     @CurrentUserId() userId: string,
     @Args('id') id: string,
     @Args('input') input
-  ): Promise<Visitor> {
-    const visitor = await this.visitorService.get<
-      ({ teamId: string } & Visitor) | undefined
-    >(id)
+  ): Promise<VisitorRecord | undefined> {
+    const visitor = await this.visitorService.get(id)
 
     if (visitor == null)
       throw new UserInputError(`Visitor with ID "${id}" does not exist`)
@@ -102,7 +98,6 @@ export class VisitorResolver {
 
   @ResolveField()
   userAgent(@Parent() visitor): IResult | undefined {
-    console.log(visitor)
     if (visitor.userAgent != null)
       return new UAParser(visitor.userAgent).getResult()
   }

--- a/apps/api-journeys/src/app/modules/visitor/visitor.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/visitor/visitor.service.spec.ts
@@ -3,7 +3,7 @@ import { Database } from 'arangojs'
 import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
 import { mockDbQueryResult } from '@core/nest/database/mock'
 import { v4 as uuidv4 } from 'uuid'
-import { DocumentCollection } from 'arangojs/collection'
+import { DocumentCollection, EdgeCollection } from 'arangojs/collection'
 import { AqlQuery } from 'arangojs/aql'
 import { keyAsId } from '@core/nest/decorators/KeyAsId'
 import { VisitorService } from './visitor.service'
@@ -16,7 +16,9 @@ jest.mock('uuid', () => ({
 const mockUuidv4 = uuidv4 as jest.MockedFunction<typeof uuidv4>
 
 describe('VisitorService', () => {
-  let service: VisitorService, db: DeepMockProxy<Database>
+  let service: VisitorService,
+    db: DeepMockProxy<Database>,
+    collectionMock: DeepMockProxy<DocumentCollection & EdgeCollection>
 
   beforeAll(() => {
     jest.useFakeTimers('modern')
@@ -24,19 +26,20 @@ describe('VisitorService', () => {
   })
 
   beforeEach(async () => {
+    db = mockDeep()
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         VisitorService,
         {
           provide: 'DATABASE',
-          useFactory: () => mockDeep<Database>()
+          useFactory: () => db
         }
       ]
     }).compile()
 
     service = module.get<VisitorService>(VisitorService)
-    db = service.db as DeepMockProxy<Database>
-    service.collection = mockDeep<DocumentCollection>()
+    collectionMock = mockDeep()
+    service.collection = collectionMock
   })
 
   afterAll(() => {

--- a/apps/api-journeys/src/app/modules/visitor/visitor.service.ts
+++ b/apps/api-journeys/src/app/modules/visitor/visitor.service.ts
@@ -1,12 +1,14 @@
 import { BaseService } from '@core/nest/database/BaseService'
 import { Injectable } from '@nestjs/common'
 import { aql } from 'arangojs'
-import { DocumentCollection } from 'arangojs/collection'
 import { KeyAsId } from '@core/nest/decorators/KeyAsId'
 import { GeneratedAqlQuery } from 'arangojs/aql'
 import { forEach } from 'lodash'
 import { v4 as uuidv4 } from 'uuid'
-import { VisitorsConnection, Visitor } from '../../__generated__/graphql'
+import {
+  VisitorsConnection,
+  MessagePlatform
+} from '../../__generated__/graphql'
 
 interface ListParams {
   after?: string | null
@@ -17,9 +19,20 @@ interface ListParams {
   sortOrder?: 'ASC' | 'DESC'
 }
 
+export interface VisitorRecord {
+  id: string
+  teamId: string
+  userId: string
+  createdAt: string
+  userAgent?: string
+  messagePlatform?: MessagePlatform
+  name?: string
+  email?: string
+}
+
 @Injectable()
-export class VisitorService extends BaseService {
-  collection: DocumentCollection = this.db.collection('visitors')
+export class VisitorService extends BaseService<VisitorRecord> {
+  collection = this.db.collection<VisitorRecord>('visitors')
 
   @KeyAsId()
   async getList({
@@ -59,7 +72,7 @@ export class VisitorService extends BaseService {
   async getByUserIdAndJourneyId(
     userId: string,
     journeyId: string
-  ): Promise<Visitor> {
+  ): Promise<VisitorRecord> {
     let visitor = await (
       await this.db.query(aql`
     FOR v in visitors

--- a/apps/api-languages/src/app/modules/country/country.resolver.spec.ts
+++ b/apps/api-languages/src/app/modules/country/country.resolver.spec.ts
@@ -24,7 +24,7 @@ describe('LangaugeResolver', () => {
     const countryService = {
       provide: CountryService,
       useFactory: () => ({
-        get: jest.fn(() => country),
+        load: jest.fn(() => country),
         getCountryBySlug: jest.fn(() => country),
         getAll: jest.fn(() => [country, country])
       })
@@ -51,7 +51,7 @@ describe('LangaugeResolver', () => {
   describe('country', () => {
     it('should return country', async () => {
       expect(await resolver.country(country.id)).toEqual(country)
-      expect(service.get).toHaveBeenCalledWith(country.id)
+      expect(service.load).toHaveBeenCalledWith(country.id)
     })
 
     it('should return country by slug', async () => {

--- a/apps/api-languages/src/app/modules/country/country.resolver.ts
+++ b/apps/api-languages/src/app/modules/country/country.resolver.ts
@@ -7,8 +7,8 @@ import {
   ResolveField,
   Parent
 } from '@nestjs/graphql'
-import { Country, IdType, Language } from '../../__generated__/graphql'
-import { LanguageService } from '../language/language.service'
+import { Country, IdType } from '../../__generated__/graphql'
+import { LanguageRecord, LanguageService } from '../language/language.service'
 import { CountryService } from './country.service'
 
 @Resolver('Country')
@@ -27,9 +27,9 @@ export class CountryResolver {
   async country(
     @Args('id') id: string,
     @Args('idType') idType: IdType = IdType.databaseId
-  ): Promise<Country> {
+  ): Promise<Country | Error> {
     return idType === IdType.databaseId
-      ? await this.countryService.get(id)
+      ? await this.countryService.load(id)
       : await this.countryService.getCountryBySlug(id)
   }
 
@@ -60,7 +60,7 @@ export class CountryResolver {
   @ResolveField()
   async languages(
     @Parent() country: Country & { languageIds: string[] }
-  ): Promise<Language[]> {
+  ): Promise<LanguageRecord[]> {
     return await this.languageService.getByIds(country.languageIds)
   }
 
@@ -68,7 +68,7 @@ export class CountryResolver {
   async resolveReference(reference: {
     __typename: 'Country'
     id: string
-  }): Promise<Country> {
-    return await this.countryService.get(reference.id)
+  }): Promise<Country | Error> {
+    return await this.countryService.load(reference.id)
   }
 }

--- a/apps/api-languages/src/app/modules/country/country.service.spec.ts
+++ b/apps/api-languages/src/app/modules/country/country.service.spec.ts
@@ -20,7 +20,7 @@ describe('CountryService', () => {
   let db: DeepMockProxy<Database>
 
   beforeEach(async () => {
-    db = mockDeep<Database>()
+    db = mockDeep()
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CountryService,
@@ -45,16 +45,7 @@ describe('CountryService', () => {
     FOR item IN 
       FILTER @value0 IN item.slug[*].value
       LIMIT 1
-      RETURN {
-        _key: item._key,
-        name: item.name,
-        population: item.population,
-        continent: item.continent,
-        slug: item.slug,
-        languageIds: item.languageIds,
-        latitude: item.latitude,
-        longitude: item.longitude
-      }
+      RETURN item
     `)
       expect(bindVars).toEqual({
         value0: 'United-States'

--- a/apps/api-languages/src/app/modules/country/country.service.ts
+++ b/apps/api-languages/src/app/modules/country/country.service.ts
@@ -2,27 +2,18 @@ import { BaseService } from '@core/nest/database/BaseService'
 import { KeyAsId } from '@core/nest/decorators/KeyAsId'
 import { Injectable } from '@nestjs/common'
 import { aql } from 'arangojs'
-import { DocumentCollection } from 'arangojs/collection'
+import { Country } from '../../__generated__/graphql'
 
 @Injectable()
-export class CountryService extends BaseService {
-  collection: DocumentCollection = this.db.collection('countries')
+export class CountryService extends BaseService<Country> {
+  collection = this.db.collection<Country>('countries')
   @KeyAsId()
-  async getCountryBySlug<T>(slug: string): Promise<T> {
+  async getCountryBySlug(slug: string): Promise<Country> {
     const res = await this.db.query(aql`
     FOR item IN ${this.collection}
       FILTER ${slug} IN item.slug[*].value
       LIMIT 1
-      RETURN {
-        _key: item._key,
-        name: item.name,
-        population: item.population,
-        continent: item.continent,
-        slug: item.slug,
-        languageIds: item.languageIds,
-        latitude: item.latitude,
-        longitude: item.longitude
-      }
+      RETURN item
     `)
     return await res.next()
   }

--- a/apps/api-languages/src/app/modules/language/language.resolver.spec.ts
+++ b/apps/api-languages/src/app/modules/language/language.resolver.spec.ts
@@ -26,7 +26,7 @@ describe('LangaugeResolver', () => {
     const languageService = {
       provide: LanguageService,
       useFactory: () => ({
-        get: jest.fn(() => language),
+        load: jest.fn(() => language),
         getAll: jest.fn(() => [language, language])
       })
     }

--- a/apps/api-languages/src/app/modules/language/language.resolver.ts
+++ b/apps/api-languages/src/app/modules/language/language.resolver.ts
@@ -7,8 +7,8 @@ import {
   Parent
 } from '@nestjs/graphql'
 import { TranslationField } from '@core/nest/decorators/TranslationField'
-import { Language, LanguageIdType } from '../../__generated__/graphql'
-import { LanguageService } from './language.service'
+import { LanguageIdType } from '../../__generated__/graphql'
+import { LanguageRecord, LanguageService } from './language.service'
 
 @Resolver('Language')
 export class LanguageResolver {
@@ -18,7 +18,7 @@ export class LanguageResolver {
   async languages(
     @Args('offset') offset: number,
     @Args('limit') limit: number
-  ): Promise<Language[]> {
+  ): Promise<LanguageRecord[]> {
     return await this.languageService.getAll(offset, limit)
   }
 
@@ -26,9 +26,9 @@ export class LanguageResolver {
   async language(
     @Args('id') id: string,
     @Args('idType') idType = LanguageIdType.databaseId
-  ): Promise<Language> {
+  ): Promise<LanguageRecord | Error> {
     return idType === LanguageIdType.databaseId
-      ? await this.languageService.get(id)
+      ? await this.languageService.load(id)
       : await this.languageService.getByBcp47(id)
   }
 
@@ -44,7 +44,7 @@ export class LanguageResolver {
   async resolveReference(reference: {
     __typename: 'Language'
     id: string
-  }): Promise<Language> {
-    return await this.languageService.get(reference.id)
+  }): Promise<LanguageRecord | Error> {
+    return await this.languageService.load(reference.id)
   }
 }

--- a/apps/api-languages/src/app/modules/language/language.service.ts
+++ b/apps/api-languages/src/app/modules/language/language.service.ts
@@ -1,15 +1,21 @@
 import { BaseService } from '@core/nest/database/BaseService'
 import { Injectable } from '@nestjs/common'
 import { aql } from 'arangojs'
-import { DocumentCollection } from 'arangojs/collection'
 import { KeyAsId } from '@core/nest/decorators/KeyAsId'
 
+export interface LanguageRecord {
+  id: string
+  bcp47?: string
+  iso3?: string
+  name: Array<{ value: string; languageId: string; primary: boolean }>
+}
+
 @Injectable()
-export class LanguageService extends BaseService {
-  collection: DocumentCollection = this.db.collection('languages')
+export class LanguageService extends BaseService<LanguageRecord> {
+  collection = this.db.collection<LanguageRecord>('languages')
 
   @KeyAsId()
-  async getAll<T>(offset = 0, limit = 1000): Promise<T[]> {
+  async getAll(offset = 0, limit = 1000): Promise<LanguageRecord[]> {
     const res = await this.db.query(aql`
       FOR item IN ${this.collection}
         LIMIT ${offset}, ${limit}
@@ -19,7 +25,7 @@ export class LanguageService extends BaseService {
   }
 
   @KeyAsId()
-  async getByBcp47<T>(_key: string): Promise<T> {
+  async getByBcp47(_key: string): Promise<LanguageRecord> {
     const res = await this.db.query(aql`
       FOR item in ${this.collection}
         FILTER item.bcp47 == ${_key}

--- a/apps/api-languages/src/app/modules/translation/translation.resolver.spec.ts
+++ b/apps/api-languages/src/app/modules/translation/translation.resolver.spec.ts
@@ -17,7 +17,7 @@ describe('Translation Resolver', () => {
     const languageService = {
       provide: LanguageService,
       useFactory: () => ({
-        get: jest.fn(() => translation)
+        load: jest.fn(() => translation)
       })
     }
     const module: TestingModule = await Test.createTestingModule({

--- a/apps/api-languages/src/app/modules/translation/translation.resolver.ts
+++ b/apps/api-languages/src/app/modules/translation/translation.resolver.ts
@@ -1,13 +1,12 @@
 import { Resolver, ResolveField, Parent } from '@nestjs/graphql'
-import { Language } from '../../__generated__/graphql'
-import { LanguageService } from '../language/language.service'
+import { LanguageRecord, LanguageService } from '../language/language.service'
 
 @Resolver('Translation')
 export class TranslationResolver {
   constructor(private readonly languageService: LanguageService) {}
 
   @ResolveField()
-  async language(@Parent() translation): Promise<Language> {
-    return await this.languageService.get(translation.languageId)
+  async language(@Parent() translation): Promise<LanguageRecord | Error> {
+    return await this.languageService.load(translation.languageId)
   }
 }

--- a/apps/api-media/src/app/modules/cloudflare/image/image.resolver.ts
+++ b/apps/api-media/src/app/modules/cloudflare/image/image.resolver.ts
@@ -42,7 +42,7 @@ export class ImageResolver {
     @Args('id') id: string,
     @CurrentUserId() userId: string
   ): Promise<boolean> {
-    const image = await this.imageService.get<CloudflareImage>(id)
+    const image = (await this.imageService.get(id)) as CloudflareImage
     if (image == null) {
       throw new UserInputError('Image not found')
     }

--- a/apps/api-media/src/app/modules/cloudflare/image/image.service.spec.ts
+++ b/apps/api-media/src/app/modules/cloudflare/image/image.service.spec.ts
@@ -1,8 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { Database } from 'arangojs'
-import { mockDeep } from 'jest-mock-extended'
+import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
 
-import { DocumentCollection } from 'arangojs/collection'
+import { DocumentCollection, EdgeCollection } from 'arangojs/collection'
 import fetch, { Response } from 'node-fetch'
 
 import { ImageService } from './image.service'
@@ -34,22 +34,29 @@ const cfDeleteResult = {
 }
 
 describe('ImageService', () => {
-  let service: ImageService
+  let service: ImageService,
+    db: DeepMockProxy<Database>,
+    collectionMock: DeepMockProxy<DocumentCollection & EdgeCollection>
 
   beforeEach(async () => {
+    db = mockDeep()
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ImageService,
         {
           provide: 'DATABASE',
-          useFactory: () => mockDeep<Database>()
+          useFactory: () => db
         }
       ]
     }).compile()
 
     service = module.get<ImageService>(ImageService)
-    service.collection = mockDeep<DocumentCollection>()
+    collectionMock = mockDeep()
+    service.collection = collectionMock
     mockFetch.mockClear()
+  })
+  afterAll(() => {
+    jest.resetAllMocks()
   })
 
   describe('getCloudflareImageUploadInfo', () => {

--- a/apps/api-media/src/app/modules/cloudflare/image/image.service.ts
+++ b/apps/api-media/src/app/modules/cloudflare/image/image.service.ts
@@ -1,7 +1,6 @@
 import { BaseService } from '@core/nest/database/BaseService'
 import { Injectable } from '@nestjs/common'
 import { aql } from 'arangojs'
-import { DocumentCollection } from 'arangojs/collection'
 import fetch from 'node-fetch'
 import { KeyAsId } from '@core/nest/decorators/KeyAsId'
 import { CloudflareImage } from '../../../__generated__/graphql'
@@ -19,7 +18,7 @@ interface CloudflareDirectCreatorUploadResponse {
 
 @Injectable()
 export class ImageService extends BaseService {
-  collection: DocumentCollection = this.db.collection('cloudflareImages')
+  collection = this.db.collection('cloudflareImages')
   async getImageInfoFromCloudflare(): Promise<CloudflareDirectCreatorUploadResponse> {
     const response = await fetch(
       `https://api.cloudflare.com/client/v4/accounts/${

--- a/apps/api-users/src/app/modules/user/user.service.spec.ts
+++ b/apps/api-users/src/app/modules/user/user.service.spec.ts
@@ -5,27 +5,30 @@ import {
   mockCollectionSaveResult,
   mockDbQueryResult
 } from '@core/nest/database/mock'
-import { DocumentCollection } from 'arangojs/collection'
+import { DocumentCollection, EdgeCollection } from 'arangojs/collection'
 import { keyAsId } from '@core/nest/decorators/KeyAsId'
 
 import { UserService } from './user.service'
 
 describe('UserService', () => {
-  let service: UserService
-
+  let service: UserService,
+    db: DeepMockProxy<Database>,
+    collectionMock: DeepMockProxy<DocumentCollection & EdgeCollection>
   beforeEach(async () => {
+    db = mockDeep()
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UserService,
         {
           provide: 'DATABASE',
-          useFactory: () => mockDeep<Database>()
+          useFactory: () => db
         }
       ]
     }).compile()
 
     service = module.get<UserService>(UserService)
-    service.collection = mockDeep<DocumentCollection>()
+    collectionMock = mockDeep()
+    service.collection = collectionMock
   })
   afterAll(() => {
     jest.resetAllMocks()
@@ -43,9 +46,7 @@ describe('UserService', () => {
 
   describe('getAll', () => {
     beforeEach(() => {
-      ;(service.db as DeepMockProxy<Database>).query.mockReturnValue(
-        mockDbQueryResult(service.db, [user, user])
-      )
+      db.query.mockReturnValue(mockDbQueryResult(service.db, [user, user]))
     })
 
     it('should return an array of users', async () => {
@@ -55,9 +56,7 @@ describe('UserService', () => {
 
   describe('get', () => {
     beforeEach(() => {
-      ;(service.db as DeepMockProxy<Database>).query.mockReturnValue(
-        mockDbQueryResult(service.db, [user])
-      )
+      db.query.mockReturnValue(mockDbQueryResult(service.db, [user]))
     })
 
     it('should return a user', async () => {
@@ -67,9 +66,7 @@ describe('UserService', () => {
 
   describe('getByUserId', () => {
     beforeEach(() => {
-      ;(service.db as DeepMockProxy<Database>).query.mockReturnValue(
-        mockDbQueryResult(service.db, [user])
-      )
+      db.query.mockReturnValue(mockDbQueryResult(service.db, [user]))
     })
 
     it('should return a user', async () => {
@@ -79,9 +76,9 @@ describe('UserService', () => {
 
   describe('save', () => {
     beforeEach(() => {
-      ;(
-        service.collection as DeepMockProxy<DocumentCollection>
-      ).save.mockReturnValue(mockCollectionSaveResult(service.collection, user))
+      collectionMock.save.mockReturnValue(
+        mockCollectionSaveResult(service.collection, user)
+      )
     })
 
     it('should return a saved user', async () => {

--- a/apps/api-users/src/app/modules/user/user.service.ts
+++ b/apps/api-users/src/app/modules/user/user.service.ts
@@ -1,14 +1,13 @@
 import { BaseService } from '@core/nest/database/BaseService'
 import { Injectable } from '@nestjs/common'
 import { aql } from 'arangojs'
-import { DocumentCollection } from 'arangojs/collection'
 import { KeyAsId } from '@core/nest/decorators/KeyAsId'
 
 import { User } from '../../__generated__/graphql'
 
 @Injectable()
 export class UserService extends BaseService {
-  collection: DocumentCollection = this.db.collection('users')
+  collection = this.db.collection('users')
   @KeyAsId()
   async getByUserId(userId: string): Promise<User> {
     const res = await this.db.query(aql`

--- a/apps/api-videos/src/app/modules/video/video.service.spec.ts
+++ b/apps/api-videos/src/app/modules/video/video.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing'
 import { mockDbQueryResult } from '@core/nest/database/mock'
 import { Database, aql } from 'arangojs'
 import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
-import { DocumentCollection } from 'arangojs/collection'
+import { DocumentCollection, EdgeCollection } from 'arangojs/collection'
 import { ArrayCursor } from 'arangojs/cursor'
 import { AqlQuery, GeneratedAqlQuery } from 'arangojs/aql'
 import { VideoLabel } from '../../__generated__/graphql'
@@ -63,11 +63,12 @@ const GET_VIDEO_BY_SLUG_QUERY = aql`
     `.query
 
 describe('VideoService', () => {
-  let service: VideoService
-  let db: DeepMockProxy<Database>
+  let service: VideoService,
+    db: DeepMockProxy<Database>,
+    collectionMock: DeepMockProxy<DocumentCollection & EdgeCollection>
 
   beforeEach(async () => {
-    db = mockDeep<Database>()
+    db = mockDeep()
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         VideoService,
@@ -79,7 +80,8 @@ describe('VideoService', () => {
     }).compile()
 
     service = module.get<VideoService>(VideoService)
-    service.collection = mockDeep<DocumentCollection>()
+    collectionMock = mockDeep()
+    service.collection = collectionMock
   })
 
   describe('videoFilter', () => {

--- a/apps/api-videos/src/app/modules/video/video.service.ts
+++ b/apps/api-videos/src/app/modules/video/video.service.ts
@@ -1,7 +1,6 @@
 import { BaseService } from '@core/nest/database/BaseService'
 import { Injectable } from '@nestjs/common'
 import { aql } from 'arangojs'
-import { DocumentCollection } from 'arangojs/collection'
 import { KeyAsId } from '@core/nest/decorators/KeyAsId'
 import { AqlQuery, GeneratedAqlQuery } from 'arangojs/aql'
 import { compact } from 'lodash'
@@ -15,7 +14,7 @@ interface ExtendedVideosFilter extends VideosFilter {
 
 @Injectable()
 export class VideoService extends BaseService {
-  collection: DocumentCollection = this.db.collection('videos')
+  collection = this.db.collection('videos')
   baseVideo: GeneratedAqlQuery[] = [
     aql`_key: item._key,
         label: item.label,

--- a/apps/api-videos/src/libs/arclight/arclight.spec.ts
+++ b/apps/api-videos/src/libs/arclight/arclight.spec.ts
@@ -46,7 +46,9 @@ describe('arclight', () => {
       } as unknown as Response)
       await expect(getArclightMediaLanguages()).resolves.toEqual([])
       expect(request).toHaveBeenCalledWith(
-        'https://api.arclight.org/v2/media-languages?limit=5000&filter=default&apiKey=',
+        expect.stringContaining(
+          'https://api.arclight.org/v2/media-languages?limit=5000&filter=default&apiKey='
+        ),
         undefined
       )
     })
@@ -65,7 +67,9 @@ describe('arclight', () => {
       } as unknown as Response)
       await expect(getArclightMediaComponents(1)).resolves.toEqual([])
       expect(request).toHaveBeenCalledWith(
-        'https://api.arclight.org/v2/media-components?limit=25&isDeprecated=false&contentTypes=video&page=1&apiKey=',
+        expect.stringContaining(
+          'https://api.arclight.org/v2/media-components?limit=25&isDeprecated=false&contentTypes=video&page=1&apiKey='
+        ),
         undefined
       )
     })
@@ -81,7 +85,9 @@ describe('arclight', () => {
       } as unknown as Response)
       await expect(getArclightMediaComponents(1)).resolves.toEqual([])
       expect(request).toHaveBeenCalledWith(
-        'https://api.arclight.org/v2/media-components?limit=25&isDeprecated=false&contentTypes=video&page=1&apiKey=',
+        expect.stringContaining(
+          'https://api.arclight.org/v2/media-components?limit=25&isDeprecated=false&contentTypes=video&page=1&apiKey='
+        ),
         undefined
       )
     })
@@ -102,7 +108,9 @@ describe('arclight', () => {
         getArclightMediaComponentLanguages('mediaComponentId')
       ).resolves.toEqual([])
       expect(request).toHaveBeenCalledWith(
-        'https://api.arclight.org/v2/media-components/mediaComponentId/languages?platform=android&apiKey=',
+        expect.stringContaining(
+          'https://api.arclight.org/v2/media-components/mediaComponentId/languages?platform=android&apiKey='
+        ),
         undefined
       )
     })
@@ -123,7 +131,9 @@ describe('arclight', () => {
         getArclightMediaComponentLinks('mediaComponentId')
       ).resolves.toEqual([])
       expect(request).toHaveBeenCalledWith(
-        'https://api.arclight.org/v2/media-component-links/mediaComponentId?apiKey=',
+        expect.stringContaining(
+          'https://api.arclight.org/v2/media-component-links/mediaComponentId?apiKey='
+        ),
         undefined
       )
     })
@@ -139,7 +149,9 @@ describe('arclight', () => {
         getArclightMediaComponentLinks('mediaComponentId')
       ).resolves.toEqual([])
       expect(request).toHaveBeenCalledWith(
-        'https://api.arclight.org/v2/media-component-links/mediaComponentId?apiKey=',
+        expect.stringContaining(
+          'https://api.arclight.org/v2/media-component-links/mediaComponentId?apiKey='
+        ),
         undefined
       )
     })

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "allowJs": true,
-    "esModuleInterop": true,
     "jsx": "react",
     "lib": ["dom"],
     "noEmit": true,

--- a/apps/journeys-admin/tsconfig.json
+++ b/apps/journeys-admin/tsconfig.json
@@ -4,7 +4,6 @@
     "jsx": "preserve",
     "jsxImportSource": "@emotion/react",
     "allowJs": true,
-    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "types": ["node", "jest"],
     "strict": false,

--- a/apps/journeys/tsconfig.json
+++ b/apps/journeys/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "jsx": "preserve",
     "allowJs": true,
-    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "types": ["node", "jest"],
     "strict": false,

--- a/apps/watch-admin/tsconfig.json
+++ b/apps/watch-admin/tsconfig.json
@@ -4,7 +4,6 @@
     "jsx": "preserve",
     "jsxImportSource": "@emotion/react",
     "allowJs": true,
-    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "types": ["node", "jest"],
     "strict": false,

--- a/apps/watch/src/components/VideosPage/VideosPage.spec.tsx
+++ b/apps/watch/src/components/VideosPage/VideosPage.spec.tsx
@@ -51,7 +51,7 @@ describe('VideosPage', () => {
 
   describe('filters', () => {
     it('should handle audio language filter', async () => {
-      const { getAllByRole, getByText } = render(
+      const { getAllByRole, getByText, getByRole } = render(
         <MockedProvider
           mocks={[
             {
@@ -66,7 +66,7 @@ describe('VideosPage', () => {
               },
               result: {
                 data: {
-                  videos
+                  videos: [videos[0]]
                 }
               }
             },
@@ -79,7 +79,17 @@ describe('VideosPage', () => {
               },
               result: {
                 data: {
-                  languages
+                  languages: [
+                    {
+                      id: '529',
+                      name: [
+                        {
+                          value: 'English',
+                          primary: true
+                        }
+                      ]
+                    }
+                  ]
                 }
               }
             },
@@ -95,7 +105,7 @@ describe('VideosPage', () => {
               },
               result: {
                 data: {
-                  videos
+                  videos: [videos[1]]
                 }
               }
             }
@@ -104,14 +114,22 @@ describe('VideosPage', () => {
           <VideosPage />
         </MockedProvider>
       )
-      const textbox = getAllByRole('combobox')[0]
-
-      await act(async () => {
-        await waitFor(() => fireEvent.focus(textbox))
-        await waitFor(() => fireEvent.keyDown(textbox, { key: 'ArrowDown' }))
-        await waitFor(() => fireEvent.keyDown(textbox, { key: 'Enter' }))
-      })
-      expect(getByText(videos[0].title[0].value)).toBeInTheDocument()
+      await waitFor(() =>
+        expect(
+          getAllByRole('combobox', { name: 'Search Languages' })[0]
+        ).toBeInTheDocument()
+      )
+      const comboboxEl = getAllByRole('combobox', {
+        name: 'Search Languages'
+      })[0]
+      fireEvent.focus(comboboxEl)
+      fireEvent.keyDown(comboboxEl, { key: 'ArrowDown' })
+      await waitFor(() => getByRole('option', { name: 'English' }))
+      fireEvent.click(getByRole('option', { name: 'English' }))
+      expect(comboboxEl).toHaveValue('English')
+      await waitFor(() =>
+        expect(getByText(videos[1].title[0].value)).toBeInTheDocument()
+      )
     })
 
     it('should handle subtitle language filter', async () => {

--- a/apps/watch/tsconfig.json
+++ b/apps/watch/tsconfig.json
@@ -4,7 +4,6 @@
     "jsx": "preserve",
     "jsxImportSource": "@emotion/react",
     "allowJs": true,
-    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "types": ["node", "jest"],
     "strict": false,

--- a/libs/journeys/ui/tsconfig.json
+++ b/libs/journeys/ui/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "allowJs": true,
-    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,

--- a/libs/nest/database/src/lib/BaseService.spec.ts
+++ b/libs/nest/database/src/lib/BaseService.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { Database } from 'arangojs'
 import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
-import { DocumentCollection } from 'arangojs/collection'
+import { DocumentCollection, EdgeCollection } from 'arangojs/collection'
 import { Injectable } from '@nestjs/common'
 import { omit } from 'lodash'
 import { AqlQuery } from 'arangojs/aql'
@@ -12,7 +12,7 @@ import { BaseService } from './BaseService'
 
 @Injectable()
 export class MockService extends BaseService {
-  collection: DocumentCollection = this.db.collection('mocks')
+  collection = this.db.collection('mocks')
 }
 
 const block = {
@@ -58,11 +58,12 @@ const blockResponse2 = omit(
 )
 
 describe('Base Service', () => {
-  let service: MockService
-  let db: DeepMockProxy<Database>
+  let service: MockService,
+    db: DeepMockProxy<Database>,
+    collectionMock: DeepMockProxy<DocumentCollection & EdgeCollection>
 
   beforeEach(async () => {
-    db = mockDeep<Database>()
+    db = mockDeep()
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         MockService,
@@ -74,27 +75,39 @@ describe('Base Service', () => {
     }).compile()
 
     service = module.get<MockService>(MockService)
-    service.collection = mockDeep<DocumentCollection>()
+    collectionMock = mockDeep()
+    service.collection = collectionMock
   })
   afterAll(() => {
     jest.resetAllMocks()
   })
 
-  describe('updateAll', () => {
-    it('should return updated objects', async () => {
-      ;(
-        service.collection as DeepMockProxy<DocumentCollection>
-      ).updateAll.mockReturnValue(
-        mockCollectionUpdateAllResult(service.collection, [block, block2])
-      )
-      expect(await service.updateAll([block, block2])).toEqual([
+  describe('load', () => {
+    it('should call getByIds with _key', async () => {
+      db.query.mockImplementationOnce(async (q) => {
+        const { bindVars } = q as unknown as AqlQuery
+        expect(bindVars).toEqual({
+          value0: [block._key]
+        })
+        return { all: () => [block] } as unknown as ArrayCursor
+      })
+      expect(await service.load(block._key)).toEqual(blockResponse)
+    })
+  })
+
+  describe('loadMany', () => {
+    it('should call getByIds with _keys', async () => {
+      db.query.mockImplementationOnce(async (q) => {
+        const { bindVars } = q as unknown as AqlQuery
+        expect(bindVars).toEqual({
+          value0: [block._key, block2._key]
+        })
+        return { all: () => [block, block2] } as unknown as ArrayCursor
+      })
+      expect(await service.loadMany([block._key, block2._key])).toEqual([
         blockResponse,
         blockResponse2
       ])
-      expect(service.collection.updateAll).toHaveBeenCalledWith(
-        [block, block2],
-        { returnNew: true }
-      )
     })
   })
 
@@ -115,6 +128,22 @@ describe('Base Service', () => {
         blockResponse,
         blockResponse2
       ])
+    })
+  })
+
+  describe('updateAll', () => {
+    it('should return updated objects', async () => {
+      collectionMock.updateAll.mockReturnValue(
+        mockCollectionUpdateAllResult(service.collection, [block, block2])
+      )
+      expect(await service.updateAll([block, block2])).toEqual([
+        blockResponse,
+        blockResponse2
+      ])
+      expect(service.collection.updateAll).toHaveBeenCalledWith(
+        [block, block2],
+        { returnNew: true }
+      )
     })
   })
 })

--- a/libs/shared/ui/tsconfig.json
+++ b/libs/shared/ui/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "allowJs": true,
-    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "clsx": "^1.2.1",
         "core-js": "^3.23.3",
         "cross-fetch": "^3.1.5",
+        "dataloader": "^2.1.0",
         "date-fns": "^2.27.0",
         "dd-trace": "^3.11.0",
         "express": "4.17.2",
@@ -35225,6 +35226,11 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
       "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
       "dev": true
+    },
+    "node_modules/dataloader": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.1.0.tgz",
+      "integrity": "sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ=="
     },
     "node_modules/date-fns": {
       "version": "2.29.3",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "clsx": "^1.2.1",
     "core-js": "^3.23.3",
     "cross-fetch": "^3.1.5",
+    "dataloader": "^2.1.0",
     "date-fns": "^2.27.0",
     "dd-trace": "^3.11.0",
     "express": "4.17.2",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,6 +14,7 @@
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "strictNullChecks": true,
+    "esModuleInterop": true,
     "baseUrl": ".",
     "paths": {
       "@core/journeys/ui/*": [


### PR DESCRIPTION
# Description

This PR solves the issue where n+1 calls were being made when loading languages. This PR attempts to resolve this performance issue by introducing data loaders.

This PR begins the work to start typing the nest BaseService class in the eventual hope of introducing document schemas to be used by child classes of the Base Service. Eventually all service consumers should use load instead of get.

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] API calls to video collections with languages should be significantly faster.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
