### PR TITLE
fix: update earliest good commit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Prettier
         run: npx prettier --check .
       - name: lint commit messages
-        run: npx commitlint --from 5364963 # earliest good commit to main
+        run: npx commitlint --from f654382 # earliest good commit to main
       - name: lint branch name
         if: ${{ github.event_name == 'pull_request' }}
         run: npx validate-branch-name -t $GITHUB_HEAD_REF


### PR DESCRIPTION
# Description

An incorrect PR title was used in [this commit](https://github.com/JesusFilm/core/commit/732f3cfd06b66a3a5cc140e0544912c49e1bf3f5).
The solution is to force push a good commit title which was done in [this commit](https://github.com/JesusFilm/core/commit/f654382ef8ecaaf07529923ac99dc0afc123ece6).

This PR then points commit lint to the latest good commit.