### PR TITLE
chore: update router cors to match domains and be cacheable

### DIFF
--- a/.devcontainer/post-create-command.sh
+++ b/.devcontainer/post-create-command.sh
@@ -37,7 +37,7 @@ rm -rf bin
 # - update .devcontainer/post-create-command.sh apollo router version (...nix/vX.X.X)
 # - update app/api-gateway/Dockerfile image version (...router/vX.X.X)
 # - inform all developers to rebuild their containers
-curl -sSL https://router.apollo.dev/download/nix/v1.9.0 | sh
+curl -sSL https://router.apollo.dev/download/nix/v1.10.1 | sh
 mv router apps/api-gateway/
 
 # install doppler

--- a/apps/api-gateway/Dockerfile
+++ b/apps/api-gateway/Dockerfile
@@ -2,5 +2,5 @@
 # - update .devcontainer/post-create-command.sh apollo router version (...nix/vX.X.X)
 # - update app/api-gateway/Dockerfile image version (...router/vX.X.X)
 # - inform all developers to rebuild their containers
-FROM ghcr.io/apollographql/router:v1.9.0
+FROM ghcr.io/apollographql/router:v1.10.1
 COPY ./apps/api-gateway/router.prod.yaml /dist/config/router.yaml

--- a/apps/api-gateway/router.prod.yaml
+++ b/apps/api-gateway/router.prod.yaml
@@ -6,17 +6,14 @@ cors:
     # apollo studio
     - https://studio.apollographql.com
     # journeys-admin
-    - https://journeys-admin.vercel.app
     - https://admin.nextstep.is
     - https://admin-stage.nextstep.is
     # journeys
-    - https://journeys-phi.vercel.app
     - https://your.nextstep.is
     - https://your-stage.nextstep.is
     # watch
-    - https://watch-jesusfilm.vercel.app
-    - https://watch-one.vercel.app
     - https://watch.jesusfilm.org
+    - https://watch-stage.jesusfilm.org
   match_origins:
     # any project deployed on the jesusfilm vercel account
     - '^https://([a-z0-9-]+)-jesusfilm[.]vercel[.]app$'

--- a/apps/api-gateway/router.prod.yaml
+++ b/apps/api-gateway/router.prod.yaml
@@ -17,6 +17,7 @@ cors:
   match_origins:
     # any project deployed on the jesusfilm vercel account
     - '^https://([a-z0-9-]+)-jesusfilm[.]vercel[.]app$'
+  max_age: 24h
 headers:
   all:
     request:
@@ -26,7 +27,7 @@ headers:
           named: 'user-agent'
       - propagate:
           named: 'x-forwarded-for'
-health-check:
+health_check:
   listen: 0.0.0.0:8088
   enabled: true
 include_subgraph_errors:

--- a/apps/api-gateway/router.yaml
+++ b/apps/api-gateway/router.yaml
@@ -5,6 +5,7 @@ cors:
   match_origins:
     # any localhost
     - '^http://localhost:\d+$'
+  max_age: 24h
 headers:
   all:
     request:
@@ -14,7 +15,7 @@ headers:
           named: 'user-agent'
       - propagate:
           named: 'x-forwarded-for'
-health-check:
+health_check:
   listen: 0.0.0.0:8088
   enabled: true
 include_subgraph_errors:

--- a/apps/api-gateway/routerSchema.json
+++ b/apps/api-gateway/routerSchema.json
@@ -17,7 +17,7 @@
             "jwt": {
               "description": "The JWT configuration",
               "type": "object",
-              "required": ["jwks_url"],
+              "required": ["jwks_urls"],
               "properties": {
                 "cooldown": {
                   "description": "JWKS retrieval cooldown",
@@ -34,9 +34,12 @@
                   "default": "Bearer",
                   "type": "string"
                 },
-                "jwks_url": {
-                  "description": "Retrieve our JWK Set from here",
-                  "type": "string"
+                "jwks_urls": {
+                  "description": "Retrieve our JWK Sets from these locations",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               }
             }
@@ -53,7 +56,8 @@
         "expose_headers": null,
         "origins": ["https://studio.apollographql.com"],
         "match_origins": null,
-        "methods": ["GET", "POST", "OPTIONS"]
+        "methods": ["GET", "POST", "OPTIONS"],
+        "max_age": null
       },
       "type": "object",
       "properties": {
@@ -92,6 +96,11 @@
             "type": "string"
           },
           "nullable": true
+        },
+        "max_age": {
+          "description": "The `Access-Control-Max-Age` header value in time units",
+          "default": null,
+          "type": "string"
         },
         "methods": {
           "description": "Allowed request methods. Defaults to GET, POST, OPTIONS.",
@@ -473,7 +482,7 @@
       },
       "additionalProperties": false
     },
-    "health-check": {
+    "health_check": {
       "description": "Health check configuration",
       "default": {
         "listen": "127.0.0.1:8088",
@@ -2123,11 +2132,13 @@
                   "properties": {
                     "ca": {
                       "description": "The optional certificate authority (CA) certificate to be used in TLS configuration.",
+                      "default": null,
                       "type": "string",
                       "nullable": true
                     },
                     "cert": {
                       "description": "The optional cert for tls config",
+                      "default": null,
                       "type": "string",
                       "nullable": true
                     },
@@ -2139,6 +2150,7 @@
                     },
                     "key": {
                       "description": "The optional private key file for TLS configuration.",
+                      "default": null,
                       "type": "string",
                       "nullable": true
                     },
@@ -2552,11 +2564,13 @@
                   "properties": {
                     "ca": {
                       "description": "The optional certificate authority (CA) certificate to be used in TLS configuration.",
+                      "default": null,
                       "type": "string",
                       "nullable": true
                     },
                     "cert": {
                       "description": "The optional cert for tls config",
+                      "default": null,
                       "type": "string",
                       "nullable": true
                     },
@@ -2568,6 +2582,7 @@
                     },
                     "key": {
                       "description": "The optional private key file for TLS configuration.",
+                      "default": null,
                       "type": "string",
                       "nullable": true
                     },
@@ -3028,7 +3043,8 @@
           "nullable": true
         },
         "deduplicate_variables": {
-          "description": "Enable variable deduplication optimization when sending requests to subgraphs (https://github.com/apollographql/router/issues/87)",
+          "description": "DEPRECATED, now always enabled: Enable variable deduplication optimization when sending requests to subgraphs (https://github.com/apollographql/router/issues/87)",
+          "default": null,
           "type": "boolean",
           "nullable": true
         },


### PR DESCRIPTION
# Description

This PR forces projects to use only nextstep.is and jesusfilm.org domains for deployed main and stage. This also caches cors requests for 24 hours in the browser. This was made available in apollo router 1.10.

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] https://admin-stage.nextstep.is can call the stage API
- [ ] https://your-stage.nextstep.is can call the stage API
- [ ] https://watch-stage.jesusfilm.org can call the stage API

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
