### PR TITLE
fix: render custom dialog action component

### DIFF
--- a/libs/shared/ui/src/components/Dialog/Dialog.spec.tsx
+++ b/libs/shared/ui/src/components/Dialog/Dialog.spec.tsx
@@ -14,19 +14,16 @@ describe('Dialog', () => {
       title: 'Title',
       closeButton: true
     },
-    dialogAction: {
-      onSubmit: jest.fn()
-    },
     children: <Typography>Children</Typography>
   }
   it('should display the content', () => {
-    const { getByText, getByRole, getByTestId } = render(
+    const { getByText, getByTestId, queryByTestId } = render(
       <Dialog {...dialogProps} />
     )
     expect(getByTestId('LanguageIcon')).toBeInTheDocument()
     expect(getByText('Title')).toBeInTheDocument()
     expect(getByText('Children')).toBeInTheDocument()
-    expect(getByRole('button', { name: 'Save' })).toBeInTheDocument()
+    expect(queryByTestId('dialog-action')).not.toBeInTheDocument()
   })
 
   it('should close the dialog when the close button is clicked', () => {
@@ -35,36 +32,66 @@ describe('Dialog', () => {
     expect(dialogProps.onClose).toHaveBeenCalled()
   })
 
-  it('should show the custom labels for buttons', () => {
+  describe('dialogAction', () => {
     const input: ComponentProps<typeof Dialog> = {
       ...dialogProps,
       dialogAction: {
         onSubmit: jest.fn(),
         submitLabel: 'Accept',
         closeLabel: 'Cancel'
-      }
+      },
+      dialogActionChildren: <Typography>Custom Action Component</Typography>
     }
-    const { getByRole } = render(<Dialog {...input} />)
-    expect(getByRole('button', { name: 'Accept' })).toBeInTheDocument()
-    expect(getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+
+    it('should show Save button by default', () => {
+      const { getByTestId, getByRole } = render(
+        <Dialog {...input} dialogAction={{ onSubmit: jest.fn() }} />
+      )
+      expect(getByTestId('dialog-action').children).toHaveLength(1)
+      expect(getByTestId('dialog-action').children[0]).toEqual(
+        getByRole('button', { name: 'Save' })
+      )
+    })
+
+    it('should show the custom labels for buttons', () => {
+      const { getByTestId, getByRole } = render(<Dialog {...input} />)
+      expect(getByTestId('dialog-action').children).toHaveLength(2)
+      expect(getByTestId('dialog-action').children[0]).toEqual(
+        getByRole('button', { name: 'Cancel' })
+      )
+      expect(getByTestId('dialog-action').children[1]).toEqual(
+        getByRole('button', { name: 'Accept' })
+      )
+    })
+
+    it('should close the dialog when cancel is clicked', () => {
+      const { getByRole } = render(<Dialog {...input} />)
+      fireEvent.click(getByRole('button', { name: 'Cancel' }))
+      expect(dialogProps.onClose).toHaveBeenCalled()
+    })
+
+    it('should call the submit function', () => {
+      const { getByRole } = render(<Dialog {...input} />)
+      fireEvent.click(getByRole('button', { name: 'Accept' }))
+      expect(input.dialogAction?.onSubmit).toHaveBeenCalled()
+    })
   })
 
-  it('should close the dialog when cancel is clicked', () => {
-    const input: ComponentProps<typeof Dialog> = {
-      ...dialogProps,
-      dialogAction: {
-        onSubmit: jest.fn(),
-        closeLabel: 'Cancel'
-      }
-    }
-    const { getByRole } = render(<Dialog {...input} />)
-    fireEvent.click(getByRole('button', { name: 'Cancel' }))
-    expect(dialogProps.onClose).toHaveBeenCalled()
-  })
-
-  it('should call the submit function', () => {
-    const { getByRole } = render(<Dialog {...dialogProps} />)
-    fireEvent.click(getByRole('button', { name: 'Save' }))
-    expect(dialogProps.dialogAction?.onSubmit).toHaveBeenCalled()
+  describe('dialogActionChildren', () => {
+    it('should display the dialog action component if no dialog action buttons', () => {
+      const { getByText, getByTestId } = render(
+        <Dialog
+          {...dialogProps}
+          dialogAction={undefined}
+          dialogActionChildren={
+            <Typography>Custom Action Component</Typography>
+          }
+        />
+      )
+      expect(getByTestId('dialog-action').children).toHaveLength(1)
+      expect(getByTestId('dialog-action').children[0]).toEqual(
+        getByText('Custom Action Component')
+      )
+    })
   })
 })

--- a/libs/shared/ui/src/components/Dialog/Dialog.stories.tsx
+++ b/libs/shared/ui/src/components/Dialog/Dialog.stories.tsx
@@ -1,6 +1,7 @@
 import { ComponentProps } from 'react'
 import { Story, Meta } from '@storybook/react'
 import { noop } from 'lodash'
+import Button from '@mui/material/Button'
 import Typography from '@mui/material/Typography'
 import TextField from '@mui/material/TextField'
 import MuiListItem from '@mui/material/ListItem'
@@ -68,6 +69,29 @@ MinHeight.args = {
     title: 'Minimum Height Dialog',
     closeButton: true
   },
+  children: <Typography>This is the content</Typography>
+}
+
+export const ActionComponent = Template.bind({})
+ActionComponent.args = {
+  open: true,
+  onClose: noop,
+  dialogTitle: {
+    title: 'Custom Action Component Dialog',
+    closeButton: true
+  },
+  dialogActionChildren: (
+    <>
+      <TextField
+        fullWidth
+        label="Dialog Action Field"
+        value="Value"
+        sx={{ ml: 4 }}
+        margin="dense"
+      />
+      <Button sx={{ mx: 2 }}>Add</Button>
+    </>
+  ),
   children: <Typography>This is the content</Typography>
 }
 

--- a/libs/shared/ui/src/components/Dialog/Dialog.tsx
+++ b/libs/shared/ui/src/components/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, ReactNode } from 'react'
+import { ReactElement, ReactChild } from 'react'
 import { styled } from '@mui/material/styles'
 import MuiDialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
@@ -13,9 +13,11 @@ interface DialogProps {
   onClose: () => void
   dialogTitle?: DialogTitle
   dialogAction?: DialogAction
+  /** Prefer `dialogAction` when child elements are buttons */
+  dialogActionChildren?: ReactChild
   divider?: boolean
   fullscreen?: boolean
-  children?: ReactElement
+  children?: ReactChild
 }
 
 interface DialogAction {
@@ -25,7 +27,7 @@ interface DialogAction {
 }
 
 interface DialogTitle {
-  icon?: ReactNode
+  icon?: ReactElement
   title: string
   closeButton?: boolean
 }
@@ -68,6 +70,7 @@ export function Dialog({
   onClose,
   dialogTitle,
   dialogAction,
+  dialogActionChildren,
   divider,
   fullscreen,
   children
@@ -95,9 +98,11 @@ export function Dialog({
           )}
         </MuiDialogTitle>
       )}
-      <DialogContent dividers={divider}>{children}</DialogContent>
-      {dialogAction != null && (
-        <DialogActions>
+      <DialogContent dividers={divider ?? dialogActionChildren != null}>
+        {children}
+      </DialogContent>
+      {dialogAction != null ? (
+        <DialogActions data-testid="dialog-action">
           {dialogAction.closeLabel != null && (
             <Button onClick={onClose}>{dialogAction.closeLabel}</Button>
           )}
@@ -105,7 +110,11 @@ export function Dialog({
             {dialogAction.submitLabel ?? 'Save'}
           </Button>
         </DialogActions>
-      )}
+      ) : dialogActionChildren != null ? (
+        <DialogActions data-testid="dialog-action">
+          {dialogActionChildren}
+        </DialogActions>
+      ) : null}
     </StyledDialog>
   )
 }


### PR DESCRIPTION
# Description

Allow us to pass in a custom component in dialog action section so we can create this for access dialog

<img width="471" alt="image" src="https://user-images.githubusercontent.com/10802634/217673215-8d2c3d9a-1bab-4cc6-a52d-90d26d2d70fb.png">

[- Link to Basecamp Todo
](https://3.basecamp.com/3105655/buckets/31245893/todos/5819657286)
# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Checks are green
- [ ] Component displays custom dialog action

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
