### PR TITLE
fix: loader sort order according to ids

### DIFF
--- a/libs/nest/database/src/lib/BaseService.spec.ts
+++ b/libs/nest/database/src/lib/BaseService.spec.ts
@@ -102,7 +102,7 @@ describe('Base Service', () => {
         expect(bindVars).toEqual({
           value0: [block._key, block2._key]
         })
-        return { all: () => [block, block2] } as unknown as ArrayCursor
+        return { all: () => [block2, block] } as unknown as ArrayCursor
       })
       expect(await service.loadMany([block._key, block2._key])).toEqual([
         blockResponse,

--- a/libs/nest/database/src/lib/BaseService.ts
+++ b/libs/nest/database/src/lib/BaseService.ts
@@ -17,8 +17,15 @@ export abstract class BaseService<T extends Record<string, any> = any> {
   constructor(
     @Inject('DATABASE') public readonly db: Database | DeepMockProxy<Database>
   ) {
-    this.getByIdsDataLoader = new DataLoader(
-      async (ids: readonly string[]) => await this.getByIds(ids)
+    this.getByIdsDataLoader = new DataLoader<string, T>(
+      async (ids: readonly string[]) => {
+        const items: T[] = []
+        const data = await this.getByIds(ids)
+        data.forEach((item) => {
+          items[ids.indexOf(item.id)] = item
+        })
+        return items
+      }
     )
   }
 


### PR DESCRIPTION
# Description

Loader expects requested Ids to be returned in the same order.

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] changing languages on watch should return correct language and slug

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
