### PR TITLE
fix: keep collection when changing language

### DIFF
--- a/apps/watch/src/components/AudioLanguageDialog/AudioLanguageDialog.spec.tsx
+++ b/apps/watch/src/components/AudioLanguageDialog/AudioLanguageDialog.spec.tsx
@@ -59,4 +59,27 @@ describe('AudioLanguageDialog', () => {
     await waitFor(() => expect(push).toHaveBeenCalled())
     expect(push).toHaveBeenCalledWith('/jesus/a-hmao')
   })
+
+  it('should redirect to the selected language with container', async () => {
+    const push = jest.fn()
+    mockUseRouter.mockReturnValue({ push } as unknown as NextRouter)
+    const { getByRole, queryAllByRole } = render(
+      <MockedProvider mocks={[getLanguagesSlugMock]}>
+        <VideoProvider
+          value={{
+            content: videos[0],
+            container: videos.find(({ id }) => id === 'LUMOCollection')
+          }}
+        >
+          <AudioLanguageDialog open onClose={jest.fn()} />
+        </VideoProvider>
+      </MockedProvider>
+    )
+    await waitFor(() => fireEvent.focus(getByRole('combobox')))
+    fireEvent.keyDown(getByRole('combobox'), { key: 'ArrowDown' })
+    expect(queryAllByRole('option')[1]).toHaveTextContent('A-HmaoA-Hmao')
+    fireEvent.click(queryAllByRole('option')[1])
+    await waitFor(() => expect(push).toHaveBeenCalled())
+    expect(push).toHaveBeenCalledWith('/lumo/jesus/a-hmao')
+  })
 })

--- a/apps/watch/src/components/AudioLanguageDialog/AudioLanguageDialog.tsx
+++ b/apps/watch/src/components/AudioLanguageDialog/AudioLanguageDialog.tsx
@@ -34,7 +34,7 @@ export function AudioLanguageDialog({
   open,
   onClose
 }: AudioLanguageDialogProps): ReactElement {
-  const { id, variant, variantLanguagesCount } = useVideo()
+  const { id, variant, variantLanguagesCount, container } = useVideo()
   const router = useRouter()
 
   const { data } = useQuery<GetLanguagesSlug>(GET_LANGUAGES_SLUG, {
@@ -52,7 +52,11 @@ export function AudioLanguageDialog({
       (languages) => languages.language?.id === value.id
     )?.slug
     if (selectedLanguageSlug != null) {
-      void router.push(`/${selectedLanguageSlug}`)
+      void router.push(
+        `${
+          container?.slug != null ? `/${container.slug}/` : '/'
+        }${selectedLanguageSlug}`
+      )
     }
     onClose()
   }


### PR DESCRIPTION
# Description

Changing languages on a video that belongs to a collection should retain collection on changed video page.

e.g changing from afrikaans to english should keep collection:
/watch/lumo/lumo-matthew-1-1-2-23/afrikaans -> /watch/lumo/lumo-matthew-1-1-2-23/english

However current code does this:
/watch/lumo/lumo-matthew-1-1-2-23/afrikaans -> /watch/lumo-matthew-1-1-2-23/english

This PR fixes that issue.

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/31485426/todos/5818822944)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] go to a video page that belongs to a collection and change language. New page should retain collection.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
