### PR TITLE
feat: skip blurhash processing

### DIFF
--- a/apps/api-journeys/src/app/modules/block/image/image.graphql
+++ b/apps/api-journeys/src/app/modules/block/image/image.graphql
@@ -23,7 +23,13 @@ input ImageBlockCreateInput {
   journeyId: ID!
   src: String
   alt: String!
+  """
+  If blurhash, width, & height are provided, the image will skip blurhash processing. Otherwise these values will be calculated.
+  """
   blurhash: String
+  width: Int
+  height: Int
+
   """
   True if the coverBlockId in a parent block should be set to this block's id.
   """

--- a/apps/api-journeys/src/app/modules/block/image/image.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/image/image.resolver.spec.ts
@@ -13,7 +13,7 @@ import { BlockResolver } from '../block.resolver'
 import { BlockService } from '../block.service'
 import { UserRoleService } from '../../userRole/userRole.service'
 import { JourneyService } from '../../journey/journey.service'
-import { ImageBlockResolver } from './image.resolver'
+import { handleImage, ImageBlockResolver } from './image.resolver'
 
 jest.mock('node-fetch', () => {
   const originalModule = jest.requireActual('node-fetch')
@@ -227,6 +227,20 @@ describe('ImageBlockResolver', () => {
       expect(await resolver.imageBlockUpdate('1', '2', blockUpdate)).toEqual(
         updatedBlock
       )
+    })
+  })
+
+  describe('handleImage', () => {
+    it('should skip processing of image block if blurhash, width and height are defined', async () => {
+      const imageBlock = {
+        id: '1',
+        journeyId: '2',
+        width: 640,
+        height: 425,
+        blurhash: 'UHFO~6Yk^6#M@-5b,1J5@[or[k6o};Fxi^OZ',
+        src: 'bad url that would cause exception in sharp'
+      }
+      expect(await handleImage(imageBlock)).toEqual(imageBlock)
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/block/image/image.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/image/image.resolver.ts
@@ -16,9 +16,17 @@ import {
 } from '../../../__generated__/graphql'
 import { RoleGuard } from '../../../lib/roleGuard/roleGuard'
 
-async function handleImage(
+export async function handleImage(
   input
 ): Promise<ImageBlockCreateInput | ImageBlockUpdateInput> {
+  if (
+    (input.width ?? 0) > 0 &&
+    (input.height ?? 0) > 0 &&
+    (input.blurhash ?? '').length > 0
+  ) {
+    return input
+  }
+
   const defaultBlock = {
     ...input,
     width: 0,
@@ -59,6 +67,7 @@ async function handleImage(
 
   return block
 }
+
 @Resolver('ImageBlock')
 export class ImageBlockResolver {
   constructor(private readonly blockService: BlockService) {}


### PR DESCRIPTION
# Description

This PR allows unsplash to skip blurhash processing when creating an image block.
https://3.basecamp.com/3105655/buckets/31265497/todos/5844141257

# How should this PR be QA Tested?

- [ ] Unsplash image block creation works when providing blurhash, width & height

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
