### PR TITLE
fix: header and footer links opening in window or new window

### DIFF
--- a/apps/watch/src/components/Footer/FooterLink/FooterLink.spec.tsx
+++ b/apps/watch/src/components/Footer/FooterLink/FooterLink.spec.tsx
@@ -4,14 +4,12 @@ import { FooterLink } from './FooterLink'
 
 describe('FooterLink', () => {
   it('should have text link', () => {
-    const { getByRole, getByText } = render(
+    const { getByRole } = render(
       <FooterLink url="https://www.jesusfilm.org/about/" label="About Us" />
     )
-    expect(getByText('About Us')).toBeInTheDocument()
-    expect(getByRole('link', { name: 'About Us' })).toHaveAttribute(
-      'href',
-      'https://www.jesusfilm.org/about/'
-    )
+    const el = getByRole('link', { name: 'About Us' })
+    expect(el).toHaveAttribute('href', 'https://www.jesusfilm.org/about/')
+    expect(el).not.toHaveAttribute('target')
   })
 
   it('should have image link', () => {
@@ -22,13 +20,13 @@ describe('FooterLink', () => {
         src={Facebook}
         width="66"
         height="72"
+        target="_blank"
       />
     )
     expect(getByRole('img')).toHaveAttribute('src', 'facebook.svg')
     expect(getByRole('img')).toHaveAccessibleName('Facebook')
-    expect(getByRole('link', { name: 'Facebook' })).toHaveAttribute(
-      'href',
-      'https://www.facebook.com/jesusfilm'
-    )
+    const el = getByRole('link', { name: 'Facebook' })
+    expect(el).toHaveAttribute('href', 'https://www.facebook.com/jesusfilm')
+    expect(el).toHaveAttribute('target', '_blank')
   })
 })

--- a/apps/watch/src/components/Footer/FooterLink/FooterLink.tsx
+++ b/apps/watch/src/components/Footer/FooterLink/FooterLink.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react'
+import { HTMLAttributeAnchorTarget, ReactElement } from 'react'
 import MuiLink, { LinkProps } from '@mui/material/Link'
 import Typography from '@mui/material/Typography'
 import Image from 'next/image'
@@ -13,6 +13,7 @@ interface FooterLinkProps {
   src?: string
   width?: string
   height?: string
+  target?: HTMLAttributeAnchorTarget
   noFollow?: boolean
 }
 
@@ -24,13 +25,14 @@ export function FooterLink({
   src,
   width,
   height,
+  target,
   noFollow = false
 }: FooterLinkProps): ReactElement {
   return (
     <MuiLink
       href={url}
       underline={underline}
-      target="_blank"
+      target={target}
       rel={noFollow ? 'nofollow noopener' : 'noopener'}
       color="text.primary"
     >

--- a/apps/watch/src/components/Footer/FooterLinks/FooterLinks.spec.tsx
+++ b/apps/watch/src/components/Footer/FooterLinks/FooterLinks.spec.tsx
@@ -3,67 +3,73 @@ import { FooterLinks } from './FooterLinks'
 
 describe('FooterLinks', () => {
   describe('About', () => {
-    it('should have about link', () => {
+    it('should have About Jesus Film Project link', () => {
       const { getByRole } = render(<FooterLinks />)
-      expect(getByRole('link', { name: 'About Us' })).toHaveAttribute(
-        'href',
-        'https://www.jesusfilm.org/about/'
-      )
+      const el = getByRole('link', { name: 'About Jesus Film Project' })
+      expect(el).toHaveAttribute('href', 'https://www.jesusfilm.org/about/')
+      expect(el).not.toHaveAttribute('target')
     })
     it('should have Contact link', () => {
       const { getByRole } = render(<FooterLinks />)
-      expect(getByRole('link', { name: 'Contact' })).toHaveAttribute(
-        'href',
-        'https://www.jesusfilm.org/contact/'
-      )
+      const el = getByRole('link', { name: 'Contact' })
+      expect(el).toHaveAttribute('href', 'https://www.jesusfilm.org/contact/')
+      expect(el).not.toHaveAttribute('target')
     })
     it('should have Ways to Give link', () => {
       const { getByRole } = render(<FooterLinks />)
-      expect(getByRole('link', { name: 'Ways to Give' })).toHaveAttribute(
-        'href',
-        'https://www.jesusfilm.org/give/'
-      )
+      const el = getByRole('link', { name: 'Ways to Give' })
+      expect(el).toHaveAttribute('href', 'https://www.jesusfilm.org/give/')
+      expect(el).not.toHaveAttribute('target')
     })
   })
   describe('Sections', () => {
+    it('should have Watch link', () => {
+      const { getByRole } = render(<FooterLinks />)
+      const el = getByRole('link', { name: 'Watch' })
+      expect(el).toHaveAttribute('href', 'https://www.jesusfilm.org/watch/')
+      expect(el).not.toHaveAttribute('target')
+    })
     it('should have Strategies and Tools link', () => {
       const { getByRole } = render(<FooterLinks />)
-      expect(
-        getByRole('link', { name: 'Strategies and Tools' })
-      ).toHaveAttribute(
+      const el = getByRole('link', { name: 'Strategies and Tools' })
+      expect(el).toHaveAttribute(
         'href',
-        'https://www.jesusfilm.org/partners/mission-trips/'
+        'https://www.jesusfilm.org/partners/resources/'
       )
+      expect(el).not.toHaveAttribute('target')
     })
+
     it('should have Blog link', () => {
       const { getByRole } = render(<FooterLinks />)
-      expect(getByRole('link', { name: 'Blog' })).toHaveAttribute(
-        'href',
-        'https://www.jesusfilm.org/blog/'
-      )
+      const el = getByRole('link', { name: 'Blog' })
+      expect(el).toHaveAttribute('href', 'https://www.jesusfilm.org/blog/')
+      expect(el).not.toHaveAttribute('target')
     })
-    it('should have How to help link', () => {
+    it('should have How to Help link', () => {
       const { getByRole } = render(<FooterLinks />)
-      expect(getByRole('link', { name: 'How to Help' })).toHaveAttribute(
-        'href',
-        'https://www.jesusfilm.org/partners/'
-      )
+      const el = getByRole('link', { name: 'How to Help' })
+      expect(el).toHaveAttribute('href', 'https://www.jesusfilm.org/partners/')
+      expect(el).not.toHaveAttribute('target')
     })
   })
   describe('Apps', () => {
     it('should have Android link', () => {
       const { getByRole } = render(<FooterLinks />)
-      expect(getByRole('link', { name: 'Android' })).toHaveAttribute(
+      const el = getByRole('link', { name: 'Android' })
+      expect(el).toHaveAttribute(
         'href',
         'https://play.google.com/store/apps/details?id=com.jesusfilmmedia.android.jesusfilm'
       )
+      expect(el).toHaveAttribute('target', '_blank')
     })
     it('should have iPhone link', () => {
       const { getByRole } = render(<FooterLinks />)
-      expect(getByRole('link', { name: 'iPhone' })).toHaveAttribute(
+      const el = getByRole('link', { name: 'iPhone' })
+      expect(el).toHaveAttribute(
         'href',
         'https://apps.apple.com/us/app/jesus-film-media/id550525738'
       )
+      expect(el).toHaveAttribute('target', '_blank')
     })
   })
 })

--- a/apps/watch/src/components/Footer/FooterLinks/FooterLinks.tsx
+++ b/apps/watch/src/components/Footer/FooterLinks/FooterLinks.tsx
@@ -14,7 +14,10 @@ export function FooterLinks(): ReactElement {
         >
           About
         </Typography>
-        <FooterLink label="About Us" url="https://www.jesusfilm.org/about/" />
+        <FooterLink
+          label="About Jesus Film Project"
+          url="https://www.jesusfilm.org/about/"
+        />
         <FooterLink label="Contact" url="https://www.jesusfilm.org/contact/" />
         <FooterLink
           label="Ways to Give"
@@ -27,11 +30,12 @@ export function FooterLinks(): ReactElement {
           component="h2"
           sx={{ textTransform: 'uppercase' }}
         >
-          Sections
+          Section
         </Typography>
+        <FooterLink label="Watch" url="https://www.jesusfilm.org/watch/" />
         <FooterLink
           label="Strategies and Tools"
-          url="https://www.jesusfilm.org/partners/mission-trips/"
+          url="https://www.jesusfilm.org/partners/resources/"
         />
         <FooterLink label="Blog" url="https://www.jesusfilm.org/blog/" />
         <FooterLink
@@ -50,10 +54,12 @@ export function FooterLinks(): ReactElement {
         <FooterLink
           label="Android"
           url="https://play.google.com/store/apps/details?id=com.jesusfilmmedia.android.jesusfilm"
+          target="_blank"
         />
         <FooterLink
           label="iPhone"
           url="https://apps.apple.com/us/app/jesus-film-media/id550525738"
+          target="_blank"
         />
       </Stack>
     </Stack>

--- a/apps/watch/src/components/Footer/FooterLogos/FooterLogos.spec.tsx
+++ b/apps/watch/src/components/Footer/FooterLogos/FooterLogos.spec.tsx
@@ -2,18 +2,16 @@ import { render } from '@testing-library/react'
 import { FooterLogos } from './FooterLogos'
 
 describe('FooterLogos', () => {
-  it('should have the terms and conditions link', () => {
+  it('should have the jesus film logo link', () => {
     const { getByAltText } = render(<FooterLogos />)
-    expect(getByAltText('Jesus Film logo').closest('a')).toHaveAttribute(
-      'href',
-      'https://www.jesusfilm.org'
-    )
+    const el = getByAltText('Jesus Film logo').closest('a')
+    expect(el).toHaveAttribute('href', 'https://www.jesusfilm.org')
+    expect(el).not.toHaveAttribute('target')
   })
-  it('should have the privacy policy link', () => {
+  it('should have the cru logo link', () => {
     const { getByAltText } = render(<FooterLogos />)
-    expect(getByAltText('Cru logo').closest('a')).toHaveAttribute(
-      'href',
-      'https://www.cru.org/'
-    )
+    const el = getByAltText('Cru logo').closest('a')
+    expect(el).toHaveAttribute('href', 'https://www.cru.org')
+    expect(el).toHaveAttribute('target', '_blank')
   })
 })

--- a/apps/watch/src/components/Footer/FooterLogos/FooterLogos.tsx
+++ b/apps/watch/src/components/Footer/FooterLogos/FooterLogos.tsx
@@ -8,11 +8,12 @@ export function FooterLogos(): ReactElement {
   return (
     <Stack direction="row" spacing={2} justifyContent="end">
       <FooterLink
-        url="https://www.cru.org/"
+        url="https://www.cru.org"
         label="Cru logo"
         src={CruLogo}
         width="72"
         height="52"
+        target="_blank"
       />
       <FooterLink
         url="https://www.jesusfilm.org"

--- a/apps/watch/src/components/Footer/FooterSocials/FooterSocials.spec.tsx
+++ b/apps/watch/src/components/Footer/FooterSocials/FooterSocials.spec.tsx
@@ -2,32 +2,28 @@ import { render } from '@testing-library/react'
 import { FooterSocials } from './FooterSocials'
 
 describe('FooterSocials', () => {
-  it('should have the privacy policy link', () => {
+  it('should have the facebook link', () => {
     const { getByRole } = render(<FooterSocials />)
-    expect(getByRole('link', { name: 'Facebook' })).toHaveAttribute(
-      'href',
-      'https://www.facebook.com/jesusfilm'
-    )
+    const el = getByRole('link', { name: 'Facebook' })
+    expect(el).toHaveAttribute('href', 'https://www.facebook.com/jesusfilm')
+    expect(el).toHaveAttribute('target', '_blank')
   })
-  it('should have the privacy policy link', () => {
+  it('should have the twitter link', () => {
     const { getByRole } = render(<FooterSocials />)
-    expect(getByRole('link', { name: 'Twitter' })).toHaveAttribute(
-      'href',
-      'https://twitter.com/jesusfilm'
-    )
+    const el = getByRole('link', { name: 'Twitter' })
+    expect(el).toHaveAttribute('href', 'https://twitter.com/jesusfilm')
+    expect(el).toHaveAttribute('target', '_blank')
   })
-  it('should have the privacy policy link', () => {
+  it('should have the youtube link', () => {
     const { getByRole } = render(<FooterSocials />)
-    expect(getByRole('link', { name: 'Youtube' })).toHaveAttribute(
-      'href',
-      'https://www.youtube.com/user/jesusfilm'
-    )
+    const el = getByRole('link', { name: 'Youtube' })
+    expect(el).toHaveAttribute('href', 'https://www.youtube.com/user/jesusfilm')
+    expect(el).toHaveAttribute('target', '_blank')
   })
-  it('should have the privacy policy link', () => {
+  it('should have the instagram link', () => {
     const { getByRole } = render(<FooterSocials />)
-    expect(getByRole('link', { name: 'Instagram' })).toHaveAttribute(
-      'href',
-      'https://www.instagram.com/jesusfilm'
-    )
+    const el = getByRole('link', { name: 'Instagram' })
+    expect(el).toHaveAttribute('href', 'https://www.instagram.com/jesusfilm')
+    expect(el).toHaveAttribute('target', '_blank')
   })
 })

--- a/apps/watch/src/components/Footer/FooterSocials/FooterSocials.tsx
+++ b/apps/watch/src/components/Footer/FooterSocials/FooterSocials.tsx
@@ -15,24 +15,28 @@ export function FooterSocials(): ReactElement {
         label="Facebook"
         src={Facebook}
         noFollow
+        target="_blank"
       />
       <FooterLink
         url="https://twitter.com/jesusfilm"
         label="Twitter"
         src={Twitter}
         noFollow
+        target="_blank"
       />
       <FooterLink
         url="https://www.youtube.com/user/jesusfilm"
         label="Youtube"
         src={Youtube}
         noFollow
+        target="_blank"
       />
       <FooterLink
         url="https://www.instagram.com/jesusfilm"
         label="Instagram"
         src={Instagram}
         noFollow
+        target="_blank"
       />
     </Stack>
   )

--- a/apps/watch/src/components/Header/HeaderMenuPanel/HeaderMenuPanel.spec.tsx
+++ b/apps/watch/src/components/Header/HeaderMenuPanel/HeaderMenuPanel.spec.tsx
@@ -9,51 +9,55 @@ describe('HeaderMenuPanel', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
-  it('should redirect to Jesus Film About page', () => {
+  it('should have Give link', () => {
     const { getByRole } = render(<HeaderMenuPanel onClose={jest.fn()} />)
-    expect(getByRole('link', { name: 'About' })).toHaveAttribute(
-      'href',
-      'https://www.jesusfilm.org/about'
-    )
+    const el = getByRole('link', { name: 'Give' })
+    expect(el).toHaveAttribute('href', 'https://www.jesusfilm.org/give/')
+    expect(el).not.toHaveAttribute('target')
   })
 
-  it('should redirect to Jesus Film Give page', () => {
+  it('should have About link', () => {
     const { getByRole } = render(<HeaderMenuPanel onClose={jest.fn()} />)
-    expect(getByRole('link', { name: 'Give' })).toHaveAttribute(
-      'href',
-      'https://www.jesusfilm.org/give'
-    )
+    const el = getByRole('link', { name: 'About' })
+    expect(el).toHaveAttribute('href', 'https://www.jesusfilm.org/about/')
+    expect(el).not.toHaveAttribute('target')
   })
 
-  it('should redirect to Jesus Film Partner page', () => {
+  it('should have Partners link', () => {
     const { getByRole } = render(<HeaderMenuPanel onClose={jest.fn()} />)
-    expect(getByRole('link', { name: 'Partner' })).toHaveAttribute(
-      'href',
-      'https://www.jesusfilm.org/partners'
-    )
+    const el = getByRole('link', { name: 'Partners' })
+    expect(el).toHaveAttribute('href', 'https://www.jesusfilm.org/partners/')
+    expect(el).not.toHaveAttribute('target')
   })
 
-  it('should redirect to Jesus Film Tools page', () => {
+  it('should have Blog link', () => {
     const { getByRole } = render(<HeaderMenuPanel onClose={jest.fn()} />)
-    expect(getByRole('link', { name: 'Tools' })).toHaveAttribute(
-      'href',
-      'https://www.jesusfilm.org/tools'
-    )
+    const el = getByRole('link', { name: 'Blog' })
+    expect(el).toHaveAttribute('href', 'https://www.jesusfilm.org/blog/')
+    expect(el).not.toHaveAttribute('target')
   })
 
-  it('should redirect to Jesus Film Blog page', () => {
+  it('should have Tools link', () => {
     const { getByRole } = render(<HeaderMenuPanel onClose={jest.fn()} />)
-    expect(getByRole('link', { name: 'Blog' })).toHaveAttribute(
-      'href',
-      'https://www.jesusfilm.org/blog'
-    )
+    const el = getByRole('link', { name: 'Tools' })
+    expect(el).toHaveAttribute('href', 'https://www.jesusfilm.org/tools/')
+    expect(el).not.toHaveAttribute('target')
   })
 
-  it('should redirect to Jesus Film Give Now page', () => {
+  it('should have Contact link', () => {
     const { getByRole } = render(<HeaderMenuPanel onClose={jest.fn()} />)
-    expect(getByRole('link', { name: 'Give Now' })).toHaveAttribute(
+    const el = getByRole('link', { name: 'Contact' })
+    expect(el).toHaveAttribute('href', 'https://www.jesusfilm.org/contact/')
+    expect(el).not.toHaveAttribute('target')
+  })
+
+  it('should have Give Now button', () => {
+    const { getByRole } = render(<HeaderMenuPanel onClose={jest.fn()} />)
+    const el = getByRole('link', { name: 'Give Now' })
+    expect(el).toHaveAttribute(
       'href',
       'https://www.jesusfilm.org/how-to-help/ways-to-donate/give-now-2/?amount=&frequency=single&campaign-code=NXWJPO&designation-number=2592320&thankYouRedirect=https%3A%2F%2Fwww.jesusfilm.org%2Fcontent%2Fjf%2Fus%2Fdevelopment%2Fspecial%2Fthank-you-refer%2Fsocial-share.html'
     )
+    expect(el).not.toHaveAttribute('target')
   })
 })

--- a/apps/watch/src/components/Header/HeaderMenuPanel/HeaderMenuPanel.tsx
+++ b/apps/watch/src/components/Header/HeaderMenuPanel/HeaderMenuPanel.tsx
@@ -34,7 +34,6 @@ export function HeaderMenuPanel({
     <MuiLink
       href={url}
       underline="none"
-      target="_blank"
       rel="noopener"
       color="text.primary"
       variant="overline2"
@@ -90,19 +89,22 @@ export function HeaderMenuPanel({
             spacing={{ xs: 3, sm: 3, md: 8 }}
             direction={{ xs: 'column', sm: 'row' }}
           >
-            <HeaderLink url="https://www.jesusfilm.org/about" label="About" />
-            <HeaderLink url="https://www.jesusfilm.org/give" label="Give" />
+            <HeaderLink url="https://www.jesusfilm.org/give/" label="Give" />
+            <HeaderLink url="https://www.jesusfilm.org/about/" label="About" />
             <HeaderLink
-              url="https://www.jesusfilm.org/partners"
-              label="Partner"
+              url="https://www.jesusfilm.org/partners/"
+              label="Partners"
             />
-            <HeaderLink url="https://www.jesusfilm.org/tools" label="Tools" />
-            <HeaderLink url="https://www.jesusfilm.org/blog" label="Blog" />
+            <HeaderLink url="https://www.jesusfilm.org/blog/" label="Blog" />
+            <HeaderLink url="https://www.jesusfilm.org/tools/" label="Tools" />
+            <HeaderLink
+              url="https://www.jesusfilm.org/contact/"
+              label="Contact"
+            />
           </Stack>
           <Button
             startIcon={<FavoriteIcon />}
             href="https://www.jesusfilm.org/how-to-help/ways-to-donate/give-now-2/?amount=&frequency=single&campaign-code=NXWJPO&designation-number=2592320&thankYouRedirect=https%3A%2F%2Fwww.jesusfilm.org%2Fcontent%2Fjf%2Fus%2Fdevelopment%2Fspecial%2Fthank-you-refer%2Fsocial-share.html"
-            target="_blank"
             rel="noopener"
           >
             <Typography variant="overline2">Give Now</Typography>


### PR DESCRIPTION
# Description

All www.jesusfilm.org links should open in the current window. Everything else should open in a new window/tab.

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/31485426/todos/5839080429)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Header links should open in the current window
- [ ] local footer links should open in the current window
- [ ] external footer links should open in a new window (cru, social, iPhone, Android)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
