### PR TITLE
fix: forward root to base path on watch

### DIFF
--- a/apps/watch/next.config.js
+++ b/apps/watch/next.config.js
@@ -33,6 +33,13 @@ const nextConfig = {
         destination: '/watch',
         basePath: false,
         permanent: false
+      },
+
+      {
+        source: '/:path((?!watch).*)',
+        destination: '/watch/:path',
+        basePath: false,
+        permanent: false
       }
     ]
   }

--- a/apps/watch/next.config.js
+++ b/apps/watch/next.config.js
@@ -24,13 +24,18 @@ const nextConfig = {
     // See: https://github.com/gregberge/svgr
     svgr: false
   },
-  i18n: {
-    locales: ['en'],
-    defaultLocale: 'en',
-    localeDetection: false
-  },
   basePath: '/watch',
-  productionBrowserSourceMaps: true
+  productionBrowserSourceMaps: true,
+  async redirects() {
+    return [
+      {
+        source: '/',
+        destination: '/watch',
+        basePath: false,
+        permanent: false
+      }
+    ]
+  }
 }
 module.exports = (_phase, { defaultConfig }) => {
   const plugins = [withBundleAnalyzer, withNx]


### PR DESCRIPTION
# Description

- root url on watch should redirect to base path
- URLs without base path should redirect to the same resource with base path
- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/31485426/todos/5843982295)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] / should go to /watch
- [ ] /jesus/english should go to /watch/jesus/english

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
