### PR TITLE
chore: add loaders to language dialog

### DIFF
--- a/apps/watch/src/components/AudioLanguageDialog/AudioLanguageDialog.stories.tsx
+++ b/apps/watch/src/components/AudioLanguageDialog/AudioLanguageDialog.stories.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react'
+import { ComponentProps } from 'react'
 import { Meta, Story } from '@storybook/react'
-import { MockedProvider } from '@apollo/client/testing'
+import { MockedProvider, MockedResponse } from '@apollo/client/testing'
 import { watchConfig } from '../../libs/storybook'
 import { VideoProvider } from '../../libs/videoContext'
 import { videos } from '../Videos/__generated__/testData'
@@ -10,20 +10,36 @@ import { AudioLanguageDialog } from '.'
 const AudioLanguageDialogStory = {
   ...watchConfig,
   component: AudioLanguageDialog,
-  title: 'Watch/AudioLanguageDialog'
+  title: 'Watch/AudioLanguageDialog',
+  argTypes: {
+    onClose: { action: 'close clicked' }
+  }
 }
 
-const Template: Story = () => {
-  const [open, setOpen] = useState(true)
+const Template: Story<
+  ComponentProps<typeof AudioLanguageDialog> & {
+    mocks?: readonly MockedResponse[]
+  }
+> = ({ mocks, ...args }) => {
   return (
-    <MockedProvider mocks={[getLanguagesSlugMock]}>
+    <MockedProvider mocks={mocks}>
       <VideoProvider value={{ content: videos[0] }}>
-        <AudioLanguageDialog open={open} onClose={() => setOpen(false)} />
+        <AudioLanguageDialog {...args} />
       </VideoProvider>
     </MockedProvider>
   )
 }
 
 export const Default = Template.bind({})
+Default.args = {
+  open: true,
+  mocks: [getLanguagesSlugMock]
+}
+
+export const Loading = Template.bind({})
+Loading.args = {
+  open: true,
+  mocks: [{ ...getLanguagesSlugMock, delay: 100000000000000 }]
+}
 
 export default AudioLanguageDialogStory as Meta

--- a/apps/watch/src/components/AudioLanguageDialog/AudioLanguageDialog.tsx
+++ b/apps/watch/src/components/AudioLanguageDialog/AudioLanguageDialog.tsx
@@ -4,6 +4,7 @@ import { Dialog } from '@core/shared/ui/Dialog'
 import { LanguageAutocomplete } from '@core/shared/ui/LanguageAutocomplete'
 import { Formik, Form, FormikValues } from 'formik'
 import TextField from '@mui/material/TextField'
+import CircularProgress from '@mui/material/CircularProgress'
 import LanguageIcon from '@mui/icons-material/Language'
 import { useRouter } from 'next/router'
 import { compact } from 'lodash'
@@ -37,7 +38,7 @@ export function AudioLanguageDialog({
   const { id, variant, variantLanguagesCount, container } = useVideo()
   const router = useRouter()
 
-  const { data } = useQuery<GetLanguagesSlug>(GET_LANGUAGES_SLUG, {
+  const { loading, data } = useQuery<GetLanguagesSlug>(GET_LANGUAGES_SLUG, {
     variables: {
       id
     }
@@ -114,7 +115,8 @@ export function AudioLanguageDialog({
               onClose={handleClose(resetForm)}
               dialogTitle={{
                 icon: <LanguageIcon sx={{ mr: 3 }} />,
-                title: 'Language'
+                title: 'Language',
+                closeButton: true
               }}
               divider
             >
@@ -126,7 +128,7 @@ export function AudioLanguageDialog({
                   }}
                   value={values.language}
                   languages={languages}
-                  loading={languages == null}
+                  loading={loading}
                   renderInput={(params) => (
                     <TextField
                       {...params}
@@ -140,6 +142,17 @@ export function AudioLanguageDialog({
                         '> .MuiOutlinedInput-root': {
                           borderRadius: 2
                         }
+                      }}
+                      InputProps={{
+                        ...params.InputProps,
+                        endAdornment: (
+                          <>
+                            {loading ? (
+                              <CircularProgress color="inherit" size={20} />
+                            ) : null}
+                            {params.InputProps.endAdornment}
+                          </>
+                        )
                       }}
                     />
                   )}

--- a/apps/watch/src/components/SubtitleDialog/SubtitleDialog.stories.tsx
+++ b/apps/watch/src/components/SubtitleDialog/SubtitleDialog.stories.tsx
@@ -1,10 +1,8 @@
 import { ComponentProps } from 'react'
 import { Story, Meta } from '@storybook/react'
-import { noop } from 'lodash'
-import { MockedProvider } from '@apollo/client/testing'
+import { MockedProvider, MockedResponse } from '@apollo/client/testing'
 import { VideoProvider } from '../../libs/videoContext'
 import { watchConfig } from '../../libs/storybook'
-import { VideoContentFields } from '../../../__generated__/VideoContentFields'
 import { videos } from '../Videos/__generated__/testData'
 import { SubtitleDialog } from './SubtitleDialog'
 import { getSubtitleMock } from './testData'
@@ -13,16 +11,17 @@ const SubtitleDialogStory = {
   ...watchConfig,
   component: SubtitleDialog,
   title: 'Watch/SubtitleDialog',
-  parameters: {
-    theme: 'light'
+  argTypes: {
+    onClose: { action: 'close clicked' }
   }
 }
-
 const Template: Story<
-  ComponentProps<typeof SubtitleDialog> & { video: VideoContentFields }
-> = ({ ...args }) => {
+  ComponentProps<typeof SubtitleDialog> & {
+    mocks?: readonly MockedResponse[]
+  }
+> = ({ mocks, ...args }) => {
   return (
-    <MockedProvider mocks={[getSubtitleMock]}>
+    <MockedProvider mocks={mocks}>
       <VideoProvider value={{ content: videos[0] }}>
         <SubtitleDialog {...args} />
       </VideoProvider>
@@ -30,10 +29,16 @@ const Template: Story<
   )
 }
 
-export const Basic = Template.bind({})
-Basic.args = {
+export const Default = Template.bind({})
+Default.args = {
   open: true,
-  onClose: noop
+  mocks: [getSubtitleMock]
+}
+
+export const Loading = Template.bind({})
+Loading.args = {
+  open: true,
+  mocks: [{ ...getSubtitleMock, delay: 100000000000000 }]
 }
 
 export default SubtitleDialogStory as Meta

--- a/apps/watch/src/components/SubtitleDialog/SubtitleDialog.tsx
+++ b/apps/watch/src/components/SubtitleDialog/SubtitleDialog.tsx
@@ -1,6 +1,7 @@
 import { ReactElement, ComponentProps, useState } from 'react'
 import { Dialog } from '@core/shared/ui/Dialog'
 import TextField from '@mui/material/TextField'
+import CircularProgress from '@mui/material/CircularProgress'
 import SubtitlesOutlined from '@mui/icons-material/SubtitlesOutlined'
 import {
   Language,
@@ -46,7 +47,7 @@ export function SubtitleDialog({
   const { variant } = useVideo()
   const [selected, setSelected] = useState<Language | undefined>(undefined)
 
-  const { data } = useQuery<GetSubtitles>(GET_SUBTITLES, {
+  const { loading, data } = useQuery<GetSubtitles>(GET_SUBTITLES, {
     variables: {
       id: variant?.slug
     }
@@ -129,6 +130,17 @@ export function SubtitleDialog({
                 '> .MuiOutlinedInput-root': {
                   borderRadius: 2
                 }
+              }}
+              InputProps={{
+                ...params.InputProps,
+                endAdornment: (
+                  <>
+                    {loading ? (
+                      <CircularProgress color="inherit" size={20} />
+                    ) : null}
+                    {params.InputProps.endAdornment}
+                  </>
+                )
               }}
             />
           )}


### PR DESCRIPTION
# Description

Opening audio and subtitle language dialogs should show a loaders. Clicking on the dropdown while loading should show "Loading..." instead of "No options". This also makes audio language consistent with subtitle dialog in regards to a close button.

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/31485426/todos/5843900928)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] changing audio language should show loader when dialog opens
- [ ] changing subtitle language should show loader when dialog opens

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
