### PR TITLE
fix: hide player loader and mute button on hero

### DIFF
--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoHero.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoHero.tsx
@@ -69,7 +69,8 @@ export function VideoHero({ onPlay, hasPlayed }: VideoHeroProps): ReactElement {
             height: '100%',
             width: '100%',
             '.vjs-hidden': { display: 'none' },
-            '.vjs-loading-spinner': { display: 'none' },
+            '.vjs-loading-spinner, .vjs-seeking .vjs-loading-spinner, .vjs-waiting .vjs-loading-spinner':
+              { display: 'none' },
             '.vjs, .vjs-tech': {
               height: '100%',
               width: '100%'

--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoHeroOverlay/VideoHeroOverlay.spec.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoHeroOverlay/VideoHeroOverlay.spec.tsx
@@ -70,7 +70,7 @@ describe('VideoHeroOverlay', () => {
   }
 
   it('should render the Video Hero Overlay', () => {
-    const { getByRole, getByText, getByTestId } = render(
+    const { getByRole, getByText } = render(
       <MockedProvider>
         <SnackbarProvider>
           <VideoProvider value={{ content: video }}>

--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoHeroOverlay/VideoHeroOverlay.spec.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoHeroOverlay/VideoHeroOverlay.spec.tsx
@@ -82,9 +82,6 @@ describe('VideoHeroOverlay', () => {
     expect(getByText('The Story of Jesus for Children')).toBeInTheDocument()
     expect(getByText('61 min')).toBeInTheDocument()
     expect(getByRole('button', { name: 'Play Video' })).toBeInTheDocument()
-    expect(getByTestId('VolumeOffOutlinedIcon').parentElement).toHaveClass(
-      'MuiIconButton-root'
-    )
   })
 
   it('should play video on the Play Video button click', () => {
@@ -99,21 +96,6 @@ describe('VideoHeroOverlay', () => {
       </MockedProvider>
     )
     fireEvent.click(getByRole('button', { name: 'Play Video' }))
-    expect(handlePlay).toHaveBeenCalled()
-  })
-
-  it('should play video on the Mute Icon click', () => {
-    const handlePlay = jest.fn()
-    const { getByTestId } = render(
-      <MockedProvider>
-        <SnackbarProvider>
-          <VideoProvider value={{ content: video }}>
-            <VideoHeroOverlay handlePlay={handlePlay} />
-          </VideoProvider>
-        </SnackbarProvider>
-      </MockedProvider>
-    )
-    fireEvent.click(getByTestId('VolumeOffOutlinedIcon'))
     expect(handlePlay).toHaveBeenCalled()
   })
 })

--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoHeroOverlay/VideoHeroOverlay.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoHeroOverlay/VideoHeroOverlay.tsx
@@ -3,12 +3,10 @@ import { secondsToMinutes } from '@core/shared/ui/timeFormat'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Container from '@mui/material/Container'
-import IconButton from '@mui/material/IconButton'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import AccessTime from '@mui/icons-material/AccessTime'
 import PlayArrowRounded from '@mui/icons-material/PlayArrowRounded'
-import VolumeOffOutlined from '@mui/icons-material/VolumeOffOutlined'
 import Image from 'next/image'
 import { useVideo } from '../../../../libs/videoContext'
 import { HeroOverlay } from '../../../HeroOverlay'
@@ -59,26 +57,6 @@ export function VideoHeroOverlay({
           alignItems: 'flex-end'
         }}
       >
-        <IconButton
-          onClick={handlePlay}
-          sx={{
-            position: 'absolute',
-            top: 80,
-            right: 35,
-            width: 68,
-            height: 68,
-            borderRadius: 10,
-            backgroundColor: 'background.default',
-            opacity: 0.45,
-            alignSelf: 'end',
-            '&:hover': {
-              backgroundColor: 'background.default'
-            },
-            zIndex: 2
-          }}
-        >
-          <VolumeOffOutlined />
-        </IconButton>
         <Stack
           spacing={{ xs: 2, lg: 5 }}
           sx={{ pb: { xs: 15, lg: 33 }, width: '100%' }}


### PR DESCRIPTION
# Description

- [hide videojs loaders](https://3.basecamp.com/3105655/buckets/31485426/todos/5848282546)
- [remove mute button from video hero](https://3.basecamp.com/3105655/buckets/31485426/todos/5848273505)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] when loading video to play (try setting network to slow 3g) alternative loaders should not show
- [ ] when on a video page before playing the video for the first time the mute button in the top right should not show

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
