### PR TITLE
fix: remove start icon from CopyLinkField

### DIFF
--- a/libs/shared/ui/src/components/CopyTextField/CopyTextField.tsx
+++ b/libs/shared/ui/src/components/CopyTextField/CopyTextField.tsx
@@ -2,7 +2,6 @@ import { ReactElement, useRef } from 'react'
 import IconButton from '@mui/material/IconButton'
 import InputAdornment from '@mui/material/InputAdornment'
 import TextField from '@mui/material/TextField'
-import LinkRoundedIcon from '@mui/icons-material/LinkRounded'
 import ContentCopyRoundedIcon from '@mui/icons-material/ContentCopyRounded'
 import { useSnackbar } from 'notistack'
 import { SxProps } from '@mui/system/styleFunctionSx'
@@ -38,26 +37,13 @@ export function CopyTextField({
   return (
     <TextField
       fullWidth
-      sx={{
-        '.MuiInputLabel-root': {
-          marginLeft: '32px'
-        },
-        '.MuiInputAdornment-root.MuiInputAdornment-positionStart': {
-          marginTop: '0 !important'
-        },
-        ...sx
-      }}
+      sx={{ ...sx }}
       hiddenLabel={label == null}
       label={label}
       inputRef={inputRef}
       disabled={value == null}
       inputProps={{ onFocus: handleFocus, value }}
       InputProps={{
-        startAdornment: (
-          <InputAdornment position="start">
-            <LinkRoundedIcon />
-          </InputAdornment>
-        ),
         endAdornment: (
           <InputAdornment position="end">
             <IconButton


### PR DESCRIPTION
# Description

UX wanted the copy link icon removed. Blocking  https://github.com/JesusFilm/core/pull/1323

<img width="1251" alt="image" src="https://user-images.githubusercontent.com/10802634/219526063-300d0b64-98be-434a-89c5-4bd8394d0396.png">

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Checks green

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
