### PR TITLE
fix: opened at mutation call

### DIFF
--- a/apps/journeys-admin/pages/journeys/[journeyId]/edit.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/edit.tsx
@@ -11,7 +11,6 @@ import { NextSeo } from 'next-seo'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'react-i18next'
 import { getLaunchDarklyClient } from '@core/shared/ui/getLaunchDarklyClient'
-import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import { GetJourney } from '../../../__generated__/GetJourney'
 import { UserInviteAcceptAll } from '../../../__generated__/UserInviteAcceptAll'
 import { Editor } from '../../../src/components/Editor'
@@ -30,12 +29,15 @@ function JourneyEditPage(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   const router = useRouter()
   const AuthUser = useAuthUser()
-  const { journey } = useJourney()
   const { data, error } = useQuery<GetJourney>(GET_JOURNEY, {
     variables: { id: router.query.journeyId }
   })
 
-  useUserJourneyOpen(AuthUser.id, journey?.id, journey?.userJourneys)
+  useUserJourneyOpen(
+    AuthUser.id,
+    data?.journey?.id,
+    data?.journey?.userJourneys
+  )
   useTermsRedirect()
 
   return (

--- a/apps/journeys-admin/pages/journeys/[journeyId]/reports.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/reports.tsx
@@ -11,12 +11,13 @@ import { useTranslation } from 'react-i18next'
 import { getLaunchDarklyClient } from '@core/shared/ui/getLaunchDarklyClient'
 import Box from '@mui/material/Box'
 import { useRouter } from 'next/router'
-import { useJourney } from '@core/journeys/ui/JourneyProvider'
+import { useQuery } from '@apollo/client'
 import { PageWrapper } from '../../../src/components/PageWrapper'
 import { UserInviteAcceptAll } from '../../../__generated__/UserInviteAcceptAll'
 import i18nConfig from '../../../next-i18next.config'
 import { MemoizedDynamicReport } from '../../../src/components/DynamicPowerBiReport'
-
+import { GetJourney } from '../../../__generated__/GetJourney'
+import { GET_JOURNEY } from '../[journeyId]'
 import { createApolloClient } from '../../../src/libs/apolloClient'
 import { JourneysReportType } from '../../../__generated__/globalTypes'
 import { useUserJourneyOpen } from '../../../src/libs/useUserJourneyOpen'
@@ -27,11 +28,17 @@ function JourneyReportsPage(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   const AuthUser = useAuthUser()
   const router = useRouter()
-  const { journey } = useJourney()
 
   const journeyId = router.query.journeyId as string
+  const { data } = useQuery<GetJourney>(GET_JOURNEY, {
+    variables: { id: journeyId }
+  })
 
-  useUserJourneyOpen(AuthUser.id, journey?.id, journey?.userJourneys)
+  useUserJourneyOpen(
+    AuthUser.id,
+    data?.journey?.id,
+    data?.journey?.userJourneys
+  )
   useTermsRedirect()
 
   return (


### PR DESCRIPTION
# Description

Fix a bug where userJourney openedAt was not being called for `/journeys/[journeyId]/edit` and `/journeys/[journeyId]/report `

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/31245472/todos/5859436392)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] For a un-viewed journey navigating to `/journeys/[journeyId]/edit` should call userJourneyOpen
- [ ] For a un-viewed journey navigating to `/journeys/[journeyId]/report ` should call userJourneyOpen

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
