### PR TITLE
fix: big divider render logic

### DIFF
--- a/apps/journeys-admin/src/components/JourneyList/ActiveJourneyList/ActivePriorityList/ActivePriorityList.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/ActiveJourneyList/ActivePriorityList/ActivePriorityList.spec.tsx
@@ -84,4 +84,42 @@ describe('ActivePriorityList', () => {
       'Default Journey'
     )
   })
+
+  it('should show big divider if there is a new journey and normal journeys', () => {
+    const authUser = { id: 'user1.id' } as unknown as AuthUser
+    const { getByLabelText } = render(
+      <MockedProvider>
+        <ThemeProvider>
+          <SnackbarProvider>
+            <ActivePriorityList
+              journeys={[journey, newJourney]}
+              sortOrder={SortOrder.TITLE}
+              refetch={jest.fn()}
+              authUser={authUser}
+            />
+          </SnackbarProvider>
+        </ThemeProvider>
+      </MockedProvider>
+    )
+    expect(getByLabelText('big-divider')).toBeInTheDocument()
+  })
+
+  it('should show big divider if there is a journey with access requested and normal journeys', () => {
+    const authUser = { id: 'user1.id' } as unknown as AuthUser
+    const { getByLabelText } = render(
+      <MockedProvider>
+        <ThemeProvider>
+          <SnackbarProvider>
+            <ActivePriorityList
+              journeys={[journey, pendingActionJourney]}
+              sortOrder={SortOrder.TITLE}
+              refetch={jest.fn()}
+              authUser={authUser}
+            />
+          </SnackbarProvider>
+        </ThemeProvider>
+      </MockedProvider>
+    )
+    expect(getByLabelText('big-divider')).toBeInTheDocument()
+  })
 })

--- a/apps/journeys-admin/src/components/JourneyList/ActiveJourneyList/ActivePriorityList/ActivePriorityList.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/ActiveJourneyList/ActivePriorityList/ActivePriorityList.tsx
@@ -107,18 +107,20 @@ export function ActivePriorityList({
       ))}
 
       {(sortedActionRequiredJourneys.length > 0 ||
-        sortedNewJourneys.length > 0) && (
-        <Box
-          sx={{
-            height: 8,
-            width: '100%',
-            borderTop: '1px solid',
-            borderLeft: '1px solid',
-            borderRight: '1px solid',
-            borderColor: 'divider'
-          }}
-        />
-      )}
+        sortedNewJourneys.length > 0) &&
+        sortedJourneys.length > 0 && (
+          <Box
+            aria-label="big-divider"
+            sx={{
+              height: 8,
+              width: '100%',
+              borderTop: '1px solid',
+              borderLeft: '1px solid',
+              borderRight: '1px solid',
+              borderColor: 'divider'
+            }}
+          />
+        )}
 
       {sortedJourneys.map((journey) => (
         <JourneyProvider


### PR DESCRIPTION
# Description

Fix big divider render logic on active journeys list

[Link to BaseCamp todo ](https://3.basecamp.com/3105655/buckets/31245472/todos/5864473076)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Shows big divider is there is a `new journey` and `normal journeys`
<img width="600" alt="image" src="https://user-images.githubusercontent.com/10802634/220495963-d310d719-cf7d-4bc5-8aec-49b6b13283a7.png">
<img width="600" alt="image" src="https://user-images.githubusercontent.com/10802634/220496050-6ac674e4-c398-436b-8ed1-12286a43c1f7.png">

- [x] Shows big divider is there is a `access requested journey` and `normal journeys`
<img width="600" alt="image" src="https://user-images.githubusercontent.com/10802634/220496185-58321256-0882-4827-bf4e-ac76687fc28b.png">
<img width="600" alt="image" src="https://user-images.githubusercontent.com/10802634/220496239-a5e64bd2-1cf2-47bd-b485-9ef068d10a71.png">


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
