### PR TITLE
feat: hide report with flag

### DIFF
--- a/apps/journeys-admin/src/components/JourneyList/JourneyList.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyList.spec.tsx
@@ -2,6 +2,7 @@ import { render, waitFor } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
 import { SnackbarProvider } from 'notistack'
 import { NextRouter } from 'next/router'
+import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 import { ThemeProvider } from '../ThemeProvider'
 import { defaultJourney, publishedJourney, oldJourney } from './journeyListData'
 import { JourneyList } from '.'
@@ -22,14 +23,16 @@ describe('JourneyList', () => {
   it('should render tab panel', () => {
     const { getByRole } = render(
       <SnackbarProvider>
-        <MockedProvider>
-          <ThemeProvider>
-            <JourneyList
-              journeys={[defaultJourney, publishedJourney, oldJourney]}
-              event=""
-            />
-          </ThemeProvider>
-        </MockedProvider>
+        <FlagsProvider>
+          <MockedProvider>
+            <ThemeProvider>
+              <JourneyList
+                journeys={[defaultJourney, publishedJourney, oldJourney]}
+                event=""
+              />
+            </ThemeProvider>
+          </MockedProvider>
+        </FlagsProvider>
       </SnackbarProvider>
     )
     expect(getByRole('tablist')).toBeInTheDocument()
@@ -38,11 +41,13 @@ describe('JourneyList', () => {
   it('should show access denied message to new user', () => {
     const { getByText, getByRole, queryByText } = render(
       <SnackbarProvider>
-        <MockedProvider>
-          <ThemeProvider>
-            <JourneyList journeys={[]} event="" />
-          </ThemeProvider>
-        </MockedProvider>
+        <FlagsProvider>
+          <MockedProvider>
+            <ThemeProvider>
+              <JourneyList journeys={[]} event="" />
+            </ThemeProvider>
+          </MockedProvider>
+        </FlagsProvider>
       </SnackbarProvider>
     )
     expect(queryByText('All Journeys')).not.toBeInTheDocument()
@@ -60,14 +65,16 @@ describe('JourneyList', () => {
   it('should render report', async () => {
     const { getByTestId } = render(
       <SnackbarProvider>
-        <MockedProvider>
-          <ThemeProvider>
-            <JourneyList
-              journeys={[defaultJourney, publishedJourney, oldJourney]}
-              event=""
-            />
-          </ThemeProvider>
-        </MockedProvider>
+        <FlagsProvider flags={{ journeysSummaryReport: true }}>
+          <MockedProvider>
+            <ThemeProvider>
+              <JourneyList
+                journeys={[defaultJourney, publishedJourney, oldJourney]}
+                event=""
+              />
+            </ThemeProvider>
+          </MockedProvider>
+        </FlagsProvider>
       </SnackbarProvider>
     )
     await waitFor(() =>
@@ -78,11 +85,13 @@ describe('JourneyList', () => {
   it('should hide report if the user has no journeys', async () => {
     const { queryByTestId } = render(
       <SnackbarProvider>
-        <MockedProvider>
-          <ThemeProvider>
-            <JourneyList journeys={[]} event="" />
-          </ThemeProvider>
-        </MockedProvider>
+        <FlagsProvider flags={{ journeysSummaryReport: true }}>
+          <MockedProvider>
+            <ThemeProvider>
+              <JourneyList journeys={[]} event="" />
+            </ThemeProvider>
+          </MockedProvider>
+        </FlagsProvider>
       </SnackbarProvider>
     )
     await waitFor(() =>
@@ -93,14 +102,16 @@ describe('JourneyList', () => {
   it('should show add journey button', () => {
     const { getByRole } = render(
       <SnackbarProvider>
-        <MockedProvider>
-          <ThemeProvider>
-            <JourneyList
-              journeys={[defaultJourney, publishedJourney, oldJourney]}
-              event=""
-            />
-          </ThemeProvider>
-        </MockedProvider>
+        <FlagsProvider>
+          <MockedProvider>
+            <ThemeProvider>
+              <JourneyList
+                journeys={[defaultJourney, publishedJourney, oldJourney]}
+                event=""
+              />
+            </ThemeProvider>
+          </MockedProvider>
+        </FlagsProvider>
       </SnackbarProvider>
     )
     expect(getByRole('button', { name: 'Add' })).toBeInTheDocument()
@@ -110,15 +121,17 @@ describe('JourneyList', () => {
     const router = { query: { tab: 'active' } } as unknown as NextRouter
     const { getByRole } = render(
       <SnackbarProvider>
-        <MockedProvider>
-          <ThemeProvider>
-            <JourneyList
-              journeys={[defaultJourney, publishedJourney, oldJourney]}
-              router={router}
-              event=""
-            />
-          </ThemeProvider>
-        </MockedProvider>
+        <FlagsProvider>
+          <MockedProvider>
+            <ThemeProvider>
+              <JourneyList
+                journeys={[defaultJourney, publishedJourney, oldJourney]}
+                router={router}
+                event=""
+              />
+            </ThemeProvider>
+          </MockedProvider>
+        </FlagsProvider>
       </SnackbarProvider>
     )
     expect(getByRole('button', { name: 'Add' })).toBeInTheDocument()
@@ -128,15 +141,17 @@ describe('JourneyList', () => {
     const router = { query: { tab: 'trashed' } } as unknown as NextRouter
     const { queryByRole } = render(
       <SnackbarProvider>
-        <MockedProvider>
-          <ThemeProvider>
-            <JourneyList
-              journeys={[defaultJourney, publishedJourney, oldJourney]}
-              event=""
-              router={router}
-            />
-          </ThemeProvider>
-        </MockedProvider>
+        <FlagsProvider>
+          <MockedProvider>
+            <ThemeProvider>
+              <JourneyList
+                journeys={[defaultJourney, publishedJourney, oldJourney]}
+                event=""
+                router={router}
+              />
+            </ThemeProvider>
+          </MockedProvider>
+        </FlagsProvider>
       </SnackbarProvider>
     )
     expect(queryByRole('button', { name: 'Add' })).toBeNull()
@@ -146,15 +161,17 @@ describe('JourneyList', () => {
     const router = { query: { tab: 'archived' } } as unknown as NextRouter
     const { queryByRole } = render(
       <SnackbarProvider>
-        <MockedProvider>
-          <ThemeProvider>
-            <JourneyList
-              journeys={[defaultJourney, publishedJourney, oldJourney]}
-              router={router}
-              event=""
-            />
-          </ThemeProvider>
-        </MockedProvider>
+        <FlagsProvider>
+          <MockedProvider>
+            <ThemeProvider>
+              <JourneyList
+                journeys={[defaultJourney, publishedJourney, oldJourney]}
+                router={router}
+                event=""
+              />
+            </ThemeProvider>
+          </MockedProvider>
+        </FlagsProvider>
       </SnackbarProvider>
     )
     expect(queryByRole('button', { name: 'Add' })).toBeNull()

--- a/apps/journeys-admin/src/components/JourneyList/JourneyList.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyList.tsx
@@ -8,6 +8,7 @@ import NewReleasesRounded from '@mui/icons-material/NewReleasesRounded'
 import ContactSupportRounded from '@mui/icons-material/ContactSupportRounded'
 import { NextRouter } from 'next/router'
 import { AuthUser } from 'next-firebase-auth'
+import { useFlags } from '@core/shared/ui/FlagsProvider'
 import { GetJourneys_journeys as Journey } from '../../../__generated__/GetJourneys'
 import { MultipleSummaryReport } from '../MultipleSummaryReport'
 import { StatusTabPanel } from '../StatusTabPanel'
@@ -33,6 +34,7 @@ export function JourneyList({
   const [sortOrder, setSortOrder] = useState<SortOrder>()
   const [activeTabLoaded, setActiveTabLoaded] = useState(false)
   const [activeEvent, setActiveEvent] = useState(event)
+  const { journeysSummaryReport } = useFlags()
 
   useEffect(() => {
     setActiveEvent(event)
@@ -51,7 +53,9 @@ export function JourneyList({
 
   return (
     <>
-      {journeys != null && journeys.length > 0 && <MultipleSummaryReport />}
+      {journeys != null && journeys.length > 0 && journeysSummaryReport && (
+        <MultipleSummaryReport />
+      )}
       <Container sx={{ px: { xs: 0, sm: 8 } }}>
         {(journeys == null || journeys.length > 0) && (
           <StatusTabPanel


### PR DESCRIPTION
# Description

Hide journeys summary report behind launch darkly feature flag

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/31245472/todos/5847006549)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Should no longer see journeys summary report

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
