### PR TITLE
fix: background media selection

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
@@ -214,6 +214,7 @@ describe('BackgroundMediaVideo', () => {
         </JourneyProvider>
       </MockedProvider>
     )
+    fireEvent.click(getByRole('button', { name: 'Select Video' }))
     await waitFor(() => expect(getByText('Brand Video')).toBeInTheDocument())
     fireEvent.click(getByText('Brand Video'))
     await waitFor(() =>
@@ -292,6 +293,7 @@ describe('BackgroundMediaVideo', () => {
         </JourneyProvider>
       </MockedProvider>
     )
+    fireEvent.click(getByRole('button', { name: 'Select Video' }))
     await waitFor(() => expect(getByText('Brand Video')).toBeInTheDocument())
     fireEvent.click(getByText('Brand Video'))
     await waitFor(() =>
@@ -370,6 +372,7 @@ describe('BackgroundMediaVideo', () => {
           </JourneyProvider>
         </MockedProvider>
       )
+      fireEvent.click(getByRole('button', { name: 'Select Video' }))
       await waitFor(() => expect(getByText('Brand_Video')).toBeInTheDocument())
       fireEvent.click(getByText('Brand Video'))
       await waitFor(() =>
@@ -386,8 +389,13 @@ describe('BackgroundMediaVideo', () => {
     // TODO: add delete video back once it's working
 
     describe('Video Settings', () => {
+      const existingCoverBlockWithId: TreeBlock<CardBlock> = {
+        ...card,
+        coverBlockId: video.id,
+        children: [{ ...video, videoId: 'id' }]
+      }
       it('shows settings', async () => {
-        const { getAllByRole, getByTestId } = render(
+        const { getAllByRole } = render(
           <MockedProvider>
             <JourneyProvider
               value={{
@@ -397,15 +405,12 @@ describe('BackgroundMediaVideo', () => {
             >
               <ThemeProvider>
                 <SnackbarProvider>
-                  <BackgroundMediaVideo cardBlock={existingCoverBlock} />
+                  <BackgroundMediaVideo cardBlock={existingCoverBlockWithId} />
                 </SnackbarProvider>
               </ThemeProvider>
             </JourneyProvider>
           </MockedProvider>
         )
-        const closeButton = getAllByRole('button')[0]
-        expect(closeButton).toContainElement(getByTestId('CloseIcon'))
-        fireEvent.click(closeButton)
         expect(getAllByRole('checkbox', { name: 'Muted' })[0]).toBeChecked()
         expect(getAllByRole('checkbox', { name: 'Autoplay' })[0]).toBeChecked()
         expect(getAllByRole('textbox', { name: 'Starts At' })[0]).toHaveValue(
@@ -436,7 +441,7 @@ describe('BackgroundMediaVideo', () => {
             }
           }
         }))
-        const { getAllByRole, getByTestId } = render(
+        const { getAllByRole } = render(
           <MockedProvider
             cache={cache}
             mocks={[
@@ -467,207 +472,195 @@ describe('BackgroundMediaVideo', () => {
             >
               <ThemeProvider>
                 <SnackbarProvider>
-                  <BackgroundMediaVideo cardBlock={existingCoverBlock} />
+                  <BackgroundMediaVideo cardBlock={existingCoverBlockWithId} />
                 </SnackbarProvider>
               </ThemeProvider>
             </JourneyProvider>
           </MockedProvider>
         )
-        const closeButton = getAllByRole('button')[0]
-        expect(closeButton).toContainElement(getByTestId('CloseIcon'))
-        fireEvent.click(closeButton)
         const checkbox = await getAllByRole('checkbox', { name: 'Autoplay' })[0]
         fireEvent.click(checkbox)
         await waitFor(() => expect(videoBlockResult).toHaveBeenCalled())
       })
-    })
 
-    it('updates muted', async () => {
-      const cache = new InMemoryCache()
-      cache.restore({
-        'Journey:journeyId': {
-          blocks: [
-            { __ref: 'CardBlock:cardId' },
-            { __ref: 'VideoBlock:videoId' }
-          ],
-          id: 'journeyId',
-          __typename: 'Journey'
-        }
-      })
-      const videoBlockResult = jest.fn(() => ({
-        data: {
-          videoBlockUpdate: video
-        }
-      }))
-      const { getAllByRole, getByTestId } = render(
-        <MockedProvider
-          cache={cache}
-          mocks={[
-            {
-              request: {
-                query: CARD_BLOCK_COVER_VIDEO_BLOCK_UPDATE,
-                variables: {
-                  id: video.id,
-                  journeyId: 'journeyId',
-                  input: {
-                    startAt: 0,
-                    endAt: 144,
-                    muted: false,
-                    autoplay: true,
-                    objectFit: 'fill'
+      it('updates muted', async () => {
+        const cache = new InMemoryCache()
+        cache.restore({
+          'Journey:journeyId': {
+            blocks: [
+              { __ref: 'CardBlock:cardId' },
+              { __ref: 'VideoBlock:videoId' }
+            ],
+            id: 'journeyId',
+            __typename: 'Journey'
+          }
+        })
+        const videoBlockResult = jest.fn(() => ({
+          data: {
+            videoBlockUpdate: video
+          }
+        }))
+        const { getAllByRole } = render(
+          <MockedProvider
+            cache={cache}
+            mocks={[
+              {
+                request: {
+                  query: CARD_BLOCK_COVER_VIDEO_BLOCK_UPDATE,
+                  variables: {
+                    id: video.id,
+                    journeyId: 'journeyId',
+                    input: {
+                      startAt: 0,
+                      endAt: 144,
+                      muted: false,
+                      autoplay: true,
+                      objectFit: 'fill'
+                    }
                   }
-                }
-              },
-              result: videoBlockResult
-            }
-          ]}
-        >
-          <JourneyProvider
-            value={{
-              journey: { id: 'journeyId' } as unknown as Journey,
-              admin: true
-            }}
+                },
+                result: videoBlockResult
+              }
+            ]}
           >
-            <ThemeProvider>
-              <SnackbarProvider>
-                <BackgroundMediaVideo cardBlock={existingCoverBlock} />
-              </SnackbarProvider>
-            </ThemeProvider>
-          </JourneyProvider>
-        </MockedProvider>
-      )
-      const closeButton = getAllByRole('button')[0]
-      expect(closeButton).toContainElement(getByTestId('CloseIcon'))
-      fireEvent.click(closeButton)
-      const checkbox = await getAllByRole('checkbox', { name: 'Muted' })[0]
-      fireEvent.click(checkbox)
-      await waitFor(() => expect(videoBlockResult).toHaveBeenCalled())
-    })
-
-    it('updates startAt', async () => {
-      const cache = new InMemoryCache()
-      cache.restore({
-        'Journey:journeyId': {
-          blocks: [
-            { __ref: 'CardBlock:cardId' },
-            { __ref: 'VideoBlock:videoId' }
-          ],
-          id: 'journeyId',
-          __typename: 'Journey'
-        }
-      })
-      const videoBlockResult = jest.fn(() => ({
-        data: {
-          videoBlockUpdate: video
-        }
-      }))
-      const { getAllByRole, getByTestId } = render(
-        <MockedProvider
-          cache={cache}
-          mocks={[
-            {
-              request: {
-                query: CARD_BLOCK_COVER_VIDEO_BLOCK_UPDATE,
-                variables: {
-                  id: video.id,
-                  journeyId: 'journeyId',
-                  input: {
-                    startAt: 11,
-                    endAt: 144,
-                    autoplay: true,
-                    muted: true,
-                    objectFit: 'fill'
-                  }
-                }
-              },
-              result: videoBlockResult
-            }
-          ]}
-        >
-          <JourneyProvider
-            value={{
-              journey: { id: 'journeyId' } as unknown as Journey,
-              admin: true
-            }}
-          >
-            <ThemeProvider>
-              <SnackbarProvider>
-                <BackgroundMediaVideo cardBlock={existingCoverBlock} />
-              </SnackbarProvider>
-            </ThemeProvider>
-          </JourneyProvider>
-        </MockedProvider>
-      )
-      const closeButton = getAllByRole('button')[0]
-      expect(closeButton).toContainElement(getByTestId('CloseIcon'))
-      fireEvent.click(closeButton)
-      const textbox = await getAllByRole('textbox', { name: 'Starts At' })[0]
-      fireEvent.change(textbox, { target: { value: '00:00:11' } })
-      fireEvent.blur(textbox)
-      await waitFor(() => expect(videoBlockResult).toHaveBeenCalled())
-    })
-
-    it('updates endAt', async () => {
-      const cache = new InMemoryCache()
-      cache.restore({
-        'Journey:journeyId': {
-          blocks: [
-            { __ref: 'CardBlock:cardId' },
-            { __ref: 'VideoBlock:videoId' }
-          ],
-          id: 'journeyId',
-          __typename: 'Journey'
-        }
-      })
-      const videoBlockResult = jest.fn(() => ({
-        data: {
-          videoBlockUpdate: video
-        }
-      }))
-      const { getAllByRole, getByTestId } = render(
-        <MockedProvider
-          cache={cache}
-          mocks={[
-            {
-              request: {
-                query: CARD_BLOCK_COVER_VIDEO_BLOCK_UPDATE,
-                variables: {
-                  id: video.id,
-                  journeyId: 'journeyId',
-                  input: {
-                    autoplay: true,
-                    muted: true,
-                    startAt: 0,
-                    endAt: 31,
-                    objectFit: 'fill'
-                  }
-                }
-              },
-              result: videoBlockResult
-            }
-          ]}
-        >
-          <ThemeProvider>
             <JourneyProvider
               value={{
                 journey: { id: 'journeyId' } as unknown as Journey,
                 admin: true
               }}
             >
-              <SnackbarProvider>
-                <BackgroundMediaVideo cardBlock={existingCoverBlock} />
-              </SnackbarProvider>
+              <ThemeProvider>
+                <SnackbarProvider>
+                  <BackgroundMediaVideo cardBlock={existingCoverBlockWithId} />
+                </SnackbarProvider>
+              </ThemeProvider>
             </JourneyProvider>
-          </ThemeProvider>
-        </MockedProvider>
-      )
-      const closeButton = getAllByRole('button')[0]
-      expect(closeButton).toContainElement(getByTestId('CloseIcon'))
-      fireEvent.click(closeButton)
-      const textbox = await getAllByRole('textbox', { name: 'Ends At' })[0]
-      fireEvent.change(textbox, { target: { value: '00:00:31' } })
-      fireEvent.blur(textbox)
-      await waitFor(() => expect(videoBlockResult).toHaveBeenCalled())
+          </MockedProvider>
+        )
+        const checkbox = await getAllByRole('checkbox', { name: 'Muted' })[0]
+        fireEvent.click(checkbox)
+        await waitFor(() => expect(videoBlockResult).toHaveBeenCalled())
+      })
+
+      it('updates startAt', async () => {
+        const cache = new InMemoryCache()
+        cache.restore({
+          'Journey:journeyId': {
+            blocks: [
+              { __ref: 'CardBlock:cardId' },
+              { __ref: 'VideoBlock:videoId' }
+            ],
+            id: 'journeyId',
+            __typename: 'Journey'
+          }
+        })
+        const videoBlockResult = jest.fn(() => ({
+          data: {
+            videoBlockUpdate: video
+          }
+        }))
+        const { getAllByRole } = render(
+          <MockedProvider
+            cache={cache}
+            mocks={[
+              {
+                request: {
+                  query: CARD_BLOCK_COVER_VIDEO_BLOCK_UPDATE,
+                  variables: {
+                    id: video.id,
+                    journeyId: 'journeyId',
+                    input: {
+                      startAt: 11,
+                      endAt: 144,
+                      autoplay: true,
+                      muted: true,
+                      objectFit: 'fill'
+                    }
+                  }
+                },
+                result: videoBlockResult
+              }
+            ]}
+          >
+            <JourneyProvider
+              value={{
+                journey: { id: 'journeyId' } as unknown as Journey,
+                admin: true
+              }}
+            >
+              <ThemeProvider>
+                <SnackbarProvider>
+                  <BackgroundMediaVideo cardBlock={existingCoverBlockWithId} />
+                </SnackbarProvider>
+              </ThemeProvider>
+            </JourneyProvider>
+          </MockedProvider>
+        )
+        const textbox = await getAllByRole('textbox', { name: 'Starts At' })[0]
+        fireEvent.change(textbox, { target: { value: '00:00:11' } })
+        fireEvent.blur(textbox)
+        await waitFor(() => expect(videoBlockResult).toHaveBeenCalled())
+      })
+
+      it('updates endAt', async () => {
+        const cache = new InMemoryCache()
+        cache.restore({
+          'Journey:journeyId': {
+            blocks: [
+              { __ref: 'CardBlock:cardId' },
+              { __ref: 'VideoBlock:videoId' }
+            ],
+            id: 'journeyId',
+            __typename: 'Journey'
+          }
+        })
+        const videoBlockResult = jest.fn(() => ({
+          data: {
+            videoBlockUpdate: video
+          }
+        }))
+        const { getAllByRole } = render(
+          <MockedProvider
+            cache={cache}
+            mocks={[
+              {
+                request: {
+                  query: CARD_BLOCK_COVER_VIDEO_BLOCK_UPDATE,
+                  variables: {
+                    id: video.id,
+                    journeyId: 'journeyId',
+                    input: {
+                      autoplay: true,
+                      muted: true,
+                      startAt: 0,
+                      endAt: 31,
+                      objectFit: 'fill'
+                    }
+                  }
+                },
+                result: videoBlockResult
+              }
+            ]}
+          >
+            <ThemeProvider>
+              <JourneyProvider
+                value={{
+                  journey: { id: 'journeyId' } as unknown as Journey,
+                  admin: true
+                }}
+              >
+                <SnackbarProvider>
+                  <BackgroundMediaVideo cardBlock={existingCoverBlockWithId} />
+                </SnackbarProvider>
+              </JourneyProvider>
+            </ThemeProvider>
+          </MockedProvider>
+        )
+        const textbox = await getAllByRole('textbox', { name: 'Ends At' })[0]
+        fireEvent.change(textbox, { target: { value: '00:00:31' } })
+        fireEvent.blur(textbox)
+        await waitFor(() => expect(videoBlockResult).toHaveBeenCalled())
+      })
     })
   })
 })

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.spec.tsx
@@ -173,6 +173,7 @@ describe('VideoOptions', () => {
         </JourneyProvider>
       </MockedProvider>
     )
+    fireEvent.click(getByRole('button', { name: 'Select Video' }))
     await waitFor(() => expect(getByText('Brand Video')).toBeInTheDocument())
     fireEvent.click(getByText('Brand Video'))
     await waitFor(() =>
@@ -295,6 +296,7 @@ describe('VideoOptions', () => {
         </JourneyProvider>
       </MockedProvider>
     )
+    fireEvent.click(getByRole('button', { name: 'Select Video' }))
     await waitFor(() => expect(getByText('Brand Video')).toBeInTheDocument())
     fireEvent.click(getByText('Brand Video'))
     await waitFor(() =>

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Source/Source.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Source/Source.spec.tsx
@@ -76,6 +76,7 @@ describe('Source', () => {
         <Source selectedBlock={null} onChange={onChange} />
       </MockedProvider>
     )
+    fireEvent.click(getByRole('button', { name: 'Select Video' }))
     await waitFor(() => expect(getByText('Brand Video')).toBeInTheDocument())
     fireEvent.click(getByText('Brand Video'))
     await waitFor(() =>

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Source/Source.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Source/Source.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useEffect, useState } from 'react'
+import { ReactElement, useState } from 'react'
 import type { TreeBlock } from '@core/journeys/ui/block'
 import Card from '@mui/material/Card'
 import CardActionArea from '@mui/material/CardActionArea'
@@ -20,12 +20,6 @@ interface SourceProps {
 
 export function Source({ selectedBlock, onChange }: SourceProps): ReactElement {
   const [open, setOpen] = useState(false)
-
-  useEffect(() => {
-    if (selectedBlock?.videoId == null) {
-      setOpen(true)
-    }
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   let SourceContent
 

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.tsx
@@ -22,18 +22,22 @@ export function VideoBlockEditor({
     (child) => child.id === (selectedBlock as VideoBlock).posterBlockId
   ) as ImageBlock | null
 
+  const videoBlock = selectedBlock as VideoBlock
+
   return (
     <>
       <Box sx={{ px: 6, py: 4 }}>
         <Source selectedBlock={selectedBlock} onChange={onChange} />
       </Box>
-      <Box>
-        <VideoBlockEditorSettings
-          selectedBlock={selectedBlock}
-          posterBlock={posterBlock}
-          onChange={onChange}
-        />
-      </Box>
+      {videoBlock?.videoId != null && (
+        <Box>
+          <VideoBlockEditorSettings
+            selectedBlock={selectedBlock}
+            posterBlock={posterBlock}
+            onChange={onChange}
+          />
+        </Box>
+      )}
     </>
   )
 }


### PR DESCRIPTION
# Description

Don't open Video Selection tab by default when clicking on the Background property

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/31245472/todos/5847653659#__recording_5865811300)

# How should this PR be QA Tested?

- [ ] it should not open the video library on background media click

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
