### PR TITLE
refactor: sort by popup in journeys admin

### DIFF
--- a/apps/journeys-admin/src/components/JourneyList/JourneySort/JourneySort.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneySort/JourneySort.spec.tsx
@@ -36,16 +36,6 @@ describe('JourneyList/JourneySort', () => {
     expect(updatedButton).toBeInTheDocument()
   })
 
-  it('should not set sort value on cancel button click', () => {
-    const { getByText, getByRole } = render(<JourneySortMock />)
-    const button = getByRole('button', { name: 'Sort By' })
-
-    fireEvent.click(button)
-    fireEvent.click(getByText('Cancel'))
-
-    expect(button).toBeInTheDocument()
-  })
-
   it('should be disabled', () => {
     const { getByRole } = render(<JourneySortMock disabled />)
     expect(getByRole('button', { name: 'Sort By' })).toHaveAttribute(

--- a/apps/journeys-admin/src/components/JourneyList/JourneySort/JourneySort.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneySort/JourneySort.tsx
@@ -90,7 +90,7 @@ export function JourneySort({
             flexDirection: 'row',
             justifyContent: 'flex-end'
           }}
-         />
+        />
       </FormControl>
     </Box>
   )

--- a/apps/journeys-admin/src/components/JourneyList/JourneySort/JourneySort.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneySort/JourneySort.tsx
@@ -7,11 +7,9 @@ import {
   ChangeEvent
 } from 'react'
 import Box from '@mui/material/Box'
-import Button from '@mui/material/Button'
 import Chip from '@mui/material/Chip'
 import Drawer from '@mui/material/Drawer'
 import FormControl from '@mui/material/FormControl'
-import FormLabel from '@mui/material/FormLabel'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import Popover from '@mui/material/Popover'
 import RadioGroup from '@mui/material/RadioGroup'
@@ -69,7 +67,6 @@ export function JourneySort({
   const Form = (): ReactElement => (
     <Box sx={{ p: 4 }}>
       <FormControl component="fieldset" fullWidth>
-        <FormLabel component="legend">Sort By</FormLabel>
         <RadioGroup
           aria-label="sort-by-options"
           defaultValue={sortOrder ?? SortOrder.CREATED_AT}
@@ -93,15 +90,7 @@ export function JourneySort({
             flexDirection: 'row',
             justifyContent: 'flex-end'
           }}
-        >
-          <Button
-            sx={{ mt: 1, mr: 1 }}
-            onClick={() => setShowSortOrder(false)}
-            variant="text"
-          >
-            Cancel
-          </Button>
-        </Box>
+         />
       </FormControl>
     </Box>
   )


### PR DESCRIPTION
# Description

Remove the sort-by label and the cancel button from the sort-by pop-up in JourneysList/JourneysSort.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/31245472/todos/5846992126)

# How should this PR be QA Tested?

- [ ] Check that the sort-by pop-up no longer has a label or cancel button.
- [ ] Check that the tests still work and there is no missing case.

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
