### PR TITLE
fix: watch links to use proper extensions

### DIFF
--- a/apps/watch/pages/[part1]/[part2].tsx
+++ b/apps/watch/pages/[part1]/[part2].tsx
@@ -58,13 +58,27 @@ export default function Part2Page({ content }: Part2PageProps): ReactElement {
 export const getStaticProps: GetStaticProps<Part2PageProps> = async (
   context
 ) => {
+  const [contentId, contentIdExtension] = (
+    context.params?.part1 as string
+  ).split('.')
+  const [languageId, languageIdExtension] = (
+    context.params?.part2 as string
+  ).split('.')
+
+  if (contentIdExtension !== 'html' || languageIdExtension !== 'html') {
+    return {
+      redirect: {
+        permanent: false,
+        destination: `/${contentId}.html/${languageId}.html`
+      }
+    }
+  }
+
   const client = createApolloClient()
   const { data } = await client.query<GetVideoContent>({
     query: GET_VIDEO_CONTENT,
     variables: {
-      id: `${(context.params?.part1 as string).split('.')[0]}/${
-        (context.params?.part2 as string).split('.')[0]
-      }`
+      id: `${contentId}/${languageId}`
     }
   })
   if (data.content == null) {

--- a/apps/watch/pages/[part1]/[part2].tsx
+++ b/apps/watch/pages/[part1]/[part2].tsx
@@ -97,30 +97,56 @@ export const getStaticProps: GetStaticProps<Part2PageProps> = async (
 export const getStaticPaths: GetStaticPaths = () => {
   return {
     paths: [
-      { params: { part1: 'jesus', part2: 'english' } },
-      { params: { part1: 'life-of-jesus-gospel-of-john', part2: 'english' } },
-      { params: { part1: 'jesus-calms-the-storm', part2: 'english' } },
-      { params: { part1: 'magdalena', part2: 'english' } },
-      { params: { part1: 'reflections-of-hope', part2: 'english' } },
-      { params: { part1: 'day-6-jesus-died-for-me', part2: 'english' } },
-      { params: { part1: 'book-of-acts', part2: 'english' } },
-      { params: { part1: 'wedding-in-cana', part2: 'english' } },
-      { params: { part1: 'lumo', part2: 'english' } },
+      { params: { part1: 'jesus.html', part2: 'english.html' } },
       {
         params: {
-          part1: 'peter-miraculous-escape-from-prison',
-          part2: 'english'
+          part1: 'life-of-jesus-gospel-of-john.html',
+          part2: 'english.html'
         }
       },
-      { params: { part1: '8-days-with-jesus-who-is-jesus', part2: 'english' } },
-      { params: { part1: 'chosen-witness', part2: 'english' } },
-      { params: { part1: 'lumo-the-gospel-of-luke', part2: 'english' } },
-      { params: { part1: 'storyclubs-jesus-and-zacchaeus', part2: 'english' } },
-      { params: { part1: 'birth-of-jesus', part2: 'english' } },
-      { params: { part1: 'fallingplates', part2: 'english' } },
-      { params: { part1: 'paul-and-silas-in-prison', part2: 'english' } },
-      { params: { part1: 'my-last-day', part2: 'english' } },
-      { params: { part1: 'the-beginning', part2: 'english' } }
+      {
+        params: { part1: 'jesus-calms-the-storm.html', part2: 'english.html' }
+      },
+      { params: { part1: 'magdalena.html', part2: 'english.html' } },
+      { params: { part1: 'reflections-of-hope.html', part2: 'english.html' } },
+      {
+        params: { part1: 'day-6-jesus-died-for-me.html', part2: 'english.html' }
+      },
+      { params: { part1: 'book-of-acts.html', part2: 'english.html' } },
+      { params: { part1: 'wedding-in-cana.html', part2: 'english.html' } },
+      { params: { part1: 'lumo.html', part2: 'english.html' } },
+      {
+        params: {
+          part1: 'peter-miraculous-escape-from-prison.html',
+          part2: 'english.html'
+        }
+      },
+      {
+        params: {
+          part1: '8-days-with-jesus-who-is-jesus.html',
+          part2: 'english.html'
+        }
+      },
+      { params: { part1: 'chosen-witness.html', part2: 'english.html' } },
+      {
+        params: { part1: 'lumo-the-gospel-of-luke.html', part2: 'english.html' }
+      },
+      {
+        params: {
+          part1: 'storyclubs-jesus-and-zacchaeus.html',
+          part2: 'english.html'
+        }
+      },
+      { params: { part1: 'birth-of-jesus.html', part2: 'english.html' } },
+      { params: { part1: 'fallingplates.html', part2: 'english.html' } },
+      {
+        params: {
+          part1: 'paul-and-silas-in-prison.html',
+          part2: 'english.html'
+        }
+      },
+      { params: { part1: 'my-last-day.html', part2: 'english.html' } },
+      { params: { part1: 'the-beginning.html', part2: 'english.html' } }
     ],
     fallback: 'blocking'
   }

--- a/apps/watch/pages/[part1]/[part2]/[part3].tsx
+++ b/apps/watch/pages/[part1]/[part2]/[part3].tsx
@@ -49,16 +49,35 @@ export default function Part3Page({
 export const getStaticProps: GetStaticProps<Part3PageProps> = async (
   context
 ) => {
+  const [containerId, containerIdExtension] = (
+    context.params?.part1 as string
+  ).split('.')
+  const [contentId, contentIdExtension] = (
+    context.params?.part2 as string
+  ).split('.')
+  const [languageId, languageIdExtension] = (
+    context.params?.part3 as string
+  ).split('.')
+
+  if (
+    containerIdExtension !== 'html' ||
+    contentIdExtension !== undefined ||
+    languageIdExtension !== 'html'
+  ) {
+    return {
+      redirect: {
+        permanent: false,
+        destination: `/${containerId}.html/${contentId}/${languageId}.html`
+      }
+    }
+  }
+
   const client = createApolloClient()
   const { data } = await client.query<GetVideoContainerAndVideoContent>({
     query: GET_VIDEO_CONTAINER_AND_VIDEO_CONTENT,
     variables: {
-      containerId: `${(context.params?.part1 as string).split('.')[0]}/${
-        (context.params?.part3 as string).split('.')[0]
-      }`,
-      contentId: `${(context.params?.part2 as string).split('.')[0]}/${
-        (context.params?.part3 as string).split('.')[0]
-      }`
+      containerId: `${containerId}/${languageId}`,
+      contentId: `${contentId}/${languageId}`
     }
   })
   if (data.container == null || data.content == null) {

--- a/apps/watch/src/components/VideoCard/VideoCard.spec.tsx
+++ b/apps/watch/src/components/VideoCard/VideoCard.spec.tsx
@@ -17,9 +17,12 @@ describe('VideoCard', () => {
       const { getByRole } = render(
         <VideoCard video={videos[0]} variant="contained" />
       )
+      const [videoId, languageId] = (videos[0].variant?.slug as string).split(
+        '/'
+      )
       expect(getByRole('link')).toHaveAttribute(
         'href',
-        `/${videos[0].variant?.slug as string}`
+        `/${videoId}.html/${languageId}.html`
       )
     })
 
@@ -28,12 +31,12 @@ describe('VideoCard', () => {
         <VideoCard
           video={videos[0]}
           variant="contained"
-          containerSlug="jesus"
+          containerSlug="container"
         />
       )
       expect(getByRole('link')).toHaveAttribute(
         'href',
-        `/jesus/${videos[0].variant?.slug as string}`
+        `/container.html/${videos[0].variant?.slug as string}.html`
       )
     })
 
@@ -45,9 +48,12 @@ describe('VideoCard', () => {
           containerSlug="jesus"
         />
       )
+      const [videoId, languageId] = (videos[9].variant?.slug as string).split(
+        '/'
+      )
       expect(getByRole('link')).toHaveAttribute(
         'href',
-        `/${videos[9].variant?.slug as string}`
+        `/${videoId}.html/${languageId}.html`
       )
     })
 
@@ -59,9 +65,12 @@ describe('VideoCard', () => {
           containerSlug="jesus"
         />
       )
+      const [videoId, languageId] = (videos[5].variant?.slug as string).split(
+        '/'
+      )
       expect(getByRole('link')).toHaveAttribute(
         'href',
-        `/${videos[5].variant?.slug as string}`
+        `/${videoId}.html/${languageId}.html`
       )
     })
 

--- a/apps/watch/src/components/VideoCard/VideoCard.tsx
+++ b/apps/watch/src/components/VideoCard/VideoCard.tsx
@@ -51,18 +51,21 @@ export function VideoCard({
     video?.label,
     video?.childrenCount ?? 0
   )
+  let href = ''
+
+  if (
+    containerSlug != null &&
+    video?.label != null &&
+    ![VideoLabel.collection, VideoLabel.series].includes(video.label)
+  ) {
+    href += `/${containerSlug}.html/${video?.variant?.slug ?? ''}.html`
+  } else {
+    const [videoId, languageId] = (video?.variant?.slug ?? '').split('/')
+    href = `/${videoId}.html/${languageId}.html`
+  }
 
   return (
-    <NextLink
-      href={`/${
-        containerSlug != null &&
-        video?.label != null &&
-        ![VideoLabel.collection, VideoLabel.series].includes(video.label)
-          ? `${containerSlug}/`
-          : ''
-      }${video?.variant?.slug ?? ''}`}
-      passHref
-    >
+    <NextLink href={href} passHref>
       <Link
         display="block"
         underline="none"


### PR DESCRIPTION
# Description

- redirect /videoId/languageId to /videoId.html/languageId.html
- redirect /containerId/videoId/languageId to /containerId.html/videoId/languageId.html
- on video card use the correct extensions
- prerendered /videoId/languageId pages should use correct extension 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
