### PR TITLE
fix: redirect bin to api on watch

### DIFF
--- a/apps/watch/next.config.js
+++ b/apps/watch/next.config.js
@@ -34,11 +34,15 @@ const nextConfig = {
         basePath: false,
         permanent: false
       },
-
       {
         source: '/:path((?!watch).*)',
         destination: '/watch/:path',
         basePath: false,
+        permanent: false
+      },
+      {
+        source: '/bin/jf/watch.html/:videoId/:languageId',
+        destination: '/api/jf/watch.html/:videoId/:languageId',
         permanent: false
       }
     ]

--- a/apps/watch/pages/api/jf/watch.html/[videoId]/[languageId].ts
+++ b/apps/watch/pages/api/jf/watch.html/[videoId]/[languageId].ts
@@ -29,8 +29,9 @@ export default async function Handler(
     }
   })
   if (data.video?.variant?.slug != null) {
-    res.redirect(302, `/${data.video.variant.slug}`)
+    const [videoId, languageId] = data.video.variant.slug.split('/')
+    res.redirect(`/watch/${videoId}.html/${languageId}.html`)
   } else {
-    res.redirect(302, '/404')
+    res.status(404).send({ error: 'video could not be found' })
   }
 }


### PR DESCRIPTION
# Description

Handle /api and /bin redirects to the proper resources on watch.

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] /watch/bin/jf/watch.html/7_0-nfs0101/529 should redirect to /watch/11-has-the-universe-always-existed.html/english.html
- [ ] /watch/api/jf/watch.html/7_0-nfs0101/529 should redirect to /watch/11-has-the-universe-always-existed.html/english.html

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
