### PR TITLE
fix: keep consistent target for input

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.tsx
@@ -84,22 +84,18 @@ export function TypographyEdit({
       value={value}
       placeholder={t('Add your text here...')}
       onSelect={(e) => {
-        const input = e.currentTarget as HTMLInputElement
+        const input = e.target as HTMLTextAreaElement
         setSelection({
           start: input.selectionStart ?? 0,
           end: input.selectionEnd ?? value.length
         })
       }}
-      onFocus={(e) =>
-        (e.currentTarget as HTMLInputElement).setSelectionRange(
-          selection.start,
-          selection.end
-        )
-      }
-      onBlur={handleSaveBlock}
-      onChange={(e) => {
-        setValue(e.currentTarget.value)
+      onFocus={(e) => {
+        const input = e.target as HTMLTextAreaElement
+        input.setSelectionRange(selection.start, selection.end)
       }}
+      onBlur={handleSaveBlock}
+      onChange={(e) => setValue(e.target.value)}
     />
   )
 

--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.tsx
@@ -84,7 +84,7 @@ export function TypographyEdit({
       value={value}
       placeholder={t('Add your text here...')}
       onSelect={(e) => {
-        const input = e.target as HTMLInputElement
+        const input = e.currentTarget as HTMLInputElement
         setSelection({
           start: input.selectionStart ?? 0,
           end: input.selectionEnd ?? value.length
@@ -97,7 +97,9 @@ export function TypographyEdit({
         )
       }
       onBlur={handleSaveBlock}
-      onChange={(e) => setValue(e.currentTarget.value)}
+      onChange={(e) => {
+        setValue(e.currentTarget.value)
+      }}
     />
   )
 


### PR DESCRIPTION
# Description

I broken main :( 

[- Link to Basecamp Todo
](https://3.basecamp.com/3105655/buckets/31245472/todos/5861894458)

# How should this PR be QA Tested?

Test in main, it's working on stage and locally.

- [ ] Create a text block, change a text property, click outside the card to save. It should save. This was always working locally and in stage but broken in main :( 

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
