### PR TITLE
fix: use input ref for value

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/InlineEditWrapper/TypographyEdit/TypographyEdit.tsx
@@ -41,11 +41,14 @@ export function TypographyEdit({
   )
 
   const { journey } = useJourney()
-  const [value, setValue] = useState(content)
+  const [value, setValue] = useState(content ?? '')
   const [selection, setSelection] = useState({ start: 0, end: value.length })
-
   async function handleSaveBlock(): Promise<void> {
-    const currentContent = value.trimStart().trimEnd()
+    // Production not saving value correctly
+    const inputRefValue = inputRef.current?.children[0].innerHTML
+    const currentContent = (value !== '' ? value : inputRefValue ?? '')
+      .trimStart()
+      .trimEnd()
 
     if (currentContent === '') {
       deleteSelf()


### PR DESCRIPTION
# Description
Second test fix for https://github.com/JesusFilm/core/pull/1393

[- Link to Basecamp Todo
](https://3.basecamp.com/3105655/buckets/31245472/todos/5861894458)
# How should this PR be QA Tested?

- [ ] Clicking outside of card on canvas saves the text on prod

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
