### PR TITLE
feat: create seed for onboarding journey

### DIFF
--- a/apps/api-journeys/db/seed.ts
+++ b/apps/api-journeys/db/seed.ts
@@ -4,6 +4,7 @@ import { nua2 } from './seeds/nua2'
 import { nua8 } from './seeds/nua8'
 import { nua9 } from './seeds/nua9'
 import { jfpTeam } from './seeds/jfpTeam'
+import { onboarding } from './seeds/onboarding'
 
 const db = ArangoDB()
 
@@ -115,6 +116,7 @@ async function main(): Promise<void> {
   await nua2()
   await nua8()
   await nua9()
+  await onboarding()
 
   // this should be removed when the UI can support team management
   await jfpTeam()

--- a/apps/api-journeys/db/seeds/onboarding.ts
+++ b/apps/api-journeys/db/seeds/onboarding.ts
@@ -1,0 +1,125 @@
+import { aql } from 'arangojs'
+import { ArangoDB } from '../db'
+import {
+  JourneyStatus,
+  ThemeMode,
+  ThemeName
+} from '../../src/app/__generated__/graphql'
+
+const db = ArangoDB()
+
+export async function onboarding(reset?: boolean): Promise<void> {
+  // reset should only be used for dev and stage, using it on production will overwrite the existing onboarding journey
+
+  const slug = 'onboarding' // TODO: update this to what prod is using
+
+  if (reset === true) {
+    await db.query(aql`
+    FOR journey in journeys
+      FILTER journey.slug == ${slug}
+      FOR block in blocks
+        FILTER block.journeyId == journey._key
+        REMOVE block IN blocks
+  `)
+
+    await db.query(aql`
+    FOR journey in journeys
+      FILTER journey.slug == ${slug}
+      REMOVE journey in journeys
+  `)
+  }
+
+  const existingJourney = await db.query(aql`
+      FOR journey in journeys
+        FILTER journey.slug == ${slug}
+          LIMIT 1
+          return journey
+    `)
+  if (existingJourney != null) return
+
+  const journey = await db.collection('journeys').save({
+    _key: '5',
+    title: 'Dev Onboarding Journey',
+    description:
+      'Only used for development and staging. Production should use actual onboarding journey. \n\nImportant: This slug should match the production onboarding journey slug',
+    languageId: 529,
+    themeMode: ThemeMode.dark,
+    themeName: ThemeName.base,
+    slug,
+    status: JourneyStatus.published,
+    template: true,
+    createdAt: new Date(),
+    publishedAt: new Date()
+  })
+
+  const primaryImageBlock = await db.collection('blocks').save({
+    journeyId: journey._key,
+    __typename: 'ImageBlock',
+    src: 'https://imagedelivery.net/tMY86qEHFACTO8_0kAeRFA/e8692352-21c7-4f66-cb57-0298e86a3300/public',
+    alt: 'onboarding primary',
+    width: 1152,
+    height: 768,
+    blurhash: 'UE9Qmr%MIpWCtmbH%Mxu_4xuWYoL-;oIWYt7',
+    parentOrder: 1,
+    parentBlockId: journey._key
+  })
+  await db
+    .collection('journeys')
+    .update(journey._key, { primaryImageBlockId: primaryImageBlock._key })
+
+  const step = await db.collection('blocks').save({
+    journeyId: journey._key,
+    __typename: 'StepBlock',
+    locked: false,
+    parentOrder: 0
+  })
+
+  const card = await db.collection('blocks').save({
+    journeyId: journey._key,
+    __typename: 'CardBlock',
+    parentBlockId: step._key,
+    fullScreen: false,
+    parentOrder: 0
+  })
+
+  const coverBlock = await db.collection('blocks').save({
+    journeyId: journey._key,
+    __typename: 'ImageBlock',
+    src: 'https://imagedelivery.net/tMY86qEHFACTO8_0kAeRFA/ae95a856-1401-41e1-6f3e-7b4e6f707f00/public',
+    alt: 'onboarding card 1 cover',
+    width: 1152,
+    height: 768,
+    blurhash: 'UbLX6?~p9FtRkX.8ogD%IUj@M{adxaM_ofkW',
+    parentBlockId: card._key
+  })
+  await db
+    .collection('blocks')
+    .update(card._key, { coverBlockId: coverBlock._key })
+
+  await db.collection('blocks').saveAll([
+    {
+      journeyId: journey._key,
+      __typename: 'TypographyBlock',
+      parentBlockId: card._key,
+      content: 'The Journey Is On',
+      variant: 'h3',
+      parentOrder: 0
+    },
+    {
+      journeyId: journey._key,
+      __typename: 'TypographyBlock',
+      parentBlockId: card._key,
+      content: '"Go, and lead the people on their way..."',
+      variant: 'body1',
+      parentOrder: 1
+    },
+    {
+      journeyId: journey._key,
+      __typename: 'TypographyBlock',
+      parentBlockId: card._key,
+      content: 'Deuteronomy 10:11',
+      variant: 'caption',
+      parentOrder: 2
+    }
+  ])
+}

--- a/apps/api-journeys/db/seeds/onboarding.ts
+++ b/apps/api-journeys/db/seeds/onboarding.ts
@@ -8,12 +8,12 @@ import {
 
 const db = ArangoDB()
 
-export async function onboarding(reset?: boolean): Promise<void> {
+export async function onboarding(action?: 'reset'): Promise<void> {
   // reset should only be used for dev and stage, using it on production will overwrite the existing onboarding journey
 
   const slug = 'onboarding' // TODO: update this to what prod is using
 
-  if (reset === true) {
+  if (action === 'reset') {
     await db.query(aql`
     FOR journey in journeys
       FILTER journey.slug == ${slug}
@@ -29,12 +29,14 @@ export async function onboarding(reset?: boolean): Promise<void> {
   `)
   }
 
-  const existingJourney = await db.query(aql`
+  const existingJourney = await (
+    await db.query(aql`
       FOR journey in journeys
         FILTER journey.slug == ${slug}
           LIMIT 1
           return journey
     `)
+  ).next()
   if (existingJourney != null) return
 
   const journey = await db.collection('journeys').save({

--- a/apps/api-journeys/db/seeds/onboarding.ts
+++ b/apps/api-journeys/db/seeds/onboarding.ts
@@ -11,12 +11,17 @@ const db = ArangoDB()
 export async function onboarding(action?: 'reset'): Promise<void> {
   // reset should only be used for dev and stage, using it on production will overwrite the existing onboarding journey
 
-  const slug = 'onboarding' // TODO: update this to what prod is using
+  // id and slug should be the same as the real onboarding journey in production
+  // duplicating the onboarding journey for new users relies on these values to be kept in sync
+  const onboardingJourney = {
+    id: '9d9ca229-9fb5-4d06-a18c-2d1a4ceba457',
+    slug: 'onboarding-journey'
+  }
 
   if (action === 'reset') {
     await db.query(aql`
     FOR journey in journeys
-      FILTER journey.slug == ${slug}
+      FILTER journey.slug == ${onboardingJourney.slug}
       FOR block in blocks
         FILTER block.journeyId == journey._key
         REMOVE block IN blocks
@@ -24,7 +29,7 @@ export async function onboarding(action?: 'reset'): Promise<void> {
 
     await db.query(aql`
     FOR journey in journeys
-      FILTER journey.slug == ${slug}
+      FILTER journey.slug == ${onboardingJourney.slug}
       REMOVE journey in journeys
   `)
   }
@@ -32,7 +37,7 @@ export async function onboarding(action?: 'reset'): Promise<void> {
   const existingJourney = await (
     await db.query(aql`
       FOR journey in journeys
-        FILTER journey.slug == ${slug}
+        FILTER journey.slug == ${onboardingJourney.slug}
           LIMIT 1
           return journey
     `)
@@ -40,14 +45,14 @@ export async function onboarding(action?: 'reset'): Promise<void> {
   if (existingJourney != null) return
 
   const journey = await db.collection('journeys').save({
-    _key: '5',
+    _key: onboardingJourney.id,
     title: 'Dev Onboarding Journey',
     description:
-      'Only used for development and staging. Production should use actual onboarding journey. \n\nImportant: This slug should match the production onboarding journey slug',
+      'Only used for development and staging. Production should use actual onboarding journey.',
     languageId: 529,
     themeMode: ThemeMode.dark,
     themeName: ThemeName.base,
-    slug,
+    slug: onboardingJourney.slug,
     status: JourneyStatus.published,
     template: true,
     createdAt: new Date(),


### PR DESCRIPTION
# Description

Adds a onboarding journey for dev use, with the id and slug matching the real onboarding journey in production

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/31822575/todos/5910584578)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Run `nx seed api-journeys`
- [x] You should have dev onboarding journey in template library that can be used

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
