### PR TITLE
fix: 500 from members index

### DIFF
--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -683,6 +683,23 @@ describe('JourneyResolver', () => {
       )
     })
 
+    it('doesnt create an existing Member', async () => {
+      mockUuidv4.mockReturnValueOnce('journeyId')
+      const member = {
+        id: 'existingId',
+        userId: 'userId',
+        teamId: 'jfp-team'
+      }
+      mService.getMemberByTeamId = jest.fn(
+        async () => await Promise.resolve(member)
+      )
+      await resolver.journeyCreate(
+        { title: 'Untitled Journey', languageId: '529' },
+        'userId'
+      )
+      expect(mService.save).not.toHaveBeenCalled()
+    })
+
     it('adds uuid if slug already taken', async () => {
       const mockSave = service.save as jest.MockedFunction<typeof service.save>
       mockSave.mockRejectedValueOnce({ errorNum: 1210 })

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -254,7 +254,8 @@ describe('JourneyResolver', () => {
   const memberService = {
     provide: MemberService,
     useFactory: () => ({
-      save: jest.fn((member) => member)
+      save: jest.fn((member) => member),
+      getMemberByTeamId: jest.fn(() => null)
     })
   }
 
@@ -656,11 +657,14 @@ describe('JourneyResolver', () => {
         { title: 'Untitled Journey', languageId: '529' },
         'userId'
       )
-      expect(ujService.save).toHaveBeenCalledWith({
-        userId: 'userId',
-        journeyId: 'journeyId',
-        role: UserJourneyRole.owner
-      })
+      expect(ujService.save).toHaveBeenCalledWith(
+        {
+          userId: 'userId',
+          journeyId: 'journeyId',
+          role: UserJourneyRole.owner
+        },
+        { returnNew: false }
+      )
     })
 
     it('creates a Member', async () => {
@@ -675,7 +679,7 @@ describe('JourneyResolver', () => {
           userId: 'userId',
           teamId: 'jfp-team'
         },
-        { overwriteMode: 'ignore' }
+        { overwriteMode: 'ignore', returnNew: false }
       )
     })
 

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -189,20 +189,32 @@ export class JourneyResolver {
           teamId: team.id,
           ...input
         })
-        await this.userJourneyService.save({
-          id: uuidv4(),
-          userId,
-          journeyId: journey.id,
-          role: UserJourneyRole.owner
-        })
-        await this.memberService.save(
+        await this.userJourneyService.save(
           {
-            id: `${userId}:${team.id}`,
+            id: uuidv4(),
             userId,
-            teamId: team.id
+            journeyId: journey.id,
+            role: UserJourneyRole.owner
           },
-          { overwriteMode: 'ignore' }
+          {
+            returnNew: false
+          }
         )
+        const existingMember = this.memberService.getMemberByTeamId(
+          userId,
+          team.id
+        )
+
+        if (existingMember == null) {
+          await this.memberService.save(
+            {
+              id: `${userId}:${team.id}`,
+              userId,
+              teamId: team.id
+            },
+            { overwriteMode: 'ignore', returnNew: false }
+          )
+        }
         retry = false
         return journey
       } catch (err) {


### PR DESCRIPTION
# Description

The PR addresses a 500 error edge case where a member record already exists, but is an index collision. 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
