### PR TITLE
fix: title of journey from template

### DIFF
--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -69,6 +69,13 @@ describe('JourneyResolver', () => {
     createdAt
   }
 
+  const template: Journey = {
+    ...journey,
+    title: 'template',
+    id: 'templateJourneyId',
+    template: true
+  }
+
   const draftJourney = {
     ...journey,
     id: 'draftJourney',
@@ -176,6 +183,8 @@ describe('JourneyResolver', () => {
         switch (id) {
           case journey.id:
             return journey
+          case template.id:
+            return template
           case draftJourney.id:
             return draftJourney
           case archivedJourney.id:
@@ -209,7 +218,9 @@ describe('JourneyResolver', () => {
         }
       }),
       getAllByRole: jest.fn(() => [journey, journey]),
-      getAllByTitle: jest.fn(() => [journey]),
+      getAllByTitle: jest.fn((title) =>
+        title === journey.title ? [journey] : []
+      ),
       save: jest.fn((input) => input),
       update: jest.fn(() => journey),
       updateAll: jest.fn(() => [journey, draftJourney])
@@ -811,7 +822,7 @@ describe('JourneyResolver', () => {
   })
 
   describe('journeyDuplicate', () => {
-    it('duplicates a Journey', async () => {
+    it('duplicates your journey', async () => {
       mockUuidv4.mockReturnValueOnce('duplicateJourneyId')
       expect(await resolver.journeyDuplicate('journeyId', 'userId')).toEqual({
         ...journey,
@@ -821,6 +832,21 @@ describe('JourneyResolver', () => {
         publishedAt: undefined,
         slug: `${journey.title}-copy`,
         title: `${journey.title} copy`,
+        template: false
+      })
+    })
+
+    it('duplicates a template journey', async () => {
+      mockUuidv4.mockReturnValueOnce('templateJourneyId')
+      expect(
+        await resolver.journeyDuplicate('templateJourneyId', 'userId')
+      ).toEqual({
+        ...template,
+        title: 'template',
+        slug: 'template',
+        createdAt: new Date().toISOString(),
+        status: JourneyStatus.draft,
+        publishedAt: undefined,
         template: false
       })
     })

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -284,8 +284,12 @@ export class JourneyResolver {
       journey.title
     )
     const duplicateNumber = this.getFirstMissingNumber(duplicates)
-    const duplicateTitle = `${journey.title} copy ${
-      duplicateNumber === 1 ? '' : duplicateNumber
+    const duplicateTitle = `${journey.title}${
+      duplicateNumber === 0
+        ? ''
+        : duplicateNumber === 1
+        ? ' copy'
+        : ` copy ${duplicateNumber}`
     }`.trimEnd()
 
     const slug = slugify(duplicateTitle, {


### PR DESCRIPTION
# Description

We get "copy 0" whenever we use a template from the template library. 
We want it just to display the template name, or add copy only if another journey with the template name already exists in our journey list.
<img width="1345" alt="image" src="https://user-images.githubusercontent.com/10802634/223894311-2dc89173-fd8f-413b-b976-d66143ae0d92.png">

[- Link to Basecamp Todo
](https://3.basecamp.com/3105655/buckets/31822575/todos/5909445092)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Go to the template library and use a template to create a journey. The created journey should have the same name as the template.
- [x] Repeat the step above, this time the created journey should have the template name + "copy" at the end.

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
