### PR TITLE
refactor: nav drawer remove redundant router and title

### DIFF
--- a/apps/journeys-admin/pages/journeys/[journeyId].tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId].tsx
@@ -69,7 +69,6 @@ function JourneyIdPage(): ReactElement {
               backHref="/"
               menu={<Menu />}
               authUser={AuthUser}
-              router={router}
             >
               <JourneyView journeyType="Journey" />
             </PageWrapper>

--- a/apps/journeys-admin/pages/journeys/[journeyId]/edit.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/edit.tsx
@@ -56,7 +56,6 @@ function JourneyEditPage(): ReactElement {
           backHref={`/journeys/${router.query.journeyId as string}`}
           menu={<EditToolbar />}
           authUser={AuthUser}
-          router={router}
         >
           <JourneyEdit />
         </PageWrapper>

--- a/apps/journeys-admin/pages/journeys/[journeyId]/reports.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/reports.tsx
@@ -39,7 +39,6 @@ function JourneyReportsPage(): ReactElement {
         title={t('Journey Report')}
         authUser={AuthUser}
         backHref={`/journeys/${journeyId}`}
-        router={router}
       >
         <Box sx={{ height: 'calc(100vh - 48px)' }}>
           <MemoizedDynamicReport

--- a/apps/journeys-admin/pages/publisher/[journeyId].tsx
+++ b/apps/journeys-admin/pages/publisher/[journeyId].tsx
@@ -75,7 +75,6 @@ function TemplateDetailsAdmin(): ReactElement {
               showDrawer
               backHref="/publisher"
               menu={<Menu />}
-              router={router}
             >
               <JourneyView journeyType="Template" />
             </PageWrapper>

--- a/apps/journeys-admin/pages/publisher/[journeyId]/edit.tsx
+++ b/apps/journeys-admin/pages/publisher/[journeyId]/edit.tsx
@@ -61,7 +61,6 @@ function TemplateEditPage(): ReactElement {
               backHref={`/publisher/${router.query.journeyId as string}`}
               authUser={AuthUser}
               menu={<EditToolbar />}
-              router={router}
             >
               <JourneyEdit />
             </PageWrapper>

--- a/apps/journeys-admin/pages/publisher/index.tsx
+++ b/apps/journeys-admin/pages/publisher/index.tsx
@@ -53,7 +53,6 @@ function TemplateIndex(): ReactElement {
         title={t('Templates Admin')}
         authUser={AuthUser}
         menu={<JourneyListMenu router={router} onClick={handleClick} />}
-        router={router}
       >
         <TemplateList router={router} event={listEvent} authUser={AuthUser} />
       </PageWrapper>

--- a/apps/journeys-admin/pages/reports/journeys.tsx
+++ b/apps/journeys-admin/pages/reports/journeys.tsx
@@ -6,7 +6,6 @@ import {
   withAuthUserTokenSSR
 } from 'next-firebase-auth'
 import { NextSeo } from 'next-seo'
-import { useRouter } from 'next/router'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'react-i18next'
 import { getLaunchDarklyClient } from '@core/shared/ui/getLaunchDarklyClient'
@@ -18,7 +17,6 @@ import { JourneysReportType } from '../../__generated__/globalTypes'
 import { useTermsRedirect } from '../../src/libs/useTermsRedirect/useTermsRedirect'
 
 function ReportsJourneysPage(): ReactElement {
-  const router = useRouter()
   const { t } = useTranslation('apps-journeys-admin')
   const AuthUser = useAuthUser()
 
@@ -27,11 +25,7 @@ function ReportsJourneysPage(): ReactElement {
   return (
     <>
       <NextSeo title={t('Journeys Report')} />
-      <PageWrapper
-        title={t('Journeys Report')}
-        authUser={AuthUser}
-        router={router}
-      >
+      <PageWrapper title={t('Journeys Report')} authUser={AuthUser}>
         <Box sx={{ height: 'calc(100vh - 48px)' }}>
           <MemoizedDynamicReport reportType={JourneysReportType.multipleFull} />
         </Box>

--- a/apps/journeys-admin/pages/reports/visitors.tsx
+++ b/apps/journeys-admin/pages/reports/visitors.tsx
@@ -6,7 +6,6 @@ import {
   withAuthUserTokenSSR
 } from 'next-firebase-auth'
 import { NextSeo } from 'next-seo'
-import { useRouter } from 'next/router'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'react-i18next'
 import { getLaunchDarklyClient } from '@core/shared/ui/getLaunchDarklyClient'
@@ -15,7 +14,6 @@ import i18nConfig from '../../next-i18next.config'
 import { useTermsRedirect } from '../../src/libs/useTermsRedirect/useTermsRedirect'
 
 function ReportsVisitorsPage(): ReactElement {
-  const router = useRouter()
   const { t } = useTranslation('apps-journeys-admin')
   const AuthUser = useAuthUser()
 
@@ -24,11 +22,7 @@ function ReportsVisitorsPage(): ReactElement {
   return (
     <>
       <NextSeo title={t('Visitors Report')} />
-      <PageWrapper
-        title={t('Visitors Report')}
-        authUser={AuthUser}
-        router={router}
-      >
+      <PageWrapper title={t('Visitors Report')} authUser={AuthUser}>
         Visitors report list
       </PageWrapper>
     </>

--- a/apps/journeys-admin/pages/reports/visitors/[visitorId].tsx
+++ b/apps/journeys-admin/pages/reports/visitors/[visitorId].tsx
@@ -25,11 +25,7 @@ function SingleVisitorReportsPage(): ReactElement {
   return (
     <>
       <NextSeo title={t('Visitor Info')} />
-      <PageWrapper
-        title={t('Visitor Info')}
-        authUser={AuthUser}
-        router={router}
-      >
+      <PageWrapper title={t('Visitor Info')} authUser={AuthUser}>
         <VisitorInfo id={router.query.visitorId as string} />
       </PageWrapper>
     </>

--- a/apps/journeys-admin/pages/templates/[journeyId].tsx
+++ b/apps/journeys-admin/pages/templates/[journeyId].tsx
@@ -53,7 +53,6 @@ function TemplateDetails(): ReactElement {
           showDrawer
           backHref="/templates"
           menu={<Menu />}
-          router={router}
         >
           <JourneyView journeyType="Template" />
         </PageWrapper>

--- a/apps/journeys-admin/pages/templates/index.tsx
+++ b/apps/journeys-admin/pages/templates/index.tsx
@@ -8,7 +8,6 @@ import {
   withAuthUser,
   withAuthUserTokenSSR
 } from 'next-firebase-auth'
-import { useRouter } from 'next/router'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { getLaunchDarklyClient } from '@core/shared/ui/getLaunchDarklyClient'
 import { PageWrapper } from '../../src/components/PageWrapper'
@@ -72,7 +71,6 @@ function LibraryIndex(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   const AuthUser = useAuthUser()
   const { data } = useQuery<GetPublishedTemplates>(GET_PUBLISHED_TEMPLATES)
-  const router = useRouter()
   const journeys = useJourneys()
   const { data: userData } = useQuery<GetUserRole>(GET_USER_ROLE)
 
@@ -83,11 +81,7 @@ function LibraryIndex(): ReactElement {
   return (
     <>
       <NextSeo title={t('Journey Templates')} />
-      <PageWrapper
-        title={t('Journey Templates')}
-        authUser={AuthUser}
-        router={router}
-      >
+      <PageWrapper title={t('Journey Templates')} authUser={AuthUser}>
         <TemplateLibrary
           isPublisher={isPublisher}
           journeys={journeys}

--- a/apps/journeys-admin/src/components/JourneyView/JourneyView.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyView.stories.tsx
@@ -2,7 +2,6 @@ import { Story, Meta } from '@storybook/react'
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 import { MockedProvider } from '@apollo/client/testing'
 import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
-import { NextRouter } from 'next/router'
 import { journeysAdminConfig } from '../../libs/storybook'
 import { PageWrapper } from '../PageWrapper'
 import { ApolloLoadingProvider } from '../../../test/ApolloLoadingProvider'
@@ -30,7 +29,6 @@ const Template: Story = ({ ...args }) => (
           showDrawer
           backHref="/"
           menu={<Menu />}
-          router={{ pathname: undefined } as unknown as NextRouter}
         >
           <JourneyView journeyType="Journey" />
         </PageWrapper>

--- a/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.spec.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.spec.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, waitFor } from '@testing-library/react'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import { AuthUser } from 'next-firebase-auth'
 import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
-import { NextRouter } from 'next/router'
+import { NextRouter, useRouter } from 'next/router'
 import { Role } from '../../../../__generated__/globalTypes'
 import { GET_USER_ROLE } from '../../JourneyView/JourneyView'
 import { GET_ME } from './NavigationDrawer'
@@ -23,24 +23,26 @@ jest.mock('react-i18next', () => ({
   }
 }))
 
-describe('NavigationDrawer', () => {
-  beforeEach(() => (useMediaQuery as jest.Mock).mockImplementation(() => true))
+jest.mock('next/router', () => ({
+  __esModule: true,
+  useRouter: jest.fn()
+}))
 
+const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
+
+beforeEach(() => (useMediaQuery as jest.Mock).mockImplementation(() => true))
+
+afterEach(() => jest.resetAllMocks())
+
+describe('NavigationDrawer', () => {
   const onClose = jest.fn()
   const signOut = jest.fn()
-
-  function getRouter(path: string): NextRouter {
-    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
-    return {
-      pathname: path
-    } as unknown as NextRouter
-  }
 
   it('should render the default menu items', () => {
     const { getByText, getAllByRole, getByTestId } = render(
       <MockedProvider>
         <FlagsProvider>
-          <NavigationDrawer open onClose={onClose} title="Journeys" />
+          <NavigationDrawer open onClose={onClose} />
         </FlagsProvider>
       </MockedProvider>
     )
@@ -89,7 +91,6 @@ describe('NavigationDrawer', () => {
           <NavigationDrawer
             open
             onClose={onClose}
-            title="Journeys"
             authUser={
               {
                 displayName: 'Amin One',
@@ -108,15 +109,14 @@ describe('NavigationDrawer', () => {
   })
 
   it('should select templates button', () => {
+    mockUseRouter.mockReturnValue({
+      pathname: '/templates'
+    } as unknown as NextRouter)
+
     const { getByTestId } = render(
       <MockedProvider>
         <FlagsProvider flags={{ templates: true }}>
-          <NavigationDrawer
-            open
-            onClose={onClose}
-            title="Journey Templates"
-            router={getRouter('/templates')}
-          />
+          <NavigationDrawer open onClose={onClose} />
         </FlagsProvider>
       </MockedProvider>
     )
@@ -127,15 +127,14 @@ describe('NavigationDrawer', () => {
   })
 
   it('should select the reports button', () => {
+    mockUseRouter.mockReturnValue({
+      pathname: '/reports'
+    } as unknown as NextRouter)
+
     const { getByTestId } = render(
       <MockedProvider>
         <FlagsProvider>
-          <NavigationDrawer
-            open
-            onClose={onClose}
-            title="Reports"
-            router={getRouter('/reports')}
-          />
+          <NavigationDrawer open onClose={onClose} />
         </FlagsProvider>
       </MockedProvider>
     )
@@ -146,6 +145,10 @@ describe('NavigationDrawer', () => {
   })
 
   it('should select publisher button', async () => {
+    mockUseRouter.mockReturnValue({
+      pathname: '/publisher/[journeyId]'
+    } as unknown as NextRouter)
+
     const { getByTestId } = render(
       <MockedProvider
         mocks={[
@@ -184,7 +187,6 @@ describe('NavigationDrawer', () => {
           <NavigationDrawer
             open
             onClose={onClose}
-            title="Templates Admin"
             authUser={
               {
                 displayName: 'Amin One',
@@ -193,7 +195,6 @@ describe('NavigationDrawer', () => {
                 signOut
               } as unknown as AuthUser
             }
-            router={getRouter('/publisher/[journeyId]')}
           />
         </FlagsProvider>
       </MockedProvider>
@@ -245,7 +246,6 @@ describe('NavigationDrawer', () => {
           <NavigationDrawer
             open
             onClose={onClose}
-            title="Templates Admin"
             authUser={
               {
                 displayName: 'Amin One',
@@ -275,7 +275,7 @@ describe('NavigationDrawer', () => {
     const { getAllByRole, getByTestId } = render(
       <MockedProvider>
         <FlagsProvider>
-          <NavigationDrawer open onClose={onClose} title="Journeys" />
+          <NavigationDrawer open onClose={onClose} />
         </FlagsProvider>
       </MockedProvider>
     )
@@ -289,7 +289,7 @@ describe('NavigationDrawer', () => {
     const { getByTestId } = render(
       <MockedProvider>
         <FlagsProvider>
-          <NavigationDrawer open onClose={onClose} title="Active Journeys" />
+          <NavigationDrawer open onClose={onClose} />
         </FlagsProvider>
       </MockedProvider>
     )

--- a/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.spec.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.spec.tsx
@@ -286,6 +286,10 @@ describe('NavigationDrawer', () => {
   })
 
   it('should select the journeys drawer', () => {
+    mockUseRouter.mockReturnValue({
+      pathname: '/'
+    } as unknown as NextRouter)
+
     const { getByTestId } = render(
       <MockedProvider>
         <FlagsProvider>

--- a/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.stories.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.stories.tsx
@@ -4,7 +4,6 @@ import { noop } from 'lodash'
 import { MockedProvider } from '@apollo/client/testing'
 import { AuthUser } from 'next-firebase-auth'
 import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
-import { NextRouter } from 'next/router'
 import { journeysAdminConfig } from '../../../libs/storybook'
 import { Role, UserJourneyRole } from '../../../../__generated__/globalTypes'
 import { GET_USER_ROLE } from '../../JourneyView/JourneyView'
@@ -74,8 +73,6 @@ const Template: Story = ({ ...args }) => {
               signOut: noop
             } as unknown as AuthUser
           }
-          title={args.title}
-          router={{ pathname: undefined } as unknown as NextRouter}
         />
       </FlagsProvider>
     </MockedProvider>
@@ -84,20 +81,17 @@ const Template: Story = ({ ...args }) => {
 
 export const Default = Template.bind({})
 Default.args = {
-  templates: false,
-  title: 'Active Journeys'
+  templates: false
 }
 
 export const Complete = Template.bind({})
 Complete.args = {
-  templates: true,
-  title: 'Journeys'
+  templates: true
 }
 
 export const WithBadge = Template.bind({})
 WithBadge.args = {
   templates: false,
-  title: 'Active Journeys',
   result: {
     data: {
       journeys: [

--- a/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.tsx
@@ -157,7 +157,9 @@ export function NavigationDrawer({
         <NavigationListItem
           icon={<ViewCarouselRoundedIcon />}
           label="Discover"
-          selected={selectedPage === 'journeys' || selectedPage === ''}
+          selected={
+            selectedPage === 'journeys' || selectedPage === '' || router == null
+          }
           link="/"
           tooltipText={journeyTooltip}
         />

--- a/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.tsx
@@ -16,7 +16,7 @@ import ShopRoundedIcon from '@mui/icons-material/ShopRounded'
 import ShopTwoRoundedIcon from '@mui/icons-material/ShopTwoRounded'
 import Backdrop from '@mui/material/Backdrop'
 import Image from 'next/image'
-import { NextRouter } from 'next/router'
+import { useRouter } from 'next/router'
 import { compact } from 'lodash'
 import { gql, useQuery } from '@apollo/client'
 import { useFlags } from '@core/shared/ui/FlagsProvider'
@@ -40,8 +40,6 @@ export interface NavigationDrawerProps {
   open: boolean
   onClose: (value: boolean) => void
   authUser?: AuthUser
-  title: string
-  router?: NextRouter
 }
 
 export const GET_ME = gql`
@@ -102,15 +100,14 @@ export const StyledList = styled(List)({
 export function NavigationDrawer({
   open,
   onClose,
-  authUser,
-  title,
-  router
+  authUser
 }: NavigationDrawerProps): ReactElement {
   const activeJourneys = useActiveJourneys()
   const journeys = activeJourneys?.data?.journeys
   const { t } = useTranslation('apps-journeys-admin')
   const smUp = useMediaQuery((theme: Theme) => theme.breakpoints.up('sm'))
   const [profileAnchorEl, setProfileAnchorEl] = useState(null)
+  const router = useRouter()
 
   const selectedPage = router?.pathname?.split('/')[1]
 
@@ -160,7 +157,7 @@ export function NavigationDrawer({
         <NavigationListItem
           icon={<ViewCarouselRoundedIcon />}
           label="Discover"
-          selected={selectedPage === 'journeys' || selectedPage == null} // null for when page is index. UPDATE when we add the actual index page
+          selected={selectedPage === 'journeys' || selectedPage === ''}
           link="/"
           tooltipText={journeyTooltip}
         />

--- a/apps/journeys-admin/src/components/PageWrapper/PageWrapper.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/PageWrapper.tsx
@@ -9,7 +9,6 @@ import ChevronLeftRounded from '@mui/icons-material/ChevronLeftRounded'
 import Image from 'next/image'
 import { AuthUser } from 'next-firebase-auth'
 import useMediaQuery from '@mui/material/useMediaQuery'
-import { NextRouter } from 'next/router'
 import MenuIcon from '@mui/icons-material/Menu'
 import { Theme } from '@mui/material/styles'
 import taskbarIcon from '../../../public/taskbar-icon.svg'
@@ -22,7 +21,6 @@ export interface PageWrapperProps {
   menu?: ReactNode
   children?: ReactNode
   authUser?: AuthUser
-  router?: NextRouter
 }
 
 export function PageWrapper({
@@ -31,8 +29,7 @@ export function PageWrapper({
   title,
   menu: customMenu,
   children,
-  authUser,
-  router
+  authUser
 }: PageWrapperProps): ReactElement {
   const [open, setOpen] = useState<boolean>(false)
   const smUp = useMediaQuery((theme: Theme) => theme.breakpoints.up('sm'))
@@ -119,13 +116,7 @@ export function PageWrapper({
           {customMenu != null && customMenu}
         </Toolbar>
       </AppBar>
-      <NavigationDrawer
-        open={open}
-        onClose={setOpen}
-        authUser={authUser}
-        title={title}
-        router={router}
-      />
+      <NavigationDrawer open={open} onClose={setOpen} authUser={authUser} />
       <Box
         sx={{
           ml: { sm: '72px' }


### PR DESCRIPTION
# Description

Fixing this before I add in my PageWrapper changes. Starting PageWrapper changes so we can easily add in the side panel on the landing page.

2 Changes:
- Use useRouter directly in NavigationDrawer instead of passing `router` down 2 levels
- remove unused `title` prop

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Checks are green
- [ ] Drawer still highlights correct page
- [ ] Drawer still shows correctly on desktop and mobile

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
