### PR TITLE
fix: badge disappears when visiting edit and report pages 

### DIFF
--- a/apps/journeys-admin/pages/journeys/[journeyId]/edit.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/edit.tsx
@@ -113,7 +113,7 @@ export const getServerSideProps = withAuthUserTokenSSR({
     }
   }
 
-  void apolloClient.mutate<UserJourneyOpen>({
+  await apolloClient.mutate<UserJourneyOpen>({
     mutation: USER_JOURNEY_OPEN,
     variables: { id: query?.journeyId }
   })

--- a/apps/journeys-admin/pages/journeys/[journeyId]/reports.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/reports.tsx
@@ -88,7 +88,7 @@ export const getServerSideProps = withAuthUserTokenSSR({
     }
   }
 
-  void apolloClient.mutate<UserJourneyOpen>({
+  await apolloClient.mutate<UserJourneyOpen>({
     mutation: USER_JOURNEY_OPEN,
     variables: { id: query?.journeyId }
   })


### PR DESCRIPTION
# Description

Adds the missing fix for the /edit and /report pages.

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/31739517/todos/5912136746)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

Precondition: Make sure you don't have any other journeys that are display the badge

- [ ] Create a new journey, you should be redirected to journey edit, the journey icon on the left nav should not have a badge
- [ ] Create a new journey, refresh the page before you are redirected, visit `/journeys/[journeyId]/reports`, badge should disappear 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
