### PR TITLE
feat: action details

### DIFF
--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
@@ -183,11 +183,11 @@ export function CardPreview({
               type: 'SetJourneyEditContentAction',
               component: ActiveJourneyEditContent.Action
             })
+            // remove this dispatch once merge with actions table
             dispatch({
               type: 'SetDrawerPropsAction',
               mobileOpen: true,
-              // remove url once merge with action details
-              // update url to see editor and cards function
+              title: 'Goal Details',
               children: <ActionDetails url="https://www.google.com/" />
             })
           }}

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.tsx
@@ -195,7 +195,7 @@ export function CardPreview({
           borderRadius: 2,
           outline: (theme) =>
             state.journeyEditContentComponent ===
-              ActiveJourneyEditContent.Action
+            ActiveJourneyEditContent.Action
               ? `2px solid ${theme.palette.primary.main} `
               : '2px solid transparent'
         }}

--- a/apps/journeys-admin/src/components/Editor/ActionDetails/ActionCards/ActionCards.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionDetails/ActionCards/ActionCards.spec.tsx
@@ -19,7 +19,7 @@ describe('ActionCards', () => {
     expect(getByText('Appears on the cards')).toBeInTheDocument()
     expect(getByText('Button')).toBeInTheDocument()
     expect(getByText('Google link')).toBeInTheDocument()
-    expect(getByText('Sign Up')).toBeInTheDocument()
+    expect(getByText('Subscribe')).toBeInTheDocument()
     expect(getByText('Sign Up Form')).toBeInTheDocument()
   })
 })

--- a/apps/journeys-admin/src/components/Editor/ActionDetails/ActionCards/ActionCards.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionDetails/ActionCards/ActionCards.spec.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react'
+import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
+import { MockedProvider } from '@apollo/client/testing'
+import { SnackbarProvider } from 'notistack'
+import { journey } from '../data'
+import { ActionCards } from './ActionCards'
+
+describe('ActionCards', () => {
+  it('should render action cards', () => {
+    const { getByText } = render(
+      <SnackbarProvider>
+        <MockedProvider>
+          <JourneyProvider value={{ journey }}>
+            <ActionCards url="https://www.google.com/" />
+          </JourneyProvider>
+        </MockedProvider>
+      </SnackbarProvider>
+    )
+    expect(getByText('Appears on the cards')).toBeInTheDocument()
+    expect(getByText('Button')).toBeInTheDocument()
+    expect(getByText('Google link')).toBeInTheDocument()
+    expect(getByText('Sign Up')).toBeInTheDocument()
+    expect(getByText('Sign Up Form')).toBeInTheDocument()
+  })
+})

--- a/apps/journeys-admin/src/components/Editor/ActionDetails/ActionCards/ActionCards.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionDetails/ActionCards/ActionCards.tsx
@@ -31,7 +31,7 @@ export function ActionCards({ url }: ActionCardsProps): ReactElement {
   const blocks = transformer(journey?.blocks as TreeBlock[]).filter(hasAction)
 
   return (
-    <Stack gap={6} sx={{ mt: 7, mb: 14 }}>
+    <Stack gap={6} sx={{ mt: 5, mb: 14 }}>
       <Box>
         <Typography variant="subtitle2" color="secondary.dark">
           Appears on the cards
@@ -44,9 +44,9 @@ export function ActionCards({ url }: ActionCardsProps): ReactElement {
         <Stack key={block.id} gap={4} direction="row">
           <Box
             sx={{
-              width: 102,
+              width: 85,
               position: 'relative',
-              height: 154,
+              height: 129,
               mb: 2,
               overflow: 'hidden',
               borderRadius: 2
@@ -55,7 +55,7 @@ export function ActionCards({ url }: ActionCardsProps): ReactElement {
             {block != null && (
               <Box
                 sx={{
-                  transform: 'scale(0.3)',
+                  transform: 'scale(0.25)',
                   transformOrigin: 'left top'
                 }}
               >

--- a/apps/journeys-admin/src/components/Editor/ActionDetails/ActionCards/ActionCards.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionDetails/ActionCards/ActionCards.tsx
@@ -31,8 +31,15 @@ export function ActionCards({ url }: ActionCardsProps): ReactElement {
   const blocks = transformer(journey?.blocks as TreeBlock[]).filter(hasAction)
 
   return (
-    <>
-      <Typography>It appears on following cards and elements: </Typography>
+    <Stack gap={6} sx={{ mt: 7, mb: 14 }}>
+      <Box>
+        <Typography variant="subtitle2" color="secondary.dark">
+          Appears on the cards
+        </Typography>
+        <Typography variant="caption" sx={{ opacity: 0.5 }}>
+          Once you replace the URL it will apply on each of the following cards:
+        </Typography>
+      </Box>
       {blocks?.map((block) => (
         <Stack key={block.id} gap={4} direction="row">
           <Box
@@ -74,7 +81,7 @@ export function ActionCards({ url }: ActionCardsProps): ReactElement {
           <ActionCardsDetail block={block} url={url} />
         </Stack>
       ))}
-    </>
+    </Stack>
   )
 }
 
@@ -101,16 +108,25 @@ function ActionCardsDetail({
   const actionBlock = findBlockWithAction(block)
 
   let blockType: string | undefined
+  let label: string | undefined
+  const buttonBlock = actionBlock as ButtonBlock
 
   switch (actionBlock?.__typename) {
     case 'TextResponseBlock':
       blockType = 'Text'
+      label = actionBlock?.submitLabel ?? ''
       break
     case 'RadioOptionBlock':
       blockType = 'Poll'
+      label = actionBlock?.label ?? ''
+      break
+    case 'SignUpBlock':
+      blockType = 'Sign Up'
+      label = actionBlock?.submitLabel ?? ''
       break
     default:
-      blockType = actionBlock?.__typename.replace('Block', '')
+      blockType = buttonBlock?.__typename.replace('Block', '')
+      label = buttonBlock?.label ?? ''
       break
   }
 
@@ -119,9 +135,7 @@ function ActionCardsDetail({
       <Typography variant="subtitle2" color="text.secondary">
         {blockType}
       </Typography>
-      <Typography variant="subtitle1">
-        {(actionBlock as ButtonBlock)?.label}
-      </Typography>
+      <Typography variant="subtitle1">{label}</Typography>
     </Stack>
   )
 }

--- a/apps/journeys-admin/src/components/Editor/ActionDetails/ActionCards/ActionCards.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionDetails/ActionCards/ActionCards.tsx
@@ -8,6 +8,7 @@ import type { TreeBlock } from '@core/journeys/ui/block'
 import { transformer } from '@core/journeys/ui/transformer'
 import Typography from '@mui/material/Typography'
 import Stack from '@mui/material/Stack'
+import { ActiveFab, useEditor } from '@core/journeys/ui/EditorProvider'
 import { FramePortal } from '../../../FramePortal'
 import { ThemeMode, ThemeName } from '../../../../../__generated__/globalTypes'
 import {
@@ -21,6 +22,7 @@ interface ActionCardsProps {
 
 export function ActionCards({ url }: ActionCardsProps): ReactElement {
   const { journey } = useJourney()
+  const { dispatch } = useEditor()
   const { rtl } = getJourneyRTL(journey)
 
   function hasAction(block: TreeBlock): boolean {
@@ -29,6 +31,11 @@ export function ActionCards({ url }: ActionCardsProps): ReactElement {
     return block.children?.some(hasAction)
   }
   const blocks = transformer(journey?.blocks as TreeBlock[]).filter(hasAction)
+
+  function handleClick(step): void {
+    dispatch({ type: 'SetSelectedStepAction', step })
+    dispatch({ type: 'SetActiveFabAction', activeFab: ActiveFab.Add })
+  }
 
   return (
     <Stack gap={6} sx={{ mt: 5, mb: 14 }}>
@@ -51,6 +58,7 @@ export function ActionCards({ url }: ActionCardsProps): ReactElement {
               overflow: 'hidden',
               borderRadius: 2
             }}
+            onClick={() => handleClick(block)}
           >
             {block != null && (
               <Box
@@ -113,7 +121,7 @@ function ActionCardsDetail({
 
   switch (actionBlock?.__typename) {
     case 'TextResponseBlock':
-      blockType = 'Text'
+      blockType = 'Feedback'
       label = actionBlock?.submitLabel ?? ''
       break
     case 'RadioOptionBlock':
@@ -121,7 +129,7 @@ function ActionCardsDetail({
       label = actionBlock?.label ?? ''
       break
     case 'SignUpBlock':
-      blockType = 'Sign Up'
+      blockType = 'Subscribe'
       label = actionBlock?.submitLabel ?? ''
       break
     default:
@@ -135,7 +143,7 @@ function ActionCardsDetail({
       <Typography variant="subtitle2" color="text.secondary">
         {blockType}
       </Typography>
-      <Typography variant="subtitle1">{label}</Typography>
+      <Typography variant="subtitle2">{label}</Typography>
     </Stack>
   )
 }

--- a/apps/journeys-admin/src/components/Editor/ActionDetails/ActionCards/ActionCards.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionDetails/ActionCards/ActionCards.tsx
@@ -67,6 +67,16 @@ export function ActionCards({ url }: ActionCardsProps): ReactElement {
                   transformOrigin: 'left top'
                 }}
               >
+                <Box
+                  sx={{
+                    position: 'absolute',
+                    display: 'block',
+                    width: 340,
+                    height: 520,
+                    zIndex: 2,
+                    cursor: 'pointer'
+                  }}
+                />
                 <FramePortal width={340} height={520} dir={rtl ? 'rtl' : 'ltr'}>
                   <ThemeProvider
                     themeName={journey?.themeName ?? ThemeName.base}

--- a/apps/journeys-admin/src/components/Editor/ActionDetails/ActionDetails.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionDetails/ActionDetails.spec.tsx
@@ -1,30 +1,45 @@
 import { MockedProvider } from '@apollo/client/testing'
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 import { render } from '@testing-library/react'
+import { SnackbarProvider } from 'notistack'
 import { ActionDetails } from './ActionDetails'
 import { journey } from './data'
 
 describe('ActionDetails', () => {
   const url = 'https://www.google.com/'
-  it('should return action editor', () => {
-    const { getByDisplayValue } = render(
+
+  it('should return placeholder text', () => {
+    const { getByText } = render(
       <MockedProvider>
-        <ActionDetails url={url} />
+        <ActionDetails goalLabel={() => 'Visit a website'} />
+      </MockedProvider>
+    )
+    expect(getByText('What are Goals?')).toBeInTheDocument()
+    expect(getByText('Start a conversation')).toBeInTheDocument()
+    expect(getByText('Visit a website')).toBeInTheDocument()
+    expect(getByText('Link to Bible')).toBeInTheDocument()
+  })
+
+  it('should return action editor', () => {
+    const { getByDisplayValue, getByText } = render(
+      <MockedProvider>
+        <ActionDetails url={url} goalLabel={() => 'Visit a website'} />
       </MockedProvider>
     )
     expect(getByDisplayValue('https://www.google.com/')).toBeInTheDocument()
+    expect(getByText('Visit a website')).toBeInTheDocument()
   })
 
   it('should return action cards', () => {
     const { getByText } = render(
-      <MockedProvider>
-        <JourneyProvider value={{ journey }}>
-          <ActionDetails url={url} />
-        </JourneyProvider>
-      </MockedProvider>
+      <SnackbarProvider>
+        <MockedProvider>
+          <JourneyProvider value={{ journey }}>
+            <ActionDetails url={url} goalLabel={() => 'Visit a website'} />
+          </JourneyProvider>
+        </MockedProvider>
+      </SnackbarProvider>
     )
-    expect(
-      getByText('It appears on following cards and elements:')
-    ).toBeInTheDocument()
+    expect(getByText('Appears on the cards')).toBeInTheDocument()
   })
 })

--- a/apps/journeys-admin/src/components/Editor/ActionDetails/ActionDetails.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionDetails/ActionDetails.stories.tsx
@@ -2,27 +2,34 @@ import { Story, Meta } from '@storybook/react'
 import { MockedProvider } from '@apollo/client/testing'
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 import { ComponentProps } from 'react'
-import { simpleComponentConfig } from '../../../libs/storybook'
+import Box from '@mui/material/Box'
+import { journeysAdminConfig } from '../../../libs/storybook'
 import { journey } from './data'
 import { ActionDetails } from '.'
 
 const ActionDetailsStory = {
-  ...simpleComponentConfig,
+  ...journeysAdminConfig,
   component: ActionDetails,
-  title: 'Journeys-Admin/Editor/ActionDetails'
+  title: 'Journeys-Admin/Editor/ActionDetails',
+  parameters: {
+    layout: 'fullscreen'
+  }
 }
 
 const Template: Story<ComponentProps<typeof ActionDetails>> = (args) => (
   <MockedProvider>
     <JourneyProvider value={{ journey }}>
-      <ActionDetails {...args} />
+      <Box sx={{ backgroundColor: 'background.paper' }}>
+        <ActionDetails {...args} />
+      </Box>
     </JourneyProvider>
   </MockedProvider>
 )
 
 export const Default = Template.bind({})
 Default.args = {
-  url: 'https://www.google.com/'
+  url: 'https://www.google.com/',
+  goalLabel: () => 'Visit a website'
 }
 
 export const Placeholder = Template.bind({})

--- a/apps/journeys-admin/src/components/Editor/ActionDetails/ActionDetails.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionDetails/ActionDetails.stories.tsx
@@ -1,6 +1,7 @@
 import { Story, Meta } from '@storybook/react'
 import { MockedProvider } from '@apollo/client/testing'
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
+import { ComponentProps } from 'react'
 import { simpleComponentConfig } from '../../../libs/storybook'
 import { journey } from './data'
 import { ActionDetails } from '.'
@@ -11,14 +12,22 @@ const ActionDetailsStory = {
   title: 'Journeys-Admin/Editor/ActionDetails'
 }
 
-const Template: Story = () => (
+const Template: Story<ComponentProps<typeof ActionDetails>> = (args) => (
   <MockedProvider>
     <JourneyProvider value={{ journey }}>
-      <ActionDetails url="https://www.google.com/" />
+      <ActionDetails {...args} />
     </JourneyProvider>
   </MockedProvider>
 )
 
 export const Default = Template.bind({})
+Default.args = {
+  url: 'https://www.google.com/'
+}
+
+export const Placeholder = Template.bind({})
+Placeholder.args = {
+  url: null
+}
 
 export default ActionDetailsStory as Meta

--- a/apps/journeys-admin/src/components/Editor/ActionDetails/ActionDetails.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionDetails/ActionDetails.tsx
@@ -1,17 +1,44 @@
 import { ReactElement } from 'react'
 import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
 import { ActionCards } from './ActionCards'
 import { ActionEditor } from './ActionEditor'
 
 interface ActionDetailsProps {
-  url: string
+  url?: string
 }
 
 export function ActionDetails({ url }: ActionDetailsProps): ReactElement {
   return (
-    <Stack gap={2} sx={{ p: 6 }}>
-      <ActionEditor url={url} />
-      <ActionCards url={url} />
-    </Stack>
+    <>
+      {url == null ? (
+        <Stack gap={2} sx={{ p: 6 }}>
+          <Typography variant="subtitle2">What are Possible Goals?</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Depending on the link you provide for the actions, the target of
+            your Journey will be determined automatically from the following
+            list:
+          </Typography>
+          <Typography variant="subtitle2">Start a conversation</Typography>
+          <Typography variant="body2" color="text.secondary">
+            If the goal is to go any chat platform
+          </Typography>
+          <Typography variant="subtitle2">Visit a website</Typography>
+          <Typography variant="body2" color="text.secondary">
+            This could be your church or ministry website, or whatever you want
+            to redirect the viewer to.
+          </Typography>
+          <Typography variant="subtitle2">Link to bible</Typography>
+          <Typography variant="body2" color="text.secondary">
+            If the target of the journey is to download the Bible
+          </Typography>
+        </Stack>
+      ) : (
+        <Stack gap={2} sx={{ p: 6 }}>
+          <ActionEditor url={url} />
+          <ActionCards url={url} />
+        </Stack>
+      )}
+    </>
   )
 }

--- a/apps/journeys-admin/src/components/Editor/ActionDetails/ActionDetails.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionDetails/ActionDetails.tsx
@@ -12,7 +12,6 @@ import { ActionEditor } from './ActionEditor'
 interface ActionDetailsProps {
   url?: string
   goalLabel: () => string
-  // onSelect - go to card and edit it
 }
 
 interface GoalDescriptionProps {

--- a/apps/journeys-admin/src/components/Editor/ActionDetails/ActionDetails.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionDetails/ActionDetails.tsx
@@ -30,7 +30,7 @@ export function ActionDetails({
     description,
     icon
   }: GoalDescriptionProps): ReactElement => (
-    <Stack direction="row" gap={2.5}>
+    <Stack direction="row" gap={2.5} sx={{ pb: 2 }}>
       {icon}
       <Stack direction="column">
         <Typography variant="subtitle2" gutterBottom sx={{ pt: 0.5 }}>

--- a/apps/journeys-admin/src/components/Editor/ActionDetails/ActionDetails.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionDetails/ActionDetails.tsx
@@ -1,44 +1,83 @@
-import { ReactElement } from 'react'
+import { ReactElement, ReactNode } from 'react'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
+import Divider from '@mui/material/Divider'
+import Box from '@mui/material/Box'
+import QuestionAnswerOutlined from '@mui/icons-material/QuestionAnswerOutlined'
+import WebOutlined from '@mui/icons-material/WebOutlined'
+import MenuBookRounded from '@mui/icons-material/MenuBookRounded'
 import { ActionCards } from './ActionCards'
 import { ActionEditor } from './ActionEditor'
 
 interface ActionDetailsProps {
   url?: string
+  goalLabel: () => string
+  // onSelect - go to card and edit it
 }
 
-export function ActionDetails({ url }: ActionDetailsProps): ReactElement {
+interface GoalDescriptionProps {
+  label: string
+  description: string
+  icon: ReactNode
+}
+
+export function ActionDetails({
+  url,
+  goalLabel
+}: ActionDetailsProps): ReactElement {
+  const GoalDescription = ({
+    label,
+    description,
+    icon
+  }: GoalDescriptionProps): ReactElement => (
+    <Stack direction="row" gap={2.5}>
+      {icon}
+      <Stack direction="column">
+        <Typography variant="subtitle2" gutterBottom sx={{ pt: 0.5 }}>
+          {label}
+        </Typography>
+        <Typography variant="caption" color="secondary.light" gutterBottom>
+          {description}
+        </Typography>
+      </Stack>
+    </Stack>
+  )
+
   return (
-    <>
+    <Box sx={{ overflow: 'auto', height: '100%' }}>
       {url == null ? (
         <Stack gap={2} sx={{ p: 6 }}>
-          <Typography variant="subtitle2">What are Possible Goals?</Typography>
-          <Typography variant="body2" color="text.secondary">
+          <Typography variant="subtitle2" color="secondary.dark">
+            What are Goals?
+          </Typography>
+          <Typography variant="body1" color="secondary.light">
             Depending on the link you provide for the actions, the target of
             your Journey will be determined automatically from the following
             list:
           </Typography>
-          <Typography variant="subtitle2">Start a conversation</Typography>
-          <Typography variant="body2" color="text.secondary">
-            If the goal is to go any chat platform
-          </Typography>
-          <Typography variant="subtitle2">Visit a website</Typography>
-          <Typography variant="body2" color="text.secondary">
-            This could be your church or ministry website, or whatever you want
-            to redirect the viewer to.
-          </Typography>
-          <Typography variant="subtitle2">Link to bible</Typography>
-          <Typography variant="body2" color="text.secondary">
-            If the target of the journey is to download the Bible
-          </Typography>
+          <Divider sx={{ my: 2 }} />
+          <GoalDescription
+            label="Start a conversation"
+            description="If the goal is to go any chat platform"
+            icon={<QuestionAnswerOutlined />}
+          />
+          <GoalDescription
+            label="Visit a website"
+            description="This could be your church or ministry website, or whatever you want to redirect the viewer to."
+            icon={<WebOutlined />}
+          />
+          <GoalDescription
+            label="Link to Bible"
+            description="If the target of the journey is to download the Bible"
+            icon={<MenuBookRounded />}
+          />
         </Stack>
       ) : (
-        <Stack gap={2} sx={{ p: 6 }}>
-          <ActionEditor url={url} />
+        <Stack gap={2} sx={{ px: 6, pb: 6 }}>
+          <ActionEditor url={url} goalLabel={goalLabel?.()} />
           <ActionCards url={url} />
         </Stack>
       )}
-    </>
+    </Box>
   )
 }

--- a/apps/journeys-admin/src/components/Editor/ActionDetails/ActionEditor/ActionEditor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionDetails/ActionEditor/ActionEditor.spec.tsx
@@ -10,13 +10,13 @@ describe('ActionDetails', () => {
     const url =
       'https://www.youtube.com/watch?v=ga057VTHdP0&list=RDga057VTHdP0&start_radio=1'
 
-    const buttonBlock1 = journey.blocks?.[2]
-    const buttonBlock2 = journey.blocks?.[6]
+    const buttonBlock = journey.blocks?.[2]
+    const signUpBlock = journey.blocks?.[6]
 
     const result1 = jest.fn(() => ({
       data: {
         blockUpdateLinkAction: {
-          id: buttonBlock1?.id,
+          id: buttonBlock?.id,
           gtmEventName: 'gtmEventName',
           url
         }
@@ -26,7 +26,7 @@ describe('ActionDetails', () => {
     const result2 = jest.fn(() => ({
       data: {
         blockUpdateLinkAction: {
-          id: buttonBlock2?.id,
+          id: signUpBlock?.id,
           gtmEventName: 'gtmEventName',
           url
         }
@@ -40,7 +40,7 @@ describe('ActionDetails', () => {
             request: {
               query: MULTIPLE_LINK_ACTION_UPDATE,
               variables: {
-                id: buttonBlock1?.id,
+                id: buttonBlock?.id,
                 journeyId: 'journeyId',
                 input: {
                   url
@@ -53,7 +53,7 @@ describe('ActionDetails', () => {
             request: {
               query: MULTIPLE_LINK_ACTION_UPDATE,
               variables: {
-                id: buttonBlock2?.id,
+                id: signUpBlock?.id,
                 journeyId: 'journeyId',
                 input: {
                   url
@@ -65,7 +65,10 @@ describe('ActionDetails', () => {
         ]}
       >
         <JourneyProvider value={{ journey }}>
-          <ActionEditor url="https://www.google.com/" />
+          <ActionEditor
+            url="https://www.google.com/"
+            goalLabel="Visit a website"
+          />
         </JourneyProvider>
       </MockedProvider>
     )

--- a/apps/journeys-admin/src/components/Editor/ActionDetails/ActionEditor/ActionEditor.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionDetails/ActionEditor/ActionEditor.tsx
@@ -1,13 +1,18 @@
-import { ReactElement } from 'react'
+import { ReactElement, ReactNode } from 'react'
 import Box from '@mui/material/Box'
 import { Formik, Form } from 'formik'
 import InputAdornment from '@mui/material/InputAdornment'
-import InsertLinkRoundedIcon from '@mui/icons-material/InsertLinkRounded'
 import TextField from '@mui/material/TextField'
 import { noop } from 'lodash'
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import { gql, useMutation } from '@apollo/client'
 import { object, string } from 'yup'
+import Typography from '@mui/material/Typography'
+import EditRounded from '@mui/icons-material/EditRounded'
+import QuestionAnswerOutlined from '@mui/icons-material/QuestionAnswerOutlined'
+import WebOutlined from '@mui/icons-material/WebOutlined'
+import MenuBookRounded from '@mui/icons-material/MenuBookRounded'
+import Stack from '@mui/material/Stack'
 import { BlockFields_ButtonBlock as ButtonBlock } from '../../../../../__generated__/BlockFields'
 import { ActionFields_LinkAction as LinkAction } from '../../../../../__generated__/ActionFields'
 import { MultipleLinkActionUpdate } from '../../../../../__generated__/MultipleLinkActionUpdate'
@@ -27,9 +32,13 @@ export const MULTIPLE_LINK_ACTION_UPDATE = gql`
 
 interface ActionEditorProps {
   url: string
+  goalLabel: string
 }
 
-export function ActionEditor({ url }: ActionEditorProps): ReactElement {
+export function ActionEditor({
+  url,
+  goalLabel
+}: ActionEditorProps): ReactElement {
   const { journey } = useJourney()
 
   const blocks = (journey?.blocks ?? [])
@@ -73,8 +82,25 @@ export function ActionEditor({ url }: ActionEditorProps): ReactElement {
     })
   }
 
+  let icon: ReactNode
+  switch (goalLabel) {
+    case 'Start a conversation':
+      icon = <QuestionAnswerOutlined />
+      break
+    case 'Link to bible':
+      icon = <MenuBookRounded />
+      break
+    default:
+      icon = <WebOutlined />
+      break
+  }
+
   return (
     <Box sx={{ pt: 8 }}>
+      <Stack gap={2} direction="row" alignItems="center" sx={{ pb: 2.5 }}>
+        {icon}
+        <Typography variant="subtitle2">{goalLabel}</Typography>
+      </Stack>
       <Formik
         initialValues={{
           link: url ?? ''
@@ -89,15 +115,15 @@ export function ActionEditor({ url }: ActionEditorProps): ReactElement {
               id="link"
               name="link"
               variant="filled"
-              label="Paste URL here..."
+              label="Navigate to"
               fullWidth
               value={values.link}
               error={touched.link === true && Boolean(errors.link)}
               helperText={touched.link === true && errors.link}
               InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <InsertLinkRoundedIcon />
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <EditRounded sx={{ color: 'divider' }} />
                   </InputAdornment>
                 )
               }}

--- a/apps/journeys-admin/src/components/Editor/ActionDetails/ActionEditor/ActionEditor.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionDetails/ActionEditor/ActionEditor.tsx
@@ -85,22 +85,18 @@ export function ActionEditor({
   let icon: ReactNode
   switch (goalLabel) {
     case 'Start a conversation':
-      icon = <QuestionAnswerOutlined />
+      icon = <QuestionAnswerOutlined sx={{ color: 'secondary.light' }} />
       break
     case 'Link to bible':
-      icon = <MenuBookRounded />
+      icon = <MenuBookRounded sx={{ color: 'secondary.light' }} />
       break
     default:
-      icon = <WebOutlined />
+      icon = <WebOutlined sx={{ color: 'secondary.light' }} />
       break
   }
 
   return (
-    <Box sx={{ pt: 8 }}>
-      <Stack gap={2} direction="row" alignItems="center" sx={{ pb: 2.5 }}>
-        {icon}
-        <Typography variant="subtitle2">{goalLabel}</Typography>
-      </Stack>
+    <Box sx={{ pt: 6 }}>
       <Formik
         initialValues={{
           link: url ?? ''
@@ -136,6 +132,10 @@ export function ActionEditor({
           </Form>
         )}
       </Formik>
+      <Stack gap={2} direction="row" alignItems="center" sx={{ pt: 2.5 }}>
+        {icon}
+        <Typography variant="subtitle2">{goalLabel}</Typography>
+      </Stack>
     </Box>
   )
 }

--- a/apps/journeys-admin/src/components/Editor/ActionDetails/data.ts
+++ b/apps/journeys-admin/src/components/Editor/ActionDetails/data.ts
@@ -106,22 +106,18 @@ export const journey: Journey = {
       fullscreen: false
     },
     {
-      __typename: 'ButtonBlock',
-      id: 'button2.id',
+      id: 'signup.id',
+      __typename: 'SignUpBlock',
       parentBlockId: 'card2.id',
       parentOrder: 0,
-      label: 'Google link',
-      buttonVariant: ButtonVariant.contained,
-      buttonColor: ButtonColor.primary,
-      size: ButtonSize.medium,
-      startIconId: 'null',
-      endIconId: 'null',
+      submitLabel: 'Sign Up Form',
       action: {
         __typename: 'LinkAction',
-        parentBlockId: 'button2.id',
-        gtmEventName: null,
+        parentBlockId: 'signup.id',
+        gtmEventName: 'signup',
         url: 'https://www.google.com/'
-      }
+      },
+      submitIconId: 'icon'
     },
     {
       __typename: 'StepBlock',

--- a/apps/journeys-admin/src/components/Editor/ActionsTable/ActionsList/ActionsList.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionsTable/ActionsList/ActionsList.spec.tsx
@@ -6,7 +6,6 @@ import {
   ActiveFab,
   ActiveJourneyEditContent
 } from '@core/journeys/ui/EditorProvider'
-import { ActionDetails } from '../../ActionDetails'
 import { Actions } from '../ActionsTable'
 import { ActionsList } from './ActionsList'
 
@@ -46,20 +45,19 @@ describe('ActionsList', () => {
   })
 
   it('should render a list of actions', () => {
-    const { getByText } = render(<ActionsList actions={actions} />)
+    const { getByText } = render(
+      <ActionsList actions={actions} goalLabel={() => 'Visit a website'} />
+    )
     expect(getByText('https://www.google.com/')).toBeInTheDocument()
     expect(getByText('Visit a website')).toBeInTheDocument()
     expect(getByText(2)).toBeInTheDocument()
   })
 
   it('should dispatch on click', () => {
-    const { getByTestId } = render(<ActionsList actions={actions} />)
+    const { getByTestId } = render(
+      <ActionsList actions={actions} goalLabel={() => 'Visit a website'} />
+    )
     fireEvent.click(getByTestId('EditRoundedIcon'))
-    expect(dispatch).toHaveBeenCalledWith({
-      type: 'SetDrawerPropsAction',
-      mobileOpen: true,
-      title: 'Goal Details',
-      children: <ActionDetails url={actions[0].url} />
-    })
+    expect(dispatch).toHaveBeenCalled()
   })
 })

--- a/apps/journeys-admin/src/components/Editor/ActionsTable/ActionsList/ActionsList.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionsTable/ActionsList/ActionsList.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useEffect } from 'react'
+import { ReactElement } from 'react'
 import Typography from '@mui/material/Typography'
 import Table from '@mui/material/Table'
 import TableBody from '@mui/material/TableBody'
@@ -16,44 +16,15 @@ import type { Actions } from '../ActionsTable'
 
 interface ActionsListProps {
   actions: Actions[]
+  goalLabel: (url: string) => string
 }
 
-export function ActionsList({ actions }: ActionsListProps): ReactElement {
+export function ActionsList({
+  actions,
+  goalLabel
+}: ActionsListProps): ReactElement {
   const { dispatch } = useEditor()
   const theme = useTheme()
-
-  const goalLabel = (url: string): string => {
-    const urlObject = new URL(url)
-    switch (urlObject.hostname.replace('www.', '')) {
-      case 'm.me':
-      case 'messenger.com':
-      case 't.me':
-      case 'telegram.org':
-      case 'wa.me':
-      case 'whatsapp.com':
-      case 'vb.me':
-      case 'viber.com':
-      case 'snapchat.com':
-      case 'skype.com':
-      case 'line.me':
-      case 'vk.com':
-        return 'Start a conversation'
-      default:
-        return 'Visit a website'
-    }
-  }
-
-  useEffect(() => {
-    dispatch({
-      type: 'SetDrawerPropsAction',
-      mobileOpen: true,
-      title: 'Goal Details',
-      children: <ActionDetails url={actions[0]?.url} />
-    })
-    console.log(actions)
-    console.log('I was ran')
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
 
   return (
     <TableContainer component={Paper} sx={{ width: '95%' }}>
@@ -86,7 +57,12 @@ export function ActionsList({ actions }: ActionsListProps): ReactElement {
                       type: 'SetDrawerPropsAction',
                       mobileOpen: true,
                       title: 'Goal Details',
-                      children: <ActionDetails url={url} />
+                      children: (
+                        <ActionDetails
+                          url={url}
+                          goalLabel={() => goalLabel(url)}
+                        />
+                      )
                     })
                   }}
                 >

--- a/apps/journeys-admin/src/components/Editor/ActionsTable/ActionsTable.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionsTable/ActionsTable.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react'
+import { ReactElement, useEffect } from 'react'
 import Stack from '@mui/material/Stack'
 import Button from '@mui/material/Button'
 import {
@@ -10,6 +10,7 @@ import { ActionFields_LinkAction as LinkAction } from '../../../../__generated__
 import { BlockFields_ButtonBlock as ButtonBlock } from '../../../../__generated__/BlockFields'
 import { SocialShareAppearance } from '../Drawer/SocialShareAppearance'
 import { GetJourney_journey as Journey } from '../../../../__generated__/GetJourney'
+import { ActionDetails } from '../ActionDetails'
 import { ActionsList } from './ActionsList'
 import { ActionsBanner } from './ActionsBanner'
 
@@ -20,6 +21,10 @@ export interface Actions {
 
 export function ActionsTable(): ReactElement {
   const { journey } = useJourney()
+  const {
+    state: { steps },
+    dispatch
+  } = useEditor()
 
   function countUrls(journey: Journey | undefined): Actions[] {
     const actions = (journey?.blocks ?? [])
@@ -42,10 +47,41 @@ export function ActionsTable(): ReactElement {
 
   const actions = countUrls(journey)
 
-  const {
-    state: { steps },
-    dispatch
-  } = useEditor()
+  const goalLabel = (url: string): string => {
+    const urlObject = new URL(url)
+    switch (urlObject.hostname.replace('www.', '')) {
+      case 'm.me':
+      case 'messenger.com':
+      case 't.me':
+      case 'telegram.org':
+      case 'wa.me':
+      case 'whatsapp.com':
+      case 'vb.me':
+      case 'viber.com':
+      case 'snapchat.com':
+      case 'skype.com':
+      case 'line.me':
+      case 'vk.com':
+        return 'Start a conversation'
+      default:
+        return 'Visit a website'
+    }
+  }
+
+  useEffect(() => {
+    dispatch({
+      type: 'SetDrawerPropsAction',
+      mobileOpen: true,
+      title: actions.length > 0 ? 'Goal Details' : 'Help Information',
+      children: (
+        <ActionDetails
+          url={actions[0]?.url}
+          goalLabel={() => goalLabel(actions[0]?.url)}
+        />
+      )
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const onStartClick = (): void => {
     if (steps == null) return
@@ -65,7 +101,7 @@ export function ActionsTable(): ReactElement {
     <Stack gap={2} justifyContent="center" alignItems="center">
       <ActionsBanner hasActions={actions.length > 0} />
       {actions != null && actions.length > 0 ? (
-        <ActionsList actions={actions} />
+        <ActionsList actions={actions} goalLabel={goalLabel} />
       ) : (
         <Button variant="contained" onClick={onStartClick}>
           Start

--- a/apps/journeys-admin/src/components/Editor/Drawer/Drawer.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/Drawer.tsx
@@ -80,7 +80,8 @@ export function Drawer(): ReactElement {
         width: '328px',
         borderLeft: 1,
         borderColor: 'divider',
-        borderRadius: 0
+        borderRadius: 0,
+        overflow: 'hidden'
       }}
     >
       <DrawerContent title={title} handleDrawerToggle={handleDrawerToggle}>


### PR DESCRIPTION
# Description

This should render the currently selectedURL within the drawer and it should also renders all the cards that's currently using the URL

Any components/files changes that are connected to ActionsTable are due to change. This PR is focused only on ActionDetails

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/31822561/todos/5910004274)

# How should this PR be QA Tested?

- [ ] it should render the currently selected URL.
- [ ] if there's no selected URL, it should render the first URL from actions.
- [ ] it should render all the cards that are using the URL.
- [ ] it should render the type of block the URL is in.
- [ ] if a label is connected to the URL, it should render the label used.

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
