### PR TITLE
fix: discovery journey width

### DIFF
--- a/apps/journeys-admin/src/components/DiscoveryJourneys/EmbedJourney/EmbedJourney.tsx
+++ b/apps/journeys-admin/src/components/DiscoveryJourneys/EmbedJourney/EmbedJourney.tsx
@@ -10,7 +10,7 @@ export function EmbedJourney({ slug }: Props): ReactElement {
   const width = {
     xs: '270%',
     sm: '180%',
-    md: '133%'
+    md: '129%'
   }
 
   const mb = {


### PR DESCRIPTION
# Description

Due to change in page wrapper, missed a case on large screen sizes where the discovery journey card was misaligned

<img width="1427" alt="image" src="https://user-images.githubusercontent.com/67619008/226801407-21bf4727-c12f-420b-940b-c2cbe8780857.png">

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Right edge of the last discovery journey should align with edge of the journey card for large screen sizes (1440+)

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
