### PR TITLE
fix: add og url

### DIFF
--- a/apps/watch/src/components/VideoContentPage/VideoContentPage.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoContentPage.tsx
@@ -37,6 +37,17 @@ export function VideoContentPage(): ReactElement {
   const [openShare, setOpenShare] = useState(false)
   const [openDownload, setOpenDownload] = useState(false)
 
+  const ogSlug =
+    container !== undefined
+      ? `${container.slug}.html/${
+          variant?.slug === undefined ? '' : variant.slug
+        }.html`
+      : `${
+          variant?.slug === undefined
+            ? ''
+            : `${variant.slug.split('/')[0]}.html/${variant.slug.split('/')[1]}`
+        }.html`
+
   return (
     <>
       <NextSeo
@@ -48,7 +59,7 @@ export function VideoContentPage(): ReactElement {
           url: `${
             process.env.NEXT_PUBLIC_WATCH_URL ??
             'https://watch-jesusfilm.vercel.app'
-          }/${slug}`,
+          }/watch/${ogSlug}`,
           description: snippet[0].value ?? undefined,
           images:
             image != null


### PR DESCRIPTION
# Description

The open graph url is incorrect in watch as it links to non-existent pages so Facebook shows a 404 for all shares. This PR changes that so the OG url is accurate. 

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
