### PR TITLE
fix: respect language id

### DIFF
--- a/apps/api-videos/src/app/modules/video/video.resolver.spec.ts
+++ b/apps/api-videos/src/app/modules/video/video.resolver.spec.ts
@@ -105,26 +105,12 @@ describe('VideoResolver', () => {
 
     it('return a filtered video', async () => {
       const filteredInfo = {
-        fieldNodes: [
-          {
-            selectionSet: {
-              selections: [
-                {
-                  name: { value: 'variant' },
-                  arguments: [
-                    {
-                      name: { value: 'languageId' },
-                      value: { value: 'en' }
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        variableValues: {
+          languageId: '529'
+        }
       }
       expect(await resolver.video(filteredInfo, '20615')).toEqual(video)
-      expect(service.getVideo).toHaveBeenCalledWith('20615', 'en')
+      expect(service.getVideo).toHaveBeenCalledWith('20615', '529')
     })
 
     it('should return video with slug as idtype', async () => {

--- a/apps/api-videos/src/app/modules/video/video.resolver.ts
+++ b/apps/api-videos/src/app/modules/video/video.resolver.ts
@@ -47,13 +47,12 @@ export class VideoResolver {
     @Args('id') id: string,
     @Args('idType') idType: IdType = IdType.databaseId
   ): Promise<Video> {
-    const variantLanguageId = info.fieldNodes[0].selectionSet.selections
-      .find(({ name }) => name.value === 'variant')
-      ?.arguments.find(({ name }) => name.value === 'languageId')?.value?.value
-
     switch (idType) {
       case IdType.databaseId:
-        return await this.videoService.getVideo(id, variantLanguageId)
+        return await this.videoService.getVideo(
+          id,
+          info.variableValues?.languageId
+        )
       case IdType.slug:
         return await this.videoService.getVideoBySlug(id)
     }


### PR DESCRIPTION
# Description

Visiting here localhost:4300/watch/api/jf/watch.html/1_jf-0-0/3934?apiSessionId=6418FEE7A1A34223 should respect 3934 language. Could swap for 529 for English.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
