### PR TITLE
refactor: image block thumbnail to image thumbnail

### DIFF
--- a/apps/journeys-admin/src/components/ImageThumbnail/ImageThumbnail.spec.tsx
+++ b/apps/journeys-admin/src/components/ImageThumbnail/ImageThumbnail.spec.tsx
@@ -1,0 +1,48 @@
+import { render } from '@testing-library/react'
+
+import { GetJourney_journey_blocks_ImageBlock as ImageBlock } from '../../../__generated__/GetJourney'
+import { ImageThumbnail } from './ImageThumbnail'
+
+const image: ImageBlock = {
+  id: 'image1.id',
+  __typename: 'ImageBlock',
+  parentBlockId: 'card.id',
+  parentOrder: 0,
+  src: 'https://example.com/image.jpg',
+  alt: 'image.jpg',
+  width: 1920,
+  height: 1080,
+  blurhash: ''
+}
+
+describe('ImageThumbnail', () => {
+  describe('No existing ImageBlock', () => {
+    it('shows placeholders on null', async () => {
+      const { getByTestId } = render(<ImageThumbnail imageSrc={null} />)
+      expect(getByTestId('imageThumbnailPlaceholder')).toBeInTheDocument()
+    })
+  })
+  describe('Existing ImageBlock', () => {
+    it('shows image', async () => {
+      const { getByRole } = render(
+        <ImageThumbnail imageSrc={image.src} imageAlt={image.alt} />
+      )
+      const img = await getByRole('img')
+      expect(img).toHaveAttribute('src', image.src)
+      expect(img).toHaveAttribute('alt', image.alt)
+    })
+  })
+  it('should show the loading circle', () => {
+    const { getByRole } = render(
+      <ImageThumbnail imageSrc={image.src} imageAlt={image.alt} loading />
+    )
+    expect(getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('should render error state', () => {
+    const { getByTestId } = render(
+      <ImageThumbnail imageSrc={image.src} imageAlt={image.alt} error />
+    )
+    expect(getByTestId('BrokenImageOutlinedIcon')).toBeInTheDocument()
+  })
+})

--- a/apps/journeys-admin/src/components/ImageThumbnail/ImageThumbnail.spec.tsx
+++ b/apps/journeys-admin/src/components/ImageThumbnail/ImageThumbnail.spec.tsx
@@ -16,13 +16,13 @@ const image: ImageBlock = {
 }
 
 describe('ImageThumbnail', () => {
-  describe('No existing ImageBlock', () => {
+  describe('No existing Image', () => {
     it('shows placeholders on null', async () => {
       const { getByTestId } = render(<ImageThumbnail imageSrc={null} />)
       expect(getByTestId('imageThumbnailPlaceholder')).toBeInTheDocument()
     })
   })
-  describe('Existing ImageBlock', () => {
+  describe('Existing Image', () => {
     it('shows image', async () => {
       const { getByRole } = render(
         <ImageThumbnail imageSrc={image.src} imageAlt={image.alt} />

--- a/apps/journeys-admin/src/components/ImageThumbnail/ImageThumbnail.stories.tsx
+++ b/apps/journeys-admin/src/components/ImageThumbnail/ImageThumbnail.stories.tsx
@@ -1,0 +1,93 @@
+import { Story, Meta } from '@storybook/react'
+import type { TreeBlock } from '@core/journeys/ui/block'
+import Box from '@mui/material/Box'
+
+import NoteAddIcon from '@mui/icons-material/NoteAdd'
+import {
+  GetJourney_journey_blocks_CardBlock as CardBlock,
+  GetJourney_journey_blocks_ImageBlock as ImageBlock
+} from '../../../__generated__/GetJourney'
+import { simpleComponentConfig } from '../../libs/storybook'
+import { ThemeMode } from '../../../__generated__/globalTypes'
+import { ImageThumbnail } from './ImageThumbnail'
+
+const ImageEditorStory = {
+  ...simpleComponentConfig,
+  component: ImageThumbnail,
+  title: 'Journeys-Admin/Editor/ImageThumbnail',
+  parameters: {
+    ...simpleComponentConfig.parameters,
+    layout: 'fullscreen'
+  }
+}
+
+const card: TreeBlock<CardBlock> = {
+  id: 'card1.id',
+  __typename: 'CardBlock',
+  parentBlockId: 'step1.id',
+  parentOrder: 0,
+  coverBlockId: null,
+  backgroundColor: null,
+  themeMode: ThemeMode.light,
+  themeName: null,
+  fullscreen: true,
+  children: []
+}
+
+const image: ImageBlock = {
+  id: 'poster1.id',
+  __typename: 'ImageBlock',
+  parentBlockId: card.id,
+  parentOrder: 0,
+  src: 'https://images.unsplash.com/photo-1558704164-ab7a0016c1f3',
+  width: 300,
+  height: 200,
+  blurhash: '',
+  alt: 'poster'
+}
+
+const Template: Story = ({ ...args }) => (
+  <Box bgcolor="white">
+    <ImageThumbnail
+      imageSrc={args.imageSrc}
+      imageAlt={args.imageAlt}
+      loading={args.loading}
+      icon={args.icon}
+      error={args.error}
+    />
+  </Box>
+)
+
+export const Default = Template.bind({})
+Default.args = {
+  imageSrc: null,
+  loading: false
+}
+
+export const ImageFromBlock = Template.bind({})
+ImageFromBlock.args = {
+  imageSrc: image.src,
+  imageAlt: image.alt,
+  loading: false
+}
+
+export const Icon = Template.bind({})
+Icon.arg = {
+  imageSrc: null,
+  icon: <NoteAddIcon />,
+  loading: false
+}
+
+export const Loading = Template.bind({})
+Loading.args = {
+  selectedBlock: image,
+  loading: true
+}
+
+export const Error = Template.bind({})
+Error.args = {
+  selectedBlock: null,
+  error: true
+}
+
+export default ImageEditorStory as Meta

--- a/apps/journeys-admin/src/components/ImageThumbnail/ImageThumbnail.tsx
+++ b/apps/journeys-admin/src/components/ImageThumbnail/ImageThumbnail.tsx
@@ -50,7 +50,12 @@ export function ImageThumbnail({
           }}
         />
       ) : (
-        <Icon data-testid="imageThumbnailPlaceholder">{icon}</Icon>
+        <Icon
+          data-testid="imageThumbnailPlaceholder"
+          sx={{ color: 'secondary.light' }}
+        >
+          {icon}
+        </Icon>
       )}
     </Box>
   )

--- a/apps/journeys-admin/src/components/ImageThumbnail/ImageThumbnail.tsx
+++ b/apps/journeys-admin/src/components/ImageThumbnail/ImageThumbnail.tsx
@@ -1,0 +1,56 @@
+import { ReactElement, ReactNode } from 'react'
+import CircularProgress from '@mui/material/CircularProgress'
+import Icon from '@mui/material/Icon'
+import BrokenImageOutlined from '@mui/icons-material/BrokenImageOutlined'
+import Box from '@mui/material/Box'
+
+interface ImageThumbnailProps {
+  imageSrc?: string | null
+  imageAlt?: string
+  loading?: boolean
+  icon: ReactNode
+  error?: boolean
+}
+
+export function ImageThumbnail({
+  imageSrc,
+  imageAlt,
+  loading,
+  icon,
+  error
+}: ImageThumbnailProps): ReactElement {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        borderRadius: 2,
+        height: 55,
+        width: 55,
+        backgroundColor: 'background.default',
+        position: 'relative',
+        justifyContent: 'center',
+        alignItems: 'center',
+        overflow: 'hidden'
+      }}
+    >
+      {loading === true ? (
+        <CircularProgress size={20} />
+      ) : error === true ? (
+        <BrokenImageOutlined sx={{ color: 'error.main' }} />
+      ) : imageSrc != null ? (
+        <Box
+          component="img"
+          src={imageSrc}
+          alt={imageAlt}
+          sx={{
+            width: 55,
+            height: 55,
+            objectFit: 'cover'
+          }}
+        />
+      ) : (
+        <Icon>{icon}</Icon>
+      )}
+    </Box>
+  )
+}

--- a/apps/journeys-admin/src/components/ImageThumbnail/ImageThumbnail.tsx
+++ b/apps/journeys-admin/src/components/ImageThumbnail/ImageThumbnail.tsx
@@ -3,12 +3,13 @@ import CircularProgress from '@mui/material/CircularProgress'
 import Icon from '@mui/material/Icon'
 import BrokenImageOutlined from '@mui/icons-material/BrokenImageOutlined'
 import Box from '@mui/material/Box'
+import NoteAddIcon from '@mui/icons-material/NoteAdd'
 
 interface ImageThumbnailProps {
   imageSrc?: string | null
   imageAlt?: string
   loading?: boolean
-  icon: ReactNode
+  icon?: ReactNode
   error?: boolean
 }
 
@@ -16,7 +17,7 @@ export function ImageThumbnail({
   imageSrc,
   imageAlt,
   loading,
-  icon,
+  icon = <NoteAddIcon />,
   error
 }: ImageThumbnailProps): ReactElement {
   return (
@@ -49,7 +50,7 @@ export function ImageThumbnail({
           }}
         />
       ) : (
-        <Icon>{icon}</Icon>
+        <Icon data-testid="imageThumbnailPlaceholder">{icon}</Icon>
       )}
     </Box>
   )

--- a/apps/journeys-admin/src/components/ImageThumbnail/index.ts
+++ b/apps/journeys-admin/src/components/ImageThumbnail/index.ts
@@ -1,0 +1,1 @@
+export { ImageThumbnail } from './ImageThumbnail'


### PR DESCRIPTION
# Description

Refactored Image Block Thumbnail in Editor to ImageThumbnail in general journeys admin component. In order to use the image thumbnail in the contained icon button.

-[ Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/31822575/todos/5935534867)

# How should this PR be QA Tested?

- [ ] Check the storybook looks accurate and has all the necessary functionality
- [ ] Check tests to ensure everything is covered

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
