### PR TITLE
fix: ignore health check logs

### DIFF
--- a/apps/api-journeys/src/app/app.module.ts
+++ b/apps/api-journeys/src/app/app.module.ts
@@ -50,6 +50,9 @@ import { TeamModule } from './modules/team/team.module'
     }),
     LoggerModule.forRoot({
       pinoHttp: {
+        autoLogging: {
+          ignore: (req) => req.url === '/.well-known/apollo/server-health'
+        },
         transport:
           process.env.NODE_ENV !== 'production'
             ? {

--- a/apps/api-languages/src/app/app.module.ts
+++ b/apps/api-languages/src/app/app.module.ts
@@ -34,6 +34,9 @@ import { CountryModule } from './modules/country/country.module'
     }),
     LoggerModule.forRoot({
       pinoHttp: {
+        autoLogging: {
+          ignore: (req) => req.url === '/.well-known/apollo/server-health'
+        },
         transport:
           process.env.NODE_ENV !== 'production'
             ? {

--- a/apps/api-media/src/app/app.module.ts
+++ b/apps/api-media/src/app/app.module.ts
@@ -32,6 +32,9 @@ import { UnsplashImageModule } from './modules/unsplash/image/image.module'
     }),
     LoggerModule.forRoot({
       pinoHttp: {
+        autoLogging: {
+          ignore: (req) => req.url === '/.well-known/apollo/server-health'
+        },
         transport:
           process.env.NODE_ENV !== 'production'
             ? {

--- a/apps/api-users/src/app/app.module.ts
+++ b/apps/api-users/src/app/app.module.ts
@@ -30,6 +30,9 @@ import { UserModule } from './modules/user/user.module'
     }),
     LoggerModule.forRoot({
       pinoHttp: {
+        autoLogging: {
+          ignore: (req) => req.url === '/.well-known/apollo/server-health'
+        },
         transport:
           process.env.NODE_ENV !== 'production'
             ? {

--- a/apps/api-videos/src/app/app.module.ts
+++ b/apps/api-videos/src/app/app.module.ts
@@ -34,6 +34,9 @@ import { VideoVariantModule } from './modules/videoVariant/videoVariant.module'
     }),
     LoggerModule.forRoot({
       pinoHttp: {
+        autoLogging: {
+          ignore: (req) => req.url === '/.well-known/apollo/server-health'
+        },
         transport:
           process.env.NODE_ENV !== 'production'
             ? {


### PR DESCRIPTION
# Description

Ignore health check logs. These should no longer show up in datadog.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged into main
