### PR TITLE
fix: schema federation 2 translation import

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,16 +28,18 @@ jobs:
       - name: NPM Install
         run: npm install --silent
       - name: NPM apollo and graphql for codegen
-        run: npm i -g apollo graphql
+        run: npm i -g apollo graphql @apollo/rover@0.10.0
       - name: Codegen
         uses: mansagroup/nrwl-nx-action@v3
         with:
           targets: codegen
           all: true
-      - name: lint and typecheck
+      - name: lint, type-check, extract-translation, subgraph-check
         uses: mansagroup/nrwl-nx-action@v3
         with:
-          targets: lint,type-check,extract-translations
+          targets: lint,type-check,extract-translations,subgraph-check
+        env:
+          APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
       - name: Prettier
         run: npx prettier --check .
       - name: lint commit messages

--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -663,6 +663,8 @@ input JourneyViewEventCreateInput
 type Language
   @join__type(graph: JOURNEYS, key: "id")
   @join__type(graph: LANGUAGES, key: "id")
+  @join__type(graph: MEDIA, key: "id")
+  @join__type(graph: USERS, key: "id")
   @join__type(graph: VIDEOS, key: "id")
 {
   id: ID!
@@ -1336,7 +1338,10 @@ enum ThemeName
 }
 
 type Translation
+  @join__type(graph: JOURNEYS)
   @join__type(graph: LANGUAGES)
+  @join__type(graph: MEDIA)
+  @join__type(graph: USERS)
   @join__type(graph: VIDEOS)
 {
   value: String!

--- a/apps/api-journeys/project.json
+++ b/apps/api-journeys/project.json
@@ -82,21 +82,19 @@
     "generate-graphql": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
-        "commands": [
-          {
-            "command": "rover subgraph introspect http://localhost:4001/graphql > apps/api-journeys/schema.graphql"
-          }
-        ]
+        "command": "rover subgraph introspect http://localhost:4001/graphql > apps/api-journeys/schema.graphql"
+      }
+    },
+    "subgraph-check": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "rover subgraph check API-GATEWAY-0zuda@current --name api-journeys --schema apps/api-journeys/schema.graphql"
       }
     },
     "fetch-secrets": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
-        "commands": [
-          {
-            "command": "DOPPLER_TOKEN=$DOPPLER_API_JOURNEYS_TOKEN doppler secrets download --no-file --format=env-no-quotes --project api-journeys > apps/api-journeys/.env"
-          }
-        ]
+        "command": "DOPPLER_TOKEN=$DOPPLER_API_JOURNEYS_TOKEN doppler secrets download --no-file --format=env-no-quotes --project api-journeys > apps/api-journeys/.env"
       }
     }
   },

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -986,7 +986,7 @@ input JourneyViewEventCreateInput {
 extend type Language
   @key(fields: "id")
 {
-  id: ID!
+  id: ID! @external
 }
 
 type JourneyViewEvent implements Event {
@@ -1838,6 +1838,12 @@ input VisitorUpdateInput {
 
   """Status of the visitor."""
   status: VisitorStatus
+}
+
+type Translation {
+  value: String!
+  language: Language!
+  primary: Boolean!
 }
 
 scalar _FieldSet

--- a/apps/api-journeys/src/app/modules/event/journey/journey.graphql
+++ b/apps/api-journeys/src/app/modules/event/journey/journey.graphql
@@ -15,7 +15,7 @@ input JourneyViewEventCreateInput {
 }
 
 extend type Language @key(fields: "id") {
-  id: ID!
+  id: ID! @external
 }
 
 type JourneyViewEvent implements Event {

--- a/apps/api-journeys/src/app/modules/journey/journey.graphql
+++ b/apps/api-journeys/src/app/modules/journey/journey.graphql
@@ -1,5 +1,5 @@
 extend type Language @key(fields: "id") {
-  id: ID!
+  id: ID! @external
 }
 
 type Journey @key(fields: "id") {

--- a/apps/api-languages/project.json
+++ b/apps/api-languages/project.json
@@ -71,21 +71,19 @@
     "generate-graphql": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
-        "commands": [
-          {
-            "command": "rover subgraph introspect http://localhost:4003/graphql > apps/api-languages/schema.graphql"
-          }
-        ]
+        "command": "rover subgraph introspect http://localhost:4003/graphql > apps/api-languages/schema.graphql"
+      }
+    },
+    "subgraph-check": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "rover subgraph check API-GATEWAY-0zuda@current --name api-languages --schema apps/api-languages/schema.graphql"
       }
     },
     "fetch-secrets": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
-        "commands": [
-          {
-            "command": "DOPPLER_TOKEN=$DOPPLER_API_LANGUAGES_TOKEN doppler secrets download --no-file --format=env-no-quotes --project api-languages > apps/api-languages/.env"
-          }
-        ]
+        "command": "DOPPLER_TOKEN=$DOPPLER_API_LANGUAGES_TOKEN doppler secrets download --no-file --format=env-no-quotes --project api-languages > apps/api-languages/.env"
       }
     }
   },

--- a/apps/api-languages/project.json
+++ b/apps/api-languages/project.json
@@ -16,11 +16,6 @@
             "glob": "**/*.graphql",
             "input": "apps/api-languages/src/app/",
             "output": "./assets"
-          },
-          {
-            "glob": "**/*.graphql",
-            "input": "libs/nest/common/src/lib/TranslationModule/",
-            "output": "./assets"
           }
         ],
         "generatePackageJson": true

--- a/apps/api-languages/src/app/app.module.ts
+++ b/apps/api-languages/src/app/app.module.ts
@@ -21,11 +21,14 @@ import { CountryModule } from './modules/country/country.module'
       typePaths:
         process.env.NODE_ENV !== 'production'
           ? [
-              join(process.cwd(), 'apps/api-languages/src/app/**/*.graphql'),
-              join(
-                process.cwd(),
-                'libs/nest/common/src/lib/TranslationModule/translation.graphql'
-              )
+              join(process.cwd(), 'apps/api-languages/src/app/**/*.graphql')
+              /* As a language is defined by this API translation.graphql
+               * is deliberately not imported:
+               * join(
+               *   process.cwd(),
+               *   'libs/nest/common/src/lib/TranslationModule/translation.graphql'
+               * )
+               */
             ]
           : [join(process.cwd(), 'assets/**/*.graphql')],
       cors: true,

--- a/apps/api-languages/src/app/modules/translation/translation.graphql
+++ b/apps/api-languages/src/app/modules/translation/translation.graphql
@@ -1,7 +1,3 @@
-extend type Language @key(fields: "id") {
-  id: ID! @external
-}
-
 type Translation {
   value: String!
   language: Language!

--- a/apps/api-media/project.json
+++ b/apps/api-media/project.json
@@ -76,21 +76,19 @@
     "generate-graphql": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
-        "commands": [
-          {
-            "command": "rover subgraph introspect http://localhost:4005/graphql > apps/api-media/schema.graphql"
-          }
-        ]
+        "command": "rover subgraph introspect http://localhost:4005/graphql > apps/api-media/schema.graphql"
+      }
+    },
+    "subgraph-check": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "rover subgraph check API-GATEWAY-0zuda@current --name api-media --schema apps/api-media/schema.graphql"
       }
     },
     "fetch-secrets": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
-        "commands": [
-          {
-            "command": "DOPPLER_TOKEN=$DOPPLER_API_MEDIA_TOKEN doppler secrets download --no-file --format=env-no-quotes --project api-media > apps/api-media/.env"
-          }
-        ]
+        "command": "DOPPLER_TOKEN=$DOPPLER_API_MEDIA_TOKEN doppler secrets download --no-file --format=env-no-quotes --project api-media > apps/api-media/.env"
       }
     }
   },

--- a/apps/api-media/schema.graphql
+++ b/apps/api-media/schema.graphql
@@ -18,6 +18,7 @@ type CloudflareImage {
 }
 
 type Query {
+  _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service!
 }
 
@@ -141,6 +142,18 @@ type UnsplashPhotoLinks {
   download_location: String!
 }
 
+extend type Language
+  @key(fields: "id")
+{
+  id: ID! @external
+}
+
+type Translation {
+  value: String!
+  language: Language!
+  primary: Boolean!
+}
+
 scalar _FieldSet
 
 scalar _Any
@@ -148,3 +161,5 @@ scalar _Any
 type _Service {
   sdl: String
 }
+
+union _Entity = Language

--- a/apps/api-users/project.json
+++ b/apps/api-users/project.json
@@ -76,21 +76,19 @@
     "generate-graphql": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
-        "commands": [
-          {
-            "command": "rover subgraph introspect http://localhost:4002/graphql > apps/api-users/schema.graphql"
-          }
-        ]
+        "command": "rover subgraph introspect http://localhost:4002/graphql > apps/api-users/schema.graphql"
+      }
+    },
+    "subgraph-check": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "rover subgraph check API-GATEWAY-0zuda@current --name api-users --schema apps/api-users/schema.graphql"
       }
     },
     "fetch-secrets": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
-        "commands": [
-          {
-            "command": "DOPPLER_TOKEN=$DOPPLER_API_USERS_TOKEN doppler secrets download --no-file --format=env-no-quotes --project api-users > apps/api-users/.env"
-          }
-        ]
+        "command": "DOPPLER_TOKEN=$DOPPLER_API_USERS_TOKEN doppler secrets download --no-file --format=env-no-quotes --project api-users > apps/api-users/.env"
       }
     }
   },

--- a/apps/api-users/schema.graphql
+++ b/apps/api-users/schema.graphql
@@ -29,6 +29,18 @@ extend type Query {
   me: User
 }
 
+extend type Language
+  @key(fields: "id")
+{
+  id: ID! @external
+}
+
+type Translation {
+  value: String!
+  language: Language!
+  primary: Boolean!
+}
+
 scalar _FieldSet
 
 scalar _Any
@@ -37,4 +49,4 @@ type _Service {
   sdl: String
 }
 
-union _Entity = User
+union _Entity = Language | User

--- a/apps/api-videos/project.json
+++ b/apps/api-videos/project.json
@@ -76,21 +76,19 @@
     "generate-graphql": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
-        "commands": [
-          {
-            "command": "rover subgraph introspect http://localhost:4004/graphql > apps/api-videos/schema.graphql"
-          }
-        ]
+        "command": "rover subgraph introspect http://localhost:4004/graphql > apps/api-videos/schema.graphql"
+      }
+    },
+    "subgraph-check": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "rover subgraph check API-GATEWAY-0zuda@current --name api-videos --schema apps/api-videos/schema.graphql"
       }
     },
     "fetch-secrets": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
-        "commands": [
-          {
-            "command": "DOPPLER_TOKEN=$DOPPLER_API_VIDEOS_TOKEN doppler secrets download --no-file --format=env-no-quotes --project api-videos > apps/api-videos/.env"
-          }
-        ]
+        "command": "DOPPLER_TOKEN=$DOPPLER_API_VIDEOS_TOKEN doppler secrets download --no-file --format=env-no-quotes --project api-videos > apps/api-videos/.env"
       }
     }
   },

--- a/apps/api-videos/schema.graphql
+++ b/apps/api-videos/schema.graphql
@@ -13,7 +13,7 @@ directive @extends on OBJECT | INTERFACE
 extend type Language
   @key(fields: "id")
 {
-  id: ID!
+  id: ID! @external
 }
 
 enum IdType {

--- a/apps/api-videos/src/app/modules/video/video.graphql
+++ b/apps/api-videos/src/app/modules/video/video.graphql
@@ -1,5 +1,5 @@
 extend type Language @key(fields: "id") {
-  id: ID!
+  id: ID! @external
 }
 
 enum IdType {


### PR DESCRIPTION
# Description

The following issues occur when defining a federation 2 compatible schema. This fixes that!

## api-videos
```
KEY_FIELDS_MISSING_EXTERNAL

Language -> A @key directive specifies the `id` field which has no matching @external field.

KEY_FIELDS_MISSING_ON_BASE

Language -> A @key selects id, but Language.id was either created or overwritten by api-journeys, not api-videos
```

## api-journeys
```
KEY_FIELDS_MISSING_EXTERNAL

Language -> A @key directive specifies the `id` field which has no matching @external field.

KEY_FIELDS_MISSING_ON_BASE

Language -> A @key selects id, but Language.id was either created or overwritten by api-journeys, not api-journeys
```

## api-languages
```
Language.id -> Field "Language.id" already exists in the schema. It cannot also be defined in this type extension. If this is meant to be an external field, add the `@external` directive.

Language.id -> Field "Language.id" already exists in the schema. It cannot also be defined in this type extension. If this is meant to be an external field, add the `@external` directive.

KEY_FIELDS_MISSING_ON_BASE

Language -> A @key selects id, but Language.id was either created or overwritten by api-journeys, not api-languages
```
