### PR TITLE
feat: reports navigation

### DIFF
--- a/apps/journeys-admin/pages/reports/journeys.tsx
+++ b/apps/journeys-admin/pages/reports/journeys.tsx
@@ -6,12 +6,11 @@ import {
   withAuthUserTokenSSR
 } from 'next-firebase-auth'
 import { NextSeo } from 'next-seo'
-import { useRouter } from 'next/router'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'react-i18next'
 import { getLaunchDarklyClient } from '@core/shared/ui/getLaunchDarklyClient'
 import Box from '@mui/material/Box'
-import { PageWrapper } from '../../src/components/PageWrapper'
+import { PageWrapper } from '../../src/components/NewPageWrapper'
 import i18nConfig from '../../next-i18next.config'
 import { MemoizedDynamicReport } from '../../src/components/DynamicPowerBiReport'
 import { JourneysReportType } from '../../__generated__/globalTypes'
@@ -19,7 +18,6 @@ import { useTermsRedirect } from '../../src/libs/useTermsRedirect/useTermsRedire
 import { ReportsNavigation } from '../../src/components/ReportsNavigation'
 
 function ReportsJourneysPage(): ReactElement {
-  const router = useRouter()
   const { t } = useTranslation('apps-journeys-admin')
   const AuthUser = useAuthUser()
 
@@ -28,11 +26,7 @@ function ReportsJourneysPage(): ReactElement {
   return (
     <>
       <NextSeo title={t('Journeys Report')} />
-      <PageWrapper
-        title={t('Journeys Report')}
-        authUser={AuthUser}
-        router={router}
-      >
+      <PageWrapper title={t('Journeys Report')} authUser={AuthUser}>
         <Box sx={{ height: 'calc(100vh - 48px)' }}>
           <ReportsNavigation selected="journeys" />
           <MemoizedDynamicReport reportType={JourneysReportType.multipleFull} />

--- a/apps/journeys-admin/pages/reports/journeys.tsx
+++ b/apps/journeys-admin/pages/reports/journeys.tsx
@@ -16,6 +16,7 @@ import i18nConfig from '../../next-i18next.config'
 import { MemoizedDynamicReport } from '../../src/components/DynamicPowerBiReport'
 import { JourneysReportType } from '../../__generated__/globalTypes'
 import { useTermsRedirect } from '../../src/libs/useTermsRedirect/useTermsRedirect'
+import { ReportsNavigation } from '../../src/components/ReportsNavigation'
 
 function ReportsJourneysPage(): ReactElement {
   const router = useRouter()
@@ -33,6 +34,7 @@ function ReportsJourneysPage(): ReactElement {
         router={router}
       >
         <Box sx={{ height: 'calc(100vh - 48px)' }}>
+          <ReportsNavigation selected="journeys" />
           <MemoizedDynamicReport reportType={JourneysReportType.multipleFull} />
         </Box>
       </PageWrapper>

--- a/apps/journeys-admin/pages/reports/visitors.tsx
+++ b/apps/journeys-admin/pages/reports/visitors.tsx
@@ -6,17 +6,15 @@ import {
   withAuthUserTokenSSR
 } from 'next-firebase-auth'
 import { NextSeo } from 'next-seo'
-import { useRouter } from 'next/router'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'react-i18next'
 import { getLaunchDarklyClient } from '@core/shared/ui/getLaunchDarklyClient'
-import { PageWrapper } from '../../src/components/PageWrapper'
+import { PageWrapper } from '../../src/components/NewPageWrapper'
 import i18nConfig from '../../next-i18next.config'
 import { useTermsRedirect } from '../../src/libs/useTermsRedirect/useTermsRedirect'
 import { ReportsNavigation } from '../../src/components/ReportsNavigation'
 
 function ReportsVisitorsPage(): ReactElement {
-  const router = useRouter()
   const { t } = useTranslation('apps-journeys-admin')
   const AuthUser = useAuthUser()
 
@@ -25,11 +23,7 @@ function ReportsVisitorsPage(): ReactElement {
   return (
     <>
       <NextSeo title={t('Visitors Report')} />
-      <PageWrapper
-        title={t('Visitors Report')}
-        authUser={AuthUser}
-        router={router}
-      >
+      <PageWrapper title={t('Visitors Report')} authUser={AuthUser}>
         <ReportsNavigation selected="visitors" />
         Visitors report list
       </PageWrapper>

--- a/apps/journeys-admin/pages/reports/visitors.tsx
+++ b/apps/journeys-admin/pages/reports/visitors.tsx
@@ -13,6 +13,7 @@ import { getLaunchDarklyClient } from '@core/shared/ui/getLaunchDarklyClient'
 import { PageWrapper } from '../../src/components/PageWrapper'
 import i18nConfig from '../../next-i18next.config'
 import { useTermsRedirect } from '../../src/libs/useTermsRedirect/useTermsRedirect'
+import { ReportsNavigation } from '../../src/components/ReportsNavigation'
 
 function ReportsVisitorsPage(): ReactElement {
   const router = useRouter()
@@ -29,6 +30,7 @@ function ReportsVisitorsPage(): ReactElement {
         authUser={AuthUser}
         router={router}
       >
+        <ReportsNavigation selected="visitors" />
         Visitors report list
       </PageWrapper>
     </>

--- a/apps/journeys-admin/src/components/ReportsNavigation/NavigationButton/NavigationButton.spec.tsx
+++ b/apps/journeys-admin/src/components/ReportsNavigation/NavigationButton/NavigationButton.spec.tsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react'
+import { NavigationButton } from '.'
+
+describe('NavigationButton', () => {
+  it('should be selected', () => {
+    const { getByRole } = render(
+      <NavigationButton selected value="value" link="/some/link" />
+    )
+    expect(getByRole('link', { name: 'value' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+  })
+
+  it('should have link', () => {
+    const { getByRole } = render(
+      <NavigationButton selected value="value" link="/some/link" />
+    )
+    expect(getByRole('link', { name: 'value' })).toHaveAttribute(
+      'href',
+      '/some/link'
+    )
+  })
+})

--- a/apps/journeys-admin/src/components/ReportsNavigation/NavigationButton/NavigationButton.stories.tsx
+++ b/apps/journeys-admin/src/components/ReportsNavigation/NavigationButton/NavigationButton.stories.tsx
@@ -1,0 +1,35 @@
+import { Meta, Story } from '@storybook/react'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { simpleComponentConfig } from '../../../libs/storybook'
+import { NavigationButton } from '.'
+
+const NavigationButtonStory = {
+  ...simpleComponentConfig,
+  title: 'Journeys-Admin/ReportsNavigation/NavigationButton'
+}
+
+const Template: Story = ({ ...args }) => (
+  <Stack spacing={4} sx={{ maxWidth: '300px' }}>
+    <Typography>Default Navigation Button</Typography>
+    <NavigationButton {...args.default} />
+    <Typography>Selected Navigation Button</Typography>
+    <NavigationButton {...args.selected} />
+  </Stack>
+)
+
+export const Default = Template.bind({})
+Default.args = {
+  default: {
+    selected: false,
+    value: 'default',
+    link: '/some/link'
+  },
+  selected: {
+    selected: true,
+    value: 'selected',
+    link: '/some/link'
+  }
+}
+
+export default NavigationButtonStory as Meta

--- a/apps/journeys-admin/src/components/ReportsNavigation/NavigationButton/NavigationButton.tsx
+++ b/apps/journeys-admin/src/components/ReportsNavigation/NavigationButton/NavigationButton.tsx
@@ -1,0 +1,33 @@
+import Typography from '@mui/material/Typography'
+import Button from '@mui/material/Button'
+import NextLink from 'next/link'
+import { ReactElement } from 'react'
+
+interface Props {
+  selected: boolean
+  value: string
+  link: string
+}
+
+export function NavigationButton({
+  selected,
+  value,
+  link
+}: Props): ReactElement {
+  return (
+    <NextLink href={link} passHref>
+      <Button
+        aria-selected={selected}
+        variant={selected ? 'contained' : 'outlined'}
+        sx={{
+          p: 4,
+          minWidth: '250px',
+          borderRadius: 1,
+          backgroundColor: selected ? undefined : 'background.paper'
+        }}
+      >
+        <Typography variant="subtitle1">{value}</Typography>
+      </Button>
+    </NextLink>
+  )
+}

--- a/apps/journeys-admin/src/components/ReportsNavigation/NavigationButton/index.ts
+++ b/apps/journeys-admin/src/components/ReportsNavigation/NavigationButton/index.ts
@@ -1,0 +1,1 @@
+export { NavigationButton } from './NavigationButton'

--- a/apps/journeys-admin/src/components/ReportsNavigation/ReportsNavigation.spec.tsx
+++ b/apps/journeys-admin/src/components/ReportsNavigation/ReportsNavigation.spec.tsx
@@ -1,6 +1,15 @@
 import { render } from '@testing-library/react'
 import { ReportsNavigation } from './ReportsNavigation'
 
+jest.mock('react-i18next', () => ({
+  __esModule: true,
+  useTranslation: () => {
+    return {
+      t: (str: string) => str
+    }
+  }
+}))
+
 describe('ReportsNavigation', () => {
   it('should should select journeys', () => {
     const { getByRole } = render(<ReportsNavigation selected="journeys" />)

--- a/apps/journeys-admin/src/components/ReportsNavigation/ReportsNavigation.spec.tsx
+++ b/apps/journeys-admin/src/components/ReportsNavigation/ReportsNavigation.spec.tsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react'
+import { ReportsNavigation } from './ReportsNavigation'
+
+describe('ReportsNavigation', () => {
+  it('should should select journeys', () => {
+    const { getByRole } = render(<ReportsNavigation selected="journeys" />)
+    expect(getByRole('link', { name: 'Journeys' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+    expect(getByRole('link', { name: 'Visitors' })).toHaveAttribute(
+      'aria-selected',
+      'false'
+    )
+  })
+
+  it('should should select visitors', () => {
+    const { getByRole } = render(<ReportsNavigation selected="visitors" />)
+    expect(getByRole('link', { name: 'Visitors' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+    expect(getByRole('link', { name: 'Journeys' })).toHaveAttribute(
+      'aria-selected',
+      'false'
+    )
+  })
+})

--- a/apps/journeys-admin/src/components/ReportsNavigation/ReportsNavigation.stories.tsx
+++ b/apps/journeys-admin/src/components/ReportsNavigation/ReportsNavigation.stories.tsx
@@ -1,0 +1,20 @@
+import { Meta, Story } from '@storybook/react'
+import { ComponentProps } from 'react'
+import { simpleComponentConfig } from '../../libs/storybook'
+import { ReportsNavigation } from '.'
+
+const ReportsNavigationStory = {
+  ...simpleComponentConfig,
+  title: 'Journeys-Admin/ReportsNavigation'
+}
+
+const Template: Story<ComponentProps<typeof ReportsNavigation>> = ({
+  ...args
+}) => <ReportsNavigation {...args} />
+
+export const Default = Template.bind({})
+Default.args = {
+  selected: 'journeys'
+}
+
+export default ReportsNavigationStory as Meta

--- a/apps/journeys-admin/src/components/ReportsNavigation/ReportsNavigation.tsx
+++ b/apps/journeys-admin/src/components/ReportsNavigation/ReportsNavigation.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export function ReportsNavigation({ selected }: Props): ReactElement {
   return (
-    <Stack direction="row" spacing={4} sx={{ p: 4 }}>
+    <Stack direction="row" spacing={4} sx={{ pb: 6 }}>
       <NavigationButton
         selected={selected === 'journeys'}
         value="Journeys"

--- a/apps/journeys-admin/src/components/ReportsNavigation/ReportsNavigation.tsx
+++ b/apps/journeys-admin/src/components/ReportsNavigation/ReportsNavigation.tsx
@@ -1,5 +1,6 @@
 import Stack from '@mui/material/Stack'
 import { ReactElement } from 'react'
+import { useTranslation } from 'react-i18next'
 import { NavigationButton } from './NavigationButton'
 
 interface Props {
@@ -7,16 +8,17 @@ interface Props {
 }
 
 export function ReportsNavigation({ selected }: Props): ReactElement {
+  const { t } = useTranslation('journeys-admin')
   return (
     <Stack direction="row" spacing={4} sx={{ pb: 6 }}>
       <NavigationButton
         selected={selected === 'journeys'}
-        value="Journeys"
+        value={t('Journeys')}
         link="/reports/journeys"
       />
       <NavigationButton
         selected={selected === 'visitors'}
-        value="Visitors"
+        value={t('Visitors')}
         link="/reports/visitors"
       />
     </Stack>

--- a/apps/journeys-admin/src/components/ReportsNavigation/ReportsNavigation.tsx
+++ b/apps/journeys-admin/src/components/ReportsNavigation/ReportsNavigation.tsx
@@ -1,7 +1,6 @@
 import Stack from '@mui/material/Stack'
-import Button from '@mui/material/Button'
-import NextLink from 'next/link'
 import { ReactElement } from 'react'
+import { NavigationButton } from './NavigationButton'
 
 interface Props {
   selected: 'journeys' | 'visitors'
@@ -10,16 +9,16 @@ interface Props {
 export function ReportsNavigation({ selected }: Props): ReactElement {
   return (
     <Stack direction="row" spacing={4} sx={{ p: 4 }}>
-      <NextLink href="/reports/journeys" passHref>
-        <Button variant={selected === 'journeys' ? 'contained' : 'outlined'}>
-          Journeys
-        </Button>
-      </NextLink>
-      <NextLink href="/reports/visitors" passHref>
-        <Button variant={selected === 'visitors' ? 'contained' : 'outlined'}>
-          Visitors
-        </Button>
-      </NextLink>
+      <NavigationButton
+        selected={selected === 'journeys'}
+        value="Journeys"
+        link="/reports/journeys"
+      />
+      <NavigationButton
+        selected={selected === 'visitors'}
+        value="Visitors"
+        link="/reports/visitors"
+      />
     </Stack>
   )
 }

--- a/apps/journeys-admin/src/components/ReportsNavigation/ReportsNavigation.tsx
+++ b/apps/journeys-admin/src/components/ReportsNavigation/ReportsNavigation.tsx
@@ -1,0 +1,25 @@
+import Stack from '@mui/material/Stack'
+import Button from '@mui/material/Button'
+import NextLink from 'next/link'
+import { ReactElement } from 'react'
+
+interface Props {
+  selected: 'journeys' | 'visitors'
+}
+
+export function ReportsNavigation({ selected }: Props): ReactElement {
+  return (
+    <Stack direction="row" spacing={4} sx={{ p: 4 }}>
+      <NextLink href="/reports/journeys" passHref>
+        <Button variant={selected === 'journeys' ? 'contained' : 'outlined'}>
+          Journeys
+        </Button>
+      </NextLink>
+      <NextLink href="/reports/visitors" passHref>
+        <Button variant={selected === 'visitors' ? 'contained' : 'outlined'}>
+          Visitors
+        </Button>
+      </NextLink>
+    </Stack>
+  )
+}

--- a/apps/journeys-admin/src/components/ReportsNavigation/index.ts
+++ b/apps/journeys-admin/src/components/ReportsNavigation/index.ts
@@ -1,0 +1,1 @@
+export { ReportsNavigation } from './ReportsNavigation'

--- a/libs/locales/en/journeys-admin.json
+++ b/libs/locales/en/journeys-admin.json
@@ -1,0 +1,4 @@
+{
+  "Journeys": "Journeys",
+  "Visitors": "Visitors"
+}


### PR DESCRIPTION
# Description

Adds button to navigate between journey reports and visitor reports

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/31822546/todos/5931094273)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Journeys button, should be selected when on journeys report
- [ ] Clicking on the journeys button should navigate to journeys report
- [ ] Visitors button, should be selected when on visitors report
- [ ] Clicking on the visitors button should navigate to visitors report

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
