### PR TITLE
fix: show selected typography variant when editing block

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Variant/Variant.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Typography/Variant/Variant.tsx
@@ -39,40 +39,65 @@ export function Variant(): ReactElement {
   const selectedBlock = state.selectedBlock as
     | TreeBlock<TypographyBlock>
     | undefined
+
+  const withJourneyTheme = (children): ReactElement => (
+    <ThemeProvider
+      themeName={ThemeName.base}
+      themeMode={ThemeMode.light}
+      rtl={rtl}
+      locale={locale}
+      nested
+    >
+      {children}
+    </ThemeProvider>
+  )
+
   const options = [
     {
       value: TypographyVariant.h1,
-      label: <Typography variant={TypographyVariant.h1}>Header 1</Typography>,
+      label: withJourneyTheme(
+        <Typography variant={TypographyVariant.h1}>Header 1</Typography>
+      ),
       icon: <HorizontalRuleRoundedIcon />
     },
     {
       value: TypographyVariant.h2,
-      label: <Typography variant={TypographyVariant.h2}>Header 2</Typography>,
+      label: withJourneyTheme(
+        <Typography variant={TypographyVariant.h2}>Header 2</Typography>
+      ),
       icon: <HorizontalRuleRoundedIcon />
     },
     {
       value: TypographyVariant.h3,
-      label: <Typography variant={TypographyVariant.h3}>Header 3</Typography>,
+      label: withJourneyTheme(
+        <Typography variant={TypographyVariant.h3}>Header 3</Typography>
+      ),
       icon: <HorizontalRuleRoundedIcon />
     },
     {
       value: TypographyVariant.h4,
-      label: <Typography variant={TypographyVariant.h4}>Header 4</Typography>,
+      label: withJourneyTheme(
+        <Typography variant={TypographyVariant.h4}>Header 4</Typography>
+      ),
       icon: <HorizontalRuleRoundedIcon />
     },
     {
       value: TypographyVariant.h5,
-      label: <Typography variant={TypographyVariant.h5}>Header 5</Typography>,
+      label: withJourneyTheme(
+        <Typography variant={TypographyVariant.h5}>Header 5</Typography>
+      ),
       icon: <HorizontalRuleRoundedIcon />
     },
     {
       value: TypographyVariant.h6,
-      label: <Typography variant={TypographyVariant.h6}>Header 6</Typography>,
+      label: withJourneyTheme(
+        <Typography variant={TypographyVariant.h6}>Header 6</Typography>
+      ),
       icon: <HorizontalRuleRoundedIcon />
     },
     {
       value: TypographyVariant.subtitle1,
-      label: (
+      label: withJourneyTheme(
         <Typography variant={TypographyVariant.subtitle1}>
           Subtitle 1
         </Typography>
@@ -81,7 +106,7 @@ export function Variant(): ReactElement {
     },
     {
       value: TypographyVariant.subtitle2,
-      label: (
+      label: withJourneyTheme(
         <Typography variant={TypographyVariant.subtitle2}>
           Subtitle 2
         </Typography>
@@ -90,24 +115,28 @@ export function Variant(): ReactElement {
     },
     {
       value: TypographyVariant.body1,
-      label: <Typography variant={TypographyVariant.body1}>Body 1</Typography>,
+      label: withJourneyTheme(
+        <Typography variant={TypographyVariant.body1}>Body 1</Typography>
+      ),
       icon: <HorizontalRuleRoundedIcon />
     },
     {
       value: TypographyVariant.body2,
-      label: <Typography variant={TypographyVariant.body2}>Body 2</Typography>,
+      label: withJourneyTheme(
+        <Typography variant={TypographyVariant.body2}>Body 2</Typography>
+      ),
       icon: <HorizontalRuleRoundedIcon />
     },
     {
       value: TypographyVariant.caption,
-      label: (
+      label: withJourneyTheme(
         <Typography variant={TypographyVariant.caption}>Caption</Typography>
       ),
       icon: <HorizontalRuleRoundedIcon />
     },
     {
       value: TypographyVariant.overline,
-      label: (
+      label: withJourneyTheme(
         <Typography variant={TypographyVariant.overline}>Overline</Typography>
       ),
       icon: <HorizontalRuleRoundedIcon />
@@ -134,18 +163,10 @@ export function Variant(): ReactElement {
   }
 
   return (
-    <ThemeProvider
-      themeName={ThemeName.base}
-      themeMode={ThemeMode.light}
-      rtl={rtl}
-      locale={locale}
-      nested
-    >
-      <ToggleButtonGroup
-        value={selectedBlock?.variant ?? TypographyVariant.body2}
-        onChange={handleChange}
-        options={options}
-      />
-    </ThemeProvider>
+    <ToggleButtonGroup
+      value={selectedBlock?.variant ?? TypographyVariant.body2}
+      onChange={handleChange}
+      options={options}
+    />
   )
 }


### PR DESCRIPTION
# Description

The selection background color on a toggle button group is `background.default`.  Previously adding the ThemeProvider on the whole toggle button group meant that we use the  journeys theme token which is white and so doesn't show selection at all. 

Refactor so that we just re-theme the label with the journeys theme.

[- Link to Basecamp Todo
](https://3.basecamp.com/3105655/buckets/31739517/todos/5936194572)
# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] The typography variant shows selected state
- [ ] Other typography props and button props that have similar toggle button groups continue to display correctly

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
