### PR TITLE
refactor: components to use duplicate journey hook

### DIFF
--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.spec.tsx
@@ -3,10 +3,8 @@ import { MockedProvider } from '@apollo/client/testing'
 import { SnackbarProvider } from 'notistack'
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 import { GetJourney_journey as Journey } from '../../../../../../__generated__/GetJourney'
-import {
-  DuplicateJourneyMenuItem,
-  JOURNEY_DUPLICATE
-} from './DuplicateJourneyMenuItem'
+import { DUPLICATE_JOURNEY } from '../../../../../libs/useJourneyDuplicate'
+import { DuplicateJourneyMenuItem } from './DuplicateJourneyMenuItem'
 
 describe('DuplicateJourneys', () => {
   const handleCloseMenu = jest.fn()
@@ -20,12 +18,12 @@ describe('DuplicateJourneys', () => {
         }
       }
     })
-    const { getByRole } = render(
+    const { getByRole, getByText } = render(
       <MockedProvider
         mocks={[
           {
             request: {
-              query: JOURNEY_DUPLICATE,
+              query: DUPLICATE_JOURNEY,
               variables: {
                 id: 'journeyId'
               }
@@ -51,45 +49,8 @@ describe('DuplicateJourneys', () => {
     )
     fireEvent.click(getByRole('menuitem', { name: 'Duplicate' }))
     await waitFor(() => expect(result).toHaveBeenCalled())
-  })
 
-  it('should close the menu on click', () => {
-    const { getByRole } = render(
-      <MockedProvider
-        mocks={[
-          {
-            request: {
-              query: JOURNEY_DUPLICATE,
-              variables: {
-                id: 'journeyId'
-              }
-            },
-            result: {
-              data: {
-                journeyDuplicate: {
-                  id: 'duplicatedJourneyId'
-                }
-              }
-            }
-          }
-        ]}
-      >
-        <SnackbarProvider>
-          <JourneyProvider
-            value={{
-              journey: { id: 'journeyId' } as unknown as Journey,
-              admin: true
-            }}
-          >
-            <DuplicateJourneyMenuItem
-              id="journeyId"
-              handleCloseMenu={handleCloseMenu}
-            />
-          </JourneyProvider>
-        </SnackbarProvider>
-      </MockedProvider>
-    )
-    fireEvent.click(getByRole('menuitem', { name: 'Duplicate' }))
     expect(handleCloseMenu).toHaveBeenCalled()
+    expect(getByText('Journey Duplicated')).toBeInTheDocument()
   })
 })

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.tsx
@@ -1,62 +1,33 @@
 import { ReactElement } from 'react'
 import ContentCopyRounded from '@mui/icons-material/ContentCopyRounded'
-import { gql, useMutation } from '@apollo/client'
 import { useSnackbar } from 'notistack'
-import { JourneyDuplicate } from '../../../../../../__generated__/JourneyDuplicate'
 import { MenuItem } from '../../../../MenuItem'
+import { useJourneyDuplicate } from '../../../../../libs/useJourneyDuplicate'
 
 interface DuplicateJourneyMenuItemProps {
   id?: string
   handleCloseMenu: () => void
 }
 
-export const JOURNEY_DUPLICATE = gql`
-  mutation JourneyDuplicate($id: ID!) {
-    journeyDuplicate(id: $id) {
-      id
-    }
-  }
-`
-
 export function DuplicateJourneyMenuItem({
   id,
   handleCloseMenu
 }: DuplicateJourneyMenuItemProps): ReactElement {
-  const [journeyDuplicate] = useMutation<JourneyDuplicate>(JOURNEY_DUPLICATE)
+  const { duplicateJourney } = useJourneyDuplicate()
   const { enqueueSnackbar } = useSnackbar()
 
   const handleDuplicateJourney = async (): Promise<void> => {
     if (id == null) return
 
-    await journeyDuplicate({
-      variables: {
-        id
-      },
-      update(cache, { data }) {
-        if (data?.journeyDuplicate != null) {
-          cache.modify({
-            fields: {
-              adminJourneys(existingAdminJourneyRefs = []) {
-                const duplicatedJourneyRef = cache.writeFragment({
-                  data: data.journeyDuplicate,
-                  fragment: gql`
-                    fragment DuplicatedJourney on Journey {
-                      id
-                    }
-                  `
-                })
-                return [...existingAdminJourneyRefs, duplicatedJourneyRef]
-              }
-            }
-          })
-        }
-      }
-    })
-    handleCloseMenu()
-    enqueueSnackbar(`Journey Duplicated`, {
-      variant: 'success',
-      preventDuplicate: true
-    })
+    const data = await duplicateJourney({ id })
+
+    if (data != null) {
+      handleCloseMenu()
+      enqueueSnackbar(`Journey Duplicated`, {
+        variant: 'success',
+        preventDuplicate: true
+      })
+    }
   }
 
   return (

--- a/apps/journeys-admin/src/components/JourneyView/JourneyViewFab/JourneyViewFab.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyViewFab/JourneyViewFab.spec.tsx
@@ -6,7 +6,8 @@ import { NextRouter, useRouter } from 'next/router'
 import { SnackbarProvider } from 'notistack'
 import TagManager from 'react-gtm-module'
 import { defaultJourney } from '../data'
-import { CONVERT_TEMPLATE, JourneyViewFab } from './JourneyViewFab'
+import { DUPLICATE_JOURNEY } from '../../../libs/useJourneyDuplicate'
+import { JourneyViewFab } from './JourneyViewFab'
 
 jest.mock('next/router', () => ({
   __esModule: true,
@@ -71,6 +72,7 @@ describe('JourneyViewFab', () => {
   it('should convert template to journey on use template click', async () => {
     const push = jest.fn()
     mockUseRouter.mockReturnValue({ push } as unknown as NextRouter)
+
     const result = jest.fn(() => {
       return {
         data: {
@@ -80,12 +82,13 @@ describe('JourneyViewFab', () => {
         }
       }
     })
+
     const { getByRole, getByText } = render(
       <MockedProvider
         mocks={[
           {
             request: {
-              query: CONVERT_TEMPLATE,
+              query: DUPLICATE_JOURNEY,
               variables: {
                 id: 'journey-id'
               }
@@ -106,7 +109,9 @@ describe('JourneyViewFab', () => {
       </MockedProvider>
     )
     expect(getByText('Use Template')).toBeInTheDocument()
-    fireEvent.click(getByRole('button'))
+
+    fireEvent.click(getByRole('button', { name: 'Use Template Use It' }))
+
     await waitFor(() => expect(result).toHaveBeenCalled())
     await waitFor(() => {
       expect(push).toHaveBeenCalledWith(
@@ -118,12 +123,15 @@ describe('JourneyViewFab', () => {
   })
 
   it('should send custom event to GTM when preview button is clicked', async () => {
+    const push = jest.fn()
+    mockUseRouter.mockReturnValue({ push } as unknown as NextRouter)
+
     const { getByRole } = render(
       <MockedProvider
         mocks={[
           {
             request: {
-              query: CONVERT_TEMPLATE,
+              query: DUPLICATE_JOURNEY,
               variables: {
                 id: 'journey-id'
               }
@@ -150,7 +158,8 @@ describe('JourneyViewFab', () => {
       </MockedProvider>
     )
 
-    fireEvent.click(getByRole('button'))
+    fireEvent.click(getByRole('button', { name: 'Use Template Use It' }))
+
     await waitFor(() =>
       expect(mockedDataLayer).toHaveBeenCalledWith({
         dataLayer: {

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.spec.tsx
@@ -5,7 +5,8 @@ import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 import { NextRouter, useRouter } from 'next/router'
 import { defaultJourney, publishedJourney } from '../data'
 import { JourneyStatus, Role } from '../../../../__generated__/globalTypes'
-import { APPLY_TEMPLATE, GET_ROLE } from './Menu'
+import { DUPLICATE_JOURNEY } from '../../../libs/useJourneyDuplicate'
+import { GET_ROLE } from './Menu'
 import { Menu, JOURNEY_PUBLISH } from '.'
 
 Object.assign(navigator, {
@@ -252,7 +253,7 @@ describe('JourneyView/Menu', () => {
           mocks={[
             {
               request: {
-                query: APPLY_TEMPLATE,
+                query: DUPLICATE_JOURNEY,
                 variables: {
                   id: defaultJourney.id
                 }


### PR DESCRIPTION
# Description

Refactor components to use `useJourneyDuplicate` hook.

https://3.basecamp.com/3105655/buckets/31739517/todos/5999206814

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Duplicate journey menu item still duplicates the journey 
<img width="363" alt="image" src="https://user-images.githubusercontent.com/10802634/229988864-81f9852a-36b6-4b5d-90c7-afc2678c1e67.png">

- [ ] Templates page fab & top toolbar menu item still apply/use template.

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
