### PR TITLE
fix: hide children on video content

### DIFF
--- a/apps/watch/src/components/VideoContentPage/VideoContentPage.spec.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoContentPage.spec.tsx
@@ -1,9 +1,9 @@
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { fireEvent, render /*, waitFor */ } from '@testing-library/react'
 import { SnackbarProvider } from 'notistack'
 import { MockedProvider } from '@apollo/client/testing'
 import { videos } from '../Videos/__generated__/testData'
 import { VideoProvider } from '../../libs/videoContext'
-import { getVideoChildrenMock } from '../../libs/useVideoChildren/getVideoChildrenMock'
+// import { getVideoChildrenMock } from '../../libs/useVideoChildren/getVideoChildrenMock'
 import { VideoContentPage } from '.'
 
 describe('VideoContentPage', () => {
@@ -34,23 +34,23 @@ describe('VideoContentPage', () => {
     expect(getByRole('tab', { name: 'Description' })).toBeInTheDocument()
   })
 
-  it('should render children', async () => {
-    const { getByRole } = render(
-      <MockedProvider mocks={[getVideoChildrenMock]}>
-        <SnackbarProvider>
-          <VideoProvider value={{ content: videos[0] }}>
-            <VideoContentPage />
-          </VideoProvider>
-        </SnackbarProvider>
-      </MockedProvider>
-    )
+  // it('should render children', async () => {
+  //   const { getByRole } = render(
+  //     <MockedProvider mocks={[getVideoChildrenMock]}>
+  //       <SnackbarProvider>
+  //         <VideoProvider value={{ content: videos[0] }}>
+  //           <VideoContentPage />
+  //         </VideoProvider>
+  //       </SnackbarProvider>
+  //     </MockedProvider>
+  //   )
 
-    await waitFor(() =>
-      expect(
-        getByRole('heading', { name: videos[1].title[0].value })
-      ).toBeInTheDocument()
-    )
-  })
+  //   await waitFor(() =>
+  //     expect(
+  //       getByRole('heading', { name: videos[1].title[0].value })
+  //     ).toBeInTheDocument()
+  //   )
+  // })
 
   it('should render share button', () => {
     const { getByRole } = render(

--- a/apps/watch/src/components/VideoContentPage/VideoContentPage.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoContentPage.tsx
@@ -8,8 +8,8 @@ import { PageWrapper } from '../PageWrapper'
 import { ShareDialog } from '../ShareDialog'
 import { DownloadDialog } from '../DownloadDialog'
 import { ShareButton } from '../ShareButton'
-import { useVideoChildren } from '../../libs/useVideoChildren'
-import { VideoCarousel } from '../VideoCarousel'
+// import { useVideoChildren } from '../../libs/useVideoChildren'
+// import { VideoCarousel } from '../VideoCarousel'
 import { getSlug } from '../VideoCard'
 import { VideoContent } from './VideoContent/VideoContent'
 import { DownloadButton } from './DownloadButton'
@@ -25,16 +25,16 @@ export function VideoContentPage(): ReactElement {
     snippet,
     image,
     imageAlt,
-    slug,
+    // slug,
     variant,
-    id,
+    // id,
     label,
     container,
     childrenCount
   } = useVideo()
-  const { loading, children } = useVideoChildren(
-    container?.variant?.slug ?? variant?.slug
-  )
+  // const { loading, children } = useVideoChildren(
+  //   container?.variant?.slug ?? variant?.slug
+  // )
   const [hasPlayed, setHasPlayed] = useState(false)
   const [openShare, setOpenShare] = useState(false)
   const [openDownload, setOpenDownload] = useState(false)
@@ -98,13 +98,13 @@ export function VideoContentPage(): ReactElement {
               spacing={5}
             >
               <VideoHeading
-                loading={loading}
+                // loading={loading}
                 hasPlayed={hasPlayed}
-                videos={children}
+                // videos={children}
                 onShareClick={() => setOpenShare(true)}
                 onDownloadClick={() => setOpenDownload(true)}
               />
-              {((container?.childrenCount ?? 0) > 0 || childrenCount > 0) && (
+              {/* {((container?.childrenCount ?? 0) > 0 || childrenCount > 0) && (
                 <Box pb={4}>
                   <VideoCarousel
                     loading={loading}
@@ -113,7 +113,7 @@ export function VideoContentPage(): ReactElement {
                     activeVideoId={id}
                   />
                 </Box>
-              )}
+              )} */}
             </Stack>
           </>
         }


### PR DESCRIPTION
stop calling useVideoChildren. Causing API to crash.
