### PR TITLE
fix: race condition

### DIFF
--- a/apps/journeys/src/libs/apolloClient/apolloClient.ts
+++ b/apps/journeys/src/libs/apolloClient/apolloClient.ts
@@ -4,7 +4,7 @@ import {
   NormalizedCacheObject
 } from '@apollo/client'
 import { setContext } from '@apollo/client/link/context'
-import { getAuth, signInAnonymously } from 'firebase/auth'
+import { getAuth, signInAnonymously, UserCredential } from 'firebase/auth'
 import { useMemo } from 'react'
 import { firebaseClient } from '../firebaseClient'
 import { cache } from './cache'
@@ -13,18 +13,18 @@ const httpLink = createHttpLink({
   uri: process.env.NEXT_PUBLIC_GATEWAY_URL
 })
 
+let signInPromise: Promise<UserCredential>
+
 const authLink = setContext(async (_, { headers }) => {
-  const isSsrMode = typeof window === 'undefined'
   const auth = getAuth(firebaseClient)
-  const userCredential = await signInAnonymously(auth)
+  if (signInPromise == null) signInPromise = signInAnonymously(auth)
+  const userCredential = await signInPromise
+
   const token = await userCredential.user.getIdToken()
 
-  // If this is SSR, DO NOT PASS THE REQUEST HEADERS.
-  // Just send along the authorization headers.
-  // The **correct** headers will be supplied by the `getServerSideProps` invocation of the query
   return {
     headers: {
-      ...(!isSsrMode ? headers : []),
+      ...headers,
       Authorization: token ?? ''
     }
   }


### PR DESCRIPTION
# Description

Visitors are getting duplicated the first time they interact with the journeys project, not ideal for analytics and reports. Issue caused by a race condition between journeyViewEventCreate and stepViewEventCreate. Trying out a solution to delay rendering the step block until journeyViewEvent has finished.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/31739517/todos/6010955893)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- Open a journey in the journeys project (eg fact or fiction)
- Record the id for `journeyViewEventCreate` and `stepViewEventCreate`
-  [ ] search up both events in the events table in arrango (stage), both `visitorId`'s should match

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
