### PR TITLE
fix: custom upload state

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ImageBlockEditor/CustomImage/CustomImage.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockEditor/CustomImage/CustomImage.tsx
@@ -7,6 +7,7 @@ import { ImageUpload } from './ImageUpload'
 
 interface CustomImageProps {
   onChange: (src: string) => void
+  setUploading?: (uploading?: boolean) => void
   selectedBlock: ImageBlock | null
   loading?: boolean
   error?: boolean
@@ -15,6 +16,7 @@ interface CustomImageProps {
 export function CustomImage({
   onChange,
   selectedBlock,
+  setUploading,
   loading,
   error
 }: CustomImageProps): ReactElement {
@@ -22,6 +24,7 @@ export function CustomImage({
     <Stack sx={{ bgcolor: 'background.paper' }}>
       <ImageUpload
         onChange={onChange}
+        setUploading={setUploading}
         loading={loading}
         selectedBlock={selectedBlock}
         error={error}

--- a/apps/journeys-admin/src/components/Editor/ImageBlockEditor/CustomImage/ImageUpload/ImageUpload.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockEditor/CustomImage/ImageUpload/ImageUpload.spec.tsx
@@ -156,4 +156,48 @@ describe('ImageUpload', () => {
     expect(getByTestId('CloudOffRoundedIcon')).toBeInTheDocument()
     expect(getByText('Upload Failed!'))
   })
+
+  it('should call setUploading on file drop', async () => {
+    const setUploading = jest.fn()
+    const { getByTestId, getByText } = render(
+      <MockedProvider
+        mocks={[
+          {
+            request: {
+              query: CREATE_CLOUDFLARE_UPLOAD_BY_FILE
+            },
+            result: {
+              data: {
+                createCloudflareUploadByFile: {
+                  id: 'uploadId',
+                  uploadUrl: 'https://upload.imagedelivery.net/uploadId',
+                  userId: 'userId',
+                  __typename: 'CloudflareImage'
+                }
+              }
+            }
+          }
+        ]}
+      >
+        <ImageUpload
+          onChange={jest.fn()}
+          setUploading={setUploading}
+          loading
+          selectedBlock={imageBlock}
+          error
+        />
+      </MockedProvider>
+    )
+    const inputEl = getByTestId('drop zone')
+    Object.defineProperty(inputEl, 'files', {
+      value: [
+        new File([new Blob(['file'])], 'testFile.png', {
+          type: 'image/png'
+        })
+      ]
+    })
+    fireEvent.drop(inputEl)
+    await waitFor(() => expect(setUploading).toHaveBeenCalled())
+    expect(getByText('Uploading...'))
+  })
 })

--- a/apps/journeys-admin/src/components/Editor/ImageBlockEditor/CustomImage/ImageUpload/ImageUpload.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockEditor/CustomImage/ImageUpload/ImageUpload.tsx
@@ -25,6 +25,7 @@ export const CREATE_CLOUDFLARE_UPLOAD_BY_FILE = gql`
 
 interface ImageUploadProps {
   onChange: (src: string) => void
+  setUploading?: (uploading?: boolean) => void
   selectedBlock: ImageBlock | null
   loading?: boolean
   error?: boolean
@@ -33,6 +34,7 @@ interface ImageUploadProps {
 export function ImageUpload({
   onChange,
   selectedBlock,
+  setUploading,
   loading,
   error
 }: ImageUploadProps): ReactElement {
@@ -42,6 +44,7 @@ export function ImageUpload({
 
   const onDrop = async (acceptedFiles: File[]): Promise<void> => {
     const { data } = await createCloudflareUploadByFile({})
+    setUploading?.(true)
 
     if (data?.createCloudflareUploadByFile?.uploadUrl != null) {
       const file = acceptedFiles[0]
@@ -66,6 +69,7 @@ export function ImageUpload({
         }/public`
         onChange(src)
         setTimeout(() => setSuccess(undefined), 4000)
+        setUploading?.(undefined)
       } catch (e) {
         setSuccess(false)
       }

--- a/apps/journeys-admin/src/components/Editor/ImageBlockEditor/ImageBlockEditor.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockEditor/ImageBlockEditor.tsx
@@ -31,6 +31,7 @@ export function ImageBlockEditor({
 }: ImageBlockEditorProps): ReactElement {
   const [tabValue, setTabValue] = useState(0)
   const [unsplashAuthor, setUnsplashAuthor] = useState<UnsplashAuthor>()
+  const [uploading, setUploading] = useState<boolean>()
 
   const handleTabChange = (
     _event: SyntheticEvent<Element, Event>,
@@ -85,7 +86,7 @@ export function ImageBlockEditor({
         <ImageBlockHeader
           selectedBlock={selectedBlock}
           onDelete={onDelete}
-          loading={loading}
+          loading={uploading != null ? uploading : loading}
           showAdd={showAdd}
           error={error}
           unsplashAuthor={unsplashAuthor}
@@ -123,8 +124,9 @@ export function ImageBlockEditor({
       <TabPanel name="custom" value={tabValue} index={1}>
         <CustomImage
           onChange={handleSrcChange}
+          setUploading={(upload) => setUploading(upload)}
           selectedBlock={selectedBlock}
-          loading={loading}
+          loading={uploading != null ? uploading : loading}
           error={error}
         />
       </TabPanel>


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at faf3ea2</samp>

This pull request adds a feature to the image block editor that shows the upload progress of the image file and updates the block data accordingly. It modifies the `CustomImage` and `ImageUpload` components to accept and use a `setUploading` prop, and adds a test case for the new functionality.

There's currently a delay once a user drops an image in the dropzone. The uploading text takes a while to show. This PR fixes that issue and once a users drops an image it should almost instantly show the uploading text

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/31739517/todos/5908768074)

# How should this PR be QA Tested?

- [ ] it should render the uploading text almost straightaway on image drop

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged into main
