### PR TITLE
fix: no link action issue

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ActionsTable/ActionsTable.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionsTable/ActionsTable.tsx
@@ -43,6 +43,7 @@ export function ActionsTable({ hasAction }: ActionsTableProps): ReactElement {
   if (actions.length > 1) hasAction?.(true)
 
   const goalLabel = (url: string): string => {
+    if (url === '') return ''
     const urlObject = new URL(url)
     const hostname = urlObject.hostname.replace('www.', '') // Remove 'www.' and top-level domain suffixes
     switch (hostname) {


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fb056f7</samp>

Fix invalid links in the actions table of the journey editor. Add a check for empty `url` values in `ActionsTable.tsx` and return an empty string instead of a link.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/31739517/todos/6042679069)

# How should this PR be QA Tested?

- [ ] it shouldn't render any links if users didnt add on button block creation

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fb056f7</samp>

*  Add a guard clause to return an empty string if the `url` parameter is empty in the `ActionsTable` function ([link](https://github.com/JesusFilm/core/pull/1484/files?diff=unified&w=0#diff-1e4daaaf44b8fb09b28464e3ae4c952f9fbe8e09737bec92bd5e4e9935077d36R46)). This prevents rendering an invalid link in the table of actions for each journey step in the `ActionsTable.tsx` file.
