### PR TITLE
fix: add vercel token to prod

### DIFF
--- a/apps/docs/project.json
+++ b/apps/docs/project.json
@@ -22,9 +22,9 @@
       "configurations": {
         "production": {
           "commands": [
-            "VERCEL_PROJECT_ID=$DOCS_VERCEL_PROJECT_ID npx vercel pull --environment=production",
+            "VERCEL_PROJECT_ID=$DOCS_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
             "npx vercel build",
-            "VERCEL_PROJECT_ID=$DOCS_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod > apps/docs/.vercel-url"
+            "VERCEL_PROJECT_ID=$DOCS_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN > apps/docs/.vercel-url"
           ]
         }
       }

--- a/apps/journeys-admin/project.json
+++ b/apps/journeys-admin/project.json
@@ -46,9 +46,9 @@
       "configurations": {
         "production": {
           "commands": [
-            "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel pull --environment=production",
+            "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
             "npx vercel build",
-            "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod > apps/journeys-admin/.vercel-url"
+            "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN > apps/journeys-admin/.vercel-url"
           ]
         }
       }

--- a/apps/journeys/project.json
+++ b/apps/journeys/project.json
@@ -46,9 +46,9 @@
       "configurations": {
         "production": {
           "commands": [
-            "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel pull --environment=production",
+            "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
             "npx vercel build",
-            "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod > apps/journeys/.vercel-url"
+            "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN > apps/journeys/.vercel-url"
           ]
         }
       }

--- a/apps/watch/project.json
+++ b/apps/watch/project.json
@@ -42,9 +42,9 @@
       "configurations": {
         "production": {
           "commands": [
-            "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel pull --environment=production",
+            "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
             "npx vercel build",
-            "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod > apps/watch/.vercel-url"
+            "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN > apps/watch/.vercel-url"
           ]
         }
       }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 765ab9e</samp>

Add vercel token flag to production scripts for all apps. This fixes the authentication issue when deploying to vercel from GitHub actions.

- Link to Basecamp Todo

# How should this PR be QA Tested?

This is related to prod deploys so cannot be tested.

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 765ab9e</samp>

*  Add `--token=$VERCEL_TOKEN` flag to vercel commands in production scripts for four apps to fix authentication issue when deploying from GitHub actions ([link](https://github.com/JesusFilm/core/pull/1494/files?diff=unified&w=0#diff-92d9997980c0871325f1a46a6d363cc28da597bd19ed327e979774d9e7838cabL25-R27), [link](https://github.com/JesusFilm/core/pull/1494/files?diff=unified&w=0#diff-6db2543346cb5deb37fb15d46779760691a5c6aa003df54659bd35d74f85a661L49-R51), [link](https://github.com/JesusFilm/core/pull/1494/files?diff=unified&w=0#diff-3efedbfcf2a27083cc54397746311aa1b491e5d469b75b9012baa4aca66e0b69L49-R51), [link](https://github.com/JesusFilm/core/pull/1494/files?diff=unified&w=0#diff-b08d4e805876fecd32fd77a4785c9ac3cbfe0500d0ad536f024dc697a261cc6cL45-R47))
