### PR TITLE
fix: add prod arg to vercel build

### DIFF
--- a/apps/docs/project.json
+++ b/apps/docs/project.json
@@ -23,7 +23,7 @@
         "production": {
           "commands": [
             "VERCEL_PROJECT_ID=$DOCS_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
-            "npx vercel build",
+            "npx vercel build --prod",
             "VERCEL_PROJECT_ID=$DOCS_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN > apps/docs/.vercel-url"
           ]
         }

--- a/apps/journeys-admin/project.json
+++ b/apps/journeys-admin/project.json
@@ -47,7 +47,7 @@
         "production": {
           "commands": [
             "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
-            "npx vercel build",
+            "npx vercel build --prod",
             "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN > apps/journeys-admin/.vercel-url"
           ]
         }

--- a/apps/journeys/project.json
+++ b/apps/journeys/project.json
@@ -47,7 +47,7 @@
         "production": {
           "commands": [
             "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
-            "npx vercel build",
+            "npx vercel build --prod",
             "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN > apps/journeys/.vercel-url"
           ]
         }

--- a/apps/watch/project.json
+++ b/apps/watch/project.json
@@ -43,7 +43,7 @@
         "production": {
           "commands": [
             "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
-            "npx vercel build",
+            "npx vercel build --prod",
             "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN > apps/watch/.vercel-url"
           ]
         }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ef0594</samp>

This pull request adds the `--prod` flag to the `npx vercel build` command in the `project.json` files of four apps: docs, journeys-admin, journeys, and watch. This ensures that the vercel builds are optimized for production and consistent across the apps.

- Link to Basecamp Todo

# How should this PR be QA Tested?

This cannot be qa'd as it related to production deploys.

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6ef0594</samp>

*  Add `--prod` flag to `npx vercel build` commands in `project.json` files for apps `docs`, `journeys-admin`, `journeys`, and `watch` to optimize production builds and match deployment commands ([link](https://github.com/JesusFilm/core/pull/1495/files?diff=unified&w=0#diff-92d9997980c0871325f1a46a6d363cc28da597bd19ed327e979774d9e7838cabL26-R26), [link](https://github.com/JesusFilm/core/pull/1495/files?diff=unified&w=0#diff-6db2543346cb5deb37fb15d46779760691a5c6aa003df54659bd35d74f85a661L50-R50), [link](https://github.com/JesusFilm/core/pull/1495/files?diff=unified&w=0#diff-3efedbfcf2a27083cc54397746311aa1b491e5d469b75b9012baa4aca66e0b69L50-R50), [link](https://github.com/JesusFilm/core/pull/1495/files?diff=unified&w=0#diff-b08d4e805876fecd32fd77a4785c9ac3cbfe0500d0ad536f024dc697a261cc6cL46-R46))
