### PR TITLE
fix: remove goals in template

### DIFF
--- a/apps/journeys-admin/src/components/CardPreview/CardList/CardList.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardList/CardList.tsx
@@ -86,7 +86,7 @@ export function CardList({
       footer={showAddButton === true && <AddCardSlide />}
       view={state.journeyEditContentComponent}
     >
-      {showNavigationCards && (
+      {showNavigationCards && journey?.template !== true && (
         <NavigationCard
           key="goals"
           id="goals"
@@ -113,7 +113,7 @@ export function CardList({
           loading={journey == null}
         />
       )}
-      {showNavigationCards && (
+      {showNavigationCards && journey?.template !== true && (
         <Divider
           id="cardlist-divider"
           orientation="vertical"


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c051658</samp>

Hide non-editable cards for template journeys in admin app. This change modifies the `CardList` component in `apps/journeys-admin` to exclude `NavigationCard` and `Divider` components from the preview of template journeys, since they cannot be edited by the user.

- Link to Basecamp Todo

# How should this PR be QA Tested?

- [ ] it should not render goals button in templates page

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c051658</samp>

*  Prevent rendering of `NavigationCard` and `Divider` components for template journeys in `CardList.tsx` ([link](https://github.com/JesusFilm/core/pull/1499/files?diff=unified&w=0#diff-f46f261ecacd86ac3e40df1941722bffdfb47ccc07eef05e4d08368207685f4aL89-R89), [link](https://github.com/JesusFilm/core/pull/1499/files?diff=unified&w=0#diff-f46f261ecacd86ac3e40df1941722bffdfb47ccc07eef05e4d08368207685f4aL116-R116))
