### PR TITLE
fix: deploy comments when main or stage

### DIFF
--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -101,11 +101,11 @@ jobs:
           echo "$delimiter" >> $GITHUB_OUTPUT
       - uses: mshick/add-pr-comment@v2
         if: ${{ github.event_name == 'pull_request' }}
-        name: Add deployment comment to PR
+        name: add deployment comment to pull request
         with:
           message: ${{ steps.get-comment-body.outputs.body }}
           message-id: ${{ matrix.app }}
-      - name: Create commit comment
+      - name: add deployment comment to commit
         if: ${{ github.event_name != 'pull_request' }}
         uses: peter-evans/commit-comment@v2
         with:
@@ -176,7 +176,7 @@ jobs:
           echo "body<<$delimiter" >> $GITHUB_OUTPUT
           echo "$body" >> $GITHUB_OUTPUT
           echo "$delimiter" >> $GITHUB_OUTPUT
-      - name: Create commit comment
+      - name: add deployment comment to commit
         if: ${{ github.event_name != 'pull_request' }}
         uses: peter-evans/commit-comment@v2
         with:

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -53,6 +53,7 @@ jobs:
     permissions:
       pull-requests: write
       deployments: write
+      contents: write
     steps:
       - name: start deployment
         uses: chrnorm/deployment-action@v2
@@ -129,6 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       deployments: write
+      contents: write
     steps:
       - name: start deployment
         uses: chrnorm/deployment-action@v2

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -91,12 +91,25 @@ jobs:
         env:
           APP: ${{ matrix.app }}
         run: ./tools/scripts/generate-deployment-comment.sh
+      - id: get-comment-body
+        run: |
+          body="$(cat .github/deployment_comment.md)"
+          delimiter="$(openssl rand -hex 8)"
+          echo "body<<$delimiter" >> $GITHUB_OUTPUT
+          echo "$body" >> $GITHUB_OUTPUT
+          echo "$delimiter" >> $GITHUB_OUTPUT
       - uses: mshick/add-pr-comment@v2
-        name: Add deployment comment
+        if: ${{ github.event_name == 'pull_request' }}
+        name: Add deployment comment to PR
         with:
-          message-path: .github/deployment_comment.md
+          message: ${{ steps.get-comment-body.outputs.body }}
           message-id: ${{ matrix.app }}
-      - name: update deployment
+      - name: Create commit comment
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: peter-evans/commit-comment@v2
+        with:
+          body: ${{ steps.get-comment-body.outputs.body }}
+      - name: update deployment status
         uses: chrnorm/deployment-status@v2
         if: always()
         with:
@@ -154,11 +167,18 @@ jobs:
         env:
           APP: ${{ matrix.app }}
         run: ./tools/scripts/generate-deployment-comment.sh
-      - uses: mshick/add-pr-comment@v2
-        name: Add deployment comment
+      - id: get-comment-body
+        run: |
+          body="$(cat .github/deployment_comment.md)"
+          delimiter="$(openssl rand -hex 8)"
+          echo "body<<$delimiter" >> $GITHUB_OUTPUT
+          echo "$body" >> $GITHUB_OUTPUT
+          echo "$delimiter" >> $GITHUB_OUTPUT
+      - name: Create commit comment
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: peter-evans/commit-comment@v2
         with:
-          message-path: .github/deployment_comment.md
-          message-id: ${{ matrix.app }}
+          body: ${{ steps.get-comment-body.outputs.body }}
       - name: update deployment status
         uses: chrnorm/deployment-status@v2
         if: always()


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7eb47dd</samp>

Update app-deploy and undeploy workflows to fix comment bug and improve feedback. Use a new method of passing the comment message to the `add-pr-comment` and `commit-comment` actions, and post the comment to the correct source of the trigger.

# How should this PR be QA Tested?

This will be tested on this PR and stage.

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7eb47dd</samp>

*  Modify app-deploy and undeploy workflows to use message argument instead of message-path argument for passing deployment comment to actions ([link](https://github.com/JesusFilm/core/pull/1506/files?diff=unified&w=0#diff-9e0c9c0f4afe54c489ddc47b38619a84a911c7fdae64ac8e5a48dd7bde43b95cL94-R112), [link](https://github.com/JesusFilm/core/pull/1506/files?diff=unified&w=0#diff-9e0c9c0f4afe54c489ddc47b38619a84a911c7fdae64ac8e5a48dd7bde43b95cL157-R181))
*  Add conditional logic to app-deploy and undeploy workflows to post deployment comment to pull request or commit depending on the event type ([link](https://github.com/JesusFilm/core/pull/1506/files?diff=unified&w=0#diff-9e0c9c0f4afe54c489ddc47b38619a84a911c7fdae64ac8e5a48dd7bde43b95cL94-R112), [link](https://github.com/JesusFilm/core/pull/1506/files?diff=unified&w=0#diff-9e0c9c0f4afe54c489ddc47b38619a84a911c7fdae64ac8e5a48dd7bde43b95cL157-R181))
*  Add step to app-deploy and undeploy workflows to read deployment comment file and output it to a variable ([link](https://github.com/JesusFilm/core/pull/1506/files?diff=unified&w=0#diff-9e0c9c0f4afe54c489ddc47b38619a84a911c7fdae64ac8e5a48dd7bde43b95cL94-R112), [link](https://github.com/JesusFilm/core/pull/1506/files?diff=unified&w=0#diff-9e0c9c0f4afe54c489ddc47b38619a84a911c7fdae64ac8e5a48dd7bde43b95cL157-R181))
