### PR TITLE
fix: watch serve to use underscore build

### DIFF
--- a/apps/watch/project.json
+++ b/apps/watch/project.json
@@ -2,6 +2,7 @@
   "root": "apps/watch",
   "sourceRoot": "apps/watch",
   "projectType": "application",
+  "implicitDependencies": ["locales"],
   "targets": {
     "build": {
       "executor": "@nrwl/workspace:run-commands",
@@ -52,14 +53,14 @@
     "serve": {
       "executor": "@nrwl/next:server",
       "options": {
-        "buildTarget": "watch:build",
+        "buildTarget": "watch:_build",
         "dev": true,
         "hostname": "0.0.0.0",
         "port": 4300
       },
       "configurations": {
         "production": {
-          "buildTarget": "watch:build:production",
+          "buildTarget": "watch:_build:production",
           "dev": false
         }
       }


### PR DESCRIPTION
# Description

This should fix the `nx serve watch` command.