### PR TITLE
test: disable video loop snapshot

### DIFF
--- a/apps/journeys/src/components/Conductor/Conductor.stories.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.stories.tsx
@@ -117,6 +117,9 @@ export const WithVideoLoop = Template.bind({})
 WithVideoLoop.args = {
   blocks: videoLoop
 }
+WithVideoLoop.parameters = {
+  chromatic: { disableSnapshot: true }
+}
 
 export const RTL = Template.bind({})
 RTL.args = {

--- a/apps/journeys/src/components/EmbeddedPreview/EmbeddedPreview.stories.tsx
+++ b/apps/journeys/src/components/EmbeddedPreview/EmbeddedPreview.stories.tsx
@@ -61,5 +61,8 @@ export const WithVideoLoop = Template.bind({})
 WithVideoLoop.args = {
   blocks: videoLoop
 }
+WithVideoLoop.parameters = {
+  chromatic: { disableSnapshot: true }
+}
 
 export default Demo as Meta


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cfed2c0</samp>

Disable snapshot testing for stories with video loop animation. This is to avoid flaky results in Chromatic due to the dynamic nature of the video. The parameter is added to the `WithVideoLoop` stories in the `Conductor` and `EmbeddedPreview` components.

- Link to Basecamp Todo

# How should this PR be QA Tested?

- [ ] it shouldn't take a snapshot of video loop for Conductor
- [ ] it shouldn't take a snapshot of video loop for EmbeddedPreview

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cfed2c0</samp>

* Disable snapshot testing for stories with video loop animation to avoid flaky results ([link](https://github.com/JesusFilm/core/pull/1515/files?diff=unified&w=0#diff-2ffa7076d5451181d47ce4b3b65e089e0e8e81a9cd5ed06f1bf674fab919c5c2R120-R122), [link](https://github.com/JesusFilm/core/pull/1515/files?diff=unified&w=0#diff-406a28acee10416112c2d7ad39b6270b9f52a886f95da64629690853d396831aR64-R66))
