### PR TITLE
fix: change bg color for single action

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ActionsTable/ActionsTable.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionsTable/ActionsTable.tsx
@@ -40,7 +40,7 @@ export function ActionsTable({ hasAction }: ActionsTableProps): ReactElement {
 
   const actions = countUrls(journey)
 
-  if (actions.length >= 1) hasAction?.(true)
+  actions.length >= 1 ? hasAction?.(true) : hasAction?.(false)
 
   const goalLabel = (url: string): string => {
     if (url === '') return ''

--- a/apps/journeys-admin/src/components/Editor/ActionsTable/ActionsTable.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionsTable/ActionsTable.tsx
@@ -40,7 +40,7 @@ export function ActionsTable({ hasAction }: ActionsTableProps): ReactElement {
 
   const actions = countUrls(journey)
 
-  if (actions.length > 1) hasAction?.(true)
+  if (actions.length >= 1) hasAction?.(true)
 
   const goalLabel = (url: string): string => {
     if (url === '') return ''


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ccb4317</samp>

Changed the condition for calling the `hasAction` function to check for `actions.length >= 1` instead of `actions.length > 1`.

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/32318254/todos/6051672202)

# How should this PR be QA Tested?

- it should render component as per the design

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ccb4317</samp>

* Fix a bug where the background color was white if there was only one action in the journey by changing the condition for calling the `hasAction` function ([link](https://github.com/JesusFilm/core/pull/1516/files?diff=unified&w=0#diff-1e4daaaf44b8fb09b28464e3ae4c952f9fbe8e09737bec92bd5e4e9935077d36L43-R43))
