### PR TITLE
fix: social preview margins

### DIFF
--- a/apps/journeys-admin/src/components/Editor/JourneyEdit/JourneyEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/JourneyEdit/JourneyEdit.tsx
@@ -59,6 +59,8 @@ export function JourneyEdit(): ReactElement {
               my:
                 journeyEditContentComponent === 'canvas'
                   ? 'auto'
+                  : journeyEditContentComponent === 'social'
+                  ? 'auto'
                   : journeyEditContentComponent === 'action'
                   ? 5
                   : 0


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at be80e16</samp>

Adjust editor container height for social media journeys. This change improves the user experience of editing journeys with social media content by setting the `height` of the `Editor` component to 'auto' when the content component is `social`.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] social preview should be centered

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at be80e16</samp>

*  Set editor container height to 'auto' when content component is 'social' to avoid scrolling and fit preview ([link](https://github.com/JesusFilm/core/pull/1525/files?diff=unified&w=0#diff-506a347f69b7e96aed1c0079e1cd356f13bbc6d623754bdf0e1bab028961c8c2R62-R63))
