### PR TITLE
refactor: cloudflare upload key

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
@@ -80,7 +80,7 @@ const image: TreeBlock<ImageBlock> = {
   __typename: 'ImageBlock',
   parentBlockId: card.id,
   parentOrder: 0,
-  src: 'https://imagedelivery.net/tMY86qEHFACTO8_0kAeRFA/uploadId/public',
+  src: 'https://imagedelivery.net/cloudflare-key/uploadId/public',
   alt: 'public',
   width: 1920,
   height: 1080,
@@ -130,6 +130,19 @@ const video: TreeBlock<VideoBlock> = {
 
 describe('BackgroundMediaImage', () => {
   beforeEach(() => (useMediaQuery as jest.Mock).mockImplementation(() => true))
+
+  let originalEnv
+  beforeEach(() => {
+    originalEnv = process.env
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_CLOUDFLARE_UPLOAD_KEY: 'cloudflare-key'
+    }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
 
   it('creates a new image cover block', async () => {
     const cache = new InMemoryCache()

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/ImageEdit/ImageEdit.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/ImageEdit/ImageEdit.spec.tsx
@@ -21,12 +21,25 @@ jest.mock('@mui/material/useMediaQuery', () => ({
 }))
 
 describe('ImageEdit', () => {
+  let originalEnv
+  beforeEach(() => {
+    originalEnv = process.env
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_CLOUDFLARE_UPLOAD_KEY: 'cloudflare-key'
+    }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
   const image: ImageBlock = {
     id: 'image1.id',
     __typename: 'ImageBlock',
     parentBlockId: null,
     parentOrder: 0,
-    src: 'https://imagedelivery.net/tMY86qEHFACTO8_0kAeRFA/uploadId/public',
+    src: 'https://imagedelivery.net/cloudflare-key/uploadId/public',
     alt: 'public',
     width: 1920,
     height: 1080,

--- a/apps/journeys-admin/src/components/Editor/ImageBlockEditor/CustomImage/CustomUrl/CustomUrl.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockEditor/CustomImage/CustomUrl/CustomUrl.spec.tsx
@@ -41,7 +41,7 @@ describe('CustomUrl', () => {
     fireEvent.blur(textBox)
     await waitFor(() => expect(result).toHaveBeenCalled())
     expect(onChange).toHaveBeenCalledWith(
-      'https://imagedelivery.net/tMY86qEHFACTO8_0kAeRFA/uploadId/public'
+      'https://imagedelivery.net//uploadId/public'
     )
   })
 })

--- a/apps/journeys-admin/src/components/Editor/ImageBlockEditor/CustomImage/CustomUrl/CustomUrl.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockEditor/CustomImage/CustomUrl/CustomUrl.spec.tsx
@@ -4,6 +4,19 @@ import { CREATE_CLOUDFLARE_UPLOAD_BY_URL } from './CustomUrl'
 import { CustomUrl } from '.'
 
 describe('CustomUrl', () => {
+  let originalEnv
+  beforeEach(() => {
+    originalEnv = process.env
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_CLOUDFLARE_UPLOAD_KEY: 'cloudflare-key'
+    }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
   it('should check if the mutation gets called', async () => {
     const result = jest.fn(() => ({
       data: {
@@ -41,7 +54,7 @@ describe('CustomUrl', () => {
     fireEvent.blur(textBox)
     await waitFor(() => expect(result).toHaveBeenCalled())
     expect(onChange).toHaveBeenCalledWith(
-      'https://imagedelivery.net//uploadId/public'
+      'https://imagedelivery.net/cloudflare-key/uploadId/public'
     )
   })
 })

--- a/apps/journeys-admin/src/components/Editor/ImageBlockEditor/CustomImage/CustomUrl/CustomUrl.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockEditor/CustomImage/CustomUrl/CustomUrl.tsx
@@ -39,7 +39,9 @@ export function CustomUrl({ onChange }: CustomUrlProps): ReactElement {
     })
 
     if (data?.createCloudflareUploadByUrl != null) {
-      const src = `https://imagedelivery.net/tMY86qEHFACTO8_0kAeRFA/${data?.createCloudflareUploadByUrl.id}/public`
+      const src = `https://imagedelivery.net/${
+        process.env.NEXT_PUBLIC_CLOUDFLARE_UPLOAD_KEY ?? ''
+      }/${data?.createCloudflareUploadByUrl.id}/public`
       onChange(src)
       formik.resetForm({ values: { src: '' } })
     }

--- a/apps/journeys-admin/src/components/Editor/ImageBlockEditor/CustomImage/ImageUpload/ImageUpload.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockEditor/CustomImage/ImageUpload/ImageUpload.tsx
@@ -64,9 +64,9 @@ export function ImageUpload({
           setSuccess(false)
         }
 
-        const src = `https://imagedelivery.net/tMY86qEHFACTO8_0kAeRFA/${
-          response.result.id as string
-        }/public`
+        const src = `https://imagedelivery.net/${
+          process.env.NEXT_PUBLIC_CLOUDFLARE_UPLOAD_KEY ?? ''
+        }/${response.result.id as string}/public`
         onChange(src)
         setTimeout(() => setSuccess(undefined), 4000)
         setUploading?.(undefined)

--- a/apps/journeys-admin/src/components/Editor/ImageSource/ImageSource.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageSource/ImageSource.spec.tsx
@@ -13,6 +13,19 @@ const onChange = jest.fn()
 const onDelete = jest.fn()
 
 describe('ImageSource', () => {
+  let originalEnv
+  beforeEach(() => {
+    originalEnv = process.env
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_CLOUDFLARE_UPLOAD_KEY: 'cloudflare-key'
+    }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
   beforeEach(() => (useMediaQuery as jest.Mock).mockImplementation(() => true))
 
   describe('No existing ImageBlock', () => {

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Library/VideoBlockEditorSettingsPosterLibrary.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Library/VideoBlockEditorSettingsPosterLibrary.spec.tsx
@@ -108,7 +108,7 @@ const image: ImageBlock = {
   __typename: 'ImageBlock',
   parentBlockId: video.id,
   parentOrder: 0,
-  src: 'https://imagedelivery.net/tMY86qEHFACTO8_0kAeRFA/uploadId/public',
+  src: 'https://imagedelivery.net/cloudflare-key/uploadId/public',
   alt: 'public',
   width: 1920,
   height: 1080,
@@ -119,6 +119,20 @@ const onClose = jest.fn()
 
 describe('VideoBlockEditorSettingsPosterLibrary', () => {
   beforeEach(() => (useMediaQuery as jest.Mock).mockImplementation(() => true))
+
+  let originalEnv
+  beforeEach(() => {
+    originalEnv = process.env
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_CLOUDFLARE_UPLOAD_KEY: 'cloudflare-key'
+    }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
   describe('No existing Image', () => {
     it('creates a new image poster block', async () => {
       const cache = new InMemoryCache()


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0283d56</samp>

Updated the `src` variables in the `CustomUrl` and `ImageUpload` components to use an environment variable for the Cloudflare upload key. This improves security and flexibility for the image delivery service.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/32318254/todos/6115345296)

# How should this PR be QA Tested?

- [x] it should retain current functionality for uploading custom images

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0283d56</samp>

*  Use environment variable for Cloudflare upload key in `CustomUrl` and `ImageUpload` components ([link](https://github.com/JesusFilm/core/pull/1533/files?diff=unified&w=0#diff-2f5eaaa35189cd1c83a42c9e4b1573fe242eb9027e2b298f9c9ee348cbe3bae9L42-R44), [link](https://github.com/JesusFilm/core/pull/1533/files?diff=unified&w=0#diff-71405024cf4d9f413c3f7f40ecf5bcaa55174f1123adc590b7550586dc4b8494L67-R69))
