### PR TITLE
fix: show video controls on cropped aspect ratio

### DIFF
--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -46,7 +46,6 @@ export function Video({
   objectFit
 }: TreeBlock<VideoFields>): ReactElement {
   const [loading, setLoading] = useState(true)
-  // const [touchPause, setTouchPause] = useState(false)
   const theme = useTheme()
   const {
     state: { selectedBlock }
@@ -146,12 +145,6 @@ export function Video({
     source,
     objectFit
   ])
-
-  // useEffect(() => {
-  //   if (playerRef.current != null) {
-
-  //   }
-  // })
 
   useEffect(() => {
     if (selectedBlock !== undefined) {

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -69,7 +69,7 @@ export function Video({
       playerRef.current = videojs(videoRef.current, {
         autoplay: autoplay === true,
         controls: true,
-        nativeControlsForTouch: true,
+        nativeControlsForTouch: objectFit !== VideoBlockObjectFit.zoomed,
         userActions: {
           hotkeys: true,
           doubleClick: true
@@ -134,7 +134,8 @@ export function Video({
     posterBlock,
     selectedBlock,
     blurBackground,
-    source
+    source,
+    objectFit
   ])
 
   useEffect(() => {

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -46,6 +46,7 @@ export function Video({
   objectFit
 }: TreeBlock<VideoFields>): ReactElement {
   const [loading, setLoading] = useState(true)
+  // const [touchPause, setTouchPause] = useState(false)
   const theme = useTheme()
   const {
     state: { selectedBlock }
@@ -99,6 +100,14 @@ export function Video({
           void playerRef.current?.play()
       })
 
+      playerRef.current.on('touchstart', (e) => {
+        if (playerRef.current !== undefined) {
+          if (e.target.nodeName === 'VIDEO' && !playerRef.current?.paused()) {
+            playerRef.current?.pause()
+          }
+        }
+      })
+
       if (selectedBlock === undefined) {
         // Video jumps to new time and finishes loading - occurs on autoplay
         playerRef.current.on('seeked', () => {
@@ -137,6 +146,12 @@ export function Video({
     source,
     objectFit
   ])
+
+  // useEffect(() => {
+  //   if (playerRef.current != null) {
+
+  //   }
+  // })
 
   useEffect(() => {
     if (selectedBlock !== undefined) {


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 610bb01</samp>

Enhanced the video player component in the `journeys` UI library by customizing the native controls and fit mode.

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/32318254/todos/6057657958)

# How should this PR be QA Tested?

- [ ] When a cropped aspect ratio is expected on the video, it should show display video controls

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 610bb01</samp>

*  Add `objectFit` prop to control how video is scaled to fit container (`Video.tsx`, `Video.stories.tsx`, `Video.spec.tsx`)
*  Disable native controls for touch devices when `objectFit` is `zoomed` to avoid overlap with video ([link](https://github.com/JesusFilm/core/pull/1537/files?diff=unified&w=0#diff-6dc9cc6dc88d08c752fe4265169afff94ccef2829748bdb712ecf417a9117aecL72-R72))
*  Reinitialize video player when `objectFit` prop changes to update scaling and controls ([link](https://github.com/JesusFilm/core/pull/1537/files?diff=unified&w=0#diff-6dc9cc6dc88d08c752fe4265169afff94ccef2829748bdb712ecf417a9117aecL137-R138))
