### PR TITLE
fix: remove navigation on template view

### DIFF
--- a/apps/journeys-admin/src/components/CardPreview/CardList/CardList.spec.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardList/CardList.spec.tsx
@@ -449,7 +449,7 @@ describe('CardList', () => {
     expect(getByTestId('social-preview-navigation-card')).toBeInTheDocument()
   })
 
-  it('should not ernder the goal and social navigation card if journey is a template', () => {
+  it('should not render the goal and social navigation card if journey is a template', () => {
     const { queryByTestId } = render(
       <MockedProvider>
         <JourneyProvider

--- a/apps/journeys-admin/src/components/CardPreview/CardList/CardList.spec.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardList/CardList.spec.tsx
@@ -7,10 +7,12 @@ import { BlockFields_StepBlock as StepBlock } from '../../../../__generated__/Bl
 import {
   VideoBlockSource,
   ThemeName,
-  ThemeMode
+  ThemeMode,
+  Role
 } from '../../../../__generated__/globalTypes'
 import { JourneyFields as Journey } from '../../../../__generated__/JourneyFields'
 import { SocialProvider } from '../../Editor/SocialProvider'
+import { GET_USER_ROLE } from '../../JourneyView/JourneyView'
 import { CardList } from '.'
 
 jest.mock('react-beautiful-dnd', () => ({
@@ -393,5 +395,95 @@ describe('CardList', () => {
     expect(getAllByRole('img')[0].attributes.getNamedItem('src')?.value).toBe(
       'https://images.unsplash.com/photo-1600133153574-25d98a99528c?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1600&q=80'
     )
+  })
+
+  it('should render the goal and social navigation card if journey is not a template', async () => {
+    const { getByTestId } = render(
+      <MockedProvider>
+        <SocialProvider>
+          <CardList
+            steps={steps}
+            selected={selected}
+            showAddButton
+            handleClick={jest.fn()}
+            showNavigationCards
+          />
+        </SocialProvider>
+      </MockedProvider>
+    )
+    expect(getByTestId('goals-navigation-card')).toBeInTheDocument()
+    expect(getByTestId('social-preview-navigation-card')).toBeInTheDocument()
+  })
+
+  it('should render the goal and social navigation card if the user is a publisher', () => {
+    const { getByTestId } = render(
+      <MockedProvider
+        mocks={[
+          {
+            request: {
+              query: GET_USER_ROLE
+            },
+            result: {
+              data: {
+                getUserRole: {
+                  id: 'userRoleId',
+                  roles: [Role.publisher]
+                }
+              }
+            }
+          }
+        ]}
+      >
+        <DragDropContext>
+          <CardList
+            steps={steps}
+            selected={selected}
+            droppableProvided={droppableProvided}
+            handleChange={jest.fn()}
+            showNavigationCards
+          />
+        </DragDropContext>
+      </MockedProvider>
+    )
+    expect(getByTestId('goals-navigation-card')).toBeInTheDocument()
+    expect(getByTestId('social-preview-navigation-card')).toBeInTheDocument()
+  })
+
+  it('should not ernder the goal and social navigation card if journey is a template', () => {
+    const { queryByTestId } = render(
+      <MockedProvider>
+        <JourneyProvider
+          value={{
+            journey: {
+              id: 'journeyId',
+              themeMode: ThemeMode.light,
+              themeName: ThemeName.base,
+              language: {
+                __typename: 'Language',
+                id: '529',
+                bcp47: 'en',
+                iso3: 'eng'
+              },
+              template: true
+            } as unknown as Journey,
+            admin: true
+          }}
+        >
+          <DragDropContext>
+            <CardList
+              steps={steps}
+              selected={selected}
+              droppableProvided={droppableProvided}
+              handleChange={jest.fn()}
+              showNavigationCards
+            />
+          </DragDropContext>
+        </JourneyProvider>
+      </MockedProvider>
+    )
+    expect(queryByTestId('goals-navigation-card')).not.toBeInTheDocument()
+    expect(
+      queryByTestId('social-preview-navigation-card')
+    ).not.toBeInTheDocument()
   })
 })

--- a/apps/journeys-admin/src/components/CardPreview/CardList/CardList.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardList/CardList.tsx
@@ -70,7 +70,7 @@ export function CardList({
   const isPublisher = data?.getUserRole?.roles?.includes(Role.publisher)
 
   const showNavigation =
-    (showNavigationCards && journey?.template !== true) || isPublisher
+    showNavigationCards && (journey?.template !== true || isPublisher)
 
   function AddCardSlide(): ReactElement {
     return (

--- a/apps/journeys-admin/src/components/CardPreview/CardList/CardList.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardList/CardList.tsx
@@ -23,14 +23,21 @@ import { CustomIcon } from '@core/shared/ui/CustomIcon'
 import Divider from '@mui/material/Divider'
 import Image from 'next/image'
 
+import { useQuery } from '@apollo/client'
 import { FramePortal } from '../../FramePortal'
-import { ThemeName, ThemeMode } from '../../../../__generated__/globalTypes'
+import {
+  ThemeName,
+  ThemeMode,
+  Role
+} from '../../../../__generated__/globalTypes'
 import { HorizontalSelect } from '../../HorizontalSelect'
 import { VideoWrapper } from '../../Editor/Canvas/VideoWrapper'
 import { CardWrapper } from '../../Editor/Canvas/CardWrapper'
 import { BlockFields_StepBlock as StepBlock } from '../../../../__generated__/BlockFields'
 import { NavigationCard } from '../NavigationCard'
 import { useSocialPreview } from '../../Editor/SocialProvider'
+import { GetUserRole } from '../../../../__generated__/GetUserRole'
+import { GET_USER_ROLE } from '../../JourneyView/JourneyView'
 
 interface CardListProps {
   steps: Array<TreeBlock<StepBlock>>
@@ -58,29 +65,38 @@ export function CardList({
   const { state } = useEditor()
   const { journey } = useJourney()
   const { primaryImageBlock } = useSocialPreview()
-  const AddCardSlide = (): ReactElement => (
-    <Card
-      id="CardPreviewAddButton"
-      variant="outlined"
-      sx={{
-        display: 'flex',
-        width: 87,
-        height: 132,
-        m: 1
-      }}
-    >
-      <CardActionArea
+
+  const { data } = useQuery<GetUserRole>(GET_USER_ROLE)
+  const isPublisher = data?.getUserRole?.roles?.includes(Role.publisher)
+
+  const showNavigation =
+    (showNavigationCards && journey?.template !== true) || isPublisher
+
+  function AddCardSlide(): ReactElement {
+    return (
+      <Card
+        id="CardPreviewAddButton"
+        variant="outlined"
         sx={{
           display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center'
+          width: 87,
+          height: 132,
+          m: 1
         }}
-        onClick={handleClick}
       >
-        <AddIcon color="primary" />
-      </CardActionArea>
-    </Card>
-  )
+        <CardActionArea
+          sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center'
+          }}
+          onClick={handleClick}
+        >
+          <AddIcon color="primary" />
+        </CardActionArea>
+      </Card>
+    )
+  }
   return (
     <HorizontalSelect
       onChange={handleChange}
@@ -89,7 +105,7 @@ export function CardList({
       footer={showAddButton === true && <AddCardSlide />}
       view={state.journeyEditContentComponent}
     >
-      {showNavigationCards && (
+      {showNavigation === true && (
         <NavigationCard
           key="goals"
           id="goals"
@@ -116,7 +132,7 @@ export function CardList({
           loading={journey == null}
         />
       )}
-      {showNavigationCards && (
+      {showNavigation === true && (
         <Divider
           id="cardlist-divider"
           orientation="vertical"
@@ -126,7 +142,7 @@ export function CardList({
           }}
         />
       )}
-      {showNavigationCards && (
+      {showNavigation === true && (
         <NavigationCard
           key="social"
           id="social"


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ad5d06c</samp>

Updated the `CardList` component and its tests to support different user roles. The component now shows or hides the navigation cards and the divider based on the role and the journey status. The tests check the expected card display for each role.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/32318254/todos/6136794457)

# How should this PR be QA Tested?
**Requirements for QA**
- Have two accounts ready to use
- One with Publisher role and one without
- Reach out to a developer if you need a Publisher role in the staging link

**Role: Not a publisher**
- [x] it should render the goals and social navigation cards in JourneyView page
- [x] it should render the goals and social navigation cards in JourneyEdit page
- [x] it should not render the goals and social navigation cards in TemplateView page

**Role: Publisher**

- [x] it should render the goals and social navigation cards in JourneyView page
- [x] it should render the goals and social navigation cards in JourneyEdit page
- [x] it should render the goals and social navigation cards in TemplateView page
- [x] it should render the goals and social navigation cards in PublisherView page
- [x] it should render the goals and social navigation cards in PublisherEdit page

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ad5d06c</samp>

* Import the `Role` enum from the globalTypes file to use it in the CardList component and its tests ([link](https://github.com/JesusFilm/core/pull/1538/files?diff=unified&w=0#diff-d859ffc33e276b9b2aa9fb99a45c066aacd4811f87c4a21b5fabf3169b733dc5L10-R15))
* Import the `useQuery` hook, the `GetUserRole` type, and the `GET_USER_ROLE` query from the apollo client library and the JourneyView component to fetch the user role in the CardList component ([link](https://github.com/JesusFilm/core/pull/1538/files?diff=unified&w=0#diff-f46f261ecacd86ac3e40df1941722bffdfb47ccc07eef05e4d08368207685f4aL26-R32), [link](https://github.com/JesusFilm/core/pull/1538/files?diff=unified&w=0#diff-f46f261ecacd86ac3e40df1941722bffdfb47ccc07eef05e4d08368207685f4aR39-R40))
* Declare and assign the `showNavigation` variable to a boolean expression that checks if the journey is not a template or the user is a publisher in the CardList component ([link](https://github.com/JesusFilm/core/pull/1538/files?diff=unified&w=0#diff-f46f261ecacd86ac3e40df1941722bffdfb47ccc07eef05e4d08368207685f4aL61-R99))
* Replace the `showNavigationCards` prop by the `showNavigation` variable in the conditional rendering of the goal navigation card, the divider element, and the social navigation card in the CardList component ([link](https://github.com/JesusFilm/core/pull/1538/files?diff=unified&w=0#diff-f46f261ecacd86ac3e40df1941722bffdfb47ccc07eef05e4d08368207685f4aL92-R108), [link](https://github.com/JesusFilm/core/pull/1538/files?diff=unified&w=0#diff-f46f261ecacd86ac3e40df1941722bffdfb47ccc07eef05e4d08368207685f4aL119-R135), [link](https://github.com/JesusFilm/core/pull/1538/files?diff=unified&w=0#diff-f46f261ecacd86ac3e40df1941722bffdfb47ccc07eef05e4d08368207685f4aL129-R145))
* Refactor the `AddCardSlide` function to use a function declaration instead of a function expression in the CardList component ([link](https://github.com/JesusFilm/core/pull/1538/files?diff=unified&w=0#diff-f46f261ecacd86ac3e40df1941722bffdfb47ccc07eef05e4d08368207685f4aL61-R99))
* Add three new test cases to the CardList.spec.tsx file to check the rendering of the goal and social navigation cards based on the journey template status and the user role ([link](https://github.com/JesusFilm/core/pull/1538/files?diff=unified&w=0#diff-d859ffc33e276b9b2aa9fb99a45c066aacd4811f87c4a21b5fabf3169b733dc5R399-R488))
