### PR TITLE
fix: shrink label journey link

### DIFF
--- a/libs/shared/ui/src/components/CopyTextField/CopyTextField.tsx
+++ b/libs/shared/ui/src/components/CopyTextField/CopyTextField.tsx
@@ -40,6 +40,7 @@ export function CopyTextField({
       sx={{ ...sx }}
       hiddenLabel={label == null}
       label={label}
+      InputLabelProps={{ shrink: true }}
       inputRef={inputRef}
       disabled={value == null}
       inputProps={{ onFocus: handleFocus, value }}


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9068c31</samp>

Add `shrinkLabel` prop to `TextField` component to improve UI. This prop allows the label to shrink when the input is not empty or focused, avoiding overlap and clutter. The change affects the `CopyTextField` component in `libs/shared/ui`.

- [L - Journey URL on Journey Details page glitchy in mobile view](https://3.basecamp.com/3105655/buckets/32318254/todos/6137335010)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

**Steps:**

- Enter mobile view before you select a Journey

- [ ] Journey link should not overlap label in mobile view

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9068c31</samp>

* Add a `shrinkLabel` prop to the `TextField` component to control the label shrinking behavior ([link](https://github.com/JesusFilm/core/pull/1546/files?diff=unified&w=0#diff-3afc982815b86255a8a2ba84be6443d6d50f8f151f4f894580bc346fab905bc7R43))
* Use the `shrinkLabel` prop in the `CopyTextField` component to shrink the label when the input is not empty or focused ([link](https://github.com/JesusFilm/core/pull/1546/files?diff=unified&w=0#diff-3afc982815b86255a8a2ba84be6443d6d50f8f151f4f894580bc346fab905bc7R43))
