### PR TITLE
fix: youtube video start frame

### DIFF
--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -145,8 +145,6 @@ export function Video({
 
   const eventVideoTitle = video?.title[0].value ?? title
   const eventVideoId = video?.id ?? videoId
-  let youtubeAutoplay = 0
-  if (autoplay === true) youtubeAutoplay = 1
 
   const videoImage = source === VideoBlockSource.internal ? video?.image : image
 
@@ -259,7 +257,7 @@ export function Video({
               <source
                 src={`https://www.youtube.com/embed/${videoId}?start=${
                   startAt ?? 0
-                }&end=${endAt ?? 0}&autoplay=${youtubeAutoplay}`}
+                }&end=${endAt ?? 0}`}
                 type="video/youtube"
               />
             )}

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -145,9 +145,9 @@ export function Video({
 
   const eventVideoTitle = video?.title[0].value ?? title
   const eventVideoId = video?.id ?? videoId
-  let ytAutoplay = 0
+  let youtubeAutoplay = 0
   if (autoplay != null) {
-    if (autoplay) ytAutoplay = 1
+    if (autoplay) youtubeAutoplay = 1
   }
 
   const videoImage = source === VideoBlockSource.internal ? video?.image : image
@@ -172,8 +172,6 @@ export function Video({
     }
   }
 
-  console.log('startAt', startAt)
-  console.log('endAt', endAt)
   return (
     <Box
       data-testid={`video-${blockId}`}
@@ -263,7 +261,7 @@ export function Video({
               <source
                 src={`https://www.youtube.com/embed/${videoId}?start=${
                   startAt ?? 0
-                }&end=${endAt ?? 0}&autoplay=${ytAutoplay}`}
+                }&end=${endAt ?? 0}&autoplay=${youtubeAutoplay}`}
                 type="video/youtube"
               />
             )}

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -88,7 +88,7 @@ export function Video({
           }
         },
         responsive: true,
-        muted: true,
+        muted: muted === true,
         // VideoJS blur background persists so we cover video when using png poster on non-autoplay videos
         poster: blurBackground
       })

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -88,7 +88,7 @@ export function Video({
           }
         },
         responsive: true,
-        muted: muted === true,
+        muted: true,
         // VideoJS blur background persists so we cover video when using png poster on non-autoplay videos
         poster: blurBackground
       })
@@ -145,6 +145,10 @@ export function Video({
 
   const eventVideoTitle = video?.title[0].value ?? title
   const eventVideoId = video?.id ?? videoId
+  let ytAutoplay = 0
+  if (autoplay != null) {
+    if (autoplay) ytAutoplay = 1
+  }
 
   const videoImage = source === VideoBlockSource.internal ? video?.image : image
 
@@ -168,6 +172,8 @@ export function Video({
     }
   }
 
+  console.log('startAt', startAt)
+  console.log('endAt', endAt)
   return (
     <Box
       data-testid={`video-${blockId}`}
@@ -255,7 +261,9 @@ export function Video({
               )}
             {source === VideoBlockSource.youTube && (
               <source
-                src={`https://www.youtube.com/watch?v=${videoId}`}
+                src={`https://www.youtube.com/embed/${videoId}?start=${
+                  startAt ?? 0
+                }&end=${endAt ?? 0}&autoplay=${ytAutoplay}`}
                 type="video/youtube"
               />
             )}

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -146,9 +146,7 @@ export function Video({
   const eventVideoTitle = video?.title[0].value ?? title
   const eventVideoId = video?.id ?? videoId
   let youtubeAutoplay = 0
-  if (autoplay != null) {
-    if (autoplay) youtubeAutoplay = 1
-  }
+  if (autoplay === true) youtubeAutoplay = 1
 
   const videoImage = source === VideoBlockSource.internal ? video?.image : image
 


### PR DESCRIPTION
# Description


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at beef89b</samp>

Added support for video block start and end times in `Video` component. Modified `src` attribute of YouTube videos to use `startAt` and `endAt` props as query parameters.



- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/32318254/todos/6052667019)

# How should this PR be QA Tested?


- [ ] it should start  youtube videos at the right time frame as selected on journeys admin
- [ ] it should end  youtube videos at the right time frame as selected on journeys admin

# Walkthrough


<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at beef89b</samp>

*  Add query parameters to YouTube video source to enable start and end times ([link](https://github.com/JesusFilm/core/pull/1549/files?diff=unified&w=0#diff-6dc9cc6dc88d08c752fe4265169afff94ccef2829748bdb712ecf417a9117aecL258-R260))

