### PR TITLE
fix: color picker

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundColor/BackgroundColor.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundColor/BackgroundColor.tsx
@@ -8,7 +8,7 @@ import Tabs from '@mui/material/Tabs'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import Stack from '@mui/material/Stack'
-import ColorizeIcon from '@mui/icons-material/Colorize'
+import EditIcon from '@mui/icons-material/Edit'
 import { HexColorPicker } from 'react-colorful'
 import { gql, useMutation } from '@apollo/client'
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
@@ -170,7 +170,7 @@ export function BackgroundColor(): ReactElement {
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">
-                <ColorizeIcon
+                <EditIcon
                   onClick={(e) => handleTabChange(e, 1)}
                   style={{ cursor: 'pointer' }}
                 />


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e2b7ec3</samp>

Changed the icon for editing card block background color in the journey editor. This makes the UI more consistent and user-friendly.

-[ Link to Basecamp Todo
](https://3.basecamp.com/3105655/buckets/32318254/todos/6051672162)
# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] should have pencil icon for the color picker in background color attribute

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e2b7ec3</samp>

*  Replace `ColorizeIcon` with `EditIcon` for editing card background color ([link](https://github.com/JesusFilm/core/pull/1551/files?diff=unified&w=0#diff-2402a558d3ef6831a72f1d42948102baf3a0b0a2eea016cc466b6e8dacb35d3aL11-R11), [link](https://github.com/JesusFilm/core/pull/1551/files?diff=unified&w=0#diff-2402a558d3ef6831a72f1d42948102baf3a0b0a2eea016cc466b6e8dacb35d3aL173-R173))
