### PR TITLE
fix: exclude special characters when sorting

### DIFF
--- a/apps/journeys-admin/src/components/JourneyList/JourneySort/utils/sortJourneys.ts
+++ b/apps/journeys-admin/src/components/JourneyList/JourneySort/utils/sortJourneys.ts
@@ -29,8 +29,13 @@ export function sortJourneys(
     sortOrder === SortOrder.TITLE
       ? orderBy(
           journeys,
-          [({ title }) => title.toLowerCase()[0], ({ title }) => title],
-          ['asc', 'asc']
+          [
+            ({ title }) => {
+              const noSpecialCharacters = title.replace(/[^a-zA-Z0-9 ]/g, '')
+              return noSpecialCharacters.toLowerCase()
+            }
+          ],
+          ['asc']
         )
       : orderBy(journeys, ({ createdAt }) =>
           new Date(createdAt).getTime()


### PR DESCRIPTION
# Description

copilot:summary

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/32318254/todos/6051672096)

# How should this PR be QA Tested?

- [ ] it should sort active, archived and trashed journeys list alphabetically regardless of special characters

# Walkthrough

copilot:walkthrough
