### PR TITLE
feat: journey report navigation

### DIFF
--- a/apps/journeys-admin/pages/journeys/[journeyId]/reports.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/reports.tsx
@@ -12,7 +12,7 @@ import { getLaunchDarklyClient } from '@core/shared/ui/getLaunchDarklyClient'
 import Box from '@mui/material/Box'
 import { useRouter } from 'next/router'
 import { GetJourney } from '../../../__generated__/GetJourney'
-import { PageWrapper } from '../../../src/components/PageWrapper'
+import { PageWrapper } from '../../../src/components/NewPageWrapper'
 import { GET_JOURNEY, USER_JOURNEY_OPEN } from '../[journeyId]'
 import { UserInviteAcceptAll } from '../../../__generated__/UserInviteAcceptAll'
 import i18nConfig from '../../../next-i18next.config'
@@ -22,6 +22,7 @@ import { JourneysReportType } from '../../../__generated__/globalTypes'
 import { ACCEPT_USER_INVITE } from '../..'
 import { useTermsRedirect } from '../../../src/libs/useTermsRedirect/useTermsRedirect'
 import { UserJourneyOpen } from '../../../__generated__/UserJourneyOpen'
+import { ReportsNavigation } from '../../../src/components/ReportsNavigation'
 
 function JourneyReportsPage(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
@@ -41,6 +42,11 @@ function JourneyReportsPage(): ReactElement {
         backHref={`/journeys/${journeyId}`}
       >
         <Box sx={{ height: 'calc(100vh - 48px)' }}>
+          <ReportsNavigation
+            reportType={JourneysReportType.singleFull}
+            journeyId={journeyId}
+            selected="journeys"
+          />
           <MemoizedDynamicReport
             reportType={JourneysReportType.singleFull}
             journeyId={journeyId}

--- a/apps/journeys-admin/pages/reports/journeys.tsx
+++ b/apps/journeys-admin/pages/reports/journeys.tsx
@@ -28,7 +28,10 @@ function ReportsJourneysPage(): ReactElement {
       <NextSeo title={t('Journeys Report')} />
       <PageWrapper title={t('Journeys Report')} authUser={AuthUser}>
         <Box sx={{ height: 'calc(100vh - 48px)' }}>
-          <ReportsNavigation selected="journeys" />
+          <ReportsNavigation
+            reportType={JourneysReportType.multipleFull}
+            selected="journeys"
+          />
           <MemoizedDynamicReport reportType={JourneysReportType.multipleFull} />
         </Box>
       </PageWrapper>

--- a/apps/journeys-admin/src/components/ReportsNavigation/ReportsNavigation.spec.tsx
+++ b/apps/journeys-admin/src/components/ReportsNavigation/ReportsNavigation.spec.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react'
+import { JourneysReportType } from '../../../__generated__/globalTypes'
 import { ReportsNavigation } from './ReportsNavigation'
 
 jest.mock('react-i18next', () => ({
@@ -32,6 +33,60 @@ describe('ReportsNavigation', () => {
     expect(getByRole('link', { name: 'Journeys' })).toHaveAttribute(
       'aria-selected',
       'false'
+    )
+  })
+
+  it('should navigate to single journey report', () => {
+    const { getByRole } = render(
+      <ReportsNavigation
+        reportType={JourneysReportType.singleFull}
+        journeyId="test"
+        selected="visitors"
+      />
+    )
+    expect(getByRole('link', { name: 'Journeys' })).toHaveAttribute(
+      'href',
+      '/journeys/test/reports'
+    )
+  })
+
+  it('should navigate to single visitor report', () => {
+    const { getByRole } = render(
+      <ReportsNavigation
+        reportType={JourneysReportType.singleFull}
+        journeyId="test"
+        selected="visitors"
+      />
+    )
+    expect(getByRole('link', { name: 'Visitors' })).toHaveAttribute(
+      'href',
+      '/journeys/test/reports/visitors'
+    )
+  })
+
+  it('should navigate to multiple journeys report', () => {
+    const { getByRole } = render(
+      <ReportsNavigation
+        reportType={JourneysReportType.multipleFull}
+        selected="visitors"
+      />
+    )
+    expect(getByRole('link', { name: 'Journeys' })).toHaveAttribute(
+      'href',
+      '/reports/journeys'
+    )
+  })
+
+  it('should navigate to multiple visitors report', () => {
+    const { getByRole } = render(
+      <ReportsNavigation
+        reportType={JourneysReportType.multipleFull}
+        selected="visitors"
+      />
+    )
+    expect(getByRole('link', { name: 'Visitors' })).toHaveAttribute(
+      'href',
+      '/reports/visitors'
     )
   })
 })

--- a/apps/journeys-admin/src/components/ReportsNavigation/ReportsNavigation.tsx
+++ b/apps/journeys-admin/src/components/ReportsNavigation/ReportsNavigation.tsx
@@ -5,7 +5,7 @@ import { JourneysReportType } from '../../../__generated__/globalTypes'
 import { NavigationButton } from './NavigationButton'
 
 interface Props {
-  reportType: JourneysReportType
+  reportType?: JourneysReportType
   journeyId?: string
   selected: 'journeys' | 'visitors'
 }

--- a/apps/journeys-admin/src/components/ReportsNavigation/ReportsNavigation.tsx
+++ b/apps/journeys-admin/src/components/ReportsNavigation/ReportsNavigation.tsx
@@ -1,25 +1,42 @@
 import Stack from '@mui/material/Stack'
 import { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
+import { JourneysReportType } from '../../../__generated__/globalTypes'
 import { NavigationButton } from './NavigationButton'
 
 interface Props {
+  reportType: JourneysReportType
+  journeyId?: string
   selected: 'journeys' | 'visitors'
 }
 
-export function ReportsNavigation({ selected }: Props): ReactElement {
+export function ReportsNavigation({
+  reportType,
+  journeyId,
+  selected
+}: Props): ReactElement {
   const { t } = useTranslation('journeys-admin')
   return (
     <Stack direction="row" spacing={4} sx={{ pb: 8 }}>
       <NavigationButton
         selected={selected === 'journeys'}
         value={t('Journeys')}
-        link="/reports/journeys"
+        link={
+          reportType === JourneysReportType.singleFull &&
+          journeyId !== undefined
+            ? `/journeys/${journeyId}/reports`
+            : '/reports/journeys'
+        }
       />
       <NavigationButton
         selected={selected === 'visitors'}
         value={t('Visitors')}
-        link="/reports/visitors"
+        link={
+          reportType === JourneysReportType.singleFull &&
+          journeyId !== undefined
+            ? `/journeys/${journeyId}/reports/visitors`
+            : '/reports/visitors'
+        }
       />
     </Stack>
   )


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f0414b4</samp>

Added a new `ReportsNavigation` component to improve the layout and navigation of the reports pages in the journeys-admin app. The component accepts a `reportType` prop to render the appropriate links for single or multiple journeys reports. The reports pages were updated to use the new component and pass the correct props.

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/32387047/todos/6067128983)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] should navigate to /journeys/[journeyId]/reports when journeys is clicked on single journey report
- [ ] should navigate to (/journeys/[journeyId]/reports/visitors when visitors is clicked on single journey report

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f0414b4</samp>

* Add `reportType` and `journeyId` props to `ReportsNavigation` component to generate correct links for navigation buttons ([link](https://github.com/JesusFilm/core/pull/1554/files?diff=unified&w=0#diff-4d27b0771a16509369030f6343c03d4d1aed3d45353059af2f18b0ed6d4f5bf7L4-R17), [link](https://github.com/JesusFilm/core/pull/1554/files?diff=unified&w=0#diff-4d27b0771a16509369030f6343c03d4d1aed3d45353059af2f18b0ed6d4f5bf7L17-R39), [link](https://github.com/JesusFilm/core/pull/1554/files?diff=unified&w=0#diff-824ddc1c371aa3b7ceb1c0fd559ae685413b6dde99ee3bd62b77adf4ea9a3533R2))
* Replace `PageWrapper` with `NewPageWrapper` in `reports.tsx` to change layout and style of reports pages ([link](https://github.com/JesusFilm/core/pull/1554/files?diff=unified&w=0#diff-fd55f0b59a40cc07f4ea8ad5b314119563477d59a19267ed74705d84595e668aL15-R15))
* Import and render `ReportsNavigation` component in `reports.tsx` and `journeys.tsx` with appropriate props to show navigation buttons for switching between reports ([link](https://github.com/JesusFilm/core/pull/1554/files?diff=unified&w=0#diff-fd55f0b59a40cc07f4ea8ad5b314119563477d59a19267ed74705d84595e668aR25), [link](https://github.com/JesusFilm/core/pull/1554/files?diff=unified&w=0#diff-fd55f0b59a40cc07f4ea8ad5b314119563477d59a19267ed74705d84595e668aR45-R49), [link](https://github.com/JesusFilm/core/pull/1554/files?diff=unified&w=0#diff-6ff93dab52e48ae1c09dd135997b060c10f1dc4eae7bfc03f82b4836b8377fe8L31-R34))
* Add four test cases to `ReportsNavigation.spec.tsx` to test navigation functionality for different report types and journey ids ([link](https://github.com/JesusFilm/core/pull/1554/files?diff=unified&w=0#diff-824ddc1c371aa3b7ceb1c0fd559ae685413b6dde99ee3bd62b77adf4ea9a3533R38-R91))
