### PR TITLE
fix: typography drag

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Canvas/SelectableWrapper/SelectableWrapper.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/SelectableWrapper/SelectableWrapper.tsx
@@ -93,17 +93,17 @@ export function SelectableWrapper({
   const videoOutlineStyles =
     selectedBlock?.__typename === 'VideoBlock'
       ? {
-        width: '100%',
-        height: '100%',
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        outlineOffset: '-3px',
-        borderRadius: '16px',
-        '&:first-child': {
-          '& > *': { zIndex: -1 }
+          width: '100%',
+          height: '100%',
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          outlineOffset: '-3px',
+          borderRadius: '16px',
+          '&:first-child': {
+            '& > *': { zIndex: -1 }
+          }
         }
-      }
       : {}
 
   return isSelectable ? (

--- a/apps/journeys-admin/src/components/Editor/Canvas/SelectableWrapper/SelectableWrapper.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/SelectableWrapper/SelectableWrapper.tsx
@@ -78,6 +78,13 @@ export function SelectableWrapper({
     }
   }
 
+  const handleMouseOut = (): void => {
+    // TODO: it'll always run this everytime, fix it
+    if (block.__typename === 'TypographyBlock') {
+      selectBlock(block)
+    }
+  }
+
   // Container Blocks (RadioQuestion, Grid) don't stop propogation on ClickCapture, stop onClick so child events still occur.
   const blockNonSelectionEvents = (e: MouseEvent<HTMLElement>): void => {
     e.stopPropagation()
@@ -86,17 +93,17 @@ export function SelectableWrapper({
   const videoOutlineStyles =
     selectedBlock?.__typename === 'VideoBlock'
       ? {
-          width: '100%',
-          height: '100%',
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          outlineOffset: '-3px',
-          borderRadius: '16px',
-          '&:first-child': {
-            '& > *': { zIndex: -1 }
-          }
+        width: '100%',
+        height: '100%',
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        outlineOffset: '-3px',
+        borderRadius: '16px',
+        '&:first-child': {
+          '& > *': { zIndex: -1 }
         }
+      }
       : {}
 
   return isSelectable ? (
@@ -120,6 +127,7 @@ export function SelectableWrapper({
         zIndex: selectedBlock?.id === block.id ? 1 : 0,
         ...videoOutlineStyles
       }}
+      onMouseOut={handleMouseOut}
       onClickCapture={handleSelectBlock}
       onClick={blockNonSelectionEvents}
     >


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 870934e</samp>

This pull request enhances the editor canvas by improving the selection of typography and video blocks. It adds a `handleMouseOut` function for typography blocks and fixes the style code indentation for `SelectableWrapper.tsx`.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 870934e</samp>

*  Add mouse out logic to select typography blocks ([link](https://github.com/JesusFilm/core/pull/1556/files?diff=unified&w=0#diff-e3b621a4c4559744ebece26647642aa64ebf638fa0b134faefcb2225c1f23235R81-R87), [link](https://github.com/JesusFilm/core/pull/1556/files?diff=unified&w=0#diff-e3b621a4c4559744ebece26647642aa64ebf638fa0b134faefcb2225c1f23235R130))
* Fix indentation of video block styles ([link](https://github.com/JesusFilm/core/pull/1556/files?diff=unified&w=0#diff-e3b621a4c4559744ebece26647642aa64ebf638fa0b134faefcb2225c1f23235L89-R106))
