### PR TITLE
fix: api gateway schema

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -892,7 +892,6 @@ type Mutation
   createCloudflareVideoUploadByFile(uploadLength: Int!, name: String!): CloudflareVideo @join__field(graph: MEDIA)
   createCloudflareVideoUploadByUrl(url: String!): CloudflareVideo @join__field(graph: MEDIA)
   deleteCloudflareVideo(id: ID!): Boolean @join__field(graph: MEDIA)
-  cloudflareUploadVideoComplete(id: ID!): Boolean @join__field(graph: MEDIA)
   triggerUnsplashDownload(url: String!): Boolean @join__field(graph: MEDIA)
 }
 


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0675673</samp>

Remove `cloudflareUploadVideoComplete` mutation from API schema. This simplifies the communication between the API and the media service for video uploads.

Did not run `nx generate-graphql api-gateway` when merging https://github.com/JesusFilm/core/pull/1557

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0675673</samp>

* Remove `cloudflareUploadVideoComplete` mutation from schema ([link](https://github.com/JesusFilm/core/pull/1559/files?diff=unified&w=0#diff-e60078ed0fc71b8cd3bb2fca25505e7dba866b7d463147662a12432dfe287273L895))
