### PR TITLE
fix: fetch video id from input instead of block

### DIFF
--- a/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
@@ -32,7 +32,7 @@ jest.mock('node-fetch', () => {
 const mockFetch = fetch as jest.MockedFunction<typeof fetch>
 
 describe('VideoBlockResolver', () => {
-  let resolver: VideoBlockResolver, service: BlockService
+  let resolver: VideoBlockResolver, service: jest.Mocked<BlockService>
 
   const block = {
     id: 'abc',
@@ -430,6 +430,10 @@ describe('VideoBlockResolver', () => {
       })
 
       it('updates videoId', async () => {
+        service.get.mockResolvedValueOnce({
+          ...updatedBlock,
+          videoId: undefined
+        })
         mockFetch.mockResolvedValueOnce({
           ok: true,
           json: async () =>
@@ -474,6 +478,10 @@ describe('VideoBlockResolver', () => {
           title: 'video.mp4',
           objectFit: 'fill'
         })
+        expect(mockFetch).toHaveBeenCalledWith(
+          'https://api.cloudflare.com/client/v4/accounts//stream/ea95132c15732412d22c1476fa83f27a',
+          { headers: { Authorization: 'Bearer ' } }
+        )
       })
 
       it('updates videoId title when meta name not present', async () => {

--- a/apps/api-journeys/src/app/modules/block/video/video.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/video/video.resolver.ts
@@ -213,7 +213,7 @@ export class VideoBlockResolver {
         if (input.videoId != null) {
           input = {
             ...input,
-            ...(await this.fetchFieldsFromCloudflare(block.videoId))
+            ...(await this.fetchFieldsFromCloudflare(input.videoId))
           }
         }
         break
@@ -305,6 +305,8 @@ export class VideoBlockResolver {
         }
       )
     ).json()
+
+    console.log(response)
 
     if (response.result == null) {
       throw new UserInputError('videoId cannot be found on Cloudflare', {

--- a/apps/api-journeys/src/app/modules/block/video/video.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/video/video.resolver.ts
@@ -306,8 +306,6 @@ export class VideoBlockResolver {
       )
     ).json()
 
-    console.log(response)
-
     if (response.result == null) {
       throw new UserInputError('videoId cannot be found on Cloudflare', {
         videoId: ['videoId cannot be found on Cloudflare']


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ae6595</samp>

Fixed a bug and added a test for the video resolver in `api-journeys`. The bug affected the updating of video blocks with Cloudflare video details. The test ensures the resolver can handle video blocks without Cloudflare data.

# How should this PR be QA Tested?

Will be tested by frontend components for video uploading.

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3ae6595</samp>

* Fix bug in `updateVideoBlock` method that used wrong videoId to fetch fields from Cloudflare ([link](https://github.com/JesusFilm/core/pull/1561/files?diff=unified&w=0#diff-979f24487665f31f744097b2dc824525ba6bef81182373426d29517927b20da4L216-R216))
* Add test case for `updateVideoBlock` method to handle undefined videoId in existing block ([link](https://github.com/JesusFilm/core/pull/1561/files?diff=unified&w=0#diff-55d83a9b722785eaa6c21849f22a07c64cc1c239c4baa1f43039266124cb8bd1R433-R436), [link](https://github.com/JesusFilm/core/pull/1561/files?diff=unified&w=0#diff-55d83a9b722785eaa6c21849f22a07c64cc1c239c4baa1f43039266124cb8bd1R481-R484))
* Type `service` variable as mocked `BlockService` to enable jest mocking methods ([link](https://github.com/JesusFilm/core/pull/1561/files?diff=unified&w=0#diff-55d83a9b722785eaa6c21849f22a07c64cc1c239c4baa1f43039266124cb8bd1L35-R35))
