### PR TITLE
fix: broken story

### DIFF
--- a/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoFromYouTube/VideoFromYouTube.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoFromYouTube/VideoFromYouTube.stories.tsx
@@ -1,6 +1,7 @@
 import { Story, Meta } from '@storybook/react'
 import { SWRConfig } from 'swr'
 import { journeysAdminConfig } from '../../../../libs/storybook'
+import { ApolloLoadingProvider } from '../../../../../test/ApolloLoadingProvider'
 import {
   getPlaylistItemsLoading,
   getPlaylistItemsWithOffsetAndUrl
@@ -15,9 +16,11 @@ const VideoFromYouTubeStory = {
 }
 
 const Template: Story = ({ onSelect }) => (
-  <SWRConfig value={{ provider: () => new Map() }}>
-    <VideoFromYouTube onSelect={onSelect} />
-  </SWRConfig>
+  <ApolloLoadingProvider>
+    <SWRConfig value={{ provider: () => new Map() }}>
+      <VideoFromYouTube onSelect={onSelect} />
+    </SWRConfig>
+  </ApolloLoadingProvider>
 )
 
 export const Default = Template.bind({})


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 28d0750</samp>

Improved the testing of the `VideoFromYouTube` component by adding a loading state story. This story uses the `ApolloLoadingProvider` component to simulate a data fetching delay from YouTube.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 28d0750</samp>

*  Wrap `Template` story with `ApolloLoadingProvider` component to simulate loading state when fetching data from YouTube ([link](https://github.com/JesusFilm/core/pull/1562/files?diff=unified&w=0#diff-a176b64a044f6fccf55d13eec7d13caba46c7c991332b9d01d94ff0d27c9eafaL18-R23))
* Import `ApolloLoadingProvider` component from test folder ([link](https://github.com/JesusFilm/core/pull/1562/files?diff=unified&w=0#diff-a176b64a044f6fccf55d13eec7d13caba46c7c991332b9d01d94ff0d27c9eafaR4))
