### PR TITLE
feat: serverless v2

### DIFF
--- a/infrastructure/modules/aws/aurora/main.tf
+++ b/infrastructure/modules/aws/aurora/main.tf
@@ -8,7 +8,7 @@ resource "aws_rds_cluster" "default" {
   apply_immediately           = true
   cluster_identifier          = "${var.name}-${var.env}"
   engine                      = "aurora-postgresql"
-  engine_mode                 = "serverless"
+  engine_mode                 = "provisioned"
   engine_version              = "13.9"
   availability_zones          = data.aws_availability_zones.current.names.*
   db_subnet_group_name        = var.subnet_group_name
@@ -19,9 +19,18 @@ resource "aws_rds_cluster" "default" {
   preferred_backup_window     = "07:00-09:00"
   vpc_security_group_ids      = [var.vpc_security_group_id]
   allow_major_version_upgrade = true
-  scaling_configuration {
-    min_capacity = 2
+  serverlessv2_scaling_configuration {
+    max_capacity = 16
+    min_capacity = 0.5
   }
+}
+
+resource "aws_rds_cluster_instance" "default" {
+  cluster_identifier = aws_rds_cluster.default.id
+  instance_class     = "db.serverless"
+  engine             = aws_rds_cluster.default.engine
+  engine_version     = aws_rds_cluster.default.engine_version
+  promotion_tier     = 1
 }
 
 resource "aws_ssm_parameter" "parameter" {


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 19ad4f6</samp>

Upgraded Aurora database to serverless v2 for better scaling. Modified `aws_rds_cluster` and added `aws_rds_cluster_instance` in `infrastructure/modules/aws/aurora/main.tf`.

https://3.basecamp.com/3105655/buckets/32387047/todos/6067449941

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 19ad4f6</samp>

*  Enable serverless v2 feature for Aurora database ([link](https://github.com/JesusFilm/core/pull/1564/files?diff=unified&w=0#diff-73b553a01d0ea00ac3ed34bc813c605506caabf3a464684b4781e949f9fb8f55L11-R11), [link](https://github.com/JesusFilm/core/pull/1564/files?diff=unified&w=0#diff-73b553a01d0ea00ac3ed34bc813c605506caabf3a464684b4781e949f9fb8f55L22-R35))
