### PR TITLE
feat: cloudflare check ready to stream

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -304,6 +304,7 @@ type CloudflareVideo
   uploadUrl: String
   userId: ID!
   createdAt: String!
+  readyToStream: Boolean!
 }
 
 type Country
@@ -892,6 +893,7 @@ type Mutation
   createCloudflareVideoUploadByFile(uploadLength: Int!, name: String!): CloudflareVideo @join__field(graph: MEDIA)
   createCloudflareVideoUploadByUrl(url: String!): CloudflareVideo @join__field(graph: MEDIA)
   deleteCloudflareVideo(id: ID!): Boolean @join__field(graph: MEDIA)
+  cloudflareVideoCheckReadyToStream(id: ID!): CloudflareVideo @join__field(graph: MEDIA)
   triggerUnsplashDownload(url: String!): Boolean @join__field(graph: MEDIA)
 }
 

--- a/apps/api-media/schema.graphql
+++ b/apps/api-media/schema.graphql
@@ -37,6 +37,7 @@ extend type Mutation {
   createCloudflareVideoUploadByFile(uploadLength: Int!, name: String!): CloudflareVideo
   createCloudflareVideoUploadByUrl(url: String!): CloudflareVideo
   deleteCloudflareVideo(id: ID!): Boolean
+  cloudflareVideoCheckReadyToStream(id: ID!): CloudflareVideo
   triggerUnsplashDownload(url: String!): Boolean
 }
 
@@ -45,6 +46,7 @@ type CloudflareVideo {
   uploadUrl: String
   userId: ID!
   createdAt: String!
+  readyToStream: Boolean!
 }
 
 type UnsplashQueryResponse {

--- a/apps/api-media/src/app/__generated__/graphql.ts
+++ b/apps/api-media/src/app/__generated__/graphql.ts
@@ -64,6 +64,7 @@ export class CloudflareVideo {
     uploadUrl?: Nullable<string>;
     userId: string;
     createdAt: string;
+    readyToStream: boolean;
 }
 
 export class UnsplashQueryResponse {
@@ -170,6 +171,8 @@ export abstract class IMutation {
     abstract createCloudflareVideoUploadByUrl(url: string): Nullable<CloudflareVideo> | Promise<Nullable<CloudflareVideo>>;
 
     abstract deleteCloudflareVideo(id: string): Nullable<boolean> | Promise<Nullable<boolean>>;
+
+    abstract cloudflareVideoCheckReadyToStream(id: string): Nullable<CloudflareVideo> | Promise<Nullable<CloudflareVideo>>;
 
     abstract triggerUnsplashDownload(url: string): Nullable<boolean> | Promise<Nullable<boolean>>;
 }

--- a/apps/api-media/src/app/modules/cloudflare/video/video.graphql
+++ b/apps/api-media/src/app/modules/cloudflare/video/video.graphql
@@ -3,6 +3,7 @@ type CloudflareVideo {
   uploadUrl: String
   userId: ID!
   createdAt: String!
+  readyToStream: Boolean!
 }
 
 extend type Query {
@@ -16,4 +17,5 @@ extend type Mutation {
   ): CloudflareVideo
   createCloudflareVideoUploadByUrl(url: String!): CloudflareVideo
   deleteCloudflareVideo(id: ID!): Boolean
+  cloudflareVideoCheckReadyToStream(id: ID!): CloudflareVideo
 }

--- a/apps/api-media/src/app/modules/cloudflare/video/video.resolver.spec.ts
+++ b/apps/api-media/src/app/modules/cloudflare/video/video.resolver.spec.ts
@@ -12,7 +12,8 @@ const cloudflareVideo: CloudflareVideo = {
   id: '1',
   uploadUrl: 'https://upload.com',
   createdAt: new Date().toISOString(),
-  userId: 'user_1'
+  userId: 'user_1',
+  readyToStream: false
 }
 
 describe('VideoResolver', () => {
@@ -50,13 +51,14 @@ describe('VideoResolver', () => {
           delete response._key
           return response
         }),
-        update: jest.fn((input) => input),
+        update: jest.fn((id, input) => input),
         uploadToCloudflareByFile: jest.fn(() => cloudflareVideoUploadUrl),
         deleteVideoFromCloudflare: jest.fn(() => cloudflareVideo),
         uploadToCloudflareByUrl: jest.fn(
           () => cloudflareVideoUrlUploadResponse
         ),
         getCloudflareVideosForUserId: jest.fn(() => [cloudflareVideo]),
+        getVideoFromCloudflare: jest.fn(() => cloudflareVideo),
         remove: jest.fn(() => cloudflareVideo)
       })
     }
@@ -75,7 +77,8 @@ describe('VideoResolver', () => {
         ...cloudflareVideoUploadUrl,
         name: 'name',
         createdAt: expect.any(String),
-        userId: 'userId'
+        userId: 'userId',
+        readyToStream: false
       })
       expect(service.uploadToCloudflareByFile).toHaveBeenCalledWith(
         100,
@@ -110,7 +113,8 @@ describe('VideoResolver', () => {
       ).toEqual({
         id: 'cloudflareUid',
         createdAt: expect.any(String),
-        userId: user.id
+        userId: user.id,
+        readyToStream: false
       })
       expect(service.uploadToCloudflareByUrl).toHaveBeenCalledWith(
         'https://example.com/video.mp4',
@@ -174,6 +178,49 @@ describe('VideoResolver', () => {
     it('calls service.remove', async () => {
       expect(await resolver.deleteCloudflareVideo('1', user.id)).toEqual(true)
       expect(service.remove).toHaveBeenCalledWith('1')
+    })
+  })
+  describe('cloudflareVideoCheckReadyToStream', () => {
+    it('throws an error if not found', async () => {
+      service.get.mockResolvedValueOnce(undefined)
+      await expect(
+        async () =>
+          await resolver.cloudflareVideoCheckReadyToStream('videoId', user.id)
+      ).rejects.toThrow('Video not found')
+    })
+    it('throws an error if wrong user', async () => {
+      await expect(
+        async () =>
+          await resolver.cloudflareVideoCheckReadyToStream('videoId', 'user2Id')
+      ).rejects.toThrow('This video does not belong to you')
+    })
+    it('throws an error if could not be retrieved from cloudflare', async () => {
+      service.getVideoFromCloudflare.mockResolvedValueOnce({
+        result: null,
+        success: false,
+        errors: ['Video could not be retrieved from cloudflare'],
+        messages: []
+      })
+      await expect(
+        async () =>
+          await resolver.cloudflareVideoCheckReadyToStream('videoId', user.id)
+      ).rejects.toThrow('Video could not be retrieved from cloudflare')
+    })
+    it('updates video and returns updated video', async () => {
+      service.getVideoFromCloudflare.mockResolvedValueOnce({
+        result: {
+          readyToStream: true
+        },
+        success: true,
+        errors: [],
+        messages: []
+      })
+      expect(
+        await resolver.cloudflareVideoCheckReadyToStream('videoId', user.id)
+      ).toEqual({ readyToStream: true })
+      expect(service.update).toHaveBeenCalledWith('videoId', {
+        readyToStream: true
+      })
     })
   })
 })

--- a/apps/api-media/src/app/modules/cloudflare/video/video.resolver.ts
+++ b/apps/api-media/src/app/modules/cloudflare/video/video.resolver.ts
@@ -25,7 +25,8 @@ export class VideoResolver {
       uploadUrl: response.uploadUrl,
       userId,
       name,
-      createdAt: new Date().toISOString()
+      createdAt: new Date().toISOString(),
+      readyToStream: false
     })
   }
 
@@ -43,7 +44,8 @@ export class VideoResolver {
     return await this.videoService.save({
       _key: response.result.uid,
       userId,
-      createdAt: new Date().toISOString()
+      createdAt: new Date().toISOString(),
+      readyToStream: false
     })
   }
 
@@ -72,5 +74,26 @@ export class VideoResolver {
     }
     await this.videoService.remove(id)
     return true
+  }
+
+  @Mutation()
+  async cloudflareVideoCheckReadyToStream(
+    @Args('id') id: string,
+    @CurrentUserId() userId: string
+  ): Promise<CloudflareVideo> {
+    const video = await this.videoService.get(id)
+    if (video == null) {
+      throw new UserInputError('Video not found')
+    }
+    if (video.userId !== userId) {
+      throw new ForbiddenError('This video does not belong to you')
+    }
+    const response = await this.videoService.getVideoFromCloudflare(id)
+    if (!response.success) {
+      throw new Error(response.errors[0])
+    }
+    return await this.videoService.update(id, {
+      readyToStream: response.result?.readyToStream ?? false
+    })
   }
 }

--- a/apps/api-media/src/app/modules/cloudflare/video/video.service.ts
+++ b/apps/api-media/src/app/modules/cloudflare/video/video.service.ts
@@ -18,6 +18,15 @@ export interface CloudflareVideoUrlUploadResponse {
   messages: string[]
 }
 
+export interface CloudflareVideoGetResponse {
+  result: {
+    readyToStream: boolean
+  } | null
+  success: boolean
+  errors: string[]
+  messages: string[]
+}
+
 @Injectable()
 export class VideoService extends BaseService {
   collection = this.db.collection('cloudflareVideos')
@@ -64,6 +73,23 @@ export class VideoService extends BaseService {
       }
     )
     return response.ok
+  }
+
+  async getVideoFromCloudflare(
+    videoId: string
+  ): Promise<CloudflareVideoGetResponse> {
+    const response = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${
+        process.env.CLOUDFLARE_ACCOUNT_ID ?? ''
+      }/stream/${videoId}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${process.env.CLOUDFLARE_STREAM_TOKEN ?? ''}`
+        }
+      }
+    )
+    return await response.json()
   }
 
   async uploadToCloudflareByUrl(


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9ea5936</samp>

This pull request adds a new feature to the api-gateway and api-media apps that allows checking the streaming status of videos from Cloudflare. It introduces a new GraphQL field `readyToStream` and a new mutation `cloudflareVideoCheckReadyToStream` to the schemas and resolvers. It also adds the necessary services, interfaces, and tests to handle the Cloudflare API calls and responses.

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/32577228/todos/6170819046)

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9ea5936</samp>

*  Add a new field `readyToStream` to the type `CloudflareVideo` in the schema and the generated TypeScript file of the api-gateway and api-media apps. The field indicates whether the video is ready to be streamed from Cloudflare or not. The field is non-nullable and of type Boolean. ([link](https://github.com/JesusFilm/core/pull/1565/files?diff=unified&w=0#diff-e60078ed0fc71b8cd3bb2fca25505e7dba866b7d463147662a12432dfe287273R307), [link](https://github.com/JesusFilm/core/pull/1565/files?diff=unified&w=0#diff-e60078ed0fc71b8cd3bb2fca25505e7dba866b7d463147662a12432dfe287273R896), [link](https://github.com/JesusFilm/core/pull/1565/files?diff=unified&w=0#diff-46a9b880e32bef81e8745711b5f7356164752b2c164f17c8ff964f859446185dR49), [link](https://github.com/JesusFilm/core/pull/1565/files?diff=unified&w=0#diff-f252069f7eff887cec189bd2a972d6e03f0c9523c0e71ab20b3681983e1f3f11R67), [link](https://github.com/JesusFilm/core/pull/1565/files?diff=unified&w=0#diff-a418964c67ece303753a2a40114a6808edb92e53fdf4bd6c9d1f6bc1d92efde7R6))
* Add a new mutation `cloudflareVideoCheckReadyToStream` to the schema and the generated TypeScript file of the api-gateway and api-media apps. The mutation takes an id argument of type ID and returns a `CloudflareVideo` type. The mutation also uses a `@join__field` directive to indicate that it is delegated to the MEDIA subgraph. ([link](https://github.com/JesusFilm/core/pull/1565/files?diff=unified&w=0#diff-e60078ed0fc71b8cd3bb2fca25505e7dba866b7d463147662a12432dfe287273R896), [link](https://github.com/JesusFilm/core/pull/1565/files?diff=unified&w=0#diff-46a9b880e32bef81e8745711b5f7356164752b2c164f17c8ff964f859446185dR40), [link](https://github.com/JesusFilm/core/pull/1565/files?diff=unified&w=0#diff-f252069f7eff887cec189bd2a972d6e03f0c9523c0e71ab20b3681983e1f3f11R175-R176), [link](https://github.com/JesusFilm/core/pull/1565/files?diff=unified&w=0#diff-a418964c67ece303753a2a40114a6808edb92e53fdf4bd6c9d1f6bc1d92efde7R20))
* Implement the mutation logic in the `VideoResolver` class of the `video.resolver.ts` file in the api-media app. The mutation checks if the video exists and belongs to the user, then calls the `VideoService` to get the video from Cloudflare and update its `readyToStream` field, and then returns the updated video. ([link](https://github.com/JesusFilm/core/pull/1565/files?diff=unified&w=0#diff-61cff936a34d9ef3d5d35bbda83ab59e2669993f360aee600da1ede2cdb6f412R78-R98))
* Implement the service logic in the `VideoService` class of the `video.service.ts` file in the api-media app. The service defines a new interface `CloudflareVideoGetResponse` to represent the response from the Cloudflare API when getting a video. The service also adds a new function `getVideoFromCloudflare` that takes a videoId argument and returns a promise of a `CloudflareVideoGetResponse` type. The function calls the Cloudflare API with the videoId and the authorization header and parses the response as JSON. ([link](https://github.com/JesusFilm/core/pull/1565/files?diff=unified&w=0#diff-74854176966d1f04bf00f5fcb8af60f7a205c62a7dff8b881c5dd2d8dd953c56R21-R29), [link](https://github.com/JesusFilm/core/pull/1565/files?diff=unified&w=0#diff-74854176966d1f04bf00f5fcb8af60f7a205c62a7dff8b881c5dd2d8dd953c56R78-R94))
* Modify the object returned by the `uploadToCloudflareByFile` and `uploadToCloudflareByUrl` mutations in the `VideoResolver` class of the `video.resolver.ts` file in the api-media app. The object now includes the `readyToStream` field set to false. This is to initialize the field when uploading a new video. ([link](https://github.com/JesusFilm/core/pull/1565/files?diff=unified&w=0#diff-61cff936a34d9ef3d5d35bbda83ab59e2669993f360aee600da1ede2cdb6f412L28-R29), [link](https://github.com/JesusFilm/core/pull/1565/files?diff=unified&w=0#diff-61cff936a34d9ef3d5d35bbda83ab59e2669993f360aee600da1ede2cdb6f412L46-R48))
* Test the mutation logic in the `video.resolver.spec.ts` file in the api-media app. The file adds a new function `getVideoFromCloudflare` to mock the service function that calls the Cloudflare API. The file also adds a new describe block to test the `cloudflareVideoCheckReadyToStream` mutation and its various scenarios. The file also modifies the update function to take an id argument and an input argument, and adds the `readyToStream` field to the expected objects in the tests for the upload mutations. ([link](https://github.com/JesusFilm/core/pull/1565/files?diff=unified&w=0#diff-1386fbbdaaaada188b215b4c23e522a6d69e30c0800ed974710a37a1845a71c8L15-R16), [link](https://github.com/JesusFilm/core/pull/1565/files?diff=unified&w=0#diff-1386fbbdaaaada188b215b4c23e522a6d69e30c0800ed974710a37a1845a71c8L53-R54), [link](https://github.com/JesusFilm/core/pull/1565/files?diff=unified&w=0#diff-1386fbbdaaaada188b215b4c23e522a6d69e30c0800ed974710a37a1845a71c8R61), [link](https://github.com/JesusFilm/core/pull/1565/files?diff=unified&w=0#diff-1386fbbdaaaada188b215b4c23e522a6d69e30c0800ed974710a37a1845a71c8L78-R81), [link](https://github.com/JesusFilm/core/pull/1565/files?diff=unified&w=0#diff-1386fbbdaaaada188b215b4c23e522a6d69e30c0800ed974710a37a1845a71c8L113-R117), [link](https://github.com/JesusFilm/core/pull/1565/files?diff=unified&w=0#diff-1386fbbdaaaada188b215b4c23e522a6d69e30c0800ed974710a37a1845a71c8R183-R225))
