### PR TITLE
fix: change get cf video to query

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -893,7 +893,6 @@ type Mutation
   createCloudflareVideoUploadByFile(uploadLength: Int!, name: String!): CloudflareVideo @join__field(graph: MEDIA)
   createCloudflareVideoUploadByUrl(url: String!): CloudflareVideo @join__field(graph: MEDIA)
   deleteCloudflareVideo(id: ID!): Boolean @join__field(graph: MEDIA)
-  cloudflareVideoCheckReadyToStream(id: ID!): CloudflareVideo @join__field(graph: MEDIA)
   triggerUnsplashDownload(url: String!): Boolean @join__field(graph: MEDIA)
 }
 
@@ -1025,6 +1024,7 @@ type Query
   language(id: ID!, idType: LanguageIdType): Language @join__field(graph: LANGUAGES)
   getMyCloudflareImages: [CloudflareImage] @join__field(graph: MEDIA)
   getMyCloudflareVideos: [CloudflareVideo] @join__field(graph: MEDIA)
+  getMyCloudflareVideo(id: ID!): CloudflareVideo @join__field(graph: MEDIA)
   listUnsplashCollectionPhotos(collectionId: String!, page: Int, perPage: Int, orientation: UnsplashPhotoOrientation): [UnsplashPhoto!]! @join__field(graph: MEDIA)
   searchUnsplashPhotos(query: String!, page: Int, perPage: Int, orderBy: UnsplashOrderBy, collections: [String], contentFilter: UnsplashContentFilter, color: UnsplashColor, orientation: UnsplashPhotoOrientation): UnsplashQueryResponse! @join__field(graph: MEDIA)
   tags: [Tag!]! @join__field(graph: TAGS)

--- a/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
@@ -473,6 +473,7 @@ describe('VideoBlockResolver', () => {
           videoId: 'ea95132c15732412d22c1476fa83f27a',
           source: VideoBlockSource.cloudflare,
           duration: 100,
+          endAt: 100,
           image:
             'https://cloudflarestream.com/ea95132c15732412d22c1476fa83f27a/thumbnails/thumbnail.jpg?time=2s',
           title: 'video.mp4',
@@ -522,6 +523,7 @@ describe('VideoBlockResolver', () => {
           videoId: 'ea95132c15732412d22c1476fa83f27a',
           source: VideoBlockSource.cloudflare,
           duration: 100,
+          endAt: 100,
           image:
             'https://cloudflarestream.com/ea95132c15732412d22c1476fa83f27a/thumbnails/thumbnail.jpg?time=2s',
           title: 'ea95132c15732412d22c1476fa83f27a',

--- a/apps/api-journeys/src/app/modules/block/video/video.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/video/video.resolver.ts
@@ -212,8 +212,8 @@ export class VideoBlockResolver {
         })
         if (input.videoId != null) {
           input = {
-            ...input,
-            ...(await this.fetchFieldsFromCloudflare(input.videoId))
+            ...(await this.fetchFieldsFromCloudflare(input.videoId)),
+            ...input
           }
         }
         break
@@ -314,7 +314,8 @@ export class VideoBlockResolver {
     return {
       title: response.result.meta.name ?? response.result.uid,
       image: `${response.result.thumbnail}?time=2s`,
-      duration: Math.round(response.result.duration)
+      duration: Math.round(response.result.duration),
+      endAt: Math.round(response.result.duration)
     }
   }
 }

--- a/apps/api-media/schema.graphql
+++ b/apps/api-media/schema.graphql
@@ -25,6 +25,7 @@ type Query {
 extend type Query {
   getMyCloudflareImages: [CloudflareImage]
   getMyCloudflareVideos: [CloudflareVideo]
+  getMyCloudflareVideo(id: ID!): CloudflareVideo
   listUnsplashCollectionPhotos(collectionId: String!, page: Int, perPage: Int, orientation: UnsplashPhotoOrientation): [UnsplashPhoto!]!
   searchUnsplashPhotos(query: String!, page: Int, perPage: Int, orderBy: UnsplashOrderBy, collections: [String], contentFilter: UnsplashContentFilter, color: UnsplashColor, orientation: UnsplashPhotoOrientation): UnsplashQueryResponse!
 }
@@ -37,7 +38,6 @@ extend type Mutation {
   createCloudflareVideoUploadByFile(uploadLength: Int!, name: String!): CloudflareVideo
   createCloudflareVideoUploadByUrl(url: String!): CloudflareVideo
   deleteCloudflareVideo(id: ID!): Boolean
-  cloudflareVideoCheckReadyToStream(id: ID!): CloudflareVideo
   triggerUnsplashDownload(url: String!): Boolean
 }
 

--- a/apps/api-media/src/app/__generated__/graphql.ts
+++ b/apps/api-media/src/app/__generated__/graphql.ts
@@ -53,6 +53,8 @@ export abstract class IQuery {
 
     abstract getMyCloudflareVideos(): Nullable<Nullable<CloudflareVideo>[]> | Promise<Nullable<Nullable<CloudflareVideo>[]>>;
 
+    abstract getMyCloudflareVideo(id: string): Nullable<CloudflareVideo> | Promise<Nullable<CloudflareVideo>>;
+
     abstract listUnsplashCollectionPhotos(collectionId: string, page?: Nullable<number>, perPage?: Nullable<number>, orientation?: Nullable<UnsplashPhotoOrientation>): UnsplashPhoto[] | Promise<UnsplashPhoto[]>;
 
     abstract searchUnsplashPhotos(query: string, page?: Nullable<number>, perPage?: Nullable<number>, orderBy?: Nullable<UnsplashOrderBy>, collections?: Nullable<Nullable<string>[]>, contentFilter?: Nullable<UnsplashContentFilter>, color?: Nullable<UnsplashColor>, orientation?: Nullable<UnsplashPhotoOrientation>): UnsplashQueryResponse | Promise<UnsplashQueryResponse>;
@@ -171,8 +173,6 @@ export abstract class IMutation {
     abstract createCloudflareVideoUploadByUrl(url: string): Nullable<CloudflareVideo> | Promise<Nullable<CloudflareVideo>>;
 
     abstract deleteCloudflareVideo(id: string): Nullable<boolean> | Promise<Nullable<boolean>>;
-
-    abstract cloudflareVideoCheckReadyToStream(id: string): Nullable<CloudflareVideo> | Promise<Nullable<CloudflareVideo>>;
 
     abstract triggerUnsplashDownload(url: string): Nullable<boolean> | Promise<Nullable<boolean>>;
 }

--- a/apps/api-media/src/app/modules/cloudflare/video/video.graphql
+++ b/apps/api-media/src/app/modules/cloudflare/video/video.graphql
@@ -8,6 +8,7 @@ type CloudflareVideo {
 
 extend type Query {
   getMyCloudflareVideos: [CloudflareVideo]
+  getMyCloudflareVideo(id: ID!): CloudflareVideo
 }
 
 extend type Mutation {
@@ -17,5 +18,4 @@ extend type Mutation {
   ): CloudflareVideo
   createCloudflareVideoUploadByUrl(url: String!): CloudflareVideo
   deleteCloudflareVideo(id: ID!): Boolean
-  cloudflareVideoCheckReadyToStream(id: ID!): CloudflareVideo
 }

--- a/apps/api-media/src/app/modules/cloudflare/video/video.resolver.ts
+++ b/apps/api-media/src/app/modules/cloudflare/video/video.resolver.ts
@@ -56,6 +56,27 @@ export class VideoResolver {
     return await this.videoService.getCloudflareVideosForUserId(userId)
   }
 
+  @Query()
+  async getMyCloudflareVideo(
+    @Args('id') id: string,
+    @CurrentUserId() userId: string
+  ): Promise<CloudflareVideo> {
+    const video = await this.videoService.get(id)
+    if (video == null) {
+      throw new UserInputError('Video not found')
+    }
+    if (video.userId !== userId) {
+      throw new ForbiddenError('This video does not belong to you')
+    }
+    const response = await this.videoService.getVideoFromCloudflare(id)
+    if (!response.success) {
+      throw new Error(response.errors[0])
+    }
+    return await this.videoService.update(id, {
+      readyToStream: response.result?.readyToStream ?? false
+    })
+  }
+
   @Mutation()
   async deleteCloudflareVideo(
     @Args('id') id: string,
@@ -74,26 +95,5 @@ export class VideoResolver {
     }
     await this.videoService.remove(id)
     return true
-  }
-
-  @Mutation()
-  async cloudflareVideoCheckReadyToStream(
-    @Args('id') id: string,
-    @CurrentUserId() userId: string
-  ): Promise<CloudflareVideo> {
-    const video = await this.videoService.get(id)
-    if (video == null) {
-      throw new UserInputError('Video not found')
-    }
-    if (video.userId !== userId) {
-      throw new ForbiddenError('This video does not belong to you')
-    }
-    const response = await this.videoService.getVideoFromCloudflare(id)
-    if (!response.success) {
-      throw new Error(response.errors[0])
-    }
-    return await this.videoService.update(id, {
-      readyToStream: response.result?.readyToStream ?? false
-    })
   }
 }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e0dca62</samp>

This pull request simplifies the API for fetching and streaming videos from Cloudflare by removing an unnecessary mutation and adding a query that delegates to the `api-media` service. It also adds a mutation to delete videos from Cloudflare and the database. It updates the schema, the generated typescript file, the video module, and the tests to reflect these changes.

This needed to be a query instead of a mutation so we can enable polling on the endpoint.

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e0dca62</samp>

*  Remove `cloudflareVideoCheckReadyToStream` mutation from both `api-gateway` and `api-media` schemas and resolvers as it is replaced by `getMyCloudflareVideo` query ([link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-e60078ed0fc71b8cd3bb2fca25505e7dba866b7d463147662a12432dfe287273L896), [link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-e60078ed0fc71b8cd3bb2fca25505e7dba866b7d463147662a12432dfe287273R1027), [link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-46a9b880e32bef81e8745711b5f7356164752b2c164f17c8ff964f859446185dR28), [link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-46a9b880e32bef81e8745711b5f7356164752b2c164f17c8ff964f859446185dL40), [link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-a418964c67ece303753a2a40114a6808edb92e53fdf4bd6c9d1f6bc1d92efde7L20), [link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-1386fbbdaaaada188b215b4c23e522a6d69e30c0800ed974710a37a1845a71c8L205-R174), [link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-1386fbbdaaaada188b215b4c23e522a6d69e30c0800ed974710a37a1845a71c8L218-R188), [link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-61cff936a34d9ef3d5d35bbda83ab59e2669993f360aee600da1ede2cdb6f412L71-R84), [link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-61cff936a34d9ef3d5d35bbda83ab59e2669993f360aee600da1ede2cdb6f412L91-R97))
* Add `getMyCloudflareVideo` query to both `api-gateway` and `api-media` schemas and resolvers to fetch a video by id from the database and Cloudflare and update the database with the readyToStream flag ([link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-e60078ed0fc71b8cd3bb2fca25505e7dba866b7d463147662a12432dfe287273R1027), [link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-46a9b880e32bef81e8745711b5f7356164752b2c164f17c8ff964f859446185dR28), [link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-f252069f7eff887cec189bd2a972d6e03f0c9523c0e71ab20b3681983e1f3f11R56-R57), [link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-a418964c67ece303753a2a40114a6808edb92e53fdf4bd6c9d1f6bc1d92efde7R11), [link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-1386fbbdaaaada188b215b4c23e522a6d69e30c0800ed974710a37a1845a71c8L154-R165), [link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-61cff936a34d9ef3d5d35bbda83ab59e2669993f360aee600da1ede2cdb6f412L59-R63))
* Add `deleteCloudflareVideo` mutation to `api-media` schema and resolver to delete a video from Cloudflare and the database and return true ([link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-46a9b880e32bef81e8745711b5f7356164752b2c164f17c8ff964f859446185dL40), [link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-f252069f7eff887cec189bd2a972d6e03f0c9523c0e71ab20b3681983e1f3f11L175-L176), [link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-a418964c67ece303753a2a40114a6808edb92e53fdf4bd6c9d1f6bc1d92efde7L20), [link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-1386fbbdaaaada188b215b4c23e522a6d69e30c0800ed974710a37a1845a71c8R194-R222), [link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-61cff936a34d9ef3d5d35bbda83ab59e2669993f360aee600da1ede2cdb6f412L71-R84))
* Update `api-media` generated typescript file to reflect the schema changes ([link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-f252069f7eff887cec189bd2a972d6e03f0c9523c0e71ab20b3681983e1f3f11R56-R57), [link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-f252069f7eff887cec189bd2a972d6e03f0c9523c0e71ab20b3681983e1f3f11L175-L176))
* Update `video.resolver.spec.ts` file in `api-media` video module to test the new query and mutation and remove the old mutation test ([link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-1386fbbdaaaada188b215b4c23e522a6d69e30c0800ed974710a37a1845a71c8L154-R165), [link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-1386fbbdaaaada188b215b4c23e522a6d69e30c0800ed974710a37a1845a71c8L205-R174), [link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-1386fbbdaaaada188b215b4c23e522a6d69e30c0800ed974710a37a1845a71c8L218-R188), [link](https://github.com/JesusFilm/core/pull/1566/files?diff=unified&w=0#diff-1386fbbdaaaada188b215b4c23e522a6d69e30c0800ed974710a37a1845a71c8R194-R222))
