### PR TITLE
feat: rds subnet update

### DIFF
--- a/infrastructure/modules/aws/aurora/main.tf
+++ b/infrastructure/modules/aws/aurora/main.tf
@@ -19,6 +19,8 @@ resource "aws_rds_cluster" "default" {
   preferred_backup_window     = "07:00-09:00"
   vpc_security_group_ids      = [var.vpc_security_group_id]
   allow_major_version_upgrade = true
+  snapshot_identifier         = "${var.name}-${var.env}-final-snapshot"
+  final_snapshot_identifier   = "${var.name}-${var.env}-final-snapshot"
   serverlessv2_scaling_configuration {
     max_capacity = 16
     min_capacity = 0.5
@@ -26,11 +28,12 @@ resource "aws_rds_cluster" "default" {
 }
 
 resource "aws_rds_cluster_instance" "default" {
-  cluster_identifier = aws_rds_cluster.default.id
-  instance_class     = "db.serverless"
-  engine             = aws_rds_cluster.default.engine
-  engine_version     = aws_rds_cluster.default.engine_version
-  promotion_tier     = 1
+  cluster_identifier  = aws_rds_cluster.default.id
+  instance_class      = "db.serverless"
+  engine              = aws_rds_cluster.default.engine
+  engine_version      = aws_rds_cluster.default.engine_version
+  publicly_accessible = true
+  promotion_tier      = 1
 }
 
 resource "aws_ssm_parameter" "parameter" {

--- a/infrastructure/modules/aws/main.tf
+++ b/infrastructure/modules/aws/main.tf
@@ -24,14 +24,7 @@ module "internal_rds_security_group" {
       cidr_blocks = concat([var.cidr], local.google_datastream_ip_list)
     }
   ]
-  egress_rules = [
-    {
-      from_port   = 0
-      to_port     = 0
-      protocol    = "-1"
-      cidr_blocks = [var.cidr]
-    }
-  ]
+  egress_rules = local.egress_rules
 }
 
 module "public_alb_security_group" {

--- a/infrastructure/modules/aws/vpc/main.tf
+++ b/infrastructure/modules/aws/vpc/main.tf
@@ -103,7 +103,7 @@ resource "aws_eip" "eip" {
   }
 }
 
-resource "aws_db_subnet_group" "default" {
-  name       = var.env
-  subnet_ids = [for subnet in aws_subnet.internal_subnet : subnet.id]
+resource "aws_db_subnet_group" "public" {
+  name       = "${var.env}-public"
+  subnet_ids = [for subnet in aws_subnet.public_subnet : subnet.id]
 }

--- a/infrastructure/modules/aws/vpc/outputs.tf
+++ b/infrastructure/modules/aws/vpc/outputs.tf
@@ -11,5 +11,5 @@ output "public_subnets" {
 }
 
 output "db_subnet_group_name" {
-  value = aws_db_subnet_group.default.name
+  value = aws_db_subnet_group.public.name
 }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 91b445d</samp>

This pull request enables public access and snapshot management for the Aurora serverless cluster. It creates a new `aws_db_subnet_group` for the public subnets, modifies the `aws_security_group` and `aws_rds_cluster` resources, and updates the output of the `vpc` module.

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 91b445d</samp>

*  Enable public access to Aurora serverless cluster by:
  - Adding `publicly_accessible` parameter to `aws_rds_cluster_instance` resource ([link](https://github.com/JesusFilm/core/pull/1569/files?diff=unified&w=0#diff-73b553a01d0ea00ac3ed34bc813c605506caabf3a464684b4781e949f9fb8f55L29-R36))
  - Creating `public` `aws_db_subnet_group` resource with public subnets ([link](https://github.com/JesusFilm/core/pull/1569/files?diff=unified&w=0#diff-63e0100b32bbf302a723d3c7c0e8d3c8cb51b469cdb589d420672ef0be2f586cL106-R108))
  - Changing `db_subnet_group_name` output to return public subnet group name ([link](https://github.com/JesusFilm/core/pull/1569/files?diff=unified&w=0#diff-7740e7c0ff96956f94dee58ed3cac177e3ee8e839041dda3c4cd5e8f609d49f4L14-R14))
* Add snapshot parameters to `aws_rds_cluster` resource to specify snapshot names for cluster deletion and restoration ([link](https://github.com/JesusFilm/core/pull/1569/files?diff=unified&w=0#diff-73b553a01d0ea00ac3ed34bc813c605506caabf3a464684b4781e949f9fb8f55R22-R23))
* Refactor `egress_rules` for `aws_security_group` resource to use local variable for easier customization ([link](https://github.com/JesusFilm/core/pull/1569/files?diff=unified&w=0#diff-1c723fa4d980c09bb55ef9f5b8a4b585ea3d1a36b8ebad7ac1042e20515877a5L27-R27))
