### PR TITLE
feat: revert rds subnet vpn

### DIFF
--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -1,9 +1,10 @@
 module "prod" {
-  source            = "../../modules/aws"
-  certificate_arn   = data.aws_acm_certificate.acm_central_jesusfilm_org.arn
-  env               = "prod"
-  cidr              = "10.10.0.0/16"
-  internal_url_name = "service.internal"
+  source              = "../../modules/aws"
+  certificate_arn     = data.aws_acm_certificate.acm_central_jesusfilm_org.arn
+  env                 = "prod"
+  cidr                = "10.10.0.0/16"
+  internal_url_name   = "service.internal"
+  vpn_certificate_arn = data.aws_acm_certificate.acm_central_jesusfilm_org.arn
 }
 
 locals {

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -1,10 +1,9 @@
 module "prod" {
-  source              = "../../modules/aws"
-  certificate_arn     = data.aws_acm_certificate.acm_central_jesusfilm_org.arn
-  env                 = "prod"
-  cidr                = "10.10.0.0/16"
-  internal_url_name   = "service.internal"
-  vpn_certificate_arn = data.aws_acm_certificate.acm_central_jesusfilm_org.arn
+  source            = "../../modules/aws"
+  certificate_arn   = data.aws_acm_certificate.acm_central_jesusfilm_org.arn
+  env               = "prod"
+  cidr              = "10.10.0.0/16"
+  internal_url_name = "service.internal"
 }
 
 locals {
@@ -98,4 +97,14 @@ module "arango-bigquery-etl" {
   task_execution_role_arn = data.aws_iam_role.ecs_task_execution_role.arn
   subnet_ids              = module.prod.vpc.internal_subnets
   cluster_arn             = module.prod.ecs.ecs_cluster.arn
+}
+
+module "bastion" {
+  source             = "../../modules/aws/ec2-bastion"
+  name               = "bastion"
+  env                = "prod"
+  dns_name           = "bastion.central.jesusfilm.org"
+  subnet_id          = module.prod.vpc.public_subnets[0]
+  zone_id            = data.aws_route53_zone.route53_central_jesusfilm_org.zone_id
+  security_group_ids = [module.prod.public_bastion_security_group_id]
 }

--- a/infrastructure/environments/stage/data.tf
+++ b/infrastructure/environments/stage/data.tf
@@ -6,6 +6,10 @@ data "aws_route53_zone" "route53_central_jesusfilm_org" {
   name = "central.jesusfilm.org"
 }
 
+data "aws_route53_zone" "route53_stage_central_jesusfilm_org" {
+  name = "stage.central.jesusfilm.org"
+}
+
 data "aws_iam_role" "ecs_task_execution_role" {
   name = "jfp-ecs-task-execution-role"
 }

--- a/infrastructure/environments/stage/main.tf
+++ b/infrastructure/environments/stage/main.tf
@@ -1,9 +1,10 @@
 module "stage" {
-  source            = "../../modules/aws"
-  env               = "stage"
-  cidr              = "10.11.0.0/16"
-  internal_url_name = "stage.internal"
-  certificate_arn   = aws_acm_certificate.stage.arn
+  source              = "../../modules/aws"
+  env                 = "stage"
+  cidr                = "10.11.0.0/16"
+  internal_url_name   = "stage.internal"
+  certificate_arn     = aws_acm_certificate.stage.arn
+  vpn_certificate_arn = data.aws_acm_certificate.acm_central_jesusfilm_org.arn
 }
 
 module "route53_stage_central_jesusfilm_org" {

--- a/infrastructure/environments/stage/main.tf
+++ b/infrastructure/environments/stage/main.tf
@@ -132,6 +132,6 @@ module "bastion" {
   env                = "stage"
   dns_name           = "bastion.stage.central.jesusfilm.org"
   subnet_id          = module.stage.vpc.public_subnets[0]
-  zone_id            = data.aws_route53_zone.route53_central_jesusfilm_org.zone_id
+  zone_id            = data.aws_route53_zone.route53_stage_central_jesusfilm_org.zone_id
   security_group_ids = [module.stage.public_bastion_security_group_id]
 }

--- a/infrastructure/environments/stage/main.tf
+++ b/infrastructure/environments/stage/main.tf
@@ -1,10 +1,9 @@
 module "stage" {
-  source              = "../../modules/aws"
-  env                 = "stage"
-  cidr                = "10.11.0.0/16"
-  internal_url_name   = "stage.internal"
-  certificate_arn     = aws_acm_certificate.stage.arn
-  vpn_certificate_arn = data.aws_acm_certificate.acm_central_jesusfilm_org.arn
+  source            = "../../modules/aws"
+  env               = "stage"
+  cidr              = "10.11.0.0/16"
+  internal_url_name = "stage.internal"
+  certificate_arn   = aws_acm_certificate.stage.arn
 }
 
 module "route53_stage_central_jesusfilm_org" {
@@ -125,4 +124,14 @@ module "api-media" {
   ecs_config    = local.internal_ecs_config
   env           = "stage"
   doppler_token = data.aws_ssm_parameter.doppler_api_media_stage_token.value
+}
+
+module "bastion" {
+  source             = "../../modules/aws/ec2-bastion"
+  name               = "bastion"
+  env                = "stage"
+  dns_name           = "bastion.stage.central.jesusfilm.org"
+  subnet_id          = module.stage.vpc.public_subnets[0]
+  zone_id            = data.aws_route53_zone.route53_central_jesusfilm_org.zone_id
+  security_group_ids = [module.stage.public_bastion_security_group_id]
 }

--- a/infrastructure/modules/aws/aurora/main.tf
+++ b/infrastructure/modules/aws/aurora/main.tf
@@ -19,6 +19,8 @@ resource "aws_rds_cluster" "default" {
   preferred_backup_window     = "07:00-09:00"
   vpc_security_group_ids      = [var.vpc_security_group_id]
   allow_major_version_upgrade = true
+  snapshot_identifier         = "${var.name}-${var.env}-final-snapshot"
+  final_snapshot_identifier   = "${var.name}-${var.env}-final-snapshot"
   serverlessv2_scaling_configuration {
     max_capacity = 16
     min_capacity = 0.5

--- a/infrastructure/modules/aws/ec2-bastion/data.tf
+++ b/infrastructure/modules/aws/ec2-bastion/data.tf
@@ -1,0 +1,3 @@
+data "aws_ssm_parameter" "public_ssh_key" {
+  name = "/terraform/prd/SSH_TUNNEL_PUBLIC_KEY"
+}

--- a/infrastructure/modules/aws/ec2-bastion/main.tf
+++ b/infrastructure/modules/aws/ec2-bastion/main.tf
@@ -1,0 +1,26 @@
+
+resource "aws_cloudwatch_log_group" "ecs_cw_log_group" {
+  name = "${var.name}-${var.env}-logs"
+}
+
+resource "aws_key_pair" "default" {
+  key_name   = "${var.name}-${var.env}-keypair"
+  public_key = data.aws_ssm_parameter.public_ssh_key.value
+}
+
+resource "aws_instance" "bastion" {
+  ami                         = "ami-08333bccc35d71140"
+  instance_type               = "t2.micro"
+  associate_public_ip_address = true
+  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = var.security_group_ids
+  key_name                    = aws_key_pair.default.key_name
+}
+
+resource "aws_route53_record" "record" {
+  name    = var.dns_name
+  type    = "A"
+  ttl     = 300
+  zone_id = var.zone_id
+  records = [aws_instance.bastion.public_ip]
+}

--- a/infrastructure/modules/aws/ec2-bastion/variables.tf
+++ b/infrastructure/modules/aws/ec2-bastion/variables.tf
@@ -1,0 +1,23 @@
+variable "subnet_id" {
+  type = string
+}
+
+variable "security_group_ids" {
+  type = list(string)
+}
+
+variable "name" {
+  type = string
+}
+
+variable "env" {
+  type = string
+}
+
+variable "dns_name" {
+  type = string
+}
+
+variable "zone_id" {
+  type = string
+}

--- a/infrastructure/modules/aws/main.tf
+++ b/infrastructure/modules/aws/main.tf
@@ -21,17 +21,10 @@ module "internal_rds_security_group" {
       from_port   = 5432
       to_port     = 5432
       protocol    = "tcp"
-      cidr_blocks = concat([var.cidr], local.google_datastream_ip_list)
-    }
-  ]
-  egress_rules = [
-    {
-      from_port   = 0
-      to_port     = 0
-      protocol    = "-1"
       cidr_blocks = [var.cidr]
     }
   ]
+  egress_rules = local.egress_rules
 }
 
 module "public_alb_security_group" {
@@ -83,3 +76,14 @@ module "ecs" {
   public_alb_security_group   = module.public_alb_security_group
 }
 
+module "vpn" {
+  source          = "./vpn"
+  dns_name        = "vpn-${var.env}.central.jesusfilm.org"
+  name            = "jfp-vpn-${var.env}"
+  vpc_id          = module.vpc.vpc_id
+  vpc_cidr_block  = var.cidr
+  cidr_block      = "10.0.0.0/16"
+  subnets         = module.vpc.public_subnets
+  certificate_arn = var.vpn_certificate_arn
+  dns_server      = var.env == "prod" ? "10.10.0.2" : "10.11.0.2"
+}

--- a/infrastructure/modules/aws/outputs.tf
+++ b/infrastructure/modules/aws/outputs.tf
@@ -38,6 +38,9 @@ output "private_rds_security_group_id" {
   value = module.internal_rds_security_group.security_group_id
 }
 
+output "public_bastion_security_group_id" {
+  value = module.public_bastion_security_group.security_group_id
+}
 
 output "ecs" {
   value = {

--- a/infrastructure/modules/aws/variables.tf
+++ b/infrastructure/modules/aws/variables.tf
@@ -17,6 +17,3 @@ variable "certificate_arn" {
   type = string
 }
 
-variable "vpn_certificate_arn" {
-  type = string
-}

--- a/infrastructure/modules/aws/variables.tf
+++ b/infrastructure/modules/aws/variables.tf
@@ -16,3 +16,7 @@ variable "internal_url_name" {
 variable "certificate_arn" {
   type = string
 }
+
+variable "vpn_certificate_arn" {
+  type = string
+}


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 35c9382</samp>

This pull request adds features to enable VPN access and improve database backup and restore. It creates a new `vpn` module and configures its certificate and security group rules. It also adds parameters to the `aurora` module to handle snapshots. It updates the `prod` and `stage` modules to use these new features.

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 35c9382</samp>

* Enable VPN access to the prod and stage environments by creating a VPN endpoint and associated resources in the AWS VPC ([link](https://github.com/JesusFilm/core/pull/1570/files?diff=unified&w=0#diff-1c723fa4d980c09bb55ef9f5b8a4b585ea3d1a36b8ebad7ac1042e20515877a5R79-R89))
  * Add a new variable `vpn_certificate_arn` to the `aws`, `prod`, and `stage` modules, which is used to specify the ACM certificate ARN for the VPN module ([link](https://github.com/JesusFilm/core/pull/1570/files?diff=unified&w=0#diff-9ca20189fcff1e8339a2408bdaaf186a63438e1173cfc7ba6a8289ef66bcb6deL2-R7), [link](https://github.com/JesusFilm/core/pull/1570/files?diff=unified&w=0#diff-16ccc6a5a02661c2618449c5bf7dece8b8a3e7bca8720cd6a074efe098ae6ca8L2-R7), [link](https://github.com/JesusFilm/core/pull/1570/files?diff=unified&w=0#diff-229c43c9343fd0c134066e2cc4907442785479dbde3cc6f4efebd536a936ff02R19-R22))
  * Modify the `egress_rules` parameter of the `security_group` module to use a local variable instead of a hard-coded list, to make the security group rules more configurable and flexible ([link](https://github.com/JesusFilm/core/pull/1570/files?diff=unified&w=0#diff-1c723fa4d980c09bb55ef9f5b8a4b585ea3d1a36b8ebad7ac1042e20515877a5L24-R27))
* Improve the backup and restore process of the Aurora database by adding two new parameters to the `aurora` module, `snapshot_identifier` and `final_snapshot_identifier`, which are used to create and restore snapshots of the database ([link](https://github.com/JesusFilm/core/pull/1570/files?diff=unified&w=0#diff-73b553a01d0ea00ac3ed34bc813c605506caabf3a464684b4781e949f9fb8f55R22-R23))
