### PR TITLE
fix: change submit button mobile

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ImageBlockEditor/UnsplashGallery/UnsplashSearch/UnsplashSearch.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockEditor/UnsplashGallery/UnsplashSearch/UnsplashSearch.tsx
@@ -28,7 +28,7 @@ export function UnsplashSearch({
           <TextField
             id="src"
             name="src"
-            type="Search"
+            type="search"
             variant="filled"
             hiddenLabel
             placeholder="Search by keyword"
@@ -37,6 +37,12 @@ export function UnsplashSearch({
             fullWidth
             inputProps={{
               'aria-label': 'UnsplashSearch'
+              // enterkeyhint: 'Search'
+            }}
+            sx={{
+              'input[type="search"]::-webkit-search-cancel-button': {
+                WebkitAppearance: 'none'
+              }
             }}
             InputProps={{
               startAdornment: (

--- a/apps/journeys-admin/src/components/Editor/ImageBlockEditor/UnsplashGallery/UnsplashSearch/UnsplashSearch.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockEditor/UnsplashGallery/UnsplashSearch/UnsplashSearch.tsx
@@ -28,7 +28,7 @@ export function UnsplashSearch({
           <TextField
             id="src"
             name="src"
-            type="search"
+            // type="search"
             variant="filled"
             hiddenLabel
             placeholder="Search by keyword"
@@ -36,14 +36,14 @@ export function UnsplashSearch({
             onChange={handleChange}
             fullWidth
             inputProps={{
-              'aria-label': 'UnsplashSearch'
-              // enterkeyhint: 'Search'
+              'aria-label': 'UnsplashSearch',
+              enterkeyhint: 'Search'
             }}
-            sx={{
-              'input[type="search"]::-webkit-search-cancel-button': {
-                WebkitAppearance: 'none'
-              }
-            }}
+            // sx={{
+            //   'input[type="search"]::-webkit-search-cancel-button': {
+            //     WebkitAppearance: 'none'
+            //   }
+            // }}
             InputProps={{
               startAdornment: (
                 <InputAdornment position="start">

--- a/apps/journeys-admin/src/components/Editor/ImageBlockEditor/UnsplashGallery/UnsplashSearch/UnsplashSearch.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockEditor/UnsplashGallery/UnsplashSearch/UnsplashSearch.tsx
@@ -28,6 +28,7 @@ export function UnsplashSearch({
           <TextField
             id="src"
             name="src"
+            type="Search"
             variant="filled"
             hiddenLabel
             placeholder="Search by keyword"

--- a/apps/journeys-admin/src/components/Editor/ImageBlockEditor/UnsplashGallery/UnsplashSearch/UnsplashSearch.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockEditor/UnsplashGallery/UnsplashSearch/UnsplashSearch.tsx
@@ -28,7 +28,6 @@ export function UnsplashSearch({
           <TextField
             id="src"
             name="src"
-            // type="search"
             variant="filled"
             hiddenLabel
             placeholder="Search by keyword"
@@ -39,11 +38,6 @@ export function UnsplashSearch({
               'aria-label': 'UnsplashSearch',
               enterkeyhint: 'Search'
             }}
-            // sx={{
-            //   'input[type="search"]::-webkit-search-cancel-button': {
-            //     WebkitAppearance: 'none'
-            //   }
-            // }}
             InputProps={{
               startAdornment: (
                 <InputAdornment position="start">


### PR DESCRIPTION
# Description


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6995705</samp>

Added `enterkeyhint` attribute to `TextField` component in `UnsplashSearch.tsx` to provide a hint for the enter key action. This improves the UX and accessibility of the image search feature.


[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/32387559/todos/6069155338)

# How should this PR be QA Tested?



- [ ] iOS devices should have "Search" for the label on the enter button keyboard
- [ ] Android devices will either show 'search' or a picture of a magnifying glass on the enter button keyboard

# Walkthrough


<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6995705</samp>

*  Add `enterkeyhint` attribute to `TextField` input props to provide a hint for the enter key action ([link](https://github.com/JesusFilm/core/pull/1574/files?diff=unified&w=0#diff-20f69ef9476dc0048dc62fd8041b3da454c9b0c437ae05cb46a6a826e282daaeL38-R39))


