### PR TITLE
feat: text field form

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ActionDetails/ActionEditor/ActionEditor.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionDetails/ActionEditor/ActionEditor.tsx
@@ -1,7 +1,5 @@
 import { ReactElement, ReactNode } from 'react'
 import Box from '@mui/material/Box'
-import { Formik, Form } from 'formik'
-import TextField from '@mui/material/TextField'
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import { gql, useMutation } from '@apollo/client'
 import { object, string } from 'yup'
@@ -13,6 +11,7 @@ import Stack from '@mui/material/Stack'
 import { BlockFields_ButtonBlock as ButtonBlock } from '../../../../../__generated__/BlockFields'
 import { ActionFields_LinkAction as LinkAction } from '../../../../../__generated__/ActionFields'
 import { MultipleLinkActionUpdate } from '../../../../../__generated__/MultipleLinkActionUpdate'
+import { TextFieldForm } from '../../../TextFieldForm'
 
 export const MULTIPLE_LINK_ACTION_UPDATE = gql`
   mutation MultipleLinkActionUpdate(
@@ -118,36 +117,13 @@ export function ActionEditor({
 
   return (
     <Box sx={{ pt: 6 }} data-testid="ActionEditor">
-      <Formik
-        initialValues={{
-          link: url ?? ''
-        }}
+      <TextFieldForm
+        id="link"
+        label="Navigate to"
+        initialValues={url}
         validationSchema={linkActionSchema}
-        onSubmit={async (values): Promise<void> => {
-          await handleSubmit(values.link)
-        }}
-        enableReinitialize
-      >
-        {({ values, touched, errors, handleChange, handleBlur }) => (
-          <Form>
-            <TextField
-              id="link"
-              name="link"
-              variant="filled"
-              label="Navigate to"
-              fullWidth
-              value={values.link}
-              error={touched.link === true && Boolean(errors.link)}
-              helperText={touched.link === true && errors.link}
-              onBlur={(e) => {
-                handleBlur(e)
-                errors.link == null && handleSubmit(e.target.value)
-              }}
-              onChange={handleChange}
-            />
-          </Form>
-        )}
-      </Formik>
+        handleSubmit={handleSubmit}
+      />
       <Stack gap={2} direction="row" alignItems="center" sx={{ pt: 3 }}>
         {icon}
         <Typography variant="subtitle2">{goalLabel?.(url)}</Typography>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/EmailAction/EmailAction.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/EmailAction/EmailAction.tsx
@@ -3,13 +3,12 @@ import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import { useEditor } from '@core/journeys/ui/EditorProvider'
 import type { TreeBlock } from '@core/journeys/ui/block'
 import { gql, useMutation } from '@apollo/client'
-import TextField from '@mui/material/TextField'
-import { Formik, Form } from 'formik'
 import { object, string } from 'yup'
 import InputAdornment from '@mui/material/InputAdornment'
 import DraftsIcon from '@mui/icons-material/Drafts'
 import Box from '@mui/material/Box'
 import { GetJourney_journey_blocks_ButtonBlock as ButtonBlock } from '../../../../../../../__generated__/GetJourney'
+import { TextFieldForm } from '../../../../../TextFieldForm'
 
 export const EMAIL_ACTION_UPDATE = gql`
   mutation EmailActionUpdate(
@@ -24,10 +23,6 @@ export const EMAIL_ACTION_UPDATE = gql`
   }
 `
 
-interface EmailActionFormValues {
-  email: string
-}
-
 export function EmailAction(): ReactElement {
   const { state } = useEditor()
   const { journey } = useJourney()
@@ -41,10 +36,6 @@ export function EmailAction(): ReactElement {
     selectedBlock?.action?.__typename === 'EmailAction'
       ? selectedBlock.action
       : undefined
-
-  const initialValues: EmailActionFormValues = {
-    email: emailAction?.email ?? ''
-  }
 
   const emailActionSchema = object({
     email: string()
@@ -82,41 +73,18 @@ export function EmailAction(): ReactElement {
 
   return (
     <Box sx={{ pt: 8 }}>
-      <Formik
-        initialValues={initialValues}
+      <TextFieldForm
+        id="email"
+        label="Paste Email here..."
+        initialValues={emailAction?.email}
         validationSchema={emailActionSchema}
-        onSubmit={async (values): Promise<void> => {
-          await handleSubmit(values.email)
-        }}
-        enableReinitialize
-      >
-        {({ values, touched, errors, handleChange, handleBlur }) => (
-          <Form>
-            <TextField
-              id="email"
-              name="email"
-              variant="filled"
-              label="Paste Email here..."
-              fullWidth
-              value={values.email}
-              error={touched.email === true && Boolean(errors.email)}
-              helperText={touched.email === true && errors.email}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <DraftsIcon />
-                  </InputAdornment>
-                )
-              }}
-              onBlur={async (e) => {
-                handleBlur(e)
-                errors.email == null && (await handleSubmit(e.target.value))
-              }}
-              onChange={handleChange}
-            />
-          </Form>
-        )}
-      </Formik>
+        handleSubmit={handleSubmit}
+        startIcon={
+          <InputAdornment position="start">
+            <DraftsIcon />
+          </InputAdornment>
+        }
+      />
     </Box>
   )
 }

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/LinkAction/LinkAction.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/LinkAction/LinkAction.tsx
@@ -3,14 +3,13 @@ import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import { useEditor } from '@core/journeys/ui/EditorProvider'
 import type { TreeBlock } from '@core/journeys/ui/block'
 import { gql, useMutation } from '@apollo/client'
-import TextField from '@mui/material/TextField'
-import { Formik, Form } from 'formik'
 import { object, string } from 'yup'
-import InputAdornment from '@mui/material/InputAdornment'
 import InsertLinkRoundedIcon from '@mui/icons-material/InsertLinkRounded'
 import Box from '@mui/material/Box'
+import InputAdornment from '@mui/material/InputAdornment'
 import { GetJourney_journey_blocks_ButtonBlock as ButtonBlock } from '../../../../../../../__generated__/GetJourney'
 import { LinkActionUpdate } from '../../../../../../../__generated__/LinkActionUpdate'
+import { TextFieldForm } from '../../../../../TextFieldForm'
 
 export const LINK_ACTION_UPDATE = gql`
   mutation LinkActionUpdate(
@@ -25,10 +24,6 @@ export const LINK_ACTION_UPDATE = gql`
   }
 `
 
-interface LinkActionFormValues {
-  link: string
-}
-
 export function LinkAction(): ReactElement {
   const { state } = useEditor()
   const { journey } = useJourney()
@@ -42,8 +37,6 @@ export function LinkAction(): ReactElement {
     selectedBlock?.action?.__typename === 'LinkAction'
       ? selectedBlock.action
       : undefined
-
-  const initialValues: LinkActionFormValues = { link: linkAction?.url ?? '' }
 
   // check for valid URL
   function checkURL(value?: string): boolean {
@@ -98,41 +91,18 @@ export function LinkAction(): ReactElement {
 
   return (
     <Box sx={{ pt: 8 }}>
-      <Formik
-        initialValues={initialValues}
+      <TextFieldForm
+        id="link"
+        label="Paste URL here..."
+        initialValues={linkAction?.url}
         validationSchema={linkActionSchema}
-        onSubmit={async (values): Promise<void> => {
-          await handleSubmit(values.link)
-        }}
-        enableReinitialize
-      >
-        {({ values, touched, errors, handleChange, handleBlur }) => (
-          <Form>
-            <TextField
-              id="link"
-              name="link"
-              variant="filled"
-              label="Paste URL here..."
-              fullWidth
-              value={values.link}
-              error={touched.link === true && Boolean(errors.link)}
-              helperText={touched.link === true && errors.link}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <InsertLinkRoundedIcon />
-                  </InputAdornment>
-                )
-              }}
-              onBlur={(e) => {
-                handleBlur(e)
-                errors.link == null && handleSubmit(e.target.value)
-              }}
-              onChange={handleChange}
-            />
-          </Form>
-        )}
-      </Formik>
+        handleSubmit={handleSubmit}
+        startIcon={
+          <InputAdornment position="start">
+            <InsertLinkRoundedIcon />
+          </InputAdornment>
+        }
+      />
     </Box>
   )
 }

--- a/apps/journeys-admin/src/components/TextFieldForm/TextFieldForm.spec.tsx
+++ b/apps/journeys-admin/src/components/TextFieldForm/TextFieldForm.spec.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import Search from '@mui/icons-material/Search'
+import { object, string } from 'yup'
+import { TextFieldForm } from './TextFieldForm'
+
+describe('TextFieldForm', () => {
+  it('should render TextFieldForm', () => {
+    const { getByText, getByRole, getByTestId } = render(
+      <TextFieldForm
+        id="TextField form"
+        label="Navigate to..."
+        initialValues="Default Value"
+        placeholder="Placeholder Value"
+        inputProps={{
+          'data-testid': 'TextField form',
+          'aria-label': 'Search'
+        }}
+        handleSubmit={jest.fn()}
+        endIcon={<Search />}
+      />
+    )
+    const textField = getByRole('textbox')
+    expect(getByText('Navigate to...')).toBeInTheDocument()
+    expect(textField).toHaveAttribute('id', 'TextField form')
+    expect(textField).toHaveAttribute('value', 'Default Value')
+    expect(textField).toHaveAttribute('placeholder', 'Placeholder Value')
+    expect(textField).toHaveAttribute('aria-label', 'Search')
+    expect(getByTestId('TextField form')).toBeInTheDocument()
+    expect(getByTestId('SearchIcon'))
+  })
+
+  it('should show helper text if present', () => {
+    const { getByText } = render(
+      <TextFieldForm
+        label="Navigate to..."
+        initialValues="Default Value"
+        helperText="Label goes here"
+        handleSubmit={jest.fn()}
+      />
+    )
+    expect(getByText('Label goes here')).toBeInTheDocument()
+  })
+
+  it('should call handleSubmit on enter keypress', async () => {
+    const handleSubmit = jest.fn()
+    const { getByRole, getByText } = render(
+      <TextFieldForm
+        label="Navigate to..."
+        initialValues="Default Value"
+        handleSubmit={handleSubmit}
+      />
+    )
+    expect(getByText('Navigate to...')).toBeInTheDocument()
+    fireEvent.change(getByRole('textbox'), {
+      target: { value: 'google.com' }
+    })
+    fireEvent.submit(getByRole('textbox'), { target: { value: 'google.com' } })
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalled()
+    })
+  })
+
+  it('should show error', async () => {
+    const validationSchema = object({
+      link: string().required('This field is required')
+    })
+
+    const { getByRole, getByText } = render(
+      <TextFieldForm
+        id="link"
+        label="Navigate to..."
+        initialValues=""
+        validationSchema={validationSchema}
+        handleSubmit={jest.fn()}
+      />
+    )
+
+    fireEvent.change(getByRole('textbox'), {
+      target: { value: '' }
+    })
+    fireEvent.blur(getByRole('textbox'), { target: { value: '' } })
+
+    await waitFor(() => {
+      expect(getByText('This field is required')).toBeInTheDocument()
+    })
+  })
+
+  it('should call handleSubmit on blur', async () => {
+    const handleSubmit = jest.fn()
+    const validationSchema = object({
+      link: string().required('This field is required')
+    })
+
+    const { getByRole } = render(
+      <TextFieldForm
+        id="link"
+        label="Navigate to..."
+        initialValues="https://google.com"
+        validationSchema={validationSchema}
+        handleSubmit={handleSubmit}
+      />
+    )
+    fireEvent.change(getByRole('textbox'), {
+      target: { value: 'google.com' }
+    })
+    fireEvent.blur(getByRole('textbox'), { target: { value: 'google.com' } })
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/journeys-admin/src/components/TextFieldForm/TextFieldForm.stories.tsx
+++ b/apps/journeys-admin/src/components/TextFieldForm/TextFieldForm.stories.tsx
@@ -1,0 +1,51 @@
+import { Story, Meta } from '@storybook/react'
+import { ComponentProps } from 'react'
+import { noop } from 'lodash'
+import EditRounded from '@mui/icons-material/EditRounded'
+import Stack from '@mui/material/Stack'
+import InputAdornment from '@mui/material/InputAdornment'
+import { simpleComponentConfig } from '../../libs/storybook'
+import { TextFieldForm } from './TextFieldForm'
+
+const TextFieldFormStory = {
+  ...simpleComponentConfig,
+  component: TextFieldForm,
+  title: 'Journeys-Admin/TextFieldForm'
+}
+
+const Template: Story<ComponentProps<typeof TextFieldForm>> = () => (
+  <Stack spacing={4}>
+    <TextFieldForm handleSubmit={noop} />
+    <TextFieldForm
+      label="Initial Value"
+      initialValues="Default Value"
+      handleSubmit={noop}
+    />
+    <TextFieldForm label="Helper text" helperText="Hint" handleSubmit={noop} />
+    <TextFieldForm
+      label="Placeholder"
+      placeholder="Placeholder"
+      handleSubmit={noop}
+    />
+    <TextFieldForm
+      initialValues="Start Icon"
+      handleSubmit={noop}
+      startIcon={
+        <InputAdornment position="start">
+          <EditRounded />
+        </InputAdornment>
+      }
+    />
+    <TextFieldForm
+      label="End Icon"
+      handleSubmit={noop}
+      endIcon={<EditRounded />}
+      hiddenLabel
+    />
+    <TextFieldForm label="Disabled" handleSubmit={noop} disabled />
+  </Stack>
+)
+
+export const States = Template.bind({})
+
+export default TextFieldFormStory as Meta

--- a/apps/journeys-admin/src/components/TextFieldForm/TextFieldForm.stories.tsx
+++ b/apps/journeys-admin/src/components/TextFieldForm/TextFieldForm.stories.tsx
@@ -28,7 +28,7 @@ const Template: Story<ComponentProps<typeof TextFieldForm>> = () => (
       handleSubmit={noop}
     />
     <TextFieldForm
-      initialValues="Start Icon"
+      label="Start Icon"
       handleSubmit={noop}
       startIcon={
         <InputAdornment position="start">

--- a/apps/journeys-admin/src/components/TextFieldForm/TextFieldForm.tsx
+++ b/apps/journeys-admin/src/components/TextFieldForm/TextFieldForm.tsx
@@ -1,0 +1,87 @@
+import { ReactElement, ReactNode } from 'react'
+import { Formik, Form } from 'formik'
+import TextField, { TextFieldProps } from '@mui/material/TextField'
+import { ObjectSchema } from 'yup'
+import { ObjectShape } from 'yup/lib/object'
+
+type FieldProps = Pick<
+  TextFieldProps,
+  | 'id'
+  | 'label'
+  | 'placeholder'
+  | 'disabled'
+  | 'helperText'
+  | 'hiddenLabel'
+  | 'inputProps'
+  | 'sx'
+>
+
+interface TextFieldFormProps extends FieldProps {
+  initialValues?: string
+  validationSchema?: ObjectSchema<ObjectShape>
+  handleSubmit: (value?: string) => void
+  startIcon?: ReactNode
+  endIcon?: ReactNode
+}
+
+export function TextFieldForm({
+  id = 'textFieldValue',
+  label = 'Label',
+  initialValues,
+  validationSchema,
+  helperText,
+  inputProps,
+  hiddenLabel,
+  placeholder,
+  disabled,
+  handleSubmit,
+  startIcon,
+  endIcon
+}: TextFieldFormProps): ReactElement {
+  return (
+    <Formik
+      initialValues={{
+        [id]: initialValues
+      }}
+      validationSchema={validationSchema}
+      onSubmit={async (values): Promise<void> => {
+        await handleSubmit(values[id])
+      }}
+      enableReinitialize
+    >
+      {({ values, touched, errors, handleChange, handleBlur }) => (
+        <Form>
+          <TextField
+            id={id}
+            name={id}
+            variant="filled"
+            fullWidth
+            label={label}
+            placeholder={placeholder}
+            hiddenLabel={hiddenLabel}
+            disabled={disabled}
+            inputProps={inputProps}
+            value={values[id]}
+            error={touched[id] === true && Boolean(errors[id])}
+            helperText={
+              touched[id] === true && errors[id] != null
+                ? errors[id]
+                : helperText
+            }
+            InputProps={{
+              startAdornment: startIcon,
+              endAdornment: endIcon
+            }}
+            onBlur={(e) => {
+              handleBlur(e)
+              errors[id] == null && handleSubmit(e.target.value)
+            }}
+            onChange={(e) => {
+              handleChange(e)
+            }}
+          />
+        </Form>
+      )}
+    </Formik>
+  )
+}

--- a/apps/journeys-admin/src/components/TextFieldForm/index.ts
+++ b/apps/journeys-admin/src/components/TextFieldForm/index.ts
@@ -1,0 +1,1 @@
+export { TextFieldForm } from './TextFieldForm'


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e48f4c</samp>

This pull request introduces a new component called `TextFieldForm` that simplifies the creation and validation of text input forms. It also refactors several existing components that use text input forms to use the new component and improve code quality and performance. The components affected are `ActionEditor`, `LinkAction`, `BackgroundColor`, `Hint`, `Label`, `CustomUrl`, `VideoSearch`, and `AddByUrl`. The pull request also adds tests and stories for the new component.

- Link to Basecamp Todo

# How should this PR be QA Tested?

- [ ] it should enable users to press enter on our text fields

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2e48f4c</samp>

*  Create a reusable `TextFieldForm` component that wraps the `Formik` and `TextField` components and handles the common logic and props for text input forms (F10,F11,F12,F13)
* Replace the `Formik` and `TextField` components with the `TextFieldForm` component in various components that use text input forms, such as `ActionEditor`, `LinkAction`, `BackgroundColor`, `Hint`, `Label`, `CustomUrl`, `UnsplashSearch`, and `VideoSearch` ([link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-c756c0cb7d84870e93284936d771bd0d9e7104ecc5bb7670d15837d3e30fac65L123-R134),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-68de83e3d69405e039b3bfaeca8632ac38c8a9f56ba646244057ee619c38291bL101-R106),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-2402a558d3ef6831a72f1d42948102baf3a0b0a2eea016cc466b6e8dacb35d3aL163-R177),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-4f4aead41054f01f9421a93681666819c9c7ebeeaa8ba92c8f20278f44ff46e2L57-R66),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-a38c015cd8eaa7f4d443566ad58bbeb8a0a5af149a5eba5a0fcf00259d62e7d5L60-R70),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-2f5eaaa35189cd1c83a42c9e4b1573fe242eb9027e2b298f9c9ee348cbe3bae9L90-R87),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-20f69ef9476dc0048dc62fd8041b3da454c9b0c437ae05cb46a6a826e282daaeL17-R31),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-1fe4ffb9952f9097732f45d51d76e116738c2247fc71cba416ffeb389c0fee44L89-R86),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-6c3f6d54f0a5e67a68302a47f58a3fa31f64e8467090b4ffbcccdb9e474c3bc2L45-R58))
* Simplify the `handleSubmit` functions in the `Hint` and `Label` components by taking a value parameter instead of an event and using it for the mutation input, optimistic response, and callback ([link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-4f4aead41054f01f9421a93681666819c9c7ebeeaa8ba92c8f20278f44ff46e2L36-R35),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-4f4aead41054f01f9421a93681666819c9c7ebeeaa8ba92c8f20278f44ff46e2L44-R41),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-4f4aead41054f01f9421a93681666819c9c7ebeeaa8ba92c8f20278f44ff46e2L51-R48),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-a38c015cd8eaa7f4d443566ad58bbeb8a0a5af149a5eba5a0fcf00259d62e7d5L39-R38),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-a38c015cd8eaa7f4d443566ad58bbeb8a0a5af149a5eba5a0fcf00259d62e7d5L47-R44),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-a38c015cd8eaa7f4d443566ad58bbeb8a0a5af149a5eba5a0fcf00259d62e7d5L54-R51))
* Simplify the `handleChange` functions in the `CustomUrl` and `AddByUrl` components by taking an optional value parameter instead of a required one and checking for empty values before making requests ([link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-2f5eaaa35189cd1c83a42c9e4b1573fe242eb9027e2b298f9c9ee348cbe3bae9L34-R34),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-1fe4ffb9952f9097732f45d51d76e116738c2247fc71cba416ffeb389c0fee44L36-R36))
* Rename the `link` field to `value` in the `linkActionSchema` in the `ActionEditor` and `LinkAction` components to match the `Formik` field name and fix the validation schema bug ([link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-c756c0cb7d84870e93284936d771bd0d9e7104ecc5bb7670d15837d3e30fac65L71-R70),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-68de83e3d69405e039b3bfaeca8632ac38c8a9f56ba646244057ee619c38291bL64-R57))
* Reorder and remove unused imports in various files to clean up the code and follow the import order convention ([link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-c756c0cb7d84870e93284936d771bd0d9e7104ecc5bb7670d15837d3e30fac65L3-R16),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-68de83e3d69405e039b3bfaeca8632ac38c8a9f56ba646244057ee619c38291bL6-R12),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-2402a558d3ef6831a72f1d42948102baf3a0b0a2eea016cc466b6e8dacb35d3aL8),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-4f4aead41054f01f9421a93681666819c9c7ebeeaa8ba92c8f20278f44ff46e2L2-R9),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-a38c015cd8eaa7f4d443566ad58bbeb8a0a5af149a5eba5a0fcf00259d62e7d5L1-R10),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-2f5eaaa35189cd1c83a42c9e4b1573fe242eb9027e2b298f9c9ee348cbe3bae9L1-R4),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-2f5eaaa35189cd1c83a42c9e4b1573fe242eb9027e2b298f9c9ee348cbe3bae9L13-R14),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-1fe4ffb9952f9097732f45d51d76e116738c2247fc71cba416ffeb389c0fee44L1-R4),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-1fe4ffb9952f9097732f45d51d76e116738c2247fc71cba416ffeb389c0fee44L13-R14),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-6c3f6d54f0a5e67a68302a47f58a3fa31f64e8467090b4ffbcccdb9e474c3bc2L1-R1))
* Remove unused variables and functions in the `CustomUrl` and `AddByUrl` components, such as the `handlePaste` function and the `formik` constant ([link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-2f5eaaa35189cd1c83a42c9e4b1573fe242eb9027e2b298f9c9ee348cbe3bae9L46-R48),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-1fe4ffb9952f9097732f45d51d76e116738c2247fc71cba416ffeb389c0fee44L45-R47))
* Remove unused types and constants in the `LinkAction` component, such as the `LinkActionFormValues` interface and the `initialValues` constant ([link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-68de83e3d69405e039b3bfaeca8632ac38c8a9f56ba646244057ee619c38291bL28-L31),[link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-68de83e3d69405e039b3bfaeca8632ac38c8a9f56ba646244057ee619c38291bL46-L47))
* Add a `fireEvent.submit` function to the test case in the `VideoSearch` component to simulate a form submission and test the `handleSubmit` prop of the `TextFieldForm` component ([link](https://github.com/JesusFilm/core/pull/1578/files?diff=unified&w=0#diff-6408f68db7fc2d2536fed61c9363a46b15bc8b4a84f5072c3579a8a2621f97c7R19-R21))
