### PR TITLE
fix: visitor journey card style

### DIFF
--- a/apps/journeys-admin/src/components/JourneyVisitorsList/VisitorCard/VisitorCard.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyVisitorsList/VisitorCard/VisitorCard.spec.tsx
@@ -49,7 +49,7 @@ describe('VisitorCard', () => {
       '/reports/visitors/visitor.id-012345678901'
     )
   })
-  it('should use a shortened id for name', () => {
+  it('should show name', () => {
     const emptyVisitor = {
       ...visitorNode,
       visitor: {

--- a/apps/journeys-admin/src/components/JourneyVisitorsList/VisitorCard/VisitorCard.tsx
+++ b/apps/journeys-admin/src/components/JourneyVisitorsList/VisitorCard/VisitorCard.tsx
@@ -43,9 +43,7 @@ export function VisitorCard({ visitorNode, loading }: Props): ReactElement {
           />
 
           <VisitorCardDetails
-            name={
-              visitorNode?.visitor.name ?? visitorNode?.visitorId.slice(-12)
-            }
+            name={visitorNode?.visitor.name}
             events={visitorNode?.events ?? []}
             loading={loading}
           />

--- a/apps/journeys-admin/src/components/JourneyVisitorsList/VisitorCard/VisitorCardDetails/VisitorCardDetails.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyVisitorsList/VisitorCard/VisitorCardDetails/VisitorCardDetails.spec.tsx
@@ -31,6 +31,13 @@ describe('VisitorCardDetails', () => {
     expect(getByText('test name')).toBeInTheDocument()
   })
 
+  it('should hide details if there are no events', () => {
+    const { queryByText } = render(
+      <VisitorCardDetails loading={false} name="test name" events={[]} />
+    )
+    expect(queryByText('test name')).not.toBeInTheDocument()
+  })
+
   it('should show filtered events', () => {
     const events: Event[] = [
       {
@@ -111,6 +118,6 @@ describe('VisitorCardDetails', () => {
     expect(queryByText('text value')).not.toBeInTheDocument()
     expect(queryByText('radio value')).not.toBeInTheDocument()
     expect(queryByText('button value')).not.toBeInTheDocument()
-    expect(getAllByTestId('description-skeleton')).toHaveLength(4)
+    expect(getAllByTestId('description-skeleton')).toHaveLength(2)
   })
 })

--- a/apps/journeys-admin/src/components/JourneyVisitorsList/VisitorCard/VisitorCardDetails/VisitorCardDetails.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyVisitorsList/VisitorCard/VisitorCardDetails/VisitorCardDetails.spec.tsx
@@ -31,13 +31,6 @@ describe('VisitorCardDetails', () => {
     expect(getByText('test name')).toBeInTheDocument()
   })
 
-  it('should hide details if there are no events', () => {
-    const { queryByText } = render(
-      <VisitorCardDetails loading={false} name="test name" events={[]} />
-    )
-    expect(queryByText('test name')).not.toBeInTheDocument()
-  })
-
   it('should show filtered events', () => {
     const events: Event[] = [
       {

--- a/apps/journeys-admin/src/components/JourneyVisitorsList/VisitorCard/VisitorCardDetails/VisitorCardDetails.tsx
+++ b/apps/journeys-admin/src/components/JourneyVisitorsList/VisitorCard/VisitorCardDetails/VisitorCardDetails.tsx
@@ -32,7 +32,10 @@ export function VisitorCardDetails({
 
   return (
     <Box
-      sx={{ pl: { xs: '9px', sm: 9 }, pt: filteredEvents.length > 0 ? 3 : 0 }}
+      sx={{
+        pl: { xs: '9px', sm: 9 },
+        pt: filteredEvents.length > 0 || loading ? 3 : 0
+      }}
     >
       {loading ? (
         <>

--- a/apps/journeys-admin/src/components/JourneyVisitorsList/VisitorCard/VisitorCardDetails/VisitorCardDetails.tsx
+++ b/apps/journeys-admin/src/components/JourneyVisitorsList/VisitorCard/VisitorCardDetails/VisitorCardDetails.tsx
@@ -8,7 +8,7 @@ import Skeleton from '@mui/material/Skeleton'
 import { GetJourneyVisitors_visitors_edges_node_events as Event } from '../../../../../__generated__/GetJourneyVisitors'
 
 interface Props {
-  name?: string
+  name?: string | null
   events: Event[]
   loading: boolean
 }
@@ -31,7 +31,9 @@ export function VisitorCardDetails({
   )
 
   return (
-    <Box sx={{ pl: { xs: '9px', sm: 9 }, pt: 3 }}>
+    <Box
+      sx={{ pl: { xs: '9px', sm: 9 }, pt: filteredEvents.length > 0 ? 3 : 0 }}
+    >
       {loading ? (
         <>
           {[0, 1].map((i) => (
@@ -44,7 +46,7 @@ export function VisitorCardDetails({
         </>
       ) : (
         <>
-          {filteredEvents.length > 0 && (
+          {name != null && (
             <DetailsRow label={t('Name')} value={name} loading={loading} />
           )}
 

--- a/apps/journeys-admin/src/components/JourneyVisitorsList/VisitorCard/VisitorCardDetails/VisitorCardDetails.tsx
+++ b/apps/journeys-admin/src/components/JourneyVisitorsList/VisitorCard/VisitorCardDetails/VisitorCardDetails.tsx
@@ -31,38 +31,48 @@ export function VisitorCardDetails({
   )
 
   return (
-    <>
-      <Box sx={{ pt: 3, pl: { xs: '9px', sm: 9 } }}>
-        <DetailsRow label={t('Name')} value={name} loading={loading} />
-      </Box>
+    <Box sx={{ pl: { xs: '9px', sm: 9 }, pt: 3 }}>
+      {loading ? (
+        <>
+          {[0, 1].map((i) => (
+            <DetailsRow
+              key={i}
+              label={i as unknown as string}
+              loading={loading}
+            />
+          ))}
+        </>
+      ) : (
+        <>
+          {filteredEvents.length > 0 && (
+            <DetailsRow label={t('Name')} value={name} loading={loading} />
+          )}
 
-      {filteredEvents.map((event) => {
-        if (event.__typename === 'ChatOpenEvent') {
-          return (
-            <Box sx={{ pl: { xs: '9px', sm: 9 } }}>
-              <DetailsRow
-                key={event.id}
-                label={t('Chat Started')}
-                value={format(parseISO(event.createdAt), 'h:mmaaa')}
-                chatEvent
-                loading={loading}
-              />
-            </Box>
-          )
-        } else {
-          return (
-            <Box sx={{ pl: { xs: '9px', sm: 9 } }}>
-              <DetailsRow
-                key={event.id}
-                label={event.label}
-                value={event.value}
-                loading={loading}
-              />
-            </Box>
-          )
-        }
-      })}
-    </>
+          {filteredEvents.map((event) => {
+            if (event.__typename === 'ChatOpenEvent') {
+              return (
+                <DetailsRow
+                  key={event.id}
+                  label={t('Chat Started')}
+                  value={format(parseISO(event.createdAt), 'h:mmaaa')}
+                  chatEvent
+                  loading={loading}
+                />
+              )
+            } else {
+              return (
+                <DetailsRow
+                  key={event.id}
+                  label={event.label}
+                  value={event.value}
+                  loading={loading}
+                />
+              )
+            }
+          })}
+        </>
+      )}
+    </Box>
   )
 }
 
@@ -84,7 +94,7 @@ function DetailsRow({
   return (
     <Stack direction="row">
       <Typography
-        variant="subtitle1"
+        variant="h5"
         color={textColor}
         sx={{
           display: { xs: 'flex', sm: 'none' },
@@ -113,7 +123,7 @@ function DetailsRow({
             sx={{
               minWidth: '262px',
               maxWidth: '262px',
-              paddingRight: { xs: 'none', sm: '35px' }
+              paddingRight: { xs: 0, sm: 5 }
             }}
           >
             {label}
@@ -121,11 +131,11 @@ function DetailsRow({
         )}
 
         <Typography
-          variant="subtitle1"
+          variant="h5"
           color={textColor}
           sx={{
             display: { xs: 'none', sm: 'flex' },
-            paddingRight: { xs: 'none', sm: '10px' }
+            paddingRight: { xs: 0, sm: 3 }
           }}
         >
           {'\u00B7\u00A0'}


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4d09354</samp>

This pull request enhances the `VisitorCardDetails` component in the journeys-admin app by updating the UI and the tests. It makes the component more consistent with the design spec and more responsive to different loading and data scenarios.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/32387047/todos/6169808867)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Spacing in visitor journey card details match figma
- [ ] Hide name in the description section if there are no other events

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4d09354</samp>

*  Modify the visitor card details component to handle loading and empty states ([link](https://github.com/JesusFilm/core/pull/1579/files?diff=unified&w=0#diff-d19a099f58b80b8252eaa566a2264b411c1b0d95d61cb46aba8514749dd51310L34-R75))
* Update the typography variants and the padding of the elements in the details row component to match the design spec ([link](https://github.com/JesusFilm/core/pull/1579/files?diff=unified&w=0#diff-d19a099f58b80b8252eaa566a2264b411c1b0d95d61cb46aba8514749dd51310L87-R97), [link](https://github.com/JesusFilm/core/pull/1579/files?diff=unified&w=0#diff-d19a099f58b80b8252eaa566a2264b411c1b0d95d61cb46aba8514749dd51310L116-R126), [link](https://github.com/JesusFilm/core/pull/1579/files?diff=unified&w=0#diff-d19a099f58b80b8252eaa566a2264b411c1b0d95d61cb46aba8514749dd51310L124-R138))
* Add a new test case to check that the visitor card details component hides the name when there are no events ([link](https://github.com/JesusFilm/core/pull/1579/files?diff=unified&w=0#diff-63c121d47fb0f426ac2e4a6af15aa9a833b9652639dca805d32ff806afa6a5cbR34-R40))
* Update the expected number of skeleton elements in the existing test cases to match the new logic of the visitor card details component ([link](https://github.com/JesusFilm/core/pull/1579/files?diff=unified&w=0#diff-63c121d47fb0f426ac2e4a6af15aa9a833b9652639dca805d32ff806afa6a5cbL114-R121))
