### PR TITLE
fix: visitor details back nav

### DIFF
--- a/apps/journeys-admin/pages/reports/visitors/[visitorId].tsx
+++ b/apps/journeys-admin/pages/reports/visitors/[visitorId].tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useEffect, useRef } from 'react'
+import { ReactElement } from 'react'
 import {
   AuthAction,
   useAuthUser,
@@ -16,16 +16,9 @@ import i18nConfig from '../../../next-i18next.config'
 import { useTermsRedirect } from '../../../src/libs/useTermsRedirect/useTermsRedirect'
 
 function SingleVisitorReportsPage(): ReactElement {
-  const historyRef = useRef<boolean | undefined>(undefined)
   const router = useRouter()
   const { t } = useTranslation('apps-journeys-admin')
   const AuthUser = useAuthUser()
-
-  useEffect(() => {
-    document.referrer === ''
-      ? (historyRef.current = true)
-      : (historyRef.current = false)
-  }, [historyRef])
 
   useTermsRedirect()
 
@@ -35,7 +28,7 @@ function SingleVisitorReportsPage(): ReactElement {
       <PageWrapper
         title={t('Visitor Info')}
         authUser={AuthUser}
-        backHrefHistory={historyRef.current}
+        backHrefHistory
         backHref="/reports/visitors"
       >
         <VisitorInfo id={router.query.visitorId as string} />


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6c16c42</samp>

Improved the back button functionality and code quality in the `visitors/[visitorId].tsx` page.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Click on the back navigation from `/reports/visitors/[visitorId]` should navigate back to the previous page

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6c16c42</samp>

*  Simplify back button logic for visitor report page by using a prop instead of a ref and an effect hook (`[link](https://github.com/JesusFilm/core/pull/1580/files?diff=unified&w=0#diff-248c502b4d4dd9765deed3e48f69c3166bf084611faff144926b733324ee7d34L1-R1)`, `[link](https://github.com/JesusFilm/core/pull/1580/files?diff=unified&w=0#diff-248c502b4d4dd9765deed3e48f69c3166bf084611faff144926b733324ee7d34L19-R22)`, `[link](https://github.com/JesusFilm/core/pull/1580/files?diff=unified&w=0#diff-248c502b4d4dd9765deed3e48f69c3166bf084611faff144926b733324ee7d34L38-R31)`)
