### PR TITLE
feat: chatstarted activity

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       PGPASSWORD: postgres
       PGUSER: postgres
       PGDATABASE: postgres
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
   arangodb:
     image: arangodb/arangodb:3.8.8
     volumes:

--- a/apps/api-journeys/db/seeds/psMigrate.ts
+++ b/apps/api-journeys/db/seeds/psMigrate.ts
@@ -54,16 +54,17 @@ export async function psMigrate(): Promise<void> {
             userAgent: visitor.userAgent ?? undefined
           }
         })
-
-        console.log(`Importing events for visitor ${visitor._key as string}...`)
-        const events = await (
-          await db.query(aql`
+      } catch {}
+      console.log(`Importing events for visitor ${visitor._key as string}...`)
+      const events = await (
+        await db.query(aql`
           FOR event IN events
-          FILTER event.visitorId == ${visitor._key}
+          FILTER event.userId == ${visitor.userId}
           RETURN event
       `)
-        ).all()
-        if (events.length === 0) continue
+      ).all()
+      if (events.length === 0) continue
+      try {
         await prisma.event.createMany({
           data: events.map((event) => ({
             id: event._key,
@@ -75,7 +76,7 @@ export async function psMigrate(): Promise<void> {
             stepId: event.stepId ?? undefined,
             label: event.label ?? undefined,
             value: event.value ?? undefined,
-            visitorId: event.visitorId,
+            visitorId: visitor._key,
             actionValue: event.actionValue ?? undefined,
             messagePlatform: event.messagePlatform ?? undefined,
             languageId: event.languageId ?? undefined,

--- a/apps/api-journeys/src/app/modules/event/button/button.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/event/button/button.resolver.spec.ts
@@ -101,11 +101,21 @@ describe('ChatOpenEventResolver', () => {
 
   const response = {
     visitor: { id: 'visitor.id', messagePlatform: MessagePlatform.facebook },
+    journeyVisitor: {
+      journeyId: 'journey.id',
+      visitorId: 'visitor.id',
+      activityCount: 0
+    },
     journeyId: 'journey.id'
   }
 
   const newResponse = {
     visitor: { id: 'newVisitor.id' },
+    journeyVisitor: {
+      journeyId: 'journey.id',
+      visitorId: 'newVisitor.id',
+      activityCount: 0
+    },
     journeyId: 'journey.id'
   }
 
@@ -199,7 +209,8 @@ describe('ChatOpenEventResolver', () => {
         },
         data: {
           lastChatStartedAt: new Date(),
-          lastChatPlatform: MessagePlatform.facebook
+          lastChatPlatform: MessagePlatform.facebook,
+          activityCount: 1
         }
       })
     })

--- a/apps/api-journeys/src/app/modules/event/button/button.resolver.ts
+++ b/apps/api-journeys/src/app/modules/event/button/button.resolver.ts
@@ -82,11 +82,12 @@ export class ChatOpenEventResolver {
     @CurrentUserId() userId: string,
     @Args('input') input: ChatOpenEventCreateInput
   ): Promise<ChatOpenEvent> {
-    const { visitor, journeyId } = await this.eventService.validateBlockEvent(
-      userId,
-      input.blockId,
-      input.stepId
-    )
+    const { visitor, journeyId, journeyVisitor } =
+      await this.eventService.validateBlockEvent(
+        userId,
+        input.blockId,
+        input.stepId
+      )
 
     const promises = [
       this.eventService.save({
@@ -117,7 +118,10 @@ export class ChatOpenEventResolver {
     promises.push(
       this.prismaService.journeyVisitor.update({
         where: { journeyId_visitorId: { journeyId, visitorId: visitor.id } },
-        data
+        data: {
+          ...data,
+          activityCount: journeyVisitor.activityCount + 1
+        }
       })
     )
 


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ffed16d</samp>

This pull request improves the data migration script, adds and updates some tests for the chat button resolver, and enhances the resolver to return and update the visitor's activity count. It also adds a host entry to the docker-compose file for debugging and testing.

# How should this PR be QA Tested?

- [ ] Open Chat now increases activityCount

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ffed16d</samp>

*  Add extra host entry to docker-compose file for API service to access host network ([link](https://github.com/JesusFilm/core/pull/1583/files?diff=unified&w=0#diff-67a4805fdcc6145d7b3ada2a6099a9b2e91c9d0fd108c22f95d2f01d219793d1R27-R28))
*  Fix bug and add error handling in psMigrate script for importing data from old database ([link](https://github.com/JesusFilm/core/pull/1583/files?diff=unified&w=0#diff-4c751918bc82c27b617ee56b263e1f837d16157549516cb214628e5103d08692L57-R67), [link](https://github.com/JesusFilm/core/pull/1583/files?diff=unified&w=0#diff-4c751918bc82c27b617ee56b263e1f837d16157549516cb214628e5103d08692L78-R79))
*  Implement and test new feature for tracking visitor activity count in journeys ([link](https://github.com/JesusFilm/core/pull/1583/files?diff=unified&w=0#diff-a5bd79c1d24a16f9021044536fa8fa49606cb4fd2829e97c06c643100e164c3eR104-R108), [link](https://github.com/JesusFilm/core/pull/1583/files?diff=unified&w=0#diff-a5bd79c1d24a16f9021044536fa8fa49606cb4fd2829e97c06c643100e164c3eR114-R118), [link](https://github.com/JesusFilm/core/pull/1583/files?diff=unified&w=0#diff-a5bd79c1d24a16f9021044536fa8fa49606cb4fd2829e97c06c643100e164c3eL202-R213), [link](https://github.com/JesusFilm/core/pull/1583/files?diff=unified&w=0#diff-8781cd0196e95d3108a8cfbcecde16f30ff5b9be217a68057022e7766c65ab10L85-R90), [link](https://github.com/JesusFilm/core/pull/1583/files?diff=unified&w=0#diff-8781cd0196e95d3108a8cfbcecde16f30ff5b9be217a68057022e7766c65ab10L120-R124))
   *  Modify `button.resolver.ts` to return and update `journeyVisitor` object with `activityCount` field when creating chat open event ([link](https://github.com/JesusFilm/core/pull/1583/files?diff=unified&w=0#diff-8781cd0196e95d3108a8cfbcecde16f30ff5b9be217a68057022e7766c65ab10L85-R90), [link](https://github.com/JesusFilm/core/pull/1583/files?diff=unified&w=0#diff-8781cd0196e95d3108a8cfbcecde16f30ff5b9be217a68057022e7766c65ab10L120-R124))
   *  Add mock `journeyVisitor` objects to `button.resolver.spec.ts` to simulate different database states and update expected data ([link](https://github.com/JesusFilm/core/pull/1583/files?diff=unified&w=0#diff-a5bd79c1d24a16f9021044536fa8fa49606cb4fd2829e97c06c643100e164c3eR104-R108), [link](https://github.com/JesusFilm/core/pull/1583/files?diff=unified&w=0#diff-a5bd79c1d24a16f9021044536fa8fa49606cb4fd2829e97c06c643100e164c3eR114-R118), [link](https://github.com/JesusFilm/core/pull/1583/files?diff=unified&w=0#diff-a5bd79c1d24a16f9021044536fa8fa49606cb4fd2829e97c06c643100e164c3eL202-R213))
