### PR TITLE
fix: journey visitor country code

### DIFF
--- a/apps/journeys-admin/__generated__/GetJourneyVisitors.ts
+++ b/apps/journeys-admin/__generated__/GetJourneyVisitors.ts
@@ -21,6 +21,15 @@ export interface GetJourneyVisitors_visitors_edges_node_visitor {
    */
   status: VisitorStatus | null;
   /**
+   * The country code of the visitor as poulated by visitor ip address detected in
+   * the JourneyViewEventCreate mutation. This field country code is converted
+   * from an IP address by the @maxmind/geoip2-node library. If this field is empty
+   * it is likely that the JourneyViewEventCreate mutation was not called by the
+   * visitor or that the country was not able to be determined based on the
+   * visitor IP address.
+   */
+  countryCode: string | null;
+  /**
    * The url visitor was referred from
    */
   referrer: string | null;
@@ -37,15 +46,6 @@ export interface GetJourneyVisitors_visitors_edges_node_events {
 export interface GetJourneyVisitors_visitors_edges_node {
   __typename: "JourneyVisitor";
   visitorId: string;
-  /**
-   * The country code of the visitor as poulated by visitor ip address detected in
-   * the JourneyViewEventCreate mutation. This field country code is converted
-   * from an IP address by the @maxmind/geoip2-node library. If this field is empty
-   * it is likely that the JourneyViewEventCreate mutation was not called by the
-   * visitor or that the country was not able to be determined based on the
-   * visitor IP address.
-   */
-  countryCode: string | null;
   /**
    * The time when the visitor created their first event on a journey connected
    * to the requested team.

--- a/apps/journeys-admin/pages/journeys/[journeyId]/reports/visitors.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/reports/visitors.tsx
@@ -50,12 +50,12 @@ export const GET_JOURNEY_VISITORS = gql`
         cursor
         node {
           visitorId
-          countryCode
           createdAt
           duration
           visitor {
             name
             status
+            countryCode
             referrer
           }
           events {

--- a/apps/journeys-admin/src/components/JourneyVisitorsList/JourneyVisitorsList.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyVisitorsList/JourneyVisitorsList.spec.tsx
@@ -11,12 +11,12 @@ describe('JourneyVisitorsList', () => {
       node: {
         __typename: 'JourneyVisitor',
         visitorId: 'visitor1.id',
-        countryCode: null,
         createdAt: '2021-11-19T12:35:56.647Z',
         duration: null,
         visitor: {
           __typename: 'Visitor',
           name: null,
+          countryCode: null,
           status: null,
           referrer: null
         },
@@ -29,12 +29,12 @@ describe('JourneyVisitorsList', () => {
       node: {
         __typename: 'JourneyVisitor',
         visitorId: 'visitor2.id',
-        countryCode: null,
         createdAt: '2021-11-19T12:35:56.647Z',
         duration: null,
         visitor: {
           __typename: 'Visitor',
           name: null,
+          countryCode: null,
           status: null,
           referrer: null
         },
@@ -47,12 +47,12 @@ describe('JourneyVisitorsList', () => {
       node: {
         __typename: 'JourneyVisitor',
         visitorId: 'visitor3.id',
-        countryCode: null,
         createdAt: '2021-11-19T12:35:56.647Z',
         duration: null,
         visitor: {
           __typename: 'Visitor',
           name: null,
+          countryCode: null,
           status: null,
           referrer: null
         },

--- a/apps/journeys-admin/src/components/JourneyVisitorsList/JourneyVisitorsList.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyVisitorsList/JourneyVisitorsList.stories.tsx
@@ -23,12 +23,12 @@ Default.args = {
       node: {
         __typename: 'JourneyVisitor',
         visitorId: '36f0af56-2aa0-4477-8b79-f8303182c69b',
-        countryCode: 'Dnipro, Ukraine',
         createdAt: '2021-11-19T12:35:56.647Z',
         duration: 300,
         visitor: {
           __typename: 'Visitor',
           name: 'Ben',
+          countryCode: 'Dnipro, Ukraine',
           status: VisitorStatus.checkMarkSymbol,
           referrer: 'Facebook'
         },
@@ -63,11 +63,11 @@ Default.args = {
       node: {
         __typename: 'JourneyVisitor',
         visitorId: '416960f7-b037-481e-80e3-3e4d9897970a',
-        countryCode: 'Dnipro, Ukraine',
         createdAt: '2021-11-19T12:35:56.647Z',
         duration: 3,
         visitor: {
           __typename: 'Visitor',
+          countryCode: 'Dnipro, Ukraine',
           name: null,
           status: null,
           referrer: 'Youtube'
@@ -81,12 +81,12 @@ Default.args = {
       node: {
         __typename: 'JourneyVisitor',
         visitorId: '0c874c32-ac87-4480-b0fb-23ef3d61babe',
-        countryCode: 'Halifax, Canada',
         createdAt: '2021-11-19T12:35:56.647Z',
         duration: 300,
         visitor: {
           __typename: 'Visitor',
           name: 'John',
+          countryCode: 'Halifax, Canada',
           status: VisitorStatus.warning,
           referrer: 'Facebook'
         },
@@ -106,11 +106,11 @@ Default.args = {
       node: {
         __typename: 'JourneyVisitor',
         visitorId: '0357598b-597d-4419-8c7c-d94854f8a95b',
-        countryCode: 'Auckland, New Zealand',
         createdAt: '2021-11-19T12:35:56.647Z',
         duration: null,
         visitor: {
           __typename: 'Visitor',
+          countryCode: 'Auckland, New Zealand',
           name: null,
           status: null,
           referrer: 'WhatsApp'

--- a/apps/journeys-admin/src/components/JourneyVisitorsList/VisitorCard/VisitorCard.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyVisitorsList/VisitorCard/VisitorCard.spec.tsx
@@ -19,13 +19,13 @@ describe('VisitorCard', () => {
   const visitorNode: VisitorNode = {
     __typename: 'JourneyVisitor',
     visitorId: 'visitor.id-012345678901',
-    countryCode: 'Town, City',
     createdAt: '2021-11-19T12:34:56.647Z',
     duration: 75,
     visitor: {
       __typename: 'Visitor',
       name: 'FirstName LastName',
       status: VisitorStatus.star,
+      countryCode: 'Town, City',
       referrer: 'referrer.com'
     },
     events: [
@@ -71,12 +71,12 @@ describe('VisitorCard', () => {
     const visitorNode: VisitorNode = {
       __typename: 'JourneyVisitor',
       visitorId: 'visitor.id-012345678901',
-      countryCode: 'Town, City',
       createdAt: '2021-11-19T12:34:56.647Z',
       duration: 75,
       visitor: {
         __typename: 'Visitor',
         name: 'FirstName LastName',
+        countryCode: 'Town, City',
         status: VisitorStatus.star,
         referrer: 'referrer.com'
       },

--- a/apps/journeys-admin/src/components/JourneyVisitorsList/VisitorCard/VisitorCard.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyVisitorsList/VisitorCard/VisitorCard.stories.tsx
@@ -18,12 +18,12 @@ Default.args = {
   visitorNode: {
     __typename: 'JourneyVisitor',
     visitorId: 'visitor.id-012345678901',
-    countryCode: null,
     createdAt: '2021-11-19T12:34:56.647Z',
     duration: 5,
     visitor: {
       __typename: 'Visitor',
       name: null,
+      countryCode: null,
       status: null,
       referrer: null
     },
@@ -37,12 +37,12 @@ Complete.args = {
   visitorNode: {
     __typename: 'JourneyVisitor',
     visitorId: 'visitor.id',
-    countryCode: 'Town, City',
     createdAt: '2021-11-19T12:34:56.647Z',
     duration: 75,
     visitor: {
       __typename: 'Visitor',
       name: 'John Doe',
+      countryCode: 'Town, City',
       status: VisitorStatus.star,
       referrer: 'referrer.com'
     },

--- a/apps/journeys-admin/src/components/JourneyVisitorsList/VisitorCard/VisitorCard.tsx
+++ b/apps/journeys-admin/src/components/JourneyVisitorsList/VisitorCard/VisitorCard.tsx
@@ -36,7 +36,7 @@ export function VisitorCard({ visitorNode, loading }: Props): ReactElement {
               visitorNode?.visitor?.name ??
               `#${visitorNode?.visitorId.slice(-12) as unknown as string}`
             }
-            location={visitorNode?.countryCode}
+            location={visitorNode?.visitor.countryCode}
             source={visitorNode?.visitor.referrer}
             createdAt={visitorNode?.createdAt}
             duration={visitorNode?.duration}


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 042f093</samp>

This pull request refactors the code for fetching and displaying the country code of the visitors for a journey. It removes the `countryCode` field from the top-level visitor node and uses the `countryCode` field from the `visitor` details instead. This affects the GraphQL schema, the `GET_JOURNEY_VISITORS` query, the `VisitorCard` component, and the corresponding test files.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Country code shows up on journey visitor cards

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 042f093</samp>

*  Remove `countryCode` field from top-level visitor node and add it to nested visitor field in GraphQL query and interfaces ([link](https://github.com/JesusFilm/core/pull/1585/files?diff=unified&w=0#diff-ea8c85f7941c8cafb40fe8da944e8673862b9eb3c390bf99c32741559d4d33d7R24-R32), [link](https://github.com/JesusFilm/core/pull/1585/files?diff=unified&w=0#diff-ea8c85f7941c8cafb40fe8da944e8673862b9eb3c390bf99c32741559d4d33d7L41-L49), [link](https://github.com/JesusFilm/core/pull/1585/files?diff=unified&w=0#diff-e9e60ec48f7928f205dea4cd73b81cd0498ead851b3bf03af91d9a24b3055ba8L53), [link](https://github.com/JesusFilm/core/pull/1585/files?diff=unified&w=0#diff-e9e60ec48f7928f205dea4cd73b81cd0498ead851b3bf03af91d9a24b3055ba8R58))
*  Update `VisitorCard` component to use `countryCode` from nested visitor prop instead of top-level prop ([link](https://github.com/JesusFilm/core/pull/1585/files?diff=unified&w=0#diff-a644effba72df05db723e52ab10085af1bc089be669052c76472904b5564736eL39-R39))
*  Remove `countryCode` prop and add `countryCode` field to visitor prop in `VisitorCard` component tests ([link](https://github.com/JesusFilm/core/pull/1585/files?diff=unified&w=0#diff-c412a6d4e126d496cddd29dab2207a385b15c14d0807e6f2828173cfe5e1f81fL22), [link](https://github.com/JesusFilm/core/pull/1585/files?diff=unified&w=0#diff-c412a6d4e126d496cddd29dab2207a385b15c14d0807e6f2828173cfe5e1f81fR28), [link](https://github.com/JesusFilm/core/pull/1585/files?diff=unified&w=0#diff-c412a6d4e126d496cddd29dab2207a385b15c14d0807e6f2828173cfe5e1f81fL74), [link](https://github.com/JesusFilm/core/pull/1585/files?diff=unified&w=0#diff-c412a6d4e126d496cddd29dab2207a385b15c14d0807e6f2828173cfe5e1f81fR79))
