### PR TITLE
fix: ignore case sensitive emails

### DIFF
--- a/apps/journeys-admin/src/components/AccessDialog/AddUserSection/EmailInviteForm/EmailInviteForm.spec.tsx
+++ b/apps/journeys-admin/src/components/AccessDialog/AddUserSection/EmailInviteForm/EmailInviteForm.spec.tsx
@@ -60,6 +60,25 @@ describe('EmailInviteForm', () => {
     })
   })
 
+  it('should validate when user inputs uppercase strings for email', async () => {
+    const { getByRole, getByText } = render(
+      <SnackbarProvider>
+        <MockedProvider>
+          <EmailInviteForm users={[]} />
+        </MockedProvider>
+      </SnackbarProvider>
+    )
+    const email = getByRole('textbox', { name: 'Email' })
+    fireEvent.change(email, {
+      target: { value: 'Edmondshenwashere@gmail.com' }
+    })
+    fireEvent.click(getByRole('button', { name: 'add user' }))
+    await waitFor(() => {
+      const inlineError = getByText('email must be a lowercase string')
+      expect(inlineError).toBeInTheDocument()
+    })
+  })
+
   it('should validate when email is already exists', async () => {
     const { getByRole, getByText } = render(
       <SnackbarProvider>

--- a/apps/journeys-admin/src/components/AccessDialog/AddUserSection/EmailInviteForm/EmailInviteForm.spec.tsx
+++ b/apps/journeys-admin/src/components/AccessDialog/AddUserSection/EmailInviteForm/EmailInviteForm.spec.tsx
@@ -60,22 +60,22 @@ describe('EmailInviteForm', () => {
     })
   })
 
-  it('should validate when user inputs uppercase strings for email', async () => {
+  it('should validate when user inputs uppercase strings for email if email already exists', async () => {
     const { getByRole, getByText } = render(
       <SnackbarProvider>
         <MockedProvider>
-          <EmailInviteForm users={[]} />
+          <EmailInviteForm users={['edmondshenwashere@gmail.com']} />
         </MockedProvider>
       </SnackbarProvider>
     )
     const email = getByRole('textbox', { name: 'Email' })
     fireEvent.change(email, {
-      target: { value: 'Edmondshenwashere@gmail.com' }
+      target: { value: 'EdmondShenWasHere@gmail.com' }
     })
     fireEvent.click(getByRole('button', { name: 'add user' }))
     await waitFor(() => {
-      const inlineError = getByText('email must be a lowercase string')
-      expect(inlineError).toBeInTheDocument()
+      const inlineError = getByText('This email is already on the list')
+      expect(inlineError).toHaveProperty('id', 'email-helper-text')
     })
   })
 

--- a/apps/journeys-admin/src/components/AccessDialog/AddUserSection/EmailInviteForm/EmailInviteForm.tsx
+++ b/apps/journeys-admin/src/components/AccessDialog/AddUserSection/EmailInviteForm/EmailInviteForm.tsx
@@ -81,7 +81,6 @@ export function EmailInviteForm({ users }: EmailInviteFormProps): ReactElement {
 
   const validationSchema = object().shape({
     email: string()
-      .strict()
       .lowercase()
       .email(t('Please enter a valid email address'))
       .required(t('Required'))

--- a/apps/journeys-admin/src/components/AccessDialog/AddUserSection/EmailInviteForm/EmailInviteForm.tsx
+++ b/apps/journeys-admin/src/components/AccessDialog/AddUserSection/EmailInviteForm/EmailInviteForm.tsx
@@ -39,7 +39,7 @@ export function EmailInviteForm({ users }: EmailInviteFormProps): ReactElement {
         variables: {
           journeyId: journey.id,
           input: {
-            email: values.email.toLowerCase()
+            email: values.email
           }
         },
         update(cache, { data }) {
@@ -79,12 +79,13 @@ export function EmailInviteForm({ users }: EmailInviteFormProps): ReactElement {
     }
   }
 
+  const usersToLowerCase = users.map((user) => user.toLowerCase())
   const validationSchema = object().shape({
     email: string()
       .lowercase()
       .email(t('Please enter a valid email address'))
       .required(t('Required'))
-      .notOneOf(users, t('This email is already on the list'))
+      .notOneOf(usersToLowerCase, t('This email is already on the list'))
   })
 
   return (

--- a/apps/journeys-admin/src/components/AccessDialog/AddUserSection/EmailInviteForm/EmailInviteForm.tsx
+++ b/apps/journeys-admin/src/components/AccessDialog/AddUserSection/EmailInviteForm/EmailInviteForm.tsx
@@ -39,7 +39,7 @@ export function EmailInviteForm({ users }: EmailInviteFormProps): ReactElement {
         variables: {
           journeyId: journey.id,
           input: {
-            email: values.email
+            email: values.email.toLowerCase()
           }
         },
         update(cache, { data }) {

--- a/apps/journeys-admin/src/components/AccessDialog/AddUserSection/EmailInviteForm/EmailInviteForm.tsx
+++ b/apps/journeys-admin/src/components/AccessDialog/AddUserSection/EmailInviteForm/EmailInviteForm.tsx
@@ -81,6 +81,8 @@ export function EmailInviteForm({ users }: EmailInviteFormProps): ReactElement {
 
   const validationSchema = object().shape({
     email: string()
+      .strict()
+      .lowercase()
       .email(t('Please enter a valid email address'))
       .required(t('Required'))
       .notOneOf(users, t('This email is already on the list'))


### PR DESCRIPTION
# Description


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 08bec1b</samp>

This pull request improves the email validation logic in the `EmailInviteForm` component. It adds a test case for uppercase inputs and modifies the validation schema to be case-insensitive.


- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/32387559/todos/6109559789)

# How should this PR be QA Tested?


- [ ] it will not allow the user to put in two emails that are identical
- [ ] if the user puts in an email with some lower case and upper case letters, if the email exists, it will not allow the user to add the email

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 08bec1b</samp>

*  Make email validation case-insensitive in email invite form ([link](https://github.com/JesusFilm/core/pull/1588/files?diff=unified&w=0#diff-0b33003b7d61e9b4b10dcf055b1ebae6fac8d68956184cd856360bc57b906b98L82-R88))
* Add test case for email validation with uppercase input ([link](https://github.com/JesusFilm/core/pull/1588/files?diff=unified&w=0#diff-ecb1c2a789f4cae77b40d67db2b19c999596d63194ade82494a0631f32739412R63-R81))

