### PR TITLE
fix: display more videos

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
@@ -96,7 +96,7 @@ const getVideosMock = {
     query: GET_VIDEOS,
     variables: {
       offset: 0,
-      limit: 5,
+      limit: 18,
       where: {
         availableVariantLanguageIds: ['529'],
         title: null,

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Video/Options/VideoOptions.spec.tsx
@@ -73,7 +73,7 @@ describe('VideoOptions', () => {
         query: GET_VIDEOS,
         variables: {
           offset: 0,
-          limit: 5,
+          limit: 18,
           where: {
             availableVariantLanguageIds: ['529'],
             title: null,

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Source/Source.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Source/Source.spec.tsx
@@ -19,7 +19,7 @@ const getVideosMock = {
     query: GET_VIDEOS,
     variables: {
       offset: 0,
-      limit: 5,
+      limit: 18,
       where: {
         availableVariantLanguageIds: ['529'],
         title: null,

--- a/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoFromLocal/VideoFromLocal.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoFromLocal/VideoFromLocal.spec.tsx
@@ -16,7 +16,7 @@ const getVideosMock = {
     query: GET_VIDEOS,
     variables: {
       offset: 0,
-      limit: 5,
+      limit: 18,
       where: {
         availableVariantLanguageIds: ['529'],
         title: null,
@@ -41,7 +41,7 @@ const getVideosEmptyWithOffsetMock = {
     query: GET_VIDEOS,
     variables: {
       offset: 3,
-      limit: 5,
+      limit: 18,
       where: {
         availableVariantLanguageIds: ['529'],
         title: null,
@@ -66,7 +66,7 @@ const getVideosEmptyMock = {
     query: GET_VIDEOS,
     variables: {
       offset: 0,
-      limit: 5,
+      limit: 18,
       where: {
         availableVariantLanguageIds: ['529'],
         title: null,
@@ -91,7 +91,7 @@ const getVideosWithTitleMock = {
     query: GET_VIDEOS,
     variables: {
       offset: 0,
-      limit: 5,
+      limit: 18,
       where: {
         availableVariantLanguageIds: ['529'],
         title: 'abc',

--- a/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoFromLocal/VideoFromLocal.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoFromLocal/VideoFromLocal.tsx
@@ -46,7 +46,7 @@ export function VideoFromLocal({
     notifyOnNetworkStatusChange: true,
     variables: {
       offset: 0,
-      limit: 5,
+      limit: 18,
       where: {
         availableVariantLanguageIds: ['529'],
         title: searchQuery === '' ? null : searchQuery,

--- a/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoFromYouTube/VideoFromYouTube.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoFromYouTube/VideoFromYouTube.tsx
@@ -111,7 +111,7 @@ export function VideoFromYouTube({
         ? `id=${id}`
         : `playlistId=${
             process.env.NEXT_PUBLIC_YOUTUBE_PLAYLIST_ID ?? ''
-          }&pageToken=${pageToken}`
+          }&maxResults=18&pageToken=${pageToken}`
     },
     fetcher
   )

--- a/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoLibrary.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoLibrary.spec.tsx
@@ -85,7 +85,7 @@ describe('VideoLibrary', () => {
                 query: GET_VIDEOS,
                 variables: {
                   offset: 0,
-                  limit: 5,
+                  limit: 18,
                   where: {
                     availableVariantLanguageIds: ['529'],
                     title: 'Andreas',
@@ -169,7 +169,7 @@ describe('VideoLibrary', () => {
               query: GET_VIDEOS,
               variables: {
                 offset: 0,
-                limit: 5,
+                limit: 18,
                 where: {
                   availableVariantLanguageIds: ['529'],
                   title: null,


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9bf051e</samp>

Increased the number of videos per page in the `VideoLibrary` component from 5 to 18. This affects both the `VideoFromLocal` and the `VideoFromYouTube` subcomponents, which use different hooks and parameters to fetch videos from the local database and the YouTube API, respectively.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/32387559/todos/6105614976)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] it should initially load 18 videos for local
- [ ] it should initially load 18 videos for youtube
- [ ] it should load 18 more videos when clicking load more for local
- [ ] it should load 18 more videos when clicking load more for youtube, unless there isn't 18 more to load, in which case the "Load More" button will be disabled

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9bf051e</samp>

*  Increase the number of videos displayed per page in the `VideoFromLocal` component from 5 to 18 ([link](https://github.com/JesusFilm/core/pull/1595/files?diff=unified&w=0#diff-b6aed9a1431cb3e8de236b82a2edfd285ee5daf676a4451004eadfa3445ea20bL49-R49))
*  Update the mock functions for testing the `VideoFromLocal` component to match the new limit of 18 videos per page ([link](https://github.com/JesusFilm/core/pull/1595/files?diff=unified&w=0#diff-2bdbfa9206dcb4839197275b29fad9146cb2907ce6eb6cd1f7571629cc91546cL19-R19), [link](https://github.com/JesusFilm/core/pull/1595/files?diff=unified&w=0#diff-2bdbfa9206dcb4839197275b29fad9146cb2907ce6eb6cd1f7571629cc91546cL44-R44), [link](https://github.com/JesusFilm/core/pull/1595/files?diff=unified&w=0#diff-2bdbfa9206dcb4839197275b29fad9146cb2907ce6eb6cd1f7571629cc91546cL69-R69), [link](https://github.com/JesusFilm/core/pull/1595/files?diff=unified&w=0#diff-2bdbfa9206dcb4839197275b29fad9146cb2907ce6eb6cd1f7571629cc91546cL94-R94))
*  Add the `maxResults` parameter to the `useSWR` hook in the `VideoFromYouTube` component and set it to 18 to match the `VideoFromLocal` component ([link](https://github.com/JesusFilm/core/pull/1595/files?diff=unified&w=0#diff-257654ab0a182916f1e25cdc26ec90a1169fee3807a972f3d89c0b91aeb7054cL114-R114))
