### PR TITLE
chore: remove redundant templates flag

### DIFF
--- a/apps/journeys-admin/src/components/NewPageWrapper/NavigationDrawer/NavigationDrawer.spec.tsx
+++ b/apps/journeys-admin/src/components/NewPageWrapper/NavigationDrawer/NavigationDrawer.spec.tsx
@@ -85,7 +85,7 @@ describe('NavigationDrawer', () => {
           }
         ]}
       >
-        <FlagsProvider flags={{ templates: true, reports: true }}>
+        <FlagsProvider flags={{ reports: true }}>
           <NavigationDrawer
             open
             onClose={onClose}
@@ -109,13 +109,11 @@ describe('NavigationDrawer', () => {
   it('should select templates button', () => {
     const { getByTestId } = render(
       <MockedProvider>
-        <FlagsProvider flags={{ templates: true }}>
-          <NavigationDrawer
-            open
-            onClose={onClose}
-            router={getRouter('/templates')}
-          />
-        </FlagsProvider>
+        <NavigationDrawer
+          open
+          onClose={onClose}
+          router={getRouter('/templates')}
+        />
       </MockedProvider>
     )
     expect(getByTestId('Templates-list-item')).toHaveAttribute(
@@ -127,13 +125,11 @@ describe('NavigationDrawer', () => {
   it('should select the reports button', () => {
     const { getByTestId } = render(
       <MockedProvider>
-        <FlagsProvider>
-          <NavigationDrawer
-            open
-            onClose={onClose}
-            router={getRouter('/reports')}
-          />
-        </FlagsProvider>
+        <NavigationDrawer
+          open
+          onClose={onClose}
+          router={getRouter('/reports')}
+        />
       </MockedProvider>
     )
     expect(getByTestId('Reports-list-item')).toHaveAttribute(
@@ -177,21 +173,19 @@ describe('NavigationDrawer', () => {
           }
         ]}
       >
-        <FlagsProvider flags={{ templates: true }}>
-          <NavigationDrawer
-            open
-            onClose={onClose}
-            authUser={
-              {
-                displayName: 'Amin One',
-                photoURL: 'https://bit.ly/3Gth4Yf',
-                email: 'amin@email.com',
-                signOut
-              } as unknown as AuthUser
-            }
-            router={getRouter('/publisher/[journeyId]')}
-          />
-        </FlagsProvider>
+        <NavigationDrawer
+          open
+          onClose={onClose}
+          authUser={
+            {
+              displayName: 'Amin One',
+              photoURL: 'https://bit.ly/3Gth4Yf',
+              email: 'amin@email.com',
+              signOut
+            } as unknown as AuthUser
+          }
+          router={getRouter('/publisher/[journeyId]')}
+        />
       </MockedProvider>
     )
     await waitFor(() =>
@@ -237,20 +231,18 @@ describe('NavigationDrawer', () => {
           }
         ]}
       >
-        <FlagsProvider flags={{ templates: true }}>
-          <NavigationDrawer
-            open
-            onClose={onClose}
-            authUser={
-              {
-                displayName: 'Amin One',
-                photoURL: 'https://bit.ly/3Gth4Yf',
-                email: 'amin@email.com',
-                signOut
-              } as unknown as AuthUser
-            }
-          />
-        </FlagsProvider>
+        <NavigationDrawer
+          open
+          onClose={onClose}
+          authUser={
+            {
+              displayName: 'Amin One',
+              photoURL: 'https://bit.ly/3Gth4Yf',
+              email: 'amin@email.com',
+              signOut
+            } as unknown as AuthUser
+          }
+        />
       </MockedProvider>
     )
     await waitFor(() =>
@@ -269,9 +261,7 @@ describe('NavigationDrawer', () => {
   it('should close the navigation drawer on chevron left click', () => {
     const { getAllByRole, getByTestId } = render(
       <MockedProvider>
-        <FlagsProvider>
-          <NavigationDrawer open onClose={onClose} />
-        </FlagsProvider>
+        <NavigationDrawer open onClose={onClose} />
       </MockedProvider>
     )
     const button = getAllByRole('button')[0]
@@ -283,9 +273,7 @@ describe('NavigationDrawer', () => {
   it('should select the journeys drawer', () => {
     const { getByTestId } = render(
       <MockedProvider>
-        <FlagsProvider>
-          <NavigationDrawer open onClose={onClose} router={getRouter('/')} />
-        </FlagsProvider>
+        <NavigationDrawer open onClose={onClose} router={getRouter('/')} />
       </MockedProvider>
     )
     expect(getByTestId('ViewCarouselRoundedIcon').parentElement).toHaveStyle(

--- a/apps/journeys-admin/src/components/NewPageWrapper/NavigationDrawer/NavigationDrawer.stories.tsx
+++ b/apps/journeys-admin/src/components/NewPageWrapper/NavigationDrawer/NavigationDrawer.stories.tsx
@@ -3,7 +3,6 @@ import { Meta, Story } from '@storybook/react'
 import { noop } from 'lodash'
 import { MockedProvider } from '@apollo/client/testing'
 import { AuthUser } from 'next-firebase-auth'
-import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 import { NextRouter } from 'next/router'
 import { journeysAdminConfig } from '../../../libs/storybook'
 import { Role, UserJourneyRole } from '../../../../__generated__/globalTypes'
@@ -61,35 +60,25 @@ const Template: Story = ({ ...args }) => {
         }
       ]}
     >
-      <FlagsProvider flags={{ templates: args.templates }}>
-        <NavigationDrawer
-          open={open}
-          onClose={() => setOpen(!open)}
-          authUser={
-            {
-              id: 'user.id',
-              displayName: 'Amin One',
-              photoURL: 'https://bit.ly/3Gth4Yf',
-              email: 'amin@email.com',
-              signOut: noop
-            } as unknown as AuthUser
-          }
-          router={{ pathname: undefined } as unknown as NextRouter}
-        />
-      </FlagsProvider>
+      <NavigationDrawer
+        open={open}
+        onClose={() => setOpen(!open)}
+        authUser={
+          {
+            id: 'user.id',
+            displayName: 'Amin One',
+            photoURL: 'https://bit.ly/3Gth4Yf',
+            email: 'amin@email.com',
+            signOut: noop
+          } as unknown as AuthUser
+        }
+        router={{ pathname: undefined } as unknown as NextRouter}
+      />
     </MockedProvider>
   )
 }
 
 export const Default = Template.bind({})
-Default.args = {
-  templates: false
-}
-
-export const Complete = Template.bind({})
-Complete.args = {
-  templates: true
-}
 
 export const WithBadge = Template.bind({})
 WithBadge.args = {

--- a/apps/journeys-admin/src/components/NewPageWrapper/NavigationDrawer/NavigationDrawer.tsx
+++ b/apps/journeys-admin/src/components/NewPageWrapper/NavigationDrawer/NavigationDrawer.tsx
@@ -19,7 +19,6 @@ import Image from 'next/image'
 import { NextRouter } from 'next/router'
 import { compact } from 'lodash'
 import { gql, useQuery } from '@apollo/client'
-import { useFlags } from '@core/shared/ui/FlagsProvider'
 import ViewCarouselRoundedIcon from '@mui/icons-material/ViewCarouselRounded'
 import LeaderboardRoundedIcon from '@mui/icons-material/LeaderboardRounded'
 import { useTranslation } from 'react-i18next'
@@ -111,8 +110,6 @@ export function NavigationDrawer({
 
   const selectedPage = router?.pathname?.split('/')[1]
 
-  const { templates } = useFlags()
-
   const profileOpen = Boolean(profileAnchorEl)
   const handleProfileClick = (event): void => {
     setProfileAnchorEl(event.currentTarget)
@@ -162,14 +159,12 @@ export function NavigationDrawer({
           tooltipText={journeyTooltip}
         />
 
-        {templates && (
-          <NavigationListItem
-            icon={<ShopRoundedIcon />}
-            label="Templates"
-            selected={selectedPage === 'templates'}
-            link="/templates"
-          />
-        )}
+        <NavigationListItem
+          icon={<ShopRoundedIcon />}
+          label="Templates"
+          selected={selectedPage === 'templates'}
+          link="/templates"
+        />
 
         <NavigationListItem
           icon={<LeaderboardRoundedIcon />}
@@ -183,15 +178,14 @@ export function NavigationDrawer({
             <Divider sx={{ mb: 2, mx: 6, borderColor: 'secondary.main' }} />
 
             {userRoleData?.getUserRole?.roles?.includes(Role.publisher) ===
-              true &&
-              templates && (
-                <NavigationListItem
-                  icon={<ShopTwoRoundedIcon />}
-                  label="Publisher"
-                  selected={selectedPage === 'publisher'}
-                  link="/publisher"
-                />
-              )}
+              true && (
+              <NavigationListItem
+                icon={<ShopTwoRoundedIcon />}
+                label="Publisher"
+                selected={selectedPage === 'publisher'}
+                link="/publisher"
+              />
+            )}
 
             <NavigationListItem
               icon={

--- a/apps/journeys-admin/src/components/NewPageWrapper/PageWrapper.stories.tsx
+++ b/apps/journeys-admin/src/components/NewPageWrapper/PageWrapper.stories.tsx
@@ -5,7 +5,6 @@ import MenuRounded from '@mui/icons-material/MenuRounded'
 import Typography from '@mui/material/Typography'
 import { noop } from 'lodash'
 import { MockedProvider } from '@apollo/client/testing'
-import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 import ListItemButton from '@mui/material/ListItemButton'
 import Paper from '@mui/material/Paper'
 import { journeysAdminConfig } from '../../libs/storybook'
@@ -53,9 +52,7 @@ const SidePanelContainers = (): ReactElement => (
   </>
 )
 
-const Template: Story<
-  ComponentProps<typeof PageWrapper> & { templates?: boolean }
-> = ({ templates = false, ...args }) => {
+const Template: Story<ComponentProps<typeof PageWrapper>> = ({ ...args }) => {
   return (
     <MockedProvider
       mocks={[
@@ -90,9 +87,7 @@ const Template: Story<
         }
       ]}
     >
-      <FlagsProvider flags={{ templates }}>
-        <PageWrapper {...args} />
-      </FlagsProvider>
+      <PageWrapper {...args} />
     </MockedProvider>
   )
 }

--- a/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.spec.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.spec.tsx
@@ -3,7 +3,6 @@ import { fireEvent, render, waitFor } from '@testing-library/react'
 import { NextRouter, useRouter } from 'next/router'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import { AuthUser } from 'next-firebase-auth'
-import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 import { Role } from '../../../../__generated__/globalTypes'
 import { GET_USER_ROLE } from '../../JourneyView/JourneyView'
 import { GET_ME } from '../../NewPageWrapper/NavigationDrawer'
@@ -38,9 +37,7 @@ describe('NavigationDrawer', () => {
   it('should render the default menu items', () => {
     const { getByText, getAllByRole, getByTestId } = render(
       <MockedProvider>
-        <FlagsProvider>
-          <NavigationDrawer open onClose={onClose} />
-        </FlagsProvider>
+        <NavigationDrawer open onClose={onClose} />
       </MockedProvider>
     )
     expect(getAllByRole('button')[0]).toContainElement(
@@ -84,20 +81,18 @@ describe('NavigationDrawer', () => {
           }
         ]}
       >
-        <FlagsProvider flags={{ templates: true, reports: true }}>
-          <NavigationDrawer
-            open
-            onClose={onClose}
-            authUser={
-              {
-                displayName: 'Amin One',
-                photoURL: 'https://bit.ly/3Gth4Yf',
-                email: 'amin@email.com',
-                signOut
-              } as unknown as AuthUser
-            }
-          />
-        </FlagsProvider>
+        <NavigationDrawer
+          open
+          onClose={onClose}
+          authUser={
+            {
+              displayName: 'Amin One',
+              photoURL: 'https://bit.ly/3Gth4Yf',
+              email: 'amin@email.com',
+              signOut
+            } as unknown as AuthUser
+          }
+        />
       </MockedProvider>
     )
     expect(getByText('Templates')).toBeInTheDocument()
@@ -112,9 +107,7 @@ describe('NavigationDrawer', () => {
 
     const { getByTestId } = render(
       <MockedProvider>
-        <FlagsProvider flags={{ templates: true }}>
-          <NavigationDrawer open onClose={onClose} />
-        </FlagsProvider>
+        <NavigationDrawer open onClose={onClose} />
       </MockedProvider>
     )
     expect(getByTestId('Templates-list-item')).toHaveAttribute(
@@ -130,9 +123,7 @@ describe('NavigationDrawer', () => {
 
     const { getByTestId } = render(
       <MockedProvider>
-        <FlagsProvider>
-          <NavigationDrawer open onClose={onClose} />
-        </FlagsProvider>
+        <NavigationDrawer open onClose={onClose} />
       </MockedProvider>
     )
     expect(getByTestId('Reports-list-item')).toHaveAttribute(
@@ -180,20 +171,18 @@ describe('NavigationDrawer', () => {
           }
         ]}
       >
-        <FlagsProvider flags={{ templates: true }}>
-          <NavigationDrawer
-            open
-            onClose={onClose}
-            authUser={
-              {
-                displayName: 'Amin One',
-                photoURL: 'https://bit.ly/3Gth4Yf',
-                email: 'amin@email.com',
-                signOut
-              } as unknown as AuthUser
-            }
-          />
-        </FlagsProvider>
+        <NavigationDrawer
+          open
+          onClose={onClose}
+          authUser={
+            {
+              displayName: 'Amin One',
+              photoURL: 'https://bit.ly/3Gth4Yf',
+              email: 'amin@email.com',
+              signOut
+            } as unknown as AuthUser
+          }
+        />
       </MockedProvider>
     )
     await waitFor(() =>
@@ -239,20 +228,18 @@ describe('NavigationDrawer', () => {
           }
         ]}
       >
-        <FlagsProvider flags={{ templates: true }}>
-          <NavigationDrawer
-            open
-            onClose={onClose}
-            authUser={
-              {
-                displayName: 'Amin One',
-                photoURL: 'https://bit.ly/3Gth4Yf',
-                email: 'amin@email.com',
-                signOut
-              } as unknown as AuthUser
-            }
-          />
-        </FlagsProvider>
+        <NavigationDrawer
+          open
+          onClose={onClose}
+          authUser={
+            {
+              displayName: 'Amin One',
+              photoURL: 'https://bit.ly/3Gth4Yf',
+              email: 'amin@email.com',
+              signOut
+            } as unknown as AuthUser
+          }
+        />
       </MockedProvider>
     )
     await waitFor(() =>
@@ -271,9 +258,7 @@ describe('NavigationDrawer', () => {
   it('should close the navigation drawer on chevron left click', () => {
     const { getAllByRole, getByTestId } = render(
       <MockedProvider>
-        <FlagsProvider>
-          <NavigationDrawer open onClose={onClose} />
-        </FlagsProvider>
+        <NavigationDrawer open onClose={onClose} />
       </MockedProvider>
     )
     const button = getAllByRole('button')[0]
@@ -289,9 +274,7 @@ describe('NavigationDrawer', () => {
 
     const { getByTestId } = render(
       <MockedProvider>
-        <FlagsProvider>
-          <NavigationDrawer open onClose={onClose} />
-        </FlagsProvider>
+        <NavigationDrawer open onClose={onClose} />
       </MockedProvider>
     )
     expect(getByTestId('ViewCarouselRoundedIcon').parentElement).toHaveStyle(

--- a/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.stories.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.stories.tsx
@@ -3,7 +3,6 @@ import { Meta, Story } from '@storybook/react'
 import { noop } from 'lodash'
 import { MockedProvider } from '@apollo/client/testing'
 import { AuthUser } from 'next-firebase-auth'
-import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 import { journeysAdminConfig } from '../../../libs/storybook'
 import { Role, UserJourneyRole } from '../../../../__generated__/globalTypes'
 import { GET_USER_ROLE } from '../../JourneyView/JourneyView'
@@ -60,38 +59,27 @@ const Template: Story = ({ ...args }) => {
         }
       ]}
     >
-      <FlagsProvider flags={{ templates: args.templates }}>
-        <NavigationDrawer
-          open={open}
-          onClose={() => setOpen(!open)}
-          authUser={
-            {
-              id: 'user.id',
-              displayName: 'Amin One',
-              photoURL: 'https://bit.ly/3Gth4Yf',
-              email: 'amin@email.com',
-              signOut: noop
-            } as unknown as AuthUser
-          }
-        />
-      </FlagsProvider>
+      <NavigationDrawer
+        open={open}
+        onClose={() => setOpen(!open)}
+        authUser={
+          {
+            id: 'user.id',
+            displayName: 'Amin One',
+            photoURL: 'https://bit.ly/3Gth4Yf',
+            email: 'amin@email.com',
+            signOut: noop
+          } as unknown as AuthUser
+        }
+      />
     </MockedProvider>
   )
 }
 
 export const Default = Template.bind({})
-Default.args = {
-  templates: false
-}
-
-export const Complete = Template.bind({})
-Complete.args = {
-  templates: true
-}
 
 export const WithBadge = Template.bind({})
 WithBadge.args = {
-  templates: false,
   result: {
     data: {
       journeys: [

--- a/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.tsx
@@ -19,7 +19,6 @@ import Image from 'next/image'
 import { useRouter } from 'next/router'
 import { compact } from 'lodash'
 import { useQuery } from '@apollo/client'
-import { useFlags } from '@core/shared/ui/FlagsProvider'
 import ViewCarouselRoundedIcon from '@mui/icons-material/ViewCarouselRounded'
 import LeaderboardRoundedIcon from '@mui/icons-material/LeaderboardRounded'
 import { useTranslation } from 'react-i18next'
@@ -99,8 +98,6 @@ export function NavigationDrawer({
 
   const selectedPage = router?.pathname?.split('/')[1]
 
-  const { templates } = useFlags()
-
   const profileOpen = Boolean(profileAnchorEl)
   const handleProfileClick = (event): void => {
     setProfileAnchorEl(event.currentTarget)
@@ -150,14 +147,12 @@ export function NavigationDrawer({
           tooltipText={journeyTooltip}
         />
 
-        {templates && (
-          <NavigationListItem
-            icon={<ShopRoundedIcon />}
-            label="Templates"
-            selected={selectedPage === 'templates'}
-            link="/templates"
-          />
-        )}
+        <NavigationListItem
+          icon={<ShopRoundedIcon />}
+          label="Templates"
+          selected={selectedPage === 'templates'}
+          link="/templates"
+        />
 
         <NavigationListItem
           icon={<LeaderboardRoundedIcon />}
@@ -171,15 +166,14 @@ export function NavigationDrawer({
             <Divider sx={{ mb: 2, mx: 6, borderColor: 'secondary.main' }} />
 
             {userRoleData?.getUserRole?.roles?.includes(Role.publisher) ===
-              true &&
-              templates && (
-                <NavigationListItem
-                  icon={<ShopTwoRoundedIcon />}
-                  label="Publisher"
-                  selected={selectedPage === 'publisher'}
-                  link="/publisher"
-                />
-              )}
+              true && (
+              <NavigationListItem
+                icon={<ShopTwoRoundedIcon />}
+                label="Publisher"
+                selected={selectedPage === 'publisher'}
+                link="/publisher"
+              />
+            )}
 
             <NavigationListItem
               icon={

--- a/apps/journeys-admin/src/components/PageWrapper/PageWrapper.stories.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/PageWrapper.stories.tsx
@@ -3,7 +3,6 @@ import IconButton from '@mui/material/IconButton'
 import MenuRounded from '@mui/icons-material/MenuRounded'
 import { noop } from 'lodash'
 import { MockedProvider } from '@apollo/client/testing'
-import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 import { journeysAdminConfig } from '../../libs/storybook'
 import { Role } from '../../../__generated__/globalTypes'
 import { GET_USER_ROLE } from '../JourneyView/JourneyView'
@@ -55,9 +54,7 @@ const Template: Story = ({ ...args }) => (
       }
     ]}
   >
-    <FlagsProvider flags={{ templates: args.templates }}>
-      <PageWrapper {...(args.props as unknown as PageWrapperProps)} />
-    </FlagsProvider>
+    <PageWrapper {...(args.props as unknown as PageWrapperProps)} />
   </MockedProvider>
 )
 
@@ -83,8 +80,7 @@ Complete.args = {
         <MenuRounded />
       </IconButton>
     )
-  },
-  templates: true
+  }
 }
 
 export default PageWrapperStory as Meta

--- a/apps/journeys-admin/src/components/TemplateList/TemplateList.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateList/TemplateList.stories.tsx
@@ -1,6 +1,5 @@
 import { Story, Meta } from '@storybook/react'
 import { MockedProvider } from '@apollo/client/testing'
-import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 import { journeysAdminConfig } from '../../libs/storybook'
 import {
   defaultTemplate,
@@ -41,9 +40,7 @@ const Template: Story = ({ ...args }) => (
       }
     ]}
   >
-    <FlagsProvider flags={{ templates: true }}>
-      <TemplateList {...args.props} />
-    </FlagsProvider>
+    <TemplateList {...args.props} />
   </MockedProvider>
 )
 


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2dc4b7e</samp>

Removed the feature flag for templates from the journeys-admin app. Simplified the code and tests for the `NavigationDrawer` and `PageWrapper` components and their stories. Made the templates and publisher menu items always visible to the users who have access to them.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/32387559/todos/6077091965)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Can still access templates

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2dc4b7e</samp>

*  Remove `FlagsProvider` component and `useFlags` hook from all files, as they are no longer needed to conditionally render the templates menu item. ([link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-0b66a55c4389516b7cf55773a557d9b57bfe721b4f217c94655b920ef4d55b09L88-R88), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-0b66a55c4389516b7cf55773a557d9b57bfe721b4f217c94655b920ef4d55b09L112-R116), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-0b66a55c4389516b7cf55773a557d9b57bfe721b4f217c94655b920ef4d55b09L130-R132), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-0b66a55c4389516b7cf55773a557d9b57bfe721b4f217c94655b920ef4d55b09L180-R188), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-0b66a55c4389516b7cf55773a557d9b57bfe721b4f217c94655b920ef4d55b09L240-R245), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-0b66a55c4389516b7cf55773a557d9b57bfe721b4f217c94655b920ef4d55b09L272-R264), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-0b66a55c4389516b7cf55773a557d9b57bfe721b4f217c94655b920ef4d55b09L286-R276), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-27ea62121bd0529ee73a29273085be0849f468ea2c26f6f39a886ea1c6387126L6), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-27ea62121bd0529ee73a29273085be0849f468ea2c26f6f39a886ea1c6387126L64-R76), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-27ea62121bd0529ee73a29273085be0849f468ea2c26f6f39a886ea1c6387126L85-R82), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-24151e0fb3ef8e0b5c22ecf5dc45ac477594c019f117933a4cfcc48ac7caa4fcL22), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-24151e0fb3ef8e0b5c22ecf5dc45ac477594c019f117933a4cfcc48ac7caa4fcL114-L115), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-dc30d606e0c50db44ab970c84244650e1af0caab2fafa6d589f64e300d37c4b7L8), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-dc30d606e0c50db44ab970c84244650e1af0caab2fafa6d589f64e300d37c4b7L56-R55), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-dc30d606e0c50db44ab970c84244650e1af0caab2fafa6d589f64e300d37c4b7L93-R90), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-90838db6249e45b7ec3e7eaf20922b49b28087b7b196ff126aab6f53dd8b2eadL6), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-90838db6249e45b7ec3e7eaf20922b49b28087b7b196ff126aab6f53dd8b2eadL41-R40), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-90838db6249e45b7ec3e7eaf20922b49b28087b7b196ff126aab6f53dd8b2eadL87-R95), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-90838db6249e45b7ec3e7eaf20922b49b28087b7b196ff126aab6f53dd8b2eadL115-R110), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-90838db6249e45b7ec3e7eaf20922b49b28087b7b196ff126aab6f53dd8b2eadL133-R126), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-90838db6249e45b7ec3e7eaf20922b49b28087b7b196ff126aab6f53dd8b2eadL183-R185), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-90838db6249e45b7ec3e7eaf20922b49b28087b7b196ff126aab6f53dd8b2eadL242-R242), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-90838db6249e45b7ec3e7eaf20922b49b28087b7b196ff126aab6f53dd8b2eadL274-R261), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-90838db6249e45b7ec3e7eaf20922b49b28087b7b196ff126aab6f53dd8b2eadL292-R277), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-ee5925d5c0881713923bc86ffc84d43c40cb16699c2a614dc43f83db4503365dL6), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-ee5925d5c0881713923bc86ffc84d43c40cb16699c2a614dc43f83db4503365dL63-R74), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-ee5925d5c0881713923bc86ffc84d43c40cb16699c2a614dc43f83db4503365dL83-R82), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-edae5bf8473925856e8b7a5d32aeb3f802f946dd642c9833548989bc79a292dcL22), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-edae5bf8473925856e8b7a5d32aeb3f802f946dd642c9833548989bc79a292dcL102-L103), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-951943273533d3de5a4b7441337f52ad30bb19955a713bcee8209248edbed26bL6), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-951943273533d3de5a4b7441337f52ad30bb19955a713bcee8209248edbed26bL58-R57), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-7109186d501ebbf6711a7dfefe4ba4cfb687ad0c65ee1c4a7e5ccce44a9e4062L3), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-7109186d501ebbf6711a7dfefe4ba4cfb687ad0c65ee1c4a7e5ccce44a9e4062L44-R43))
* Remove `templates` condition from `NavigationDrawer` component, as the templates and publisher menu items are always rendered. ([link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-24151e0fb3ef8e0b5c22ecf5dc45ac477594c019f117933a4cfcc48ac7caa4fcL165-R167), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-24151e0fb3ef8e0b5c22ecf5dc45ac477594c019f117933a4cfcc48ac7caa4fcL186-R188), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-edae5bf8473925856e8b7a5d32aeb3f802f946dd642c9833548989bc79a292dcL153-R155), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-edae5bf8473925856e8b7a5d32aeb3f802f946dd642c9833548989bc79a292dcL174-R176))
* Remove `Complete` story from `NavigationDrawer` story, as it is no longer relevant to have a story with the templates flag enabled. ([link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-27ea62121bd0529ee73a29273085be0849f468ea2c26f6f39a886ea1c6387126L85-R82), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-ee5925d5c0881713923bc86ffc84d43c40cb16699c2a614dc43f83db4503365dL83-R82))
* Remove `templates` prop from `PageWrapper` story, as it is no longer needed to conditionally render the templates menu item. ([link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-dc30d606e0c50db44ab970c84244650e1af0caab2fafa6d589f64e300d37c4b7L56-R55), [link](https://github.com/JesusFilm/core/pull/1596/files?diff=unified&w=0#diff-951943273533d3de5a4b7441337f52ad30bb19955a713bcee8209248edbed26bL86-R83))
