### PR TITLE
fix: remove network mode line

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,8 +13,6 @@ services:
       - core-node-doppler:/home/node/.doppler
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
-    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
-    network_mode: service:arangodb
     # Uncomment the next line to use a non-root user for all processes.
     # user: node
     # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.


### PR DESCRIPTION
# Description

networking line causing error:
`Error response from daemon: conflicting options: custom host-to-IP mapping and the network mode`

remove as still functions without this line.