### PR TITLE
fix: remove trailing space from affected

### DIFF
--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -33,7 +33,7 @@ jobs:
       - id: set-matrix
         name: set matrix app to affected array
         run: |
-          AFFECTED=$(echo "$(npx nx affected:apps --plain)" | sed -e 's/api-\w* *//g')
+          AFFECTED=$(echo "$(npx nx affected:apps --plain)" | sed -e 's/ *api-\w* *//g')
           echo $AFFECTED
           if [ -n "${AFFECTED}" ]; then
             echo "matrix=[\"${AFFECTED// /\",\"}\"]" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a21aba0</samp>

Fixed a bug in the app deployment workflow that could cause errors when parsing the affected apps list. Improved the regular expression to trim any spaces around the `api-` prefix in `.github/workflows/app-deploy.yml`.