### PR TITLE
fix: adjust host model avatar props deprecation pr

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -482,8 +482,8 @@ input HostCreateInput
 {
   title: String!
   location: String
-  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
-  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  avatar1Id: ID
+  avatar2Id: ID
   src1: String
   src2: String
 }
@@ -496,8 +496,8 @@ input HostUpdateInput
   """
   title: String
   location: String
-  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
-  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  avatar1Id: ID
+  avatar2Id: ID
   src1: String
   src2: String
 }

--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -471,8 +471,10 @@ type Host
   teamId: ID!
   title: String!
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
+  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
+  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  src1: String
+  src2: String
 }
 
 input HostCreateInput
@@ -480,8 +482,10 @@ input HostCreateInput
 {
   title: String!
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
+  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
+  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  src1: String
+  src2: String
 }
 
 input HostUpdateInput
@@ -492,8 +496,10 @@ input HostUpdateInput
   """
   title: String
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
+  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
+  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  src1: String
+  src2: String
 }
 
 type IconBlock implements Block

--- a/apps/api-journeys/db/migrations/20230615223656_20230615223654/migration.sql
+++ b/apps/api-journeys/db/migrations/20230615223656_20230615223654/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Host" ADD COLUMN     "src1" TEXT,
+ADD COLUMN     "src2" TEXT;

--- a/apps/api-journeys/db/schema.prisma
+++ b/apps/api-journeys/db/schema.prisma
@@ -143,6 +143,8 @@ model Host {
   location  String?
   avatar1Id String?
   avatar2Id String?
+  src1      String?
+  src2      String?
 }
 
 model JourneyVisitor {

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -1581,8 +1581,8 @@ input HostUpdateInput {
   """
   title: String
   location: String
-  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
-  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  avatar1Id: ID
+  avatar2Id: ID
   src1: String
   src2: String
 }
@@ -1643,8 +1643,8 @@ extend type Query {
 input HostCreateInput {
   title: String!
   location: String
-  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
-  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  avatar1Id: ID
+  avatar2Id: ID
   src1: String
   src2: String
 }

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -1569,8 +1569,10 @@ type Host {
   teamId: ID!
   title: String!
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
+  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
+  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  src1: String
+  src2: String
 }
 
 input HostUpdateInput {
@@ -1579,8 +1581,10 @@ input HostUpdateInput {
   """
   title: String
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
+  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
+  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  src1: String
+  src2: String
 }
 
 type Query {
@@ -1639,8 +1643,10 @@ extend type Query {
 input HostCreateInput {
   title: String!
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
+  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
+  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  src1: String
+  src2: String
 }
 
 enum IdType {

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -573,6 +573,8 @@ export class HostUpdateInput {
     location?: Nullable<string>;
     avatar1Id?: Nullable<string>;
     avatar2Id?: Nullable<string>;
+    src1?: Nullable<string>;
+    src2?: Nullable<string>;
 }
 
 export class HostCreateInput {
@@ -580,6 +582,8 @@ export class HostCreateInput {
     location?: Nullable<string>;
     avatar1Id?: Nullable<string>;
     avatar2Id?: Nullable<string>;
+    src1?: Nullable<string>;
+    src2?: Nullable<string>;
 }
 
 export class JourneysFilter {
@@ -1065,6 +1069,8 @@ export class Host {
     location?: Nullable<string>;
     avatar1Id?: Nullable<string>;
     avatar2Id?: Nullable<string>;
+    src1?: Nullable<string>;
+    src2?: Nullable<string>;
 }
 
 export abstract class IQuery {

--- a/apps/api-journeys/src/app/modules/host/host.graphql
+++ b/apps/api-journeys/src/app/modules/host/host.graphql
@@ -3,8 +3,10 @@ type Host {
   teamId: ID!
   title: String!
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
+  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
+  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  src1: String
+  src2: String
 }
 
 input HostUpdateInput {
@@ -13,8 +15,10 @@ input HostUpdateInput {
   """
   title: String
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
+  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
+  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  src1: String
+  src2: String
 }
 
 extend type Query {
@@ -24,8 +28,10 @@ extend type Query {
 input HostCreateInput {
   title: String!
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
+  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
+  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  src1: String
+  src2: String
 }
 
 extend type Mutation {

--- a/apps/api-journeys/src/app/modules/host/host.graphql
+++ b/apps/api-journeys/src/app/modules/host/host.graphql
@@ -15,8 +15,8 @@ input HostUpdateInput {
   """
   title: String
   location: String
-  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
-  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  avatar1Id: ID
+  avatar2Id: ID
   src1: String
   src2: String
 }
@@ -28,8 +28,8 @@ extend type Query {
 input HostCreateInput {
   title: String!
   location: String
-  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
-  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  avatar1Id: ID
+  avatar2Id: ID
   src1: String
   src2: String
 }

--- a/apps/api-journeys/src/app/modules/host/host.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/host/host.resolver.spec.ts
@@ -21,7 +21,9 @@ describe('HostResolver', () => {
         title: 'New Host',
         location: 'Location',
         avatar1Id: 'avatar1',
-        avatar2Id: 'avatar2'
+        avatar2Id: 'avatar2',
+        src1: 'avatar1',
+        src2: 'avatar2'
       }
       const mockHost = { teamId, ...input, id: 'hostid' }
       jest.spyOn(prismaService.host, 'create').mockResolvedValue(mockHost)
@@ -46,7 +48,9 @@ describe('HostResolver', () => {
           title: 'Edmond Shen & Nisal Cottingham',
           location: 'New Zealand',
           avatar1Id: 'avatar1-id',
-          avatar2Id: 'vatar2-id'
+          avatar2Id: 'vatar2-id',
+          src1: 'avatar1',
+          src2: 'avatar2'
         },
         {
           id: 'host-id2',
@@ -54,7 +58,9 @@ describe('HostResolver', () => {
           title: 'Edmond Shen & Nisal Cottingham',
           location: 'New Zealand',
           avatar1Id: 'avatar1-id',
-          avatar2Id: 'avatar2-id'
+          avatar2Id: 'avatar2-id',
+          src1: 'avatar1',
+          src2: 'avatar2'
         }
       ]
       jest.spyOn(prismaService.host, 'findMany').mockResolvedValue(mockHosts)
@@ -75,7 +81,9 @@ describe('HostResolver', () => {
         title: 'Edmond Shen',
         location: 'National Team Staff',
         avatar1Id: 'new-profile-pic-who-thos',
-        avatar2Id: 'new-avatar2'
+        avatar2Id: 'new-avatar2',
+        src1: 'avatar1',
+        src2: 'avatar2'
       }
       const mockHost = {
         id: 'host-id',
@@ -83,7 +91,9 @@ describe('HostResolver', () => {
         title: 'Edmond Shen & Nisal Cottingham',
         location: 'JFP Staff',
         avatar1Id: 'avatar1-id',
-        avatar2Id: 'avatar2-id'
+        avatar2Id: 'avatar2-id',
+        src1: 'avatar1',
+        src2: 'avatar2'
       }
       const mockUpdatedHost = { ...mockHost, ...input }
       jest
@@ -100,7 +110,9 @@ describe('HostResolver', () => {
           title: input.title,
           location: input.location,
           avatar1Id: input.avatar1Id,
-          avatar2Id: input.avatar2Id
+          avatar2Id: input.avatar2Id,
+          src1: input.src1,
+          src2: input.src2
         }
       })
     })
@@ -110,7 +122,9 @@ describe('HostResolver', () => {
       const input = {
         location: 'National Team Staff',
         avatar1Id: 'new-profile-pic-who-thos',
-        avatar2Id: 'new-avatar2'
+        avatar2Id: 'new-avatar2',
+        src1: 'avatar1',
+        src2: 'avatar2'
       }
       const mockHost = {
         id: 'host-id',
@@ -118,7 +132,9 @@ describe('HostResolver', () => {
         title: 'Edmond Shen & Nisal Cottingham',
         location: 'JFP Staff',
         avatar1Id: 'avatar1-id',
-        avatar2Id: 'avatar2-id'
+        avatar2Id: 'avatar2-id',
+        src1: 'avatar1',
+        src2: 'avatar2'
       }
       const mockUpdatedHost = { ...mockHost, ...input }
       jest
@@ -135,7 +151,9 @@ describe('HostResolver', () => {
           title: undefined,
           location: input.location,
           avatar1Id: input.avatar1Id,
-          avatar2Id: input.avatar2Id
+          avatar2Id: input.avatar2Id,
+          src1: input.src1,
+          src2: input.src2
         }
       })
     })
@@ -146,7 +164,9 @@ describe('HostResolver', () => {
         title: null,
         location: 'National Team Staff',
         avatar1Id: 'new-profile-pic-who-thos',
-        avatar2Id: 'new-avatar2'
+        avatar2Id: 'new-avatar2',
+        src1: 'avatar1',
+        src2: 'avatar2'
       }
 
       await expect(hostResolver.hostUpdate(hostId, input)).rejects.toThrow(
@@ -164,7 +184,9 @@ describe('HostResolver', () => {
         title: 'Edmond Shen & Nisal Cottingham',
         location: 'JFP Staff',
         avatar1Id: 'avatar1-id',
-        avatar2Id: 'avatar2-id'
+        avatar2Id: 'avatar2-id',
+        src1: 'avatar1',
+        src2: 'avatar2'
       }
       jest
         .spyOn(prismaService.host, 'delete')


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8e6a3fa</samp>

Refactored the `Host` type and related types to use image URLs instead of IDs for the host avatars. This simplifies the image handling logic and aligns the GraphQL schemas for the gateway and journeys services. Updated the database schema, the Prisma schema, and the unit tests to reflect the new fields.

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/33034387/todos/6261817734)

# How should this PR be QA Tested?

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8e6a3fa</samp>

*  Deprecate `avatar1Id` and `avatar2Id` fields and add `src1` and `src2` fields to `Host`, `HostUpdateInput`, and `HostCreateInput` types in GraphQL schema ([link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-e60078ed0fc71b8cd3bb2fca25505e7dba866b7d463147662a12432dfe287273L474-R477), [link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-e60078ed0fc71b8cd3bb2fca25505e7dba866b7d463147662a12432dfe287273L483-R488), [link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-e60078ed0fc71b8cd3bb2fca25505e7dba866b7d463147662a12432dfe287273L495-R502), [link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-3cbd0d77b8eff95fb0f62db7f9f1a4b69ccd568ae3902a3450bac7d752c817a3L1572-R1575), [link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-3cbd0d77b8eff95fb0f62db7f9f1a4b69ccd568ae3902a3450bac7d752c817a3L1582-R1587), [link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-3cbd0d77b8eff95fb0f62db7f9f1a4b69ccd568ae3902a3450bac7d752c817a3L1642-R1649), [link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-9d7884c06becb3354bff04153f4f1f2d29ff6f85d92ffbca288b41aa336d6b75L6-R9), [link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-9d7884c06becb3354bff04153f4f1f2d29ff6f85d92ffbca288b41aa336d6b75L16-R21), [link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-9d7884c06becb3354bff04153f4f1f2d29ff6f85d92ffbca288b41aa336d6b75L27-R34))
* Add `src1` and `src2` columns to `Host` table in database migration ([link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-8a0e9b48bab6c6ca823bc001b1dee4cd6558bc8c90e9dfb6f60516fbc747ed99R1-R3))
* Add `src1` and `src2` fields to `Host` model in Prisma schema ([link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-881378863f13d5e9573c2c2e756ae61e8161918ebb4a384a8d5dddd7bf7385b0R146-R147))
* Update `HostUpdateInput`, `HostCreateInput`, and `Host` classes in TypeScript code generation from GraphQL schema ([link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-bef781d45ccbb6775960a589c940a77584bd143e501a8ae9b83d699d803561f2R576-R577), [link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-bef781d45ccbb6775960a589c940a77584bd143e501a8ae9b83d699d803561f2R585-R586), [link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-bef781d45ccbb6775960a589c940a77584bd143e501a8ae9b83d699d803561f2R1072-R1073))
* Include `src1` and `src2` fields in mock host input and output in unit tests ([link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L24-R26), [link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L49-R53), [link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L57-R63), [link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L78-R86), [link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L86-R96), [link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L103-R115), [link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L113-R127), [link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L121-R137), [link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L138-R156), [link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L149-R169), [link](https://github.com/JesusFilm/core/pull/1627/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L167-R189))
