### PR TITLE
fix: adjust host model remove deprecation directives and props

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -482,8 +482,8 @@ input HostCreateInput
 {
   title: String!
   location: String
-  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
-  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  avatar1Id: ID
+  avatar2Id: ID
   src1: String
   src2: String
 }
@@ -496,8 +496,8 @@ input HostUpdateInput
   """
   title: String
   location: String
-  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
-  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  avatar1Id: ID
+  avatar2Id: ID
   src1: String
   src2: String
 }

--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -471,8 +471,6 @@ type Host
   teamId: ID!
   title: String!
   location: String
-  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
-  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
   src1: String
   src2: String
 }
@@ -482,8 +480,6 @@ input HostCreateInput
 {
   title: String!
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
   src1: String
   src2: String
 }
@@ -496,8 +492,6 @@ input HostUpdateInput
   """
   title: String
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
   src1: String
   src2: String
 }

--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -471,8 +471,10 @@ type Host
   teamId: ID!
   title: String!
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
+  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
+  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  src1: String
+  src2: String
 }
 
 input HostCreateInput
@@ -480,8 +482,10 @@ input HostCreateInput
 {
   title: String!
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
+  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
+  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  src1: String
+  src2: String
 }
 
 input HostUpdateInput
@@ -492,8 +496,10 @@ input HostUpdateInput
   """
   title: String
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
+  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
+  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  src1: String
+  src2: String
 }
 
 type IconBlock implements Block

--- a/apps/api-journeys/db/migrations/20230615223656_20230615223654/migration.sql
+++ b/apps/api-journeys/db/migrations/20230615223656_20230615223654/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Host" ADD COLUMN     "src1" TEXT,
+ADD COLUMN     "src2" TEXT;

--- a/apps/api-journeys/db/migrations/20230615233217_20230615233215/migration.sql
+++ b/apps/api-journeys/db/migrations/20230615233217_20230615233215/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `avatar1Id` on the `Host` table. All the data in the column will be lost.
+  - You are about to drop the column `avatar2Id` on the `Host` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Host" DROP COLUMN "avatar1Id",
+DROP COLUMN "avatar2Id";

--- a/apps/api-journeys/db/schema.prisma
+++ b/apps/api-journeys/db/schema.prisma
@@ -136,15 +136,13 @@ model Visitor {
 }
 
 model Host {
-  id        String  @id @default(uuid())
-  teamId    String
-  team      Team    @relation(fields: [teamId], references: [id])
-  title     String
-  location  String?
-  avatar1Id String?
-  avatar2Id String?
-  src1      String?
-  src2      String?
+  id       String  @id @default(uuid())
+  teamId   String
+  team     Team    @relation(fields: [teamId], references: [id])
+  title    String
+  location String?
+  src1     String?
+  src2     String?
 }
 
 model JourneyVisitor {

--- a/apps/api-journeys/db/schema.prisma
+++ b/apps/api-journeys/db/schema.prisma
@@ -143,6 +143,8 @@ model Host {
   location  String?
   avatar1Id String?
   avatar2Id String?
+  src1      String?
+  src2      String?
 }
 
 model JourneyVisitor {

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -1581,8 +1581,8 @@ input HostUpdateInput {
   """
   title: String
   location: String
-  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
-  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  avatar1Id: ID
+  avatar2Id: ID
   src1: String
   src2: String
 }
@@ -1643,8 +1643,8 @@ extend type Query {
 input HostCreateInput {
   title: String!
   location: String
-  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
-  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  avatar1Id: ID
+  avatar2Id: ID
   src1: String
   src2: String
 }

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -1569,8 +1569,10 @@ type Host {
   teamId: ID!
   title: String!
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
+  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
+  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  src1: String
+  src2: String
 }
 
 input HostUpdateInput {
@@ -1579,8 +1581,10 @@ input HostUpdateInput {
   """
   title: String
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
+  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
+  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  src1: String
+  src2: String
 }
 
 type Query {
@@ -1639,8 +1643,10 @@ extend type Query {
 input HostCreateInput {
   title: String!
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
+  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
+  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  src1: String
+  src2: String
 }
 
 enum IdType {

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -1569,8 +1569,6 @@ type Host {
   teamId: ID!
   title: String!
   location: String
-  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
-  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
   src1: String
   src2: String
 }
@@ -1581,8 +1579,6 @@ input HostUpdateInput {
   """
   title: String
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
   src1: String
   src2: String
 }
@@ -1643,8 +1639,6 @@ extend type Query {
 input HostCreateInput {
   title: String!
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
   src1: String
   src2: String
 }

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -573,6 +573,8 @@ export class HostUpdateInput {
     location?: Nullable<string>;
     avatar1Id?: Nullable<string>;
     avatar2Id?: Nullable<string>;
+    src1?: Nullable<string>;
+    src2?: Nullable<string>;
 }
 
 export class HostCreateInput {
@@ -580,6 +582,8 @@ export class HostCreateInput {
     location?: Nullable<string>;
     avatar1Id?: Nullable<string>;
     avatar2Id?: Nullable<string>;
+    src1?: Nullable<string>;
+    src2?: Nullable<string>;
 }
 
 export class JourneysFilter {
@@ -1065,6 +1069,8 @@ export class Host {
     location?: Nullable<string>;
     avatar1Id?: Nullable<string>;
     avatar2Id?: Nullable<string>;
+    src1?: Nullable<string>;
+    src2?: Nullable<string>;
 }
 
 export abstract class IQuery {

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -571,8 +571,6 @@ export class VideoProgressEventCreateInput {
 export class HostUpdateInput {
     title?: Nullable<string>;
     location?: Nullable<string>;
-    avatar1Id?: Nullable<string>;
-    avatar2Id?: Nullable<string>;
     src1?: Nullable<string>;
     src2?: Nullable<string>;
 }
@@ -580,8 +578,6 @@ export class HostUpdateInput {
 export class HostCreateInput {
     title: string;
     location?: Nullable<string>;
-    avatar1Id?: Nullable<string>;
-    avatar2Id?: Nullable<string>;
     src1?: Nullable<string>;
     src2?: Nullable<string>;
 }
@@ -1067,8 +1063,6 @@ export class Host {
     teamId: string;
     title: string;
     location?: Nullable<string>;
-    avatar1Id?: Nullable<string>;
-    avatar2Id?: Nullable<string>;
     src1?: Nullable<string>;
     src2?: Nullable<string>;
 }

--- a/apps/api-journeys/src/app/modules/host/host.graphql
+++ b/apps/api-journeys/src/app/modules/host/host.graphql
@@ -3,8 +3,10 @@ type Host {
   teamId: ID!
   title: String!
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
+  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
+  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  src1: String
+  src2: String
 }
 
 input HostUpdateInput {
@@ -13,8 +15,10 @@ input HostUpdateInput {
   """
   title: String
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
+  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
+  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  src1: String
+  src2: String
 }
 
 extend type Query {
@@ -24,8 +28,10 @@ extend type Query {
 input HostCreateInput {
   title: String!
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
+  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
+  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  src1: String
+  src2: String
 }
 
 extend type Mutation {

--- a/apps/api-journeys/src/app/modules/host/host.graphql
+++ b/apps/api-journeys/src/app/modules/host/host.graphql
@@ -15,8 +15,8 @@ input HostUpdateInput {
   """
   title: String
   location: String
-  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
-  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  avatar1Id: ID
+  avatar2Id: ID
   src1: String
   src2: String
 }
@@ -28,8 +28,8 @@ extend type Query {
 input HostCreateInput {
   title: String!
   location: String
-  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
-  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
+  avatar1Id: ID
+  avatar2Id: ID
   src1: String
   src2: String
 }

--- a/apps/api-journeys/src/app/modules/host/host.graphql
+++ b/apps/api-journeys/src/app/modules/host/host.graphql
@@ -3,8 +3,6 @@ type Host {
   teamId: ID!
   title: String!
   location: String
-  avatar1Id: ID @deprecated(reason: "Use `src1` instead.")
-  avatar2Id: ID @deprecated(reason: "Use `src2` instead.")
   src1: String
   src2: String
 }
@@ -15,8 +13,6 @@ input HostUpdateInput {
   """
   title: String
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
   src1: String
   src2: String
 }
@@ -28,8 +24,6 @@ extend type Query {
 input HostCreateInput {
   title: String!
   location: String
-  avatar1Id: ID
-  avatar2Id: ID
   src1: String
   src2: String
 }

--- a/apps/api-journeys/src/app/modules/host/host.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/host/host.resolver.spec.ts
@@ -20,8 +20,6 @@ describe('HostResolver', () => {
       const input = {
         title: 'New Host',
         location: 'Location',
-        avatar1Id: 'avatar1',
-        avatar2Id: 'avatar2',
         src1: 'avatar1',
         src2: 'avatar2'
       }
@@ -47,8 +45,6 @@ describe('HostResolver', () => {
           teamId: 'edmond-shen-fans',
           title: 'Edmond Shen & Nisal Cottingham',
           location: 'New Zealand',
-          avatar1Id: 'avatar1-id',
-          avatar2Id: 'vatar2-id',
           src1: 'avatar1',
           src2: 'avatar2'
         },
@@ -57,8 +53,6 @@ describe('HostResolver', () => {
           teamId: 'best-juniors-engineers-gang',
           title: 'Edmond Shen & Nisal Cottingham',
           location: 'New Zealand',
-          avatar1Id: 'avatar1-id',
-          avatar2Id: 'avatar2-id',
           src1: 'avatar1',
           src2: 'avatar2'
         }
@@ -80,9 +74,7 @@ describe('HostResolver', () => {
       const input = {
         title: 'Edmond Shen',
         location: 'National Team Staff',
-        avatar1Id: 'new-profile-pic-who-thos',
-        avatar2Id: 'new-avatar2',
-        src1: 'avatar1',
+        src1: 'new-profile-pic-who-this',
         src2: 'avatar2'
       }
       const mockHost = {
@@ -90,8 +82,6 @@ describe('HostResolver', () => {
         teamId: 'best-juniors-engineers-gang',
         title: 'Edmond Shen & Nisal Cottingham',
         location: 'JFP Staff',
-        avatar1Id: 'avatar1-id',
-        avatar2Id: 'avatar2-id',
         src1: 'avatar1',
         src2: 'avatar2'
       }
@@ -109,8 +99,6 @@ describe('HostResolver', () => {
         data: {
           title: input.title,
           location: input.location,
-          avatar1Id: input.avatar1Id,
-          avatar2Id: input.avatar2Id,
           src1: input.src1,
           src2: input.src2
         }
@@ -121,9 +109,7 @@ describe('HostResolver', () => {
       const id = 'host-id'
       const input = {
         location: 'National Team Staff',
-        avatar1Id: 'new-profile-pic-who-thos',
-        avatar2Id: 'new-avatar2',
-        src1: 'avatar1',
+        src1: 'new-profile-pic-who-this',
         src2: 'avatar2'
       }
       const mockHost = {
@@ -131,8 +117,6 @@ describe('HostResolver', () => {
         teamId: 'best-juniors-engineers-gang',
         title: 'Edmond Shen & Nisal Cottingham',
         location: 'JFP Staff',
-        avatar1Id: 'avatar1-id',
-        avatar2Id: 'avatar2-id',
         src1: 'avatar1',
         src2: 'avatar2'
       }
@@ -150,8 +134,6 @@ describe('HostResolver', () => {
         data: {
           title: undefined,
           location: input.location,
-          avatar1Id: input.avatar1Id,
-          avatar2Id: input.avatar2Id,
           src1: input.src1,
           src2: input.src2
         }
@@ -163,9 +145,7 @@ describe('HostResolver', () => {
       const input = {
         title: null,
         location: 'National Team Staff',
-        avatar1Id: 'new-profile-pic-who-thos',
-        avatar2Id: 'new-avatar2',
-        src1: 'avatar1',
+        src1: 'new-profile-pic-who-this',
         src2: 'avatar2'
       }
 
@@ -183,8 +163,6 @@ describe('HostResolver', () => {
         teamId: 'best-juniors-engineers-gang',
         title: 'Edmond Shen & Nisal Cottingham',
         location: 'JFP Staff',
-        avatar1Id: 'avatar1-id',
-        avatar2Id: 'avatar2-id',
         src1: 'avatar1',
         src2: 'avatar2'
       }

--- a/apps/api-journeys/src/app/modules/host/host.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/host/host.resolver.spec.ts
@@ -21,7 +21,9 @@ describe('HostResolver', () => {
         title: 'New Host',
         location: 'Location',
         avatar1Id: 'avatar1',
-        avatar2Id: 'avatar2'
+        avatar2Id: 'avatar2',
+        src1: 'avatar1',
+        src2: 'avatar2'
       }
       const mockHost = { teamId, ...input, id: 'hostid' }
       jest.spyOn(prismaService.host, 'create').mockResolvedValue(mockHost)
@@ -46,7 +48,9 @@ describe('HostResolver', () => {
           title: 'Edmond Shen & Nisal Cottingham',
           location: 'New Zealand',
           avatar1Id: 'avatar1-id',
-          avatar2Id: 'vatar2-id'
+          avatar2Id: 'vatar2-id',
+          src1: 'avatar1',
+          src2: 'avatar2'
         },
         {
           id: 'host-id2',
@@ -54,7 +58,9 @@ describe('HostResolver', () => {
           title: 'Edmond Shen & Nisal Cottingham',
           location: 'New Zealand',
           avatar1Id: 'avatar1-id',
-          avatar2Id: 'avatar2-id'
+          avatar2Id: 'avatar2-id',
+          src1: 'avatar1',
+          src2: 'avatar2'
         }
       ]
       jest.spyOn(prismaService.host, 'findMany').mockResolvedValue(mockHosts)
@@ -75,7 +81,9 @@ describe('HostResolver', () => {
         title: 'Edmond Shen',
         location: 'National Team Staff',
         avatar1Id: 'new-profile-pic-who-thos',
-        avatar2Id: 'new-avatar2'
+        avatar2Id: 'new-avatar2',
+        src1: 'avatar1',
+        src2: 'avatar2'
       }
       const mockHost = {
         id: 'host-id',
@@ -83,7 +91,9 @@ describe('HostResolver', () => {
         title: 'Edmond Shen & Nisal Cottingham',
         location: 'JFP Staff',
         avatar1Id: 'avatar1-id',
-        avatar2Id: 'avatar2-id'
+        avatar2Id: 'avatar2-id',
+        src1: 'avatar1',
+        src2: 'avatar2'
       }
       const mockUpdatedHost = { ...mockHost, ...input }
       jest
@@ -100,7 +110,9 @@ describe('HostResolver', () => {
           title: input.title,
           location: input.location,
           avatar1Id: input.avatar1Id,
-          avatar2Id: input.avatar2Id
+          avatar2Id: input.avatar2Id,
+          src1: input.src1,
+          src2: input.src2
         }
       })
     })
@@ -110,7 +122,9 @@ describe('HostResolver', () => {
       const input = {
         location: 'National Team Staff',
         avatar1Id: 'new-profile-pic-who-thos',
-        avatar2Id: 'new-avatar2'
+        avatar2Id: 'new-avatar2',
+        src1: 'avatar1',
+        src2: 'avatar2'
       }
       const mockHost = {
         id: 'host-id',
@@ -118,7 +132,9 @@ describe('HostResolver', () => {
         title: 'Edmond Shen & Nisal Cottingham',
         location: 'JFP Staff',
         avatar1Id: 'avatar1-id',
-        avatar2Id: 'avatar2-id'
+        avatar2Id: 'avatar2-id',
+        src1: 'avatar1',
+        src2: 'avatar2'
       }
       const mockUpdatedHost = { ...mockHost, ...input }
       jest
@@ -135,7 +151,9 @@ describe('HostResolver', () => {
           title: undefined,
           location: input.location,
           avatar1Id: input.avatar1Id,
-          avatar2Id: input.avatar2Id
+          avatar2Id: input.avatar2Id,
+          src1: input.src1,
+          src2: input.src2
         }
       })
     })
@@ -146,7 +164,9 @@ describe('HostResolver', () => {
         title: null,
         location: 'National Team Staff',
         avatar1Id: 'new-profile-pic-who-thos',
-        avatar2Id: 'new-avatar2'
+        avatar2Id: 'new-avatar2',
+        src1: 'avatar1',
+        src2: 'avatar2'
       }
 
       await expect(hostResolver.hostUpdate(hostId, input)).rejects.toThrow(
@@ -164,7 +184,9 @@ describe('HostResolver', () => {
         title: 'Edmond Shen & Nisal Cottingham',
         location: 'JFP Staff',
         avatar1Id: 'avatar1-id',
-        avatar2Id: 'avatar2-id'
+        avatar2Id: 'avatar2-id',
+        src1: 'avatar1',
+        src2: 'avatar2'
       }
       jest
         .spyOn(prismaService.host, 'delete')


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 333fd68</samp>

This pull request simplifies the host data model by using source URLs for the host avatars instead of IDs. It updates the GraphQL schema, the Prisma data model, the database schema, the frontend queries, and the unit tests to use `src1` and `src2` fields for the host avatars. It also adds SQL migration scripts to add and drop the relevant columns in the `Host` table.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/33034387/todos/6261817734)


# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 333fd68</samp>

*  Replace `avatar1Id` and `avatar2Id` with `src1` and `src2` in the `Host` type and the `HostCreateInput` and `HostUpdateInput` input types in the GraphQL schema of the `api-gateway` app (`apps/api-gateway/schema.graphql`) ([link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-e60078ed0fc71b8cd3bb2fca25505e7dba866b7d463147662a12432dfe287273L474-R475), [link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-e60078ed0fc71b8cd3bb2fca25505e7dba866b7d463147662a12432dfe287273L483-R484), [link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-e60078ed0fc71b8cd3bb2fca25505e7dba866b7d463147662a12432dfe287273L495-R496))
*  Add SQL migration scripts to add `src1` and `src2` columns and drop `avatar1Id` and `avatar2Id` columns in the `Host` table in the database (`apps/api-journeys/db/migrations/20230615223656_20230615223654/migration.sql` and `apps/api-journeys/db/migrations/20230615233217_20230615233215/migration.sql`) ([link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-8a0e9b48bab6c6ca823bc001b1dee4cd6558bc8c90e9dfb6f60516fbc747ed99R1-R3), [link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-6ae1be7773f102c4cd826c972f378db2caa4477478e4151ea77ed6f93d12cb8cR1-R10))
*  Update the Prisma data model for the `api-journeys` app to use `src1` and `src2` fields instead of `avatar1Id` and `avatar2Id` fields in the `Host` model (`apps/api-journeys/db/schema.prisma`) ([link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-881378863f13d5e9573c2c2e756ae61e8161918ebb4a384a8d5dddd7bf7385b0L139-R145))
*  Update the GraphQL schema for the `api-journeys` app to match the `api-gateway` app schema, using `src1` and `src2` fields instead of `avatar1Id` and `avatar2Id` fields in the `Host` type and the `HostCreateInput` and `HostUpdateInput` input types (`apps/api-journeys/schema.graphql`) ([link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-3cbd0d77b8eff95fb0f62db7f9f1a4b69ccd568ae3902a3450bac7d752c817a3L1572-R1573), [link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-3cbd0d77b8eff95fb0f62db7f9f1a4b69ccd568ae3902a3450bac7d752c817a3L1582-R1583), [link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-3cbd0d77b8eff95fb0f62db7f9f1a4b69ccd568ae3902a3450bac7d752c817a3L1642-R1643))
*  Update the TypeScript types and interfaces generated from the GraphQL schema for the `api-journeys` app to use `src1` and `src2` fields instead of `avatar1Id` and `avatar2Id` fields in the `Host`, `HostCreateInput`, and `HostUpdateInput` classes (`apps/api-journeys/src/app/__generated__/graphql.ts`) ([link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-bef781d45ccbb6775960a589c940a77584bd143e501a8ae9b83d699d803561f2L574-R575), [link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-bef781d45ccbb6775960a589c940a77584bd143e501a8ae9b83d699d803561f2L581-R582), [link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-bef781d45ccbb6775960a589c940a77584bd143e501a8ae9b83d699d803561f2L1066-R1067))
*  Update the GraphQL definitions for the host module in the `api-journeys` app to use `src1` and `src2` fields instead of `avatar1Id` and `avatar2Id` fields in the `Host` type and the `HostCreateInput` and `HostUpdateInput` input types (`apps/api-journeys/src/app/modules/host/host.graphql`) ([link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-9d7884c06becb3354bff04153f4f1f2d29ff6f85d92ffbca288b41aa336d6b75L6-R7), [link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-9d7884c06becb3354bff04153f4f1f2d29ff6f85d92ffbca288b41aa336d6b75L16-R17), [link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-9d7884c06becb3354bff04153f4f1f2d29ff6f85d92ffbca288b41aa336d6b75L27-R28))
*  Update the unit tests for the host resolver in the `api-journeys` app to use `src1` and `src2` fields instead of `avatar1Id` and `avatar2Id` fields in the input and mock objects for the `hosts`, `createHost`, and `updateHost` operations (`apps/api-journeys/src/app/modules/host/host.resolver.spec.ts`) ([link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L23-R24), [link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L48-R49), [link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L56-R57), [link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L77-R78), [link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L85-R86), [link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L102-R103), [link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L112-R113), [link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L120-R121), [link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L137-R138), [link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L148-R149), [link](https://github.com/JesusFilm/core/pull/1628/files?diff=unified&w=0#diff-8abe5155ea81457ba8d7bf2fd19dd1d93319806d3564f003198f3fd45b1dead3L166-R167))
