### PR TITLE
fix: update userTeams input variable type

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -1105,7 +1105,7 @@ type Mutation
   userJourneyRemoveAll(id: ID!): [UserJourney!]! @join__field(graph: JOURNEYS)
   userJourneyRequest(journeyId: ID!, idType: IdType): UserJourney! @join__field(graph: JOURNEYS)
   userJourneyOpen(id: ID!): UserJourney @join__field(graph: JOURNEYS)
-  userTeamUpdate(id: ID!, input: TeamUpdateInput): UserTeam! @join__field(graph: JOURNEYS)
+  userTeamUpdate(id: ID!, input: UserTeamUpdateInput): UserTeam! @join__field(graph: JOURNEYS)
   userTeamDelete(id: ID!): UserTeam! @join__field(graph: JOURNEYS)
 
   """Update a visitor"""

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -188,7 +188,7 @@ extend type Mutation {
   userJourneyRemoveAll(id: ID!): [UserJourney!]!
   userJourneyRequest(journeyId: ID!, idType: IdType): UserJourney!
   userJourneyOpen(id: ID!): UserJourney
-  userTeamUpdate(id: ID!, input: TeamUpdateInput): UserTeam!
+  userTeamUpdate(id: ID!, input: UserTeamUpdateInput): UserTeam!
   userTeamDelete(id: ID!): UserTeam!
 
   """Update a visitor"""

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -1443,7 +1443,7 @@ export abstract class IMutation {
 
     abstract userJourneyOpen(id: string): Nullable<UserJourney> | Promise<Nullable<UserJourney>>;
 
-    abstract userTeamUpdate(id: string, input?: Nullable<TeamUpdateInput>): UserTeam | Promise<UserTeam>;
+    abstract userTeamUpdate(id: string, input?: Nullable<UserTeamUpdateInput>): UserTeam | Promise<UserTeam>;
 
     abstract userTeamDelete(id: string): UserTeam | Promise<UserTeam>;
 

--- a/apps/api-journeys/src/app/modules/userTeam/userTeam.graphql
+++ b/apps/api-journeys/src/app/modules/userTeam/userTeam.graphql
@@ -26,6 +26,6 @@ input UserTeamUpdateInput {
 }
 
 extend type Mutation {
-  userTeamUpdate(id: ID!, input: TeamUpdateInput): UserTeam!
+  userTeamUpdate(id: ID!, input: UserTeamUpdateInput): UserTeam!
   userTeamDelete(id: ID!): UserTeam!
 }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a5ff863</samp>

Changed the input type for the `userTeamUpdate` mutation from `TeamUpdateInput` to `UserTeamUpdateInput` in both the schema and the generated types. This fixed a type error and enabled updating user team attributes.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/33034379/todos/6289475146)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] it should take the correct input

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a5ff863</samp>

*  Update the type of the `input` argument for the `userTeamUpdate` mutation to `UserTeamUpdateInput` in both the schema definition and the generated types ([link](https://github.com/JesusFilm/core/pull/1664/files?diff=unified&w=0#diff-264fa5deeded771a89a030b093b35cea371ee82e252464f29b9be8ed4ff0f656L29-R29), [link](https://github.com/JesusFilm/core/pull/1664/files?diff=unified&w=0#diff-bef781d45ccbb6775960a589c940a77584bd143e501a8ae9b83d699d803561f2L1446-R1446))
