### PR TITLE
fix: api-videos existing slugs

### DIFF
--- a/apps/api-videos/db/seed.ts
+++ b/apps/api-videos/db/seed.ts
@@ -23,8 +23,23 @@ async function getVideo(
   return await rst.next()
 }
 
+async function getVideoSlugs(): Promise<Record<string, string>> {
+  const result = await db.query(aql`
+    FOR video IN videos
+    RETURN {
+      slug: video.slug,
+      _key: video._key
+    }
+  `)
+  const results = await result.all()
+  const slugs: Record<string, string> = {}
+  for await (const video of results) {
+    slugs[video.slug] = video._key
+  }
+  return slugs
+}
 async function importMediaComponents(): Promise<void> {
-  const usedVideoSlugs = []
+  const usedVideoSlugs: Record<string, string> = await getVideoSlugs()
   const languages = await fetchMediaLanguagesAndTransformToLanguages()
   let videos: Video[]
   let page = 1

--- a/apps/api-videos/src/libs/arclight/arclight.spec.ts
+++ b/apps/api-videos/src/libs/arclight/arclight.spec.ts
@@ -442,7 +442,7 @@ describe('arclight', () => {
           usedSlugs
         )
       ).toEqual(video)
-      expect(usedSlugs).toEqual(['title'])
+      expect(usedSlugs).toEqual({ title: 'mediaComponentId' })
     })
 
     it('transforms media component to video when slug exists', () => {
@@ -465,7 +465,7 @@ describe('arclight', () => {
           }
         ]
       })
-      expect(usedSlugs).toEqual(['title', 'title-2'])
+      expect(usedSlugs).toEqual({ title: 'id', 'title-2': 'mediaComponentId' })
     })
 
     it('transforms media component to video without languages', () => {
@@ -479,7 +479,7 @@ describe('arclight', () => {
           usedSlugs
         )
       ).toEqual({ ...video, variants: [] })
-      expect(usedSlugs).toEqual(['title'])
+      expect(usedSlugs).toEqual({ title: 'mediaComponentId' })
     })
 
     it('transforms media component to video with study questions', () => {
@@ -502,7 +502,7 @@ describe('arclight', () => {
           }
         ]
       })
-      expect(usedSlugs).toEqual(['title'])
+      expect(usedSlugs).toEqual({ title: 'mediaComponentId' })
     })
 
     it('transforms media component to video with long title', () => {
@@ -553,9 +553,10 @@ describe('arclight', () => {
           }
         ]
       })
-      expect(usedSlugs).toEqual([
-        'the-quick-brown-fox-jumps-over-the-lazy-dog-many-times-over-and-over-until-it-gets-cut-off-when-over-100-characters'
-      ])
+      expect(usedSlugs).toEqual({
+        'the-quick-brown-fox-jumps-over-the-lazy-dog-many-times-over-and-over-until-it-gets-cut-off-when-over-100-characters':
+          'mediaComponentId'
+      })
     })
   })
 

--- a/apps/api-videos/src/libs/arclight/arclight.spec.ts
+++ b/apps/api-videos/src/libs/arclight/arclight.spec.ts
@@ -432,7 +432,7 @@ describe('arclight', () => {
     }
 
     it('transforms media component to video', () => {
-      const usedSlugs = []
+      const usedSlugs = {}
       expect(
         transformArclightMediaComponentToVideo(
           mediaComponent,
@@ -446,7 +446,7 @@ describe('arclight', () => {
     })
 
     it('transforms media component to video when slug exists', () => {
-      const usedSlugs = ['title']
+      const usedSlugs = { title: 'id' }
       expect(
         transformArclightMediaComponentToVideo(
           mediaComponent,
@@ -469,7 +469,7 @@ describe('arclight', () => {
     })
 
     it('transforms media component to video without languages', () => {
-      const usedSlugs = []
+      const usedSlugs = {}
       expect(
         transformArclightMediaComponentToVideo(
           mediaComponent,
@@ -483,7 +483,7 @@ describe('arclight', () => {
     })
 
     it('transforms media component to video with study questions', () => {
-      const usedSlugs = []
+      const usedSlugs = {}
       expect(
         transformArclightMediaComponentToVideo(
           { ...mediaComponent, studyQuestions: ['How can I know Jesus?'] },
@@ -506,7 +506,7 @@ describe('arclight', () => {
     })
 
     it('transforms media component to video with long title', () => {
-      const usedSlugs = []
+      const usedSlugs = {}
       expect(
         transformArclightMediaComponentToVideo(
           {
@@ -568,15 +568,15 @@ describe('arclight', () => {
 
     it('adds slug', () => {
       expect(
-        transformArclightMediaLanguageToLanguage(mediaLanguage, []).slug
+        transformArclightMediaLanguageToLanguage(mediaLanguage, {}).slug
       ).toEqual('english-new-zealand')
     })
 
     it('when slug already used then slug value will have number following', () => {
       expect(
-        transformArclightMediaLanguageToLanguage(mediaLanguage, [
-          'english-new-zealand'
-        ]).slug
+        transformArclightMediaLanguageToLanguage(mediaLanguage, {
+          'english-new-zealand': 'id'
+        }).slug
       ).toEqual('english-new-zealand-2')
     })
   })
@@ -701,7 +701,7 @@ describe('arclight', () => {
         }
       ]
       await expect(
-        fetchMediaComponentsAndTransformToVideos(languages, [], 1)
+        fetchMediaComponentsAndTransformToVideos(languages, {}, 1)
       ).resolves.toEqual([
         {
           _key: 'mediaComponentId',

--- a/apps/api-videos/src/libs/arclight/arclight.ts
+++ b/apps/api-videos/src/libs/arclight/arclight.ts
@@ -223,14 +223,18 @@ export function transformArclightMediaComponentToVideo(
   mediaComponentLanguages: ArclightMediaComponentLanguage[],
   mediaComponentLinks: string[],
   languages: Language[],
-  usedSlugs: string[]
+  usedSlugs: Record<string, string>
 ): Video {
   const metadataLanguageId =
     languages
       .find(({ bcp47 }) => bcp47 === mediaComponent.metadataLanguageTag)
       ?.languageId.toString() ?? '529' // english by default
 
-  const slug = slugify(mediaComponent.title, usedSlugs)
+  const slug = slugify(
+    mediaComponent.mediaComponentId,
+    mediaComponent.title,
+    usedSlugs
+  )
 
   const variants: VideoVariant[] = []
   for (const mediaComponentLanguage of mediaComponentLanguages) {
@@ -307,9 +311,13 @@ export function transformArclightMediaComponentToVideo(
 
 export function transformArclightMediaLanguageToLanguage(
   mediaLanguage: ArclightMediaLanguage,
-  usedSlugs: string[]
+  usedSlugs: Record<string, string>
 ): Language {
-  const slug = slugify(mediaLanguage.name, usedSlugs)
+  const slug = slugify(
+    mediaLanguage.languageId.toString(),
+    mediaLanguage.name,
+    usedSlugs
+  )
   return {
     ...mediaLanguage,
     slug
@@ -319,7 +327,7 @@ export function transformArclightMediaLanguageToLanguage(
 export async function fetchMediaLanguagesAndTransformToLanguages(): Promise<
   Language[]
 > {
-  const usedLanguageSlugs = []
+  const usedLanguageSlugs: Record<string, string> = {}
   const mediaLanguages = await getArclightMediaLanguages()
   return mediaLanguages.map((mediaLanguage) =>
     transformArclightMediaLanguageToLanguage(mediaLanguage, usedLanguageSlugs)
@@ -328,7 +336,7 @@ export async function fetchMediaLanguagesAndTransformToLanguages(): Promise<
 
 export async function fetchMediaComponentsAndTransformToVideos(
   languages: Language[],
-  usedVideoSlugs: string[],
+  usedVideoSlugs: Record<string, string>,
   page: number
 ): Promise<Video[]> {
   const mediaComponents = await getArclightMediaComponents(page)

--- a/apps/api-videos/src/libs/slugify/slugify.spec.ts
+++ b/apps/api-videos/src/libs/slugify/slugify.spec.ts
@@ -2,44 +2,46 @@ import { slugify } from '.'
 
 describe('slugify', () => {
   it('transforms My Title to my-title', () => {
-    expect(slugify('My Title')).toEqual('my-title')
+    expect(slugify('id', 'My Title')).toEqual('my-title')
   })
 
   it('when slug already used transforms My Title to my-title-2', () => {
-    expect(slugify('My Title', ['my-title'])).toEqual('my-title-2')
-  })
-
-  it('when slug already used twice transforms My Title to my-title-3', () => {
-    expect(slugify('My Title', ['my-title', 'my-title-2'])).toEqual(
-      'my-title-3'
+    expect(slugify('id', 'My Title', { 'my-title': 'id2' })).toEqual(
+      'my-title-2'
     )
   })
 
+  it('when slug already used twice transforms My Title to my-title-3', () => {
+    expect(
+      slugify('id', 'My Title', { 'my-title': 'id2', 'my-title-2': 'id3' })
+    ).toEqual('my-title-3')
+  })
+
   it('removes start characters outside of the unicode letter or number sets', () => {
-    expect(slugify('€™ And Test')).toEqual('and-test')
+    expect(slugify('id', '€™ And Test')).toEqual('and-test')
   })
 
   it('removes end characters outside of the unicode letter or number sets', () => {
-    expect(slugify('Test And €™')).toEqual('test-and')
+    expect(slugify('id', 'Test And €™')).toEqual('test-and')
   })
 
   it('removes apostrophe s', () => {
-    expect(slugify("Bob's and Mary's")).toEqual('bob-and-mary')
+    expect(slugify('id', "Bob's and Mary's")).toEqual('bob-and-mary')
   })
 
   it('removes â€™s', () => {
-    expect(slugify('Bobâ€™s and Maryâ€™s')).toEqual('bob-and-mary')
+    expect(slugify('id', 'Bobâ€™s and Maryâ€™s')).toEqual('bob-and-mary')
   })
 
   it("removes 'â€™,.", () => {
-    expect(slugify("Bob And 'â€™,. Mary")).toEqual('bob-and-mary')
+    expect(slugify('id', "Bob And 'â€™,. Mary")).toEqual('bob-and-mary')
   })
 
   it('replaces space dash with dash', () => {
-    expect(slugify('Bob -And -Mary')).toEqual('bob-and-mary')
+    expect(slugify('id', 'Bob -And -Mary')).toEqual('bob-and-mary')
   })
 
   it('replaces dash space with dash', () => {
-    expect(slugify('Bob- And- Mary')).toEqual('bob-and-mary')
+    expect(slugify('id', 'Bob- And- Mary')).toEqual('bob-and-mary')
   })
 })

--- a/apps/api-videos/src/libs/slugify/slugify.ts
+++ b/apps/api-videos/src/libs/slugify/slugify.ts
@@ -1,8 +1,12 @@
-function ensureSlugUnique(slug: string, usedSlugs: string[]): string {
-  const exists = usedSlugs.find((t) => t === slug)
-  if (exists == null) return slug
+function ensureSlugUnique(
+  id: string,
+  slug: string,
+  usedSlugs: Record<string, string>
+): string {
+  const exists = usedSlugs[slug] === id || usedSlugs[slug] == null
+  if (exists) return slug
   let suffix = 2
-  while (usedSlugs.find((t) => t === `${slug}-${suffix}`) != null) {
+  while (usedSlugs[`${slug}-${suffix}`] != null) {
     suffix++
   }
   return `${slug}-${suffix}`
@@ -22,8 +26,12 @@ function convertToSlug(name: string): string {
     .toLowerCase()
 }
 
-export function slugify(title: string, usedSlugs: string[] = []): string {
-  const slug = ensureSlugUnique(convertToSlug(title), usedSlugs)
-  usedSlugs.push(slug)
+export function slugify(
+  id: string,
+  title: string,
+  usedSlugs: Record<string, string> = {}
+): string {
+  const slug = ensureSlugUnique(id, convertToSlug(title), usedSlugs)
+  usedSlugs[slug] = id
   return slug
 }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0823d2f</samp>

The pull request improves the slug generation and validation logic for media components and languages in the `arclight.ts` file. It uses entity ids to avoid duplicates and records to optimize performance. It also updates the `slugify.ts` and `seed.ts` files to support the new logic.

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Video seed now runs correctly (unique index was failing)

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0823d2f</samp>

*  Add a new function `getVideoSlugs` to query the database and return a record of video slugs and their corresponding keys ([link](https://github.com/JesusFilm/core/pull/1665/files?diff=unified&w=0#diff-9edfb14edfc99d4ac04afbe92c6e8f861ed57e882de81b11460e46de30cd8faaL26-R42))
*  Change the parameter `usedSlugs` in the function `transformArclightMediaComponentToVideo` from an array to a record to match the new data structure ([link](https://github.com/JesusFilm/core/pull/1665/files?diff=unified&w=0#diff-0a09f7c154f0fa2d094085e9fc12bb2784bcaf85572bb492fe43c406f0b30c6bL226-R226))
*  Modify the function `slugify` to take an additional parameter `id`, which is the entity identifier, and use it to ensure slug uniqueness for media components and languages ([link](https://github.com/JesusFilm/core/pull/1665/files?diff=unified&w=0#diff-0a09f7c154f0fa2d094085e9fc12bb2784bcaf85572bb492fe43c406f0b30c6bL233-R237), [link](https://github.com/JesusFilm/core/pull/1665/files?diff=unified&w=0#diff-0a09f7c154f0fa2d094085e9fc12bb2784bcaf85572bb492fe43c406f0b30c6bL310-R320), [link](https://github.com/JesusFilm/core/pull/1665/files?diff=unified&w=0#diff-4d8a9c388dea969f529570dc0b6540147a50b4817139a19d7c056e0c286e3a94L1-R9), [link](https://github.com/JesusFilm/core/pull/1665/files?diff=unified&w=0#diff-4d8a9c388dea969f529570dc0b6540147a50b4817139a19d7c056e0c286e3a94L25-R35))
*  Change the variable `usedLanguageSlugs` in the function `fetchMediaLanguagesAndTransformToLanguages` from an array to a record to match the new data structure ([link](https://github.com/JesusFilm/core/pull/1665/files?diff=unified&w=0#diff-0a09f7c154f0fa2d094085e9fc12bb2784bcaf85572bb492fe43c406f0b30c6bL322-R330))
*  Change the parameter `usedVideoSlugs` in the function `fetchMediaComponentsAndTransformToVideos` from an array to a record to match the new data structure ([link](https://github.com/JesusFilm/core/pull/1665/files?diff=unified&w=0#diff-0a09f7c154f0fa2d094085e9fc12bb2784bcaf85572bb492fe43c406f0b30c6bL331-R339))
