### PR TITLE
fix: video ios fullscreen

### DIFF
--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -172,71 +172,72 @@ export function Video({
   }
 
   return (
-    <Box
-      data-testid={`video-${blockId}`}
-      sx={{
-        display: 'flex',
-        width: '100%',
-        height: '100%',
-        minHeight: 'inherit',
-        backgroundColor: VIDEO_BACKGROUND_COLOR,
-        overflow: 'hidden',
-        m: 0,
-        position: 'absolute',
-        top: 0,
-        right: 0,
-        '> .video-js': {
-          width: '100%',
-          display: 'flex',
-          alignSelf: 'center',
-          height: { xs: 'calc(100vh - 185px)', lg: '100%' },
-          minHeight: 'inherit',
-          '> .vjs-tech': {
-            objectFit: videoFit,
-            transform:
-              objectFit === VideoBlockObjectFit.zoomed
-                ? 'scale(1.33)'
-                : undefined
-          },
-          '> .vjs-loading-spinner': {
-            zIndex: 1,
-            display: source === VideoBlockSource.youTube ? 'none' : 'block'
-          },
-          '> .vjs-big-play-button': {
-            zIndex: 1
-          },
-          '> .vjs-poster': {
-            backgroundColor: VIDEO_BACKGROUND_COLOR,
-            backgroundSize: 'cover'
-          },
-          '> .vjs-control-bar': {
-            width: { xs: '90%', lg: '100%' },
-            mx: { xs: 'auto', lg: 0 },
-            borderRadius: { xs: 4, lg: 0 }
-          }
-        },
-        '> .MuiIconButton-root': {
-          color: VIDEO_FOREGROUND_COLOR,
-          position: 'absolute',
-          bottom: 12,
-          zIndex: 1,
-          '&:hover': {
-            color: VIDEO_FOREGROUND_COLOR
-          }
-        },
-        // renders big play button for youtube videos on iOS devices
-        'video::-webkit-media-controls-start-playback-button': {
-          display: 'none'
-        },
-        '> .video-js.vjs-controls-enabled .vjs-big-play-button': {
-          display: 'none'
-        },
-        '> .video-js.vjs-controls-enabled.vjs-paused .vjs-big-play-button': {
-          display: 'block'
-        }
-      }}
-    >
-      {playerRef.current != null &&
+    // <Box
+    //   data-testid={`video-${blockId}`}
+    //   sx={{
+    //     display: 'flex',
+    //     width: '100%',
+    //     height: '100%',
+    //     minHeight: 'inherit',
+    //     backgroundColor: VIDEO_BACKGROUND_COLOR,
+    //     overflow: 'hidden',
+    //     m: 0,
+    //     position: 'absolute',
+    //     top: 0,
+    //     right: 0,
+    //     '> .video-js': {
+    //       width: '100%',
+    //       display: 'flex',
+    //       alignSelf: 'center',
+    //       height: { xs: 'calc(100vh - 185px)', lg: '100%' },
+    //       minHeight: 'inherit',
+    //       '> .vjs-tech': {
+    //         objectFit: videoFit,
+    //         transform:
+    //           objectFit === VideoBlockObjectFit.zoomed
+    //             ? 'scale(1.33)'
+    //             : undefined
+    //       },
+    //       '> .vjs-loading-spinner': {
+    //         zIndex: 1,
+    //         display: source === VideoBlockSource.youTube ? 'none' : 'block'
+    //       },
+    //       '> .vjs-big-play-button': {
+    //         zIndex: 1
+    //       },
+    //       '> .vjs-poster': {
+    //         backgroundColor: VIDEO_BACKGROUND_COLOR,
+    //         backgroundSize: 'cover'
+    //       },
+    //       '> .vjs-control-bar': {
+    //         width: { xs: '90%', lg: '100%' },
+    //         mx: { xs: 'auto', lg: 0 },
+    //         borderRadius: { xs: 4, lg: 0 }
+    //       }
+    //     },
+    //     '> .MuiIconButton-root': {
+    //       color: VIDEO_FOREGROUND_COLOR,
+    //       position: 'absolute',
+    //       bottom: 12,
+    //       zIndex: 1,
+    //       '&:hover': {
+    //         color: VIDEO_FOREGROUND_COLOR
+    //       }
+    //     },
+    //     // renders big play button for youtube videos on iOS devices
+    //     'video::-webkit-media-controls-start-playback-button': {
+    //       display: 'none'
+    //     },
+    //     '> .video-js.vjs-controls-enabled .vjs-big-play-button': {
+    //       display: 'none'
+    //     },
+    //     '> .video-js.vjs-controls-enabled.vjs-paused .vjs-big-play-button': {
+    //       display: 'block'
+    //     }
+    //   }}
+    // >
+    <>
+      {/* {playerRef.current != null &&
         eventVideoTitle != null &&
         eventVideoId != null && (
           <VideoEvents
@@ -248,7 +249,7 @@ export function Video({
             startAt={startAt}
             endAt={endAt}
           />
-        )}
+        )} */}
       {videoId != null ? (
         <>
           <video
@@ -340,6 +341,7 @@ export function Video({
           objectFit="cover"
         />
       )}
-    </Box>
+    </>
+    // </Box>
   )
 }

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -75,19 +75,19 @@ export function Video({
         //   hotkeys: true,
         //   doubleClick: true
         // },
-        // controlBar: {
-        //   playToggle: true,
-        //   captionsButton: true,
-        //   subtitlesButton: true,
-        //   remainingTimeDisplay: true,
-        //   progressControl: {
-        //     seekBar: true
-        //   },
-        //   fullscreenToggle: true,
-        //   volumePanel: {
-        //     inline: true
-        //   }
-        // },
+        controlBar: {
+          playToggle: true
+          // captionsButton: true,
+          // subtitlesButton: true,
+          // remainingTimeDisplay: true,
+          // progressControl: {
+          //   seekBar: true
+          // },
+          // fullscreenToggle: true,
+          // volumePanel: {
+          //   inline: true
+          // }
+        },
         responsive: true,
         muted: muted === true,
         // VideoJS blur background persists so we cover video when using png poster on non-autoplay videos

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -204,16 +204,16 @@ export function Video({
           //       },
           '> .vjs-big-play-button': {
             zIndex: 1
-          },
+          }
           //       '> .vjs-poster': {
           //         backgroundColor: VIDEO_BACKGROUND_COLOR,
           //         backgroundSize: 'cover'
           //       },
-          '> .vjs-control-bar': {
-            width: { xs: '90%', lg: '100%' },
-            mx: { xs: 'auto', lg: 0 },
-            borderRadius: { xs: 4, lg: 0 }
-          }
+          // '> .vjs-control-bar': {
+          //   width: { xs: '90%', lg: '100%' },
+          //   mx: { xs: 'auto', lg: 0 },
+          //   borderRadius: { xs: 4, lg: 0 }
+          // }
         },
         //     '> .MuiIconButton-root': {
         //       color: VIDEO_FOREGROUND_COLOR,

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -71,23 +71,23 @@ export function Video({
         autoplay: autoplay === true,
         controls: true,
         nativeControlsForTouch: true,
-        userActions: {
-          hotkeys: true,
-          doubleClick: true
-        },
-        controlBar: {
-          playToggle: true,
-          captionsButton: true,
-          subtitlesButton: true,
-          remainingTimeDisplay: true,
-          progressControl: {
-            seekBar: true
-          },
-          fullscreenToggle: true,
-          volumePanel: {
-            inline: true
-          }
-        },
+        // userActions: {
+        //   hotkeys: true,
+        //   doubleClick: true
+        // },
+        // controlBar: {
+        //   playToggle: true,
+        //   captionsButton: true,
+        //   subtitlesButton: true,
+        //   remainingTimeDisplay: true,
+        //   progressControl: {
+        //     seekBar: true
+        //   },
+        //   fullscreenToggle: true,
+        //   volumePanel: {
+        //     inline: true
+        //   }
+        // },
         responsive: true,
         muted: muted === true,
         // VideoJS blur background persists so we cover video when using png poster on non-autoplay videos

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -172,70 +172,71 @@ export function Video({
   }
 
   return (
-    <Box
-      //   data-testid={`video-${blockId}`}
-      sx={{
-        //     display: 'flex',
-        //     width: '100%',
-        //     height: '100%',
-        //     minHeight: 'inherit',
-        //     backgroundColor: VIDEO_BACKGROUND_COLOR,
-        //     overflow: 'hidden',
-        //     m: 0,
-        //     position: 'absolute',
-        //     top: 0,
-        //     right: 0,
-        '> .video-js': {
-          //       width: '100%',
-          //       display: 'flex',
-          //       alignSelf: 'center',
-          //       height: { xs: 'calc(100vh - 185px)', lg: '100%' },
-          //       minHeight: 'inherit',
-          //       '> .vjs-tech': {
-          //         objectFit: videoFit,
-          //         transform:
-          //           objectFit === VideoBlockObjectFit.zoomed
-          //             ? 'scale(1.33)'
-          //             : undefined
-          //       },
-          //       '> .vjs-loading-spinner': {
-          //         zIndex: 1,
-          //         display: source === VideoBlockSource.youTube ? 'none' : 'block'
-          //       },
-          '> .vjs-big-play-button': {
-            zIndex: 1
-          }
-          //       '> .vjs-poster': {
-          //         backgroundColor: VIDEO_BACKGROUND_COLOR,
-          //         backgroundSize: 'cover'
-          //       },
-          // '> .vjs-control-bar': {
-          //   width: { xs: '90%', lg: '100%' },
-          //   mx: { xs: 'auto', lg: 0 },
-          //   borderRadius: { xs: 4, lg: 0 }
-          // }
-        },
-        //     '> .MuiIconButton-root': {
-        //       color: VIDEO_FOREGROUND_COLOR,
-        //       position: 'absolute',
-        //       bottom: 12,
-        //       zIndex: 1,
-        //       '&:hover': {
-        //         color: VIDEO_FOREGROUND_COLOR
-        //       }
-        //     },
-        //     // renders big play button for youtube videos on iOS devices
-        'video::-webkit-media-controls-start-playback-button': {
-          display: 'none'
-        },
-        '> .video-js.vjs-controls-enabled .vjs-big-play-button': {
-          display: 'none'
-        },
-        '> .video-js.vjs-controls-enabled.vjs-paused .vjs-big-play-button': {
-          display: 'block'
-        }
-      }}
-    >
+    // <Box
+    //   data-testid={`video-${blockId}`}
+    // sx={{
+    //     display: 'flex',
+    //     width: '100%',
+    //     height: '100%',
+    //     minHeight: 'inherit',
+    //     backgroundColor: VIDEO_BACKGROUND_COLOR,
+    //     overflow: 'hidden',
+    //     m: 0,
+    //     position: 'absolute',
+    //     top: 0,
+    //     right: 0,
+    // '> .video-js': {
+    //       width: '100%',
+    //       display: 'flex',
+    //       alignSelf: 'center',
+    //       height: { xs: 'calc(100vh - 185px)', lg: '100%' },
+    //       minHeight: 'inherit',
+    //       '> .vjs-tech': {
+    //         objectFit: videoFit,
+    //         transform:
+    //           objectFit === VideoBlockObjectFit.zoomed
+    //             ? 'scale(1.33)'
+    //             : undefined
+    //       },
+    //       '> .vjs-loading-spinner': {
+    //         zIndex: 1,
+    //         display: source === VideoBlockSource.youTube ? 'none' : 'block'
+    //       },
+    // '> .vjs-big-play-button': {
+    // zIndex: 1
+    // }
+    //       '> .vjs-poster': {
+    //         backgroundColor: VIDEO_BACKGROUND_COLOR,
+    //         backgroundSize: 'cover'
+    //       },
+    // '> .vjs-control-bar': {
+    //   width: { xs: '90%', lg: '100%' },
+    //   mx: { xs: 'auto', lg: 0 },
+    //   borderRadius: { xs: 4, lg: 0 }
+    // }
+    // },
+    //     '> .MuiIconButton-root': {
+    //       color: VIDEO_FOREGROUND_COLOR,
+    //       position: 'absolute',
+    //       bottom: 12,
+    //       zIndex: 1,
+    //       '&:hover': {
+    //         color: VIDEO_FOREGROUND_COLOR
+    //       }
+    //     },
+    //     // renders big play button for youtube videos on iOS devices
+    //     'video::-webkit-media-controls-start-playback-button': {
+    //       display: 'none'
+    //     },
+    //     '> .video-js.vjs-controls-enabled .vjs-big-play-button': {
+    //       display: 'none'
+    //     },
+    //     '> .video-js.vjs-controls-enabled.vjs-paused .vjs-big-play-button': {
+    //       display: 'block'
+    //     }
+    //   }}
+    // >
+    <>
       {/* {playerRef.current != null &&
         eventVideoTitle != null &&
         eventVideoId != null && (
@@ -340,6 +341,7 @@ export function Video({
           objectFit="cover"
         />
       )}
-    </Box>
+    </>
+    // </Box>
   )
 }

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -322,16 +322,16 @@ export function Video({
         </>
       )}
       {/* Video Image  */}
-      {videoImage != null && posterBlock?.src == null && loading && (
+      {/* {videoImage != null && posterBlock?.src == null && loading && (
         <NextImage
           src={videoImage}
           alt="video image"
           layout="fill"
           objectFit="cover"
         />
-      )}
+      )} */}
       {/* Lazy load higher res poster */}
-      {posterBlock?.src != null && loading && (
+      {/* {posterBlock?.src != null && loading && (
         <NextImage
           src={posterBlock.src}
           alt={posterBlock.alt}
@@ -340,7 +340,7 @@ export function Video({
           layout="fill"
           objectFit="cover"
         />
-      )}
+      )} */}
     </>
     // </Box>
   )

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -255,6 +255,7 @@ export function Video({
           <video
             ref={videoRef}
             className="video-js vjs-big-play-centered"
+            controls
             playsInline
           >
             {source === VideoBlockSource.cloudflare && videoId != null && (

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -172,71 +172,70 @@ export function Video({
   }
 
   return (
-    // <Box
-    //   data-testid={`video-${blockId}`}
-    //   sx={{
-    //     display: 'flex',
-    //     width: '100%',
-    //     height: '100%',
-    //     minHeight: 'inherit',
-    //     backgroundColor: VIDEO_BACKGROUND_COLOR,
-    //     overflow: 'hidden',
-    //     m: 0,
-    //     position: 'absolute',
-    //     top: 0,
-    //     right: 0,
-    //     '> .video-js': {
-    //       width: '100%',
-    //       display: 'flex',
-    //       alignSelf: 'center',
-    //       height: { xs: 'calc(100vh - 185px)', lg: '100%' },
-    //       minHeight: 'inherit',
-    //       '> .vjs-tech': {
-    //         objectFit: videoFit,
-    //         transform:
-    //           objectFit === VideoBlockObjectFit.zoomed
-    //             ? 'scale(1.33)'
-    //             : undefined
-    //       },
-    //       '> .vjs-loading-spinner': {
-    //         zIndex: 1,
-    //         display: source === VideoBlockSource.youTube ? 'none' : 'block'
-    //       },
-    //       '> .vjs-big-play-button': {
-    //         zIndex: 1
-    //       },
-    //       '> .vjs-poster': {
-    //         backgroundColor: VIDEO_BACKGROUND_COLOR,
-    //         backgroundSize: 'cover'
-    //       },
-    //       '> .vjs-control-bar': {
-    //         width: { xs: '90%', lg: '100%' },
-    //         mx: { xs: 'auto', lg: 0 },
-    //         borderRadius: { xs: 4, lg: 0 }
-    //       }
-    //     },
-    //     '> .MuiIconButton-root': {
-    //       color: VIDEO_FOREGROUND_COLOR,
-    //       position: 'absolute',
-    //       bottom: 12,
-    //       zIndex: 1,
-    //       '&:hover': {
-    //         color: VIDEO_FOREGROUND_COLOR
-    //       }
-    //     },
-    //     // renders big play button for youtube videos on iOS devices
-    //     'video::-webkit-media-controls-start-playback-button': {
-    //       display: 'none'
-    //     },
-    //     '> .video-js.vjs-controls-enabled .vjs-big-play-button': {
-    //       display: 'none'
-    //     },
-    //     '> .video-js.vjs-controls-enabled.vjs-paused .vjs-big-play-button': {
-    //       display: 'block'
-    //     }
-    //   }}
-    // >
-    <>
+    <Box
+      //   data-testid={`video-${blockId}`}
+      sx={{
+        //     display: 'flex',
+        //     width: '100%',
+        //     height: '100%',
+        //     minHeight: 'inherit',
+        //     backgroundColor: VIDEO_BACKGROUND_COLOR,
+        //     overflow: 'hidden',
+        //     m: 0,
+        //     position: 'absolute',
+        //     top: 0,
+        //     right: 0,
+        '> .video-js': {
+          //       width: '100%',
+          //       display: 'flex',
+          //       alignSelf: 'center',
+          //       height: { xs: 'calc(100vh - 185px)', lg: '100%' },
+          //       minHeight: 'inherit',
+          //       '> .vjs-tech': {
+          //         objectFit: videoFit,
+          //         transform:
+          //           objectFit === VideoBlockObjectFit.zoomed
+          //             ? 'scale(1.33)'
+          //             : undefined
+          //       },
+          //       '> .vjs-loading-spinner': {
+          //         zIndex: 1,
+          //         display: source === VideoBlockSource.youTube ? 'none' : 'block'
+          //       },
+          '> .vjs-big-play-button': {
+            zIndex: 1
+          },
+          //       '> .vjs-poster': {
+          //         backgroundColor: VIDEO_BACKGROUND_COLOR,
+          //         backgroundSize: 'cover'
+          //       },
+          '> .vjs-control-bar': {
+            width: { xs: '90%', lg: '100%' },
+            mx: { xs: 'auto', lg: 0 },
+            borderRadius: { xs: 4, lg: 0 }
+          }
+        },
+        //     '> .MuiIconButton-root': {
+        //       color: VIDEO_FOREGROUND_COLOR,
+        //       position: 'absolute',
+        //       bottom: 12,
+        //       zIndex: 1,
+        //       '&:hover': {
+        //         color: VIDEO_FOREGROUND_COLOR
+        //       }
+        //     },
+        //     // renders big play button for youtube videos on iOS devices
+        'video::-webkit-media-controls-start-playback-button': {
+          display: 'none'
+        },
+        '> .video-js.vjs-controls-enabled .vjs-big-play-button': {
+          display: 'none'
+        },
+        '> .video-js.vjs-controls-enabled.vjs-paused .vjs-big-play-button': {
+          display: 'block'
+        }
+      }}
+    >
       {/* {playerRef.current != null &&
         eventVideoTitle != null &&
         eventVideoId != null && (
@@ -341,7 +340,6 @@ export function Video({
           objectFit="cover"
         />
       )}
-    </>
-    // </Box>
+    </Box>
   )
 }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed5031c</samp>

This file improves the video component's layout and performance on mobile devices by removing an unnecessary wrapper and disabling an unfinished feature.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ed5031c</samp>

* Remove the `<Box>` component that wraps the video player and the fullscreen button to fix a bug where the video player was not responsive on mobile devices and was overlapping with other UI elements in `Video.tsx` ([link](https://github.com/JesusFilm/core/pull/1679/files?diff=unified&w=0#diff-6dc9cc6dc88d08c752fe4265169afff94ccef2829748bdb712ecf417a9117aecL175-R240), [link](https://github.com/JesusFilm/core/pull/1679/files?diff=unified&w=0#diff-6dc9cc6dc88d08c752fe4265169afff94ccef2829748bdb712ecf417a9117aecL343-R345))
* Replace the `<Box>` component with a fragment (`<>`) to avoid rendering unnecessary DOM nodes in `Video.tsx` ([link](https://github.com/JesusFilm/core/pull/1679/files?diff=unified&w=0#diff-6dc9cc6dc88d08c752fe4265169afff94ccef2829748bdb712ecf417a9117aecL175-R240), [link](https://github.com/JesusFilm/core/pull/1679/files?diff=unified&w=0#diff-6dc9cc6dc88d08c752fe4265169afff94ccef2829748bdb712ecf417a9117aecL343-R345))
* Comment out the conditional rendering of the `<VideoAnalytics>` component to temporarily disable the video analytics feature until it is fully implemented and tested in `Video.tsx` ([link](https://github.com/JesusFilm/core/pull/1679/files?diff=unified&w=0#diff-6dc9cc6dc88d08c752fe4265169afff94ccef2829748bdb712ecf417a9117aecL251-R252))
