### PR TITLE
feat: local dev device config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -66,5 +66,6 @@
   },
   "typescript.preferences.importModuleSpecifier": "project-relative",
   "javascript.preferences.importModuleSpecifier": "project-relative",
-  "prettier.prettierPath": "./node_modules/prettier"
+  "prettier.prettierPath": "./node_modules/prettier",
+  "remote.localPortHost": "allInterfaces"
 }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 462d1a0</samp>

Add a VS Code setting to enable port forwarding to any network interface. This helps with testing and debugging web applications remotely.

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 462d1a0</samp>

*  Add `remote.localPortHost` setting to `.vscode/settings.json` to enable port forwarding to any network interface ([link](https://github.com/JesusFilm/core/pull/1685/files?diff=unified&w=0#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L69-R70))
