### PR TITLE
ci: add coverage reports to github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,6 +172,11 @@ jobs:
         with:
           targets: test
           args: --ci
+      - uses: mansagroup/nrwl-nx-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          targets: codecov
   visual-test:
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,8 @@ jobs:
           curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key' | sudo apt-key add -
           echo "deb https://packages.doppler.com/public/cli/deb/debian any-version main" | sudo tee /etc/apt/sources.list.d/doppler-cli.list
           sudo apt-get update && sudo apt-get -y install doppler
-      - uses: mansagroup/nrwl-nx-action@v3
+      - name: fetch-secrets and build
+        uses: mansagroup/nrwl-nx-action@v3
         env:
           DOPPLER_API_GATEWAY_TOKEN: ${{ secrets.DOPPLER_API_GATEWAY_TOKEN }}
           DOPPLER_API_JOURNEYS_TOKEN: ${{ secrets.DOPPLER_API_JOURNEYS_TOKEN }}
@@ -168,11 +169,17 @@ jobs:
         with:
           targets: prisma-generate
           all: true
-      - uses: mansagroup/nrwl-nx-action@v3
+      - name: run tests
+        uses: mansagroup/nrwl-nx-action@v3
         with:
           targets: test
           args: --ci
-      - uses: mansagroup/nrwl-nx-action@v3
+      - name: download codecov
+        run: |
+          curl -o /usr/local/bin/codecov https://uploader.codecov.io/latest/linux/codecov
+          chmod +x /usr/local/bin/codecov
+      - name: upload coverage to codecov
+        uses: mansagroup/nrwl-nx-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/apps/api-journeys/jest.config.js
+++ b/apps/api-journeys/jest.config.js
@@ -11,5 +11,7 @@ module.exports = {
     '^.+\\.[tj]s$': 'ts-jest'
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
-  coverageDirectory: '../../coverage/apps/api-journeys'
+  coverageDirectory: '../../coverage/apps/api-journeys',
+  collectCoverage: true,
+  coverageReporters: ['cobertura']
 }

--- a/apps/api-journeys/project.json
+++ b/apps/api-journeys/project.json
@@ -157,6 +157,12 @@
       "options": {
         "command": "npx tsc -b apps/api-journeys/tsconfig.json"
       }
+    },
+    "codecov": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "codecov -f coverage/apps/api-journeys/cobertura-coverage.xml -F apps.api-journeys"
+      }
     }
   },
   "tags": []

--- a/apps/api-languages/jest.config.js
+++ b/apps/api-languages/jest.config.js
@@ -11,5 +11,7 @@ module.exports = {
     '^.+\\.[tj]s$': 'ts-jest'
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
-  coverageDirectory: '../../coverage/apps/api-languages'
+  coverageDirectory: '../../coverage/apps/api-languages',
+  collectCoverage: true,
+  coverageReporters: ['cobertura']
 }

--- a/apps/api-languages/project.json
+++ b/apps/api-languages/project.json
@@ -85,6 +85,12 @@
       "options": {
         "command": "DOPPLER_TOKEN=$DOPPLER_API_LANGUAGES_TOKEN doppler secrets download --no-file --format=env-no-quotes --project api-languages > apps/api-languages/.env"
       }
+    },
+    "codecov": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "codecov -f coverage/apps/api-languages/cobertura-coverage.xml -F apps.api-languages"
+      }
     }
   },
   "tags": []

--- a/apps/api-media/jest.config.js
+++ b/apps/api-media/jest.config.js
@@ -11,5 +11,7 @@ module.exports = {
     '^.+\\.[tj]s$': 'ts-jest'
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
-  coverageDirectory: '../../coverage/apps/api-media'
+  coverageDirectory: '../../coverage/apps/api-media',
+  collectCoverage: true,
+  coverageReporters: ['cobertura']
 }

--- a/apps/api-media/project.json
+++ b/apps/api-media/project.json
@@ -144,6 +144,12 @@
       "options": {
         "command": "npx tsc -b apps/api-media/tsconfig.json"
       }
+    },
+    "codecov": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "codecov -f coverage/apps/api-media/cobertura-coverage.xml -F apps.api-media"
+      }
     }
   },
   "tags": []

--- a/apps/api-tags/jest.config.js
+++ b/apps/api-tags/jest.config.js
@@ -11,5 +11,7 @@ module.exports = {
     '^.+\\.[tj]s$': 'ts-jest'
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
-  coverageDirectory: '../../coverage/apps/api-tags'
+  coverageDirectory: '../../coverage/apps/api-tags',
+  collectCoverage: true,
+  coverageReporters: ['cobertura']
 }

--- a/apps/api-tags/project.json
+++ b/apps/api-tags/project.json
@@ -139,6 +139,12 @@
           "npx prisma validate --schema apps/api-tags/db/schema.prisma"
         ]
       }
+    },
+    "codecov": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "codecov -f coverage/apps/api-tags/cobertura-coverage.xml -F apps.api-tags"
+      }
     }
   },
   "tags": []

--- a/apps/api-users/jest.config.js
+++ b/apps/api-users/jest.config.js
@@ -11,5 +11,7 @@ module.exports = {
     '^.+\\.[tj]s$': 'ts-jest'
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
-  coverageDirectory: '../../coverage/apps/api-users'
+  coverageDirectory: '../../coverage/apps/api-users',
+  collectCoverage: true,
+  coverageReporters: ['cobertura']
 }

--- a/apps/api-users/project.json
+++ b/apps/api-users/project.json
@@ -137,12 +137,18 @@
           "npx prisma validate --schema apps/api-users/db/schema.prisma"
         ]
       }
-    }
-  },
-  "type-check": {
-    "executor": "@nrwl/workspace:run-commands",
-    "options": {
-      "command": "npx tsc -b apps/api-users/tsconfig.json"
+    },
+    "type-check": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "npx tsc -b apps/api-users/tsconfig.json"
+      }
+    },
+    "codecov": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "codecov -f coverage/apps/api-users/cobertura-coverage.xml -F apps.api-users"
+      }
     }
   },
   "tags": []

--- a/apps/api-videos/jest.config.js
+++ b/apps/api-videos/jest.config.js
@@ -11,5 +11,7 @@ module.exports = {
     '^.+\\.[tj]s$': 'ts-jest'
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
-  coverageDirectory: '../../coverage/apps/api-videos'
+  coverageDirectory: '../../coverage/apps/api-videos',
+  collectCoverage: true,
+  coverageReporters: ['cobertura']
 }

--- a/apps/api-videos/project.json
+++ b/apps/api-videos/project.json
@@ -90,6 +90,12 @@
       "options": {
         "command": "DOPPLER_TOKEN=$DOPPLER_API_VIDEOS_TOKEN doppler secrets download --no-file --format=env-no-quotes --project api-videos > apps/api-videos/.env"
       }
+    },
+    "codecov": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "codecov -f coverage/apps/api-videos/cobertura-coverage.xml -F apps.api-videos"
+      }
     }
   },
   "tags": []

--- a/apps/journeys-admin/jest.config.js
+++ b/apps/journeys-admin/jest.config.js
@@ -7,5 +7,7 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/apps/journeys-admin',
-  setupFilesAfterEnv: ['<rootDir>setupTests.tsx']
+  setupFilesAfterEnv: ['<rootDir>setupTests.tsx'],
+  collectCoverage: true,
+  coverageReporters: ['cobertura']
 }

--- a/apps/journeys-admin/project.json
+++ b/apps/journeys-admin/project.json
@@ -169,6 +169,12 @@
           }
         ]
       }
+    },
+    "codecov": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "codecov -f coverage/apps/journeys-admin/cobertura-coverage.xml -F apps.journeys-admin"
+      }
     }
   },
   "tags": []

--- a/apps/journeys/jest.config.js
+++ b/apps/journeys/jest.config.js
@@ -7,5 +7,7 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/apps/journeys',
-  setupFilesAfterEnv: ['<rootDir>setupTests.ts']
+  setupFilesAfterEnv: ['<rootDir>setupTests.ts'],
+  collectCoverage: true,
+  coverageReporters: ['cobertura']
 }

--- a/apps/journeys/project.json
+++ b/apps/journeys/project.json
@@ -169,6 +169,12 @@
           }
         ]
       }
+    },
+    "codecov": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "codecov -f coverage/apps/journeys/cobertura-coverage.xml -F apps.journeys"
+      }
     }
   },
   "tags": []

--- a/apps/watch-admin/jest.config.js
+++ b/apps/watch-admin/jest.config.js
@@ -7,5 +7,7 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/apps/watch-admin',
-  setupFilesAfterEnv: ['<rootDir>setupTests.tsx']
+  setupFilesAfterEnv: ['<rootDir>setupTests.tsx'],
+  collectCoverage: true,
+  coverageReporters: ['cobertura']
 }

--- a/apps/watch-admin/project.json
+++ b/apps/watch-admin/project.json
@@ -111,6 +111,12 @@
           }
         ]
       }
+    },
+    "codecov": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "codecov -f coverage/apps/watch-admin/cobertura-coverage.xml -F apps.watch-admin"
+      }
     }
   },
   "tags": []

--- a/apps/watch/jest.config.js
+++ b/apps/watch/jest.config.js
@@ -7,5 +7,7 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/apps/watch',
-  setupFilesAfterEnv: ['<rootDir>setupTests.tsx']
+  setupFilesAfterEnv: ['<rootDir>setupTests.tsx'],
+  collectCoverage: true,
+  coverageReporters: ['cobertura']
 }

--- a/apps/watch/project.json
+++ b/apps/watch/project.json
@@ -162,6 +162,12 @@
           }
         ]
       }
+    },
+    "codecov": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "codecov -f coverage/apps/watch/cobertura-coverage.xml -F apps.watch"
+      }
     }
   },
   "tags": []

--- a/libs/journeys/ui/jest.config.js
+++ b/libs/journeys/ui/jest.config.js
@@ -6,5 +6,7 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../../coverage/libs/journeys/ui',
-  setupFilesAfterEnv: ['<rootDir>setupTests.ts']
+  setupFilesAfterEnv: ['<rootDir>setupTests.ts'],
+  collectCoverage: true,
+  coverageReporters: ['cobertura']
 }

--- a/libs/journeys/ui/project.json
+++ b/libs/journeys/ui/project.json
@@ -66,6 +66,12 @@
           }
         ]
       }
+    },
+    "codecov": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "codecov -f coverage/libs/journeys/ui/cobertura-coverage.xml -F libs.journeys.ui"
+      }
     }
   }
 }

--- a/libs/nest/common/jest.config.js
+++ b/libs/nest/common/jest.config.js
@@ -10,5 +10,7 @@ module.exports = {
     '^.+\\.[tj]sx?$': 'ts-jest'
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-  coverageDirectory: '../../../coverage/libs/nest/common'
+  coverageDirectory: '../../../coverage/libs/nest/common',
+  collectCoverage: true,
+  coverageReporters: ['cobertura']
 }

--- a/libs/nest/common/project.json
+++ b/libs/nest/common/project.json
@@ -17,6 +17,12 @@
         "jestConfig": "libs/nest/common/jest.config.js",
         "passWithNoTests": true
       }
+    },
+    "codecov": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "codecov -f coverage/libs/nest/common/cobertura-coverage.xml -F libs.nest.common"
+      }
     }
   },
   "tags": []

--- a/libs/nest/database/jest.config.js
+++ b/libs/nest/database/jest.config.js
@@ -11,5 +11,7 @@ module.exports = {
     '^.+\\.[tj]sx?$': 'ts-jest'
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-  coverageDirectory: '../../../coverage/libs/nest/database'
+  coverageDirectory: '../../../coverage/libs/nest/database',
+  collectCoverage: true,
+  coverageReporters: ['cobertura']
 }

--- a/libs/nest/database/project.json
+++ b/libs/nest/database/project.json
@@ -17,6 +17,12 @@
         "jestConfig": "libs/nest/database/jest.config.js",
         "passWithNoTests": true
       }
+    },
+    "codecov": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "codecov -f coverage/libs/nest/database/cobertura-coverage.xml -F libs.nest.database"
+      }
     }
   },
   "tags": []

--- a/libs/nest/decorators/jest.config.js
+++ b/libs/nest/decorators/jest.config.js
@@ -10,5 +10,7 @@ module.exports = {
     '^.+\\.[tj]sx?$': 'ts-jest'
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-  coverageDirectory: '../../../coverage/libs/nest/decorators'
+  coverageDirectory: '../../../coverage/libs/nest/decorators',
+  collectCoverage: true,
+  coverageReporters: ['cobertura']
 }

--- a/libs/nest/decorators/project.json
+++ b/libs/nest/decorators/project.json
@@ -17,6 +17,12 @@
         "jestConfig": "libs/nest/decorators/jest.config.js",
         "passWithNoTests": true
       }
+    },
+    "codecov": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "codecov -f coverage/libs/nest/decorators/cobertura-coverage.xml -F libs.nest.decorators"
+      }
     }
   },
   "tags": []

--- a/libs/nest/gqlAuthGuard/jest.config.js
+++ b/libs/nest/gqlAuthGuard/jest.config.js
@@ -10,5 +10,7 @@ module.exports = {
     '^.+\\.[tj]sx?$': 'ts-jest'
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-  coverageDirectory: '../../../coverage/libs/nest/gqlAuthGuard'
+  coverageDirectory: '../../../coverage/libs/nest/gqlAuthGuard',
+  collectCoverage: true,
+  coverageReporters: ['cobertura']
 }

--- a/libs/nest/gqlAuthGuard/project.json
+++ b/libs/nest/gqlAuthGuard/project.json
@@ -17,6 +17,12 @@
         "jestConfig": "libs/nest/gqlAuthGuard/jest.config.js",
         "passWithNoTests": true
       }
+    },
+    "codecov": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "codecov -f coverage/libs/nest/gqlAuthGuard/cobertura-coverage.xml -F libs.nest.gqlAuthGuard"
+      }
     }
   },
   "tags": []

--- a/libs/nest/powerBi/jest.config.js
+++ b/libs/nest/powerBi/jest.config.js
@@ -11,5 +11,7 @@ module.exports = {
     '^.+\\.[tj]sx?$': 'ts-jest'
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-  coverageDirectory: '../../../coverage/libs/nest/powerBi'
+  coverageDirectory: '../../../coverage/libs/nest/powerBi',
+  collectCoverage: true,
+  coverageReporters: ['cobertura']
 }

--- a/libs/nest/powerBi/project.json
+++ b/libs/nest/powerBi/project.json
@@ -17,6 +17,12 @@
         "jestConfig": "libs/nest/powerBi/jest.config.js",
         "passWithNoTests": true
       }
+    },
+    "codecov": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "codecov -f coverage/libs/nest/powerBi/cobertura-coverage.xml -F libs.nest.powerBi"
+      }
     }
   },
   "tags": []

--- a/libs/shared/ui/jest.config.js
+++ b/libs/shared/ui/jest.config.js
@@ -6,5 +6,7 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../../coverage/libs/shared/ui',
-  setupFilesAfterEnv: ['<rootDir>setupTests.ts']
+  setupFilesAfterEnv: ['<rootDir>setupTests.ts'],
+  collectCoverage: true,
+  coverageReporters: ['cobertura']
 }

--- a/libs/shared/ui/project.json
+++ b/libs/shared/ui/project.json
@@ -38,6 +38,12 @@
           "quiet": true
         }
       }
+    },
+    "codecov": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "codecov -f coverage/libs/shared/ui/cobertura-coverage.xml -F libs.shared.ui"
+      }
     }
   },
   "tags": []


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9877f46</samp>

This pull request adds code coverage reporting to all the apps using codecov.io. It modifies the `jest.config.js` and `project.json` files for each app to enable the cobertura format and the codecov target. It also adds a step to the `.github/workflows/main.yml` file to run the codecov target for all the apps using the mansagroup/nrwl-nx-action.