### PR TITLE
fix: next block

### DIFF
--- a/apps/api-journeys/db/migrations/20230718233012_20230718233010/migration.sql
+++ b/apps/api-journeys/db/migrations/20230718233012_20230718233010/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "Block_nextBlockId_key";

--- a/apps/api-journeys/db/schema.prisma
+++ b/apps/api-journeys/db/schema.prisma
@@ -363,7 +363,7 @@ model Block {
   blurhash                String?
   submitIconId            String?
   submitLabel             String?
-  nextBlockId             String?              @unique
+  nextBlockId             String?
   locked                  Boolean?
   hint                    String?
   minRows                 Int?
@@ -392,7 +392,7 @@ model Block {
   coverBlockParent        Block?               @relation("CoverBlock")
   primaryImageBlockParent Journey?             @relation("PrimaryImageBlock")
   nextBlock               Block?               @relation("NextBlock", fields: [nextBlockId], references: [id])
-  nextBlockParent         Block?               @relation("NextBlock")
+  nextBlockParents        Block[]              @relation("NextBlock")
   parentBlock             Block?               @relation("ParentBlock", fields: [parentBlockId], references: [id], onDelete: Cascade)
   childBlocks             Block[]              @relation("ParentBlock")
   targetAction            Action[]             @relation("Block")


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f921172</samp>

This pull request enables branching logic for journeys by allowing multiple blocks to link to the same next block. It modifies the `schema.prisma` file and the `Block` table in the database to support this feature.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f921172</samp>

* Remove the unique constraint on the `nextBlockId` field of the `Block` model and table, allowing multiple blocks to point to the same next block ([link](https://github.com/JesusFilm/core/pull/1706/files?diff=unified&w=0#diff-9b3a240e12618191f85008cdad1ac5acede12795c4dae8549c786e4f62b3adefR1-R2), [link](https://github.com/JesusFilm/core/pull/1706/files?diff=unified&w=0#diff-881378863f13d5e9573c2c2e756ae61e8161918ebb4a384a8d5dddd7bf7385b0L366-R366))
* Rename the `nextBlockParent` field of the `Block` model to `nextBlockParents` and change it to an array type, enabling the Prisma client to access all the blocks that point to a given next block ([link](https://github.com/JesusFilm/core/pull/1706/files?diff=unified&w=0#diff-881378863f13d5e9573c2c2e756ae61e8161918ebb4a384a8d5dddd7bf7385b0L395-R395))
