### PR TITLE
fix: background video bug

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.tsx
@@ -112,6 +112,9 @@ export function BackgroundMediaImage({
   const createImageBlock = async (block): Promise<void> => {
     if (journey == null) return
 
+    if (coverBlock != null && coverBlock.__typename === 'VideoBlock')
+      await deleteCoverBlock()
+
     await imageBlockCreate({
       variables: {
         input: {


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c58a8bf</samp>

This pull request fixes a bug where a card block could have both a video block and an image block as its background media. It modifies the `BackgroundMediaImage` component and its test suite to delete the video block from the cache when an image block is selected.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/33281894/todos/6363222455)

# How should this PR be QA Tested?

- [ ] it should enable users to change from background video to image
- [ ] it shouldn't prevent users from adding blocks when action mentioned above has been done

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c58a8bf</samp>

*  Delete video block from cache when adding image block as background media of card block ([link](https://github.com/JesusFilm/core/pull/1707/files?diff=unified&w=0#diff-af7fdd8f1a3301138ca1fd3c79f4c47417f44eb823fefd1cf416b2001bd9dca2R115-R117), [link](https://github.com/JesusFilm/core/pull/1707/files?diff=unified&w=0#diff-1a5fff924efb0ab3d388f869c66118b3f4de285acb666e50fec67501f65c5785R229-R234), [link](https://github.com/JesusFilm/core/pull/1707/files?diff=unified&w=0#diff-1a5fff924efb0ab3d388f869c66118b3f4de285acb666e50fec67501f65c5785R257-R267), [link](https://github.com/JesusFilm/core/pull/1707/files?diff=unified&w=0#diff-1a5fff924efb0ab3d388f869c66118b3f4de285acb666e50fec67501f65c5785L281-R302))
  - Add conditional statement to `BackgroundMediaImage` component to check if cover block is a video block and call `deleteCoverBlock` function ([link](https://github.com/JesusFilm/core/pull/1707/files?diff=unified&w=0#diff-af7fdd8f1a3301138ca1fd3c79f4c47417f44eb823fefd1cf416b2001bd9dca2R115-R117))
  - Define mock function `videoBlockDeleteResult` to simulate mutation result of deleting video block ([link](https://github.com/JesusFilm/core/pull/1707/files?diff=unified&w=0#diff-1a5fff924efb0ab3d388f869c66118b3f4de285acb666e50fec67501f65c5785R229-R234))
  - Add mock request and result for `BLOCK_DELETE_FOR_BACKGROUND_IMAGE` mutation to `BackgroundMediaImage.spec.tsx` ([link](https://github.com/JesusFilm/core/pull/1707/files?diff=unified&w=0#diff-1a5fff924efb0ab3d388f869c66118b3f4de285acb666e50fec67501f65c5785R257-R267))
  - Modify test case to expect `videoBlockDeleteResult` to be called and cache to only contain card block and image block ([link](https://github.com/JesusFilm/core/pull/1707/files?diff=unified&w=0#diff-1a5fff924efb0ab3d388f869c66118b3f4de285acb666e50fec67501f65c5785L281-R302))
