### PR TITLE
refactor: contained cover always uses desktop theme

### DIFF
--- a/libs/journeys/ui/src/components/Card/ContainedCover/ContainedCover.tsx
+++ b/libs/journeys/ui/src/components/Card/ContainedCover/ContainedCover.tsx
@@ -160,7 +160,8 @@ export function ContainedCover({
           flexGrow: 1,
           zIndex: 1,
           top: 0,
-          position: { xs: 'relative', lg: 'absolute' },
+          // position: { xs: 'relative', lg: 'absolute' },
+          position: 'absolute',
           WebkitMask: { xs: overlayImageMask, lg: 'unset' },
           mask: { xs: overlayImageMask, lg: 'unset' }
         }}
@@ -183,9 +184,12 @@ export function ContainedCover({
           position: 'relative',
           zIndex: 1,
           width: '100%',
-          height: { xs: hasFullscreenVideo ? '100%' : undefined, lg: '100%' },
-          justifyContent: { xs: 'flex-end', lg: 'center' },
-          alignItems: { lg: rtl ? 'flex-start' : 'flex-end' }
+          height: '100%',
+          // height: { xs: hasFullscreenVideo ? '100%' : undefined, lg: '100%' },
+          justifyContent: 'center',
+          alignItems: rtl ? 'flex-start' : 'flex-end'
+          // justifyContent: { xs: 'flex-end', lg: 'center' }
+          // alignItems: { lg: rtl ? 'flex-start' : 'flex-end' }
         }}
       >
         {children.length !== 0 ? (
@@ -193,35 +197,38 @@ export function ContainedCover({
             <Stack
               data-testid="overlay-blur"
               sx={{
-                width: { xs: videoBlock != null ? '100%' : '0%', lg: 380 },
-                height: { xs: videoBlock != null ? '85%' : '0%', lg: '100%' },
-                flexDirection: {
-                  xs: 'column-reverse',
-                  lg: rtl ? 'row' : 'row-reverse'
-                },
+                width: 380,
+                height: '100%',
+                // width: { xs: videoBlock != null ? '100%' : '0%', lg: 380 },
+                // height: { xs: videoBlock != null ? '85%' : '0%', lg: '100%' },
+                flexDirection: rtl ? 'row' : 'row-reverse',
+                // flexDirection: {
+                //   xs: 'column-reverse',
+                //   lg: rtl ? 'row' : 'row-reverse'
+                // },
                 position: 'absolute'
               }}
             >
               <StyledSoftBlurBackground
-                sx={{ width: { lg: 500 }, height: contentHeight - 40 }}
+                sx={{ width: 500, height: contentHeight - 40 }}
               />
               <StyledSoftBlurBackground
-                sx={{ width: { lg: 450 }, height: contentHeight - 80 }}
+                sx={{ width: 450, height: contentHeight - 80 }}
               />
               <StyledSoftBlurBackground
-                sx={{ width: { lg: 400 }, height: contentHeight * 0.9 - 80 }}
+                sx={{ width: 400, height: contentHeight * 0.9 - 80 }}
               />
               <StyledBlurBackground
-                sx={{ width: { lg: 350 }, height: contentHeight * 0.8 - 80 }}
+                sx={{ width: 350, height: contentHeight * 0.8 - 80 }}
               />
               <StyledBlurBackground
-                sx={{ width: { lg: 325 }, height: contentHeight * 0.7 - 80 }}
+                sx={{ width: 325, height: contentHeight * 0.7 - 80 }}
               />
               <StyledBlurBackground
-                sx={{ width: { lg: 275 }, height: contentHeight * 0.6 - 80 }}
+                sx={{ width: 275, height: contentHeight * 0.6 - 80 }}
               />
               <StyledBlurBackground
-                sx={{ width: { lg: 250 }, height: contentHeight * 0.5 - 80 }}
+                sx={{ width: 250, height: contentHeight * 0.5 - 80 }}
               />
             </Stack>
 
@@ -233,19 +240,26 @@ export function ContainedCover({
               sx={{
                 position: 'absolute',
                 width: '100%',
-                height: { xs: '100%', lg: '100%' },
-                maxWidth: { xs: '100%', lg: '380px' },
-                pt: { xs: videoBlock != null ? 40 : 5, lg: 0 },
-                pb: { xs: 10, lg: 0 },
-                pl: { lg: 50 },
-                WebkitMask: {
-                  xs: overlayGradient('bottom'),
-                  lg: overlayGradient(rtl ? 'left' : 'right')
-                },
-                mask: {
-                  xs: overlayGradient('bottom'),
-                  lg: overlayGradient(rtl ? 'left' : 'right')
-                },
+                height: '100%',
+                // height: { xs: '100%', lg: '100%' },
+                maxWidth: '380px',
+                // maxWidth: { xs: '100%', lg: '380px' },
+                pt: 0,
+                // pt: { xs: videoBlock != null ? 40 : 5, lg: 0 },
+                pb: 0,
+                // pb: { xs: 10, lg: 0 },
+                pl: 50,
+                // pl: { lg: 50 },
+                WebkitMask: overlayGradient(rtl ? 'left' : 'right'),
+                // WebkitMask: {
+                //   xs: overlayGradient('bottom'),
+                //   lg: overlayGradient(rtl ? 'left' : 'right')
+                // },
+                mask: overlayGradient(rtl ? 'left' : 'right'),
+                // mask: {
+                //   xs: overlayGradient('bottom'),
+                //   lg: overlayGradient(rtl ? 'left' : 'right')
+                // },
                 backgroundColor: `${backgroundColor}d9`
               }}
             />
@@ -253,10 +267,14 @@ export function ContainedCover({
               hasFullscreenVideo={hasFullscreenVideo}
               sx={{
                 // This should match width of journey card content in admin
-                width: { lg: '312px' },
-                maxHeight: { xs: '55vh', lg: '100%' },
-                px: { xs: 6, lg: 10 },
-                mb: { xs: 16, lg: 0 }
+                width: '312px',
+                maxHeight: '100%',
+                px: 10,
+                mb: 0
+                // width: { lg: '312px' },
+                // maxHeight: { xs: '55vh', lg: '100%' },
+                // px: { xs: 6, lg: 10 },
+                // mb: { xs: 16, lg: 0 }
               }}
             >
               {children}
@@ -266,10 +284,11 @@ export function ContainedCover({
           <StyledGradientBackground
             className="overlay-gradient"
             sx={{
-              background: {
-                xs: `linear-gradient(to top,  ${backgroundColor}ff 0%, ${backgroundColor}33 60%, ${backgroundColor}00 100%)`,
-                lg: 'unset'
-              }
+              background: 'unset'
+              // background: {
+              //   xs: `linear-gradient(to top,  ${backgroundColor}ff 0%, ${backgroundColor}33 60%, ${backgroundColor}00 100%)`,
+              //   lg: 'unset'
+              // }
             }}
           />
         )}


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6d99007</samp>

Improved the layout and appearance of the `ContainedCover` component for different screen sizes. Removed an unnecessary gradient background and simplified the responsive styling.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6d99007</samp>

*  Simplify the `position` property of the `Box` component that wraps the cover image to fix a layout issue on smaller screens ([link](https://github.com/JesusFilm/core/pull/1709/files?diff=unified&w=0#diff-de466867478c6ebdafd8654eee49297476e8dd17f7c99bc8ed3b552c1e161d70L163-R164))
*  Simplify the `height`, `justifyContent` and `alignItems` properties of the `Flex` component that wraps the video and overlay elements to make them fill and center the cover area ([link](https://github.com/JesusFilm/core/pull/1709/files?diff=unified&w=0#diff-de466867478c6ebdafd8654eee49297476e8dd17f7c99bc8ed3b552c1e161d70L186-R192))
*  Simplify the `width`, `height` and `flexDirection` properties of the `Stack` component that contains the blur elements to make them consistent across screen sizes and orientations ([link](https://github.com/JesusFilm/core/pull/1709/files?diff=unified&w=0#diff-de466867478c6ebdafd8654eee49297476e8dd17f7c99bc8ed3b552c1e161d70L196-R231))
*  Simplify the `height`, `maxWidth`, `pt`, `pb`, `pl`, `WebkitMask` and `mask` properties of the `Box` component that wraps the overlay content to make it consistent and masked ([link](https://github.com/JesusFilm/core/pull/1709/files?diff=unified&w=0#diff-de466867478c6ebdafd8654eee49297476e8dd17f7c99bc8ed3b552c1e161d70L236-R262))
*  Remove the `background` property of the `Box` component that adds a gradient to the overlay content for the large screen size to avoid overlapping with the blur elements and the mask ([link](https://github.com/JesusFilm/core/pull/1709/files?diff=unified&w=0#diff-de466867478c6ebdafd8654eee49297476e8dd17f7c99bc8ed3b552c1e161d70L269-R291))
*  Simplify the `width`, `maxHeight`, `px` and `mb` properties of the `Box` component that wraps the card content to make it consistent ([link](https://github.com/JesusFilm/core/pull/1709/files?diff=unified&w=0#diff-de466867478c6ebdafd8654eee49297476e8dd17f7c99bc8ed3b552c1e161d70L256-R277))
