### PR TITLE
fix: visitor endpoints to use acls

### DIFF
--- a/apps/api-journeys/db/migrations/20230721193632_20230721193621/migration.sql
+++ b/apps/api-journeys/db/migrations/20230721193632_20230721193621/migration.sql
@@ -1,0 +1,2 @@
+-- AddForeignKey
+ALTER TABLE "JourneyVisitor" ADD CONSTRAINT "JourneyVisitor_journeyId_fkey" FOREIGN KEY ("journeyId") REFERENCES "Journey"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api-journeys/db/schema.prisma
+++ b/apps/api-journeys/db/schema.prisma
@@ -137,7 +137,7 @@ model Visitor {
   userId                    String
   userAgent                 Json?
   updatedAt                 DateTime         @default(now()) @updatedAt
-  journeyVisitor            JourneyVisitor[]
+  journeyVisitors           JourneyVisitor[]
   team                      Team             @relation(fields: [teamId], references: [id])
 
   @@index([id, teamId, createdAt, userId, status, countryCode])
@@ -170,6 +170,7 @@ model JourneyVisitor {
   lastRadioOptionSubmission String?
   activityCount             Int              @default(0)
   updatedAt                 DateTime         @default(now()) @updatedAt
+  journey                   Journey          @relation(fields: [journeyId], references: [id], onDelete: Cascade)
   visitor                   Visitor          @relation(fields: [visitorId], references: [id], onDelete: Cascade)
   events                    Event[]
 
@@ -260,13 +261,13 @@ enum ThemeName {
 }
 
 model Journey {
-  id                  String        @id @default(uuid())
+  id                  String           @id @default(uuid())
   title               String
   languageId          String
   description         String?
-  slug                String        @unique
+  slug                String           @unique
   archivedAt          DateTime?
-  createdAt           DateTime      @default(now())
+  createdAt           DateTime         @default(now())
   deletedAt           DateTime?
   publishedAt         DateTime?
   trashedAt           DateTime?
@@ -274,21 +275,22 @@ model Journey {
   status              JourneyStatus
   seoTitle            String?
   seoDescription      String?
-  primaryImageBlockId String?       @unique
-  template            Boolean?      @default(false)
+  primaryImageBlockId String?          @unique
+  template            Boolean?         @default(false)
   teamId              String
   hostId              String?
-  themeMode           ThemeMode?    @default(light)
-  themeName           ThemeName?    @default(base)
-  updatedAt           DateTime      @default(now()) @updatedAt
+  themeMode           ThemeMode?       @default(light)
+  themeName           ThemeName?       @default(base)
+  updatedAt           DateTime         @default(now()) @updatedAt
   userJourneys        UserJourney[]
-  team                Team          @relation(fields: [teamId], references: [id])
+  team                Team             @relation(fields: [teamId], references: [id])
   userInvites         UserInvite[]
   blocks              Block[]
   chatButtons         ChatButton[]
-  host                Host?         @relation(fields: [hostId], references: [id])
-  Action              Action[]
-  primaryImageBlock   Block?        @relation("PrimaryImageBlock", fields: [primaryImageBlockId], references: [id])
+  host                Host?            @relation(fields: [hostId], references: [id])
+  actions             Action[]
+  primaryImageBlock   Block?           @relation("PrimaryImageBlock", fields: [primaryImageBlockId], references: [id])
+  journeyVisitors     JourneyVisitor[]
 
   @@index([title])
 }
@@ -394,7 +396,7 @@ model Block {
   nextBlockParents        Block[]              @relation("NextBlock")
   parentBlock             Block?               @relation("ParentBlock", fields: [parentBlockId], references: [id], onDelete: Cascade)
   childBlocks             Block[]              @relation("ParentBlock")
-  targetAction            Action[]             @relation("Block")
+  targetActions           Action[]             @relation("Block")
 }
 
 model Action {

--- a/apps/api-journeys/src/app/lib/casl/caslFactory/caslFactory.spec.ts
+++ b/apps/api-journeys/src/app/lib/casl/caslFactory/caslFactory.spec.ts
@@ -5,7 +5,8 @@ import {
   UserTeam,
   UserTeamInvite,
   Host,
-  Journey
+  Journey,
+  Visitor
 } from '.prisma/api-journeys-client'
 import { Action, AppAbility, AppCaslFactory } from '.'
 
@@ -82,6 +83,18 @@ describe('AppCaslFactory', () => {
               userTeams: [{ userId: user.id, role: UserTeamRole.manager }]
             }
           } as unknown as UserTeamInvite)
+        )
+      ).toEqual(true)
+    })
+  })
+  describe('Visitor', () => {
+    it('should allow manage when visitor is user', () => {
+      expect(
+        ability.can(
+          Action.Manage,
+          subject('Visitor', {
+            userId: 'userId'
+          } as unknown as Visitor)
         )
       ).toEqual(true)
     })

--- a/apps/api-journeys/src/app/lib/casl/caslFactory/caslFactory.spec.ts
+++ b/apps/api-journeys/src/app/lib/casl/caslFactory/caslFactory.spec.ts
@@ -6,6 +6,7 @@ import {
   UserTeamInvite,
   Host,
   Journey,
+  JourneyVisitor,
   Visitor
 } from '.prisma/api-journeys-client'
 import { Action, AppAbility, AppCaslFactory } from '.'
@@ -46,6 +47,20 @@ describe('AppCaslFactory', () => {
               userTeams: [{ userId: user.id, role: UserTeamRole.manager }]
             }
           } as unknown as Journey)
+        )
+      ).toEqual(true)
+    })
+  })
+  describe('JourneyVisitor', () => {
+    it('should allow manage when visitor is user', () => {
+      expect(
+        ability.can(
+          Action.Manage,
+          subject('JourneyVisitor', {
+            visitor: {
+              userId: 'userId'
+            }
+          } as unknown as JourneyVisitor)
         )
       ).toEqual(true)
     })

--- a/apps/api-journeys/src/app/lib/casl/caslFactory/caslFactory.ts
+++ b/apps/api-journeys/src/app/lib/casl/caslFactory/caslFactory.ts
@@ -9,6 +9,7 @@ import { userTeamAcl } from '../../../modules/userTeam/userTeam.acl'
 import { journeyAcl } from '../../../modules/journey/journey.acl'
 import { hostAcl } from '../../../modules/host/host.acl'
 import { userTeamInviteAcl } from '../../../modules/userTeamInvite/userTeamInvite.acl'
+import { visitorAcl } from '../../../modules/visitor/visitor.acl'
 
 export enum Action {
   Manage = 'manage',
@@ -40,7 +41,14 @@ export class AppCaslFactory extends CaslFactory<Role> {
     const { can, cannot, build } = new AbilityBuilder<AppAbility>(
       createPrismaAbility
     )
-    const acls = [hostAcl, journeyAcl, teamAcl, userTeamAcl, userTeamInviteAcl]
+    const acls = [
+      hostAcl,
+      journeyAcl,
+      teamAcl,
+      userTeamAcl,
+      userTeamInviteAcl,
+      visitorAcl
+    ]
     acls.forEach((acl) => acl({ can, cannot, user }))
 
     return build()

--- a/apps/api-journeys/src/app/lib/casl/caslFactory/caslFactory.ts
+++ b/apps/api-journeys/src/app/lib/casl/caslFactory/caslFactory.ts
@@ -10,6 +10,7 @@ import { journeyAcl } from '../../../modules/journey/journey.acl'
 import { hostAcl } from '../../../modules/host/host.acl'
 import { userTeamInviteAcl } from '../../../modules/userTeamInvite/userTeamInvite.acl'
 import { visitorAcl } from '../../../modules/visitor/visitor.acl'
+import { journeyVisitorAcl } from '../../../modules/journeyVisitor/journeyVisitor.acl'
 
 export enum Action {
   Manage = 'manage',
@@ -44,6 +45,7 @@ export class AppCaslFactory extends CaslFactory<Role> {
     const acls = [
       hostAcl,
       journeyAcl,
+      journeyVisitorAcl,
       teamAcl,
       userTeamAcl,
       userTeamInviteAcl,

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -413,7 +413,13 @@ export class JourneyResolver {
               }
             })
             const duplicateJourney = await tx.journey.findUnique({
-              where: { id: duplicateJourneyId }
+              where: { id: duplicateJourneyId },
+              include: {
+                userJourneys: true,
+                team: {
+                  include: { userTeams: true }
+                }
+              }
             })
             if (duplicateJourney == null)
               throw new GraphQLError('journey not found', {
@@ -566,7 +572,13 @@ export class JourneyResolver {
     @Args('id') id: string
   ): Promise<Journey> {
     const journey = await this.prismaService.journey.findUnique({
-      where: { id }
+      where: { id },
+      include: {
+        userJourneys: true,
+        team: {
+          include: { userTeams: true }
+        }
+      }
     })
     if (journey == null)
       throw new GraphQLError('journey not found', {
@@ -666,7 +678,13 @@ export class JourneyResolver {
     @Args('input') input: JourneyTemplateInput
   ): Promise<Journey> {
     const journey = await this.prismaService.journey.findUnique({
-      where: { id }
+      where: { id },
+      include: {
+        userJourneys: true,
+        team: {
+          include: { userTeams: true }
+        }
+      }
     })
     if (journey == null)
       throw new GraphQLError('journey not found', {

--- a/apps/api-journeys/src/app/modules/journeyVisitor/journeyVisitor.acl.spec.ts
+++ b/apps/api-journeys/src/app/modules/journeyVisitor/journeyVisitor.acl.spec.ts
@@ -1,0 +1,101 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { subject } from '@casl/ability'
+import {
+  JourneyVisitor,
+  UserTeamRole,
+  UserJourneyRole
+} from '.prisma/api-journeys-client'
+import { Action, AppAbility, AppCaslFactory } from '../../lib/casl/caslFactory'
+
+describe('journeyVisitorAcl', () => {
+  let factory: AppCaslFactory, ability: AppAbility
+  const user = { id: 'userId' }
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AppCaslFactory]
+    }).compile()
+    factory = module.get<AppCaslFactory>(AppCaslFactory)
+    ability = await factory.createAbility(user)
+  })
+  const journeyVisitorUserTeamManager = subject('JourneyVisitor', {
+    id: 'visitorId',
+    visitor: {
+      team: {
+        userTeams: [{ userId: user.id, role: UserTeamRole.manager }]
+      }
+    }
+  } as unknown as JourneyVisitor)
+  const journeyVisitorUserTeamMember = subject('JourneyVisitor', {
+    id: 'visitorId',
+    visitor: {
+      team: {
+        userTeams: [{ userId: user.id, role: UserTeamRole.member }]
+      }
+    }
+  } as unknown as JourneyVisitor)
+  const journeyVisitorUserJourneyOwner = subject('JourneyVisitor', {
+    id: 'visitorId',
+    journey: {
+      userJourneys: [
+        {
+          userId: user.id,
+          role: UserJourneyRole.owner
+        }
+      ]
+    }
+  } as unknown as JourneyVisitor)
+  const journeyVisitorUserJourneyEditor = subject('JourneyVisitor', {
+    id: 'visitorId',
+    journey: {
+      userJourneys: [
+        {
+          userId: user.id,
+          role: UserJourneyRole.editor
+        }
+      ]
+    }
+  } as unknown as JourneyVisitor)
+  const journeyVisitorEmpty = subject('JourneyVisitor', {
+    id: 'visitorId',
+    journey: {
+      userJourneys: []
+    },
+    visitor: {
+      team: { userTeams: [] }
+    }
+  } as unknown as JourneyVisitor)
+  const journeyVisitorUser = subject('JourneyVisitor', {
+    id: 'visitorId',
+    visitor: {
+      userId: user.id
+    }
+  } as unknown as JourneyVisitor)
+  describe('manage', () => {
+    it('allow when user is team manager', () => {
+      expect(ability.can(Action.Manage, journeyVisitorUserTeamManager)).toEqual(
+        true
+      )
+    })
+    it('allow when user is journey owner', () => {
+      expect(
+        ability.can(Action.Manage, journeyVisitorUserJourneyOwner)
+      ).toEqual(true)
+    })
+    it('allow when user is team member', () => {
+      expect(ability.can(Action.Manage, journeyVisitorUserTeamMember)).toEqual(
+        true
+      )
+    })
+    it('allow when user is journey editor', () => {
+      expect(
+        ability.can(Action.Manage, journeyVisitorUserJourneyEditor)
+      ).toEqual(true)
+    })
+    it('allow when user is visitor', () => {
+      expect(ability.can(Action.Manage, journeyVisitorUser)).toEqual(true)
+    })
+    it('deny when user has no userTeam or relevant journey', () => {
+      expect(ability.can(Action.Create, journeyVisitorEmpty)).toEqual(false)
+    })
+  })
+})

--- a/apps/api-journeys/src/app/modules/journeyVisitor/journeyVisitor.acl.ts
+++ b/apps/api-journeys/src/app/modules/journeyVisitor/journeyVisitor.acl.ts
@@ -1,0 +1,50 @@
+import { UserTeamRole, UserJourneyRole } from '.prisma/api-journeys-client'
+import { Action, AppAclFn, AppAclParameters } from '../../lib/casl/caslFactory'
+
+export const journeyVisitorAcl: AppAclFn = ({
+  can,
+  user
+}: AppAclParameters) => {
+  // manage journey visitor if visitor is current user
+  can(Action.Manage, 'JourneyVisitor', {
+    visitor: {
+      is: {
+        userId: user.id
+      }
+    }
+  })
+  // manage journey visitor as a team member
+  can(Action.Manage, 'JourneyVisitor', {
+    visitor: {
+      is: {
+        team: {
+          is: {
+            userTeams: {
+              some: {
+                userId: user.id,
+                role: {
+                  in: [UserTeamRole.manager, UserTeamRole.member]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+  // manage journey visitor as a journey owner or editor
+  can(Action.Manage, 'JourneyVisitor', {
+    journey: {
+      is: {
+        userJourneys: {
+          some: {
+            userId: user.id,
+            role: {
+              in: [UserJourneyRole.owner, UserJourneyRole.editor]
+            }
+          }
+        }
+      }
+    }
+  })
+}

--- a/apps/api-journeys/src/app/modules/journeyVisitor/journeyVisitor.module.ts
+++ b/apps/api-journeys/src/app/modules/journeyVisitor/journeyVisitor.module.ts
@@ -1,11 +1,13 @@
 import { Global, Module } from '@nestjs/common'
+import { CaslAuthModule } from '@core/nest/common/CaslAuthModule'
 import { PrismaService } from '../../lib/prisma.service'
+import { AppCaslFactory } from '../../lib/casl/caslFactory'
 import { JourneyVisitorService } from './journeyVisitor.service'
 import { JourneyVisitorResolver } from './journeyVisitor.resolver'
 
 @Global()
 @Module({
-  imports: [],
+  imports: [CaslAuthModule.register(AppCaslFactory)],
   providers: [JourneyVisitorService, JourneyVisitorResolver, PrismaService],
   exports: [JourneyVisitorService]
 })

--- a/apps/api-journeys/src/app/modules/journeyVisitor/journeyVisitor.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journeyVisitor/journeyVisitor.resolver.spec.ts
@@ -78,9 +78,6 @@ describe('JourneyVisitorResolver', () => {
     prismaService = module.get<PrismaService>(
       PrismaService
     ) as DeepMockProxy<PrismaService>
-    // prismaService.event.findMany = jest.fn().mockReturnValue([event])
-    // prismaService.visitor.findUnique = jest.fn().mockReturnValue(visitor)
-    // prismaService.userTeam.findUnique = jest.fn().mockReturnValue(userTeam)
   })
 
   describe('journeyVisitorsConnection', () => {

--- a/apps/api-journeys/src/app/modules/journeyVisitor/journeyVisitor.service.ts
+++ b/apps/api-journeys/src/app/modules/journeyVisitor/journeyVisitor.service.ts
@@ -21,12 +21,10 @@ export interface JourneyVisitorsConnection {
 export class JourneyVisitorService {
   constructor(private readonly prismaService: PrismaService) {}
 
-  generateWhere(
-    filter?: JourneyVisitorFilter
-  ): Prisma.JourneyVisitorWhereInput {
+  generateWhere(filter: JourneyVisitorFilter): Prisma.JourneyVisitorWhereInput {
     return omitBy(
       {
-        journeyId: filter?.journeyId ?? undefined,
+        journeyId: filter.journeyId,
         lastChatStartedAt:
           filter?.hasChatStarted === true ? { not: null } : undefined,
         lastRadioQuestion:
@@ -60,11 +58,11 @@ export class JourneyVisitorService {
   }: {
     after?: string | null
     first: number
-    filter: JourneyVisitorFilter
+    filter: Prisma.JourneyVisitorWhereInput
     sort?: JourneyVisitorSort
   }): Promise<JourneyVisitorsConnection> {
     const result = await this.prismaService.journeyVisitor.findMany({
-      where: this.generateWhere(filter),
+      where: filter,
       cursor: after != null ? { id: after } : undefined,
       orderBy: omitBy(
         {
@@ -94,9 +92,11 @@ export class JourneyVisitorService {
     }
   }
 
-  async getJourneyVisitorCount(filter: JourneyVisitorFilter): Promise<number> {
+  async getJourneyVisitorCount(
+    filter: Prisma.JourneyVisitorWhereInput
+  ): Promise<number> {
     return await this.prismaService.journeyVisitor.count({
-      where: this.generateWhere(filter)
+      where: filter
     })
   }
 }

--- a/apps/api-journeys/src/app/modules/visitor/visitor.acl.spec.ts
+++ b/apps/api-journeys/src/app/modules/visitor/visitor.acl.spec.ts
@@ -1,0 +1,97 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { subject } from '@casl/ability'
+import {
+  Visitor,
+  UserTeamRole,
+  UserJourneyRole
+} from '.prisma/api-journeys-client'
+import { Action, AppAbility, AppCaslFactory } from '../../lib/casl/caslFactory'
+
+describe('visitorAcl', () => {
+  let factory: AppCaslFactory, ability: AppAbility
+  const user = { id: 'userId' }
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AppCaslFactory]
+    }).compile()
+    factory = module.get<AppCaslFactory>(AppCaslFactory)
+    ability = await factory.createAbility(user)
+  })
+  const visitorUserTeamManager = subject('Visitor', {
+    id: 'visitorId',
+    team: {
+      userTeams: [{ userId: user.id, role: UserTeamRole.manager }]
+    }
+  } as unknown as Visitor)
+  const visitorUserTeamMember = subject('Visitor', {
+    id: 'visitorId',
+    team: {
+      userTeams: [{ userId: user.id, role: UserTeamRole.member }]
+    }
+  } as unknown as Visitor)
+  const visitorUserJourneyOwner = subject('Visitor', {
+    id: 'visitorId',
+    journeyVisitors: [
+      {
+        journey: {
+          userJourneys: [
+            {
+              userId: user.id,
+              role: UserJourneyRole.owner
+            }
+          ]
+        }
+      }
+    ]
+  } as unknown as Visitor)
+  const visitorUserJourneyEditor = subject('Visitor', {
+    id: 'visitorId',
+    journeyVisitors: [
+      {
+        journey: {
+          userJourneys: [
+            {
+              userId: user.id,
+              role: UserJourneyRole.editor
+            }
+          ]
+        }
+      }
+    ]
+  } as unknown as Visitor)
+  const visitorEmpty = subject('Visitor', {
+    id: 'visitorId',
+    journeyVisitors: [
+      {
+        journey: {
+          userJourneys: []
+        }
+      }
+    ],
+    team: { userTeams: [] }
+  } as unknown as Visitor)
+  const visitorUser = subject('Visitor', {
+    id: 'visitorId',
+    userId: user.id
+  } as unknown as Visitor)
+  describe('manage', () => {
+    it('allow when user is team manager', () => {
+      expect(ability.can(Action.Manage, visitorUserTeamManager)).toEqual(true)
+    })
+    it('allow when user is journey owner', () => {
+      expect(ability.can(Action.Manage, visitorUserJourneyOwner)).toEqual(true)
+    })
+    it('allow when user is team member', () => {
+      expect(ability.can(Action.Manage, visitorUserTeamMember)).toEqual(true)
+    })
+    it('allow when user is journey editor', () => {
+      expect(ability.can(Action.Manage, visitorUserJourneyEditor)).toEqual(true)
+    })
+    it('allow when user is visitor', () => {
+      expect(ability.can(Action.Manage, visitorUser)).toEqual(true)
+    })
+    it('deny when user has no userTeam or relevant journey', () => {
+      expect(ability.can(Action.Create, visitorEmpty)).toEqual(false)
+    })
+  })
+})

--- a/apps/api-journeys/src/app/modules/visitor/visitor.acl.ts
+++ b/apps/api-journeys/src/app/modules/visitor/visitor.acl.ts
@@ -1,0 +1,43 @@
+import { UserTeamRole, UserJourneyRole } from '.prisma/api-journeys-client'
+import { Action, AppAclFn, AppAclParameters } from '../../lib/casl/caslFactory'
+
+export const visitorAcl: AppAclFn = ({ can, user }: AppAclParameters) => {
+  // manage visitor if visitor is current user
+  can(Action.Manage, 'Visitor', {
+    userId: user.id
+  })
+  // manage visitor as a team member
+  can(Action.Manage, 'Visitor', {
+    team: {
+      is: {
+        userTeams: {
+          some: {
+            userId: user.id,
+            role: {
+              in: [UserTeamRole.manager, UserTeamRole.member]
+            }
+          }
+        }
+      }
+    }
+  })
+  // manage visitor as a journey owner or editor
+  can(Action.Manage, 'Visitor', {
+    journeyVisitors: {
+      some: {
+        journey: {
+          is: {
+            userJourneys: {
+              some: {
+                userId: user.id,
+                role: {
+                  in: [UserJourneyRole.owner, UserJourneyRole.editor]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+}

--- a/apps/api-journeys/src/app/modules/visitor/visitor.module.ts
+++ b/apps/api-journeys/src/app/modules/visitor/visitor.module.ts
@@ -1,12 +1,14 @@
 import { Global, Module } from '@nestjs/common'
+import { CaslAuthModule } from '@core/nest/common/CaslAuthModule'
 import { PrismaService } from '../../lib/prisma.service'
 import { BlockService } from '../block/block.service'
+import { AppCaslFactory } from '../../lib/casl/caslFactory'
 import { VisitorService } from './visitor.service'
 import { VisitorResolver } from './visitor.resolver'
 
 @Global()
 @Module({
-  imports: [],
+  imports: [CaslAuthModule.register(AppCaslFactory)],
   providers: [VisitorService, VisitorResolver, BlockService, PrismaService],
   exports: [VisitorService]
 })

--- a/apps/api-journeys/src/app/modules/visitor/visitor.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/visitor/visitor.resolver.spec.ts
@@ -1,17 +1,23 @@
 import { Test, TestingModule } from '@nestjs/testing'
+import { CaslAuthModule } from '@core/nest/common/CaslAuthModule'
+import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
+import { Visitor, Event } from '.prisma/api-journeys-client'
 import {
   MessagePlatform,
+  VisitorStatus,
+  VisitorUpdateInput,
   VisitorsConnection
 } from '../../__generated__/graphql'
-import { EventService } from '../event/event.service'
 import { PrismaService } from '../../lib/prisma.service'
+import { AppAbility, AppCaslFactory } from '../../lib/casl/caslFactory'
 import { VisitorResolver } from './visitor.resolver'
 import { VisitorService } from './visitor.service'
 
 describe('VisitorResolver', () => {
   let resolver: VisitorResolver,
     vService: VisitorService,
-    prismaService: PrismaService
+    prismaService: DeepMockProxy<PrismaService>,
+    ability: AppAbility
 
   const connection: VisitorsConnection = {
     edges: [],
@@ -22,7 +28,7 @@ describe('VisitorResolver', () => {
     }
   }
 
-  const visitor = {
+  const visitor: Visitor = {
     id: 'visitorId',
     countryCode: null,
     email: 'bob@example.com',
@@ -33,166 +39,201 @@ describe('VisitorResolver', () => {
     notes: 'Bob called this afternoon to arrange a meet-up.',
     status: 'star',
     teamId: 'teamId',
-    userAgent: null
+    userAgent: null,
+    createdAt: new Date(),
+    duration: 0,
+    lastChatPlatform: null,
+    lastStepViewedAt: null,
+    lastLinkAction: null,
+    lastTextResponse: null,
+    lastRadioQuestion: null,
+    lastRadioOptionSubmission: null,
+    referrer: null,
+    userId: 'visitorUserId',
+    updatedAt: new Date()
+  }
+
+  const visitorWithUser = {
+    ...visitor,
+    userId: 'userId'
   }
 
   const visitorService = {
     provide: VisitorService,
     useFactory: () => ({
-      getList: jest.fn(() => connection),
-      get: jest.fn((id) => {
-        switch (id) {
-          case 'visitorId':
-            return { ...visitor, id, teamId: 'teamId' }
-          case 'unknownVisitorId':
-            return undefined
-          case 'visitorWithDifferentTeamId':
-            return { ...visitor, id, teamId: 'differentTeamId' }
-        }
-      }),
-      update: jest.fn((_id, input) => ({ ...visitor, ...input }))
-    })
-  }
-
-  const userTeam = {
-    id: 'userTeamId',
-    userId: 'userId',
-    teamId: 'teamId'
-  }
-
-  const event = {
-    id: 'eventId'
-  }
-
-  const eventService = {
-    provide: EventService,
-    useFactory: () => ({
-      getAllByVisitorId: jest.fn(() => [event])
+      getList: jest.fn(() => connection)
     })
   }
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [VisitorResolver, visitorService, eventService, PrismaService]
+      imports: [CaslAuthModule.register(AppCaslFactory)],
+      providers: [
+        VisitorResolver,
+        visitorService,
+        {
+          provide: PrismaService,
+          useValue: mockDeep<PrismaService>()
+        }
+      ]
     }).compile()
     resolver = module.get<VisitorResolver>(VisitorResolver)
     vService = module.get<VisitorService>(VisitorService)
-    prismaService = module.get<PrismaService>(PrismaService)
-    prismaService.event.findMany = jest.fn().mockReturnValue([event])
-    prismaService.userTeam.findUnique = jest
-      .fn()
-      .mockResolvedValueOnce(userTeam)
-    prismaService.visitor.findUnique = jest.fn().mockReturnValue(visitor)
+    prismaService = module.get<PrismaService>(
+      PrismaService
+    ) as DeepMockProxy<PrismaService>
+    ability = await new AppCaslFactory().createAbility({ id: 'userId' })
   })
 
   describe('visitorsConnection', () => {
     it('returns connection', async () => {
-      expect(await resolver.visitorsConnection('userId', 'teamId')).toEqual(
+      expect(await resolver.visitorsConnection({ OR: [] }, 'teamId')).toEqual(
         connection
       )
     })
 
     it('calls service with first, after and filter', async () => {
-      await resolver.visitorsConnection('userId', 'teamId', 50, 'cursorId')
+      await resolver.visitorsConnection({ OR: [] }, 'teamId', 50, 'cursorId')
       expect(vService.getList).toHaveBeenCalledWith({
         after: 'cursorId',
-        filter: { teamId: 'teamId' },
+        filter: { AND: [{ OR: [] }, { teamId: 'teamId' }] },
         first: 50
       })
-    })
-
-    it('throws error when user is not a team member', async () => {
-      prismaService.userTeam.findUnique = jest.fn().mockReturnValue(null)
-      await expect(
-        async () =>
-          await resolver.visitorsConnection('userId', 'differentTeamId')
-      ).rejects.toThrow('User is not a member of the team.')
     })
   })
 
   describe('visitor', () => {
     it('returns visitor', async () => {
-      prismaService.event.findMany = jest.fn().mockReturnValue([])
-      expect(await resolver.visitor('userId', 'visitorId')).toEqual({
-        ...visitor
-      })
+      prismaService.visitor.findUnique.mockResolvedValueOnce(visitorWithUser)
+      expect(await resolver.visitor(ability, 'visitorId')).toEqual(
+        visitorWithUser
+      )
     })
-
-    it('throws error when invalid visitor ID', async () => {
-      prismaService.visitor.findUnique = jest.fn().mockReturnValue(null)
-      await expect(
-        async () => await resolver.visitor('userId', 'unknownVisitorId')
-      ).rejects.toThrow('Visitor with ID "unknownVisitorId" does not exist')
+    it('throws error if not found', async () => {
+      prismaService.visitor.findUnique.mockResolvedValueOnce(null)
+      await expect(resolver.visitor(ability, 'visitorId')).rejects.toThrow(
+        'visitor with id "visitorId" not found'
+      )
     })
-
-    it('throws error when user is not member of visitors team', async () => {
-      prismaService.visitor.findUnique = jest
-        .fn()
-        .mockReturnValue({ ...visitor, teamId: 'junk' })
-      prismaService.userTeam.findUnique = jest.fn().mockReturnValue(null)
-      await expect(
-        async () =>
-          await resolver.visitor('userId', 'visitorWithDifferentTeamId')
-      ).rejects.toThrow(
-        'User is not a member of the team the visitor belongs to'
+    it('throws error if not authorized', async () => {
+      prismaService.visitor.findUnique.mockResolvedValueOnce(visitor)
+      await expect(resolver.visitor(ability, 'visitorId')).rejects.toThrow(
+        'user is not allowed to view visitor'
       )
     })
   })
 
   describe('visitorUpdate', () => {
-    const input = {
+    const input: VisitorUpdateInput = {
       email: 'sarah@example.com',
       messagePlatformId: '0800838383',
       messagePlatform: MessagePlatform.whatsApp,
       name: 'Sarah',
       notes: 'this is a test',
-      status: 'star'
+      status: VisitorStatus.star
     }
-    it('returns updated visitor', async () => {
-      prismaService.visitor.update = jest
-        .fn()
-        .mockReturnValueOnce({ ...visitor, ...input })
-      expect(
-        await resolver.visitorUpdate('userId', 'visitorId', input)
-      ).toEqual({ ...visitor, ...input })
-    })
-
-    it('throws error when invalid visitor ID', async () => {
-      prismaService.visitor.findUnique = jest.fn().mockReturnValueOnce(null)
-      await expect(
-        async () =>
-          await resolver.visitorUpdate('userId', 'unknownVisitorId', input)
-      ).rejects.toThrow('Visitor with ID "unknownVisitorId" does not exist')
-    })
-
-    it('throws error when user is not member of visitors team', async () => {
-      prismaService.visitor.findUnique = jest
-        .fn()
-        .mockReturnValueOnce({ ...visitor, teamId: 'junk' })
-      prismaService.userTeam.findUnique = jest.fn().mockReturnValue(null)
-      await expect(
-        async () =>
-          await resolver.visitorUpdate(
-            'userId',
-            'visitorWithDifferentTeamId',
-            input
-          )
-      ).rejects.toThrow(
-        'User is not a member of the team the visitor belongs to'
+    it('updates visitor', async () => {
+      prismaService.visitor.findUnique.mockResolvedValueOnce(visitorWithUser)
+      prismaService.visitor.update.mockResolvedValueOnce({
+        ...visitorWithUser,
+        ...input
+      })
+      expect(await resolver.visitorUpdate(ability, 'visitorId', input)).toEqual(
+        { ...visitorWithUser, ...input }
       )
+    })
+    it('throws error if not found', async () => {
+      prismaService.visitor.findUnique.mockResolvedValueOnce(null)
+      await expect(
+        resolver.visitorUpdate(ability, 'visitorId', input)
+      ).rejects.toThrow('visitor with id "visitorId" not found')
+    })
+    it('throws error if not authorized', async () => {
+      prismaService.visitor.findUnique.mockResolvedValueOnce(visitor)
+      await expect(
+        resolver.visitorUpdate(ability, 'visitorId', input)
+      ).rejects.toThrow('user is not allowed to update visitor')
+    })
+  })
+
+  describe('visitorUpdateForCurrentUser', () => {
+    const input: VisitorUpdateInput = {
+      email: 'sarah@example.com',
+      messagePlatformId: '0800838383',
+      messagePlatform: MessagePlatform.whatsApp,
+      name: 'Sarah',
+      notes: 'this is a test',
+      status: VisitorStatus.star,
+      countryCode: 'South Lake Tahoe, CA, USA',
+      referrer: 'https://example.com'
+    }
+    it('updates visitor', async () => {
+      prismaService.visitor.findFirst.mockResolvedValueOnce(visitorWithUser)
+      prismaService.visitor.update.mockResolvedValueOnce({
+        ...visitorWithUser,
+        countryCode: 'South Lake Tahoe, CA, USA',
+        referrer: 'https://example.com'
+      })
+      expect(
+        await resolver.visitorUpdateForCurrentUser(ability, 'userId', input)
+      ).toEqual({
+        ...visitorWithUser,
+        countryCode: 'South Lake Tahoe, CA, USA',
+        referrer: 'https://example.com'
+      })
+      expect(prismaService.visitor.update).toHaveBeenCalledWith({
+        where: { id: 'visitorId' },
+        data: {
+          countryCode: 'South Lake Tahoe, CA, USA',
+          referrer: 'https://example.com'
+        }
+      })
+    })
+    it('throws error if not found', async () => {
+      prismaService.visitor.findFirst.mockResolvedValueOnce(null)
+      await expect(
+        resolver.visitorUpdateForCurrentUser(ability, 'userId', input)
+      ).rejects.toThrow('visitor with userId "userId" not found')
+    })
+    it('throws error if not authorized', async () => {
+      prismaService.visitor.findFirst.mockResolvedValueOnce(visitor)
+      await expect(
+        resolver.visitorUpdateForCurrentUser(ability, 'userId', input)
+      ).rejects.toThrow('user is not allowed to update visitor')
     })
   })
 
   describe('events', () => {
+    const event: Event = {
+      id: 'eventId',
+      typename: 'event',
+      visitorId: 'visitorId',
+      journeyId: null,
+      blockId: null,
+      stepId: null,
+      label: null,
+      value: null,
+      action: null,
+      actionValue: null,
+      messagePlatform: null,
+      languageId: null,
+      radioOptionBlockId: null,
+      email: null,
+      nextStepId: null,
+      position: null,
+      source: null,
+      progress: null,
+      userId: null,
+      journeyVisitorJourneyId: null,
+      journeyVisitorVisitorId: null,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }
     it('returns visitor events', async () => {
-      expect(await resolver.events({ id: 'visitorId' })).toEqual([event])
-    })
-
-    it('calls event service with visitorId', async () => {
-      await resolver.events({ id: 'visitorId' })
-      expect(prismaService.event.findMany).toHaveBeenCalledWith({
-        where: { visitorId: 'visitorId' }
-      })
+      prismaService.event.findMany.mockResolvedValueOnce([event])
+      expect(await resolver.events({ id: 'visitorId' })).toEqual([
+        { ...event, typename: undefined, __typename: 'event' }
+      ])
     })
   })
 
@@ -225,31 +266,6 @@ describe('VisitorResolver', () => {
         device: { model: 'iPhone', type: 'mobile', vendor: 'Apple' },
         os: { name: 'iOS', version: '5.1.1' }
       })
-    })
-  })
-
-  describe('visitorUpdateForCurrentUser', () => {
-    it('returns updated visitor', async () => {
-      prismaService.visitor.findFirst = jest.fn().mockReturnValueOnce(visitor)
-      prismaService.visitor.update = jest.fn().mockReturnValueOnce({
-        ...visitor,
-        countryCode: 'South Lake Tahoe, CA, USA'
-      })
-      expect(
-        await resolver.visitorUpdateForCurrentUser('userId', {
-          countryCode: 'South Lake Tahoe, CA, USA'
-        })
-      ).toEqual({ ...visitor, countryCode: 'South Lake Tahoe, CA, USA' })
-    })
-
-    it('throws error when invalid visitor ID', async () => {
-      prismaService.visitor.findFirst = jest.fn().mockReturnValueOnce(null)
-      await expect(
-        async () =>
-          await resolver.visitorUpdateForCurrentUser('unknownVisitorId', {
-            countryCode: 'South Lake Tahoe, CA, USA'
-          })
-      ).rejects.toThrow('No visitor record found for user "unknownVisitorId"')
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/visitor/visitor.service.ts
+++ b/apps/api-journeys/src/app/modules/visitor/visitor.service.ts
@@ -1,15 +1,13 @@
 import { Injectable } from '@nestjs/common'
 import { v4 as uuidv4 } from 'uuid'
-import { Visitor, JourneyVisitor } from '.prisma/api-journeys-client'
+import { Visitor, JourneyVisitor, Prisma } from '.prisma/api-journeys-client'
 import { PageInfo } from '../../__generated__/graphql'
 import { PrismaService } from '../../lib/prisma.service'
 
 interface ListParams {
   after?: string | null
   first: number
-  filter: {
-    teamId: string | undefined
-  }
+  filter: Prisma.VisitorWhereInput
   sortOrder?: 'ASC' | 'DESC'
 }
 


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7aab2c1</samp>

This pull request implements role-based access control for the visitor and journey visitor resources, using the casl module and the core nest common library. It also fixes some issues in the schema.prisma file and the prisma types, and adds tests for the authorization and resolver logic.

- visitor report should work
- journey visitor report should work