### PR TITLE
feat: datadog aurora agent

### DIFF
--- a/apps/api-journeys/infrastructure/outputs.tf
+++ b/apps/api-journeys/infrastructure/outputs.tf
@@ -1,0 +1,3 @@
+output "database" {
+  value = module.database
+}

--- a/apps/api-languages/infrastructure/outputs.tf
+++ b/apps/api-languages/infrastructure/outputs.tf
@@ -1,0 +1,3 @@
+output "database" {
+  value = module.database
+}

--- a/apps/api-media/infrastructure/outputs.tf
+++ b/apps/api-media/infrastructure/outputs.tf
@@ -1,0 +1,3 @@
+output "database" {
+  value = module.database
+}

--- a/apps/api-tags/infrastructure/outputs.tf
+++ b/apps/api-tags/infrastructure/outputs.tf
@@ -1,0 +1,3 @@
+output "database" {
+  value = module.database
+}

--- a/apps/api-users/infrastructure/outputs.tf
+++ b/apps/api-users/infrastructure/outputs.tf
@@ -1,0 +1,3 @@
+output "database" {
+  value = module.database
+}

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -132,38 +132,38 @@ module "datadog_aurora" {
   subnet_id          = module.prod.vpc.public_subnets[0]
   security_group_ids = [module.prod.private_rds_security_group_id]
   rds_instances = [{
-    host     = module.api-journeys.database.aws_rds_cluster.endpoint
-    port     = module.api-journeys.database.aws_rds_cluster.port
-    username = module.api-journeys.database.aws_rds_cluster.master_username
-    password = module.api-journeys.database.random_password.result
-    db_name  = module.api-journeys.database.aws_rds_cluster.database_name
+    host             = module.api-journeys.database.aws_rds_cluster.endpoint
+    port             = module.api-journeys.database.aws_rds_cluster.port
+    username         = module.api-journeys.database.aws_rds_cluster.master_username
+    password         = module.api-journeys.database.random_password.result
+    db_instance_name = module.api-journeys.database.aws_rds_cluster.id
     },
     {
-      host     = module.api-tags.database.aws_rds_cluster.endpoint
-      port     = module.api-tags.database.aws_rds_cluster.port
-      username = module.api-tags.database.aws_rds_cluster.master_username
-      password = module.api-tags.database.random_password.result
-      db_name  = module.api-tags.database.aws_rds_cluster.database_name
+      host             = module.api-tags.database.aws_rds_cluster.endpoint
+      port             = module.api-tags.database.aws_rds_cluster.port
+      username         = module.api-tags.database.aws_rds_cluster.master_username
+      password         = module.api-tags.database.random_password.result
+      db_instance_name = module.api-tags.database.aws_rds_cluster.id
     },
     {
-      host     = module.api-users.database.aws_rds_cluster.endpoint
-      port     = module.api-users.database.aws_rds_cluster.port
-      username = module.api-users.database.aws_rds_cluster.master_username
-      password = module.api-users.database.random_password.result
-      db_name  = module.api-users.database.aws_rds_cluster.database_name
+      host             = module.api-users.database.aws_rds_cluster.endpoint
+      port             = module.api-users.database.aws_rds_cluster.port
+      username         = module.api-users.database.aws_rds_cluster.master_username
+      password         = module.api-users.database.random_password.result
+      db_instance_name = module.api-users.database.aws_rds_cluster.id
     },
     {
-      host     = module.api-media.database.aws_rds_cluster.endpoint
-      port     = module.api-media.database.aws_rds_cluster.port
-      username = module.api-media.database.aws_rds_cluster.master_username
-      password = module.api-media.database.random_password.result
-      db_name  = module.api-media.database.aws_rds_cluster.database_name
+      host             = module.api-media.database.aws_rds_cluster.endpoint
+      port             = module.api-media.database.aws_rds_cluster.port
+      username         = module.api-media.database.aws_rds_cluster.master_username
+      password         = module.api-media.database.random_password.result
+      db_instance_name = module.api-media.database.aws_rds_cluster.id
     },
     {
-      host     = module.api-languages.database.aws_rds_cluster.endpoint
-      port     = module.api-languages.database.aws_rds_cluster.port
-      username = module.api-languages.database.aws_rds_cluster.master_username
-      password = module.api-languages.database.random_password.result
-      db_name  = module.api-languages.database.aws_rds_cluster.database_name
+      host             = module.api-languages.database.aws_rds_cluster.endpoint
+      port             = module.api-languages.database.aws_rds_cluster.port
+      username         = module.api-languages.database.aws_rds_cluster.master_username
+      password         = module.api-languages.database.random_password.result
+      db_instance_name = module.api-languages.database.aws_rds_cluster.id
   }]
 }

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -124,3 +124,46 @@ module "cloudflared" {
   security_group_ids = [module.prod.public_bastion_security_group_id]
   cloudflared_token  = data.aws_ssm_parameter.cloudflared_prod_token.value
 }
+
+module "datadog_aurora" {
+  source             = "../../modules/aws/ec2-dd-agent-aurora"
+  name               = "dd-aurora"
+  env                = "prod"
+  subnet_id          = module.prod.vpc.public_subnets[0]
+  security_group_ids = [module.prod.private_rds_security_group_id]
+  rds_instances = [{
+    host     = module.api-journeys.database.aws_rds_cluster.endpoint
+    port     = module.api-journeys.database.aws_rds_cluster.port
+    username = module.api-journeys.database.aws_rds_cluster.master_username
+    password = module.api-journeys.database.random_password.result
+    db_name  = module.api-journeys.database.aws_rds_cluster.database_name
+    },
+    {
+      host     = module.api-tags.database.aws_rds_cluster.endpoint
+      port     = module.api-tags.database.aws_rds_cluster.port
+      username = module.api-tags.database.aws_rds_cluster.master_username
+      password = module.api-tags.database.random_password.result
+      db_name  = module.api-tags.database.aws_rds_cluster.database_name
+    },
+    {
+      host     = module.api-users.database.aws_rds_cluster.endpoint
+      port     = module.api-users.database.aws_rds_cluster.port
+      username = module.api-users.database.aws_rds_cluster.master_username
+      password = module.api-users.database.random_password.result
+      db_name  = module.api-users.database.aws_rds_cluster.database_name
+    },
+    {
+      host     = module.api-media.database.aws_rds_cluster.endpoint
+      port     = module.api-media.database.aws_rds_cluster.port
+      username = module.api-media.database.aws_rds_cluster.master_username
+      password = module.api-media.database.random_password.result
+      db_name  = module.api-media.database.aws_rds_cluster.database_name
+    },
+    {
+      host     = module.api-languages.database.aws_rds_cluster.endpoint
+      port     = module.api-languages.database.aws_rds_cluster.port
+      username = module.api-languages.database.aws_rds_cluster.master_username
+      password = module.api-languages.database.random_password.result
+      db_name  = module.api-languages.database.aws_rds_cluster.database_name
+  }]
+}

--- a/infrastructure/environments/stage/main.tf
+++ b/infrastructure/environments/stage/main.tf
@@ -152,3 +152,45 @@ module "cloudflared" {
   cloudflared_token  = data.aws_ssm_parameter.cloudflared_stage_token.value
 }
 
+module "datadog_aurora" {
+  source             = "../../modules/aws/ec2-dd-agent-aurora"
+  name               = "dd-aurora"
+  env                = "stage"
+  subnet_id          = module.stage.vpc.public_subnets[0]
+  security_group_ids = [module.stage.private_rds_security_group_id]
+  rds_instances = [{
+    host             = module.api-journeys.database.aws_rds_cluster.endpoint
+    port             = module.api-journeys.database.aws_rds_cluster.port
+    username         = module.api-journeys.database.aws_rds_cluster.master_username
+    password         = module.api-journeys.database.random_password.result
+    db_instance_name = module.api-journeys.database.aws_rds_cluster.id
+    },
+    {
+      host             = module.api-tags.database.aws_rds_cluster.endpoint
+      port             = module.api-tags.database.aws_rds_cluster.port
+      username         = module.api-tags.database.aws_rds_cluster.master_username
+      password         = module.api-tags.database.random_password.result
+      db_instance_name = module.api-tags.database.aws_rds_cluster.id
+    },
+    {
+      host             = module.api-users.database.aws_rds_cluster.endpoint
+      port             = module.api-users.database.aws_rds_cluster.port
+      username         = module.api-users.database.aws_rds_cluster.master_username
+      password         = module.api-users.database.random_password.result
+      db_instance_name = module.api-users.database.aws_rds_cluster.id
+    },
+    {
+      host             = module.api-media.database.aws_rds_cluster.endpoint
+      port             = module.api-media.database.aws_rds_cluster.port
+      username         = module.api-media.database.aws_rds_cluster.master_username
+      password         = module.api-media.database.random_password.result
+      db_instance_name = module.api-media.database.aws_rds_cluster.id
+    },
+    {
+      host             = module.api-languages.database.aws_rds_cluster.endpoint
+      port             = module.api-languages.database.aws_rds_cluster.port
+      username         = module.api-languages.database.aws_rds_cluster.master_username
+      password         = module.api-languages.database.random_password.result
+      db_instance_name = module.api-languages.database.aws_rds_cluster.id
+  }]
+}

--- a/infrastructure/modules/aws/aurora/outputs.tf
+++ b/infrastructure/modules/aws/aurora/outputs.tf
@@ -1,0 +1,7 @@
+output "aws_rds_cluster" {
+  value = aws_rds_cluster.default
+}
+
+output "random_password" {
+  value = random_password.password
+}

--- a/infrastructure/modules/aws/ec2-dd-agent-aurora/data.tf
+++ b/infrastructure/modules/aws/ec2-dd-agent-aurora/data.tf
@@ -1,0 +1,3 @@
+data "aws_ssm_parameter" "datadog_api_key" {
+  name = "/terraform/prd/DATADOG_API_KEY"
+}

--- a/infrastructure/modules/aws/ec2-dd-agent-aurora/main.tf
+++ b/infrastructure/modules/aws/ec2-dd-agent-aurora/main.tf
@@ -13,9 +13,9 @@ resource "aws_instance" "datadog_aurora" {
     port: ${v.port}
     username: ${v.username}
     password: ${v.password}
-    dbname: ${v.db_name}
+    dbname: ${var.env}
     tags:
-      - 'dbinstanceidentifier:${v.db_name}'
+      - 'dbinstanceidentifier:${v.db_instance_name}'
 %{endfor~}
 EOT
   })

--- a/infrastructure/modules/aws/ec2-dd-agent-aurora/main.tf
+++ b/infrastructure/modules/aws/ec2-dd-agent-aurora/main.tf
@@ -1,0 +1,28 @@
+resource "aws_instance" "datadog_aurora" {
+  ami                         = "ami-02af4904e34687a9e"
+  instance_type               = "t2.micro"
+  associate_public_ip_address = true
+  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = var.security_group_ids
+  user_data_replace_on_change = true
+  user_data = templatefile("${path.module}/startup.sh", {
+    datadog_api_key    = data.aws_ssm_parameter.datadog_api_key.value
+    postgres_instances = <<EOT
+%{for v in var.rds_instances~}
+  - host: ${v.host}
+    port: ${v.port}
+    username: ${v.username}
+    password: ${v.password}
+    dbname: ${v.db_name}
+    tags:
+      - 'dbinstanceidentifier:${v.db_name}'
+%{endfor~}
+EOT
+  })
+  private_dns_name_options {
+    hostname_type = "resource-name"
+  }
+  tags = {
+    Name = "${var.name}-${var.env}"
+  }
+}

--- a/infrastructure/modules/aws/ec2-dd-agent-aurora/startup.sh
+++ b/infrastructure/modules/aws/ec2-dd-agent-aurora/startup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# install curl
+apt-get update && apt-get install -y curl sudo
+
+# install datadog agent
+DD_INSTALL_ONLY=true DD_API_KEY="${datadog_api_key}" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
+
+# add dd-agent to systemd-journal group
+usermod -a -G systemd-journal dd-agent
+
+# update datadog config
+sudo -u dd-agent cat <<EOF > /etc/datadog-agent/datadog.yaml
+api_key: ${datadog_api_key}
+logs_enabled: true
+inventories_configuration_enabled: true
+process_config:
+  process_collection:
+    enabled: true
+EOF
+
+sudo -u dd-agent cat <<EOF > /etc/datadog-agent/conf.d/postgres.yaml
+init_config:
+
+instances:
+${postgres_instances}  
+EOF
+
+# start data dog agent
+service datadog-agent start
+

--- a/infrastructure/modules/aws/ec2-dd-agent-aurora/variables.tf
+++ b/infrastructure/modules/aws/ec2-dd-agent-aurora/variables.tf
@@ -16,10 +16,10 @@ variable "env" {
 
 variable "rds_instances" {
   type = list(object({
-    host     = string
-    port     = number
-    username = string
-    password = string
-    db_name  = string
+    host             = string
+    port             = number
+    username         = string
+    password         = string
+    db_instance_name = string
   }))
 }

--- a/infrastructure/modules/aws/ec2-dd-agent-aurora/variables.tf
+++ b/infrastructure/modules/aws/ec2-dd-agent-aurora/variables.tf
@@ -1,0 +1,25 @@
+variable "subnet_id" {
+  type = string
+}
+
+variable "security_group_ids" {
+  type = list(string)
+}
+
+variable "name" {
+  type = string
+}
+
+variable "env" {
+  type = string
+}
+
+variable "rds_instances" {
+  type = list(object({
+    host     = string
+    port     = number
+    username = string
+    password = string
+    db_name  = string
+  }))
+}


### PR DESCRIPTION
# Description

View available at: https://app.datadoghq.com/dash/integration/62/aws-rds

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 03814cc</samp>

This pull request adds outputs for the database modules and a new module for deploying an EC2 instance with a Datadog agent that monitors the Aurora clusters in the prod and stage environments. The outputs allow other modules or environments to access the database attributes. The EC2 Datadog agent module uses a template file and a data source to configure the agent with the API key and the Postgres instances to monitor.

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] visit https://app.datadoghq.com/dash/integration/62/aws-rds

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 03814cc</samp>

*  Add outputs for the database modules in the api-journeys, api-languages, api-media, api-tags, and api-users apps to expose the module attributes to other modules or environments ([link](https://github.com/JesusFilm/core/pull/1733/files?diff=unified&w=0#diff-c6ea5de7d737f0007d0884eb36d7d454b540365408a628ddef0a75d5938afb19R1-R3), [link](https://github.com/JesusFilm/core/pull/1733/files?diff=unified&w=0#diff-72bd74f49d55f6633b4017173dabaeabd3b0d62fcee66ceb1b210f5cfc107396R1-R3), [link](https://github.com/JesusFilm/core/pull/1733/files?diff=unified&w=0#diff-80243bfb3d4df0425e951a46fe7743f58e420aeda3ad1d7500627da138979a14R1-R3), [link](https://github.com/JesusFilm/core/pull/1733/files?diff=unified&w=0#diff-b67f42465887d7ead8c8021df0daa814bfe83fcf2729f514f99697959ec42be9R1-R3), [link](https://github.com/JesusFilm/core/pull/1733/files?diff=unified&w=0#diff-9e0977090c847cbe6c7ed76abfdc1a3f121b607044bd153e809b56a4bd2b5db7R1-R3))
*  Add modules for deploying EC2 instances with Datadog agents that monitor the Aurora clusters for the different apps in the prod and stage environments ([link](https://github.com/JesusFilm/core/pull/1733/files?diff=unified&w=0#diff-9ca20189fcff1e8339a2408bdaaf186a63438e1173cfc7ba6a8289ef66bcb6deR127-R169), [link](https://github.com/JesusFilm/core/pull/1733/files?diff=unified&w=0#diff-16ccc6a5a02661c2618449c5bf7dece8b8a3e7bca8720cd6a074efe098ae6ca8R155-R196))
*  Add outputs for the Aurora module that creates the RDS clusters for the apps to expose the aws_rds_cluster and random_password resources ([link](https://github.com/JesusFilm/core/pull/1733/files?diff=unified&w=0#diff-cf2f9fb1d7b4a9bd8609b77ab6eb93fc3360151740ec7d2e580f32088bfb3043R1-R7))
*  Add a data source for fetching the Datadog API key from the AWS SSM parameter store in the `ec2-dd-agent-aurora` module ([link](https://github.com/JesusFilm/core/pull/1733/files?diff=unified&w=0#diff-a1dfaf67db7eeab02873f4466d4045810eaef1f4cce092d39aecdc2ad9449ac2R1-R3))
*  Add the main Terraform configuration for the `ec2-dd-agent-aurora` module that creates an AWS instance resource with the specified AMI, instance type, subnet, security group, and user data ([link](https://github.com/JesusFilm/core/pull/1733/files?diff=unified&w=0#diff-49617f4123c1560e725bd0b69f32622c9c098a0993f9828e14147560f31a2870R1-R28))
*  Add the `startup.sh` template file for the `ec2-dd-agent-aurora` module that contains a bash script that installs and configures the Datadog agent with the API key and the Postgres instances ([link](https://github.com/JesusFilm/core/pull/1733/files?diff=unified&w=0#diff-64c5a2df253d548de11ecb8b53765c91b5aa9fb324bb15dff474ead7ca19de2eR1-R31))
*  Add the `variables.tf` file for the `ec2-dd-agent-aurora` module that defines the input variables for the module, such as the subnet id, security group ids, name, env, and rds instances ([link](https://github.com/JesusFilm/core/pull/1733/files?diff=unified&w=0#diff-635ddaa3a32f8f573c6e9cacc268673c72acd9df8225d3c6e93abe5be86d8952R1-R25))
