### PR TITLE
fix: request access screen

### DIFF
--- a/apps/journeys-admin/pages/journeys/[journeyId].tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId].tsx
@@ -73,7 +73,7 @@ function JourneyIdPage(): ReactElement {
         </>
       )}
       {error?.graphQLErrors[0].message ===
-        'User has not received an invitation to edit this journey.' && (
+        'user is not allowed to view journey' && (
         <>
           <NextSeo title={t('Access Denied')} />
           <JourneyInvite journeyId={router.query.journeyId as string} />

--- a/apps/journeys-admin/pages/journeys/[journeyId].tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId].tsx
@@ -79,15 +79,6 @@ function JourneyIdPage(): ReactElement {
           <JourneyInvite journeyId={router.query.journeyId as string} />
         </>
       )}
-      {error?.graphQLErrors[0].message === 'User invitation pending.' && (
-        <>
-          <NextSeo title={t('Access Denied')} />
-          <JourneyInvite
-            journeyId={router.query.journeyId as string}
-            requestReceived
-          />
-        </>
-      )}
     </>
   )
 }

--- a/apps/journeys-admin/src/components/JourneyInvite/JourneyInvite.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyInvite/JourneyInvite.spec.tsx
@@ -33,14 +33,4 @@ describe('JourneyInvite', () => {
     fireEvent.click(getAllByRole('button', { name: 'Request Now' })[0])
     await waitFor(() => expect(getAllByText('Request Sent')).toHaveLength(2))
   })
-
-  it('should render invite request received', () => {
-    const { getAllByText, queryAllByRole } = render(
-      <MockedProvider mocks={[]}>
-        <JourneyInvite journeyId="journeyId" />
-      </MockedProvider>
-    )
-    expect(queryAllByRole('button', { name: 'Request Access' })).toHaveLength(0)
-    expect(getAllByText('Request Sent')).toHaveLength(2)
-  })
 })

--- a/apps/journeys-admin/src/components/JourneyInvite/JourneyInvite.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyInvite/JourneyInvite.spec.tsx
@@ -37,7 +37,7 @@ describe('JourneyInvite', () => {
   it('should render invite request received', () => {
     const { getAllByText, queryAllByRole } = render(
       <MockedProvider mocks={[]}>
-        <JourneyInvite journeyId="journeyId" requestReceived />
+        <JourneyInvite journeyId="journeyId" />
       </MockedProvider>
     )
     expect(queryAllByRole('button', { name: 'Request Access' })).toHaveLength(0)

--- a/apps/journeys-admin/src/components/JourneyInvite/JourneyInvite.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyInvite/JourneyInvite.stories.tsx
@@ -42,10 +42,4 @@ Default.args = {
   journeyId: 'journeyId'
 }
 
-export const Sent = Template.bind({})
-Sent.args = {
-  journeyId: 'journeyId',
-  requestReceived: true
-}
-
 export default Demo as Meta

--- a/apps/journeys-admin/src/components/JourneyInvite/JourneyInvite.tsx
+++ b/apps/journeys-admin/src/components/JourneyInvite/JourneyInvite.tsx
@@ -13,18 +13,12 @@ export const USER_JOURNEY_REQUEST = gql`
 
 export interface JourneyInviteProps {
   journeyId: string
-  requestReceived?: boolean
 }
 
-export function JourneyInvite({
-  journeyId,
-  requestReceived: initialRequestReceived
-}: JourneyInviteProps): ReactElement {
+export function JourneyInvite({ journeyId }: JourneyInviteProps): ReactElement {
   const [userJourneyRequest] =
     useMutation<UserJourneyRequest>(USER_JOURNEY_REQUEST)
-  const [requestReceived, setRequestReceived] = useState(
-    Boolean(initialRequestReceived)
-  )
+  const [requestReceived, setRequestReceived] = useState(false)
 
   const handleClick = async (): Promise<void> => {
     await userJourneyRequest({


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 13a2665</samp>

Simplified the journey invitation feature in the journeys-admin app. Removed `requestReceived` from `JourneyInvite` component and `JourneyInvite` code from `[journeyId].tsx` page.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/33281894/todos/6393269270)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Visiting a page with you don't have access to should show the button to request access
- [ ] Should **no longer** show if you have already requested access to the journey

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 13a2665</samp>

*  Removed conditional rendering and state for pending invitations to journeys ([link](https://github.com/JesusFilm/core/pull/1738/files?diff=unified&w=0#diff-3873b898541aff5b78e0bc4aba59192c3d0e767d86c2e57185f5c88dd3f02063L82-L90), [link](https://github.com/JesusFilm/core/pull/1738/files?diff=unified&w=0#diff-23e73f854cb193e8b55ea12c3a04077dc7930d4322ca18fdd4ef32eae0b79f77L16-R21))
* Updated error message for unauthorized access to a journey ([link](https://github.com/JesusFilm/core/pull/1738/files?diff=unified&w=0#diff-3873b898541aff5b78e0bc4aba59192c3d0e767d86c2e57185f5c88dd3f02063L76-R76))
