### PR TITLE
fix: add loading to videoblockeditorposterlibrary

### DIFF
--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Library/VideoBlockEditorSettingsPosterLibrary.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Library/VideoBlockEditorSettingsPosterLibrary.tsx
@@ -230,6 +230,7 @@ export function VideoBlockEditorSettingsPosterLibrary({
       onClose={onClose}
       onChange={handleChange}
       onDelete={deleteCoverBlock}
+      loading={createLoading || updateLoading}
       selectedBlock={selectedBlock}
       error={createError != null ?? updateError != null}
     />


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6f27118</samp>

Added loading indicator for poster image selection in video block editor. This improves the user feedback and experience when creating or updating a video block with a custom poster image.

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/33281894/todos/6385169132)

# How should this PR be QA Tested?

Checked that loading icon appeared when uploading a background image 

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6f27118</samp>

*  Add `loading` prop to `ImageLibrary` component to show loading indicator while poster image is being created or updated ([link](https://github.com/JesusFilm/core/pull/1739/files?diff=unified&w=0#diff-67bb64174c7324e212c1ea7033becff02802c6be9d9f37d42695a6f571790a0dR233))
