### PR TITLE
fix: dynamic load language dialog

### DIFF
--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.spec.tsx
@@ -363,7 +363,7 @@ describe('JourneyView/Menu', () => {
     expect(menu).not.toHaveAttribute('aria-expanded')
   })
 
-  it('should handle edit journey language', () => {
+  it('should handle edit journey language', async () => {
     const { getByRole, getByText } = render(
       <SnackbarProvider>
         <MockedProvider mocks={[]}>
@@ -377,7 +377,7 @@ describe('JourneyView/Menu', () => {
     const menu = getByRole('button')
     fireEvent.click(menu)
     fireEvent.click(getByRole('menuitem', { name: 'Language' }))
-    expect(getByRole('dialog')).toBeInTheDocument()
+    await waitFor(() => expect(getByRole('dialog')).toBeInTheDocument())
     expect(getByText('Edit Language')).toBeInTheDocument()
     expect(menu).not.toHaveAttribute('aria-expanded')
   })

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
@@ -38,7 +38,7 @@ const DynamicLanguageDialog = dynamic<{
 }>(
   async () =>
     await import(
-      /* webpackChunkName: "LanguageDialog" */
+      /* webpackChunkName: "MenuLanguageDialog" */
       './LanguageDialog'
     ).then((mod) => mod.LanguageDialog)
 )

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
@@ -17,6 +17,7 @@ import NextLink from 'next/link'
 import { useSnackbar } from 'notistack'
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import { useRouter } from 'next/router'
+import dynamic from 'next/dynamic'
 import {
   JourneyStatus,
   Role,
@@ -29,8 +30,15 @@ import { TitleDescriptionDialog } from '../TitleDescription/TitleDescriptionDial
 import { useJourneyDuplicate } from '../../../libs/useJourneyDuplicate'
 import { DescriptionDialog } from './DescriptionDialog'
 import { TitleDialog } from './TitleDialog'
-import { LanguageDialog } from './LanguageDialog'
 import { CreateTemplateMenuItem } from './CreateTemplateMenuItem'
+
+const DynamicLanguageDialog = dynamic(
+  async () =>
+    await import(
+      /* webpackChunkName: "LanguageDialog" */
+      './LanguageDialog'
+    ).then((mod) => mod.LanguageDialog)
+)
 
 export const JOURNEY_PUBLISH = gql`
   mutation JourneyPublish($id: ID!) {
@@ -271,7 +279,7 @@ export function Menu(): ReactElement {
             open={showDescriptionDialog}
             onClose={() => setShowDescriptionDialog(false)}
           />
-          <LanguageDialog
+          <DynamicLanguageDialog
             open={showLanguageDialog}
             onClose={() => setShowLanguageDialog(false)}
           />

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
@@ -32,7 +32,10 @@ import { DescriptionDialog } from './DescriptionDialog'
 import { TitleDialog } from './TitleDialog'
 import { CreateTemplateMenuItem } from './CreateTemplateMenuItem'
 
-const DynamicLanguageDialog = dynamic(
+const DynamicLanguageDialog = dynamic<{
+  open: boolean
+  onClose: () => void
+}>(
   async () =>
     await import(
       /* webpackChunkName: "LanguageDialog" */
@@ -279,10 +282,12 @@ export function Menu(): ReactElement {
             open={showDescriptionDialog}
             onClose={() => setShowDescriptionDialog(false)}
           />
-          <DynamicLanguageDialog
-            open={showLanguageDialog}
-            onClose={() => setShowLanguageDialog(false)}
-          />
+          {showLanguageDialog && (
+            <DynamicLanguageDialog
+              open={showLanguageDialog}
+              onClose={() => setShowLanguageDialog(false)}
+            />
+          )}
         </>
       ) : (
         <IconButton edge="end" disabled>

--- a/apps/journeys-admin/src/components/JourneyView/Properties/JourneyDetails/Language/Language.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Properties/JourneyDetails/Language/Language.spec.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, waitFor } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 import { SnackbarProvider } from 'notistack'
@@ -172,7 +172,7 @@ describe('Language', () => {
     expect(queryByText('(English)')).toBeNull()
   })
 
-  it('should render language and edit button', () => {
+  it('should render language and edit button', async () => {
     const { getByText, getByRole } = render(
       <MockedProvider>
         <SnackbarProvider>
@@ -209,6 +209,6 @@ describe('Language', () => {
     )
     expect(getByText('Belorussian')).toBeInTheDocument()
     fireEvent.click(getByRole('button'))
-    expect(getByText('Edit Language')).toBeInTheDocument()
+    await waitFor(() => expect(getByText('Edit Language')).toBeInTheDocument())
   })
 })

--- a/apps/journeys-admin/src/components/JourneyView/Properties/JourneyDetails/Language/Language.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Properties/JourneyDetails/Language/Language.tsx
@@ -6,7 +6,18 @@ import IconButton from '@mui/material/IconButton'
 import CreateRoundedIcon from '@mui/icons-material/CreateRounded'
 import Box from '@mui/material/Box'
 import { useTheme } from '@mui/material/styles'
-import { LanguageDialog } from '../../../Menu/LanguageDialog'
+import dynamic from 'next/dynamic'
+
+const DynamicLanguageDialog = dynamic<{
+  open: boolean
+  onClose: () => void
+}>(
+  async () =>
+    await import(
+      /* webpackChunkName: "PropertiesLanguageDialog" */
+      '../../../Menu/LanguageDialog'
+    ).then((mod) => mod.LanguageDialog)
+)
 
 interface LanguageProps {
   isPublisher?: boolean
@@ -61,10 +72,12 @@ export function Language({ isPublisher }: LanguageProps): ReactElement {
           </IconButton>
         )}
       </Box>
-      <LanguageDialog
-        open={showLanguageDialog}
-        onClose={() => setShowLanguageDialog(false)}
-      />
+      {showLanguageDialog && (
+        <DynamicLanguageDialog
+          open={showLanguageDialog}
+          onClose={() => setShowLanguageDialog(false)}
+        />
+      )}
     </>
   )
 }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1b345f0</samp>

Lazy-load `LanguageDialog` component in `Menu` component. This reduces the initial loading time and code size of the `Menu` component, which is used to manage the journey settings.

- Link to Basecamp Todo

# How should this PR be QA Tested?

- [ ] it should retain language dialog functionalities
- [ ] it should not fail any tests

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1b345f0</samp>

*  Dynamically import `LanguageDialog` component to improve performance and reduce bundle size ([link](https://github.com/JesusFilm/core/pull/1740/files?diff=unified&w=0#diff-2c9f44f9db6ec77ee7fdf06b593abfe7aab0fc14735b41b66094629ff25bc082R20), [link](https://github.com/JesusFilm/core/pull/1740/files?diff=unified&w=0#diff-2c9f44f9db6ec77ee7fdf06b593abfe7aab0fc14735b41b66094629ff25bc082L32-R42), [link](https://github.com/JesusFilm/core/pull/1740/files?diff=unified&w=0#diff-2c9f44f9db6ec77ee7fdf06b593abfe7aab0fc14735b41b66094629ff25bc082L274-R282))
