### PR TITLE
fix: add team prop to journey

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -661,6 +661,7 @@ type Journey
   seoDescription: String
   template: Boolean
   host: Host
+  team: Team
   userJourneys: [UserJourney!]
 }
 

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -234,6 +234,7 @@ type Journey
   seoDescription: String
   template: Boolean
   host: Host
+  team: Team
   userJourneys: [UserJourney!]
 }
 

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -747,6 +747,7 @@ export class Journey {
     seoDescription?: Nullable<string>;
     template?: Nullable<boolean>;
     host?: Nullable<Host>;
+    team?: Nullable<Team>;
     userJourneys?: Nullable<UserJourney[]>;
 }
 

--- a/apps/api-journeys/src/app/modules/journey/journey.graphql
+++ b/apps/api-journeys/src/app/modules/journey/journey.graphql
@@ -21,6 +21,7 @@ type Journey @key(fields: "id") {
   seoDescription: String
   template: Boolean
   host: Host
+  team: Team
 }
 
 enum IdType {

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -6,6 +6,7 @@ import {
   Prisma,
   UserTeamRole,
   Host,
+  Team,
   Block,
   UserJourney,
   ChatButton,
@@ -1479,6 +1480,26 @@ describe('JourneyResolver', () => {
     })
     it('returns null if no hostId', async () => {
       expect(await resolver.host(journey)).toEqual(null)
+    })
+  })
+
+  describe('team', () => {
+    it('returns team', async () => {
+      const team: Team = {
+        id: 'teamId',
+        title: 'My Cool Team',
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+      const journeyWithTeam = {
+        ...journeyWithUserTeam,
+        teamId: 'teamId'
+      }
+      prismaService.team.findUnique.mockResolvedValueOnce(team)
+      expect(await resolver.team(journeyWithTeam)).toEqual(team)
+      expect(prismaService.team.findUnique).toHaveBeenCalledWith({
+        where: { id: journeyWithTeam.teamId }
+      })
     })
   })
   describe('primaryImageBlock', () => {

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -733,6 +733,14 @@ export class JourneyResolver {
   }
 
   @ResolveField()
+  async team(@Parent() journey: Journey): Promise<Team | null> {
+    if (journey.teamId == null) return null
+    return await this.prismaService.team.findUnique({
+      where: { id: journey.teamId }
+    })
+  }
+
+  @ResolveField()
   async primaryImageBlock(@Parent() journey: Journey): Promise<Block | null> {
     if (journey.primaryImageBlockId == null) return null
     const block = await this.prismaService.block.findUnique({
@@ -747,14 +755,6 @@ export class JourneyResolver {
   async userJourneys(@Parent() journey: Journey): Promise<UserJourney[]> {
     return await this.prismaService.userJourney.findMany({
       where: { journeyId: journey.id }
-    })
-  }
-
-  @ResolveField()
-  async team(@Parent() journey: Journey): Promise<Team | null> {
-    if (journey.teamId == null) return null
-    return await this.prismaService.team.findUnique({
-      where: { id: journey.teamId }
     })
   }
 

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -22,7 +22,8 @@ import {
   Journey,
   UserJourney,
   UserJourneyRole,
-  Prisma
+  Prisma,
+  Team
 } from '.prisma/api-journeys-client'
 import { FromPostgresql } from '@core/nest/decorators/FromPostgresql'
 import isEmpty from 'lodash/isEmpty'
@@ -746,6 +747,14 @@ export class JourneyResolver {
   async userJourneys(@Parent() journey: Journey): Promise<UserJourney[]> {
     return await this.prismaService.userJourney.findMany({
       where: { journeyId: journey.id }
+    })
+  }
+
+  @ResolveField()
+  async team(@Parent() journey: Journey): Promise<Team | null> {
+    if (journey.teamId == null) return null
+    return await this.prismaService.team.findUnique({
+      where: { id: journey.teamId }
     })
   }
 


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7260696</samp>

Added `team` field to `Journey` type in `journey.graphql` to enable team collaboration on journeys. This is part of the core API team feature implementation.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/33034379/todos/6289496079#__recording_6389742078)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7260696</samp>

* Add a new field `team` to the `Journey` type to enable team collaboration on journeys ([link](https://github.com/JesusFilm/core/pull/1742/files?diff=unified&w=0#diff-5d25ebcb2d0b7fb3abd35ecaaf839372a6a9b86152fab8eea293c5eb974e5588R24))
