### PR TITLE
fix: removed default opened at

### DIFF
--- a/apps/api-journeys/db/migrations/20230728004724_20230728004722/migration.sql
+++ b/apps/api-journeys/db/migrations/20230728004724_20230728004722/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "UserJourney" ALTER COLUMN "openedAt" DROP DEFAULT;

--- a/apps/api-journeys/db/schema.prisma
+++ b/apps/api-journeys/db/schema.prisma
@@ -238,7 +238,7 @@ model UserJourney {
   updatedAt DateTime        @default(now()) @updatedAt
   journey   Journey         @relation(fields: [journeyId], references: [id], onDelete: Cascade)
   role      UserJourneyRole
-  openedAt  DateTime?       @default(now())
+  openedAt  DateTime?
 
   @@unique([journeyId, userId])
 }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7b11958</samp>

Remove database default for `openedAt` field in `UserJourney` model. This allows the API to control when a user journey is considered opened and improve engagement metrics.
