### PR TITLE
revert: "fix: get journey to be called in ssrprops"

### DIFF
--- a/apps/journeys-admin/pages/journeys/[journeyId].tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId].tsx
@@ -1,5 +1,5 @@
 import { ReactElement } from 'react'
-import { ApolloError, gql } from '@apollo/client'
+import { gql, useQuery } from '@apollo/client'
 import { JOURNEY_FIELDS } from '@core/journeys/ui/JourneyProvider/journeyFields'
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 import { useRouter } from 'next/router'
@@ -39,15 +39,13 @@ export const USER_JOURNEY_OPEN = gql`
   }
 `
 
-interface JourneyIdPageProps {
-  data?: GetJourney
-  error: ApolloError
-}
-
-function JourneyIdPage({ data, error }: JourneyIdPageProps): ReactElement {
+function JourneyIdPage(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   const router = useRouter()
   const AuthUser = useAuthUser()
+  const { data, error } = useQuery<GetJourney>(GET_JOURNEY, {
+    variables: { id: router.query.journeyId }
+  })
 
   useInvalidJourneyRedirect(data)
 
@@ -105,23 +103,14 @@ export const getServerSideProps = withAuthUserTokenSSR({
     })
   ])
 
-  const { data, error } = await apolloClient.query<GetJourney>({
-    query: GET_JOURNEY,
-    variables: {
-      id: query?.journeyId
-    }
-  })
-
   return {
     props: {
       flags,
-      data,
-      error: error ?? null,
       ...translations
     }
   }
 })
 
-export default withAuthUser<JourneyIdPageProps>({
+export default withAuthUser({
   whenUnauthedAfterInit: AuthAction.REDIRECT_TO_LOGIN
 })(JourneyIdPage)

--- a/apps/journeys-admin/pages/journeys/[journeyId]/edit.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/edit.tsx
@@ -1,4 +1,5 @@
 import { ReactElement } from 'react'
+import { useQuery } from '@apollo/client'
 import {
   AuthAction,
   useAuthUser,
@@ -24,15 +25,13 @@ import { UserJourneyOpen } from '../../../__generated__/UserJourneyOpen'
 import { initAndAuthApp } from '../../../src/libs/initAndAuthApp'
 import { AcceptAllInvites } from '../../../__generated__/AcceptAllInvites'
 
-interface JourneyEditPageProps {
-  data: GetJourney
-}
-
-function JourneyEditPage({ data }: JourneyEditPageProps): ReactElement {
+function JourneyEditPage(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   const router = useRouter()
   const AuthUser = useAuthUser()
-
+  const { data } = useQuery<GetJourney>(GET_JOURNEY, {
+    variables: { id: router.query.journeyId }
+  })
   useInvalidJourneyRedirect(data)
 
   return (
@@ -79,7 +78,6 @@ export const getServerSideProps = withAuthUserTokenSSR({
   })
 
   let journey: Journey | null
-  let result: GetJourney
   try {
     const { data } = await apolloClient.query<GetJourney>({
       query: GET_JOURNEY,
@@ -89,7 +87,6 @@ export const getServerSideProps = withAuthUserTokenSSR({
     })
 
     journey = data?.journey
-    result = data
   } catch (error) {
     return {
       redirect: {
@@ -116,12 +113,11 @@ export const getServerSideProps = withAuthUserTokenSSR({
   return {
     props: {
       flags,
-      data: result,
       ...translations
     }
   }
 })
 
-export default withAuthUser<JourneyEditPageProps>({
+export default withAuthUser({
   whenUnauthedAfterInit: AuthAction.REDIRECT_TO_LOGIN
 })(JourneyEditPage)


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0dd4b5a</samp>

This pull request refactors two components in the `journeys-admin` app to use client-side data fetching with the `useQuery` hook. This improves the code readability and maintainability by removing server-side logic and props from the `JourneyIdPage` and the `JourneyEditPage` components.

- Link to Basecamp Todo

# How should this PR be QA Tested?

- [ ] it should enable users to add cards/blocks again

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0dd4b5a</samp>

*  Remove server-side data fetching and props for journey pages and use `useQuery` hook instead ([link](https://github.com/JesusFilm/core/pull/1748/files?diff=unified&w=0#diff-3873b898541aff5b78e0bc4aba59192c3d0e767d86c2e57185f5c88dd3f02063L2-R2),[link](https://github.com/JesusFilm/core/pull/1748/files?diff=unified&w=0#diff-3873b898541aff5b78e0bc4aba59192c3d0e767d86c2e57185f5c88dd3f02063L42-R48),[link](https://github.com/JesusFilm/core/pull/1748/files?diff=unified&w=0#diff-3873b898541aff5b78e0bc4aba59192c3d0e767d86c2e57185f5c88dd3f02063L108-R108),[link](https://github.com/JesusFilm/core/pull/1748/files?diff=unified&w=0#diff-3873b898541aff5b78e0bc4aba59192c3d0e767d86c2e57185f5c88dd3f02063L125-R114),[link](https://github.com/JesusFilm/core/pull/1748/files?diff=unified&w=0#diff-ab2c99ee20aa6e4b571a26b0852c0ee8921667986f52a040fd694cad75003ba6R2),[link](https://github.com/JesusFilm/core/pull/1748/files?diff=unified&w=0#diff-ab2c99ee20aa6e4b571a26b0852c0ee8921667986f52a040fd694cad75003ba6L27-R34),[link](https://github.com/JesusFilm/core/pull/1748/files?diff=unified&w=0#diff-ab2c99ee20aa6e4b571a26b0852c0ee8921667986f52a040fd694cad75003ba6L82),[link](https://github.com/JesusFilm/core/pull/1748/files?diff=unified&w=0#diff-ab2c99ee20aa6e4b571a26b0852c0ee8921667986f52a040fd694cad75003ba6L92),[link](https://github.com/JesusFilm/core/pull/1748/files?diff=unified&w=0#diff-ab2c99ee20aa6e4b571a26b0852c0ee8921667986f52a040fd694cad75003ba6L119),[link](https://github.com/JesusFilm/core/pull/1748/files?diff=unified&w=0#diff-ab2c99ee20aa6e4b571a26b0852c0ee8921667986f52a040fd694cad75003ba6L125-R121))
