### PR TITLE
revert: ssr changes

### DIFF
--- a/apps/journeys-admin/pages/journeys/[journeyId].tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId].tsx
@@ -1,5 +1,5 @@
 import { ReactElement } from 'react'
-import { ApolloError, gql } from '@apollo/client'
+import { gql, useQuery } from '@apollo/client'
 import { JOURNEY_FIELDS } from '@core/journeys/ui/JourneyProvider/journeyFields'
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 import { useRouter } from 'next/router'
@@ -39,15 +39,13 @@ export const USER_JOURNEY_OPEN = gql`
   }
 `
 
-interface JourneyIdPageProps {
-  data?: GetJourney
-  error: ApolloError
-}
-
-function JourneyIdPage({ data, error }: JourneyIdPageProps): ReactElement {
+function JourneyIdPage(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   const router = useRouter()
   const AuthUser = useAuthUser()
+  const { data, error } = useQuery<GetJourney>(GET_JOURNEY, {
+    variables: { id: router.query.journeyId }
+  })
 
   useInvalidJourneyRedirect(data)
 
@@ -105,23 +103,14 @@ export const getServerSideProps = withAuthUserTokenSSR({
     })
   ])
 
-  const { data, error } = await apolloClient.query<GetJourney>({
-    query: GET_JOURNEY,
-    variables: {
-      id: query?.journeyId
-    }
-  })
-
   return {
     props: {
       flags,
-      data,
-      error: error ?? null,
       ...translations
     }
   }
 })
 
-export default withAuthUser<JourneyIdPageProps>({
+export default withAuthUser({
   whenUnauthedAfterInit: AuthAction.REDIRECT_TO_LOGIN
 })(JourneyIdPage)

--- a/apps/journeys-admin/pages/journeys/[journeyId]/edit.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/edit.tsx
@@ -1,4 +1,5 @@
 import { ReactElement } from 'react'
+import { useQuery } from '@apollo/client'
 import {
   AuthAction,
   useAuthUser,
@@ -24,15 +25,13 @@ import { UserJourneyOpen } from '../../../__generated__/UserJourneyOpen'
 import { initAndAuthApp } from '../../../src/libs/initAndAuthApp'
 import { AcceptAllInvites } from '../../../__generated__/AcceptAllInvites'
 
-interface JourneyEditPageProps {
-  data: GetJourney
-}
-
-function JourneyEditPage({ data }: JourneyEditPageProps): ReactElement {
+function JourneyEditPage(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   const router = useRouter()
   const AuthUser = useAuthUser()
-
+  const { data } = useQuery<GetJourney>(GET_JOURNEY, {
+    variables: { id: router.query.journeyId }
+  })
   useInvalidJourneyRedirect(data)
 
   return (
@@ -79,7 +78,6 @@ export const getServerSideProps = withAuthUserTokenSSR({
   })
 
   let journey: Journey | null
-  let result: GetJourney
   try {
     const { data } = await apolloClient.query<GetJourney>({
       query: GET_JOURNEY,
@@ -89,7 +87,6 @@ export const getServerSideProps = withAuthUserTokenSSR({
     })
 
     journey = data?.journey
-    result = data
   } catch (error) {
     return {
       redirect: {
@@ -116,12 +113,11 @@ export const getServerSideProps = withAuthUserTokenSSR({
   return {
     props: {
       flags,
-      data: result,
       ...translations
     }
   }
 })
 
-export default withAuthUser<JourneyEditPageProps>({
+export default withAuthUser({
   whenUnauthedAfterInit: AuthAction.REDIRECT_TO_LOGIN
 })(JourneyEditPage)


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7e0152a</samp>

Refactored the journey details and edit pages to use client-side data fetching with `useQuery`. This improves the performance and consistency of the pages and simplifies the code.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7e0152a</samp>

*  Move the query for the journey data from the server-side to the client-side, using the `useQuery` hook instead of the `apolloClient.query` method ([link](https://github.com/JesusFilm/core/pull/1749/files?diff=unified&w=0#diff-3873b898541aff5b78e0bc4aba59192c3d0e767d86c2e57185f5c88dd3f02063L2-R2), [link](https://github.com/JesusFilm/core/pull/1749/files?diff=unified&w=0#diff-3873b898541aff5b78e0bc4aba59192c3d0e767d86c2e57185f5c88dd3f02063L42-R48), [link](https://github.com/JesusFilm/core/pull/1749/files?diff=unified&w=0#diff-3873b898541aff5b78e0bc4aba59192c3d0e767d86c2e57185f5c88dd3f02063L108-R108), [link](https://github.com/JesusFilm/core/pull/1749/files?diff=unified&w=0#diff-ab2c99ee20aa6e4b571a26b0852c0ee8921667986f52a040fd694cad75003ba6R2), [link](https://github.com/JesusFilm/core/pull/1749/files?diff=unified&w=0#diff-ab2c99ee20aa6e4b571a26b0852c0ee8921667986f52a040fd694cad75003ba6L27-R34), [link](https://github.com/JesusFilm/core/pull/1749/files?diff=unified&w=0#diff-ab2c99ee20aa6e4b571a26b0852c0ee8921667986f52a040fd694cad75003ba6L82), [link](https://github.com/JesusFilm/core/pull/1749/files?diff=unified&w=0#diff-ab2c99ee20aa6e4b571a26b0852c0ee8921667986f52a040fd694cad75003ba6L92), [link](https://github.com/JesusFilm/core/pull/1749/files?diff=unified&w=0#diff-ab2c99ee20aa6e4b571a26b0852c0ee8921667986f52a040fd694cad75003ba6L119))
* Remove the generic type parameter for the `withAuthUser` higher-order component, as it no longer expects the `data` and `error` props from the server-side ([link](https://github.com/JesusFilm/core/pull/1749/files?diff=unified&w=0#diff-3873b898541aff5b78e0bc4aba59192c3d0e767d86c2e57185f5c88dd3f02063L125-R114), [link](https://github.com/JesusFilm/core/pull/1749/files?diff=unified&w=0#diff-ab2c99ee20aa6e4b571a26b0852c0ee8921667986f52a040fd694cad75003ba6L125-R121))
* Remove the `ApolloError` import, as it is no longer used ([link](https://github.com/JesusFilm/core/pull/1749/files?diff=unified&w=0#diff-3873b898541aff5b78e0bc4aba59192c3d0e767d86c2e57185f5c88dd3f02063L2-R2))
