### PR TITLE
fix: navigation on last card if nextBlockId

### DIFF
--- a/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.spec.tsx
+++ b/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.spec.tsx
@@ -122,6 +122,16 @@ describe('NavigationButton', () => {
 
       expect(getByTestId('conductorNextButton')).not.toBeVisible()
     })
+
+    it('should show right button if on last card but set to navigate to another card', () => {
+      treeBlocksVar([step1, step2, { ...step3, nextBlockId: step1.id }])
+      blockHistoryVar([step1, step2, { ...step3, nextBlockId: step1.id }])
+      const { getByTestId } = render(
+        <NavigationButton variant="next" alignment="right" />
+      )
+
+      expect(getByTestId('conductorNextButton')).toBeVisible()
+    })
   })
 
   describe('rtl', () => {
@@ -177,6 +187,16 @@ describe('NavigationButton', () => {
       )
 
       expect(getByTestId('conductorNextButton')).not.toBeVisible()
+    })
+
+    it('should show left button if on last card but set to navigate to another card', () => {
+      treeBlocksVar([step1, step2, { ...step3, nextBlockId: step1.id }])
+      blockHistoryVar([step1, step2, { ...step3, nextBlockId: step1.id }])
+      const { getByTestId } = render(
+        <NavigationButton variant="next" alignment="left" />
+      )
+
+      expect(getByTestId('conductorNextButton')).toBeVisible()
     })
   })
 })

--- a/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.spec.tsx
+++ b/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.spec.tsx
@@ -123,14 +123,18 @@ describe('NavigationButton', () => {
       expect(getByTestId('conductorNextButton')).not.toBeVisible()
     })
 
-    it('should show right button if on last card but set to navigate to another card', () => {
+    it('should show right button if on last card but set to navigate to another card', async () => {
       treeBlocksVar([step1, step2, { ...step3, nextBlockId: step1.id }])
       blockHistoryVar([step1, step2, { ...step3, nextBlockId: step1.id }])
       const { getByTestId } = render(
         <NavigationButton variant="next" alignment="right" />
       )
 
-      expect(getByTestId('conductorNextButton')).toBeVisible()
+      fireEvent.mouseOver(getByTestId('conductorNextButton'))
+
+      await waitFor(() => {
+        expect(getByTestId('conductorNextButton')).toBeVisible()
+      })
     })
   })
 
@@ -189,14 +193,18 @@ describe('NavigationButton', () => {
       expect(getByTestId('conductorNextButton')).not.toBeVisible()
     })
 
-    it('should show left button if on last card but set to navigate to another card', () => {
+    it('should show left button if on last card but set to navigate to another card', async () => {
       treeBlocksVar([step1, step2, { ...step3, nextBlockId: step1.id }])
       blockHistoryVar([step1, step2, { ...step3, nextBlockId: step1.id }])
       const { getByTestId } = render(
         <NavigationButton variant="next" alignment="left" />
       )
 
-      expect(getByTestId('conductorNextButton')).toBeVisible()
+      fireEvent.mouseOver(getByTestId('conductorNextButton'))
+
+      await waitFor(() => {
+        expect(getByTestId('conductorNextButton')).toBeVisible()
+      })
     })
   })
 })

--- a/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.tsx
+++ b/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.tsx
@@ -43,8 +43,8 @@ export function NavigationButton({
   const onFirstStep = activeBlock === treeBlocks[0]
   const onLastStep = activeBlock === last(treeBlocks)
   const navigateToAnotherBlock =
-    activeBlock.nextBlockId != null &&
-    activeBlock.nextBlockId !== activeBlock.id
+    activeBlock?.nextBlockId != null &&
+    activeBlock?.nextBlockId !== activeBlock.id
   const canNavigate =
     variant === 'prev'
       ? !onFirstStep

--- a/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.tsx
+++ b/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.tsx
@@ -42,7 +42,13 @@ export function NavigationButton({
 
   const onFirstStep = activeBlock === treeBlocks[0]
   const onLastStep = activeBlock === last(treeBlocks)
-  const canNavigate = variant === 'prev' ? !onFirstStep : !onLastStep
+  const navigateToAnotherBlock =
+    activeBlock.nextBlockId != null &&
+    activeBlock.nextBlockId !== activeBlock.id
+  const canNavigate =
+    variant === 'prev'
+      ? !onFirstStep
+      : !onLastStep || (onLastStep && navigateToAnotherBlock)
   const disabled = variant === 'next' && activeBlock?.locked
 
   // Handle fade navigation after 3 seconds inactive

--- a/libs/journeys/ui/src/components/Card/Card.tsx
+++ b/libs/journeys/ui/src/components/Card/Card.tsx
@@ -75,14 +75,14 @@ export function Card({
     if (rtl) {
       const divide = view.innerWidth * 0.66
       if (e.clientX <= divide) {
-        if (!activeBlock.locked) nextActiveBlock()
+        if (!activeBlock?.locked) nextActiveBlock()
       } else {
         prevActiveBlock()
       }
     } else {
       const divide = view.innerWidth * 0.33
       if (e.clientX >= divide) {
-        if (!activeBlock.locked) nextActiveBlock()
+        if (!activeBlock?.locked) nextActiveBlock()
       } else {
         prevActiveBlock()
       }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a198a9</samp>

Modified `NavigationButton` component and added tests to enable custom navigation logic for journey cards. This allows the journey author to specify which card to navigate to from any card, including the last one.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8a198a9</samp>

*  Enable navigation button on last card if block has custom next block id ([link](https://github.com/JesusFilm/core/pull/1754/files?diff=unified&w=0#diff-684ea1b2346c27f9252ea686988ffaa756a41f56bd7c62530441bfe2d034df3dL45-R51))
  * Add test cases for left and right buttons on last card with custom next block id ([link](https://github.com/JesusFilm/core/pull/1754/files?diff=unified&w=0#diff-3c3c31bf2041808306ffab49b753614c03f532376e6c0056aadb888efd19b2beR125-R134), [link](https://github.com/JesusFilm/core/pull/1754/files?diff=unified&w=0#diff-3c3c31bf2041808306ffab49b753614c03f532376e6c0056aadb888efd19b2beR191-R200))
