### PR TITLE
fix: ensure pr title is shorter than 100 characters otherwise fail to merge the pr

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -33,7 +33,9 @@ export default async () => {
   }
 
   // check PR has well-formed title
-  const commitlintReport = await lintPrTitle(danger.github.pr.title)
+  const commitlintReport = await lintPrTitle(
+    `${danger.github.pr.title} #(${danger.github.pr.number})`
+  )
   if (!commitlintReport.valid) {
     fail('Please ensure your PR title matches commitlint convention.')
     let errors = ''


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3b1d234</samp>

Improved PR title validation in `dangerfile.ts` by adding PR number automatically. This fixes a bug where PR titles without issue or PR references would fail the commitlint check.