### PR TITLE
fix: reorder optional params to end

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -1322,14 +1322,14 @@ type Query
 
   """Get a list of Visitor Information by Journey"""
   journeyVisitorsConnection(
+    """Returns the elements in the list that match the specified filter."""
+    filter: JourneyVisitorFilter!
+
     """
     Returns the visitor items related to a specific team.
     TODO: remove when teams is released
     """
     teamId: String
-
-    """Returns the elements in the list that match the specified filter."""
-    filter: JourneyVisitorFilter!
 
     """Returns the first n elements from the list."""
     first: Int

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -1706,14 +1706,14 @@ extend type Query {
 
   """Get a list of Visitor Information by Journey"""
   journeyVisitorsConnection(
+    """Returns the elements in the list that match the specified filter."""
+    filter: JourneyVisitorFilter!
+
     """
     Returns the visitor items related to a specific team.
     TODO: remove when teams is released
     """
     teamId: String
-
-    """Returns the elements in the list that match the specified filter."""
-    filter: JourneyVisitorFilter!
 
     """Returns the first n elements from the list."""
     first: Int

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -1119,7 +1119,7 @@ export abstract class IQuery {
 
     abstract getJourneyProfile(): Nullable<JourneyProfile> | Promise<Nullable<JourneyProfile>>;
 
-    abstract journeyVisitorsConnection(teamId: string, filter: JourneyVisitorFilter, first?: Nullable<number>, after?: Nullable<string>, sort?: Nullable<JourneyVisitorSort>): JourneyVisitorsConnection | Promise<JourneyVisitorsConnection>;
+    abstract journeyVisitorsConnection(filter: JourneyVisitorFilter, teamId?: Nullable<string>, first?: Nullable<number>, after?: Nullable<string>, sort?: Nullable<JourneyVisitorSort>): JourneyVisitorsConnection | Promise<JourneyVisitorsConnection>;
 
     abstract journeyVisitorCount(filter: JourneyVisitorFilter): number | Promise<number>;
 
@@ -1137,7 +1137,7 @@ export abstract class IQuery {
 
     abstract userTeamInvites(teamId: string): UserTeamInvite[] | Promise<UserTeamInvite[]>;
 
-    abstract visitorsConnection(teamId: string, first?: Nullable<number>, after?: Nullable<string>): VisitorsConnection | Promise<VisitorsConnection>;
+    abstract visitorsConnection(teamId?: Nullable<string>, first?: Nullable<number>, after?: Nullable<string>): VisitorsConnection | Promise<VisitorsConnection>;
 
     abstract visitor(id: string): Visitor | Promise<Visitor>;
 }

--- a/apps/api-journeys/src/app/modules/journeyVisitor/journeyVisitor.graphql
+++ b/apps/api-journeys/src/app/modules/journeyVisitor/journeyVisitor.graphql
@@ -112,14 +112,14 @@ extend type Query {
   """
   journeyVisitorsConnection(
     """
+    Returns the elements in the list that match the specified filter.
+    """
+    filter: JourneyVisitorFilter!
+    """
     Returns the visitor items related to a specific team.
     TODO: remove when teams is released
     """
     teamId: String
-    """
-    Returns the elements in the list that match the specified filter.
-    """
-    filter: JourneyVisitorFilter!
     """
     Returns the first n elements from the list.
     """


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 988a3f9</samp>

This pull request fixes some schema duplication errors and adds a new input type for filtering journey visitors in the API gateway and journeys services. It also updates the generated GraphQL types and methods to support optional `teamId` arguments.

![Screenshot 2023-08-01 at 6 22 26 PM](https://github.com/JesusFilm/core/assets/802117/2375472c-f3e2-4b0a-baf2-42569bba0071)
