### PR TITLE
fix: allow duplicate when teams flag is false

### DIFF
--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DefaultMenu/DefaultMenu.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DefaultMenu/DefaultMenu.spec.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render } from '@testing-library/react'
+import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 import noop from 'lodash/noop'
 import { MockedProvider } from '@apollo/client/testing'
 import { SnackbarProvider } from 'notistack'
@@ -11,18 +12,20 @@ describe('DefaultMenu', () => {
     const { getByRole } = render(
       <MockedProvider>
         <SnackbarProvider>
-          <TeamProvider>
-            <DefaultMenu
-              id="journeyId"
-              slug="journey-slug"
-              status={JourneyStatus.draft}
-              journeyId="journey-id"
-              published={false}
-              setOpenAccessDialog={noop}
-              handleCloseMenu={noop}
-              setOpenTrashDialog={noop}
-            />
-          </TeamProvider>
+          <FlagsProvider flags={{ teams: true }}>
+            <TeamProvider>
+              <DefaultMenu
+                id="journeyId"
+                slug="journey-slug"
+                status={JourneyStatus.draft}
+                journeyId="journey-id"
+                published={false}
+                setOpenAccessDialog={noop}
+                handleCloseMenu={noop}
+                setOpenTrashDialog={noop}
+              />
+            </TeamProvider>
+          </FlagsProvider>
         </SnackbarProvider>
       </MockedProvider>
     )

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DefaultMenu/DefaultMenu.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DefaultMenu/DefaultMenu.tsx
@@ -1,4 +1,6 @@
 import { ReactElement } from 'react'
+// TODO: remove when teams is released
+import { useFlags } from '@core/shared/ui/FlagsProvider'
 import EditIcon from '@mui/icons-material/Edit'
 import PeopleIcon from '@mui/icons-material/People'
 import VisibilityIcon from '@mui/icons-material/Visibility'
@@ -38,6 +40,8 @@ export function DefaultMenu({
   template,
   refetch
 }: DefaultMenuProps): ReactElement {
+  // TODO: remove when teams is released
+  const { teams } = useFlags()
   return (
     <>
       <NextLink
@@ -72,7 +76,12 @@ export function DefaultMenu({
         <DuplicateJourneyMenuItem id={id} handleCloseMenu={handleCloseMenu} />
       )}
       <Divider />
-      <CopyToTeamMenuItem id={id} handleCloseMenu={handleCloseMenu} />
+      {
+        // TODO: remove when teams is released
+        teams && (
+          <CopyToTeamMenuItem id={id} handleCloseMenu={handleCloseMenu} />
+        )
+      }
       <ArchiveJourney
         status={status}
         id={journeyId}

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.tsx
@@ -24,10 +24,11 @@ export function DuplicateJourneyMenuItem({
   const { teams } = useFlags()
 
   const handleDuplicateJourney = async (): Promise<void> => {
-    if (id == null || activeTeam?.id == null) return
+    // TODO: add activeteam.id not null check when teams is released
+    if (id == null) return
 
     const data = await journeyDuplicate({
-      variables: { id, teamId: activeTeam.id }
+      variables: { id, teamId: activeTeam?.id }
     })
     if (data != null) {
       handleCloseMenu()

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.tsx
@@ -1,6 +1,7 @@
 import { ReactElement } from 'react'
 import ContentCopyRounded from '@mui/icons-material/ContentCopyRounded'
 import { useSnackbar } from 'notistack'
+import { useFlags } from '@core/shared/ui/FlagsProvider'
 import { MenuItem } from '../../../../MenuItem'
 import { useJourneyDuplicateMutation } from '../../../../../libs/useJourneyDuplicateMutation'
 import { useTeam } from '../../../../Team/TeamProvider'
@@ -17,6 +18,7 @@ export function DuplicateJourneyMenuItem({
   const [journeyDuplicate] = useJourneyDuplicateMutation()
   const { enqueueSnackbar } = useSnackbar()
   const { activeTeam } = useTeam()
+  const { teams } = useFlags()
 
   const handleDuplicateJourney = async (): Promise<void> => {
     if (id == null || activeTeam?.id == null) return
@@ -35,7 +37,7 @@ export function DuplicateJourneyMenuItem({
 
   return (
     <MenuItem
-      disabled={activeTeam?.id == null}
+      disabled={activeTeam?.id == null && teams}
       label="Duplicate"
       icon={<ContentCopyRounded color="secondary" />}
       onClick={handleDuplicateJourney}

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.tsx
@@ -4,6 +4,7 @@ import { useSnackbar } from 'notistack'
 import { useFlags } from '@core/shared/ui/FlagsProvider'
 import { MenuItem } from '../../../../MenuItem'
 import { useJourneyDuplicateMutation } from '../../../../../libs/useJourneyDuplicateMutation'
+// TODO: remove when teams is released
 import { useTeam } from '../../../../Team/TeamProvider'
 
 interface DuplicateJourneyMenuItemProps {
@@ -18,6 +19,8 @@ export function DuplicateJourneyMenuItem({
   const [journeyDuplicate] = useJourneyDuplicateMutation()
   const { enqueueSnackbar } = useSnackbar()
   const { activeTeam } = useTeam()
+
+  // TODO: remove when teams is released
   const { teams } = useFlags()
 
   const handleDuplicateJourney = async (): Promise<void> => {

--- a/apps/journeys-admin/src/components/JourneyView/JourneyViewFab/JourneyViewFab.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyViewFab/JourneyViewFab.spec.tsx
@@ -133,7 +133,7 @@ describe('JourneyViewFab', () => {
       >
         <SnackbarProvider>
           <TeamProvider>
-            <FlagsProvider>
+            <FlagsProvider flags={{ teams: true }}>
               <JourneyProvider
                 value={{ journey: { ...defaultJourney, template: true } }}
               >
@@ -208,7 +208,7 @@ describe('JourneyViewFab', () => {
       >
         <SnackbarProvider>
           <TeamProvider>
-            <FlagsProvider>
+            <FlagsProvider flags={{ teams: true }}>
               <JourneyProvider
                 value={{ journey: { ...defaultJourney, template: true } }}
               >

--- a/apps/journeys-admin/src/components/JourneyView/JourneyViewFab/JourneyViewFab.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyViewFab/JourneyViewFab.stories.tsx
@@ -19,9 +19,13 @@ const Template: Story = ({ ...args }) => (
     <FlagsProvider>
       <TeamProvider>
         <SnackbarProvider>
-          <JourneyProvider value={{ journey: args.journey }}>
-            <JourneyViewFab isPublisher={args.isPublisher} />
-          </JourneyProvider>
+          {/* TODO: remove when teams is released */}
+          <FlagsProvider flags={{ teams: true }}>
+            <JourneyProvider value={{ journey: args.journey }}>
+              <JourneyViewFab isPublisher={args.isPublisher} />
+            </JourneyProvider>
+            {/* TODO: remove when teams is released */}
+          </FlagsProvider>
         </SnackbarProvider>
       </TeamProvider>
     </FlagsProvider>

--- a/apps/journeys-admin/src/components/JourneyView/JourneyViewFab/JourneyViewFab.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyViewFab/JourneyViewFab.tsx
@@ -7,6 +7,8 @@ import CheckRoundedIcon from '@mui/icons-material/CheckRounded'
 import Typography from '@mui/material/Typography'
 import NextLink from 'next/link'
 import { useRouter } from 'next/router'
+// TODO: remove when teams is released
+import { useFlags } from '@core/shared/ui/FlagsProvider'
 import { useJourneyDuplicateMutation } from '../../../libs/useJourneyDuplicateMutation'
 import { CopyToTeamDialog } from '../../Team/CopyToTeamDialog'
 
@@ -21,8 +23,12 @@ export function JourneyViewFab({
   const router = useRouter()
   const [duplicateTeamDialogOpen, setDuplicateTeamDialogOpen] = useState(false)
   const [journeyDuplicate] = useJourneyDuplicateMutation()
+  // TODO: remove when teams is released
+  const { teams } = useFlags()
 
-  const handleConvertTemplate = async (teamId: string): Promise<void> => {
+  const handleConvertTemplate = async (
+    teamId: string | undefined
+  ): Promise<void> => {
     if (journey == null) return
 
     const { data } = await journeyDuplicate({
@@ -66,7 +72,13 @@ export function JourneyViewFab({
           }}
           color="primary"
           disabled={journey == null}
-          onClick={() => setDuplicateTeamDialogOpen(true)}
+          onClick={() =>
+            // TODO: remove when teams is released
+            teams
+              ? setDuplicateTeamDialogOpen(true)
+              : // TODO: remove when teams is released
+                handleConvertTemplate(undefined)
+          }
         >
           <CheckRoundedIcon sx={{ mr: 3 }} />
           <Typography

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.spec.tsx
@@ -3,6 +3,8 @@ import { render, fireEvent, waitFor, within } from '@testing-library/react'
 import { SnackbarProvider } from 'notistack'
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 import { NextRouter, useRouter } from 'next/router'
+// TODO: remove when teams is released
+import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 import { defaultJourney, publishedJourney } from '../data'
 import { JourneyStatus, Role } from '../../../../__generated__/globalTypes'
 import { JOURNEY_DUPLICATE } from '../../../libs/useJourneyDuplicateMutation'
@@ -12,7 +14,6 @@ import {
 } from '../../Team/TeamProvider'
 import { GET_ROLE } from './Menu'
 import { Menu, JOURNEY_PUBLISH } from '.'
-import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 
 Object.assign(navigator, {
   clipboard: {

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.spec.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../Team/TeamProvider'
 import { GET_ROLE } from './Menu'
 import { Menu, JOURNEY_PUBLISH } from '.'
+import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 
 Object.assign(navigator, {
   clipboard: {
@@ -299,14 +300,16 @@ describe('JourneyView/Menu', () => {
           ]}
         >
           <TeamProvider>
-            <JourneyProvider
-              value={{
-                journey: { ...defaultJourney, template: true },
-                admin: true
-              }}
-            >
-              <Menu />
-            </JourneyProvider>
+            <FlagsProvider flags={{ teams: true }}>
+              <JourneyProvider
+                value={{
+                  journey: { ...defaultJourney, template: true },
+                  admin: true
+                }}
+              >
+                <Menu />
+              </JourneyProvider>
+            </FlagsProvider>
           </TeamProvider>
         </MockedProvider>
       </SnackbarProvider>
@@ -654,14 +657,16 @@ describe('JourneyView/Menu', () => {
           ]}
         >
           <TeamProvider>
-            <JourneyProvider
-              value={{
-                journey: { ...defaultJourney, template: true },
-                admin: true
-              }}
-            >
-              <Menu />
-            </JourneyProvider>
+            <FlagsProvider flags={{ teams: true }}>
+              <JourneyProvider
+                value={{
+                  journey: { ...defaultJourney, template: true },
+                  admin: true
+                }}
+              >
+                <Menu />
+              </JourneyProvider>
+            </FlagsProvider>
           </TeamProvider>
         </MockedProvider>
       </SnackbarProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.stories.tsx
@@ -8,6 +8,8 @@ import { defaultJourney } from '../data'
 import { TeamProvider } from '../../Team/TeamProvider'
 import { GET_LANGUAGES } from './LanguageDialog'
 import { Menu, JOURNEY_PUBLISH, GET_ROLE } from './Menu'
+// TODO: remove when teams is released
+import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 
 const MenuStory = {
   ...simpleComponentConfig,
@@ -93,9 +95,13 @@ const journeyMocks = [
 const Template: Story = ({ ...args }) => (
   <MockedProvider mocks={args.mocks}>
     <TeamProvider>
-      <JourneyProvider value={{ journey: args.journey, admin: true }}>
-        <Menu {...args} />
-      </JourneyProvider>
+      {/* TODO: remove when teams is released */}
+      <FlagsProvider flags={{ teams: true }}>
+        <JourneyProvider value={{ journey: args.journey, admin: true }}>
+          <Menu {...args} />
+        </JourneyProvider>
+        {/* TODO: remove when teams is released */}
+      </FlagsProvider>
     </TeamProvider>
   </MockedProvider>
 )

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.stories.tsx
@@ -1,4 +1,6 @@
 import { Story, Meta } from '@storybook/react'
+// TODO: remove when teams is released
+import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 import { screen, userEvent } from '@storybook/testing-library'
 import { MockedProvider } from '@apollo/client/testing'
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
@@ -8,8 +10,6 @@ import { defaultJourney } from '../data'
 import { TeamProvider } from '../../Team/TeamProvider'
 import { GET_LANGUAGES } from './LanguageDialog'
 import { Menu, JOURNEY_PUBLISH, GET_ROLE } from './Menu'
-// TODO: remove when teams is released
-import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 
 const MenuStory = {
   ...simpleComponentConfig,

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
@@ -7,6 +7,8 @@ import MoreVert from '@mui/icons-material/MoreVert'
 import BeenHereRoundedIcon from '@mui/icons-material/BeenhereRounded'
 import VisibilityIcon from '@mui/icons-material/Visibility'
 import EditIcon from '@mui/icons-material/Edit'
+// TODO: remove when teams is released
+import { useFlags } from '@core/shared/ui/FlagsProvider'
 import DescriptionIcon from '@mui/icons-material/Description'
 import AssessmentRoundedIcon from '@mui/icons-material/AssessmentRounded'
 import TranslateIcon from '@mui/icons-material/Translate'
@@ -32,8 +34,6 @@ import { CopyToTeamDialog } from '../../Team/CopyToTeamDialog'
 import { DescriptionDialog } from './DescriptionDialog'
 import { TitleDialog } from './TitleDialog'
 import { CreateTemplateMenuItem } from './CreateTemplateMenuItem'
-// TODO: remove when teams is released
-import { useFlags } from '@core/shared/ui/FlagsProvider'
 
 const DynamicLanguageDialog = dynamic<{
   open: boolean

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
@@ -32,6 +32,8 @@ import { CopyToTeamDialog } from '../../Team/CopyToTeamDialog'
 import { DescriptionDialog } from './DescriptionDialog'
 import { TitleDialog } from './TitleDialog'
 import { CreateTemplateMenuItem } from './CreateTemplateMenuItem'
+// TODO: remove when teams is released
+import { useFlags } from '@core/shared/ui/FlagsProvider'
 
 const DynamicLanguageDialog = dynamic<{
   open: boolean
@@ -82,6 +84,10 @@ export function Menu(): ReactElement {
   const [showDescriptionDialog, setShowDescriptionDialog] = useState(false)
   const [showLanguageDialog, setShowLanguageDialog] = useState(false)
   const [duplicateTeamDialogOpen, setDuplicateTeamDialogOpen] = useState(false)
+
+  // TODO: remove when teams is released
+  const { teams } = useFlags()
+
   const { enqueueSnackbar } = useSnackbar()
 
   const openMenu = Boolean(anchorEl)
@@ -116,7 +122,7 @@ export function Menu(): ReactElement {
           preventDuplicate: true
         })
   }
-  const handleTemplate = async (teamId: string): Promise<void> => {
+  const handleTemplate = async (teamId: string | undefined): Promise<void> => {
     if (journey == null) return
 
     const { data } = await journeyDuplicate({
@@ -216,7 +222,13 @@ export function Menu(): ReactElement {
               <MenuItem
                 label="Use Template"
                 icon={<CheckRounded />}
-                onClick={() => setDuplicateTeamDialogOpen(true)}
+                onClick={() =>
+                  // TODO: remove when teams is released
+                  teams
+                    ? setDuplicateTeamDialogOpen(true)
+                    : // TODO: remove when teams is released
+                      handleTemplate(undefined)
+                }
               />
             )}
             {journey.template === true && isPublisher && (


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6238679</samp>

Added feature flag for duplicating journeys in admin app. The `DuplicateJourneyMenuItem` component now respects the teams feature flag and disables the option if it is not enabled.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/33034379/todos/6404560051)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] it should not disable duplicate button if no teams flag

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6238679</samp>

*  Import `useFlags` hook to access feature flags ([link](https://github.com/JesusFilm/core/pull/1770/files?diff=unified&w=0#diff-3e1d2af5c201a307b9682413d9133e14295dc4f6272132b530eef5ab760a1c82R4))
*  Destructure `teams` flag from `useFlags` hook in `DuplicateJourneyMenuItem` component ([link](https://github.com/JesusFilm/core/pull/1770/files?diff=unified&w=0#diff-3e1d2af5c201a307b9682413d9133e14295dc4f6272132b530eef5ab760a1c82R21))
*  Disable duplicate menu item if `teams` flag is false or active team id is null ([link](https://github.com/JesusFilm/core/pull/1770/files?diff=unified&w=0#diff-3e1d2af5c201a307b9682413d9133e14295dc4f6272132b530eef5ab760a1c82L38-R40))
