### PR TITLE
fix: add invites accept in terms

### DIFF
--- a/apps/journeys-admin/pages/users/terms-and-conditions.tsx
+++ b/apps/journeys-admin/pages/users/terms-and-conditions.tsx
@@ -5,12 +5,10 @@ import {
   AuthAction
 } from 'next-firebase-auth'
 import { NextSeo } from 'next-seo'
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'react-i18next'
 import { initAndAuthApp } from '../../src/libs/initAndAuthApp'
 
 import { TermsAndConditions } from '../../src/components/TermsAndConditions'
-import i18nConfig from '../../next-i18next.config'
 import { AcceptAllInvites } from '../../__generated__/AcceptAllInvites'
 import { ACCEPT_ALL_INVITES } from '..'
 
@@ -27,7 +25,7 @@ function TermsAndConditionsPage(): ReactElement {
 export const getServerSideProps = withAuthUserTokenSSR({
   whenUnauthed: AuthAction.REDIRECT_TO_LOGIN
 })(async ({ AuthUser, locale }) => {
-  const { apolloClient } = await initAndAuthApp({
+  const { apolloClient, flags, translations } = await initAndAuthApp({
     AuthUser,
     locale
   })
@@ -38,16 +36,12 @@ export const getServerSideProps = withAuthUserTokenSSR({
 
   return {
     props: {
-      ...(await serverSideTranslations(
-        locale ?? 'en',
-        ['apps-journeys-admin', 'libs-journeys-ui'],
-        i18nConfig
-      ))
+      flags,
+      ...translations
     }
   }
 })
 
 export default withAuthUser({
-  whenAuthed: AuthAction.RENDER,
   whenUnauthedAfterInit: AuthAction.REDIRECT_TO_LOGIN
 })(TermsAndConditionsPage)

--- a/apps/journeys-admin/pages/users/terms-and-conditions.tsx
+++ b/apps/journeys-admin/pages/users/terms-and-conditions.tsx
@@ -7,9 +7,12 @@ import {
 import { NextSeo } from 'next-seo'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'react-i18next'
+import { initAndAuthApp } from '../../src/libs/initAndAuthApp'
 
 import { TermsAndConditions } from '../../src/components/TermsAndConditions'
 import i18nConfig from '../../next-i18next.config'
+import { AcceptAllInvites } from '../../__generated__/AcceptAllInvites'
+import { ACCEPT_ALL_INVITES } from '..'
 
 function TermsAndConditionsPage(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
@@ -23,7 +26,16 @@ function TermsAndConditionsPage(): ReactElement {
 
 export const getServerSideProps = withAuthUserTokenSSR({
   whenUnauthed: AuthAction.REDIRECT_TO_LOGIN
-})(async ({ locale }) => {
+})(async ({ AuthUser, locale }) => {
+  const { apolloClient } = await initAndAuthApp({
+    AuthUser,
+    locale
+  })
+
+  await apolloClient.mutate<AcceptAllInvites>({
+    mutation: ACCEPT_ALL_INVITES
+  })
+
   return {
     props: {
       ...(await serverSideTranslations(

--- a/apps/journeys-admin/src/components/TermsAndConditions/TermsAndConditions.tsx
+++ b/apps/journeys-admin/src/components/TermsAndConditions/TermsAndConditions.tsx
@@ -40,7 +40,7 @@ export function TermsAndConditions(): ReactElement {
 
   const handleJourneyProfileCreate = async (): Promise<void> => {
     await journeyProfileCreate()
-    await router.push('/')
+    await router.push('/?onboarding=true')
   }
 
   return (


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 97e4a41</samp>

Add functionality to accept user invites on the terms and conditions page. Use imported functions and types from `@jesus-film/core` and a mutation call to `acceptAllInvites` in `apps/journeys-admin/pages/users/terms-and-conditions.tsx`.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/33034379/todos/6404816783)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] invite new email address to a team, then create a new account with that email, accepts terms, should not have to create team in onboarding, popup should show
# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 97e4a41</samp>

* Initialize and authenticate the Apollo client and accept all pending invites for the current user before rendering the terms and conditions page ([link](https://github.com/JesusFilm/core/pull/1771/files?diff=unified&w=0#diff-ef867b0e65506d55a5ddbafcb116593a39bff54c87299af98409795593a56456L10-R15), [link](https://github.com/JesusFilm/core/pull/1771/files?diff=unified&w=0#diff-ef867b0e65506d55a5ddbafcb116593a39bff54c87299af98409795593a56456L26-R38))
  * Import `initAndAuthApp`, `AcceptAllInvites`, and `ACCEPT_ALL_INVITES` from `src/libs`, `__generated__`, and the parent folder respectively ([link](https://github.com/JesusFilm/core/pull/1771/files?diff=unified&w=0#diff-ef867b0e65506d55a5ddbafcb116593a39bff54c87299af98409795593a56456L10-R15))
  * Destructure `AuthUser` from the argument of `getServerSideProps` and pass it to `initAndAuthApp` along with `locale` ([link](https://github.com/JesusFilm/core/pull/1771/files?diff=unified&w=0#diff-ef867b0e65506d55a5ddbafcb116593a39bff54c87299af98409795593a56456L26-R38))
  * Call `mutate` method of `apolloClient` with `ACCEPT_ALL_INVITES` mutation ([link](https://github.com/JesusFilm/core/pull/1771/files?diff=unified&w=0#diff-ef867b0e65506d55a5ddbafcb116593a39bff54c87299af98409795593a56456L26-R38))
