### PR TITLE
fix: discovery admin migrations

### DIFF
--- a/apps/api-journeys/db/seed.ts
+++ b/apps/api-journeys/db/seed.ts
@@ -22,9 +22,9 @@ async function main(): Promise<void> {
   await nua1()
   await onboarding()
   await onboardingTemplates()
-  await discoveryAdminLeft('reset')
-  await discoveryAdminCenter('reset')
-  await discoveryAdminRight('reset')
+  await discoveryAdminLeft()
+  await discoveryAdminCenter()
+  await discoveryAdminRight()
 }
 main().catch((e) => {
   console.error(e)

--- a/apps/api-journeys/db/seeds/discoveryAdminCenter.ts
+++ b/apps/api-journeys/db/seeds/discoveryAdminCenter.ts
@@ -42,7 +42,7 @@ export async function discoveryAdminCenter(action?: 'reset'): Promise<void> {
         publishedAt: new Date()
       }
 
-      if (existingJourney?.id !== journeyData.id) {
+      if (existingJourney != null && existingJourney?.id !== journeyData.id) {
         await tx.journey.delete({ where: { id: existingJourney?.id } })
       }
 

--- a/apps/api-journeys/db/seeds/discoveryAdminLeft.ts
+++ b/apps/api-journeys/db/seeds/discoveryAdminLeft.ts
@@ -42,7 +42,7 @@ export async function discoveryAdminLeft(action?: 'reset'): Promise<void> {
         publishedAt: new Date()
       }
 
-      if (existingJourney?.id !== journeyData.id) {
+      if (existingJourney != null && existingJourney?.id !== journeyData.id) {
         await tx.journey.delete({ where: { id: existingJourney?.id } })
       }
 

--- a/apps/api-journeys/db/seeds/discoveryAdminRight.ts
+++ b/apps/api-journeys/db/seeds/discoveryAdminRight.ts
@@ -42,7 +42,7 @@ export async function discoveryAdminRight(action?: 'reset'): Promise<void> {
         publishedAt: new Date()
       }
 
-      if (existingJourney?.id !== journeyData.id) {
+      if (existingJourney != null && existingJourney?.id !== journeyData.id) {
         await tx.journey.delete({ where: { id: existingJourney?.id } })
       }
 


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 53f3da1</samp>

Removed the `reset` argument from the seed functions and fixed a bug in the deletion condition. These changes improved the performance and reliability of the seed script for `apps/api-journeys`.
