### PR TITLE
fix: video controls blocked by navigation button

### DIFF
--- a/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.tsx
+++ b/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.tsx
@@ -100,7 +100,7 @@ export function NavigationButton({
           lg: 'calc(100% - 105px)'
         },
         alignItems: 'center',
-        pointerEvents: { xs: 'none', lg: 'all' }
+        pointerEvents: 'none'
       }}
     >
       <Fade


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6878924</samp>

Simplified `pointerEvents` logic for `NavigationButton` component to avoid unwanted clicks. Fixed bug #101.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/33281894/todos/6406056652)

# How should this PR be QA Tested?
**Requirements**
Visit a card with a video

- [ ] it should enable users to click on play button on desktop
- [ ] it should enable users to click on fullscreen button
- [ ] it should enable users to change the volume of the video

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6878924</samp>

*  Prevent user from clicking on navigation button when it is not visible or active by simplifying `pointerEvents` property of `Box` component to 'none' ([link](https://github.com/JesusFilm/core/pull/1775/files?diff=unified&w=0#diff-684ea1b2346c27f9252ea686988ffaa756a41f56bd7c62530441bfe2d034df3dL103-R103))
