### PR TITLE
feat: add user team api

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -1669,6 +1669,7 @@ type Team
   title: String!
   createdAt: DateTime!
   updatedAt: DateTime!
+  userTeamsConnection(first: Int, after: String): UserTeamsConnection!
 }
 
 input TeamCreateInput
@@ -2058,6 +2059,17 @@ type UserTeam
   updatedAt: DateTime!
 }
 
+"""An edge in a connection."""
+type UserTeamEdge
+  @join__type(graph: JOURNEYS)
+{
+  """A cursor for use in pagination."""
+  cursor: String!
+
+  """The item at the end of the edge."""
+  node: UserTeam!
+}
+
 input UserTeamFilterInput
   @join__type(graph: JOURNEYS)
 {
@@ -2083,6 +2095,20 @@ enum UserTeamRole
 {
   manager @join__enumValue(graph: JOURNEYS)
   member @join__enumValue(graph: JOURNEYS)
+}
+
+"""A list of userTeams connected with a team."""
+type UserTeamsConnection
+  @join__type(graph: JOURNEYS)
+{
+  """Count of user teams"""
+  totalCount: Int!
+
+  """A list of edges."""
+  edges: [UserTeamEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
 }
 
 input UserTeamUpdateInput

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -1988,6 +1988,7 @@ type Team
   title: String!
   createdAt: DateTime!
   updatedAt: DateTime!
+  userTeamsConnection(first: Int, after: String): UserTeamsConnection!
 }
 
 input TeamCreateInput {
@@ -2054,6 +2055,39 @@ type UserTeam
   role: UserTeamRole!
   createdAt: DateTime!
   updatedAt: DateTime!
+}
+
+"""An edge in a connection."""
+type UserTeamEdge {
+  """A cursor for use in pagination."""
+  cursor: String!
+
+  """The item at the end of the edge."""
+  node: UserTeam!
+}
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+}
+
+"""A list of userTeams connected with a team."""
+type UserTeamsConnection {
+  """Count of user teams"""
+  totalCount: Int!
+
+  """A list of edges."""
+  edges: [UserTeamEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
 }
 
 input UserTeamUpdateInput {
@@ -2241,18 +2275,6 @@ type VisitorEdge {
 
   """The item at the end of the edge."""
   node: Visitor!
-}
-
-"""Information about pagination in a connection."""
-type PageInfo {
-  """When paginating forwards, are there more items?"""
-  hasNextPage: Boolean!
-
-  """When paginating backwards, the cursor to continue."""
-  startCursor: String
-
-  """When paginating forwards, the cursor to continue."""
-  endCursor: String
 }
 
 """A list of visitors connected with a team."""

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -1208,6 +1208,7 @@ export class Team {
     title: string;
     createdAt: DateTime;
     updatedAt: DateTime;
+    userTeamsConnection: UserTeamsConnection;
 }
 
 export class UserInvite {
@@ -1234,6 +1235,26 @@ export class UserTeam {
     role: UserTeamRole;
     createdAt: DateTime;
     updatedAt: DateTime;
+}
+
+export class UserTeamEdge {
+    __typename?: 'UserTeamEdge';
+    cursor: string;
+    node: UserTeam;
+}
+
+export class PageInfo {
+    __typename?: 'PageInfo';
+    hasNextPage: boolean;
+    startCursor?: Nullable<string>;
+    endCursor?: Nullable<string>;
+}
+
+export class UserTeamsConnection {
+    __typename?: 'UserTeamsConnection';
+    totalCount: number;
+    edges: UserTeamEdge[];
+    pageInfo: PageInfo;
 }
 
 export class UserTeamInvite {
@@ -1297,13 +1318,6 @@ export class VisitorEdge {
     __typename?: 'VisitorEdge';
     cursor: string;
     node: Visitor;
-}
-
-export class PageInfo {
-    __typename?: 'PageInfo';
-    hasNextPage: boolean;
-    startCursor?: Nullable<string>;
-    endCursor?: Nullable<string>;
 }
 
 export class VisitorsConnection {

--- a/apps/api-journeys/src/app/modules/team/team.graphql
+++ b/apps/api-journeys/src/app/modules/team/team.graphql
@@ -3,6 +3,7 @@ type Team @key(fields: "id") {
   title: String!
   createdAt: DateTime!
   updatedAt: DateTime!
+  userTeamsConnection(first: Int, after: String): UserTeamsConnection!
 }
 
 extend type Query {

--- a/apps/api-journeys/src/app/modules/team/team.resolver.ts
+++ b/apps/api-journeys/src/app/modules/team/team.resolver.ts
@@ -1,4 +1,11 @@
-import { Resolver, Query, Mutation, Args } from '@nestjs/graphql'
+import {
+  Resolver,
+  Query,
+  Mutation,
+  Args,
+  ResolveField,
+  Parent
+} from '@nestjs/graphql'
 import { UseGuards } from '@nestjs/common'
 import { Team, Prisma } from '.prisma/api-journeys-client'
 import { subject } from '@casl/ability'
@@ -12,6 +19,7 @@ import {
 import { PrismaService } from '../../lib/prisma.service'
 import { Action, AppAbility } from '../../lib/casl/caslFactory'
 import { AppCaslGuard } from '../../lib/casl/caslGuard'
+import { UserTeamRole, UserTeamsConnection } from '../../__generated__/graphql'
 
 @Resolver('Team')
 export class TeamResolver {
@@ -82,5 +90,44 @@ export class TeamResolver {
     throw new GraphQLError('user is not allowed to update team', {
       extensions: { code: 'FORBIDDEN' }
     })
+  }
+
+  @ResolveField()
+  async userTeamsConnection(
+    @CaslAccessible('UserTeam') accessibleUserTeams: Prisma.UserTeamWhereInput,
+    @Parent() team: Team,
+    @Args('first') first = 50,
+    @Args('after') after?: string | null
+  ): Promise<UserTeamsConnection> {
+    const result = await this.prismaService.userTeam.findMany({
+      where: { AND: [accessibleUserTeams, { teamId: team.id }] },
+      cursor: after != null ? { id: after } : undefined,
+      orderBy: { role: 'asc' },
+      skip: after == null ? 0 : 1,
+      take: first + 1
+    })
+
+    const sendResult = result.length > first ? result.slice(0, -1) : result
+    return {
+      edges: sendResult.map((userTeam) => ({
+        node: {
+          ...userTeam,
+          role: userTeam.role as UserTeamRole,
+          createdAt: userTeam.createdAt.toISOString(),
+          updatedAt: userTeam.createdAt.toISOString(),
+          user: { id: userTeam.userId }
+        },
+        cursor: userTeam.id
+      })),
+      pageInfo: {
+        hasNextPage: result.length > first,
+        startCursor: result.length > 0 ? result[0].id : null,
+        endCursor:
+          result.length > 0 ? sendResult[sendResult.length - 1].id : null
+      },
+      totalCount: await this.prismaService.userTeam.count({
+        where: { AND: [accessibleUserTeams, { teamId: team.id }] }
+      })
+    }
   }
 }

--- a/apps/api-journeys/src/app/modules/userTeam/userTeam.graphql
+++ b/apps/api-journeys/src/app/modules/userTeam/userTeam.graphql
@@ -15,6 +15,56 @@ type UserTeam @key(fields: "id") {
   updatedAt: DateTime!
 }
 
+"""
+An edge in a connection.
+"""
+type UserTeamEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+  """
+  The item at the end of the edge.
+  """
+  node: UserTeam!
+}
+
+"""
+Information about pagination in a connection.
+"""
+type PageInfo {
+  """
+  When paginating forwards, are there more items?
+  """
+  hasNextPage: Boolean!
+  """
+  When paginating backwards, the cursor to continue.
+  """
+  startCursor: String
+  """
+  When paginating forwards, the cursor to continue.
+  """
+  endCursor: String
+}
+
+"""
+A list of userTeams connected with a team.
+"""
+type UserTeamsConnection {
+  """
+  Count of user teams
+  """
+  totalCount: Int!
+  """
+  A list of edges.
+  """
+  edges: [UserTeamEdge!]!
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
 extend type Query {
   userTeams(teamId: ID!, where: UserTeamFilterInput): [UserTeam!]!
   userTeam(id: ID!): UserTeam!


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 973a7e1</samp>

This pull request adds a new feature to the `api-gateway` and `api-journeys` schemas that allows querying user teams associated with a team, using a connection type with pagination support. It also updates the generated code and resolver functions to match the schema changes. It uses partial schema files and the `@join__type` directive to modularize and link the schemas.

