### PR TITLE
fix: add user team to team api

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -1669,6 +1669,7 @@ type Team
   title: String!
   createdAt: DateTime!
   updatedAt: DateTime!
+  userTeams: [UserTeam!]!
 }
 
 input TeamCreateInput

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -1988,6 +1988,7 @@ type Team
   title: String!
   createdAt: DateTime!
   updatedAt: DateTime!
+  userTeams: [UserTeam!]!
 }
 
 input TeamCreateInput {

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -1208,6 +1208,7 @@ export class Team {
     title: string;
     createdAt: DateTime;
     updatedAt: DateTime;
+    userTeams: UserTeam[];
 }
 
 export class UserInvite {

--- a/apps/api-journeys/src/app/modules/team/team.graphql
+++ b/apps/api-journeys/src/app/modules/team/team.graphql
@@ -3,6 +3,7 @@ type Team @key(fields: "id") {
   title: String!
   createdAt: DateTime!
   updatedAt: DateTime!
+  userTeams: [UserTeam!]!
 }
 
 extend type Query {

--- a/apps/api-journeys/src/app/modules/team/team.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/team/team.resolver.spec.ts
@@ -1,79 +1,79 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { CaslAuthModule } from '@core/nest/common/CaslAuthModule'
-import { UserTeamRole } from '.prisma/api-journeys-client'
+import {
+  Team,
+  UserTeam,
+  UserTeamRole,
+  Prisma
+} from '.prisma/api-journeys-client'
+import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
 import { PrismaService } from '../../lib/prisma.service'
-import { AppCaslFactory } from '../../lib/casl/caslFactory'
+import { AppAbility, AppCaslFactory } from '../../lib/casl/caslFactory'
 import { TeamResolver } from './team.resolver'
 
 describe('TeamResolver', () => {
-  let teamResolver: TeamResolver, prismaService: PrismaService
+  let resolver: TeamResolver,
+    prismaService: DeepMockProxy<PrismaService>,
+    ability: AppAbility
+
+  const team = {
+    id: 'teamId'
+  } as unknown as Team
+  const teamWithUserTeam = {
+    ...team,
+    userTeams: [{ userId: 'userId', role: UserTeamRole.manager }]
+  }
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [CaslAuthModule.register(AppCaslFactory)],
-      providers: [TeamResolver, PrismaService]
+      providers: [
+        TeamResolver,
+        {
+          provide: PrismaService,
+          useValue: mockDeep<PrismaService>()
+        }
+      ]
     }).compile()
-    teamResolver = module.get<TeamResolver>(TeamResolver)
-    prismaService = module.get<PrismaService>(PrismaService)
-    prismaService.team.findMany = jest
-      .fn()
-      .mockResolvedValue([{ id: 'teamId' }])
+    resolver = module.get<TeamResolver>(TeamResolver)
+    prismaService = module.get<PrismaService>(
+      PrismaService
+    ) as DeepMockProxy<PrismaService>
+    ability = await new AppCaslFactory().createAbility({ id: 'userId' })
   })
   describe('teams', () => {
     it('fetches accessible teams', async () => {
-      const teams = await teamResolver.teams({
-        userTeams: { some: { userId: 'userId' } }
+      prismaService.team.findMany.mockResolvedValue([team])
+      const teams = await resolver.teams({
+        OR: [{}]
       })
       expect(prismaService.team.findMany).toHaveBeenCalledWith({
         where: {
-          userTeams: { some: { userId: 'userId' } }
+          AND: [{ OR: [{}] }]
         }
       })
-      expect(teams).toEqual([{ id: 'teamId' }])
+      expect(teams).toEqual([team])
     })
   })
 
   describe('team', () => {
     it('fetches team', async () => {
-      const team = {
-        id: 'teamId',
-        userTeams: [
-          {
-            userId: 'userId',
-            role: UserTeamRole.member
-          }
-        ]
-      }
-      prismaService.team.findUnique = jest.fn().mockResolvedValue(team)
-      const ability = await new AppCaslFactory().createAbility({ id: 'userId' })
-      await expect(teamResolver.team(ability, 'teamId')).resolves.toEqual(team)
+      prismaService.team.findUnique.mockResolvedValue(teamWithUserTeam)
+      await expect(resolver.team(ability, 'teamId')).resolves.toEqual(
+        teamWithUserTeam
+      )
     })
 
     it('throws forbidden error if user is not allowed to view team', async () => {
-      const team = {
-        id: 'teamId',
-        userTeams: [
-          {
-            userId: 'userId',
-            role: UserTeamRole.member
-          }
-        ]
-      }
-      prismaService.team.findUnique = jest.fn().mockResolvedValue(team)
-      const ability = await new AppCaslFactory().createAbility({
-        id: 'userId2'
-      })
-      await expect(teamResolver.team(ability, 'teamId')).rejects.toThrow(
+      prismaService.team.findUnique.mockResolvedValue(team)
+      await expect(resolver.team(ability, 'teamId')).rejects.toThrow(
         'user is not allowed to view team'
       )
     })
 
     it('throws not found error if team is not found', async () => {
-      prismaService.team.findUnique = jest.fn().mockResolvedValue(null)
-      const ability = await new AppCaslFactory().createAbility({
-        id: 'userId'
-      })
-      await expect(teamResolver.team(ability, 'teamId')).rejects.toThrow(
+      prismaService.team.findUnique.mockResolvedValue(null)
+      await expect(resolver.team(ability, 'teamId')).rejects.toThrow(
         'team not found'
       )
     })
@@ -81,18 +81,9 @@ describe('TeamResolver', () => {
 
   describe('teamCreate', () => {
     it('creates team with userTeam', async () => {
-      const team = {
-        id: 'teamId',
-        userTeams: [
-          {
-            userId: 'userId',
-            role: UserTeamRole.manager
-          }
-        ]
-      }
-      prismaService.team.create = jest.fn().mockResolvedValue(team)
+      prismaService.team.create.mockResolvedValue(team)
       await expect(
-        teamResolver.teamCreate('userId', { name: 'team' })
+        resolver.teamCreate('userId', { name: 'team' })
       ).resolves.toEqual(team)
       expect(prismaService.team.create).toHaveBeenCalledWith({
         data: {
@@ -110,23 +101,11 @@ describe('TeamResolver', () => {
 
   describe('teamUpdate', () => {
     it('updates team', async () => {
-      const team = {
-        id: 'teamId',
-        userTeams: [
-          {
-            userId: 'userId',
-            role: UserTeamRole.manager
-          }
-        ]
-      }
-      prismaService.team.findUnique = jest.fn().mockResolvedValue(team)
-      prismaService.team.update = jest.fn().mockResolvedValue(team)
-      const ability = await new AppCaslFactory().createAbility({
-        id: 'userId'
-      })
+      prismaService.team.findUnique.mockResolvedValue(teamWithUserTeam)
+      prismaService.team.update.mockResolvedValue(teamWithUserTeam)
       await expect(
-        teamResolver.teamUpdate(ability, 'teamId', { name: 'team' })
-      ).resolves.toEqual(team)
+        resolver.teamUpdate(ability, 'teamId', { name: 'team' })
+      ).resolves.toEqual(teamWithUserTeam)
       expect(prismaService.team.update).toHaveBeenCalledWith({
         where: { id: 'teamId' },
         data: {
@@ -136,32 +115,52 @@ describe('TeamResolver', () => {
     })
 
     it('throws forbidden error if user is not allowed to update team', async () => {
-      const team = {
-        id: 'teamId',
-        userTeams: [
-          {
-            userId: 'userId',
-            role: UserTeamRole.member
-          }
-        ]
-      }
-      prismaService.team.findUnique = jest.fn().mockResolvedValue(team)
-      const ability = await new AppCaslFactory().createAbility({
-        id: 'userId2'
-      })
+      prismaService.team.findUnique.mockResolvedValue(team)
       await expect(
-        teamResolver.teamUpdate(ability, 'teamId', { name: 'team' })
+        resolver.teamUpdate(ability, 'teamId', { name: 'team' })
       ).rejects.toThrow('user is not allowed to update team')
     })
 
     it('throws not found error if team is not found', async () => {
-      prismaService.team.findUnique = jest.fn().mockResolvedValue(null)
-      const ability = await new AppCaslFactory().createAbility({
-        id: 'userId'
-      })
+      prismaService.team.findUnique.mockResolvedValue(null)
       await expect(
-        teamResolver.teamUpdate(ability, 'teamId', { name: 'team' })
+        resolver.teamUpdate(ability, 'teamId', { name: 'team' })
       ).rejects.toThrow('team not found')
+    })
+  })
+
+  describe('userTeams', () => {
+    const team = {
+      id: 'teamId',
+      userTeams: [
+        {
+          userId: 'userId',
+          role: UserTeamRole.manager
+        }
+      ]
+    } as unknown as Team & { userTeams: UserTeam[] }
+    it('returns userTeams of parent', async () => {
+      expect(await resolver.userTeams(team)).toEqual(team.userTeams)
+    })
+    it('returns userTeams from database', async () => {
+      const userTeams = jest.fn().mockResolvedValue(team.userTeams)
+      prismaService.team.findUnique.mockReturnValue({
+        ...team,
+        userTeams
+      } as unknown as Prisma.Prisma__TeamClient<Team>)
+      await expect(
+        resolver.userTeams({ ...team, userTeams: undefined })
+      ).resolves.toEqual(team.userTeams)
+    })
+    it('returns empty array when null', async () => {
+      const userTeams = jest.fn().mockResolvedValue(null)
+      prismaService.team.findUnique.mockReturnValue({
+        ...team,
+        userTeams
+      } as unknown as Prisma.Prisma__TeamClient<Team>)
+      await expect(
+        resolver.userTeams({ ...team, userTeams: undefined })
+      ).resolves.toEqual([])
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/team/team.resolver.ts
+++ b/apps/api-journeys/src/app/modules/team/team.resolver.ts
@@ -30,7 +30,7 @@ export class TeamResolver {
     @CaslAccessible('Team') accessibleTeams: Prisma.TeamWhereInput
   ): Promise<Team[]> {
     return await this.prismaService.team.findMany({
-      where: accessibleTeams
+      where: { AND: [accessibleTeams] }
     })
   }
 

--- a/apps/api-journeys/src/app/modules/team/team.resolver.ts
+++ b/apps/api-journeys/src/app/modules/team/team.resolver.ts
@@ -1,6 +1,13 @@
-import { Resolver, Query, Mutation, Args } from '@nestjs/graphql'
+import {
+  Resolver,
+  Query,
+  Mutation,
+  Args,
+  ResolveField,
+  Parent
+} from '@nestjs/graphql'
 import { UseGuards } from '@nestjs/common'
-import { Team, Prisma } from '.prisma/api-journeys-client'
+import { Team, Prisma, UserTeam } from '.prisma/api-journeys-client'
 import { subject } from '@casl/ability'
 import { GraphQLError } from 'graphql'
 import { CurrentUserId } from '@core/nest/decorators/CurrentUserId'
@@ -82,5 +89,20 @@ export class TeamResolver {
     throw new GraphQLError('user is not allowed to update team', {
       extensions: { code: 'FORBIDDEN' }
     })
+  }
+
+  @ResolveField()
+  async userTeams(
+    @Parent() team: Team & { userTeams?: UserTeam[] }
+  ): Promise<UserTeam[]> {
+    if (team.userTeams != null) return team.userTeams
+
+    return (
+      (await this.prismaService.team
+        .findUnique({
+          where: { id: team.id }
+        })
+        .userTeams()) ?? []
+    )
   }
 }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at caac2ee</samp>

This pull request adds a new field `userTeams` to the `Team` type in the GraphQL schema of the `api-gateway` and `api-journeys` apps. This field enables fetching the users that belong to a team and their roles, as part of the team management functionality.