### PR TITLE
fix: custom error page

### DIFF
--- a/apps/journeys/pages/500.tsx
+++ b/apps/journeys/pages/500.tsx
@@ -1,6 +1,7 @@
 import { ReactElement } from 'react'
 import { transformer } from '@core/journeys/ui/transformer'
 import { ThemeProvider } from '@core/shared/ui/ThemeProvider'
+import { NextSeo } from 'next-seo'
 import { Conductor } from '../src/components/Conductor'
 import { GetJourney_journey_blocks as Block } from '../__generated__/GetJourney'
 import {
@@ -36,7 +37,7 @@ const blocks: Block[] = [
   },
   {
     __typename: 'ImageBlock',
-    alt: 'error-404-image',
+    alt: 'error-500-image',
     blurhash: 'U05OKJ0300sq5O?Y~VM|0M-.%1%K~o9HEKxu',
     height: 2230,
     id: 'imageBlock1.id',
@@ -49,7 +50,7 @@ const blocks: Block[] = [
     __typename: 'TypographyBlock',
     align: TypographyAlign.center,
     color: null,
-    content: '404',
+    content: '500',
     id: 'typog1.id',
     parentBlockId: 'cardBlock1.id',
     parentOrder: 0,
@@ -105,9 +106,12 @@ const blocks: Block[] = [
 
 export function Custom500(): ReactElement {
   return (
-    <ThemeProvider themeName={ThemeName.base} themeMode={ThemeMode.dark}>
-      <Conductor blocks={transformer(blocks)} />
-    </ThemeProvider>
+    <>
+      <NextSeo title="500" description="Journey not found." />
+      <ThemeProvider themeName={ThemeName.base} themeMode={ThemeMode.dark}>
+        <Conductor blocks={transformer(blocks)} />
+      </ThemeProvider>
+    </>
   )
 }
 

--- a/apps/journeys/pages/500.tsx
+++ b/apps/journeys/pages/500.tsx
@@ -103,7 +103,7 @@ const blocks: Block[] = [
   }
 ]
 
-export function Custom404(): ReactElement {
+export function Custom500(): ReactElement {
   return (
     <ThemeProvider themeName={ThemeName.base} themeMode={ThemeMode.dark}>
       <Conductor blocks={transformer(blocks)} />
@@ -111,4 +111,4 @@ export function Custom404(): ReactElement {
   )
 }
 
-export default Custom404
+export default Custom500

--- a/apps/journeys/pages/500.tsx
+++ b/apps/journeys/pages/500.tsx
@@ -1,7 +1,6 @@
 import { ReactElement } from 'react'
 import { transformer } from '@core/journeys/ui/transformer'
 import { ThemeProvider } from '@core/shared/ui/ThemeProvider'
-import { NextSeo } from 'next-seo'
 import { Conductor } from '../src/components/Conductor'
 import { GetJourney_journey_blocks as Block } from '../__generated__/GetJourney'
 import {
@@ -106,12 +105,9 @@ const blocks: Block[] = [
 
 export function Custom500(): ReactElement {
   return (
-    <>
-      <NextSeo title="500" description="Journey not found." />
-      <ThemeProvider themeName={ThemeName.base} themeMode={ThemeMode.dark}>
-        <Conductor blocks={transformer(blocks)} />
-      </ThemeProvider>
-    </>
+    <ThemeProvider themeName={ThemeName.base} themeMode={ThemeMode.dark}>
+      <Conductor blocks={transformer(blocks)} />
+    </ThemeProvider>
   )
 }
 


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 490c2b0</samp>

Refactored error handling component for server-side errors. Renamed `Custom404` to `Custom500` and updated `500.tsx` page accordingly.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Visiting a journey that doesnt exist should show the custom 500 screen

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 490c2b0</samp>

*  Rename function and default export from `Custom404` to `Custom500` in `500.tsx` to indicate server-side error page ([link](https://github.com/JesusFilm/core/pull/1780/files?diff=unified&w=0#diff-e4769d2444af9dc6fcb1a441218dada45f0c2a5dd71a9cf539006f1117d21b73L106-R106), [link](https://github.com/JesusFilm/core/pull/1780/files?diff=unified&w=0#diff-e4769d2444af9dc6fcb1a441218dada45f0c2a5dd71a9cf539006f1117d21b73L114-R114))
