### PR TITLE
fix: edit publisher permissions

### DIFF
--- a/apps/api-journeys/src/app/modules/journey/journey.acl.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.acl.ts
@@ -74,6 +74,6 @@ export const journeyAcl: AppAclFn = ({ can, user }: AppAclParameters) => {
     // publisher can manage template
     can(Action.Manage, 'Journey', { template: true })
     // publisher can convert a journey to a template
-    can(Action.Manage, 'Journey', 'template')
+    can(Action.Create, 'Journey', 'template')
   }
 }

--- a/apps/api-journeys/src/app/modules/journey/journey.acl.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.acl.ts
@@ -5,10 +5,15 @@ import {
 } from '.prisma/api-journeys-client'
 import { Action, AppAclFn, AppAclParameters } from '../../lib/casl/caslFactory'
 
-export const journeyAcl: AppAclFn = ({ can, user }: AppAclParameters) => {
+export const journeyAcl: AppAclFn = ({
+  can,
+  cannot,
+  user
+}: AppAclParameters) => {
   // TODO: remove when teams is released
   can(Action.Create, 'Journey', { teamId: 'jfp-team' })
   // create journey as a team member
+
   can(Action.Create, 'Journey', {
     team: {
       is: {
@@ -70,6 +75,9 @@ export const journeyAcl: AppAclFn = ({ can, user }: AppAclParameters) => {
     template: true,
     status: JourneyStatus.published
   })
+
+  cannot(Action.Manage, 'Journey', 'template')
+
   if (user.roles?.includes('publisher') === true) {
     // publisher can manage template
     can(Action.Manage, 'Journey', { template: true })

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -692,7 +692,7 @@ export class JourneyResolver {
       throw new GraphQLError('journey not found', {
         extensions: { code: 'NOT_FOUND' }
       })
-    if (ability.cannot(Action.Manage, subject('Journey', journey), 'template'))
+    if (ability.cannot(Action.Create, subject('Journey', journey), 'template'))
       throw new GraphQLError(
         'user is not allowed to change journey to or from a template',
         {

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
@@ -267,6 +267,7 @@ export function Menu(): ReactElement {
             {journey.template !== true && isPublisher === true && (
               <CreateTemplateMenuItem />
             )}
+            <CreateTemplateMenuItem />
             {(journey.template !== true || isPublisher) && (
               <>
                 <Divider />

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
@@ -267,6 +267,7 @@ export function Menu(): ReactElement {
             {journey.template !== true && isPublisher === true && (
               <CreateTemplateMenuItem />
             )}
+            {/* TODO: remove before pushing branch */}
             <CreateTemplateMenuItem />
             {(journey.template !== true || isPublisher) && (
               <>


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0e0556e</samp>

This pull request adds a new permission check for the `template` attribute of journeys, using the `caslFactory` library. It also updates the `JourneyResolver` class to use the correct action for the check, and adds a temporary component for testing the template creation.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/33281894/todos/6411853661)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] publishers cannot access journeys that they are not a team or are an editor/owner of
- [ ] backend validation for normal users not being able to create templates from existing journeys

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0e0556e</samp>

*  Restrict the ability to manage the `template` attribute of a journey to users with the `publisher` role ([link](https://github.com/JesusFilm/core/pull/1783/files?diff=unified&w=0#diff-b4b7cd8ccccfa45b72b7ac65221c321bbe4e71655ef2c2b872385ebe3bdf0d22L8-R16),[link](https://github.com/JesusFilm/core/pull/1783/files?diff=unified&w=0#diff-b4b7cd8ccccfa45b72b7ac65221c321bbe4e71655ef2c2b872385ebe3bdf0d22L73-R85),[link](https://github.com/JesusFilm/core/pull/1783/files?diff=unified&w=0#diff-be9eaaadc38880434cdfe42dc6e2fe0f5cae94cf78d3e9e05f9a39093dae42dfL695-R695))
  - Import the `cannot` function from the `caslFactory` module in `journey.acl.ts` ([link](https://github.com/JesusFilm/core/pull/1783/files?diff=unified&w=0#diff-b4b7cd8ccccfa45b72b7ac65221c321bbe4e71655ef2c2b872385ebe3bdf0d22L8-R16))
  - Add a default rule in the `journeyAcl` function that denies any user the `Manage` action for the `template` attribute ([link](https://github.com/JesusFilm/core/pull/1783/files?diff=unified&w=0#diff-b4b7cd8ccccfa45b72b7ac65221c321bbe4e71655ef2c2b872385ebe3bdf0d22L73-R85))
  - Change the `Manage` action to `Create` for the `publisher` role in the `journeyAcl` function, to allow creating templates from journeys ([link](https://github.com/JesusFilm/core/pull/1783/files?diff=unified&w=0#diff-b4b7cd8ccccfa45b72b7ac65221c321bbe4e71655ef2c2b872385ebe3bdf0d22L73-R85))
  - Use the `Create` action instead of the `Manage` action in the `JourneyResolver` class in `journey.resolver.ts` for checking the permission to change the `template` attribute ([link](https://github.com/JesusFilm/core/pull/1783/files?diff=unified&w=0#diff-be9eaaadc38880434cdfe42dc6e2fe0f5cae94cf78d3e9e05f9a39093dae42dfL695-R695))
* Add a temporary component for creating templates from journeys in the `Menu` component in `journeys-admin` ([link](https://github.com/JesusFilm/core/pull/1783/files?diff=unified&w=0#diff-2c9f44f9db6ec77ee7fdf06b593abfe7aab0fc14735b41b66094629ff25bc082R270-R271))
  - Render the `CreateTemplateMenuItem` component in the `Menu` component in `Menu.tsx` for testing purposes ([link](https://github.com/JesusFilm/core/pull/1783/files?diff=unified&w=0#diff-2c9f44f9db6ec77ee7fdf06b593abfe7aab0fc14735b41b66094629ff25bc082R270-R271))
