### PR TITLE
chore: remove teams flag todos

### DIFF
--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DefaultMenu/DefaultMenu.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DefaultMenu/DefaultMenu.spec.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render } from '@testing-library/react'
-import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 import noop from 'lodash/noop'
 import { MockedProvider } from '@apollo/client/testing'
 import { SnackbarProvider } from 'notistack'
@@ -12,20 +11,18 @@ describe('DefaultMenu', () => {
     const { getByRole } = render(
       <MockedProvider>
         <SnackbarProvider>
-          <FlagsProvider flags={{ teams: true }}>
-            <TeamProvider>
-              <DefaultMenu
-                id="journeyId"
-                slug="journey-slug"
-                status={JourneyStatus.draft}
-                journeyId="journey-id"
-                published={false}
-                setOpenAccessDialog={noop}
-                handleCloseMenu={noop}
-                setOpenTrashDialog={noop}
-              />
-            </TeamProvider>
-          </FlagsProvider>
+          <TeamProvider>
+            <DefaultMenu
+              id="journeyId"
+              slug="journey-slug"
+              status={JourneyStatus.draft}
+              journeyId="journey-id"
+              published={false}
+              setOpenAccessDialog={noop}
+              handleCloseMenu={noop}
+              setOpenTrashDialog={noop}
+            />
+          </TeamProvider>
         </SnackbarProvider>
       </MockedProvider>
     )

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DefaultMenu/DefaultMenu.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DefaultMenu/DefaultMenu.tsx
@@ -1,6 +1,4 @@
 import { ReactElement } from 'react'
-// TODO: remove when teams is released
-import { useFlags } from '@core/shared/ui/FlagsProvider'
 import EditIcon from '@mui/icons-material/Edit'
 import PeopleIcon from '@mui/icons-material/People'
 import VisibilityIcon from '@mui/icons-material/Visibility'
@@ -40,8 +38,6 @@ export function DefaultMenu({
   template,
   refetch
 }: DefaultMenuProps): ReactElement {
-  // TODO: remove when teams is released
-  const { teams } = useFlags()
   return (
     <>
       <NextLink
@@ -76,12 +72,7 @@ export function DefaultMenu({
         <DuplicateJourneyMenuItem id={id} handleCloseMenu={handleCloseMenu} />
       )}
       <Divider />
-      {
-        // TODO: remove when teams is released
-        teams && (
-          <CopyToTeamMenuItem id={id} handleCloseMenu={handleCloseMenu} />
-        )
-      }
+      <CopyToTeamMenuItem id={id} handleCloseMenu={handleCloseMenu} />
       <ArchiveJourney
         status={status}
         id={journeyId}

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.tsx
@@ -1,10 +1,8 @@
 import { ReactElement } from 'react'
 import ContentCopyRounded from '@mui/icons-material/ContentCopyRounded'
 import { useSnackbar } from 'notistack'
-import { useFlags } from '@core/shared/ui/FlagsProvider'
 import { MenuItem } from '../../../../MenuItem'
 import { useJourneyDuplicateMutation } from '../../../../../libs/useJourneyDuplicateMutation'
-// TODO: remove when teams is released
 import { useTeam } from '../../../../Team/TeamProvider'
 
 interface DuplicateJourneyMenuItemProps {
@@ -20,15 +18,11 @@ export function DuplicateJourneyMenuItem({
   const { enqueueSnackbar } = useSnackbar()
   const { activeTeam } = useTeam()
 
-  // TODO: remove when teams is released
-  const { teams } = useFlags()
-
   const handleDuplicateJourney = async (): Promise<void> => {
-    // TODO: add activeteam.id not null check when teams is released
-    if (id == null) return
+    if (id == null || activeTeam?.id == null) return
 
     const data = await journeyDuplicate({
-      variables: { id, teamId: activeTeam?.id }
+      variables: { id, teamId: activeTeam.id }
     })
     if (data != null) {
       handleCloseMenu()
@@ -41,7 +35,7 @@ export function DuplicateJourneyMenuItem({
 
   return (
     <MenuItem
-      disabled={activeTeam?.id == null && teams}
+      disabled={activeTeam?.id == null}
       label="Duplicate"
       icon={<ContentCopyRounded color="secondary" />}
       onClick={handleDuplicateJourney}

--- a/apps/journeys-admin/src/components/JourneyView/JourneyViewFab/JourneyViewFab.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyViewFab/JourneyViewFab.spec.tsx
@@ -1,7 +1,6 @@
 import { render, fireEvent, waitFor, within } from '@testing-library/react'
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 import { MockedProvider } from '@apollo/client/testing'
-import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 import { NextRouter, useRouter } from 'next/router'
 import { SnackbarProvider } from 'notistack'
 import TagManager from 'react-gtm-module'
@@ -44,15 +43,13 @@ describe('JourneyViewFab', () => {
   it('should redirect to journey editor on edit button click', () => {
     const { getByRole } = render(
       <MockedProvider>
-        <FlagsProvider>
-          <SnackbarProvider>
-            <TeamProvider>
-              <JourneyProvider value={{ journey: defaultJourney, admin: true }}>
-                <JourneyViewFab />
-              </JourneyProvider>
-            </TeamProvider>
-          </SnackbarProvider>
-        </FlagsProvider>
+        <SnackbarProvider>
+          <TeamProvider>
+            <JourneyProvider value={{ journey: defaultJourney, admin: true }}>
+              <JourneyViewFab />
+            </JourneyProvider>
+          </TeamProvider>
+        </SnackbarProvider>
       </MockedProvider>
     )
     expect(getByRole('link', { name: 'Edit' })).toHaveAttribute(
@@ -64,20 +61,18 @@ describe('JourneyViewFab', () => {
   it('should redirect to template editor on edit button click', () => {
     const { getByRole } = render(
       <MockedProvider>
-        <FlagsProvider>
-          <SnackbarProvider>
-            <TeamProvider>
-              <JourneyProvider
-                value={{
-                  journey: { ...defaultJourney, template: true },
-                  admin: true
-                }}
-              >
-                <JourneyViewFab isPublisher />
-              </JourneyProvider>
-            </TeamProvider>
-          </SnackbarProvider>
-        </FlagsProvider>
+        <SnackbarProvider>
+          <TeamProvider>
+            <JourneyProvider
+              value={{
+                journey: { ...defaultJourney, template: true },
+                admin: true
+              }}
+            >
+              <JourneyViewFab isPublisher />
+            </JourneyProvider>
+          </TeamProvider>
+        </SnackbarProvider>
       </MockedProvider>
     )
     expect(getByRole('link', { name: 'Edit' })).toHaveAttribute(
@@ -133,13 +128,11 @@ describe('JourneyViewFab', () => {
       >
         <SnackbarProvider>
           <TeamProvider>
-            <FlagsProvider flags={{ teams: true }}>
-              <JourneyProvider
-                value={{ journey: { ...defaultJourney, template: true } }}
-              >
-                <JourneyViewFab />
-              </JourneyProvider>
-            </FlagsProvider>
+            <JourneyProvider
+              value={{ journey: { ...defaultJourney, template: true } }}
+            >
+              <JourneyViewFab />
+            </JourneyProvider>
           </TeamProvider>
         </SnackbarProvider>
       </MockedProvider>
@@ -208,13 +201,11 @@ describe('JourneyViewFab', () => {
       >
         <SnackbarProvider>
           <TeamProvider>
-            <FlagsProvider flags={{ teams: true }}>
-              <JourneyProvider
-                value={{ journey: { ...defaultJourney, template: true } }}
-              >
-                <JourneyViewFab />
-              </JourneyProvider>
-            </FlagsProvider>
+            <JourneyProvider
+              value={{ journey: { ...defaultJourney, template: true } }}
+            >
+              <JourneyViewFab />
+            </JourneyProvider>
           </TeamProvider>
         </SnackbarProvider>
       </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyView/JourneyViewFab/JourneyViewFab.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyViewFab/JourneyViewFab.stories.tsx
@@ -1,7 +1,6 @@
 import { Story, Meta } from '@storybook/react'
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 import { MockedProvider } from '@apollo/client/testing'
-import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 import { SnackbarProvider } from 'notistack'
 import { simpleComponentConfig } from '../../../libs/storybook'
 import { defaultJourney } from '../data'
@@ -16,19 +15,13 @@ const JourneyViewFabStory = {
 
 const Template: Story = ({ ...args }) => (
   <MockedProvider mocks={args.mocks}>
-    <FlagsProvider>
-      <TeamProvider>
-        <SnackbarProvider>
-          {/* TODO: remove when teams is released */}
-          <FlagsProvider flags={{ teams: true }}>
-            <JourneyProvider value={{ journey: args.journey }}>
-              <JourneyViewFab isPublisher={args.isPublisher} />
-            </JourneyProvider>
-            {/* TODO: remove when teams is released */}
-          </FlagsProvider>
-        </SnackbarProvider>
-      </TeamProvider>
-    </FlagsProvider>
+    <TeamProvider>
+      <SnackbarProvider>
+        <JourneyProvider value={{ journey: args.journey }}>
+          <JourneyViewFab isPublisher={args.isPublisher} />
+        </JourneyProvider>
+      </SnackbarProvider>
+    </TeamProvider>
   </MockedProvider>
 )
 

--- a/apps/journeys-admin/src/components/JourneyView/JourneyViewFab/JourneyViewFab.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyViewFab/JourneyViewFab.tsx
@@ -7,8 +7,6 @@ import CheckRoundedIcon from '@mui/icons-material/CheckRounded'
 import Typography from '@mui/material/Typography'
 import NextLink from 'next/link'
 import { useRouter } from 'next/router'
-// TODO: remove when teams is released
-import { useFlags } from '@core/shared/ui/FlagsProvider'
 import { useJourneyDuplicateMutation } from '../../../libs/useJourneyDuplicateMutation'
 import { CopyToTeamDialog } from '../../Team/CopyToTeamDialog'
 
@@ -23,8 +21,6 @@ export function JourneyViewFab({
   const router = useRouter()
   const [duplicateTeamDialogOpen, setDuplicateTeamDialogOpen] = useState(false)
   const [journeyDuplicate] = useJourneyDuplicateMutation()
-  // TODO: remove when teams is released
-  const { teams } = useFlags()
 
   const handleConvertTemplate = async (
     teamId: string | undefined
@@ -72,13 +68,7 @@ export function JourneyViewFab({
           }}
           color="primary"
           disabled={journey == null}
-          onClick={() =>
-            // TODO: remove when teams is released
-            teams
-              ? setDuplicateTeamDialogOpen(true)
-              : // TODO: remove when teams is released
-                handleConvertTemplate(undefined)
-          }
+          onClick={() => setDuplicateTeamDialogOpen(true)}
         >
           <CheckRoundedIcon sx={{ mr: 3 }} />
           <Typography

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.spec.tsx
@@ -3,8 +3,6 @@ import { render, fireEvent, waitFor, within } from '@testing-library/react'
 import { SnackbarProvider } from 'notistack'
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 import { NextRouter, useRouter } from 'next/router'
-// TODO: remove when teams is released
-import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 import { defaultJourney, publishedJourney } from '../data'
 import { JourneyStatus, Role } from '../../../../__generated__/globalTypes'
 import { JOURNEY_DUPLICATE } from '../../../libs/useJourneyDuplicateMutation'
@@ -301,16 +299,14 @@ describe('JourneyView/Menu', () => {
           ]}
         >
           <TeamProvider>
-            <FlagsProvider flags={{ teams: true }}>
-              <JourneyProvider
-                value={{
-                  journey: { ...defaultJourney, template: true },
-                  admin: true
-                }}
-              >
-                <Menu />
-              </JourneyProvider>
-            </FlagsProvider>
+            <JourneyProvider
+              value={{
+                journey: { ...defaultJourney, template: true },
+                admin: true
+              }}
+            >
+              <Menu />
+            </JourneyProvider>
           </TeamProvider>
         </MockedProvider>
       </SnackbarProvider>
@@ -658,16 +654,14 @@ describe('JourneyView/Menu', () => {
           ]}
         >
           <TeamProvider>
-            <FlagsProvider flags={{ teams: true }}>
-              <JourneyProvider
-                value={{
-                  journey: { ...defaultJourney, template: true },
-                  admin: true
-                }}
-              >
-                <Menu />
-              </JourneyProvider>
-            </FlagsProvider>
+            <JourneyProvider
+              value={{
+                journey: { ...defaultJourney, template: true },
+                admin: true
+              }}
+            >
+              <Menu />
+            </JourneyProvider>
           </TeamProvider>
         </MockedProvider>
       </SnackbarProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.stories.tsx
@@ -1,6 +1,4 @@
 import { Story, Meta } from '@storybook/react'
-// TODO: remove when teams is released
-import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 import { screen, userEvent } from '@storybook/testing-library'
 import { MockedProvider } from '@apollo/client/testing'
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
@@ -95,13 +93,9 @@ const journeyMocks = [
 const Template: Story = ({ ...args }) => (
   <MockedProvider mocks={args.mocks}>
     <TeamProvider>
-      {/* TODO: remove when teams is released */}
-      <FlagsProvider flags={{ teams: true }}>
-        <JourneyProvider value={{ journey: args.journey, admin: true }}>
-          <Menu {...args} />
-        </JourneyProvider>
-        {/* TODO: remove when teams is released */}
-      </FlagsProvider>
+      <JourneyProvider value={{ journey: args.journey, admin: true }}>
+        <Menu {...args} />
+      </JourneyProvider>
     </TeamProvider>
   </MockedProvider>
 )

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
@@ -7,8 +7,6 @@ import MoreVert from '@mui/icons-material/MoreVert'
 import BeenHereRoundedIcon from '@mui/icons-material/BeenhereRounded'
 import VisibilityIcon from '@mui/icons-material/Visibility'
 import EditIcon from '@mui/icons-material/Edit'
-// TODO: remove when teams is released
-import { useFlags } from '@core/shared/ui/FlagsProvider'
 import DescriptionIcon from '@mui/icons-material/Description'
 import AssessmentRoundedIcon from '@mui/icons-material/AssessmentRounded'
 import TranslateIcon from '@mui/icons-material/Translate'
@@ -84,9 +82,6 @@ export function Menu(): ReactElement {
   const [showDescriptionDialog, setShowDescriptionDialog] = useState(false)
   const [showLanguageDialog, setShowLanguageDialog] = useState(false)
   const [duplicateTeamDialogOpen, setDuplicateTeamDialogOpen] = useState(false)
-
-  // TODO: remove when teams is released
-  const { teams } = useFlags()
 
   const { enqueueSnackbar } = useSnackbar()
 
@@ -222,13 +217,7 @@ export function Menu(): ReactElement {
               <MenuItem
                 label="Use Template"
                 icon={<CheckRounded />}
-                onClick={() =>
-                  // TODO: remove when teams is released
-                  teams
-                    ? setDuplicateTeamDialogOpen(true)
-                    : // TODO: remove when teams is released
-                      handleTemplate(undefined)
-                }
+                onClick={() => setDuplicateTeamDialogOpen(true)}
               />
             )}
             {journey.template === true && isPublisher && (


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 86b6c90</samp>

This pull request simplifies and cleans up various components and test files in the `journeys-admin` app by removing unused code related to the `teams` feature flag, which is no longer relevant. It also ensures consistent behavior for copying and duplicating journeys to other teams.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/33034379/todos/6371946891)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] it should not show // TODO: remove when teams is released in global search results for front end
- [ ] it should not show // TODO: remove when teams is released in the front end code
- [x] it should not show any flag logic revolving around teams: true

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 86b6c90</samp>

*  Remove unused imports of `useFlags` and `FlagsProvider` from component, test, and story files ([link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-3302693f7385e9de539e22962de14e792d5114a9499b742def163d720cab73d3L2), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-86d529e4d489989f10958e22c539e389c36d6458fbd54dbc4d546a0c493e6ed2L2-L3), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-3e1d2af5c201a307b9682413d9133e14295dc4f6272132b530eef5ab760a1c82L4-R5), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-277789467d9501dd2852fd612fecfee070578adfa0ad5f52c1445738844f66c5L4), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-efb2fd9d2dcb98d825f17cff7384a39a14fbbf86e8f12af45ec88332a51259f6L4), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-3287c14bdbf1ee1ed811ae1b539c9e00cf960327217767ea4110f40d8a03a4d8L10-L11), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-1d5916eb0f82f8964cc8f46e5ad5732a01ebab4e56bb137d1ec9608a1d0bede7L6-L7), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-049fecef5d1052c9fb98ed884d3ac7071d3ede281c887639a1a4af553ddec62cL2-L3), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-2c9f44f9db6ec77ee7fdf06b593abfe7aab0fc14735b41b66094629ff25bc082L10-L11))
*  Remove unused variables obtained from `useFlags` in `DefaultMenu`, `DuplicateJourneyMenuItem`, `JourneyViewFab`, and `Menu` components ([link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-86d529e4d489989f10958e22c539e389c36d6458fbd54dbc4d546a0c493e6ed2L43-L44), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-3e1d2af5c201a307b9682413d9133e14295dc4f6272132b530eef5ab760a1c82L23-R25), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-3287c14bdbf1ee1ed811ae1b539c9e00cf960327217767ea4110f40d8a03a4d8L26-L27), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-2c9f44f9db6ec77ee7fdf06b593abfe7aab0fc14735b41b66094629ff25bc082L88-L90))
*  Remove conditional rendering or disabling of components based on the `teams` flag, such as `CopyToTeamMenuItem`, `DuplicateJourneyMenuItem`, and `JourneyViewFab` ([link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-86d529e4d489989f10958e22c539e389c36d6458fbd54dbc4d546a0c493e6ed2L79-R75), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-3e1d2af5c201a307b9682413d9133e14295dc4f6272132b530eef5ab760a1c82L44-R38), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-3287c14bdbf1ee1ed811ae1b539c9e00cf960327217767ea4110f40d8a03a4d8L75-R71), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-2c9f44f9db6ec77ee7fdf06b593abfe7aab0fc14735b41b66094629ff25bc082L225-R220))
*  Remove `FlagsProvider` component from test and story render trees, as it is no longer needed after the removal of the `teams` feature flag ([link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-3302693f7385e9de539e22962de14e792d5114a9499b742def163d720cab73d3L15-R25), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-277789467d9501dd2852fd612fecfee070578adfa0ad5f52c1445738844f66c5L47-R52), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-277789467d9501dd2852fd612fecfee070578adfa0ad5f52c1445738844f66c5L67-R75), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-277789467d9501dd2852fd612fecfee070578adfa0ad5f52c1445738844f66c5L136-R135), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-277789467d9501dd2852fd612fecfee070578adfa0ad5f52c1445738844f66c5L211-R208), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-efb2fd9d2dcb98d825f17cff7384a39a14fbbf86e8f12af45ec88332a51259f6L19-R24), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-1d5916eb0f82f8964cc8f46e5ad5732a01ebab4e56bb137d1ec9608a1d0bede7L304-R309), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-1d5916eb0f82f8964cc8f46e5ad5732a01ebab4e56bb137d1ec9608a1d0bede7L661-R664), [link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-049fecef5d1052c9fb98ed884d3ac7071d3ede281c887639a1a4af553ddec62cL98-R98))
*  Add a null check for `activeTeam?.id` before calling the `journeyDuplicate` mutation in `DuplicateJourneyMenuItem` component ([link](https://github.com/JesusFilm/core/pull/1785/files?diff=unified&w=0#diff-3e1d2af5c201a307b9682413d9133e14295dc4f6272132b530eef5ab760a1c82L23-R25))
