### PR TITLE
fix: publisher can edit template field

### DIFF
--- a/apps/api-journeys/src/app/modules/journey/journey.acl.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.acl.spec.ts
@@ -105,7 +105,7 @@ describe('journeyAcl', () => {
     })
     it('deny template field when user is not publisher', () => {
       expect(
-        ability.can(Action.Manage, journeyUnpublishedTemplate, 'template')
+        ability.can(Action.Manage, journeyUserTeamManager, 'template')
       ).toEqual(false)
     })
     describe('publisher', () => {
@@ -117,10 +117,20 @@ describe('journeyAcl', () => {
           true
         )
       })
-      it('allow template field when user is publisher', () => {
+      it('allow template field when user is publisher and team manager', () => {
         expect(
-          ability.can(Action.Manage, journeyUnpublishedTemplate, 'template')
+          ability.can(Action.Manage, journeyUserTeamManager, 'template')
         ).toEqual(true)
+      })
+      it('allow template field when user is publisher and journey owner', () => {
+        expect(
+          ability.can(Action.Manage, journeyUserJourneyOwner, 'template')
+        ).toEqual(true)
+      })
+      it('deny when user is publisher but has no userTeam or userJourneys', () => {
+        expect(ability.can(Action.Manage, journeyEmpty, 'template')).toEqual(
+          false
+        )
       })
     })
   })

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -1353,7 +1353,9 @@ describe('JourneyResolver', () => {
         })
       })
       it('updates template', async () => {
-        prismaService.journey.findUnique.mockResolvedValueOnce(journey)
+        prismaService.journey.findUnique.mockResolvedValueOnce(
+          journeyWithUserTeam
+        )
         await resolver.journeyTemplate(ability, 'journeyId', { template: true })
         expect(prismaService.journey.update).toHaveBeenCalledWith({
           where: { id: 'journeyId' },


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4e4e853</samp>

Improved the access control logic for the template field of journeys in the `api-journeys` app. Only the publisher can manage the template if the journey is published or has pending changes.

- https://3.basecamp.com/3105655/buckets/33281894/todos/6411853661

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] publisher can convert to template a journey that either they own/editor, or that belongs to a team they manage/member of.

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4e4e853</samp>

*  Add a `cannot` parameter to the `journeyAcl` function to deny actions on subjects ([link](https://github.com/JesusFilm/core/pull/1787/files?diff=unified&w=0#diff-b4b7cd8ccccfa45b72b7ac65221c321bbe4e71655ef2c2b872385ebe3bdf0d22L8-R12))
*  Change the logic for the template field in the journey ACL to deny the manage action for all users, and grant it to the publisher only if they have a userTeam or userJourney relation with the appropriate role ([link](https://github.com/JesusFilm/core/pull/1787/files?diff=unified&w=0#diff-b4b7cd8ccccfa45b72b7ac65221c321bbe4e71655ef2c2b872385ebe3bdf0d22L73-R102))
*  Update the test case for denying the template field when the user is not a publisher to use a journey object with a userTeam relation (`journeyUserTeamManager`) instead of one with a template flag (`journeyUnpublishedTemplate`) ([link](https://github.com/JesusFilm/core/pull/1787/files?diff=unified&w=0#diff-1ac8416ad764615e86527357b4381e3ba20db73264ebc0293762778dd75ba7b3L108-R108))
*  Split the test case for allowing the template field when the user is a publisher into three cases: one for the publisher and team manager, one for the publisher and journey owner, and one for the publisher without any relation ([link](https://github.com/JesusFilm/core/pull/1787/files?diff=unified&w=0#diff-1ac8416ad764615e86527357b4381e3ba20db73264ebc0293762778dd75ba7b3L120-R134))
