### PR TITLE
fix: allow user to be upserted

### DIFF
--- a/apps/api-users/src/app/modules/user/user.resolver.spec.ts
+++ b/apps/api-users/src/app/modules/user/user.resolver.spec.ts
@@ -1,46 +1,92 @@
 import { Test, TestingModule } from '@nestjs/testing'
+import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
+
+import { User } from '.prisma/api-users-client'
 
 import { PrismaService } from '../../lib/prisma.service'
 
 import { UserResolver } from './user.resolver'
 
+jest.mock('@core/nest/common/firebaseClient', () => ({
+  firebaseClient: {
+    auth: jest.fn().mockReturnValue({
+      getUser: jest.fn().mockResolvedValue({
+        displayName: 'fo sho',
+        email: 'tho@no.co',
+        photoURL: 'p'
+      })
+    })
+  }
+}))
+
 describe('UserResolver', () => {
-  let resolver: UserResolver, prisma: PrismaService
+  let resolver: UserResolver, prismaService: DeepMockProxy<PrismaService>
 
   const user = {
-    id: '1',
+    id: 'userId',
     firstName: 'fo',
     lastName: 'sho',
     email: 'tho@no.co',
     imageUrl: 'po'
-  }
+  } as unknown as User
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UserResolver, PrismaService]
+      providers: [
+        UserResolver,
+        {
+          provide: PrismaService,
+          useValue: mockDeep<PrismaService>()
+        }
+      ]
     }).compile()
     resolver = module.get<UserResolver>(UserResolver)
-    prisma = module.get<PrismaService>(PrismaService)
+    prismaService = module.get<PrismaService>(
+      PrismaService
+    ) as DeepMockProxy<PrismaService>
   })
 
   describe('me', () => {
     it('returns User', async () => {
-      prisma.user.findUnique = jest.fn().mockReturnValueOnce(user)
-      expect(await resolver.me(user.id)).toEqual(user)
-      expect(prisma.user.findUnique).toHaveBeenCalledWith({
+      prismaService.user.findUnique.mockResolvedValueOnce(user)
+      expect(await resolver.me('userId')).toEqual(user)
+      expect(prismaService.user.findUnique).toHaveBeenCalledWith({
         where: { userId: user.id }
+      })
+    })
+
+    it('fetches user from firebase', async () => {
+      prismaService.user.findUnique.mockResolvedValueOnce(null)
+      prismaService.user.upsert.mockResolvedValueOnce(user)
+      expect(await resolver.me('userId')).toEqual(user)
+      expect(prismaService.user.upsert).toHaveBeenCalledWith({
+        create: {
+          email: 'tho@no.co',
+          firstName: 'fo',
+          imageUrl: 'p',
+          lastName: 'sho',
+          userId: 'userId'
+        },
+        update: {
+          email: 'tho@no.co',
+          firstName: 'fo',
+          imageUrl: 'p',
+          lastName: 'sho',
+          userId: 'userId'
+        },
+        where: { userId: 'userId' }
       })
     })
   })
 
   describe('resolveReference', () => {
     it('returns User', async () => {
-      prisma.user.findUnique = jest.fn().mockReturnValueOnce(user)
+      prismaService.user.findUnique.mockResolvedValueOnce(user)
       expect(
-        await resolver.resolveReference({ __typename: 'User', id: user.id })
+        await resolver.resolveReference({ __typename: 'User', id: 'userId' })
       ).toEqual(user)
-      expect(prisma.user.findUnique).toHaveBeenCalledWith({
-        where: { userId: user.id }
+      expect(prismaService.user.findUnique).toHaveBeenCalledWith({
+        where: { userId: 'userId' }
       })
     })
   })

--- a/apps/api-users/src/app/modules/user/user.resolver.ts
+++ b/apps/api-users/src/app/modules/user/user.resolver.ts
@@ -40,8 +40,15 @@ export class UserResolver {
       imageUrl
     }
 
-    return await this.prismaService.user.create({
-      data
+    // this function can run in parallel as such it is possible for multiple
+    // calls to reach this point and try to create the same user
+    // due to the earlier firebase async call.
+    return await this.prismaService.user.upsert({
+      where: {
+        userId
+      },
+      create: data,
+      update: data
     })
   }
 


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d5f77f6</samp>

Refactored the user resolver test file to use jest-mock-extended and jest.mock for better mocking. Updated the user resolver to use the upsert method instead of the create method to avoid race conditions when creating new users.

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/33281894/todos/6425709842)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Invite new non-existant user to join a team. Sign the new user up for an account. Accept terms. Manage teams. Should show list of users within team.
