### PR TITLE
fix: team select to match design

### DIFF
--- a/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.tsx
@@ -1,4 +1,5 @@
 import { gql, useMutation } from '@apollo/client'
+import ExpandMoreRoundedIcon from '@mui/icons-material/ExpandMoreRounded'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Divider from '@mui/material/Divider'
@@ -61,7 +62,7 @@ export function TeamSelect({ onboarding }: TeamSelectProps): ReactElement {
         sx={{ overflow: 'hidden', flexGrow: 1 }}
         ref={anchorRef}
       >
-        <UsersProfiles3Icon sx={{ mr: 3, ml: '3px' }} />
+        <UsersProfiles3Icon sx={{ mr: 1, ml: '3px' }} />
         <FormControl variant="standard" sx={{ minWidth: 100 }}>
           <Select
             defaultValue={activeTeam?.id}
@@ -72,8 +73,18 @@ export function TeamSelect({ onboarding }: TeamSelectProps): ReactElement {
             autoWidth
             sx={{
               '> .MuiSelect-select': {
-                whiteSpace: 'normal',
-                wordWrap: 'break-word'
+                backgroundColor: 'transparent',
+                wordWrap: 'break-word',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                mr: 1
+              },
+              fontWeight: 600,
+              '&:before, &:after': {
+                display: 'none'
+              },
+              '> .MuiSvgIcon-root': {
+                transition: 'transform 0.2s ease-in-out'
               }
             }}
             MenuProps={{
@@ -86,6 +97,7 @@ export function TeamSelect({ onboarding }: TeamSelectProps): ReactElement {
                 horizontal: 'left'
               }
             }}
+            IconComponent={ExpandMoreRoundedIcon}
           >
             {(query?.data?.teams != null
               ? sortBy(query.data?.teams, 'title')


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a98f863</samp>

Improved the UI of the `TeamSelect` component in the journeys-admin app. Used a custom icon for the select menu and adjusted the alignment and style of the team icon and text.

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/33281894/todos/6425701093)

![Screenshot 2023-08-09 at 10 59 53 AM](https://github.com/JesusFilm/core/assets/802117/975f5918-71df-4d11-83dd-a5ab616c4e36)
