### PR TITLE
fix: add loader icons

### DIFF
--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.spec.tsx
@@ -37,7 +37,7 @@ describe('DuplicateJourneys', () => {
       }
     }))
 
-    const { getByRole, getByText } = render(
+    const { getByRole, getByText, getByTestId } = render(
       <MockedProvider
         mocks={[
           {
@@ -77,6 +77,7 @@ describe('DuplicateJourneys', () => {
     )
     await waitFor(() => expect(result2).toHaveBeenCalled())
     await fireEvent.click(getByRole('menuitem', { name: 'Duplicate' }))
+    expect(getByTestId('journey-duplicate-loader')).toBeInTheDocument()
     await waitFor(() => expect(result).toHaveBeenCalled())
     expect(handleCloseMenu).toHaveBeenCalled()
     expect(getByText('Journey Duplicated')).toBeInTheDocument()

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.tsx
@@ -1,4 +1,5 @@
 import ContentCopyRounded from '@mui/icons-material/ContentCopyRounded'
+import CircularProgress from '@mui/material/CircularProgress'
 import { useSnackbar } from 'notistack'
 import { ReactElement } from 'react'
 
@@ -15,7 +16,7 @@ export function DuplicateJourneyMenuItem({
   id,
   handleCloseMenu
 }: DuplicateJourneyMenuItemProps): ReactElement {
-  const [journeyDuplicate] = useJourneyDuplicateMutation()
+  const [journeyDuplicate, { loading }] = useJourneyDuplicateMutation()
   const { enqueueSnackbar } = useSnackbar()
   const { activeTeam } = useTeam()
 
@@ -38,7 +39,13 @@ export function DuplicateJourneyMenuItem({
     <MenuItem
       disabled={activeTeam?.id == null}
       label="Duplicate"
-      icon={<ContentCopyRounded color="secondary" />}
+      icon={
+        loading ? (
+          <CircularProgress size={24} color="inherit" />
+        ) : (
+          <ContentCopyRounded color="secondary" />
+        )
+      }
       onClick={handleDuplicateJourney}
     />
   )

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.tsx
@@ -41,7 +41,11 @@ export function DuplicateJourneyMenuItem({
       label="Duplicate"
       icon={
         loading ? (
-          <CircularProgress size={24} color="inherit" />
+          <CircularProgress
+            size={24}
+            color="inherit"
+            data-testid="journey-duplicate-loader"
+          />
         ) : (
           <ContentCopyRounded color="secondary" />
         )

--- a/apps/journeys-admin/src/components/Team/CopyToTeamDialog/CopyToTeamDialog.tsx
+++ b/apps/journeys-admin/src/components/Team/CopyToTeamDialog/CopyToTeamDialog.tsx
@@ -41,10 +41,11 @@ export function CopyToTeamDialog({
     values: FormikValues,
     { resetForm }: FormikHelpers<FormikValues>
   ): Promise<void> {
+    await submitAction(values.teamSelect)
     await setActiveTeam(
       query?.data?.teams.find((team) => team.id === values.teamSelect) ?? null
     )
-    await submitAction(values.teamSelect)
+
     resetForm()
   }
 
@@ -59,6 +60,7 @@ export function CopyToTeamDialog({
           open={open}
           onClose={handleClose}
           dialogTitle={{ title: t(title) }}
+          isSubmitting={isSubmitting}
           dialogAction={{
             onSubmit: () => {
               if (!isSubmitting) handleSubmit()

--- a/apps/journeys-admin/src/components/Team/CopyToTeamDialog/CopyToTeamDialog.tsx
+++ b/apps/journeys-admin/src/components/Team/CopyToTeamDialog/CopyToTeamDialog.tsx
@@ -41,7 +41,7 @@ export function CopyToTeamDialog({
     values: FormikValues,
     { resetForm }: FormikHelpers<FormikValues>
   ): Promise<void> {
-    //submitAction runs first so loading state can be shown
+    // submitAction runs first so loading state can be shown
     await submitAction(values.teamSelect)
     await setActiveTeam(
       query?.data?.teams.find((team) => team.id === values.teamSelect) ?? null

--- a/apps/journeys-admin/src/components/Team/CopyToTeamDialog/CopyToTeamDialog.tsx
+++ b/apps/journeys-admin/src/components/Team/CopyToTeamDialog/CopyToTeamDialog.tsx
@@ -41,6 +41,7 @@ export function CopyToTeamDialog({
     values: FormikValues,
     { resetForm }: FormikHelpers<FormikValues>
   ): Promise<void> {
+    //submitAction runs first so loading state can be shown
     await submitAction(values.teamSelect)
     await setActiveTeam(
       query?.data?.teams.find((team) => team.id === values.teamSelect) ?? null
@@ -60,7 +61,7 @@ export function CopyToTeamDialog({
           open={open}
           onClose={handleClose}
           dialogTitle={{ title: t(title) }}
-          isSubmitting={isSubmitting}
+          loading={isSubmitting}
           dialogAction={{
             onSubmit: () => {
               if (!isSubmitting) handleSubmit()

--- a/apps/journeys-admin/src/components/Team/CopyToTeamMenuItem/CopyToTeamMenuItem.tsx
+++ b/apps/journeys-admin/src/components/Team/CopyToTeamMenuItem/CopyToTeamMenuItem.tsx
@@ -1,5 +1,4 @@
 import ContentCopyRounded from '@mui/icons-material/ContentCopyRounded'
-import CircularProgress from '@mui/material/CircularProgress'
 import { useSnackbar } from 'notistack'
 import { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -19,7 +18,7 @@ export function CopyToTeamMenuItem({
 }: DuplicateJourneyMenuItemProps): ReactElement {
   const [duplicateTeamDialogOpen, setDuplicateTeamDialogOpen] =
     useState<boolean>(false)
-  const [journeyDuplicate, { loading }] = useJourneyDuplicateMutation()
+  const [journeyDuplicate] = useJourneyDuplicateMutation()
   const { enqueueSnackbar } = useSnackbar()
   const { t } = useTranslation('apps-journeys-admin')
 
@@ -46,13 +45,7 @@ export function CopyToTeamMenuItem({
     <>
       <MenuItem
         label={t('Copy to ...')}
-        icon={
-          loading ? (
-            <CircularProgress size={24} color="inherit" />
-          ) : (
-            <ContentCopyRounded color="secondary" />
-          )
-        }
+        icon={<ContentCopyRounded color="secondary" />}
         onClick={() => {
           setDuplicateTeamDialogOpen(true)
         }}

--- a/apps/journeys-admin/src/components/Team/CopyToTeamMenuItem/CopyToTeamMenuItem.tsx
+++ b/apps/journeys-admin/src/components/Team/CopyToTeamMenuItem/CopyToTeamMenuItem.tsx
@@ -1,4 +1,5 @@
 import ContentCopyRounded from '@mui/icons-material/ContentCopyRounded'
+import CircularProgress from '@mui/material/CircularProgress'
 import { useSnackbar } from 'notistack'
 import { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -18,7 +19,7 @@ export function CopyToTeamMenuItem({
 }: DuplicateJourneyMenuItemProps): ReactElement {
   const [duplicateTeamDialogOpen, setDuplicateTeamDialogOpen] =
     useState<boolean>(false)
-  const [journeyDuplicate] = useJourneyDuplicateMutation()
+  const [journeyDuplicate, { loading }] = useJourneyDuplicateMutation()
   const { enqueueSnackbar } = useSnackbar()
   const { t } = useTranslation('apps-journeys-admin')
 
@@ -45,7 +46,13 @@ export function CopyToTeamMenuItem({
     <>
       <MenuItem
         label={t('Copy to ...')}
-        icon={<ContentCopyRounded color="secondary" />}
+        icon={
+          loading ? (
+            <CircularProgress size={24} color="inherit" />
+          ) : (
+            <ContentCopyRounded color="secondary" />
+          )
+        }
         onClick={() => {
           setDuplicateTeamDialogOpen(true)
         }}
@@ -54,7 +61,6 @@ export function CopyToTeamMenuItem({
         title={t('Copy to Another Team')}
         open={duplicateTeamDialogOpen}
         onClose={() => {
-          handleCloseMenu()
           setDuplicateTeamDialogOpen(false)
         }}
         submitAction={handleDuplicateJourney}

--- a/libs/shared/ui/src/components/Dialog/Dialog.spec.tsx
+++ b/libs/shared/ui/src/components/Dialog/Dialog.spec.tsx
@@ -79,7 +79,7 @@ describe('Dialog', () => {
     })
 
     it('should show loading spinner if dialog is in submitting state', () => {
-      const { getByTestId } = render(<Dialog {...input} isSubmitting />)
+      const { getByTestId } = render(<Dialog {...input} loading />)
       expect(getByTestId('dialog-loading-icon')).toBeInTheDocument()
     })
   })

--- a/libs/shared/ui/src/components/Dialog/Dialog.spec.tsx
+++ b/libs/shared/ui/src/components/Dialog/Dialog.spec.tsx
@@ -3,7 +3,6 @@ import Typography from '@mui/material/Typography'
 import { fireEvent } from '@storybook/testing-library'
 import { render } from '@testing-library/react'
 import { ComponentProps } from 'react'
-import { ApolloLoadingProvider } from '../../../../../journeys/ui/test/ApolloLoadingProvider'
 
 import { Dialog } from './Dialog'
 

--- a/libs/shared/ui/src/components/Dialog/Dialog.spec.tsx
+++ b/libs/shared/ui/src/components/Dialog/Dialog.spec.tsx
@@ -3,6 +3,7 @@ import Typography from '@mui/material/Typography'
 import { fireEvent } from '@storybook/testing-library'
 import { render } from '@testing-library/react'
 import { ComponentProps } from 'react'
+import { ApolloLoadingProvider } from '../../../../../journeys/ui/test/ApolloLoadingProvider'
 
 import { Dialog } from './Dialog'
 
@@ -76,6 +77,11 @@ describe('Dialog', () => {
       const { getByRole } = render(<Dialog {...input} />)
       fireEvent.click(getByRole('button', { name: 'Accept' }))
       expect(input.dialogAction?.onSubmit).toHaveBeenCalled()
+    })
+
+    it('should show loading spinner if dialog is in submitting state', () => {
+      const { getByTestId } = render(<Dialog {...input} isSubmitting />)
+      expect(getByTestId('dialog-loading-icon')).toBeInTheDocument()
     })
   })
 

--- a/libs/shared/ui/src/components/Dialog/Dialog.stories.tsx
+++ b/libs/shared/ui/src/components/Dialog/Dialog.stories.tsx
@@ -41,7 +41,7 @@ Basic.args = {
 
 export const Submitting = Template.bind({})
 Submitting.args = {
-  isSubmitting: true,
+  loading: true,
   open: true,
   onClose: noop,
   dialogTitle: { title: 'Simple Dialog' },

--- a/libs/shared/ui/src/components/Dialog/Dialog.stories.tsx
+++ b/libs/shared/ui/src/components/Dialog/Dialog.stories.tsx
@@ -39,8 +39,8 @@ Basic.args = {
   children: <Typography>This is the content</Typography>
 }
 
-export const Submitting = Template.bind({})
-Submitting.args = {
+export const Loading = Template.bind({})
+Loading.args = {
   loading: true,
   open: true,
   onClose: noop,

--- a/libs/shared/ui/src/components/Dialog/Dialog.stories.tsx
+++ b/libs/shared/ui/src/components/Dialog/Dialog.stories.tsx
@@ -39,6 +39,19 @@ Basic.args = {
   children: <Typography>This is the content</Typography>
 }
 
+export const Submitting = Template.bind({})
+Submitting.args = {
+  isSubmitting: true,
+  open: true,
+  onClose: noop,
+  dialogTitle: { title: 'Simple Dialog' },
+  dialogAction: {
+    onSubmit: noop,
+    submitLabel: 'Ok'
+  },
+  children: <Typography>This is the content</Typography>
+}
+
 export const IconTitle = Template.bind({})
 IconTitle.args = {
   open: true,

--- a/libs/shared/ui/src/components/Dialog/Dialog.tsx
+++ b/libs/shared/ui/src/components/Dialog/Dialog.tsx
@@ -117,7 +117,7 @@ export function Dialog({
               {dialogAction.submitLabel ?? 'Save'}
             </Button>
           ) : (
-            <Button>
+            <Button disabled>
               <CircularProgress size={24} data-testid="dialog-loading-icon" />
             </Button>
           )}

--- a/libs/shared/ui/src/components/Dialog/Dialog.tsx
+++ b/libs/shared/ui/src/components/Dialog/Dialog.tsx
@@ -20,7 +20,7 @@ interface DialogProps {
   fullscreen?: boolean
   children?: ReactChild
   container?: HTMLElement
-  isSubmitting?: boolean
+  loading?: boolean
 }
 
 interface DialogAction {
@@ -78,7 +78,7 @@ export function Dialog({
   fullscreen,
   children,
   container,
-  isSubmitting = false
+  loading = false
 }: DialogProps): ReactElement {
   return (
     <StyledDialog
@@ -109,10 +109,10 @@ export function Dialog({
       </DialogContent>
       {dialogAction != null ? (
         <DialogActions data-testid="dialog-action">
-          {dialogAction.closeLabel != null && !isSubmitting && (
+          {dialogAction.closeLabel != null && !loading && (
             <Button onClick={onClose}>{dialogAction.closeLabel}</Button>
           )}
-          {!isSubmitting ? (
+          {!loading ? (
             <Button onClick={dialogAction?.onSubmit}>
               {dialogAction.submitLabel ?? 'Save'}
             </Button>

--- a/libs/shared/ui/src/components/Dialog/Dialog.tsx
+++ b/libs/shared/ui/src/components/Dialog/Dialog.tsx
@@ -1,5 +1,6 @@
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded'
 import Button from '@mui/material/Button'
+import CircularProgress from '@mui/material/CircularProgress'
 import MuiDialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'
@@ -19,6 +20,7 @@ interface DialogProps {
   fullscreen?: boolean
   children?: ReactChild
   container?: HTMLElement
+  isSubmitting?: boolean
 }
 
 interface DialogAction {
@@ -75,7 +77,8 @@ export function Dialog({
   divider,
   fullscreen,
   children,
-  container
+  container,
+  isSubmitting = false
 }: DialogProps): ReactElement {
   return (
     <StyledDialog
@@ -106,12 +109,18 @@ export function Dialog({
       </DialogContent>
       {dialogAction != null ? (
         <DialogActions data-testid="dialog-action">
-          {dialogAction.closeLabel != null && (
+          {dialogAction.closeLabel != null && !isSubmitting && (
             <Button onClick={onClose}>{dialogAction.closeLabel}</Button>
           )}
-          <Button onClick={dialogAction?.onSubmit}>
-            {dialogAction.submitLabel ?? 'Save'}
-          </Button>
+          {!isSubmitting ? (
+            <Button onClick={dialogAction?.onSubmit}>
+              {dialogAction.submitLabel ?? 'Save'}
+            </Button>
+          ) : (
+            <Button>
+              <CircularProgress size={24} data-testid="dialog-loading-icon" />
+            </Button>
+          )}
         </DialogActions>
       ) : dialogActionChildren != null ? (
         <DialogActions data-testid="dialog-action">


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cf29094</samp>

This pull request adds loading indicators and improves the menu behavior for duplicating and copying journeys in the journeys-admin app. It uses the `CircularProgress` component and the `useJourneyDuplicateMutation` hook in `DuplicateJourneyMenuItem.tsx` and `CopyToTeamMenuItem.tsx`.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/33281894/todos/6425720303)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] it should show loader icon when clicking copy to and waiting for query to resolve
- [ ] it should show loader icon when duplicate and waiting for query to resolve

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cf29094</samp>

*  Add loading indicators to duplicate journey and copy to team menu items ([link](https://github.com/JesusFilm/core/pull/1807/files?diff=unified&w=0#diff-3e1d2af5c201a307b9682413d9133e14295dc4f6272132b530eef5ab760a1c82R2), [link](https://github.com/JesusFilm/core/pull/1807/files?diff=unified&w=0#diff-3e1d2af5c201a307b9682413d9133e14295dc4f6272132b530eef5ab760a1c82L18-R19), [link](https://github.com/JesusFilm/core/pull/1807/files?diff=unified&w=0#diff-3e1d2af5c201a307b9682413d9133e14295dc4f6272132b530eef5ab760a1c82L41-R48), [link](https://github.com/JesusFilm/core/pull/1807/files?diff=unified&w=0#diff-bab70ac28b8351adba7e37093d01d82a4133fc8f216955d89261e58e05b32a16R2), [link](https://github.com/JesusFilm/core/pull/1807/files?diff=unified&w=0#diff-bab70ac28b8351adba7e37093d01d82a4133fc8f216955d89261e58e05b32a16L21-R22), [link](https://github.com/JesusFilm/core/pull/1807/files?diff=unified&w=0#diff-bab70ac28b8351adba7e37093d01d82a4133fc8f216955d89261e58e05b32a16L48-R55))
* Prevent journey card menu from closing before duplicate team dialog opens ([link](https://github.com/JesusFilm/core/pull/1807/files?diff=unified&w=0#diff-bab70ac28b8351adba7e37093d01d82a4133fc8f216955d89261e58e05b32a16L57))
