### PR TITLE
fix: reduce line height in step header and remove privacy policy

### DIFF
--- a/libs/journeys/ui/src/components/StepHeader/StepHeader.spec.tsx
+++ b/libs/journeys/ui/src/components/StepHeader/StepHeader.spec.tsx
@@ -24,15 +24,6 @@ describe('StepHeader', () => {
     )
   })
 
-  it('should have the privacy policy link', () => {
-    const { getByRole } = render(<StepHeader />)
-    fireEvent.click(getByRole('button'))
-    expect(getByRole('link', { name: 'Privacy Policy' })).toHaveAttribute(
-      'href',
-      'https://www.cru.org/us/en/about/privacy.html'
-    )
-  })
-
   it('should have the journey creator privacy policy', () => {
     const { getByText, getByRole } = render(<StepHeader />)
     fireEvent.click(getByRole('button'))
@@ -42,5 +33,16 @@ describe('StepHeader', () => {
         'All personal identifiable data registered on this website will be processed by journey creator: "{{ teamTitle }}".'
       )
     ).toBeInTheDocument()
+  })
+
+  it('should have the correct line height for journey creator privacy policy', () => {
+    const { getByText, getByRole } = render(<StepHeader />)
+    fireEvent.click(getByRole('button'))
+
+    expect(
+      getByText(
+        'All personal identifiable data registered on this website will be processed by journey creator: "{{ teamTitle }}".'
+      )
+    ).toHaveStyle({ 'line-height': 1.2, display: 'block' })
   })
 })

--- a/libs/journeys/ui/src/components/StepHeader/StepHeader.tsx
+++ b/libs/journeys/ui/src/components/StepHeader/StepHeader.tsx
@@ -89,22 +89,11 @@ export function StepHeader(): ReactElement {
             <MuiMenuItem>{t('Terms & Conditions')}</MuiMenuItem>
           </Link>
         </NextLink>
-        <NextLink href="https://www.cru.org/us/en/about/privacy.html" passHref>
-          <Link
-            variant="body2"
-            underline="none"
-            target="_blank"
-            rel="noopener"
-            sx={{ px: 0 }}
-            onClick={handleClose}
-          >
-            <MuiMenuItem>{t('Privacy Policy')}</MuiMenuItem>
-          </Link>
-        </NextLink>
         <Box sx={{ px: 4, py: 1, maxWidth: '204px' }}>
           <Typography
             color={(theme) => theme.palette.action.disabled}
             variant="caption"
+            sx={{ display: 'block', lineHeight: 1.2 }}
           >
             {t(
               'All personal identifiable data registered on this website will be processed by journey creator: "{{ teamTitle }}".',

--- a/libs/locales/en/libs-journeys-ui.json
+++ b/libs/locales/en/libs-journeys-ui.json
@@ -14,7 +14,6 @@
   "Twitter": "Twitter",
   "Report this content": "Report this content",
   "Terms & Conditions": "Terms & Conditions",
-  "Privacy Policy": "Privacy Policy",
   "All personal identifiable data registered on this website will be processed by journey creator: \"{{ teamTitle }}\".": "All personal identifiable data registered on this website will be processed by journey creator: \"{{ teamTitle }}\".",
   "NextSteps © {{year}}": "NextSteps © {{year}}",
   "Untitled": "Untitled",


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 577de88</samp>

Updated the menu design in `StepHeader` component. Removed the privacy policy link and added the journey creator privacy policy text in `StepHeader.tsx` and `StepHeader.spec.tsx`.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/33281894/todos/6407936100)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] line height and is reduced to 1.2 as per design
- [ ] no privacy policy link in step header

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 577de88</samp>

*  Removed the privacy policy link and added the journey creator privacy policy text to the menu ([link](https://github.com/JesusFilm/core/pull/1809/files?diff=unified&w=0#diff-00869f75b6301e1727b13219c1365543ef481680482b942225f048e83ea9ccd4L92-R96), [link](https://github.com/JesusFilm/core/pull/1809/files?diff=unified&w=0#diff-1a2ade6df1a3d9f0ff3f07d0811e35fb103c3dc075a26fd9533b9dbc6e8590b9L27-R38), [link](https://github.com/JesusFilm/core/pull/1809/files?diff=unified&w=0#diff-1a2ade6df1a3d9f0ff3f07d0811e35fb103c3dc075a26fd9533b9dbc6e8590b9L44-R46))
