### PR TITLE
ci: upload sourcemaps to datadog

### DIFF
--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -83,7 +83,7 @@ jobs:
           JOURNEYS_ADMIN_VERCEL_PROJECT_ID: ${{ secrets.JOURNEYS_ADMIN_VERCEL_PROJECT_ID }}
           WATCH_VERCEL_PROJECT_ID: ${{ secrets.WATCH_VERCEL_PROJECT_ID }}
           NEXT_PUBLIC_VERCEL_ENV: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
-          NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA: $${{ github.sha }}
+          NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA: ${{ github.sha }}
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
         # use run-namy to avoid case where deploy command doesn't exist for a project
         run: npx nx run-many --target=deploy --projects=${{ matrix.app }}

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -82,6 +82,9 @@ jobs:
           JOURNEYS_VERCEL_PROJECT_ID: ${{ secrets.JOURNEYS_VERCEL_PROJECT_ID }}
           JOURNEYS_ADMIN_VERCEL_PROJECT_ID: ${{ secrets.JOURNEYS_ADMIN_VERCEL_PROJECT_ID }}
           WATCH_VERCEL_PROJECT_ID: ${{ secrets.WATCH_VERCEL_PROJECT_ID }}
+          NEXT_PUBLIC_VERCEL_ENV: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
+          NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA: $${{ github.sha }}
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
         # use run-namy to avoid case where deploy command doesn't exist for a project
         run: npx nx run-many --target=deploy --projects=${{ matrix.app }}
       - name: vercel set alias

--- a/apps/journeys-admin/project.json
+++ b/apps/journeys-admin/project.json
@@ -40,7 +40,7 @@
           "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel pull --environment=preview --token=$VERCEL_TOKEN",
           "npx vercel build",
           "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --token=$VERCEL_TOKEN --archive=tgz > apps/journeys-admin/.vercel-url",
-          "npx @datadog/datadog-ci sourcemaps upload dist/apps/journeys-admin/.next/static --service=journeys-admin --release-version=$VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/journeys-admin/.vercel-url)/_next/static/"
+          "npx @datadog/datadog-ci sourcemaps upload dist/apps/journeys-admin/.next/static --service=journeys-admin --release-version=$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/journeys-admin/.vercel-url)/_next/static/"
         ],
         "parallel": false
       },
@@ -50,7 +50,7 @@
             "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
             "npx vercel build --prod",
             "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --archive=tgz > apps/journeys-admin/.vercel-url",
-            "npx @datadog/datadog-ci sourcemaps upload dist/apps/journeys-admin/.next/static --service=journeys-admin --release-version=$VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/journeys-admin/.vercel-url)/_next/static/"
+            "npx @datadog/datadog-ci sourcemaps upload dist/apps/journeys-admin/.next/static --service=journeys-admin --release-version=$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/journeys-admin/.vercel-url)/_next/static/"
           ]
         }
       }

--- a/apps/journeys-admin/project.json
+++ b/apps/journeys-admin/project.json
@@ -40,7 +40,7 @@
           "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel pull --environment=preview --token=$VERCEL_TOKEN",
           "npx vercel build",
           "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --token=$VERCEL_TOKEN --archive=tgz > apps/journeys-admin/.vercel-url",
-          "npx @datadog/datadog-ci sourcemaps upload dist/apps/journeys-admin/.next/static --service=journeys-admin --release-version=$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/journeys-admin/.vercel-url)/_next/static/"
+          "npx @datadog/datadog-ci sourcemaps upload dist/apps/journeys-admin/.next/static --service=journeys-admin --release-version=$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(cat apps/journeys-admin/.vercel-url)/_next/static/"
         ],
         "parallel": false
       },
@@ -50,7 +50,7 @@
             "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
             "npx vercel build --prod",
             "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --archive=tgz > apps/journeys-admin/.vercel-url",
-            "npx @datadog/datadog-ci sourcemaps upload dist/apps/journeys-admin/.next/static --service=journeys-admin --release-version=$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/journeys-admin/.vercel-url)/_next/static/"
+            "npx @datadog/datadog-ci sourcemaps upload dist/apps/journeys-admin/.next/static --service=journeys-admin --release-version=$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(cat apps/journeys-admin/.vercel-url)/_next/static/"
           ]
         }
       }

--- a/apps/journeys-admin/project.json
+++ b/apps/journeys-admin/project.json
@@ -39,7 +39,8 @@
         "commands": [
           "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel pull --environment=preview --token=$VERCEL_TOKEN",
           "npx vercel build",
-          "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --token=$VERCEL_TOKEN --archive=tgz > apps/journeys-admin/.vercel-url"
+          "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --token=$VERCEL_TOKEN --archive=tgz > apps/journeys-admin/.vercel-url",
+          "npx @datadog/datadog-ci sourcemaps upload dist/apps/journeys-admin/.next/static --service=journeys-admin --release-version=$VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/journeys-admin/.vercel-url)/_next/static/"
         ],
         "parallel": false
       },
@@ -48,7 +49,8 @@
           "commands": [
             "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
             "npx vercel build --prod",
-            "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --archive=tgz > apps/journeys-admin/.vercel-url"
+            "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --archive=tgz > apps/journeys-admin/.vercel-url",
+            "npx @datadog/datadog-ci sourcemaps upload dist/apps/journeys-admin/.next/static --service=journeys-admin --release-version=$VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/journeys-admin/.vercel-url)/_next/static/"
           ]
         }
       }

--- a/apps/journeys/project.json
+++ b/apps/journeys/project.json
@@ -39,7 +39,8 @@
         "commands": [
           "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel pull --environment=preview --token=$VERCEL_TOKEN",
           "npx vercel build",
-          "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --token=$VERCEL_TOKEN --archive=tgz > apps/journeys/.vercel-url"
+          "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --token=$VERCEL_TOKEN --archive=tgz > apps/journeys/.vercel-url",
+          "npx @datadog/datadog-ci sourcemaps upload dist/apps/journeys/.next/static --service=journeys --release-version=$VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/journeys/.vercel-url)/_next/static/"
         ],
         "parallel": false
       },
@@ -48,7 +49,8 @@
           "commands": [
             "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
             "npx vercel build --prod",
-            "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --archive=tgz > apps/journeys/.vercel-url"
+            "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --archive=tgz > apps/journeys/.vercel-url",
+            "npx @datadog/datadog-ci sourcemaps upload dist/apps/journeys/.next/static --service=journeys --release-version=$VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/journeys/.vercel-url)/_next/static/"
           ]
         }
       }

--- a/apps/journeys/project.json
+++ b/apps/journeys/project.json
@@ -40,7 +40,7 @@
           "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel pull --environment=preview --token=$VERCEL_TOKEN",
           "npx vercel build",
           "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --token=$VERCEL_TOKEN --archive=tgz > apps/journeys/.vercel-url",
-          "npx @datadog/datadog-ci sourcemaps upload dist/apps/journeys/.next/static --service=journeys --release-version=$VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/journeys/.vercel-url)/_next/static/"
+          "npx @datadog/datadog-ci sourcemaps upload dist/apps/journeys/.next/static --service=journeys --release-version=$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/journeys/.vercel-url)/_next/static/"
         ],
         "parallel": false
       },
@@ -50,7 +50,7 @@
             "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
             "npx vercel build --prod",
             "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --archive=tgz > apps/journeys/.vercel-url",
-            "npx @datadog/datadog-ci sourcemaps upload dist/apps/journeys/.next/static --service=journeys --release-version=$VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/journeys/.vercel-url)/_next/static/"
+            "npx @datadog/datadog-ci sourcemaps upload dist/apps/journeys/.next/static --service=journeys --release-version=$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/journeys/.vercel-url)/_next/static/"
           ]
         }
       }

--- a/apps/journeys/project.json
+++ b/apps/journeys/project.json
@@ -40,7 +40,7 @@
           "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel pull --environment=preview --token=$VERCEL_TOKEN",
           "npx vercel build",
           "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --token=$VERCEL_TOKEN --archive=tgz > apps/journeys/.vercel-url",
-          "npx @datadog/datadog-ci sourcemaps upload dist/apps/journeys/.next/static --service=journeys --release-version=$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/journeys/.vercel-url)/_next/static/"
+          "npx @datadog/datadog-ci sourcemaps upload dist/apps/journeys/.next/static --service=journeys --release-version=$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(cat apps/journeys/.vercel-url)/_next/static/"
         ],
         "parallel": false
       },
@@ -50,7 +50,7 @@
             "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
             "npx vercel build --prod",
             "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --archive=tgz > apps/journeys/.vercel-url",
-            "npx @datadog/datadog-ci sourcemaps upload dist/apps/journeys/.next/static --service=journeys --release-version=$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/journeys/.vercel-url)/_next/static/"
+            "npx @datadog/datadog-ci sourcemaps upload dist/apps/journeys/.next/static --service=journeys --release-version=$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(cat apps/journeys/.vercel-url)/_next/static/"
           ]
         }
       }

--- a/apps/watch/project.json
+++ b/apps/watch/project.json
@@ -37,7 +37,7 @@
           "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel pull --environment=preview --token=$VERCEL_TOKEN",
           "npx vercel build",
           "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --token=$VERCEL_TOKEN --archive=tgz > apps/watch/.vercel-url",
-          "npx @datadog/datadog-ci sourcemaps upload dist/apps/watch/.next/static --service=watch --release-version=$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/watch/.vercel-url)/_next/static/"
+          "npx @datadog/datadog-ci sourcemaps upload dist/apps/watch/.next/static --service=watch --release-version=$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(cat apps/watch/.vercel-url)/_next/static/"
         ],
         "parallel": false
       },
@@ -47,7 +47,7 @@
             "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
             "npx vercel build --prod",
             "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --archive=tgz > apps/watch/.vercel-url",
-            "npx @datadog/datadog-ci sourcemaps upload dist/apps/watch/.next/static --service=watch --release-version=$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/watch/.vercel-url)/_next/static/"
+            "npx @datadog/datadog-ci sourcemaps upload dist/apps/watch/.next/static --service=watch --release-version=$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(cat apps/watch/.vercel-url)/_next/static/"
           ]
         }
       }

--- a/apps/watch/project.json
+++ b/apps/watch/project.json
@@ -36,7 +36,8 @@
         "commands": [
           "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel pull --environment=preview --token=$VERCEL_TOKEN",
           "npx vercel build",
-          "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --token=$VERCEL_TOKEN --archive=tgz > apps/watch/.vercel-url"
+          "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --token=$VERCEL_TOKEN --archive=tgz > apps/watch/.vercel-url",
+          "npx @datadog/datadog-ci sourcemaps upload dist/apps/watch/.next/static --service=watch --release-version=$VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/watch/.vercel-url)/_next/static/"
         ],
         "parallel": false
       },
@@ -45,7 +46,8 @@
           "commands": [
             "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
             "npx vercel build --prod",
-            "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --archive=tgz > apps/watch/.vercel-url"
+            "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --archive=tgz > apps/watch/.vercel-url",
+            "npx @datadog/datadog-ci sourcemaps upload dist/apps/watch/.next/static --service=watch --release-version=$VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/watch/.vercel-url)/_next/static/"
           ]
         }
       }

--- a/apps/watch/project.json
+++ b/apps/watch/project.json
@@ -37,7 +37,7 @@
           "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel pull --environment=preview --token=$VERCEL_TOKEN",
           "npx vercel build",
           "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --token=$VERCEL_TOKEN --archive=tgz > apps/watch/.vercel-url",
-          "npx @datadog/datadog-ci sourcemaps upload dist/apps/watch/.next/static --service=watch --release-version=$VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/watch/.vercel-url)/_next/static/"
+          "npx @datadog/datadog-ci sourcemaps upload dist/apps/watch/.next/static --service=watch --release-version=$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/watch/.vercel-url)/_next/static/"
         ],
         "parallel": false
       },
@@ -47,7 +47,7 @@
             "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
             "npx vercel build --prod",
             "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --archive=tgz > apps/watch/.vercel-url",
-            "npx @datadog/datadog-ci sourcemaps upload dist/apps/watch/.next/static --service=watch --release-version=$VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/watch/.vercel-url)/_next/static/"
+            "npx @datadog/datadog-ci sourcemaps upload dist/apps/watch/.next/static --service=watch --release-version=$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA --minified-path-prefix=$(apps/watch/.vercel-url)/_next/static/"
           ]
         }
       }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b98d27d</samp>

This pull request adds commands to upload source maps to Datadog in the `build` steps of three projects: `journeys-admin`, `journeys`, and `watch`. It also adds environment variables to the `app-deploy` workflow to enable Datadog integration with Vercel. These changes aim to enhance the error and trace visibility and performance monitoring of the deployed applications.

