### PR TITLE
feat: disable duplicate for video block

### DIFF
--- a/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.spec.tsx
@@ -2,9 +2,17 @@ import { MockedProvider } from '@apollo/client/testing'
 import { render } from '@testing-library/react'
 import { SnackbarProvider } from 'notistack'
 
+import { TreeBlock } from '@core/journeys/ui/block'
+import {
+  ActiveJourneyEditContent,
+  EditorProvider
+} from '@core/journeys/ui/EditorProvider'
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 
-import { GetJourney_journey as Journey } from '../../../../__generated__/GetJourney'
+import {
+  GetJourney_journey as Journey,
+  GetJourney_journey_blocks_VideoBlock as VideoBlock
+} from '../../../../__generated__/GetJourney'
 import { JourneyStatus } from '../../../../__generated__/globalTypes'
 
 import { EditToolbar } from '.'
@@ -73,5 +81,59 @@ describe('Edit Toolbar', () => {
     )
     const button = getAllByRole('link', { name: 'Preview' })[0]
     expect(button).toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('should disable duplicate button when active journey content is not canvas', () => {
+    const { getByRole } = render(
+      <SnackbarProvider>
+        <MockedProvider>
+          <JourneyProvider
+            value={{
+              journey: { slug: 'untitled-journey' } as unknown as Journey,
+              variant: 'admin'
+            }}
+          >
+            <EditorProvider
+              initialState={{
+                journeyEditContentComponent: ActiveJourneyEditContent.Action
+              }}
+            >
+              <EditToolbar />
+            </EditorProvider>
+          </JourneyProvider>
+        </MockedProvider>
+      </SnackbarProvider>
+    )
+    expect(
+      getByRole('button', { name: 'Duplicate Block Actions' })
+    ).toBeDisabled()
+  })
+
+  it('should disable duplicate button when selectedBlock is a video block', () => {
+    const { getByRole } = render(
+      <SnackbarProvider>
+        <MockedProvider>
+          <JourneyProvider
+            value={{
+              journey: { slug: 'untitled-journey' } as unknown as Journey,
+              variant: 'admin'
+            }}
+          >
+            <EditorProvider
+              initialState={{
+                selectedBlock: {
+                  __typename: 'VideoBlock'
+                } as unknown as TreeBlock<VideoBlock>
+              }}
+            >
+              <EditToolbar />
+            </EditorProvider>
+          </JourneyProvider>
+        </MockedProvider>
+      </SnackbarProvider>
+    )
+    expect(
+      getByRole('button', { name: 'Duplicate Block Actions' })
+    ).toBeDisabled()
   })
 })

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.tsx
@@ -37,7 +37,9 @@ export function EditToolbar(): ReactElement {
       <DuplicateBlock
         variant="button"
         disabled={
-          state.journeyEditContentComponent !== ActiveJourneyEditContent.Canvas
+          state.journeyEditContentComponent !==
+            ActiveJourneyEditContent.Canvas ||
+          state.selectedBlock?.__typename === 'VideoBlock'
         }
       />
       <Menu />

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.spec.tsx
@@ -10,7 +10,8 @@ import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 import {
   GetJourney_journey as Journey,
   GetJourney_journey_blocks_StepBlock as StepBlock,
-  GetJourney_journey_blocks_TypographyBlock as TypographyBlock
+  GetJourney_journey_blocks_TypographyBlock as TypographyBlock,
+  GetJourney_journey_blocks_VideoBlock as VideoBlock
 } from '../../../../../__generated__/GetJourney'
 import { JourneyStatus } from '../../../../../__generated__/globalTypes'
 import { ThemeProvider } from '../../../ThemeProvider'
@@ -23,6 +24,38 @@ jest.mock('@mui/material/useMediaQuery', () => ({
 }))
 
 describe('EditToolbar Menu', () => {
+  it('should disable duplicate button when video block is selected', async () => {
+    const { getByRole } = render(
+      <SnackbarProvider>
+        <MockedProvider>
+          <JourneyProvider
+            value={{
+              journey: {
+                status: JourneyStatus.draft
+              } as unknown as Journey,
+              variant: 'admin'
+            }}
+          >
+            <EditorProvider
+              initialState={{
+                selectedBlock: {
+                  __typename: 'VideoBlock'
+                } as unknown as TreeBlock<VideoBlock>
+              }}
+            >
+              <Menu />
+            </EditorProvider>
+          </JourneyProvider>
+        </MockedProvider>
+      </SnackbarProvider>
+    )
+    fireEvent.click(getByRole('button', { name: 'Edit Journey Actions' }))
+    expect(getByRole('menuitem', { name: 'Duplicate Block' })).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    )
+  })
+
   describe('desktop', () => {
     beforeEach(() =>
       (useMediaQuery as jest.Mock).mockImplementation(() => true)

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.tsx
@@ -48,7 +48,10 @@ export function Menu(): ReactElement {
           />
         </NextLink>
 
-        <DuplicateBlock variant="list-item" />
+        <DuplicateBlock
+          variant="list-item"
+          disabled={selectedBlock?.__typename === 'VideoBlock'}
+        />
         <DeleteBlock variant="list-item" />
         {!smUp && (
           <MenuItem


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e124d48</samp>

The pull request adds a feature that prevents duplicating video blocks in the journey editor. It updates the `EditToolbar` component and its tests to disable the duplicate button when a video block is selected.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/33281894/todos/6363706398)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] You should not be able to duplicate a video block

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e124d48</samp>

*  Prevent duplicating video blocks in the journey editor by disabling the duplicate button when the selected block is a video block or the active journey content is not the canvas component ([link](https://github.com/JesusFilm/core/pull/1814/files?diff=unified&w=0#diff-27c6cf6d3fecc00fd493f0de6b287b0ef6b94bcd9ea91381a3f8287fefd5a582L40-R42), [link](https://github.com/JesusFilm/core/pull/1814/files?diff=unified&w=0#diff-2722fccd789df35bdf59a6d582cf9f449ca6608715a19b4b9d242678f8b65f3cR85-R138))
* Import additional modules and types for the EditToolbar component and its tests, such as `TreeBlock`, `ActiveJourneyEditContent`, `EditorProvider`, and `VideoBlock` ([link](https://github.com/JesusFilm/core/pull/1814/files?diff=unified&w=0#diff-2722fccd789df35bdf59a6d582cf9f449ca6608715a19b4b9d242678f8b65f3cL5-R15))
