### PR TITLE
fix: refine video progress display

### DIFF
--- a/libs/journeys/ui/src/components/Video/VideoControls/VideoControls.tsx
+++ b/libs/journeys/ui/src/components/Video/VideoControls/VideoControls.tsx
@@ -133,7 +133,7 @@ export function VideoControls({
           })
         )
       }
-      setProgress(Math.round(player.currentTime()))
+      setProgress(player.currentTime())
     }
     player.on('timeupdate', handleVideoTimeChange)
     return () => {
@@ -391,7 +391,7 @@ export function VideoControls({
               <Slider
                 aria-label="desktop-progress-control"
                 min={startAt}
-                max={endAt}
+                max={endAt - 0.25}
                 value={progress}
                 valueLabelFormat={displayTime}
                 valueLabelDisplay="auto"
@@ -498,7 +498,7 @@ export function VideoControls({
             <Slider
               aria-label="mobile-progress-control"
               min={startAt}
-              max={endAt}
+              max={endAt - 0.25}
               value={progress}
               valueLabelFormat={displayTime}
               valueLabelDisplay="auto"

--- a/libs/journeys/ui/src/components/VideoTrigger/VideoTrigger.tsx
+++ b/libs/journeys/ui/src/components/VideoTrigger/VideoTrigger.tsx
@@ -26,7 +26,10 @@ export function VideoTrigger({
   useEffect(() => {
     if (player != null && !triggered) {
       const handleTimeUpdate = (): void => {
-        if (player.currentTime() >= triggerStart - 1 && !player.scrubbing()) {
+        if (
+          player.currentTime() >= triggerStart - 0.25 &&
+          !player.scrubbing()
+        ) {
           setTriggered(true)
           player.pause()
 


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 00e5b46</samp>

This pull request improves the video player and the video trigger components in the `journeys` library. It fixes some bugs with the time display and the progress sliders, and makes the event triggering more precise and timely.

https://3.basecamp.com/3105655/buckets/33281894/todos/6405999710

# How should this PR be QA Tested?

See the basecamp issue. This PR makes the progress bar finish closer to the end.

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 00e5b46</samp>

* Remove rounding of video current time to prevent mismatch with actual time ([link](https://github.com/JesusFilm/core/pull/1818/files?diff=unified&w=0#diff-06e07264a1143c474a72e689d3fb191dc359b22558c3567745068c9263adf2f3L136-R136))
* Adjust maximum value of desktop and mobile progress sliders to avoid reaching end before video finishes ([link](https://github.com/JesusFilm/core/pull/1818/files?diff=unified&w=0#diff-06e07264a1143c474a72e689d3fb191dc359b22558c3567745068c9263adf2f3L394-R394), [link](https://github.com/JesusFilm/core/pull/1818/files?diff=unified&w=0#diff-06e07264a1143c474a72e689d3fb191dc359b22558c3567745068c9263adf2f3L501-R501))
* Reduce buffer time before triggering video events to make them more responsive and accurate ([link](https://github.com/JesusFilm/core/pull/1818/files?diff=unified&w=0#diff-6d3f4d77fcab20225e463116e402bfbee32317bad21bc4d00ec01ea77934d84eL29-R32))
