### PR TITLE
fix: preview icon broken story

### DIFF
--- a/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/EditToolbar.stories.tsx
@@ -1,4 +1,5 @@
 import { MockedProvider } from '@apollo/client/testing'
+import Stack from '@mui/material/Stack'
 import { Meta, Story } from '@storybook/react'
 
 import type { TreeBlock } from '@core/journeys/ui/block'
@@ -42,7 +43,9 @@ export const Default: Story = () => {
         }}
       >
         <EditorProvider initialState={{ selectedBlock }}>
-          <EditToolbar />
+          <Stack direction="row">
+            <EditToolbar />
+          </Stack>
         </EditorProvider>
       </JourneyProvider>
     </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.stories.tsx
@@ -1,4 +1,5 @@
 import { MockedProvider } from '@apollo/client/testing'
+import Stack from '@mui/material/Stack'
 import { Meta, Story } from '@storybook/react'
 import { screen, userEvent } from '@storybook/testing-library'
 
@@ -97,7 +98,9 @@ const Template: Story = ({ ...args }) => (
   <MockedProvider mocks={args.mocks}>
     <TeamProvider>
       <JourneyProvider value={{ journey: args.journey, variant: 'admin' }}>
-        <Menu {...args} />
+        <Stack direction="row">
+          <Menu {...args} />
+        </Stack>
       </JourneyProvider>
     </TeamProvider>
   </MockedProvider>

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
@@ -178,34 +178,38 @@ export function Menu(): ReactElement {
     <>
       {journey != null ? (
         <>
-          <Chip
-            icon={<VisibilityIcon />}
-            label="Preview"
-            component="a"
-            href={`/api/preview?slug=${journey.slug}`}
-            target="_blank"
-            variant="outlined"
-            clickable
-            sx={{
-              display: {
-                xs: 'none',
-                md: 'flex'
-              }
-            }}
-          />
-          <IconButton
-            aria-label="Preview"
-            href={`/api/preview?slug=${journey.slug}`}
-            target="_blank"
-            sx={{
-              display: {
-                xs: 'flex',
-                md: 'none'
-              }
-            }}
-          >
-            <VisibilityIcon />
-          </IconButton>
+          {journey != null && journey.template !== true && (
+            <>
+              <Chip
+                icon={<VisibilityIcon />}
+                label="Preview"
+                component="a"
+                href={`/api/preview?slug=${journey.slug}`}
+                target="_blank"
+                variant="outlined"
+                clickable
+                sx={{
+                  display: {
+                    xs: 'none',
+                    md: 'flex'
+                  }
+                }}
+              />
+              <IconButton
+                aria-label="Preview"
+                href={`/api/preview?slug=${journey.slug}`}
+                target="_blank"
+                sx={{
+                  display: {
+                    xs: 'flex',
+                    md: 'none'
+                  }
+                }}
+              >
+                <VisibilityIcon />
+              </IconButton>
+            </>
+          )}
           <IconButton
             id="single-journey-actions"
             edge="end"

--- a/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/Menu/Menu.tsx
@@ -178,7 +178,7 @@ export function Menu(): ReactElement {
     <>
       {journey != null ? (
         <>
-          {journey != null && journey.template !== true && (
+          {journey.template !== true && (
             <>
               <Chip
                 icon={<VisibilityIcon />}


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5449e66</samp>

This pull request improves the layout and functionality of some components in the journeys-admin app. It uses the `Stack` component from Material UI to align the `EditToolbar` and `Menu` components, and adds a condition to hide the preview buttons for template journeys in the `Menu` component.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/33281894/todos/6405614349)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5449e66</samp>

* Import the Stack component from Material UI to arrange components horizontally ([link](https://github.com/JesusFilm/core/pull/1824/files?diff=unified&w=0#diff-fc01f403f1abff1e9e846a81a447bf63d1fe39b52ef20906a35d0ce2d91073b8R2), [link](https://github.com/JesusFilm/core/pull/1824/files?diff=unified&w=0#diff-049fecef5d1052c9fb98ed884d3ac7071d3ede281c887639a1a4af553ddec62cR2))
* Wrap the EditToolbar and Menu components inside Stack components with direction="row" to align their items horizontally ([link](https://github.com/JesusFilm/core/pull/1824/files?diff=unified&w=0#diff-fc01f403f1abff1e9e846a81a447bf63d1fe39b52ef20906a35d0ce2d91073b8L45-R48), [link](https://github.com/JesusFilm/core/pull/1824/files?diff=unified&w=0#diff-049fecef5d1052c9fb98ed884d3ac7071d3ede281c887639a1a4af553ddec62cL100-R103))
* Add a conditional rendering of the preview buttons in `Menu.tsx` to only show them for non-template journeys ([link](https://github.com/JesusFilm/core/pull/1824/files?diff=unified&w=0#diff-2c9f44f9db6ec77ee7fdf06b593abfe7aab0fc14735b41b66094629ff25bc082L181-R213))
