### PR TITLE
fix: use higher quality poster image

### DIFF
--- a/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/video/video.resolver.spec.ts
@@ -586,7 +586,7 @@ describe('VideoBlockResolver', () => {
           duration: 100,
           endAt: 100,
           image:
-            'https://cloudflarestream.com/ea95132c15732412d22c1476fa83f27a/thumbnails/thumbnail.jpg?time=2s',
+            'https://cloudflarestream.com/ea95132c15732412d22c1476fa83f27a/thumbnails/thumbnail.jpg?time=2s&height=768',
           title: 'video.mp4'
         })
         expect(mockFetch).toHaveBeenCalledWith(
@@ -634,7 +634,7 @@ describe('VideoBlockResolver', () => {
           duration: 100,
           endAt: 100,
           image:
-            'https://cloudflarestream.com/ea95132c15732412d22c1476fa83f27a/thumbnails/thumbnail.jpg?time=2s',
+            'https://cloudflarestream.com/ea95132c15732412d22c1476fa83f27a/thumbnails/thumbnail.jpg?time=2s&height=768',
           title: 'ea95132c15732412d22c1476fa83f27a'
         })
       })

--- a/apps/api-journeys/src/app/modules/block/video/video.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/video/video.resolver.ts
@@ -339,7 +339,7 @@ export class VideoBlockResolver {
     }
     return {
       title: response.result.meta.name ?? response.result.uid,
-      image: `${response.result.thumbnail}?time=2s`,
+      image: `${response.result.thumbnail}?time=2s&height=768`,
       duration: Math.round(response.result.duration),
       endAt: Math.round(response.result.duration)
     }

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -386,6 +386,7 @@ export function Video({
           alt="video image"
           layout="fill"
           objectFit={videoFit}
+          unoptimized
           style={{
             transform:
               objectFit === VideoBlockObjectFit.zoomed


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4d34eb7</samp>

The pull request improves the video block thumbnail image quality and performance by adjusting the image URL and disabling Next.js optimization. It modifies the `image` field in the `video.resolver.ts` file and the `Image` component in the `Video.tsx` file.

https://3.basecamp.com/3105655/buckets/33281894/todos/6405979946

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4d34eb7</samp>

*  Disable image optimization for video thumbnails ([link](https://github.com/JesusFilm/core/pull/1827/files?diff=unified&w=0#diff-6dc9cc6dc88d08c752fe4265169afff94ccef2829748bdb712ecf417a9117aecR389))
* Adjust image URL for video block ([link](https://github.com/JesusFilm/core/pull/1827/files?diff=unified&w=0#diff-979f24487665f31f744097b2dc824525ba6bef81182373426d29517927b20da4L342-R342))
