### PR TITLE
fix: variant languageid specificity

### DIFF
--- a/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoFromLocal/LocalDetails/LocalDetails.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoFromLocal/LocalDetails/LocalDetails.tsx
@@ -35,7 +35,7 @@ export const GET_VIDEO = gql`
         primary
         value
       }
-      variant {
+      variant(languageId: $languageId) {
         id
         duration
         hls

--- a/apps/watch/src/libs/videoContentFields.ts
+++ b/apps/watch/src/libs/videoContentFields.ts
@@ -20,7 +20,7 @@ export const VIDEO_CONTENT_FIELDS = gql`
     title(languageId: $languageId, primary: true) {
       value
     }
-    variant {
+    variant(languageId: $languageId) {
       id
       duration
       hls


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1b93a05</samp>

Modified the `GET_VIDEO` query and the `VIDEO_CONTENT_FIELDS` fragment to support fetching video variants by language. This enables the admin and watch apps to display accurate video metadata for different languages.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Video Language selector works in journeys-admin

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1b93a05</samp>

*  Pass `languageId` variable to `variant` field in `GET_VIDEO` query to fetch video variant for selected language ([link](https://github.com/JesusFilm/core/pull/1828/files?diff=unified&w=0#diff-21965ea058cb7a30f27547734a5418bed29f950adaa8e192c24c59dad949d84bL38-R38), [link](https://github.com/JesusFilm/core/pull/1828/files?diff=unified&w=0#diff-7199f06709639ca3a188516e875b8fd57fbd8d2cb93c6e4119f705977fbd872eL23-R23))
*  Display video duration and file size for selected language variant in `LocalDetails` component ([link](https://github.com/JesusFilm/core/pull/1828/files?diff=unified&w=0#diff-21965ea058cb7a30f27547734a5418bed29f950adaa8e192c24c59dad949d84bL38-R38))
*  Update `VIDEO_CONTENT_FIELDS` fragment to include `languageId` variable in `variant` field for consistency with `GET_VIDEO` query ([link](https://github.com/JesusFilm/core/pull/1828/files?diff=unified&w=0#diff-7199f06709639ca3a188516e875b8fd57fbd8d2cb93c6e4119f705977fbd872eL23-R23))
