### PR TITLE
fix: make journeys published by default

### DIFF
--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -564,7 +564,8 @@ describe('JourneyResolver', () => {
           id: 'journeyId',
           languageId: '529',
           slug: 'untitled-journey',
-          status: 'draft',
+          status: 'published',
+          publishedAt: new Date(),
           team: {
             connect: {
               id: 'teamId'
@@ -606,7 +607,8 @@ describe('JourneyResolver', () => {
           id: 'myJourneyId',
           languageId: '529',
           slug: 'special-journey-myJourneyId',
-          status: 'draft',
+          status: 'published',
+          publishedAt: new Date(),
           team: {
             connect: {
               id: 'teamId'
@@ -845,7 +847,8 @@ describe('JourneyResolver', () => {
             'createdAt'
           ]),
           id: 'duplicateJourneyId',
-          status: JourneyStatus.draft,
+          status: JourneyStatus.published,
+          publishedAt: new Date(),
           slug: `${journey.title}-copy`,
           title: `${journey.title} copy`,
           template: false,
@@ -892,7 +895,8 @@ describe('JourneyResolver', () => {
           'createdAt'
         ]),
         id: 'duplicateJourneyId',
-        status: JourneyStatus.draft,
+        status: JourneyStatus.published,
+        publishedAt: new Date(),
         slug: journey.title,
         title: journey.title,
         template: false,
@@ -990,7 +994,8 @@ describe('JourneyResolver', () => {
             'createdAt'
           ]),
           id: 'duplicateJourneyId',
-          status: JourneyStatus.draft,
+          status: JourneyStatus.published,
+          publishedAt: new Date(),
           slug: `${journey.title}-copy-2`,
           title: `${journey.title} copy 2`,
           template: false,
@@ -1393,22 +1398,6 @@ describe('JourneyResolver', () => {
       expect(prismaService.journey.update).toHaveBeenCalledWith({
         where: { id: 'journeyId' },
         data: { status: JourneyStatus.published }
-      })
-    })
-
-    it('restores an draft Journey', async () => {
-      prismaService.journey.findMany.mockResolvedValueOnce([
-        { ...journey, publishedAt: null }
-      ])
-      await resolver.journeysRestore(accessibleJourneys, ['journeyId'])
-      expect(prismaService.journey.findMany).toHaveBeenCalledWith({
-        where: {
-          AND: [accessibleJourneys, { id: { in: ['journeyId'] } }]
-        }
-      })
-      expect(prismaService.journey.update).toHaveBeenCalledWith({
-        where: { id: 'journeyId' },
-        data: { status: JourneyStatus.draft }
       })
     })
   })

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -1397,7 +1397,7 @@ describe('JourneyResolver', () => {
       })
       expect(prismaService.journey.update).toHaveBeenCalledWith({
         where: { id: 'journeyId' },
-        data: { status: JourneyStatus.published }
+        data: { status: JourneyStatus.published, publishedAt: new Date() }
       })
     })
   })

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -1387,7 +1387,7 @@ describe('JourneyResolver', () => {
   })
 
   describe('journeysRestore', () => {
-    it('resores a published Journey', async () => {
+    it('restores a Journey', async () => {
       prismaService.journey.findMany.mockResolvedValueOnce([journey])
       await resolver.journeysRestore(accessibleJourneys, ['journeyId'])
       expect(prismaService.journey.findMany).toHaveBeenCalledWith({

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -564,7 +564,7 @@ describe('JourneyResolver', () => {
           id: 'journeyId',
           languageId: '529',
           slug: 'untitled-journey',
-          status: 'published',
+          status: JourneyStatus.published,
           publishedAt: new Date(),
           team: {
             connect: {
@@ -607,7 +607,7 @@ describe('JourneyResolver', () => {
           id: 'myJourneyId',
           languageId: '529',
           slug: 'special-journey-myJourneyId',
-          status: 'published',
+          status: JourneyStatus.published,
           publishedAt: new Date(),
           team: {
             connect: {

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -669,7 +669,8 @@ export class JourneyResolver {
         this.prismaService.journey.update({
           where: { id: journey.id },
           data: {
-            status: JourneyStatus.published
+            status: JourneyStatus.published,
+            publishedAt: new Date()
           }
         })
       )

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -224,7 +224,8 @@ export class JourneyResolver {
               languageId: input.languageId,
               id,
               slug,
-              status: JourneyStatus.draft,
+              status: JourneyStatus.published,
+              publishedAt: new Date(),
               team: { connect: { id: teamId } },
               userJourneys: {
                 create: {
@@ -408,7 +409,8 @@ export class JourneyResolver {
                 id: duplicateJourneyId,
                 slug,
                 title: duplicateTitle,
-                status: JourneyStatus.draft,
+                status: JourneyStatus.published,
+                publishedAt: new Date(),
                 template: false,
                 team: { connect: { id: teamId } },
                 userJourneys: {
@@ -667,10 +669,7 @@ export class JourneyResolver {
         this.prismaService.journey.update({
           where: { id: journey.id },
           data: {
-            status:
-              journey.publishedAt == null
-                ? JourneyStatus.draft
-                : JourneyStatus.published
+            status: JourneyStatus.published
           }
         })
       )


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 67e6d1f</samp>

This pull request enhances the journey resolver to support publishing journeys with different scenarios. It adds and updates tests for the `journeysPublish` and `duplicateJourney` mutations, and removes the obsolete `journeysRestore` mutation.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/33184123/todos/6444395182)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] it should make new journeys published by default
- [ ] it should make new template journeys published by default
- [ ] it should make duplicate journeys published by default
- [ ] it should make restored journeys published by default

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 67e6d1f</samp>

*  Publish journeys by default and set publishedAt date when creating or duplicating journeys ([link](https://github.com/JesusFilm/core/pull/1829/files?diff=unified&w=0#diff-be9eaaadc38880434cdfe42dc6e2fe0f5cae94cf78d3e9e05f9a39093dae42dfL227-R228), [link](https://github.com/JesusFilm/core/pull/1829/files?diff=unified&w=0#diff-be9eaaadc38880434cdfe42dc6e2fe0f5cae94cf78d3e9e05f9a39093dae42dfL411-R413), [link](https://github.com/JesusFilm/core/pull/1829/files?diff=unified&w=0#diff-93528ee54010f1df0fe00fab3e9cf53b524ade137814f4899de8d3151a7b1882L848-R851), [link](https://github.com/JesusFilm/core/pull/1829/files?diff=unified&w=0#diff-93528ee54010f1df0fe00fab3e9cf53b524ade137814f4899de8d3151a7b1882L895-R899), [link](https://github.com/JesusFilm/core/pull/1829/files?diff=unified&w=0#diff-93528ee54010f1df0fe00fab3e9cf53b524ade137814f4899de8d3151a7b1882L993-R998))
*  Add `journeysPublish` mutation to publish journeys and set publishedAt date in `journey.resolver.ts` and test it in `journey.resolver.spec.ts` ([link](https://github.com/JesusFilm/core/pull/1829/files?diff=unified&w=0#diff-be9eaaadc38880434cdfe42dc6e2fe0f5cae94cf78d3e9e05f9a39093dae42dfL670-R673), [link](https://github.com/JesusFilm/core/pull/1829/files?diff=unified&w=0#diff-93528ee54010f1df0fe00fab3e9cf53b524ade137814f4899de8d3151a7b1882L567-R568), [link](https://github.com/JesusFilm/core/pull/1829/files?diff=unified&w=0#diff-93528ee54010f1df0fe00fab3e9cf53b524ade137814f4899de8d3151a7b1882L609-R611))
*  Remove `journeysRestore` mutation and test case as it is no longer needed ([link](https://github.com/JesusFilm/core/pull/1829/files?diff=unified&w=0#diff-be9eaaadc38880434cdfe42dc6e2fe0f5cae94cf78d3e9e05f9a39093dae42dfL670-R673), [link](https://github.com/JesusFilm/core/pull/1829/files?diff=unified&w=0#diff-93528ee54010f1df0fe00fab3e9cf53b524ade137814f4899de8d3151a7b1882L1395-R1402))
