### PR TITLE
fix: journeys variant language

### DIFF
--- a/apps/api-videos/src/app/modules/video/video.resolver.spec.ts
+++ b/apps/api-videos/src/app/modules/video/video.resolver.spec.ts
@@ -299,6 +299,27 @@ describe('VideoResolver', () => {
       })
     })
 
+    it('returns variant for journeys', async () => {
+      const info = {
+        variableValues: {
+          representations: [
+            {
+              primaryLanguageId: '1234'
+            }
+          ]
+        }
+      } as unknown as GraphQLResolveInfo
+      expect(await resolver.variant(info, video)).toEqual(videoVariant[0])
+      expect(prismaService.videoVariant.findUnique).toHaveBeenCalledWith({
+        where: {
+          languageId_videoId: {
+            languageId: '1234',
+            videoId: video.id
+          }
+        }
+      })
+    })
+
     it('returns variant without languageId', async () => {
       expect(await resolver.variant(info, video)).toEqual(videoVariant[0])
       expect(prismaService.videoVariant.findUnique).toHaveBeenCalledWith({

--- a/apps/api-videos/src/app/modules/video/video.resolver.ts
+++ b/apps/api-videos/src/app/modules/video/video.resolver.ts
@@ -181,6 +181,12 @@ export class VideoResolver {
       ? variableValueId.substring(variableValueId.lastIndexOf('/') + 1)
       : ''
 
+    const journeysLanguageIdForBlock = (
+      info.variableValues as {
+        representations: Array<{ primaryLanguageId: string }>
+      }
+    ).representations?.[0].primaryLanguageId
+
     return info.variableValues.idType !== IdType.databaseId &&
       !isEmpty(variableValueId) &&
       !isEmpty(requestedLanguage)
@@ -193,7 +199,7 @@ export class VideoResolver {
           where: {
             languageId_videoId: {
               videoId: video.id,
-              languageId: languageId ?? '529'
+              languageId: languageId ?? journeysLanguageIdForBlock ?? '529'
             }
           }
         })


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3eb4154</samp>

This pull request adds support for language blocks in journeys to the `variant` resolver of the `VideoResolver` class. It also adds a test case to verify the new logic in `video.resolver.spec.ts`.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] variant language now works on journeys

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3eb4154</samp>

*  Add a new variable to the `variant` resolver method to get the primary language id of the journey block ([link](https://github.com/JesusFilm/core/pull/1830/files?diff=unified&w=0#diff-f4acc76adff0d32b89352c109b443878c0d65db1e54824f8eba0bc357500434eR184-R189))
*  Use the new variable as a fallback value for the `languageId` field in the `prismaService.videoVariant.findUnique` method call to return the correct video variant for journeys ([link](https://github.com/JesusFilm/core/pull/1830/files?diff=unified&w=0#diff-f4acc76adff0d32b89352c109b443878c0d65db1e54824f8eba0bc357500434eL196-R202))
*  Test the `variant` resolver method with a mock `prismaService` and a mock GraphQL query info with a language id variable and a journey block variable ([link](https://github.com/JesusFilm/core/pull/1830/files?diff=unified&w=0#diff-442de4c76709f08c9b886e5355af46d1c130eb43f01eb191216bbfa056eb4946R302-R322))
