### PR TITLE
fix: make all VR dry run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -239,3 +239,4 @@ jobs:
           skip: '@(dependabot/**|00-00-CI-chore-update-translations)'
           untraced: '@(package*.json|.storybook/**)'
           traceChanged: 'expanded'
+          dryRun: 'true'


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 27ac235</samp>

This pull request enables dry-run mode for semantic-release in the main workflow. This allows testing the release process without publishing any artifacts.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 27ac235</samp>

*  Add `dryRun` option to `semantic-release` action to test release process without publishing ([link](https://github.com/JesusFilm/core/pull/1845/files?diff=unified&w=0#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R242))
