### PR TITLE
fix: trying to read id from null variant

### DIFF
--- a/apps/api-journeys/db/seeds/onboardingTemplates.ts
+++ b/apps/api-journeys/db/seeds/onboardingTemplates.ts
@@ -118,7 +118,8 @@ export async function onboardingTemplates(action?: 'reset'): Promise<void> {
         width: 1152,
         height: 768,
         blurhash: 'UbLX6?~p9FtRkX.8ogD%IUj@M{adxaM_ofkW',
-        parentBlockId: card.id
+        parentBlockId: card.id,
+        parentOrder: 0
       }
     })
     await prisma.block.update({

--- a/apps/journeys/src/libs/apolloClient/cache/cache.ts
+++ b/apps/journeys/src/libs/apolloClient/cache/cache.ts
@@ -1,8 +1,4 @@
-import {
-  InMemoryCache,
-  StoreObject,
-  defaultDataIdFromObject
-} from '@apollo/client'
+import { InMemoryCache, defaultDataIdFromObject } from '@apollo/client'
 
 export const cache = (): InMemoryCache =>
   new InMemoryCache({
@@ -38,15 +34,19 @@ export const cache = (): InMemoryCache =>
       ]
     },
     dataIdFromObject(responseObject) {
+      let id: string
       switch (responseObject.__typename) {
         case 'Video':
-          return `Video:${
-            (
-              responseObject.variant as unknown as StoreObject & {
+          if (responseObject.variant != null) {
+            id = (
+              responseObject.variant as unknown as {
                 id: string
               }
-            ).id ?? responseObject.id
-          }`
+            ).id
+          } else {
+            id = responseObject.id as unknown as string
+          }
+          return `Video:${id}`
         case 'Person':
         default:
           return defaultDataIdFromObject(responseObject)


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c2f6b5b</samp>

Improved the cache handling of `Video` objects in the `journeys` app. Refactored the `dataIdFromObject` function and removed an unused import in `cache.ts`.

- Link to Basecamp Todo