### PR TITLE
fix: new page wrapper header children and main body padding

### DIFF
--- a/apps/journeys-admin/pages/index.tsx
+++ b/apps/journeys-admin/pages/index.tsx
@@ -1,4 +1,5 @@
 import { gql } from '@apollo/client'
+import Stack from '@mui/material/Stack'
 import { useRouter } from 'next/router'
 import {
   AuthAction,
@@ -63,15 +64,21 @@ function IndexPage({ onboardingJourneys }: IndexPageProps): ReactElement {
     <>
       <NextSeo title={t('Journeys')} />
       <PageWrapper
-        title={
-          teams ? (
-            <TeamSelect onboarding={router.query.onboarding === 'true'} />
-          ) : (
-            t('Journeys')
+        title={!teams ? t('Journeys') : undefined}
+        authUser={AuthUser}
+        mainHeaderChildren={
+          teams && (
+            <Stack
+              direction="row"
+              flexGrow={1}
+              justifyContent="space-between"
+              alignItems="center"
+            >
+              <TeamSelect onboarding={router.query.onboarding === 'true'} />
+              <TeamMenu />
+            </Stack>
           )
         }
-        authUser={AuthUser}
-        menu={teams && <TeamMenu />}
         sidePanelChildren={
           <OnboardingPanelContent onboardingJourneys={onboardingJourneys} />
         }

--- a/apps/journeys-admin/pages/journeys/[journeyId]/reports/visitors.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/reports/visitors.tsx
@@ -181,29 +181,32 @@ function JourneyVisitorsPage(): ReactElement {
     <>
       <NextSeo title={t('Visitors')} />
       <PageWrapper
-        title={
-          <Stack direction="row" alignItems="center">
-            {t('Visitors')}
+        title={t('Visitors')}
+        authUser={AuthUser}
+        backHref={`/journeys/${journeyId}/reports`}
+        mainHeaderChildren={
+          <Stack
+            direction="row"
+            flexGrow={1}
+            alignItems="center"
+            justifyContent="space-between"
+          >
             {data?.journeyVisitorCount != null && (
               <Typography variant="caption" sx={{ pl: 4 }}>
                 {data?.journeyVisitorCount}
               </Typography>
             )}
+            <VisitorToolbar
+              handleChange={handleChange}
+              sortSetting={sortSetting}
+              chatStarted={chatStarted}
+              withPollAnswers={withPollAnswers}
+              withSubmittedText={withSubmittedText}
+              withIcon={withIcon}
+              hideInteractive={hideInteractive}
+              handleClearAll={handleClearAll}
+            />
           </Stack>
-        }
-        authUser={AuthUser}
-        backHref={`/journeys/${journeyId}/reports`}
-        menu={
-          <VisitorToolbar
-            handleChange={handleChange}
-            sortSetting={sortSetting}
-            chatStarted={chatStarted}
-            withPollAnswers={withPollAnswers}
-            withSubmittedText={withSubmittedText}
-            withIcon={withIcon}
-            hideInteractive={hideInteractive}
-            handleClearAll={handleClearAll}
-          />
         }
         sidePanelTitle={
           <>

--- a/apps/journeys-admin/src/components/NewPageWrapper/MainPanelBody/MainPanelBody.tsx
+++ b/apps/journeys-admin/src/components/NewPageWrapper/MainPanelBody/MainPanelBody.tsx
@@ -20,7 +20,7 @@ export function MainPanelBody({
       border="hidden"
       sx={{
         overflow: 'none',
-        overflowY: { sm: 'auto' },
+        overflowY: { md: 'auto' },
         width: 'inherit'
       }}
     >
@@ -33,7 +33,10 @@ export function MainPanelBody({
           // backgroundColor: 'background.paper',
           px: { xs: 6, sm: 8 },
           py: { xs: 6, sm: 9 },
-          mb: bottomPanelChildren != null ? bottomPanel.height : 0
+          mb: {
+            xs: 0,
+            md: bottomPanelChildren != null ? bottomPanel.height : 0
+          }
         }}
       >
         {children}

--- a/apps/journeys-admin/src/components/NewPageWrapper/MainPanelHeader/MainPanelHeader.spec.tsx
+++ b/apps/journeys-admin/src/components/NewPageWrapper/MainPanelHeader/MainPanelHeader.spec.tsx
@@ -12,20 +12,22 @@ const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
 
 describe('MainPanelHeader', () => {
   it('should show back button with correct link', () => {
-    const { getByRole } = render(
+    const { getByRole, getByText } = render(
       <MainPanelHeader title="Page title" backHref="/" />
     )
     expect(getByRole('link')).toHaveAttribute('href', '/')
+    expect(getByText('Page title')).toBeInTheDocument()
   })
 
   it('should show back button with backHrefHistory', async () => {
     const back = jest.fn()
     mockUseRouter.mockReturnValue({ back } as unknown as NextRouter)
-    const { getByTestId } = render(
+    const { getByTestId, getByText } = render(
       <MainPanelHeader title="Page title" backHrefHistory />
     )
     fireEvent.click(getByTestId('backHref-history-button'))
 
     await waitFor(() => expect(back).toHaveBeenCalled())
+    expect(getByText('Page title')).toBeInTheDocument()
   })
 })

--- a/apps/journeys-admin/src/components/NewPageWrapper/MainPanelHeader/MainPanelHeader.tsx
+++ b/apps/journeys-admin/src/components/NewPageWrapper/MainPanelHeader/MainPanelHeader.tsx
@@ -11,16 +11,16 @@ import { ReactElement, ReactNode } from 'react'
 import { usePageWrapperStyles } from '../utils/usePageWrapperStyles'
 
 export interface MainPanelHeaderProps {
-  title: string | ReactNode
+  title?: string
   backHref?: string
-  menu?: ReactNode
+  children?: ReactNode
   backHrefHistory?: boolean
 }
 
 export function MainPanelHeader({
   title,
   backHref,
-  menu,
+  children,
   backHrefHistory
 }: MainPanelHeaderProps): ReactElement {
   const { toolbar } = usePageWrapperStyles()
@@ -31,8 +31,8 @@ export function MainPanelHeader({
       <AppBar
         color="default"
         sx={{
-          position: { xs: 'fixed', sm: 'sticky' },
-          top: { xs: toolbar.height, sm: 0 }
+          position: { xs: 'fixed', md: 'sticky' },
+          top: { xs: toolbar.height, md: 0 }
         }}
       >
         <Toolbar variant={toolbar.variant}>
@@ -62,23 +62,16 @@ export function MainPanelHeader({
               </NextLink>
             )
           )}
-          {typeof title === 'string' ? (
-            <Typography
-              variant="subtitle1"
-              component="div"
-              noWrap
-              sx={{ flexGrow: 1 }}
-            >
+          {title != null && (
+            <Typography variant="subtitle1" component="div" noWrap>
               {title}
             </Typography>
-          ) : (
-            title
           )}
-          {menu}
+          {children}
         </Toolbar>
       </AppBar>
       {/* Reserves space beneath MainHeader on mobile - allows us to export MainPanel */}
-      <Toolbar variant={toolbar.variant} sx={{ display: { sm: 'none' } }} />
+      <Toolbar variant={toolbar.variant} sx={{ display: { md: 'none' } }} />
     </>
   )
 }

--- a/apps/journeys-admin/src/components/NewPageWrapper/PageWrapper.spec.tsx
+++ b/apps/journeys-admin/src/components/NewPageWrapper/PageWrapper.spec.tsx
@@ -13,7 +13,7 @@ jest.mock('@mui/material/useMediaQuery', () => ({
 
 describe('PageWrapper', () => {
   describe('MainPanel', () => {
-    it('should show main panel title', () => {
+    it('should show main header title', () => {
       const { getByRole } = render(
         <MockedProvider>
           <FlagsProvider>
@@ -35,18 +35,21 @@ describe('PageWrapper', () => {
       expect(getByRole('link')).toHaveAttribute('href', '/')
     })
 
-    it('should show custom menu', () => {
+    it('should show main header children', () => {
       const { getByRole } = render(
         <MockedProvider>
           <FlagsProvider>
-            <PageWrapper title="Page title" menu={<>Custom Content</>} />
+            <PageWrapper
+              title="Page title"
+              mainHeaderChildren={<>Custom Content</>}
+            />
           </FlagsProvider>
         </MockedProvider>
       )
       expect(getByRole('main')).toHaveTextContent('Custom Content')
     })
 
-    it('should show children', () => {
+    it('should show main body children', () => {
       const { getByTestId } = render(
         <MockedProvider>
           <FlagsProvider>

--- a/apps/journeys-admin/src/components/NewPageWrapper/PageWrapper.stories.tsx
+++ b/apps/journeys-admin/src/components/NewPageWrapper/PageWrapper.stories.tsx
@@ -129,14 +129,7 @@ export const Default = {
 export const SidePanel = {
   ...Template,
   args: {
-    title: (
-      <Stack direction="row" alignItems="center">
-        Main Content
-        <Typography variant="caption" sx={{ pl: 4 }}>
-          custom content
-        </Typography>
-      </Stack>
-    ),
+    ...Default.args,
     children: (
       <>
         <Typography variant="h3" gutterBottom>
@@ -193,10 +186,20 @@ export const Complete = {
       email: 'amin@email.com',
       signOut: noop
     },
-    menu: (
-      <IconButton edge="end" size="large" color="inherit" sx={{ ml: 2 }}>
-        <MenuRounded />
-      </IconButton>
+    mainHeaderChildren: (
+      <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="flex-end"
+        flexGrow={1}
+      >
+        <Typography variant="caption" sx={{ pl: 4 }}>
+          custom content
+        </Typography>
+        <IconButton edge="end" size="large" color="inherit" sx={{ ml: 2 }}>
+          <MenuRounded />
+        </IconButton>
+      </Stack>
     ),
     templates: true
   }

--- a/apps/journeys-admin/src/components/NewPageWrapper/PageWrapper.tsx
+++ b/apps/journeys-admin/src/components/NewPageWrapper/PageWrapper.tsx
@@ -16,34 +16,34 @@ import { SidePanel } from './SidePanel'
 import { usePageWrapperStyles } from './utils/usePageWrapperStyles'
 
 interface PageWrapperProps {
-  backHref?: string
-  title: string | ReactNode
-  menu?: ReactNode
-  children?: ReactNode
   showAppHeader?: boolean
+  title?: string
+  mainHeaderChildren?: ReactNode
+  backHref?: string
+  backHrefHistory?: boolean
+  children?: ReactNode
+  bottomPanelChildren?: ReactNode
   sidePanelTitle?: string | ReactNode
   /**
    * Add default side panel padding and border by wrapping components with `SidePanelContainer`
    */
   sidePanelChildren?: ReactNode
-  bottomPanelChildren?: ReactNode
   authUser?: AuthUser
   initialState?: Partial<PageState>
-  backHrefHistory?: boolean
 }
 
 export function PageWrapper({
-  backHref,
   showAppHeader = true,
   title,
-  menu: customMenu,
+  mainHeaderChildren,
+  backHref,
+  backHrefHistory,
+  children,
+  bottomPanelChildren,
   sidePanelTitle,
   sidePanelChildren,
-  bottomPanelChildren,
-  children,
   authUser,
-  initialState,
-  backHrefHistory
+  initialState
 }: PageWrapperProps): ReactElement {
   const [open, setOpen] = useState<boolean>(false)
   const theme = useTheme()
@@ -97,9 +97,10 @@ export function PageWrapper({
               <MainPanelHeader
                 title={title}
                 backHref={backHref}
-                menu={customMenu}
                 backHrefHistory={backHrefHistory}
-              />
+              >
+                {mainHeaderChildren}
+              </MainPanelHeader>
               <MainPanelBody bottomPanelChildren={bottomPanelChildren}>
                 {children}
               </MainPanelBody>


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ff1f5e0</samp>

This pull request improves the layout and responsiveness of the main header in the journeys-admin app. It refactors the `PageWrapper` and `MainPanelHeader` components to accept custom content as children and make the title prop optional. It also updates the tests and stories for these components to match the changes.

https://3.basecamp.com/3105655/buckets/33184123/todos/6519743133

# How should this PR be QA Tested?

See bugs described in basecamp, one can be tested in storybook - other can be tested via vercel link.

Main landing page and visitors page should look / work the same.


# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ff1f5e0</samp>

*  Simplify and improve the layout and responsiveness of the main header in the PageWrapper component by removing the menu prop and adding the mainHeaderChildren prop, which accepts custom content as children of the MainPanelHeader component ([link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-5965e5f2f61464ac798b2d978eb50c82874afd08713ad90b1fbd61c962f04237L19-R25),[link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-5965e5f2f61464ac798b2d978eb50c82874afd08713ad90b1fbd61c962f04237L29-R46),[link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-5965e5f2f61464ac798b2d978eb50c82874afd08713ad90b1fbd61c962f04237L100-R103),[link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-dc30d606e0c50db44ab970c84244650e1af0caab2fafa6d589f64e300d37c4b7L196-R202),[link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-2ce7fd8777e1be5b5ec657940e0b2e29ae6b6fb4d8d88f12d4142e8bb0f2aa3dL38-R45),[link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-bf2c6bf3ac54cbf68d8f2fa56ccafebc7fd7ffb5fb0480777e6688e0ceea9dc9L14-R16),[link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-bf2c6bf3ac54cbf68d8f2fa56ccafebc7fd7ffb5fb0480777e6688e0ceea9dc9L23-R23),[link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-bf2c6bf3ac54cbf68d8f2fa56ccafebc7fd7ffb5fb0480777e6688e0ceea9dc9L65-R74))
* Update the title prop of the PageWrapper and MainPanelHeader components to be optional and accept only a string, and render it as a Typography component only if it is not null ([link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-5965e5f2f61464ac798b2d978eb50c82874afd08713ad90b1fbd61c962f04237L19-R25),[link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-bf2c6bf3ac54cbf68d8f2fa56ccafebc7fd7ffb5fb0480777e6688e0ceea9dc9L14-R16),[link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-bf2c6bf3ac54cbf68d8f2fa56ccafebc7fd7ffb5fb0480777e6688e0ceea9dc9L65-R74),[link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-f835c193d4567e65eeca3196d0a26205540f5298b1534e7a165bfbfa4c9c1a36L15-R19),[link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-f835c193d4567e65eeca3196d0a26205540f5298b1534e7a165bfbfa4c9c1a36L24-R25),[link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-f835c193d4567e65eeca3196d0a26205540f5298b1534e7a165bfbfa4c9c1a36R31))
* Adjust the sx prop of the AppBar and Box components in the MainPanelHeader and MainPanelBody components to change the breakpoints for the position, top, overflowY, and mb styles, which improve the usability and appearance of the main header and main panel on smaller screens ([link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-bf2c6bf3ac54cbf68d8f2fa56ccafebc7fd7ffb5fb0480777e6688e0ceea9dc9L34-R35),[link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-aaa30726a6c713e10fbe0f082868f7daaa62cdc749a2240ebeeb588166abcbacL23-R23),[link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-aaa30726a6c713e10fbe0f082868f7daaa62cdc749a2240ebeeb588166abcbacL36-R39))
* Modify the IndexPage and JourneyVisitorsPage components in `index.tsx` and `visitors.tsx` to use the mainHeaderChildren prop instead of the menu prop, and to wrap the custom content in a Stack component with some spacing and alignment styles ([link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-a17998961a44a113591b11adfc6194a80ca17d3e8c4edb13d12c897e826f28eeL66-R81),[link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-e9e60ec48f7928f205dea4cd73b81cd0498ead851b3bf03af91d9a24b3055ba8L184-R193),[link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-e9e60ec48f7928f205dea4cd73b81cd0498ead851b3bf03af91d9a24b3055ba8L192-R210))
* Import the Stack component from the Material UI library in `index.tsx` to create a horizontal or vertical layout of other components ([link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-a17998961a44a113591b11adfc6194a80ca17d3e8c4edb13d12c897e826f28eeR2))
* Simplify the SidePanel story of the PageWrapper component by reusing the existing props from the Default story ([link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-dc30d606e0c50db44ab970c84244650e1af0caab2fafa6d589f64e300d37c4b7L132-R132))
* Change the wording of the test descriptions for the PageWrapper component to match the terminology of the component ([link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-2ce7fd8777e1be5b5ec657940e0b2e29ae6b6fb4d8d88f12d4142e8bb0f2aa3dL16-R16),[link](https://github.com/JesusFilm/core/pull/1859/files?diff=unified&w=0#diff-2ce7fd8777e1be5b5ec657940e0b2e29ae6b6fb4d8d88f12d4142e8bb0f2aa3dL49-R52))
