### PR TITLE
fix: upload video polling not calling on complete

### DIFF
--- a/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoFromCloudflare/AddByFile/AddByFile.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoFromCloudflare/AddByFile/AddByFile.tsx
@@ -63,6 +63,7 @@ export function AddByFile({
   const [getMyCloudflareVideo, { stopPolling }] =
     useLazyQuery<GetMyCloudflareVideoQuery>(GET_MY_CLOUDFLARE_VIDEO_QUERY, {
       pollInterval: 1000,
+      notifyOnNetworkStatusChange: true,
       onCompleted: (data) => {
         if (
           data.getMyCloudflareVideo?.readyToStream === true &&


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ee65bb5</samp>

Enable re-rendering of video data component based on network status. Add `notifyOnNetworkStatusChange` option to `useQuery` hook in `AddByFile.tsx`.