### PR TITLE
feat: add public title to team

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -1671,6 +1671,7 @@ type Team
 {
   id: ID!
   title: String!
+  publicTitle: String
   createdAt: DateTime!
   updatedAt: DateTime!
   userTeams: [UserTeam!]!
@@ -1680,12 +1681,14 @@ input TeamCreateInput
   @join__type(graph: JOURNEYS)
 {
   title: String!
+  publicTitle: String
 }
 
 input TeamUpdateInput
   @join__type(graph: JOURNEYS)
 {
   title: String!
+  publicTitle: String
 }
 
 type TextResponseBlock implements Block

--- a/apps/api-journeys/db/migrations/20230914053518_20230914053516/migration.sql
+++ b/apps/api-journeys/db/migrations/20230914053518_20230914053516/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Team" ADD COLUMN     "publicTitle" TEXT;

--- a/apps/api-journeys/db/schema.prisma
+++ b/apps/api-journeys/db/schema.prisma
@@ -181,6 +181,7 @@ model JourneyVisitor {
 model Team {
   id              String           @id @default(uuid())
   title           String
+  publicTitle     String?
   createdAt       DateTime         @default(now())
   updatedAt       DateTime         @updatedAt
   visitors        Visitor[]

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -1980,6 +1980,7 @@ type Team
 {
   id: ID!
   title: String!
+  publicTitle: String
   createdAt: DateTime!
   updatedAt: DateTime!
   userTeams: [UserTeam!]!
@@ -1987,10 +1988,12 @@ type Team
 
 input TeamCreateInput {
   title: String!
+  publicTitle: String
 }
 
 input TeamUpdateInput {
   title: String!
+  publicTitle: String
 }
 
 type UserInvite

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -640,10 +640,12 @@ export class JourneyVisitorFilter {
 
 export class TeamCreateInput {
     title: string;
+    publicTitle?: Nullable<string>;
 }
 
 export class TeamUpdateInput {
     title: string;
+    publicTitle?: Nullable<string>;
 }
 
 export class UserInviteCreateInput {
@@ -1206,6 +1208,7 @@ export class Team {
     __typename?: 'Team';
     id: string;
     title: string;
+    publicTitle?: Nullable<string>;
     createdAt: DateTime;
     updatedAt: DateTime;
     userTeams: UserTeam[];

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -1529,6 +1529,7 @@ describe('JourneyResolver', () => {
       const team: Team = {
         id: 'teamId',
         title: 'My Cool Team',
+        publicTitle: null,
         createdAt: new Date(),
         updatedAt: new Date()
       }

--- a/apps/api-journeys/src/app/modules/team/team.graphql
+++ b/apps/api-journeys/src/app/modules/team/team.graphql
@@ -1,6 +1,7 @@
 type Team @key(fields: "id") {
   id: ID!
   title: String!
+  publicTitle: String
   createdAt: DateTime!
   updatedAt: DateTime!
   userTeams: [UserTeam!]!
@@ -13,10 +14,12 @@ extend type Query {
 
 input TeamCreateInput {
   title: String!
+  publicTitle: String
 }
 
 input TeamUpdateInput {
   title: String!
+  publicTitle: String
 }
 
 extend type Mutation {

--- a/apps/api-journeys/src/app/modules/team/team.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/team/team.resolver.spec.ts
@@ -87,11 +87,15 @@ describe('TeamResolver', () => {
     it('creates team with userTeam', async () => {
       prismaService.team.create.mockResolvedValue(team)
       await expect(
-        resolver.teamCreate('userId', { name: 'team' })
+        resolver.teamCreate('userId', {
+          name: 'team',
+          publicName: 'public team name'
+        })
       ).resolves.toEqual(team)
       expect(prismaService.team.create).toHaveBeenCalledWith({
         data: {
           name: 'team',
+          publicName: 'public team name',
           userTeams: {
             create: {
               userId: 'userId',
@@ -108,12 +112,16 @@ describe('TeamResolver', () => {
       prismaService.team.findUnique.mockResolvedValue(teamWithUserTeam)
       prismaService.team.update.mockResolvedValue(teamWithUserTeam)
       await expect(
-        resolver.teamUpdate(ability, 'teamId', { name: 'team' })
+        resolver.teamUpdate(ability, 'teamId', {
+          name: 'team',
+          publicName: 'public team name'
+        })
       ).resolves.toEqual(teamWithUserTeam)
       expect(prismaService.team.update).toHaveBeenCalledWith({
         where: { id: 'teamId' },
         data: {
-          name: 'team'
+          name: 'team',
+          publicName: 'public team name'
         }
       })
     })

--- a/apps/journeys-admin/__generated__/globalTypes.ts
+++ b/apps/journeys-admin/__generated__/globalTypes.ts
@@ -447,10 +447,12 @@ export interface StepViewEventCreateInput {
 
 export interface TeamCreateInput {
   title: string;
+  publicTitle?: string | null;
 }
 
 export interface TeamUpdateInput {
   title: string;
+  publicTitle?: string | null;
 }
 
 export interface TextResponseBlockCreateInput {

--- a/apps/journeys-admin/src/components/Team/TeamCreateForm/TeamCreateForm.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamCreateForm/TeamCreateForm.tsx
@@ -23,11 +23,13 @@ export function TeamCreateForm({
   children
 }: TeamCreateFormProps): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
-  const teamCreateSchema: ObjectSchema<TeamCreateInput> = object({
-    title: string()
-      .required(t('Team Name must be at least one character.'))
-      .max(40, t('Max {{ count }} Characters', { count: 40 }))
-  })
+  const teamCreateSchema: ObjectSchema<Pick<TeamCreateInput, 'title'>> = object(
+    {
+      title: string()
+        .required(t('Team Name must be at least one character.'))
+        .max(40, t('Max {{ count }} Characters', { count: 40 }))
+    }
+  )
   const [teamCreate] = useTeamCreateMutation()
   const { enqueueSnackbar } = useSnackbar()
 


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 294e2f6</samp>

This pull request adds a `publicTitle` field to the `Team` type and its input types in the GraphQL schemas of `api-gateway` and `api-journeys` apps. This field allows teams to have different names for internal and external use. It also updates the related resolvers and tests to handle the new field.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/33184123/todos/6543002804)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 294e2f6</samp>

*  Add `publicTitle` field to `Team` type to allow teams to have different names for internal and external purposes ([link](https://github.com/JesusFilm/core/pull/1876/files?diff=unified&w=0#diff-e60078ed0fc71b8cd3bb2fca25505e7dba866b7d463147662a12432dfe287273R1674), [link](https://github.com/JesusFilm/core/pull/1876/files?diff=unified&w=0#diff-3cbd0d77b8eff95fb0f62db7f9f1a4b69ccd568ae3902a3450bac7d752c817a3R1983), [link](https://github.com/JesusFilm/core/pull/1876/files?diff=unified&w=0#diff-bef781d45ccbb6775960a589c940a77584bd143e501a8ae9b83d699d803561f2R1211), [link](https://github.com/JesusFilm/core/pull/1876/files?diff=unified&w=0#diff-41d403336e29ab179760e88aa306f9e877b82482443bb2d0f29a8125cac766acR4))
*  Add `publicTitle` field to `TeamCreateInput` and `TeamUpdateInput` types to enable users to specify and modify the public title for teams ([link](https://github.com/JesusFilm/core/pull/1876/files?diff=unified&w=0#diff-e60078ed0fc71b8cd3bb2fca25505e7dba866b7d463147662a12432dfe287273R1684), [link](https://github.com/JesusFilm/core/pull/1876/files?diff=unified&w=0#diff-e60078ed0fc71b8cd3bb2fca25505e7dba866b7d463147662a12432dfe287273R1691), [link](https://github.com/JesusFilm/core/pull/1876/files?diff=unified&w=0#diff-3cbd0d77b8eff95fb0f62db7f9f1a4b69ccd568ae3902a3450bac7d752c817a3L1990-R1996), [link](https://github.com/JesusFilm/core/pull/1876/files?diff=unified&w=0#diff-bef781d45ccbb6775960a589c940a77584bd143e501a8ae9b83d699d803561f2L643-R648), [link](https://github.com/JesusFilm/core/pull/1876/files?diff=unified&w=0#diff-41d403336e29ab179760e88aa306f9e877b82482443bb2d0f29a8125cac766acL16-R22))
*  Update `team` resolver to handle the `publicTitle` input for creating and updating teams and mock the expected response from `prismaService` in the unit tests ([link](https://github.com/JesusFilm/core/pull/1876/files?diff=unified&w=0#diff-94767855b0f2244d37bdaef0e664cdfe27bd1263b627a42229aa9de3b178a22fL90-R98), [link](https://github.com/JesusFilm/core/pull/1876/files?diff=unified&w=0#diff-94767855b0f2244d37bdaef0e664cdfe27bd1263b627a42229aa9de3b178a22fL111-R124))
