### PR TITLE
fix: journeys call

### DIFF
--- a/apps/journeys/pages/index.tsx
+++ b/apps/journeys/pages/index.tsx
@@ -149,7 +149,7 @@ export const getStaticProps: GetStaticProps<JourneysPageProps> = async (
   const { data } = await apolloClient.query<GetJourneys>({
     query: gql`
       query GetJourneys {
-        journeys(where: { featured: true }) {
+        journeys(where: { featured: true, template: false }) {
           id
           title
           slug


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4509032</samp>

Filter out template journeys from index page. This prevents users from seeing journeys that are only used for creating new ones.

[- Link to Basecamp Todo
](https://3.basecamp.com/3105655/buckets/34356579/todos/6566593803)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] it should call journeys that are featured but not templates

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4509032</samp>

*  Filter out template journeys from index page query ([link](https://github.com/JesusFilm/core/pull/1894/files?diff=unified&w=0#diff-7704898472a9a49a40503ef4bbac23b8f64cca8f7cb6006e59717d2f2f524be1L152-R152))
