### PR TITLE
fix: unsplash flakey test

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ImageBlockEditor/UnsplashGallery/UnsplashGallery.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockEditor/UnsplashGallery/UnsplashGallery.spec.tsx
@@ -157,9 +157,11 @@ describe('UnsplashGallery', () => {
     fireEvent.change(textbox, { target: { value: 'Jesus' } })
     fireEvent.submit(textbox, { target: { value: 'Jesus' } })
     await waitFor(() => expect(getByRole('list')).toBeInTheDocument())
-    expect(
-      getAllByAltText('white dome building during daytime')[0]
-    ).toBeInTheDocument()
+    await waitFor(() =>
+      expect(
+        getAllByAltText('white dome building during daytime')[0]
+      ).toBeInTheDocument()
+    )
     const chip = getByRole('button', { name: 'Church' })
     fireEvent.click(chip)
     expect(getByRole('textbox', { name: 'UnsplashSearch' })).toHaveValue(


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3b83b79</samp>

Improve test reliability for `UnsplashGallery` component. Add `waitFor` call to `UnsplashGallery.spec.tsx` to ensure images are rendered before assertions.

- Link to Basecamp Todo

# How should this PR be QA Tested?

- [ ] unsplash test should fail or be flakey

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3b83b79</samp>

* Add an extra `waitFor` call to avoid flaky tests in UnsplashGallery component ([link](https://github.com/JesusFilm/core/pull/1901/files?diff=unified&w=0#diff-d459146af34fc40956d22e014d982aff2931399f822aa7597d32a6de227aaa2eL160-R164))
