### PR TITLE
feat: add limit and order by recent in journeys

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -713,6 +713,8 @@ input JourneysFilter
   template: Boolean
   ids: [ID!]
   tagIds: [ID!]
+  limit: Int
+  orderByRecent: Boolean
 }
 
 enum JourneysReportType

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -1781,6 +1781,8 @@ input JourneysFilter {
   template: Boolean
   ids: [ID!]
   tagIds: [ID!]
+  limit: Int
+  orderByRecent: Boolean
 }
 
 enum JourneysReportType {

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -596,6 +596,8 @@ export class JourneysFilter {
     template?: Nullable<boolean>;
     ids?: Nullable<string[]>;
     tagIds?: Nullable<string[]>;
+    limit?: Nullable<number>;
+    orderByRecent?: Nullable<boolean>;
 }
 
 export class JourneyCreateInput {

--- a/apps/api-journeys/src/app/modules/journey/journey.graphql
+++ b/apps/api-journeys/src/app/modules/journey/journey.graphql
@@ -48,6 +48,8 @@ input JourneysFilter {
   template: Boolean
   ids: [ID!]
   tagIds: [ID!]
+  limit: Int
+  orderByRecent: Boolean
 }
 
 enum JourneysReportType {

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -556,6 +556,31 @@ describe('JourneyResolver', () => {
         }
       })
     })
+
+    it('returns limited number of published journeys', async () => {
+      prismaService.journey.findMany.mockResolvedValueOnce([journey, journey])
+      expect(await resolver.journeys({ limit: 2 })).toEqual([journey, journey])
+      expect(prismaService.journey.findMany).toHaveBeenCalledWith({
+        where: {
+          status: 'published'
+        },
+        take: 2
+      })
+    })
+
+    it('returns published journeys ordered by recent', async () => {
+      prismaService.journey.findMany.mockResolvedValueOnce([journey, journey])
+      expect(await resolver.journeys({ orderByRecent: true })).toEqual([
+        journey,
+        journey
+      ])
+      expect(prismaService.journey.findMany).toHaveBeenCalledWith({
+        where: {
+          status: 'published'
+        },
+        orderBy: { createdAt: 'desc' }
+      })
+    })
   })
 
   describe('journey', () => {

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -578,7 +578,7 @@ describe('JourneyResolver', () => {
         where: {
           status: 'published'
         },
-        orderBy: { createdAt: 'desc' }
+        orderBy: { publishedAt: 'desc' }
       })
     })
   })

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -180,8 +180,11 @@ export class JourneyResolver {
     if (where?.featured === true) filter.featuredAt = { not: null }
     if (where?.ids != null) filter.id = { in: where?.ids }
     if (where?.tagIds != null) filter.tagIds = { hasEvery: where?.tagIds }
+
     return await this.prismaService.journey.findMany({
-      where: filter
+      where: filter,
+      take: where?.limit ?? undefined,
+      orderBy: where?.orderByRecent === true ? { createdAt: 'desc' } : undefined
     })
   }
 

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -184,7 +184,8 @@ export class JourneyResolver {
     return await this.prismaService.journey.findMany({
       where: filter,
       take: where?.limit ?? undefined,
-      orderBy: where?.orderByRecent === true ? { createdAt: 'desc' } : undefined
+      orderBy:
+        where?.orderByRecent === true ? { publishedAt: 'desc' } : undefined
     })
   }
 

--- a/apps/journeys-admin/__generated__/globalTypes.ts
+++ b/apps/journeys-admin/__generated__/globalTypes.ts
@@ -367,6 +367,8 @@ export interface JourneysFilter {
   template?: boolean | null;
   ids?: string[] | null;
   tagIds?: string[] | null;
+  limit?: number | null;
+  orderByRecent?: boolean | null;
 }
 
 export interface LinkActionInput {


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 991ef97</samp>

This pull request adds pagination and sorting features to the `journeys` query in the `api-gateway` and `api-journeys` schemas and services. It updates the GraphQL types, resolvers, and tests to handle the new arguments and query options.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34356579/todos/6557663024)

# How should this PR be QA Tested?

- [ ] it should enable users to limit the amount of journeys returned
- [ ] it should enable users to get a descending order of journeys

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 991ef97</samp>

*  Add `limit` and `orderByRecent` arguments to `journeys` query in `api-gateway` and `api-journeys` schemas ([link](https://github.com/JesusFilm/core/pull/1903/files?diff=unified&w=0#diff-e60078ed0fc71b8cd3bb2fca25505e7dba866b7d463147662a12432dfe287273R716-R717), [link](https://github.com/JesusFilm/core/pull/1903/files?diff=unified&w=0#diff-3cbd0d77b8eff95fb0f62db7f9f1a4b69ccd568ae3902a3450bac7d752c817a3R1784-R1785))
*  Generate TypeScript types for the new arguments in `graphql.ts` ([link](https://github.com/JesusFilm/core/pull/1903/files?diff=unified&w=0#diff-bef781d45ccbb6775960a589c940a77584bd143e501a8ae9b83d699d803561f2R599-R600))
*  Annotate the arguments with `@Args` decorator in `journey.graphql` resolver ([link](https://github.com/JesusFilm/core/pull/1903/files?diff=unified&w=0#diff-5d25ebcb2d0b7fb3abd35ecaaf839372a6a9b86152fab8eea293c5eb974e5588R51-R52))
*  Use the arguments to construct query options for `prismaService` in `journey.resolver.ts` ([link](https://github.com/JesusFilm/core/pull/1903/files?diff=unified&w=0#diff-be9eaaadc38880434cdfe42dc6e2fe0f5cae94cf78d3e9e05f9a39093dae42dfL183-R187))
*  Add unit tests for the resolver logic with mock data and services in `journey.resolver.spec.ts` ([link](https://github.com/JesusFilm/core/pull/1903/files?diff=unified&w=0#diff-93528ee54010f1df0fe00fab3e9cf53b524ade137814f4899de8d3151a7b1882R559-R583))
