### PR TITLE
fix: featured filter false logic

### DIFF
--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -501,6 +501,20 @@ describe('JourneyResolver', () => {
       })
     })
 
+    it('returns published journeys where featuredAt is false', async () => {
+      prismaService.journey.findMany.mockResolvedValueOnce([journey, journey])
+      expect(await resolver.journeys({ featured: false })).toEqual([
+        journey,
+        journey
+      ])
+      expect(prismaService.journey.findMany).toHaveBeenCalledWith({
+        where: {
+          status: 'published',
+          featuredAt: null
+        }
+      })
+    })
+
     it('returns published journeys where template', async () => {
       prismaService.journey.findMany.mockResolvedValueOnce([
         journeyWithTemplate,

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -177,7 +177,8 @@ export class JourneyResolver {
   async journeys(@Args('where') where?: JourneysFilter): Promise<Journey[]> {
     const filter: Prisma.JourneyWhereInput = { status: JourneyStatus.published }
     if (where?.template != null) filter.template = where.template
-    if (where?.featured === true) filter.featuredAt = { not: null }
+    if (where?.featured != null)
+      filter.featuredAt = where?.featured ? { not: null } : null
     if (where?.ids != null) filter.id = { in: where?.ids }
     if (where?.tagIds != null) filter.tagIds = { hasEvery: where?.tagIds }
 


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aef7660</samp>

The pull request adds a test case and modifies the logic for the `journeys` query in the `JourneyResolver` class. The purpose is to enable filtering journeys by both featured and non-featured status using the `where.featured` argument.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34356579/todos/6557663024)
Backend related changes

# How should this PR be QA Tested?

- [ ] it should enable users to query journeys where featured is set to false
- [ ] it should not return a journey with featuredAt value if featured is false
- [ ] it should not return a template with featuredAt value if featured is false
- [ ] it should not do anything if featured value is undefined or null

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aef7660</samp>

*  Add a test case for the `journeys` query to filter non-featured journeys ([link](https://github.com/JesusFilm/core/pull/1909/files?diff=unified&w=0#diff-93528ee54010f1df0fe00fab3e9cf53b524ade137814f4899de8d3151a7b1882R504-R517))
*  Update the `journeys` query to handle both featured and non-featured filters ([link](https://github.com/JesusFilm/core/pull/1909/files?diff=unified&w=0#diff-be9eaaadc38880434cdfe42dc6e2fe0f5cae94cf78d3e9e05f9a39093dae42dfL180-R181))
