### PR TITLE
test: test ids for ns journeys components

### DIFF
--- a/apps/journeys/src/components/Conductor/Conductor.spec.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.spec.tsx
@@ -270,8 +270,8 @@ describe('Conductor', () => {
           </SnackbarProvider>
         </MockedProvider>
       )
-      const leftButton = getByTestId('NavigationButtonPrev')
-      const rightButton = getByTestId('NavigationButtonNext')
+      const leftButton = getByTestId('ButtonNavigationButtonPrev')
+      const rightButton = getByTestId('ButtonNavigationButtonNext')
 
       expect(treeBlocksVar()).toBe(basic)
       expect(blockHistoryVar()[0].id).toBe('step1.id')
@@ -304,8 +304,8 @@ describe('Conductor', () => {
           </SnackbarProvider>
         </MockedProvider>
       )
-      const leftButton = getByTestId('NavigationButtonNext')
-      const rightButton = getByTestId('NavigationButtonPrev')
+      const leftButton = getByTestId('ButtonNavigationButtonNext')
+      const rightButton = getByTestId('ButtonNavigationButtonPrev')
 
       expect(treeBlocksVar()).toBe(basic)
       expect(blockHistoryVar()[0].id).toBe('step1.id')

--- a/apps/journeys/src/components/Conductor/Conductor.spec.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.spec.tsx
@@ -270,8 +270,8 @@ describe('Conductor', () => {
           </SnackbarProvider>
         </MockedProvider>
       )
-      const leftButton = getByTestId('conductorPrevButton')
-      const rightButton = getByTestId('conductorNextButton')
+      const leftButton = getByTestId('NavigationButtonPrev')
+      const rightButton = getByTestId('NavigationButtonNext')
 
       expect(treeBlocksVar()).toBe(basic)
       expect(blockHistoryVar()[0].id).toBe('step1.id')
@@ -304,8 +304,8 @@ describe('Conductor', () => {
           </SnackbarProvider>
         </MockedProvider>
       )
-      const leftButton = getByTestId('conductorNextButton')
-      const rightButton = getByTestId('conductorPrevButton')
+      const leftButton = getByTestId('NavigationButtonNext')
+      const rightButton = getByTestId('NavigationButtonPrev')
 
       expect(treeBlocksVar()).toBe(basic)
       expect(blockHistoryVar()[0].id).toBe('step1.id')

--- a/apps/journeys/src/components/Conductor/Conductor.spec.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.spec.tsx
@@ -270,8 +270,8 @@ describe('Conductor', () => {
           </SnackbarProvider>
         </MockedProvider>
       )
-      const leftButton = getByTestId('ButtonNavigationButtonPrev')
-      const rightButton = getByTestId('ButtonNavigationButtonNext')
+      const leftButton = getByTestId('ConductorNavigationButtonPrev')
+      const rightButton = getByTestId('ConductorNavigationButtonNext')
 
       expect(treeBlocksVar()).toBe(basic)
       expect(blockHistoryVar()[0].id).toBe('step1.id')
@@ -304,8 +304,8 @@ describe('Conductor', () => {
           </SnackbarProvider>
         </MockedProvider>
       )
-      const leftButton = getByTestId('ButtonNavigationButtonNext')
-      const rightButton = getByTestId('ButtonNavigationButtonPrev')
+      const leftButton = getByTestId('ConductorNavigationButtonNext')
+      const rightButton = getByTestId('ConductorNavigationButtonPrev')
 
       expect(treeBlocksVar()).toBe(basic)
       expect(blockHistoryVar()[0].id).toBe('step1.id')

--- a/apps/journeys/src/components/Conductor/Conductor.stories.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.stories.tsx
@@ -131,7 +131,7 @@ export const WithContent = {
     blocks: imageBlocks
   },
   play: async () => {
-    const nextButton = screen.getAllByTestId('NavigationButtonNext')[0]
+    const nextButton = screen.getAllByTestId('ButtonNavigationButtonNext')[0]
     await userEvent.click(nextButton)
     await waitFor(async () => {
       await expect(

--- a/apps/journeys/src/components/Conductor/Conductor.stories.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.stories.tsx
@@ -131,7 +131,7 @@ export const WithContent = {
     blocks: imageBlocks
   },
   play: async () => {
-    const nextButton = screen.getAllByTestId('conductorNextButton')[0]
+    const nextButton = screen.getAllByTestId('NavigationButtonNext')[0]
     await userEvent.click(nextButton)
     await waitFor(async () => {
       await expect(

--- a/apps/journeys/src/components/Conductor/Conductor.stories.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.stories.tsx
@@ -135,7 +135,7 @@ export const WithContent = {
     await userEvent.click(nextButton)
     await waitFor(async () => {
       await expect(
-        screen.getAllByTestId('prevNavContainer')[1]
+        screen.getAllByTestId('NavigationContainerPrev')[1]
       ).toBeInTheDocument()
     })
   }

--- a/apps/journeys/src/components/Conductor/Conductor.stories.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.stories.tsx
@@ -135,7 +135,7 @@ export const WithContent = {
     await userEvent.click(nextButton)
     await waitFor(async () => {
       await expect(
-        screen.getAllByTestId('ConductorNavigationContainer')[1]
+        screen.getAllByTestId('ConductorNavigationContainerPrev')[1]
       ).toBeInTheDocument()
     })
   }

--- a/apps/journeys/src/components/Conductor/Conductor.stories.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.stories.tsx
@@ -131,11 +131,11 @@ export const WithContent = {
     blocks: imageBlocks
   },
   play: async () => {
-    const nextButton = screen.getAllByTestId('ButtonNavigationButtonNext')[0]
+    const nextButton = screen.getAllByTestId('ConductorNavigationButtonNext')[0]
     await userEvent.click(nextButton)
     await waitFor(async () => {
       await expect(
-        screen.getAllByTestId('NavigationContainerPrev')[1]
+        screen.getAllByTestId('ConductorNavigationContainer')[1]
       ).toBeInTheDocument()
     })
   }

--- a/apps/journeys/src/components/Conductor/Conductor.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.tsx
@@ -186,6 +186,7 @@ export function Conductor({ blocks }: ConductorProps): ReactElement {
           height: '100%',
           background: theme.palette.grey[900]
         }}
+        data-testid="Conductor"
       >
         <Box sx={{ height: { xs: '100%', lg: 'unset' } }}>
           <StyledSwiperContainer

--- a/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.spec.tsx
+++ b/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.spec.tsx
@@ -42,12 +42,12 @@ describe('NavigationButton', () => {
     const { getByTestId } = render(
       <NavigationButton variant="next" alignment="right" />
     )
-    expect(getByTestId('conductorNextButton')).not.toBeVisible()
+    expect(getByTestId('NavigationButtonNext')).not.toBeVisible()
 
-    fireEvent.mouseOver(getByTestId('conductorNextButton'))
+    fireEvent.mouseOver(getByTestId('NavigationButtonNext'))
 
     await waitFor(() => {
-      expect(getByTestId('conductorNextButton')).toBeVisible()
+      expect(getByTestId('NavigationButtonNext')).toBeVisible()
     })
   })
 
@@ -59,11 +59,11 @@ describe('NavigationButton', () => {
     const { getByTestId } = render(
       <NavigationButton variant="next" alignment="right" />
     )
-    expect(getByTestId('conductorNextButton')).toBeVisible()
+    expect(getByTestId('NavigationButtonNext')).toBeVisible()
 
     await waitFor(
       () => {
-        expect(getByTestId('conductorNextButton')).not.toBeVisible()
+        expect(getByTestId('NavigationButtonNext')).not.toBeVisible()
       },
       { timeout: 3000 }
     )
@@ -77,7 +77,7 @@ describe('NavigationButton', () => {
       const { getByTestId } = render(
         <NavigationButton variant="next" alignment="right" />
       )
-      fireEvent.click(getByTestId('conductorNextButton'))
+      fireEvent.click(getByTestId('NavigationButtonNext'))
 
       expect(blockHistoryVar()[1].id).toBe('step3.id')
     })
@@ -90,7 +90,7 @@ describe('NavigationButton', () => {
       )
       expect(blockHistoryVar()[1].id).toBe('step2.id')
 
-      fireEvent.click(getByTestId('conductorPrevButton'))
+      fireEvent.click(getByTestId('NavigationButtonPrev'))
 
       expect(blockHistoryVar()[0].id).toBe('step1.id')
     })
@@ -102,7 +102,7 @@ describe('NavigationButton', () => {
         <NavigationButton variant="prev" alignment="left" />
       )
 
-      expect(getByTestId('conductorPrevButton')).not.toBeVisible()
+      expect(getByTestId('NavigationButtonPrev')).not.toBeVisible()
     })
 
     it('should hide right button if next step is locked', () => {
@@ -111,7 +111,7 @@ describe('NavigationButton', () => {
       const { getByTestId } = render(
         <NavigationButton variant="next" alignment="right" />
       )
-      expect(getByTestId('conductorNextButton')).not.toBeVisible()
+      expect(getByTestId('NavigationButtonNext')).not.toBeVisible()
     })
 
     it('should hide right button if on last card', () => {
@@ -121,7 +121,7 @@ describe('NavigationButton', () => {
         <NavigationButton variant="next" alignment="right" />
       )
 
-      expect(getByTestId('conductorNextButton')).not.toBeVisible()
+      expect(getByTestId('NavigationButtonNext')).not.toBeVisible()
     })
 
     it('should show right button if on last card but set to navigate to another card', async () => {
@@ -131,10 +131,10 @@ describe('NavigationButton', () => {
         <NavigationButton variant="next" alignment="right" />
       )
 
-      fireEvent.mouseOver(getByTestId('conductorNextButton'))
+      fireEvent.mouseOver(getByTestId('NavigationButtonNext'))
 
       await waitFor(() => {
-        expect(getByTestId('conductorNextButton')).toBeVisible()
+        expect(getByTestId('NavigationButtonNext')).toBeVisible()
       })
     })
   })
@@ -147,7 +147,7 @@ describe('NavigationButton', () => {
       const { getByTestId } = render(
         <NavigationButton variant="next" alignment="left" />
       )
-      fireEvent.click(getByTestId('conductorNextButton'))
+      fireEvent.click(getByTestId('NavigationButtonNext'))
 
       expect(blockHistoryVar()[1].id).toBe('step3.id')
     })
@@ -160,7 +160,7 @@ describe('NavigationButton', () => {
       )
       expect(blockHistoryVar()[1].id).toBe('step2.id')
 
-      fireEvent.click(getByTestId('conductorPrevButton'))
+      fireEvent.click(getByTestId('NavigationButtonPrev'))
 
       expect(blockHistoryVar()[0].id).toBe('step1.id')
     })
@@ -172,7 +172,7 @@ describe('NavigationButton', () => {
         <NavigationButton variant="prev" alignment="right" />
       )
 
-      expect(getByTestId('conductorPrevButton')).not.toBeVisible()
+      expect(getByTestId('NavigationButtonPrev')).not.toBeVisible()
     })
 
     it('should hide left button if next step is locked', () => {
@@ -181,7 +181,7 @@ describe('NavigationButton', () => {
       const { getByTestId } = render(
         <NavigationButton variant="next" alignment="left" />
       )
-      expect(getByTestId('conductorNextButton')).not.toBeVisible()
+      expect(getByTestId('NavigationButtonNext')).not.toBeVisible()
     })
 
     it('should hide left button if on last card', () => {
@@ -191,7 +191,7 @@ describe('NavigationButton', () => {
         <NavigationButton variant="next" alignment="left" />
       )
 
-      expect(getByTestId('conductorNextButton')).not.toBeVisible()
+      expect(getByTestId('NavigationButtonNext')).not.toBeVisible()
     })
 
     it('should show left button if on last card but set to navigate to another card', async () => {
@@ -201,10 +201,10 @@ describe('NavigationButton', () => {
         <NavigationButton variant="next" alignment="left" />
       )
 
-      fireEvent.mouseOver(getByTestId('conductorNextButton'))
+      fireEvent.mouseOver(getByTestId('NavigationButtonNext'))
 
       await waitFor(() => {
-        expect(getByTestId('conductorNextButton')).toBeVisible()
+        expect(getByTestId('NavigationButtonNext')).toBeVisible()
       })
     })
   })

--- a/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.spec.tsx
+++ b/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.spec.tsx
@@ -42,12 +42,12 @@ describe('NavigationButton', () => {
     const { getByTestId } = render(
       <NavigationButton variant="next" alignment="right" />
     )
-    expect(getByTestId('NavigationButtonNext')).not.toBeVisible()
+    expect(getByTestId('ButtonNavigationButtonNext')).not.toBeVisible()
 
-    fireEvent.mouseOver(getByTestId('NavigationButtonNext'))
+    fireEvent.mouseOver(getByTestId('ButtonNavigationButtonNext'))
 
     await waitFor(() => {
-      expect(getByTestId('NavigationButtonNext')).toBeVisible()
+      expect(getByTestId('ButtonNavigationButtonNext')).toBeVisible()
     })
   })
 
@@ -59,11 +59,11 @@ describe('NavigationButton', () => {
     const { getByTestId } = render(
       <NavigationButton variant="next" alignment="right" />
     )
-    expect(getByTestId('NavigationButtonNext')).toBeVisible()
+    expect(getByTestId('ButtonNavigationButtonNext')).toBeVisible()
 
     await waitFor(
       () => {
-        expect(getByTestId('NavigationButtonNext')).not.toBeVisible()
+        expect(getByTestId('ButtonNavigationButtonNext')).not.toBeVisible()
       },
       { timeout: 3000 }
     )
@@ -77,7 +77,7 @@ describe('NavigationButton', () => {
       const { getByTestId } = render(
         <NavigationButton variant="next" alignment="right" />
       )
-      fireEvent.click(getByTestId('NavigationButtonNext'))
+      fireEvent.click(getByTestId('ButtonNavigationButtonNext'))
 
       expect(blockHistoryVar()[1].id).toBe('step3.id')
     })
@@ -90,7 +90,7 @@ describe('NavigationButton', () => {
       )
       expect(blockHistoryVar()[1].id).toBe('step2.id')
 
-      fireEvent.click(getByTestId('NavigationButtonPrev'))
+      fireEvent.click(getByTestId('ButtonNavigationButtonPrev'))
 
       expect(blockHistoryVar()[0].id).toBe('step1.id')
     })
@@ -102,7 +102,7 @@ describe('NavigationButton', () => {
         <NavigationButton variant="prev" alignment="left" />
       )
 
-      expect(getByTestId('NavigationButtonPrev')).not.toBeVisible()
+      expect(getByTestId('ButtonNavigationButtonPrev')).not.toBeVisible()
     })
 
     it('should hide right button if next step is locked', () => {
@@ -111,7 +111,7 @@ describe('NavigationButton', () => {
       const { getByTestId } = render(
         <NavigationButton variant="next" alignment="right" />
       )
-      expect(getByTestId('NavigationButtonNext')).not.toBeVisible()
+      expect(getByTestId('ButtonNavigationButtonNext')).not.toBeVisible()
     })
 
     it('should hide right button if on last card', () => {
@@ -121,7 +121,7 @@ describe('NavigationButton', () => {
         <NavigationButton variant="next" alignment="right" />
       )
 
-      expect(getByTestId('NavigationButtonNext')).not.toBeVisible()
+      expect(getByTestId('ButtonNavigationButtonNext')).not.toBeVisible()
     })
 
     it('should show right button if on last card but set to navigate to another card', async () => {
@@ -131,10 +131,10 @@ describe('NavigationButton', () => {
         <NavigationButton variant="next" alignment="right" />
       )
 
-      fireEvent.mouseOver(getByTestId('NavigationButtonNext'))
+      fireEvent.mouseOver(getByTestId('ButtonNavigationButtonNext'))
 
       await waitFor(() => {
-        expect(getByTestId('NavigationButtonNext')).toBeVisible()
+        expect(getByTestId('ButtonNavigationButtonNext')).toBeVisible()
       })
     })
   })
@@ -147,7 +147,7 @@ describe('NavigationButton', () => {
       const { getByTestId } = render(
         <NavigationButton variant="next" alignment="left" />
       )
-      fireEvent.click(getByTestId('NavigationButtonNext'))
+      fireEvent.click(getByTestId('ButtonNavigationButtonNext'))
 
       expect(blockHistoryVar()[1].id).toBe('step3.id')
     })
@@ -160,7 +160,7 @@ describe('NavigationButton', () => {
       )
       expect(blockHistoryVar()[1].id).toBe('step2.id')
 
-      fireEvent.click(getByTestId('NavigationButtonPrev'))
+      fireEvent.click(getByTestId('ButtonNavigationButtonPrev'))
 
       expect(blockHistoryVar()[0].id).toBe('step1.id')
     })
@@ -172,7 +172,7 @@ describe('NavigationButton', () => {
         <NavigationButton variant="prev" alignment="right" />
       )
 
-      expect(getByTestId('NavigationButtonPrev')).not.toBeVisible()
+      expect(getByTestId('ButtonNavigationButtonPrev')).not.toBeVisible()
     })
 
     it('should hide left button if next step is locked', () => {
@@ -181,7 +181,7 @@ describe('NavigationButton', () => {
       const { getByTestId } = render(
         <NavigationButton variant="next" alignment="left" />
       )
-      expect(getByTestId('NavigationButtonNext')).not.toBeVisible()
+      expect(getByTestId('ButtonNavigationButtonNext')).not.toBeVisible()
     })
 
     it('should hide left button if on last card', () => {
@@ -191,7 +191,7 @@ describe('NavigationButton', () => {
         <NavigationButton variant="next" alignment="left" />
       )
 
-      expect(getByTestId('NavigationButtonNext')).not.toBeVisible()
+      expect(getByTestId('ButtonNavigationButtonNext')).not.toBeVisible()
     })
 
     it('should show left button if on last card but set to navigate to another card', async () => {
@@ -201,10 +201,10 @@ describe('NavigationButton', () => {
         <NavigationButton variant="next" alignment="left" />
       )
 
-      fireEvent.mouseOver(getByTestId('NavigationButtonNext'))
+      fireEvent.mouseOver(getByTestId('ButtonNavigationButtonNext'))
 
       await waitFor(() => {
-        expect(getByTestId('NavigationButtonNext')).toBeVisible()
+        expect(getByTestId('ButtonNavigationButtonNext')).toBeVisible()
       })
     })
   })

--- a/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.spec.tsx
+++ b/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.spec.tsx
@@ -42,12 +42,12 @@ describe('NavigationButton', () => {
     const { getByTestId } = render(
       <NavigationButton variant="next" alignment="right" />
     )
-    expect(getByTestId('ButtonNavigationButtonNext')).not.toBeVisible()
+    expect(getByTestId('ConductorNavigationButtonNext')).not.toBeVisible()
 
-    fireEvent.mouseOver(getByTestId('ButtonNavigationButtonNext'))
+    fireEvent.mouseOver(getByTestId('ConductorNavigationButtonNext'))
 
     await waitFor(() => {
-      expect(getByTestId('ButtonNavigationButtonNext')).toBeVisible()
+      expect(getByTestId('ConductorNavigationButtonNext')).toBeVisible()
     })
   })
 
@@ -59,11 +59,11 @@ describe('NavigationButton', () => {
     const { getByTestId } = render(
       <NavigationButton variant="next" alignment="right" />
     )
-    expect(getByTestId('ButtonNavigationButtonNext')).toBeVisible()
+    expect(getByTestId('ConductorNavigationButtonNext')).toBeVisible()
 
     await waitFor(
       () => {
-        expect(getByTestId('ButtonNavigationButtonNext')).not.toBeVisible()
+        expect(getByTestId('ConductorNavigationButtonNext')).not.toBeVisible()
       },
       { timeout: 3000 }
     )
@@ -77,7 +77,7 @@ describe('NavigationButton', () => {
       const { getByTestId } = render(
         <NavigationButton variant="next" alignment="right" />
       )
-      fireEvent.click(getByTestId('ButtonNavigationButtonNext'))
+      fireEvent.click(getByTestId('ConductorNavigationButtonNext'))
 
       expect(blockHistoryVar()[1].id).toBe('step3.id')
     })
@@ -90,7 +90,7 @@ describe('NavigationButton', () => {
       )
       expect(blockHistoryVar()[1].id).toBe('step2.id')
 
-      fireEvent.click(getByTestId('ButtonNavigationButtonPrev'))
+      fireEvent.click(getByTestId('ConductorNavigationButtonPrev'))
 
       expect(blockHistoryVar()[0].id).toBe('step1.id')
     })
@@ -102,7 +102,7 @@ describe('NavigationButton', () => {
         <NavigationButton variant="prev" alignment="left" />
       )
 
-      expect(getByTestId('ButtonNavigationButtonPrev')).not.toBeVisible()
+      expect(getByTestId('ConductorNavigationButtonPrev')).not.toBeVisible()
     })
 
     it('should hide right button if next step is locked', () => {
@@ -111,7 +111,7 @@ describe('NavigationButton', () => {
       const { getByTestId } = render(
         <NavigationButton variant="next" alignment="right" />
       )
-      expect(getByTestId('ButtonNavigationButtonNext')).not.toBeVisible()
+      expect(getByTestId('ConductorNavigationButtonNext')).not.toBeVisible()
     })
 
     it('should hide right button if on last card', () => {
@@ -121,7 +121,7 @@ describe('NavigationButton', () => {
         <NavigationButton variant="next" alignment="right" />
       )
 
-      expect(getByTestId('ButtonNavigationButtonNext')).not.toBeVisible()
+      expect(getByTestId('ConductorNavigationButtonNext')).not.toBeVisible()
     })
 
     it('should show right button if on last card but set to navigate to another card', async () => {
@@ -131,10 +131,10 @@ describe('NavigationButton', () => {
         <NavigationButton variant="next" alignment="right" />
       )
 
-      fireEvent.mouseOver(getByTestId('ButtonNavigationButtonNext'))
+      fireEvent.mouseOver(getByTestId('ConductorNavigationButtonNext'))
 
       await waitFor(() => {
-        expect(getByTestId('ButtonNavigationButtonNext')).toBeVisible()
+        expect(getByTestId('ConductorNavigationButtonNext')).toBeVisible()
       })
     })
   })
@@ -147,7 +147,7 @@ describe('NavigationButton', () => {
       const { getByTestId } = render(
         <NavigationButton variant="next" alignment="left" />
       )
-      fireEvent.click(getByTestId('ButtonNavigationButtonNext'))
+      fireEvent.click(getByTestId('ConductorNavigationButtonNext'))
 
       expect(blockHistoryVar()[1].id).toBe('step3.id')
     })
@@ -160,7 +160,7 @@ describe('NavigationButton', () => {
       )
       expect(blockHistoryVar()[1].id).toBe('step2.id')
 
-      fireEvent.click(getByTestId('ButtonNavigationButtonPrev'))
+      fireEvent.click(getByTestId('ConductorNavigationButtonPrev'))
 
       expect(blockHistoryVar()[0].id).toBe('step1.id')
     })
@@ -172,7 +172,7 @@ describe('NavigationButton', () => {
         <NavigationButton variant="prev" alignment="right" />
       )
 
-      expect(getByTestId('ButtonNavigationButtonPrev')).not.toBeVisible()
+      expect(getByTestId('ConductorNavigationButtonPrev')).not.toBeVisible()
     })
 
     it('should hide left button if next step is locked', () => {
@@ -181,7 +181,7 @@ describe('NavigationButton', () => {
       const { getByTestId } = render(
         <NavigationButton variant="next" alignment="left" />
       )
-      expect(getByTestId('ButtonNavigationButtonNext')).not.toBeVisible()
+      expect(getByTestId('ConductorNavigationButtonNext')).not.toBeVisible()
     })
 
     it('should hide left button if on last card', () => {
@@ -191,7 +191,7 @@ describe('NavigationButton', () => {
         <NavigationButton variant="next" alignment="left" />
       )
 
-      expect(getByTestId('ButtonNavigationButtonNext')).not.toBeVisible()
+      expect(getByTestId('ConductorNavigationButtonNext')).not.toBeVisible()
     })
 
     it('should show left button if on last card but set to navigate to another card', async () => {
@@ -201,10 +201,10 @@ describe('NavigationButton', () => {
         <NavigationButton variant="next" alignment="left" />
       )
 
-      fireEvent.mouseOver(getByTestId('ButtonNavigationButtonNext'))
+      fireEvent.mouseOver(getByTestId('ConductorNavigationButtonNext'))
 
       await waitFor(() => {
-        expect(getByTestId('ButtonNavigationButtonNext')).toBeVisible()
+        expect(getByTestId('ConductorNavigationButtonNext')).toBeVisible()
       })
     })
   })

--- a/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.tsx
+++ b/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.tsx
@@ -100,7 +100,7 @@ export function NavigationButton({
 
   return (
     <NavigationContainer
-      data-testid={`${variant}NavContainer`}
+      data-testid={`NavigationContainer-${variant}`}
       onMouseOver={() => setShowNavigation(true)}
       sx={{
         ...alignSx,
@@ -124,9 +124,9 @@ export function NavigationButton({
         timeout={{ appear: 300, exit: 1000 }}
       >
         <IconButton
-          data-testid={`conductor${variant
+          data-testid={`NavigationButton${variant
             .charAt(0)
-            .toUpperCase()}${variant.slice(1)}Button`}
+            .toUpperCase()}${variant.slice(1)}`}
           size="small"
           onClick={() => handleNav(variant)}
           disableRipple

--- a/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.tsx
+++ b/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.tsx
@@ -100,7 +100,7 @@ export function NavigationButton({
 
   return (
     <NavigationContainer
-      data-testid={`NavigationContainer-${variant}`}
+      data-testid={`NavigationContainer${variant}`}
       onMouseOver={() => setShowNavigation(true)}
       sx={{
         ...alignSx,

--- a/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.tsx
+++ b/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.tsx
@@ -2,6 +2,7 @@ import Box from '@mui/material/Box'
 import Fade from '@mui/material/Fade'
 import IconButton from '@mui/material/IconButton'
 import { styled } from '@mui/material/styles'
+import capitalize from 'lodash/capitalize'
 import last from 'lodash/last'
 import { ReactElement, useEffect } from 'react'
 
@@ -100,9 +101,7 @@ export function NavigationButton({
 
   return (
     <NavigationContainer
-      data-testid={`NavigationContainer${variant
-        .charAt(0)
-        .toUpperCase()}${variant.slice(1)}`}
+      data-testid={`ContainerNavigationContainer${capitalize(variant)}`}
       onMouseOver={() => setShowNavigation(true)}
       sx={{
         ...alignSx,
@@ -126,9 +125,7 @@ export function NavigationButton({
         timeout={{ appear: 300, exit: 1000 }}
       >
         <IconButton
-          data-testid={`NavigationButton${variant
-            .charAt(0)
-            .toUpperCase()}${variant.slice(1)}`}
+          data-testid={`ButtonNavigationButton${capitalize(variant)}`}
           size="small"
           onClick={() => handleNav(variant)}
           disableRipple

--- a/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.tsx
+++ b/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.tsx
@@ -100,7 +100,9 @@ export function NavigationButton({
 
   return (
     <NavigationContainer
-      data-testid={`NavigationContainer${variant}`}
+      data-testid={`NavigationContainer${variant
+        .charAt(0)
+        .toUpperCase()}${variant.slice(1)}`}
       onMouseOver={() => setShowNavigation(true)}
       sx={{
         ...alignSx,

--- a/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.tsx
+++ b/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.tsx
@@ -101,7 +101,7 @@ export function NavigationButton({
 
   return (
     <NavigationContainer
-      data-testid={`ContainerNavigationContainer${capitalize(variant)}`}
+      data-testid={`ConductorNavigationContainer${capitalize(variant)}`}
       onMouseOver={() => setShowNavigation(true)}
       sx={{
         ...alignSx,
@@ -125,7 +125,7 @@ export function NavigationButton({
         timeout={{ appear: 300, exit: 1000 }}
       >
         <IconButton
-          data-testid={`ButtonNavigationButton${capitalize(variant)}`}
+          data-testid={`ConductorNavigationButton${capitalize(variant)}`}
           size="small"
           onClick={() => handleNav(variant)}
           disableRipple

--- a/apps/journeys/src/components/EmbeddedPreview/ButtonWrapper/ButtonWrapper.tsx
+++ b/apps/journeys/src/components/EmbeddedPreview/ButtonWrapper/ButtonWrapper.tsx
@@ -36,7 +36,7 @@ export function ButtonWrapper({
             ? 4
             : 5
       }}
-      data-testid="ButtonWrapper"
+      data-testid="EmbedButtonWrapper"
     >
       <MuiButton
         variant={block.buttonVariant ?? ButtonVariant.contained}

--- a/apps/journeys/src/components/EmbeddedPreview/ButtonWrapper/ButtonWrapper.tsx
+++ b/apps/journeys/src/components/EmbeddedPreview/ButtonWrapper/ButtonWrapper.tsx
@@ -36,6 +36,7 @@ export function ButtonWrapper({
             ? 4
             : 5
       }}
+      data-testid="ButtonWrapper"
     >
       <MuiButton
         variant={block.buttonVariant ?? ButtonVariant.contained}

--- a/apps/journeys/src/components/EmbeddedPreview/EmbeddedPreview.tsx
+++ b/apps/journeys/src/components/EmbeddedPreview/EmbeddedPreview.tsx
@@ -128,7 +128,7 @@ export function EmbeddedPreview({
           box-shadow: none !important;
         }
       `}</style>
-      <Div100vh data-testid="embedded-preview">
+      <Div100vh data-testid="EmbeddedPreview">
         {!isFullWindow && <ClickableCard />}
         <Box
           id="embed-fullscreen-container"

--- a/apps/journeys/src/components/EmbeddedPreview/RadioOptionWrapper/RadioOptionWrapper.tsx
+++ b/apps/journeys/src/components/EmbeddedPreview/RadioOptionWrapper/RadioOptionWrapper.tsx
@@ -36,6 +36,7 @@ export function RadioOptionWrapper({
       sx={{
         '&.MuiButtonBase-root': { pointerEvents: 'none' }
       }}
+      data-testid="RadioOptionWrapper"
     >
       {block.label}
     </StyledRadioOption>

--- a/apps/journeys/src/components/EmbeddedPreview/RadioOptionWrapper/RadioOptionWrapper.tsx
+++ b/apps/journeys/src/components/EmbeddedPreview/RadioOptionWrapper/RadioOptionWrapper.tsx
@@ -36,7 +36,7 @@ export function RadioOptionWrapper({
       sx={{
         '&.MuiButtonBase-root': { pointerEvents: 'none' }
       }}
-      data-testid="RadioOptionWrapper"
+      data-testid="EmbedRadioOptionWrapper"
     >
       {block.label}
     </StyledRadioOption>

--- a/apps/journeys/src/components/EmbeddedPreview/VideoWrapper/VideoWrapper.spec.tsx
+++ b/apps/journeys/src/components/EmbeddedPreview/VideoWrapper/VideoWrapper.spec.tsx
@@ -71,7 +71,7 @@ describe('VideoWrapper', () => {
 
   it('should render internal video', async () => {
     const { getByTestId } = render(<VideoWrapper block={videoBlock} />)
-    const sourceTag = getByTestId('VideoWrapper-video0.id').querySelector(
+    const sourceTag = getByTestId('EmbedVideoWrapper-video0.id').querySelector(
       '.vjs-tech source'
     )
     expect(sourceTag?.getAttribute('src')).toBe(
@@ -90,7 +90,7 @@ describe('VideoWrapper', () => {
         }}
       />
     )
-    const sourceTag = getByTestId('VideoWrapper-video0.id').querySelector(
+    const sourceTag = getByTestId('EmbedVideoWrapper-video0.id').querySelector(
       '.vjs-tech source'
     )
     expect(sourceTag?.getAttribute('src')).toBe(
@@ -109,7 +109,7 @@ describe('VideoWrapper', () => {
         }}
       />
     )
-    const sourceTag = getByTestId('VideoWrapper-video0.id').querySelector(
+    const sourceTag = getByTestId('EmbedVideoWrapper-video0.id').querySelector(
       '.vjs-tech source'
     )
     expect(sourceTag?.getAttribute('src')).toBe(

--- a/apps/journeys/src/components/EmbeddedPreview/VideoWrapper/VideoWrapper.spec.tsx
+++ b/apps/journeys/src/components/EmbeddedPreview/VideoWrapper/VideoWrapper.spec.tsx
@@ -72,7 +72,7 @@ describe('VideoWrapper', () => {
   it('should render internal video', async () => {
     const { getByTestId } = render(<VideoWrapper block={videoBlock} />)
     const sourceTag =
-      getByTestId('video-video0.id').querySelector('.vjs-tech source')
+      getByTestId('VideoWrapper-video0.id').querySelector('.vjs-tech source')
     expect(sourceTag?.getAttribute('src')).toBe(
       'https://arc.gt/hls/2_0-FallingPlates/529'
     )
@@ -90,7 +90,7 @@ describe('VideoWrapper', () => {
       />
     )
     const sourceTag =
-      getByTestId('video-video0.id').querySelector('.vjs-tech source')
+      getByTestId('VideoWrapper-video0.id').querySelector('.vjs-tech source')
     expect(sourceTag?.getAttribute('src')).toBe(
       'https://customer-.cloudflarestream.com/videoId/manifest/video.m3u8'
     )
@@ -108,7 +108,7 @@ describe('VideoWrapper', () => {
       />
     )
     const sourceTag =
-      getByTestId('video-video0.id').querySelector('.vjs-tech source')
+      getByTestId('VideoWrapper-video0.id').querySelector('.vjs-tech source')
     expect(sourceTag?.getAttribute('src')).toBe(
       'https://www.youtube.com/embed/F7k5pqBVinA?start=10&end=0'
     )

--- a/apps/journeys/src/components/EmbeddedPreview/VideoWrapper/VideoWrapper.spec.tsx
+++ b/apps/journeys/src/components/EmbeddedPreview/VideoWrapper/VideoWrapper.spec.tsx
@@ -71,8 +71,9 @@ describe('VideoWrapper', () => {
 
   it('should render internal video', async () => {
     const { getByTestId } = render(<VideoWrapper block={videoBlock} />)
-    const sourceTag =
-      getByTestId('VideoWrapper-video0.id').querySelector('.vjs-tech source')
+    const sourceTag = getByTestId('VideoWrapper-video0.id').querySelector(
+      '.vjs-tech source'
+    )
     expect(sourceTag?.getAttribute('src')).toBe(
       'https://arc.gt/hls/2_0-FallingPlates/529'
     )
@@ -89,8 +90,9 @@ describe('VideoWrapper', () => {
         }}
       />
     )
-    const sourceTag =
-      getByTestId('VideoWrapper-video0.id').querySelector('.vjs-tech source')
+    const sourceTag = getByTestId('VideoWrapper-video0.id').querySelector(
+      '.vjs-tech source'
+    )
     expect(sourceTag?.getAttribute('src')).toBe(
       'https://customer-.cloudflarestream.com/videoId/manifest/video.m3u8'
     )
@@ -107,8 +109,9 @@ describe('VideoWrapper', () => {
         }}
       />
     )
-    const sourceTag =
-      getByTestId('VideoWrapper-video0.id').querySelector('.vjs-tech source')
+    const sourceTag = getByTestId('VideoWrapper-video0.id').querySelector(
+      '.vjs-tech source'
+    )
     expect(sourceTag?.getAttribute('src')).toBe(
       'https://www.youtube.com/embed/F7k5pqBVinA?start=10&end=0'
     )

--- a/apps/journeys/src/components/EmbeddedPreview/VideoWrapper/VideoWrapper.tsx
+++ b/apps/journeys/src/components/EmbeddedPreview/VideoWrapper/VideoWrapper.tsx
@@ -58,7 +58,7 @@ export function VideoWrapper({
 
   return (
     <Box
-      data-testid={`video-${block.id}`}
+      data-testid={`VideoWrapper-${block.id}`}
       sx={{
         display: 'flex',
         width: '100%',

--- a/apps/journeys/src/components/EmbeddedPreview/VideoWrapper/VideoWrapper.tsx
+++ b/apps/journeys/src/components/EmbeddedPreview/VideoWrapper/VideoWrapper.tsx
@@ -58,7 +58,7 @@ export function VideoWrapper({
 
   return (
     <Box
-      data-testid={`VideoWrapper-${block.id}`}
+      data-testid={`EmbedVideoWrapper-${block.id}`}
       sx={{
         display: 'flex',
         width: '100%',


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 67e1fc8</samp>

This pull request updates the data-testid attributes of several components in the `apps/journeys` app to follow a new naming convention. The new convention aims to make the test identifiers more consistent, readable, and descriptive, and to enable testing the components' rendering and behavior with different variants and blocks. The affected components are `Conductor`, `NavigationButton`, `VideoWrapper`, `EmbeddedPreview`, `ButtonWrapper`, and `RadioOptionWrapper`. The corresponding test and story files are also updated to reflect the changes.

Naming convention: 
Component name for data-testid
If unique id should be concatenated with test id (multiple elements, etc), test Id becomes `testid-${uniqueid}`

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34319441/todos/6568590416)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Confirm Test Ids are present in all high-level components in journeys module / DOM

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 67e1fc8</samp>

*  Add data-testid attributes to Conductor, ButtonWrapper, and RadioOptionWrapper components to enable testing their rendering and behavior ([link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-a8d7730e579396800e245cffe8231010bcec4f0f60fe7ae229fe721377a88f0aR189), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-a563b65374ec8936751b55c4c48818f0ca229965eb31b831706669726cd70a30R39), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-8d202267c1ba105f84f78b9c14d5e6543baf02fa79d76d54bc49fe04804bd45aR39))
*  Change data-testid attributes of navigation buttons and containers in Conductor and NavigationButton components to match new naming convention of NavigationButton{Variant} and NavigationContainer-{variant} ([link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-ff6ca1e767f7ecd71807683913c0f9283c9a644b85e58d5a4fe13e50514c708aL273-R274), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-ff6ca1e767f7ecd71807683913c0f9283c9a644b85e58d5a4fe13e50514c708aL307-R308), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-2ffa7076d5451181d47ce4b3b65e089e0e8e81a9cd5ed06f1bf674fab919c5c2L134-R134), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-3c3c31bf2041808306ffab49b753614c03f532376e6c0056aadb888efd19b2beL45-R50), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-3c3c31bf2041808306ffab49b753614c03f532376e6c0056aadb888efd19b2beL62-R66), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-3c3c31bf2041808306ffab49b753614c03f532376e6c0056aadb888efd19b2beL80-R80), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-3c3c31bf2041808306ffab49b753614c03f532376e6c0056aadb888efd19b2beL93-R93), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-3c3c31bf2041808306ffab49b753614c03f532376e6c0056aadb888efd19b2beL105-R105), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-3c3c31bf2041808306ffab49b753614c03f532376e6c0056aadb888efd19b2beL114-R114), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-3c3c31bf2041808306ffab49b753614c03f532376e6c0056aadb888efd19b2beL124-R124), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-3c3c31bf2041808306ffab49b753614c03f532376e6c0056aadb888efd19b2beL134-R137), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-3c3c31bf2041808306ffab49b753614c03f532376e6c0056aadb888efd19b2beL150-R150), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-3c3c31bf2041808306ffab49b753614c03f532376e6c0056aadb888efd19b2beL163-R163), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-3c3c31bf2041808306ffab49b753614c03f532376e6c0056aadb888efd19b2beL175-R175), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-3c3c31bf2041808306ffab49b753614c03f532376e6c0056aadb888efd19b2beL184-R184), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-3c3c31bf2041808306ffab49b753614c03f532376e6c0056aadb888efd19b2beL194-R194), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-3c3c31bf2041808306ffab49b753614c03f532376e6c0056aadb888efd19b2beL204-R207), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-684ea1b2346c27f9252ea686988ffaa756a41f56bd7c62530441bfe2d034df3dL103-R103), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-684ea1b2346c27f9252ea686988ffaa756a41f56bd7c62530441bfe2d034df3dL127-R129))
*  Change data-testid attribute of EmbeddedPreview component to match new naming convention of EmbeddedPreview ([link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-d8151a4b652167cad738062ac4194e3b4b2afd6e0e64add15e70c7f51d2a6a73L131-R131))
*  Change data-testid attributes of video wrappers in VideoWrapper component to match new naming convention of VideoWrapper-{block.id} ([link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-390482eccdc44707a7ce48edb995a83b54f330b53f1d8da018482d8260c7155aL75-R75), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-390482eccdc44707a7ce48edb995a83b54f330b53f1d8da018482d8260c7155aL93-R93), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-390482eccdc44707a7ce48edb995a83b54f330b53f1d8da018482d8260c7155aL111-R111), [link](https://github.com/JesusFilm/core/pull/1911/files?diff=unified&w=0#diff-28d718ce6061eca77c98351c589323f20ddc9d068fbdb8d0780e734870fc6a32L61-R61))
