### PR TITLE
feat: make template pages public

### DIFF
--- a/apps/journeys-admin/pages/templates/[journeyId].tsx
+++ b/apps/journeys-admin/pages/templates/[journeyId].tsx
@@ -71,27 +71,20 @@ function TemplateDetails(): ReactElement {
   )
 }
 
-export const getServerSideProps = withAuthUserTokenSSR({
-  whenUnauthed: AuthAction.REDIRECT_TO_LOGIN
-})(async ({ AuthUser, locale }) => {
-  if (AuthUser == null)
-    return { redirect: { permanent: false, destination: '/users/sign-in' } }
+export const getServerSideProps = withAuthUserTokenSSR()(
+  async ({ AuthUser, locale }) => {
+    const { flags, translations } = await initAndAuthApp({
+      AuthUser,
+      locale
+    })
 
-  const { flags, redirect, translations } = await initAndAuthApp({
-    AuthUser,
-    locale
-  })
-
-  if (redirect != null) return { redirect }
-
-  return {
-    props: {
-      flags,
-      ...translations
+    return {
+      props: {
+        flags,
+        ...translations
+      }
     }
   }
-})
+)
 
-export default withAuthUser({
-  whenUnauthedAfterInit: AuthAction.REDIRECT_TO_LOGIN
-})(TemplateDetails)
+export default withAuthUser()(TemplateDetails)

--- a/apps/journeys-admin/pages/templates/[journeyId].tsx
+++ b/apps/journeys-admin/pages/templates/[journeyId].tsx
@@ -1,7 +1,6 @@
 import { gql, useQuery } from '@apollo/client'
 import { useRouter } from 'next/router'
 import {
-  AuthAction,
   useAuthUser,
   withAuthUser,
   withAuthUserTokenSSR

--- a/apps/journeys-admin/pages/templates/index.tsx
+++ b/apps/journeys-admin/pages/templates/index.tsx
@@ -1,5 +1,4 @@
 import {
-  AuthAction,
   useAuthUser,
   withAuthUser,
   withAuthUserTokenSSR
@@ -30,27 +29,20 @@ function LibraryIndex(): ReactElement {
   )
 }
 
-export const getServerSideProps = withAuthUserTokenSSR({
-  whenUnauthed: AuthAction.REDIRECT_TO_LOGIN
-})(async ({ AuthUser, locale }) => {
-  if (AuthUser == null)
-    return { redirect: { permanent: false, destination: '/users/sign-in' } }
+export const getServerSideProps = withAuthUserTokenSSR()(
+  async ({ AuthUser, locale }) => {
+    const { flags, translations } = await initAndAuthApp({
+      AuthUser,
+      locale
+    })
 
-  const { flags, redirect, translations } = await initAndAuthApp({
-    AuthUser,
-    locale
-  })
-
-  if (redirect != null) return { redirect }
-
-  return {
-    props: {
-      flags,
-      ...translations
+    return {
+      props: {
+        flags,
+        ...translations
+      }
     }
   }
-})
+)
 
-export default withAuthUser({
-  whenUnauthedAfterInit: AuthAction.REDIRECT_TO_LOGIN
-})(LibraryIndex)
+export default withAuthUser()(LibraryIndex)

--- a/apps/journeys-admin/src/libs/initAndAuthApp/initAndAuthApp.spec.tsx
+++ b/apps/journeys-admin/src/libs/initAndAuthApp/initAndAuthApp.spec.tsx
@@ -75,7 +75,7 @@ describe('initAndAuthApp', () => {
     })
   })
 
-  it('should return with apolloClient, flags, redirect, and translations with auth user', async () => {
+  it('should return with apolloClient, flags, redirect, and translations when auth user', async () => {
     const result = await initAndAuthApp({
       AuthUser: mockAuthUser,
       locale: 'en'
@@ -92,7 +92,7 @@ describe('initAndAuthApp', () => {
     })
   })
 
-  it('should return with apolloClient, flags, redirect, and translations with anonymous user', async () => {
+  it('should return with apolloClient, flags, redirect, and translations when anonymous user', async () => {
     const result = await initAndAuthApp({
       AuthUser: {
         id: null

--- a/apps/journeys-admin/src/libs/initAndAuthApp/initAndAuthApp.spec.tsx
+++ b/apps/journeys-admin/src/libs/initAndAuthApp/initAndAuthApp.spec.tsx
@@ -75,7 +75,7 @@ describe('initAndAuthApp', () => {
     })
   })
 
-  it('should return with apolloClient, flags, redirect, and translations', async () => {
+  it('should return with apolloClient, flags, redirect, and translations with auth user', async () => {
     const result = await initAndAuthApp({
       AuthUser: mockAuthUser,
       locale: 'en'
@@ -88,6 +88,22 @@ describe('initAndAuthApp', () => {
         destination: '/users/terms-and-conditions',
         permanent: false
       },
+      translations: mockSSRConfig
+    })
+  })
+
+  it('should return with apolloClient, flags, redirect, and translations with anonymous user', async () => {
+    const result = await initAndAuthApp({
+      AuthUser: {
+        id: null
+      } as unknown as AuthUser,
+      locale: 'en'
+    })
+
+    expect(result).toEqual({
+      apolloClient: expect.any(ApolloClient),
+      flags: { termsAndConditions: true },
+      redirect: undefined,
       translations: mockSSRConfig
     })
   })

--- a/apps/journeys-admin/src/libs/initAndAuthApp/initAndAuthApp.ts
+++ b/apps/journeys-admin/src/libs/initAndAuthApp/initAndAuthApp.ts
@@ -57,7 +57,10 @@ export async function initAndAuthApp({
   }
 
   const apolloClient = createApolloClient(token != null ? token : '')
-  const redirect = await checkConditionalRedirect(apolloClient, flags)
+  const redirect =
+    token != null
+      ? await checkConditionalRedirect(apolloClient, flags)
+      : undefined
 
   return { apolloClient, flags, redirect, translations }
 }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 47ddadf</samp>

Simplified authentication logic and added feature flagging for journeys-admin app. The `initAndAuthApp` function now handles both authenticated and unauthenticated users and returns a `redirect` property for some pages. The library page (`./apps/journeys-admin/pages/templates/index.tsx`) can be viewed by anyone.

https://3.basecamp.com/3105655/buckets/34356579/todos/6584839885

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Go to vercel link, with `/templates` - you should be able to view it without logging in. It should work even when you're logged in
- [ ] go to  vercel link with `/templates/0dab4c94-4970-4089-8cd3-e6b1005e2cf1` or use https://admin-stage.nextstep.is/templates to find the id of any other stage template. You should be able to view the page logged in or out.

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 47ddadf</samp>

*  Simplify authentication logic and allow unauthenticated access to library page
  * Remove unused `AuthAction` import from `index.tsx` ([link](https://github.com/JesusFilm/core/pull/1914/files?diff=unified&w=0#diff-4d089d7265256280ff64e3b201d5e5b93de7ec08609a68128848f06ced5a0effL2))
  * Remove redirect options from `withAuthUserTokenSSR` and `withAuthUser` in `index.tsx` ([link](https://github.com/JesusFilm/core/pull/1914/files?diff=unified&w=0#diff-4d089d7265256280ff64e3b201d5e5b93de7ec08609a68128848f06ced5a0effL33-R48))
  * Modify `ldUser` variable to handle both authenticated and unauthenticated users in `initAndAuthApp.ts` ([link](https://github.com/JesusFilm/core/pull/1914/files?diff=unified&w=0#diff-78cc45ccf708da9458c63348fc8c76125f291c6549ab2e739a4ad445f3701b6bL31-R42))
  * Return `redirect` property for pages that require authentication in `initAndAuthApp.ts` ([link](https://github.com/JesusFilm/core/pull/1914/files?diff=unified&w=0#diff-78cc45ccf708da9458c63348fc8c76125f291c6549ab2e739a4ad445f3701b6bL31-R42))
  * Make `AuthUser` parameter optional in `props` interface in `initAndAuthApp.ts` ([link](https://github.com/JesusFilm/core/pull/1914/files?diff=unified&w=0#diff-78cc45ccf708da9458c63348fc8c76125f291c6549ab2e739a4ad445f3701b6bL14-R15))
  * Import `uuidv4` function to generate random key for anonymous users in `initAndAuthApp.ts` ([link](https://github.com/JesusFilm/core/pull/1914/files?diff=unified&w=0#diff-78cc45ccf708da9458c63348fc8c76125f291c6549ab2e739a4ad445f3701b6bR6))
  * Check `AuthUser` parameter before calling `getIdToken` method in `initAndAuthApp.ts` ([link](https://github.com/JesusFilm/core/pull/1914/files?diff=unified&w=0#diff-78cc45ccf708da9458c63348fc8c76125f291c6549ab2e739a4ad445f3701b6bL45-R52))
