### PR TITLE
fix: update api-tags seed

### DIFF
--- a/apps/api-tags/db/seed.ts
+++ b/apps/api-tags/db/seed.ts
@@ -3,12 +3,15 @@
 
 import { PrismaClient } from '.prisma/api-tags-client'
 
+import { Service } from '../src/app/__generated__/graphql'
+
 const prisma = new PrismaClient()
 
 async function upsertTag(
   name: string,
   childrenNames: string[],
-  parentId?: string
+  parentId?: string,
+  service?: Service
 ): Promise<void> {
   const tag = await prisma.tag.upsert({
     where: {
@@ -18,13 +21,15 @@ async function upsertTag(
       name,
       // 529 is ID for English
       nameTranslations: [{ value: name, languageId: '529', primary: true }],
-      parentId
+      parentId,
+      service
     },
     update: {
       name,
       // 529 is ID for English
       nameTranslations: [{ value: name, languageId: '529', primary: true }],
-      parentId
+      parentId,
+      service
     }
   })
 
@@ -103,6 +108,7 @@ async function main(): Promise<void> {
     'Inspirational',
     'Testimonies'
   ])
+  await upsertTag('Collections', ['Jesus Film', 'NUA'])
 }
 main().catch((e) => {
   console.error(e)

--- a/apps/api-tags/db/seed.ts
+++ b/apps/api-tags/db/seed.ts
@@ -34,7 +34,7 @@ async function upsertTag(
   })
 
   await childrenNames.map(async (name) => {
-    await upsertTag(name, [], tag.id)
+    await upsertTag(name, [], tag.id, service)
   })
 }
 

--- a/apps/api-tags/db/seed.ts
+++ b/apps/api-tags/db/seed.ts
@@ -108,7 +108,12 @@ async function main(): Promise<void> {
     'Inspirational',
     'Testimonies'
   ])
-  await upsertTag('Collections', ['Jesus Film', 'NUA'], Service.apiJourneys)
+  await upsertTag(
+    'Collections',
+    ['Jesus Film', 'NUA'],
+    undefined,
+    Service.apiJourneys
+  )
 }
 main().catch((e) => {
   console.error(e)

--- a/apps/api-tags/db/seed.ts
+++ b/apps/api-tags/db/seed.ts
@@ -108,7 +108,7 @@ async function main(): Promise<void> {
     'Inspirational',
     'Testimonies'
   ])
-  await upsertTag('Collections', ['Jesus Film', 'NUA'])
+  await upsertTag('Collections', ['Jesus Film', 'NUA'], Service.apiJourneys)
 }
 main().catch((e) => {
   console.error(e)


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 303823b</samp>

Updated `seed.ts` script to assign service to tags. This enables creating and updating tags for different services in the database.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34356579/todos/6585262485)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] tags should have a service field

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 303823b</samp>

* Import the `Service` type from the generated GraphQL schema to represent the service that a tag belongs to ([link](https://github.com/JesusFilm/core/pull/1929/files?diff=unified&w=0#diff-8e38210738c5edcdaafe43b414edf52241f928f282f378df647a33af00f05c30R6-R7))
* Modify the `upsertTag` function signature to accept an optional `service` parameter of type `Service` ([link](https://github.com/JesusFilm/core/pull/1929/files?diff=unified&w=0#diff-8e38210738c5edcdaafe43b414edf52241f928f282f378df647a33af00f05c30L11-R14))
* Pass the `service` parameter to the `create` and `update` options of the `prisma.tag.upsert` call to specify the service when creating or updating a tag in the database ([link](https://github.com/JesusFilm/core/pull/1929/files?diff=unified&w=0#diff-8e38210738c5edcdaafe43b414edf52241f928f282f378df647a33af00f05c30L21-R25), [link](https://github.com/JesusFilm/core/pull/1929/files?diff=unified&w=0#diff-8e38210738c5edcdaafe43b414edf52241f928f282f378df647a33af00f05c30L27-R32))
* Call the `upsertTag` function with the name 'Collections' and the children names 'Jesus Film' and 'NUA' to create or update a tag named 'Collections' with two subtags and the default service of 'web' in the `seed.ts` file ([link](https://github.com/JesusFilm/core/pull/1929/files?diff=unified&w=0#diff-8e38210738c5edcdaafe43b414edf52241f928f282f378df647a33af00f05c30R111))
