### PR TITLE
fix: mobile mute icon correctly shows muted on first video

### DIFF
--- a/libs/journeys/ui/src/components/Video/VideoControls/VideoControls.tsx
+++ b/libs/journeys/ui/src/components/Video/VideoControls/VideoControls.tsx
@@ -330,7 +330,7 @@ export function VideoControls({
               }}
               onClick={handleMute}
             >
-              {muted ? <VolumeOffOutlined /> : <VolumeUpOutlined />}
+              {player.muted() ? <VolumeOffOutlined /> : <VolumeUpOutlined />}
             </IconButton>
           </Stack>
           {/* Play/Pause */}

--- a/libs/journeys/ui/src/components/Video/VideoControls/VideoControls.tsx
+++ b/libs/journeys/ui/src/components/Video/VideoControls/VideoControls.tsx
@@ -83,6 +83,10 @@ export function VideoControls({
   // Handle play event
   useEffect(() => {
     const handleVideoPlay = (): void => {
+      // Always mute first video
+      if (player.muted()) {
+        setMuted(true)
+      }
       setPlaying(true)
       if (startAt > 0 && player.currentTime() < startAt) {
         setProgress(startAt)
@@ -245,6 +249,7 @@ export function VideoControls({
   function handleVolume(e: Event, value: number | number[]): void {
     if (!Array.isArray(value)) {
       player.muted(false)
+      setMuted(false)
       setVolume(value)
       player.volume(value / 100)
     }
@@ -330,7 +335,7 @@ export function VideoControls({
               }}
               onClick={handleMute}
             >
-              {player.muted() ? <VolumeOffOutlined /> : <VolumeUpOutlined />}
+              {muted ? <VolumeOffOutlined /> : <VolumeUpOutlined />}
             </IconButton>
           </Stack>
           {/* Play/Pause */}
@@ -450,7 +455,7 @@ export function VideoControls({
                   }}
                 >
                   <IconButton onClick={handleMute} sx={{ p: 0 }}>
-                    {player.muted() || volume === 0 ? (
+                    {muted || volume === 0 ? (
                       <VolumeOffOutlined />
                     ) : volume > 60 ? (
                       <VolumeUpOutlined />


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 26477f7</samp>

This pull request improves the mute functionality of the `VideoControls` component. It syncs the `muted` state with the player's actual mute status and allows the user to unmute the player by adjusting the volume.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34319441/todos/6561839942)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] On the first video of a journey on mobile, the mute button should be by default on the muted state. Previously it had the volume on button icon.
- [ ] Volume for first journey card should be mute by default, if the first card is a video.

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 26477f7</samp>

*  Sync `muted` state with player's initial mute status ([link](https://github.com/JesusFilm/core/pull/1932/files?diff=unified&w=0#diff-06e07264a1143c474a72e689d3fb191dc359b22558c3567745068c9263adf2f3R86-R89))
*  Unmute player when volume is changed by user ([link](https://github.com/JesusFilm/core/pull/1932/files?diff=unified&w=0#diff-06e07264a1143c474a72e689d3fb191dc359b22558c3567745068c9263adf2f3R252))
*  Use `muted` state as source of truth for mute status ([link](https://github.com/JesusFilm/core/pull/1932/files?diff=unified&w=0#diff-06e07264a1143c474a72e689d3fb191dc359b22558c3567745068c9263adf2f3L453-R458))
