### PR TITLE
fix: apollo video cache

### DIFF
--- a/apps/journeys-admin/src/libs/apolloClient/cache.ts
+++ b/apps/journeys-admin/src/libs/apolloClient/cache.ts
@@ -59,16 +59,4 @@ export const cache = (): InMemoryCache =>
         keyFields: ['id', 'variant', ['id']]
       }
     }
-    // dataIdFromObject(responseObject) {
-    //   const videoVariant = responseObject.variant as unknown as StoreObject & {
-    //     id: string
-    //   }
-    //   switch (responseObject.__typename) {
-    //     case 'Video':
-    //       return `Video:${videoVariant?.id ?? responseObject.id}`
-    //     case 'Person':
-    //     default:
-    //       return defaultDataIdFromObject(responseObject)
-    //   }
-    // }
   })

--- a/apps/journeys-admin/src/libs/apolloClient/cache.ts
+++ b/apps/journeys-admin/src/libs/apolloClient/cache.ts
@@ -1,8 +1,4 @@
-import {
-  InMemoryCache,
-  StoreObject,
-  defaultDataIdFromObject
-} from '@apollo/client'
+import { InMemoryCache } from '@apollo/client'
 import { offsetLimitPagination } from '@apollo/client/utilities'
 
 export const cache = (): InMemoryCache =>
@@ -58,18 +54,21 @@ export const cache = (): InMemoryCache =>
             }
           }
         }
-      }
-    },
-    dataIdFromObject(responseObject) {
-      const videoVariant = responseObject.variant as unknown as StoreObject & {
-        id: string
-      }
-      switch (responseObject.__typename) {
-        case 'Video':
-          return `Video:${videoVariant?.id ?? responseObject.id}`
-        case 'Person':
-        default:
-          return defaultDataIdFromObject(responseObject)
+      },
+      Video: {
+        keyFields: ['id', 'variant', ['id']]
       }
     }
+    // dataIdFromObject(responseObject) {
+    //   const videoVariant = responseObject.variant as unknown as StoreObject & {
+    //     id: string
+    //   }
+    //   switch (responseObject.__typename) {
+    //     case 'Video':
+    //       return `Video:${videoVariant?.id ?? responseObject.id}`
+    //     case 'Person':
+    //     default:
+    //       return defaultDataIdFromObject(responseObject)
+    //   }
+    // }
   })

--- a/apps/journeys/src/libs/apolloClient/cache/cache.ts
+++ b/apps/journeys/src/libs/apolloClient/cache/cache.ts
@@ -33,23 +33,7 @@ export const cache = (): InMemoryCache =>
         'VideoTriggerBlock'
       ]
     },
-    dataIdFromObject(responseObject) {
-      let id: string
-      switch (responseObject.__typename) {
-        case 'Video':
-          if (responseObject.variant != null) {
-            id = (
-              responseObject.variant as unknown as {
-                id: string
-              }
-            ).id
-          } else {
-            id = responseObject.id as unknown as string
-          }
-          return `Video:${id}`
-        case 'Person':
-        default:
-          return defaultDataIdFromObject(responseObject)
-      }
+    typePolicies: {
+      Video: { keyFields: ['id', 'variant', ['id']] }
     }
   })

--- a/apps/journeys/src/libs/apolloClient/cache/cache.ts
+++ b/apps/journeys/src/libs/apolloClient/cache/cache.ts
@@ -1,4 +1,4 @@
-import { InMemoryCache, defaultDataIdFromObject } from '@apollo/client'
+import { InMemoryCache } from '@apollo/client'
 
 export const cache = (): InMemoryCache =>
   new InMemoryCache({


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7ab8cc1</samp>

Simplified the cache configuration for videos in both the journeys-admin and journeys apps by using `typePolicies` instead of `dataIdFromObject`. This improves readability and maintainability of the code.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Video cache object now uses typePolicy instead of custom logic (which returned undefined and caused issues)

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7ab8cc1</samp>

*  Replace `dataIdFromObject` function with `typePolicies` object to customize cache key for videos with variant property ([link](https://github.com/JesusFilm/core/pull/1934/files?diff=unified&w=0#diff-708322440248fcaebf7e215e4576ab74da9b31b7e289b7f75115081de1edde5eL61-R73), [link](https://github.com/JesusFilm/core/pull/1934/files?diff=unified&w=0#diff-a52358f135050f1effbbfbef3e017ee830a0a127ea145054252e6315a1576f32L36-R37))
*  Remove unused imports of `StoreObject` and `defaultDataIdFromObject` from `@apollo/client` ([link](https://github.com/JesusFilm/core/pull/1934/files?diff=unified&w=0#diff-708322440248fcaebf7e215e4576ab74da9b31b7e289b7f75115081de1edde5eL1-R1))
