### PR TITLE
feat: templates video preview

### DIFF
--- a/apps/journeys-admin/pages/templates/[journeyId].tsx
+++ b/apps/journeys-admin/pages/templates/[journeyId].tsx
@@ -1,3 +1,4 @@
+import Stack from '@mui/material/Stack'
 import { useRouter } from 'next/router'
 import {
   useAuthUser,
@@ -13,7 +14,7 @@ import { useFlags } from '@core/shared/ui/FlagsProvider'
 
 import { JourneyView } from '../../src/components/JourneyView'
 import { Menu } from '../../src/components/JourneyView/Menu'
-import { PageWrapper } from '../../src/components/PageWrapper'
+import { PageWrapper } from '../../src/components/NewPageWrapper'
 import { TemplateView } from '../../src/components/TemplateView/TemplateView'
 import { initAndAuthApp } from '../../src/libs/initAndAuthApp'
 import { useInvalidJourneyRedirect } from '../../src/libs/useInvalidJourneyRedirect'
@@ -33,7 +34,7 @@ function TemplateDetails(): ReactElement {
   return (
     <>
       <NextSeo
-        title={template?.title ?? t('Journey Template')}
+        title={template?.title ?? t('Template Details')}
         description={template?.description ?? undefined}
       />
       <JourneyProvider
@@ -43,11 +44,19 @@ function TemplateDetails(): ReactElement {
         }}
       >
         <PageWrapper
-          title={t('Journey Template')}
+          title={template?.title ?? t('Template Details')}
           authUser={AuthUser}
-          showDrawer
           backHref="/templates"
-          menu={<Menu />}
+          mainHeaderChildren={
+            <Stack
+              direction="row"
+              flexGrow={1}
+              justifyContent="flex-end"
+              alignItems="center"
+            >
+              <Menu />
+            </Stack>
+          }
         >
           {templates ? (
             <TemplateView />

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplatePreviewTabs.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplatePreviewTabs.spec.tsx
@@ -1,0 +1,76 @@
+import { MockedProvider } from '@apollo/client/testing'
+import { fireEvent, render, waitFor } from '@testing-library/react'
+
+import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
+
+import { JourneyFields } from '../../../../__generated__/JourneyFields'
+import { publishedJourney } from '../../JourneyView/data'
+
+import { journeyVideoBlocks } from './data'
+import { TemplatePreviewTabs } from './TemplatePreviewTabs'
+
+jest.mock('react-i18next', () => ({
+  __esModule: true,
+  useTranslation: () => {
+    return {
+      t: (str: string) => str
+    }
+  }
+}))
+
+jest.mock('@mui/material/useMediaQuery', () => ({
+  __esModule: true,
+  default: () => true
+}))
+
+describe('TemplatePreviewTabs', () => {
+  const journeyWithVideos = {
+    ...publishedJourney,
+    blocks: journeyVideoBlocks
+  }
+
+  beforeEach(() => jest.clearAllMocks())
+
+  it('should switch between tabs', async () => {
+    const { getByText, getByRole } = render(
+      <MockedProvider>
+        <JourneyProvider
+          value={{
+            journey: journeyWithVideos as JourneyFields,
+            variant: 'admin'
+          }}
+        >
+          <TemplatePreviewTabs />
+        </JourneyProvider>
+      </MockedProvider>
+    )
+
+    expect(getByText('{{cardBlockCount}} Cards')).toBeInTheDocument()
+    fireEvent.click(getByRole('tab', { name: '{{videoBlockCount}} Videos' }))
+    await waitFor(() => {
+      expect(getByRole('tab', { selected: true })).toHaveTextContent(
+        '{{videoBlockCount}} Videos'
+      )
+    })
+  })
+
+  it('should disable videos tab if no videos in journey', async () => {
+    const { getByText, getByRole } = render(
+      <MockedProvider>
+        <JourneyProvider
+          value={{
+            journey: undefined,
+            variant: 'admin'
+          }}
+        >
+          <TemplatePreviewTabs />
+        </JourneyProvider>
+      </MockedProvider>
+    )
+
+    expect(getByText('{{cardBlockCount}} Cards')).toBeInTheDocument()
+    expect(
+      getByRole('tab', { name: '{{videoBlockCount}} Videos' })
+    ).toBeDisabled()
+  })
+})

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplatePreviewTabs.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplatePreviewTabs.stories.tsx
@@ -1,0 +1,61 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { screen, userEvent } from '@storybook/testing-library'
+import { ComponentProps } from 'react'
+
+import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
+
+import { JourneyFields } from '../../../../__generated__/JourneyFields'
+import { journeysAdminConfig } from '../../../libs/storybook'
+import { publishedJourney } from '../../JourneyView/data'
+
+import { journeyVideoBlocks } from './data'
+import { TemplatePreviewTabs } from './TemplatePreviewTabs'
+
+const TemplatePreviewTabsStory: Meta<typeof TemplatePreviewTabs> = {
+  ...journeysAdminConfig,
+  component: TemplatePreviewTabs,
+  title: 'Journeys-Admin/TemplateView/TemplatePreviewTabs',
+  parameters: {
+    ...journeysAdminConfig.parameters,
+    layout: 'fullscreen',
+    docs: {
+      source: { type: 'code' }
+    }
+  }
+}
+
+const journeyWithVideos = {
+  ...publishedJourney,
+  blocks: journeyVideoBlocks
+}
+
+const Template: StoryObj<
+  ComponentProps<typeof TemplatePreviewTabs> & { journey: JourneyFields }
+> = {
+  render: (args) => (
+    <JourneyProvider value={{ journey: args.journey, variant: 'admin' }}>
+      <TemplatePreviewTabs />
+    </JourneyProvider>
+  )
+}
+
+export const CardPreview = {
+  ...Template,
+  args: {
+    journey: publishedJourney
+  }
+}
+
+export const VideoPreview = {
+  ...Template,
+  play: async () => {
+    await userEvent.click(
+      screen.getByRole('tab', { name: '{{videBlockCount}} Videos' })
+    )
+  },
+  args: {
+    journey: journeyWithVideos
+  }
+}
+
+export default TemplatePreviewTabsStory

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplatePreviewTabs.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplatePreviewTabs.tsx
@@ -1,0 +1,105 @@
+import 'swiper/swiper.min.css'
+
+import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import { Theme } from '@mui/material/styles'
+import Tab from '@mui/material/Tab'
+import Tabs from '@mui/material/Tabs'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import { ReactElement, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Swiper, SwiperSlide } from 'swiper/react'
+
+import { TreeBlock } from '@core/journeys/ui/block/TreeBlock'
+import { useJourney } from '@core/journeys/ui/JourneyProvider'
+import { transformer } from '@core/journeys/ui/transformer'
+import { NextImage } from '@core/shared/ui/NextImage'
+import { TabPanel, tabA11yProps } from '@core/shared/ui/TabPanel'
+
+import {
+  GetJourney_journey_blocks_StepBlock as StepBlock,
+  GetJourney_journey_blocks_VideoBlock as VideoBlock
+} from '../../../../__generated__/GetJourney'
+import { CardPreview } from '../../CardPreview'
+
+export function TemplatePreviewTabs(): ReactElement {
+  const [tabValue, setTabValue] = useState(0)
+  const { t } = useTranslation('apps-journeys-admin')
+  const smUp = useMediaQuery((theme: Theme) => theme.breakpoints.up('sm'))
+  const { journey } = useJourney()
+
+  const steps =
+    journey != null
+      ? (transformer(journey.blocks ?? []) as Array<TreeBlock<StepBlock>>)
+      : undefined
+
+  const videoBlocks = journey?.blocks?.filter(
+    (block) => block.__typename === 'VideoBlock'
+  ) as Array<TreeBlock<VideoBlock>>
+
+  const handleTabChange = (_event, newValue): void => {
+    setTabValue(newValue)
+  }
+
+  return (
+    <Stack>
+      <Tabs
+        value={tabValue}
+        onChange={handleTabChange}
+        sx={{ borderBottom: 1, borderColor: 'divider' }}
+      >
+        <Tab
+          label={t('{{cardBlockCount}} Cards', {
+            cardBlockCount: steps?.length ?? 0
+          })}
+          {...tabA11yProps('cards-preview-tab', 0)}
+          sx={{ width: smUp ? 200 : undefined }}
+        />
+        <Tab
+          disabled={videoBlocks?.length === 0 || videoBlocks == null}
+          label={t('{{videoBlockCount}} Videos', {
+            videoBlockCount: videoBlocks?.length ?? 0
+          })}
+          {...tabA11yProps('videos-preview-tab', 1)}
+          sx={{ width: smUp ? 200 : undefined }}
+        />
+      </Tabs>
+      <TabPanel name="cards-preview-tab" value={tabValue} index={0}>
+        <Stack sx={{ pt: 6 }}>
+          Card Preview - yet to be implemented, this is just a placeholder, for
+          more information contact support@nextstep.is
+          <CardPreview steps={steps} />
+        </Stack>
+      </TabPanel>
+      <TabPanel name="videos-preview-tab" value={tabValue} index={1}>
+        <Swiper
+          grabCursor
+          freeMode
+          slidesPerView="auto"
+          spaceBetween={24}
+          slidesOffsetAfter={64}
+          style={{
+            paddingTop: '20px',
+            // width: '130%',
+            marginLeft: smUp ? '-32px' : '-24px',
+            marginRight: smUp ? '-32px' : '-24px'
+          }}
+        >
+          {videoBlocks?.map((block) => (
+            <SwiperSlide key={block.id} style={{ width: 423 }}>
+              <NextImage
+                width={423}
+                height={239}
+                key={block.id}
+                sx={{ borderRadius: 4, objectFit: 'cover' }}
+                src={(block.image as string) ?? block.video?.image}
+              />
+            </SwiperSlide>
+          ))}
+          <Box slot="wrapper-start" sx={{ pl: 8 }} />
+          <Box slot="wrapper-end" sx={{ pr: 8 }} />
+        </Swiper>
+      </TabPanel>
+    </Stack>
+  )
+}

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplatePreviewTabs.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplatePreviewTabs.tsx
@@ -1,4 +1,5 @@
 import 'swiper/swiper.min.css'
+import 'swiper/components/scrollbar/scrollbar.min.css'
 
 import Box from '@mui/material/Box'
 import Stack from '@mui/material/Stack'
@@ -9,11 +10,12 @@ import useMediaQuery from '@mui/material/useMediaQuery'
 import { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Swiper, SwiperSlide } from 'swiper/react'
+import SwiperCore, { Mousewheel, Scrollbar, A11y } from 'swiper'
 
 import { TreeBlock } from '@core/journeys/ui/block/TreeBlock'
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import { transformer } from '@core/journeys/ui/transformer'
-import { NextImage } from '@core/shared/ui/NextImage'
+
 import { TabPanel, tabA11yProps } from '@core/shared/ui/TabPanel'
 
 import {
@@ -21,6 +23,9 @@ import {
   GetJourney_journey_blocks_VideoBlock as VideoBlock
 } from '../../../../__generated__/GetJourney'
 import { CardPreview } from '../../CardPreview'
+import { TemplateVideoPreview } from '../TemplateVideoPreview'
+
+SwiperCore.use([Mousewheel, Scrollbar, A11y])
 
 export function TemplatePreviewTabs(): ReactElement {
   const [tabValue, setTabValue] = useState(0)
@@ -72,33 +77,31 @@ export function TemplatePreviewTabs(): ReactElement {
         </Stack>
       </TabPanel>
       <TabPanel name="videos-preview-tab" value={tabValue} index={1}>
-        <Swiper
-          grabCursor
-          freeMode
-          slidesPerView="auto"
-          spaceBetween={24}
-          slidesOffsetAfter={64}
-          style={{
-            paddingTop: '20px',
-            // width: '130%',
-            marginLeft: smUp ? '-32px' : '-24px',
-            marginRight: smUp ? '-32px' : '-24px'
-          }}
-        >
-          {videoBlocks?.map((block) => (
-            <SwiperSlide key={block.id} style={{ width: 423 }}>
-              <NextImage
-                width={423}
-                height={239}
-                key={block.id}
-                sx={{ borderRadius: 4, objectFit: 'cover' }}
-                src={(block.image as string) ?? block.video?.image}
-              />
-            </SwiperSlide>
-          ))}
-          <Box slot="wrapper-start" sx={{ pl: 8 }} />
-          <Box slot="wrapper-end" sx={{ pr: 8 }} />
-        </Swiper>
+        {tabValue === 1 && (
+          <Swiper
+            slidesPerView="auto"
+            spaceBetween={24}
+            slidesOffsetAfter={64}
+            mousewheel
+            style={{
+              paddingTop: '20px',
+              marginLeft: smUp ? '-32px' : '-24px',
+              marginRight: smUp ? '-32px' : '-24px'
+            }}
+          >
+            {videoBlocks?.map((block) => (
+              <SwiperSlide key={block.id} style={{ width: 423 }}>
+                <TemplateVideoPreview
+                  id={block.video?.variant?.hls ?? block.videoId}
+                  source={block.source}
+                  poster={(block.image as string) ?? block.video?.image}
+                />
+              </SwiperSlide>
+            ))}
+            <Box slot="wrapper-start" sx={{ pl: 8 }} />
+            <Box slot="wrapper-end" sx={{ pr: 8 }} />
+          </Swiper>
+        )}
       </TabPanel>
     </Stack>
   )

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/data.ts
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/data.ts
@@ -1,0 +1,289 @@
+type VideoBlock = 'VideoBlock'
+
+export const journeyVideoBlocks = [
+  {
+    __typename: 'CardBlock',
+    id: '779a6977-73d6-42dd-b909-aa8c5c6b2bab',
+    parentBlockId: 'be86c73d-b961-48ca-9c50-f7e117975c7c',
+    parentOrder: 0,
+    backgroundColor: null,
+    coverBlockId: null,
+    themeMode: null,
+    themeName: null,
+    fullscreen: false
+  },
+  {
+    __typename: 'VideoBlock' as VideoBlock,
+    id: 'e4edb342-7ca2-4248-a548-bf182cd05587',
+    parentBlockId: '564edeb1-5407-4274-b3fd-7b1862fcc37c',
+    parentOrder: 0,
+    muted: false,
+    autoplay: true,
+    startAt: 0,
+    endAt: 118,
+    posterBlockId: null,
+    fullsize: true,
+    videoId: '1_0-TrainV_1Install',
+    videoVariantLanguageId: '529',
+    source: 'internal',
+    title: null,
+    description: null,
+    image: null,
+    duration: 118,
+    objectFit: null,
+    video: {
+      __typename: 'Video',
+      id: '1_0-TrainV_1Install',
+      title: [
+        {
+          __typename: 'Translation',
+          value: 'Installing the Jesus Film Media App'
+        }
+      ],
+      image:
+        'https://d1wl257kev7hsz.cloudfront.net/cinematics/lrg_cine_install.jpg',
+      variant: {
+        __typename: 'VideoVariant',
+        id: '1_529-0-TrainV_1Install',
+        hls: 'https://arc.gt/zxqrt'
+      }
+    },
+    action: {
+      __typename: 'NavigateAction',
+      parentBlockId: 'e4edb342-7ca2-4248-a548-bf182cd05587',
+      gtmEventName: 'NavigateAction'
+    }
+  },
+  {
+    __typename: 'VideoBlock',
+    id: 'a7f0c3a2-63c0-4618-acf3-4934791728b7',
+    parentBlockId: 'b4a6c8aa-b320-4497-a00b-4e620af5d322',
+    parentOrder: 0,
+    muted: false,
+    autoplay: true,
+    startAt: 0,
+    endAt: 129,
+    posterBlockId: '49af6ebd-8e6e-43b4-8440-c7dbe2408be0',
+    fullsize: true,
+    videoId: '1_0-TrainV_5Ministry',
+    videoVariantLanguageId: '529',
+    source: 'internal',
+    title: null,
+    description: null,
+    image: null,
+    duration: null,
+    objectFit: null,
+    video: {
+      __typename: 'Video',
+      id: '1_0-TrainV_5Ministry',
+      title: [
+        {
+          __typename: 'Translation',
+          value: 'Use this App in Ministry'
+        }
+      ],
+      image:
+        'https://d1wl257kev7hsz.cloudfront.net/cinematics/lrg_cine_ministry.jpg',
+      variant: {
+        __typename: 'VideoVariant',
+        id: '1_529-0-TrainV_5Ministry',
+        hls: 'https://arc.gt/rnfsp'
+      }
+    },
+    action: {
+      __typename: 'NavigateAction',
+      parentBlockId: 'a7f0c3a2-63c0-4618-acf3-4934791728b7',
+      gtmEventName: 'NavigateAction'
+    }
+  },
+  {
+    __typename: 'VideoBlock',
+    id: 'ced85f9e-9299-43b4-a3e5-ef832589d1c5',
+    parentBlockId: '8db74f7d-52ef-4ac9-9a4c-39704616c053',
+    parentOrder: 0,
+    muted: false,
+    autoplay: true,
+    startAt: 0,
+    endAt: 44,
+    posterBlockId: 'fa44a638-2a44-466f-8254-2f5d35ee6d3b',
+    fullsize: true,
+    videoId: '1_cl1302-0-0',
+    videoVariantLanguageId: '529',
+    source: 'internal',
+    title: null,
+    description: null,
+    image: null,
+    duration: null,
+    objectFit: null,
+    video: {
+      __typename: 'Video',
+      id: '1_cl1302-0-0',
+      title: [
+        {
+          __typename: 'Translation',
+          value: 'StoryClubs: Childhood of Jesus'
+        }
+      ],
+      image:
+        'https://d1wl257kev7hsz.cloudfront.net/cinematics/1_cl1302-0-0.mobileCinematicHigh.jpg',
+      variant: {
+        __typename: 'VideoVariant',
+        id: '1_529-cl1302-0-0',
+        hls: 'https://arc.gt/7unjy'
+      }
+    },
+    action: {
+      __typename: 'NavigateAction',
+      parentBlockId: 'ced85f9e-9299-43b4-a3e5-ef832589d1c5',
+      gtmEventName: 'NavigateAction'
+    }
+  },
+  {
+    __typename: 'VideoBlock',
+    id: '2c8913b8-4b64-49a6-a31e-16677b8f6c99',
+    parentBlockId: '779a6977-73d6-42dd-b909-aa8c5c6b2bab',
+    parentOrder: 0,
+    muted: false,
+    autoplay: true,
+    startAt: 0,
+    endAt: 120,
+    posterBlockId: null,
+    fullsize: true,
+    videoId: 'TDBSCCrem-Q',
+    videoVariantLanguageId: null,
+    source: 'youTube',
+    title: 'Medley',
+    description:
+      'Just as a body, though one, has many parts, but all its many parts form one body, so it is with Christ.  For we were all baptized by one Spirit so as to form one body—whether Jews or Gentiles, slave or free—and we were all given the one Spirit to drink. Even so the body is not made up of one part but of many.  (1 Corinthians 12:12-14)\n\nThis is a whimsical story of a bowl of singing fruit. The unity of the group is disrupted when a new fruit joins the song with a new kind of style. Will the new sound create tension in the bowl or will it bring the whole group closer together?\n\nGod’s various gifts are handed out everywhere; but they all originate in God’s Spirit. God’s various ministries are carried out everywhere; but they all originate in God’s Spirit. God’s various expressions of power are in action everywhere; but God himself is behind it all. Each person is given something to do that shows who God is: Everyone gets in on it, everyone benefits. All kinds of things are handed out by the Spirit, and to all kinds of people! (1 Corinthians 12:4-7)',
+    image: 'https://i.ytimg.com/vi/TDBSCCrem-Q/hqdefault.jpg',
+    duration: 120,
+    objectFit: null,
+    video: null,
+    action: {
+      __typename: 'NavigateAction',
+      parentBlockId: '2c8913b8-4b64-49a6-a31e-16677b8f6c99',
+      gtmEventName: 'NavigateAction'
+    }
+  },
+  {
+    __typename: 'CardBlock',
+    id: '60493dc0-840f-4948-aa27-00b51444e5b8',
+    parentBlockId: '97e8a400-4322-4c8a-b727-8f64ca5a6f36',
+    parentOrder: 0,
+    backgroundColor: null,
+    coverBlockId: null,
+    themeMode: null,
+    themeName: null,
+    fullscreen: false
+  },
+  {
+    __typename: 'StepBlock',
+    id: 'be86c73d-b961-48ca-9c50-f7e117975c7c',
+    parentBlockId: null,
+    parentOrder: 0,
+    locked: false,
+    nextBlockId: null
+  },
+  {
+    __typename: 'VideoBlock',
+    id: '064733af-9166-47cc-ac08-c4626477ddf8',
+    parentBlockId: '60493dc0-840f-4948-aa27-00b51444e5b8',
+    parentOrder: 0,
+    muted: false,
+    autoplay: true,
+    startAt: 0,
+    endAt: 147,
+    posterBlockId: null,
+    fullsize: true,
+    videoId: '1_cl1305-0-0',
+    videoVariantLanguageId: '529',
+    source: 'internal',
+    title: null,
+    description: null,
+    image: null,
+    duration: 147,
+    objectFit: null,
+    video: {
+      __typename: 'Video',
+      id: '1_cl1305-0-0',
+      title: [
+        {
+          __typename: 'Translation',
+          value: 'StoryClubs: Sinful Woman Forgiven'
+        }
+      ],
+      image:
+        'https://d1wl257kev7hsz.cloudfront.net/cinematics/1_cl1305-0-0.mobileCinematicHigh.jpg',
+      variant: {
+        __typename: 'VideoVariant',
+        id: '1_529-cl1305-0-0',
+        hls: 'https://arc.gt/hmkwc'
+      }
+    }
+  },
+  {
+    __typename: 'CardBlock',
+    id: '8db74f7d-52ef-4ac9-9a4c-39704616c053',
+    parentBlockId: 'd2b7e350-a731-4278-bcb0-b4ed8528cd72',
+    parentOrder: 0,
+    backgroundColor: null,
+    coverBlockId: null,
+    themeMode: null,
+    themeName: null,
+    fullscreen: false
+  },
+  {
+    __typename: 'CardBlock',
+    id: '564edeb1-5407-4274-b3fd-7b1862fcc37c',
+    parentBlockId: '9c14c558-ad49-4031-961b-e662a4f38f49',
+    parentOrder: 0,
+    backgroundColor: null,
+    coverBlockId: null,
+    themeMode: null,
+    themeName: null,
+    fullscreen: false
+  },
+  {
+    __typename: 'CardBlock',
+    id: 'b4a6c8aa-b320-4497-a00b-4e620af5d322',
+    parentBlockId: '8e3c7cc5-8035-40db-9696-00ff4d58cf27',
+    parentOrder: 0,
+    backgroundColor: null,
+    coverBlockId: null,
+    themeMode: null,
+    themeName: null,
+    fullscreen: false
+  },
+  {
+    __typename: 'StepBlock',
+    id: '97e8a400-4322-4c8a-b727-8f64ca5a6f36',
+    parentBlockId: null,
+    parentOrder: 1,
+    locked: false,
+    nextBlockId: null
+  },
+  {
+    __typename: 'StepBlock',
+    id: '9c14c558-ad49-4031-961b-e662a4f38f49',
+    parentBlockId: null,
+    parentOrder: 2,
+    locked: false,
+    nextBlockId: null
+  },
+  {
+    __typename: 'StepBlock',
+    id: '8e3c7cc5-8035-40db-9696-00ff4d58cf27',
+    parentBlockId: null,
+    parentOrder: 3,
+    locked: false,
+    nextBlockId: null
+  },
+  {
+    __typename: 'StepBlock',
+    id: 'd2b7e350-a731-4278-bcb0-b4ed8528cd72',
+    parentBlockId: null,
+    parentOrder: 4,
+    locked: false,
+    nextBlockId: null
+  }
+]

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/index.ts
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/index.ts
@@ -1,0 +1,1 @@
+export { TemplatePreviewTabs } from './TemplatePreviewTabs'

--- a/apps/journeys-admin/src/components/TemplateView/TemplateVideoPreview/TemplateVideoPreview.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateVideoPreview/TemplateVideoPreview.spec.tsx
@@ -1,10 +1,12 @@
-import { fireEvent, getByTestId, render, waitFor } from '@testing-library/react'
-import { TemplateVideoPreview } from './TemplateVideoPreview'
+import { render } from '@testing-library/react'
+
 import { VideoBlockSource } from '../../../../__generated__/globalTypes'
+
+import { TemplateVideoPreview } from './TemplateVideoPreview'
 
 describe('TemplateVideoPreview', () => {
   it('should render internal video', async () => {
-    const { getByRole, getByTestId } = render(
+    const { getByRole } = render(
       <TemplateVideoPreview
         id="https://arc.gt/opsgn"
         source={VideoBlockSource.internal}
@@ -23,7 +25,7 @@ describe('TemplateVideoPreview', () => {
   })
 
   it('should render cloudflare videos', async () => {
-    const { getByRole, getByTestId } = render(
+    const { getByRole } = render(
       <TemplateVideoPreview
         id="some-id-from-cloudFlare"
         source={VideoBlockSource.cloudflare}
@@ -44,7 +46,7 @@ describe('TemplateVideoPreview', () => {
   })
 
   it('should render youTube video', async () => {
-    const { getByRole, getByTestId } = render(
+    const { getByRole } = render(
       <TemplateVideoPreview
         id="sOm3iD"
         source={VideoBlockSource.youTube}

--- a/apps/journeys-admin/src/components/TemplateView/TemplateVideoPreview/TemplateVideoPreview.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateVideoPreview/TemplateVideoPreview.spec.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, getByTestId, render, waitFor } from '@testing-library/react'
+import { TemplateVideoPreview } from './TemplateVideoPreview'
+import { VideoBlockSource } from '../../../../__generated__/globalTypes'
+
+describe('TemplateVideoPreview', () => {
+  it('should render internal video', async () => {
+    const { getByRole, getByTestId } = render(
+      <TemplateVideoPreview
+        id="https://arc.gt/opsgn"
+        source={VideoBlockSource.internal}
+        poster="imageURL"
+      />
+    )
+
+    const videoPlayer = getByRole('region', {
+      name: 'Video Player'
+    })
+    const sourceTag = videoPlayer.querySelector('.vjs-tech source')
+    expect(sourceTag?.getAttribute('src')).toBe('https://arc.gt/opsgn')
+    expect(sourceTag?.getAttribute('type')).toBe('application/x-mpegURL')
+    const imageTag = videoPlayer.querySelector('.vjs-poster > picture > img')
+    expect(imageTag?.getAttribute('src')).toBe('imageURL')
+  })
+
+  it('should render cloudflare videos', async () => {
+    const { getByRole, getByTestId } = render(
+      <TemplateVideoPreview
+        id="some-id-from-cloudFlare"
+        source={VideoBlockSource.cloudflare}
+        poster="imageURL"
+      />
+    )
+
+    const videoPlayer = getByRole('region', {
+      name: 'Video Player'
+    })
+    const sourceTag = videoPlayer.querySelector('.vjs-tech source')
+    expect(sourceTag?.getAttribute('src')).toBe(
+      'https://customer-.cloudflarestream.com/some-id-from-cloudFlare/manifest/video.m3u8'
+    )
+    expect(sourceTag?.getAttribute('type')).toBe('application/x-mpegURL')
+    const imageTag = videoPlayer.querySelector('.vjs-poster > picture > img')
+    expect(imageTag?.getAttribute('src')).toBe('imageURL')
+  })
+
+  it('should render youTube video', async () => {
+    const { getByRole, getByTestId } = render(
+      <TemplateVideoPreview
+        id="sOm3iD"
+        source={VideoBlockSource.youTube}
+        poster="imageURL-YT"
+      />
+    )
+
+    const videoPlayer = getByRole('region', {
+      name: 'Video Player'
+    })
+    const sourceTag = videoPlayer.querySelector('.vjs-tech source')
+    expect(sourceTag?.getAttribute('src')).toBe(
+      'https://www.youtube.com/embed/sOm3iD'
+    )
+    expect(sourceTag?.getAttribute('type')).toBe('video/youtube')
+    const imageTag = videoPlayer.querySelector('.vjs-poster > picture > img')
+    expect(imageTag?.getAttribute('src')).toBe('imageURL-YT')
+  })
+})

--- a/apps/journeys-admin/src/components/TemplateView/TemplateVideoPreview/TemplateVideoPreview.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateVideoPreview/TemplateVideoPreview.tsx
@@ -1,13 +1,12 @@
 import Box from '@mui/material/Box'
 import { ReactElement, useEffect, useRef, useState } from 'react'
+import videojs from 'video.js'
+import Player from 'video.js/dist/types/player'
 
 import { VideoBlockSource } from '../../../../__generated__/globalTypes'
-import videojs from 'video.js'
 
 import 'videojs-youtube'
 import 'video.js/dist/video-js.css'
-
-import Player from 'video.js/dist/types/player'
 
 interface TemplateVideoPreviewProps {
   id?: string | null
@@ -30,7 +29,7 @@ export function TemplateVideoPreview({
           controls: true,
           bigPlayButton: true,
           fluid: true,
-          poster: poster,
+          poster,
           // Make video fill container instead of set aspect ratio
           fill: true,
           userActions: {
@@ -41,10 +40,10 @@ export function TemplateVideoPreview({
         })
       )
     }
-  }, [])
+  }, [poster])
 
   useEffect(() => {
-    //make sure swiper-js is not interrupting interaction with certain components of video-js
+    // make sure swiper-js is not interrupting interaction with certain components of video-js
     player
       ?.getChild('ControlBar')
       ?.getChild('ProgressControl')
@@ -66,7 +65,12 @@ export function TemplateVideoPreview({
         position: 'relative'
       }}
     >
-      <video ref={videoRef} className="video-js vjs-tech" playsInline>
+      <video
+        ref={videoRef}
+        className="video-js vjs-tech"
+        playsInline
+        style={{ height: '100%' }}
+      >
         {source === VideoBlockSource.cloudflare && id != null && (
           <source
             src={`https://customer-${

--- a/apps/journeys-admin/src/components/TemplateView/TemplateVideoPreview/TemplateVideoPreview.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateVideoPreview/TemplateVideoPreview.tsx
@@ -1,0 +1,90 @@
+import Box from '@mui/material/Box'
+import { ReactElement, useEffect, useRef, useState } from 'react'
+
+import { VideoBlockSource } from '../../../../__generated__/globalTypes'
+import videojs from 'video.js'
+
+import 'videojs-youtube'
+import 'video.js/dist/video-js.css'
+
+import Player from 'video.js/dist/types/player'
+
+interface TemplateVideoPreviewProps {
+  id?: string | null
+  source?: VideoBlockSource
+  poster?: string
+}
+
+export function TemplateVideoPreview({
+  id,
+  source,
+  poster
+}: TemplateVideoPreviewProps): ReactElement {
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const [player, setPlayer] = useState<Player>()
+
+  useEffect(() => {
+    if (videoRef.current != null) {
+      setPlayer(
+        videojs(videoRef.current, {
+          controls: true,
+          bigPlayButton: true,
+          fluid: true,
+          poster: poster,
+          // Make video fill container instead of set aspect ratio
+          fill: true,
+          userActions: {
+            hotkeys: true,
+            doubleClick: true
+          },
+          responsive: true
+        })
+      )
+    }
+  }, [])
+
+  useEffect(() => {
+    //make sure swiper-js is not interrupting interaction with certain components of video-js
+    player
+      ?.getChild('ControlBar')
+      ?.getChild('ProgressControl')
+      ?.addClass('swiper-no-swiping')
+
+    player
+      ?.getChild('ControlBar')
+      ?.getChild('VolumePanel')
+      ?.addClass('swiper-no-swiping')
+  }, [player])
+
+  return (
+    <Box
+      sx={{
+        width: '430px',
+        height: '239px',
+        overflow: 'hidden',
+        borderRadius: 4,
+        position: 'relative'
+      }}
+    >
+      <video ref={videoRef} className="video-js vjs-tech" playsInline>
+        {source === VideoBlockSource.cloudflare && id != null && (
+          <source
+            src={`https://customer-${
+              process.env.NEXT_PUBLIC_CLOUDFLARE_STREAM_CUSTOMER_CODE ?? ''
+            }.cloudflarestream.com/${id ?? ''}/manifest/video.m3u8`}
+            type="application/x-mpegURL"
+          />
+        )}
+        {source === VideoBlockSource.internal && id != null && (
+          <source src={id} type="application/x-mpegURL" />
+        )}
+        {source === VideoBlockSource.youTube && id != null && (
+          <source
+            src={`https://www.youtube.com/embed/${id}`}
+            type="video/youtube"
+          />
+        )}
+      </video>
+    </Box>
+  )
+}

--- a/apps/journeys-admin/src/components/TemplateView/TemplateVideoPreview/index.ts
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateVideoPreview/index.ts
@@ -1,0 +1,1 @@
+export { TemplateVideoPreview } from './TemplateVideoPreview'

--- a/apps/journeys-admin/src/components/TemplateView/TemplateView.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateView.tsx
@@ -4,6 +4,8 @@ import { ReactElement } from 'react'
 
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 
+import { TemplatePreviewTabs } from './TemplatePreviewTabs'
+
 export function TemplateView(): ReactElement {
   const { journey } = useJourney()
 
@@ -11,6 +13,7 @@ export function TemplateView(): ReactElement {
     <Stack gap={4}>
       <Typography variant="h1">{journey?.title}</Typography>
       <Typography variant="body1">{journey?.description}</Typography>
+      <TemplatePreviewTabs />
     </Stack>
   )
 }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 941ca49</samp>

This pull request adds a new feature to the journey template details page, which allows users to see different previews of a journey template with cards and videos. It introduces a new `TemplatePreviewTabs` component, which uses the `Swiper` library and the `TabPanel` component to render a tabbed interface for the previews. It also refactors the template details page to use a new `PageWrapper` component and a `Stack` component for the layout, and to display the template title in the page header and SEO metadata. It includes tests, stories, and data files for the new component.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34356579/todos/6557560976)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] it should render video preview images

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 941ca49</samp>

*  Add the TemplatePreviewTabs component to render a tabbed interface for previewing the cards and videos of a journey template ([link](https://github.com/JesusFilm/core/pull/1937/files?diff=unified&w=0#diff-501634969741d25ebfcafc40c5ccc588acb4eaaeb397d9b5d56f541f7a38c08fR1-R105),[link](https://github.com/JesusFilm/core/pull/1937/files?diff=unified&w=0#diff-080d8aa134f161e27b912696140af965864ce69584482aa845bfcec696bfa65aR1-R61),[link](https://github.com/JesusFilm/core/pull/1937/files?diff=unified&w=0#diff-15fb153f0861beb6dce8cb73e1de5166f1310bbce3e3a0f3d6e4960374c96bbfR1-R76),[link](https://github.com/JesusFilm/core/pull/1937/files?diff=unified&w=0#diff-260dd2a89b552ea7ac4bae5a45ea16adf3ef09bb2e8bcc78aab183da8a2e3f7aR1),[link](https://github.com/JesusFilm/core/pull/1937/files?diff=unified&w=0#diff-e41ee5182dac228c799695276d845c2f69735e29a2ae299c70b6c07ec81ec512R1-R289))
  * Use the Swiper library for the video carousel and the TabPanel component for the tab content in `TemplatePreviewTabs.tsx` ([link](https://github.com/JesusFilm/core/pull/1937/files?diff=unified&w=0#diff-501634969741d25ebfcafc40c5ccc588acb4eaaeb397d9b5d56f541f7a38c08fR1-R105))
  * Showcase the component with different journeys and allow interactive testing and documentation in `TemplatePreviewTabs.stories.tsx` ([link](https://github.com/JesusFilm/core/pull/1937/files?diff=unified&w=0#diff-080d8aa134f161e27b912696140af965864ce69584482aa845bfcec696bfa65aR1-R61))
  * Render the component with different journeys and check the functionality and accessibility of the tabs and the previews in `TemplatePreviewTabs.spec.tsx` ([link](https://github.com/JesusFilm/core/pull/1937/files?diff=unified&w=0#diff-15fb153f0861beb6dce8cb73e1de5166f1310bbce3e3a0f3d6e4960374c96bbfR1-R76))
  * Export the component for easy importing from other files in `index.ts` ([link](https://github.com/JesusFilm/core/pull/1937/files?diff=unified&w=0#diff-260dd2a89b552ea7ac4bae5a45ea16adf3ef09bb2e8bcc78aab183da8a2e3f7aR1))
  * Add a mock journey with video blocks for testing and story purposes in `data.ts` ([link](https://github.com/JesusFilm/core/pull/1937/files?diff=unified&w=0#diff-e41ee5182dac228c799695276d845c2f69735e29a2ae299c70b6c07ec81ec512R1-R289))
* Update the TemplateView component to display the preview tabs below the template title and menu ([link](https://github.com/JesusFilm/core/pull/1937/files?diff=unified&w=0#diff-436738bb5e18937497677275cf375e4dbebb3183971ed6225561bed0c82bd150R7-R8),[link](https://github.com/JesusFilm/core/pull/1937/files?diff=unified&w=0#diff-436738bb5e18937497677275cf375e4dbebb3183971ed6225561bed0c82bd150R16))
  * Import the TemplatePreviewTabs component from its index file in `TemplateView.tsx` ([link](https://github.com/JesusFilm/core/pull/1937/files?diff=unified&w=0#diff-436738bb5e18937497677275cf375e4dbebb3183971ed6225561bed0c82bd150R7-R8))
  * Pass the journey data as a prop to the TemplatePreviewTabs component in `TemplateView.tsx` ([link](https://github.com/JesusFilm/core/pull/1937/files?diff=unified&w=0#diff-436738bb5e18937497677275cf375e4dbebb3183971ed6225561bed0c82bd150R16))
* Refactor the PageWrapper component to support custom children for the main header and update the template details page to use the new version ([link](https://github.com/JesusFilm/core/pull/1937/files?diff=unified&w=0#diff-46a8849cb7583f95a436ff12b776363786b82cc424ad3415052b8c7cd85052ccL16-R17),[link](https://github.com/JesusFilm/core/pull/1937/files?diff=unified&w=0#diff-46a8849cb7583f95a436ff12b776363786b82cc424ad3415052b8c7cd85052ccL46-R59))
  * Update the import of the PageWrapper component from the NewPageWrapper file in `[journeyId].tsx` ([link](https://github.com/JesusFilm/core/pull/1937/files?diff=unified&w=0#diff-46a8849cb7583f95a436ff12b776363786b82cc424ad3415052b8c7cd85052ccL16-R17))
  * Pass the Menu component as a child of a Stack component to the mainHeaderChildren prop instead of the menu prop in `[journeyId].tsx` ([link](https://github.com/JesusFilm/core/pull/1937/files?diff=unified&w=0#diff-46a8849cb7583f95a436ff12b776363786b82cc424ad3415052b8c7cd85052ccL46-R59))
* Update the title of the NextSeo and PageWrapper components to use the template title or a fallback value of 'Template Details' instead of 'Journey Template' in `[journeyId].tsx` ([link](https://github.com/JesusFilm/core/pull/1937/files?diff=unified&w=0#diff-46a8849cb7583f95a436ff12b776363786b82cc424ad3415052b8c7cd85052ccL36-R37),[link](https://github.com/JesusFilm/core/pull/1937/files?diff=unified&w=0#diff-46a8849cb7583f95a436ff12b776363786b82cc424ad3415052b8c7cd85052ccL46-R59))
* Import the Stack component from the MUI library to create a horizontal layout for the menu in the template details page in `[journeyId].tsx` ([link](https://github.com/JesusFilm/core/pull/1937/files?diff=unified&w=0#diff-46a8849cb7583f95a436ff12b776363786b82cc424ad3415052b8c7cd85052ccR1))
