### PR TITLE
feat: template related templates

### DIFF
--- a/apps/journeys-admin/__generated__/GetAdminJourney.ts
+++ b/apps/journeys-admin/__generated__/GetAdminJourney.ts
@@ -631,6 +631,11 @@ export interface GetAdminJourney_journey_team {
   title: string;
 }
 
+export interface GetAdminJourney_journey_tags {
+  __typename: "Tag";
+  id: string;
+}
+
 export interface GetAdminJourney_journey {
   __typename: "Journey";
   id: string;
@@ -654,6 +659,7 @@ export interface GetAdminJourney_journey {
   chatButtons: GetAdminJourney_journey_chatButtons[];
   host: GetAdminJourney_journey_host | null;
   team: GetAdminJourney_journey_team | null;
+  tags: GetAdminJourney_journey_tags[];
 }
 
 export interface GetAdminJourney {

--- a/apps/journeys-admin/__generated__/GetAdminJourney.ts
+++ b/apps/journeys-admin/__generated__/GetAdminJourney.ts
@@ -631,9 +631,23 @@ export interface GetAdminJourney_journey_team {
   title: string;
 }
 
+export interface GetAdminJourney_journey_tags_name_language {
+  __typename: "Language";
+  id: string;
+}
+
+export interface GetAdminJourney_journey_tags_name {
+  __typename: "Translation";
+  value: string;
+  language: GetAdminJourney_journey_tags_name_language;
+  primary: boolean;
+}
+
 export interface GetAdminJourney_journey_tags {
   __typename: "Tag";
   id: string;
+  parentId: string | null;
+  name: GetAdminJourney_journey_tags_name[];
 }
 
 export interface GetAdminJourney_journey {

--- a/apps/journeys-admin/__generated__/GetJourney.ts
+++ b/apps/journeys-admin/__generated__/GetJourney.ts
@@ -631,9 +631,23 @@ export interface GetJourney_journey_team {
   title: string;
 }
 
+export interface GetJourney_journey_tags_name_language {
+  __typename: "Language";
+  id: string;
+}
+
+export interface GetJourney_journey_tags_name {
+  __typename: "Translation";
+  value: string;
+  language: GetJourney_journey_tags_name_language;
+  primary: boolean;
+}
+
 export interface GetJourney_journey_tags {
   __typename: "Tag";
   id: string;
+  parentId: string | null;
+  name: GetJourney_journey_tags_name[];
 }
 
 export interface GetJourney_journey {

--- a/apps/journeys-admin/__generated__/GetJourney.ts
+++ b/apps/journeys-admin/__generated__/GetJourney.ts
@@ -631,6 +631,11 @@ export interface GetJourney_journey_team {
   title: string;
 }
 
+export interface GetJourney_journey_tags {
+  __typename: "Tag";
+  id: string;
+}
+
 export interface GetJourney_journey {
   __typename: "Journey";
   id: string;
@@ -654,6 +659,7 @@ export interface GetJourney_journey {
   chatButtons: GetJourney_journey_chatButtons[];
   host: GetJourney_journey_host | null;
   team: GetJourney_journey_team | null;
+  tags: GetJourney_journey_tags[];
 }
 
 export interface GetJourney {

--- a/apps/journeys-admin/__generated__/GetPublisherTemplate.ts
+++ b/apps/journeys-admin/__generated__/GetPublisherTemplate.ts
@@ -631,6 +631,11 @@ export interface GetPublisherTemplate_publisherTemplate_team {
   title: string;
 }
 
+export interface GetPublisherTemplate_publisherTemplate_tags {
+  __typename: "Tag";
+  id: string;
+}
+
 export interface GetPublisherTemplate_publisherTemplate {
   __typename: "Journey";
   id: string;
@@ -654,6 +659,7 @@ export interface GetPublisherTemplate_publisherTemplate {
   chatButtons: GetPublisherTemplate_publisherTemplate_chatButtons[];
   host: GetPublisherTemplate_publisherTemplate_host | null;
   team: GetPublisherTemplate_publisherTemplate_team | null;
+  tags: GetPublisherTemplate_publisherTemplate_tags[];
 }
 
 export interface GetPublisherTemplate {

--- a/apps/journeys-admin/__generated__/GetPublisherTemplate.ts
+++ b/apps/journeys-admin/__generated__/GetPublisherTemplate.ts
@@ -631,9 +631,23 @@ export interface GetPublisherTemplate_publisherTemplate_team {
   title: string;
 }
 
+export interface GetPublisherTemplate_publisherTemplate_tags_name_language {
+  __typename: "Language";
+  id: string;
+}
+
+export interface GetPublisherTemplate_publisherTemplate_tags_name {
+  __typename: "Translation";
+  value: string;
+  language: GetPublisherTemplate_publisherTemplate_tags_name_language;
+  primary: boolean;
+}
+
 export interface GetPublisherTemplate_publisherTemplate_tags {
   __typename: "Tag";
   id: string;
+  parentId: string | null;
+  name: GetPublisherTemplate_publisherTemplate_tags_name[];
 }
 
 export interface GetPublisherTemplate_publisherTemplate {

--- a/apps/journeys-admin/__generated__/JourneyFields.ts
+++ b/apps/journeys-admin/__generated__/JourneyFields.ts
@@ -631,9 +631,23 @@ export interface JourneyFields_team {
   title: string;
 }
 
+export interface JourneyFields_tags_name_language {
+  __typename: "Language";
+  id: string;
+}
+
+export interface JourneyFields_tags_name {
+  __typename: "Translation";
+  value: string;
+  language: JourneyFields_tags_name_language;
+  primary: boolean;
+}
+
 export interface JourneyFields_tags {
   __typename: "Tag";
   id: string;
+  parentId: string | null;
+  name: JourneyFields_tags_name[];
 }
 
 export interface JourneyFields {

--- a/apps/journeys-admin/__generated__/JourneyFields.ts
+++ b/apps/journeys-admin/__generated__/JourneyFields.ts
@@ -631,6 +631,11 @@ export interface JourneyFields_team {
   title: string;
 }
 
+export interface JourneyFields_tags {
+  __typename: "Tag";
+  id: string;
+}
+
 export interface JourneyFields {
   __typename: "Journey";
   id: string;
@@ -654,4 +659,5 @@ export interface JourneyFields {
   chatButtons: JourneyFields_chatButtons[];
   host: JourneyFields_host | null;
   team: JourneyFields_team | null;
+  tags: JourneyFields_tags[];
 }

--- a/apps/journeys-admin/src/components/Editor/ActionDetails/data.ts
+++ b/apps/journeys-admin/src/components/Editor/ActionDetails/data.ts
@@ -137,5 +137,6 @@ export const journey: Journey = {
   seoDescription: null,
   chatButtons: [],
   host: null,
-  team: null
+  team: null,
+  tags: []
 }

--- a/apps/journeys-admin/src/components/Editor/ActionsTable/ActionsTable.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ActionsTable/ActionsTable.spec.tsx
@@ -106,7 +106,8 @@ describe('ActionsTable', () => {
     seoDescription: null,
     chatButtons: [],
     host: null,
-    team: null
+    team: null,
+    tags: []
   }
 
   it('should render placeholder', () => {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.stories.tsx
@@ -59,7 +59,8 @@ const journey: Journey = {
   seoDescription: null,
   chatButtons: [],
   host: null,
-  team: null
+  team: null,
+  tags: []
 }
 
 const Template: StoryObj<typeof Action> = {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.spec.tsx
@@ -60,7 +60,8 @@ describe('NavigateToJourneyAction', () => {
     seoDescription: null,
     chatButtons: [],
     host: null,
-    team: null
+    team: null,
+    tags: []
   }
 
   it('shows no journey selected by default', () => {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/NavigateToJourneyAction/NavigateToJourneyAction.stories.tsx
@@ -60,7 +60,8 @@ const journey: Journey = {
   seoDescription: null,
   chatButtons: [],
   host: null,
-  team: null
+  team: null,
+  tags: []
 }
 
 export const NavigateToJourney: StoryObj<typeof NavigateToJourneyAction> = {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundColor/BackgroundColor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundColor/BackgroundColor.spec.tsx
@@ -61,7 +61,8 @@ const journey: Journey = {
   seoDescription: null,
   chatButtons: [],
   host: null,
-  team: null
+  team: null,
+  tags: []
 }
 
 describe('BackgroundColor', () => {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.spec.tsx
@@ -62,7 +62,8 @@ const journey: Journey = {
   seoDescription: null,
   chatButtons: [],
   host: null,
-  team: null
+  team: null,
+  tags: []
 }
 
 describe('BackgroundMedia', () => {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/BackgroundMedia.stories.tsx
@@ -72,7 +72,8 @@ const journey: Journey = {
   seoDescription: null,
   chatButtons: [],
   host: null,
-  team: null
+  team: null,
+  tags: []
 }
 
 const card: TreeBlock<CardBlock> = {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
@@ -67,7 +67,8 @@ const journey: Journey = {
   seoDescription: null,
   chatButtons: [],
   host: null,
-  team: null
+  team: null,
+  tags: []
 }
 
 const card: TreeBlock<CardBlock> = {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/Card.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/Card.spec.tsx
@@ -92,7 +92,8 @@ describe('Card', () => {
       seoDescription: null,
       chatButtons: [],
       host: null,
-      team: null
+      team: null,
+      tags: []
     }
 
     it('shows background color from prop', () => {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardLayout/CardLayout.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardLayout/CardLayout.spec.tsx
@@ -58,7 +58,8 @@ const journey: Journey = {
   seoDescription: null,
   chatButtons: [],
   host: null,
-  team: null
+  team: null,
+  tags: []
 }
 
 describe('CardLayout', () => {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardLayout/CardLayout.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardLayout/CardLayout.stories.tsx
@@ -63,7 +63,8 @@ const journey: Journey = {
   seoDescription: null,
   chatButtons: [],
   host: null,
-  team: null
+  team: null,
+  tags: []
 }
 
 export const Default: StoryObj<typeof CardLayout> = {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardStyling/CardStyling.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardStyling/CardStyling.spec.tsx
@@ -71,7 +71,8 @@ const journey: Journey = {
   seoDescription: null,
   chatButtons: [],
   host: null,
-  team: null
+  team: null,
+  tags: []
 }
 
 describe('CardStyling', () => {

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardStyling/CardStyling.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/Card/CardStyling/CardStyling.stories.tsx
@@ -63,7 +63,8 @@ const journey: Journey = {
   seoDescription: null,
   chatButtons: [],
   host: null,
-  team: null
+  team: null,
+  tags: []
 }
 
 export const Default: StoryObj<typeof CardStyling> = {

--- a/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Drawer/SocialShareAppearance/SocialShareAppearance.stories.tsx
@@ -66,7 +66,8 @@ const journey: Journey = {
   seoDescription: null,
   chatButtons: [],
   host: null,
-  team: null
+  team: null,
+  tags: []
 }
 
 const image: ImageBlock = {

--- a/apps/journeys-admin/src/components/Editor/Editor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.spec.tsx
@@ -70,7 +70,8 @@ describe('Editor', () => {
     seoDescription: null,
     chatButtons: [],
     host: null,
-    team: null
+    team: null,
+    tags: []
   }
 
   it('should render the element', () => {

--- a/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
@@ -640,7 +640,8 @@ const journey: Journey = {
   template: null,
   chatButtons: [],
   host: null,
-  team: null
+  team: null,
+  tags: []
 }
 
 const Template: StoryObj<typeof Editor> = {

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Library/VideoBlockEditorSettingsPosterLibrary.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/Poster/Library/VideoBlockEditorSettingsPosterLibrary.spec.tsx
@@ -67,7 +67,8 @@ const journey: Journey = {
   seoDescription: null,
   chatButtons: [],
   host: null,
-  team: null
+  team: null,
+  tags: []
 }
 
 const video: TreeBlock<VideoBlock> = {

--- a/apps/journeys-admin/src/components/JourneyView/JourneyView.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/JourneyView.spec.tsx
@@ -63,7 +63,8 @@ describe('JourneyView', () => {
     userJourneys: [],
     chatButtons: [],
     host: null,
-    team: null
+    team: null,
+    tags: []
   }
 
   it.skip('should have edit button', () => {

--- a/apps/journeys-admin/src/components/JourneyView/data.ts
+++ b/apps/journeys-admin/src/components/JourneyView/data.ts
@@ -86,7 +86,8 @@ export const defaultJourney: Journey = {
         imageUrl: 'https://bit.ly/3nlwUwJ'
       }
     }
-  ]
+  ],
+  tags: []
 }
 
 export const publishedJourney: Journey = {

--- a/apps/journeys-admin/src/components/TemplateView/CreateJourneyButton/CreateJourneyButton.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/CreateJourneyButton/CreateJourneyButton.spec.tsx
@@ -81,7 +81,8 @@ describe('CreateJourneyButton', () => {
     team: null,
     blocks: [],
     primaryImageBlock: null,
-    userJourneys: []
+    userJourneys: [],
+    tags: []
   }
 
   const teamResult = jest.fn(() => ({

--- a/apps/journeys-admin/src/components/TemplateView/TemplateView.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateView.spec.tsx
@@ -4,7 +4,10 @@ import { User } from 'next-firebase-auth'
 
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 
-import { JourneyFields as Journey } from '../../../__generated__/JourneyFields'
+import {
+  JourneyFields as Journey,
+  JourneyFields_tags as Tag
+} from '../../../__generated__/JourneyFields'
 import { GET_JOURNEYS } from '../../libs/useJourneysQuery/useJourneysQuery'
 import { defaultJourney } from '../JourneyView/data'
 
@@ -25,6 +28,20 @@ jest.mock('@mui/material/useMediaQuery', () => ({
 }))
 
 describe('TemplateView', () => {
+  const tag: Tag = {
+    __typename: 'Tag',
+    id: 'tag.id',
+    parentId: 'parentTag.id',
+    name: [
+      {
+        __typename: 'Translation',
+        primary: true,
+        value: 'tag.name',
+        language: { __typename: 'Language', id: 'language.id' }
+      }
+    ]
+  }
+
   const getJourneyMock = {
     request: {
       query: GET_JOURNEYS,
@@ -42,7 +59,7 @@ describe('TemplateView', () => {
           {
             ...defaultJourney,
             id: 'taggedJourney.id',
-            tags: [{ __typename: 'Tag', id: 'tag.id' }]
+            tags: [tag]
           }
         ]
       }
@@ -53,7 +70,7 @@ describe('TemplateView', () => {
     const journeyWithStrategySlug: Journey = {
       ...defaultJourney,
       strategySlug: 'https://www.canva.com/design/DAFvDBw1z1A/view',
-      tags: [{ __typename: 'Tag', id: 'tag.id' }]
+      tags: [tag]
     }
     const { getByText } = render(
       <MockedProvider mocks={[getJourneyMock]}>
@@ -75,7 +92,7 @@ describe('TemplateView', () => {
     const journeyWithoutStrategySlug: Journey = {
       ...defaultJourney,
       strategySlug: null,
-      tags: [{ __typename: 'Tag', id: 'tag.id' }]
+      tags: [tag]
     }
     const { queryByText } = render(
       <MockedProvider mocks={[getJourneyMock]}>
@@ -97,7 +114,7 @@ describe('TemplateView', () => {
     const journeyWithTags: Journey = {
       ...defaultJourney,
       strategySlug: null,
-      tags: [{ __typename: 'Tag', id: 'tag.id' }]
+      tags: [tag]
     }
 
     const result = jest.fn(() => ({
@@ -107,7 +124,7 @@ describe('TemplateView', () => {
           {
             ...defaultJourney,
             id: 'taggedJourney.id',
-            tags: [{ __typename: 'Tag', id: 'tag.id' }]
+            tags: [tag]
           }
         ]
       }

--- a/apps/journeys-admin/src/components/TemplateView/TemplateView.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateView.spec.tsx
@@ -103,6 +103,7 @@ describe('TemplateView', () => {
     const result = jest.fn(() => ({
       data: {
         journeys: [
+          defaultJourney,
           {
             ...defaultJourney,
             id: 'taggedJourney.id',

--- a/apps/journeys-admin/src/components/TemplateView/TemplateView.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateView.tsx
@@ -31,6 +31,7 @@ export function TemplateView({ authUser }: TemplateViewProps): ReactElement {
       }
     }
   })
+  const relatedJourneys = data?.journeys.filter(({ id }) => id !== journey?.id)
 
   return (
     <Stack gap={4}>
@@ -48,10 +49,10 @@ export function TemplateView({ authUser }: TemplateViewProps): ReactElement {
           />
         </Stack>
       )}
-      {data?.journeys != null && data.journeys.length > 1 && (
+      {relatedJourneys != null && relatedJourneys.length > 1 && (
         <TemplateSection
           category={t('Related Templates')}
-          journeys={data.journeys}
+          journeys={relatedJourneys}
         />
       )}
     </Stack>

--- a/apps/journeys-admin/src/components/TemplateView/TemplateView.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateView.tsx
@@ -2,10 +2,13 @@ import Stack from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { User } from 'next-firebase-auth'
 import { ReactElement } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 
+import { useJourneysQuery } from '../../libs/useJourneysQuery'
 import { StrategySection } from '../StrategySection'
+import { TemplateSection } from '../TemplateSections/TemplateSection'
 
 import { CreateJourneyButton } from './CreateJourneyButton'
 import { TemplatePreviewTabs } from './TemplatePreviewTabs'
@@ -16,6 +19,18 @@ interface TemplateViewProps {
 
 export function TemplateView({ authUser }: TemplateViewProps): ReactElement {
   const { journey } = useJourney()
+  const { t } = useTranslation('apps-journeys-admin')
+
+  const tagIds = journey?.tags.map((tag) => tag.id)
+  const { data } = useJourneysQuery({
+    variables: {
+      where: {
+        template: true,
+        orderByRecent: true,
+        tagIds
+      }
+    }
+  })
 
   return (
     <Stack gap={4}>
@@ -32,6 +47,12 @@ export function TemplateView({ authUser }: TemplateViewProps): ReactElement {
             variant="full"
           />
         </Stack>
+      )}
+      {data?.journeys != null && data.journeys.length > 1 && (
+        <TemplateSection
+          category={t('Related Templates')}
+          journeys={data.journeys}
+        />
       )}
     </Stack>
   )

--- a/apps/journeys-admin/src/libs/blockDeleteUpdate/blockDeleteUpdate.spec.ts
+++ b/apps/journeys-admin/src/libs/blockDeleteUpdate/blockDeleteUpdate.spec.ts
@@ -103,7 +103,8 @@ const journey: Journey = {
   seoDescription: null,
   chatButtons: [],
   host: null,
-  team: null
+  team: null,
+  tags: []
 }
 
 const response = [{ ...image, parentOrder: 0 }]

--- a/apps/journeys-admin/src/libs/useJourneyQuery/useJourneyQuery.spec.tsx
+++ b/apps/journeys-admin/src/libs/useJourneyQuery/useJourneyQuery.spec.tsx
@@ -66,7 +66,8 @@ describe('useJourneyQuery', () => {
             imageUrl: 'https://bit.ly/3Gth4Yf'
           }
         }
-      ]
+      ],
+      tags: []
     }
 
     const result = jest.fn(() => ({ data: { journey } }))

--- a/apps/journeys/__generated__/GetJourney.ts
+++ b/apps/journeys/__generated__/GetJourney.ts
@@ -631,9 +631,23 @@ export interface GetJourney_journey_team {
   title: string;
 }
 
+export interface GetJourney_journey_tags_name_language {
+  __typename: "Language";
+  id: string;
+}
+
+export interface GetJourney_journey_tags_name {
+  __typename: "Translation";
+  value: string;
+  language: GetJourney_journey_tags_name_language;
+  primary: boolean;
+}
+
 export interface GetJourney_journey_tags {
   __typename: "Tag";
   id: string;
+  parentId: string | null;
+  name: GetJourney_journey_tags_name[];
 }
 
 export interface GetJourney_journey {

--- a/apps/journeys/__generated__/GetJourney.ts
+++ b/apps/journeys/__generated__/GetJourney.ts
@@ -631,6 +631,11 @@ export interface GetJourney_journey_team {
   title: string;
 }
 
+export interface GetJourney_journey_tags {
+  __typename: "Tag";
+  id: string;
+}
+
 export interface GetJourney_journey {
   __typename: "Journey";
   id: string;
@@ -654,6 +659,7 @@ export interface GetJourney_journey {
   chatButtons: GetJourney_journey_chatButtons[];
   host: GetJourney_journey_host | null;
   team: GetJourney_journey_team | null;
+  tags: GetJourney_journey_tags[];
 }
 
 export interface GetJourney {

--- a/apps/journeys/__generated__/JourneyFields.ts
+++ b/apps/journeys/__generated__/JourneyFields.ts
@@ -631,9 +631,23 @@ export interface JourneyFields_team {
   title: string;
 }
 
+export interface JourneyFields_tags_name_language {
+  __typename: "Language";
+  id: string;
+}
+
+export interface JourneyFields_tags_name {
+  __typename: "Translation";
+  value: string;
+  language: JourneyFields_tags_name_language;
+  primary: boolean;
+}
+
 export interface JourneyFields_tags {
   __typename: "Tag";
   id: string;
+  parentId: string | null;
+  name: JourneyFields_tags_name[];
 }
 
 export interface JourneyFields {

--- a/apps/journeys/__generated__/JourneyFields.ts
+++ b/apps/journeys/__generated__/JourneyFields.ts
@@ -631,6 +631,11 @@ export interface JourneyFields_team {
   title: string;
 }
 
+export interface JourneyFields_tags {
+  __typename: "Tag";
+  id: string;
+}
+
 export interface JourneyFields {
   __typename: "Journey";
   id: string;
@@ -654,4 +659,5 @@ export interface JourneyFields {
   chatButtons: JourneyFields_chatButtons[];
   host: JourneyFields_host | null;
   team: JourneyFields_team | null;
+  tags: JourneyFields_tags[];
 }

--- a/apps/journeys/src/components/Conductor/Conductor.spec.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.spec.tsx
@@ -153,7 +153,8 @@ describe('Conductor', () => {
     seoDescription: null,
     chatButtons: [],
     host: null,
-    team: null
+    team: null,
+    tags: []
   }
 
   it('should create a journeyViewEvent', async () => {

--- a/apps/journeys/src/components/Conductor/Conductor.stories.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.stories.tsx
@@ -85,7 +85,8 @@ const defaultJourney: Journey = {
   seoDescription: null,
   chatButtons: [],
   host: null,
-  team: null
+  team: null,
+  tags: []
 }
 
 type Story = StoryObj<ComponentProps<typeof Conductor> & { journey?: Journey }>

--- a/apps/journeys/src/components/EmbeddedPreview/EmbeddedPreview.stories.tsx
+++ b/apps/journeys/src/components/EmbeddedPreview/EmbeddedPreview.stories.tsx
@@ -85,7 +85,8 @@ const journey: Journey = {
     src2: 'https://tinyurl.com/mr4a78kb'
   },
   team: null,
-  blocks: basic
+  blocks: basic,
+  tags: []
 }
 
 const Template: StoryObj<typeof EmbeddedPreview> = {

--- a/apps/watch/__generated__/JourneyFields.ts
+++ b/apps/watch/__generated__/JourneyFields.ts
@@ -631,9 +631,23 @@ export interface JourneyFields_team {
   title: string;
 }
 
+export interface JourneyFields_tags_name_language {
+  __typename: "Language";
+  id: string;
+}
+
+export interface JourneyFields_tags_name {
+  __typename: "Translation";
+  value: string;
+  language: JourneyFields_tags_name_language;
+  primary: boolean;
+}
+
 export interface JourneyFields_tags {
   __typename: "Tag";
   id: string;
+  parentId: string | null;
+  name: JourneyFields_tags_name[];
 }
 
 export interface JourneyFields {

--- a/apps/watch/__generated__/JourneyFields.ts
+++ b/apps/watch/__generated__/JourneyFields.ts
@@ -631,6 +631,11 @@ export interface JourneyFields_team {
   title: string;
 }
 
+export interface JourneyFields_tags {
+  __typename: "Tag";
+  id: string;
+}
+
 export interface JourneyFields {
   __typename: "Journey";
   id: string;
@@ -654,4 +659,5 @@ export interface JourneyFields {
   chatButtons: JourneyFields_chatButtons[];
   host: JourneyFields_host | null;
   team: JourneyFields_team | null;
+  tags: JourneyFields_tags[];
 }

--- a/libs/journeys/ui/src/components/StepFooter/ChatButtons/ChatButtons.spec.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/ChatButtons/ChatButtons.spec.tsx
@@ -77,7 +77,8 @@ describe('ChatButtons', () => {
     seoDescription: null,
     chatButtons: [],
     host: null,
-    team: null
+    team: null,
+    tags: []
   }
 
   const result = jest.fn(() => ({

--- a/libs/journeys/ui/src/components/StepFooter/HostAvatars/HostAvatars.spec.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/HostAvatars/HostAvatars.spec.tsx
@@ -63,7 +63,8 @@ describe('HostAvatars', () => {
     seoDescription: null,
     chatButtons: [],
     host: hostData,
-    team: null
+    team: null,
+    tags: []
   }
 
   it('renders both avatars if both images are set', () => {

--- a/libs/journeys/ui/src/components/StepFooter/HostAvatars/HostAvatars.stories.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/HostAvatars/HostAvatars.stories.tsx
@@ -68,7 +68,8 @@ const journey: Journey = {
   seoDescription: null,
   chatButtons: [],
   host: hostData,
-  team: null
+  team: null,
+  tags: []
 }
 
 type Story = StoryObj<

--- a/libs/journeys/ui/src/components/StepFooter/HostTitleLocation/HostTitleLocation.spec.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/HostTitleLocation/HostTitleLocation.spec.tsx
@@ -52,7 +52,8 @@ describe('HostTitleLocation', () => {
       src1: null,
       src2: null
     },
-    team: null
+    team: null,
+    tags: []
   }
 
   const rtlLanguage = {

--- a/libs/journeys/ui/src/components/StepFooter/StepFooter.spec.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/StepFooter.spec.tsx
@@ -69,7 +69,8 @@ describe('StepFooter', () => {
       src1: 'https://images.unsplash.com/photo-1558704164-ab7a0016c1f3?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80',
       src2: null
     },
-    team: null
+    team: null,
+    tags: []
   }
 
   it('should display host avatar, name and location', () => {

--- a/libs/journeys/ui/src/components/StepFooter/StepFooter.stories.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/StepFooter.stories.tsx
@@ -66,7 +66,8 @@ const journey: Journey = {
   seoDescription: null,
   chatButtons: [],
   host: null,
-  team: { __typename: 'Team', id: 'teamId', title: 'My Team' }
+  team: { __typename: 'Team', id: 'teamId', title: 'My Team' },
+  tags: []
 }
 
 const rtlLanguage = {

--- a/libs/journeys/ui/src/libs/JourneyProvider/JourneyProvider.spec.tsx
+++ b/libs/journeys/ui/src/libs/JourneyProvider/JourneyProvider.spec.tsx
@@ -63,7 +63,8 @@ const journey: Journey = {
   seoDescription: null,
   chatButtons: [],
   host: null,
-  team: null
+  team: null,
+  tags: []
 }
 
 describe('JourneyContext', () => {
@@ -118,7 +119,8 @@ describe('JourneyContext', () => {
       seoDescription: null,
       chatButtons: [],
       host: null,
-      team: null
+      team: null,
+      tags: []
     })
   })
 })

--- a/libs/journeys/ui/src/libs/JourneyProvider/__generated__/JourneyFields.ts
+++ b/libs/journeys/ui/src/libs/JourneyProvider/__generated__/JourneyFields.ts
@@ -631,9 +631,23 @@ export interface JourneyFields_team {
   title: string;
 }
 
+export interface JourneyFields_tags_name_language {
+  __typename: "Language";
+  id: string;
+}
+
+export interface JourneyFields_tags_name {
+  __typename: "Translation";
+  value: string;
+  language: JourneyFields_tags_name_language;
+  primary: boolean;
+}
+
 export interface JourneyFields_tags {
   __typename: "Tag";
   id: string;
+  parentId: string | null;
+  name: JourneyFields_tags_name[];
 }
 
 export interface JourneyFields {

--- a/libs/journeys/ui/src/libs/JourneyProvider/__generated__/JourneyFields.ts
+++ b/libs/journeys/ui/src/libs/JourneyProvider/__generated__/JourneyFields.ts
@@ -631,6 +631,11 @@ export interface JourneyFields_team {
   title: string;
 }
 
+export interface JourneyFields_tags {
+  __typename: "Tag";
+  id: string;
+}
+
 export interface JourneyFields {
   __typename: "Journey";
   id: string;
@@ -654,4 +659,5 @@ export interface JourneyFields {
   chatButtons: JourneyFields_chatButtons[];
   host: JourneyFields_host | null;
   team: JourneyFields_team | null;
+  tags: JourneyFields_tags[];
 }

--- a/libs/journeys/ui/src/libs/JourneyProvider/journeyFields.tsx
+++ b/libs/journeys/ui/src/libs/JourneyProvider/journeyFields.tsx
@@ -69,5 +69,8 @@ export const JOURNEY_FIELDS = gql`
       id
       title
     }
+    tags {
+      id
+    }
   }
 `

--- a/libs/journeys/ui/src/libs/JourneyProvider/journeyFields.tsx
+++ b/libs/journeys/ui/src/libs/JourneyProvider/journeyFields.tsx
@@ -71,6 +71,14 @@ export const JOURNEY_FIELDS = gql`
     }
     tags {
       id
+      parentId
+      name {
+        value
+        language {
+          id
+        }
+        primary
+      }
     }
   }
 `

--- a/libs/journeys/ui/src/libs/rtl/rtl.spec.tsx
+++ b/libs/journeys/ui/src/libs/rtl/rtl.spec.tsx
@@ -46,7 +46,8 @@ const journey: Journey = {
   seoDescription: null,
   chatButtons: [],
   host: null,
-  team: null
+  team: null,
+  tags: []
 }
 
 describe('getJourneyRTL', () => {

--- a/libs/locales/en/apps-journeys-admin.json
+++ b/libs/locales/en/apps-journeys-admin.json
@@ -289,6 +289,7 @@
   "Preview": "Preview",
   "Use this template to make it your journey": "Use this template to make it your journey",
   "{{cardBlockCount}} Cards": "{{cardBlockCount}} Cards",
+  "Related Templates": "Related Templates",
   "Open conversation": "Open conversation",
   "Username": "Username",
   "Private Note": "Private Note",


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1bb24d0</samp>

This pull request adds support for journey tags in the journeys-admin app. It updates the GraphQL queries and the TypeScript interfaces to include the `tags` field for journeys and publisher templates. It also adds the `tags` field to various mock data objects for testing and storybook purposes.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1bb24d0</samp>

*  Add interfaces and fields for tags in journey and publisher template queries and fragments ([link](https://github.com/JesusFilm/core/pull/1954/files?diff=unified&w=0#diff-9fecf255f6a72895588618cbc843b8a568d1f488e250d433135d9762c70dc518R634-R638), [link](https://github.com/JesusFilm/core/pull/1954/files?diff=unified&w=0#diff-9fecf255f6a72895588618cbc843b8a568d1f488e250d433135d9762c70dc518R662), [link](https://github.com/JesusFilm/core/pull/1954/files?diff=unified&w=0#diff-1ec4c02e97a38e8aed295fe74ec2c3ac54754837958d07baf3587e7f8e9cf427R634-R638), [link](https://github.com/JesusFilm/core/pull/1954/files?diff=unified&w=0#diff-1ec4c02e97a38e8aed295fe74ec2c3ac54754837958d07baf3587e7f8e9cf427R662), [link](https://github.com/JesusFilm/core/pull/1954/files?diff=unified&w=0#diff-8e469721bafdbc2073a68320235979721c971a1404c2bbe6f0ec7a2b42f2fb5cR634-R638), [link](https://github.com/JesusFilm/core/pull/1954/files?diff=unified&w=0#diff-8e469721bafdbc2073a68320235979721c971a1404c2bbe6f0ec7a2b42f2fb5cR662), [link](https://github.com/JesusFilm/core/pull/1954/files?diff=unified&w=0#diff-a015b5ceb6a29272281dee2bd576cb9baad85ff58bc0981d596dbc7b84d72665R634-R638), [link](https://github.com/JesusFilm/core/pull/1954/files?diff=unified&w=0#diff-a015b5ceb6a29272281dee2bd576cb9baad85ff58bc0981d596dbc7b84d72665R662)). These changes are generated by the GraphQL code generator based on the schema and queries defined in the `apps/journeys-admin` app.
