### PR TITLE
feat: language filter

### DIFF
--- a/apps/journeys-admin/pages/templates/index.tsx
+++ b/apps/journeys-admin/pages/templates/index.tsx
@@ -22,6 +22,7 @@ function LibraryIndex(): ReactElement {
         title={t('Journey Templates')}
         user={user}
         mainPanelSx={{ backgroundColor: 'background.paper', px: 0 }}
+        showPanelHeader={false}
       >
         {templates ? <TemplateGallery /> : <TemplateLibrary />}
       </PageWrapper>

--- a/apps/journeys-admin/src/components/NewPageWrapper/PageWrapper.spec.tsx
+++ b/apps/journeys-admin/src/components/NewPageWrapper/PageWrapper.spec.tsx
@@ -35,6 +35,17 @@ describe('PageWrapper', () => {
       expect(getByRole('link')).toHaveAttribute('href', '/')
     })
 
+    it('should show main panel header', () => {
+      const { getByText } = render(
+        <MockedProvider>
+          <FlagsProvider>
+            <PageWrapper title="Page Title" showPanelHeader />
+          </FlagsProvider>
+        </MockedProvider>
+      )
+      expect(getByText('Page Title')).toBeInTheDocument()
+    })
+
     it('should show main header children', () => {
       const { getByRole } = render(
         <MockedProvider>

--- a/apps/journeys-admin/src/components/NewPageWrapper/PageWrapper.tsx
+++ b/apps/journeys-admin/src/components/NewPageWrapper/PageWrapper.tsx
@@ -19,6 +19,7 @@ interface PageWrapperProps {
   showAppHeader?: boolean
   title?: string
   mainHeaderChildren?: ReactNode
+  showPanelHeader?: boolean
   backHref?: string
   backHrefHistory?: boolean
   children?: ReactNode
@@ -37,6 +38,7 @@ export function PageWrapper({
   showAppHeader = true,
   title,
   mainHeaderChildren,
+  showPanelHeader = true,
   backHref,
   backHrefHistory,
   children,
@@ -96,13 +98,15 @@ export function PageWrapper({
                 }
               }}
             >
-              <MainPanelHeader
-                title={title}
-                backHref={backHref}
-                backHrefHistory={backHrefHistory}
-              >
-                {mainHeaderChildren}
-              </MainPanelHeader>
+              {showPanelHeader && (
+                <MainPanelHeader
+                  title={title}
+                  backHref={backHref}
+                  backHrefHistory={backHrefHistory}
+                >
+                  {mainHeaderChildren}
+                </MainPanelHeader>
+              )}
               <MainPanelBody
                 bottomPanelChildren={bottomPanelChildren}
                 sx={mainPanelSx}

--- a/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilter.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilter.spec.tsx
@@ -1,0 +1,105 @@
+import { MockedProvider } from '@apollo/client/testing'
+import { fireEvent, render, waitFor } from '@testing-library/react'
+
+import { GET_LANGUAGES } from '../../Editor/EditToolbar/Menu/LanguageMenuItem/LanguageDialog'
+
+import { LanguageFilter } from '.'
+
+describe('LanguageFilter', () => {
+  const result = jest.fn(() => ({
+    data: {
+      languages: [
+        {
+          __typename: 'Language',
+          id: '529',
+          name: [
+            {
+              value: 'English',
+              primary: true,
+              __typename: 'Translation'
+            }
+          ]
+        },
+        {
+          id: '496',
+          __typename: 'Language',
+          name: [
+            {
+              value: 'Français',
+              primary: true,
+              __typename: 'Translation'
+            },
+            {
+              value: 'French',
+              primary: false,
+              __typename: 'Translation'
+            }
+          ]
+        },
+        {
+          id: '1106',
+          __typename: 'Language',
+          name: [
+            {
+              value: 'Deutsch',
+              primary: true,
+              __typename: 'Translation'
+            },
+            {
+              value: 'German, Standard',
+              primary: false,
+              __typename: 'Translation'
+            }
+          ]
+        }
+      ]
+    }
+  }))
+
+  const mock = {
+    request: {
+      query: GET_LANGUAGES,
+      variables: {
+        languageId: '529'
+      }
+    },
+    result
+  }
+
+  it('should open the langauge filter dialog on button click', async () => {
+    const { getByRole } = render(
+      <MockedProvider mocks={[mock]}>
+        <LanguageFilter />
+      </MockedProvider>
+    )
+    await waitFor(() =>
+      fireEvent.click(getByRole('button', { name: 'English' }))
+    )
+    expect(getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('should render the selected languages with hint', async () => {
+    const { getByRole } = render(
+      <MockedProvider mocks={[mock]}>
+        <LanguageFilter />
+      </MockedProvider>
+    )
+
+    await waitFor(() => {
+      fireEvent.click(getByRole('button', { name: 'English' }))
+    })
+    expect(getByRole('dialog')).toBeInTheDocument()
+    fireEvent.focus(getByRole('combobox'))
+    fireEvent.keyDown(getByRole('combobox'), { key: 'ArrowDown' })
+    fireEvent.click(getByRole('option', { name: 'English' }))
+    fireEvent.click(getByRole('option', { name: 'French Français' }))
+    fireEvent.click(getByRole('option', { name: 'German, Standard Deutsch' }))
+    fireEvent.click(getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(
+        getByRole('button', { name: 'English, French, +1' })
+      ).toBeInTheDocument()
+    )
+  })
+})

--- a/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilter.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilter.tsx
@@ -23,7 +23,6 @@ export function LanguageFilter(): ReactElement {
     variables: { languageId: DEFAULT_LANGUAGE_ID }
   })
 
-  // make into a helper function?
   function getLanguage(languageId: string): string | undefined {
     const localName = data?.languages
       ?.find((language) => language?.id === languageId)
@@ -35,27 +34,18 @@ export function LanguageFilter(): ReactElement {
     return localName ?? nativeName
   }
 
-  // clean up
   function getLanguageNames(): string | undefined {
     const defaultLanguage = getLanguage(DEFAULT_LANGUAGE_ID)
-
-    const multipleLanguages = languageIds.map((languageId) =>
-      getLanguage(languageId)
-    )
+    const multipleLanguages = languageIds.map(getLanguage)
 
     if (multipleLanguages.length > 2) {
-      return `${multipleLanguages[0] ?? ''}, ${multipleLanguages[1] ?? ''}, +${
-        multipleLanguages.length - 2
-      }`
-    }
-    if (multipleLanguages.length === 2) {
-      return `${multipleLanguages[0] ?? ''}, ${multipleLanguages[1] ?? ''}`
+      const firstLanguages = multipleLanguages.slice(0, 2).join(', ')
+      return `${firstLanguages}, +${multipleLanguages.length - 2}`
+    } else if (multipleLanguages.length === 2) {
+      return multipleLanguages.join(', ')
     }
 
-    if (multipleLanguages.length === 1) {
-      return multipleLanguages[0]
-    }
-    return defaultLanguage
+    return multipleLanguages[0] ?? defaultLanguage
   }
 
   const languages = getLanguageNames()

--- a/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilter.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilter.tsx
@@ -1,0 +1,57 @@
+import { useQuery } from '@apollo/client'
+import Button from '@mui/material/Button'
+import castArray from 'lodash/castArray'
+import { useRouter } from 'next/router'
+import { ReactElement, useState } from 'react'
+
+import Globe1Icon from '@core/shared/ui/icons/Globe1'
+
+import { GetLanguages } from '../../../../__generated__/GetLanguages'
+import { GET_LANGUAGES } from '../../Editor/EditToolbar/Menu/LanguageMenuItem/LanguageDialog'
+
+import { LanguageFilterDialog } from './LanguageFilterDialog'
+
+const DEFAULT_LANGUAGE_ID = '529'
+
+export function LanguageFilter(): ReactElement {
+  const { query } = useRouter()
+  const [open, setOpen] = useState(false)
+
+  const languageIds = castArray(query.languageIds)
+
+  const { data, loading } = useQuery<GetLanguages>(GET_LANGUAGES, {
+    variables: { languageId: DEFAULT_LANGUAGE_ID }
+  })
+
+  console.log(languageIds)
+
+  // update to be a function that loops through the languageIds array then renders the langauges
+  const defaultLanguage = data?.languages
+    .find((language) => language.id === DEFAULT_LANGUAGE_ID)
+    ?.name?.find(({ primary }) => primary)?.value
+
+  return (
+    <>
+      <Button
+        data-testid="LanguageFilterButton"
+        variant="outlined"
+        onClick={() => setOpen(true)}
+        startIcon={<Globe1Icon />}
+        sx={{
+          border: 'none',
+          '&:hover': {
+            border: 'none'
+          }
+        }}
+      >
+        {defaultLanguage}
+      </Button>
+      <LanguageFilterDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        languages={data?.languages}
+        loading={loading}
+      />
+    </>
+  )
+}

--- a/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilter.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilter.tsx
@@ -23,12 +23,42 @@ export function LanguageFilter(): ReactElement {
     variables: { languageId: DEFAULT_LANGUAGE_ID }
   })
 
-  console.log(languageIds)
+  // make into a helper function?
+  function getLanguage(languageId: string): string | undefined {
+    const localName = data?.languages
+      ?.find((language) => language?.id === languageId)
+      ?.name?.find(({ primary }) => !primary)?.value
+    const nativeName = data?.languages
+      ?.find((language) => language?.id === languageId)
+      ?.name?.find(({ primary }) => primary)?.value
 
-  // update to be a function that loops through the languageIds array then renders the langauges
-  const defaultLanguage = data?.languages
-    .find((language) => language.id === DEFAULT_LANGUAGE_ID)
-    ?.name?.find(({ primary }) => primary)?.value
+    return localName ?? nativeName
+  }
+
+  // clean up
+  function getLanguageNames(): string | undefined {
+    const defaultLanguage = getLanguage(DEFAULT_LANGUAGE_ID)
+
+    const multipleLanguages = languageIds.map((languageId) =>
+      getLanguage(languageId)
+    )
+
+    if (multipleLanguages.length > 2) {
+      return `${multipleLanguages[0] ?? ''}, ${multipleLanguages[1] ?? ''}, +${
+        multipleLanguages.length - 2
+      }`
+    }
+    if (multipleLanguages.length === 2) {
+      return `${multipleLanguages[0] ?? ''}, ${multipleLanguages[1] ?? ''}`
+    }
+
+    if (multipleLanguages.length === 1) {
+      return multipleLanguages[0]
+    }
+    return defaultLanguage
+  }
+
+  const languages = getLanguageNames()
 
   return (
     <>
@@ -44,7 +74,7 @@ export function LanguageFilter(): ReactElement {
           }
         }}
       >
-        {defaultLanguage}
+        {languages}
       </Button>
       <LanguageFilterDialog
         open={open}

--- a/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilter.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilter.tsx
@@ -1,15 +1,28 @@
 import { useQuery } from '@apollo/client'
 import Button from '@mui/material/Button'
 import castArray from 'lodash/castArray'
+import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
 import { ReactElement, useState } from 'react'
 
 import Globe1Icon from '@core/shared/ui/icons/Globe1'
+import type { Language } from '@core/shared/ui/LanguageAutocomplete'
 
 import { GetLanguages } from '../../../../__generated__/GetLanguages'
 import { GET_LANGUAGES } from '../../Editor/EditToolbar/Menu/LanguageMenuItem/LanguageDialog'
 
-import { LanguageFilterDialog } from './LanguageFilterDialog'
+const DynamicLanguageFilterDialog = dynamic<{
+  open: boolean
+  onClose: () => void
+  languages?: Language[]
+  loading: boolean
+}>(
+  async () =>
+    await import(
+      /* webpackChunkName: "AudioLanguageDialog" */
+      './LanguageFilterDialog'
+    ).then((mod) => mod.LanguageFilterDialog)
+)
 
 const DEFAULT_LANGUAGE_ID = '529'
 
@@ -66,12 +79,14 @@ export function LanguageFilter(): ReactElement {
       >
         {languages}
       </Button>
-      <LanguageFilterDialog
-        open={open}
-        onClose={() => setOpen(false)}
-        languages={data?.languages}
-        loading={loading}
-      />
+      {data?.languages != null && !loading && (
+        <DynamicLanguageFilterDialog
+          open={open}
+          onClose={() => setOpen(false)}
+          languages={data?.languages}
+          loading={loading}
+        />
+      )}
     </>
   )
 }

--- a/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilterDialog/LanguageFilterDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilterDialog/LanguageFilterDialog.spec.tsx
@@ -1,0 +1,118 @@
+import { MockedProvider } from '@apollo/client/testing'
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import { NextRouter, useRouter } from 'next/router'
+
+import { LanguageFilterDialog } from './LanguageFilterDialog'
+
+jest.mock('next/router', () => ({
+  __esModule: true,
+  useRouter: jest.fn()
+}))
+
+const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
+
+describe('LanguageFilterDialog', () => {
+  const languages = [
+    {
+      __typename: 'Language',
+      id: '529',
+      name: [
+        {
+          value: 'English',
+          primary: true,
+          __typename: 'Translation'
+        }
+      ]
+    },
+    {
+      id: '496',
+      __typename: 'Language',
+      name: [
+        {
+          value: 'Français',
+          primary: true,
+          __typename: 'Translation'
+        },
+        {
+          value: 'French',
+          primary: false,
+          __typename: 'Translation'
+        }
+      ]
+    },
+    {
+      id: '1106',
+      __typename: 'Language',
+      name: [
+        {
+          value: 'Deutsch',
+          primary: true,
+          __typename: 'Translation'
+        },
+        {
+          value: 'German, Standard',
+          primary: false,
+          __typename: 'Translation'
+        }
+      ]
+    }
+  ]
+
+  it('submits the form with the selected language', async () => {
+    const push = jest.fn()
+    mockUseRouter.mockReturnValue({ push } as unknown as NextRouter)
+
+    const { getByRole } = render(
+      <MockedProvider>
+        <LanguageFilterDialog
+          open
+          onClose={jest.fn()}
+          languages={languages}
+          loading={false}
+        />
+      </MockedProvider>
+    )
+
+    fireEvent.focus(getByRole('combobox'))
+    fireEvent.keyDown(getByRole('combobox'), { key: 'ArrowDown' })
+    fireEvent.click(getByRole('option', { name: 'French Français' }))
+    fireEvent.click(getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(push).toHaveBeenCalledWith({
+        pathname: '/templates',
+        query: { languageIds: ['496'] }
+      })
+    })
+  })
+
+  it('submits the form with the multiple selected languages', async () => {
+    const push = jest.fn()
+    mockUseRouter.mockReturnValue({ push } as unknown as NextRouter)
+
+    const { getByRole } = render(
+      <MockedProvider>
+        <LanguageFilterDialog
+          open
+          onClose={jest.fn()}
+          languages={languages}
+          loading={false}
+        />
+      </MockedProvider>
+    )
+
+    fireEvent.focus(getByRole('combobox'))
+    fireEvent.keyDown(getByRole('combobox'), { key: 'ArrowDown' })
+    fireEvent.click(getByRole('option', { name: 'English' }))
+    fireEvent.click(getByRole('option', { name: 'French Français' }))
+    fireEvent.click(getByRole('option', { name: 'German, Standard Deutsch' }))
+    fireEvent.click(getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(push).toHaveBeenCalledWith({
+        pathname: '/templates',
+        query: { languageIds: ['529', '496', '1106'] }
+      })
+    })
+  })
+})

--- a/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilterDialog/LanguageFilterDialog.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilterDialog/LanguageFilterDialog.tsx
@@ -1,19 +1,17 @@
+import Checkbox from '@mui/material/Checkbox'
+import Typography from '@mui/material/Typography'
+import Stack from '@mui/system/Stack'
 import { Form, Formik, FormikValues } from 'formik'
+import castArray from 'lodash/castArray'
 import { useRouter } from 'next/router'
 import { ReactElement } from 'react'
 
 import { Dialog } from '@core/shared/ui/Dialog'
 import { LanguageAutocomplete } from '@core/shared/ui/LanguageAutocomplete'
-
-interface Language {
-  id: string
-  name: Translation[]
-}
-
-interface Translation {
-  value: string
-  primary: boolean
-}
+import type {
+  Language,
+  LanguageOption
+} from '@core/shared/ui/LanguageAutocomplete'
 
 interface LangaugeFilterDialogProps {
   open: boolean
@@ -22,11 +20,7 @@ interface LangaugeFilterDialogProps {
   loading
 }
 
-export interface LanguageOption {
-  id: string
-  localName?: string
-  nativeName?: string
-}
+const DEFAULT_LANGUAGE_ID = '529'
 
 export function LanguageFilterDialog({
   open,
@@ -35,12 +29,14 @@ export function LanguageFilterDialog({
   loading
 }: LangaugeFilterDialogProps): ReactElement {
   const router = useRouter()
-  // update language autocomplete to design
-
   const handleSubmit = (values: FormikValues): void => {
+    const languageOptions = castArray(values.language)
+    const languageIds = languageOptions.map(
+      (languageOption) => languageOption.id
+    )
     void router.push({
       pathname: '/templates',
-      query: { languageIds: [values.language.id] }
+      query: { languageIds }
     })
     onClose()
   }
@@ -69,7 +65,7 @@ export function LanguageFilterDialog({
         () =>
           resetForm({
             values: {
-              language: getLanguage('529')
+              language: getLanguage(DEFAULT_LANGUAGE_ID)
             }
           }),
         500
@@ -80,7 +76,8 @@ export function LanguageFilterDialog({
   return (
     <Formik
       initialValues={{
-        language: languages != null ? getLanguage('529') : undefined
+        language:
+          languages != null ? getLanguage(DEFAULT_LANGUAGE_ID) : undefined
       }}
       onSubmit={handleSubmit}
     >
@@ -100,8 +97,24 @@ export function LanguageFilterDialog({
               value={values.language}
               languages={languages}
               loading={loading}
-              // add renderOption
-              // ability to choose multiple things
+              multipleSelect
+              limit={2}
+              renderOption={(props, option, { selected }) => {
+                const { localName, nativeName } = option
+                return (
+                  <li {...props}>
+                    <Checkbox sx={{ mr: 2 }} checked={selected} />
+                    <Stack>
+                      <Typography>{localName ?? nativeName}</Typography>
+                      {localName != null && nativeName != null && (
+                        <Typography variant="body2" color="text.secondary">
+                          {nativeName}
+                        </Typography>
+                      )}
+                    </Stack>
+                  </li>
+                )
+              }}
             />
           </Form>
         </Dialog>

--- a/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilterDialog/LanguageFilterDialog.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilterDialog/LanguageFilterDialog.tsx
@@ -35,16 +35,13 @@ export function LanguageFilterDialog({
   loading
 }: LangaugeFilterDialogProps): ReactElement {
   const router = useRouter()
+  // update language autocomplete to design
 
   const handleSubmit = (values: FormikValues): void => {
-    void router.push(
-      {
-        pathname: '/templates',
-        query: { languageIds: [values.language.id] }
-      },
-      undefined,
-      { shallow: true }
-    )
+    void router.push({
+      pathname: '/templates',
+      query: { languageIds: [values.language.id] }
+    })
     onClose()
   }
 
@@ -103,6 +100,8 @@ export function LanguageFilterDialog({
               value={values.language}
               languages={languages}
               loading={loading}
+              // add renderOption
+              // ability to choose multiple things
             />
           </Form>
         </Dialog>

--- a/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilterDialog/LanguageFilterDialog.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilterDialog/LanguageFilterDialog.tsx
@@ -10,14 +10,14 @@ import { Dialog } from '@core/shared/ui/Dialog'
 import { LanguageAutocomplete } from '@core/shared/ui/LanguageAutocomplete'
 import type {
   Language,
-  LanguageOption
+  LanguageOptionVariant
 } from '@core/shared/ui/LanguageAutocomplete'
 
 interface LangaugeFilterDialogProps {
   open: boolean
   onClose: () => void
   languages?: Language[]
-  loading
+  loading: boolean
 }
 
 const DEFAULT_LANGUAGE_ID = '529'
@@ -41,7 +41,7 @@ export function LanguageFilterDialog({
     onClose()
   }
 
-  function getLanguage(languageId: string): LanguageOption {
+  function getLanguage(languageId: string): LanguageOptionVariant {
     const id = languages?.find((language) => language?.id === languageId)?.id
     const localName = languages
       ?.find((language) => language?.id === id)

--- a/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilterDialog/LanguageFilterDialog.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilterDialog/LanguageFilterDialog.tsx
@@ -1,0 +1,112 @@
+import { Form, Formik, FormikValues } from 'formik'
+import { useRouter } from 'next/router'
+import { ReactElement } from 'react'
+
+import { Dialog } from '@core/shared/ui/Dialog'
+import { LanguageAutocomplete } from '@core/shared/ui/LanguageAutocomplete'
+
+interface Language {
+  id: string
+  name: Translation[]
+}
+
+interface Translation {
+  value: string
+  primary: boolean
+}
+
+interface LangaugeFilterDialogProps {
+  open: boolean
+  onClose: () => void
+  languages?: Language[]
+  loading
+}
+
+export interface LanguageOption {
+  id: string
+  localName?: string
+  nativeName?: string
+}
+
+export function LanguageFilterDialog({
+  open,
+  onClose,
+  languages,
+  loading
+}: LangaugeFilterDialogProps): ReactElement {
+  const router = useRouter()
+
+  const handleSubmit = (values: FormikValues): void => {
+    void router.push(
+      {
+        pathname: '/templates',
+        query: { languageIds: [values.language.id] }
+      },
+      undefined,
+      { shallow: true }
+    )
+    onClose()
+  }
+
+  function getLanguage(languageId: string): LanguageOption {
+    const id = languages?.find((language) => language?.id === languageId)?.id
+    const localName = languages
+      ?.find((language) => language?.id === id)
+      ?.name?.find(({ primary }) => !primary)?.value
+    const nativeName = languages
+      ?.find((language) => language?.id === id)
+      ?.name?.find(({ primary }) => primary)?.value
+
+    return {
+      id: id != null ? id : '',
+      localName,
+      nativeName
+    }
+  }
+
+  function handleClose(resetForm: (values: FormikValues) => void): () => void {
+    return () => {
+      onClose()
+      // wait for dialog animation to complete
+      setTimeout(
+        () =>
+          resetForm({
+            values: {
+              language: getLanguage('529')
+            }
+          }),
+        500
+      )
+    }
+  }
+
+  return (
+    <Formik
+      initialValues={{
+        language: languages != null ? getLanguage('529') : undefined
+      }}
+      onSubmit={handleSubmit}
+    >
+      {({ values, handleSubmit, resetForm, setFieldValue }) => (
+        <Dialog
+          open={open}
+          onClose={handleClose(resetForm)}
+          dialogTitle={{ title: 'Edit Language' }}
+          dialogAction={{
+            onSubmit: handleSubmit,
+            closeLabel: 'Cancel'
+          }}
+        >
+          <Form>
+            <LanguageAutocomplete
+              onChange={async (value) => await setFieldValue('language', value)}
+              value={values.language}
+              languages={languages}
+              loading={loading}
+            />
+          </Form>
+        </Dialog>
+      )}
+    </Formik>
+  )
+}

--- a/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilterDialog/index.ts
+++ b/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilterDialog/index.ts
@@ -1,0 +1,1 @@
+export { LanguageFilterDialog } from './LanguageFilterDialog'

--- a/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/index.ts
+++ b/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/index.ts
@@ -1,0 +1,1 @@
+export { LanguageFilter } from './LanguageFilter'

--- a/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.tsx
@@ -21,7 +21,12 @@ export function TemplateGallery(): ReactElement {
         justifyContent="space-between"
         sx={{ px: { xs: 6, lg: 9 } }}
       >
-        <Typography variant="h2">{t('Journey Templates')}</Typography>
+        <Typography variant="h2" sx={{ display: { xs: 'none', lg: 'block' } }}>
+          {t('Journey Templates')}
+        </Typography>
+        <Typography variant="h2" sx={{ display: { xs: 'block', lg: 'none' } }}>
+          {t('Templates')}
+        </Typography>
         <LanguageFilter />
       </Stack>
       <TemplateSections

--- a/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.tsx
@@ -1,17 +1,35 @@
-import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
 import castArray from 'lodash/castArray'
 import { useRouter } from 'next/router'
 import { ReactElement } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { TemplateSections } from '../TemplateSections'
 
+import { LanguageFilter } from './LanguageFilter'
+
 export function TemplateGallery(): ReactElement {
   const { query } = useRouter()
+  const { t } = useTranslation()
+
+  // TODO: wrapper around a container
   return (
-    <Box>
+    <Stack gap={4}>
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        sx={{ px: { xs: 6, lg: 9 } }}
+      >
+        <Typography variant="h2">{t('Journey Templates')}</Typography>
+        <LanguageFilter />
+      </Stack>
       <TemplateSections
         tagIds={query.tagIds != null ? castArray(query.tagIds) : undefined}
+        languageIds={
+          query?.languageIds != null ? castArray(query.languageIds) : undefined
+        }
       />
-    </Box>
+    </Stack>
   )
 }

--- a/apps/journeys-admin/src/components/TemplateSections/TemplateSections.tsx
+++ b/apps/journeys-admin/src/components/TemplateSections/TemplateSections.tsx
@@ -27,6 +27,8 @@ export function TemplateSections({
   const { t } = useTranslation('apps-journeys-admin')
   const [contents, setContents] = useState<Contents>({})
   const [collection, setCollection] = useState<Journey[]>([])
+  const [languageMatch, setLanguageMatch] = useState<boolean>()
+
   const { data, loading } = useJourneysQuery({
     variables: {
       where: {
@@ -37,13 +39,14 @@ export function TemplateSections({
     },
     onCompleted(data) {
       let filteredJourneys = data.journeys
-
       if (languageIds != null && languageIds.length > 0) {
         filteredJourneys = data.journeys.filter((journey) =>
           languageIds.includes(journey.language.id)
         )
       }
-
+      if (filteredJourneys.length === 0) {
+        setLanguageMatch(true)
+      }
       const collection =
         tagIds == null
           ? [
@@ -83,31 +86,34 @@ export function TemplateSections({
       {map(
         contents,
         ({ category, journeys }, key) =>
-          ((tagIds == null && journeys.length >= 5) ||
+          ((languageIds != null && journeys.length >= 0) ||
+            (tagIds == null && journeys.length >= 5) ||
             tagIds?.includes(key) === true) && (
             <TemplateSection category={category} journeys={journeys} />
           )
       )}
-      {!loading && data?.journeys != null && data.journeys.length === 0 && (
-        <Paper
-          elevation={0}
-          variant="outlined"
-          sx={{
-            borderRadius: 4,
-            width: '100%',
-            padding: 8
-          }}
-        >
-          <Typography variant="h6">
-            {t('No template fully matches your search criteria.')}
-          </Typography>
-          <Typography variant="body1" sx={{ mt: 2 }}>
-            {t(
-              "Try using fewer filters or look below for templates related to the categories you've selected to search"
-            )}
-          </Typography>
-        </Paper>
-      )}
+      {!loading &&
+        ((data?.journeys != null && data?.journeys.length === 0) ||
+          languageMatch === true) && (
+          <Paper
+            elevation={0}
+            variant="outlined"
+            sx={{
+              borderRadius: 4,
+              width: '100%',
+              padding: 8
+            }}
+          >
+            <Typography variant="h6">
+              {t('No template fully matches your search criteria.')}
+            </Typography>
+            <Typography variant="body1" sx={{ mt: 2 }}>
+              {t(
+                "Try using fewer filters or look below for templates related to the categories you've selected to search"
+              )}
+            </Typography>
+          </Paper>
+        )}
     </Stack>
   )
 }

--- a/apps/journeys-admin/src/components/TemplateSections/TemplateSections.tsx
+++ b/apps/journeys-admin/src/components/TemplateSections/TemplateSections.tsx
@@ -17,10 +17,12 @@ interface Contents {
 
 interface TemplateSectionsProps {
   tagIds?: string[]
+  languageIds?: string[]
 }
 
 export function TemplateSections({
-  tagIds
+  tagIds,
+  languageIds
 }: TemplateSectionsProps): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   const [contents, setContents] = useState<Contents>({})
@@ -34,19 +36,29 @@ export function TemplateSections({
       }
     },
     onCompleted(data) {
+      let filteredJourneys = data.journeys
+
+      if (languageIds != null && languageIds.length > 0) {
+        filteredJourneys = data.journeys.filter((journey) =>
+          languageIds.includes(journey.language.id)
+        )
+      }
+
       const collection =
         tagIds == null
           ? [
-              ...data.journeys.filter(({ featuredAt }) => featuredAt != null),
+              ...filteredJourneys.filter(
+                ({ featuredAt }) => featuredAt != null
+              ),
               ...take(
-                data.journeys.filter(({ featuredAt }) => featuredAt == null),
+                filteredJourneys.filter(({ featuredAt }) => featuredAt == null),
                 10
               )
             ]
-          : data.journeys
+          : filteredJourneys
       setCollection(collection)
       const contents = {}
-      data.journeys.forEach((journey) => {
+      filteredJourneys.forEach((journey) => {
         journey.tags.forEach((tag) => {
           if (contents[tag.id] == null)
             contents[tag.id] = {

--- a/libs/locales/en/apps-journeys-admin.json
+++ b/libs/locales/en/apps-journeys-admin.json
@@ -266,6 +266,7 @@
   "Save": "Save",
   "Only a manager can invite new members to the team": "Only a manager can invite new members to the team",
   "No email notifications. New members get access instantly. Team members can see all analytics, edit any journey, and delete and copy journey.": "No email notifications. New members get access instantly. Team members can see all analytics, edit any journey, and delete and copy journey.",
+  "Templates": "Templates",
   "No templates to display.": "No templates to display.",
   "You can archive a template to to delist it from the Template Library.": "You can archive a template to to delist it from the Template Library.",
   "Are you sure you would like to archive all active templates immediately?": "Are you sure you would like to archive all active templates immediately?",

--- a/libs/shared/ui/src/components/LanguageAutocomplete/LanguageAutocomplete.spec.tsx
+++ b/libs/shared/ui/src/components/LanguageAutocomplete/LanguageAutocomplete.spec.tsx
@@ -144,4 +144,52 @@ describe('LanguageAutocomplete', () => {
 
     expect(getAllByTestId('test-option')).toHaveLength(3)
   })
+
+  it('allows multiple selections when multipleSelect is true', () => {
+    const handleChange = jest.fn()
+    const { getByRole } = render(
+      <LanguageAutocomplete
+        onChange={handleChange}
+        languages={languages}
+        multipleSelect
+        loading={false}
+      />
+    )
+
+    fireEvent.focus(getByRole('combobox'))
+    fireEvent.keyDown(getByRole('combobox'), { key: 'ArrowDown' })
+    fireEvent.click(getByRole('option', { name: 'French Français' }))
+
+    fireEvent.keyDown(getByRole('combobox'), { key: 'ArrowDown' })
+    fireEvent.click(getByRole('option', { name: 'English' }))
+
+    expect(handleChange).toHaveBeenCalledWith([
+      { id: '496', localName: 'French', nativeName: 'Français' },
+      { id: '529', localName: undefined, nativeName: 'English' }
+    ])
+  })
+
+  it('allows a single selection when multipleSelect is false or undefined', () => {
+    const handleChange = jest.fn()
+    const { getByRole } = render(
+      <LanguageAutocomplete
+        onChange={handleChange}
+        languages={languages}
+        loading={false}
+      />
+    )
+
+    fireEvent.focus(getByRole('combobox'))
+    fireEvent.keyDown(getByRole('combobox'), { key: 'ArrowDown' })
+    fireEvent.click(getByRole('option', { name: 'French Français' }))
+
+    fireEvent.keyDown(getByRole('combobox'), { key: 'ArrowDown' })
+    fireEvent.click(getByRole('option', { name: 'English' }))
+
+    expect(handleChange).toHaveBeenCalledWith({
+      id: '529',
+      localName: undefined,
+      nativeName: 'English'
+    })
+  })
 })

--- a/libs/shared/ui/src/components/LanguageAutocomplete/LanguageAutocomplete.stories.tsx
+++ b/libs/shared/ui/src/components/LanguageAutocomplete/LanguageAutocomplete.stories.tsx
@@ -5,7 +5,9 @@ import { ReactElement, useState } from 'react'
 
 import { simpleComponentConfig } from '../../libs/simpleComponentConfig'
 
-import { Language, LanguageAutocomplete, LanguageOption } from '.'
+import type { LanguageOptionVariant } from './LanguageAutocomplete'
+
+import { Language, LanguageAutocomplete } from '.'
 
 const LanguageAutocompleteStory: Meta<typeof LanguageAutocomplete> = {
   ...simpleComponentConfig,
@@ -59,15 +61,15 @@ const languages: Language[] = [
 function LanguageAutocompleteTemplate({
   onChange
 }: {
-  onChange: (value: LanguageOption | undefined) => void
+  onChange: (value: LanguageOptionVariant | undefined) => void
 }): ReactElement {
-  const [value, setValue] = useState<LanguageOption | undefined>({
+  const [value, setValue] = useState<LanguageOptionVariant | undefined>({
     id: '529',
     localName: undefined,
     nativeName: 'English'
   })
 
-  const handleChange = (value?: LanguageOption): void => {
+  const handleChange = (value?: LanguageOptionVariant): void => {
     setValue(value)
     onChange(value)
   }

--- a/libs/shared/ui/src/components/LanguageAutocomplete/LanguageAutocomplete.tsx
+++ b/libs/shared/ui/src/components/LanguageAutocomplete/LanguageAutocomplete.tsx
@@ -23,16 +23,25 @@ export interface LanguageOption {
   nativeName?: string
 }
 
+export type LanguageOptionVariant =
+  | LanguageOption
+  | LanguageOption[]
+  | readonly LanguageOption[]
+
 export interface LanguageAutocompleteProps {
-  onChange: (value?: LanguageOption | readonly LanguageOption[]) => void
-  value?: LanguageOption | LanguageOption[]
+  onChange: (value?: LanguageOptionVariant) => void
+  value?: LanguageOptionVariant
   multipleSelect?: boolean
   limit?: number
   languages?: Language[]
   loading: boolean
   helperText?: string
   renderInput?: (params: AutocompleteRenderInputParams) => ReactNode
-  renderOption?: (params: HTMLAttributes<HTMLLIElement>) => ReactNode
+  renderOption?: (
+    props: HTMLAttributes<HTMLLIElement>,
+    option: LanguageOption,
+    { selected }: { selected: boolean }
+  ) => ReactNode
 }
 
 export function LanguageAutocomplete({
@@ -119,13 +128,19 @@ export function LanguageAutocomplete({
       value={multipleSelect ? undefined : value}
       isOptionEqualToValue={(option, value) => {
         if (multipleSelect && Array.isArray(value)) {
-          return value.some((val) => val.id === option.id)
+          return value.some((val) => (val as LanguageOption).id === option.id)
         }
         return option.id === value.id
       }}
-      getOptionLabel={({ localName, nativeName }) =>
-        localName ?? nativeName ?? ''
-      }
+      getOptionLabel={(option) => {
+        if (Array.isArray(option)) {
+          return option
+            .map((opt) => opt.localName ?? opt.nativeName ?? '')
+            .join(', ')
+        } else {
+          return option.localName ?? option.nativeName ?? ''
+        }
+      }}
       onChange={(_event, option) => handleChange(option)}
       options={sortedOptions}
       loading={loading}

--- a/libs/shared/ui/src/components/LanguageAutocomplete/LanguageAutocomplete.tsx
+++ b/libs/shared/ui/src/components/LanguageAutocomplete/LanguageAutocomplete.tsx
@@ -24,8 +24,10 @@ export interface LanguageOption {
 }
 
 export interface LanguageAutocompleteProps {
-  onChange: (value?: LanguageOption) => void
-  value?: LanguageOption
+  onChange: (value?: LanguageOption | readonly LanguageOption[]) => void
+  value?: LanguageOption | LanguageOption[]
+  multipleSelect?: boolean
+  limit?: number
   languages?: Language[]
   loading: boolean
   helperText?: string
@@ -36,6 +38,8 @@ export interface LanguageAutocompleteProps {
 export function LanguageAutocomplete({
   onChange: handleChange,
   value,
+  multipleSelect = false,
+  limit,
   languages,
   loading,
   renderInput,
@@ -108,9 +112,17 @@ export function LanguageAutocomplete({
 
   return (
     <Autocomplete
+      multiple={multipleSelect}
+      disableCloseOnSelect={multipleSelect}
+      limitTags={limit}
       disableClearable
-      value={value}
-      isOptionEqualToValue={(option, value) => option.id === value.id}
+      value={multipleSelect ? undefined : value}
+      isOptionEqualToValue={(option, value) => {
+        if (multipleSelect && Array.isArray(value)) {
+          return value.some((val) => val.id === option.id)
+        }
+        return option.id === value.id
+      }}
       getOptionLabel={({ localName, nativeName }) =>
         localName ?? nativeName ?? ''
       }

--- a/libs/shared/ui/src/components/LanguageAutocomplete/index.ts
+++ b/libs/shared/ui/src/components/LanguageAutocomplete/index.ts
@@ -1,6 +1,7 @@
 export { LanguageAutocomplete } from './LanguageAutocomplete'
 export type {
   LanguageOption,
+  LanguageOptionVariant,
   Language,
   Translation,
   LanguageAutocompleteProps


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fd94c95</samp>

This pull request adds a language filter feature to the templates page, which allows users to filter journeys by language. It also adds a prop to hide the panel header on some pages, which improves the UI. It introduces two new components: `LanguageFilter` and `LanguageFilterDialog`, and modifies the existing components: `PageWrapper`, `TemplateSections`, and `TemplateGallery`. It also adds and updates some test cases and exports some components from their own files.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fd94c95</samp>

*  Add language filter feature for templates page ([link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-13372d81b3e76e196f12415e5cd0054ddb13daeb2cef1392e047609e4ac89a92R1-R57), [link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-292f7e49cefda504f2deda92476407deb657d8baf3a1663e2aae42debc4afd33R1-R112), [link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-75b1f19f628a103d6dd0fdc4643290bf0273802a2182891917c26ef28d396043R1), [link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-62fcfb9c89b7ecf047c8ad5dec882e8ed46b7264e996fce8deb02da3f3ef6454R1), [link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-b3ab650ee0dc0ee335e53cf2f72cf2700dbc0890a665f9b7a7b608c6ce920650L1-R33), [link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-8528e7b4c06335c3a765fccde78d68fff718a8b69d7384bea6782deeb45efb8aL20-R25), [link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-8528e7b4c06335c3a765fccde78d68fff718a8b69d7384bea6782deeb45efb8aL37-R61))
  - Create `LanguageFilter` component to render a button to open a dialog to select a language filter ([link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-13372d81b3e76e196f12415e5cd0054ddb13daeb2cef1392e047609e4ac89a92R1-R57), [link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-62fcfb9c89b7ecf047c8ad5dec882e8ed46b7264e996fce8deb02da3f3ef6454R1))
  - Create `LanguageFilterDialog` component to render a dialog with a language autocomplete field ([link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-292f7e49cefda504f2deda92476407deb657d8baf3a1663e2aae42debc4afd33R1-R112), [link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-75b1f19f628a103d6dd0fdc4643290bf0273802a2182891917c26ef28d396043R1))
  - Modify `TemplateGallery` component to include `LanguageFilter` component and pass `languageIds` query parameter to `TemplateSections` component ([link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-b3ab650ee0dc0ee335e53cf2f72cf2700dbc0890a665f9b7a7b608c6ce920650L1-R33))
  - Modify `TemplateSections` component to filter journeys by `languageIds` prop before grouping and displaying them ([link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-8528e7b4c06335c3a765fccde78d68fff718a8b69d7384bea6782deeb45efb8aL20-R25), [link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-8528e7b4c06335c3a765fccde78d68fff718a8b69d7384bea6782deeb45efb8aL37-R61))
* Add optional prop to control panel header visibility for `PageWrapper` component ([link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-5965e5f2f61464ac798b2d978eb50c82874afd08713ad90b1fbd61c962f04237R22), [link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-5965e5f2f61464ac798b2d978eb50c82874afd08713ad90b1fbd61c962f04237R41), [link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-5965e5f2f61464ac798b2d978eb50c82874afd08713ad90b1fbd61c962f04237L99-R109), [link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-2ce7fd8777e1be5b5ec657940e0b2e29ae6b6fb4d8d88f12d4142e8bb0f2aa3dR38-R48), [link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-4d089d7265256280ff64e3b201d5e5b93de7ec08609a68128848f06ced5a0effR25))
  - Add `showPanelHeader` prop to `PageWrapperProps` interface and set default value to true ([link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-5965e5f2f61464ac798b2d978eb50c82874afd08713ad90b1fbd61c962f04237R22), [link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-5965e5f2f61464ac798b2d978eb50c82874afd08713ad90b1fbd61c962f04237R41))
  - Add conditional rendering of `MainPanelHeader` component based on `showPanelHeader` prop ([link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-5965e5f2f61464ac798b2d978eb50c82874afd08713ad90b1fbd61c962f04237L99-R109))
  - Add test case to check panel header visibility ([link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-2ce7fd8777e1be5b5ec657940e0b2e29ae6b6fb4d8d88f12d4142e8bb0f2aa3dR38-R48))
  - Pass `showPanelHeader` prop to `LibraryIndex` component to hide panel header on templates page ([link](https://github.com/JesusFilm/core/pull/1957/files?diff=unified&w=0#diff-4d089d7265256280ff64e3b201d5e5b93de7ec08609a68128848f06ced5a0effR25))
