### PR TITLE
fix: display empty title on team creation

### DIFF
--- a/libs/journeys/ui/src/components/StepHeader/StepHeader.tsx
+++ b/libs/journeys/ui/src/components/StepHeader/StepHeader.tsx
@@ -67,7 +67,8 @@ export function StepHeader({ sx }: Props): ReactElement {
       >
         <MuiMenuItem disabled>
           <Typography color="text.primary" variant="body2">
-            {journey?.team?.publicTitle !== ''
+            {journey?.team?.publicTitle !== '' &&
+            journey?.team?.publicTitle !== null
               ? journey?.team?.publicTitle
               : journey?.team?.title ?? ''}
           </Typography>
@@ -115,7 +116,8 @@ export function StepHeader({ sx }: Props): ReactElement {
               'All personal identifiable data registered on this website will be processed by journey creator: "{{ teamTitle }}".',
               {
                 teamTitle:
-                  journey?.team?.publicTitle !== ''
+                  journey?.team?.publicTitle !== '' &&
+                  journey?.team?.publicTitle !== null
                     ? journey?.team?.publicTitle
                     : journey?.team?.title ?? ''
               }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3bd4aac</samp>

Fix bug in `StepHeader` component that could show invalid journey team name. Ensure that only non-null public titles are used and displayed in the step header menu.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3bd4aac</samp>

*  Prevent displaying null or empty team name in step header menu by adding a condition to check the public title ([link](https://github.com/JesusFilm/core/pull/1960/files?diff=unified&w=0#diff-00869f75b6301e1727b13219c1365543ef481680482b942225f048e83ea9ccd4L70-R71), [link](https://github.com/JesusFilm/core/pull/1960/files?diff=unified&w=0#diff-00869f75b6301e1727b13219c1365543ef481680482b942225f048e83ea9ccd4L118-R120))
