### PR TITLE
feat: remove navigate to journey action

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.spec.tsx
@@ -165,22 +165,6 @@ describe('Action', () => {
     )
   })
 
-  it('shows journey dropdown when Another Journey is selected', async () => {
-    const { getByRole, getByText } = render(
-      <MockedProvider>
-        <Action />
-      </MockedProvider>
-    )
-    fireEvent.mouseDown(getByRole('button', { name: 'None' }))
-    await waitFor(() =>
-      expect(getByText('Another Journey')).toBeInTheDocument()
-    )
-    fireEvent.click(getByRole('option', { name: 'Another Journey' }))
-    await waitFor(() =>
-      expect(getByText('Select the Journey...')).toBeInTheDocument()
-    )
-  })
-
   it('shows url input text box when URL/Website is selected', async () => {
     const { getByRole, getByText } = render(
       <MockedProvider>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.stories.tsx
@@ -169,12 +169,4 @@ export const NavigateToBlockAction = {
   }
 }
 
-export const NavigateToJourneyAction = {
-  ...Template,
-  args: {
-    steps,
-    selectedBlock: steps[0].children[0].children[3]
-  }
-}
-
 export default ActionStory

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/Action/Action.tsx
@@ -61,10 +61,6 @@ export const actions = [
     label: 'Selected Card'
   },
   {
-    value: 'NavigateToJourneyAction',
-    label: 'Another Journey'
-  },
-  {
     value: 'LinkAction',
     label: 'URL/Website'
   },


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3cf44a6</samp>

Removed the option and related code for navigating to another journey from an action block, as this feature was replaced by linking to a URL. Affected files include `Action.spec.tsx`, `Action.stories.tsx`, and `Action.tsx`.

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34356635/todos/6650938493)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Navigate to Journey action no longer available in admin front-end

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3cf44a6</samp>

*  Remove the option to navigate to another journey from an action block and the related stories and tests ([link](https://github.com/JesusFilm/core/pull/1963/files?diff=unified&w=0#diff-819478eb58a87ff1d52a8180add6129a65f673966346be530a77d15ea1947c09L168-L183), [link](https://github.com/JesusFilm/core/pull/1963/files?diff=unified&w=0#diff-d831fc9f24586f8ffc32f5a16edd44fc2d60ddfd43bfddb582c20935cb64fbffL172-L179), [link](https://github.com/JesusFilm/core/pull/1963/files?diff=unified&w=0#diff-5a35a228f99f223cb1f367e925c18fcfb801da1fc265692c8bda5c2fc742ea02L64-L67))
