### PR TITLE
feat: filter journeys via language ids

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -714,6 +714,7 @@ input JourneysFilter
   template: Boolean
   ids: [ID!]
   tagIds: [ID!]
+  languageIds: [ID!]
   limit: Int
   orderByRecent: Boolean
 }

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -1782,6 +1782,7 @@ input JourneysFilter {
   template: Boolean
   ids: [ID!]
   tagIds: [ID!]
+  languageIds: [ID!]
   limit: Int
   orderByRecent: Boolean
 }

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -596,6 +596,7 @@ export class JourneysFilter {
     template?: Nullable<boolean>;
     ids?: Nullable<string[]>;
     tagIds?: Nullable<string[]>;
+    languageIds?: Nullable<string[]>;
     limit?: Nullable<number>;
     orderByRecent?: Nullable<boolean>;
 }

--- a/apps/api-journeys/src/app/modules/journey/journey.graphql
+++ b/apps/api-journeys/src/app/modules/journey/journey.graphql
@@ -48,6 +48,7 @@ input JourneysFilter {
   template: Boolean
   ids: [ID!]
   tagIds: [ID!]
+  languageIds: [ID!]
   limit: Int
   orderByRecent: Boolean
 }

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -569,6 +569,18 @@ describe('JourneyResolver', () => {
       })
     })
 
+    it('returns a list of journeys filtered by languageId', async () => {
+      prismaService.journey.findMany.mockResolvedValueOnce([])
+      await resolver.journeys({ languageIds: ['529'] })
+
+      expect(prismaService.journey.findMany).toHaveBeenCalledWith({
+        where: {
+          languageId: { in: ['529'] },
+          status: 'published'
+        }
+      })
+    })
+
     it('returns limited number of published journeys', async () => {
       prismaService.journey.findMany.mockResolvedValueOnce([journey, journey])
       expect(await resolver.journeys({ limit: 2 })).toEqual([journey, journey])

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -180,6 +180,8 @@ export class JourneyResolver {
       filter.featuredAt = where?.featured ? { not: null } : null
     if (where?.ids != null) filter.id = { in: where?.ids }
     if (where?.tagIds != null) filter.tagIds = { hasEvery: where?.tagIds }
+    if (where?.languageIds != null)
+      filter.languageId = { in: where?.languageIds }
 
     return await this.prismaService.journey.findMany({
       where: filter,

--- a/apps/journeys-admin/__generated__/globalTypes.ts
+++ b/apps/journeys-admin/__generated__/globalTypes.ts
@@ -386,6 +386,7 @@ export interface JourneysFilter {
   template?: boolean | null;
   ids?: string[] | null;
   tagIds?: string[] | null;
+  languageIds?: string[] | null;
   limit?: number | null;
   orderByRecent?: boolean | null;
 }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5ea61d2</samp>

This pull request adds a new feature to the api-gateway and api-journeys services that allows users to filter journeys by language IDs. It updates the GraphQL schemas, the TypeScript types, the query resolvers, and the test cases to support this feature.

- Link to Basecamp Todo

# How should this PR be QA Tested?

- [ ] it should enable users to make an api call where they can filter journeys via Langauge IDs

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5ea61d2</samp>

*  Add `languageIds` field to `JourneysInput` type in GraphQL schemas to enable language filtering for journeys ([link](https://github.com/JesusFilm/core/pull/1964/files?diff=unified&w=0#diff-e60078ed0fc71b8cd3bb2fca25505e7dba866b7d463147662a12432dfe287273R717), [link](https://github.com/JesusFilm/core/pull/1964/files?diff=unified&w=0#diff-3cbd0d77b8eff95fb0f62db7f9f1a4b69ccd568ae3902a3450bac7d752c817a3R1785), [link](https://github.com/JesusFilm/core/pull/1964/files?diff=unified&w=0#diff-5d25ebcb2d0b7fb3abd35ecaaf839372a6a9b86152fab8eea293c5eb974e5588R51))
*  Update `JourneysFilter` class in generated TypeScript code to include `languageIds` property ([link](https://github.com/JesusFilm/core/pull/1964/files?diff=unified&w=0#diff-bef781d45ccbb6775960a589c940a77584bd143e501a8ae9b83d699d803561f2R599))
*  Modify `journeys` query resolver in `journey.resolver.ts` to apply `languageId` filter to `prismaService.journey.findMany` method when `languageIds` input is given ([link](https://github.com/JesusFilm/core/pull/1964/files?diff=unified&w=0#diff-be9eaaadc38880434cdfe42dc6e2fe0f5cae94cf78d3e9e05f9a39093dae42dfR183-R184))
*  Add test case in `journey.resolver.spec.ts` to verify that `prismaService.journey.findMany` method is called with correct filter object when `languageIds` input is provided ([link](https://github.com/JesusFilm/core/pull/1964/files?diff=unified&w=0#diff-93528ee54010f1df0fe00fab3e9cf53b524ade137814f4899de8d3151a7b1882R572-R583))
