### PR TITLE
fix: add languageid to variant in get videos query

### DIFF
--- a/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoFromLocal/VideoFromLocal.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoFromLocal/VideoFromLocal.tsx
@@ -26,7 +26,7 @@ export const GET_VIDEOS = gql`
         primary
         value
       }
-      variant {
+      variant(languageId: "529") {
         id
         duration
       }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c83c3cb</samp>

Fixed a bug in `VideoFromLocal` component where video duration was incorrect for multilingual videos. Changed the `GET_VIDEOS` query to filter by English languageId.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34356635/todos/6650938354)

and

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34356635/todos/6650938669)

# How should this PR be QA Tested?

Click load more button in Journeys Admin
Click a video to open video details
Click load more

It should remain in the same state after exiting video details.

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c83c3cb</samp>

*  Specify the languageId of the video variant to be 529 (English) in the `GET_VIDEOS` query to fix the bug of incorrect video duration display ([link](https://github.com/JesusFilm/core/pull/1966/files?diff=unified&w=0#diff-b6aed9a1431cb3e8de236b82a2edfd285ee5daf676a4451004eadfa3445ea20bL29-R29))
