### PR TITLE
fix: simplify swiper

### DIFF
--- a/apps/journeys-admin/src/components/FramePortal/FramePortal.tsx
+++ b/apps/journeys-admin/src/components/FramePortal/FramePortal.tsx
@@ -2,6 +2,7 @@ import createCache from '@emotion/cache'
 import { CacheProvider } from '@emotion/react'
 import { styled } from '@mui/material/styles'
 import {
+  ComponentProps,
   DetailedHTMLProps,
   IframeHTMLAttributes,
   ReactElement,
@@ -46,14 +47,7 @@ const StyledFrame = styled('iframe')(() => ({
   border: 0
 }))
 
-interface FrameProps
-  extends Omit<
-    DetailedHTMLProps<
-      IframeHTMLAttributes<HTMLIFrameElement>,
-      HTMLIFrameElement
-    >,
-    'css'
-  > {
+interface FrameProps extends ComponentProps<typeof StyledFrame> {
   children: ReactNode
 }
 

--- a/apps/journeys-admin/src/components/FramePortal/FramePortal.tsx
+++ b/apps/journeys-admin/src/components/FramePortal/FramePortal.tsx
@@ -3,8 +3,6 @@ import { CacheProvider } from '@emotion/react'
 import { styled } from '@mui/material/styles'
 import {
   ComponentProps,
-  DetailedHTMLProps,
-  IframeHTMLAttributes,
   ReactElement,
   ReactNode,
   memo,

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.tsx
@@ -49,7 +49,7 @@ function TemplateCardPreviewItem({
     >
       <Box
         sx={{
-          transform: { sm: 'scale(0.6)', xs: 'scale(0.4)' },
+          transform: { xs: 'scale(0.4)', sm: 'scale(0.6)' },
           transformOrigin: 'top left'
         }}
       >

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.tsx
@@ -1,11 +1,9 @@
 import 'swiper/swiper.min.css'
 
 import Box from '@mui/material/Box'
-import Stack from '@mui/material/Stack'
-import { Theme } from '@mui/material/styles'
-import useMediaQuery from '@mui/material/useMediaQuery'
+import { useTheme } from '@mui/material/styles'
 import { ReactElement } from 'react'
-import SwiperCore, { A11y, Mousewheel } from 'swiper'
+import SwiperCore, { A11y, Mousewheel, SwiperOptions } from 'swiper'
 import { Swiper, SwiperSlide } from 'swiper/react'
 
 import { TreeBlock } from '@core/journeys/ui/block'
@@ -31,12 +29,10 @@ interface TemplateCardPreviewProps {
 
 interface TemplateCardPreviewItemProps {
   step: TreeBlock<StepBlock>
-  smUp: boolean
 }
 
 function TemplateCardPreviewItem({
-  step,
-  smUp
+  step
 }: TemplateCardPreviewItemProps): ReactElement {
   const { journey } = useJourney()
   const { rtl, locale } = getJourneyRTL(journey)
@@ -44,32 +40,34 @@ function TemplateCardPreviewItem({
     (child) => child.__typename === 'CardBlock'
   ) as TreeBlock<CardBlock>
   return (
-    <Stack
+    <Box
       sx={{
         position: 'relative',
-        width: smUp ? 240 : 177,
-        height: smUp ? 380 : 280
+        width: { sm: 240, xs: 177 },
+        height: { sm: 380, xs: 280 }
       }}
     >
       <Box
         sx={{
-          transform: smUp ? 'scale(0.6)' : 'scale(0.4)',
-          transformOrigin: smUp ? 'top left' : '22.5% top'
+          transform: { sm: 'scale(0.6)', xs: 'scale(0.4)' },
+          transformOrigin: 'top left'
         }}
       >
         <Box
           sx={{
             position: 'absolute',
             display: 'block',
-            width: smUp ? 405 : 445,
-            height: '100%',
+            width: { sm: 405, xs: 445 },
+            height: { sm: 633, xs: 698 },
             zIndex: 2,
             cursor: 'grab'
           }}
         />
         <FramePortal
-          width={smUp ? 405 : 445}
-          height={smUp ? 633 : 698}
+          sx={{
+            width: { sm: 405, xs: 445 },
+            height: { sm: 633, xs: 698 }
+          }}
           dir={rtl ? 'rtl' : 'ltr'}
         >
           <ThemeProvider
@@ -95,28 +93,31 @@ function TemplateCardPreviewItem({
           </ThemeProvider>
         </FramePortal>
       </Box>
-    </Stack>
+    </Box>
   )
 }
 
 export function TemplateCardPreview({
   steps
 }: TemplateCardPreviewProps): ReactElement {
-  const smUp = useMediaQuery((theme: Theme) => theme?.breakpoints?.up('sm'))
+  const { breakpoints } = useTheme()
+  const swiperBreakpoints: SwiperOptions['breakpoints'] = {
+    [breakpoints.values.sm]: {
+      spaceBetween: 28
+    }
+  }
 
   return (
     <Swiper
       freeMode
       watchOverflow
       slidesPerView="auto"
-      spaceBetween={smUp ? 28 : 12}
+      spaceBetween={12}
+      breakpoints={swiperBreakpoints}
       mousewheel
+      autoHeight
       style={{
         overflow: 'visible',
-        marginLeft: smUp ? '-32px' : '-44px',
-        marginRight: smUp ? '-36px' : '-44px',
-        paddingLeft: smUp ? '32px' : '20px',
-        paddingRight: smUp ? '40px' : '70px',
         zIndex: 2
       }}
     >
@@ -125,12 +126,11 @@ export function TemplateCardPreview({
           data-testid="templateCardsSwiperSlide"
           key={step.id}
           style={{
-            width: smUp ? '240px' : '177px',
-            height: smUp ? '380px' : '280px',
+            width: 'fit-content',
             zIndex: 2
           }}
         >
-          <TemplateCardPreviewItem step={step} smUp={smUp} />
+          <TemplateCardPreviewItem step={step} />
         </SwiperSlide>
       ))}
     </Swiper>

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.tsx
@@ -43,8 +43,8 @@ function TemplateCardPreviewItem({
     <Box
       sx={{
         position: 'relative',
-        width: { sm: 240, xs: 177 },
-        height: { sm: 380, xs: 280 }
+        width: { xs: 177, sm: 240 },
+        height: { xs: 280, sm: 380 }
       }}
     >
       <Box
@@ -57,16 +57,16 @@ function TemplateCardPreviewItem({
           sx={{
             position: 'absolute',
             display: 'block',
-            width: { sm: 405, xs: 445 },
-            height: { sm: 633, xs: 698 },
+            width: { xs: 445, sm: 405 },
+            height: { xs: 698, sm: 633 },
             zIndex: 2,
             cursor: 'grab'
           }}
         />
         <FramePortal
           sx={{
-            width: { sm: 405, xs: 445 },
-            height: { sm: 633, xs: 698 }
+            width: { xs: 445, sm: 405 },
+            height: { xs: 698, sm: 633 }
           }}
           dir={rtl ? 'rtl' : 'ltr'}
         >

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplatePreviewTabs.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplatePreviewTabs.tsx
@@ -1,7 +1,6 @@
 import 'swiper/swiper.min.css'
 import 'swiper/components/scrollbar/scrollbar.min.css'
 
-import Stack from '@mui/material/Stack'
 import { Theme } from '@mui/material/styles'
 import Tab from '@mui/material/Tab'
 import Tabs from '@mui/material/Tabs'

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplatePreviewTabs.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplatePreviewTabs.tsx
@@ -53,9 +53,7 @@ export function TemplatePreviewTabs(): ReactElement {
         />
       </Tabs>
       <TabPanel name="cards-preview-tab" value={tabValue} index={0}>
-        <Stack sx={{ pb: { xs: 0, sm: 6 } }}>
-          <TemplateCardPreview steps={steps} />
-        </Stack>
+        <TemplateCardPreview steps={steps} />
       </TabPanel>
     </>
   )


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 43ed9f5</samp>

Refactored the `FramePortal` and `TemplateCardPreview` components to use more consistent and efficient props and styles. Improved the layout and performance of the `Swiper` component and removed unnecessary components and styles from the `TemplatePreviewTabs` component.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34356579/todos/6661055811)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] should retain same function as before

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 43ed9f5</samp>

*  Simplify the `FrameProps` interface by extending the `ComponentProps` of the `StyledFrame` component ([link](https://github.com/JesusFilm/core/pull/1967/files?diff=unified&w=0#diff-ab50a34ebc34f9f2a86bc17021e9d53cd7b2d5c84f621630f2b02b1adc1eb8b7R5),[link](https://github.com/JesusFilm/core/pull/1967/files?diff=unified&w=0#diff-ab50a34ebc34f9f2a86bc17021e9d53cd7b2d5c84f621630f2b02b1adc1eb8b7L49-R50))
* Move the `TemplateCardPreview` component from the `TemplateCardPreview` file to the `FramePortal` file, and update the imports accordingly ([link](https://github.com/JesusFilm/core/pull/1967/files?diff=unified&w=0#diff-89a406c95c26ccbfb9155819b7a64eb0357873b6f735f62df2036871c786fceaL4-R6))
* Replace the `Stack` component with a `Box` component, and use the `sx` prop to apply responsive styles to the width and height of the card preview in the `TemplateCardPreviewItem` component ([link](https://github.com/JesusFilm/core/pull/1967/files?diff=unified&w=0#diff-89a406c95c26ccbfb9155819b7a64eb0357873b6f735f62df2036871c786fceaL47-R53),[link](https://github.com/JesusFilm/core/pull/1967/files?diff=unified&w=0#diff-89a406c95c26ccbfb9155819b7a64eb0357873b6f735f62df2036871c786fceaL98-R96))
* Use the `sx` prop to pass the same responsive styles to the `StyledFrame` and `FramePortal` components, which render the card preview in an iframe ([link](https://github.com/JesusFilm/core/pull/1967/files?diff=unified&w=0#diff-89a406c95c26ccbfb9155819b7a64eb0357873b6f735f62df2036871c786fceaL64-R61),[link](https://github.com/JesusFilm/core/pull/1967/files?diff=unified&w=0#diff-89a406c95c26ccbfb9155819b7a64eb0357873b6f735f62df2036871c786fceaL71-R70))
* Use the `useTheme` hook to access the `breakpoints` object from the theme, and create a `swiperBreakpoints` variable to store the `SwiperOptions` for the `Swiper` component in the `TemplateCardPreview` component ([link](https://github.com/JesusFilm/core/pull/1967/files?diff=unified&w=0#diff-89a406c95c26ccbfb9155819b7a64eb0357873b6f735f62df2036871c786fceaL105-R108))
* Set the `spaceBetween`, `breakpoints`, and `autoHeight` props of the `Swiper` component, and simplify the inline styles in the `TemplateCardPreview` component ([link](https://github.com/JesusFilm/core/pull/1967/files?diff=unified&w=0#diff-89a406c95c26ccbfb9155819b7a64eb0357873b6f735f62df2036871c786fceaL112-R120))
* Simplify the inline styles of the `SwiperSlide` component, and remove the `smUp` prop from the `TemplateCardPreviewItem` component and its interface ([link](https://github.com/JesusFilm/core/pull/1967/files?diff=unified&w=0#diff-89a406c95c26ccbfb9155819b7a64eb0357873b6f735f62df2036871c786fceaL128-R133),[link](https://github.com/JesusFilm/core/pull/1967/files?diff=unified&w=0#diff-89a406c95c26ccbfb9155819b7a64eb0357873b6f735f62df2036871c786fceaL34-R35))
* Remove the `Stack` component and the `pb` style from the `TabPanel` component in the `TemplatePreviewTabs` component ([link](https://github.com/JesusFilm/core/pull/1967/files?diff=unified&w=0#diff-501634969741d25ebfcafc40c5ccc588acb4eaaeb397d9b5d56f541f7a38c08fL56-R56))
