### PR TITLE
ci: run monitoring every 10 mins

### DIFF
--- a/.github/workflows/journeys-admin-monitoring.yml
+++ b/.github/workflows/journeys-admin-monitoring.yml
@@ -1,4 +1,4 @@
-name: journeys-admin-monitoring-every10mins
+name: journeys-admin-monitoring
 on:
   schedule:
     - cron: '*/10 * * * *'
@@ -12,8 +12,15 @@ jobs:
         with:
           node-version: 18
           cache: 'npm'
-      - name: Install dependencies
-        run: npm ci
+      - name: Cache Node Modules
+        id: cache-node-modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: node-modules-${{ matrix.node-version }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: node-modules-${{ matrix.node-version }}-
+      - name: NPM Install
+        run: npm install --silent
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - name: Run Playwright tests

--- a/.github/workflows/journeys-admin-monitoring.yml
+++ b/.github/workflows/journeys-admin-monitoring.yml
@@ -1,11 +1,7 @@
-name: journeys-admin-monitoring-every3mins
+name: journeys-admin-monitoring-every10mins
 on:
   schedule:
-    - cron: '*/3 * * * *'
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
+    - cron: '*/10 * * * *'
 jobs:
   test:
     timeout-minutes: 60

--- a/.github/workflows/journeys-admin-monitoring.yml
+++ b/.github/workflows/journeys-admin-monitoring.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: 'npm'
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright Browsers

--- a/.github/workflows/journeys-monitoring.yml
+++ b/.github/workflows/journeys-monitoring.yml
@@ -1,4 +1,4 @@
-name: journeys-monitoring-every10mins
+name: journeys-monitoring
 on:
   schedule:
     - cron: '*/10 * * * *'
@@ -12,8 +12,15 @@ jobs:
         with:
           node-version: 18
           cache: 'npm'
-      - name: Install dependencies
-        run: npm ci
+      - name: Cache Node Modules
+        id: cache-node-modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: node-modules-${{ matrix.node-version }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: node-modules-${{ matrix.node-version }}-
+      - name: NPM Install
+        run: npm install --silent
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - name: Run Playwright tests

--- a/.github/workflows/journeys-monitoring.yml
+++ b/.github/workflows/journeys-monitoring.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: 'npm'
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright Browsers

--- a/.github/workflows/journeys-monitoring.yml
+++ b/.github/workflows/journeys-monitoring.yml
@@ -1,11 +1,7 @@
-name: journeys-monitoring-every3mins
+name: journeys-monitoring-every10mins
 on:
   schedule:
-    - cron: '*/3 * * * *'
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
+    - cron: '*/10 * * * *'
 jobs:
   test:
     timeout-minutes: 60

--- a/.github/workflows/watch-monitoring.yml
+++ b/.github/workflows/watch-monitoring.yml
@@ -1,11 +1,7 @@
-name: watch-monitoring-every3mins
+name: watch-monitoring-every10mins
 on:
   schedule:
-    - cron: '*/3 * * * *'
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
+    - cron: '*/10 * * * *'
 jobs:
   test:
     timeout-minutes: 60

--- a/.github/workflows/watch-monitoring.yml
+++ b/.github/workflows/watch-monitoring.yml
@@ -1,4 +1,4 @@
-name: watch-monitoring-every10mins
+name: watch-monitoring
 on:
   schedule:
     - cron: '*/10 * * * *'
@@ -12,8 +12,15 @@ jobs:
         with:
           node-version: 18
           cache: 'npm'
-      - name: Install dependencies
-        run: npm ci
+      - name: Cache Node Modules
+        id: cache-node-modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: node-modules-${{ matrix.node-version }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: node-modules-${{ matrix.node-version }}-
+      - name: NPM Install
+        run: npm install --silent
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - name: Run Playwright tests

--- a/.github/workflows/watch-monitoring.yml
+++ b/.github/workflows/watch-monitoring.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: 'npm'
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright Browsers


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9714874</samp>

Updated three GitHub workflows for testing different apps (`journeys-admin`, `journeys`, and `watch`) to optimize performance and efficiency. Changed the workflow names, schedules, and cache options to reduce test frequency, speed up dependency installation, and minimize network traffic.

- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34752396/todos/6662449739)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.
Monitoring should run every 10 mins instead of 3 mins.

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9714874</samp>

*  Reduce the frequency of running monitoring workflows from every 3 minutes to every 10 minutes ([link](https://github.com/JesusFilm/core/pull/1971/files?diff=unified&w=0#diff-6ebb6c0e4b3d7ef471e243a660cdd004e11723b8c5beb396d711ebc8ff549b84L1-R4), [link](https://github.com/JesusFilm/core/pull/1971/files?diff=unified&w=0#diff-97c529c326c879b6114171cf1071b57440658f994deea51ec5a8142520cd3a49L1-R4), [link](https://github.com/JesusFilm/core/pull/1971/files?diff=unified&w=0#diff-6b820c54113274399c9e05362fefde862c50300d037f24e02b47508e1c5e10a5L1-R4))
*  Enable caching for npm dependencies in monitoring workflows to improve performance and reduce network traffic ([link](https://github.com/JesusFilm/core/pull/1971/files?diff=unified&w=0#diff-6ebb6c0e4b3d7ef471e243a660cdd004e11723b8c5beb396d711ebc8ff549b84R14), [link](https://github.com/JesusFilm/core/pull/1971/files?diff=unified&w=0#diff-97c529c326c879b6114171cf1071b57440658f994deea51ec5a8142520cd3a49R14), [link](https://github.com/JesusFilm/core/pull/1971/files?diff=unified&w=0#diff-6b820c54113274399c9e05362fefde862c50300d037f24e02b47508e1c5e10a5R14))
