### PR TITLE
chore: add loading state to templates library

### DIFF
--- a/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilter.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilter.stories.tsx
@@ -1,8 +1,9 @@
-import { MockedProvider } from '@apollo/client/testing'
+import { MockedResponse } from '@apollo/client/testing'
 import { Meta, StoryObj } from '@storybook/react'
 import noop from 'lodash/noop'
 import { ComponentProps } from 'react'
 
+import { GetLanguages } from '../../../../__generated__/GetLanguages'
 import { journeysAdminConfig } from '../../../libs/storybook'
 import { GET_LANGUAGES } from '../../Editor/EditToolbar/Menu/LanguageMenuItem/LanguageDialog'
 
@@ -14,69 +15,63 @@ const LanguageFilterStory: Meta<typeof LanguageFilter> = {
   title: 'Journeys-Admin/TemplateGallery/LanguageFilter'
 }
 
-const Template: StoryObj<ComponentProps<typeof LanguageFilter>> = {
-  render: ({ ...args }) => (
-    <MockedProvider
-      mocks={[
+const getLanguagesMock: MockedResponse<GetLanguages> = {
+  request: {
+    query: GET_LANGUAGES
+  },
+  result: {
+    data: {
+      languages: [
         {
-          request: {
-            query: GET_LANGUAGES
-          },
-          result: {
-            data: {
-              languages: [
-                {
-                  __typename: 'Language',
-                  id: '529',
-                  name: [
-                    {
-                      value: 'English',
-                      primary: true,
-                      __typename: 'Translation'
-                    }
-                  ]
-                },
-                {
-                  id: '496',
-                  __typename: 'Language',
-                  name: [
-                    {
-                      value: 'Français',
-                      primary: true,
-                      __typename: 'Translation'
-                    },
-                    {
-                      value: 'French',
-                      primary: false,
-                      __typename: 'Translation'
-                    }
-                  ]
-                },
-                {
-                  id: '1106',
-                  __typename: 'Language',
-                  name: [
-                    {
-                      value: 'Deutsch',
-                      primary: true,
-                      __typename: 'Translation'
-                    },
-                    {
-                      value: 'German, Standard',
-                      primary: false,
-                      __typename: 'Translation'
-                    }
-                  ]
-                }
-              ]
+          __typename: 'Language',
+          id: '529',
+          name: [
+            {
+              value: 'English',
+              primary: true,
+              __typename: 'Translation'
             }
-          }
+          ]
+        },
+        {
+          id: '496',
+          __typename: 'Language',
+          name: [
+            {
+              value: 'Français',
+              primary: true,
+              __typename: 'Translation'
+            },
+            {
+              value: 'French',
+              primary: false,
+              __typename: 'Translation'
+            }
+          ]
+        },
+        {
+          id: '1106',
+          __typename: 'Language',
+          name: [
+            {
+              value: 'Deutsch',
+              primary: true,
+              __typename: 'Translation'
+            },
+            {
+              value: 'German, Standard',
+              primary: false,
+              __typename: 'Translation'
+            }
+          ]
         }
-      ]}
-    >
-      <LanguageFilter {...args} />
-    </MockedProvider>
-  )
+      ]
+    }
+  }
+}
+
+const Template: StoryObj<ComponentProps<typeof LanguageFilter>> = {
+  render: ({ ...args }) => <LanguageFilter {...args} />
 }
 
 export const Default = {
@@ -84,6 +79,24 @@ export const Default = {
   args: {
     languageId: '529',
     onChange: noop
+  },
+  parameters: {
+    apolloClient: {
+      mocks: [getLanguagesMock]
+    }
+  }
+}
+
+export const Loading = {
+  ...Template,
+  args: {
+    languageId: '529',
+    onChange: noop
+  },
+  parameters: {
+    apolloClient: {
+      mocks: [{ ...getLanguagesMock, delay: 100000000000000 }]
+    }
   }
 }
 

--- a/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilter.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilter.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@apollo/client'
 import Button from '@mui/material/Button'
+import Skeleton from '@mui/material/Skeleton'
 import Typography from '@mui/material/Typography'
 import { ReactElement, useState } from 'react'
 
@@ -51,7 +52,7 @@ export function LanguageFilter({
             overflow: 'hidden'
           }}
         >
-          {localName ?? nativeName}
+          {loading ? <Skeleton width={61} /> : localName ?? nativeName}
         </Typography>
       </Button>
       <LanguageFilterDialog

--- a/apps/journeys-admin/src/components/TemplateGallery/TagsFilter/TagsFilter.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagsFilter/TagsFilter.tsx
@@ -3,6 +3,7 @@ import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank'
 import Autocomplete from '@mui/material/Autocomplete'
 import Box from '@mui/material/Box'
 import Checkbox from '@mui/material/Checkbox'
+import CircularProgress from '@mui/material/CircularProgress'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import compact from 'lodash/compact'
@@ -24,7 +25,7 @@ export function TagsFilter({
   selectedTagIds,
   onChange
 }: TagsFilterProps): ReactElement {
-  const { parentTags, childTags } = useTagsQuery()
+  const { parentTags, childTags, loading } = useTagsQuery()
   const filteredParentTagIds = compact(
     tagNames.map((tagName) => {
       return parentTags.find(({ name }) =>
@@ -63,6 +64,7 @@ export function TagsFilter({
   return (
     <Box sx={{ width: '100%' }}>
       <Autocomplete
+        loading={loading}
         disableCloseOnSelect
         value={filteredSelectedTags}
         onChange={handleChange}
@@ -71,7 +73,23 @@ export function TagsFilter({
         getOptionLabel={(option) =>
           option.name.find(({ primary }) => primary)?.value ?? ''
         }
-        renderInput={(params) => <TextField {...params} label={label} />}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label={label}
+            InputProps={{
+              ...params.InputProps,
+              endAdornment: (
+                <>
+                  {loading ? (
+                    <CircularProgress color="inherit" size={20} />
+                  ) : null}
+                  {params.InputProps.endAdornment}
+                </>
+              )
+            }}
+          />
+        )}
         renderGroup={(params) => (
           <li key={params.key}>
             {tagNames.length > 1 && (

--- a/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.spec.tsx
@@ -2,7 +2,7 @@ import { MockedProvider } from '@apollo/client/testing'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { NextRouter, useRouter } from 'next/router'
 
-import { TemplateGalleryMock } from './data'
+import { getJourneysMock, getLanguagesMock, getTagsMock } from './data'
 
 import { TemplateGallery } from '.'
 
@@ -25,7 +25,7 @@ const mockedUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
 describe('TemplateGallery', () => {
   it('should render TemplateGallery', async () => {
     const { getByRole } = render(
-      <MockedProvider mocks={TemplateGalleryMock}>
+      <MockedProvider mocks={[getJourneysMock, getLanguagesMock, getTagsMock]}>
         <TemplateGallery />
       </MockedProvider>
     )
@@ -47,7 +47,7 @@ describe('TemplateGallery', () => {
     } as unknown as NextRouter)
 
     const { getByRole, queryByRole } = render(
-      <MockedProvider mocks={TemplateGalleryMock}>
+      <MockedProvider mocks={[getJourneysMock, getLanguagesMock, getTagsMock]}>
         <TemplateGallery />
       </MockedProvider>
     )

--- a/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.stories.tsx
@@ -1,11 +1,10 @@
-import { MockedProvider } from '@apollo/client/testing'
 import Box from '@mui/material/Box'
 import { Meta, StoryObj } from '@storybook/react'
 import { ComponentProps } from 'react'
 
 import { journeysAdminConfig } from '../../libs/storybook'
 
-import { TemplateGalleryMock } from './data'
+import { getJourneysMock, getLanguagesMock, getTagsMock } from './data'
 
 import { TemplateGallery } from '.'
 
@@ -20,22 +19,38 @@ const TemplateGalleryStory: Meta<typeof TemplateGallery> = {
 
 const Template: StoryObj<ComponentProps<typeof TemplateGallery>> = {
   render: () => (
-    <MockedProvider mocks={TemplateGalleryMock}>
-      <Box
-        sx={{
-          backgroundColor: 'background.paper',
-          p: 5,
-          height: '100%'
-        }}
-      >
-        <TemplateGallery />
-      </Box>
-    </MockedProvider>
+    <Box
+      sx={{
+        backgroundColor: 'background.paper',
+        p: 5,
+        height: '100%'
+      }}
+    >
+      <TemplateGallery />
+    </Box>
   )
 }
 
 export const Default = {
-  ...Template
+  ...Template,
+  parameters: {
+    apolloClient: {
+      mocks: [getJourneysMock, getLanguagesMock, getTagsMock]
+    }
+  }
+}
+
+export const Loading = {
+  ...Template,
+  parameters: {
+    apolloClient: {
+      mocks: [
+        { ...getJourneysMock, delay: 100000000000000 },
+        { ...getLanguagesMock, delay: 100000000000000 },
+        { ...getTagsMock, delay: 100000000000000 }
+      ]
+    }
+  }
 }
 
 export default TemplateGalleryStory

--- a/apps/journeys-admin/src/components/TemplateGallery/data.ts
+++ b/apps/journeys-admin/src/components/TemplateGallery/data.ts
@@ -1,7 +1,13 @@
+import { MockedResponse } from '@apollo/client/testing'
+
 import {
+  GetJourneys,
+  GetJourneysVariables,
   GetJourneys_journeys as Journey,
   GetJourneys_journeys_tags as Tag
 } from '../../../__generated__/GetJourneys'
+import { GetLanguages } from '../../../__generated__/GetLanguages'
+import { GetTags } from '../../../__generated__/GetTags'
 import {
   JourneyStatus,
   Service,
@@ -152,123 +158,129 @@ const journeys: Journey[] = [
   }
 ]
 
-export const TemplateGalleryMock = [
-  {
-    request: {
-      query: GET_JOURNEYS,
-      variables: {
-        where: {
-          template: true,
-          orderByRecent: true,
-          languageIds: ['529']
-        }
-      }
-    },
-    result: {
-      data: {
-        journeys
+export const getJourneysMock: MockedResponse<
+  GetJourneys,
+  GetJourneysVariables
+> = {
+  request: {
+    query: GET_JOURNEYS,
+    variables: {
+      where: {
+        template: true,
+        orderByRecent: true,
+        languageIds: ['529']
       }
     }
   },
-  {
-    request: {
-      query: GET_LANGUAGES
-    },
-    result: {
-      data: {
-        languages: [
-          {
-            __typename: 'Language',
-            id: '529',
-            name: [
-              {
-                value: 'English',
-                primary: true,
-                __typename: 'Translation'
-              }
-            ]
-          },
-          {
-            id: '496',
-            __typename: 'Language',
-            name: [
-              {
-                value: 'Français',
-                primary: true,
-                __typename: 'Translation'
-              },
-              {
-                value: 'French',
-                primary: false,
-                __typename: 'Translation'
-              }
-            ]
-          },
-          {
-            id: '1106',
-            __typename: 'Language',
-            name: [
-              {
-                value: 'Deutsch',
-                primary: true,
-                __typename: 'Translation'
-              },
-              {
-                value: 'German, Standard',
-                primary: false,
-                __typename: 'Translation'
-              }
-            ]
-          }
-        ]
-      }
-    }
-  },
-  {
-    request: {
-      query: GET_TAGS
-    },
-    result: {
-      data: {
-        tags: [
-          {
-            __typename: 'Tag',
-            id: 'parentId1',
-            service: Service.apiJourneys,
-            parentId: null,
-            name: [
-              {
-                value: 'Felt Needs',
-                primary: true
-              }
-            ]
-          },
-          {
-            __typename: 'Tag',
-            id: 'acceptanceTagId',
-            service: Service.apiJourneys,
-            parentId: 'parentId1',
-            name: [
-              {
-                value: 'Acceptance',
-                primary: true
-              }
-            ]
-          },
-          {
-            __typename: 'Tag',
-            id: 'addictionTagId',
-            service: Service.apiJourneys,
-            parentId: 'parentId1',
-            name: [
-              {
-                value: 'Addiction',
-                primary: true
-              }
-            ]
-          }
-        ]
-      }
+  result: {
+    data: {
+      journeys
     }
   }
-]
+}
+
+export const getLanguagesMock: MockedResponse<GetLanguages> = {
+  request: {
+    query: GET_LANGUAGES
+  },
+  result: {
+    data: {
+      languages: [
+        {
+          __typename: 'Language',
+          id: '529',
+          name: [
+            {
+              value: 'English',
+              primary: true,
+              __typename: 'Translation'
+            }
+          ]
+        },
+        {
+          id: '496',
+          __typename: 'Language',
+          name: [
+            {
+              value: 'Français',
+              primary: true,
+              __typename: 'Translation'
+            },
+            {
+              value: 'French',
+              primary: false,
+              __typename: 'Translation'
+            }
+          ]
+        },
+        {
+          id: '1106',
+          __typename: 'Language',
+          name: [
+            {
+              value: 'Deutsch',
+              primary: true,
+              __typename: 'Translation'
+            },
+            {
+              value: 'German, Standard',
+              primary: false,
+              __typename: 'Translation'
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+
+export const getTagsMock: MockedResponse<GetTags> = {
+  request: {
+    query: GET_TAGS
+  },
+  result: {
+    data: {
+      tags: [
+        {
+          __typename: 'Tag',
+          id: 'parentId1',
+          service: Service.apiJourneys,
+          parentId: null,
+          name: [
+            {
+              __typename: 'Translation',
+              value: 'Felt Needs',
+              primary: true
+            }
+          ]
+        },
+        {
+          __typename: 'Tag',
+          id: 'acceptanceTagId',
+          service: Service.apiJourneys,
+          parentId: 'parentId1',
+          name: [
+            {
+              __typename: 'Translation',
+              value: 'Acceptance',
+              primary: true
+            }
+          ]
+        },
+        {
+          __typename: 'Tag',
+          id: 'addictionTagId',
+          service: Service.apiJourneys,
+          parentId: 'parentId1',
+          name: [
+            {
+              __typename: 'Translation',
+              value: 'Addiction',
+              primary: true
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/apps/journeys-admin/src/components/TemplateSections/TemplateSection/TemplateSection.tsx
+++ b/apps/journeys-admin/src/components/TemplateSections/TemplateSection/TemplateSection.tsx
@@ -16,11 +16,13 @@ SwiperCore.use([Navigation, A11y, Virtual])
 interface TemplateSectionProps {
   journeys?: Journeys[]
   category: string
+  loading?: boolean
 }
 
 export function TemplateSection({
   journeys,
-  category
+  category,
+  loading
 }: TemplateSectionProps): ReactElement {
   const { breakpoints } = useTheme()
   const nextRef = useRef<HTMLButtonElement>(null)
@@ -60,7 +62,8 @@ export function TemplateSection({
 
   return (
     <Stack spacing={4} justifyContent="center" sx={{ position: 'relative' }}>
-      {journeys == null && (
+      <Typography variant="h5">{category}</Typography>
+      {loading === true && (journeys === null || journeys?.length === 0) && (
         <Swiper breakpoints={swiperBreakpoints}>
           <SwiperSlide>
             <TemplateGalleryCard />
@@ -89,30 +92,26 @@ export function TemplateSection({
         </Swiper>
       )}
       {journeys != null && (
-        <>
-          <Typography variant="h5">{category}</Typography>
-          <Swiper
-            autoHeight
-            speed={850}
-            watchOverflow
-            breakpoints={swiperBreakpoints}
-            navigation={{
-              nextEl: nextRef.current,
-              prevEl: prevRef.current
-            }}
-            virtual
-            style={{ overflow: 'visible' }}
-          >
-            {journeys?.map((journey) => (
-              <SwiperSlide
-                key={journey?.id}
-                data-testId={`journey-${journey.id}`}
-              >
-                <TemplateGalleryCard journey={journey} />
-              </SwiperSlide>
-            ))}
-          </Swiper>
-        </>
+        <Swiper
+          autoHeight
+          speed={850}
+          watchOverflow
+          breakpoints={swiperBreakpoints}
+          navigation={{
+            nextEl: nextRef.current,
+            prevEl: prevRef.current
+          }}
+          style={{ overflow: 'visible' }}
+        >
+          {journeys?.map((journey) => (
+            <SwiperSlide
+              key={journey?.id}
+              data-testId={`journey-${journey.id}`}
+            >
+              <TemplateGalleryCard journey={journey} />
+            </SwiperSlide>
+          ))}
+        </Swiper>
       )}
       <NavButton variant="prev" ref={prevRef} disabled={journeys == null} />
       <NavButton variant="next" ref={nextRef} disabled={journeys == null} />

--- a/apps/journeys-admin/src/components/TemplateSections/TemplateSections.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateSections/TemplateSections.spec.tsx
@@ -213,11 +213,11 @@ describe('TemplateSections', () => {
       )
       await waitFor(() =>
         expect(
-          getByRole('heading', { name: 'Featured & New' })
+          getAllByRole('heading', { name: 'Featured Template 2' })[0]
         ).toBeInTheDocument()
       )
       expect(
-        getAllByRole('heading', { name: 'Featured Template 2' })[0]
+        getByRole('heading', { name: 'Featured & New' })
       ).toBeInTheDocument()
       expect(getByRole('heading', { name: 'Acceptance' })).toBeInTheDocument()
     })
@@ -232,11 +232,11 @@ describe('TemplateSections', () => {
       )
       await waitFor(() =>
         expect(
-          getByRole('heading', { name: 'Most Relevant' })
+          getAllByRole('heading', { name: 'Featured Template 2' })[0]
         ).toBeInTheDocument()
       )
       expect(
-        getAllByRole('heading', { name: 'Featured Template 2' })[0]
+        getByRole('heading', { name: 'Most Relevant' })
       ).toBeInTheDocument()
       expect(getByRole('heading', { name: 'Addiction' })).toBeInTheDocument()
     })

--- a/apps/journeys-admin/src/components/TemplateSections/TemplateSections.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateSections/TemplateSections.stories.tsx
@@ -236,6 +236,18 @@ export const Default = {
   }
 }
 
+export const Loading = {
+  ...Template,
+  args: {
+    languageId: '529'
+  },
+  parameters: {
+    apolloClient: {
+      mocks: [{ ...getJourneysMock, delay: 100000000000000 }]
+    }
+  }
+}
+
 export const TagIds = {
   ...Template,
   args: {

--- a/apps/journeys-admin/src/components/TemplateSections/TemplateSections.tsx
+++ b/apps/journeys-admin/src/components/TemplateSections/TemplateSections.tsx
@@ -66,10 +66,11 @@ export function TemplateSections({
 
   return (
     <Stack spacing={8}>
-      {collection.length > 0 && (
+      {(loading || (data?.journeys != null && data.journeys.length > 0)) && (
         <TemplateSection
           category={tagIds == null ? t('Featured & New') : t('Most Relevant')}
           journeys={collection}
+          loading={loading}
         />
       )}
       {map(


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2652f49</samp>

Improved the loading states and mock data for the template gallery and template sections components in the journeys-admin app. Refactored the storybook and test files to use more realistic and readable mock data and apolloClient. Added loading indicators and skeletons to the `LanguageFilter`, `TagsFilter`, `TemplateSection`, and `TemplateSections` components. Removed unused `TemplateGalleryMock` from `data.ts`.

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2652f49</samp>

*  Add imports of types for mock responses and extract mock data into separate variables in `data.ts` ([link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-461e699710c126f7bf1f072280fa046f6dff3ff6be258b9cf0b58563d6fb493eL1-R10), [link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-461e699710c126f7bf1f072280fa046f6dff3ff6be258b9cf0b58563d6fb493eL155-R286))
*  Remove `MockedProvider` import and use `apolloClient` parameter with mock data in `LanguageFilter.stories.tsx` ([link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-d50c567ead59aeb4c296b572a6dd18e60640399a414939401f983f17683054a2L1-R6), [link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-d50c567ead59aeb4c296b572a6dd18e60640399a414939401f983f17683054a2L87-R102))
*  Extract mock data for `GET_LANGUAGES` query into `getLanguagesMock` variable in `LanguageFilter.stories.tsx` ([link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-d50c567ead59aeb4c296b572a6dd18e60640399a414939401f983f17683054a2L17-R76))
*  Add `Skeleton` import and conditionally render it for language name while loading in `LanguageFilter.tsx` ([link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-13372d81b3e76e196f12415e5cd0054ddb13daeb2cef1392e047609e4ac89a92R3), [link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-13372d81b3e76e196f12415e5cd0054ddb13daeb2cef1392e047609e4ac89a92L54-R55))
*  Add `CircularProgress` import and pass `loading` value to `Autocomplete` component in `TagsFilter.tsx` ([link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-390bfe94b6b7b566e0193b33dd20834171cc45285f92c73c6cc205e3dbaf9f04R6), [link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-390bfe94b6b7b566e0193b33dd20834171cc45285f92c73c6cc205e3dbaf9f04R67))
*  Add `CircularProgress` component as `endAdornment` for tags input while loading in `TagsFilter.tsx` ([link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-390bfe94b6b7b566e0193b33dd20834171cc45285f92c73c6cc205e3dbaf9f04L74-R92))
*  Add imports of mock data variables and use them as mocks for `MockedProvider` in `TemplateGallery.spec.tsx` ([link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-c2bf36c73693c861631661eb0b80f468b388a2b6256b82c32b676fd37011a1acL5-R5), [link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-c2bf36c73693c861631661eb0b80f468b388a2b6256b82c32b676fd37011a1acL28-R28), [link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-c2bf36c73693c861631661eb0b80f468b388a2b6256b82c32b676fd37011a1acL50-R50))
*  Remove `MockedProvider` import and use `apolloClient` parameter with mock data in `TemplateGallery.stories.tsx` ([link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-5e95ed0722c4d1b8faa89d49caf41231b0be3568772f61cf3a322410d22ba7b7L1), [link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-5e95ed0722c4d1b8faa89d49caf41231b0be3568772f61cf3a322410d22ba7b7L23-R55))
*  Add optional `loading` prop to `TemplateSectionProps` interface in `TemplateSection.tsx` ([link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-0016fcb7bad744aecc9ef2abfad388fd2d490ec024dc331c2800e4f4bd2069b0L19-R25))
*  Conditionally render category name and pass `loading` prop to `TemplateCard` component in `TemplateSection.tsx` ([link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-0016fcb7bad744aecc9ef2abfad388fd2d490ec024dc331c2800e4f4bd2069b0L63-R66), [link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-0016fcb7bad744aecc9ef2abfad388fd2d490ec024dc331c2800e4f4bd2069b0L92-R114))
*  Fix order of assertions for `Featured & New` and `Most Relevant` sections in `TemplateSection` test in `TemplateSections.spec.tsx` ([link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-5ba9a6b26c37d6b4ed740618400d541896323f0c68da3bf932e64fe73d2e8fd9L216-R220), [link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-5ba9a6b26c37d6b4ed740618400d541896323f0c68da3bf932e64fe73d2e8fd9L235-R239))
*  Add `Loading` story for `TemplateSections` with delayed mock response in `TemplateSections.stories.tsx` ([link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-a8df0dbccc05494a8cf4897c19491e20d422103f214e396b9af94a836422cb6dR239-R250))
*  Conditionally render `TemplateSection` components and pass `loading` value to them in `TemplateSections.tsx` ([link](https://github.com/JesusFilm/core/pull/1975/files?diff=unified&w=0#diff-8528e7b4c06335c3a765fccde78d68fff718a8b69d7384bea6782deeb45efb8aL69-R73))
