### PR TITLE
feat: collections button

### DIFF
--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCollectionsButton/TemplateCollectionsButton.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCollectionsButton/TemplateCollectionsButton.spec.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, waitFor } from '@testing-library/react'
+
+import { JourneyFields_tags as Tag } from '../../../../../__generated__/JourneyFields'
+
+import { TemplateCollectionsButton } from './TemplateCollectionsButton'
+import { NextRouter, useRouter } from 'next/router'
+
+jest.mock('next/router', () => ({
+  __esModule: true,
+  useRouter: jest.fn()
+}))
+
+const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
+
+describe('TemplateCollectionsButton', () => {
+  const mockTag: Tag = {
+    __typename: 'Tag',
+    id: 'a6b0080c-d2a5-4b92-945a-8e044c743139',
+    parentId: 'eff2c8a5-64d3-4f20-916d-270ff9ad5813',
+    name: [
+      {
+        __typename: 'Translation',
+        value: 'Jesus Film',
+        language: {
+          __typename: 'Language',
+          id: '529'
+        },
+        primary: true
+      }
+    ]
+  }
+  let push: jest.Mock
+  beforeEach(() => {
+    push = jest.fn()
+
+    mockUseRouter.mockReturnValue({
+      push,
+      query: { redirect: null }
+    } as unknown as NextRouter)
+  })
+
+  it('should redirect user to templates page with tagId of collection', async () => {
+    mockUseRouter.mockReturnValue({
+      push
+    } as unknown as NextRouter)
+    const { getByRole } = render(<TemplateCollectionsButton tag={mockTag} />)
+
+    fireEvent.click(getByRole('button'))
+    await waitFor(() =>
+      expect(push).toHaveBeenCalledWith({
+        pathname: '/templates',
+        query: { tagIds: 'a6b0080c-d2a5-4b92-945a-8e044c743139' }
+      })
+    )
+  })
+})

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCollectionsButton/TemplateCollectionsButton.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCollectionsButton/TemplateCollectionsButton.stories.tsx
@@ -1,0 +1,42 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { JourneyFields_tags as Tag } from '../../../../../__generated__/JourneyFields'
+import { journeysAdminConfig } from '../../../../libs/storybook'
+
+import { TemplateCollectionsButton } from './TemplateCollectionsButton'
+
+const TemplateCollectionsButtonStory: Meta<typeof TemplateCollectionsButton> = {
+  ...journeysAdminConfig,
+  title: 'Journeys-Admin/TemplateView/TemplateHeader/TemplateCollectionsButton',
+  component: TemplateCollectionsButton
+}
+
+const mockTag: Tag = {
+  __typename: 'Tag',
+  id: 'a6b0080c-d2a5-4b92-945a-8e044c743139',
+  parentId: 'eff2c8a5-64d3-4f20-916d-270ff9ad5813',
+  name: [
+    {
+      __typename: 'Translation',
+      value: 'Jesus Film',
+      language: {
+        __typename: 'Language',
+        id: '529'
+      },
+      primary: true
+    }
+  ]
+}
+
+const Template: StoryObj<typeof TemplateCollectionsButton> = {
+  render: (args) => <TemplateCollectionsButton tag={args.tag} />
+}
+
+export const Default = {
+  ...Template,
+  args: {
+    tag: { ...mockTag }
+  }
+}
+
+export default TemplateCollectionsButtonStory

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCollectionsButton/TemplateCollectionsButton.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCollectionsButton/TemplateCollectionsButton.tsx
@@ -1,0 +1,60 @@
+import Button from '@mui/material/Button'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { useRouter } from 'next/router'
+import { ReactElement } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { JourneyFields_tags as Tags } from '../../../../../__generated__/JourneyFields'
+
+interface TemplateCollectionsButtonProps {
+  tag: Tags
+}
+
+export function TemplateCollectionsButton({
+  tag
+}: TemplateCollectionsButtonProps): ReactElement {
+  const router = useRouter()
+  const { t } = useTranslation('apps-journeys-admin')
+  return (
+    <Stack direction="row" alignItems="center">
+      <Typography
+        variant="overline"
+        sx={{
+          color: 'secondary.light',
+          '&:first-of-type': {
+            display: { xs: 'none', sm: 'flex' }
+          },
+          flex: 'none',
+          mt: { xs: -2, sm: 0 },
+          pl: { xs: '5px', sm: 0 },
+          pr: { xs: '3px', sm: 0 }
+        }}
+        noWrap
+      >
+        {'\u00B7'}
+      </Typography>
+      <Button
+        size="small"
+        variant="text"
+        onClick={async () =>
+          await router.push({
+            pathname: '/templates',
+            query: { tagIds: tag?.id }
+          })
+        }
+        sx={{
+          color: 'primary.main',
+          minWidth: 0,
+          p: { xs: 0, sm: 1 },
+          mt: { xs: -1, sm: 0 },
+          flex: 'none'
+        }}
+      >
+        {t('{{ collectionsName }}', {
+          collectionsName: tag?.name[0]?.value
+        })}
+      </Button>
+    </Stack>
+  )
+}

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCollectionsButton/index.ts
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCollectionsButton/index.ts
@@ -1,0 +1,1 @@
+export { TemplateCollectionsButton } from './TemplateCollectionsButton'

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateViewHeader.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateViewHeader.spec.tsx
@@ -5,7 +5,10 @@ import { SnackbarProvider } from 'notistack'
 
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 
-import { JourneyFields_primaryImageBlock as PrimaryImageBlock } from '../../../../__generated__/JourneyFields'
+import {
+  JourneyFields as Journey,
+  JourneyFields_primaryImageBlock as PrimaryImageBlock
+} from '../../../../__generated__/JourneyFields'
 import { journey } from '../../Editor/ActionDetails/data'
 
 import { TemplateViewHeader } from './TemplateViewHeader'
@@ -175,5 +178,87 @@ describe('TemplateViewHeader', () => {
     expect(
       getAllByTestId('featuredAtTemplatePreviewPage')[0]
     ).toBeInTheDocument()
+  })
+
+  it('should show collections buttons if part of a collection', () => {
+    const { getAllByTestId } = render(
+      <MockedProvider>
+        <JourneyProvider
+          value={{
+            journey,
+            variant: 'admin'
+          }}
+        >
+          <TemplateViewHeader
+            isPublisher={false}
+            authUser={{} as unknown as User}
+          />
+        </JourneyProvider>
+      </MockedProvider>
+    )
+
+    expect(
+      getAllByTestId('featuredAtTemplatePreviewPage')[0]
+    ).toBeInTheDocument()
+  })
+
+  it('should render collections button', async () => {
+    const journeyWithTags = {
+      ...journey,
+      tags: [
+        {
+          __typename: 'Tag',
+          id: 'a6b0080c-d2a5-4b92-945a-8e044c743139',
+          parentId: 'eff2c8a5-64d3-4f20-916d-270ff9ad5813',
+          name: [
+            {
+              __typename: 'Translation',
+              value: 'Jesus Film',
+              language: {
+                __typename: 'Language',
+                id: '529'
+              },
+              primary: true
+            }
+          ]
+        },
+        {
+          __typename: 'Tag',
+          id: 'eff2c8a5-64d3-4f20-916d-270ff9ad5813',
+          parentId: null,
+          name: [
+            {
+              __typename: 'Translation',
+              value: 'Collections',
+              language: {
+                __typename: 'Language',
+                id: '529'
+              },
+              primary: true
+            }
+          ]
+        }
+      ]
+    }
+
+    const { getAllByRole } = render(
+      <MockedProvider>
+        <JourneyProvider
+          value={{
+            journey: journeyWithTags as Journey,
+            variant: 'admin'
+          }}
+        >
+          <TemplateViewHeader
+            isPublisher={false}
+            authUser={{} as unknown as User}
+          />
+        </JourneyProvider>
+      </MockedProvider>
+    )
+
+    expect(
+      getAllByRole('button', { name: '{{ collectionsName }}' })
+    ).toHaveLength(2)
   })
 })

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateViewHeader.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateViewHeader.stories.tsx
@@ -70,6 +70,50 @@ export const Publisher = {
   }
 }
 
+export const WithTags = {
+  ...Template,
+  args: {
+    ...Default.args,
+    journey: {
+      ...Default.args.journey,
+      tags: [
+        {
+          __typename: 'Tag',
+          id: 'a6b0080c-d2a5-4b92-945a-8e044c743139',
+          parentId: 'eff2c8a5-64d3-4f20-916d-270ff9ad5813',
+          name: [
+            {
+              __typename: 'Translation',
+              value: 'Jesus Film',
+              language: {
+                __typename: 'Language',
+                id: '529'
+              },
+              primary: true
+            }
+          ]
+        },
+        {
+          __typename: 'Tag',
+          id: 'eff2c8a5-64d3-4f20-916d-270ff9ad5813',
+          parentId: null,
+          name: [
+            {
+              __typename: 'Translation',
+              value: 'Collections',
+              language: {
+                __typename: 'Language',
+                id: '529'
+              },
+              primary: true
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+
 export const EmptyImage = {
   ...Template,
   args: {

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateViewHeader.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateViewHeader.tsx
@@ -9,10 +9,12 @@ import { ReactElement } from 'react'
 
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 
+import { JourneyFields_tags as Tag } from '../../../../__generated__/JourneyFields'
 import { SocialImage } from '../../JourneyView/SocialImage'
 import { CreateJourneyButton } from '../CreateJourneyButton'
 
 import { PreviewTemplateButton } from './PreviewTemplateButton'
+import { TemplateCollectionsButton } from './TemplateCollectionsButton'
 import { TemplateEditButton } from './TemplateEditButton/TemplateEditButton'
 
 interface TemplateViewHeaderProps {
@@ -27,24 +29,36 @@ export function TemplateViewHeader({
   const { journey } = useJourney()
   const smUp = useMediaQuery((theme: Theme) => theme.breakpoints.up('sm'))
 
+  let collectionTags: Tag[] | undefined
+  const collectionsId = journey?.tags.find(
+    (item) => item.name[0].value === 'Collections'
+  )?.id
+  if (collectionsId != null) {
+    collectionTags = journey?.tags.filter(
+      (tag) => tag.parentId === collectionsId
+    )
+  }
+
   return (
     <Stack>
       {journey?.createdAt != null && (
-        <Typography
-          data-testId="featuredAtTemplatePreviewPage"
-          variant="overline"
-          sx={{
-            color: 'secondary.light',
-            display: { xs: 'block', sm: 'none' },
-            pb: 6
-          }}
-          noWrap
-        >
-          {intlFormat(parseISO(journey?.createdAt), {
-            month: 'long',
-            year: 'numeric'
-          })}
-        </Typography>
+        <>
+          <Typography
+            data-testId="featuredAtTemplatePreviewPage"
+            variant="overline"
+            sx={{
+              color: 'secondary.light',
+              display: { xs: 'block', sm: 'none' },
+              pb: 6
+            }}
+            noWrap
+          >
+            {intlFormat(parseISO(journey?.createdAt), {
+              month: 'long',
+              year: 'numeric'
+            })}
+          </Typography>
+        </>
       )}
       <Stack direction="row" sx={{ gap: { xs: 4, sm: 6 } }}>
         <Box
@@ -62,24 +76,59 @@ export function TemplateViewHeader({
           }}
         >
           {journey?.createdAt != null && (
-            <Typography
-              variant="overline"
+            <Stack
+              direction="row"
+              alignItems="center"
               sx={{
-                color: 'secondary.light',
-                display: { xs: 'none', sm: 'block' }
+                mt: collectionTags != null ? -2 : 0,
+                display: { xs: 'none', sm: 'flex' }
               }}
-              data-testId="featuredAtTemplatePreviewPage"
-              noWrap
             >
-              {intlFormat(parseISO(journey?.createdAt), {
-                month: 'long',
-                year: 'numeric'
-              })}
-            </Typography>
+              <Typography
+                variant="overline"
+                sx={{
+                  color: 'secondary.light',
+                  pr: '5px'
+                }}
+                data-testId="featuredAtTemplatePreviewPage"
+                noWrap
+              >
+                {intlFormat(parseISO(journey?.createdAt), {
+                  month: 'long',
+                  year: 'numeric'
+                })}
+              </Typography>
+              {collectionTags != null && collectionTags.length > 0 && (
+                <>
+                  {collectionTags.map((tag) => (
+                    <TemplateCollectionsButton tag={tag} key={tag.id} />
+                  ))}
+                </>
+              )}
+            </Stack>
           )}
-          <Typography variant={smUp ? 'h1' : 'h6'} sx={{ pb: 4 }}>
-            {journey?.title}
-          </Typography>
+          <Stack>
+            {collectionTags != null && collectionTags.length > 0 && (
+              <Stack
+                direction="row"
+                sx={{
+                  display: {
+                    xs: 'flex',
+                    sm: 'none',
+                    alignItems: 'center',
+                    flexWrap: 'wrap'
+                  }
+                }}
+              >
+                {collectionTags.map((tag) => (
+                  <TemplateCollectionsButton tag={tag} key={tag.id} />
+                ))}
+              </Stack>
+            )}
+            <Typography variant={smUp ? 'h1' : 'h6'} sx={{ pb: 4, mt: 'auto' }}>
+              {journey?.title}
+            </Typography>
+          </Stack>
           <Box
             sx={{
               maxHeight: '144px',
@@ -100,7 +149,7 @@ export function TemplateViewHeader({
               display: { xs: 'none', sm: 'flex' },
               gap: 4,
               pt: 4,
-              marginTop: 'auto'
+              mt: 'auto'
             }}
           >
             <CreateJourneyButton signedIn={authUser?.id != null} />


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at de04401</samp>

This pull request adds a new feature to the `TemplateViewHeader` component that allows users to view templates by collection tags. It also adds tests, stories and a new subcomponent (`TemplateCollectionsButton`) to support this feature. Additionally, it fixes a minor styling issue and updates an import statement in the `TemplateViewHeader` component.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34356579/todos/6671152748)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] it should show collections if journey has collections tags
- [ ] it should redirect to gallery page with appropriate collections filter applied when clicked

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at de04401</samp>

*  Add a new component, `TemplateCollectionsButton`, that allows users to navigate to templates that belong to a certain collection tag ([link](https://github.com/JesusFilm/core/pull/1978/files?diff=unified&w=0#diff-ed7ad33d0d5fcf9cb2c8b95a4bd1152c98dff2447c92425f4d0defa5fc6f9b9cR1-R60), [link](https://github.com/JesusFilm/core/pull/1978/files?diff=unified&w=0#diff-fd7e4e8f5ddb552f6844a172d6588b616bcbf2366d5d61aed29523f40ba09ca0R1))
*  Add tests and stories for the new component, using mock data and hooks ([link](https://github.com/JesusFilm/core/pull/1978/files?diff=unified&w=0#diff-3a11c8fc2646197801302a4f44e38a800eefcbbd5b463afc82e3a190dbc07919R1-R42), [link](https://github.com/JesusFilm/core/pull/1978/files?diff=unified&w=0#diff-3b1183baf10439321f105b92879dad82fef4d07708fc5234bb1cf7f90672bd04R1-R56))
*  Update the `TemplateViewHeader` component to import and render the new component, and to filter and display the collection tags from the journey object ([link](https://github.com/JesusFilm/core/pull/1978/files?diff=unified&w=0#diff-ee24d1185380438fa67baa8ace69d9cdfb3ae3e712ce48150234939ea8ea096bL12-R17), [link](https://github.com/JesusFilm/core/pull/1978/files?diff=unified&w=0#diff-ee24d1185380438fa67baa8ace69d9cdfb3ae3e712ce48150234939ea8ea096bL30-R61), [link](https://github.com/JesusFilm/core/pull/1978/files?diff=unified&w=0#diff-ee24d1185380438fa67baa8ace69d9cdfb3ae3e712ce48150234939ea8ea096bL65-R131))
*  Add tests and stories for the updated component, using mock data and providers ([link](https://github.com/JesusFilm/core/pull/1978/files?diff=unified&w=0#diff-a7f97c29bef72095eee7e677a39f5819efb129784d3bf53cd2171569d540b6ecL8-R11), [link](https://github.com/JesusFilm/core/pull/1978/files?diff=unified&w=0#diff-a7f97c29bef72095eee7e677a39f5819efb129784d3bf53cd2171569d540b6ecR182-R263), [link](https://github.com/JesusFilm/core/pull/1978/files?diff=unified&w=0#diff-d5a4410a9da4454f3b1d035291a6674078dbeb1d48708d12070d720ff8de326eR73-R116))
*  Fix a typo in the margin-top property of the `Stack` component that contains the buttons for previewing, editing and creating journeys ([link](https://github.com/JesusFilm/core/pull/1978/files?diff=unified&w=0#diff-ee24d1185380438fa67baa8ace69d9cdfb3ae3e712ce48150234939ea8ea096bL103-R152))
