### PR TITLE
fix: remove mousewheel scroll

### DIFF
--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.tsx
@@ -3,7 +3,7 @@ import 'swiper/swiper.min.css'
 import Box from '@mui/material/Box'
 import { useTheme } from '@mui/material/styles'
 import { ReactElement } from 'react'
-import SwiperCore, { A11y, Mousewheel, SwiperOptions } from 'swiper'
+import { SwiperOptions } from 'swiper'
 import { Swiper, SwiperSlide } from 'swiper/react'
 
 import { TreeBlock } from '@core/journeys/ui/block'
@@ -20,8 +20,6 @@ import { ThemeMode, ThemeName } from '../../../../../__generated__/globalTypes'
 import { CardWrapper } from '../../../CardPreview/CardList/CardWrapper'
 import { VideoWrapper } from '../../../Editor/Canvas/VideoWrapper'
 import { FramePortal } from '../../../FramePortal'
-
-SwiperCore.use([Mousewheel, A11y])
 
 interface TemplateCardPreviewProps {
   steps?: Array<TreeBlock<StepBlock>>
@@ -114,7 +112,6 @@ export function TemplateCardPreview({
       slidesPerView="auto"
       spaceBetween={12}
       breakpoints={swiperBreakpoints}
-      mousewheel
       autoHeight
       style={{
         overflow: 'visible',


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7955adb</samp>

Refactored `TemplateCardPreview` component to remove unnecessary swiper dependencies and improve accessibility. Simplified the code and the UI of the template card swiper.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34356579/todos/6667334832)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] it should not scroll template card preview with mousewheel

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7955adb</samp>

* Remove unnecessary imports and props for swiper functionality and accessibility ([link](https://github.com/JesusFilm/core/pull/1979/files?diff=unified&w=0#diff-89a406c95c26ccbfb9155819b7a64eb0357873b6f735f62df2036871c786fceaL6-R6), [link](https://github.com/JesusFilm/core/pull/1979/files?diff=unified&w=0#diff-89a406c95c26ccbfb9155819b7a64eb0357873b6f735f62df2036871c786fceaL24-L25), [link](https://github.com/JesusFilm/core/pull/1979/files?diff=unified&w=0#diff-89a406c95c26ccbfb9155819b7a64eb0357873b6f735f62df2036871c786fceaL117))
