### PR TITLE
fix: hide most relevant heading if no match

### DIFF
--- a/apps/journeys-admin/src/components/TemplateSections/TemplateSections.tsx
+++ b/apps/journeys-admin/src/components/TemplateSections/TemplateSections.tsx
@@ -28,7 +28,7 @@ export function TemplateSections({
   const [contents, setContents] = useState<Contents>({})
   const [collection, setCollection] = useState<Journey[]>([])
 
-  const { data, loading } = useJourneysQuery({
+  const { loading } = useJourneysQuery({
     variables: {
       where: {
         template: true,

--- a/apps/journeys-admin/src/components/TemplateSections/TemplateSections.tsx
+++ b/apps/journeys-admin/src/components/TemplateSections/TemplateSections.tsx
@@ -66,7 +66,7 @@ export function TemplateSections({
 
   return (
     <Stack spacing={8}>
-      {(loading || (data?.journeys != null && data.journeys.length > 0)) && (
+      {(loading || (collection != null && collection.length > 0)) && (
         <TemplateSection
           category={tagIds == null ? t('Featured & New') : t('Most Relevant')}
           journeys={collection}


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8e01c00</samp>

Refactored `TemplateSections` component to use filtered and sorted journeys from `collection` prop. This improves the user experience and the component's performance.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Fixes this:
<img width="1326" alt="image" src="https://github.com/JesusFilm/core/assets/10802634/4cb423e8-1d8c-4d8c-bd18-3492e32de405">

<img width="1004" alt="image" src="https://github.com/JesusFilm/core/assets/10802634/ee661f64-cb0d-4ff2-9ff4-14d19d906c7a">

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8e01c00</samp>

*  Use `collection` prop instead of `data.journeys` query result to render `TemplateSection` component ([link](https://github.com/JesusFilm/core/pull/1994/files?diff=unified&w=0#diff-8528e7b4c06335c3a765fccde78d68fff718a8b69d7384bea6782deeb45efb8aL69-R69))
