### PR TITLE
fix: resolve reference to user from firebase

### DIFF
--- a/apps/api-users/src/app/modules/user/user.resolver.spec.ts
+++ b/apps/api-users/src/app/modules/user/user.resolver.spec.ts
@@ -124,6 +124,31 @@ describe('UserResolver', () => {
         await resolver.resolveReference({ __typename: 'User', id: 'userId' })
       ).toEqual(user)
       expect(prismaService.user.findUnique).toHaveBeenCalledWith({
+        where: { userId: user.id }
+      })
+    })
+
+    it('fetches user from firebase', async () => {
+      prismaService.user.findUnique.mockResolvedValueOnce(null)
+      prismaService.user.upsert.mockResolvedValueOnce(user)
+      expect(
+        await resolver.resolveReference({ __typename: 'User', id: 'userId' })
+      ).toEqual(user)
+      expect(prismaService.user.upsert).toHaveBeenCalledWith({
+        create: {
+          email: 'tho@no.co',
+          firstName: 'fo',
+          imageUrl: 'p',
+          lastName: 'sho',
+          userId: 'userId'
+        },
+        update: {
+          email: 'tho@no.co',
+          firstName: 'fo',
+          imageUrl: 'p',
+          lastName: 'sho',
+          userId: 'userId'
+        },
         where: { userId: 'userId' }
       })
     })


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5789d9b</samp>

This pull request improves the user resolver functionality and testing in the `api-users` app. It introduces a helper method to find or fetch users from the database or firebase, and a test case to verify that the user resolver can resolve references from firebase and upsert them in the database. The changes affect the files `user.resolver.ts` and `user.resolver.spec.ts`.

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5789d9b</samp>

*  Refactor `me` and `resolveReference` methods of `UserResolver` class to use a private helper method `findOrFetchUser` ([link](https://github.com/JesusFilm/core/pull/1996/files?diff=unified&w=0#diff-ec509dcc434844a00fec9f0c23390714cc4346604e385749d32e9093494abaeaL25-R25), [link](https://github.com/JesusFilm/core/pull/1996/files?diff=unified&w=0#diff-ec509dcc434844a00fec9f0c23390714cc4346604e385749d32e9093494abaeaL96-R103))
* Add a new test case for the `resolveReference` method of `UserResolver` class in `user.resolver.spec.ts` ([link](https://github.com/JesusFilm/core/pull/1996/files?diff=unified&w=0#diff-91c472e917bd12978510ac197fe532998e2ffa175da7f507ed2a3efd4f1ab365R127-R151))
