### PR TITLE
fix: close help scout dialog

### DIFF
--- a/apps/journeys-admin/src/components/HelpScoutBeacon/HelpScoutBeacon.tsx
+++ b/apps/journeys-admin/src/components/HelpScoutBeacon/HelpScoutBeacon.tsx
@@ -37,7 +37,7 @@ window.Beacon('init', '4f0abc47-b29c-454a-b618-39b34fd116b8')`}</Script>
 
         ${breakpoints.down('md')} {
           .hsds-beacon .BeaconContainer.is-configDisplayLeft {
-            height: calc(100% - 80px);
+            height: 100%;
             border-radius: 0px;
             left: 0px;
             max-height: 100%;

--- a/apps/journeys-admin/src/components/HelpScoutBeacon/HelpScoutBeacon.tsx
+++ b/apps/journeys-admin/src/components/HelpScoutBeacon/HelpScoutBeacon.tsx
@@ -42,7 +42,7 @@ window.Beacon('init', '4f0abc47-b29c-454a-b618-39b34fd116b8')`}</Script>
             left: 0px;
             max-height: 100%;
             right: 0px;
-            top: 0px;
+            top: 40px;
             width: 100%;
           }
         }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 614e15b</samp>

Adjusted the position of the Help Scout Beacon widget in the journeys admin app. This prevents the widget from hiding the header bar and improves the user interface.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34356635/todos/6690211363)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 614e15b</samp>

* Adjust the position of the Help Scout Beacon widget to avoid overlapping with the header bar ([link](https://github.com/JesusFilm/core/pull/1997/files?diff=unified&w=0#diff-d5f6c8eed9cbc9c4a46c3d1d0fd94808bf098624879fe45d7b4c6cf25243a40dL45-R45))
