### PR TITLE
fix: tags filter cleanup

### DIFF
--- a/apps/journeys-admin/src/components/TemplateGallery/TagsFilter/TagsFilter.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagsFilter/TagsFilter.tsx
@@ -100,7 +100,7 @@ export function TagsFilter({
                 variant="subtitle1"
                 sx={{
                   position: 'sticky',
-                  top: 0,
+                  top: -8,
                   py: 2,
                   px: 5,
                   backgroundColor: 'background.paper',
@@ -134,7 +134,7 @@ export function TagsFilter({
           popper: {
             sx: {
               '& .MuiAutocomplete-listbox': {
-                display: 'flex',
+                display: { lg: 'flex' },
                 '> li': {
                   flexGrow: 1
                 }

--- a/apps/journeys-admin/src/components/TemplateGallery/TagsFilter/TagsFilter.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagsFilter/TagsFilter.tsx
@@ -16,6 +16,7 @@ interface TagsFilterProps {
   label: string
   tagNames: string[]
   selectedTagIds: string[]
+  limitTags?: number
   onChange: (selectedTagIds: string[], filteredTagIds: string[]) => void
 }
 
@@ -23,6 +24,7 @@ export function TagsFilter({
   label,
   tagNames,
   selectedTagIds,
+  limitTags,
   onChange
 }: TagsFilterProps): ReactElement {
   const { parentTags, childTags, loading } = useTagsQuery()
@@ -67,6 +69,7 @@ export function TagsFilter({
         loading={loading}
         disableCloseOnSelect
         value={filteredSelectedTags}
+        limitTags={limitTags}
         onChange={handleChange}
         options={filteredChildTags}
         groupBy={(option) => option.parentId ?? ''}

--- a/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.tsx
@@ -63,7 +63,7 @@ export function TemplateGallery(): ReactElement {
           pb: { xs: 6, md: 9 }
         }}
       >
-        <Grid item xs={12} md={8}>
+        <Grid item xs={12} md={7}>
           <TagsFilter
             label={t('Topics, holidays, felt needs, collections')}
             tagNames={['Topics', 'Holidays', 'Felt Needs', 'Collections']}
@@ -72,7 +72,7 @@ export function TemplateGallery(): ReactElement {
             selectedTagIds={selectedTagIds}
           />
         </Grid>
-        <Grid item xs={6} md={2}>
+        <Grid item xs={6} md={2.5}>
           <TagsFilter
             label={t('Audience')}
             tagNames={['Audience']}
@@ -81,7 +81,7 @@ export function TemplateGallery(): ReactElement {
             selectedTagIds={selectedTagIds}
           />
         </Grid>
-        <Grid item xs={6} md={2}>
+        <Grid item xs={6} md={2.5}>
           <TagsFilter
             label={t('Genre')}
             tagNames={['Genre']}

--- a/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.tsx
@@ -63,7 +63,7 @@ export function TemplateGallery(): ReactElement {
           pb: { xs: 6, md: 9 }
         }}
       >
-        <Grid item xs={12} md={7}>
+        <Grid item xs={12} md={8}>
           <TagsFilter
             label={t('Topics, holidays, felt needs, collections')}
             tagNames={['Topics', 'Holidays', 'Felt Needs', 'Collections']}
@@ -72,7 +72,7 @@ export function TemplateGallery(): ReactElement {
             selectedTagIds={selectedTagIds}
           />
         </Grid>
-        <Grid item xs={6} md={2.5}>
+        <Grid item xs={6} md={2}>
           <TagsFilter
             label={t('Audience')}
             tagNames={['Audience']}
@@ -81,7 +81,7 @@ export function TemplateGallery(): ReactElement {
             selectedTagIds={selectedTagIds}
           />
         </Grid>
-        <Grid item xs={6} md={2.5}>
+        <Grid item xs={6} md={2}>
           <TagsFilter
             label={t('Genre')}
             tagNames={['Genre']}

--- a/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.tsx
@@ -68,6 +68,7 @@ export function TemplateGallery(): ReactElement {
             label={t('Topics, holidays, felt needs, collections')}
             tagNames={['Topics', 'Holidays', 'Felt Needs', 'Collections']}
             onChange={handleChange}
+            limitTags={2}
             selectedTagIds={selectedTagIds}
           />
         </Grid>
@@ -76,6 +77,7 @@ export function TemplateGallery(): ReactElement {
             label={t('Audience')}
             tagNames={['Audience']}
             onChange={handleChange}
+            limitTags={1}
             selectedTagIds={selectedTagIds}
           />
         </Grid>
@@ -84,6 +86,7 @@ export function TemplateGallery(): ReactElement {
             label={t('Genre')}
             tagNames={['Genre']}
             onChange={handleChange}
+            limitTags={1}
             selectedTagIds={selectedTagIds}
           />
         </Grid>


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bd05f64</samp>

Improved the design and functionality of the tags filter in the `TemplateGallery` component. Added a `limitTags` prop to the `TagsFilter` and `TagsFilterChip` components to control the number of tags shown per category. Adjusted the grid size and spacing of the `Grid` components that render the filters.

- Link to Basecamp Todo

# How should this PR be QA Tested?

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bd05f64</samp>

*  Add `limitTags` prop to `TagsFilter` and `TagsFilterChip` components to allow parent component to specify maximum number of tags to display in each filter category ([link](https://github.com/JesusFilm/core/pull/1999/files?diff=unified&w=0#diff-390bfe94b6b7b566e0193b33dd20834171cc45285f92c73c6cc205e3dbaf9f04R19), [link](https://github.com/JesusFilm/core/pull/1999/files?diff=unified&w=0#diff-390bfe94b6b7b566e0193b33dd20834171cc45285f92c73c6cc205e3dbaf9f04R27), [link](https://github.com/JesusFilm/core/pull/1999/files?diff=unified&w=0#diff-390bfe94b6b7b566e0193b33dd20834171cc45285f92c73c6cc205e3dbaf9f04R72))
*  Adjust grid size and spacing of `Grid` components that render `TagsFilter` components in `TemplateGallery` component and pass `limitTags` prop values to improve layout and usability of filters on different screen sizes ([link](https://github.com/JesusFilm/core/pull/1999/files?diff=unified&w=0#diff-b3ab650ee0dc0ee335e53cf2f72cf2700dbc0890a665f9b7a7b608c6ce920650L66-R89))
*  Change `top` style property of `Box` component that wraps `TagsFilterChip` component to align chips with filter label and search input ([link](https://github.com/JesusFilm/core/pull/1999/files?diff=unified&w=0#diff-390bfe94b6b7b566e0193b33dd20834171cc45285f92c73c6cc205e3dbaf9f04L100-R103))
*  Change `display` style property of `MuiAutocomplete-listbox` class to prevent tags from wrapping to next line on smaller screens and keep them in single row on larger screens ([link](https://github.com/JesusFilm/core/pull/1999/files?diff=unified&w=0#diff-390bfe94b6b7b566e0193b33dd20834171cc45285f92c73c6cc205e3dbaf9f04L134-R137))
