### PR TITLE
fix: journey duplicate journeys tags

### DIFF
--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -1023,13 +1023,6 @@ describe('JourneyResolver', () => {
             userId: 'userId',
             role: UserJourneyRole.owner
           }
-        },
-        journeyTags: {
-          create: [
-            {
-              tagId: 'tagId'
-            }
-          ]
         }
       }
 

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -1027,8 +1027,6 @@ describe('JourneyResolver', () => {
         journeyTags: {
           create: [
             {
-              journey: { connect: { id: 'duplicateJourneyId' } },
-              journeyId: 'duplicateJourneyId',
               tagId: 'tagId'
             }
           ]

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -416,6 +416,8 @@ export class JourneyResolver {
       strict: true
     })
 
+    console.log('duplicateJourneyId', duplicateJourneyId)
+
     let retry = true
     while (retry) {
       try {
@@ -444,7 +446,7 @@ export class JourneyResolver {
                     ? {
                         create: journey.journeyTags.map((tag) => ({
                           tagId: tag.tagId,
-                          journeyId: duplicateJourneyId,
+                          id: duplicateJourneyId,
                           journey: { connect: { id: duplicateJourneyId } }
                         }))
                       }

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -416,8 +416,6 @@ export class JourneyResolver {
       strict: true
     })
 
-    console.log('duplicateJourneyId', duplicateJourneyId)
-
     let retry = true
     while (retry) {
       try {
@@ -445,9 +443,7 @@ export class JourneyResolver {
                   journey.template === true
                     ? {
                         create: journey.journeyTags.map((tag) => ({
-                          tagId: tag.tagId,
-                          id: duplicateJourneyId,
-                          journey: { connect: { id: duplicateJourneyId } }
+                          tagId: tag.tagId
                         }))
                       }
                     : undefined,
@@ -484,6 +480,8 @@ export class JourneyResolver {
             return duplicateJourney
           }
         )
+
+        console.log('duplicateJourney', duplicateJourney)
         // save base blocks
         await this.blockService.saveAll(
           duplicateBlocks.map((block) => ({

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -429,7 +429,8 @@ export class JourneyResolver {
                   'hostId',
                   'teamId',
                   'createdAt',
-                  'strategySlug'
+                  'strategySlug',
+                  'journeyTags'
                 ]),
                 id: duplicateJourneyId,
                 slug,
@@ -439,14 +440,6 @@ export class JourneyResolver {
                 featuredAt: null,
                 template: false,
                 team: { connect: { id: teamId } },
-                journeyTags:
-                  journey.template === true
-                    ? {
-                        create: journey.journeyTags.map((tag) => ({
-                          tagId: tag.tagId
-                        }))
-                      }
-                    : undefined,
                 userJourneys: {
                   create: {
                     userId,
@@ -481,7 +474,6 @@ export class JourneyResolver {
           }
         )
 
-        console.log('duplicateJourney', duplicateJourney)
         // save base blocks
         await this.blockService.saveAll(
           duplicateBlocks.map((block) => ({

--- a/apps/journeys-admin/src/components/TemplateView/CreateJourneyButton/CreateJourneyButton.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/CreateJourneyButton/CreateJourneyButton.tsx
@@ -39,7 +39,7 @@ export function CreateJourneyButton({
       setLoadingJourney(true)
 
       const { data } = await journeyDuplicate({
-        variables: { id: journey.id, teamId }
+        variables: { id: journey?.id, teamId }
       })
 
       if (data != null) {

--- a/apps/journeys-admin/src/components/TemplateView/CreateJourneyButton/CreateJourneyButton.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/CreateJourneyButton/CreateJourneyButton.tsx
@@ -39,7 +39,7 @@ export function CreateJourneyButton({
       setLoadingJourney(true)
 
       const { data } = await journeyDuplicate({
-        variables: { id: journey?.id, teamId }
+        variables: { id: journey.id, teamId }
       })
 
       if (data != null) {


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dbd9eeb</samp>

Added optional chaining to `journey.id` in `CreateJourneyButton.tsx` to avoid potential error. This is part of a TypeScript error-fixing pull request for the journeys-admin app.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34356635/todos/6694302831)

# How should this PR be QA Tested?

- [ ] it shouldn't give users the loading forever state
- [ ] it should convert templates to journeys almost instantly or at least less than 1 min

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dbd9eeb</samp>

*  Add optional chaining to `journey.id` to prevent possible errors ([link](https://github.com/JesusFilm/core/pull/2000/files?diff=unified&w=0#diff-18cec4c017b3d56f23d82e6016eadd161d82c45d46b1cba614bf90c0ba722497L42-R42))
