### PR TITLE
refactor: language autocomplete

### DIFF
--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/LanguageMenuItem/LanguageDialog/LanguageDialog.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/LanguageMenuItem/LanguageDialog/LanguageDialog.tsx
@@ -119,6 +119,7 @@ export function LanguageDialog({
             >
               <Form>
                 <LanguageAutocomplete
+                  multiple={false}
                   onChange={async (value) =>
                     await setFieldValue('language', value)
                   }

--- a/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoLanguage/VideoLanguage.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoLanguage/VideoLanguage.tsx
@@ -75,6 +75,7 @@ export function VideoLanguage({
       </AppBar>
       <Box sx={{ flexGrow: 1, overflowY: 'auto', p: 6 }}>
         <LanguageAutocomplete
+          multiple={false}
           onChange={handleChange}
           value={language}
           languages={languages}

--- a/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilterDialog/LanguageFilterDialog.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/LanguageFilter/LanguageFilterDialog/LanguageFilterDialog.tsx
@@ -81,6 +81,8 @@ export function LanguageFilterDialog({
         >
           <Form>
             <LanguageAutocomplete
+              // update to be true on multiple language changes
+              multiple={false}
               onChange={async (value) => await setFieldValue('language', value)}
               value={values.language}
               languages={languages}

--- a/libs/shared/ui/src/components/LanguageAutocomplete/LanguageAutocomplete.tsx
+++ b/libs/shared/ui/src/components/LanguageAutocomplete/LanguageAutocomplete.tsx
@@ -24,12 +24,7 @@ export interface LanguageOption {
   nativeName?: string
 }
 
-type LanguageOptionVariant = LanguageOption | readonly LanguageOption[]
-
-export interface LanguageAutocompleteProps {
-  onChange: (value?: LanguageOptionVariant) => void
-  value?: LanguageOptionVariant
-  multiple?: boolean
+interface BaseLanguageAutocompleteProps {
   languages?: Language[]
   loading: boolean
   helperText?: string
@@ -40,6 +35,24 @@ export interface LanguageAutocompleteProps {
     state: AutocompleteRenderOptionState
   ) => ReactNode
 }
+
+interface SingleLanguageAutocompleteProps
+  extends BaseLanguageAutocompleteProps {
+  onChange: (value?: LanguageOption) => void
+  value?: LanguageOption
+  multiple: false | undefined
+}
+
+interface MultipleLanguageAutocompleteProps
+  extends BaseLanguageAutocompleteProps {
+  onChange: (value?: readonly LanguageOption[]) => void
+  value?: LanguageOption[]
+  multiple: true
+}
+
+export type LanguageAutocompleteProps =
+  | SingleLanguageAutocompleteProps
+  | MultipleLanguageAutocompleteProps
 
 export function LanguageAutocomplete({
   onChange: handleChange,
@@ -125,7 +138,13 @@ export function LanguageAutocomplete({
       getOptionLabel={({ localName, nativeName }) =>
         localName ?? nativeName ?? ''
       }
-      onChange={(_event, option) => handleChange(option)}
+      onChange={(_event, value) => {
+        if (multiple === true) {
+          handleChange(value as readonly LanguageOption[])
+        } else {
+          handleChange(value as LanguageOption | undefined)
+        }
+      }}
       options={sortedOptions}
       loading={loading}
       disablePortal={process.env.NODE_ENV === 'test'}

--- a/libs/shared/ui/src/components/LanguageAutocomplete/LanguageAutocomplete.tsx
+++ b/libs/shared/ui/src/components/LanguageAutocomplete/LanguageAutocomplete.tsx
@@ -1,5 +1,6 @@
 import Autocomplete, {
-  AutocompleteRenderInputParams
+  AutocompleteRenderInputParams,
+  AutocompleteRenderOptionState
 } from '@mui/material/Autocomplete'
 import CircularProgress from '@mui/material/CircularProgress'
 import Stack from '@mui/material/Stack'
@@ -23,19 +24,27 @@ export interface LanguageOption {
   nativeName?: string
 }
 
+type LanguageOptionVariant = LanguageOption | readonly LanguageOption[]
+
 export interface LanguageAutocompleteProps {
-  onChange: (value?: LanguageOption) => void
-  value?: LanguageOption
+  onChange: (value?: LanguageOptionVariant) => void
+  value?: LanguageOptionVariant
+  multiple?: boolean
   languages?: Language[]
   loading: boolean
   helperText?: string
   renderInput?: (params: AutocompleteRenderInputParams) => ReactNode
-  renderOption?: (params: HTMLAttributes<HTMLLIElement>) => ReactNode
+  renderOption?: (
+    props: HTMLAttributes<HTMLLIElement>,
+    option: LanguageOption,
+    state: AutocompleteRenderOptionState
+  ) => ReactNode
 }
 
 export function LanguageAutocomplete({
   onChange: handleChange,
   value,
+  multiple,
   languages,
   loading,
   renderInput,
@@ -110,6 +119,8 @@ export function LanguageAutocomplete({
     <Autocomplete
       disableClearable
       value={value}
+      multiple={multiple}
+      disableCloseOnSelect={multiple}
       isOptionEqualToValue={(option, value) => option.id === value.id}
       getOptionLabel={({ localName, nativeName }) =>
         localName ?? nativeName ?? ''


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 63c4f12</samp>

Updated `LanguageAutocomplete` component to allow multiple languages and improve option rendering. This enhances the user experience and functionality of the component.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 63c4f12</samp>

*  Modify `LanguageAutocompleteProps` interface to support multiple selection of languages ([link](https://github.com/JesusFilm/core/pull/2003/files?diff=unified&w=0#diff-5fbbf472cdeec968c957a92d598bc1199b9fe3a74b0b8ecd82aea8d6c0a64626L26-R41))
*  Pass `multiple` prop to `useLanguageAutocomplete` hook and `Autocomplete` component to enable multiple selection logic and behavior ([link](https://github.com/JesusFilm/core/pull/2003/files?diff=unified&w=0#diff-5fbbf472cdeec968c957a92d598bc1199b9fe3a74b0b8ecd82aea8d6c0a64626R47), [link](https://github.com/JesusFilm/core/pull/2003/files?diff=unified&w=0#diff-5fbbf472cdeec968c957a92d598bc1199b9fe3a74b0b8ecd82aea8d6c0a64626R122-R123))
*  Import `AutocompleteRenderOptionState` type and use it in `renderOption` prop to customize the rendering of each option ([link](https://github.com/JesusFilm/core/pull/2003/files?diff=unified&w=0#diff-5fbbf472cdeec968c957a92d598bc1199b9fe3a74b0b8ecd82aea8d6c0a64626L2-R3), [link](https://github.com/JesusFilm/core/pull/2003/files?diff=unified&w=0#diff-5fbbf472cdeec968c957a92d598bc1199b9fe3a74b0b8ecd82aea8d6c0a64626L26-R41))
