### PR TITLE
feat: view templates creator details

### DIFF
--- a/apps/journeys-admin/src/components/JourneyView/SocialImage/SocialImage.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/SocialImage/SocialImage.tsx
@@ -1,5 +1,6 @@
-import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
 import Skeleton from '@mui/material/Skeleton'
+import { SxProps } from '@mui/material/styles'
 import { ReactElement } from 'react'
 
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
@@ -9,20 +10,27 @@ import { NextImage } from '@core/shared/ui/NextImage'
 interface SocialImageProps {
   height?: number
   width?: number
+  sx?: SxProps
 }
 
 export function SocialImage({
   height = 167,
-  width = 213
+  width = 213,
+  sx
 }: SocialImageProps): ReactElement {
   const { journey } = useJourney()
 
   return (
-    <Box
+    <Stack
       sx={{
-        display: 'flex',
+        position: 'relative',
         justifyContent: 'center',
-        alignItems: 'center'
+        alignItems: 'center',
+        width,
+        height,
+        backgroundColor: 'background.default',
+        overflow: 'hidden',
+        ...sx
       }}
     >
       {journey?.primaryImageBlock?.src != null ? (
@@ -31,36 +39,18 @@ export function SocialImage({
           alt={journey?.primaryImageBlock.alt}
           placeholder="blur"
           blurDataURL={journey?.primaryImageBlock.blurhash}
-          width={width}
-          height={height}
+          layout="fill"
           objectFit="cover"
-          style={{
-            borderRadius: 12
-          }}
         />
+      ) : journey != null ? (
+        <GridEmptyIcon fontSize="large" />
       ) : (
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            borderRadius: 3,
-            width,
-            height,
-            backgroundColor: 'background.default'
-          }}
-        >
-          {journey != null ? (
-            <GridEmptyIcon fontSize="large" />
-          ) : (
-            <Skeleton
-              data-testid="SocialImageSkeleton"
-              variant="rounded"
-              sx={{ borderRadius: 4, width, height }}
-            />
-          )}
-        </Box>
+        <Skeleton
+          data-testid="SocialImageSkeleton"
+          variant="rectangular"
+          sx={{ width: '100%', height: '100%' }}
+        />
       )}
-    </Box>
+    </Stack>
   )
 }

--- a/apps/journeys-admin/src/components/JourneyView/SocialImage/SocialImage.tsx
+++ b/apps/journeys-admin/src/components/JourneyView/SocialImage/SocialImage.tsx
@@ -1,15 +1,15 @@
-import Stack from '@mui/material/Stack'
 import Skeleton from '@mui/material/Skeleton'
+import Stack from '@mui/material/Stack'
 import { SxProps } from '@mui/material/styles'
-import { ReactElement } from 'react'
+import { ComponentProps, ReactElement } from 'react'
 
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import GridEmptyIcon from '@core/shared/ui/icons/GridEmpty'
 import { NextImage } from '@core/shared/ui/NextImage'
 
 interface SocialImageProps {
-  height?: number
-  width?: number
+  height?: ComponentProps<typeof Stack>['height']
+  width?: ComponentProps<typeof Stack>['width']
   sx?: SxProps
 }
 
@@ -22,12 +22,12 @@ export function SocialImage({
 
   return (
     <Stack
+      width={width}
+      height={height}
       sx={{
         position: 'relative',
         justifyContent: 'center',
         alignItems: 'center',
-        width,
-        height,
         backgroundColor: 'background.default',
         overflow: 'hidden',
         ...sx

--- a/apps/journeys-admin/src/components/TemplateView/TemplateView.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateView.spec.tsx
@@ -113,6 +113,83 @@ describe('TemplateView', () => {
     expect(queryByText('Strategy')).not.toBeInTheDocument()
   })
 
+  it('should show creator details if provided', async () => {
+    const journeyWithCreatorDetails: Journey = {
+      ...defaultJourney,
+      strategySlug: null,
+      tags: [tag],
+      creatorDescription:
+        'Created by a Name of a Mission or Missionaries Organisation label by a Name of a Mission or Missionaries',
+      creatorImageBlock: {
+        id: 'creatorImageBlock.id',
+        parentBlockId: null,
+        parentOrder: 3,
+        src: 'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920',
+        alt: 'photo-1552410260-0fd9b577afa6',
+        width: 6000,
+        height: 4000,
+        blurhash: 'LHFr#AxW9a%L0KM{IVRkoMD%D%R*',
+        __typename: 'ImageBlock'
+      }
+    }
+    const { getAllByText, getAllByRole } = render(
+      <MockedProvider mocks={[getJourneyMock]}>
+        <JourneyProvider
+          value={{
+            journey: journeyWithCreatorDetails,
+            variant: 'admin'
+          }}
+        >
+          <TemplateView authUser={{} as unknown as User} />
+        </JourneyProvider>
+      </MockedProvider>
+    )
+
+    expect(getAllByText('{{ creatorDetails }}')).toHaveLength(2)
+    const creatorImages = getAllByRole('img')
+    expect(creatorImages).toHaveLength(2)
+    expect(creatorImages[0]).toHaveAttribute(
+      'src',
+      'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920'
+    )
+  })
+
+  it('should not show creator details if description is not provided', async () => {
+    const journeyWithoutCreatorDescription: Journey = {
+      ...defaultJourney,
+      strategySlug: null,
+      tags: [tag],
+      creatorDescription: null,
+      creatorImageBlock: {
+        id: 'creatorImageBlock.id',
+        parentBlockId: null,
+        parentOrder: 3,
+        src: 'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920',
+        alt: 'photo-1552410260-0fd9b577afa6',
+        width: 6000,
+        height: 4000,
+        blurhash: 'LHFr#AxW9a%L0KM{IVRkoMD%D%R*',
+        __typename: 'ImageBlock'
+      }
+    }
+    const { queryAllByText, queryAllByRole } = render(
+      <MockedProvider mocks={[getJourneyMock]}>
+        <JourneyProvider
+          value={{
+            journey: journeyWithoutCreatorDescription,
+            variant: 'admin'
+          }}
+        >
+          <TemplateView authUser={{} as unknown as User} />
+        </JourneyProvider>
+      </MockedProvider>
+    )
+
+    expect(queryAllByText('{{ creatorDetails }}')).toHaveLength(0)
+    const creatorImages = queryAllByRole('img')
+    expect(creatorImages).toHaveLength(0)
+  })
+
   it('should get related templates', async () => {
     const journeyWithTags: Journey = {
       ...defaultJourney,

--- a/apps/journeys-admin/src/components/TemplateView/TemplateView.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateView.spec.tsx
@@ -145,7 +145,11 @@ describe('TemplateView', () => {
       </MockedProvider>
     )
 
-    expect(getAllByText('{{ creatorDetails }}')).toHaveLength(2)
+    expect(
+      getAllByText(
+        'Created by a Name of a Mission or Missionaries Organisation label by a Name of a Mission or Missionaries'
+      )
+    ).toHaveLength(2)
     const creatorImages = getAllByRole('img')
     expect(creatorImages).toHaveLength(2)
     expect(creatorImages[0]).toHaveAttribute(
@@ -185,7 +189,11 @@ describe('TemplateView', () => {
       </MockedProvider>
     )
 
-    expect(queryAllByText('{{ creatorDetails }}')).toHaveLength(0)
+    expect(
+      queryAllByText(
+        'Created by a Name of a Mission or Missionaries Organisation label by a Name of a Mission or Missionaries'
+      )
+    ).toHaveLength(0)
     const creatorImages = queryAllByRole('img')
     expect(creatorImages).toHaveLength(0)
   })

--- a/apps/journeys-admin/src/components/TemplateView/TemplateView.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateView.stories.tsx
@@ -220,7 +220,20 @@ export const Complete = {
   args: {
     journey: {
       ...journey,
-      tags
+      tags,
+      creatorDescription:
+        'Created by a Name of a Mission or Missionaries Organisation label by a Name of a Mission or Missionaries',
+      creatorImageBlock: {
+        id: 'creatorImageBlock.id',
+        parentBlockId: null,
+        parentOrder: 3,
+        src: 'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920',
+        alt: 'photo-1552410260-0fd9b577afa6',
+        width: 6000,
+        height: 4000,
+        blurhash: 'LHFr#AxW9a%L0KM{IVRkoMD%D%R*',
+        __typename: 'ImageBlock'
+      }
     },
     authUser: 'user.id',
     getJourneysMock,

--- a/apps/journeys-admin/src/components/TemplateView/TemplateView.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateView.tsx
@@ -21,6 +21,7 @@ import { TemplateFooter } from './TemplateFooter'
 import { TemplatePreviewTabs } from './TemplatePreviewTabs'
 import { TemplateTags } from './TemplateTags'
 import { TemplateViewHeader } from './TemplateViewHeader/TemplateViewHeader'
+import { TemplateCreatorDetails } from './TemplateViewHeader/TemplateCreatorDetails'
 
 interface TemplateViewProps {
   authUser: User
@@ -29,7 +30,7 @@ interface TemplateViewProps {
 export function TemplateView({ authUser }: TemplateViewProps): ReactElement {
   const { journey } = useJourney()
   const { breakpoints } = useTheme()
-
+  const hasCreatorDescription = journey?.creatorDescription != null
   const { t } = useTranslation('apps-journeys-admin')
 
   const tagIds = journey?.tags.map((tag) => tag.id)
@@ -105,6 +106,13 @@ export function TemplateView({ authUser }: TemplateViewProps): ReactElement {
             </>
           )}
         </Typography>
+        {hasCreatorDescription && (
+          <TemplateCreatorDetails
+            creatorDetails={journey?.creatorDescription}
+            creatorImage={journey?.creatorImageBlock?.src}
+            sx={{ display: { xs: 'flex', sm: 'none' } }}
+          />
+        )}
         {journey?.strategySlug != null && (
           <StrategySection
             strategySlug={journey?.strategySlug}

--- a/apps/journeys-admin/src/components/TemplateView/TemplateView.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateView.tsx
@@ -30,7 +30,6 @@ interface TemplateViewProps {
 export function TemplateView({ authUser }: TemplateViewProps): ReactElement {
   const { journey } = useJourney()
   const { breakpoints } = useTheme()
-  const hasCreatorDescription = journey?.creatorDescription != null
   const { t } = useTranslation('apps-journeys-admin')
 
   const tagIds = journey?.tags.map((tag) => tag.id)
@@ -106,7 +105,7 @@ export function TemplateView({ authUser }: TemplateViewProps): ReactElement {
             </>
           )}
         </Typography>
-        {hasCreatorDescription && (
+        {journey?.creatorDescription != null && (
           <TemplateCreatorDetails
             creatorDetails={journey?.creatorDescription}
             creatorImage={journey?.creatorImageBlock?.src}

--- a/apps/journeys-admin/src/components/TemplateView/TemplateView.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateView.tsx
@@ -20,7 +20,7 @@ import { TemplateGalleryCard } from '../TemplateGalleryCard'
 import { TemplateFooter } from './TemplateFooter'
 import { TemplatePreviewTabs } from './TemplatePreviewTabs'
 import { TemplateTags } from './TemplateTags'
-import { TemplateViewHeader } from './TemplateViewHeader/TemplateViewHeader'
+import { TemplateViewHeader } from './TemplateViewHeader'
 import { TemplateCreatorDetails } from './TemplateViewHeader/TemplateCreatorDetails'
 
 interface TemplateViewProps {

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCreatorDetails/TemplateCreatorDetails.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCreatorDetails/TemplateCreatorDetails.spec.tsx
@@ -11,7 +11,11 @@ describe('TemplateCreatorDetails', () => {
       />
     )
 
-    expect(getByText('{{ creatorDetails }}')).toBeInTheDocument()
+    expect(
+      getByText(
+        'Created by a Name of a Mission or Missionaries Organisation label by a Name of a Mission or Missionaries'
+      )
+    ).toBeInTheDocument()
     expect(getByRole('img')).toBeInTheDocument()
   })
 

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCreatorDetails/TemplateCreatorDetails.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCreatorDetails/TemplateCreatorDetails.spec.tsx
@@ -1,0 +1,30 @@
+import { render } from '@testing-library/react'
+import { TemplateCreatorDetails } from './TemplateCreatorDetails'
+
+describe('TemplateCreatorDetails', () => {
+  it('should show creator image and descriptions', () => {
+    const { getByRole, getByText } = render(
+      <TemplateCreatorDetails
+        creatorDetails={
+          'Created by a Name of a Mission or Missionaries Organisation label by a Name of a Mission or Missionaries'
+        }
+        creatorImage={
+          'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920'
+        }
+      />
+    )
+
+    expect(getByText('{{ creatorDetails }}')).toBeInTheDocument()
+    expect(getByRole('img')).toBeInTheDocument()
+  })
+
+  it('should take custom styles for the underlying stack component', () => {
+    const { getByTestId } = render(
+      <TemplateCreatorDetails sx={{ backgroundColor: 'red' }} />
+    )
+
+    expect(getByTestId('TemplateCreatorDetails')).toHaveStyle(
+      'background-color: red'
+    )
+  })
+})

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCreatorDetails/TemplateCreatorDetails.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCreatorDetails/TemplateCreatorDetails.spec.tsx
@@ -1,16 +1,13 @@
 import { render } from '@testing-library/react'
+
 import { TemplateCreatorDetails } from './TemplateCreatorDetails'
 
 describe('TemplateCreatorDetails', () => {
   it('should show creator image and descriptions', () => {
     const { getByRole, getByText } = render(
       <TemplateCreatorDetails
-        creatorDetails={
-          'Created by a Name of a Mission or Missionaries Organisation label by a Name of a Mission or Missionaries'
-        }
-        creatorImage={
-          'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920'
-        }
+        creatorDetails="Created by a Name of a Mission or Missionaries Organisation label by a Name of a Mission or Missionaries"
+        creatorImage="https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920"
       />
     )
 

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCreatorDetails/TemplateCreatorDetails.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCreatorDetails/TemplateCreatorDetails.stories.tsx
@@ -1,8 +1,10 @@
-import { Meta, StoryObj } from '@storybook/react'
-import { journeysAdminConfig } from '../../../../libs/storybook'
-import { TemplateCreatorDetails } from './TemplateCreatorDetails'
 import Box from '@mui/material/Box'
+import { Meta, StoryObj } from '@storybook/react'
+
+import { journeysAdminConfig } from '../../../../libs/storybook'
 import { SocialImage } from '../../../JourneyView/SocialImage'
+
+import { TemplateCreatorDetails } from './TemplateCreatorDetails'
 
 const TemplateCreatorStory: Meta<typeof TemplateCreatorDetails> = {
   ...journeysAdminConfig,
@@ -27,7 +29,7 @@ const Template: StoryObj<typeof TemplateCreatorDetails> = {
           }
         }}
       />
-      <TemplateCreatorDetails {...args}></TemplateCreatorDetails>
+      <TemplateCreatorDetails {...args} />
     </Box>
   )
 }

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCreatorDetails/TemplateCreatorDetails.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCreatorDetails/TemplateCreatorDetails.stories.tsx
@@ -1,0 +1,52 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { journeysAdminConfig } from '../../../../libs/storybook'
+import { TemplateCreatorDetails } from './TemplateCreatorDetails'
+import Box from '@mui/material/Box'
+import { SocialImage } from '../../../JourneyView/SocialImage'
+
+const TemplateCreatorStory: Meta<typeof TemplateCreatorDetails> = {
+  ...journeysAdminConfig,
+  title: 'Journeys-Admin/TemplateView/TemplateCreatorDetails',
+  component: TemplateCreatorDetails
+}
+
+const Template: StoryObj<typeof TemplateCreatorDetails> = {
+  render: (args) => (
+    <Box sx={{ width: 244 }}>
+      <SocialImage
+        height={244}
+        width={244}
+        sx={{
+          display: { xs: 'none', sm: 'block' },
+          borderRadius: 3,
+          borderBottomRightRadius: {
+            sm: 0
+          },
+          borderBottomLeftRadius: {
+            sm: 0
+          }
+        }}
+      />
+      <TemplateCreatorDetails {...args}></TemplateCreatorDetails>
+    </Box>
+  )
+}
+
+export const Default = {
+  ...Template,
+  args: {
+    creatorDetails:
+      'Created by a Name of a Mission or Missionaries Organisation label by a Name of a Mission or Missionaries'
+  }
+}
+
+export const WithImage = {
+  ...Default,
+  args: {
+    ...Default.args,
+    creatorImage:
+      'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920'
+  }
+}
+
+export default TemplateCreatorStory

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCreatorDetails/TemplateCreatorDetails.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCreatorDetails/TemplateCreatorDetails.tsx
@@ -20,6 +20,7 @@ export function TemplateCreatorDetails({
   const { t } = useTranslation('apps-journeys-admin')
   return (
     <Stack
+      data-testid="TemplateCreatorDetails"
       sx={{
         borderWidth: { xs: 0, sm: 1 },
         borderStyle: 'solid',
@@ -40,7 +41,9 @@ export function TemplateCreatorDetails({
             mr: { xs: 3, sm: 0 },
             borderWidth: { xs: 0, sm: '2px' },
             borderStyle: 'solid',
-            borderColor: 'background.paper'
+            borderColor: 'background.paper',
+            width: { xs: 32, sm: 48 },
+            height: { xs: 32, sm: 48 }
           }}
         />
       )}
@@ -53,7 +56,7 @@ export function TemplateCreatorDetails({
           }}
         >
           <Typography
-            variant="subtitle3"
+            variant="body2"
             sx={{ color: { xs: 'text.primary', sm: 'secondary.light' } }}
           >
             {t('{{ creatorDetails }}', { creatorDetails })}

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCreatorDetails/TemplateCreatorDetails.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCreatorDetails/TemplateCreatorDetails.tsx
@@ -4,7 +4,6 @@ import Stack from '@mui/material/Stack'
 import { SxProps } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
 import { ReactElement } from 'react'
-import { useTranslation } from 'react-i18next'
 
 interface TemplateCreatorDetailsProps {
   sx?: SxProps
@@ -17,7 +16,6 @@ export function TemplateCreatorDetails({
   creatorImage,
   creatorDetails
 }: TemplateCreatorDetailsProps): ReactElement {
-  const { t } = useTranslation('apps-journeys-admin')
   return (
     <Stack
       data-testid="TemplateCreatorDetails"
@@ -59,7 +57,7 @@ export function TemplateCreatorDetails({
             variant="body2"
             sx={{ color: { xs: 'text.primary', sm: 'secondary.light' } }}
           >
-            {t('{{ creatorDetails }}', { creatorDetails })}
+            {creatorDetails}
           </Typography>
         </Box>
       )}

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCreatorDetails/TemplateCreatorDetails.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCreatorDetails/TemplateCreatorDetails.tsx
@@ -1,7 +1,7 @@
 import Avatar from '@mui/material/Avatar'
 import Box from '@mui/material/Box'
 import Stack from '@mui/material/Stack'
-import { SxProps, useTheme } from '@mui/material/styles'
+import { SxProps } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
 import { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -18,7 +18,6 @@ export function TemplateCreatorDetails({
   creatorDetails
 }: TemplateCreatorDetailsProps): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
-  const theme = useTheme()
   return (
     <Stack
       sx={{

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCreatorDetails/TemplateCreatorDetails.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCreatorDetails/TemplateCreatorDetails.tsx
@@ -1,0 +1,66 @@
+import Avatar from '@mui/material/Avatar'
+import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import { SxProps, useTheme } from '@mui/material/styles'
+import Typography from '@mui/material/Typography'
+import { ReactElement } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface TemplateCreatorDetailsProps {
+  sx?: SxProps
+  creatorImage?: string | null
+  creatorDetails?: string | null
+}
+
+export function TemplateCreatorDetails({
+  sx,
+  creatorImage,
+  creatorDetails
+}: TemplateCreatorDetailsProps): ReactElement {
+  const { t } = useTranslation('apps-journeys-admin')
+  const theme = useTheme()
+  return (
+    <Stack
+      sx={{
+        borderWidth: { xs: 0, sm: 1 },
+        borderStyle: 'solid',
+        borderColor: 'divider',
+        borderTop: 'none',
+        borderBottomLeftRadius: 12,
+        borderBottomRightRadius: 12,
+        flexDirection: { xs: 'row', sm: 'column' },
+        alignItems: { xs: 'flex-start', sm: 'center' },
+        ...sx
+      }}
+    >
+      {creatorImage != null && (
+        <Avatar
+          src={creatorImage}
+          sx={{
+            mt: { xs: 2, sm: -5 },
+            mr: { xs: 3, sm: 0 },
+            borderWidth: { xs: 0, sm: '2px' },
+            borderStyle: 'solid',
+            borderColor: 'background.paper'
+          }}
+        />
+      )}
+      {creatorDetails != null && (
+        <Box
+          sx={{
+            px: { xs: 0, sm: 5 },
+            pb: { xs: 4, sm: 5 },
+            pt: { xs: 2, sm: 4 }
+          }}
+        >
+          <Typography
+            variant="subtitle3"
+            sx={{ color: { xs: 'text.primary', sm: 'secondary.light' } }}
+          >
+            {t('{{ creatorDetails }}', { creatorDetails })}
+          </Typography>
+        </Box>
+      )}
+    </Stack>
+  )
+}

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCreatorDetails/index.ts
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateCreatorDetails/index.ts
@@ -1,0 +1,1 @@
+export { TemplateCreatorDetails } from './TemplateCreatorDetails'

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateViewHeader.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateViewHeader.spec.tsx
@@ -5,7 +5,10 @@ import { SnackbarProvider } from 'notistack'
 
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 
-import { JourneyFields_primaryImageBlock as PrimaryImageBlock } from '../../../../__generated__/JourneyFields'
+import {
+  JourneyFields as Journey,
+  JourneyFields_primaryImageBlock as PrimaryImageBlock
+} from '../../../../__generated__/JourneyFields'
 import { journey } from '../../Editor/ActionDetails/data'
 
 import { TemplateViewHeader } from './TemplateViewHeader'
@@ -48,6 +51,83 @@ describe('TemplateViewHeader', () => {
 
     expect(queryByTestId('GridEmptyIcon')).not.toBeInTheDocument()
     expect(getByRole('img', { name: 'image.jpg' })).toBeInTheDocument()
+  })
+
+  it('should show creator details if provided', async () => {
+    const journeyWithCreatorDetails = {
+      ...journey,
+      strategySlug: null,
+      tags: [],
+      creatorDescription:
+        'Created by a Name of a Mission or Missionaries Organisation label by a Name of a Mission or Missionaries',
+      creatorImageBlock: {
+        id: 'creatorImageBlock.id',
+        parentBlockId: null,
+        parentOrder: 3,
+        src: 'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920',
+        alt: 'photo-1552410260-0fd9b577afa6',
+        width: 6000,
+        height: 4000,
+        blurhash: 'LHFr#AxW9a%L0KM{IVRkoMD%D%R*',
+        __typename: 'ImageBlock'
+      }
+    }
+    const { getByText, getByRole } = render(
+      <MockedProvider>
+        <JourneyProvider
+          value={{
+            journey: journeyWithCreatorDetails as Journey,
+            variant: 'admin'
+          }}
+        >
+          <TemplateViewHeader isPublisher authUser={{} as unknown as User} />
+        </JourneyProvider>
+      </MockedProvider>
+    )
+
+    expect(getByText('{{ creatorDetails }}')).toBeInTheDocument()
+    const creatorImage = getByRole('img')
+    expect(creatorImage).toBeInTheDocument()
+    expect(creatorImage).toHaveAttribute(
+      'src',
+      'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920'
+    )
+  })
+
+  it('should not show creator details if description is not provided', async () => {
+    const journeyWithCreatorDetails = {
+      ...journey,
+      strategySlug: null,
+      tags: [],
+      creatorDescription: null,
+      creatorImageBlock: {
+        id: 'creatorImageBlock.id',
+        parentBlockId: null,
+        parentOrder: 3,
+        src: 'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920',
+        alt: 'photo-1552410260-0fd9b577afa6',
+        width: 6000,
+        height: 4000,
+        blurhash: 'LHFr#AxW9a%L0KM{IVRkoMD%D%R*',
+        __typename: 'ImageBlock'
+      }
+    }
+    const { queryByText, queryByRole } = render(
+      <MockedProvider>
+        <JourneyProvider
+          value={{
+            journey: journeyWithCreatorDetails as Journey,
+            variant: 'admin'
+          }}
+        >
+          <TemplateViewHeader isPublisher authUser={{} as unknown as User} />
+        </JourneyProvider>
+      </MockedProvider>
+    )
+
+    expect(queryByText('{{ creatorDetails }}')).not.toBeInTheDocument()
+    const creatorImage = queryByRole('img')
+    expect(creatorImage).not.toBeInTheDocument()
   })
 
   it('should display the title and description', () => {

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateViewHeader.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateViewHeader.spec.tsx
@@ -85,7 +85,11 @@ describe('TemplateViewHeader', () => {
       </MockedProvider>
     )
 
-    expect(getByText('{{ creatorDetails }}')).toBeInTheDocument()
+    expect(
+      getByText(
+        'Created by a Name of a Mission or Missionaries Organisation label by a Name of a Mission or Missionaries'
+      )
+    ).toBeInTheDocument()
     const creatorImage = getByRole('img')
     expect(creatorImage).toBeInTheDocument()
     expect(creatorImage).toHaveAttribute(
@@ -125,7 +129,11 @@ describe('TemplateViewHeader', () => {
       </MockedProvider>
     )
 
-    expect(queryByText('{{ creatorDetails }}')).not.toBeInTheDocument()
+    expect(
+      queryByText(
+        'Created by a Name of a Mission or Missionaries Organisation label by a Name of a Mission or Missionaries'
+      )
+    ).not.toBeInTheDocument()
     const creatorImage = queryByRole('img')
     expect(creatorImage).not.toBeInTheDocument()
   })

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateViewHeader.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateViewHeader.stories.tsx
@@ -78,6 +78,50 @@ export const EmptyImage = {
   }
 }
 
+export const CreatorDetails = {
+  ...Template,
+  args: {
+    ...Template.args,
+    journey: {
+      ...journey,
+      primaryImageBlock,
+      title: 'My Cool Journey',
+      description:
+        'some description with some words in it... cool journey, huh?',
+      creatorDescription:
+        'Created by a Name of a Mission or Missionaries Organisation label by a Name of a Mission or Missionaries',
+      creatorImageBlock: null
+    }
+  }
+}
+
+export const CreatorDetailsWithImage = {
+  ...Template,
+  args: {
+    ...Template.args,
+    journey: {
+      ...journey,
+      primaryImageBlock,
+      title: 'My Cool Journey',
+      description:
+        'some description with some words in it... cool journey, huh?',
+      creatorDescription:
+        'Created by a Name of a Mission or Missionaries Organisation label by a Name of a Mission or Missionaries',
+      creatorImageBlock: {
+        id: 'creatorImageBlock.id',
+        parentBlockId: null,
+        parentOrder: 3,
+        src: 'https://images.unsplash.com/photo-1508363778367-af363f107cbb?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&dl=chester-wade-hLP7lVm4KUE-unsplash.jpg&w=1920',
+        alt: 'photo-1552410260-0fd9b577afa6',
+        width: 6000,
+        height: 4000,
+        blurhash: 'LHFr#AxW9a%L0KM{IVRkoMD%D%R*',
+        __typename: 'ImageBlock'
+      }
+    }
+  }
+}
+
 export const Loading = {
   ...Template,
   args: {

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateViewHeader.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateViewHeader.tsx
@@ -58,6 +58,8 @@ export function TemplateViewHeader({
           }}
         >
           <SocialImage
+            height={{ xs: 107, sm: 244 }}
+            width={{ xs: 107, sm: 244 }}
             sx={{
               borderRadius: 3,
               borderBottomRightRadius: {
@@ -67,9 +69,7 @@ export function TemplateViewHeader({
               borderBottomLeftRadius: {
                 xs: 12,
                 sm: hasCreatorDescription ? 0 : 12
-              },
-              height: { xs: 107, sm: 244 },
-              width: { xs: 107, sm: 244 }
+              }
             }}
           />
           {hasCreatorDescription && (

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateViewHeader.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateViewHeader.tsx
@@ -14,6 +14,7 @@ import { SocialImage } from '../../JourneyView/SocialImage'
 import { CreateJourneyButton } from '../CreateJourneyButton'
 
 import { PreviewTemplateButton } from './PreviewTemplateButton'
+import { TemplateCreatorDetails } from './TemplateCreatorDetails/TemplateCreatorDetails'
 import { TemplateEditButton } from './TemplateEditButton/TemplateEditButton'
 
 interface TemplateViewHeaderProps {
@@ -26,6 +27,7 @@ export function TemplateViewHeader({
   authUser
 }: TemplateViewHeaderProps): ReactElement {
   const { journey } = useJourney()
+  const hasCreatorDescription = journey?.creatorDescription != null
   const smUp = useMediaQuery((theme: Theme) => theme.breakpoints.up('sm'))
 
   return (
@@ -51,10 +53,32 @@ export function TemplateViewHeader({
       <Stack direction="row" sx={{ gap: { xs: 4, sm: 6 } }}>
         <Box
           sx={{
-            flexShrink: 0
+            flexShrink: 0,
+            width: { xs: '107px', sm: '244px' }
           }}
         >
-          <SocialImage height={smUp ? 244 : 107} width={smUp ? 244 : 107} />
+          <SocialImage
+            sx={{
+              borderRadius: 3,
+              borderBottomRightRadius: {
+                xs: 12,
+                sm: hasCreatorDescription ? 0 : 12
+              },
+              borderBottomLeftRadius: {
+                xs: 12,
+                sm: hasCreatorDescription ? 0 : 12
+              },
+              height: { xs: 107, sm: 244 },
+              width: { xs: 107, sm: 244 }
+            }}
+          />
+          {hasCreatorDescription && (
+            <TemplateCreatorDetails
+              creatorDetails={journey?.creatorDescription}
+              creatorImage={journey?.creatorImageBlock?.src}
+              sx={{ display: { xs: 'none', sm: 'flex' } }}
+            />
+          )}
         </Box>
         <Stack
           direction="column"

--- a/libs/locales/en/apps-journeys-admin.json
+++ b/libs/locales/en/apps-journeys-admin.json
@@ -312,7 +312,6 @@
   "Use this template to make it your journey": "Use this template to make it your journey",
   "{{cardBlockCount}} Cards": "{{cardBlockCount}} Cards",
   "Related Templates": "Related Templates",
-  "{{ creatorDetails }}": "{{ creatorDetails }}",
   "Edit": "Edit",
   "Open conversation": "Open conversation",
   "Username": "Username",

--- a/libs/locales/en/apps-journeys-admin.json
+++ b/libs/locales/en/apps-journeys-admin.json
@@ -312,6 +312,7 @@
   "Use this template to make it your journey": "Use this template to make it your journey",
   "{{cardBlockCount}} Cards": "{{cardBlockCount}} Cards",
   "Related Templates": "Related Templates",
+  "{{ creatorDetails }}": "{{ creatorDetails }}",
   "Edit": "Edit",
   "Open conversation": "Open conversation",
   "Username": "Username",


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a84a71</samp>

Refactored and improved the UI components for displaying template journeys and their creators. Used `Stack`, `Skeleton`, and `next/image` components to simplify and optimize the `SocialImage` component. Created and used the `TemplateCreatorDetails` component to show the creator's image and description on the `TemplateViewHeader` component. Made the layout responsive and customizable with the `sx` prop.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34356579/todos/6701814479)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] it should display creator data if there is at least a creator description in template view page

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2a84a71</samp>

*  Add `TemplateCreatorDetails` component to display the creator's image and description for a template ([link](https://github.com/JesusFilm/core/pull/2025/files?diff=unified&w=0#diff-436738bb5e18937497677275cf375e4dbebb3183971ed6225561bed0c82bd150R24), [link](https://github.com/JesusFilm/core/pull/2025/files?diff=unified&w=0#diff-ac3726cbfd39bd9e6cb533504f32bc0421d224bdd4bdd73e8c83403fdf86189dR1), [link](https://github.com/JesusFilm/core/pull/2025/files?diff=unified&w=0#diff-92b0dc6c1af609495bd782b976806a85fd4e30212687a2312cac5efb31dfe6a7R1-R66), [link](https://github.com/JesusFilm/core/pull/2025/files?diff=unified&w=0#diff-ee24d1185380438fa67baa8ace69d9cdfb3ae3e712ce48150234939ea8ea096bR17), [link](https://github.com/JesusFilm/core/pull/2025/files?diff=unified&w=0#diff-ee24d1185380438fa67baa8ace69d9cdfb3ae3e712ce48150234939ea8ea096bR30), [link](https://github.com/JesusFilm/core/pull/2025/files?diff=unified&w=0#diff-ee24d1185380438fa67baa8ace69d9cdfb3ae3e712ce48150234939ea8ea096bL54-R81))
*  Refactor `SocialImage` component to use `Stack` instead of `Box` for layout and accept an optional `sx` prop for custom styling ([link](https://github.com/JesusFilm/core/pull/2025/files?diff=unified&w=0#diff-2f472b03d2f1e26b611957f1864d7870c6fcd7adfe64f39533e543a2485d0b6dL1-R3), [link](https://github.com/JesusFilm/core/pull/2025/files?diff=unified&w=0#diff-2f472b03d2f1e26b611957f1864d7870c6fcd7adfe64f39533e543a2485d0b6dL12-R33), [link](https://github.com/JesusFilm/core/pull/2025/files?diff=unified&w=0#diff-2f472b03d2f1e26b611957f1864d7870c6fcd7adfe64f39533e543a2485d0b6dL34-R54))
*  Simplify conditional rendering and image layout in `SocialImage` component using ternary operator and `layout="fill"` ([link](https://github.com/JesusFilm/core/pull/2025/files?diff=unified&w=0#diff-2f472b03d2f1e26b611957f1864d7870c6fcd7adfe64f39533e543a2485d0b6dL34-R54))
*  Pass `sx` prop to `SocialImage` component in `TemplateViewHeader` component to create border and border radius depending on screen size and creator description ([link](https://github.com/JesusFilm/core/pull/2025/files?diff=unified&w=0#diff-ee24d1185380438fa67baa8ace69d9cdfb3ae3e712ce48150234939ea8ea096bL54-R81))
*  Render `TemplateCreatorDetails` component in `TemplateView` component for mobile screens ([link](https://github.com/JesusFilm/core/pull/2025/files?diff=unified&w=0#diff-436738bb5e18937497677275cf375e4dbebb3183971ed6225561bed0c82bd150L32-R33), [link](https://github.com/JesusFilm/core/pull/2025/files?diff=unified&w=0#diff-436738bb5e18937497677275cf375e4dbebb3183971ed6225561bed0c82bd150R109-R115))
