### PR TITLE
feat: languages filter by ids

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -948,6 +948,12 @@ enum LanguageIdType
   bcp47 @join__enumValue(graph: LANGUAGES)
 }
 
+input LanguagesFilter
+  @join__type(graph: LANGUAGES)
+{
+  ids: [ID!]
+}
+
 type LanguageWithSlug
   @join__type(graph: VIDEOS)
 {
@@ -1379,7 +1385,7 @@ type Query
 
   """Get a single visitor"""
   visitor(id: ID!): Visitor! @join__field(graph: JOURNEYS)
-  languages(offset: Int, limit: Int): [Language!]! @join__field(graph: LANGUAGES)
+  languages(offset: Int, limit: Int, where: LanguagesFilter): [Language!]! @join__field(graph: LANGUAGES)
   language(id: ID!, idType: LanguageIdType): Language @join__field(graph: LANGUAGES)
   getMyCloudflareImages: [CloudflareImage] @join__field(graph: MEDIA)
   getMyCloudflareVideos: [CloudflareVideo] @join__field(graph: MEDIA)

--- a/apps/api-languages/schema.graphql
+++ b/apps/api-languages/schema.graphql
@@ -32,8 +32,12 @@ enum LanguageIdType {
   bcp47
 }
 
+input LanguagesFilter {
+  ids: [ID!]
+}
+
 type Query {
-  languages(offset: Int, limit: Int): [Language!]! @cacheControl(maxAge: 86400)
+  languages(offset: Int, limit: Int, where: LanguagesFilter): [Language!]! @cacheControl(maxAge: 86400)
   language(id: ID!, idType: LanguageIdType): Language @cacheControl(maxAge: 86400)
   _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service!

--- a/apps/api-languages/src/app/__generated__/graphql.ts
+++ b/apps/api-languages/src/app/__generated__/graphql.ts
@@ -18,6 +18,10 @@ export enum LanguageIdType {
     bcp47 = "bcp47"
 }
 
+export class LanguagesFilter {
+    ids?: Nullable<string[]>;
+}
+
 export class Language {
     __typename?: 'Language';
     id: string;
@@ -29,7 +33,7 @@ export class Language {
 export abstract class IQuery {
     __typename?: 'IQuery';
 
-    abstract languages(offset?: Nullable<number>, limit?: Nullable<number>): Language[] | Promise<Language[]>;
+    abstract languages(offset?: Nullable<number>, limit?: Nullable<number>, where?: Nullable<LanguagesFilter>): Language[] | Promise<Language[]>;
 
     abstract language(id: string, idType?: Nullable<LanguageIdType>): Nullable<Language> | Promise<Nullable<Language>>;
 }

--- a/apps/api-languages/src/app/modules/language/language.graphql
+++ b/apps/api-languages/src/app/modules/language/language.graphql
@@ -9,8 +9,14 @@ enum LanguageIdType {
   databaseId
   bcp47
 }
+
+input LanguagesFilter {
+  ids: [ID!]
+}
+
 type Query {
-  languages(offset: Int, limit: Int): [Language!]! @cacheControl(maxAge: 86400)
+  languages(offset: Int, limit: Int, where: LanguagesFilter): [Language!]!
+    @cacheControl(maxAge: 86400)
   language(id: ID!, idType: LanguageIdType): Language
     @cacheControl(maxAge: 86400)
 }

--- a/apps/api-languages/src/app/modules/language/language.resolver.ts
+++ b/apps/api-languages/src/app/modules/language/language.resolver.ts
@@ -7,10 +7,10 @@ import {
   Resolver
 } from '@nestjs/graphql'
 
-import { Language } from '.prisma/api-languages-client'
+import { Language, Prisma } from '.prisma/api-languages-client'
 import { TranslationField } from '@core/nest/decorators/TranslationField'
 
-import { LanguageIdType } from '../../__generated__/graphql'
+import { LanguageIdType, LanguagesFilter } from '../../__generated__/graphql'
 import { PrismaService } from '../../lib/prisma.service'
 
 @Resolver('Language')
@@ -20,9 +20,13 @@ export class LanguageResolver {
   @Query()
   async languages(
     @Args('offset') offset: number,
-    @Args('limit') limit: number
+    @Args('limit') limit: number,
+    @Args('where') where?: LanguagesFilter
   ): Promise<Language[]> {
+    const filter: Prisma.LanguageWhereInput = {}
+    if (where?.ids != null) filter.id = { in: where?.ids }
     return await this.prismaService.language.findMany({
+      where: filter,
       skip: offset,
       take: limit
     })


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 35e5a5e</samp>

This pull request adds a new feature to the `api-gateway` app that allows filtering languages by ids. It also updates the `api-languages` app to support this feature and to use a new library for testing. It modifies the schema files and the generated typescript files accordingly.

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 35e5a5e</samp>

*  Add a new input type `LanguagesFilter` to the api-gateway schema and annotate it with the `@join__type` directive ([link](https://github.com/JesusFilm/core/pull/2026/files?diff=unified&w=0#diff-e60078ed0fc71b8cd3bb2fca25505e7dba866b7d463147662a12432dfe287273R951-R956))
*  Add a new argument `where` of type `LanguagesFilter` to the `languages` query field in the api-gateway schema and annotate it with the `@join__field` directive ([link](https://github.com/JesusFilm/core/pull/2026/files?diff=unified&w=0#diff-e60078ed0fc71b8cd3bb2fca25505e7dba866b7d463147662a12432dfe287273L1382-R1388))
*  Add the `LanguagesFilter` input type to the api-languages generated typescript file and the `where` argument to the `IQuery` interface ([link](https://github.com/JesusFilm/core/pull/2026/files?diff=unified&w=0#diff-d7434f8dc8b58d870c249b987309609a2446e7b102a6302992ec7a2626188453R21-R24), [link](https://github.com/JesusFilm/core/pull/2026/files?diff=unified&w=0#diff-d7434f8dc8b58d870c249b987309609a2446e7b102a6302992ec7a2626188453L32-R36))
*  Update the language subgraph schema to match the api-gateway schema by adding the `LanguagesFilter` input type and the `where` argument to the `languages` query field ([link](https://github.com/JesusFilm/core/pull/2026/files?diff=unified&w=0#diff-5ff27741b34fb457cdce2fe78265b5589636278a0060d2fd28999bab7d0824f6L12-R19))
*  Implement the filtering by ids functionality in the language resolver by importing the Prisma namespace, creating a filter object of type Prisma.LanguageWhereInput, and passing it to the prismaService.language.findMany method ([link](https://github.com/JesusFilm/core/pull/2026/files?diff=unified&w=0#diff-45f30fb7c4deec8e8440b7cc6d6d613470485dd6de5534f68babd2e80de558b8L10-R13), [link](https://github.com/JesusFilm/core/pull/2026/files?diff=unified&w=0#diff-45f30fb7c4deec8e8440b7cc6d6d613470485dd6de5534f68babd2e80de558b8L23-R29))
*  Add tests for the filtering by ids functionality in the language resolver spec by importing the jest-mock-extended library, creating a mock instance of the PrismaService class, and verifying the expected results ([link](https://github.com/JesusFilm/core/pull/2026/files?diff=unified&w=0#diff-8f68509343007c43b016432a4c618e12243edc99df9a62e47821edd9c719fa5cL2-R5), [link](https://github.com/JesusFilm/core/pull/2026/files?diff=unified&w=0#diff-8f68509343007c43b016432a4c618e12243edc99df9a62e47821edd9c719fa5cL9-R17), [link](https://github.com/JesusFilm/core/pull/2026/files?diff=unified&w=0#diff-8f68509343007c43b016432a4c618e12243edc99df9a62e47821edd9c719fa5cL32-R80), [link](https://github.com/JesusFilm/core/pull/2026/files?diff=unified&w=0#diff-8f68509343007c43b016432a4c618e12243edc99df9a62e47821edd9c719fa5cR88), [link](https://github.com/JesusFilm/core/pull/2026/files?diff=unified&w=0#diff-8f68509343007c43b016432a4c618e12243edc99df9a62e47821edd9c719fa5cR116))
