### PR TITLE
feat: typography variant label

### DIFF
--- a/apps/journeys-admin/src/components/ThemeProvider/admin/tokens/components.ts
+++ b/apps/journeys-admin/src/components/ThemeProvider/admin/tokens/components.ts
@@ -74,6 +74,7 @@ export const adminComponents: Required<Pick<ThemeOptions, 'components'>> = {
           subtitle3: 'h6',
           body1: 'p',
           body2: 'p',
+          label: 'p',
           overline: 'span',
           overline2: 'span',
           caption: 'span'

--- a/apps/journeys-admin/src/components/ThemeProvider/admin/tokens/typography.stories.tsx
+++ b/apps/journeys-admin/src/components/ThemeProvider/admin/tokens/typography.stories.tsx
@@ -42,6 +42,7 @@ export const Typography = {
       'subtitle3',
       'body1',
       'body2',
+      'label',
       'overline',
       'overline2',
       'caption'

--- a/apps/journeys-admin/src/components/ThemeProvider/admin/tokens/typography.ts
+++ b/apps/journeys-admin/src/components/ThemeProvider/admin/tokens/typography.ts
@@ -12,12 +12,14 @@ declare module '@mui/material/styles' {
   interface TypographyVariants {
     subtitle3: React.CSSProperties
     overline2: React.CSSProperties
+    label: React.CSSProperties
   }
 
   // allow configuration using `createTheme`
   interface TypographyVariantsOptions {
     subtitle3?: React.CSSProperties
     overline2?: React.CSSProperties
+    label?: React.CSSProperties
   }
 }
 
@@ -26,6 +28,7 @@ declare module '@mui/material/Typography' {
   interface TypographyPropsVariantOverrides {
     subtitle3: true
     overline2: true
+    label: true
   }
 }
 
@@ -92,6 +95,12 @@ export const adminTypography: Pick<ThemeOptions, 'typography'> = {
       fontWeight: 400,
       fontSize: 14,
       lineHeight: '22px'
+    },
+    label: {
+      fontFamily: '"Open Sans", "Tahoma", "Verdana", sans-serif',
+      fontWeight: 600,
+      fontSize: 14,
+      lineHeight: '20px'
     },
     overline: {
       fontWeight: 600,


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2ad7191</samp>

Added a new `label` typography variant to the admin theme and its storybook. The `label` variant can be used to style descriptive text for form fields and UI sections.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34356579/todos/6742751965)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] it should allow the use of the label typography variant
- [ ] it should have correct font and stylings

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2ad7191</samp>

*  Add a label variant to the Typography component and theme for the admin app
  * Define the label property for the Typography component and its variants ([link](https://github.com/JesusFilm/core/pull/2029/files?diff=unified&w=0#diff-4cfbf14dfec026ee9aeebdd43a9820350655d82a3f2e651e6cc896b87b2e5b85R77), [link](https://github.com/JesusFilm/core/pull/2029/files?diff=unified&w=0#diff-9d9c80d6326eeda241e27429c0874c7ad4f93f3bfcf29bc16c5d9780e7708b38R15), [link](https://github.com/JesusFilm/core/pull/2029/files?diff=unified&w=0#diff-9d9c80d6326eeda241e27429c0874c7ad4f93f3bfcf29bc16c5d9780e7708b38R31))
  * Specify the default and customizable CSS properties for the label variant ([link](https://github.com/JesusFilm/core/pull/2029/files?diff=unified&w=0#diff-9d9c80d6326eeda241e27429c0874c7ad4f93f3bfcf29bc16c5d9780e7708b38R22), [link](https://github.com/JesusFilm/core/pull/2029/files?diff=unified&w=0#diff-9d9c80d6326eeda241e27429c0874c7ad4f93f3bfcf29bc16c5d9780e7708b38R99-R104))
  * Showcase the label variant in the Typography storybook (`typography.stories.tsx`, [link](https://github.com/JesusFilm/core/pull/2029/files?diff=unified&w=0#diff-2a0d3b73a54d56ce278ea600b7d33abcbeff0951056ed7bc209481a7de8bffb0R45))
