### PR TITLE
fix: template card image hover

### DIFF
--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.tsx
@@ -72,24 +72,24 @@ export function FeltNeedsButton({
           height: { xs: '56px', md: '110px' },
           overflow: 'hidden',
           '&:hover': {
-            '& .HoverEffect': {
+            '& .hoverStyles': {
               transform: 'scale(1.02)'
             }
           },
-          '& .HoverEffect': {
+          '& .hoverStyles': {
             transition: (theme) => theme.transitions.create('transform')
           }
         }}
         onClick={() => onClick(tag.id)}
       >
         <NextImage
-          className="HoverEffect"
+          className="hoverStyles"
           src={image.src}
           layout="fill"
           sx={{ borderRadius: 2 }}
         />
         <Typography
-          className="HoverEffect"
+          className="hoverStyles"
           variant="h3"
           sx={{
             zIndex: 1,
@@ -103,7 +103,7 @@ export function FeltNeedsButton({
           {tagLabel}
         </Typography>
         <Typography
-          className="HoverEffect"
+          className="hoverStyles"
           variant="subtitle2"
           sx={{
             zIndex: 1,

--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.tsx
@@ -69,12 +69,27 @@ export function FeltNeedsButton({
         key={`${tagLabel}-button}`}
         sx={{
           width: { xs: '150px', md: '222px' },
-          height: { xs: '56px', md: '110px' }
+          height: { xs: '56px', md: '110px' },
+          overflow: 'hidden',
+          '&:hover': {
+            '& .HoverEffect': {
+              transform: 'scale(1.02)'
+            }
+          },
+          '& .HoverEffect': {
+            transition: (theme) => theme.transitions.create('transform')
+          }
         }}
         onClick={() => onClick(tag.id)}
       >
-        <NextImage src={image.src} layout="fill" sx={{ borderRadius: 2 }} />
+        <NextImage
+          className="HoverEffect"
+          src={image.src}
+          layout="fill"
+          sx={{ borderRadius: 2 }}
+        />
         <Typography
+          className="HoverEffect"
           variant="h3"
           sx={{
             zIndex: 1,
@@ -88,6 +103,7 @@ export function FeltNeedsButton({
           {tagLabel}
         </Typography>
         <Typography
+          className="HoverEffect"
           variant="subtitle2"
           sx={{
             zIndex: 1,

--- a/apps/journeys-admin/src/components/TemplateGalleryCard/TemplateGalleryCard.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryCard/TemplateGalleryCard.tsx
@@ -4,6 +4,7 @@ import Card from '@mui/material/Card'
 import CardMedia from '@mui/material/CardMedia'
 import Skeleton from '@mui/material/Skeleton'
 import Stack from '@mui/material/Stack'
+import { styled } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
 import { intlFormat, isThisYear, parseISO } from 'date-fns'
 import Image from 'next/image'
@@ -16,6 +17,15 @@ import { abbreviateLanguageName } from '../../libs/abbreviateLanguageName'
 export interface TemplateGalleryCardProps {
   item?: Journey
 }
+
+const StyledImage = styled(Image)({
+  borderRadius: 8,
+  objectFit: 'cover',
+  transition: 'transform .35s ease',
+  '&:hover': {
+    transform: 'scale(1.05)'
+  }
+})
 
 export function TemplateGalleryCard({
   item: journey
@@ -65,14 +75,15 @@ export function TemplateGalleryCard({
               <Box
                 sx={{
                   position: 'relative',
-                  aspectRatio: 1
+                  aspectRatio: 1,
+                  overflow: 'hidden',
+                  borderRadius: 2
                 }}
               >
-                <Image
+                <StyledImage
                   src={journey?.primaryImageBlock?.src}
                   alt={journey?.primaryImageBlock.alt}
                   fill
-                  style={{ borderRadius: 8, objectFit: 'cover' }}
                 />
               </Box>
             ) : (

--- a/apps/journeys-admin/src/components/TemplateGalleryCard/TemplateGalleryCard.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryCard/TemplateGalleryCard.tsx
@@ -4,7 +4,6 @@ import Card from '@mui/material/Card'
 import CardMedia from '@mui/material/CardMedia'
 import Skeleton from '@mui/material/Skeleton'
 import Stack from '@mui/material/Stack'
-import { styled } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
 import { intlFormat, isThisYear, parseISO } from 'date-fns'
 import Image from 'next/image'
@@ -17,15 +16,6 @@ import { abbreviateLanguageName } from '../../libs/abbreviateLanguageName'
 export interface TemplateGalleryCardProps {
   item?: Journey
 }
-
-const StyledImage = styled(Image)({
-  borderRadius: 8,
-  objectFit: 'cover',
-  transition: 'transform .35s ease',
-  '&:hover': {
-    transform: 'scale(1.05)'
-  }
-})
 
 export function TemplateGalleryCard({
   item: journey
@@ -67,7 +57,15 @@ export function TemplateGalleryCard({
         <Box
           data-testid="templateGalleryCard"
           sx={{
-            height: 'inherit'
+            height: 'inherit',
+            '&:hover': {
+              '& .MuiImageBackground-root': {
+                transform: 'scale(1.02)'
+              }
+            },
+            '& .MuiImageBackground-root': {
+              transition: (theme) => theme.transitions.create('transform')
+            }
           }}
         >
           {journey != null ? (
@@ -80,10 +78,14 @@ export function TemplateGalleryCard({
                   borderRadius: 2
                 }}
               >
-                <StyledImage
+                <Image
+                  className="MuiImageBackground-root"
                   src={journey?.primaryImageBlock?.src}
                   alt={journey?.primaryImageBlock.alt}
                   fill
+                  style={{
+                    objectFit: 'cover'
+                  }}
                 />
               </Box>
             ) : (
@@ -99,7 +101,7 @@ export function TemplateGalleryCard({
                   backgroundColor: 'background.default'
                 }}
               >
-                <InsertPhotoRoundedIcon />
+                <InsertPhotoRoundedIcon className="MuiImageBackground-root" />
               </CardMedia>
             )
           ) : (


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4e3e3ea</samp>

Updated the `TemplateGalleryCard` component to use a custom `StyledImage` component for better UI. Added some styling and animation to the template images in `apps/journeys-admin/src/components/TemplateGalleryCard/TemplateGalleryCard.tsx`.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34879725/todos/6747859247)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] it should zoom image on hover for template gallery cards

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4e3e3ea</samp>

* Create a custom styled component for the image element using the `styled` function from `@mui/material/styles` ([link](https://github.com/JesusFilm/core/pull/2032/files?diff=unified&w=0#diff-a5682122bdc264ccbf7a71916c34a3cbf03eece7e2f730eb81fc9a1896ab0288R7), [link](https://github.com/JesusFilm/core/pull/2032/files?diff=unified&w=0#diff-a5682122bdc264ccbf7a71916c34a3cbf03eece7e2f730eb81fc9a1896ab0288R21-R29))
* Replace the `Image` component with the `StyledImage` component in the `TemplateGalleryCard` component to apply the CSS properties and the hover effect ([link](https://github.com/JesusFilm/core/pull/2032/files?diff=unified&w=0#diff-a5682122bdc264ccbf7a71916c34a3cbf03eece7e2f730eb81fc9a1896ab0288L68-R86))
* Modify the `Box` component that wraps the image to have overflow hidden and a smaller border radius to match the `StyledImage` component ([link](https://github.com/JesusFilm/core/pull/2032/files?diff=unified&w=0#diff-a5682122bdc264ccbf7a71916c34a3cbf03eece7e2f730eb81fc9a1896ab0288L68-R86))
