### PR TITLE
fix: onboarding template import

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -37,6 +37,6 @@ jobs:
       - name: NPM Install
         run: npm install --silent
       - name: Danger JS
-        run: npx danger ci
+        run: npx danger ci --failOnErrors
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/journeys-admin/pages/index.tsx
+++ b/apps/journeys-admin/pages/index.tsx
@@ -14,10 +14,6 @@ import { useTranslation } from 'react-i18next'
 import { useFlags } from '@core/shared/ui/FlagsProvider'
 
 import { AcceptAllInvites } from '../__generated__/AcceptAllInvites'
-import {
-  GetOnboardingJourneys,
-  GetOnboardingJourneys_onboardingJourneys as OnboardingJourneys
-} from '../__generated__/GetOnboardingJourneys'
 import { JourneyList } from '../src/components/JourneyList'
 import { PageWrapper } from '../src/components/NewPageWrapper'
 import { OnboardingPanelContent } from '../src/components/OnboardingPanelContent'
@@ -36,25 +32,7 @@ export const ACCEPT_ALL_INVITES = gql`
   }
 `
 
-export const GET_ONBOARDING_JOURNEYS = gql`
-  query GetOnboardingJourneys($where: JourneysFilter) {
-    onboardingJourneys: journeys(where: $where) {
-      id
-      title
-      description
-      template
-      primaryImageBlock {
-        src
-      }
-    }
-  }
-`
-
-interface IndexPageProps {
-  onboardingJourneys: OnboardingJourneys[]
-}
-
-function IndexPage({ onboardingJourneys }: IndexPageProps): ReactElement {
+function IndexPage(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   const user = useUser()
   const { teams } = useFlags()
@@ -79,9 +57,7 @@ function IndexPage({ onboardingJourneys }: IndexPageProps): ReactElement {
             </Stack>
           )
         }
-        sidePanelChildren={
-          <OnboardingPanelContent onboardingJourneys={onboardingJourneys} />
-        }
+        sidePanelChildren={<OnboardingPanelContent />}
         sidePanelTitle={t('Create a New Journey')}
       >
         <JourneyList user={user} />
@@ -108,30 +84,14 @@ export const getServerSideProps = withUserTokenSSR({
     mutation: ACCEPT_ALL_INVITES
   })
 
-  const { data } = await apolloClient.query<GetOnboardingJourneys>({
-    query: GET_ONBOARDING_JOURNEYS,
-    variables: {
-      where: {
-        ids: [
-          '014c7add-288b-4f84-ac85-ccefef7a07d3',
-          'c4889bb1-49ac-41c9-8fdb-0297afb32cd9',
-          'e978adb4-e4d8-42ef-89a9-79811f10b7e9',
-          '178c01bd-371c-4e73-a9b8-e2bb95215fd8',
-          '13317d05-a805-4b3c-b362-9018971d9b57'
-        ]
-      }
-    }
-  })
-
   return {
     props: {
       flags,
-      onboardingJourneys: data?.onboardingJourneys,
       ...translations
     }
   }
 })
 
-export default withUser<IndexPageProps>({
+export default withUser({
   whenUnauthedAfterInit: AuthAction.REDIRECT_TO_LOGIN
 })(IndexPage)

--- a/apps/journeys-admin/src/components/MediaListItem/MediaListItem.spec.tsx
+++ b/apps/journeys-admin/src/components/MediaListItem/MediaListItem.spec.tsx
@@ -11,16 +11,13 @@ describe('MediaListItem', () => {
         description="Description"
         overline="Overline"
         href="/href"
-        duration="2:34"
       />
     )
 
-    expect(getByRole('link')).toHaveTextContent(
-      '2:34OverlineHeadingDescription'
-    )
+    expect(getByRole('link')).toHaveTextContent('OverlineHeadingDescription')
   })
 
-  it('should call onClick on button click', () => {
+  it('should have link', () => {
     const { getByRole } = render(
       <MediaListItem
         image="https://d1wl257kev7hsz.cloudfront.net/cinematics/2_AndreasStory-0-0.mobileCinematicHigh.jpg"
@@ -32,20 +29,10 @@ describe('MediaListItem', () => {
     expect(getByRole('link')).toHaveAttribute('href', '/href')
   })
 
-  it('should hide image and text if loading', () => {
-    const { getByRole, getByTestId } = render(
-      <MediaListItem
-        image="https://d1wl257kev7hsz.cloudfront.net/cinematics/2_AndreasStory-0-0.mobileCinematicHigh.jpg"
-        title="Heading"
-        description="Description"
-        loading
-        overline="Overline"
-        duration="2:34"
-      />
+  it('should show placeholder when no image', () => {
+    const { getByTestId } = render(
+      <MediaListItem title="Heading" description="Description" href="/href" />
     )
-
-    expect(getByRole('button')).toHaveAttribute('aria-disabled', 'true')
-    expect(getByRole('button')).toHaveTextContent('')
-    expect(getByTestId('image-placeholder')).toBeInTheDocument()
+    expect(getByTestId('InsertPhotoRoundedIcon')).toBeInTheDocument()
   })
 })

--- a/apps/journeys-admin/src/components/MediaListItem/MediaListItem.spec.tsx
+++ b/apps/journeys-admin/src/components/MediaListItem/MediaListItem.spec.tsx
@@ -1,10 +1,8 @@
-import { fireEvent, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
 
 import { MediaListItem } from './MediaListItem'
 
 describe('MediaListItem', () => {
-  const onClick = jest.fn()
-
   it('should render content', async () => {
     const { getByRole } = render(
       <MediaListItem
@@ -12,12 +10,12 @@ describe('MediaListItem', () => {
         title="Heading"
         description="Description"
         overline="Overline"
-        onClick={onClick}
+        href="/href"
         duration="2:34"
       />
     )
 
-    expect(getByRole('button')).toHaveTextContent(
+    expect(getByRole('link')).toHaveTextContent(
       '2:34OverlineHeadingDescription'
     )
   })
@@ -28,12 +26,10 @@ describe('MediaListItem', () => {
         image="https://d1wl257kev7hsz.cloudfront.net/cinematics/2_AndreasStory-0-0.mobileCinematicHigh.jpg"
         title="Heading"
         description="Description"
-        onClick={onClick}
+        href="/href"
       />
     )
-    fireEvent.click(getByRole('button'))
-
-    expect(onClick).toHaveBeenCalled()
+    expect(getByRole('link')).toHaveAttribute('href', '/href')
   })
 
   it('should hide image and text if loading', () => {
@@ -44,7 +40,6 @@ describe('MediaListItem', () => {
         description="Description"
         loading
         overline="Overline"
-        onClick={onClick}
         duration="2:34"
       />
     )

--- a/apps/journeys-admin/src/components/MediaListItem/MediaListItem.stories.tsx
+++ b/apps/journeys-admin/src/components/MediaListItem/MediaListItem.stories.tsx
@@ -56,11 +56,11 @@ export const LongContent: Story = {
   }
 }
 
-export const Duration: Story = {
+export const NoImage: Story = {
   ...Template,
   args: {
     ...Default.args,
-    duration: '2:34'
+    image: undefined
   }
 }
 

--- a/apps/journeys-admin/src/components/MediaListItem/MediaListItem.stories.tsx
+++ b/apps/journeys-admin/src/components/MediaListItem/MediaListItem.stories.tsx
@@ -12,8 +12,10 @@ const MediaListItemDemo: Meta<typeof MediaListItem> = {
   title: 'Journeys-Admin/MediaListItem'
 }
 
-const Template: StoryObj<typeof MediaListItem> = {
-  render: ({ ...args }) => (
+type Story = StoryObj<typeof MediaListItem>
+
+const Template: Story = {
+  render: (args) => (
     <Paper elevation={0} sx={{ p: 2 }}>
       <Stack direction="row">
         <MediaListItem {...args} />
@@ -22,10 +24,9 @@ const Template: StoryObj<typeof MediaListItem> = {
   )
 }
 
-export const Default = {
+export const Default: Story = {
   ...Template,
   args: {
-    id: 'id',
     title: 'This is a Heading',
     description: 'This is a description',
     image:
@@ -33,7 +34,7 @@ export const Default = {
   }
 }
 
-export const Overline = {
+export const Overline: Story = {
   ...Template,
   args: {
     ...Default.args,
@@ -41,10 +42,9 @@ export const Overline = {
   }
 }
 
-export const LongContent = {
+export const LongContent: Story = {
   ...Template,
   args: {
-    id: 'id',
     overline:
       'This is overline is really really really really really really really really really really really really really really long',
     title:
@@ -56,17 +56,7 @@ export const LongContent = {
   }
 }
 
-export const EndImage = {
-  ...Template,
-  args: {
-    ...LongContent.args,
-    overline: '',
-    description: 'This is a description',
-    imagePosition: 'end'
-  }
-}
-
-export const Duration = {
+export const Duration: Story = {
   ...Template,
   args: {
     ...Default.args,
@@ -74,11 +64,9 @@ export const Duration = {
   }
 }
 
-export const Loading = {
+export const Loading: Story = {
   ...Template,
   args: {
-    ...Overline.args,
-    ...Duration.args,
     loading: true
   }
 }

--- a/apps/journeys-admin/src/components/MediaListItem/MediaListItem.tsx
+++ b/apps/journeys-admin/src/components/MediaListItem/MediaListItem.tsx
@@ -4,32 +4,41 @@ import Skeleton from '@mui/material/Skeleton'
 import Stack from '@mui/material/Stack'
 import { SxProps, useTheme } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
+import NextLink from 'next/link'
 import { ReactElement } from 'react'
 
 import { NextImage } from '@core/shared/ui/NextImage'
 
-interface MediaListItemProps {
+interface MediaListItemLoadingProps {
+  image?: string
+  title?: string
+  description?: string
+  loading: true
+  overline?: string
+  duration?: string
+  href?: string
+}
+
+interface MediaListItemLoadedProps {
   image: string
   title: string
   description: string
-  loading?: boolean
+  loading?: false
   overline?: string
-  imagePosition?: 'start' | 'end'
   duration?: string
-  border?: boolean
-  onClick: () => void
+  href: string
 }
+
+type MediaListItemProps = MediaListItemLoadingProps | MediaListItemLoadedProps
 
 export function MediaListItem({
   image,
   title,
   description,
-  loading = false,
+  loading,
   overline,
-  imagePosition = 'start',
   duration,
-  border = false,
-  onClick
+  href
 }: MediaListItemProps): ReactElement {
   const theme = useTheme()
   // TODO: Replace fade with `line-clamp` with ellipsis when line-clamp supported
@@ -63,135 +72,138 @@ export function MediaListItem({
       }
     }
   }
-  const bottomBorder = border
-    ? { borderBottom: '1px solid', borderColor: 'divider' }
-    : {}
 
   return (
-    <ListItemButton
-      onClick={onClick}
-      disabled={loading}
-      sx={{ ...faceOnButtonHoverFix, ...bottomBorder, px: 6 }}
-    >
-      <Stack
-        direction={imagePosition === 'start' ? 'row' : 'row-reverse'}
-        spacing={4}
-        alignItems="center"
-        sx={{ width: '100%' }}
+    <NextLink href={href ?? ''} passHref legacyBehavior>
+      <ListItemButton
+        disabled={loading}
+        sx={{
+          ...faceOnButtonHoverFix,
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          px: 6
+        }}
       >
-        {loading ? (
-          <Skeleton
-            data-testid="image-placeholder"
-            variant="rectangular"
-            height={79}
-            width={79}
-            sx={{ borderRadius: 2 }}
-          />
-        ) : (
-          <Stack>
-            <NextImage
-              src={image}
-              alt={title}
+        <Stack
+          direction="row"
+          spacing={4}
+          alignItems="center"
+          sx={{ width: '100%' }}
+        >
+          {loading === true ? (
+            <Skeleton
+              data-testid="image-placeholder"
+              variant="rectangular"
               height={79}
               width={79}
-              layout="fixed"
-              objectFit="cover"
-              style={{
-                borderRadius: 8
-              }}
+              sx={{ borderRadius: 2 }}
             />
-            {duration != null && (
-              <Stack
-                sx={{
-                  position: 'absolute',
-                  alignItems: 'flex-end',
-                  justifyContent: 'flex-end',
-                  height: 79,
-                  width: 79,
-                  borderRadius: 2,
-                  mr: 2
+          ) : (
+            <Stack>
+              <NextImage
+                src={image}
+                alt={title}
+                height={79}
+                width={79}
+                layout="fixed"
+                objectFit="cover"
+                style={{
+                  borderRadius: 8
                 }}
-              >
-                <Typography
-                  component="div"
-                  variant="caption"
-                  sx={{
-                    color: 'background.paper',
-                    backgroundColor: 'rgba(0, 0, 0, 0.35)',
-                    px: 1,
-                    m: 1,
-                    borderRadius: 2
-                  }}
-                >
-                  {duration}
-                </Typography>
-              </Stack>
-            )}
-          </Stack>
-        )}
-        <Stack flexGrow={1} sx={{ overflow: 'hidden' }}>
-          {overline != null &&
-            (loading ? (
-              <Skeleton
-                variant="text"
-                width={10.5 * overline.length}
-                sx={{ mb: 1, height: theme.typography.overline.lineHeight }}
               />
-            ) : (
-              <Typography
-                variant="overline"
-                color="secondary.light"
-                className="overflow-text"
-                sx={{ ...fadeOverflowText('overline'), mt: 2 }}
-              >
-                {overline}
-              </Typography>
-            ))}
-
-          <ListItemText
-            primary={
-              loading ? (
-                <Skeleton
-                  variant="rectangular"
-                  width={9.5 * title.length}
+              {duration != null && (
+                <Stack
                   sx={{
-                    mt: 0.5,
-                    borderRadius: 1,
-                    fontSize: theme.typography.subtitle1.fontSize
+                    position: 'absolute',
+                    alignItems: 'flex-end',
+                    justifyContent: 'flex-end',
+                    height: 79,
+                    width: 79,
+                    borderRadius: 2,
+                    mr: 2
                   }}
-                />
-              ) : (
-                <Typography
-                  variant="subtitle1"
-                  className="overflow-text"
-                  sx={{ ...fadeOverflowText('subtitle1') }}
                 >
-                  {title}
-                </Typography>
-              )
-            }
-            secondary={
-              loading ? (
+                  <Typography
+                    component="div"
+                    variant="caption"
+                    sx={{
+                      color: 'background.paper',
+                      backgroundColor: 'rgba(0, 0, 0, 0.35)',
+                      px: 1,
+                      m: 1,
+                      borderRadius: 2
+                    }}
+                  >
+                    {duration}
+                  </Typography>
+                </Stack>
+              )}
+            </Stack>
+          )}
+          <Stack flexGrow={1} sx={{ overflow: 'hidden' }}>
+            {overline != null &&
+              (loading === true ? (
                 <Skeleton
                   variant="text"
-                  width={6 * description.length}
-                  sx={{ mt: 1, fontSize: theme.typography.body2.lineHeight }}
+                  width={100}
+                  sx={{ mb: 1, height: theme.typography.overline.lineHeight }}
                 />
               ) : (
                 <Typography
-                  variant="body2"
+                  variant="overline"
                   color="secondary.light"
                   className="overflow-text"
-                  sx={{ ...fadeOverflowText('body2') }}
+                  sx={{ ...fadeOverflowText('overline'), mt: 2 }}
                 >
-                  {description}
+                  {overline}
                 </Typography>
-              )
-            }
-            sx={{ mt: 0 }}
-          />
+              ))}
+
+            <ListItemText
+              primary={
+                loading === true ? (
+                  <Skeleton
+                    variant="rectangular"
+                    width={150}
+                    sx={{
+                      mt: 0.5,
+                      borderRadius: 1,
+                      fontSize: theme.typography.subtitle1.fontSize
+                    }}
+                  />
+                ) : (
+                  <Typography
+                    variant="subtitle1"
+                    className="overflow-text"
+                    sx={{ ...fadeOverflowText('subtitle1') }}
+                  >
+                    {title}
+                  </Typography>
+                )
+              }
+              secondary={
+                loading === true ? (
+                  <Skeleton
+                    variant="text"
+                    width={125}
+                    sx={{ mt: 1, fontSize: theme.typography.body2.lineHeight }}
+                  />
+                ) : (
+                  <Typography
+                    variant="body2"
+                    color="secondary.light"
+                    className="overflow-text"
+                    sx={{ ...fadeOverflowText('body2') }}
+                  >
+                    {description}
+                  </Typography>
+                )
+              }
+              sx={{ mt: 0 }}
+            />
+          </Stack>
         </Stack>
-      </Stack>
-    </ListItemButton>
+      </ListItemButton>
+    </NextLink>
   )
 }

--- a/apps/journeys-admin/src/components/MediaListItem/MediaListItem.tsx
+++ b/apps/journeys-admin/src/components/MediaListItem/MediaListItem.tsx
@@ -1,3 +1,5 @@
+import InsertPhotoRoundedIcon from '@mui/icons-material/InsertPhotoRounded'
+import Box from '@mui/material/Box'
 import ListItemButton from '@mui/material/ListItemButton'
 import ListItemText from '@mui/material/ListItemText'
 import Skeleton from '@mui/material/Skeleton'
@@ -15,17 +17,15 @@ interface MediaListItemLoadingProps {
   description?: string
   loading: true
   overline?: string
-  duration?: string
   href?: string
 }
 
 interface MediaListItemLoadedProps {
-  image: string
+  image?: string
   title: string
-  description: string
+  description?: string
   loading?: false
   overline?: string
-  duration?: string
   href: string
 }
 
@@ -37,7 +37,6 @@ export function MediaListItem({
   description,
   loading,
   overline,
-  duration,
   href
 }: MediaListItemProps): ReactElement {
   const theme = useTheme()
@@ -84,71 +83,49 @@ export function MediaListItem({
           px: 6
         }}
       >
-        <Stack
-          direction="row"
-          spacing={4}
-          alignItems="center"
-          sx={{ width: '100%' }}
-        >
-          {loading === true ? (
-            <Skeleton
-              data-testid="image-placeholder"
-              variant="rectangular"
-              height={79}
-              width={79}
-              sx={{ borderRadius: 2 }}
-            />
-          ) : (
-            <Stack>
+        <Stack direction="row" spacing={4} alignItems="center">
+          <Box
+            sx={{
+              width: 79,
+              height: 79,
+              position: 'relative',
+              flexShrink: 0,
+              overflow: 'hidden',
+              borderRadius: 2
+            }}
+          >
+            {loading === true ? (
+              <Skeleton variant="rectangular" height="100%" />
+            ) : image != null ? (
               <NextImage
                 src={image}
                 alt={title}
-                height={79}
-                width={79}
-                layout="fixed"
+                layout="fill"
                 objectFit="cover"
-                style={{
-                  borderRadius: 8
-                }}
               />
-              {duration != null && (
-                <Stack
-                  sx={{
-                    position: 'absolute',
-                    alignItems: 'flex-end',
-                    justifyContent: 'flex-end',
-                    height: 79,
-                    width: 79,
-                    borderRadius: 2,
-                    mr: 2
-                  }}
-                >
-                  <Typography
-                    component="div"
-                    variant="caption"
-                    sx={{
-                      color: 'background.paper',
-                      backgroundColor: 'rgba(0, 0, 0, 0.35)',
-                      px: 1,
-                      m: 1,
-                      borderRadius: 2
-                    }}
-                  >
-                    {duration}
-                  </Typography>
-                </Stack>
-              )}
-            </Stack>
-          )}
+            ) : (
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                  backgroundColor: 'background.default',
+                  height: '100%'
+                }}
+              >
+                <InsertPhotoRoundedIcon />
+              </Box>
+            )}
+          </Box>
           <Stack flexGrow={1} sx={{ overflow: 'hidden' }}>
-            {overline != null &&
-              (loading === true ? (
-                <Skeleton
-                  variant="text"
-                  width={100}
-                  sx={{ mb: 1, height: theme.typography.overline.lineHeight }}
-                />
-              ) : (
+            {loading === true ? (
+              <Skeleton
+                variant="text"
+                width={100}
+                sx={{ mb: 1, height: theme.typography.overline.lineHeight }}
+              />
+            ) : (
+              overline != null && (
                 <Typography
                   variant="overline"
                   color="secondary.light"
@@ -157,7 +134,8 @@ export function MediaListItem({
                 >
                   {overline}
                 </Typography>
-              ))}
+              )
+            )}
 
             <ListItemText
               primary={
@@ -189,14 +167,16 @@ export function MediaListItem({
                     sx={{ mt: 1, fontSize: theme.typography.body2.lineHeight }}
                   />
                 ) : (
-                  <Typography
-                    variant="body2"
-                    color="secondary.light"
-                    className="overflow-text"
-                    sx={{ ...fadeOverflowText('body2') }}
-                  >
-                    {description}
-                  </Typography>
+                  description != null && (
+                    <Typography
+                      variant="body2"
+                      color="secondary.light"
+                      className="overflow-text"
+                      sx={{ ...fadeOverflowText('body2') }}
+                    >
+                      {description}
+                    </Typography>
+                  )
                 )
               }
               sx={{ mt: 0 }}

--- a/apps/journeys-admin/src/components/OnboardingPanelContent/OnboardingPanelContent.spec.tsx
+++ b/apps/journeys-admin/src/components/OnboardingPanelContent/OnboardingPanelContent.spec.tsx
@@ -3,27 +3,25 @@ import { fireEvent, render, waitFor } from '@testing-library/react'
 import { NextRouter, useRouter } from 'next/router'
 import { v4 as uuidv4 } from 'uuid'
 
-import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
-
+import {
+  CreateJourney,
+  CreateJourneyVariables
+} from '../../../__generated__/CreateJourney'
 import { GetLastActiveTeamIdAndTeams } from '../../../__generated__/GetLastActiveTeamIdAndTeams'
+import {
+  JourneyStatus,
+  ThemeMode,
+  ThemeName
+} from '../../../__generated__/globalTypes'
 import { CREATE_JOURNEY } from '../../libs/useJourneyCreateMutation'
 import {
   GET_LAST_ACTIVE_TEAM_ID_AND_TEAMS,
   TeamProvider
 } from '../Team/TeamProvider'
 
-import { onboardingJourneys } from './data'
+import { getOnboardingJourneysMock } from './data'
 
 import { OnboardingPanelContent } from '.'
-
-jest.mock('react-i18next', () => ({
-  __esModule: true,
-  useTranslation: () => {
-    return {
-      t: (str: string) => str
-    }
-  }
-}))
 
 jest.mock('next/router', () => ({
   __esModule: true,
@@ -51,90 +49,104 @@ const variables = {
   captionTypographyContent: 'Deutoronomy 10:11',
   teamId: 'teamId'
 }
-
-const data = {
-  journeyCreate: {
-    createdAt: '2022-02-17T21:47:32.004Z',
-    description: variables.description,
-    id: variables.journeyId,
-    language: {
-      id: '529',
-      name: {
-        value: 'English',
-        primary: true
-      }
-    },
-    publishedAt: null,
-    slug: 'untitled-journey-journeyId',
-    status: 'draft',
-    themeMode: 'dark',
-    themeName: 'base',
-    title: variables.title,
-    __typename: 'Journey',
-    userJourneys: [
-      {
-        __typename: 'UserJourney',
-        id: 'user-journey-id',
-        user: {
-          __typename: 'User',
-          id: 'user-id1',
-          firstName: 'Admin',
-          lastName: 'One',
-          imageUrl: 'https://bit.ly/3Gth4Yf'
-        }
-      }
-    ]
-  },
-  stepBlockCreate: {
-    id: variables.stepId,
-    __typename: 'StepBlock'
-  },
-  cardBlockCreate: {
-    id: variables.cardId,
-    __typename: 'CardBlock'
-  },
-  imageBlockCreate: {
-    id: variables.imageId,
-    __typename: 'ImageBlock'
-  },
-  headlineTypographyBlockCreate: {
-    id: 'headlineTypographyId',
-    __typename: 'TypographyBlock'
-  },
-  bodyTypographyBlockCreate: {
-    id: 'bodyTypographyId',
-    __typename: 'TypographyBlock'
-  },
-  captionTypographyBlockCreate: {
-    id: 'captionTypographyId',
-    __typename: 'TypographyBlock'
-  }
-}
-
-const mocks = [
+const createJourneyMock: MockedResponse<CreateJourney, CreateJourneyVariables> =
   {
     request: {
       query: CREATE_JOURNEY,
       variables
     },
-    result: { data }
+    result: {
+      data: {
+        journeyCreate: {
+          createdAt: '2022-02-17T21:47:32.004Z',
+          description: variables.description,
+          id: variables.journeyId,
+          language: {
+            id: '529',
+            name: [
+              {
+                value: 'English',
+                primary: true,
+                __typename: 'Translation'
+              }
+            ],
+            __typename: 'Language'
+          },
+          publishedAt: null,
+          slug: 'untitled-journey-journeyId',
+          status: JourneyStatus.draft,
+          themeMode: ThemeMode.dark,
+          themeName: ThemeName.base,
+          title: variables.title,
+          __typename: 'Journey',
+          userJourneys: [
+            {
+              __typename: 'UserJourney',
+              id: 'user-journey-id',
+              user: {
+                __typename: 'User',
+                id: 'user-id1',
+                firstName: 'Admin',
+                lastName: 'One',
+                imageUrl: 'https://bit.ly/3Gth4Yf'
+              }
+            }
+          ]
+        },
+        stepBlockCreate: {
+          id: variables.stepId,
+          __typename: 'StepBlock'
+        },
+        cardBlockCreate: {
+          id: variables.cardId,
+          __typename: 'CardBlock'
+        },
+        imageBlockCreate: {
+          id: variables.imageId,
+          __typename: 'ImageBlock'
+        },
+        headlineTypographyBlockCreate: {
+          id: 'headlineTypographyId',
+          __typename: 'TypographyBlock'
+        },
+        bodyTypographyBlockCreate: {
+          id: 'bodyTypographyId',
+          __typename: 'TypographyBlock'
+        },
+        captionTypographyBlockCreate: {
+          id: 'captionTypographyId',
+          __typename: 'TypographyBlock'
+        }
+      }
+    }
   }
-]
-
-const getTeams: MockedResponse<GetLastActiveTeamIdAndTeams> = {
+const getTeamsMock: MockedResponse<GetLastActiveTeamIdAndTeams> = {
   request: {
     query: GET_LAST_ACTIVE_TEAM_ID_AND_TEAMS
   },
   result: {
     data: {
-      teams: [],
+      teams: [
+        {
+          id: 'teamId',
+          title: 'Team Title',
+          __typename: 'Team',
+          publicTitle: 'Public Team Title',
+          userTeams: []
+        }
+      ],
       getJourneyProfile: {
         __typename: 'JourneyProfile',
-        lastActiveTeamId: null
+        lastActiveTeamId: 'teamId'
       }
     }
   }
 }
+const mocks: MockedResponse[] = [
+  createJourneyMock,
+  getOnboardingJourneysMock,
+  getTeamsMock
+]
 
 describe('OnboardingPanelContent', () => {
   it('should add a new journey on custom journey button click', async () => {
@@ -145,36 +157,16 @@ describe('OnboardingPanelContent', () => {
     mockUuidv4.mockReturnValueOnce(variables.cardId)
     mockUuidv4.mockReturnValueOnce(variables.imageId)
     const { getByRole } = render(
-      <MockedProvider
-        mocks={[
-          ...mocks,
-          {
-            ...getTeams,
-            result: {
-              data: {
-                teams: [
-                  { id: 'teamId', title: 'Team Title', __typename: 'Team' }
-                ],
-                getJourneyProfile: {
-                  __typename: 'JourneyProfile',
-                  lastActiveTeamId: 'teamId'
-                }
-              }
-            }
-          }
-        ]}
-      >
-        <FlagsProvider flags={{ teams: true }}>
-          <TeamProvider>
-            <OnboardingPanelContent onboardingJourneys={onboardingJourneys} />
-          </TeamProvider>
-        </FlagsProvider>
+      <MockedProvider mocks={mocks}>
+        <TeamProvider>
+          <OnboardingPanelContent />
+        </TeamProvider>
       </MockedProvider>
     )
     await waitFor(() =>
       expect(
         getByRole('button', { name: 'Create Custom Journey' })
-      ).toBeInTheDocument()
+      ).not.toBeDisabled()
     )
     fireEvent.click(getByRole('button', { name: 'Create Custom Journey' }))
 
@@ -189,7 +181,7 @@ describe('OnboardingPanelContent', () => {
     })
   })
 
-  it('should not show create journey button when on shared with me and teams flag is true', async () => {
+  it('should not show create journey button when on shared with me', async () => {
     const result = jest.fn().mockReturnValueOnce({
       data: {
         teams: []
@@ -198,18 +190,17 @@ describe('OnboardingPanelContent', () => {
     const { queryByRole } = render(
       <MockedProvider
         mocks={[
-          ...mocks,
+          createJourneyMock,
+          getOnboardingJourneysMock,
           {
-            ...getTeams,
+            ...getTeamsMock,
             result
           }
         ]}
       >
-        <FlagsProvider flags={{ teams: true }}>
-          <TeamProvider>
-            <OnboardingPanelContent onboardingJourneys={onboardingJourneys} />
-          </TeamProvider>
-        </FlagsProvider>
+        <TeamProvider>
+          <OnboardingPanelContent />
+        </TeamProvider>
       </MockedProvider>
     )
 
@@ -219,27 +210,12 @@ describe('OnboardingPanelContent', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('should show create journey button when on shared with me and teams flag is false', async () => {
-    const { getByRole } = render(
-      <MockedProvider mocks={mocks}>
-        <FlagsProvider flags={{ teams: false }}>
-          <TeamProvider>
-            <OnboardingPanelContent onboardingJourneys={onboardingJourneys} />
-          </TeamProvider>
-        </FlagsProvider>
-      </MockedProvider>
-    )
-    await waitFor(() =>
-      expect(
-        getByRole('button', { name: 'Create Custom Journey' })
-      ).toBeInTheDocument()
-    )
-  })
-
   it('should display onboarding templates', async () => {
     const { getByText } = render(
       <MockedProvider mocks={mocks}>
-        <OnboardingPanelContent onboardingJourneys={onboardingJourneys} />
+        <TeamProvider>
+          <OnboardingPanelContent />
+        </TeamProvider>
       </MockedProvider>
     )
     await waitFor(() =>
@@ -255,25 +231,30 @@ describe('OnboardingPanelContent', () => {
     const push = jest.fn()
     mockUseRouter.mockReturnValue({ push } as unknown as NextRouter)
 
-    const { getByText } = render(
+    const { getByText, getByRole } = render(
       <MockedProvider mocks={mocks}>
-        <OnboardingPanelContent onboardingJourneys={onboardingJourneys} />
+        <TeamProvider>
+          <OnboardingPanelContent />
+        </TeamProvider>
       </MockedProvider>
     )
 
     await waitFor(() =>
       expect(getByText('template 1 title')).toBeInTheDocument()
     )
-    fireEvent.click(getByText('template 1 title'))
-    expect(push).toHaveBeenCalledWith(
-      '/templates/014c7add-288b-4f84-ac85-ccefef7a07d3'
-    )
+    expect(
+      getByRole('link', {
+        name: 'template 1 title Template template 1 title template 1 description'
+      })
+    ).toHaveAttribute('href', '/templates/014c7add-288b-4f84-ac85-ccefef7a07d3')
   })
 
   it('should redirect on See all link', () => {
     const { getByRole } = render(
-      <MockedProvider mocks={[]}>
-        <OnboardingPanelContent onboardingJourneys={onboardingJourneys} />
+      <MockedProvider mocks={mocks}>
+        <TeamProvider>
+          <OnboardingPanelContent />
+        </TeamProvider>
       </MockedProvider>
     )
 
@@ -286,7 +267,9 @@ describe('OnboardingPanelContent', () => {
   it('should redirect on See all templates button', () => {
     const { getByRole } = render(
       <MockedProvider mocks={[]}>
-        <OnboardingPanelContent onboardingJourneys={onboardingJourneys} />
+        <TeamProvider>
+          <OnboardingPanelContent />
+        </TeamProvider>
       </MockedProvider>
     )
 

--- a/apps/journeys-admin/src/components/OnboardingPanelContent/OnboardingPanelContent.stories.tsx
+++ b/apps/journeys-admin/src/components/OnboardingPanelContent/OnboardingPanelContent.stories.tsx
@@ -5,9 +5,10 @@ import useMediaQuery from '@mui/material/useMediaQuery'
 import { Meta, StoryObj } from '@storybook/react'
 import { ReactElement } from 'react'
 
+import { cache } from '../../libs/apolloClient/cache'
 import { simpleComponentConfig } from '../../libs/storybook'
 
-import { onboardingJourneys } from './data'
+import { getOnboardingJourneysMock } from './data'
 import { OnboardingPanelContent } from './OnboardingPanelContent'
 
 const OnboardingPanelContentStory: Meta<typeof OnboardingPanelContent> = {
@@ -22,7 +23,7 @@ const OnboardingPanelContentComponent = (): ReactElement => {
   return (
     <MockedProvider>
       <Drawer anchor={isMobile ? 'bottom' : 'left'} open>
-        <OnboardingPanelContent onboardingJourneys={onboardingJourneys} />
+        <OnboardingPanelContent />
       </Drawer>
     </MockedProvider>
   )
@@ -32,6 +33,15 @@ const Template: StoryObj<typeof OnboardingPanelContent> = {
   render: () => <OnboardingPanelContentComponent />
 }
 
-export const Default = { ...Template }
+export const Default = {
+  ...Template,
+
+  parameters: {
+    apolloClient: {
+      cache: cache(),
+      mocks: [getOnboardingJourneysMock]
+    }
+  }
+}
 
 export default OnboardingPanelContentStory

--- a/apps/journeys-admin/src/components/OnboardingPanelContent/OnboardingPanelContent.stories.tsx
+++ b/apps/journeys-admin/src/components/OnboardingPanelContent/OnboardingPanelContent.stories.tsx
@@ -2,6 +2,7 @@ import { Meta, StoryObj } from '@storybook/react'
 import { ReactElement } from 'react'
 
 import { cache } from '../../libs/apolloClient/cache'
+import { PageProvider } from '../../libs/PageWrapperProvider'
 import { simpleComponentConfig } from '../../libs/storybook'
 import { SidePanel } from '../NewPageWrapper/SidePanel'
 import { TeamProvider } from '../Team/TeamProvider'
@@ -19,9 +20,11 @@ const Template: StoryObj<typeof OnboardingPanelContent> = {
   render: (): ReactElement => {
     return (
       <TeamProvider>
-        <SidePanel title="Create A New Journey">
-          <OnboardingPanelContent />
-        </SidePanel>
+        <PageProvider initialState={{ mobileDrawerOpen: true }}>
+          <SidePanel title="Create A New Journey">
+            <OnboardingPanelContent />
+          </SidePanel>
+        </PageProvider>
       </TeamProvider>
     )
   }

--- a/apps/journeys-admin/src/components/OnboardingPanelContent/OnboardingPanelContent.stories.tsx
+++ b/apps/journeys-admin/src/components/OnboardingPanelContent/OnboardingPanelContent.stories.tsx
@@ -7,6 +7,7 @@ import { ReactElement } from 'react'
 
 import { cache } from '../../libs/apolloClient/cache'
 import { simpleComponentConfig } from '../../libs/storybook'
+import { TeamProvider } from '../Team/TeamProvider'
 
 import { getOnboardingJourneysMock } from './data'
 import { OnboardingPanelContent } from './OnboardingPanelContent'
@@ -22,9 +23,11 @@ const OnboardingPanelContentComponent = (): ReactElement => {
 
   return (
     <MockedProvider>
-      <Drawer anchor={isMobile ? 'bottom' : 'left'} open>
-        <OnboardingPanelContent />
-      </Drawer>
+      <TeamProvider>
+        <Drawer anchor={isMobile ? 'bottom' : 'left'} open>
+          <OnboardingPanelContent />
+        </Drawer>
+      </TeamProvider>
     </MockedProvider>
   )
 }

--- a/apps/journeys-admin/src/components/OnboardingPanelContent/OnboardingPanelContent.stories.tsx
+++ b/apps/journeys-admin/src/components/OnboardingPanelContent/OnboardingPanelContent.stories.tsx
@@ -1,12 +1,9 @@
-import { MockedProvider } from '@apollo/client/testing'
-import Drawer from '@mui/material/Drawer'
-import { Theme } from '@mui/material/styles'
-import useMediaQuery from '@mui/material/useMediaQuery'
 import { Meta, StoryObj } from '@storybook/react'
 import { ReactElement } from 'react'
 
 import { cache } from '../../libs/apolloClient/cache'
 import { simpleComponentConfig } from '../../libs/storybook'
+import { SidePanel } from '../NewPageWrapper/SidePanel'
 import { TeamProvider } from '../Team/TeamProvider'
 
 import { getOnboardingJourneysMock } from './data'
@@ -18,31 +15,33 @@ const OnboardingPanelContentStory: Meta<typeof OnboardingPanelContent> = {
   title: 'Journeys-Admin/OnboardingPanelContent'
 }
 
-const OnboardingPanelContentComponent = (): ReactElement => {
-  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('sm'))
-
-  return (
-    <MockedProvider>
-      <TeamProvider>
-        <Drawer anchor={isMobile ? 'bottom' : 'left'} open>
-          <OnboardingPanelContent />
-        </Drawer>
-      </TeamProvider>
-    </MockedProvider>
-  )
-}
-
 const Template: StoryObj<typeof OnboardingPanelContent> = {
-  render: () => <OnboardingPanelContentComponent />
+  render: (): ReactElement => {
+    return (
+      <TeamProvider>
+        <SidePanel title="Create A New Journey">
+          <OnboardingPanelContent />
+        </SidePanel>
+      </TeamProvider>
+    )
+  }
 }
 
 export const Default = {
   ...Template,
-
   parameters: {
     apolloClient: {
       cache: cache(),
       mocks: [getOnboardingJourneysMock]
+    }
+  }
+}
+
+export const Loading = {
+  ...Template,
+  parameters: {
+    apolloClient: {
+      mocks: [{ ...getOnboardingJourneysMock, delay: 100000000000000 }]
     }
   }
 }

--- a/apps/journeys-admin/src/components/OnboardingPanelContent/OnboardingPanelContent.tsx
+++ b/apps/journeys-admin/src/components/OnboardingPanelContent/OnboardingPanelContent.tsx
@@ -114,8 +114,6 @@ export function OnboardingPanelContent(): ReactElement {
           <MediaListItem loading />
           <MediaListItem loading />
           <MediaListItem loading />
-          <MediaListItem loading />
-          <MediaListItem loading />
         </>
       ) : (
         templates.map(
@@ -123,8 +121,8 @@ export function OnboardingPanelContent(): ReactElement {
             template != null && (
               <MediaListItem
                 title={template.title}
-                description={template.description ?? ''}
-                image={template.primaryImageBlock?.src ?? ''}
+                description={template.description ?? undefined}
+                image={template.primaryImageBlock?.src ?? undefined}
                 overline={t('Template')}
                 key={template.id}
                 href={`/templates/${template.id}`}

--- a/apps/journeys-admin/src/components/OnboardingPanelContent/OnboardingPanelContent.tsx
+++ b/apps/journeys-admin/src/components/OnboardingPanelContent/OnboardingPanelContent.tsx
@@ -1,25 +1,29 @@
+import { gql, useQuery } from '@apollo/client'
 import Button from '@mui/material/Button'
 import Link from '@mui/material/Link'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
+import compact from 'lodash/compact'
 import NextLink from 'next/link'
 import { useRouter } from 'next/router'
-import { ReactElement } from 'react'
+import { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { useFlags } from '@core/shared/ui/FlagsProvider'
 import ChevronRightIcon from '@core/shared/ui/icons/ChevronRight'
 import FilePlus1Icon from '@core/shared/ui/icons/FilePlus1'
 import Grid1Icon from '@core/shared/ui/icons/Grid1'
 
-import { GetOnboardingJourneys_onboardingJourneys as OnboardingJourneys } from '../../../__generated__/GetOnboardingJourneys'
+import {
+  GetOnboardingJourneys,
+  GetOnboardingJourneys_onboardingJourneys as OnboardingJourneys
+} from '../../../__generated__/GetOnboardingJourneys'
 import { useJourneyCreateMutation } from '../../libs/useJourneyCreateMutation/useJourneyCreateMutation'
 import { ContainedIconButton } from '../ContainedIconButton'
 import { MediaListItem } from '../MediaListItem'
 import { SidePanelContainer } from '../NewPageWrapper/SidePanelContainer'
 import { useTeam } from '../Team/TeamProvider'
 
-const onboardingIds = [
+export const ONBOARDING_IDS = [
   '014c7add-288b-4f84-ac85-ccefef7a07d3',
   'c4889bb1-49ac-41c9-8fdb-0297afb32cd9',
   'e978adb4-e4d8-42ef-89a9-79811f10b7e9',
@@ -27,27 +31,49 @@ const onboardingIds = [
   '13317d05-a805-4b3c-b362-9018971d9b57'
 ]
 
-interface OnboardingPanelContentProps {
-  onboardingJourneys: OnboardingJourneys[]
-}
+export const GET_ONBOARDING_JOURNEYS = gql`
+  query GetOnboardingJourneys($where: JourneysFilter) {
+    onboardingJourneys: journeys(where: $where) {
+      id
+      title
+      description
+      template
+      primaryImageBlock {
+        src
+      }
+    }
+  }
+`
 
-export function OnboardingPanelContent({
-  onboardingJourneys
-}: OnboardingPanelContentProps): ReactElement {
+export function OnboardingPanelContent(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
-  const { activeTeam } = useTeam()
+  const {
+    query: { loading: loadingTeams },
+    activeTeam
+  } = useTeam()
   const router = useRouter()
-  const { teams } = useFlags()
+  const { createJourney, loading: loadingJourneyCreateMutation } =
+    useJourneyCreateMutation()
+  const [templates, setTemplates] = useState<OnboardingJourneys[]>([])
+  const { loading: loadingOnboardingJourneys } =
+    useQuery<GetOnboardingJourneys>(GET_ONBOARDING_JOURNEYS, {
+      variables: {
+        where: {
+          ids: ONBOARDING_IDS
+        }
+      },
+      onCompleted(data) {
+        setTemplates(
+          compact(
+            ONBOARDING_IDS.map((onboardingId) =>
+              data.onboardingJourneys.find(({ id }) => onboardingId === id)
+            )
+          )
+        )
+      }
+    })
 
-  const { createJourney, loading } = useJourneyCreateMutation()
-
-  const templates: OnboardingJourneys[] = []
-  onboardingJourneys.forEach((onboardingJourney) => {
-    templates[onboardingIds.indexOf(onboardingJourney.id)] = onboardingJourney
-  })
-  const loadingTemplates = onboardingJourneys == null
-
-  const handleCreateJourneyClick = async (): Promise<void> => {
+  async function handleCreateJourneyClick(): Promise<void> {
     const journey = await createJourney()
     if (journey != null) {
       void router.push(`/journeys/${journey.id}/edit`, undefined, {
@@ -56,19 +82,15 @@ export function OnboardingPanelContent({
     }
   }
 
-  const handleTemplateClick = (journeyId?: string): void => {
-    if (journeyId != null) void router.push(`/templates/${journeyId}`)
-  }
-
   return (
     <>
-      {(!teams || activeTeam != null) && (
+      {(activeTeam != null || loadingTeams) && (
         <SidePanelContainer>
           <ContainedIconButton
             label={t('Create Custom Journey')}
             thumbnailIcon={<FilePlus1Icon />}
             onClick={handleCreateJourneyClick}
-            loading={loading}
+            loading={loadingJourneyCreateMutation || loadingTeams}
           />
         </SidePanelContainer>
       )}
@@ -87,20 +109,28 @@ export function OnboardingPanelContent({
           </NextLink>
         </Stack>
       </SidePanelContainer>
-      {templates.map(
-        (template) =>
-          template != null && (
-            <MediaListItem
-              key={template.id}
-              loading={loadingTemplates}
-              title={template.title}
-              description={template.description ?? ''}
-              image={template.primaryImageBlock?.src ?? ''}
-              overline={t('Template')}
-              border
-              onClick={() => handleTemplateClick(template?.id)}
-            />
-          )
+      {loadingOnboardingJourneys ? (
+        <>
+          <MediaListItem loading />
+          <MediaListItem loading />
+          <MediaListItem loading />
+          <MediaListItem loading />
+          <MediaListItem loading />
+        </>
+      ) : (
+        templates.map(
+          (template) =>
+            template != null && (
+              <MediaListItem
+                title={template.title}
+                description={template.description ?? ''}
+                image={template.primaryImageBlock?.src ?? ''}
+                overline={t('Template')}
+                key={template.id}
+                href={`/templates/${template.id}`}
+              />
+            )
+        )
       )}
       <SidePanelContainer border={false}>
         <NextLink href="/templates" passHref legacyBehavior>

--- a/apps/journeys-admin/src/components/OnboardingPanelContent/data.ts
+++ b/apps/journeys-admin/src/components/OnboardingPanelContent/data.ts
@@ -1,4 +1,15 @@
-import { GetOnboardingJourneys_onboardingJourneys as OnboardingJourneys } from '../../../__generated__/GetOnboardingJourneys'
+import { MockedResponse } from '@apollo/client/testing'
+
+import {
+  GetOnboardingJourneys,
+  GetOnboardingJourneysVariables,
+  GetOnboardingJourneys_onboardingJourneys as OnboardingJourneys
+} from '../../../__generated__/GetOnboardingJourneys'
+
+import {
+  GET_ONBOARDING_JOURNEYS,
+  ONBOARDING_IDS
+} from './OnboardingPanelContent'
 
 export const onboardingJourneys: OnboardingJourneys[] = [
   {
@@ -57,3 +68,20 @@ export const onboardingJourneys: OnboardingJourneys[] = [
     }
   }
 ]
+
+export const getOnboardingJourneysMock: MockedResponse<
+  GetOnboardingJourneys,
+  GetOnboardingJourneysVariables
+> = {
+  request: {
+    query: GET_ONBOARDING_JOURNEYS,
+    variables: {
+      where: {
+        ids: ONBOARDING_IDS
+      }
+    }
+  },
+  result: {
+    data: { onboardingJourneys }
+  }
+}

--- a/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.spec.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.spec.tsx
@@ -8,7 +8,6 @@ import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 import { GetLastActiveTeamIdAndTeams } from '../../../../__generated__/GetLastActiveTeamIdAndTeams'
 import { AddJourneyButton } from '../../JourneyList/ActiveJourneyList/AddJourneyButton'
 import { OnboardingPanelContent } from '../../OnboardingPanelContent'
-import { onboardingJourneys } from '../../OnboardingPanelContent/data'
 import {
   GET_LAST_ACTIVE_TEAM_ID_AND_TEAMS,
   TeamProvider,
@@ -128,7 +127,7 @@ describe('TeamSelect', () => {
         <FlagsProvider flags={{ teams: true }}>
           <TeamProvider>
             <TeamSelect />
-            <OnboardingPanelContent onboardingJourneys={onboardingJourneys} />
+            <OnboardingPanelContent />
             <AddJourneyButton />
           </TeamProvider>
         </FlagsProvider>

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -10,6 +10,9 @@ import {
 import config from './commitlint.config'
 
 export default async () => {
+  // merge queues not supported by danger-js
+  if (danger.github.pr == null) return
+
   const isDependabot = danger.github.pr.user.login === 'dependabot[bot]'
   // check lockfile updated when package changes
   const packageChanged = danger.git.modified_files.includes('package.json')


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0647bc6</samp>

Refactored `OnboardingPanelContent` and `MediaListItem` components to improve data fetching and routing. Removed `onboardingJourneys` prop from `OnboardingPanelContent` and moved the query to the component itself. Added `NextLink` to `MediaListItem` for better navigation. Updated tests and stories accordingly.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] onboarding should still load and show up on the right

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0647bc6</samp>

*  Refactor `OnboardingPanelContent` component to fetch onboarding journeys internally using `GET_ONBOARDING_JOURNEYS` query ([link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-a17998961a44a113591b11adfc6194a80ca17d3e8c4edb13d12c897e826f28eeL17-L20), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-a17998961a44a113591b11adfc6194a80ca17d3e8c4edb13d12c897e826f28eeL39-R35), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-a17998961a44a113591b11adfc6194a80ca17d3e8c4edb13d12c897e826f28eeL82-R60), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-a17998961a44a113591b11adfc6194a80ca17d3e8c4edb13d12c897e826f28eeL111-R89), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-a17998961a44a113591b11adfc6194a80ca17d3e8c4edb13d12c897e826f28eeL135-R95), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL15-R25), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL120-R123), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL148-R163), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL177-R169), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL192-R184), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL201-R203), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL222-R218), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL258-R238), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL267-R257), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL289-R272), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-e442d5b44f16b38327c4263a805511be08ffc98b97cceb3cadf2dff9babe0e64L25-R26), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-e442d5b44f16b38327c4263a805511be08ffc98b97cceb3cadf2dff9babe0e64L35-R46), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-8f3c072dbc64b3d7d0f0b3a04d069ae84dd5c25f7519b5f5f0bb94816cbd6ba3L1-R19), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-8f3c072dbc64b3d7d0f0b3a04d069ae84dd5c25f7519b5f5f0bb94816cbd6ba3L22-R26), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-8f3c072dbc64b3d7d0f0b3a04d069ae84dd5c25f7519b5f5f0bb94816cbd6ba3L30-R76), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-8f3c072dbc64b3d7d0f0b3a04d069ae84dd5c25f7519b5f5f0bb94816cbd6ba3L59-R87), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-8f3c072dbc64b3d7d0f0b3a04d069ae84dd5c25f7519b5f5f0bb94816cbd6ba3L71-R93), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-8f3c072dbc64b3d7d0f0b3a04d069ae84dd5c25f7519b5f5f0bb94816cbd6ba3L90-R133), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-dc36cd749cf11ee38972c057ed6d0c61c2de9f905ec33c3a017fcb496efaf0d3L11), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-dc36cd749cf11ee38972c057ed6d0c61c2de9f905ec33c3a017fcb496efaf0d3L131-R130))
* Define and export `GET_ONBOARDING_JOURNEYS` query and `ONBOARDING_IDS` constant in `OnboardingPanelContent.tsx` file ([link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-8f3c072dbc64b3d7d0f0b3a04d069ae84dd5c25f7519b5f5f0bb94816cbd6ba3L22-R26), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-8f3c072dbc64b3d7d0f0b3a04d069ae84dd5c25f7519b5f5f0bb94816cbd6ba3L30-R76))
* Define and export `getOnboardingJourneysMock` variable as a mocked response for `GET_ONBOARDING_JOURNEYS` query in `data.ts` file ([link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-092103ed5072ff227d0926a8e14599c298ccbf9849e1972eee16af145c183c42L1-R13), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-092103ed5072ff227d0926a8e14599c298ccbf9849e1972eee16af145c183c42R71-R87))
* Use `getOnboardingJourneysMock` variable in `OnboardingPanelContent.spec.tsx` and `OnboardingPanelContent.stories.tsx` files to mock `GET_ONBOARDING_JOURNEYS` query ([link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL120-R123), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL201-R203), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-e442d5b44f16b38327c4263a805511be08ffc98b97cceb3cadf2dff9babe0e64L35-R46))
* Remove `onboardingJourneys` prop from `OnboardingPanelContent` component and its usage in `index.tsx`, `OnboardingPanelContent.spec.tsx`, `OnboardingPanelContent.stories.tsx`, and `TeamSelect.spec.tsx` files ([link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-a17998961a44a113591b11adfc6194a80ca17d3e8c4edb13d12c897e826f28eeL82-R60), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-a17998961a44a113591b11adfc6194a80ca17d3e8c4edb13d12c897e826f28eeL111-R89), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL148-R163), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL222-R218), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL258-R238), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL289-R272), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-e442d5b44f16b38327c4263a805511be08ffc98b97cceb3cadf2dff9babe0e64L25-R26), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-dc36cd749cf11ee38972c057ed6d0c61c2de9f905ec33c3a017fcb496efaf0d3L131-R130))
* Remove `useFlags` hook and `teams` flag from `OnboardingPanelContent` component and its usage in `OnboardingPanelContent.spec.tsx` file ([link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL15-R25), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL148-R163), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL192-R184), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL201-R203), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-8f3c072dbc64b3d7d0f0b3a04d069ae84dd5c25f7519b5f5f0bb94816cbd6ba3L59-R87), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-8f3c072dbc64b3d7d0f0b3a04d069ae84dd5c25f7519b5f5f0bb94816cbd6ba3L71-R93))
* Update `useTeam` hook to include `publicTitle` and `userTeams` fields for `Team` type and `lastActiveTeamId` field for `JourneyProfile` type in `GET_LAST_ACTIVE_TEAM_ID_AND_TEAMS` query and its mock ([link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL130-R149))
* Refactor `MediaListItem` component to use `NextLink` component internally for routing and to remove `id`, `onClick`, and `imagePosition` props ([link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-44e474f18ff40a8d18a77960313c43056b0090c23994dfec38d45d03c2987824L1-R5), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-44e474f18ff40a8d18a77960313c43056b0090c23994dfec38d45d03c2987824L15-R18), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-44e474f18ff40a8d18a77960313c43056b0090c23994dfec38d45d03c2987824L31-R32), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-44e474f18ff40a8d18a77960313c43056b0090c23994dfec38d45d03c2987824L47), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-3956634d1f5f972564ee558a0fc9806f6f7a563c25f710bd112dc8912f72e36aL15-R18), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-3956634d1f5f972564ee558a0fc9806f6f7a563c25f710bd112dc8912f72e36aL25-R29), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-3956634d1f5f972564ee558a0fc9806f6f7a563c25f710bd112dc8912f72e36aL36-R37), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-3956634d1f5f972564ee558a0fc9806f6f7a563c25f710bd112dc8912f72e36aL44-R47), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-3956634d1f5f972564ee558a0fc9806f6f7a563c25f710bd112dc8912f72e36aL59-R61), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-aa5beefc54efaf207846cc71a125e7f896d76c28c2e4451ee8e43b2a6f0e3970L7-R41), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-aa5beefc54efaf207846cc71a125e7f896d76c28c2e4451ee8e43b2a6f0e3970L66-R207), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL267-R257), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-8f3c072dbc64b3d7d0f0b3a04d069ae84dd5c25f7519b5f5f0bb94816cbd6ba3L90-R133))
* Update `MediaListItem` component stories and tests to use `href` prop instead of `onClick` prop and to remove `id` and `imagePosition` props ([link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-44e474f18ff40a8d18a77960313c43056b0090c23994dfec38d45d03c2987824L15-R18), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-44e474f18ff40a8d18a77960313c43056b0090c23994dfec38d45d03c2987824L31-R32), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-3956634d1f5f972564ee558a0fc9806f6f7a563c25f710bd112dc8912f72e36aL25-R29), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-3956634d1f5f972564ee558a0fc9806f6f7a563c25f710bd112dc8912f72e36aL44-R47), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL267-R257), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-8f3c072dbc64b3d7d0f0b3a04d069ae84dd5c25f7519b5f5f0bb94816cbd6ba3L90-R133))
* Add assertion to check `href` attribute of link element rendered by `MediaListItem` component in `MediaListItem.spec.tsx` file ([link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-44e474f18ff40a8d18a77960313c43056b0090c23994dfec38d45d03c2987824L31-R32))
* Remove `EndImage` story and `overline` and `duration` props from `Loading` story for `MediaListItem` component in `MediaListItem.stories.tsx` file ([link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-3956634d1f5f972564ee558a0fc9806f6f7a563c25f710bd112dc8912f72e36aL59-R61), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-3956634d1f5f972564ee558a0fc9806f6f7a563c25f710bd112dc8912f72e36aL77-R69))
* Remove `useTranslation` mock from `react-i18next` module in `OnboardingPanelContent.spec.tsx` file, as it is no longer needed ([link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL15-R25))
* Use `Story` type alias for `MediaListItem` component stories and simplify `render` function in `MediaListItem.stories.tsx` file ([link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-3956634d1f5f972564ee558a0fc9806f6f7a563c25f710bd112dc8912f72e36aL15-R18), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-3956634d1f5f972564ee558a0fc9806f6f7a563c25f710bd112dc8912f72e36aL36-R37))
* Use `MockedResponse` type for mocked responses of `CREATE_JOURNEY` and `GET_ONBOARDING_JOURNEYS` queries in `OnboardingPanelContent.spec.tsx` and `data.ts` files ([link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-f0b88ce7c92640f6d756574783eb0c53ec31c6e3f669653651447dce64ab58eeL54-R52), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-092103ed5072ff227d0926a8e14599c298ccbf9849e1972eee16af145c183c42L1-R13), [link](https://github.com/JesusFilm/core/pull/2033/files?diff=unified&w=0#diff-092103ed5072ff227d0926a8e14599c298ccbf9849e1972eee16af145c183c42R71-R87))
