### PR TITLE
fix: reduce worker size by removing swc and esbuild dependencies

### DIFF
--- a/apps/journeys-admin/next.config.js
+++ b/apps/journeys-admin/next.config.js
@@ -55,6 +55,15 @@ const nextConfig = {
     // handled by github actions
     ignoreDuringBuilds: process.env.CI === 'true'
   },
-  transpilePackages: ['shared-ui']
+  transpilePackages: ['shared-ui'],
+  experimental: {
+    outputFileTracingExcludes: {
+      '*': [
+        'node_modules/@swc/core-linux-x64-gnu',
+        'node_modules/@swc/core-linux-x64-musl',
+        'node_modules/esbuild-linux-64/bin'
+      ]
+    }
+  }
 }
 module.exports = composePlugins(withNx)(nextConfig)


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c216eba</samp>

Update `next.config.js` in `journeys-admin` app to exclude native binaries from output file tracing. This improves the build performance and stability of the Next.js app.

![CleanShot 2023-11-14 at 14 53 51](https://github.com/JesusFilm/core/assets/802117/86423d00-498c-4fd8-b040-ed4cc11be966)
