### PR TITLE
fix: add quotes to journeys admin env file

### DIFF
--- a/apps/journeys-admin/project.json
+++ b/apps/journeys-admin/project.json
@@ -159,7 +159,7 @@
       "options": {
         "commands": [
           {
-            "command": "DOPPLER_TOKEN=$DOPPLER_JOURNEYS_ADMIN_TOKEN doppler secrets download --no-file --format=env-no-quotes --project journeys-admin > apps/journeys-admin/.env"
+            "command": "DOPPLER_TOKEN=$DOPPLER_JOURNEYS_ADMIN_TOKEN doppler secrets download --no-file --format=env --project journeys-admin > apps/journeys-admin/.env"
           }
         ]
       }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e4c97f7</samp>

Fixed a bug in the journeys-admin app by changing the format option for downloading secrets in `project.json`. This ensures the environment variables are correctly quoted and escaped.
