### PR TITLE
fix: template view and gallery containers

### DIFF
--- a/apps/journeys-admin/pages/templates/[journeyId].tsx
+++ b/apps/journeys-admin/pages/templates/[journeyId].tsx
@@ -38,11 +38,8 @@ function TemplateDetails(): ReactElement {
           title={t('Journey Template')}
           user={user}
           backHref="/templates"
-          mainPanelSx={{
-            backgroundColor: 'background.paper',
-            overflowX: 'hidden'
-          }}
           backHrefHistory
+          mainBodyPadding={false}
         >
           <TemplateView authUser={user} />
         </PageWrapper>

--- a/apps/journeys-admin/pages/templates/index.tsx
+++ b/apps/journeys-admin/pages/templates/index.tsx
@@ -17,10 +17,7 @@ function LibraryIndex(): ReactElement {
       <PageWrapper
         title={t('Journey Templates')}
         user={user}
-        mainPanelSx={{
-          backgroundColor: 'background.paper',
-          overflowX: 'hidden'
-        }}
+        mainBodyPadding={false}
         showMainHeader={false}
       >
         <TemplateGallery />

--- a/apps/journeys-admin/src/components/NewPageWrapper/MainPanelBody/MainPanelBody.spec.tsx
+++ b/apps/journeys-admin/src/components/NewPageWrapper/MainPanelBody/MainPanelBody.spec.tsx
@@ -12,15 +12,4 @@ describe('MainPanelBody', () => {
     )
     expect(getByTestId('bottom-panel')).toHaveTextContent('Bottom Panel')
   })
-
-  it('should render the main body with custom css', () => {
-    const { getByTestId } = render(
-      <MainPanelBody sx={{ backgroundColor: 'background.paper' }}>
-        <Typography variant="h1">Child</Typography>
-      </MainPanelBody>
-    )
-    expect(getByTestId('main-body')).toHaveStyle({
-      backgroundColor: '#FFFFFF'
-    })
-  })
 })

--- a/apps/journeys-admin/src/components/NewPageWrapper/MainPanelBody/MainPanelBody.tsx
+++ b/apps/journeys-admin/src/components/NewPageWrapper/MainPanelBody/MainPanelBody.tsx
@@ -1,29 +1,35 @@
 import Stack from '@mui/material/Stack'
-import { SxProps } from '@mui/material/styles'
 import { ReactElement, ReactNode } from 'react'
 
 import { usePageWrapperStyles } from '../utils/usePageWrapperStyles'
 
 export interface MainPanelBodyProps {
   children: ReactNode
+  mainBodyPadding?: boolean
   bottomPanelChildren?: ReactNode
-  sx?: SxProps
 }
 
 export function MainPanelBody({
   children,
-  bottomPanelChildren,
-  sx
+  mainBodyPadding = true,
+  bottomPanelChildren
 }: MainPanelBodyProps): ReactElement {
   const { navbar, bottomPanel } = usePageWrapperStyles()
+
+  const padding = mainBodyPadding
+    ? {
+        px: { xs: 6, sm: 8 },
+        py: { xs: 6, sm: 9 }
+      }
+    : {}
 
   return (
     <Stack
       flexGrow={1}
       border="hidden"
       sx={{
-        overflow: 'none',
-        overflowY: { md: 'auto' },
+        overflow: 'hidden',
+        overflowY: 'auto',
         width: 'inherit'
       }}
       data-testid="MainPanelBody"
@@ -33,13 +39,11 @@ export function MainPanelBody({
         data-testid="main-body"
         flexGrow={1}
         sx={{
-          px: { xs: 6, md: 8 },
-          py: { xs: 6, md: 9 },
+          ...padding,
           mb: {
             xs: 0,
             md: bottomPanelChildren != null ? bottomPanel.height : 0
-          },
-          ...sx
+          }
         }}
       >
         {children}
@@ -58,7 +62,8 @@ export function MainPanelBody({
             left: { xs: 0, md: navbar.width },
             backgroundColor: 'background.paper',
             borderTop: '1px solid',
-            borderColor: 'divider'
+            borderColor: 'divider',
+            zIndex: 1
           }}
         >
           {bottomPanelChildren}

--- a/apps/journeys-admin/src/components/NewPageWrapper/MainPanelHeader/MainPanelHeader.tsx
+++ b/apps/journeys-admin/src/components/NewPageWrapper/MainPanelHeader/MainPanelHeader.tsx
@@ -22,7 +22,7 @@ export function MainPanelHeader({
   title,
   backHref,
   children,
-  backHrefHistory
+  backHrefHistory = false
 }: MainPanelHeaderProps): ReactElement {
   const { toolbar } = usePageWrapperStyles()
   const router = useRouter()
@@ -33,12 +33,13 @@ export function MainPanelHeader({
         color="default"
         sx={{
           position: { xs: 'fixed', md: 'sticky' },
-          top: { xs: toolbar.height, md: 0 }
+          top: { xs: toolbar.height, md: 0 },
+          width: 'inherit'
         }}
         data-testid="MainPanelHeader"
       >
         <Toolbar variant={toolbar.variant}>
-          {backHrefHistory === true ? (
+          {backHrefHistory ? (
             <Box onClick={() => router.back()}>
               <IconButton
                 data-testid="backHref-history-button"

--- a/apps/journeys-admin/src/components/NewPageWrapper/PageWrapper.tsx
+++ b/apps/journeys-admin/src/components/NewPageWrapper/PageWrapper.tsx
@@ -1,6 +1,6 @@
 import Box from '@mui/material/Box'
 import Stack from '@mui/material/Stack'
-import { SxProps, useTheme } from '@mui/material/styles'
+import { useTheme } from '@mui/material/styles'
 import { useRouter } from 'next/router'
 import { User } from 'next-firebase-auth'
 import { ReactElement, ReactNode, useState } from 'react'
@@ -18,36 +18,36 @@ import { usePageWrapperStyles } from './utils/usePageWrapperStyles'
 interface PageWrapperProps {
   showAppHeader?: boolean
   title?: string
-  mainHeaderChildren?: ReactNode
   showMainHeader?: boolean
   backHref?: string
   backHrefHistory?: boolean
+  mainHeaderChildren?: ReactNode
+  mainBodyPadding?: boolean
   children?: ReactNode
   bottomPanelChildren?: ReactNode
-  sidePanelTitle?: string | ReactNode
+  sidePanelTitle?: ReactNode
   /**
    * Add default side panel padding and border by wrapping components with `SidePanelContainer`
    */
   sidePanelChildren?: ReactNode
   user?: User
   initialState?: Partial<PageState>
-  mainPanelSx?: SxProps
 }
 
 export function PageWrapper({
   showAppHeader = true,
   title,
-  mainHeaderChildren,
   showMainHeader = true,
   backHref,
   backHrefHistory,
+  mainHeaderChildren,
+  mainBodyPadding = true,
   children,
   bottomPanelChildren,
-  sidePanelTitle,
+  sidePanelTitle = '',
   sidePanelChildren,
   user,
-  initialState,
-  mainPanelSx
+  initialState
 }: PageWrapperProps): ReactElement {
   const [open, setOpen] = useState<boolean>(false)
   const theme = useTheme()
@@ -75,11 +75,12 @@ export function PageWrapper({
           />
 
           <Stack
+            flexGrow={1}
             direction={{ xs: 'column', md: 'row' }}
             sx={{
               backgroundColor: 'background.default',
               width: { xs: '100vw', md: `calc(100vw - ${navbar.width})` },
-              pt: { xs: `${toolbar.height}px`, md: 0 },
+              pt: { xs: toolbar.height, md: 0 },
               pb: {
                 xs: bottomPanelChildren != null ? bottomPanel.height : 0,
                 md: 0
@@ -90,6 +91,7 @@ export function PageWrapper({
 
             <Stack
               component="main"
+              flexGrow={1}
               sx={{
                 width: {
                   xs: 'inherit',
@@ -110,8 +112,8 @@ export function PageWrapper({
                 </MainPanelHeader>
               )}
               <MainPanelBody
+                mainBodyPadding={mainBodyPadding}
                 bottomPanelChildren={bottomPanelChildren}
-                sx={mainPanelSx}
               >
                 {children}
               </MainPanelBody>

--- a/apps/journeys-admin/src/components/NewPageWrapper/SidePanel/SidePanel.tsx
+++ b/apps/journeys-admin/src/components/NewPageWrapper/SidePanel/SidePanel.tsx
@@ -144,7 +144,7 @@ export function SidePanel({
             '& .MuiDrawer-paper': {
               boxSizing: 'border-box',
               width: '100%',
-              height: `calc(100% - ${toolbar.height}px)`
+              height: `calc(100% - ${toolbar.height})`
             }
           }}
         >

--- a/apps/journeys-admin/src/components/NewPageWrapper/utils/usePageWrapperStyles/usePageWrapperStyles.ts
+++ b/apps/journeys-admin/src/components/NewPageWrapper/utils/usePageWrapperStyles/usePageWrapperStyles.ts
@@ -2,7 +2,7 @@ import { CSSObject, useTheme } from '@mui/material/styles'
 
 interface PageWrapperStyles {
   navbar: { width: string }
-  toolbar: { variant: 'dense' | 'regular'; height: number }
+  toolbar: { variant: 'dense' | 'regular'; height: string }
   sidePanel: { width: string }
   bottomPanel: { height: string }
 }
@@ -17,9 +17,11 @@ export function usePageWrapperStyles(): PageWrapperStyles {
       // Height of the dense toolbar variant
       height:
         theme.components?.MuiToolbar != null
-          ? ((theme.components.MuiToolbar.styleOverrides?.dense as CSSObject)
-              .maxHeight as number)
-          : 12
+          ? `${
+              (theme.components.MuiToolbar.styleOverrides?.dense as CSSObject)
+                .maxHeight as number
+            }px`
+          : '12px'
     },
     sidePanel: { width: '327px' },
     bottomPanel: { height: '300px' }

--- a/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.stories.tsx
@@ -26,13 +26,7 @@ const TemplateGalleryStory: Meta<typeof TemplateGallery> = {
 
 const Template: StoryObj<ComponentProps<typeof TemplateGallery>> = {
   render: () => (
-    <Box
-      sx={{
-        backgroundColor: 'background.paper',
-        height: '100%',
-        overflow: 'hidden'
-      }}
-    >
+    <Box sx={{ height: '100%', overflow: 'hidden' }}>
       <TemplateGallery />
     </Box>
   )

--- a/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.stories.tsx
@@ -29,7 +29,6 @@ const Template: StoryObj<ComponentProps<typeof TemplateGallery>> = {
     <Box
       sx={{
         backgroundColor: 'background.paper',
-        p: 5,
         height: '100%',
         overflow: 'hidden'
       }}

--- a/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.tsx
@@ -1,5 +1,6 @@
 import Container from '@mui/material/Container'
 import Grid from '@mui/material/Grid'
+import Paper from '@mui/material/Paper'
 import castArray from 'lodash/castArray'
 import difference from 'lodash/difference'
 import { useRouter } from 'next/router'
@@ -42,75 +43,89 @@ export function TemplateGallery(): ReactElement {
   }
 
   return (
-    <Container disableGutters data-testid="TemplateGallery">
-      <HeaderAndLanguageFilter
-        selectedLanguageIds={selectedLanguageIds}
-        onChange={handleLanguageIdsChange}
-      />
-      <Grid
-        container
-        spacing={2}
+    <Paper
+      elevation={0}
+      square
+      sx={{ height: '100%' }}
+      data-testid="TemplateGallery"
+    >
+      <Container
+        maxWidth={false}
         sx={{
-          mb: { xs: 1, md: 3 }
+          maxWidth: { md: '90vw' },
+          px: { xs: 6, sm: 8 },
+          py: { xs: 6, sm: 9 }
         }}
-        id="TemplateGalleryTagsFilter"
       >
-        <Grid item xs={12} md={7}>
-          <TagsFilter
-            label={t('Topics, holidays, felt needs, collections')}
-            tagNames={['Topics', 'Holidays', 'Felt Needs', 'Collections']}
-            onChange={handleTagIdsChange}
-            selectedTagIds={selectedTagIds}
-            popperElementId="TemplateGalleryTagsFilter"
-          />
-        </Grid>
-        <Grid item xs={12} md={5}>
-          <Grid container spacing={2}>
-            <Grid item xs={6}>
-              <TagsFilter
-                label={t('Audience')}
-                tagNames={['Audience']}
-                onChange={handleTagIdsChange}
-                selectedTagIds={selectedTagIds}
-                popperElementId="TemplateGalleryAudienceTagsFilter"
-              />
-            </Grid>
-            <Grid item xs={6}>
-              <TagsFilter
-                label={t('Genre')}
-                tagNames={['Genre']}
-                onChange={handleTagIdsChange}
-                selectedTagIds={selectedTagIds}
-                popperElementId="TemplateGalleryGenreTagsFilter"
-              />
-            </Grid>
-            <Grid
-              item
-              xs={12}
-              md={6}
-              id="TemplateGalleryAudienceTagsFilter"
-              sx={{ p: '0 !important' }}
-            />
-            <Grid
-              item
-              xs={12}
-              md={6}
-              id="TemplateGalleryGenreTagsFilter"
-              sx={{ p: '0 !important' }}
+        <HeaderAndLanguageFilter
+          selectedLanguageIds={selectedLanguageIds}
+          onChange={handleLanguageIdsChange}
+        />
+        <Grid
+          container
+          spacing={2}
+          sx={{
+            mb: { xs: 1, md: 3 }
+          }}
+          id="TemplateGalleryTagsFilter"
+        >
+          <Grid item xs={12} md={7}>
+            <TagsFilter
+              label={t('Topics, holidays, felt needs, collections')}
+              tagNames={['Topics', 'Holidays', 'Felt Needs', 'Collections']}
+              onChange={handleTagIdsChange}
+              selectedTagIds={selectedTagIds}
+              popperElementId="TemplateGalleryTagsFilter"
             />
           </Grid>
+          <Grid item xs={12} md={5}>
+            <Grid container spacing={2}>
+              <Grid item xs={6}>
+                <TagsFilter
+                  label={t('Audience')}
+                  tagNames={['Audience']}
+                  onChange={handleTagIdsChange}
+                  selectedTagIds={selectedTagIds}
+                  popperElementId="TemplateGalleryAudienceTagsFilter"
+                />
+              </Grid>
+              <Grid item xs={6}>
+                <TagsFilter
+                  label={t('Genre')}
+                  tagNames={['Genre']}
+                  onChange={handleTagIdsChange}
+                  selectedTagIds={selectedTagIds}
+                  popperElementId="TemplateGalleryGenreTagsFilter"
+                />
+              </Grid>
+              <Grid
+                item
+                xs={12}
+                md={6}
+                id="TemplateGalleryAudienceTagsFilter"
+                sx={{ p: '0 !important' }}
+              />
+              <Grid
+                item
+                xs={12}
+                md={6}
+                id="TemplateGalleryGenreTagsFilter"
+                sx={{ p: '0 !important' }}
+              />
+            </Grid>
+          </Grid>
         </Grid>
-      </Grid>
-      <TagCarousels
-        selectedTagIds={selectedTagIds}
-        onChange={handleTagIdsChange}
-      />
-      <TemplateSections
-        tagIds={selectedTagIds.length > 0 ? selectedTagIds : undefined}
-        languageIds={
-          selectedLanguageIds.length > 0 ? selectedLanguageIds : undefined
-        }
-      />
-    </Container>
+        <TagCarousels
+          selectedTagIds={selectedTagIds}
+          onChange={handleTagIdsChange}
+        />
+        <TemplateSections
+          tagIds={selectedTagIds.length > 0 ? selectedTagIds : undefined}
+          languageIds={
+            selectedLanguageIds.length > 0 ? selectedLanguageIds : undefined
+          }
+        />
+      </Container>
+    </Paper>
   )
 }

--- a/apps/journeys-admin/src/components/TemplateView/TemplateView.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateView.stories.tsx
@@ -202,13 +202,7 @@ const Template: StoryObj<
         ]}
       >
         <JourneyProvider value={{ journey: args.journey, variant: 'admin' }}>
-          <Box
-            sx={{
-              backgroundColor: 'background.paper',
-              height: '100%',
-              overflow: 'hidden'
-            }}
-          >
+          <Box sx={{ height: '100%', overflow: 'hidden' }}>
             <TemplateView authUser={args.authUser as unknown as User} />
           </Box>
         </JourneyProvider>
@@ -259,7 +253,7 @@ export const Complete = {
 export const Loading = {
   ...Template,
   args: {
-    ...Complete.args,
+    ...Default.args,
     journey: undefined
   }
 }

--- a/apps/journeys-admin/src/components/TemplateView/TemplateView.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateView.stories.tsx
@@ -1,4 +1,5 @@
 import { MockedProvider, MockedResponse } from '@apollo/client/testing'
+import Box from '@mui/material/Box'
 import { Meta, StoryObj } from '@storybook/react'
 import { User } from 'next-firebase-auth'
 import { ComponentProps } from 'react'
@@ -27,7 +28,11 @@ import { TemplateView } from './TemplateView'
 const TemplateViewStory: Meta<typeof TemplateView> = {
   ...journeysAdminConfig,
   component: TemplateView,
-  title: 'Journeys-Admin/TemplateView'
+  title: 'Journeys-Admin/TemplateView',
+  parameters: {
+    ...journeysAdminConfig.parameters,
+    layout: 'fullscreen'
+  }
 }
 
 const tag: Tag = {
@@ -197,7 +202,15 @@ const Template: StoryObj<
         ]}
       >
         <JourneyProvider value={{ journey: args.journey, variant: 'admin' }}>
-          <TemplateView authUser={args.authUser as unknown as User} />
+          <Box
+            sx={{
+              backgroundColor: 'background.paper',
+              height: '100%',
+              overflow: 'hidden'
+            }}
+          >
+            <TemplateView authUser={args.authUser as unknown as User} />
+          </Box>
         </JourneyProvider>
       </MockedProvider>
     )
@@ -220,6 +233,7 @@ export const Complete = {
   args: {
     journey: {
       ...journey,
+      strategySlug: 'https://www.canva.com/design/DAFvDBw1z1A/view',
       tags,
       creatorDescription:
         'Created by a Name of a Mission or Missionaries Organisation label by a Name of a Mission or Missionaries',
@@ -245,7 +259,7 @@ export const Complete = {
 export const Loading = {
   ...Template,
   args: {
-    ...Default.args,
+    ...Complete.args,
     journey: undefined
   }
 }

--- a/apps/journeys-admin/src/components/TemplateView/TemplateView.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateView.tsx
@@ -1,4 +1,5 @@
 import Container from '@mui/material/Container'
+import Paper from '@mui/material/Paper'
 import Skeleton from '@mui/material/Skeleton'
 import Stack from '@mui/material/Stack'
 import { useTheme } from '@mui/material/styles'
@@ -82,52 +83,64 @@ export function TemplateView({ authUser }: TemplateViewProps): ReactElement {
   }
 
   return (
-    <Container disableGutters data-testid="JourneysAdminTemplateView">
-      <Stack sx={{ gap: { xs: 3, sm: 7 } }}>
-        <TemplateViewHeader isPublisher={isPublisher} authUser={authUser} />
-        <TemplateTags tags={journey?.tags} />
-        <TemplatePreviewTabs />
-        <Typography
-          variant="body2"
-          sx={{ display: { xs: 'block', sm: 'none' } }}
-        >
-          {journey?.description != null ? (
-            journey.description
-          ) : (
-            <>
-              {[0, 1, 2].map((value) => (
-                <Skeleton
-                  key={value}
-                  data-testid="TemplateViewDescriptionSkeleton"
-                  width="100%"
-                />
-              ))}
-            </>
+    <Paper
+      elevation={0}
+      square
+      sx={{ height: '100%' }}
+      data-testid="JourneysAdminTemplateView"
+    >
+      <Container
+        sx={{
+          px: { xs: 6, sm: 8 },
+          py: { xs: 6, sm: 9 }
+        }}
+      >
+        <Stack sx={{ gap: { xs: 3, sm: 7 } }}>
+          <TemplateViewHeader isPublisher={isPublisher} authUser={authUser} />
+          <TemplateTags tags={journey?.tags} />
+          <TemplatePreviewTabs />
+          <Typography
+            variant="body2"
+            sx={{ display: { xs: 'block', sm: 'none' } }}
+          >
+            {journey?.description != null ? (
+              journey.description
+            ) : (
+              <>
+                {[0, 1, 2].map((value) => (
+                  <Skeleton
+                    key={value}
+                    data-testid="TemplateViewDescriptionSkeleton"
+                    width="100%"
+                  />
+                ))}
+              </>
+            )}
+          </Typography>
+          {journey?.creatorDescription != null && (
+            <TemplateCreatorDetails
+              creatorDetails={journey?.creatorDescription}
+              creatorImage={journey?.creatorImageBlock?.src}
+              sx={{ display: { xs: 'flex', sm: 'none' } }}
+            />
           )}
-        </Typography>
-        {journey?.creatorDescription != null && (
-          <TemplateCreatorDetails
-            creatorDetails={journey?.creatorDescription}
-            creatorImage={journey?.creatorImageBlock?.src}
-            sx={{ display: { xs: 'flex', sm: 'none' } }}
-          />
-        )}
-        {journey?.strategySlug != null && (
-          <StrategySection
-            strategySlug={journey?.strategySlug}
-            variant="full"
-          />
-        )}
-        {relatedJourneys != null && relatedJourneys.length >= 1 && (
-          <TemplateGalleryCarousel
-            heading={t('Related Templates')}
-            items={relatedJourneys}
-            renderItem={(itemProps) => <TemplateGalleryCard {...itemProps} />}
-            breakpoints={swiperBreakpoints}
-          />
-        )}
-        <TemplateFooter signedIn={authUser?.id != null} />
-      </Stack>
-    </Container>
+          {journey?.strategySlug != null && (
+            <StrategySection
+              strategySlug={journey?.strategySlug}
+              variant="full"
+            />
+          )}
+          {relatedJourneys != null && relatedJourneys.length >= 1 && (
+            <TemplateGalleryCarousel
+              heading={t('Related Templates')}
+              items={relatedJourneys}
+              renderItem={(itemProps) => <TemplateGalleryCard {...itemProps} />}
+              breakpoints={swiperBreakpoints}
+            />
+          )}
+          <TemplateFooter signedIn={authUser?.id != null} />
+        </Stack>
+      </Container>
+    </Paper>
   )
 }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 808b5a6</samp>

Refactored the `PageWrapper` component and its related components to simplify the styling and props. Removed the `mainPanelSx` and `sx` props and added a `mainBodyPadding` prop to control the main body padding. Used `Paper` components for the `TemplateGallery` and `TemplateView` components to improve their appearance and layout. Fixed some bugs and improved some stories for the new page wrapper components.

https://3.basecamp.com/3105655/buckets/34879725/todos/6747859214 

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Template gallery should have the correct margins on desktop
- [x] Template gallery and library should still have white backgrounds with correct spacing on mobile and desktop

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 808b5a6</samp>

*  Remove `mainPanelSx` prop and replace with `mainBodyPadding` prop in `PageWrapper`, `MainPanelBody`, and related components and tests to simplify styling and avoid passing custom CSS ([link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-46a8849cb7583f95a436ff12b776363786b82cc424ad3415052b8c7cd85052ccL41-R42), [link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-4d089d7265256280ff64e3b201d5e5b93de7ec08609a68128848f06ced5a0effL20-R20), [link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-2f898ddb1d2b0e930370b678baacae5b3662af4cebd9e0e400cbfe82c70cb558L15-L25), [link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-aaa30726a6c713e10fbe0f082868f7daaa62cdc749a2240ebeeb588166abcbacL2), [link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-aaa30726a6c713e10fbe0f082868f7daaa62cdc749a2240ebeeb588166abcbacL9-R25), [link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-aaa30726a6c713e10fbe0f082868f7daaa62cdc749a2240ebeeb588166abcbacL36-R46), [link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-aaa30726a6c713e10fbe0f082868f7daaa62cdc749a2240ebeeb588166abcbacL61-R66), [link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-5965e5f2f61464ac798b2d978eb50c82874afd08713ad90b1fbd61c962f04237L3-R3), [link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-5965e5f2f61464ac798b2d978eb50c82874afd08713ad90b1fbd61c962f04237L34), [link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-5965e5f2f61464ac798b2d978eb50c82874afd08713ad90b1fbd61c962f04237L40-R50), [link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-5965e5f2f61464ac798b2d978eb50c82874afd08713ad90b1fbd61c962f04237L113-R116))
*  Fix bugs with main body and main panel header not scrolling or filling the available width on mobile devices by changing `overflow` and `overflowY` styles and adding `width` and `flexGrow` styles in `MainPanelBody` and `MainPanelHeader` components ([link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-aaa30726a6c713e10fbe0f082868f7daaa62cdc749a2240ebeeb588166abcbacL25-R32), [link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-bf2c6bf3ac54cbf68d8f2fa56ccafebc7fd7ffb5fb0480777e6688e0ceea9dc9L36-R42), [link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-5965e5f2f61464ac798b2d978eb50c82874afd08713ad90b1fbd61c962f04237L78-R83), [link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-5965e5f2f61464ac798b2d978eb50c82874afd08713ad90b1fbd61c962f04237R94))
*  Make `backHrefHistory` prop optional and give it a default value of `false` in `MainPanelHeader` component ([link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-bf2c6bf3ac54cbf68d8f2fa56ccafebc7fd7ffb5fb0480777e6688e0ceea9dc9L25-R25))
*  Reorder props in `PageWrapperProps` interface to group related props together and improve readability ([link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-5965e5f2f61464ac798b2d978eb50c82874afd08713ad90b1fbd61c962f04237L21-R28))
*  Remove unnecessary padding from `Template` component in `TemplateGallery` story ([link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-5e95ed0722c4d1b8faa89d49caf41231b0be3568772f61cf3a322410d22ba7b7L32))
*  Wrap `TemplateGallery` and `TemplateView` components with `Paper` components to make them fill the available height and have a consistent background color and border ([link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-b3ab650ee0dc0ee335e53cf2f72cf2700dbc0890a665f9b7a7b608c6ce920650R3), [link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-b3ab650ee0dc0ee335e53cf2f72cf2700dbc0890a665f9b7a7b608c6ce920650L45-R129), [link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-25131dd9028eed90b85e738c192f969471e3c14909b07851f3ecb773cc3026fcR2), [link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-25131dd9028eed90b85e738c192f969471e3c14909b07851f3ecb773cc3026fcL200-R213), [link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-436738bb5e18937497677275cf375e4dbebb3183971ed6225561bed0c82bd150R2), [link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-436738bb5e18937497677275cf375e4dbebb3183971ed6225561bed0c82bd150L85-R144))
*  Add `parameters` property with `layout` value of `fullscreen` to `TemplateView` story to use the full screen layout and avoid the default padding and margin of the storybook container ([link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-25131dd9028eed90b85e738c192f969471e3c14909b07851f3ecb773cc3026fcL30-R35))
*  Add `strategySlug` property to `Complete` story in `TemplateView` story to provide a mock strategy slug for the template view to display the strategy section ([link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-25131dd9028eed90b85e738c192f969471e3c14909b07851f3ecb773cc3026fcR236))
*  Change `journey` property of `Loading` story in `TemplateView` story to use the complete journey data as the mock data for the loading state and avoid errors when accessing undefined properties of the journey ([link](https://github.com/JesusFilm/core/pull/2057/files?diff=unified&w=0#diff-25131dd9028eed90b85e738c192f969471e3c14909b07851f3ecb773cc3026fcL248-R262))
