### PR TITLE
fix: failing test strategy should not fail fast

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,6 +143,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version: [18]
         # https://jestjs.io/docs/cli#--shard

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -13,5 +13,5 @@ module.exports = {
    */
   snapshotFormat: { escapeString: true, printBasicPrototype: true },
   // https://jestjs.io/blog/2022/04/25/jest-28#github-actions-reporter
-  reporters: ['github-actions']
+  reporters: process.env.CI === 'true' ? ['github-actions'] : undefined
 }

--- a/libs/journeys/ui/src/components/BlockRenderer/BlockRenderer.tsx
+++ b/libs/journeys/ui/src/components/BlockRenderer/BlockRenderer.tsx
@@ -50,6 +50,7 @@ const DynamicCard = dynamic<
   TreeBlock<CardBlock> & { wrappers?: WrappersProps }
 >(
   async () =>
+    // eslint-disable-next-line import/no-cycle
     await import(
       /* webpackChunkName: "Card" */
       '../Card'

--- a/libs/journeys/ui/src/components/BlockRenderer/index.ts
+++ b/libs/journeys/ui/src/components/BlockRenderer/index.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-cycle
 export { BlockRenderer } from './BlockRenderer'
 export type { WrappersProps } from './BlockRenderer'
 export type { WrapperProps } from './BlockRenderer'

--- a/libs/journeys/ui/src/components/Card/index.ts
+++ b/libs/journeys/ui/src/components/Card/index.ts
@@ -1,3 +1,4 @@
 export { ExpandedCover } from './ExpandedCover'
 export { ContainedCover } from './ContainedCover'
+// eslint-disable-next-line import/no-cycle
 export { Card } from './Card'

--- a/libs/journeys/ui/src/components/RadioQuestion/RadioQuestion.tsx
+++ b/libs/journeys/ui/src/components/RadioQuestion/RadioQuestion.tsx
@@ -11,6 +11,7 @@ import type { TreeBlock } from '../../libs/block'
 import { useBlocks } from '../../libs/block'
 import { getStepHeading } from '../../libs/getStepHeading'
 import { useJourney } from '../../libs/JourneyProvider'
+// eslint-disable-next-line import/no-cycle
 import { BlockRenderer, WrappersProps } from '../BlockRenderer'
 import { RadioOption } from '../RadioOption'
 

--- a/libs/journeys/ui/src/components/RadioQuestion/index.ts
+++ b/libs/journeys/ui/src/components/RadioQuestion/index.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-cycle
 export {
   RadioQuestion,
   RADIO_QUESTION_SUBMISSION_EVENT_CREATE

--- a/libs/journeys/ui/src/components/Step/Step.tsx
+++ b/libs/journeys/ui/src/components/Step/Step.tsx
@@ -9,6 +9,7 @@ import type { TreeBlock } from '../../libs/block'
 import { isActiveBlockOrDescendant, useBlocks } from '../../libs/block'
 import { getStepHeading } from '../../libs/getStepHeading'
 import { useJourney } from '../../libs/JourneyProvider/JourneyProvider'
+// eslint-disable-next-line import/no-cycle
 import { BlockRenderer, WrappersProps } from '../BlockRenderer'
 
 import { StepFields } from './__generated__/StepFields'

--- a/libs/journeys/ui/src/components/Step/index.ts
+++ b/libs/journeys/ui/src/components/Step/index.ts
@@ -1,1 +1,2 @@
+// eslint-disable-next-line import/no-cycle
 export { Step } from './Step'


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d72bf03</samp>

This pull request adds a configuration option to the GitHub Actions workflow to run all the jobs regardless of failures, and adds ESLint comments to several files in the `journeys/ui` library to disable the `import/no-cycle` rule for intentional circular dependencies.

@storyworks mention that logs don't show for jest runs. This also fixes that.
