### PR TITLE
fix: load active journey list once on load

### DIFF
--- a/apps/journeys-admin/src/components/Team/TeamProvider/TeamProvider.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamProvider/TeamProvider.tsx
@@ -15,7 +15,8 @@ import {
 
 interface Context {
   query: QueryResult<GetLastActiveTeamIdAndTeams, OperationVariables>
-  activeTeam: Team | null
+  /** activeTeam is null if loaded and set intentionally */
+  activeTeam: Team | null | undefined
   setActiveTeam: (team: Team | null) => void
 }
 
@@ -54,7 +55,9 @@ export const GET_LAST_ACTIVE_TEAM_ID_AND_TEAMS = gql`
 `
 
 export function TeamProvider({ children }: TeamProviderProps): ReactElement {
-  const [activeTeamId, setActiveTeamId] = useState<string | null>(null)
+  const [activeTeamId, setActiveTeamId] = useState<string | null | undefined>(
+    undefined
+  )
   const query = useQuery<GetLastActiveTeamIdAndTeams>(
     GET_LAST_ACTIVE_TEAM_ID_AND_TEAMS,
     {
@@ -82,7 +85,9 @@ export function TeamProvider({ children }: TeamProviderProps): ReactElement {
     }
   }
   const activeTeam =
-    query.data?.teams.find((team) => team.id === activeTeamId) ?? null
+    activeTeamId != null
+      ? query.data?.teams.find((team) => team.id === activeTeamId) ?? null
+      : activeTeamId
   return (
     <TeamContext.Provider value={{ query, activeTeam, setActiveTeam }}>
       {children}

--- a/apps/journeys-admin/src/libs/useAdminJourneysLazyQuery/index.ts
+++ b/apps/journeys-admin/src/libs/useAdminJourneysLazyQuery/index.ts
@@ -1,0 +1,1 @@
+export { useAdminJourneysLazyQuery } from './useAdminJourneysLazyQuery'

--- a/apps/journeys-admin/src/libs/useAdminJourneysLazyQuery/useAdminJourneysLazyQuery.spec.tsx
+++ b/apps/journeys-admin/src/libs/useAdminJourneysLazyQuery/useAdminJourneysLazyQuery.spec.tsx
@@ -1,0 +1,98 @@
+import { MockedProvider } from '@apollo/client/testing'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { formatISO, startOfYear } from 'date-fns'
+
+import {
+  JourneyStatus,
+  ThemeMode,
+  ThemeName,
+  UserJourneyRole
+} from '../../../__generated__/globalTypes'
+import { GET_ADMIN_JOURNEYS } from '../useAdminJourneysQuery/useAdminJourneysQuery'
+
+import { useAdminJourneysLazyQuery } from './useAdminJourneysLazyQuery'
+
+describe('useAdminJourneysLazyQuery', () => {
+  it('should get journeys', async () => {
+    const result = jest.fn(() => ({
+      data: {
+        journeys: [
+          {
+            id: 'journey.id',
+            title: 'Default Journey Heading',
+            description: null,
+            themeName: ThemeName.base,
+            themeMode: ThemeMode.light,
+            slug: 'default',
+            language: {
+              __typename: 'Language',
+              id: '529',
+              name: [
+                {
+                  __typename: 'Translation',
+                  value: 'English',
+                  primary: true
+                }
+              ]
+            },
+            createdAt: formatISO(startOfYear(new Date())),
+            publishedAt: null,
+            status: JourneyStatus.draft,
+            seoTitle: null,
+            seoDescription: null,
+            userJourneys: [
+              {
+                __typename: 'UserJourney',
+                id: 'user-journey-id',
+                role: UserJourneyRole.owner,
+                openedAt: null,
+                user: {
+                  __typename: 'User',
+                  id: 'user-id1',
+                  firstName: 'Amin',
+                  lastName: 'One',
+                  imageUrl: 'https://bit.ly/3Gth4Yf'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }))
+
+    const { result: hookResult } = renderHook(
+      () => useAdminJourneysLazyQuery(),
+      {
+        wrapper: ({ children }) => (
+          <MockedProvider
+            mocks={[
+              {
+                request: {
+                  query: GET_ADMIN_JOURNEYS,
+                  variables: {
+                    status: [JourneyStatus.draft],
+                    template: true
+                  }
+                },
+                result
+              }
+            ]}
+          >
+            {children}
+          </MockedProvider>
+        )
+      }
+    )
+
+    await hookResult.current[0]({
+      variables: {
+        status: [JourneyStatus.draft],
+        template: true
+      }
+    })
+
+    await act(
+      async () => await waitFor(() => expect(result).toHaveBeenCalled())
+    )
+  })
+})

--- a/apps/journeys-admin/src/libs/useAdminJourneysLazyQuery/useAdminJourneysLazyQuery.ts
+++ b/apps/journeys-admin/src/libs/useAdminJourneysLazyQuery/useAdminJourneysLazyQuery.ts
@@ -1,0 +1,18 @@
+import { LazyQueryResultTuple, useLazyQuery } from '@apollo/client'
+
+import {
+  GetAdminJourneys,
+  GetAdminJourneysVariables
+} from '../../../__generated__/GetAdminJourneys'
+import { GET_ADMIN_JOURNEYS } from '../useAdminJourneysQuery/useAdminJourneysQuery'
+
+export function useAdminJourneysLazyQuery(): LazyQueryResultTuple<
+  GetAdminJourneys,
+  GetAdminJourneysVariables
+> {
+  const query = useLazyQuery<GetAdminJourneys, GetAdminJourneysVariables>(
+    GET_ADMIN_JOURNEYS
+  )
+
+  return query
+}


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 85f0296</samp>

Refactored the `ActiveJourneyList` component to use a lazy query hook for fetching journeys based on the active team. Created a new `useAdminJourneysLazyQuery` hook and its test file in the `libs` folder. Improved the type and logic of the `TeamProvider` component.

We load the active journey list before the teams selector loads. This makes it so it only loads the list once. This should reduce the LCP and the CLS scores a touch.
![CleanShot 2023-11-24 at 09 56 40](https://github.com/JesusFilm/core/assets/802117/a3f7e73c-6b3f-4f14-9f13-5113bd31354e)

This is fully tested by existing tests.