### PR TITLE
fix: add crossorigin to preload

### DIFF
--- a/apps/journeys-admin/pages/_app.tsx
+++ b/apps/journeys-admin/pages/_app.tsx
@@ -73,7 +73,11 @@ function JourneysAdminApp({
             name="viewport"
             content="minimum-scale=1, initial-scale=1, width=device-width"
           />
-          <link rel="preconnect" href={process.env.NEXT_PUBLIC_GATEWAY_URL} />
+          <link
+            rel="preconnect"
+            href={process.env.NEXT_PUBLIC_GATEWAY_URL}
+            crossOrigin=""
+          />
         </Head>
         {process.env.NEXT_PUBLIC_DATADOG_APPLICATION_ID != null &&
           process.env.NEXT_PUBLIC_DATADOG_APPLICATION_ID !== '' &&


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c758302</samp>

Added `crossOrigin` attribute to preconnect link for gateway URL in `apps/journeys-admin/pages/_app.tsx`. This improves the app performance by reusing the same connection for fetching resources.

https://www.debugbear.com/resource-hint-validator?url=https%3A%2F%2Fadmin.nextstep.is%2F
![CleanShot 2023-11-24 at 12 00 30@2x](https://github.com/JesusFilm/core/assets/802117/27676d33-8c80-43f3-8016-22266e211cac)
