### PR TITLE
feat: add batching to router

### DIFF
--- a/.devcontainer/post-create-command.sh
+++ b/.devcontainer/post-create-command.sh
@@ -37,7 +37,7 @@ rm -rf bin
 # - update .devcontainer/post-create-command.sh apollo router version (...nix/vX.X.X)
 # - update app/api-gateway/Dockerfile image version (...router/vX.X.X)
 # - inform all developers to rebuild their containers
-curl -sSL https://router.apollo.dev/download/nix/v1.13.2 | sh
+curl -sSL https://router.apollo.dev/download/nix/v1.34.1 | sh
 mv router apps/api-gateway/
 
 # install doppler

--- a/apps/api-gateway/Dockerfile
+++ b/apps/api-gateway/Dockerfile
@@ -2,5 +2,5 @@
 # - update .devcontainer/post-create-command.sh apollo router version (...nix/vX.X.X)
 # - update app/api-gateway/Dockerfile image version (...router/vX.X.X)
 # - inform all developers to rebuild their containers
-FROM ghcr.io/apollographql/router:v1.13.2
+FROM ghcr.io/apollographql/router:v1.34.1
 COPY ./apps/api-gateway/router.prod.yaml /dist/config/router.yaml

--- a/apps/api-gateway/router.prod.yaml
+++ b/apps/api-gateway/router.prod.yaml
@@ -35,3 +35,6 @@ telemetry:
   tracing:
     datadog:
       endpoint: default
+experimental_batching:
+  enabled: true
+  mode: batch_http_link

--- a/apps/api-gateway/router.yaml
+++ b/apps/api-gateway/router.yaml
@@ -20,3 +20,6 @@ health_check:
   enabled: true
 include_subgraph_errors:
   all: true
+experimental_batching:
+  enabled: true
+  mode: batch_http_link

--- a/apps/api-gateway/routerSchema.json
+++ b/apps/api-gateway/routerSchema.json
@@ -4,26 +4,168 @@
   "description": "The configuration for the router.\n\nCan be created through `serde::Deserialize` from various formats, or inline in Rust code with `serde_json::json!` and `serde_json::from_value`.",
   "type": "object",
   "properties": {
+    "apq": {
+      "description": "Configures automatic persisted queries",
+      "default": {
+        "enabled": true,
+        "router": {
+          "cache": {
+            "in_memory": {
+              "limit": 512
+            },
+            "redis": null
+          }
+        },
+        "subgraph": {
+          "all": {
+            "enabled": false
+          },
+          "subgraphs": {}
+        }
+      },
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Activates Automatic Persisted Queries (enabled by default)",
+          "default": true,
+          "type": "boolean"
+        },
+        "router": {
+          "description": "Router level (APQ) configuration",
+          "default": {
+            "cache": {
+              "in_memory": {
+                "limit": 512
+              },
+              "redis": null
+            }
+          },
+          "type": "object",
+          "properties": {
+            "cache": {
+              "description": "Cache configuration",
+              "default": {
+                "in_memory": {
+                  "limit": 512
+                },
+                "redis": null
+              },
+              "type": "object",
+              "properties": {
+                "in_memory": {
+                  "description": "Configures the in memory cache (always active)",
+                  "default": {
+                    "limit": 512
+                  },
+                  "type": "object",
+                  "required": ["limit"],
+                  "properties": {
+                    "limit": {
+                      "description": "Number of entries in the Least Recently Used cache",
+                      "type": "integer",
+                      "format": "uint",
+                      "minimum": 1.0
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "redis": {
+                  "description": "Configures and activates the Redis cache",
+                  "default": null,
+                  "type": "object",
+                  "required": ["urls"],
+                  "properties": {
+                    "timeout": {
+                      "description": "Redis request timeout (default: 2ms)",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "ttl": {
+                      "description": "TTL for entries",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "urls": {
+                      "description": "List of URLs to the Redis cluster",
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "format": "uri"
+                      }
+                    }
+                  },
+                  "additionalProperties": false,
+                  "nullable": true
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "subgraph": {
+          "description": "Configuration options pertaining to the subgraph server component.",
+          "default": {
+            "all": {
+              "enabled": false
+            },
+            "subgraphs": {}
+          },
+          "type": "object",
+          "properties": {
+            "all": {
+              "description": "options applying to all subgraphs",
+              "default": {
+                "enabled": false
+              },
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "description": "Enable",
+                  "default": false,
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            },
+            "subgraphs": {
+              "description": "per subgraph options",
+              "default": {},
+              "type": "object",
+              "additionalProperties": {
+                "description": "Subgraph level Automatic Persisted Queries (APQ) configuration",
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "description": "Enable",
+                    "default": false,
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "authentication": {
       "description": "Authentication",
       "type": "object",
-      "required": ["experimental"],
       "properties": {
-        "experimental": {
-          "description": "The experimental configuration",
+        "router": {
+          "description": "Router configuration",
           "type": "object",
           "required": ["jwt"],
           "properties": {
             "jwt": {
               "description": "The JWT configuration",
               "type": "object",
-              "required": ["jwks_urls"],
+              "required": ["jwks"],
               "properties": {
-                "cooldown": {
-                  "description": "JWKS retrieval cooldown",
-                  "default": null,
-                  "type": "string"
-                },
                 "header_name": {
                   "description": "HTTP header expected to contain JWT",
                   "default": "authorization",
@@ -34,18 +176,743 @@
                   "default": "Bearer",
                   "type": "string"
                 },
-                "jwks_urls": {
-                  "description": "Retrieve our JWK Sets from these locations",
+                "jwks": {
+                  "description": "List of JWKS used to verify tokens",
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "type": "object",
+                    "required": ["url"],
+                    "properties": {
+                      "algorithms": {
+                        "description": "List of accepted algorithms. Possible values are `HS256`, `HS384`, `HS512`, `ES256`, `ES384`, `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, `EdDSA`",
+                        "default": null,
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "nullable": true
+                      },
+                      "issuer": {
+                        "description": "Expected issuer for tokens verified by that JWKS",
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "poll_interval": {
+                        "description": "Polling interval for each JWKS endpoint in human-readable format; defaults to 60s",
+                        "default": {
+                          "secs": 60,
+                          "nanos": 0
+                        },
+                        "type": "string"
+                      },
+                      "url": {
+                        "description": "Retrieve the JWK Set",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
                   }
                 }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false,
+          "nullable": true
+        },
+        "subgraph": {
+          "description": "Subgraph configuration",
+          "type": "object",
+          "properties": {
+            "all": {
+              "description": "Configuration that will apply to all subgraphs.",
+              "oneOf": [
+                {
+                  "type": "object",
+                  "required": ["aws_sig_v4"],
+                  "properties": {
+                    "aws_sig_v4": {
+                      "description": "Configure AWS sigv4 auth.",
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "required": ["hardcoded"],
+                          "properties": {
+                            "hardcoded": {
+                              "description": "Hardcoded Config using access_key and secret. Prefer using DefaultChain instead.",
+                              "type": "object",
+                              "required": [
+                                "access_key_id",
+                                "region",
+                                "secret_access_key",
+                                "service_name"
+                              ],
+                              "properties": {
+                                "access_key_id": {
+                                  "description": "The ID for this access key.",
+                                  "type": "string"
+                                },
+                                "assume_role": {
+                                  "description": "Specify assumed role configuration.",
+                                  "type": "object",
+                                  "required": ["role_arn", "session_name"],
+                                  "properties": {
+                                    "external_id": {
+                                      "description": "Unique identifier that might be required when you assume a role in another account.",
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "role_arn": {
+                                      "description": "Amazon Resource Name (ARN) for the role assumed when making requests",
+                                      "type": "string"
+                                    },
+                                    "session_name": {
+                                      "description": "Uniquely identify a session when the same role is assumed by different principals or for different reasons.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "nullable": true
+                                },
+                                "region": {
+                                  "description": "The AWS region this chain applies to.",
+                                  "type": "string"
+                                },
+                                "secret_access_key": {
+                                  "description": "The secret key used to sign requests.",
+                                  "type": "string"
+                                },
+                                "service_name": {
+                                  "description": "The service you're trying to access, eg: \"s3\", \"vpc-lattice-svcs\", etc.",
+                                  "type": "string"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "required": ["default_chain"],
+                          "properties": {
+                            "default_chain": {
+                              "description": "Configuration of the DefaultChainProvider",
+                              "type": "object",
+                              "required": ["region", "service_name"],
+                              "properties": {
+                                "assume_role": {
+                                  "description": "Specify assumed role configuration.",
+                                  "type": "object",
+                                  "required": ["role_arn", "session_name"],
+                                  "properties": {
+                                    "external_id": {
+                                      "description": "Unique identifier that might be required when you assume a role in another account.",
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "role_arn": {
+                                      "description": "Amazon Resource Name (ARN) for the role assumed when making requests",
+                                      "type": "string"
+                                    },
+                                    "session_name": {
+                                      "description": "Uniquely identify a session when the same role is assumed by different principals or for different reasons.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "nullable": true
+                                },
+                                "profile_name": {
+                                  "description": "The profile name used by this provider",
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "region": {
+                                  "description": "The AWS region this chain applies to.",
+                                  "type": "string"
+                                },
+                                "service_name": {
+                                  "description": "The service you're trying to access, eg: \"s3\", \"vpc-lattice-svcs\", etc.",
+                                  "type": "string"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "nullable": true
+            },
+            "subgraphs": {
+              "description": "Create a configuration that will apply only to a specific subgraph.",
+              "type": "object",
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "required": ["aws_sig_v4"],
+                    "properties": {
+                      "aws_sig_v4": {
+                        "description": "Configure AWS sigv4 auth.",
+                        "oneOf": [
+                          {
+                            "type": "object",
+                            "required": ["hardcoded"],
+                            "properties": {
+                              "hardcoded": {
+                                "description": "Hardcoded Config using access_key and secret. Prefer using DefaultChain instead.",
+                                "type": "object",
+                                "required": [
+                                  "access_key_id",
+                                  "region",
+                                  "secret_access_key",
+                                  "service_name"
+                                ],
+                                "properties": {
+                                  "access_key_id": {
+                                    "description": "The ID for this access key.",
+                                    "type": "string"
+                                  },
+                                  "assume_role": {
+                                    "description": "Specify assumed role configuration.",
+                                    "type": "object",
+                                    "required": ["role_arn", "session_name"],
+                                    "properties": {
+                                      "external_id": {
+                                        "description": "Unique identifier that might be required when you assume a role in another account.",
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "role_arn": {
+                                        "description": "Amazon Resource Name (ARN) for the role assumed when making requests",
+                                        "type": "string"
+                                      },
+                                      "session_name": {
+                                        "description": "Uniquely identify a session when the same role is assumed by different principals or for different reasons.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "nullable": true
+                                  },
+                                  "region": {
+                                    "description": "The AWS region this chain applies to.",
+                                    "type": "string"
+                                  },
+                                  "secret_access_key": {
+                                    "description": "The secret key used to sign requests.",
+                                    "type": "string"
+                                  },
+                                  "service_name": {
+                                    "description": "The service you're trying to access, eg: \"s3\", \"vpc-lattice-svcs\", etc.",
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": ["default_chain"],
+                            "properties": {
+                              "default_chain": {
+                                "description": "Configuration of the DefaultChainProvider",
+                                "type": "object",
+                                "required": ["region", "service_name"],
+                                "properties": {
+                                  "assume_role": {
+                                    "description": "Specify assumed role configuration.",
+                                    "type": "object",
+                                    "required": ["role_arn", "session_name"],
+                                    "properties": {
+                                      "external_id": {
+                                        "description": "Unique identifier that might be required when you assume a role in another account.",
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "role_arn": {
+                                        "description": "Amazon Resource Name (ARN) for the role assumed when making requests",
+                                        "type": "string"
+                                      },
+                                      "session_name": {
+                                        "description": "Uniquely identify a session when the same role is assumed by different principals or for different reasons.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "nullable": true
+                                  },
+                                  "profile_name": {
+                                    "description": "The profile name used by this provider",
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "region": {
+                                    "description": "The AWS region this chain applies to.",
+                                    "type": "string"
+                                  },
+                                  "service_name": {
+                                    "description": "The service you're trying to access, eg: \"s3\", \"vpc-lattice-svcs\", etc.",
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                ]
               }
             }
+          },
+          "additionalProperties": false,
+          "nullable": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "authorization": {
+      "description": "Authorization plugin",
+      "type": "object",
+      "properties": {
+        "preview_directives": {
+          "description": "`@authenticated` and `@requiresScopes` directives",
+          "type": "object",
+          "properties": {
+            "dry_run": {
+              "description": "generates the authorization error messages without modying the query",
+              "default": false,
+              "type": "boolean"
+            },
+            "enabled": {
+              "description": "enables the `@authenticated` and `@requiresScopes` directives",
+              "default": true,
+              "type": "boolean"
+            },
+            "errors": {
+              "description": "authorization errors behaviour",
+              "default": {
+                "log": true,
+                "response": "errors"
+              },
+              "type": "object",
+              "properties": {
+                "log": {
+                  "description": "log authorization errors",
+                  "default": true,
+                  "type": "boolean"
+                },
+                "response": {
+                  "description": "location of authorization errors in the GraphQL response",
+                  "default": "errors",
+                  "oneOf": [
+                    {
+                      "description": "store authorization errors in the response errors",
+                      "type": "string",
+                      "enum": ["errors"]
+                    },
+                    {
+                      "description": "store authorization errors in the response extensions",
+                      "type": "string",
+                      "enum": ["extensions"]
+                    },
+                    {
+                      "description": "do not add the authorization errors to the GraphQL response",
+                      "type": "string",
+                      "enum": ["disabled"]
+                    }
+                  ]
+                }
+              }
+            },
+            "reject_unauthorized": {
+              "description": "refuse a query entirely if any part would be filtered",
+              "default": false,
+              "type": "boolean"
+            }
           }
+        },
+        "require_authentication": {
+          "description": "Reject unauthenticated requests",
+          "default": false,
+          "type": "boolean"
         }
       }
+    },
+    "coprocessor": {
+      "description": "Configures the externalization plugin",
+      "type": "object",
+      "required": ["url"],
+      "properties": {
+        "router": {
+          "description": "The router stage request/response configuration",
+          "default": {
+            "request": {
+              "headers": false,
+              "context": false,
+              "body": false,
+              "sdl": false,
+              "path": false,
+              "method": false
+            },
+            "response": {
+              "headers": false,
+              "context": false,
+              "body": false,
+              "sdl": false,
+              "status_code": false
+            }
+          },
+          "type": "object",
+          "properties": {
+            "request": {
+              "description": "The request configuration",
+              "default": {
+                "headers": false,
+                "context": false,
+                "body": false,
+                "sdl": false,
+                "path": false,
+                "method": false
+              },
+              "type": "object",
+              "properties": {
+                "body": {
+                  "description": "Send the body",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "context": {
+                  "description": "Send the context",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "headers": {
+                  "description": "Send the headers",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "method": {
+                  "description": "Send the method",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "path": {
+                  "description": "Send the path",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "sdl": {
+                  "description": "Send the SDL",
+                  "default": false,
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            },
+            "response": {
+              "description": "The response configuration",
+              "default": {
+                "headers": false,
+                "context": false,
+                "body": false,
+                "sdl": false,
+                "status_code": false
+              },
+              "type": "object",
+              "properties": {
+                "body": {
+                  "description": "Send the body",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "context": {
+                  "description": "Send the context",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "headers": {
+                  "description": "Send the headers",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "sdl": {
+                  "description": "Send the SDL",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "status_code": {
+                  "description": "Send the HTTP status",
+                  "default": false,
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "subgraph": {
+          "description": "The subgraph stage request/response configuration",
+          "default": {
+            "all": {
+              "request": {
+                "headers": false,
+                "context": false,
+                "body": false,
+                "uri": false,
+                "method": false,
+                "service_name": false
+              },
+              "response": {
+                "headers": false,
+                "context": false,
+                "body": false,
+                "service_name": false,
+                "status_code": false
+              }
+            }
+          },
+          "type": "object",
+          "properties": {
+            "all": {
+              "description": "What information is passed to a subgraph request/response stage",
+              "default": {
+                "request": {
+                  "headers": false,
+                  "context": false,
+                  "body": false,
+                  "uri": false,
+                  "method": false,
+                  "service_name": false
+                },
+                "response": {
+                  "headers": false,
+                  "context": false,
+                  "body": false,
+                  "service_name": false,
+                  "status_code": false
+                }
+              },
+              "type": "object",
+              "properties": {
+                "request": {
+                  "description": "What information is passed to a subgraph request/response stage",
+                  "default": {
+                    "headers": false,
+                    "context": false,
+                    "body": false,
+                    "uri": false,
+                    "method": false,
+                    "service_name": false
+                  },
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "description": "Send the body",
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "context": {
+                      "description": "Send the context",
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "headers": {
+                      "description": "Send the headers",
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "method": {
+                      "description": "Send the method URI",
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "service_name": {
+                      "description": "Send the service name",
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "uri": {
+                      "description": "Send the subgraph URI",
+                      "default": false,
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "response": {
+                  "description": "What information is passed to a subgraph request/response stage",
+                  "default": {
+                    "headers": false,
+                    "context": false,
+                    "body": false,
+                    "service_name": false,
+                    "status_code": false
+                  },
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "description": "Send the body",
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "context": {
+                      "description": "Send the context",
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "headers": {
+                      "description": "Send the headers",
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "service_name": {
+                      "description": "Send the service name",
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "status_code": {
+                      "description": "Send the http status",
+                      "default": false,
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "supergraph": {
+          "description": "The supergraph stage request/response configuration",
+          "default": {
+            "request": {
+              "headers": false,
+              "context": false,
+              "body": false,
+              "sdl": false,
+              "method": false
+            },
+            "response": {
+              "headers": false,
+              "context": false,
+              "body": false,
+              "sdl": false,
+              "status_code": false
+            }
+          },
+          "type": "object",
+          "properties": {
+            "request": {
+              "description": "The request configuration",
+              "default": {
+                "headers": false,
+                "context": false,
+                "body": false,
+                "sdl": false,
+                "method": false
+              },
+              "type": "object",
+              "properties": {
+                "body": {
+                  "description": "Send the body",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "context": {
+                  "description": "Send the context",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "headers": {
+                  "description": "Send the headers",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "method": {
+                  "description": "Send the method",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "sdl": {
+                  "description": "Send the SDL",
+                  "default": false,
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            },
+            "response": {
+              "description": "What information is passed to a router request/response stage",
+              "default": {
+                "headers": false,
+                "context": false,
+                "body": false,
+                "sdl": false,
+                "status_code": false
+              },
+              "type": "object",
+              "properties": {
+                "body": {
+                  "description": "Send the body",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "context": {
+                  "description": "Send the context",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "headers": {
+                  "description": "Send the headers",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "sdl": {
+                  "description": "Send the SDL",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "status_code": {
+                  "description": "Send the HTTP status",
+                  "default": false,
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "timeout": {
+          "description": "The timeout for external requests",
+          "default": {
+            "secs": 1,
+            "nanos": 0
+          },
+          "type": "string"
+        },
+        "url": {
+          "description": "The url you'd like to offload processing to",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
     },
     "cors": {
       "description": "Cross origin request headers.",
@@ -140,6 +1007,91 @@
         }
       },
       "additionalProperties": false
+    },
+    "experimental_api_schema_generation_mode": {
+      "description": "Set the API schema generation implementation to use.",
+      "default": "legacy",
+      "oneOf": [
+        {
+          "description": "Use the new Rust-based implementation.",
+          "type": "string",
+          "enum": ["new"]
+        },
+        {
+          "description": "Use the old JavaScript-based implementation.",
+          "type": "string",
+          "enum": ["legacy"]
+        },
+        {
+          "description": "Use Rust-based and Javascript-based implementations side by side, logging warnings if the implementations disagree.",
+          "type": "string",
+          "enum": ["both"]
+        }
+      ]
+    },
+    "experimental_batching": {
+      "description": "Batching configuration.",
+      "default": {
+        "enabled": false,
+        "mode": "batch_http_link"
+      },
+      "type": "object",
+      "required": ["mode"],
+      "properties": {
+        "enabled": {
+          "description": "Activates Batching (disabled by default)",
+          "default": false,
+          "type": "boolean"
+        },
+        "mode": {
+          "description": "Batching mode",
+          "oneOf": [
+            {
+              "description": "batch_http_link",
+              "type": "string",
+              "enum": ["batch_http_link"]
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "experimental_chaos": {
+      "description": "Configuration for chaos testing, trying to reproduce bugs that require uncommon conditions. You probably don’t want this in production!",
+      "default": {
+        "force_reload": null
+      },
+      "type": "object",
+      "properties": {
+        "force_reload": {
+          "description": "Force a hot reload of the Router (as if the schema or configuration had changed) at a regular time interval.",
+          "default": null,
+          "type": "string",
+          "nullable": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "experimental_graphql_validation_mode": {
+      "description": "Set the GraphQL validation implementation to use.",
+      "default": "legacy",
+      "oneOf": [
+        {
+          "description": "Use the new Rust-based implementation.",
+          "type": "string",
+          "enum": ["new"]
+        },
+        {
+          "description": "Use the old JavaScript-based implementation.",
+          "type": "string",
+          "enum": ["legacy"]
+        },
+        {
+          "description": "Use Rust-based and Javascript-based implementations side by side, logging warnings if the implementations disagree.",
+          "type": "string",
+          "enum": ["both"]
+        }
+      ]
     },
     "forbid_mutations": {
       "description": "Forbid mutations configuration",
@@ -486,12 +1438,13 @@
       "description": "Health check configuration",
       "default": {
         "listen": "127.0.0.1:8088",
-        "enabled": true
+        "enabled": true,
+        "path": "/health"
       },
       "type": "object",
       "properties": {
         "enabled": {
-          "description": "Set to false to disable the health check endpoint",
+          "description": "Set to false to disable the health check",
           "default": true,
           "type": "boolean"
         },
@@ -508,6 +1461,11 @@
               "type": "string"
             }
           ]
+        },
+        "path": {
+          "description": "Optionally set a custom healthcheck path Defaults to /health",
+          "default": "/health",
+          "type": "string"
         }
       },
       "additionalProperties": false
@@ -515,7 +1473,8 @@
     "homepage": {
       "description": "Homepage configuration",
       "default": {
-        "enabled": true
+        "enabled": true,
+        "graph_ref": null
       },
       "type": "object",
       "properties": {
@@ -523,6 +1482,12 @@
           "description": "Set to false to disable the homepage",
           "default": true,
           "type": "boolean"
+        },
+        "graph_ref": {
+          "description": "Graph reference This will allow you to redirect from the Apollo Router landing page back to Apollo Studio Explorer",
+          "default": null,
+          "type": "string",
+          "nullable": true
         }
       },
       "additionalProperties": false
@@ -547,6 +1512,81 @@
       },
       "additionalProperties": false
     },
+    "limits": {
+      "description": "Configuration for operation limits, parser limits, HTTP limits, etc.",
+      "default": {
+        "max_depth": null,
+        "max_height": null,
+        "max_root_fields": null,
+        "max_aliases": null,
+        "warn_only": false,
+        "parser_max_recursion": 4096,
+        "parser_max_tokens": 15000,
+        "experimental_http_max_request_bytes": 2000000
+      },
+      "type": "object",
+      "properties": {
+        "experimental_http_max_request_bytes": {
+          "description": "Limit the size of incoming HTTP requests read from the network, to protect against running out of memory. Default: 2000000 (2 MB)",
+          "default": 2000000,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "max_aliases": {
+          "description": "If set, requests with operations with more aliases than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_ALIASES_LIMIT\"}`",
+          "default": null,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0,
+          "nullable": true
+        },
+        "max_depth": {
+          "description": "If set, requests with operations deeper than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nCounts depth of an operation, looking at its selection sets, including fields in fragments and inline fragments. The following example has a depth of 3.\n\n```graphql query getProduct { book { # 1 ...bookDetails } }\n\nfragment bookDetails on Book { details { # 2 ... on ProductDetailsBook { country # 3 } } } ```",
+          "default": null,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0,
+          "nullable": true
+        },
+        "max_height": {
+          "description": "If set, requests with operations higher than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nHeight is based on simple merging of fields using the same name or alias, but only within the same selection set. For example `name` here is only counted once and the query has height 3, not 4:\n\n```graphql query { name { first } name { last } } ```\n\nThis may change in a future version of Apollo Router to do [full field merging across fragments][merging] instead.\n\n[merging]: https://spec.graphql.org/October2021/#sec-Field-Selection-Merging]",
+          "default": null,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0,
+          "nullable": true
+        },
+        "max_root_fields": {
+          "description": "If set, requests with operations with more root fields than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_ROOT_FIELDS_LIMIT\"}`\n\nThis limit counts only the top level fields in a selection set, including fragments and inline fragments.",
+          "default": null,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0,
+          "nullable": true
+        },
+        "parser_max_recursion": {
+          "description": "Limit recursion in the GraphQL parser to protect against stack overflow. default: 4096",
+          "default": 4096,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "parser_max_tokens": {
+          "description": "Limit the number of tokens the GraphQL parser processes before aborting.",
+          "default": 15000,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "warn_only": {
+          "description": "If set to true (which is the default is dev mode), requests that exceed a `max_*` limit are *not* rejected. Instead they are executed normally, and a warning is logged.",
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
     "override_subgraph_url": {
       "description": "Subgraph URL mappings",
       "anyOf": [
@@ -560,99 +1600,79 @@
         }
       ]
     },
+    "persisted_queries": {
+      "description": "Configures managed persisted queries",
+      "default": {
+        "enabled": false,
+        "log_unknown": false,
+        "safelist": {
+          "enabled": false,
+          "require_id": false
+        }
+      },
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Activates Persisted Queries (disabled by default)",
+          "default": false,
+          "type": "boolean"
+        },
+        "log_unknown": {
+          "description": "Enabling this field configures the router to log any freeform GraphQL request that is not in the persisted query list",
+          "default": false,
+          "type": "boolean"
+        },
+        "safelist": {
+          "description": "Restricts execution of operations that are not found in the Persisted Query List",
+          "default": {
+            "enabled": false,
+            "require_id": false
+          },
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "Enables using the persisted query list as a safelist (disabled by default)",
+              "default": false,
+              "type": "boolean"
+            },
+            "require_id": {
+              "description": "Enabling this field configures the router to reject any request that does not include the persisted query ID",
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
     "plugins": {
       "description": "Plugin configuration",
       "default": null,
       "properties": {
+        "experimental.broken": {
+          "description": "This is a broken plugin for testing purposes only.",
+          "type": "object",
+          "required": ["enabled"],
+          "properties": {
+            "enabled": {
+              "description": "Enable the broken plugin.",
+              "type": "boolean"
+            }
+          }
+        },
         "experimental.expose_query_plan": {
           "description": "Expose query plan",
           "type": "boolean"
         },
-        "experimental.external": {
-          "description": "Configures the externalization plugin",
+        "experimental.restricted": {
+          "description": "Restricted plugin (for testing purposes only)",
           "type": "object",
-          "required": ["url"],
+          "required": ["enabled"],
           "properties": {
-            "stages": {
-              "description": "The stages request/response configuration",
-              "default": null,
-              "type": "object",
-              "properties": {
-                "router": {
-                  "description": "The router stage",
-                  "default": null,
-                  "type": "object",
-                  "properties": {
-                    "request": {
-                      "description": "The request configuration",
-                      "default": null,
-                      "type": "object",
-                      "properties": {
-                        "body": {
-                          "description": "Send the body",
-                          "default": false,
-                          "type": "boolean"
-                        },
-                        "context": {
-                          "description": "Send the context",
-                          "default": false,
-                          "type": "boolean"
-                        },
-                        "headers": {
-                          "description": "Send the headers",
-                          "default": false,
-                          "type": "boolean"
-                        },
-                        "sdl": {
-                          "description": "Send the SDL",
-                          "default": false,
-                          "type": "boolean"
-                        }
-                      },
-                      "nullable": true
-                    },
-                    "response": {
-                      "description": "The response configuration",
-                      "default": null,
-                      "type": "object",
-                      "properties": {
-                        "body": {
-                          "description": "Send the body",
-                          "default": false,
-                          "type": "boolean"
-                        },
-                        "context": {
-                          "description": "Send the context",
-                          "default": false,
-                          "type": "boolean"
-                        },
-                        "headers": {
-                          "description": "Send the headers",
-                          "default": false,
-                          "type": "boolean"
-                        },
-                        "sdl": {
-                          "description": "Send the SDL",
-                          "default": false,
-                          "type": "boolean"
-                        }
-                      },
-                      "nullable": true
-                    }
-                  },
-                  "nullable": true
-                }
-              },
-              "nullable": true
-            },
-            "timeout": {
-              "description": "The timeout for external requests",
-              "default": null,
-              "type": "string"
-            },
-            "url": {
-              "description": "The url you'd like to offload processing to",
-              "type": "string"
+            "enabled": {
+              "description": "Enable the restricted plugin (for testing purposes only)",
+              "type": "boolean"
             }
           }
         }
@@ -691,19 +1711,142 @@
       },
       "additionalProperties": false
     },
-    "server": {
-      "description": "Configuration options pertaining to the http server component.",
-      "default": {
-        "experimental_parser_recursion_limit": 4096
-      },
+    "subscription": {
+      "description": "Subscriptions configuration",
       "type": "object",
       "properties": {
-        "experimental_parser_recursion_limit": {
-          "description": "Experimental limitation of query depth default: 4096",
-          "default": 4096,
+        "enable_deduplication": {
+          "description": "Enable the deduplication of subscription (for example if we detect the exact same request to subgraph we won't open a new websocket to the subgraph in passthrough mode) (default: true)",
+          "default": true,
+          "type": "boolean"
+        },
+        "enabled": {
+          "description": "Enable subscription",
+          "default": true,
+          "type": "boolean"
+        },
+        "max_opened_subscriptions": {
+          "description": "This is a limit to only have maximum X opened subscriptions at the same time. By default if it's not set there is no limit.",
+          "default": null,
           "type": "integer",
           "format": "uint",
-          "minimum": 0.0
+          "minimum": 0.0,
+          "nullable": true
+        },
+        "mode": {
+          "description": "Select a subscription mode (callback or passthrough)",
+          "default": {
+            "preview_callback": null,
+            "passthrough": null
+          },
+          "type": "object",
+          "properties": {
+            "passthrough": {
+              "description": "Enable passthrough mode for subgraph(s)",
+              "type": "object",
+              "properties": {
+                "all": {
+                  "description": "Configuration for all subgraphs",
+                  "default": null,
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "description": "Path on which WebSockets are listening",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "protocol": {
+                      "description": "Which WebSocket GraphQL protocol to use for this subgraph possible values are: 'graphql_ws' | 'graphql_transport_ws' (default: graphql_ws)",
+                      "default": "graphql_ws",
+                      "type": "string",
+                      "enum": ["graphql_ws", "graphql_transport_ws"]
+                    }
+                  },
+                  "additionalProperties": false,
+                  "nullable": true
+                },
+                "subgraphs": {
+                  "description": "Configuration for specific subgraphs",
+                  "default": {},
+                  "type": "object",
+                  "additionalProperties": {
+                    "description": "WebSocket configuration for a specific subgraph",
+                    "type": "object",
+                    "properties": {
+                      "path": {
+                        "description": "Path on which WebSockets are listening",
+                        "default": null,
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "protocol": {
+                        "description": "Which WebSocket GraphQL protocol to use for this subgraph possible values are: 'graphql_ws' | 'graphql_transport_ws' (default: graphql_ws)",
+                        "default": "graphql_ws",
+                        "type": "string",
+                        "enum": ["graphql_ws", "graphql_transport_ws"]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false,
+              "nullable": true
+            },
+            "preview_callback": {
+              "description": "Enable callback mode for subgraph(s)",
+              "type": "object",
+              "required": ["public_url"],
+              "properties": {
+                "listen": {
+                  "description": "Listen address on which the callback must listen (default: 127.0.0.1:4000)",
+                  "writeOnly": true,
+                  "anyOf": [
+                    {
+                      "description": "Socket address.",
+                      "type": "string"
+                    },
+                    {
+                      "description": "Unix socket.",
+                      "type": "string"
+                    }
+                  ],
+                  "nullable": true
+                },
+                "path": {
+                  "description": "Specify on which path you want to listen for callbacks (default: /callback)",
+                  "writeOnly": true,
+                  "type": "string",
+                  "nullable": true
+                },
+                "public_url": {
+                  "description": "URL used to access this router instance",
+                  "type": "string"
+                },
+                "subgraphs": {
+                  "description": "Specify on which subgraph we enable the callback mode for subscription If empty it applies to all subgraphs (passthrough mode takes precedence)",
+                  "default": [],
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                }
+              },
+              "additionalProperties": false,
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "queue_capacity": {
+          "description": "It represent the capacity of the in memory queue to know how many events we can keep in a buffer",
+          "default": null,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0,
+          "nullable": true
         }
       },
       "additionalProperties": false
@@ -714,22 +1857,8 @@
         "listen": "127.0.0.1:4000",
         "path": "/",
         "introspection": false,
+        "experimental_reuse_query_fragments": null,
         "defer_support": true,
-        "apq": {
-          "enabled": true,
-          "experimental_cache": {
-            "in_memory": {
-              "limit": 512
-            },
-            "redis": null
-          },
-          "subgraph": {
-            "all": {
-              "enabled": false
-            },
-            "subgraphs": {}
-          }
-        },
         "query_planning": {
           "experimental_cache": {
             "in_memory": {
@@ -737,131 +1866,21 @@
             },
             "redis": null
           },
-          "warmed_up_queries": 0
+          "warmed_up_queries": null
         }
       },
       "type": "object",
       "properties": {
-        "apq": {
-          "description": "Configures automatic persisted queries",
-          "default": {
-            "enabled": true,
-            "experimental_cache": {
-              "in_memory": {
-                "limit": 512
-              },
-              "redis": null
-            },
-            "subgraph": {
-              "all": {
-                "enabled": false
-              },
-              "subgraphs": {}
-            }
-          },
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "description": "Activates Automatic Persisted Queries (enabled by default)",
-              "default": true,
-              "type": "boolean"
-            },
-            "experimental_cache": {
-              "description": "Cache configuration",
-              "default": {
-                "in_memory": {
-                  "limit": 512
-                },
-                "redis": null
-              },
-              "type": "object",
-              "required": ["in_memory"],
-              "properties": {
-                "in_memory": {
-                  "description": "Configures the in memory cache (always active)",
-                  "type": "object",
-                  "required": ["limit"],
-                  "properties": {
-                    "limit": {
-                      "description": "Number of entries in the Least Recently Used cache",
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 1.0
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                "redis": {
-                  "description": "Configures and activates the Redis cache",
-                  "type": "object",
-                  "required": ["urls"],
-                  "properties": {
-                    "urls": {
-                      "description": "List of URLs to the Redis cluster",
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "additionalProperties": false,
-                  "nullable": true
-                }
-              },
-              "additionalProperties": false
-            },
-            "subgraph": {
-              "description": "Configuration options pertaining to the subgraph server component.",
-              "default": {
-                "all": {
-                  "enabled": false
-                },
-                "subgraphs": {}
-              },
-              "type": "object",
-              "properties": {
-                "all": {
-                  "description": "options applying to all subgraphs",
-                  "default": {
-                    "enabled": false
-                  },
-                  "type": "object",
-                  "properties": {
-                    "enabled": {
-                      "description": "Enable",
-                      "default": false,
-                      "type": "boolean"
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                "subgraphs": {
-                  "description": "per subgraph options",
-                  "default": {},
-                  "type": "object",
-                  "additionalProperties": {
-                    "description": "Subgraph level Automatic Persisted Queries (APQ) configuration",
-                    "type": "object",
-                    "properties": {
-                      "enabled": {
-                        "description": "Enable",
-                        "default": false,
-                        "type": "boolean"
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        },
         "defer_support": {
           "description": "Set to false to disable defer support",
           "default": true,
           "type": "boolean"
+        },
+        "experimental_reuse_query_fragments": {
+          "description": "Enable reuse of query fragments Default: depends on the federation version",
+          "default": null,
+          "type": "boolean",
+          "nullable": true
         },
         "introspection": {
           "description": "Enable introspection Default: false",
@@ -896,18 +1915,25 @@
               },
               "redis": null
             },
-            "warmed_up_queries": 0
+            "warmed_up_queries": null
           },
           "type": "object",
-          "required": ["experimental_cache"],
           "properties": {
             "experimental_cache": {
               "description": "Cache configuration",
+              "default": {
+                "in_memory": {
+                  "limit": 512
+                },
+                "redis": null
+              },
               "type": "object",
-              "required": ["in_memory"],
               "properties": {
                 "in_memory": {
                   "description": "Configures the in memory cache (always active)",
+                  "default": {
+                    "limit": 512
+                  },
                   "type": "object",
                   "required": ["limit"],
                   "properties": {
@@ -922,14 +1948,28 @@
                 },
                 "redis": {
                   "description": "Configures and activates the Redis cache",
+                  "default": null,
                   "type": "object",
                   "required": ["urls"],
                   "properties": {
+                    "timeout": {
+                      "description": "Redis request timeout (default: 2ms)",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "ttl": {
+                      "description": "TTL for entries",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    },
                     "urls": {
                       "description": "List of URLs to the Redis cluster",
                       "type": "array",
                       "items": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "uri"
                       }
                     }
                   },
@@ -940,11 +1980,12 @@
               "additionalProperties": false
             },
             "warmed_up_queries": {
-              "description": "Warm up the cache on reloads by running the query plan over a list of the most used queries Defaults to 0 (do not warm up the cache)",
-              "default": 0,
+              "description": "Warms up the cache on reloads by running the query plan over a list of the most used queries (from the in memory cache) Configures the number of queries warmed up. Defaults to 1/3 of the in memory cache",
+              "default": null,
               "type": "integer",
               "format": "uint",
-              "minimum": 0.0
+              "minimum": 0.0,
+              "nullable": true
             }
           },
           "additionalProperties": false
@@ -962,19 +2003,6 @@
           "properties": {
             "batch_processor": {
               "description": "Configuration for batch processing.",
-              "default": {
-                "scheduled_delay": {
-                  "secs": 5,
-                  "nanos": 0
-                },
-                "max_queue_size": 2048,
-                "max_export_batch_size": 512,
-                "max_export_timeout": {
-                  "secs": 30,
-                  "nanos": 0
-                },
-                "max_concurrent_exports": 1
-              },
               "type": "object",
               "properties": {
                 "max_concurrent_exports": {
@@ -1040,8 +2068,64 @@
               "default": "https://usage-reporting.api.apollographql.com/api/ingress/traces",
               "type": "string"
             },
+            "errors": {
+              "description": "Configure the way errors are transmitted to Apollo Studio",
+              "type": "object",
+              "properties": {
+                "subgraph": {
+                  "description": "Handling of errors coming from subgraph",
+                  "type": "object",
+                  "properties": {
+                    "all": {
+                      "description": "Handling of errors coming from all subgraphs",
+                      "type": "object",
+                      "properties": {
+                        "redact": {
+                          "description": "Redact subgraph errors to Apollo Studio",
+                          "default": true,
+                          "type": "boolean"
+                        },
+                        "send": {
+                          "description": "Send subgraph errors to Apollo Studio",
+                          "default": true,
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "subgraphs": {
+                      "description": "Handling of errors coming from specified subgraphs",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                          "redact": {
+                            "description": "Redact subgraph errors to Apollo Studio",
+                            "default": true,
+                            "type": "boolean"
+                          },
+                          "send": {
+                            "description": "Send subgraph errors to Apollo Studio",
+                            "default": true,
+                            "type": "boolean"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "experimental_otlp_endpoint": {
+              "description": "The Apollo Studio endpoint for exporting traces and metrics.",
+              "default": "https://usage-reporting.api.apollographql.com/",
+              "type": "string"
+            },
             "field_level_instrumentation_sampler": {
-              "description": "Enable field level instrumentation for subgraphs via ftv1. ftv1 tracing can cause performance issues as it is transmitted in band with subgraph responses. 0.0 will result in no field level instrumentation. 1.0 will result in always instrumentation. Value MUST be less than global sampling rate",
+              "description": "Field level instrumentation for subgraphs via ftv1. ftv1 tracing can cause performance issues as it is transmitted in band with subgraph responses.",
               "anyOf": [
                 {
                   "description": "Sample a given fraction. Fractions >= 1 will always sample.",
@@ -1155,8 +2239,7 @@
               ]
             }
           },
-          "additionalProperties": false,
-          "nullable": true
+          "additionalProperties": false
         },
         "experimental_logging": {
           "description": "Logging configuration",
@@ -1164,12 +2247,17 @@
           "properties": {
             "display_filename": {
               "description": "Display the filename in the logs",
-              "default": true,
+              "default": false,
               "type": "boolean"
             },
             "display_line_number": {
               "description": "Display the line number in the logs",
-              "default": true,
+              "default": false,
+              "type": "boolean"
+            },
+            "display_target": {
+              "description": "Display the target in the logs",
+              "default": false,
               "type": "boolean"
             },
             "format": {
@@ -1248,8 +2336,7 @@
               }
             }
           },
-          "additionalProperties": false,
-          "nullable": true
+          "additionalProperties": false
         },
         "metrics": {
           "description": "Metrics configuration",
@@ -1281,7 +2368,61 @@
                                 "properties": {
                                   "default": {
                                     "description": "The optional default value",
-                                    "type": "string",
+                                    "anyOf": [
+                                      {
+                                        "description": "bool values",
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "description": "i64 values",
+                                        "type": "integer",
+                                        "format": "int64"
+                                      },
+                                      {
+                                        "description": "f64 values",
+                                        "type": "number",
+                                        "format": "double"
+                                      },
+                                      {
+                                        "description": "String values",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "description": "Array of homogeneous values",
+                                        "anyOf": [
+                                          {
+                                            "description": "Array of bools",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          {
+                                            "description": "Array of integers",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "integer",
+                                              "format": "int64"
+                                            }
+                                          },
+                                          {
+                                            "description": "Array of floats",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "number",
+                                              "format": "double"
+                                            }
+                                          },
+                                          {
+                                            "description": "Array of strings",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ],
                                     "nullable": true
                                   },
                                   "named": {
@@ -1295,8 +2436,7 @@
                                   }
                                 },
                                 "additionalProperties": false
-                              },
-                              "nullable": true
+                              }
                             },
                             "errors": {
                               "description": "Configuration to forward values from the error to custom attributes/labels in metrics",
@@ -1312,7 +2452,61 @@
                                     "properties": {
                                       "default": {
                                         "description": "The optional default value",
-                                        "type": "string",
+                                        "anyOf": [
+                                          {
+                                            "description": "bool values",
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "description": "i64 values",
+                                            "type": "integer",
+                                            "format": "int64"
+                                          },
+                                          {
+                                            "description": "f64 values",
+                                            "type": "number",
+                                            "format": "double"
+                                          },
+                                          {
+                                            "description": "String values",
+                                            "type": "string"
+                                          },
+                                          {
+                                            "description": "Array of homogeneous values",
+                                            "anyOf": [
+                                              {
+                                                "description": "Array of bools",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              {
+                                                "description": "Array of integers",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "integer",
+                                                  "format": "int64"
+                                                }
+                                              },
+                                              {
+                                                "description": "Array of floats",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "number",
+                                                  "format": "double"
+                                                }
+                                              },
+                                              {
+                                                "description": "Array of strings",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ],
                                         "nullable": true
                                       },
                                       "name": {
@@ -1325,17 +2519,16 @@
                                       }
                                     },
                                     "additionalProperties": false
-                                  },
-                                  "nullable": true
+                                  }
                                 },
                                 "include_messages": {
                                   "description": "Will include the error message in a \"message\" attribute",
-                                  "default": false,
-                                  "type": "boolean"
+                                  "default": null,
+                                  "type": "boolean",
+                                  "nullable": true
                                 }
                               },
-                              "additionalProperties": false,
-                              "nullable": true
+                              "additionalProperties": false
                             },
                             "request": {
                               "description": "Configuration to forward headers or body values from the request to custom attributes/labels in metrics",
@@ -1351,7 +2544,61 @@
                                     "properties": {
                                       "default": {
                                         "description": "The optional default value",
-                                        "type": "string",
+                                        "anyOf": [
+                                          {
+                                            "description": "bool values",
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "description": "i64 values",
+                                            "type": "integer",
+                                            "format": "int64"
+                                          },
+                                          {
+                                            "description": "f64 values",
+                                            "type": "number",
+                                            "format": "double"
+                                          },
+                                          {
+                                            "description": "String values",
+                                            "type": "string"
+                                          },
+                                          {
+                                            "description": "Array of homogeneous values",
+                                            "anyOf": [
+                                              {
+                                                "description": "Array of bools",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              {
+                                                "description": "Array of integers",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "integer",
+                                                  "format": "int64"
+                                                }
+                                              },
+                                              {
+                                                "description": "Array of floats",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "number",
+                                                  "format": "double"
+                                                }
+                                              },
+                                              {
+                                                "description": "Array of strings",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ],
                                         "nullable": true
                                       },
                                       "name": {
@@ -1364,8 +2611,7 @@
                                       }
                                     },
                                     "additionalProperties": false
-                                  },
-                                  "nullable": true
+                                  }
                                 },
                                 "header": {
                                   "description": "Forward header values as custom attributes/labels in metrics",
@@ -1380,7 +2626,61 @@
                                         "properties": {
                                           "default": {
                                             "description": "The optional default value",
-                                            "type": "string",
+                                            "anyOf": [
+                                              {
+                                                "description": "bool values",
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "description": "i64 values",
+                                                "type": "integer",
+                                                "format": "int64"
+                                              },
+                                              {
+                                                "description": "f64 values",
+                                                "type": "number",
+                                                "format": "double"
+                                              },
+                                              {
+                                                "description": "String values",
+                                                "type": "string"
+                                              },
+                                              {
+                                                "description": "Array of homogeneous values",
+                                                "anyOf": [
+                                                  {
+                                                    "description": "Array of bools",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  {
+                                                    "description": "Array of integers",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "integer",
+                                                      "format": "int64"
+                                                    }
+                                                  },
+                                                  {
+                                                    "description": "Array of floats",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "number",
+                                                      "format": "double"
+                                                    }
+                                                  },
+                                                  {
+                                                    "description": "Array of strings",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            ],
                                             "nullable": true
                                           },
                                           "named": {
@@ -1408,12 +2708,10 @@
                                         "additionalProperties": false
                                       }
                                     ]
-                                  },
-                                  "nullable": true
+                                  }
                                 }
                               },
-                              "additionalProperties": false,
-                              "nullable": true
+                              "additionalProperties": false
                             },
                             "response": {
                               "description": "Configuration to forward headers or body values from the response to custom attributes/labels in metrics",
@@ -1429,7 +2727,61 @@
                                     "properties": {
                                       "default": {
                                         "description": "The optional default value",
-                                        "type": "string",
+                                        "anyOf": [
+                                          {
+                                            "description": "bool values",
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "description": "i64 values",
+                                            "type": "integer",
+                                            "format": "int64"
+                                          },
+                                          {
+                                            "description": "f64 values",
+                                            "type": "number",
+                                            "format": "double"
+                                          },
+                                          {
+                                            "description": "String values",
+                                            "type": "string"
+                                          },
+                                          {
+                                            "description": "Array of homogeneous values",
+                                            "anyOf": [
+                                              {
+                                                "description": "Array of bools",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              {
+                                                "description": "Array of integers",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "integer",
+                                                  "format": "int64"
+                                                }
+                                              },
+                                              {
+                                                "description": "Array of floats",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "number",
+                                                  "format": "double"
+                                                }
+                                              },
+                                              {
+                                                "description": "Array of strings",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ],
                                         "nullable": true
                                       },
                                       "name": {
@@ -1442,8 +2794,7 @@
                                       }
                                     },
                                     "additionalProperties": false
-                                  },
-                                  "nullable": true
+                                  }
                                 },
                                 "header": {
                                   "description": "Forward header values as custom attributes/labels in metrics",
@@ -1458,7 +2809,61 @@
                                         "properties": {
                                           "default": {
                                             "description": "The optional default value",
-                                            "type": "string",
+                                            "anyOf": [
+                                              {
+                                                "description": "bool values",
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "description": "i64 values",
+                                                "type": "integer",
+                                                "format": "int64"
+                                              },
+                                              {
+                                                "description": "f64 values",
+                                                "type": "number",
+                                                "format": "double"
+                                              },
+                                              {
+                                                "description": "String values",
+                                                "type": "string"
+                                              },
+                                              {
+                                                "description": "Array of homogeneous values",
+                                                "anyOf": [
+                                                  {
+                                                    "description": "Array of bools",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  {
+                                                    "description": "Array of integers",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "integer",
+                                                      "format": "int64"
+                                                    }
+                                                  },
+                                                  {
+                                                    "description": "Array of floats",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "number",
+                                                      "format": "double"
+                                                    }
+                                                  },
+                                                  {
+                                                    "description": "Array of strings",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            ],
                                             "nullable": true
                                           },
                                           "named": {
@@ -1486,12 +2891,10 @@
                                         "additionalProperties": false
                                       }
                                     ]
-                                  },
-                                  "nullable": true
+                                  }
                                 }
                               },
-                              "additionalProperties": false,
-                              "nullable": true
+                              "additionalProperties": false
                             },
                             "static": {
                               "description": "Configuration to insert custom attributes/labels in metrics",
@@ -1507,16 +2910,68 @@
                                   },
                                   "value": {
                                     "description": "The value of the attribute to insert",
-                                    "type": "string"
+                                    "anyOf": [
+                                      {
+                                        "description": "bool values",
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "description": "i64 values",
+                                        "type": "integer",
+                                        "format": "int64"
+                                      },
+                                      {
+                                        "description": "f64 values",
+                                        "type": "number",
+                                        "format": "double"
+                                      },
+                                      {
+                                        "description": "String values",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "description": "Array of homogeneous values",
+                                        "anyOf": [
+                                          {
+                                            "description": "Array of bools",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          {
+                                            "description": "Array of integers",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "integer",
+                                              "format": "int64"
+                                            }
+                                          },
+                                          {
+                                            "description": "Array of floats",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "number",
+                                              "format": "double"
+                                            }
+                                          },
+                                          {
+                                            "description": "Array of strings",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
                                   }
                                 },
                                 "additionalProperties": false
-                              },
-                              "nullable": true
+                              }
                             }
                           },
-                          "additionalProperties": false,
-                          "nullable": true
+                          "additionalProperties": false
                         },
                         "subgraphs": {
                           "description": "Attributes per subgraph",
@@ -1535,7 +2990,61 @@
                                   "properties": {
                                     "default": {
                                       "description": "The optional default value",
-                                      "type": "string",
+                                      "anyOf": [
+                                        {
+                                          "description": "bool values",
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "description": "i64 values",
+                                          "type": "integer",
+                                          "format": "int64"
+                                        },
+                                        {
+                                          "description": "f64 values",
+                                          "type": "number",
+                                          "format": "double"
+                                        },
+                                        {
+                                          "description": "String values",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "description": "Array of homogeneous values",
+                                          "anyOf": [
+                                            {
+                                              "description": "Array of bools",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            {
+                                              "description": "Array of integers",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "integer",
+                                                "format": "int64"
+                                              }
+                                            },
+                                            {
+                                              "description": "Array of floats",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "number",
+                                                "format": "double"
+                                              }
+                                            },
+                                            {
+                                              "description": "Array of strings",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ],
                                       "nullable": true
                                     },
                                     "named": {
@@ -1549,8 +3058,7 @@
                                     }
                                   },
                                   "additionalProperties": false
-                                },
-                                "nullable": true
+                                }
                               },
                               "errors": {
                                 "description": "Configuration to forward values from the error to custom attributes/labels in metrics",
@@ -1566,7 +3074,61 @@
                                       "properties": {
                                         "default": {
                                           "description": "The optional default value",
-                                          "type": "string",
+                                          "anyOf": [
+                                            {
+                                              "description": "bool values",
+                                              "type": "boolean"
+                                            },
+                                            {
+                                              "description": "i64 values",
+                                              "type": "integer",
+                                              "format": "int64"
+                                            },
+                                            {
+                                              "description": "f64 values",
+                                              "type": "number",
+                                              "format": "double"
+                                            },
+                                            {
+                                              "description": "String values",
+                                              "type": "string"
+                                            },
+                                            {
+                                              "description": "Array of homogeneous values",
+                                              "anyOf": [
+                                                {
+                                                  "description": "Array of bools",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                {
+                                                  "description": "Array of integers",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "integer",
+                                                    "format": "int64"
+                                                  }
+                                                },
+                                                {
+                                                  "description": "Array of floats",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number",
+                                                    "format": "double"
+                                                  }
+                                                },
+                                                {
+                                                  "description": "Array of strings",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ],
                                           "nullable": true
                                         },
                                         "name": {
@@ -1579,17 +3141,16 @@
                                         }
                                       },
                                       "additionalProperties": false
-                                    },
-                                    "nullable": true
+                                    }
                                   },
                                   "include_messages": {
                                     "description": "Will include the error message in a \"message\" attribute",
-                                    "default": false,
-                                    "type": "boolean"
+                                    "default": null,
+                                    "type": "boolean",
+                                    "nullable": true
                                   }
                                 },
-                                "additionalProperties": false,
-                                "nullable": true
+                                "additionalProperties": false
                               },
                               "request": {
                                 "description": "Configuration to forward headers or body values from the request to custom attributes/labels in metrics",
@@ -1605,7 +3166,61 @@
                                       "properties": {
                                         "default": {
                                           "description": "The optional default value",
-                                          "type": "string",
+                                          "anyOf": [
+                                            {
+                                              "description": "bool values",
+                                              "type": "boolean"
+                                            },
+                                            {
+                                              "description": "i64 values",
+                                              "type": "integer",
+                                              "format": "int64"
+                                            },
+                                            {
+                                              "description": "f64 values",
+                                              "type": "number",
+                                              "format": "double"
+                                            },
+                                            {
+                                              "description": "String values",
+                                              "type": "string"
+                                            },
+                                            {
+                                              "description": "Array of homogeneous values",
+                                              "anyOf": [
+                                                {
+                                                  "description": "Array of bools",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                {
+                                                  "description": "Array of integers",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "integer",
+                                                    "format": "int64"
+                                                  }
+                                                },
+                                                {
+                                                  "description": "Array of floats",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number",
+                                                    "format": "double"
+                                                  }
+                                                },
+                                                {
+                                                  "description": "Array of strings",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ],
                                           "nullable": true
                                         },
                                         "name": {
@@ -1618,8 +3233,7 @@
                                         }
                                       },
                                       "additionalProperties": false
-                                    },
-                                    "nullable": true
+                                    }
                                   },
                                   "header": {
                                     "description": "Forward header values as custom attributes/labels in metrics",
@@ -1634,7 +3248,61 @@
                                           "properties": {
                                             "default": {
                                               "description": "The optional default value",
-                                              "type": "string",
+                                              "anyOf": [
+                                                {
+                                                  "description": "bool values",
+                                                  "type": "boolean"
+                                                },
+                                                {
+                                                  "description": "i64 values",
+                                                  "type": "integer",
+                                                  "format": "int64"
+                                                },
+                                                {
+                                                  "description": "f64 values",
+                                                  "type": "number",
+                                                  "format": "double"
+                                                },
+                                                {
+                                                  "description": "String values",
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "description": "Array of homogeneous values",
+                                                  "anyOf": [
+                                                    {
+                                                      "description": "Array of bools",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    {
+                                                      "description": "Array of integers",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "integer",
+                                                        "format": "int64"
+                                                      }
+                                                    },
+                                                    {
+                                                      "description": "Array of floats",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "number",
+                                                        "format": "double"
+                                                      }
+                                                    },
+                                                    {
+                                                      "description": "Array of strings",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              ],
                                               "nullable": true
                                             },
                                             "named": {
@@ -1662,12 +3330,10 @@
                                           "additionalProperties": false
                                         }
                                       ]
-                                    },
-                                    "nullable": true
+                                    }
                                   }
                                 },
-                                "additionalProperties": false,
-                                "nullable": true
+                                "additionalProperties": false
                               },
                               "response": {
                                 "description": "Configuration to forward headers or body values from the response to custom attributes/labels in metrics",
@@ -1683,7 +3349,61 @@
                                       "properties": {
                                         "default": {
                                           "description": "The optional default value",
-                                          "type": "string",
+                                          "anyOf": [
+                                            {
+                                              "description": "bool values",
+                                              "type": "boolean"
+                                            },
+                                            {
+                                              "description": "i64 values",
+                                              "type": "integer",
+                                              "format": "int64"
+                                            },
+                                            {
+                                              "description": "f64 values",
+                                              "type": "number",
+                                              "format": "double"
+                                            },
+                                            {
+                                              "description": "String values",
+                                              "type": "string"
+                                            },
+                                            {
+                                              "description": "Array of homogeneous values",
+                                              "anyOf": [
+                                                {
+                                                  "description": "Array of bools",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                {
+                                                  "description": "Array of integers",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "integer",
+                                                    "format": "int64"
+                                                  }
+                                                },
+                                                {
+                                                  "description": "Array of floats",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number",
+                                                    "format": "double"
+                                                  }
+                                                },
+                                                {
+                                                  "description": "Array of strings",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ],
                                           "nullable": true
                                         },
                                         "name": {
@@ -1696,8 +3416,7 @@
                                         }
                                       },
                                       "additionalProperties": false
-                                    },
-                                    "nullable": true
+                                    }
                                   },
                                   "header": {
                                     "description": "Forward header values as custom attributes/labels in metrics",
@@ -1712,7 +3431,61 @@
                                           "properties": {
                                             "default": {
                                               "description": "The optional default value",
-                                              "type": "string",
+                                              "anyOf": [
+                                                {
+                                                  "description": "bool values",
+                                                  "type": "boolean"
+                                                },
+                                                {
+                                                  "description": "i64 values",
+                                                  "type": "integer",
+                                                  "format": "int64"
+                                                },
+                                                {
+                                                  "description": "f64 values",
+                                                  "type": "number",
+                                                  "format": "double"
+                                                },
+                                                {
+                                                  "description": "String values",
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "description": "Array of homogeneous values",
+                                                  "anyOf": [
+                                                    {
+                                                      "description": "Array of bools",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    {
+                                                      "description": "Array of integers",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "integer",
+                                                        "format": "int64"
+                                                      }
+                                                    },
+                                                    {
+                                                      "description": "Array of floats",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "number",
+                                                        "format": "double"
+                                                      }
+                                                    },
+                                                    {
+                                                      "description": "Array of strings",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              ],
                                               "nullable": true
                                             },
                                             "named": {
@@ -1740,12 +3513,10 @@
                                           "additionalProperties": false
                                         }
                                       ]
-                                    },
-                                    "nullable": true
+                                    }
                                   }
                                 },
-                                "additionalProperties": false,
-                                "nullable": true
+                                "additionalProperties": false
                               },
                               "static": {
                                 "description": "Configuration to insert custom attributes/labels in metrics",
@@ -1761,21 +3532,72 @@
                                     },
                                     "value": {
                                       "description": "The value of the attribute to insert",
-                                      "type": "string"
+                                      "anyOf": [
+                                        {
+                                          "description": "bool values",
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "description": "i64 values",
+                                          "type": "integer",
+                                          "format": "int64"
+                                        },
+                                        {
+                                          "description": "f64 values",
+                                          "type": "number",
+                                          "format": "double"
+                                        },
+                                        {
+                                          "description": "String values",
+                                          "type": "string"
+                                        },
+                                        {
+                                          "description": "Array of homogeneous values",
+                                          "anyOf": [
+                                            {
+                                              "description": "Array of bools",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            {
+                                              "description": "Array of integers",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "integer",
+                                                "format": "int64"
+                                              }
+                                            },
+                                            {
+                                              "description": "Array of floats",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "number",
+                                                "format": "double"
+                                              }
+                                            },
+                                            {
+                                              "description": "Array of strings",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
                                     }
                                   },
                                   "additionalProperties": false
-                                },
-                                "nullable": true
+                                }
                               }
                             },
                             "additionalProperties": false
-                          },
-                          "nullable": true
+                          }
                         }
                       },
-                      "additionalProperties": false,
-                      "nullable": true
+                      "additionalProperties": false
                     },
                     "supergraph": {
                       "description": "Configuration to forward header values or body values from router request/response in metric attributes/labels",
@@ -1791,7 +3613,61 @@
                             "properties": {
                               "default": {
                                 "description": "The optional default value",
-                                "type": "string",
+                                "anyOf": [
+                                  {
+                                    "description": "bool values",
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "description": "i64 values",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  {
+                                    "description": "f64 values",
+                                    "type": "number",
+                                    "format": "double"
+                                  },
+                                  {
+                                    "description": "String values",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "description": "Array of homogeneous values",
+                                    "anyOf": [
+                                      {
+                                        "description": "Array of bools",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of integers",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer",
+                                          "format": "int64"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of floats",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "number",
+                                          "format": "double"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of strings",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
                                 "nullable": true
                               },
                               "named": {
@@ -1805,8 +3681,7 @@
                               }
                             },
                             "additionalProperties": false
-                          },
-                          "nullable": true
+                          }
                         },
                         "errors": {
                           "description": "Configuration to forward values from the error to custom attributes/labels in metrics",
@@ -1822,7 +3697,61 @@
                                 "properties": {
                                   "default": {
                                     "description": "The optional default value",
-                                    "type": "string",
+                                    "anyOf": [
+                                      {
+                                        "description": "bool values",
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "description": "i64 values",
+                                        "type": "integer",
+                                        "format": "int64"
+                                      },
+                                      {
+                                        "description": "f64 values",
+                                        "type": "number",
+                                        "format": "double"
+                                      },
+                                      {
+                                        "description": "String values",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "description": "Array of homogeneous values",
+                                        "anyOf": [
+                                          {
+                                            "description": "Array of bools",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          {
+                                            "description": "Array of integers",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "integer",
+                                              "format": "int64"
+                                            }
+                                          },
+                                          {
+                                            "description": "Array of floats",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "number",
+                                              "format": "double"
+                                            }
+                                          },
+                                          {
+                                            "description": "Array of strings",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ],
                                     "nullable": true
                                   },
                                   "name": {
@@ -1835,17 +3764,16 @@
                                   }
                                 },
                                 "additionalProperties": false
-                              },
-                              "nullable": true
+                              }
                             },
                             "include_messages": {
                               "description": "Will include the error message in a \"message\" attribute",
-                              "default": false,
-                              "type": "boolean"
+                              "default": null,
+                              "type": "boolean",
+                              "nullable": true
                             }
                           },
-                          "additionalProperties": false,
-                          "nullable": true
+                          "additionalProperties": false
                         },
                         "request": {
                           "description": "Configuration to forward headers or body values from the request to custom attributes/labels in metrics",
@@ -1861,7 +3789,61 @@
                                 "properties": {
                                   "default": {
                                     "description": "The optional default value",
-                                    "type": "string",
+                                    "anyOf": [
+                                      {
+                                        "description": "bool values",
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "description": "i64 values",
+                                        "type": "integer",
+                                        "format": "int64"
+                                      },
+                                      {
+                                        "description": "f64 values",
+                                        "type": "number",
+                                        "format": "double"
+                                      },
+                                      {
+                                        "description": "String values",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "description": "Array of homogeneous values",
+                                        "anyOf": [
+                                          {
+                                            "description": "Array of bools",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          {
+                                            "description": "Array of integers",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "integer",
+                                              "format": "int64"
+                                            }
+                                          },
+                                          {
+                                            "description": "Array of floats",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "number",
+                                              "format": "double"
+                                            }
+                                          },
+                                          {
+                                            "description": "Array of strings",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ],
                                     "nullable": true
                                   },
                                   "name": {
@@ -1874,8 +3856,7 @@
                                   }
                                 },
                                 "additionalProperties": false
-                              },
-                              "nullable": true
+                              }
                             },
                             "header": {
                               "description": "Forward header values as custom attributes/labels in metrics",
@@ -1890,7 +3871,61 @@
                                     "properties": {
                                       "default": {
                                         "description": "The optional default value",
-                                        "type": "string",
+                                        "anyOf": [
+                                          {
+                                            "description": "bool values",
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "description": "i64 values",
+                                            "type": "integer",
+                                            "format": "int64"
+                                          },
+                                          {
+                                            "description": "f64 values",
+                                            "type": "number",
+                                            "format": "double"
+                                          },
+                                          {
+                                            "description": "String values",
+                                            "type": "string"
+                                          },
+                                          {
+                                            "description": "Array of homogeneous values",
+                                            "anyOf": [
+                                              {
+                                                "description": "Array of bools",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              {
+                                                "description": "Array of integers",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "integer",
+                                                  "format": "int64"
+                                                }
+                                              },
+                                              {
+                                                "description": "Array of floats",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "number",
+                                                  "format": "double"
+                                                }
+                                              },
+                                              {
+                                                "description": "Array of strings",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ],
                                         "nullable": true
                                       },
                                       "named": {
@@ -1918,12 +3953,10 @@
                                     "additionalProperties": false
                                   }
                                 ]
-                              },
-                              "nullable": true
+                              }
                             }
                           },
-                          "additionalProperties": false,
-                          "nullable": true
+                          "additionalProperties": false
                         },
                         "response": {
                           "description": "Configuration to forward headers or body values from the response to custom attributes/labels in metrics",
@@ -1939,7 +3972,61 @@
                                 "properties": {
                                   "default": {
                                     "description": "The optional default value",
-                                    "type": "string",
+                                    "anyOf": [
+                                      {
+                                        "description": "bool values",
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "description": "i64 values",
+                                        "type": "integer",
+                                        "format": "int64"
+                                      },
+                                      {
+                                        "description": "f64 values",
+                                        "type": "number",
+                                        "format": "double"
+                                      },
+                                      {
+                                        "description": "String values",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "description": "Array of homogeneous values",
+                                        "anyOf": [
+                                          {
+                                            "description": "Array of bools",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          {
+                                            "description": "Array of integers",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "integer",
+                                              "format": "int64"
+                                            }
+                                          },
+                                          {
+                                            "description": "Array of floats",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "number",
+                                              "format": "double"
+                                            }
+                                          },
+                                          {
+                                            "description": "Array of strings",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ],
                                     "nullable": true
                                   },
                                   "name": {
@@ -1952,8 +4039,7 @@
                                   }
                                 },
                                 "additionalProperties": false
-                              },
-                              "nullable": true
+                              }
                             },
                             "header": {
                               "description": "Forward header values as custom attributes/labels in metrics",
@@ -1968,7 +4054,61 @@
                                     "properties": {
                                       "default": {
                                         "description": "The optional default value",
-                                        "type": "string",
+                                        "anyOf": [
+                                          {
+                                            "description": "bool values",
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "description": "i64 values",
+                                            "type": "integer",
+                                            "format": "int64"
+                                          },
+                                          {
+                                            "description": "f64 values",
+                                            "type": "number",
+                                            "format": "double"
+                                          },
+                                          {
+                                            "description": "String values",
+                                            "type": "string"
+                                          },
+                                          {
+                                            "description": "Array of homogeneous values",
+                                            "anyOf": [
+                                              {
+                                                "description": "Array of bools",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              {
+                                                "description": "Array of integers",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "integer",
+                                                  "format": "int64"
+                                                }
+                                              },
+                                              {
+                                                "description": "Array of floats",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "number",
+                                                  "format": "double"
+                                                }
+                                              },
+                                              {
+                                                "description": "Array of strings",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ],
                                         "nullable": true
                                       },
                                       "named": {
@@ -1996,12 +4136,10 @@
                                     "additionalProperties": false
                                   }
                                 ]
-                              },
-                              "nullable": true
+                              }
                             }
                           },
-                          "additionalProperties": false,
-                          "nullable": true
+                          "additionalProperties": false
                         },
                         "static": {
                           "description": "Configuration to insert custom attributes/labels in metrics",
@@ -2017,663 +4155,104 @@
                               },
                               "value": {
                                 "description": "The value of the attribute to insert",
-                                "type": "string"
+                                "anyOf": [
+                                  {
+                                    "description": "bool values",
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "description": "i64 values",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  {
+                                    "description": "f64 values",
+                                    "type": "number",
+                                    "format": "double"
+                                  },
+                                  {
+                                    "description": "String values",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "description": "Array of homogeneous values",
+                                    "anyOf": [
+                                      {
+                                        "description": "Array of bools",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of integers",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer",
+                                          "format": "int64"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of floats",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "number",
+                                          "format": "double"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of strings",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
                               }
                             },
                             "additionalProperties": false
-                          },
-                          "nullable": true
+                          }
                         }
                       },
-                      "additionalProperties": false,
-                      "nullable": true
+                      "additionalProperties": false
                     }
                   },
-                  "additionalProperties": false,
-                  "nullable": true
+                  "additionalProperties": false
                 },
-                "resources": {
-                  "description": "Resources",
+                "buckets": {
+                  "description": "Custom buckets for histograms",
+                  "default": [
+                    0.001, 0.005, 0.015, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 1.0,
+                    5.0, 10.0
+                  ],
+                  "type": "array",
+                  "items": {
+                    "type": "number",
+                    "format": "double"
+                  }
+                },
+                "experimental_cache_metrics": {
+                  "description": "Experimental metrics to know more about caching strategies",
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "description": "Enable experimental metrics",
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "ttl": {
+                      "description": "Potential TTL for a cache if we had one (default: 5secs)",
+                      "default": "5s",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "resource": {
+                  "description": "The Open Telemetry resource",
                   "default": {},
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "string"
-                  }
-                },
-                "service_name": {
-                  "description": "Set a service.name resource in your metrics",
-                  "type": "string",
-                  "nullable": true
-                },
-                "service_namespace": {
-                  "description": "Set a service.namespace attribute in your metrics",
-                  "type": "string",
-                  "nullable": true
-                }
-              },
-              "additionalProperties": false,
-              "nullable": true
-            },
-            "otlp": {
-              "description": "Open Telemetry native exporter configuration",
-              "type": "object",
-              "required": ["endpoint"],
-              "properties": {
-                "batch_processor": {
-                  "description": "Batch processor settings",
-                  "default": {
-                    "scheduled_delay": {
-                      "secs": 5,
-                      "nanos": 0
-                    },
-                    "max_queue_size": 2048,
-                    "max_export_batch_size": 512,
-                    "max_export_timeout": {
-                      "secs": 30,
-                      "nanos": 0
-                    },
-                    "max_concurrent_exports": 1
-                  },
-                  "type": "object",
-                  "properties": {
-                    "max_concurrent_exports": {
-                      "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
-                      "default": 1,
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
-                    },
-                    "max_export_batch_size": {
-                      "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
-                      "default": 512,
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
-                    },
-                    "max_export_timeout": {
-                      "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
-                      "default": {
-                        "secs": 30,
-                        "nanos": 0
-                      },
-                      "type": "string"
-                    },
-                    "max_queue_size": {
-                      "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
-                      "default": 2048,
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
-                    },
-                    "scheduled_delay": {
-                      "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
-                      "default": {
-                        "secs": 5,
-                        "nanos": 0
-                      },
-                      "type": "string"
-                    }
-                  }
-                },
-                "endpoint": {
-                  "description": "The endpoint to send data to",
-                  "type": "string"
-                },
-                "grpc": {
-                  "description": "gRPC configuration settings",
-                  "default": {
-                    "domain_name": null,
-                    "ca": null,
-                    "cert": null,
-                    "key": null,
-                    "metadata": {}
-                  },
-                  "type": "object",
-                  "properties": {
-                    "ca": {
-                      "description": "The optional certificate authority (CA) certificate to be used in TLS configuration.",
-                      "default": null,
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "cert": {
-                      "description": "The optional cert for tls config",
-                      "default": null,
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "domain_name": {
-                      "description": "The optional domain name for tls config. Note that domain name is will be defaulted to match the endpoint is not explicitly set.",
-                      "default": null,
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "key": {
-                      "description": "The optional private key file for TLS configuration.",
-                      "default": null,
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "metadata": {
-                      "description": "gRPC metadata",
-                      "default": {},
-                      "type": "object",
-                      "additionalProperties": true
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                "http": {
-                  "description": "HTTP configuration settings",
-                  "default": {
-                    "headers": {}
-                  },
-                  "type": "object",
-                  "properties": {
-                    "headers": {
-                      "description": "Headers to send on report requests",
-                      "default": {},
-                      "type": "object",
-                      "additionalProperties": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                "protocol": {
-                  "description": "The protocol to use when sending data",
-                  "default": "grpc",
-                  "type": "string",
-                  "enum": ["grpc", "http"]
-                }
-              },
-              "additionalProperties": false,
-              "nullable": true
-            },
-            "prometheus": {
-              "description": "Prometheus exporter configuration",
-              "type": "object",
-              "required": ["enabled"],
-              "properties": {
-                "enabled": {
-                  "description": "Set to true to enable",
-                  "type": "boolean"
-                },
-                "listen": {
-                  "description": "The listen address",
-                  "default": "127.0.0.1:9090",
-                  "anyOf": [
-                    {
-                      "description": "Socket address.",
-                      "type": "string"
-                    },
-                    {
-                      "description": "Unix socket.",
-                      "type": "string"
-                    }
-                  ]
-                },
-                "path": {
-                  "description": "The path where prometheus will be exposed",
-                  "default": "/metrics",
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "nullable": true
-        },
-        "tracing": {
-          "description": "Tracing configuration",
-          "type": "object",
-          "properties": {
-            "datadog": {
-              "description": "Datadog exporter configuration",
-              "type": "object",
-              "required": ["endpoint"],
-              "properties": {
-                "batch_processor": {
-                  "description": "batch processor configuration",
-                  "default": {
-                    "scheduled_delay": {
-                      "secs": 5,
-                      "nanos": 0
-                    },
-                    "max_queue_size": 2048,
-                    "max_export_batch_size": 512,
-                    "max_export_timeout": {
-                      "secs": 30,
-                      "nanos": 0
-                    },
-                    "max_concurrent_exports": 1
-                  },
-                  "type": "object",
-                  "properties": {
-                    "max_concurrent_exports": {
-                      "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
-                      "default": 1,
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
-                    },
-                    "max_export_batch_size": {
-                      "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
-                      "default": 512,
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
-                    },
-                    "max_export_timeout": {
-                      "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
-                      "default": {
-                        "secs": 30,
-                        "nanos": 0
-                      },
-                      "type": "string"
-                    },
-                    "max_queue_size": {
-                      "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
-                      "default": 2048,
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
-                    },
-                    "scheduled_delay": {
-                      "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
-                      "default": {
-                        "secs": 5,
-                        "nanos": 0
-                      },
-                      "type": "string"
-                    }
-                  }
-                },
-                "endpoint": {
-                  "description": "The endpoint to send to",
-                  "default": "default",
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "nullable": true
-            },
-            "experimental_response_trace_id": {
-              "description": "A way to expose trace id in response headers",
-              "type": "object",
-              "properties": {
-                "enabled": {
-                  "description": "Expose the trace_id in response headers",
-                  "default": false,
-                  "type": "boolean"
-                },
-                "header_name": {
-                  "description": "Choose the header name to expose trace_id (default: apollo-trace-id)",
-                  "type": "string",
-                  "nullable": true
-                }
-              },
-              "additionalProperties": false
-            },
-            "jaeger": {
-              "description": "Jaeger exporter configuration",
-              "anyOf": [
-                {
-                  "type": "object",
-                  "required": ["agent"],
-                  "properties": {
-                    "agent": {
-                      "description": "Agent configuration",
-                      "type": "object",
-                      "required": ["endpoint"],
-                      "properties": {
-                        "endpoint": {
-                          "description": "The endpoint to send to",
-                          "default": "default",
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    "batch_processor": {
-                      "description": "Batch processor configuration",
-                      "default": {
-                        "scheduled_delay": {
-                          "secs": 5,
-                          "nanos": 0
-                        },
-                        "max_queue_size": 2048,
-                        "max_export_batch_size": 512,
-                        "max_export_timeout": {
-                          "secs": 30,
-                          "nanos": 0
-                        },
-                        "max_concurrent_exports": 1
-                      },
-                      "type": "object",
-                      "properties": {
-                        "max_concurrent_exports": {
-                          "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
-                          "default": 1,
-                          "type": "integer",
-                          "format": "uint",
-                          "minimum": 0.0
-                        },
-                        "max_export_batch_size": {
-                          "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
-                          "default": 512,
-                          "type": "integer",
-                          "format": "uint",
-                          "minimum": 0.0
-                        },
-                        "max_export_timeout": {
-                          "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
-                          "default": {
-                            "secs": 30,
-                            "nanos": 0
-                          },
-                          "type": "string"
-                        },
-                        "max_queue_size": {
-                          "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
-                          "default": 2048,
-                          "type": "integer",
-                          "format": "uint",
-                          "minimum": 0.0
-                        },
-                        "scheduled_delay": {
-                          "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
-                          "default": {
-                            "secs": 5,
-                            "nanos": 0
-                          },
-                          "type": "string"
-                        }
-                      }
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "object",
-                  "required": ["collector"],
-                  "properties": {
-                    "batch_processor": {
-                      "description": "Batch processor configuration",
-                      "default": {
-                        "scheduled_delay": {
-                          "secs": 5,
-                          "nanos": 0
-                        },
-                        "max_queue_size": 2048,
-                        "max_export_batch_size": 512,
-                        "max_export_timeout": {
-                          "secs": 30,
-                          "nanos": 0
-                        },
-                        "max_concurrent_exports": 1
-                      },
-                      "type": "object",
-                      "properties": {
-                        "max_concurrent_exports": {
-                          "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
-                          "default": 1,
-                          "type": "integer",
-                          "format": "uint",
-                          "minimum": 0.0
-                        },
-                        "max_export_batch_size": {
-                          "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
-                          "default": 512,
-                          "type": "integer",
-                          "format": "uint",
-                          "minimum": 0.0
-                        },
-                        "max_export_timeout": {
-                          "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
-                          "default": {
-                            "secs": 30,
-                            "nanos": 0
-                          },
-                          "type": "string"
-                        },
-                        "max_queue_size": {
-                          "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
-                          "default": 2048,
-                          "type": "integer",
-                          "format": "uint",
-                          "minimum": 0.0
-                        },
-                        "scheduled_delay": {
-                          "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
-                          "default": {
-                            "secs": 5,
-                            "nanos": 0
-                          },
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "collector": {
-                      "description": "Collector configuration",
-                      "type": "object",
-                      "required": ["endpoint"],
-                      "properties": {
-                        "endpoint": {
-                          "description": "The endpoint to send reports to",
-                          "type": "string",
-                          "format": "uri"
-                        },
-                        "password": {
-                          "description": "The optional password",
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "username": {
-                          "description": "The optional username",
-                          "type": "string",
-                          "nullable": true
-                        }
-                      },
-                      "additionalProperties": false
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              ],
-              "nullable": true
-            },
-            "otlp": {
-              "description": "OpenTelemetry native exporter configuration",
-              "type": "object",
-              "required": ["endpoint"],
-              "properties": {
-                "batch_processor": {
-                  "description": "Batch processor settings",
-                  "default": {
-                    "scheduled_delay": {
-                      "secs": 5,
-                      "nanos": 0
-                    },
-                    "max_queue_size": 2048,
-                    "max_export_batch_size": 512,
-                    "max_export_timeout": {
-                      "secs": 30,
-                      "nanos": 0
-                    },
-                    "max_concurrent_exports": 1
-                  },
-                  "type": "object",
-                  "properties": {
-                    "max_concurrent_exports": {
-                      "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
-                      "default": 1,
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
-                    },
-                    "max_export_batch_size": {
-                      "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
-                      "default": 512,
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
-                    },
-                    "max_export_timeout": {
-                      "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
-                      "default": {
-                        "secs": 30,
-                        "nanos": 0
-                      },
-                      "type": "string"
-                    },
-                    "max_queue_size": {
-                      "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
-                      "default": 2048,
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
-                    },
-                    "scheduled_delay": {
-                      "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
-                      "default": {
-                        "secs": 5,
-                        "nanos": 0
-                      },
-                      "type": "string"
-                    }
-                  }
-                },
-                "endpoint": {
-                  "description": "The endpoint to send data to",
-                  "type": "string"
-                },
-                "grpc": {
-                  "description": "gRPC configuration settings",
-                  "default": {
-                    "domain_name": null,
-                    "ca": null,
-                    "cert": null,
-                    "key": null,
-                    "metadata": {}
-                  },
-                  "type": "object",
-                  "properties": {
-                    "ca": {
-                      "description": "The optional certificate authority (CA) certificate to be used in TLS configuration.",
-                      "default": null,
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "cert": {
-                      "description": "The optional cert for tls config",
-                      "default": null,
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "domain_name": {
-                      "description": "The optional domain name for tls config. Note that domain name is will be defaulted to match the endpoint is not explicitly set.",
-                      "default": null,
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "key": {
-                      "description": "The optional private key file for TLS configuration.",
-                      "default": null,
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "metadata": {
-                      "description": "gRPC metadata",
-                      "default": {},
-                      "type": "object",
-                      "additionalProperties": true
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                "http": {
-                  "description": "HTTP configuration settings",
-                  "default": {
-                    "headers": {}
-                  },
-                  "type": "object",
-                  "properties": {
-                    "headers": {
-                      "description": "Headers to send on report requests",
-                      "default": {},
-                      "type": "object",
-                      "additionalProperties": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                "protocol": {
-                  "description": "The protocol to use when sending data",
-                  "default": "grpc",
-                  "type": "string",
-                  "enum": ["grpc", "http"]
-                }
-              },
-              "additionalProperties": false,
-              "nullable": true
-            },
-            "propagation": {
-              "description": "Propagation configuration",
-              "type": "object",
-              "properties": {
-                "baggage": {
-                  "description": "Propagate baggage https://www.w3.org/TR/baggage/",
-                  "default": false,
-                  "type": "boolean"
-                },
-                "datadog": {
-                  "description": "Propagate Datadog",
-                  "default": false,
-                  "type": "boolean"
-                },
-                "jaeger": {
-                  "description": "Propagate Jaeger",
-                  "default": false,
-                  "type": "boolean"
-                },
-                "request": {
-                  "description": "Select a custom request header to set your own trace_id (header value must be convertible from hexadecimal to set a correct trace_id)",
-                  "type": "object",
-                  "required": ["header_name"],
-                  "properties": {
-                    "header_name": {
-                      "description": "Choose the header name to expose trace_id (default: apollo-trace-id)",
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                "trace_context": {
-                  "description": "Propagate trace context https://www.w3.org/TR/trace-context/",
-                  "default": false,
-                  "type": "boolean"
-                },
-                "zipkin": {
-                  "description": "Propagate Zipkin",
-                  "default": false,
-                  "type": "boolean"
-                }
-              },
-              "additionalProperties": false,
-              "nullable": true
-            },
-            "trace_config": {
-              "description": "Common configuration",
-              "type": "object",
-              "properties": {
-                "attributes": {
-                  "description": "Default attributes",
                   "type": "object",
                   "additionalProperties": {
                     "anyOf": [
@@ -2733,103 +4312,28 @@
                     ]
                   }
                 },
-                "max_attributes_per_event": {
-                  "description": "The maximum attributes per event before discarding",
-                  "default": 128,
-                  "type": "integer",
-                  "format": "uint32",
-                  "minimum": 0.0
-                },
-                "max_attributes_per_link": {
-                  "description": "The maximum attributes per link before discarding",
-                  "default": 128,
-                  "type": "integer",
-                  "format": "uint32",
-                  "minimum": 0.0
-                },
-                "max_attributes_per_span": {
-                  "description": "The maximum attributes per span before discarding",
-                  "default": 128,
-                  "type": "integer",
-                  "format": "uint32",
-                  "minimum": 0.0
-                },
-                "max_events_per_span": {
-                  "description": "The maximum events per span before discarding",
-                  "default": 128,
-                  "type": "integer",
-                  "format": "uint32",
-                  "minimum": 0.0
-                },
-                "max_links_per_span": {
-                  "description": "The maximum links per span before discarding",
-                  "default": 128,
-                  "type": "integer",
-                  "format": "uint32",
-                  "minimum": 0.0
-                },
-                "parent_based_sampler": {
-                  "description": "Whether to use parent based sampling",
-                  "default": true,
-                  "type": "boolean"
-                },
-                "sampler": {
-                  "description": "The sampler, always_on, always_off or a decimal between 0.0 and 1.0",
-                  "anyOf": [
-                    {
-                      "description": "Sample a given fraction. Fractions >= 1 will always sample.",
-                      "type": "number",
-                      "format": "double"
-                    },
-                    {
-                      "oneOf": [
-                        {
-                          "description": "Always sample",
-                          "type": "string",
-                          "enum": ["always_on"]
-                        },
-                        {
-                          "description": "Never sample",
-                          "type": "string",
-                          "enum": ["always_off"]
-                        }
-                      ]
-                    }
-                  ]
-                },
                 "service_name": {
-                  "description": "The trace service name",
-                  "default": "${env.OTEL_SERVICE_NAME:-router}",
-                  "type": "string"
+                  "description": "Set a service.name resource in your metrics",
+                  "default": null,
+                  "type": "string",
+                  "nullable": true
                 },
                 "service_namespace": {
-                  "description": "The trace service namespace",
-                  "default": "",
-                  "type": "string"
+                  "description": "Set a service.namespace attribute in your metrics",
+                  "default": null,
+                  "type": "string",
+                  "nullable": true
                 }
               },
-              "additionalProperties": false,
-              "nullable": true
+              "additionalProperties": false
             },
-            "zipkin": {
-              "description": "Zipkin exporter configuration",
+            "otlp": {
+              "description": "Open Telemetry native exporter configuration",
               "type": "object",
+              "required": ["enabled"],
               "properties": {
                 "batch_processor": {
-                  "description": "Batch processor configuration",
-                  "default": {
-                    "scheduled_delay": {
-                      "secs": 5,
-                      "nanos": 0
-                    },
-                    "max_queue_size": 2048,
-                    "max_export_batch_size": 512,
-                    "max_export_timeout": {
-                      "secs": 30,
-                      "nanos": 0
-                    },
-                    "max_concurrent_exports": 1
-                  },
+                  "description": "Batch processor settings",
                   "type": "object",
                   "properties": {
                     "max_concurrent_exports": {
@@ -2871,18 +4375,765 @@
                     }
                   }
                 },
+                "enabled": {
+                  "description": "Enable otlp",
+                  "type": "boolean"
+                },
                 "endpoint": {
-                  "description": "The endpoint to send to",
-                  "default": "default",
+                  "description": "The endpoint to send data to",
+                  "type": "string"
+                },
+                "grpc": {
+                  "description": "gRPC configuration settings",
+                  "default": {
+                    "domain_name": null,
+                    "ca": null,
+                    "cert": null,
+                    "key": null,
+                    "metadata": {}
+                  },
+                  "type": "object",
+                  "properties": {
+                    "ca": {
+                      "description": "The optional certificate authority (CA) certificate to be used in TLS configuration.",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "cert": {
+                      "description": "The optional cert for tls config",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "domain_name": {
+                      "description": "The optional domain name for tls config. Note that domain name is will be defaulted to match the endpoint is not explicitly set.",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "key": {
+                      "description": "The optional private key file for TLS configuration.",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "metadata": {
+                      "description": "gRPC metadata",
+                      "default": {},
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "http": {
+                  "description": "HTTP configuration settings",
+                  "default": {
+                    "headers": {}
+                  },
+                  "type": "object",
+                  "properties": {
+                    "headers": {
+                      "description": "Headers to send on report requests",
+                      "default": {},
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "protocol": {
+                  "description": "The protocol to use when sending data",
+                  "default": "grpc",
+                  "type": "string",
+                  "enum": ["grpc", "http"]
+                },
+                "temporality": {
+                  "description": "Temporality for export (default: `Cumulative`). Note that when exporting to Datadog agent use `Delta`.",
+                  "default": "cumulative",
+                  "oneOf": [
+                    {
+                      "description": "Export cumulative metrics.",
+                      "type": "string",
+                      "enum": ["cumulative"]
+                    },
+                    {
+                      "description": "Export delta metrics. `Delta` should be used when exporting to DataDog Agent.",
+                      "type": "string",
+                      "enum": ["delta"]
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
+            "prometheus": {
+              "description": "Prometheus exporter configuration",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "description": "Set to true to enable",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "listen": {
+                  "description": "The listen address",
+                  "default": "127.0.0.1:9090",
+                  "anyOf": [
+                    {
+                      "description": "Socket address.",
+                      "type": "string"
+                    },
+                    {
+                      "description": "Unix socket.",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "path": {
+                  "description": "The path where prometheus will be exposed",
+                  "default": "/metrics",
                   "type": "string"
                 }
               },
-              "additionalProperties": false,
-              "nullable": true
+              "additionalProperties": false
             }
           },
-          "additionalProperties": false,
-          "nullable": true
+          "additionalProperties": false
+        },
+        "tracing": {
+          "description": "Tracing configuration",
+          "type": "object",
+          "properties": {
+            "common": {
+              "description": "Common configuration",
+              "type": "object",
+              "properties": {
+                "max_attributes_per_event": {
+                  "description": "The maximum attributes per event before discarding",
+                  "default": 128,
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "max_attributes_per_link": {
+                  "description": "The maximum attributes per link before discarding",
+                  "default": 128,
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "max_attributes_per_span": {
+                  "description": "The maximum attributes per span before discarding",
+                  "default": 128,
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "max_events_per_span": {
+                  "description": "The maximum events per span before discarding",
+                  "default": 128,
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "max_links_per_span": {
+                  "description": "The maximum links per span before discarding",
+                  "default": 128,
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "parent_based_sampler": {
+                  "description": "Whether to use parent based sampling",
+                  "default": true,
+                  "type": "boolean"
+                },
+                "resource": {
+                  "description": "The Open Telemetry resource",
+                  "default": {},
+                  "type": "object",
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "description": "bool values",
+                        "type": "boolean"
+                      },
+                      {
+                        "description": "i64 values",
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      {
+                        "description": "f64 values",
+                        "type": "number",
+                        "format": "double"
+                      },
+                      {
+                        "description": "String values",
+                        "type": "string"
+                      },
+                      {
+                        "description": "Array of homogeneous values",
+                        "anyOf": [
+                          {
+                            "description": "Array of bools",
+                            "type": "array",
+                            "items": {
+                              "type": "boolean"
+                            }
+                          },
+                          {
+                            "description": "Array of integers",
+                            "type": "array",
+                            "items": {
+                              "type": "integer",
+                              "format": "int64"
+                            }
+                          },
+                          {
+                            "description": "Array of floats",
+                            "type": "array",
+                            "items": {
+                              "type": "number",
+                              "format": "double"
+                            }
+                          },
+                          {
+                            "description": "Array of strings",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "sampler": {
+                  "description": "The sampler, always_on, always_off or a decimal between 0.0 and 1.0",
+                  "anyOf": [
+                    {
+                      "description": "Sample a given fraction. Fractions >= 1 will always sample.",
+                      "type": "number",
+                      "format": "double"
+                    },
+                    {
+                      "oneOf": [
+                        {
+                          "description": "Always sample",
+                          "type": "string",
+                          "enum": ["always_on"]
+                        },
+                        {
+                          "description": "Never sample",
+                          "type": "string",
+                          "enum": ["always_off"]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "service_name": {
+                  "description": "The trace service name",
+                  "default": null,
+                  "type": "string",
+                  "nullable": true
+                },
+                "service_namespace": {
+                  "description": "The trace service namespace",
+                  "default": null,
+                  "type": "string",
+                  "nullable": true
+                }
+              },
+              "additionalProperties": false
+            },
+            "datadog": {
+              "description": "Datadog exporter configuration",
+              "type": "object",
+              "required": ["enabled"],
+              "properties": {
+                "batch_processor": {
+                  "description": "batch processor configuration",
+                  "type": "object",
+                  "properties": {
+                    "max_concurrent_exports": {
+                      "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
+                      "default": 1,
+                      "type": "integer",
+                      "format": "uint",
+                      "minimum": 0.0
+                    },
+                    "max_export_batch_size": {
+                      "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
+                      "default": 512,
+                      "type": "integer",
+                      "format": "uint",
+                      "minimum": 0.0
+                    },
+                    "max_export_timeout": {
+                      "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
+                      "default": {
+                        "secs": 30,
+                        "nanos": 0
+                      },
+                      "type": "string"
+                    },
+                    "max_queue_size": {
+                      "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
+                      "default": 2048,
+                      "type": "integer",
+                      "format": "uint",
+                      "minimum": 0.0
+                    },
+                    "scheduled_delay": {
+                      "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
+                      "default": {
+                        "secs": 5,
+                        "nanos": 0
+                      },
+                      "type": "string"
+                    }
+                  }
+                },
+                "enable_span_mapping": {
+                  "description": "Enable datadog span mapping for span name and resource name.",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "enabled": {
+                  "description": "Enable datadog",
+                  "type": "boolean"
+                },
+                "endpoint": {
+                  "description": "The endpoint to send to",
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "experimental_response_trace_id": {
+              "description": "A way to expose trace id in response headers",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "description": "Expose the trace_id in response headers",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "header_name": {
+                  "description": "Choose the header name to expose trace_id (default: apollo-trace-id)",
+                  "type": "string",
+                  "nullable": true
+                }
+              },
+              "additionalProperties": false
+            },
+            "jaeger": {
+              "description": "Jaeger exporter configuration",
+              "anyOf": [
+                {
+                  "type": "object",
+                  "required": ["enabled"],
+                  "properties": {
+                    "agent": {
+                      "description": "Agent configuration",
+                      "type": "object",
+                      "properties": {
+                        "endpoint": {
+                          "description": "The endpoint to send to",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "batch_processor": {
+                      "description": "Batch processor configuration",
+                      "type": "object",
+                      "properties": {
+                        "max_concurrent_exports": {
+                          "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
+                          "default": 1,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "max_export_batch_size": {
+                          "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
+                          "default": 512,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "max_export_timeout": {
+                          "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
+                          "default": {
+                            "secs": 30,
+                            "nanos": 0
+                          },
+                          "type": "string"
+                        },
+                        "max_queue_size": {
+                          "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
+                          "default": 2048,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "scheduled_delay": {
+                          "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
+                          "default": {
+                            "secs": 5,
+                            "nanos": 0
+                          },
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "enabled": {
+                      "description": "Enable Jaeger",
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "required": ["enabled"],
+                  "properties": {
+                    "batch_processor": {
+                      "description": "Batch processor configuration",
+                      "type": "object",
+                      "properties": {
+                        "max_concurrent_exports": {
+                          "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
+                          "default": 1,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "max_export_batch_size": {
+                          "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
+                          "default": 512,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "max_export_timeout": {
+                          "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
+                          "default": {
+                            "secs": 30,
+                            "nanos": 0
+                          },
+                          "type": "string"
+                        },
+                        "max_queue_size": {
+                          "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
+                          "default": 2048,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "scheduled_delay": {
+                          "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
+                          "default": {
+                            "secs": 5,
+                            "nanos": 0
+                          },
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "collector": {
+                      "description": "Collector configuration",
+                      "type": "object",
+                      "properties": {
+                        "endpoint": {
+                          "description": "The endpoint to send reports to",
+                          "type": "string"
+                        },
+                        "password": {
+                          "description": "The optional password",
+                          "default": null,
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "username": {
+                          "description": "The optional username",
+                          "default": null,
+                          "type": "string",
+                          "nullable": true
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "enabled": {
+                      "description": "Enable Jaeger",
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "otlp": {
+              "description": "OpenTelemetry native exporter configuration",
+              "type": "object",
+              "required": ["enabled"],
+              "properties": {
+                "batch_processor": {
+                  "description": "Batch processor settings",
+                  "type": "object",
+                  "properties": {
+                    "max_concurrent_exports": {
+                      "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
+                      "default": 1,
+                      "type": "integer",
+                      "format": "uint",
+                      "minimum": 0.0
+                    },
+                    "max_export_batch_size": {
+                      "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
+                      "default": 512,
+                      "type": "integer",
+                      "format": "uint",
+                      "minimum": 0.0
+                    },
+                    "max_export_timeout": {
+                      "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
+                      "default": {
+                        "secs": 30,
+                        "nanos": 0
+                      },
+                      "type": "string"
+                    },
+                    "max_queue_size": {
+                      "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
+                      "default": 2048,
+                      "type": "integer",
+                      "format": "uint",
+                      "minimum": 0.0
+                    },
+                    "scheduled_delay": {
+                      "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
+                      "default": {
+                        "secs": 5,
+                        "nanos": 0
+                      },
+                      "type": "string"
+                    }
+                  }
+                },
+                "enabled": {
+                  "description": "Enable otlp",
+                  "type": "boolean"
+                },
+                "endpoint": {
+                  "description": "The endpoint to send data to",
+                  "type": "string"
+                },
+                "grpc": {
+                  "description": "gRPC configuration settings",
+                  "default": {
+                    "domain_name": null,
+                    "ca": null,
+                    "cert": null,
+                    "key": null,
+                    "metadata": {}
+                  },
+                  "type": "object",
+                  "properties": {
+                    "ca": {
+                      "description": "The optional certificate authority (CA) certificate to be used in TLS configuration.",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "cert": {
+                      "description": "The optional cert for tls config",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "domain_name": {
+                      "description": "The optional domain name for tls config. Note that domain name is will be defaulted to match the endpoint is not explicitly set.",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "key": {
+                      "description": "The optional private key file for TLS configuration.",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "metadata": {
+                      "description": "gRPC metadata",
+                      "default": {},
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "http": {
+                  "description": "HTTP configuration settings",
+                  "default": {
+                    "headers": {}
+                  },
+                  "type": "object",
+                  "properties": {
+                    "headers": {
+                      "description": "Headers to send on report requests",
+                      "default": {},
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "protocol": {
+                  "description": "The protocol to use when sending data",
+                  "default": "grpc",
+                  "type": "string",
+                  "enum": ["grpc", "http"]
+                },
+                "temporality": {
+                  "description": "Temporality for export (default: `Cumulative`). Note that when exporting to Datadog agent use `Delta`.",
+                  "default": "cumulative",
+                  "oneOf": [
+                    {
+                      "description": "Export cumulative metrics.",
+                      "type": "string",
+                      "enum": ["cumulative"]
+                    },
+                    {
+                      "description": "Export delta metrics. `Delta` should be used when exporting to DataDog Agent.",
+                      "type": "string",
+                      "enum": ["delta"]
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
+            "propagation": {
+              "description": "Propagation configuration",
+              "type": "object",
+              "properties": {
+                "aws_xray": {
+                  "description": "Propagate AWS X-Ray",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "baggage": {
+                  "description": "Propagate baggage https://www.w3.org/TR/baggage/",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "datadog": {
+                  "description": "Propagate Datadog",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "jaeger": {
+                  "description": "Propagate Jaeger",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "request": {
+                  "description": "Select a custom request header to set your own trace_id (header value must be convertible from hexadecimal to set a correct trace_id)",
+                  "type": "object",
+                  "required": ["header_name"],
+                  "properties": {
+                    "header_name": {
+                      "description": "Choose the header name to expose trace_id (default: apollo-trace-id)",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "trace_context": {
+                  "description": "Propagate trace context https://www.w3.org/TR/trace-context/",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "zipkin": {
+                  "description": "Propagate Zipkin",
+                  "default": false,
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            },
+            "zipkin": {
+              "description": "Zipkin exporter configuration",
+              "type": "object",
+              "required": ["enabled"],
+              "properties": {
+                "batch_processor": {
+                  "description": "Batch processor configuration",
+                  "type": "object",
+                  "properties": {
+                    "max_concurrent_exports": {
+                      "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
+                      "default": 1,
+                      "type": "integer",
+                      "format": "uint",
+                      "minimum": 0.0
+                    },
+                    "max_export_batch_size": {
+                      "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
+                      "default": 512,
+                      "type": "integer",
+                      "format": "uint",
+                      "minimum": 0.0
+                    },
+                    "max_export_timeout": {
+                      "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
+                      "default": {
+                        "secs": 30,
+                        "nanos": 0
+                      },
+                      "type": "string"
+                    },
+                    "max_queue_size": {
+                      "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
+                      "default": 2048,
+                      "type": "integer",
+                      "format": "uint",
+                      "minimum": 0.0
+                    },
+                    "scheduled_delay": {
+                      "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
+                      "default": {
+                        "secs": 5,
+                        "nanos": 0
+                      },
+                      "type": "string"
+                    }
+                  }
+                },
+                "enabled": {
+                  "description": "Enable zipkin",
+                  "type": "boolean"
+                },
+                "endpoint": {
+                  "description": "The endpoint to send to",
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -2890,9 +5141,11 @@
     "tls": {
       "description": "TLS related configuration options.",
       "default": {
+        "supergraph": null,
         "subgraph": {
           "all": {
-            "certificate_authorities": null
+            "certificate_authorities": null,
+            "client_authentication": null
           },
           "subgraphs": {}
         }
@@ -2903,7 +5156,8 @@
           "description": "Configuration options pertaining to the subgraph server component.",
           "default": {
             "all": {
-              "certificate_authorities": null
+              "certificate_authorities": null,
+              "client_authentication": null
             },
             "subgraphs": {}
           },
@@ -2912,7 +5166,8 @@
             "all": {
               "description": "options applying to all subgraphs",
               "default": {
-                "certificate_authorities": null
+                "certificate_authorities": null,
+                "client_authentication": null
               },
               "type": "object",
               "properties": {
@@ -2920,6 +5175,26 @@
                   "description": "list of certificate authorities in PEM format",
                   "default": null,
                   "type": "string",
+                  "nullable": true
+                },
+                "client_authentication": {
+                  "description": "client certificate authentication",
+                  "default": null,
+                  "type": "object",
+                  "required": ["certificate_chain", "key"],
+                  "properties": {
+                    "certificate_chain": {
+                      "description": "list of certificates in PEM format",
+                      "writeOnly": true,
+                      "type": "string"
+                    },
+                    "key": {
+                      "description": "key in PEM format",
+                      "writeOnly": true,
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
                   "nullable": true
                 }
               },
@@ -2938,13 +5213,57 @@
                     "default": null,
                     "type": "string",
                     "nullable": true
+                  },
+                  "client_authentication": {
+                    "description": "client certificate authentication",
+                    "default": null,
+                    "type": "object",
+                    "required": ["certificate_chain", "key"],
+                    "properties": {
+                      "certificate_chain": {
+                        "description": "list of certificates in PEM format",
+                        "writeOnly": true,
+                        "type": "string"
+                      },
+                      "key": {
+                        "description": "key in PEM format",
+                        "writeOnly": true,
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "nullable": true
                   }
                 },
                 "additionalProperties": false
               }
             }
+          }
+        },
+        "supergraph": {
+          "description": "TLS server configuration\n\nthis will affect the GraphQL endpoint and any other endpoint targeting the same listen address",
+          "default": null,
+          "type": "object",
+          "required": ["certificate", "certificate_chain", "key"],
+          "properties": {
+            "certificate": {
+              "description": "server certificate in PEM format",
+              "writeOnly": true,
+              "type": "string"
+            },
+            "certificate_chain": {
+              "description": "list of certificate authorities in PEM format",
+              "writeOnly": true,
+              "type": "string"
+            },
+            "key": {
+              "description": "server key in PEM format",
+              "writeOnly": true,
+              "type": "string"
+            }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "nullable": true
         }
       },
       "additionalProperties": false
@@ -2981,6 +5300,40 @@
             "deduplicate_query": {
               "description": "Enable query deduplication",
               "type": "boolean",
+              "nullable": true
+            },
+            "experimental_entity_caching": {
+              "description": "Enable entity caching",
+              "type": "object",
+              "required": ["ttl"],
+              "properties": {
+                "ttl": {
+                  "description": "expiration for all keys",
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "nullable": true
+            },
+            "experimental_http2": {
+              "description": "Enable HTTP2 for subgraphs",
+              "oneOf": [
+                {
+                  "description": "Enable HTTP2 for subgraphs",
+                  "type": "string",
+                  "enum": ["enable"]
+                },
+                {
+                  "description": "Disable HTTP2 for subgraphs",
+                  "type": "string",
+                  "enum": ["disable"]
+                },
+                {
+                  "description": "Only HTTP2 is active",
+                  "type": "string",
+                  "enum": ["http2only"]
+                }
+              ],
               "nullable": true
             },
             "experimental_retry": {
@@ -3048,6 +5401,36 @@
           "type": "boolean",
           "nullable": true
         },
+        "experimental_cache": {
+          "description": "Experimental URLs of Redis cache used for subgraph response caching",
+          "default": null,
+          "type": "object",
+          "required": ["urls"],
+          "properties": {
+            "timeout": {
+              "description": "Redis request timeout (default: 2ms)",
+              "default": null,
+              "type": "string",
+              "nullable": true
+            },
+            "ttl": {
+              "description": "TTL for entries",
+              "default": null,
+              "type": "string",
+              "nullable": true
+            },
+            "urls": {
+              "description": "List of URLs to the Redis cluster",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          },
+          "additionalProperties": false,
+          "nullable": true
+        },
         "router": {
           "description": "Applied at the router level",
           "type": "object",
@@ -3111,6 +5494,40 @@
               "deduplicate_query": {
                 "description": "Enable query deduplication",
                 "type": "boolean",
+                "nullable": true
+              },
+              "experimental_entity_caching": {
+                "description": "Enable entity caching",
+                "type": "object",
+                "required": ["ttl"],
+                "properties": {
+                  "ttl": {
+                    "description": "expiration for all keys",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "nullable": true
+              },
+              "experimental_http2": {
+                "description": "Enable HTTP2 for subgraphs",
+                "oneOf": [
+                  {
+                    "description": "Enable HTTP2 for subgraphs",
+                    "type": "string",
+                    "enum": ["enable"]
+                  },
+                  {
+                    "description": "Disable HTTP2 for subgraphs",
+                    "type": "string",
+                    "enum": ["disable"]
+                  },
+                  {
+                    "description": "Only HTTP2 is active",
+                    "type": "string",
+                    "enum": ["http2only"]
+                  }
+                ],
                 "nullable": true
               },
               "experimental_retry": {


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 51c70bd</samp>

Upgraded the Apollo router for the `api-gateway` app to v1.34.1 and enabled experimental batching features. This is to test the performance and functionality of batching multiple GraphQL requests into a single HTTP request to the upstream services.
