### PR TITLE
fix: parallelize invite accept

### DIFF
--- a/apps/journeys-admin/pages/index.tsx
+++ b/apps/journeys-admin/pages/index.tsx
@@ -1,4 +1,3 @@
-import { gql } from '@apollo/client'
 import Stack from '@mui/material/Stack'
 import { useRouter } from 'next/router'
 import {
@@ -11,24 +10,12 @@ import { NextSeo } from 'next-seo'
 import { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { AcceptAllInvites } from '../__generated__/AcceptAllInvites'
 import { JourneyList } from '../src/components/JourneyList'
 import { OnboardingPanelContent } from '../src/components/OnboardingPanelContent'
 import { PageWrapper } from '../src/components/PageWrapper'
 import { TeamMenu } from '../src/components/Team/TeamMenu'
 import { TeamSelect } from '../src/components/Team/TeamSelect'
 import { initAndAuthApp } from '../src/libs/initAndAuthApp'
-
-export const ACCEPT_ALL_INVITES = gql`
-  mutation AcceptAllInvites {
-    userTeamInviteAcceptAll {
-      id
-    }
-    userInviteAcceptAll {
-      id
-    }
-  }
-`
 
 function IndexPage(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
@@ -66,17 +53,13 @@ export const getServerSideProps = withUserTokenSSR({
   if (user == null)
     return { redirect: { permanent: false, destination: '/users/sign-in' } }
 
-  const { apolloClient, redirect, translations } = await initAndAuthApp({
+  const { redirect, translations } = await initAndAuthApp({
     user,
     locale,
     resolvedUrl
   })
 
   if (redirect != null) return { redirect }
-
-  await apolloClient.mutate<AcceptAllInvites>({
-    mutation: ACCEPT_ALL_INVITES
-  })
 
   return {
     props: {

--- a/apps/journeys-admin/pages/journeys/[journeyId].tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId].tsx
@@ -13,8 +13,6 @@ import { useTranslation } from 'react-i18next'
 import { ActiveJourneyEditContent } from '@core/journeys/ui/EditorProvider'
 import { JOURNEY_FIELDS } from '@core/journeys/ui/JourneyProvider/journeyFields'
 
-import { ACCEPT_ALL_INVITES } from '..'
-import { AcceptAllInvites } from '../../__generated__/AcceptAllInvites'
 import {
   GetAdminJourney,
   GetAdminJourney_journey as Journey
@@ -99,10 +97,6 @@ export const getServerSideProps = withUserTokenSSR({
   })
 
   if (redirect != null) return { redirect }
-
-  await apolloClient.mutate<AcceptAllInvites>({
-    mutation: ACCEPT_ALL_INVITES
-  })
 
   let journey: Journey | null
   try {

--- a/apps/journeys-admin/pages/journeys/[journeyId]/reports.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/reports.tsx
@@ -10,8 +10,6 @@ import { NextSeo } from 'next-seo'
 import { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { ACCEPT_ALL_INVITES } from '../..'
-import { AcceptAllInvites } from '../../../__generated__/AcceptAllInvites'
 import { GetAdminJourney } from '../../../__generated__/GetAdminJourney'
 import { JourneysReportType } from '../../../__generated__/globalTypes'
 import { UserJourneyOpen } from '../../../__generated__/UserJourneyOpen'
@@ -65,10 +63,6 @@ export const getServerSideProps = withUserTokenSSR({
   })
 
   if (redirect != null) return { redirect }
-
-  await apolloClient.mutate<AcceptAllInvites>({
-    mutation: ACCEPT_ALL_INVITES
-  })
 
   try {
     await apolloClient.query<GetAdminJourney>({

--- a/apps/journeys-admin/pages/journeys/[journeyId]/reports/visitors.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/reports/visitors.tsx
@@ -11,8 +11,6 @@ import { NextSeo } from 'next-seo'
 import { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { ACCEPT_ALL_INVITES } from '../../..'
-import { AcceptAllInvites } from '../../../../__generated__/AcceptAllInvites'
 import { GetAdminJourney } from '../../../../__generated__/GetAdminJourney'
 import {
   GetJourneyVisitors,
@@ -251,10 +249,6 @@ export const getServerSideProps = withUserTokenSSR({
   })
 
   if (redirect != null) return { redirect }
-
-  await apolloClient.mutate<AcceptAllInvites>({
-    mutation: ACCEPT_ALL_INVITES
-  })
 
   try {
     await apolloClient.query<GetAdminJourney>({

--- a/apps/journeys-admin/pages/users/terms-and-conditions.tsx
+++ b/apps/journeys-admin/pages/users/terms-and-conditions.tsx
@@ -3,8 +3,6 @@ import { NextSeo } from 'next-seo'
 import { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { ACCEPT_ALL_INVITES } from '..'
-import { AcceptAllInvites } from '../../__generated__/AcceptAllInvites'
 import { OnboardingPageWrapper } from '../../src/components/OnboardingPageWrapper'
 import { TermsAndConditions } from '../../src/components/TermsAndConditions'
 import { initAndAuthApp } from '../../src/libs/initAndAuthApp'
@@ -29,17 +27,13 @@ export const getServerSideProps = withUserTokenSSR({
   if (user == null)
     return { redirect: { permanent: false, destination: '/users/sign-in' } }
 
-  const { apolloClient, redirect, translations } = await initAndAuthApp({
+  const { redirect, translations } = await initAndAuthApp({
     user,
     locale,
     resolvedUrl
   })
 
   if (redirect != null) return { redirect }
-
-  await apolloClient.mutate<AcceptAllInvites>({
-    mutation: ACCEPT_ALL_INVITES
-  })
 
   return {
     props: {

--- a/apps/journeys-admin/src/libs/initAndAuthApp/initAndAuthApp.spec.tsx
+++ b/apps/journeys-admin/src/libs/initAndAuthApp/initAndAuthApp.spec.tsx
@@ -1,11 +1,9 @@
-import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
 import { User } from 'next-firebase-auth'
 import { SSRConfig } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 import i18nConfig from '../../../next-i18next.config'
 import { createApolloClient } from '../apolloClient'
-import { cache } from '../apolloClient/cache'
 import { checkConditionalRedirect } from '../checkConditionalRedirect'
 
 import { ACCEPT_ALL_INVITES, initAndAuthApp } from './initAndAuthApp'

--- a/apps/journeys-admin/src/libs/initAndAuthApp/initAndAuthApp.ts
+++ b/apps/journeys-admin/src/libs/initAndAuthApp/initAndAuthApp.ts
@@ -1,9 +1,10 @@
-import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
+import { ApolloClient, NormalizedCacheObject, gql } from '@apollo/client'
 import { Redirect } from 'next'
 import { User } from 'next-firebase-auth'
 import { SSRConfig } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
+import { AcceptAllInvites } from '../../../__generated__/AcceptAllInvites'
 import i18nConfig from '../../../next-i18next.config'
 import { createApolloClient } from '../apolloClient'
 import { checkConditionalRedirect } from '../checkConditionalRedirect'
@@ -19,6 +20,17 @@ interface InitAndAuth {
   redirect: Redirect | undefined
   translations: SSRConfig
 }
+
+export const ACCEPT_ALL_INVITES = gql`
+  mutation AcceptAllInvites {
+    userTeamInviteAcceptAll {
+      id
+    }
+    userInviteAcceptAll {
+      id
+    }
+  }
+`
 
 export async function initAndAuthApp({
   user,
@@ -36,13 +48,20 @@ export async function initAndAuthApp({
   ])
 
   const apolloClient = createApolloClient(token != null ? token : '')
-  const redirect =
-    token != null
-      ? await checkConditionalRedirect({
-          apolloClient,
-          resolvedUrl
-        })
-      : undefined
+
+  if (token == null) {
+    return { apolloClient, redirect: undefined, translations }
+  }
+
+  const [, redirect] = await Promise.all([
+    apolloClient.mutate<AcceptAllInvites>({
+      mutation: ACCEPT_ALL_INVITES
+    }),
+    checkConditionalRedirect({
+      apolloClient,
+      resolvedUrl
+    })
+  ])
 
   return { apolloClient, redirect, translations }
 }


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at af77769</samp>

This pull request removes unused code and refactors the invite acceptance feature in the `journeys-admin` app. It deletes the `ACCEPT_ALL_INVITES` mutation and its references from several pages, and moves the logic to the `initAndAuthApp` function. It also updates the test file for the function to mock and expect the new mutation.

should reduce initial server response time slightly.
