### PR TITLE
fix: add new loading state

### DIFF
--- a/apps/journeys-admin/src/components/TemplateSections/TemplateSections.tsx
+++ b/apps/journeys-admin/src/components/TemplateSections/TemplateSections.tsx
@@ -30,8 +30,9 @@ export function TemplateSections({
   const { breakpoints } = useTheme()
   const [contents, setContents] = useState<Contents>({})
   const [collection, setCollection] = useState<Journey[]>([])
+  const [loading, setLoading] = useState(true)
 
-  const { loading } = useJourneysQuery({
+  useJourneysQuery({
     variables: {
       where: {
         template: true,
@@ -67,6 +68,7 @@ export function TemplateSections({
         })
       })
       setContents(contents)
+      setLoading(false)
     }
   })
 


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e1b28e9</samp>

Improved loading performance and accuracy of `TemplateSections` component by managing `loading` state locally and updating it after data processing. Refactored `apps/journeys-admin/src/components/TemplateSections/TemplateSections.tsx` to implement this change.

[- Link to Basecamp Todo
](https://3.basecamp.com/3105655/buckets/34879725/todos/6765991478)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] it should now show no results page on templates on initial load

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e1b28e9</samp>

* Move `loading` state variable from `useJourneysQuery` to `TemplateSections` component to control loading state independently of query result ([link](https://github.com/JesusFilm/core/pull/2084/files?diff=unified&w=0#diff-8528e7b4c06335c3a765fccde78d68fff718a8b69d7384bea6782deeb45efb8aL33-R35))
* Set `loading` to false after processing query result and render template sections ([link](https://github.com/JesusFilm/core/pull/2084/files?diff=unified&w=0#diff-8528e7b4c06335c3a765fccde78d68fff718a8b69d7384bea6782deeb45efb8aR71))
