### PR TITLE
perf: add dd-trace to journeys admin

### DIFF
--- a/apps/journeys-admin/instrumentation.ts
+++ b/apps/journeys-admin/instrumentation.ts
@@ -1,0 +1,11 @@
+export async function register(): Promise<void> {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { default: tracer } = await import(
+      /* webpackChunkName: "dd-trace" */
+      'dd-trace'
+    )
+
+    tracer.init({ logInjection: true })
+    tracer.use('next')
+  }
+}

--- a/apps/journeys-admin/next.config.js
+++ b/apps/journeys-admin/next.config.js
@@ -71,7 +71,8 @@ const nextConfig = {
         'node_modules/esbuild-linux-64/bin'
       ]
     },
-    fallbackNodePolyfills: false
+    fallbackNodePolyfills: false,
+    instrumentationHook: true
   }
 }
 const plugins = [withNx]


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 54a42bf</samp>

This pull request adds tracing and monitoring capabilities to the `journeys-admin` app using the `dd-trace` library and the `next` plugin. It creates a new module `instrumentation.ts` that initializes the library and configures it for serverless environments, and modifies the `next.config.js` file to use the module.