### PR TITLE
chore: terraform cleanup

### DIFF
--- a/apps/api-gateway/infrastructure/variables.tf
+++ b/apps/api-gateway/infrastructure/variables.tf
@@ -5,8 +5,6 @@ variable "ecs_config" {
     subnets      = list(string)
     alb_dns_name = string
     zone_id      = string
-    zone_id      = string
-    alb_dns_name = string
     alb_listener = object({
       alb_arn         = string
       port            = number

--- a/apps/api-journeys/infrastructure/variables.tf
+++ b/apps/api-journeys/infrastructure/variables.tf
@@ -5,8 +5,6 @@ variable "ecs_config" {
     subnets      = list(string)
     alb_dns_name = string
     zone_id      = string
-    zone_id      = string
-    alb_dns_name = string
     alb_listener = object({
       alb_arn  = string
       protocol = string

--- a/apps/api-languages/infrastructure/variables.tf
+++ b/apps/api-languages/infrastructure/variables.tf
@@ -5,8 +5,6 @@ variable "ecs_config" {
     subnets      = list(string)
     alb_dns_name = string
     zone_id      = string
-    zone_id      = string
-    alb_dns_name = string
     alb_listener = object({
       alb_arn  = string
       protocol = string

--- a/apps/api-media/infrastructure/variables.tf
+++ b/apps/api-media/infrastructure/variables.tf
@@ -5,8 +5,6 @@ variable "ecs_config" {
     subnets      = list(string)
     alb_dns_name = string
     zone_id      = string
-    zone_id      = string
-    alb_dns_name = string
     alb_listener = object({
       alb_arn  = string
       protocol = string

--- a/apps/api-tags/infrastructure/variables.tf
+++ b/apps/api-tags/infrastructure/variables.tf
@@ -5,8 +5,6 @@ variable "ecs_config" {
     subnets      = list(string)
     alb_dns_name = string
     zone_id      = string
-    zone_id      = string
-    alb_dns_name = string
     alb_listener = object({
       alb_arn  = string
       protocol = string

--- a/apps/api-users/infrastructure/variables.tf
+++ b/apps/api-users/infrastructure/variables.tf
@@ -5,8 +5,6 @@ variable "ecs_config" {
     subnets      = list(string)
     alb_dns_name = string
     zone_id      = string
-    zone_id      = string
-    alb_dns_name = string
     alb_listener = object({
       alb_arn  = string
       protocol = string

--- a/apps/api-videos/infrastructure/variables.tf
+++ b/apps/api-videos/infrastructure/variables.tf
@@ -5,8 +5,6 @@ variable "ecs_config" {
     subnets      = list(string)
     alb_dns_name = string
     zone_id      = string
-    zone_id      = string
-    alb_dns_name = string
     alb_listener = object({
       alb_arn  = string
       protocol = string

--- a/infrastructure/modules/aws/aurora/main.tf
+++ b/infrastructure/modules/aws/aurora/main.tf
@@ -21,6 +21,7 @@ resource "aws_rds_cluster" "default" {
   allow_major_version_upgrade     = true
   final_snapshot_identifier       = "${var.name}-${var.env}-final-snapshot"
   db_cluster_parameter_group_name = "aurora-postgresql13-cluster-replication"
+  enabled_cloudwatch_logs_exports = ["postgresql"]
   serverlessv2_scaling_configuration {
     max_capacity = 16
     min_capacity = 0.5
@@ -34,8 +35,9 @@ resource "aws_rds_cluster_instance" "default" {
   engine_version     = aws_rds_cluster.default.engine_version
   promotion_tier     = 1
 
-  monitoring_interval = 30
-  monitoring_role_arn = aws_iam_role.rds_enhanced_monitoring.arn
+  performance_insights_enabled = true
+  monitoring_interval          = 15
+  monitoring_role_arn          = aws_iam_role.rds_enhanced_monitoring.arn
 }
 
 resource "aws_ssm_parameter" "parameter" {

--- a/infrastructure/modules/aws/datadog/main.tf
+++ b/infrastructure/modules/aws/datadog/main.tf
@@ -119,3 +119,15 @@ resource "datadog_integration_aws" "sandbox" {
   account_id = data.aws_caller_identity.current.account_id
   role_name  = "DatadogAWSIntegrationRole"
 }
+
+module "datadog_log_forwarder" {
+  source     = "terraform-aws-modules/datadog-forwarders/aws//modules/log_forwarder"
+  dd_api_key = data.aws_ssm_parameter.datadog_api_key.value
+
+}
+
+module "datadog_rds_enhanced_monitoring_forwarder" {
+  source = "terraform-aws-modules/datadog-forwarders/aws//modules/rds_enhanced_monitoring_forwarder"
+
+  dd_api_key = data.aws_ssm_parameter.datadog_api_key.value
+}

--- a/infrastructure/modules/aws/ecs-task/data.tf
+++ b/infrastructure/modules/aws/ecs-task/data.tf
@@ -4,3 +4,7 @@ data "doppler_secrets" "app" {
 
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
+
+data "aws_route53_zone" "zone" {
+  zone_id = var.service_config.zone_id
+}

--- a/infrastructure/modules/aws/ecs-task/main.tf
+++ b/infrastructure/modules/aws/ecs-task/main.tf
@@ -257,8 +257,8 @@ resource "aws_alb_listener_rule" "alb_listener_rule" {
     target_group_arn = aws_alb_target_group.alb_target_group.arn
   }
   condition {
-    path_pattern {
-      values = var.service_config.alb_target_group.path_pattern
+    host_header {
+      values = ["${var.service_config.name}.${data.aws_route53_zone.zone.name}"]
     }
   }
 }

--- a/infrastructure/modules/aws/main.tf
+++ b/infrastructure/modules/aws/main.tf
@@ -52,6 +52,12 @@ module "public_bastion_security_group" {
       protocol    = "tcp"
       cidr_blocks = ["172.221.20.111/32"]
     },
+    {
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = ["47.36.114.169/32"]
+    },
     // EC2_INSTANCE_CONNECT
     {
       from_port   = 22


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2a83e78</samp>

This pull request enhances the logging and monitoring capabilities of the Aurora database cluster and the ECS services by integrating them with Datadog. It also simplifies the service configuration by removing unnecessary variables and enabling host-based routing based on the service name and the DNS zone name.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2a83e78</samp>

*  Remove `zone_id` and `alb_dns_name` variables from service configurations, as they are no longer needed for host-based routing ([link](https://github.com/JesusFilm/core/pull/2090/files?diff=unified&w=0#diff-07a09b8043b663987b868a28efad2b69772503f3e15c372f284ada281401d888L8-L9), [link](https://github.com/JesusFilm/core/pull/2090/files?diff=unified&w=0#diff-45d5866af0c4904d05b5f999997cce5c9fd4885f597432ad38fe6ac2688d04d6L8-L9), [link](https://github.com/JesusFilm/core/pull/2090/files?diff=unified&w=0#diff-11d2a7cddf4dfb854ffc0395d89cf7641f4b993ff5943e6c4efbe17f8851da94L8-L9), [link](https://github.com/JesusFilm/core/pull/2090/files?diff=unified&w=0#diff-277246dc6c81077412fbedf808e9d3fa14af67c5e28a6e74b74a8edae18829c5L8-L9), [link](https://github.com/JesusFilm/core/pull/2090/files?diff=unified&w=0#diff-c3a62739971e8043156072aa666db72d88636530057d42996a7ae1e1c6a2417aL8-L9), [link](https://github.com/JesusFilm/core/pull/2090/files?diff=unified&w=0#diff-1400d7ddc5347b1abbbb087a028c0e9b899d5ccf051e4228ba5e112575771bc7L8-L9), [link](https://github.com/JesusFilm/core/pull/2090/files?diff=unified&w=0#diff-4ecd9769c24c8531511eab77a9874e1f32860edb3ee1fe2aaed23a2009a30f8bL8-L9))
*  Add `host_header` condition to `aws_lb_listener_rule` resource in `ecs-task` module, to enable host-based routing for ECS services based on service name and DNS zone name ([link](https://github.com/JesusFilm/core/pull/2090/files?diff=unified&w=0#diff-2c3661fca608030e5c86473611095fca72922c79ea544a8812583e7ba2f37448L260-R261))
*  Add `aws_route53_zone` data source to `ecs-task` module, to fetch DNS zone name from zone ID provided by service configuration ([link](https://github.com/JesusFilm/core/pull/2090/files?diff=unified&w=0#diff-b264010e73c9faadd72abfa9303472eb0892abb0f7f27225c1dc1a585d025da3R7-R10))
*  Add `enabled_cloudwatch_logs_exports` parameter to `aws_rds_cluster` resource in `aurora` module, to enable exporting PostgreSQL logs to CloudWatch ([link](https://github.com/JesusFilm/core/pull/2090/files?diff=unified&w=0#diff-73b553a01d0ea00ac3ed34bc813c605506caabf3a464684b4781e949f9fb8f55R24))
*  Add `performance_insights_enabled` and `monitoring_interval` parameters to `aws_rds_cluster_instance` resource in `aurora` module, to enable performance insights and enhanced monitoring for Aurora database cluster ([link](https://github.com/JesusFilm/core/pull/2090/files?diff=unified&w=0#diff-73b553a01d0ea00ac3ed34bc813c605506caabf3a464684b4781e949f9fb8f55L37-R40))
*  Add `datadog_log_forwarder` and `datadog_rds_enhanced_monitoring_forwarder` modules to `datadog` module, to enable forwarding logs and metrics from AWS services to Datadog ([link](https://github.com/JesusFilm/core/pull/2090/files?diff=unified&w=0#diff-fa9eefeef6d11497bfb1cf087596bfcbb05357f83dc128b283426b8a918e1e50R122-R133))
*  Add SSH ingress rule to `aws_security_group` resource in `aws` module, to allow access to Bastion host from a specific IP address for debugging purposes ([link](https://github.com/JesusFilm/core/pull/2090/files?diff=unified&w=0#diff-1c723fa4d980c09bb55ef9f5b8a4b585ea3d1a36b8ebad7ac1042e20515877a5R55-R60))
