### PR TITLE
fix: carousel hover buttons state

### DIFF
--- a/apps/journeys-admin/src/components/TemplateGallery/TemplateGalleryCarousel/TemplateGalleryCarousel.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TemplateGalleryCarousel/TemplateGalleryCarousel.tsx
@@ -70,6 +70,8 @@ export function TemplateGalleryCarousel<T>({
       data-testid={`${
         heading?.replace(' ', '') ?? ''
       }-template-gallery-carousel`}
+      onMouseOver={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
     >
       {heading != null && <Typography variant="h5">{heading}</Typography>}
       {loading ? (
@@ -105,12 +107,7 @@ export function TemplateGalleryCarousel<T>({
         >
           {items.map((item) => {
             return (
-              <SwiperSlide
-                key={item.id}
-                data-testid={`journey-${item.id}`}
-                onMouseOver={() => setHovered(true)}
-                onMouseLeave={() => setHovered(false)}
-              >
+              <SwiperSlide key={item.id} data-testid={`journey-${item.id}`}>
                 {renderItem({ item })}
               </SwiperSlide>
             )


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 688f4d0</samp>

Improved UI and performance of `TemplateGalleryCarousel` component. Removed redundant code and simplified state management.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34951353/todos/6789923535)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] it should not make nav buttons disappear when hovering off card but staying inside carousel

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 688f4d0</samp>

*  Add event handlers to `Carousel` component to toggle `hovered` state on mouse enter and leave ([link](https://github.com/JesusFilm/core/pull/2092/files?diff=unified&w=0#diff-1c593b6377ba23e94739bd9a97c76355f393a133578cae7f13d19c91b2e5e561R73-R74))
*  Use `hovered` state to control navigation button visibility and carousel autoplay behavior ([link](https://github.com/JesusFilm/core/pull/2092/files?diff=unified&w=0#diff-1c593b6377ba23e94739bd9a97c76355f393a133578cae7f13d19c91b2e5e561R73-R74))
*  Remove redundant event handlers from `SwiperSlide` components ([link](https://github.com/JesusFilm/core/pull/2092/files?diff=unified&w=0#diff-1c593b6377ba23e94739bd9a97c76355f393a133578cae7f13d19c91b2e5e561L108-R110))
