### PR TITLE
fix: felt needs and collection on change event

### DIFF
--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/TagCarousels.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/TagCarousels.spec.tsx
@@ -58,22 +58,7 @@ describe('TagCarousels', () => {
       })
     )
 
-    expect(onChange).toHaveBeenCalledWith(
-      ['acceptanceTagId'],
-      [
-        'acceptanceTagId',
-        'depressionTagId',
-        'fearTagId',
-        'forgivenessTagId',
-        'hopeTagId',
-        'lonelinessTagId',
-        'loveTagId',
-        'securityTagId',
-        'significanceTagId',
-        'jesusFilmTagId',
-        'nuaTagId'
-      ]
-    )
+    expect(onChange).toHaveBeenCalledWith('acceptanceTagId')
   })
 
   it('should filter by collections tag', async () => {
@@ -98,65 +83,6 @@ describe('TagCarousels', () => {
       })
     )
 
-    expect(onChange).toHaveBeenCalledWith(
-      ['nuaTagId'],
-      [
-        'acceptanceTagId',
-        'depressionTagId',
-        'fearTagId',
-        'forgivenessTagId',
-        'hopeTagId',
-        'lonelinessTagId',
-        'loveTagId',
-        'securityTagId',
-        'significanceTagId',
-        'jesusFilmTagId',
-        'nuaTagId'
-      ]
-    )
-  })
-
-  it('should preserve existing selected tags on filter', async () => {
-    const onChange = jest.fn()
-    const { getByRole } = render(
-      <MockedProvider mocks={[getTagsMock]}>
-        <TagCarousels
-          selectedTagIds={['addictionTagId', 'acceptanceTagId', 'nuaTagId']}
-          onChange={onChange}
-        />
-      </MockedProvider>
-    )
-
-    await waitFor(async () => {
-      await expect(
-        getByRole('button', {
-          name: 'NUA NUA'
-        })
-      ).toBeInTheDocument()
-    })
-
-    fireEvent.click(
-      getByRole('button', {
-        name: 'NUA NUA'
-      })
-    )
-
-    // Should remove tags that don't belong to these carousels, keep existing tags without duplicates
-    expect(onChange).toHaveBeenCalledWith(
-      ['acceptanceTagId', 'nuaTagId'],
-      [
-        'acceptanceTagId',
-        'depressionTagId',
-        'fearTagId',
-        'forgivenessTagId',
-        'hopeTagId',
-        'lonelinessTagId',
-        'loveTagId',
-        'securityTagId',
-        'significanceTagId',
-        'jesusFilmTagId',
-        'nuaTagId'
-      ]
-    )
+    expect(onChange).toHaveBeenCalledWith('nuaTagId')
   })
 })

--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/TagCarousels.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/TagCarousels.tsx
@@ -1,7 +1,5 @@
 import Stack from '@mui/material/Stack'
 import { useTheme } from '@mui/material/styles'
-import compact from 'lodash/compact'
-import difference from 'lodash/difference'
 import { ReactElement, useMemo } from 'react'
 import { SwiperOptions } from 'swiper'
 
@@ -13,12 +11,12 @@ import { FeltNeedsButton } from './FeltNeedsButton'
 
 interface TagCarouselsProps {
   selectedTagIds: string[]
-  onChange: (selectedTagIds: string[], availableTagIds: string[]) => void
+  onChange: (selectedTagId: string) => void
 }
 
 export function TagCarousels({
   selectedTagIds,
-  onChange
+  onChange: handleChange
 }: TagCarouselsProps): ReactElement {
   const { parentTags, childTags, loading } = useTagsQuery()
   const { breakpoints } = useTheme()
@@ -44,10 +42,6 @@ export function TagCarousels({
       ? childTags.filter((tag) => tag.parentId === feltNeedsTagId)
       : []
   }, [childTags, feltNeedsTagId])
-  const feltNeedsTagIds = useMemo(
-    () => feltNeedsTags.map(({ id }) => id),
-    [feltNeedsTags]
-  )
 
   const collectionTagId = useMemo(() => {
     return parentTags.find((tag) => tag.name[0].value === 'Collections')?.id
@@ -58,23 +52,6 @@ export function TagCarousels({
       ? childTags.filter((tag) => tag.parentId === collectionTagId)
       : []
   }, [childTags, collectionTagId])
-  const collectionTagIds = useMemo(
-    () => collectionTags.map(({ id }) => id),
-    [collectionTags]
-  )
-
-  const handleChange = (selectedTagId: string): void => {
-    const carouselsTagIds = [...feltNeedsTagIds, ...collectionTagIds] ?? []
-
-    // Existing selected tag ids from these carousels only
-    const carouselSelectedTagIds = compact(
-      selectedTagIds.map((tagId) => carouselsTagIds.find((id) => id === tagId))
-    )
-    // Remove newly selected tag id from existing tag ids
-    const existingTagIds = difference(carouselSelectedTagIds, [selectedTagId])
-
-    onChange([...existingTagIds, selectedTagId], carouselsTagIds)
-  }
 
   return (
     <Stack

--- a/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.spec.tsx
@@ -52,7 +52,7 @@ describe('TemplateGallery', () => {
     expect(getByRole('heading', { level: 5, name: 'Hope' })).toBeInTheDocument()
   })
 
-  it('should render templates filtered via tags', async () => {
+  it('should render templates with multiple filtered tags', async () => {
     const push = jest.fn()
     mockedUseRouter.mockReturnValue({
       push,
@@ -119,6 +119,37 @@ describe('TemplateGallery', () => {
         push,
         query: {
           languageIds: ['496']
+        }
+      })
+    })
+  })
+
+  it('should render templates with a felt needs tags selected', async () => {
+    const push = jest.fn()
+    mockedUseRouter.mockReturnValue({
+      push,
+      query: { tagIds: [], languageIds: ['529'] }
+    } as unknown as NextRouter)
+
+    const { getByRole } = render(
+      <MockedProvider mocks={[getJourneysMock, getLanguagesMock, getTagsMock]}>
+        <TemplateGallery />
+      </MockedProvider>
+    )
+
+    await waitFor(() => {
+      expect(
+        getByRole('button', { name: 'Acceptance Acceptance' })
+      ).toBeInTheDocument()
+    })
+
+    fireEvent.click(getByRole('button', { name: 'Acceptance Acceptance' }))
+    await waitFor(() => {
+      expect(push).toHaveBeenCalledWith({
+        push,
+        query: {
+          tagIds: 'acceptanceTagId',
+          languageIds: ['529']
         }
       })
     })

--- a/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.tsx
@@ -36,6 +36,12 @@ export function TemplateGallery(): ReactElement {
     void router.push(router)
   }
 
+  function handleTagIdChange(selectedTagId: string): void {
+    setSelectedTagIds([selectedTagId])
+    router.query.tagIds = selectedTagId
+    void router.push(router)
+  }
+
   function handleLanguageIdsChange(values: string[]): void {
     setSelectedLanguageIds(values)
     router.query.languageIds = values
@@ -117,7 +123,7 @@ export function TemplateGallery(): ReactElement {
         </Grid>
         <TagCarousels
           selectedTagIds={selectedTagIds}
-          onChange={handleTagIdsChange}
+          onChange={handleTagIdChange}
         />
         <TemplateSections
           tagIds={selectedTagIds.length > 0 ? selectedTagIds : undefined}


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 38527bf</samp>

Refactored the `TagCarousels` and `TemplateGallery` components to support a single-tag selection feature for filtering templates. Updated and simplified the tests for both components accordingly.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34951353/todos/6789923547#__recording_6795357275)

# How should this PR be QA Tested?

- [ ] it should let user click on a felt needs tag and apply it as a filter

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 38527bf</samp>

*  Simplify `TagCarousels` component to only handle one tag selection at a time and remove unused imports and variables ([link](https://github.com/JesusFilm/core/pull/2093/files?diff=unified&w=0#diff-736eb0c656dd5c0b2ace0f75882edf66c289cbbcd62e8b9d9db4ab27c01b04c0L3-L4), [link](https://github.com/JesusFilm/core/pull/2093/files?diff=unified&w=0#diff-736eb0c656dd5c0b2ace0f75882edf66c289cbbcd62e8b9d9db4ab27c01b04c0L16-R19), [link](https://github.com/JesusFilm/core/pull/2093/files?diff=unified&w=0#diff-736eb0c656dd5c0b2ace0f75882edf66c289cbbcd62e8b9d9db4ab27c01b04c0L47-L50), [link](https://github.com/JesusFilm/core/pull/2093/files?diff=unified&w=0#diff-736eb0c656dd5c0b2ace0f75882edf66c289cbbcd62e8b9d9db4ab27c01b04c0L61-R55))
*  Simplify tests for `TagCarousels` component to only check for last selected tag id and remove test for preserving existing selected tags on filter ([link](https://github.com/JesusFilm/core/pull/2093/files?diff=unified&w=0#diff-7c8faec01b289e30df1d2815f91dce5a3e1261078be2547e6d4bd9b9cc3b1b6cL61-R61), [link](https://github.com/JesusFilm/core/pull/2093/files?diff=unified&w=0#diff-7c8faec01b289e30df1d2815f91dce5a3e1261078be2547e6d4bd9b9cc3b1b6cL101-R87))
*  Add `handleTagIdChange` function to `TemplateGallery` component to update state and router query with last selected tag id from `TagCarousels` component ([link](https://github.com/JesusFilm/core/pull/2093/files?diff=unified&w=0#diff-b3ab650ee0dc0ee335e53cf2f72cf2700dbc0890a665f9b7a7b608c6ce920650R39-R44))
*  Change `onChange` prop passed to `TagCarousels` component to use `handleTagIdChange` function and remove unused `handleTagIdsChange` function ([link](https://github.com/JesusFilm/core/pull/2093/files?diff=unified&w=0#diff-b3ab650ee0dc0ee335e53cf2f72cf2700dbc0890a665f9b7a7b608c6ce920650L120-R126))
*  Change test description for `TemplateGallery` component to reflect new functionality of `TagCarousels` component and add new test for rendering templates with a felt needs tag selected ([link](https://github.com/JesusFilm/core/pull/2093/files?diff=unified&w=0#diff-c2bf36c73693c861631661eb0b80f468b388a2b6256b82c32b676fd37011a1acL55-R55), [link](https://github.com/JesusFilm/core/pull/2093/files?diff=unified&w=0#diff-c2bf36c73693c861631661eb0b80f468b388a2b6256b82c32b676fd37011a1acR126-R156))
