### PR TITLE
fix: align carousels

### DIFF
--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/TagCarousels.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/TagCarousels.tsx
@@ -93,7 +93,7 @@ export function TagCarousels({
           md: 5
         }}
       />
-      <Stack direction="row" gap={10}>
+      <Stack direction="row" gap={10} sx={{ ml: -2 }}>
         {loading
           ? [0, 1].map((item, index) => {
               return (

--- a/apps/journeys-admin/src/components/TemplateGallery/TemplateGalleryCarousel/TemplateGalleryCarousel.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TemplateGalleryCarousel/TemplateGalleryCarousel.tsx
@@ -102,7 +102,7 @@ export function TemplateGalleryCarousel<T>({
           watchOverflow
           allowTouchMove
           observer
-          slidesOffsetBefore={slidesOffsetBefore}
+          slidesOffsetBefore={slidesOffsetBefore ?? 0}
           observeParents
           resizeObserver
           mousewheel={{ forceToAxis: true }}

--- a/apps/journeys-admin/src/components/TemplateGallery/TemplateGalleryCarousel/TemplateGalleryCarousel.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TemplateGalleryCarousel/TemplateGalleryCarousel.tsx
@@ -36,6 +36,7 @@ interface TemplateGalleryCarouselProps<T> {
   breakpoints: SwiperOptions['breakpoints']
   loading?: boolean
   loadingSpacing?: ComponentProps<typeof Stack>['spacing']
+  slidesOffsetBefore?: number
 }
 
 export function TemplateGalleryCarousel<T>({
@@ -44,7 +45,8 @@ export function TemplateGalleryCarousel<T>({
   heading,
   breakpoints,
   loading = false,
-  loadingSpacing
+  loadingSpacing,
+  slidesOffsetBefore
 }: TemplateGalleryCarouselProps<T>): ReactElement {
   const [swiper, setSwiper] = useState<SwiperCore>()
   const [hovered, setHovered] = useState(false)
@@ -97,6 +99,7 @@ export function TemplateGalleryCarousel<T>({
           watchOverflow
           allowTouchMove
           observer
+          slidesOffsetBefore={slidesOffsetBefore}
           observeParents
           resizeObserver
           mousewheel={{ forceToAxis: true }}

--- a/apps/journeys-admin/src/components/TemplateGallery/TemplateGalleryCarousel/TemplateGalleryCarousel.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TemplateGalleryCarousel/TemplateGalleryCarousel.tsx
@@ -83,7 +83,8 @@ export function TemplateGalleryCarousel<T>({
           sx={{
             mt: 4,
             minWidth: 'max-content',
-            boxSizing: 'unset'
+            boxSizing: 'unset',
+            ml: slidesOffsetBefore != null ? slidesOffsetBefore / 4 : 0
           }}
         >
           {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => {

--- a/apps/journeys-admin/src/components/TemplateSections/TemplateSections.tsx
+++ b/apps/journeys-admin/src/components/TemplateSections/TemplateSections.tsx
@@ -108,6 +108,7 @@ export function TemplateSections({
           renderItem={(itemProps) => <TemplateGalleryCard {...itemProps} />}
           breakpoints={swiperBreakpoints}
           loading={loading}
+          slidesOffsetBefore={-8}
           loadingSpacing={{
             xs: 1,
             md: 8,
@@ -145,6 +146,7 @@ export function TemplateSections({
               items={journeys}
               renderItem={(itemProps) => <TemplateGalleryCard {...itemProps} />}
               breakpoints={swiperBreakpoints}
+              slidesOffsetBefore={-8}
               loadingSpacing={{
                 xs: 1,
                 md: 8,


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 61f429e</samp>

Added a new prop to `TemplateGalleryCarousel` to customize the spacing between slides and updated the template gallery UI to use overlapping slides and aligned tag carousels.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34951353/todos/6789923561)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] carousel items should be aligned to left hand side of parent container in template gallery

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 61f429e</samp>

*  Add `slidesOffsetBefore` prop to `TemplateGalleryCarousel` component and interface to enable custom offset for swiper slides ([link](https://github.com/JesusFilm/core/pull/2095/files?diff=unified&w=0#diff-1c593b6377ba23e94739bd9a97c76355f393a133578cae7f13d19c91b2e5e561R39), [link](https://github.com/JesusFilm/core/pull/2095/files?diff=unified&w=0#diff-1c593b6377ba23e94739bd9a97c76355f393a133578cae7f13d19c91b2e5e561L47-R49), [link](https://github.com/JesusFilm/core/pull/2095/files?diff=unified&w=0#diff-1c593b6377ba23e94739bd9a97c76355f393a133578cae7f13d19c91b2e5e561R102))
*  Pass `slidesOffsetBefore={-8}` prop to `TemplateGalleryCarousel` component in `TemplateSections.tsx` for `Featured` and `All` sections to create overlap effect ([link](https://github.com/JesusFilm/core/pull/2095/files?diff=unified&w=0#diff-8528e7b4c06335c3a765fccde78d68fff718a8b69d7384bea6782deeb45efb8aR111), [link](https://github.com/JesusFilm/core/pull/2095/files?diff=unified&w=0#diff-8528e7b4c06335c3a765fccde78d68fff718a8b69d7384bea6782deeb45efb8aR149))
*  Adjust margin-left of tag carousels in `TagCarousels.tsx` to align with template sections using `sx={{ ml: -2 }}` style on `Stack` component ([link](https://github.com/JesusFilm/core/pull/2095/files?diff=unified&w=0#diff-736eb0c656dd5c0b2ace0f75882edf66c289cbbcd62e8b9d9db4ab27c01b04c0L96-R96))
