### PR TITLE
fix: most relevant not show on one tag

### DIFF
--- a/apps/journeys-admin/src/components/TemplateSections/TemplateSections.tsx
+++ b/apps/journeys-admin/src/components/TemplateSections/TemplateSections.tsx
@@ -53,7 +53,9 @@ export function TemplateSections({
         )
       ]
       const mostRelevant = data.journeys.filter(({ tags }) =>
-        tagIds?.every((tagId) => tags.find((tag) => tag.id === tagId))
+        tagIds != null && tagIds.length > 1
+          ? tagIds.every((tagId) => tags.find((tag) => tag.id === tagId))
+          : true
       )
       setCollection(tagIds == null ? featuredAndNew : mostRelevant)
       const contents = {}


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at aa99ee8</samp>

Improved the filter logic for journeys by tags in `TemplateSections.tsx`. The change ensures that the user always sees some relevant journeys when filtering by one or no tags.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at aa99ee8</samp>

*  Modify the filter condition for the most relevant journeys to return all journeys if the tagIds array is empty or has only one element ([link](https://github.com/JesusFilm/core/pull/2097/files?diff=unified&w=0#diff-8528e7b4c06335c3a765fccde78d68fff718a8b69d7384bea6782deeb45efb8aL56-R58))
