### PR TITLE
fix: template gallery default filter english

### DIFF
--- a/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.spec.tsx
@@ -43,13 +43,15 @@ describe('TemplateGallery', () => {
     ).toBeInTheDocument()
     await waitFor(() =>
       expect(
-        getAllByRole('heading', { name: 'All Languages' })[0]
+        getAllByRole('heading', { name: 'English' })[0]
       ).toBeInTheDocument()
     )
-    expect(
-      getByRole('heading', { level: 5, name: 'Acceptance' })
-    ).toBeInTheDocument()
-    expect(getByRole('heading', { level: 5, name: 'Hope' })).toBeInTheDocument()
+    await waitFor(() =>
+      expect(
+        getByRole('heading', { level: 6, name: 'Acceptance' })
+      ).toBeInTheDocument()
+    )
+    expect(getByRole('heading', { level: 6, name: 'Hope' })).toBeInTheDocument()
   })
 
   it('should render templates with multiple filtered tags', async () => {

--- a/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.tsx
@@ -17,7 +17,9 @@ export function TemplateGallery(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   const router = useRouter()
   const [selectedLanguageIds, setSelectedLanguageIds] = useState<string[]>(
-    router.query.languageIds != null ? castArray(router.query.languageIds) : []
+    router.query.languageIds != null
+      ? castArray(router.query.languageIds)
+      : ['529']
   )
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>(
     router.query.tagIds != null ? castArray(router.query.tagIds) : []


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 568d137</samp>

This pull request changes the TemplateGallery component and its test case to use English as the default language for displaying templates. It also adjusts the UI elements to match the new design.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34951353/todos/6789923536)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] it should load english filtered templates in templates gallery by default

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 568d137</samp>

*  Set the default language id to '529' for English in the `TemplateGallery` component ([link](https://github.com/JesusFilm/core/pull/2101/files?diff=unified&w=0#diff-b3ab650ee0dc0ee335e53cf2f72cf2700dbc0890a665f9b7a7b608c6ce920650L20-R22))
*  Update the test case for the `TemplateGallery` component to expect the heading 'English' and the subheadings with level 6 ([link](https://github.com/JesusFilm/core/pull/2101/files?diff=unified&w=0#diff-c2bf36c73693c861631661eb0b80f468b388a2b6256b82c32b676fd37011a1acL46-R54))
