### PR TITLE
fix: audience autocomplete tags stay on one line

### DIFF
--- a/apps/journeys-admin/src/components/TemplateGallery/TagsFilter/TagsFilter.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagsFilter/TagsFilter.tsx
@@ -188,7 +188,14 @@ export function TagsFilter({
           </Typography>
         </Stack>
       )}
-      ChipProps={{ size: 'small' }}
+      ChipProps={{
+        size: 'small',
+        sx: {
+          '&.MuiChip-root': {
+            maxWidth: 'calc(100% - 15px)'
+          }
+        }
+      }}
       slotProps={{
         popper: {
           sx: {


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a960747</samp>

Improved the styling of the tags filter chips in the template gallery. Adjusted the `ChipProps` prop of the `Autocomplete` component in `TagsFilter.tsx` to prevent overflow.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/34951353/todos/6789923486)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] autocomplete audience tag selector will stay on one line when clicking "Guilt & Righteousness"

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a960747</samp>

* Limit the maximum width of the chips in the tags filter to avoid overflow issues ([link](https://github.com/JesusFilm/core/pull/2102/files?diff=unified&w=0#diff-390bfe94b6b7b566e0193b33dd20834171cc45285f92c73c6cc205e3dbaf9f04L191-R198))
* Add a custom `sx` style to the `Autocomplete` component in `TagsFilter.tsx` to apply the width limit ([link](https://github.com/JesusFilm/core/pull/2102/files?diff=unified&w=0#diff-390bfe94b6b7b566e0193b33dd20834171cc45285f92c73c6cc205e3dbaf9f04L191-R198))
