### PR TITLE
perf: add prefetch

### DIFF
--- a/apps/journeys-admin/pages/templates/[journeyId].tsx
+++ b/apps/journeys-admin/pages/templates/[journeyId].tsx
@@ -124,7 +124,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
         journeyId: id
       }
     })),
-    fallback: 'blocking'
+    fallback: true
   }
 }
 

--- a/apps/journeys-admin/src/components/AccessDenied/AccessDenied.tsx
+++ b/apps/journeys-admin/src/components/AccessDenied/AccessDenied.tsx
@@ -110,7 +110,7 @@ export function AccessDenied({
           </List>
           <Stack direction="row" justifyContent="space-between" sx={{ mt: 7 }}>
             <Box display={{ xs: 'none', sm: 'flex' }}>
-              <NextLink href="/" passHref legacyBehavior prefetch={false}>
+              <NextLink href="/" passHref legacyBehavior>
                 <Button
                   sx={{ color: 'primary.main' }}
                   startIcon={<ChevronLeftIcon />}
@@ -121,7 +121,7 @@ export function AccessDenied({
               </NextLink>
             </Box>
             <Box display={{ xs: 'flex', sm: 'none' }}>
-              <NextLink href="/" passHref legacyBehavior prefetch={false}>
+              <NextLink href="/" passHref legacyBehavior>
                 <Button
                   sx={{ color: 'primary.main' }}
                   startIcon={<ChevronLeftIcon />}

--- a/apps/journeys-admin/src/components/OnboardingPanel/OnboardingPanel.tsx
+++ b/apps/journeys-admin/src/components/OnboardingPanel/OnboardingPanel.tsx
@@ -32,7 +32,7 @@ export function OnboardingPanel(): ReactElement {
       <SidePanelContainer border={false}>
         <Stack direction="row" justifyContent="space-between">
           <Typography variant="subtitle1">{t('Use Template')}</Typography>
-          <NextLink href="/templates" passHref legacyBehavior prefetch={false}>
+          <NextLink href="/templates" passHref legacyBehavior>
             <Link
               underline="none"
               variant="subtitle2"
@@ -48,7 +48,7 @@ export function OnboardingPanel(): ReactElement {
         <DynamicOnboardingList />
       </Suspense>
       <SidePanelContainer border={false}>
-        <NextLink href="/templates" passHref legacyBehavior prefetch={false}>
+        <NextLink href="/templates" passHref legacyBehavior>
           <Button
             variant="outlined"
             startIcon={<Grid1Icon />}

--- a/apps/journeys-admin/src/components/PageWrapper/MainPanelHeader/MainPanelHeader.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/MainPanelHeader/MainPanelHeader.tsx
@@ -53,12 +53,7 @@ export function MainPanelHeader({
             </Box>
           ) : (
             backHref != null && (
-              <NextLink
-                href={backHref}
-                passHref
-                legacyBehavior
-                prefetch={false}
-              >
+              <NextLink href={backHref} passHref legacyBehavior>
                 <IconButton
                   edge="start"
                   size="small"

--- a/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.tsx
@@ -132,7 +132,7 @@ export function NavigationDrawer({
             <ChevronRightIcon />
           </ListItemIcon>
         </ListItemButton>
-        <NextLink href="/" passHref legacyBehavior prefetch={false}>
+        <NextLink href="/" passHref legacyBehavior>
           <Tooltip title={tooltip} placement="right" arrow>
             <ListItemButton
               selected={selectedPage === 'journeys' || selectedPage === ''}
@@ -152,7 +152,7 @@ export function NavigationDrawer({
             </ListItemButton>
           </Tooltip>
         </NextLink>
-        <NextLink href="/templates" passHref legacyBehavior prefetch={false}>
+        <NextLink href="/templates" passHref legacyBehavior>
           <ListItemButton
             selected={selectedPage === 'templates'}
             data-testid="NavigationListItemTemplates"

--- a/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/UserNavigation/UserNavigation.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/UserNavigation/UserNavigation.tsx
@@ -110,7 +110,7 @@ export function UserNavigation({
     <>
       <Divider sx={{ mb: 0.5, mx: 6, borderColor: 'secondary.main' }} />
       {userRoleData?.getUserRole?.roles?.includes(Role.publisher) === true && (
-        <NextLink href="/publisher" passHref legacyBehavior prefetch={false}>
+        <NextLink href="/publisher" passHref legacyBehavior>
           <ListItemButton
             selected={selectedPage === 'publisher'}
             data-testid="NavigationListItemPublisher"

--- a/apps/journeys-admin/src/components/TemplateGalleryCard/TemplateGalleryCard.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryCard/TemplateGalleryCard.tsx
@@ -102,7 +102,6 @@ export function TemplateGalleryCard({
         href={`/templates/${journey?.id ?? ''}`}
         passHref
         legacyBehavior
-        prefetch={false}
       >
         <Box
           component="a"


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d963851</samp>

Removed `prefetch` option from various `NextLink` components in the journeys-admin app to improve performance and reduce unnecessary data fetching. Changed `fallback` option in `getStaticPaths` to `true` for template pages to show a fallback page while the page is being generated on the server.