### PR TITLE
feat: add launch darkly

### DIFF
--- a/apps/journeys-admin/pages/_app.tsx
+++ b/apps/journeys-admin/pages/_app.tsx
@@ -12,6 +12,7 @@ import TagManager from 'react-gtm-module'
 import { useTranslation } from 'react-i18next'
 
 import { createEmotionCache } from '@core/shared/ui/createEmotionCache'
+import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 
 import i18nConfig from '../next-i18next.config'
 import { HelpScoutBeacon } from '../src/components/HelpScoutBeacon'
@@ -32,6 +33,7 @@ const clientSideEmotionCache = createEmotionCache({})
 
 type JourneysAdminAppProps = NextJsAppProps<{
   userSerialized?: string
+  flags?: { [key: string]: boolean }
   initialApolloState?: NormalizedCacheObject
 }> & {
   pageProps: SSRConfig
@@ -69,30 +71,31 @@ function JourneysAdminApp({
   }, [user])
 
   return (
-    <CacheProvider value={emotionCache}>
-      <ThemeProvider>
-        <DefaultSeo
-          titleTemplate={t('%s | Next Steps')}
-          defaultTitle={t('Admin | Next Steps')}
-        />
-        <HelpScoutBeacon />
-        <Head>
-          <meta
-            name="viewport"
-            content="minimum-scale=1, initial-scale=1, width=device-width"
+    <FlagsProvider flags={pageProps.flags}>
+      <CacheProvider value={emotionCache}>
+        <ThemeProvider>
+          <DefaultSeo
+            titleTemplate={t('%s | Next Steps')}
+            defaultTitle={t('Admin | Next Steps')}
           />
-          <link
-            rel="preconnect"
-            href={process.env.NEXT_PUBLIC_GATEWAY_URL}
-            crossOrigin=""
-          />
-        </Head>
-        {process.env.NEXT_PUBLIC_DATADOG_APPLICATION_ID != null &&
-          process.env.NEXT_PUBLIC_DATADOG_APPLICATION_ID !== '' &&
-          process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN != null &&
-          process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN !== '' && (
-            <Script id="datadog-rum">
-              {`
+          <HelpScoutBeacon />
+          <Head>
+            <meta
+              name="viewport"
+              content="minimum-scale=1, initial-scale=1, width=device-width"
+            />
+            <link
+              rel="preconnect"
+              href={process.env.NEXT_PUBLIC_GATEWAY_URL}
+              crossOrigin=""
+            />
+          </Head>
+          {process.env.NEXT_PUBLIC_DATADOG_APPLICATION_ID != null &&
+            process.env.NEXT_PUBLIC_DATADOG_APPLICATION_ID !== '' &&
+            process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN != null &&
+            process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN !== '' && (
+              <Script id="datadog-rum">
+                {`
              (function(h,o,u,n,d) {
                h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
                d=o.createElement(u);d.async=1;d.src=n
@@ -119,22 +122,23 @@ function JourneysAdminApp({
                });
              })
            `}
-            </Script>
-          )}
-        <ApolloProvider client={apolloClient}>
-          <TeamProvider>
-            <SnackbarProvider
-              anchorOrigin={{
-                vertical: 'bottom',
-                horizontal: 'right'
-              }}
-            >
-              <Component {...pageProps} />
-            </SnackbarProvider>
-          </TeamProvider>
-        </ApolloProvider>
-      </ThemeProvider>
-    </CacheProvider>
+              </Script>
+            )}
+          <ApolloProvider client={apolloClient}>
+            <TeamProvider>
+              <SnackbarProvider
+                anchorOrigin={{
+                  vertical: 'bottom',
+                  horizontal: 'right'
+                }}
+              >
+                <Component {...pageProps} />
+              </SnackbarProvider>
+            </TeamProvider>
+          </ApolloProvider>
+        </ThemeProvider>
+      </CacheProvider>
+    </FlagsProvider>
   )
 }
 

--- a/libs/shared/ui/src/components/FlagsProvider/FlagsProvider.spec.tsx
+++ b/libs/shared/ui/src/components/FlagsProvider/FlagsProvider.spec.tsx
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/react'
+import { ReactElement } from 'react'
+
+import { FlagsProvider, useFlags } from '.'
+
+describe('FlagsProvider', () => {
+  it('should render children', () => {
+    const { getByText } = render(
+      <FlagsProvider>Hello from FlagsProvider</FlagsProvider>
+    )
+    expect(getByText('Hello from FlagsProvider')).toBeInTheDocument()
+  })
+})
+
+describe('useFlags', () => {
+  const FlagsComponent = (): ReactElement => {
+    const flags = useFlags()
+    return <>{JSON.stringify(flags)}</>
+  }
+
+  it('should render empty object', () => {
+    const { getByText } = render(<FlagsComponent />)
+    expect(getByText('{}')).toBeInTheDocument()
+  })
+
+  it('should render flags when in provider', () => {
+    const { getByText } = render(
+      <FlagsProvider flags={{ testFlag: true }}>
+        <FlagsComponent />
+      </FlagsProvider>
+    )
+    expect(getByText('{"testFlag":true}')).toBeInTheDocument()
+  })
+})

--- a/libs/shared/ui/src/components/FlagsProvider/FlagsProvider.tsx
+++ b/libs/shared/ui/src/components/FlagsProvider/FlagsProvider.tsx
@@ -1,0 +1,27 @@
+import { ReactElement, ReactNode, createContext, useContext } from 'react'
+
+const FlagsContext = createContext<{ [key: string]: boolean } | undefined>(
+  undefined
+)
+
+interface FlagsProviderProps {
+  flags?: { [key: string]: boolean }
+  children: ReactNode
+}
+
+export const FlagsProvider = ({
+  flags = {},
+  children
+}: FlagsProviderProps): ReactElement => {
+  return (
+    <FlagsContext.Provider value={{ ...flags }}>
+      {children}
+    </FlagsContext.Provider>
+  )
+}
+
+export function useFlags(): { [key: string]: boolean } {
+  const context = useContext(FlagsContext)
+
+  return context ?? {}
+}

--- a/libs/shared/ui/src/components/FlagsProvider/index.ts
+++ b/libs/shared/ui/src/components/FlagsProvider/index.ts
@@ -1,0 +1,1 @@
+export { FlagsProvider, useFlags } from './FlagsProvider'

--- a/libs/shared/ui/src/libs/getLaunchDarklyClient/getLaunchDarklyClient.ts
+++ b/libs/shared/ui/src/libs/getLaunchDarklyClient/getLaunchDarklyClient.ts
@@ -1,0 +1,19 @@
+import { LDClient, LDUser, init } from 'launchdarkly-node-server-sdk'
+
+let launchDarklyClient: LDClient
+
+/**
+ * This requires the LAUNCH_DARKLY_SDK_KEY environment variable to be set.
+ * @returns a LaunchDarkly server-side client as a singleton.
+ */
+export async function getLaunchDarklyClient(user?: LDUser): Promise<LDClient> {
+  if (launchDarklyClient == null) {
+    launchDarklyClient = init(process.env.LAUNCH_DARKLY_SDK_KEY ?? '')
+  }
+
+  await launchDarklyClient.waitForInitialization()
+
+  if (user != null) launchDarklyClient.identify(user)
+
+  return launchDarklyClient
+}

--- a/libs/shared/ui/src/libs/getLaunchDarklyClient/index.ts
+++ b/libs/shared/ui/src/libs/getLaunchDarklyClient/index.ts
@@ -1,0 +1,1 @@
+export { getLaunchDarklyClient } from './getLaunchDarklyClient'

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "i18next": "23.6.0",
         "jsondiffpatch": "^0.5.0",
         "jsonwebtoken": "^9.0.2",
+        "launchdarkly-node-server-sdk": "^7.0.3",
         "leaflet": "^1.9.4",
         "lodash": "^4.17.21",
         "nestjs-ddtrace": "3.0.3",
@@ -25403,7 +25404,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
       "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "dev": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -37098,6 +37098,66 @@
         "shell-quote": "^1.7.3"
       }
     },
+    "node_modules/launchdarkly-eventsource": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/launchdarkly-eventsource/-/launchdarkly-eventsource-1.4.4.tgz",
+      "integrity": "sha512-GL+r2Y3WccJlhFyL2buNKel+9VaMnYpbE/FfCkOST5jSNSFodahlxtGyrE8o7R+Qhobyq0Ree4a7iafJDQi9VQ==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/launchdarkly-node-server-sdk": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/launchdarkly-node-server-sdk/-/launchdarkly-node-server-sdk-7.0.3.tgz",
+      "integrity": "sha512-uSkBezAiQ9nwv8N6CmI7OmyJ9e3xpueJzYOso8+5vMf7VtBtPjz6RRsUkUsSzUDo7siclmW8USjCwqn9aX2EbQ==",
+      "dependencies": {
+        "async": "^3.2.4",
+        "launchdarkly-eventsource": "1.4.4",
+        "lru-cache": "^6.0.0",
+        "node-cache": "^5.1.0",
+        "semver": "^7.5.4",
+        "tunnel": "0.0.6",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/launchdarkly-node-server-sdk/node_modules/async": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+    },
+    "node_modules/launchdarkly-node-server-sdk/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/launchdarkly-node-server-sdk/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/launchdarkly-node-server-sdk/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "node_modules/lazy-ass": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
@@ -41547,6 +41607,17 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/node-cleanup": {
       "version": "2.1.2",
@@ -50143,7 +50214,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "dev": true,
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "i18next": "23.6.0",
     "jsondiffpatch": "^0.5.0",
     "jsonwebtoken": "^9.0.2",
+    "launchdarkly-node-server-sdk": "^7.0.3",
     "leaflet": "^1.9.4",
     "lodash": "^4.17.21",
     "nestjs-ddtrace": "3.0.3",


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f024092</samp>

This pull request adds feature flagging support to the journeys-admin app and the shared UI library using the LaunchDarkly service. It introduces a `FlagsProvider` component and a `useFlags` hook to provide and consume feature flags in the app components. It also adds a `getLaunchDarklyClient` function to initialize and get a LaunchDarkly client. It updates the `initAndAuthApp` function and its tests to use the feature flags. It adds the `launchdarkly-node-server-sdk` dependency to the `package.json` file.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f024092</samp>

*  Add feature flagging functionality to the journeys-admin app and the shared UI library using the LaunchDarkly service ([link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7face15d274124f516ac5e594f571f1a58fcc38107ebe00aa471e180d1dd7761R15),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7face15d274124f516ac5e594f571f1a58fcc38107ebe00aa471e180d1dd7761R36),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7face15d274124f516ac5e594f571f1a58fcc38107ebe00aa471e180d1dd7761L72-R98),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7face15d274124f516ac5e594f571f1a58fcc38107ebe00aa471e180d1dd7761L122-R141),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7dfe2bf5183167e3c9311032afaaf0c0d189a57de559cc22a42f8feb7f87a211L1-R7),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7dfe2bf5183167e3c9311032afaaf0c0d189a57de559cc22a42f8feb7f87a211R15),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7dfe2bf5183167e3c9311032afaaf0c0d189a57de559cc22a42f8feb7f87a211L17-R23),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7dfe2bf5183167e3c9311032afaaf0c0d189a57de559cc22a42f8feb7f87a211R54-R60),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7dfe2bf5183167e3c9311032afaaf0c0d189a57de559cc22a42f8feb7f87a211L59-R72),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7dfe2bf5183167e3c9311032afaaf0c0d189a57de559cc22a42f8feb7f87a211R85),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7dfe2bf5183167e3c9311032afaaf0c0d189a57de559cc22a42f8feb7f87a211L80-R94),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7dfe2bf5183167e3c9311032afaaf0c0d189a57de559cc22a42f8feb7f87a211R107),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-78cc45ccf708da9458c63348fc8c76125f291c6549ab2e739a4ad445f3701b6bL6-R9),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-78cc45ccf708da9458c63348fc8c76125f291c6549ab2e739a4ad445f3701b6bR23-R25),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-78cc45ccf708da9458c63348fc8c76125f291c6549ab2e739a4ad445f3701b6bL40-R59),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-78cc45ccf708da9458c63348fc8c76125f291c6549ab2e739a4ad445f3701b6bL47-R76),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-78cc45ccf708da9458c63348fc8c76125f291c6549ab2e739a4ad445f3701b6bL68-R91),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-6d4361e28147ae82d582a9db9c4647ffbdd91261c8446d93abba17a48793cf4bR1-R34),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-585a8657a809885e55502d96bdfcb1b781e57330448f0d667202d186ae55be8bR1-R27),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-ee3cd876f50376c5e8abf5e8fa2a99a97f2bfe03237f53aa48d498952116fc77R1),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-fd37cb50452eaf0d384809f744b1c39494cc2450f505d91c8bdff93d367cfc20R1-R19),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-9a5f5e04ea043088670a7c311c59fc22b5115dccc190ebcd0b4ac4b94127e55bR1),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R86))
  * Import the `FlagsProvider` component and the `getLaunchDarklyClient` function from the `shared/ui` library in the `_app.tsx` file of the journeys-admin app ([link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7face15d274124f516ac5e594f571f1a58fcc38107ebe00aa471e180d1dd7761R15),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7dfe2bf5183167e3c9311032afaaf0c0d189a57de559cc22a42f8feb7f87a211L1-R7))
  * Add a `flags` property to the `JourneysAdminAppProps` type and the `InitAndAuth` interface to store the feature flags from the LaunchDarkly client ([link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7face15d274124f516ac5e594f571f1a58fcc38107ebe00aa471e180d1dd7761R36),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-78cc45ccf708da9458c63348fc8c76125f291c6549ab2e739a4ad445f3701b6bR23-R25))
  * Wrap the app components with the `FlagsProvider` component and pass the `flags` prop from the page props in the `_app.tsx` file ([link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7face15d274124f516ac5e594f571f1a58fcc38107ebe00aa471e180d1dd7761L72-R98),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7face15d274124f516ac5e594f571f1a58fcc38107ebe00aa471e180d1dd7761L122-R141))
  * Mock the `getLaunchDarklyClient` function and create a fake LaunchDarkly client with a `termsAndConditions` flag for testing purposes in the `initAndAuthApp.spec.tsx` file ([link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7dfe2bf5183167e3c9311032afaaf0c0d189a57de559cc22a42f8feb7f87a211R15),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7dfe2bf5183167e3c9311032afaaf0c0d189a57de559cc22a42f8feb7f87a211L17-R23),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7dfe2bf5183167e3c9311032afaaf0c0d189a57de559cc22a42f8feb7f87a211R54-R60))
  * Update the test descriptions and expectations to include the `flags` property that is returned by the `initAndAuthApp` function in the `initAndAuthApp.spec.tsx` file ([link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7dfe2bf5183167e3c9311032afaaf0c0d189a57de559cc22a42f8feb7f87a211L59-R72),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7dfe2bf5183167e3c9311032afaaf0c0d189a57de559cc22a42f8feb7f87a211R85),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7dfe2bf5183167e3c9311032afaaf0c0d189a57de559cc22a42f8feb7f87a211L80-R94),[link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7dfe2bf5183167e3c9311032afaaf0c0d189a57de559cc22a42f8feb7f87a211R107))
  * Import the `uuid` library and use it to create a unique user identifier for the LaunchDarkly client in the `initAndAuthApp.ts` file ([link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-78cc45ccf708da9458c63348fc8c76125f291c6549ab2e739a4ad445f3701b6bL6-R9))
  * Add a `launchDarklyClient` promise to the array of concurrent tasks that are awaited by the `initAndAuthApp` function, using the `getLaunchDarklyClient` function with a `ldUser` object that contains the user's key, first name, and email if authenticated, or a random key and anonymous flag if not ([link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-78cc45ccf708da9458c63348fc8c76125f291c6549ab2e739a4ad445f3701b6bL40-R59))
  * Destructure the `launchDarklyClient` promise and call the `allFlagsState` method with the `ldUser` object to get a JSON object with the feature flags, and assign it to a `flags` variable in the `initAndAuthApp.ts` file ([link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-78cc45ccf708da9458c63348fc8c76125f291c6549ab2e739a4ad445f3701b6bL47-R76))
  * Update the `apolloClient` creation to use the optional chaining operator instead of the nullish coalescing operator for the `token` argument, as the latter is not supported by the Apollo client library in the `initAndAuthApp.ts` file ([link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-78cc45ccf708da9458c63348fc8c76125f291c6549ab2e739a4ad445f3701b6bL47-R76))
  * Add the `flags` variable to the returned object of the `initAndAuthApp` function, both when the user is not authenticated and when the user is authenticated in the `initAndAuthApp.ts` file ([link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-78cc45ccf708da9458c63348fc8c76125f291c6549ab2e739a4ad445f3701b6bL68-R91))
  * Add a test file for the `FlagsProvider` component and the `useFlags` hook, which are used to provide and consume feature flags in the app components, in the `shared/ui` library ([link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-6d4361e28147ae82d582a9db9c4647ffbdd91261c8446d93abba17a48793cf4bR1-R34))
  * Add a source file for the `FlagsProvider` component and the `useFlags` hook, which take an optional `flags` prop and a `children` prop, and create a context provider with the `flags` value, and return the context value or an empty object if the context is undefined, respectively, in the `shared/ui` library ([link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-585a8657a809885e55502d96bdfcb1b781e57330448f0d667202d186ae55be8bR1-R27))
  * Export the `FlagsProvider` component and the `useFlags` hook from the index file of the `FlagsProvider` folder in the `shared/ui` library ([link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-ee3cd876f50376c5e8abf5e8fa2a99a97f2bfe03237f53aa48d498952116fc77R1))
  * Add a source file for the `getLaunchDarklyClient` function, which takes an optional `user` argument, and returns a singleton instance of the LaunchDarkly client, and waits for the client initialization and identifies the user to the client if the user is provided, in the `shared/ui` library ([link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-fd37cb50452eaf0d384809f744b1c39494cc2450f505d91c8bdff93d367cfc20R1-R19))
  * Export the `getLaunchDarklyClient` function from the index file of the `getLaunchDarklyClient` folder in the `shared/ui` library ([link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-9a5f5e04ea043088670a7c311c59fc22b5115dccc190ebcd0b4ac4b94127e55bR1))
  * Add the `launchdarkly-node-server-sdk` dependency to the `package.json` file, which is used to interact with the LaunchDarkly service for feature flagging ([link](https://github.com/JesusFilm/core/pull/2139/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R86))
