### PR TITLE
fix: embed tests

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Properties/JourneyLink/EmbedJourneyDialog/EmbedJourneyDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Properties/JourneyLink/EmbedJourneyDialog/EmbedJourneyDialog.spec.tsx
@@ -57,7 +57,7 @@ describe('embedJourneyDialog', () => {
     it('should copy the embed code from the modal', async () => {
       const embedCode = `<div style="position: relative; width: 100%; overflow: hidden; padding-top: 150%;"><iframe  id="jfm-iframe" src="${
         process.env.NEXT_PUBLIC_JOURNEYS_URL as string
-      }/embed/undefined" style="position: absolute; top: 0; left: 0; bottom: 0; right: 0; width: 100%; height: 100%; border: none;" allow="fullscreen"></iframe></div><script>window.addEventListener('message', event => { if(event.origin==='https://your.nextstep.is'){ const iframe=document.getElementById('jfm-iframe')
+      }/embed/undefined" style="position: absolute; top: 0; left: 0; bottom: 0; right: 0; width: 100%; height: 100%; border: none;" allow="fullscreen; autoplay"></iframe></div><script>window.addEventListener('message', event => { if(event.origin==='https://your.nextstep.is'){ const iframe=document.getElementById('jfm-iframe')
 if(event.data === true){ 
 iframe.style.position="fixed"
 iframe.style.zIndex="999999999999999999999"


### PR DESCRIPTION
# Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 59adbdf</samp>

Updated the embed code for journeys to enable autoplay for videos. Added a test case to verify the `autoplay` attribute in the `iframe` element.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 59adbdf</samp>

*  Add `autoplay` attribute to the embed code for journey iframe ([link](https://github.com/JesusFilm/core/pull/2144/files?diff=unified&w=0#diff-41f18083af5f47475ce6a3d63e72bcc705968d130fef890a5991904ee27dc510L60-R60))
