### PR TITLE
fix: shallow route help scout query params

### DIFF
--- a/apps/journeys-admin/__generated__/GetLastActiveTeamIdAndTeams.ts
+++ b/apps/journeys-admin/__generated__/GetLastActiveTeamIdAndTeams.ts
@@ -9,6 +9,7 @@
 
 export interface GetLastActiveTeamIdAndTeams_getJourneyProfile {
   __typename: "JourneyProfile";
+  id: string;
   lastActiveTeamId: string | null;
 }
 

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.spec.tsx
@@ -226,37 +226,49 @@ describe('ControlPanel', () => {
     fireEvent.click(getByTestId('CardItem-step2.id'))
     expect(getByText('Locked With Interaction')).toBeInTheDocument()
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith({
-        push,
-        events: {
-          on
+      expect(push).toHaveBeenCalledWith(
+        {
+          push,
+          events: {
+            on
+          },
+          query: { param: 'properties-tab' }
         },
-        query: { param: 'properties-tab' }
-      })
+        undefined,
+        { shallow: true }
+      )
     })
 
     fireEvent.click(getByRole('tab', { name: 'Blocks' }))
     expect(getByRole('tabpanel', { name: 'Blocks' })).toBeInTheDocument()
     await waitFor(() => {
       expect(getByRole('button', { name: 'Text' })).toBeInTheDocument()
-      expect(push).toHaveBeenCalledWith({
-        push,
-        events: {
-          on
+      expect(push).toHaveBeenCalledWith(
+        {
+          push,
+          events: {
+            on
+          },
+          query: { param: 'blocks-tab' }
         },
-        query: { param: 'blocks-tab' }
-      })
+        undefined,
+        { shallow: true }
+      )
     })
 
     fireEvent.click(getByRole('tab', { name: 'Journey' }))
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith({
-        push,
-        events: {
-          on
+      expect(push).toHaveBeenCalledWith(
+        {
+          push,
+          events: {
+            on
+          },
+          query: { param: 'journeys-tab' }
         },
-        query: { param: 'journeys-tab' }
-      })
+        undefined,
+        { shallow: true }
+      )
     })
   })
 

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/ControlPanel.tsx
@@ -72,7 +72,7 @@ export function ControlPanel(): ReactElement {
 
   function setRoute(param: string): void {
     router.query.param = param
-    void router.push(router)
+    void router.push(router, undefined, { shallow: true })
     router.events.on('routeChangeComplete', () => {
       setBeaconPageViewed(param)
     })

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/LanguageMenuItem/LanguageMenuItem.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/LanguageMenuItem/LanguageMenuItem.spec.tsx
@@ -53,13 +53,17 @@ describe('LanguageMenuItem', () => {
     await waitFor(() => expect(onClose).toHaveBeenCalled())
 
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith({
-        query: { param: 'languages' },
-        push,
-        events: {
-          on
-        }
-      })
+      expect(push).toHaveBeenCalledWith(
+        {
+          query: { param: 'languages' },
+          push,
+          events: {
+            on
+          }
+        },
+        undefined,
+        { shallow: true }
+      )
     })
   })
 })

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/LanguageMenuItem/LanguageMenuItem.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/LanguageMenuItem/LanguageMenuItem.tsx
@@ -29,7 +29,7 @@ export function LanguageMenuItem({
 
   function setRoute(param: string): void {
     router.query.param = param
-    void router.push(router)
+    void router.push(router, undefined, { shallow: true })
     router.events.on('routeChangeComplete', () => {
       setBeaconPageViewed(param)
     })

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.spec.tsx
@@ -393,13 +393,17 @@ describe('EditToolbar Menu', () => {
     expect(menu).not.toHaveAttribute('aria-expanded')
 
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith({
-        query: { param: 'title' },
-        push,
-        events: {
-          on
-        }
-      })
+      expect(push).toHaveBeenCalledWith(
+        {
+          query: { param: 'title' },
+          push,
+          events: {
+            on
+          }
+        },
+        undefined,
+        { shallow: true }
+      )
     })
   })
 
@@ -439,13 +443,17 @@ describe('EditToolbar Menu', () => {
     expect(menu).not.toHaveAttribute('aria-expanded')
 
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith({
-        query: { param: 'description' },
-        push,
-        events: {
-          on
-        }
-      })
+      expect(push).toHaveBeenCalledWith(
+        {
+          query: { param: 'description' },
+          push,
+          events: {
+            on
+          }
+        },
+        undefined,
+        { shallow: true }
+      )
     })
   })
 })

--- a/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/Editor/EditToolbar/Menu/Menu.tsx
@@ -83,7 +83,7 @@ export function Menu(): ReactElement {
 
   function setRoute(param: string): void {
     router.query.param = param
-    void router.push(router)
+    void router.push(router, undefined, { shallow: true })
     router.events.on('routeChangeComplete', () => {
       setBeaconPageViewed(param)
     })

--- a/apps/journeys-admin/src/components/Editor/ImageBlockEditor/ImageBlockEditor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockEditor/ImageBlockEditor.spec.tsx
@@ -64,13 +64,17 @@ describe('ImageBlockEditor', () => {
     expect(getByText('Unsplash')).toBeInTheDocument()
     fireEvent.click(getByRole('tab', { name: 'Custom' }))
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith({
-        query: { param: 'custom-image' },
-        push,
-        events: {
-          on
-        }
-      })
+      expect(push).toHaveBeenCalledWith(
+        {
+          query: { param: 'custom-image' },
+          push,
+          events: {
+            on
+          }
+        },
+        undefined,
+        { shallow: true }
+      )
     })
 
     expect(getByText('Add image by URL')).toBeInTheDocument()
@@ -79,24 +83,32 @@ describe('ImageBlockEditor', () => {
       expect(getByRole('button', { name: 'Prompt' })).toBeInTheDocument()
     )
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith({
-        query: { param: 'ai-image' },
-        push,
-        events: {
-          on
-        }
-      })
+      expect(push).toHaveBeenCalledWith(
+        {
+          query: { param: 'ai-image' },
+          push,
+          events: {
+            on
+          }
+        },
+        undefined,
+        { shallow: true }
+      )
     })
 
     fireEvent.click(getByRole('tab', { name: 'Gallery' }))
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith({
-        query: { param: 'unsplash-image' },
-        push,
-        events: {
-          on
-        }
-      })
+      expect(push).toHaveBeenCalledWith(
+        {
+          query: { param: 'unsplash-image' },
+          push,
+          events: {
+            on
+          }
+        },
+        undefined,
+        { shallow: true }
+      )
     })
   })
 })

--- a/apps/journeys-admin/src/components/Editor/ImageBlockEditor/ImageBlockEditor.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockEditor/ImageBlockEditor.tsx
@@ -68,7 +68,7 @@ export function ImageBlockEditor({
 
   function setRoute(param: string): void {
     router.query.param = param
-    void router.push(router)
+    void router.push(router, undefined, { shallow: true })
     router.events.on('routeChangeComplete', () => {
       setBeaconPageViewed(param)
     })

--- a/apps/journeys-admin/src/components/Editor/Properties/JourneyLink/JourneyLink.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Properties/JourneyLink/JourneyLink.spec.tsx
@@ -54,13 +54,17 @@ describe('JourneyLink', () => {
     await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument())
 
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith({
-        query: { param: 'edit-url' },
-        push,
-        events: {
-          on
-        }
-      })
+      expect(push).toHaveBeenCalledWith(
+        {
+          query: { param: 'edit-url' },
+          push,
+          events: {
+            on
+          }
+        },
+        undefined,
+        { shallow: true }
+      )
     })
   })
 
@@ -92,13 +96,17 @@ describe('JourneyLink', () => {
     await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument())
 
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith({
-        query: { param: 'embed-journey' },
-        push,
-        events: {
-          on
-        }
-      })
+      expect(push).toHaveBeenCalledWith(
+        {
+          query: { param: 'embed-journey' },
+          push,
+          events: {
+            on
+          }
+        },
+        undefined,
+        { shallow: true }
+      )
     })
   })
 })

--- a/apps/journeys-admin/src/components/Editor/Properties/JourneyLink/JourneyLink.tsx
+++ b/apps/journeys-admin/src/components/Editor/Properties/JourneyLink/JourneyLink.tsx
@@ -27,7 +27,7 @@ export function JourneyLink(): ReactElement {
 
   function setRoute(param: string): void {
     router.query.param = param
-    void router.push(router)
+    void router.push(router, undefined, { shallow: true })
     router.events.on('routeChangeComplete', () => {
       setBeaconPageViewed(param)
     })

--- a/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoLibrary.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoLibrary.spec.tsx
@@ -296,13 +296,17 @@ describe('VideoLibrary', () => {
       expect(getByText('Paste any YouTube Link')).toBeInTheDocument()
     )
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith({
-        query: { param: 'video-youtube' },
-        push,
-        events: {
-          on
-        }
-      })
+      expect(push).toHaveBeenCalledWith(
+        {
+          query: { param: 'video-youtube' },
+          push,
+          events: {
+            on
+          }
+        },
+        undefined,
+        { shallow: true }
+      )
     })
   })
 
@@ -323,13 +327,17 @@ describe('VideoLibrary', () => {
     fireEvent.click(getByRole('tab', { name: 'Upload' }))
     fireEvent.click(getByRole('tab', { name: 'Library' }))
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith({
-        query: { param: 'video-library' },
-        push,
-        events: {
-          on
-        }
-      })
+      expect(push).toHaveBeenCalledWith(
+        {
+          query: { param: 'video-library' },
+          push,
+          events: {
+            on
+          }
+        },
+        undefined,
+        { shallow: true }
+      )
     })
   })
 
@@ -350,13 +358,17 @@ describe('VideoLibrary', () => {
     fireEvent.click(getByRole('tab', { name: 'Upload' }))
     expect(getByText('Drop a video here')).toBeInTheDocument()
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith({
-        query: { param: 'video-upload' },
-        push,
-        events: {
-          on
-        }
-      })
+      expect(push).toHaveBeenCalledWith(
+        {
+          query: { param: 'video-upload' },
+          push,
+          events: {
+            on
+          }
+        },
+        undefined,
+        { shallow: true }
+      )
     })
   })
 })

--- a/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoLibrary.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoLibrary.tsx
@@ -83,7 +83,7 @@ export function VideoLibrary({
 
   function setRoute(param: string): void {
     router.query.param = param
-    void router.push(router)
+    void router.push(router, undefined, { shallow: true })
     router.events.on('routeChangeComplete', () => {
       setBeaconPageViewed(param)
     })

--- a/apps/journeys-admin/src/components/JourneyList/ActiveJourneyList/AddJourneyButton/AddJourneyButton.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/ActiveJourneyList/AddJourneyButton/AddJourneyButton.spec.tsx
@@ -118,6 +118,7 @@ describe('AddJourneyButton', () => {
         teams: [],
         getJourneyProfile: {
           __typename: 'JourneyProfile',
+          id: 'journeyProfileId',
           lastActiveTeamId: null
         }
       }

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.spec.tsx
@@ -188,11 +188,15 @@ describe('DuplicateJourneys', () => {
     await waitFor(() => expect(result2).toHaveBeenCalled())
     await fireEvent.click(getByRole('menuitem', { name: 'Duplicate' }))
     await waitFor(() => expect(result).not.toHaveBeenCalled())
-    expect(push).toHaveBeenCalledWith({
-      query: { param: 'duplicate-journey' },
-      push,
-      events
-    })
+    expect(push).toHaveBeenCalledWith(
+      {
+        query: { param: 'duplicate-journey' },
+        push,
+        events
+      },
+      undefined,
+      { shallow: true }
+    )
     expect(getByText('Copy to Another Team')).toBeInTheDocument()
     const muiSelect = getByTestId('team-duplicate-select')
     const muiSelectDropDownButton = await within(muiSelect).getByRole('button')

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DuplicateJourneyMenuItem/DuplicateJourneyMenuItem.tsx
@@ -60,7 +60,7 @@ export function DuplicateJourneyMenuItem({
 
   function setRoute(param: string): void {
     router.query.param = param
-    void router.push(router)
+    void router.push(router, undefined, { shallow: true })
     router.events.on('routeChangeComplete', () => {
       setBeaconPageViewed(param)
     })

--- a/apps/journeys-admin/src/components/OnboardingPanel/data.ts
+++ b/apps/journeys-admin/src/components/OnboardingPanel/data.ts
@@ -88,6 +88,7 @@ export const getTeamsMock: MockedResponse<GetLastActiveTeamIdAndTeams> = {
       ],
       getJourneyProfile: {
         __typename: 'JourneyProfile',
+        id: 'journeyProfileId',
         lastActiveTeamId: 'teamId'
       }
     }

--- a/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/UserNavigation/UserMenu/UserMenu.spec.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/UserNavigation/UserMenu/UserMenu.spec.tsx
@@ -67,6 +67,7 @@ describe('UserMenu', () => {
           ],
           getJourneyProfile: {
             __typename: 'JourneyProfile',
+            id: 'journeyProfileId',
             lastActiveTeamId: 'teamId'
           }
         }

--- a/apps/journeys-admin/src/components/Team/CopyToTeamDialog/CopyToTeamDialog.stories.tsx
+++ b/apps/journeys-admin/src/components/Team/CopyToTeamDialog/CopyToTeamDialog.stories.tsx
@@ -38,6 +38,7 @@ const getTeamsMock: MockedResponse<GetLastActiveTeamIdAndTeams> = {
       ],
       getJourneyProfile: {
         __typename: 'JourneyProfile',
+        id: 'journeyProfileId',
         lastActiveTeamId: 'teamId'
       }
     }

--- a/apps/journeys-admin/src/components/Team/CopyToTeamMenuItem/CopyToTeamMenuItem.spec.tsx
+++ b/apps/journeys-admin/src/components/Team/CopyToTeamMenuItem/CopyToTeamMenuItem.spec.tsx
@@ -142,13 +142,17 @@ describe('DuplicateJourneys', () => {
     expect(getByText('Journey Copied')).toBeInTheDocument()
 
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith({
-        query: { param: 'copy-journey' },
-        push,
-        events: {
-          on
-        }
-      })
+      expect(push).toHaveBeenCalledWith(
+        {
+          query: { param: 'copy-journey' },
+          push,
+          events: {
+            on
+          }
+        },
+        undefined,
+        { shallow: true }
+      )
     })
   })
 })

--- a/apps/journeys-admin/src/components/Team/CopyToTeamMenuItem/CopyToTeamMenuItem.tsx
+++ b/apps/journeys-admin/src/components/Team/CopyToTeamMenuItem/CopyToTeamMenuItem.tsx
@@ -48,7 +48,7 @@ export function CopyToTeamMenuItem({
 
   function setRoute(param: string): void {
     router.query.param = param
-    void router.push(router)
+    void router.push(router, undefined, { shallow: true })
     router.events.on('routeChangeComplete', () => {
       setBeaconPageViewed(param)
     })

--- a/apps/journeys-admin/src/components/Team/TeamCreateDialog/TeamCreateDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamCreateDialog/TeamCreateDialog.spec.tsx
@@ -73,6 +73,7 @@ describe('TeamCreateDialog', () => {
         ],
         getJourneyProfile: {
           __typename: 'JourneyProfile',
+          id: 'journeyProfileId',
           lastActiveTeamId: null
         }
       }

--- a/apps/journeys-admin/src/components/Team/TeamCreateForm/TeamCreateForm.spec.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamCreateForm/TeamCreateForm.spec.tsx
@@ -66,6 +66,7 @@ describe('TeamCreateForm', () => {
         ],
         getJourneyProfile: {
           __typename: 'JourneyProfile',
+          id: 'journeyProfileId',
           lastActiveTeamId: null
         }
       }

--- a/apps/journeys-admin/src/components/Team/TeamManageDialog/TeamManageDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamManageDialog/TeamManageDialog.spec.tsx
@@ -100,6 +100,7 @@ describe('TeamManageDialog', () => {
         ],
         getJourneyProfile: {
           __typename: 'JourneyProfile',
+          id: 'journeyProfileId',
           lastActiveTeamId: 'teamId'
         }
       }

--- a/apps/journeys-admin/src/components/Team/TeamManageDialog/TeamManageWrapper/TeamManageWrapper.spec.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamManageDialog/TeamManageWrapper/TeamManageWrapper.spec.tsx
@@ -79,6 +79,7 @@ describe('TeamMembersList', () => {
         ],
         getJourneyProfile: {
           __typename: 'JourneyProfile',
+          id: 'journeyProfileId',
           lastActiveTeamId: 'teamId'
         }
       }

--- a/apps/journeys-admin/src/components/Team/TeamMenu/TeamMenu.spec.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamMenu/TeamMenu.spec.tsx
@@ -116,13 +116,17 @@ describe('TeamMenu', () => {
       expect(queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument()
     )
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith({
-        query: { param: 'create-team' },
-        push,
-        events: {
-          on
-        }
-      })
+      expect(push).toHaveBeenCalledWith(
+        {
+          query: { param: 'create-team' },
+          push,
+          events: {
+            on
+          }
+        },
+        undefined,
+        { shallow: true }
+      )
     })
 
     fireEvent.click(getByRole('button'))
@@ -135,13 +139,17 @@ describe('TeamMenu', () => {
       expect(queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument()
     )
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith({
-        query: { param: 'rename-team' },
-        push,
-        events: {
-          on
-        }
-      })
+      expect(push).toHaveBeenCalledWith(
+        {
+          query: { param: 'rename-team' },
+          push,
+          events: {
+            on
+          }
+        },
+        undefined,
+        { shallow: true }
+      )
     })
 
     fireEvent.click(getByRole('button'))
@@ -154,13 +162,17 @@ describe('TeamMenu', () => {
       expect(queryByTestId('dialog-close-button')).not.toBeInTheDocument()
     )
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith({
-        query: { param: 'teams' },
-        push,
-        events: {
-          on
-        }
-      })
+      expect(push).toHaveBeenCalledWith(
+        {
+          query: { param: 'teams' },
+          push,
+          events: {
+            on
+          }
+        },
+        undefined,
+        { shallow: true }
+      )
     })
   })
 

--- a/apps/journeys-admin/src/components/Team/TeamMenu/TeamMenu.spec.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamMenu/TeamMenu.spec.tsx
@@ -54,6 +54,7 @@ describe('TeamMenu', () => {
         ],
         getJourneyProfile: {
           __typename: 'JourneyProfile',
+          id: 'journeyProfileId',
           lastActiveTeamId: null
         }
       }
@@ -83,6 +84,7 @@ describe('TeamMenu', () => {
         ],
         getJourneyProfile: {
           __typename: 'JourneyProfile',
+          id: 'journeyProfileId',
           lastActiveTeamId: null
         }
       }

--- a/apps/journeys-admin/src/components/Team/TeamMenu/TeamMenu.stories.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamMenu/TeamMenu.stories.tsx
@@ -42,6 +42,7 @@ const getTeamsMock: MockedResponse<GetLastActiveTeamIdAndTeams> = {
       ],
       getJourneyProfile: {
         __typename: 'JourneyProfile',
+        id: 'journeyProfileId',
         lastActiveTeamId: 'teamId'
       }
     }
@@ -56,6 +57,7 @@ const getEmptyTeamsMock: MockedResponse<GetLastActiveTeamIdAndTeams> = {
       teams: [],
       getJourneyProfile: {
         __typename: 'JourneyProfile',
+        id: 'journeyProfileId',
         lastActiveTeamId: null
       }
     }

--- a/apps/journeys-admin/src/components/Team/TeamMenu/TeamMenu.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamMenu/TeamMenu.tsx
@@ -59,7 +59,7 @@ export function TeamMenu(): ReactElement {
 
   function setRoute(param: string): void {
     router.query.param = param
-    void router.push(router)
+    void router.push(router, undefined, { shallow: true })
     router.events.on('routeChangeComplete', () => {
       setBeaconPageViewed(param)
     })
@@ -90,8 +90,8 @@ export function TeamMenu(): ReactElement {
       {activeTeam != null && (
         <Box sx={{ display: { xs: 'none', sm: 'block' } }}>
           <TeamAvatars
-            onClick={() => {
-              setRoute('teams')
+            onClick={async () => {
+              await setRoute('teams')
               setTeamManageOpen(true)
             }}
             userTeams={activeTeam.userTeams}

--- a/apps/journeys-admin/src/components/Team/TeamMenu/TeamMenu.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamMenu/TeamMenu.tsx
@@ -90,8 +90,8 @@ export function TeamMenu(): ReactElement {
       {activeTeam != null && (
         <Box sx={{ display: { xs: 'none', sm: 'block' } }}>
           <TeamAvatars
-            onClick={async () => {
-              await setRoute('teams')
+            onClick={() => {
+              setRoute('teams')
               setTeamManageOpen(true)
             }}
             userTeams={activeTeam.userTeams}

--- a/apps/journeys-admin/src/components/Team/TeamOnboarding/TeamOnboarding.spec.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamOnboarding/TeamOnboarding.spec.tsx
@@ -129,6 +129,7 @@ describe('TeamOnboarding', () => {
         ],
         getJourneyProfile: {
           __typename: 'JourneyProfile',
+          id: 'journeyProfileId',
           lastActiveTeamId: 'teamId'
         }
       }

--- a/apps/journeys-admin/src/components/Team/TeamOnboarding/TeamOnboarding.stories.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamOnboarding/TeamOnboarding.stories.tsx
@@ -62,6 +62,7 @@ const getTeams: MockedResponse<GetLastActiveTeamIdAndTeams> = {
       ],
       getJourneyProfile: {
         __typename: 'JourneyProfile',
+        id: 'journeyProfileId',
         lastActiveTeamId: 'teamId'
       }
     }

--- a/apps/journeys-admin/src/components/Team/TeamProvider/TeamProvider.spec.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamProvider/TeamProvider.spec.tsx
@@ -69,6 +69,7 @@ const getTeamsMock: MockedResponse<GetLastActiveTeamIdAndTeams> = {
       teams,
       getJourneyProfile: {
         __typename: 'JourneyProfile',
+        id: 'journeyProfileId',
         lastActiveTeamId: 'teamId1'
       }
     }
@@ -96,6 +97,7 @@ describe('TeamProvider', () => {
           teams,
           getJourneyProfile: {
             __typename: 'JourneyProfile',
+            id: 'journeyProfileId',
             lastActiveTeamId: 'teamId2'
           }
         }

--- a/apps/journeys-admin/src/components/Team/TeamProvider/TeamProvider.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamProvider/TeamProvider.tsx
@@ -35,6 +35,7 @@ interface TeamProviderProps {
 export const GET_LAST_ACTIVE_TEAM_ID_AND_TEAMS = gql`
   query GetLastActiveTeamIdAndTeams {
     getJourneyProfile {
+      id
       lastActiveTeamId
     }
     teams {

--- a/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.spec.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.spec.tsx
@@ -50,6 +50,7 @@ describe('TeamSelect', () => {
         ],
         getJourneyProfile: {
           __typename: 'JourneyProfile',
+          id: 'journeyProfileId',
           lastActiveTeamId: 'teamId1'
         }
       }

--- a/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.stories.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.stories.tsx
@@ -48,6 +48,7 @@ const getTeamsMock: MockedResponse<GetLastActiveTeamIdAndTeams> = {
       ],
       getJourneyProfile: {
         __typename: 'JourneyProfile',
+        id: 'journeyProfileId',
         lastActiveTeamId: 'teamId'
       }
     }
@@ -62,6 +63,7 @@ const getEmptyTeamsMock: MockedResponse<GetLastActiveTeamIdAndTeams> = {
       teams: [],
       getJourneyProfile: {
         __typename: 'JourneyProfile',
+        id: 'journeyProfileId',
         lastActiveTeamId: null
       }
     }

--- a/apps/journeys-admin/src/components/Team/TeamUpdateDialog/TeamUpdateDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamUpdateDialog/TeamUpdateDialog.spec.tsx
@@ -41,6 +41,7 @@ describe('TeamUpdateDialog', () => {
         ],
         getJourneyProfile: {
           __typename: 'JourneyProfile',
+          id: 'journeyProfileId',
           lastActiveTeamId: 'teamId'
         }
       }

--- a/apps/journeys-admin/src/components/Team/TeamUpdateDialog/TeamUpdateDialog.stories.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamUpdateDialog/TeamUpdateDialog.stories.tsx
@@ -40,6 +40,7 @@ const getTeamsMock: MockedResponse<GetLastActiveTeamIdAndTeams> = {
       ],
       getJourneyProfile: {
         __typename: 'JourneyProfile',
+        id: 'journeyProfileId',
         lastActiveTeamId: 'teamId'
       }
     }

--- a/apps/journeys-admin/src/components/Team/UserTeamInviteForm/UserTeamInviteForm.spec.tsx
+++ b/apps/journeys-admin/src/components/Team/UserTeamInviteForm/UserTeamInviteForm.spec.tsx
@@ -57,6 +57,7 @@ describe('UserTeamInviteForm', () => {
         ],
         getJourneyProfile: {
           __typename: 'JourneyProfile',
+          id: 'journeyProfileId',
           lastActiveTeamId: 'teamId'
         }
       }

--- a/apps/journeys-admin/src/components/VisitorsList/VisitorList.spec.tsx
+++ b/apps/journeys-admin/src/components/VisitorsList/VisitorList.spec.tsx
@@ -82,6 +82,7 @@ describe('VisitorList', () => {
         ],
         getJourneyProfile: {
           __typename: 'JourneyProfile',
+          id: 'journeyProfileId',
           lastActiveTeamId: 'teamId'
         }
       }


### PR DESCRIPTION
# Description

fixes team manage dialog create and deleting invitations to team

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/35391220/todos/6863743461)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] it should enable CRUD of Team manage dialog using apollo cache data
- [ ] it should shallow route query params when clicking on copy to dialog
- [ ] it should shallow route query params when clicking team menu 

# Walkthrough

copilot:walkthrough
