### PR TITLE
fix: maintain card aspect ratio

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Canvas/Canvas.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/Canvas.tsx
@@ -132,6 +132,7 @@ export function Canvas(): ReactElement {
             width: 'calc(100% - 32px)',
             maxWidth: 360,
             maxHeight: 640,
+            aspectRatio: '9 / 16',
             display: 'flex',
             borderRadius: 5,
             transition: '0.2s outline ease-out 0.1s',

--- a/apps/journeys-admin/src/components/Editor/Canvas/Canvas.tsx
+++ b/apps/journeys-admin/src/components/Editor/Canvas/Canvas.tsx
@@ -128,11 +128,13 @@ export function Canvas(): ReactElement {
         <Box
           data-testid={`step-${selectedStep.id}`}
           sx={{
-            height: 'calc(100% - 32px)',
-            width: 'calc(100% - 32px)',
+            width: '100%',
             maxWidth: 360,
             maxHeight: 640,
             aspectRatio: '9 / 16',
+            boxSizing: 'border-box',
+            margin: '16px',
+            position: 'relative',
             display: 'flex',
             borderRadius: 5,
             transition: '0.2s outline ease-out 0.1s',


### PR DESCRIPTION
# Description

On admin editor, card should maintain aspect ratio on smaller screens where the maximum card size of 360 x 640 cannot be properly displayed. 

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/35391220/todos/6926638219)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Card should maintain aspect ratio when phone height cannot display the card's height fully (height < 950px)
- [ ] Card and content positioning should be acceptable for the smallest supported screen sizes. 
- [ ] When width cannot be displayed, card shrinks to maintain aspect ratio. 
