### PR TITLE
fix: conditional helpscout theme for login

### DIFF
--- a/apps/journeys-admin/src/components/HelpScoutBeacon/HelpScoutBeacon.tsx
+++ b/apps/journeys-admin/src/components/HelpScoutBeacon/HelpScoutBeacon.tsx
@@ -49,7 +49,15 @@ export function HelpScoutBeacon({
   const [hasLoaded, setHasLoaded] = useState(false)
   const [beaconOpen, setBeaconOpen] = useState(false)
 
+  const newUserPaths = [
+    '/users/sign-in',
+    '/users/terms-and-conditions',
+    '/onboarding-form',
+    '/teams/new'
+  ]
+
   const handleClick = (): void => {
+    console.log(router.route)
     if (window.Beacon != null) {
       window.Beacon('on', 'open', () => {
         setBeaconOpen(true)
@@ -122,7 +130,7 @@ export function HelpScoutBeacon({
           width: 24,
           height: 24,
           color:
-            mdUp || router.route === '/users/sign-in'
+            mdUp || newUserPaths.includes(router.route)
               ? 'secondary.dark'
               : 'background.paper'
         }}

--- a/apps/journeys-admin/src/components/HelpScoutBeacon/HelpScoutBeacon.tsx
+++ b/apps/journeys-admin/src/components/HelpScoutBeacon/HelpScoutBeacon.tsx
@@ -121,7 +121,10 @@ export function HelpScoutBeacon({
           right: { xs: 10, md: 10 },
           width: 24,
           height: 24,
-          color: matches ? 'secondary.dark' : 'background.paper'
+          color:
+            matches || userInfo.email === null
+              ? 'secondary.dark'
+              : 'background.paper'
         }}
       >
         {beaconOpen ? <XCircleContained /> : <HelpCircleContained />}

--- a/apps/journeys-admin/src/components/HelpScoutBeacon/HelpScoutBeacon.tsx
+++ b/apps/journeys-admin/src/components/HelpScoutBeacon/HelpScoutBeacon.tsx
@@ -45,7 +45,7 @@ export function HelpScoutBeacon({
   const { breakpoints, zIndex } = useTheme()
   const router = useRouter()
   const previousUrlRef = useRef(router.asPath)
-  const matches = useMediaQuery(breakpoints.up('md'))
+  const mdUp = useMediaQuery(breakpoints.up('md'))
   const [hasLoaded, setHasLoaded] = useState(false)
   const [beaconOpen, setBeaconOpen] = useState(false)
 
@@ -122,7 +122,7 @@ export function HelpScoutBeacon({
           width: 24,
           height: 24,
           color:
-            matches || userInfo.email === null
+            mdUp || router.route === '/users/sign-in'
               ? 'secondary.dark'
               : 'background.paper'
         }}

--- a/apps/journeys-admin/src/components/HelpScoutBeacon/HelpScoutBeacon.tsx
+++ b/apps/journeys-admin/src/components/HelpScoutBeacon/HelpScoutBeacon.tsx
@@ -57,7 +57,6 @@ export function HelpScoutBeacon({
   ]
 
   const handleClick = (): void => {
-    console.log(router.route)
     if (window.Beacon != null) {
       window.Beacon('on', 'open', () => {
         setBeaconOpen(true)


### PR DESCRIPTION
# Description

On the login page, helpscout icon should have the dark theme regardless of sizing, making it more contrasted and easier to spot. After login, everything functions normally.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/35391220/todos/6872004087)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Create a new user. Button should be dark on all sizes on login page, new user creation (team select, onboarding, etc)
- [ ] After user logs in to journeys home page, button should be dark on a light background, and vice versa.
