### PR TITLE
fix: clear photo author

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ImageBlockHeader/ImageBlockHeader.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockHeader/ImageBlockHeader.tsx
@@ -93,12 +93,12 @@ export function ImageBlockHeader({
             ) : (
               <Typography
                 variant="caption"
-                display={selectedBlock != null ? 'flex' : 'none'}
+                display={
+                  selectedBlock?.src != null && !loading ? 'flex' : 'none'
+                }
                 color="text.secondary"
               >
-                {selectedBlock?.src != null
-                  ? `${selectedBlock.width} x ${selectedBlock.height} pixels`
-                  : ''}
+                {`${selectedBlock?.width} x ${selectedBlock?.height} pixels`}
               </Typography>
             )}
           </Stack>

--- a/apps/journeys-admin/src/components/Editor/ImageBlockHeader/ImageBlockHeader.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockHeader/ImageBlockHeader.tsx
@@ -75,7 +75,9 @@ export function ImageBlockHeader({
                 ? 'Upload failed'
                 : 'No Image Selected'}
             </Typography>
-            {unsplashAuthor != null && selectedBlock?.src != null ? (
+            {unsplashAuthor != null &&
+            selectedBlock?.src != null &&
+            !loading ? (
               <Link
                 href={`https://unsplash.com/@${
                   unsplashAuthor.username ?? ''

--- a/apps/journeys-admin/src/components/Editor/ImageBlockHeader/ImageBlockHeader.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockHeader/ImageBlockHeader.tsx
@@ -67,7 +67,7 @@ export function ImageBlockHeader({
             <Typography variant="subtitle2" color="text.secondary">
               {loading
                 ? 'Image is uploading...'
-                : selectedBlock != null
+                : selectedBlock?.src != null
                 ? 'Selected Image'
                 : showAdd
                 ? 'Select Image'

--- a/apps/journeys-admin/src/components/Editor/ImageBlockHeader/ImageBlockHeader.tsx
+++ b/apps/journeys-admin/src/components/Editor/ImageBlockHeader/ImageBlockHeader.tsx
@@ -75,7 +75,7 @@ export function ImageBlockHeader({
                 ? 'Upload failed'
                 : 'No Image Selected'}
             </Typography>
-            {unsplashAuthor != null ? (
+            {unsplashAuthor != null && selectedBlock?.src != null ? (
               <Link
                 href={`https://unsplash.com/@${
                   unsplashAuthor.username ?? ''
@@ -94,7 +94,7 @@ export function ImageBlockHeader({
                 display={selectedBlock != null ? 'flex' : 'none'}
                 color="text.secondary"
               >
-                {selectedBlock != null
+                {selectedBlock?.src != null
                   ? `${selectedBlock.width} x ${selectedBlock.height} pixels`
                   : ''}
               </Typography>

--- a/apps/journeys-admin/src/components/TemplateGallery/HeaderAndLanguageFilter/LanguagesFilterPopper/LanguagesFilterPopper.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/HeaderAndLanguageFilter/LanguagesFilterPopper/LanguagesFilterPopper.tsx
@@ -5,7 +5,7 @@ import ButtonBase from '@mui/material/ButtonBase'
 import Checkbox from '@mui/material/Checkbox'
 import Popper from '@mui/material/Popper'
 import Stack from '@mui/material/Stack'
-import { styled } from '@mui/material/styles'
+import { styled, useTheme } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
 import { FieldArray, Form, Formik, FormikValues } from 'formik'
 import { Dispatch, ReactElement, SetStateAction } from 'react'
@@ -38,6 +38,8 @@ export function LanguagesFilterPopper({
   anchorEl,
   sortedLanguages
 }: LanguagesFilterPopperProps): ReactElement {
+  const { zIndex } = useTheme()
+
   return (
     <Formik
       initialValues={{
@@ -61,7 +63,7 @@ export function LanguagesFilterPopper({
               left: 0,
               right: 0,
               backgroundColor: 'transparent',
-              zIndex: 9999,
+              zIndex: zIndex.fab,
               display: open ? 'block' : 'none'
             }}
           />
@@ -78,7 +80,7 @@ export function LanguagesFilterPopper({
                   open={open}
                   anchorEl={anchorEl}
                   sx={{
-                    zIndex: 9999,
+                    zIndex: zIndex.fab,
                     py: 2,
                     backgroundColor: 'background.paper',
                     borderRadius: 1,


### PR DESCRIPTION
# Description

Fixed the issue where the image block header would not drop the author name if the photo was deleted. Also fixed the issue where upon creating a new image block, the header would again say "Selected image" although no image had yet been loaded.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/35391220/todos/6930875869)

# How should this PR be QA Tested?

- [ ] On both image background and block image selection, upon deleting an unsplash image, the author's name should disappear properly. (See basecamp video for better context)
- [ ] On creating an image block from the blocks tab, or deleting the cover image of an image block, the image block header label should revert to "No Image Selected". 
