### PR TITLE
feat: substring matching for journey links

### DIFF
--- a/libs/journeys/ui/src/libs/action/action.spec.ts
+++ b/libs/journeys/ui/src/libs/action/action.spec.ts
@@ -125,7 +125,9 @@ describe('action', () => {
       expect(router.push).toHaveBeenCalledWith('fact-or-fiction')
     })
 
-    it('should handle internal LinkAction for Journey Link', () => {
+    it('should not open new tab for internal links to journeys', () => {
+      window.open = jest.fn()
+
       handleAction(router, {
         __typename: 'LinkAction',
         parentBlockId: 'parent-id',
@@ -135,6 +137,7 @@ describe('action', () => {
       expect(router.push).toHaveBeenCalledWith(
         'https://your.nextstep.is/fact-or-fiction'
       )
+      expect(window.open).not.toHaveBeenCalled()
     })
   })
 })

--- a/libs/journeys/ui/src/libs/action/action.spec.ts
+++ b/libs/journeys/ui/src/libs/action/action.spec.ts
@@ -115,7 +115,7 @@ describe('action', () => {
       )
     })
 
-    it('should handle internal LinkAction', () => {
+    it('should handle internal LinkAction for non http url', () => {
       handleAction(router, {
         __typename: 'LinkAction',
         parentBlockId: 'parent-id',
@@ -123,6 +123,18 @@ describe('action', () => {
         url: 'fact-or-fiction'
       })
       expect(router.push).toHaveBeenCalledWith('fact-or-fiction')
+    })
+
+    it('should handle internal LinkAction for Journey Link', () => {
+      handleAction(router, {
+        __typename: 'LinkAction',
+        parentBlockId: 'parent-id',
+        gtmEventName: null,
+        url: 'https://your.nextstep.is/fact-or-fiction'
+      })
+      expect(router.push).toHaveBeenCalledWith(
+        'https://your.nextstep.is/fact-or-fiction'
+      )
     })
   })
 })

--- a/libs/journeys/ui/src/libs/action/action.ts
+++ b/libs/journeys/ui/src/libs/action/action.ts
@@ -32,7 +32,12 @@ export function handleAction(
       nextActiveBlock()
       break
     case 'LinkAction':
-      if (action.url.startsWith('http')) {
+      if (
+        action.url.startsWith('http') &&
+        !action.url.includes('your.nextstep.is') &&
+        !action.url.includes('localhost:4100') &&
+        !action.url.includes('journeys')
+      ) {
         window.open(action.url, '_blank')
       } else {
         void router.push(action.url)

--- a/libs/journeys/ui/src/libs/action/action.ts
+++ b/libs/journeys/ui/src/libs/action/action.ts
@@ -10,6 +10,12 @@ export function handleAction(
   router: NextRouter,
   action?: ActionFields | null
 ): void {
+  const journeysUrls = [
+    'your.nextstep.is',
+    'localhost:4100',
+    'your-stage.nextstep.is'
+  ]
+
   if (action == null) return
   switch (action.__typename) {
     case 'NavigateToBlockAction':
@@ -34,9 +40,7 @@ export function handleAction(
     case 'LinkAction':
       if (
         action.url.startsWith('http') &&
-        !action.url.includes('your.nextstep.is') &&
-        !action.url.includes('localhost:4100') &&
-        !action.url.includes('journeys')
+        !journeysUrls.some((substring) => action.url.includes(substring))
       ) {
         window.open(action.url, '_blank')
       } else {


### PR DESCRIPTION
# Description

Fixed an issue where journey links on buttons would open in a new tab. Now, buttons linked to other journeys should open on the same tab for a smoother UX experience.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/35391220/todos/6943261826)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

Create / Open a Journey with button block(s) that have urls. Some buttons should be linked to Journeys, and some to other websites. 
- [ ] URLs on journeys buttons with new links should open in the same tab
- [ ] Other URLs on journeys buttons should open in a new tab still.
