### PR TITLE
fix: hide most relevant with one tag

### DIFF
--- a/apps/journeys-admin/src/components/TemplateSections/TemplateSections.tsx
+++ b/apps/journeys-admin/src/components/TemplateSections/TemplateSections.tsx
@@ -100,22 +100,23 @@ export function TemplateSections({
 
   return (
     <Stack spacing={8} data-testid="JourneysAdminTemplateSections">
-      {(loading || (collection != null && collection.length > 0)) && (
-        <TemplateGalleryCarousel
-          priority
-          heading={tagIds == null ? t('Featured & New') : t('Most Relevant')}
-          items={collection}
-          renderItem={(itemProps) => <TemplateGalleryCard {...itemProps} />}
-          breakpoints={swiperBreakpoints}
-          loading={loading}
-          slidesOffsetBefore={-8}
-          cardSpacing={{
-            xs: 1,
-            md: 8,
-            xl: 11
-          }}
-        />
-      )}
+      {tagIds?.length !== 1 &&
+        (loading || (collection != null && collection.length > 0)) && (
+          <TemplateGalleryCarousel
+            priority
+            heading={tagIds == null ? t('Featured & New') : t('Most Relevant')}
+            items={collection}
+            renderItem={(itemProps) => <TemplateGalleryCard {...itemProps} />}
+            breakpoints={swiperBreakpoints}
+            loading={loading}
+            slidesOffsetBefore={-8}
+            cardSpacing={{
+              xs: 1,
+              md: 8,
+              xl: 11
+            }}
+          />
+        )}
       {!loading && collection != null && collection.length === 0 && (
         <Paper
           elevation={0}


### PR DESCRIPTION
# Description

"Most relevant" tab should be hidden in templates search when 1 tag is applied. If more tags are applied, section should reappear.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/35391220/todos/6858629274)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] With no tags, should be labelled "Featured & New"
- [ ] With 1 tag, most relevant section should disappear
- [ ] With 2+ tags, most relevant should appear again. 

