### PR TITLE
fix: load more button on video library state

### DIFF
--- a/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoFromLocal/VideoFromLocal.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoFromLocal/VideoFromLocal.tsx
@@ -43,8 +43,7 @@ export function VideoFromLocal({
 }: VideoFromLocalProps): ReactElement {
   const [searchQuery, setSearchQuery] = useState<string>('')
   const [videos, setVideos] = useState<VideoListProps['videos']>()
-  const { loading, data, fetchMore } = useQuery<GetVideos>(GET_VIDEOS, {
-    notifyOnNetworkStatusChange: true,
+  const { loading, fetchMore } = useQuery<GetVideos>(GET_VIDEOS, {
     variables: {
       offset: 0,
       limit: 5,
@@ -76,10 +75,26 @@ export function VideoFromLocal({
   const handleFetchMore = async (): Promise<void> => {
     const response = await fetchMore({
       variables: {
-        offset: data?.videos?.length ?? 0
+        offset: videos?.length ?? 0
       }
     })
-    if (response.data?.videos?.length === 0) setHasMore(false)
+    if (response.data?.videos?.length === 0) {
+      setHasMore(false)
+    } else {
+      console.log('Response in fetch More', response.data.videos)
+      setVideos(prevVideos => [
+        ...(prevVideos ?? []),
+        ...response.data.videos.map((video) => ({
+          id: video.id,
+          title: video.title.find(({ primary }) => primary)?.value,
+          description: video.snippet.find(({ primary }) => primary)?.value,
+          image: video.image ?? '',
+          duration: video.variant?.duration,
+          source: VideoBlockSource.internal
+        }))
+      ])
+    }
+
   }
 
   useEffect(() => setHasMore(true), [searchQuery, setHasMore])

--- a/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoFromLocal/VideoFromLocal.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoFromLocal/VideoFromLocal.tsx
@@ -82,7 +82,7 @@ export function VideoFromLocal({
       setHasMore(false)
     } else {
       console.log('Response in fetch More', response.data.videos)
-      setVideos(prevVideos => [
+      setVideos((prevVideos) => [
         ...(prevVideos ?? []),
         ...response.data.videos.map((video) => ({
           id: video.id,
@@ -94,7 +94,6 @@ export function VideoFromLocal({
         }))
       ])
     }
-
   }
 
   useEffect(() => setHasMore(true), [searchQuery, setHasMore])

--- a/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoFromLocal/VideoFromLocal.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoLibrary/VideoFromLocal/VideoFromLocal.tsx
@@ -81,7 +81,6 @@ export function VideoFromLocal({
     if (response.data?.videos?.length === 0) {
       setHasMore(false)
     } else {
-      console.log('Response in fetch More', response.data.videos)
       setVideos((prevVideos) => [
         ...(prevVideos ?? []),
         ...response.data.videos.map((video) => ({


### PR DESCRIPTION
# Description

Changed state management of the videos array when clicking the load more button.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Check that the load more button works in the video library.

- [ ] Test A
- [ ] Test B

# Considerations
There is most likely another fix for this involving settings with Apollo cache or a more refined pagination implementation.
https://www.apollographql.com/docs/react/pagination/core-api/#the-fetchmore-function

The load was broken because the data from useQuery was overwritten instead of appended. With our current settings in the Apollo cache to videos, this should not happen as far as  I can tell. 

I did remove `notifyOnNetworkStatusChange` from the query. So the query component does not rerender on refetch. The initial data is set by the initial query and subsequent data is appended by the fetchMore query. The rerender was causing both sets of data to be added to videos.

# Walkthrough

copilot:walkthrough
