### PR TITLE
feat: add info message when unmuting autoplay videos

### DIFF
--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.spec.tsx
@@ -137,7 +137,9 @@ describe('VideoBlockEditorSettings', () => {
     )
 
     expect(
-      queryByText(/Some mobile browsers may override this choice/i)
+      queryByText(
+        'Some mobile browsers may override this choice and default the video to play muted when autoplay is enabled'
+      )
     ).not.toBeInTheDocument()
 
     fireEvent.click(getByRole('checkbox', { name: 'Muted' }))

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.spec.tsx
@@ -154,7 +154,9 @@ describe('VideoBlockEditorSettings', () => {
     })
 
     expect(
-      getByText(/Some mobile browsers may override this choice/i)
+      getByText(
+        'Some mobile browsers may override this choice and default the video to play muted when autoplay is enabled'
+      )
     ).toBeInTheDocument()
   })
 

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.spec.tsx
@@ -122,7 +122,7 @@ describe('VideoBlockEditorSettings', () => {
 
   it('should update muted', async () => {
     const onChange = jest.fn()
-    const { getByRole } = render(
+    const { getByRole, getByText, queryByText } = render(
       <ThemeProvider>
         <MockedProvider>
           <SnackbarProvider>
@@ -135,6 +135,11 @@ describe('VideoBlockEditorSettings', () => {
         </MockedProvider>
       </ThemeProvider>
     )
+
+    expect(
+      queryByText(/Some mobile browsers may override this choice/i)
+    ).toBeNull()
+
     fireEvent.click(getByRole('checkbox', { name: 'Muted' }))
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith({
@@ -145,6 +150,10 @@ describe('VideoBlockEditorSettings', () => {
         objectFit: ObjectFit.fill
       })
     })
+
+    expect(
+      getByText(/Some mobile browsers may override this choice/i)
+    ).toBeInTheDocument()
   })
 
   it('should update startAt', async () => {

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.spec.tsx
@@ -138,7 +138,7 @@ describe('VideoBlockEditorSettings', () => {
 
     expect(
       queryByText(/Some mobile browsers may override this choice/i)
-    ).toBeNull()
+    ).not.toBeInTheDocument()
 
     fireEvent.click(getByRole('checkbox', { name: 'Muted' }))
     await waitFor(() => {

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.tsx
@@ -13,9 +13,9 @@ import { useSnackbar } from 'notistack'
 import { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import TimeField from 'react-simple-timefield'
-import InformationCircleContainedIcon from '@core/shared/ui/icons/InformationCircleContained'
 
 import type { TreeBlock } from '@core/journeys/ui/block'
+import InformationCircleContainedIcon from '@core/shared/ui/icons/InformationCircleContained'
 import Play2Icon from '@core/shared/ui/icons/Play2'
 import StopCircleContainedIcon from '@core/shared/ui/icons/StopCircleContained'
 import {

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.tsx
@@ -292,6 +292,16 @@ export function VideoBlockEditorSettings({
               >
                 {t('Video always muted on the first card')}
               </Typography>
+              {values.autoplay && !values.muted && (
+                <Typography
+                  variant="caption"
+                  sx={{
+                    color: 'warning.main'
+                  }}
+                >
+                  {t('Some mobile browsers may override this choice')}
+                </Typography>
+              )}
             </Stack>
             <Switch
               checked={values.muted}

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.tsx
@@ -292,18 +292,16 @@ export function VideoBlockEditorSettings({
               >
                 {t('Video always muted on the first card')}
               </Typography>
-              {values.autoplay != null &&
-                values.muted != null &&
-                !values.muted && (
-                  <Typography
-                    variant="caption"
-                    sx={{
-                      color: 'warning.main'
-                    }}
-                  >
-                    {t('Some mobile browsers may override this choice')}
-                  </Typography>
-                )}
+              {values.autoplay === true && values.muted === false && (
+                <Typography
+                  variant="caption"
+                  sx={{
+                    color: 'warning.main'
+                  }}
+                >
+                  {t('Some mobile browsers may override this choice')}
+                </Typography>
+              )}
             </Stack>
             <Switch
               checked={values.muted}

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.tsx
@@ -13,6 +13,7 @@ import { useSnackbar } from 'notistack'
 import { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import TimeField from 'react-simple-timefield'
+import InformationCircleContainedIcon from '@core/shared/ui/icons/InformationCircleContained'
 
 import type { TreeBlock } from '@core/journeys/ui/block'
 import Play2Icon from '@core/shared/ui/icons/Play2'
@@ -292,16 +293,6 @@ export function VideoBlockEditorSettings({
               >
                 {t('Video always muted on the first card')}
               </Typography>
-              {values.autoplay === true && values.muted === false && (
-                <Typography
-                  variant="caption"
-                  sx={{
-                    color: 'warning.main'
-                  }}
-                >
-                  {t('Some mobile browsers may override this choice')}
-                </Typography>
-              )}
             </Stack>
             <Switch
               checked={values.muted}
@@ -315,6 +306,16 @@ export function VideoBlockEditorSettings({
               }}
             />
           </Stack>
+          {values.autoplay === true && values.muted === false && (
+            <Stack direction="row" alignItems="center" color="text.secondary">
+              <InformationCircleContainedIcon sx={{ mr: 4 }} />
+              <Typography variant="caption">
+                {t(
+                  'Some mobile browsers may override this choice and default the playback to mute when autoplay is enabled'
+                )}
+              </Typography>
+            </Stack>
+          )}
           <Divider />
           <VideoBlockEditorSettingsPoster
             selectedBlock={posterBlock}

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.tsx
@@ -292,16 +292,18 @@ export function VideoBlockEditorSettings({
               >
                 {t('Video always muted on the first card')}
               </Typography>
-              {values.autoplay && !values.muted && (
-                <Typography
-                  variant="caption"
-                  sx={{
-                    color: 'warning.main'
-                  }}
-                >
-                  {t('Some mobile browsers may override this choice')}
-                </Typography>
-              )}
+              {values.autoplay != null &&
+                values.muted != null &&
+                !values.muted && (
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      color: 'warning.main'
+                    }}
+                  >
+                    {t('Some mobile browsers may override this choice')}
+                  </Typography>
+                )}
             </Stack>
             <Switch
               checked={values.muted}

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/Settings/VideoBlockEditorSettings.tsx
@@ -311,7 +311,7 @@ export function VideoBlockEditorSettings({
               <InformationCircleContainedIcon sx={{ mr: 4 }} />
               <Typography variant="caption">
                 {t(
-                  'Some mobile browsers may override this choice and default the playback to mute when autoplay is enabled'
+                  'Some mobile browsers may override this choice and default the video to play muted when autoplay is enabled'
                 )}
               </Typography>
             </Stack>

--- a/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/VideoBlockEditor/VideoBlockEditor.stories.tsx
@@ -279,4 +279,14 @@ export const PosterModal = {
   }
 }
 
+export const Muted = {
+  ...Template,
+  args: {
+    selectedBlock: {
+      ...videoYouTube,
+      muted: true
+    }
+  }
+}
+
 export default BackgroundMediaStory

--- a/libs/locales/en/apps-journeys-admin.json
+++ b/libs/locales/en/apps-journeys-admin.json
@@ -259,6 +259,7 @@
   "Start video automatically when card appears": "Start video automatically when card appears",
   "Muted": "Muted",
   "Video always muted on the first card": "Video always muted on the first card",
+  "Some mobile browsers may override this choice and default the playback to mute when autoplay is enabled": "Some mobile browsers may override this choice and default the playback to mute when autoplay is enabled",
   "Select Video": "Select Video",
   "Custom Video": "Custom Video",
   "YouTube": "YouTube",


### PR DESCRIPTION
# Description
This PR adds work to display an info message letting users know that some mobile browsers may autoplay the video still muted instead of unmuted as the admin intends. 

copilot:summary

- [Link](https://3.basecamp.com/3105655/buckets/35958767/todos/6986085571) to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] When the autoplay option is turned on and the mute option is turned off, an info message should display that lets the user know mobile browsers may override this option.
- [ ] If the autoplay option is turned off and the mute option is turned off, the info message should not be displayed.

# Walkthrough

As an admin on the journey editor. Add a video block for the journey and toggle the autoplay and mute options.

copilot:walkthrough
