### PR TITLE
test: disable visual regression tests for now

### DIFF
--- a/apps/journeys-admin-e2e/src/e2e/journeys-admin.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/journeys-admin.spec.ts
@@ -6,7 +6,7 @@ import { LandingPage } from '../pages/landing-page'
 This is just a sample test
 Test that 'journeys-admin' part of the URL
 */
-test('sample journeys-admin e2e test', async ({ page }) => {
+test('journeys-admin landing page vr test', async ({ page }) => {
   const landingPage = new LandingPage(page)
   await landingPage.goToAdminUrl()
 
@@ -14,8 +14,8 @@ test('sample journeys-admin e2e test', async ({ page }) => {
   const url = page.url()
   console.log('Current URL:', url)
 
-  await expect(page).toHaveScreenshot('home-page.png', {
-    animations: 'disabled',
-    fullPage: true
-  })
+  // await expect(page).toHaveScreenshot('home-page.png', {
+  //   animations: 'disabled',
+  //   fullPage: true
+  // })
 })

--- a/apps/journeys-e2e/src/e2e/journeys.spec.ts
+++ b/apps/journeys-e2e/src/e2e/journeys.spec.ts
@@ -22,27 +22,27 @@ test('journeys', async ({ page }) => {
   await expect(
     page.getByText('Can we trust the story of Jesus?')
   ).toBeInViewport()
-  await expect(page).toHaveScreenshot('can-we-trust.png', {
-    animations: 'disabled',
-    fullPage: true
-  })
+  // await expect(page).toHaveScreenshot('can-we-trust.png', {
+  //   animations: 'disabled',
+  //   fullPage: true
+  // })
   await page.getByText('Yes, it’s a true story 👍').click()
   // Test Video Screen
   await page.getByTestId('JourneysVideoControls').click()
   await page.getByTestId('ConductorNavigationButtonNext').click()
   // Test Jesus in History screen
   await expect(page.getByText('Jesus in History')).toBeInViewport()
-  await expect(page).toHaveScreenshot('jesus-history.png', {
-    animations: 'disabled',
-    fullPage: true
-  })
+  // await expect(page).toHaveScreenshot('jesus-history.png', {
+  //   animations: 'disabled',
+  //   fullPage: true
+  // })
   await page.getByText('One question remains', { exact: false }).click()
   // Test Who was this Jesus? screen
   await expect(page.getByText('Who was this Jesus?')).toBeInViewport()
-  await expect(page).toHaveScreenshot('who-was-jesus.png', {
-    animations: 'disabled',
-    fullPage: true
-  })
+  // await expect(page).toHaveScreenshot('who-was-jesus.png', {
+  //   animations: 'disabled',
+  //   fullPage: true
+  // })
   await page.getByText('The Son of God').click()
   // Test navigation to next journey
   await expect(page).toHaveURL(/.*what-about-the-resurrection/)


### PR DESCRIPTION
# Description
Disable visual regression tests for now while large design changes are on the way. We will enable them back once all those design changes are stabilised.

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

copilot:walkthrough
