### PR TITLE
feat: center navigation button to viewport

### DIFF
--- a/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.tsx
+++ b/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.tsx
@@ -214,16 +214,11 @@ export function NavigationButton({
       sx={{
         ...alignSx,
         position: 'absolute',
-        // StepFooter heights
-        bottom: { xs: '170px', sm: '133px', lg: '60.5px' },
+        top: 0,
         zIndex: 2,
         display: 'flex',
         width: { xs: 82, lg: 114 },
-        height: {
-          xs: 'calc(100vh - 275px)',
-          sm: 'calc(100vh - 238px)',
-          lg: 'calc(100% - 105px)'
-        },
+        height: '100svh',
         alignItems: 'center',
         pointerEvents: 'none'
       }}


### PR DESCRIPTION
# Description
Centers the Navigation Buttons to the viewport instead of the fixed width between the step header and step footer


- [Link](https://3.basecamp.com/3105655/buckets/35958878/todos/6970068229) to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Navigation Buttons should be centered to viewport for mobile, tablet, and desktop
- [ ] Header and Footer actions are not blocked

# Walkthrough
