### PR TITLE
feat: set drawer action for text response blocks

### DIFF
--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/TextResponse/TextResponse.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/TextResponse/TextResponse.tsx
@@ -1,5 +1,5 @@
 import Divider from '@mui/material/Divider'
-import { ReactElement } from 'react'
+import { ReactElement, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { TreeBlock } from '@core/journeys/ui/block'
@@ -32,6 +32,19 @@ export function TextResponse({
   const submitLabel = icons.find(
     ({ value }) => value === submitIcon?.iconName
   )?.label
+
+  useEffect(() => {
+    dispatch({
+      type: 'SetSelectedAttributeIdAction',
+      id: `${id}-text-field-options`
+    })
+    dispatch({
+      type: 'SetDrawerPropsAction',
+      title: t('Feedback Properties'),
+      mobileOpen: true,
+      children: <TextResponseFields />
+    })
+  }, [dispatch, id, t])
 
   return (
     <>

--- a/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/TextResponse/TextResponseFields/Label/Label.tsx
+++ b/apps/journeys-admin/src/components/Editor/ControlPanel/Attributes/blocks/TextResponse/TextResponseFields/Label/Label.tsx
@@ -65,7 +65,11 @@ export function Label(): ReactElement {
   return (
     <Box sx={{ px: 6, py: 4 }} data-testid="Label">
       {selectedBlock != null ? (
-        <Formik initialValues={initialValues} onSubmit={noop}>
+        <Formik
+          initialValues={initialValues}
+          onSubmit={noop}
+          enableReinitialize
+        >
           {({ values, errors, handleChange, handleBlur, setValues }) => (
             <Form>
               <TextField


### PR DESCRIPTION
# Description
Sets the selected attribute and opens the editor drawer for Feedback blocks

- [Link](https://3.basecamp.com/3105655/buckets/35958878/todos/7072352129) to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Should set the selected attribute to the Feedback Properties when selecting the block
- [ ] Should open the editor drawer with the Property options when selecting the block
- [ ] Text field values should change to reflect their respective block if there are multiple feedback blocks

# Walkthrough

