### PR TITLE
fix: overflow caused by inactive card height

### DIFF
--- a/apps/journeys/src/components/Conductor/DynamicCardList/DynamicCardList.tsx
+++ b/apps/journeys/src/components/Conductor/DynamicCardList/DynamicCardList.tsx
@@ -39,13 +39,11 @@ export function DynamicCardList(): ReactElement {
 
         const cardSx: SxProps = isCurrent
           ? {
-              height: '100%',
               width: 'inherit',
               position: 'relative',
               display: 'block'
             }
           : {
-              height: 'inherit',
               width: '-webkit-fill-available',
               position: 'absolute',
               top: 0,
@@ -62,6 +60,7 @@ export function DynamicCardList(): ReactElement {
               className={isCurrent ? 'active-card' : undefined}
               onClick={() => setShowNavigation(true)}
               sx={{
+                height: '100%',
                 ...cardSx
               }}
             >

--- a/apps/journeys/src/components/Conductor/SwipeNavigation/SwipeNavigation.tsx
+++ b/apps/journeys/src/components/Conductor/SwipeNavigation/SwipeNavigation.tsx
@@ -190,7 +190,8 @@ export function SwipeNavigation({
       sx={{
         height: 'inherit',
         maxHeight: 'inherit',
-        overflow: 'hidden'
+        overflow: 'hidden',
+        position: 'relative'
       }}
       {...swipeHandlers}
     >


### PR DESCRIPTION
# Description
This should fix the next pre-rendered card causing overflow. `DynamicCardList` was not properly inheriting the height from `SwipeNavigation` due to the missing `max-height` value and absolute positioning. 

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] The viewport should no longer scroll when viewing journeys with multiple steps

# Walkthrough
