### PR TITLE
fix: hide navbar on templates

### DIFF
--- a/apps/journeys-admin/pages/templates/index.tsx
+++ b/apps/journeys-admin/pages/templates/index.tsx
@@ -39,6 +39,8 @@ function TemplateIndexPage(): ReactElement {
         user={user}
         mainBodyPadding={false}
         showMainHeader={false}
+        showAppHeader={user?.id != null}
+        showNavBar={user?.id != null}
       >
         <TemplateGallery />
       </PageWrapper>

--- a/apps/journeys-admin/src/components/PageWrapper/PageWrapper.stories.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/PageWrapper.stories.tsx
@@ -224,6 +224,23 @@ export const CustomSidePanel = {
   }
 }
 
+export const NoNavBar = {
+  ...Template,
+  args: {
+    ...Default.args,
+    showNavBar: false
+  }
+}
+
+export const NoHeader = {
+  ...Template,
+  args: {
+    ...Default.args,
+    showMainHeader: false,
+    showAppHeader: false
+  }
+}
+
 export const Complete = {
   ...Template,
   args: {

--- a/apps/journeys-admin/src/components/PageWrapper/PageWrapper.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/PageWrapper.tsx
@@ -19,6 +19,7 @@ interface PageWrapperProps {
   showAppHeader?: boolean
   title?: string
   showMainHeader?: boolean
+  showNavBar?: boolean
   backHref?: string
   backHrefHistory?: boolean
   mainHeaderChildren?: ReactNode
@@ -41,6 +42,7 @@ export function PageWrapper({
   showAppHeader = true,
   title,
   showMainHeader = true,
+  showNavBar = true,
   backHref,
   backHrefHistory,
   mainHeaderChildren,
@@ -71,20 +73,25 @@ export function PageWrapper({
         data-testid="JourneysAdminPageWrapper"
       >
         <Stack direction={{ md: 'row' }} sx={{ height: 'inherit' }}>
-          <NavigationDrawer
-            open={open}
-            onClose={setOpen}
-            user={user}
-            selectedPage={router?.pathname?.split('/')[1]}
-          />
+          {showNavBar && (
+            <NavigationDrawer
+              open={open}
+              onClose={setOpen}
+              user={user}
+              selectedPage={router?.pathname?.split('/')[1]}
+            />
+          )}
 
           <Stack
             flexGrow={1}
             direction={{ xs: 'column', md: 'row' }}
             sx={{
               backgroundColor: 'background.default',
-              width: { xs: '100vw', md: `calc(100vw - ${navbar.width})` },
-              pt: { xs: toolbar.height, md: 0 },
+              width: {
+                xs: '100vw',
+                md: showNavBar ? `calc(100vw - ${navbar.width})` : '100vw'
+              },
+              pt: { xs: showAppHeader ? toolbar.height : 0, md: 0 },
               pb: {
                 xs: bottomPanelChildren != null ? bottomPanel.height : 0,
                 md: 0


### PR DESCRIPTION
# Description

Hide the navbar on templates when there is no logged in user.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/36562315/todos/7145661788)

# How should this PR be QA Tested?

**Requirements**
Visit the templates page
Log out if you're logged in

- [ ] it shouldn't show the navbar when there is no logged in user
- [ ] it shouldn't show the header when there is no logged in user
- [ ] it should show the navbar when there is a logged in user
- [ ] it should show the header when there is a logged in user

# Walkthrough

copilot:walkthrough
