### PR TITLE
fix: logging level on datadog

### DIFF
--- a/apps/journeys-admin/next-logger.config.js
+++ b/apps/journeys-admin/next-logger.config.js
@@ -6,6 +6,14 @@ tracer.init({
   logInjection: true
 })
 
+const logger = (defaultConfig) =>
+  pino({
+    ...defaultConfig,
+    formatters: {
+      level: (label, _number) => ({ level: label })
+    }
+  })
+
 module.exports = {
-  logger: pino
+  logger
 }


### PR DESCRIPTION
# Description

[Make pino Log Messages Appear with the Correct Status in Datadog](https://benlimmer.com/2020/10/23/make-pino-log-messages-appear-with-the-correct-status-in-datadog/).