### PR TITLE
fix: sign in redirect issue

### DIFF
--- a/apps/journeys-admin/src/components/SignIn/PasswordPage/PasswordPage.tsx
+++ b/apps/journeys-admin/src/components/SignIn/PasswordPage/PasswordPage.tsx
@@ -29,7 +29,6 @@ export function PasswordPage({
     event.preventDefault()
   }
   const { t } = useTranslation('apps-journeys-admin')
-  const router = useRouter()
   const validationSchema = object().shape({
     email: string()
       .trim()
@@ -41,13 +40,6 @@ export function PasswordPage({
   async function handleLogin(values, { setFieldError }): Promise<void> {
     try {
       await signInWithEmailAndPassword(auth, values.email, values.password)
-      const redirect =
-        router.query.redirect != null
-          ? new URL(
-              `${window.location.origin}${router.query.redirect as string}`
-            )
-          : '/'
-      await router.push(redirect)
     } catch (error) {
       if (error.code === 'auth/wrong-password') {
         setFieldError(


### PR DESCRIPTION
# Description

Signing in is causing our users to get to a 404 page. This is due to the redirect URL not being set right.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/36562315/todos/7180739223)

# How should this PR be QA Tested?

- [ ] it should not redirect our users to a 404 page
- [ ] it should sign in our users to admin

# Walkthrough

copilot:walkthrough
