### PR TITLE
test: test for cancel button

### DIFF
--- a/apps/journeys-admin/src/components/SignIn/RegisterPage/RegisterPage.spec.tsx
+++ b/apps/journeys-admin/src/components/SignIn/RegisterPage/RegisterPage.spec.tsx
@@ -5,6 +5,7 @@ import {
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword
 } from 'firebase/auth'
+import { NextRouter, useRouter } from 'next/router'
 
 import { RegisterPage } from './RegisterPage'
 
@@ -15,7 +16,25 @@ jest.mock('firebase/auth', () => ({
   updateProfile: jest.fn()
 }))
 
+jest.mock('next/router', () => ({
+  __esModule: true,
+  useRouter: jest.fn()
+}))
+const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
+
 describe('PasswordPage', () => {
+  const back = jest.fn()
+
+  beforeEach(() => {
+    mockUseRouter.mockReturnValue({
+      back,
+      push: jest.fn(),
+      query: {
+        redirect: null
+      }
+    } as unknown as NextRouter)
+  })
+
   it('should render register page', () => {
     const { getByText, getByRole } = render(
       <RegisterPage setActivePage={jest.fn()} userEmail="example@example.com" />
@@ -174,5 +193,12 @@ describe('PasswordPage', () => {
     await waitFor(() => {
       expect(mockSetActivePage).toHaveBeenCalledWith('home')
     })
+  })
+
+  it('should navigate back when clicking cancel button', () => {
+    const { getByRole } = render(<RegisterPage />)
+    fireEvent.click(getByRole('button', { name: 'Cancel' }))
+
+    expect(back).toHaveBeenCalled()
   })
 })

--- a/apps/journeys-admin/src/components/SignIn/RegisterPage/RegisterPage.tsx
+++ b/apps/journeys-admin/src/components/SignIn/RegisterPage/RegisterPage.tsx
@@ -13,6 +13,7 @@ import {
   updateProfile
 } from 'firebase/auth'
 import { Form, Formik } from 'formik'
+import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import React, { ReactElement } from 'react'
 import { object, string } from 'yup'
@@ -26,6 +27,7 @@ export function RegisterPage({
 }: PageProps): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   const [showPassword, setShowPassword] = React.useState(false)
+  const router = useRouter()
 
   useHandleNewAccountRedirect()
 
@@ -176,7 +178,10 @@ export function RegisterPage({
                   variant="text"
                   size="large"
                   fullWidth
-                  onClick={() => setActivePage?.('home')}
+                  onClick={() => {
+                    setActivePage?.('home')
+                    router.back()
+                  }}
                 >
                   {t('Cancel')}
                 </Button>


### PR DESCRIPTION
# Description

Fixed issue where createAccount was still in the redirect even after navigating back from the `RegisterPage`

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/36562315/todos/7181040827)
# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] should remove createAccount when clicking cancel on the `RegisterPage`

# Walkthrough

copilot:walkthrough
