### PR TITLE
fix: redirect issue

### DIFF
--- a/apps/journeys-admin/src/components/OnboardingPageWrapper/OnboardingDrawer/OnboardingDrawer.tsx
+++ b/apps/journeys-admin/src/components/OnboardingPageWrapper/OnboardingDrawer/OnboardingDrawer.tsx
@@ -25,11 +25,9 @@ export function OnboardingDrawer(): ReactElement {
     if (url == null) return
 
     const redirect = decodeURIComponent(url)
-    const pathnameParts = redirect?.split('/')
-    if (redirect?.includes('templates') && pathnameParts != null) {
-      const idIndex = pathnameParts.indexOf('templates') + 1
-      const id = pathnameParts[idIndex]
-      return id.split('?')[0]
+    const match = redirect.match(/\/templates\/([^/?]+)/)
+    if (match) {
+      return match[1]
     }
   }
 

--- a/apps/journeys-admin/src/components/OnboardingPageWrapper/OnboardingDrawer/OnboardingDrawer.tsx
+++ b/apps/journeys-admin/src/components/OnboardingPageWrapper/OnboardingDrawer/OnboardingDrawer.tsx
@@ -26,7 +26,7 @@ export function OnboardingDrawer(): ReactElement {
 
     const redirect = decodeURIComponent(url)
     const match = redirect.match(/\/templates\/([^/?]+)/)
-    if (match) {
+    if (match != null) {
       return match[1]
     }
   }

--- a/apps/journeys-admin/src/components/Team/TeamOnboarding/TeamOnboarding.spec.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamOnboarding/TeamOnboarding.spec.tsx
@@ -327,8 +327,6 @@ describe('TeamOnboarding', () => {
       ])
     )
     expect(getByText('Team Title created.')).toBeInTheDocument()
-    expect(push).toHaveBeenCalledWith(
-      new URL('http://localhost/custom-location')
-    )
+    expect(push).toHaveBeenCalledWith('/custom-location')
   })
 })

--- a/apps/journeys-admin/src/components/Team/TeamOnboarding/TeamOnboarding.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamOnboarding/TeamOnboarding.tsx
@@ -31,7 +31,7 @@ export function TeamOnboarding(): ReactElement {
   async function handleSubmit(data?: TeamCreate | null): Promise<void> {
     const redirect =
       router.query.redirect != null
-        ? new URL(`${window.location.origin}${router.query.redirect as string}`)
+        ? `${router.query.redirect as string}`
         : '/?onboarding=true'
 
     if (data?.teamCreate.id == null) return

--- a/apps/journeys-admin/src/libs/useRedirectNewAccount/useHandleNewAccountRedirect.spec.tsx
+++ b/apps/journeys-admin/src/libs/useRedirectNewAccount/useHandleNewAccountRedirect.spec.tsx
@@ -22,12 +22,12 @@ describe('HandleNewAccountRedirect', () => {
     jest.clearAllMocks()
   })
 
-  it('should append newAccount to redirect', () => {
+  it('should return redirect if exists', () => {
     mockUseRouter.mockReturnValue({
       push,
       pathname: '/users/sign-in',
       query: {
-        redirect: 'http://localhost:4200/'
+        redirect: 'http://localhost:4200/customparam'
       },
       asPath: '/users/sign-in'
     } as unknown as NextRouter)
@@ -36,7 +36,26 @@ describe('HandleNewAccountRedirect', () => {
     expect(push).toHaveBeenCalledWith({
       pathname: '/users/sign-in',
       query: {
-        redirect: 'http://localhost:4200?newAccount=true'
+        redirect: 'http://localhost:4200/customparam'
+      }
+    })
+  })
+
+  it('should append newAccount to redirect', () => {
+    mockUseRouter.mockReturnValue({
+      push,
+      pathname: '/users/sign-in',
+      query: {
+        redirect: 'http://localhost:4200/?createNew=true'
+      },
+      asPath: '/users/sign-in'
+    } as unknown as NextRouter)
+    renderHook(() => useHandleNewAccountRedirect())
+
+    expect(push).toHaveBeenCalledWith({
+      pathname: '/users/sign-in',
+      query: {
+        redirect: 'http://localhost:4200/?createNew=true&newAccount=true'
       }
     })
   })

--- a/apps/journeys-admin/src/libs/useRedirectNewAccount/useHandleNewAccountRedirect.spec.tsx
+++ b/apps/journeys-admin/src/libs/useRedirectNewAccount/useHandleNewAccountRedirect.spec.tsx
@@ -41,12 +41,12 @@ describe('HandleNewAccountRedirect', () => {
     })
   })
 
-  it('should append newAccount to redirect', () => {
+  it('should append newAccount to url', () => {
     mockUseRouter.mockReturnValue({
       push,
       pathname: '/users/sign-in',
       query: {
-        redirect: 'http://localhost:4200/?createNew=true'
+        redirect: null
       },
       asPath: '/users/sign-in'
     } as unknown as NextRouter)
@@ -55,7 +55,7 @@ describe('HandleNewAccountRedirect', () => {
     expect(push).toHaveBeenCalledWith({
       pathname: '/users/sign-in',
       query: {
-        redirect: 'http://localhost:4200/?createNew=true&newAccount=true'
+        redirect: 'http://localhost:4200?newAccount=true'
       }
     })
   })

--- a/apps/journeys-admin/src/libs/useRedirectNewAccount/useHandleNewAccountRedirect.ts
+++ b/apps/journeys-admin/src/libs/useRedirectNewAccount/useHandleNewAccountRedirect.ts
@@ -6,6 +6,7 @@ export function useHandleNewAccountRedirect(): void {
 
   useEffect(() => {
     const redirectUrl = router.query.redirect as string
+    console.log('redirectUrl', redirectUrl)
 
     let updatedRedirectUrl
 
@@ -13,9 +14,12 @@ export function useHandleNewAccountRedirect(): void {
     const containsCreateNew = redirectUrl?.includes('createNew')
 
     if (!containsNewAccount) {
-      if (containsCreateNew && redirectUrl != null) {
-        updatedRedirectUrl = `${redirectUrl ?? ''}&newAccount=true`
+      if (redirectUrl != null) {
+        updatedRedirectUrl = `${redirectUrl ?? ''}${
+          containsCreateNew ? '&newAccount=true' : ''
+        }`
       } else {
+        console.log('window location origin ran')
         updatedRedirectUrl = `${window.location.origin}?newAccount=true`
       }
     }

--- a/apps/journeys-admin/src/libs/useRedirectNewAccount/useHandleNewAccountRedirect.ts
+++ b/apps/journeys-admin/src/libs/useRedirectNewAccount/useHandleNewAccountRedirect.ts
@@ -6,7 +6,6 @@ export function useHandleNewAccountRedirect(): void {
 
   useEffect(() => {
     const redirectUrl = router.query.redirect as string
-    console.log('redirectUrl', redirectUrl)
 
     let updatedRedirectUrl
 

--- a/apps/journeys-admin/src/libs/useRedirectNewAccount/useHandleNewAccountRedirect.ts
+++ b/apps/journeys-admin/src/libs/useRedirectNewAccount/useHandleNewAccountRedirect.ts
@@ -18,7 +18,6 @@ export function useHandleNewAccountRedirect(): void {
           containsCreateNew ? '&newAccount=true' : ''
         }`
       } else {
-        console.log('window location origin ran')
         updatedRedirectUrl = `${window.location.origin}?newAccount=true`
       }
     }


### PR DESCRIPTION
# Description

Getting a 500 error when users goes away from verification page to templates page. And also gives a 404 error when a user logs in through google

[- 404 error after creating teams through google](https://3.basecamp.com/3105655/buckets/36562315/todos/7200590006)
[- 500 error when redirect from templates to verification](https://3.basecamp.com/3105655/buckets/36562315/todos/7200871234)

# How should this PR be QA Tested?

- [ ] it should not return a 500 error when redirecting from templates page to redirection (create account until verification, visit templates page, should redirect to verification page)
- [ ] it should not return a 404 error after creating teams

# Walkthrough

copilot:walkthrough
