### PR TITLE
test: add tests for editor Content

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Content.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Content.spec.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react'
+
+import { ActiveContent, EditorProvider } from '@core/journeys/ui/EditorProvider'
+
+import { Content } from '.'
+
+jest.mock('@mui/material/useMediaQuery', () => ({
+  __esModule: true,
+  default: jest.fn(() => false)
+}))
+
+describe('Content', () => {
+  it('should render social preview', () => {
+    render(
+      <EditorProvider initialState={{ activeContent: ActiveContent.Social }}>
+        <Content />
+      </EditorProvider>
+    )
+
+    expect(screen.getByTestId('SocialPreview')).toBeInTheDocument()
+  })
+
+  it('should render goals', () => {
+    render(
+      <EditorProvider initialState={{ activeContent: ActiveContent.Goals }}>
+        <Content />
+      </EditorProvider>
+    )
+
+    expect(screen.getByTestId('Goals')).toBeInTheDocument()
+  })
+
+  it('should render canvas', () => {
+    render(
+      <EditorProvider initialState={{ activeContent: ActiveContent.Canvas }}>
+        <Content />
+      </EditorProvider>
+    )
+
+    expect(screen.getByTestId('EditorCanvas')).toBeInTheDocument()
+  })
+})

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Goals/Goals.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Goals/Goals.tsx
@@ -60,6 +60,7 @@ export function Goals(): ReactElement {
       }
       py={6}
       flexGrow={1}
+      data-testid="Goals"
     >
       {journey != null &&
         (goals != null && goals.length > 0 ? (


### PR DESCRIPTION
# Description
- Adds tests for editor `Content`

[Link](https://3.basecamp.com/3105655/buckets/36562260/todos/7145951569) to Basecamp Todo