### PR TITLE
test: remove teamName check from response time check

### DIFF
--- a/apps/journeys-admin-e2e/src/e2e/response-time.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/response-time.spec.ts
@@ -1,15 +1,12 @@
 /* eslint-disable playwright/expect-expect */
 import { expect, test } from '@playwright/test'
 
-import { getTeamName } from '../framework/helpers'
 import { LandingPage } from '../pages/landing-page'
 import { LoginPage } from '../pages/login-page'
-import { TopNav } from '../pages/top-nav'
 
 test('Home page - response time test', async ({ page, browser }) => {
   const landingPage = new LandingPage(page)
   const loginPage = new LoginPage(page)
-  const topNav = new TopNav(page)
   await browser.startTracing()
   await landingPage.goToAdminUrl()
 
@@ -17,11 +14,6 @@ test('Home page - response time test', async ({ page, browser }) => {
 
   // Using Performanc.mark API
   await page.evaluate(() => window.performance.mark('Start:FoF'))
-
-  // Get team name from env vars compare it with actual team name in the app
-  const teamName = await getTeamName()
-  await topNav.clickTeamName(teamName)
-  expect(await topNav.getTeamName()).toContain(teamName)
 
   // Using performance.mark API
   await page.evaluate(() => window.performance.mark('End:FoF'))


### PR DESCRIPTION
# Description
Tests running in CI fail to check 'teamName' as it always defaults to the recently used team. However, while writing other tests, we change the team name for the automated test user. So removing this check for now. 

This will be later added as a separate test.

copilot:summary

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

copilot:walkthrough
