### PR TITLE
feat: proxy client side graphql requests via rewrite

### DIFF
--- a/apps/journeys/next.config.js
+++ b/apps/journeys/next.config.js
@@ -45,6 +45,15 @@ const nextConfig = {
         'node_modules/esbuild-linux-64/bin'
       ]
     }
+  },
+  async rewrites() {
+    return [
+      {
+        source: '/graphql',
+        destination: process.env.GATEWAY_URL,
+        locale: false
+      }
+    ]
   }
 }
 module.exports = composePlugins(withNx)(nextConfig)

--- a/apps/journeys/next.config.js
+++ b/apps/journeys/next.config.js
@@ -50,8 +50,7 @@ const nextConfig = {
     return [
       {
         source: '/api/graphql',
-        destination: process.env.GATEWAY_URL,
-        locale: false
+        destination: process.env.GATEWAY_URL
       }
     ]
   }

--- a/apps/journeys/next.config.js
+++ b/apps/journeys/next.config.js
@@ -49,7 +49,7 @@ const nextConfig = {
   async rewrites() {
     return [
       {
-        source: '/graphql',
+        source: '/api/graphql',
         destination: process.env.GATEWAY_URL,
         locale: false
       }

--- a/apps/journeys/src/libs/apolloClient/apolloClient.ts
+++ b/apps/journeys/src/libs/apolloClient/apolloClient.ts
@@ -12,7 +12,7 @@ import { firebaseClient } from '../firebaseClient'
 import { cache } from './cache'
 
 const httpLink = createHttpLink({
-  uri: process.env.GATEWAY_URL ?? '/graphql'
+  uri: process.env.GATEWAY_URL ?? '/api/graphql'
 })
 
 let signInPromise: Promise<UserCredential>

--- a/apps/journeys/src/libs/apolloClient/apolloClient.ts
+++ b/apps/journeys/src/libs/apolloClient/apolloClient.ts
@@ -12,7 +12,7 @@ import { firebaseClient } from '../firebaseClient'
 import { cache } from './cache'
 
 const httpLink = createHttpLink({
-  uri: process.env.NEXT_PUBLIC_GATEWAY_URL
+  uri: process.env.GATEWAY_URL ?? '/graphql'
 })
 
 let signInPromise: Promise<UserCredential>


### PR DESCRIPTION
# Description

Proxy client side GraphQL API requests through the current domain using a rewrite. Server side requests will still go directly to the GraphQL API. This will help hide the jesusfilm.org domain from NextSteps and future custom domains.
