### PR TITLE
fix: embedded videos playing when not activeStep

### DIFF
--- a/libs/journeys/ui/src/components/Video/VideoControls/VideoControls.tsx
+++ b/libs/journeys/ui/src/components/Video/VideoControls/VideoControls.tsx
@@ -214,11 +214,11 @@ export function VideoControls({
         setShowHeaderFooter(!fullscreen)
       }
 
-      if (!fullscreen && variant === 'embed' && !iPhone()) {
+      if (!fullscreen && variant === 'embed' && !iPhone() && activeStep) {
         player.pause()
       }
 
-      if (fullscreen && variant === 'embed' && !iPhone()) {
+      if (fullscreen && variant === 'embed' && !iPhone() && activeStep) {
         void player.play()
       }
     }


### PR DESCRIPTION
# Description
- Fixes bug causing videos on the second card of embedded journeys to play automatically when the embedded journey enters fullscreen

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Embedded journeys with a video on the second card should not play when the embedded journey enters fullscreen
- [ ] Test B
