### PR TITLE
chore: add journeys-stage app

### DIFF
--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -218,15 +218,6 @@ jobs:
     outputs:
       url: ${{ steps.deployment-url.outputs.deployment-url }}
     steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_EVENT_NAME: ${{  github.event_name }}
-          GITHUB_REF: ${{ github.ref }}
-          MATRIX_CONTEXT: ${{ toJson(matrix) }}
-        run: |
-          echo "GITHUB_EVENT_NAME: $GITHUB_EVENT_NAME"
-          echo "GITHUB_REF: $GITHUB_REF"
-          echo "MATRIX_CONTEXT: $MATRIX_CONTEXT"
       - name: start deployment
         uses: chrnorm/deployment-action@v2
         id: deployment

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -44,7 +44,10 @@ jobs:
     name: Deploy Preview and Test
     needs: affected
     # if branch is not main or is a pull request
-    # and not stage branch, push and journeys app
+    # and not:
+    # - stage branch
+    # - push
+    # - journeys app
     if: |
       ${{
         needs.affected.outputs.matrix != '[]' &&
@@ -194,9 +197,9 @@ jobs:
     # or stage branch where app is journeys
     if: |
       ${{
-        github.event_name != 'pull_request' &&
         needs.affected.outputs.matrix != '[]' &&
-        needs.affected.outputs.matrix != '' && (
+        needs.affected.outputs.matrix != '' &&
+        github.event_name != 'pull_request' && (
           (
             github.ref == 'refs/heads/main' &&
             fromJson(needs.affected.outputs.matrix) != 'journeys-admin'
@@ -219,6 +222,15 @@ jobs:
     outputs:
       url: ${{ steps.deployment-url.outputs.deployment-url }}
     steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_EVENT_NAME: ${{  github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
+        run: |
+          echo "GITHUB_EVENT_NAME: $GITHUB_EVENT_NAME"
+          echo "GITHUB_REF: $GITHUB_REF"
+          echo "MATRIX_CONTEXT: $MATRIX_CONTEXT"
       - name: start deployment
         uses: chrnorm/deployment-action@v2
         id: deployment

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -43,8 +43,20 @@ jobs:
   deploy-preview:
     name: Deploy Preview and Test
     needs: affected
-    # feature branch, stage branch, or pull request
-    if: ${{ needs.affected.outputs.matrix != '[]' && needs.affected.outputs.matrix != '' && (github.ref != 'refs/heads/main' || github.event_name == 'pull_request') }}
+    # if branch is not main or is a pull request
+    # and not stage branch, push and journeys app
+    if: |
+      ${{
+        needs.affected.outputs.matrix != '[]' &&
+        needs.affected.outputs.matrix != '' && (
+          github.ref != 'refs/heads/main' || 
+          github.event_name == 'pull_request'
+        ) && !(
+          github.ref == 'refs/heads/stage' &&
+          github.event_name == 'push' &&
+          fromJson(needs.affected.outputs.matrix) == 'journeys'
+        )
+      }}
     strategy:
       fail-fast: false
       matrix:
@@ -86,7 +98,7 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           DOCS_VERCEL_PROJECT_ID: ${{ secrets.DOCS_VERCEL_PROJECT_ID }}
-          JOURNEYS_VERCEL_PROJECT_ID: ${{ secrets.JOURNEYS_VERCEL_PROJECT_ID }}
+          JOURNEYS_VERCEL_PROJECT_ID: ${{ secrets.JOURNEYS_STAGE_VERCEL_PROJECT_ID }}
           JOURNEYS_ADMIN_VERCEL_PROJECT_ID: ${{ secrets.JOURNEYS_ADMIN_VERCEL_PROJECT_ID }}
           NEXUS_ADMIN_VERCEL_PROJECT_ID: ${{ secrets.NEXUS_ADMIN_VERCEL_PROJECT_ID }}
           WATCH_VERCEL_PROJECT_ID: ${{ secrets.WATCH_VERCEL_PROJECT_ID }}
@@ -177,8 +189,23 @@ jobs:
         run: exit 1
   deploy-production:
     name: Deploy Production
-    # main branch and not a pull request
-    if: ${{ needs.affected.outputs.matrix != '[]' && needs.affected.outputs.matrix != '' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && fromJson(needs.affected.outputs.matrix) != 'journeys-admin' }}
+    # if not a pull request
+    # and main branch where app is not journeys-admin
+    # or stage branch where app is journeys
+    if: |
+      ${{
+        github.event_name != 'pull_request' &&
+        needs.affected.outputs.matrix != '[]' &&
+        needs.affected.outputs.matrix != '' && (
+          (
+            github.ref == 'refs/heads/main' &&
+            fromJson(needs.affected.outputs.matrix) != 'journeys-admin'
+          ) || (
+            github.ref == 'refs/heads/stage' &&
+            fromJson(needs.affected.outputs.matrix) == 'journeys'
+          )
+        )
+      }}
     needs: affected
     strategy:
       fail-fast: false
@@ -220,7 +247,7 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           DOCS_VERCEL_PROJECT_ID: ${{ secrets.DOCS_VERCEL_PROJECT_ID }}
-          JOURNEYS_VERCEL_PROJECT_ID: ${{ secrets.JOURNEYS_VERCEL_PROJECT_ID }}
+          JOURNEYS_VERCEL_PROJECT_ID: ${{ github.ref == 'refs/heads/stage' && secrets.JOURNEYS_STAGE_VERCEL_PROJECT_ID || secrets.JOURNEYS_VERCEL_PROJECT_ID }}
           JOURNEYS_ADMIN_VERCEL_PROJECT_ID: ${{ secrets.JOURNEYS_ADMIN_VERCEL_PROJECT_ID }}
           NEXUS_ADMIN_VERCEL_PROJECT_ID: ${{ secrets.NEXUS_ADMIN_VERCEL_PROJECT_ID }}
           WATCH_VERCEL_PROJECT_ID: ${{ secrets.WATCH_VERCEL_PROJECT_ID }}

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -49,17 +49,15 @@ jobs:
     # - push
     # - journeys app
     if: |
-      ${{
-        needs.affected.outputs.matrix != '[]' &&
-        needs.affected.outputs.matrix != '' && (
-          github.ref != 'refs/heads/main' || 
-          github.event_name == 'pull_request'
-        ) && !(
-          github.ref == 'refs/heads/stage' &&
-          github.event_name == 'push' &&
-          fromJson(needs.affected.outputs.matrix) == 'journeys'
-        )
-      }}
+      needs.affected.outputs.matrix != '[]' &&
+      needs.affected.outputs.matrix != '' && (
+        github.ref != 'refs/heads/main' || 
+        github.event_name == 'pull_request'
+      ) && !(
+        github.ref == 'refs/heads/stage' &&
+        github.event_name == 'push' &&
+        fromJson(needs.affected.outputs.matrix) == 'journeys'
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -196,19 +194,17 @@ jobs:
     # and main branch where app is not journeys-admin
     # or stage branch where app is journeys
     if: |
-      ${{
-        needs.affected.outputs.matrix != '[]' &&
-        needs.affected.outputs.matrix != '' &&
-        github.event_name != 'pull_request' && (
-          (
-            github.ref == 'refs/heads/main' &&
-            fromJson(needs.affected.outputs.matrix) != 'journeys-admin'
-          ) || (
-            github.ref == 'refs/heads/stage' &&
-            fromJson(needs.affected.outputs.matrix) == 'journeys'
-          )
+      needs.affected.outputs.matrix != '[]' &&
+      needs.affected.outputs.matrix != '' &&
+      github.event_name != 'pull_request' && (
+        (
+          github.ref == 'refs/heads/main' &&
+          fromJson(needs.affected.outputs.matrix) != 'journeys-admin'
+        ) || (
+          github.ref == 'refs/heads/stage' &&
+          fromJson(needs.affected.outputs.matrix) == 'journeys'
         )
-      }}
+      )
     needs: affected
     strategy:
       fail-fast: false

--- a/apps/journeys/pages/index.tsx
+++ b/apps/journeys/pages/index.tsx
@@ -30,7 +30,7 @@ interface JourneysPageProps {
   journeys: Journey[]
 }
 
-const StyledIframe = styled('iframe')(({ theme }) => ({}))
+const StyledIframe = styled('iframe')(() => ({}))
 
 function JourneysPage({ journeys }: JourneysPageProps): ReactElement {
   const { t } = useTranslation('apps-journeys')


### PR DESCRIPTION
# Description

when deploying to stage custom domains were not able to point to stage without requiring a redeploy. This creates a new vercel app called journeys-stage where stage is its production branch. This means custom domains on stage will automatically get access to the most recent production build.