### PR TITLE
fix: stop redirect for empty accept language

### DIFF
--- a/apps/journeys-admin/middleware.spec.ts
+++ b/apps/journeys-admin/middleware.spec.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server'
 
-import { middleware } from './middleware'
+import { COOKIE_FINGERPRINT, middleware } from './middleware'
 
 describe('middleware', () => {
   const url = 'http://localhost:4200/'
@@ -9,6 +9,21 @@ describe('middleware', () => {
   }
 
   describe('no cookie set', () => {
+    it('should set browsers language to default locale when no accept headers', async () => {
+      const request = new Request(url, {
+        headers: new Headers({})
+      })
+      const req = new NextRequest(request, requestInit)
+      const result = await middleware(req)
+
+      expect(req.cookies.get('NEXT_LOCALE')?.value).toBeUndefined()
+      expect(result?.status).toBe(307) // checks for temporary redirect
+      expect(result?.headers.get('location')).toBe('http://localhost:4200/en/')
+      expect(result?.headers.get('set-cookie')).toBe(
+        `NEXT_LOCALE=${COOKIE_FINGERPRINT}---en; Path=/`
+      )
+    })
+
     it('should set browsers language as cookie, and redirect to that locale', async () => {
       const request = new Request(url, {
         headers: new Headers({
@@ -23,7 +38,7 @@ describe('middleware', () => {
       expect(result?.status).toBe(307) // checks for temporary redirect
       expect(result?.headers.get('location')).toBe('http://localhost:4200/zh/')
       expect(result?.headers.get('set-cookie')).toBe(
-        'NEXT_LOCALE=00002-zh; Path=/'
+        `NEXT_LOCALE=${COOKIE_FINGERPRINT}---zh; Path=/`
       )
     })
 
@@ -41,7 +56,7 @@ describe('middleware', () => {
       expect(result?.status).toBe(307) // checks for temporary redirect
       expect(result?.headers.get('location')).toBe('http://localhost:4200/ja/')
       expect(result?.headers.get('set-cookie')).toBe(
-        'NEXT_LOCALE=00002-ja; Path=/'
+        `NEXT_LOCALE=${COOKIE_FINGERPRINT}---ja; Path=/`
       )
     })
 
@@ -61,7 +76,7 @@ describe('middleware', () => {
         'http://localhost:4200/zh-Hans-CN/'
       )
       expect(result?.headers.get('set-cookie')).toBe(
-        'NEXT_LOCALE=00002-zh-Hans-CN; Path=/'
+        `NEXT_LOCALE=${COOKIE_FINGERPRINT}---zh-Hans-CN; Path=/`
       )
     })
   })
@@ -71,14 +86,16 @@ describe('middleware', () => {
       const request = new Request(url, {
         headers: new Headers({
           'accept-language': 'af,zh;q=0.9',
-          cookie: 'NEXT_LOCALE=00002-ja'
+          cookie: `NEXT_LOCALE=${COOKIE_FINGERPRINT}---ja`
         })
       })
       const req = new NextRequest(request, requestInit)
       const result = await middleware(req)
 
       expect(req.nextUrl.locale).toBe('en')
-      expect(req.cookies.get('NEXT_LOCALE')?.value).toBe('00002-ja')
+      expect(req.cookies.get('NEXT_LOCALE')?.value).toBe(
+        `${COOKIE_FINGERPRINT}---ja`
+      )
       expect(result?.status).toBe(307) // checks for temporary redirect
       expect(result?.headers.get('location')).toBe('http://localhost:4200/ja/')
     })
@@ -87,18 +104,20 @@ describe('middleware', () => {
       const request = new Request(url, {
         headers: new Headers({
           'accept-language': 'af,zh;q=0.9',
-          cookie: 'NEXT_LOCALE=00002-es-CO'
+          cookie: `NEXT_LOCALE=${COOKIE_FINGERPRINT}---es-CO`
         })
       })
       const req = new NextRequest(request, requestInit)
       const result = await middleware(req)
 
       expect(req.nextUrl.locale).toBe('en')
-      expect(req.cookies.get('NEXT_LOCALE')?.value).toBe('00002-es-CO')
+      expect(req.cookies.get('NEXT_LOCALE')?.value).toBe(
+        `${COOKIE_FINGERPRINT}---es-CO`
+      )
       expect(result?.status).toBe(307) // checks for temporary redirect
       expect(result?.headers.get('location')).toBe('http://localhost:4200/es/')
       expect(result?.headers.get('set-cookie')).toBe(
-        'NEXT_LOCALE=00002-es; Path=/'
+        `NEXT_LOCALE=${COOKIE_FINGERPRINT}---es; Path=/`
       )
     })
 
@@ -106,20 +125,22 @@ describe('middleware', () => {
       const request = new Request(url, {
         headers: new Headers({
           'accept-language': 'af,zh;q=0.9',
-          cookie: 'NEXT_LOCALE=00002-zh-Hans-CN'
+          cookie: `NEXT_LOCALE=${COOKIE_FINGERPRINT}---zh-Hans-CN`
         })
       })
       const req = new NextRequest(request, requestInit)
       const result = await middleware(req)
 
       expect(req.nextUrl.locale).toBe('en')
-      expect(req.cookies.get('NEXT_LOCALE')?.value).toBe('00002-zh-Hans-CN')
+      expect(req.cookies.get('NEXT_LOCALE')?.value).toBe(
+        `${COOKIE_FINGERPRINT}---zh-Hans-CN`
+      )
       expect(result?.status).toBe(307) // checks for temporary redirect
       expect(result?.headers.get('location')).toBe(
         'http://localhost:4200/zh-Hans-CN/'
       )
       expect(result?.headers.get('set-cookie')).toBe(
-        'NEXT_LOCALE=00002-zh-Hans-CN; Path=/'
+        `NEXT_LOCALE=${COOKIE_FINGERPRINT}---zh-Hans-CN; Path=/`
       )
     })
   })

--- a/apps/journeys-admin/middleware.ts
+++ b/apps/journeys-admin/middleware.ts
@@ -3,9 +3,11 @@ import { NextRequest, NextResponse } from 'next/server'
 const PUBLIC_FILE_REGEX = /\.(.*)$/
 
 // update the fingerprint when updating cookies logic
-const COOKIE_FINGERPRINT = '00002'
+export const COOKIE_FINGERPRINT = '00003'
 
-const supportedLocales = [
+const DEFAULT_LOCALE = 'en'
+
+const SUPPORTED_LOCALES = [
   'en', // English
   'es', // Spanish
   'fr', // French
@@ -36,18 +38,21 @@ function getPreferredLanguage(
 ): string | undefined {
   const preferredLanguage = languages?.find(
     (language) =>
-      supportedLocales.includes(language.code) ||
-      supportedLocales.includes(language.code.split('-')[0])
+      SUPPORTED_LOCALES.includes(language.code) ||
+      SUPPORTED_LOCALES.includes(language.code.split('-')[0])
   )
 
   if (preferredLanguage == null) return
   return getSupportedLocale(preferredLanguage?.code)
 }
 
-function getSupportedLocale(input: string): string {
+function getSupportedLocale(input?: string): string {
+  if (input == null) return DEFAULT_LOCALE
+
   const languageCode = input.split('-')[0]
 
-  const isSupported = (code: string): boolean => supportedLocales.includes(code)
+  const isSupported = (code: string): boolean =>
+    SUPPORTED_LOCALES.includes(code)
 
   return isSupported(input)
     ? input
@@ -56,16 +61,16 @@ function getSupportedLocale(input: string): string {
     : 'en'
 }
 
-function getBrowserLanguage(req: NextRequest): string | undefined {
+function getBrowserLanguage(req: NextRequest): string {
   const acceptedLanguagesHeader = req.headers.get('accept-language')
 
-  if (acceptedLanguagesHeader == null) return
+  if (acceptedLanguagesHeader == null) return DEFAULT_LOCALE
 
   const acceptedLanguages = parseAcceptLanguageHeader(acceptedLanguagesHeader)
   const sortedLanguages = acceptedLanguages?.sort(
     (a, b) => b.priority - a.priority
   )
-  return getPreferredLanguage(sortedLanguages)
+  return getPreferredLanguage(sortedLanguages) ?? DEFAULT_LOCALE
 }
 
 function handleRedirect(req: NextRequest, locale?: string): NextResponse {
@@ -74,7 +79,7 @@ function handleRedirect(req: NextRequest, locale?: string): NextResponse {
     req.url
   )
   const response = NextResponse.redirect(redirectUrl)
-  response.cookies.set('NEXT_LOCALE', `${COOKIE_FINGERPRINT}-${locale}`)
+  response.cookies.set('NEXT_LOCALE', `${COOKIE_FINGERPRINT}---${locale}`)
   return response
 }
 
@@ -86,18 +91,20 @@ export function middleware(req: NextRequest): NextResponse | undefined {
   )
     return
 
-  const nextLocale = req.nextUrl.locale
-  const browserLanguage = getBrowserLanguage(req)
-  const nextLocaleCookie = req.cookies.get('NEXT_LOCALE')?.value
-  const extractedLocale = getSupportedLocale(nextLocaleCookie?.slice(6) ?? '')
+  const nextLocaleCookie = req.cookies
+    .get('NEXT_LOCALE')
+    ?.value?.split('---')[1]
 
   // Redirect if NEXT_LOCALE cookie is not set
   if (nextLocaleCookie == null) {
+    const browserLanguage = getBrowserLanguage(req)
     return handleRedirect(req, browserLanguage)
   }
 
+  const nextLocale = req.nextUrl.locale
+  const extractedLocale = getSupportedLocale(nextLocaleCookie ?? '')
+
   // Check if the NEXT_LOCALE cookie is set and does not match the current locale
-  if (extractedLocale != null && extractedLocale !== nextLocale) {
+  if (extractedLocale != null && extractedLocale !== nextLocale)
     return handleRedirect(req, extractedLocale)
-  }
 }


### PR DESCRIPTION
# Description

Some browsers do not have an accept-header. For example the facebook crawler:
![CleanShot 2024-03-25 at 14 47 40](https://github.com/JesusFilm/core/assets/802117/6bdb7091-fda6-4bf3-ae3e-9b1c97ecba80)

This should handle empty accept headers. This also updates the cookie separator to --- to allow for a split that allows the Cookie Fingerprint to change size.
