### PR TITLE
fix: no redirect for languages when same url

### DIFF
--- a/apps/journeys-admin/middleware.spec.ts
+++ b/apps/journeys-admin/middleware.spec.ts
@@ -17,8 +17,7 @@ describe('middleware', () => {
       const result = await middleware(req)
 
       expect(req.cookies.get('NEXT_LOCALE')?.value).toBeUndefined()
-      expect(result?.status).toBe(307) // checks for temporary redirect
-      expect(result?.headers.get('location')).toBe('http://localhost:4200/en/')
+      expect(result?.status).toBe(200)
       expect(result?.headers.get('set-cookie')).toBe(
         `NEXT_LOCALE=${COOKIE_FINGERPRINT}---en; Path=/`
       )

--- a/apps/journeys-admin/middleware.ts
+++ b/apps/journeys-admin/middleware.ts
@@ -75,10 +75,15 @@ function getBrowserLanguage(req: NextRequest): string {
 
 function handleRedirect(req: NextRequest, locale?: string): NextResponse {
   const redirectUrl = new URL(
-    `/${locale}${req.nextUrl.pathname}${req.nextUrl.search}`,
+    `${locale !== DEFAULT_LOCALE ? `/${locale}` : ''}${req.nextUrl.pathname}${
+      req.nextUrl.search
+    }`,
     req.url
   )
-  const response = NextResponse.redirect(redirectUrl)
+  const response =
+    redirectUrl.toString() === req.url.toString()
+      ? NextResponse.next()
+      : NextResponse.redirect(redirectUrl)
   response.cookies.set('NEXT_LOCALE', `${COOKIE_FINGERPRINT}---${locale}`)
   return response
 }


### PR DESCRIPTION
# Description

middleware currently redirects users without accept-language headers from / to /. This causes a redirection loop.
![CleanShot 2024-03-25 at 15 42 53](https://github.com/JesusFilm/core/assets/802117/fc71956f-7542-4056-a3a2-fbc1c13c7962)
![CleanShot 2024-03-25 at 15 44 57](https://github.com/JesusFilm/core/assets/802117/64b94388-236d-4430-b265-dabcba0f7774)

