### PR TITLE
fix: use templates slide

### DIFF
--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.spec.tsx
@@ -14,11 +14,6 @@ jest.mock('@mui/material/useMediaQuery', () => ({
   default: jest.fn()
 }))
 
-jest.mock('next-firebase-auth', () => ({
-  __esModule: true,
-  useUser: jest.fn(() => ({ id: 'userId', name: 'userName' }))
-}))
-
 describe('TemplateCardPreview', () => {
   it('renders correct number of cards', async () => {
     ;(useMediaQuery as unknown as jest.Mock).mockReturnValue(false)

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.spec.tsx
@@ -1,3 +1,4 @@
+import { MockedProvider } from '@apollo/client/testing'
 import { ThemeProvider, createTheme } from '@mui/material/styles'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import { render, waitFor } from '@testing-library/react'
@@ -11,6 +12,11 @@ import { TemplateCardPreview } from './TemplateCardPreview'
 jest.mock('@mui/material/useMediaQuery', () => ({
   __esModule: true,
   default: jest.fn()
+}))
+
+jest.mock('next-firebase-auth', () => ({
+  __esModule: true,
+  useUser: jest.fn(() => ({ id: 'userId', name: 'userName' }))
 }))
 
 describe('TemplateCardPreview', () => {
@@ -30,6 +36,33 @@ describe('TemplateCardPreview', () => {
     await waitFor(() =>
       expect(getAllByTestId('TemplateCardsSwiperSlide')).toHaveLength(3)
     )
+  })
+
+  it('renders use template slide if more than 7 cards in journey', async () => {
+    const steps = [
+      { id: '1', children: [{ __typename: 'CardBlock' }] },
+      { id: '2', children: [{ __typename: 'CardBlock' }] },
+      { id: '3', children: [{ __typename: 'CardBlock' }] },
+      { id: '4', children: [{ __typename: 'CardBlock' }] },
+      { id: '5', children: [{ __typename: 'CardBlock' }] },
+      { id: '6', children: [{ __typename: 'CardBlock' }] },
+      { id: '7', children: [{ __typename: 'CardBlock' }] },
+      { id: '8', children: [{ __typename: 'CardBlock' }] },
+      { id: '9', children: [{ __typename: 'CardBlock' }] },
+      { id: '10', children: [{ __typename: 'CardBlock' }] }
+    ] as Array<TreeBlock<StepBlock>>
+
+    const { getAllByTestId, getByTestId } = render(
+      <MockedProvider>
+        <ThemeProvider theme={createTheme()}>
+          <TemplateCardPreview steps={steps} />
+        </ThemeProvider>
+      </MockedProvider>
+    )
+    await waitFor(() =>
+      expect(getAllByTestId('TemplateCardsSwiperSlide')).toHaveLength(7)
+    )
+    expect(getByTestId('UseTemplatesSlide')).toBeInTheDocument()
   })
 
   it('renders correct number of cards on small breakpoints', async () => {

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.stories.tsx
@@ -1,3 +1,4 @@
+import { MockedProvider } from '@apollo/client/testing'
 import { Meta, StoryObj } from '@storybook/react'
 
 import { TreeBlock } from '@core/journeys/ui/block'
@@ -22,7 +23,11 @@ const TemplateCardPreviewStory: Meta<typeof TemplateCardPreview> = {
 const steps = transformer(journeyVideoBlocks) as Array<TreeBlock<StepBlock>>
 
 const Template: StoryObj<typeof TemplateCardPreview> = {
-  render: (args) => <TemplateCardPreview steps={args.steps} />
+  render: (args) => (
+    <MockedProvider>
+      <TemplateCardPreview steps={args.steps} />
+    </MockedProvider>
+  )
 }
 
 export const Default = {

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.stories.tsx
@@ -1,4 +1,3 @@
-import { MockedProvider } from '@apollo/client/testing'
 import { Meta, StoryObj } from '@storybook/react'
 
 import { TreeBlock } from '@core/journeys/ui/block'
@@ -23,11 +22,7 @@ const TemplateCardPreviewStory: Meta<typeof TemplateCardPreview> = {
 const steps = transformer(journeyVideoBlocks) as Array<TreeBlock<StepBlock>>
 
 const Template: StoryObj<typeof TemplateCardPreview> = {
-  render: (args) => (
-    <MockedProvider>
-      <TemplateCardPreview steps={args.steps} />
-    </MockedProvider>
-  )
+  render: (args) => <TemplateCardPreview steps={args.steps} />
 }
 
 export const Default = {

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.tsx
@@ -4,7 +4,7 @@ import Stack from '@mui/material/Stack'
 import { styled, useTheme } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
 import take from 'lodash/take'
-import { useUser } from 'next-firebase-auth'
+import { User } from 'next-firebase-auth'
 import { useTranslation } from 'next-i18next'
 import { ReactElement } from 'react'
 import { A11y, FreeMode, Mousewheel } from 'swiper/modules'
@@ -29,6 +29,7 @@ import { CreateJourneyButton } from '../../CreateJourneyButton'
 
 interface TemplateCardPreviewProps {
   steps?: Array<TreeBlock<StepBlock>>
+  authUser?: User
 }
 
 interface TemplateCardPreviewItemProps {
@@ -109,11 +110,11 @@ function TemplateCardPreviewItem({
 }
 
 export function TemplateCardPreview({
-  steps
+  steps,
+  authUser
 }: TemplateCardPreviewProps): ReactElement {
   const { breakpoints } = useTheme()
   const { t } = useTranslation('apps-journeys-admin')
-  const user = useUser()
   const swiperBreakpoints: SwiperOptions['breakpoints'] = {
     [breakpoints.values.xs]: {
       spaceBetween: 12
@@ -197,7 +198,7 @@ export function TemplateCardPreview({
             >
               {t('Use this template to see more!')}
             </Typography>
-            <CreateJourneyButton signedIn={user?.id != null} />
+            <CreateJourneyButton signedIn={authUser?.id != null} />
           </Stack>
           <Box
             sx={{

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.tsx
@@ -186,7 +186,9 @@ export function TemplateCardPreview({
               color="background.paper"
               textAlign="center"
             >
-              {t(`+${steps.length - 7} more cards`)}
+              {t('{{count}} more cards', {
+                count: steps.length - slidesToRender.length
+              })}
             </Typography>
             <Typography
               variant="overline2"

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.tsx
@@ -2,6 +2,10 @@ import Box from '@mui/material/Box'
 import Skeleton from '@mui/material/Skeleton'
 import Stack from '@mui/material/Stack'
 import { styled, useTheme } from '@mui/material/styles'
+import Typography from '@mui/material/Typography'
+import take from 'lodash/take'
+import { useUser } from 'next-firebase-auth'
+import { useTranslation } from 'next-i18next'
 import { ReactElement } from 'react'
 import { A11y, FreeMode, Mousewheel } from 'swiper/modules'
 import { Swiper, SwiperSlide } from 'swiper/react'
@@ -21,6 +25,7 @@ import { ThemeMode, ThemeName } from '../../../../../__generated__/globalTypes'
 import { CardWrapper } from '../../../CardPreview/CardList/CardWrapper'
 import { VideoWrapper } from '../../../Editor/Canvas/VideoWrapper'
 import { FramePortal } from '../../../FramePortal'
+import { CreateJourneyButton } from '../../CreateJourneyButton'
 
 interface TemplateCardPreviewProps {
   steps?: Array<TreeBlock<StepBlock>>
@@ -31,6 +36,7 @@ interface TemplateCardPreviewItemProps {
 }
 
 const StyledSwiperSlide = styled(SwiperSlide)(() => ({}))
+const StyledSwiper = styled(Swiper)(() => ({}))
 
 function TemplateCardPreviewItem({
   step
@@ -106,6 +112,8 @@ export function TemplateCardPreview({
   steps
 }: TemplateCardPreviewProps): ReactElement {
   const { breakpoints } = useTheme()
+  const { t } = useTranslation('apps-journeys-admin')
+  const user = useUser()
   const swiperBreakpoints: SwiperOptions['breakpoints'] = {
     [breakpoints.values.xs]: {
       spaceBetween: 12
@@ -115,8 +123,10 @@ export function TemplateCardPreview({
     }
   }
 
+  const slidesToRender: Array<TreeBlock<StepBlock>> | undefined = take(steps, 7)
+
   return steps != null ? (
-    <Swiper
+    <StyledSwiper
       modules={[Mousewheel, FreeMode, A11y]}
       mousewheel={{
         forceToAxis: true
@@ -128,13 +138,13 @@ export function TemplateCardPreview({
       observer
       observeParents
       breakpoints={swiperBreakpoints}
-      autoHeight
-      style={{
+      sx={{
         overflow: 'visible',
-        zIndex: 2
+        zIndex: 2,
+        height: { xs: 295, sm: 404 }
       }}
     >
-      {steps.map((step) => {
+      {slidesToRender.map((step) => {
         return (
           <StyledSwiperSlide
             data-testid="TemplateCardsSwiperSlide"
@@ -149,7 +159,77 @@ export function TemplateCardPreview({
           </StyledSwiperSlide>
         )
       })}
-    </Swiper>
+      {steps.length > slidesToRender.length && (
+        <StyledSwiperSlide
+          data-testid="UseTemplatesSlide"
+          sx={{
+            width: 'unset !important',
+            cursor: 'grab',
+            zIndex: 2
+          }}
+        >
+          <Stack
+            alignItems="center"
+            justifyContent="center"
+            gap={2}
+            sx={{
+              width: { xs: 194, sm: 267 },
+              mr: { xs: 3, sm: 7 },
+              height: { xs: 295, sm: 404 },
+              borderRadius: 2,
+              backgroundColor: 'secondary.main',
+              px: 1
+            }}
+          >
+            <Typography
+              variant="overline2"
+              color="background.paper"
+              textAlign="center"
+            >
+              {t(`+${steps.length - 7} more cards`)}
+            </Typography>
+            <Typography
+              variant="overline2"
+              color="background.paper"
+              textAlign="center"
+            >
+              {t('Use this template to see more!')}
+            </Typography>
+            <CreateJourneyButton signedIn={user?.id != null} />
+          </Stack>
+          <Box
+            alignItems="center"
+            justifyContent="center"
+            sx={{
+              position: 'relative',
+              bottom: { xs: 290, sm: 400 },
+              left: 10,
+              zIndex: -1,
+              minWidth: { xs: 194, sm: 267 },
+              mr: { xs: 3, sm: 7 },
+              height: { xs: 295, sm: 404 },
+              borderRadius: 2,
+              backgroundColor: 'secondary.light'
+            }}
+          />
+          <Box
+            alignItems="center"
+            justifyContent="center"
+            sx={{
+              position: 'absolute',
+              bottom: { xs: -10, sm: -10 },
+              left: 30,
+              zIndex: -2,
+              minWidth: { xs: 194, sm: 267 },
+              mr: { xs: 3, sm: 7 },
+              height: { xs: 295, sm: 404 },
+              borderRadius: 2,
+              backgroundColor: 'divider'
+            }}
+          />
+        </StyledSwiperSlide>
+      )}
+    </StyledSwiper>
   ) : (
     <Stack
       data-testid="TemplateCardsPreviewPlaceholder"

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.tsx
@@ -198,8 +198,6 @@ export function TemplateCardPreview({
             <CreateJourneyButton signedIn={user?.id != null} />
           </Stack>
           <Box
-            alignItems="center"
-            justifyContent="center"
             sx={{
               position: 'relative',
               bottom: { xs: 290, sm: 400 },
@@ -213,8 +211,6 @@ export function TemplateCardPreview({
             }}
           />
           <Box
-            alignItems="center"
-            justifyContent="center"
             sx={{
               position: 'absolute',
               bottom: { xs: -10, sm: -10 },

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplatePreviewTabs.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplatePreviewTabs.tsx
@@ -2,6 +2,7 @@ import Box from '@mui/material/Box'
 import Skeleton from '@mui/material/Skeleton'
 import Tab from '@mui/material/Tab'
 import Tabs from '@mui/material/Tabs'
+import { User } from 'next-firebase-auth'
 import { useTranslation } from 'next-i18next'
 import { ReactElement, useMemo, useState } from 'react'
 
@@ -19,7 +20,13 @@ import {
 import { TemplateCardPreview } from './TemplateCardPreview/TemplateCardPreview'
 import { TemplateVideoPreview } from './TemplateVideoPreview'
 
-export function TemplatePreviewTabs(): ReactElement {
+interface TemplatePreviewTabsProps {
+  authUser?: User
+}
+
+export function TemplatePreviewTabs({
+  authUser
+}: TemplatePreviewTabsProps): ReactElement {
   const [tabValue, setTabValue] = useState(0)
   const { t } = useTranslation('apps-journeys-admin')
 
@@ -86,7 +93,7 @@ export function TemplatePreviewTabs(): ReactElement {
         />
       </Tabs>
       <TabPanel name="cards-preview-tab" value={tabValue} index={0}>
-        <TemplateCardPreview steps={steps} />
+        <TemplateCardPreview steps={steps} authUser={authUser} />
       </TabPanel>
       <TabPanel name="videos-preview-tab" value={tabValue} index={1}>
         <TemplateVideoPreview videoBlocks={videos} />

--- a/apps/journeys-admin/src/components/TemplateView/TemplateView.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateView.tsx
@@ -98,7 +98,7 @@ export function TemplateView({ authUser }: TemplateViewProps): ReactElement {
         <Stack sx={{ gap: { xs: 3, sm: 7 } }}>
           <TemplateViewHeader isPublisher={isPublisher} authUser={authUser} />
           <TemplateTags tags={journey?.tags} />
-          <TemplatePreviewTabs />
+          <TemplatePreviewTabs authUser={authUser} />
           <Typography
             variant="body2"
             sx={{ display: { xs: 'block', sm: 'none' } }}

--- a/libs/locales/en/apps-journeys-admin.json
+++ b/libs/locales/en/apps-journeys-admin.json
@@ -670,6 +670,8 @@
   "Use This Template": "Use This Template",
   "Add Journey to Team": "Add Journey to Team",
   "Use this template to make it your journey": "Use this template to make it your journey",
+  "{{count}} more cards_one": "{{count}} more cards",
+  "{{count}} more cards_other": "{{count}} more cards",
   "Use this template to see more!": "Use this template to see more!",
   "{{count}} Cards_one": "{{count}} Card",
   "{{count}} Cards_other": "{{count}} Cards",

--- a/libs/locales/en/apps-journeys-admin.json
+++ b/libs/locales/en/apps-journeys-admin.json
@@ -670,7 +670,7 @@
   "Use This Template": "Use This Template",
   "Add Journey to Team": "Add Journey to Team",
   "Use this template to make it your journey": "Use this template to make it your journey",
-  "{{count}} more cards_one": "{{count}} more cards",
+  "{{count}} more cards_one": "{{count}} more card",
   "{{count}} more cards_other": "{{count}} more cards",
   "Use this template to see more!": "Use this template to see more!",
   "{{count}} Cards_one": "{{count}} Card",

--- a/libs/locales/en/apps-journeys-admin.json
+++ b/libs/locales/en/apps-journeys-admin.json
@@ -670,6 +670,7 @@
   "Use This Template": "Use This Template",
   "Add Journey to Team": "Add Journey to Team",
   "Use this template to make it your journey": "Use this template to make it your journey",
+  "Use this template to see more!": "Use this template to see more!",
   "{{count}} Cards_one": "{{count}} Card",
   "{{count}} Cards_other": "{{count}} Cards",
   "{{count}} Videos_one": "{{count}} Video",


### PR DESCRIPTION
# Description

cut the number of cards shown in templates to optimise performance
append a use templates slide that tells the user to see more cards they can create a template to view them

- Link to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

# Walkthrough

copilot:walkthrough
