### PR TITLE
fix: swipe not being blocked on slider

### DIFF
--- a/apps/journeys/src/components/Conductor/SwipeNavigation/SwipeNavigation.spec.tsx
+++ b/apps/journeys/src/components/Conductor/SwipeNavigation/SwipeNavigation.spec.tsx
@@ -248,19 +248,49 @@ describe('SwipeNavigation', () => {
     const { getByTestId } = render(
       <MockedProvider>
         <SwipeNavigation activeBlock={step1} rtl={false}>
-          <Box data-testid="swipe-test-box" className="MuiSlider-thumb" />
+          <Box data-testid="swipe-test-box-root" className="MuiSlider-root" />
+          <Box data-testid="swipe-test-box-rail" className="MuiSlider-rail" />
+          <Box data-testid="swipe-test-box-track" className="MuiSlider-track" />
+          <Box data-testid="swipe-test-box-thumb" className="MuiSlider-thumb" />
         </SwipeNavigation>
       </MockedProvider>
     )
-    const swipeElement = getByTestId('swipe-test-box')
+    const swipeElementRoot = getByTestId('swipe-test-box-root')
+    const swipeElementRail = getByTestId('swipe-test-box-rail')
+    const swipeElementTrack = getByTestId('swipe-test-box-track')
+    const swipeElementThumb = getByTestId('swipe-test-box-thumb')
 
-    fireEvent.touchStart(swipeElement, {
+    fireEvent.touchStart(swipeElementRoot, {
       touches: [{ clientX: 0, clientY: 0 }]
     })
-    fireEvent.touchMove(swipeElement, {
+    fireEvent.touchMove(swipeElementRoot, {
       touches: [{ clientX: swipeLeft, clientY: 0 }]
     })
-    fireEvent.touchEnd(swipeElement)
+    fireEvent.touchEnd(swipeElementRoot)
+
+    fireEvent.touchStart(swipeElementRail, {
+      touches: [{ clientX: 0, clientY: 0 }]
+    })
+    fireEvent.touchMove(swipeElementRail, {
+      touches: [{ clientX: swipeLeft, clientY: 0 }]
+    })
+    fireEvent.touchEnd(swipeElementRail)
+
+    fireEvent.touchStart(swipeElementTrack, {
+      touches: [{ clientX: 0, clientY: 0 }]
+    })
+    fireEvent.touchMove(swipeElementTrack, {
+      touches: [{ clientX: swipeLeft, clientY: 0 }]
+    })
+    fireEvent.touchEnd(swipeElementTrack)
+
+    fireEvent.touchStart(swipeElementThumb, {
+      touches: [{ clientX: 0, clientY: 0 }]
+    })
+    fireEvent.touchMove(swipeElementThumb, {
+      touches: [{ clientX: swipeLeft, clientY: 0 }]
+    })
+    fireEvent.touchEnd(swipeElementThumb)
 
     expect(blockHistoryVar()).toHaveLength(1)
   })
@@ -272,19 +302,49 @@ describe('SwipeNavigation', () => {
     const { getByTestId } = render(
       <MockedProvider>
         <SwipeNavigation activeBlock={step2} rtl={false}>
-          <Box data-testid="swipe-test-box" className="MuiSlider-thumb" />
+          <Box data-testid="swipe-test-box-root" className="MuiSlider-root" />
+          <Box data-testid="swipe-test-box-rail" className="MuiSlider-rail" />
+          <Box data-testid="swipe-test-box-track" className="MuiSlider-track" />
+          <Box data-testid="swipe-test-box-thumb" className="MuiSlider-thumb" />
         </SwipeNavigation>
       </MockedProvider>
     )
-    const swipeElement = getByTestId('swipe-test-box')
+    const swipeElementRoot = getByTestId('swipe-test-box-root')
+    const swipeElementRail = getByTestId('swipe-test-box-rail')
+    const swipeElementTrack = getByTestId('swipe-test-box-track')
+    const swipeElementThumb = getByTestId('swipe-test-box-thumb')
 
-    fireEvent.touchStart(swipeElement, {
+    fireEvent.touchStart(swipeElementRoot, {
       touches: [{ clientX: 0, clientY: 0 }]
     })
-    fireEvent.touchMove(swipeElement, {
-      touches: [{ clientX: swipeRight, clientY: 0 }]
+    fireEvent.touchMove(swipeElementRoot, {
+      touches: [{ clientX: swipeLeft, clientY: 0 }]
     })
-    fireEvent.touchEnd(swipeElement)
+    fireEvent.touchEnd(swipeElementRoot)
+
+    fireEvent.touchStart(swipeElementRail, {
+      touches: [{ clientX: 0, clientY: 0 }]
+    })
+    fireEvent.touchMove(swipeElementRail, {
+      touches: [{ clientX: swipeLeft, clientY: 0 }]
+    })
+    fireEvent.touchEnd(swipeElementRail)
+
+    fireEvent.touchStart(swipeElementTrack, {
+      touches: [{ clientX: 0, clientY: 0 }]
+    })
+    fireEvent.touchMove(swipeElementTrack, {
+      touches: [{ clientX: swipeLeft, clientY: 0 }]
+    })
+    fireEvent.touchEnd(swipeElementTrack)
+
+    fireEvent.touchStart(swipeElementThumb, {
+      touches: [{ clientX: 0, clientY: 0 }]
+    })
+    fireEvent.touchMove(swipeElementThumb, {
+      touches: [{ clientX: swipeLeft, clientY: 0 }]
+    })
+    fireEvent.touchEnd(swipeElementThumb)
 
     expect(blockHistoryVar()).toHaveLength(2)
   })

--- a/apps/journeys/src/components/Conductor/SwipeNavigation/SwipeNavigation.tsx
+++ b/apps/journeys/src/components/Conductor/SwipeNavigation/SwipeNavigation.tsx
@@ -163,10 +163,18 @@ export function SwipeNavigation({
     ]
   )
 
+  function isSliderElement(element: HTMLElement): boolean {
+    if (element.classList.contains('MuiSlider-root')) return true
+    if (element.classList.contains('MuiSlider-rail')) return true
+    if (element.classList.contains('MuiSlider-track')) return true
+    if (element.classList.contains('MuiSlider-thumb')) return true
+    return false
+  }
+
   const swipeHandlers = useSwipeable({
     onSwipedLeft: (eventData) => {
       const targetElement = eventData.event.target as HTMLElement
-      if (targetElement.classList.contains('MuiSlider-thumb')) return
+      if (isSliderElement(targetElement)) return
       if (rtl) {
         handleNavigation('previous')
       } else {
@@ -175,7 +183,7 @@ export function SwipeNavigation({
     },
     onSwipedRight: (eventData) => {
       const targetElement = eventData.event.target as HTMLElement
-      if (targetElement.classList.contains('MuiSlider-thumb')) return
+      if (isSliderElement(targetElement)) return
       if (rtl) {
         handleNavigation('next')
       } else {

--- a/apps/journeys/src/components/Conductor/SwipeNavigation/SwipeNavigation.tsx
+++ b/apps/journeys/src/components/Conductor/SwipeNavigation/SwipeNavigation.tsx
@@ -4,7 +4,7 @@ import last from 'lodash/last'
 import { useTranslation } from 'next-i18next'
 import { ReactElement, ReactNode, useCallback } from 'react'
 import TagManager from 'react-gtm-module'
-import { useSwipeable } from 'react-swipeable'
+import { SwipeEventData, useSwipeable } from 'react-swipeable'
 import { v4 as uuidv4 } from 'uuid'
 
 import { TreeBlock, useBlocks } from '@core/journeys/ui/block'
@@ -163,18 +163,20 @@ export function SwipeNavigation({
     ]
   )
 
-  function isSliderElement(element: HTMLElement): boolean {
+  function isSliderElement(eventData: SwipeEventData): boolean {
+    const element = eventData.event.target as HTMLElement
+
     if (element.classList.contains('MuiSlider-root')) return true
     if (element.classList.contains('MuiSlider-rail')) return true
     if (element.classList.contains('MuiSlider-track')) return true
     if (element.classList.contains('MuiSlider-thumb')) return true
+
     return false
   }
 
   const swipeHandlers = useSwipeable({
     onSwipedLeft: (eventData) => {
-      const targetElement = eventData.event.target as HTMLElement
-      if (isSliderElement(targetElement)) return
+      if (isSliderElement(eventData)) return
       if (rtl) {
         handleNavigation('previous')
       } else {
@@ -182,8 +184,7 @@ export function SwipeNavigation({
       }
     },
     onSwipedRight: (eventData) => {
-      const targetElement = eventData.event.target as HTMLElement
-      if (isSliderElement(targetElement)) return
+      if (isSliderElement(eventData)) return
       if (rtl) {
         handleNavigation('next')
       } else {


### PR DESCRIPTION
# Description

Swiping was only being blocked on the `MuiSlider-thumb`, also block on the other slider elements

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/36562350/todos/7248596429)

