### PR TITLE
fix: redirect value null initially

### DIFF
--- a/apps/journeys-admin/pages/users/verify.tsx
+++ b/apps/journeys-admin/pages/users/verify.tsx
@@ -228,7 +228,7 @@ export const getServerSideProps = withUserTokenSSR({
   // skip if already verified
   const apiUser = await apolloClient.query<GetMe>({
     query: GET_ME,
-    variables: { input: { redirect: undefined } }
+    variables: { input: { redirect: query.redirect ?? undefined } }
   })
   if (apiUser.data?.me?.emailVerified ?? false) {
     return {


### PR DESCRIPTION
# Description

Found that signing in with a new account doesn't retain the redirect unless you click on the resend button link

- Link to Basecamp Todo

# How should this PR be QA Tested?

- [ ] it should retain redirect value in email button link

# Walkthrough

copilot:walkthrough
