### PR TITLE
fix: new create journey button

### DIFF
--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.spec.tsx
@@ -25,7 +25,11 @@ describe('TemplateCardPreview', () => {
 
     const { getAllByTestId } = render(
       <ThemeProvider theme={createTheme()}>
-        <TemplateCardPreview steps={steps} />
+        <TemplateCardPreview
+          steps={steps}
+          openTeamDialog={false}
+          setOpenTeamDialog={jest.fn()}
+        />
       </ThemeProvider>
     )
     await waitFor(() =>
@@ -50,7 +54,11 @@ describe('TemplateCardPreview', () => {
     const { getAllByTestId, getByTestId } = render(
       <MockedProvider>
         <ThemeProvider theme={createTheme()}>
-          <TemplateCardPreview steps={steps} />
+          <TemplateCardPreview
+            steps={steps}
+            openTeamDialog={false}
+            setOpenTeamDialog={jest.fn()}
+          />
         </ThemeProvider>
       </MockedProvider>
     )
@@ -70,7 +78,11 @@ describe('TemplateCardPreview', () => {
 
     const { getAllByTestId } = render(
       <ThemeProvider theme={createTheme()}>
-        <TemplateCardPreview steps={steps} />
+        <TemplateCardPreview
+          steps={steps}
+          openTeamDialog={false}
+          setOpenTeamDialog={jest.fn()}
+        />
       </ThemeProvider>
     )
     await waitFor(() =>
@@ -83,7 +95,11 @@ describe('TemplateCardPreview', () => {
 
     const { getAllByTestId } = render(
       <ThemeProvider theme={createTheme()}>
-        <TemplateCardPreview steps={steps} />
+        <TemplateCardPreview
+          steps={steps}
+          openTeamDialog={false}
+          setOpenTeamDialog={jest.fn()}
+        />
       </ThemeProvider>
     )
     await waitFor(() =>

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react'
+import noop from 'lodash/noop'
 
 import { TreeBlock } from '@core/journeys/ui/block'
 import { transformer } from '@core/journeys/ui/transformer'
@@ -22,7 +23,13 @@ const TemplateCardPreviewStory: Meta<typeof TemplateCardPreview> = {
 const steps = transformer(journeyVideoBlocks) as Array<TreeBlock<StepBlock>>
 
 const Template: StoryObj<typeof TemplateCardPreview> = {
-  render: (args) => <TemplateCardPreview steps={args.steps} />
+  render: (args) => (
+    <TemplateCardPreview
+      steps={args.steps}
+      openTeamDialog={false}
+      setOpenTeamDialog={noop}
+    />
+  )
 }
 
 export const Default = {

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.tsx
@@ -6,7 +6,7 @@ import Typography from '@mui/material/Typography'
 import take from 'lodash/take'
 import { User } from 'next-firebase-auth'
 import { useTranslation } from 'next-i18next'
-import { ReactElement } from 'react'
+import { Dispatch, ReactElement, SetStateAction } from 'react'
 import { A11y, FreeMode, Mousewheel } from 'swiper/modules'
 import { Swiper, SwiperSlide } from 'swiper/react'
 import { SwiperOptions } from 'swiper/types'
@@ -30,6 +30,8 @@ import { CreateJourneyButton } from '../../CreateJourneyButton'
 interface TemplateCardPreviewProps {
   steps?: Array<TreeBlock<StepBlock>>
   authUser?: User
+  openTeamDialog: boolean
+  setOpenTeamDialog: Dispatch<SetStateAction<boolean>>
 }
 
 interface TemplateCardPreviewItemProps {
@@ -111,7 +113,9 @@ function TemplateCardPreviewItem({
 
 export function TemplateCardPreview({
   steps,
-  authUser
+  authUser,
+  openTeamDialog,
+  setOpenTeamDialog
 }: TemplateCardPreviewProps): ReactElement {
   const { breakpoints } = useTheme()
   const { t } = useTranslation('apps-journeys-admin')
@@ -198,7 +202,11 @@ export function TemplateCardPreview({
             >
               {t('Use this template to see more!')}
             </Typography>
-            <CreateJourneyButton signedIn={authUser?.id != null} />
+            <CreateJourneyButton
+              signedIn={authUser?.id != null}
+              openTeamDialog={openTeamDialog}
+              setOpenTeamDialog={setOpenTeamDialog}
+            />
           </Stack>
           <Box
             sx={{

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplatePreviewTabs.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplatePreviewTabs.spec.tsx
@@ -31,7 +31,10 @@ describe('TemplatePreviewTabs', () => {
             variant: 'admin'
           }}
         >
-          <TemplatePreviewTabs />
+          <TemplatePreviewTabs
+            openTeamDialog={false}
+            setOpenTeamDialog={jest.fn()}
+          />
         </JourneyProvider>
       </MockedProvider>
     )
@@ -52,7 +55,10 @@ describe('TemplatePreviewTabs', () => {
             variant: 'admin'
           }}
         >
-          <TemplatePreviewTabs />
+          <TemplatePreviewTabs
+            openTeamDialog={false}
+            setOpenTeamDialog={jest.fn()}
+          />
         </JourneyProvider>
       </MockedProvider>
     )

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplatePreviewTabs.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplatePreviewTabs.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react'
 import { fireEvent, within } from '@storybook/testing-library'
+import noop from 'lodash/noop'
 import { ComponentProps } from 'react'
 
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
@@ -28,7 +29,7 @@ const Template: StoryObj<
   render: (args) => {
     return (
       <JourneyProvider value={{ journey: args.journey, variant: 'admin' }}>
-        <TemplatePreviewTabs />
+        <TemplatePreviewTabs openTeamDialog={false} setOpenTeamDialog={noop} />
       </JourneyProvider>
     )
   }

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplatePreviewTabs.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/TemplatePreviewTabs.tsx
@@ -4,7 +4,13 @@ import Tab from '@mui/material/Tab'
 import Tabs from '@mui/material/Tabs'
 import { User } from 'next-firebase-auth'
 import { useTranslation } from 'next-i18next'
-import { ReactElement, useMemo, useState } from 'react'
+import {
+  Dispatch,
+  ReactElement,
+  SetStateAction,
+  useMemo,
+  useState
+} from 'react'
 
 import { TreeBlock } from '@core/journeys/ui/block/TreeBlock'
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
@@ -22,10 +28,14 @@ import { TemplateVideoPreview } from './TemplateVideoPreview'
 
 interface TemplatePreviewTabsProps {
   authUser?: User
+  openTeamDialog: boolean
+  setOpenTeamDialog: Dispatch<SetStateAction<boolean>>
 }
 
 export function TemplatePreviewTabs({
-  authUser
+  authUser,
+  openTeamDialog,
+  setOpenTeamDialog
 }: TemplatePreviewTabsProps): ReactElement {
   const [tabValue, setTabValue] = useState(0)
   const { t } = useTranslation('apps-journeys-admin')
@@ -93,7 +103,12 @@ export function TemplatePreviewTabs({
         />
       </Tabs>
       <TabPanel name="cards-preview-tab" value={tabValue} index={0}>
-        <TemplateCardPreview steps={steps} authUser={authUser} />
+        <TemplateCardPreview
+          steps={steps}
+          authUser={authUser}
+          openTeamDialog={openTeamDialog}
+          setOpenTeamDialog={setOpenTeamDialog}
+        />
       </TabPanel>
       <TabPanel name="videos-preview-tab" value={tabValue} index={1}>
         <TemplateVideoPreview videoBlocks={videos} />

--- a/apps/journeys-admin/src/components/TemplateView/TemplateView.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateView.tsx
@@ -104,7 +104,11 @@ export function TemplateView({ authUser }: TemplateViewProps): ReactElement {
             setOpenTeamDialog={setOpenTeamDialog}
           />
           <TemplateTags tags={journey?.tags} />
-          <TemplatePreviewTabs authUser={authUser} />
+          <TemplatePreviewTabs
+            authUser={authUser}
+            openTeamDialog={openTeamDialog}
+            setOpenTeamDialog={setOpenTeamDialog}
+          />
           <Typography
             variant="body2"
             sx={{ display: { xs: 'block', sm: 'none' } }}

--- a/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateViewHeader.tsx
+++ b/apps/journeys-admin/src/components/TemplateView/TemplateViewHeader/TemplateViewHeader.tsx
@@ -4,7 +4,7 @@ import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { intlFormat, parseISO } from 'date-fns'
 import { User } from 'next-firebase-auth'
-import { ReactElement } from 'react'
+import { Dispatch, ReactElement, SetStateAction } from 'react'
 
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 
@@ -19,7 +19,7 @@ interface TemplateViewHeaderProps {
   isPublisher: boolean | undefined
   authUser: User
   openTeamDialog: boolean
-  setOpenTeamDialog: React.Dispatch<React.SetStateAction<boolean>>
+  setOpenTeamDialog: Dispatch<SetStateAction<boolean>>
 }
 
 export function TemplateViewHeader({


### PR DESCRIPTION
# Description

We had an issue of the next steps crashing when there's too much cards within a template page. The solution was to add a bunch of cards with a create a journey button on top of it. Update it to accept states from parent 

- Link to Basecamp Todo

# How should this PR be QA Tested?

- [ ] it should open the dialog
- [ ] it should close the dialog

# Walkthrough

copilot:walkthrough
