### PR TITLE
fix: card padding

### DIFF
--- a/apps/journeys-admin/src/components/OnboardingPageWrapper/OnboardingPageWrapper.tsx
+++ b/apps/journeys-admin/src/components/OnboardingPageWrapper/OnboardingPageWrapper.tsx
@@ -43,7 +43,7 @@ export function OnboardingPageWrapper({
         gap={10}
         sx={{
           m: { xs: 0, sm: 5 },
-          ml: { xs: 0, sm: 0 },
+          ml: { xs: 0, md: 0 },
           flexGrow: 1,
           display: 'flex',
           borderColor: 'divider',

--- a/apps/journeys-admin/src/components/OnboardingPageWrapper/OnboardingPageWrapper.tsx
+++ b/apps/journeys-admin/src/components/OnboardingPageWrapper/OnboardingPageWrapper.tsx
@@ -54,7 +54,11 @@ export function OnboardingPageWrapper({
         }}
         data-testid="JourneysAdminOnboardingPageWrapper"
       >
-        <Typography variant="h1" sx={{ display: { xs: 'none', sm: 'flex' } }}>
+        <Typography
+          variant="h1"
+          textAlign="center"
+          sx={{ display: { xs: 'none', sm: 'flex' } }}
+        >
           {title}
         </Typography>
         <Stack


### PR DESCRIPTION
# Description

Fixed padding on medium sized devices while still retaining 40/60 ratio of `OnbaordingDrawer` and other elements on the `OnboardingPageWrapper`.

Center aligned title text.

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/36562315/todos/7196108413)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] should have padding on the left of the card on onboarding for medium sized devices
- [ ] should have centre aligned text for all onboarding pages

# Walkthrough

copilot:walkthrough
