### PR TITLE
fix: close menu on dialog open

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/AccessItem/AccessItem.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/AccessItem/AccessItem.spec.tsx
@@ -41,7 +41,7 @@ describe('AccessItem', () => {
       id: 'journeyId',
       title: 'Some Title'
     } as unknown as JourneyFields
-    const { getByText, getByTestId, queryByTestId } = render(
+    const { getByText, getByTestId, queryByTestId, queryByRole } = render(
       <MockedProvider>
         <SnackbarProvider>
           <JourneyProvider value={{ journey: mockJourney }}>
@@ -53,6 +53,7 @@ describe('AccessItem', () => {
 
     fireEvent.click(getByText('Manage Access'))
     await waitFor(() => expect(getByTestId('AccessDialog')).toBeInTheDocument())
+    expect(queryByRole('menuitem')).not.toBeInTheDocument()
     fireEvent.click(getByTestId('dialog-close-button'))
     await waitFor(() =>
       expect(queryByTestId('AccessDialog')).not.toBeInTheDocument()

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/AccessItem/AccessItem.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/AccessItem/AccessItem.tsx
@@ -45,11 +45,11 @@ export function AccessItem({
   function handleClick(): void {
     setRoute('access')
     setAccessDialogOpen(true)
+    onClose?.()
   }
 
   function handleClose(): void {
     setAccessDialogOpen(false)
-    onClose?.()
   }
 
   return (

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/DescriptionItem/DescriptionItem.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/DescriptionItem/DescriptionItem.spec.tsx
@@ -36,7 +36,7 @@ describe('DescriptionItem', () => {
       id: 'journeyId',
       title: 'Some Title'
     } as unknown as JourneyFields
-    const { getByText, getByTestId, queryByTestId } = render(
+    const { getByText, getByTestId, queryByTestId, queryByRole } = render(
       <MockedProvider>
         <SnackbarProvider>
           <JourneyProvider value={{ journey: mockJourney }}>
@@ -50,6 +50,7 @@ describe('DescriptionItem', () => {
     await waitFor(() =>
       expect(getByTestId('DescriptionDialog')).toBeInTheDocument()
     )
+    expect(queryByRole('menuitem')).not.toBeInTheDocument()
     fireEvent.click(getByText('Cancel'))
     await waitFor(() =>
       expect(queryByTestId('DescriptionDialog')).not.toBeInTheDocument()

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/DescriptionItem/DescriptionItem.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/DescriptionItem/DescriptionItem.tsx
@@ -45,11 +45,11 @@ export function DescriptionItem({
   function handleClick(): void {
     setRoute('description')
     setDescriptionDialogOpen(true)
+    onClose?.()
   }
 
   function handleClose(): void {
     setDescriptionDialogOpen(false)
-    onClose?.()
   }
 
   return (

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/LanguageItem/LanguageItem.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/LanguageItem/LanguageItem.spec.tsx
@@ -30,7 +30,7 @@ describe('LanguageItem', () => {
     } as unknown as NextRouter)
 
     const onClose = jest.fn()
-    const { getByRole } = render(
+    const { getByRole, queryByRole } = render(
       <SnackbarProvider>
         <MockedProvider>
           <TeamProvider>
@@ -49,6 +49,7 @@ describe('LanguageItem', () => {
 
     fireEvent.click(getByRole('menuitem', { name: 'Language' }))
     await waitFor(() => expect(getByRole('dialog')).toBeInTheDocument())
+    expect(queryByRole('menuitem')).not.toBeInTheDocument()
     fireEvent.click(getByRole('button', { name: 'Cancel' }))
     await waitFor(() => expect(onClose).toHaveBeenCalled())
 

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/LanguageItem/LanguageItem.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/LanguageItem/LanguageItem.tsx
@@ -42,11 +42,11 @@ export function LanguageItem({
   const handleUpdateLanguage = (): void => {
     setRoute('languages')
     setShowLanguageDialog(true)
+    onClose?.()
   }
 
   const handleClose = (): void => {
     setShowLanguageDialog(false)
-    onClose?.()
   }
 
   return (

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/TemplateSettingsItem/TemplateSettingsItem.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/TemplateSettingsItem/TemplateSettingsItem.spec.tsx
@@ -52,13 +52,13 @@ describe('TemplateSettingsItem', () => {
         </SnackbarProvider>
       </MockedProvider>
     )
-
     fireEvent.click(getByRole('menuitem'))
     await waitFor(() =>
       expect(
         getByRole('dialog', { name: 'Template Settings' })
       ).toBeInTheDocument()
     )
+    expect(queryByRole('menuitem')).not.toBeInTheDocument()
     fireEvent.click(getByText('Cancel'))
     await waitFor(() =>
       expect(

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/TemplateSettingsItem/TemplateSettingsItem.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/TemplateSettingsItem/TemplateSettingsItem.tsx
@@ -45,11 +45,11 @@ export function TemplateSettingsItem({
   function handleClick(): void {
     setRoute('templatesettings')
     setTemplateSettingsDialogOpen(true)
+    onClose?.()
   }
 
   function handleClose(): void {
     setTemplateSettingsDialogOpen(false)
-    onClose?.()
   }
 
   return (

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/TitleItem/TitleItem.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/TitleItem/TitleItem.spec.tsx
@@ -36,7 +36,7 @@ describe('TitleItem', () => {
       id: 'journeyId',
       title: 'Some Title'
     } as unknown as JourneyFields
-    const { getByText, getByTestId, queryByTestId } = render(
+    const { getByText, getByTestId, queryByTestId, queryByRole } = render(
       <MockedProvider>
         <SnackbarProvider>
           <JourneyProvider value={{ journey: mockJourney }}>
@@ -48,6 +48,7 @@ describe('TitleItem', () => {
 
     fireEvent.click(getByText('Title'))
     await waitFor(() => expect(getByTestId('TitleDialog')).toBeInTheDocument())
+    expect(queryByRole('menuitem')).not.toBeInTheDocument()
     fireEvent.click(getByText('Cancel'))
     await waitFor(() =>
       expect(queryByTestId('TitleDialog')).not.toBeInTheDocument()

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/TitleItem/TitleItem.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/TitleItem/TitleItem.tsx
@@ -40,11 +40,11 @@ export function TitleItem({ variant, onClose }: TitleItemProps): ReactElement {
   function handleClick(): void {
     setRoute('title')
     setTitleDialogOpen(true)
+    onClose?.()
   }
 
   function handleClose(): void {
     setTitleDialogOpen(false)
-    onClose?.()
   }
 
   return (

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Menu/Menu.tsx
@@ -69,6 +69,7 @@ export function Menu(): ReactElement {
         anchorEl={anchorEl}
         open={Boolean(anchorEl)}
         onClose={handleCloseMenu}
+        keepMounted
         MenuListProps={{
           'aria-labelledby': 'edit-journey-actions'
         }}


### PR DESCRIPTION
# Description

keep menu behaviour consistent with rest of app (close menu on dialog open)
this will fix t,l,d,c,m not being inputted in textfields properly 
This also has the benefit of being easily testable

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/36562260/todos/7161003520)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

copilot:walkthrough
