### PR TITLE
fix: show felt needs button without images

### DIFF
--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.spec.tsx
@@ -17,25 +17,25 @@ describe('FeltNeedsButton', () => {
 
   // TODO: Image is missing required "src" property error cause by jest transforming image to a string in test instead of object with src
   it('should render a felt needs button', () => {
-    const { getByRole } = render(
+    const { getByRole, queryByTestId } = render(
       <FeltNeedsButton item={tag} onClick={jest.fn()} />
     )
 
     expect(
       getByRole('button', { name: 'Acceptance Acceptance Acceptance' })
     ).toBeInTheDocument()
+    expect(queryByTestId('felt-needs-button-loading')).not.toBeInTheDocument()
   })
 
   it('should render loading skeleton if no tag is passed', () => {
     const { getByTestId } = render(
       <FeltNeedsButton item={undefined} onClick={jest.fn()} />
     )
-
     expect(getByTestId('felt-needs-button-loading')).toBeInTheDocument()
   })
 
-  it('should render nothing if no tag image', () => {
-    const { queryByRole, queryByTestId } = render(
+  it('should render without image', () => {
+    const { getByRole, queryByTestId } = render(
       <FeltNeedsButton
         item={{
           ...tag,
@@ -50,7 +50,9 @@ describe('FeltNeedsButton', () => {
         onClick={jest.fn()}
       />
     )
-    expect(queryByRole('button')).not.toBeInTheDocument()
+    expect(
+      getByRole('button', { name: 'invalid name invalid name' })
+    ).toBeInTheDocument()
     expect(queryByTestId('felt-needs-button-loading')).not.toBeInTheDocument()
   })
 

--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.tsx
@@ -99,45 +99,45 @@ export function FeltNeedsButton({
   const image = tagImageData?.tagImg
 
   return tag != null ? (
-    image != null ? (
-      <ButtonBase
-        key={`${tagLabel ?? 'felt-needs'}-button}`}
-        sx={{
-          backgroundColor: 'grey',
-          padding: '32px 28px',
-          color: 'white',
-          borderRadius: '8px',
-          width: { xs: '150px', md: '222px' },
-          height: { xs: '56px', md: '110px' },
-          overflow: 'hidden',
-          '&:focus': {
-            outline: '2px solid',
-            outlineColor: theme.palette.primary.main,
-            outlineOffset: '2px'
-          },
-          '&:hover': {
-            '& .hoverStyles': {
-              transform: 'scale(1.05)'
-            }
-          },
+    <ButtonBase
+      key={`${tagLabel ?? 'felt-needs'}-button}`}
+      sx={{
+        backgroundColor: 'grey',
+        padding: '32px 28px',
+        color: 'white',
+        borderRadius: '8px',
+        width: { xs: '150px', md: '222px' },
+        height: { xs: '56px', md: '110px' },
+        overflow: 'hidden',
+        '&:focus': {
+          outline: '2px solid',
+          outlineColor: theme.palette.primary.main,
+          outlineOffset: '2px'
+        },
+        '&:hover': {
           '& .hoverStyles': {
-            transition: theme.transitions.create('transform')
+            transform: 'scale(1.05)'
           }
+        },
+        '& .hoverStyles': {
+          transition: theme.transitions.create('transform')
+        }
+      }}
+      onClick={() => tag?.id != null && onClick(tag.id)}
+    >
+      <Box
+        data-testid="gradientLayer"
+        sx={{
+          position: 'absolute',
+          top: 0,
+          bottom: 0,
+          left: 0,
+          right: 0,
+          zIndex: 2,
+          background: tagImageData?.backgroundStyle
         }}
-        onClick={() => tag?.id != null && onClick(tag.id)}
-      >
-        <Box
-          data-testid="gradientLayer"
-          sx={{
-            position: 'absolute',
-            top: 0,
-            bottom: 0,
-            left: 0,
-            right: 0,
-            zIndex: 2,
-            background: tagImageData?.backgroundStyle
-          }}
-        />
+      />
+      {image != null && (
         <NextImage
           priority
           className="hoverStyles"
@@ -148,41 +148,38 @@ export function FeltNeedsButton({
           }px) 150px, 222px`}
           fill
         />
-        <Typography
-          className="hoverStyles"
-          variant="h3"
-          sx={{
-            zIndex: 3,
-            display: { xs: 'none', md: 'flex' },
-            position: 'absolute',
-            opacity: '70%',
-            left: 12,
-            bottom: 8,
-            mixBlendMode: 'plus-lighter'
-          }}
-        >
-          {tagLabel ?? <Skeleton width={80} />}
-        </Typography>
-        <Typography
-          className="hoverStyles"
-          variant="subtitle2"
-          sx={{
-            zIndex: 1,
-            display: { md: 'none' },
-            position: 'absolute',
-            opacity: '70%',
-            left: 8,
-            bottom: 4,
-            mixBlendMode: 'plus-lighter'
-          }}
-        >
-          {tagLabel ?? <Skeleton width={80} />}
-        </Typography>
-      </ButtonBase>
-    ) : (
-      // Hack to return something since must return element with renderProps
-      <></>
-    )
+      )}
+      <Typography
+        className="hoverStyles"
+        variant="h3"
+        sx={{
+          zIndex: 3,
+          display: { xs: 'none', md: 'flex' },
+          position: 'absolute',
+          opacity: '70%',
+          left: 12,
+          bottom: 8,
+          mixBlendMode: 'plus-lighter'
+        }}
+      >
+        {tagLabel ?? <Skeleton width={80} />}
+      </Typography>
+      <Typography
+        className="hoverStyles"
+        variant="subtitle2"
+        sx={{
+          zIndex: 1,
+          display: { md: 'none' },
+          position: 'absolute',
+          opacity: '70%',
+          left: 8,
+          bottom: 4,
+          mixBlendMode: 'plus-lighter'
+        }}
+      >
+        {tagLabel ?? <Skeleton width={80} />}
+      </Typography>
+    </ButtonBase>
   ) : (
     <Skeleton
       data-testid="felt-needs-button-loading"


### PR DESCRIPTION
[basecamp link](https://3.basecamp.com/3105655/buckets/36562350/todos/7202436355)

Tags have been added to felt needs without relevant images being added. This allows felt needs to be displayed regardless of the image. Luyba to add images at a later date.

![CleanShot 2024-04-10 at 12 12 54](https://github.com/JesusFilm/core/assets/802117/9fee15eb-7d0a-45b8-bec7-0c9addfdc6f4)
