### PR TITLE
fix: move icon panel

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/QuickControls/QuickControls.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/QuickControls/QuickControls.tsx
@@ -16,6 +16,7 @@ export function QuickControls({ open, anchorEl }): ReactElement {
       <Popper
         open={open}
         anchorEl={anchorEl}
+        placement="top"
         sx={{
           zIndex: (theme) => theme.zIndex.modal + 1
         }}
@@ -23,7 +24,7 @@ export function QuickControls({ open, anchorEl }): ReactElement {
       >
         {({ TransitionProps }) => (
           <Fade {...TransitionProps} timeout={350}>
-            <Paper sx={{ mt: 2, p: 1 }}>
+            <Paper sx={{ mb: 2, p: 1 }}>
               <Stack spacing={2} direction="row">
                 <MoveBlock />
                 <DuplicateBlock variant="button" />


### PR DESCRIPTION
# Description

[- Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/36562260/todos/7173921592)

Quickaccess panel should display above block

link to deployment: [https://journeys-admin-2619-jesusfilm.vercel.app/](https://journeys-admin-2619-jesusfilm.vercel.app/)

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B
