### PR TITLE
fix: creating nodes on mobile drag

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/JourneyFlow.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/JourneyFlow.tsx
@@ -331,9 +331,21 @@ export function JourneyFlow(): ReactElement {
   }
 
   const onConnectEnd: OnConnectEnd = (event) => {
+    let eventTarget = event.target
+
+    // Using MouseEvent since TouchEvent throws an error
+    if (!(event instanceof MouseEvent)) {
+      const touchEvent = event.changedTouches[0]
+
+      eventTarget = document.elementFromPoint(
+        touchEvent.clientX,
+        touchEvent.clientY
+      )
+    }
+
     if (
-      (event.target as HTMLElement | undefined)?.className ===
-        'react-flow__pane' &&
+      eventTarget instanceof HTMLElement &&
+      eventTarget?.classList.contains('react-flow__pane') &&
       previousNodeId != null
     ) {
       const nodeData = nodes.find((node) => node.id === previousNodeId)?.data


### PR DESCRIPTION
# Description
- Allows nodes to be created using mobile devices.

[Link](https://3.basecamp.com/3105655/buckets/36562260/todos/7181078000) to Basecamp Todo

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Nodes can now be created when dragging on mobile
- [ ] Nodes can still be created on desktop
