### PR TITLE
fix: handle long team name

### DIFF
--- a/apps/journeys-admin/pages/index.tsx
+++ b/apps/journeys-admin/pages/index.tsx
@@ -41,12 +41,14 @@ function IndexPage(): ReactElement {
         mainHeaderChildren={
           <Stack
             direction="row"
-            flexGrow={1}
             justifyContent="space-between"
             alignItems="center"
+            width="100%"
           >
             <TeamSelect onboarding={router.query.onboarding === 'true'} />
-            <TeamMenu />
+            <Stack direction="row" alignItems="center">
+              <TeamMenu />
+            </Stack>
           </Stack>
         }
         sidePanelChildren={<OnboardingPanel />}

--- a/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.tsx
@@ -62,7 +62,7 @@ export function TeamSelect({ onboarding }: TeamSelectProps): ReactElement {
         direction="row"
         spacing={2}
         alignItems="center"
-        sx={{ overflow: 'hidden', flexGrow: 1 }}
+        sx={{ overflow: 'hidden', flexGrow: 0 }}
         ref={anchorRef}
         data-testid="TeamSelect"
       >

--- a/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.tsx
@@ -78,7 +78,6 @@ export function TeamSelect({ onboarding }: TeamSelectProps): ReactElement {
             renderValue={() => activeTeam?.title ?? t('Shared With Me')}
             autoWidth
             sx={{
-              width: { xs: 200, sm: '100%' },
               '> .MuiSelect-select': {
                 backgroundColor: 'transparent',
                 wordWrap: 'break-word',

--- a/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.tsx
@@ -78,6 +78,7 @@ export function TeamSelect({ onboarding }: TeamSelectProps): ReactElement {
             renderValue={() => activeTeam?.title ?? t('Shared With Me')}
             autoWidth
             sx={{
+              width: { xs: 200, sm: '100%' },
               '> .MuiSelect-select': {
                 backgroundColor: 'transparent',
                 wordWrap: 'break-word',
@@ -146,23 +147,25 @@ export function TeamSelect({ onboarding }: TeamSelectProps): ReactElement {
           vertical: 35,
           horizontal: 'left'
         }}
-        PaperProps={{
-          sx: {
-            maxWidth: { xs: 'calc(100% - 30px)', sm: 300 },
-            mt: 4,
-            position: 'relative',
-            overflow: 'visible',
-            '&::before': {
-              backgroundColor: 'white',
-              content: '""',
-              display: 'block',
-              position: 'absolute',
-              width: 12,
-              height: 12,
-              top: -6,
-              transform: 'rotate(45deg)',
-              left: { xs: 20, sm: 10 },
-              zIndex: 1
+        slotProps={{
+          paper: {
+            sx: {
+              maxWidth: { xs: 'calc(100% - 30px)', sm: 300 },
+              mt: 4,
+              position: 'relative',
+              overflow: 'visible',
+              '&::before': {
+                backgroundColor: 'white',
+                content: '""',
+                display: 'block',
+                position: 'absolute',
+                width: 12,
+                height: 12,
+                top: -6,
+                transform: 'rotate(45deg)',
+                left: { xs: 20, sm: 10 },
+                zIndex: 1
+              }
             }
           }
         }}


### PR DESCRIPTION
# Description

made the team select smaller on xs viewports. 
also in the same component - paperProps is depreciated so used slotProps.paper instead.


[- Link to Basecamp Todo
](https://3.basecamp.com/3105655/buckets/36562350/todos/7230198242)

# How should this PR be QA Tested?

Please describe the QA tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Walkthrough

copilot:walkthrough
