### PR TITLE
fix: cors localhost for api-gateway

### DIFF
--- a/apps/api-gateway/router.prod.yaml
+++ b/apps/api-gateway/router.prod.yaml
@@ -14,6 +14,8 @@ cors:
     - https://your.nextstep.is
     - https://your-stage.nextstep.is
   match_origins:
+    # any localhost (can now run dev apps against the stg and prd api)
+    - '^http://localhost:\d+$'
     # any project deployed on the jesusfilm vercel account
     - '^https://([a-z0-9-]+)-jesusfilm[.]vercel[.]app$'
     # any project deployed on the jesusfilm.org domain (used primarily for watch)


### PR DESCRIPTION
# Description

allow localhost to connect to api-gateway. This is useful when running stg_dev or prd_dev doppler environments.