### PR TITLE
fix: slider canvas drag

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/Canvas.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/Canvas.tsx
@@ -146,7 +146,8 @@ export function Canvas(): ReactElement {
           sx={{
             flexGrow: { xs: 1, sm: 0 },
             height: { xs: '100%', sm: 'auto' },
-            p: { xs: 3, sm: 0 },
+            pb: { xs: 5, sm: 0 },
+            px: { xs: 3, sm: 0 },
             justifyContent: 'center'
           }}
         >

--- a/apps/journeys-admin/src/components/Editor/Slider/Slider.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Slider.tsx
@@ -1,6 +1,7 @@
 import Box from '@mui/material/Box'
 import IconButton from '@mui/material/IconButton'
 import { styled, useTheme } from '@mui/material/styles'
+import Zoom from '@mui/material/Zoom'
 import { ReactElement, useEffect, useRef } from 'react'
 import { Swiper, SwiperRef, SwiperSlide } from 'swiper/react'
 import { SwiperOptions } from 'swiper/types'
@@ -188,22 +189,21 @@ export function Slider(): ReactElement {
               xs: 'flex',
               sm: 'none'
             },
-            alignItems: 'flex-end',
+            alignItems: 'center',
             justifyContent: 'center',
-            height: activeSlide === ActiveSlide.JourneyFlow ? 16 : 0,
-            flexShrink: 0,
-            transition: (theme) => theme.transitions.create('height'),
-            overflow: 'hidden'
+            height: '32px'
           }}
         >
-          <Box
-            sx={{
-              width: 56,
-              height: 6,
-              bgcolor: '#AAACBB',
-              borderRadius: '3px'
-            }}
-          />
+          <Zoom in={activeSlide === ActiveSlide.JourneyFlow}>
+            <Box
+              sx={{
+                width: 56,
+                height: 6,
+                bgcolor: '#AAACBB',
+                borderRadius: '3px'
+              }}
+            />
+          </Zoom>
         </Box>
         <Content />
       </StyledSwiperSlide>


### PR DESCRIPTION
## Description
Issue: card canvas was not draggable and took up a large amount of space in journey flow (mobile) making it seem like the entire bottom bar is not draggable.
Solution:
- Increase the padding around the drag handle so there is less space for the card canvas
- Made height static so the card canvas doesn't keep shrinking and growing on slide


- [Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7292062305)

## External Changes
N/A

## Additional information
- This PR should only affect the mobile behaviour, and desktop behaviour should remain unchanged.
- The fixed height now means there is less space than on the design on the card canvas
