### PR TITLE
fix: remove hover icon

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/AddBlock/Button/Button.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/AddBlock/Button/Button.tsx
@@ -73,7 +73,7 @@ export function Button({
             ]
           }
         }}
-        sx={{ opacity: { xs: 0, sm: 1 } }}
+        sx={{ display: { xs: 'none', sm: 'flex' } }}
       >
         <Box>
           <Card
@@ -86,8 +86,7 @@ export function Button({
                 borderColor: { xs: 'editor.divider', sm: 'primary.main' },
                 borderWidth: { xs: '1px', sm: '2px' },
                 '.plus2-icon': {
-                  display: 'flex',
-                  opacity: { xs: 0, sm: 1 }
+                  display: { xs: 'none', sm: 'flex' }
                 }
               }
             }}

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/AddBlock/Button/Button.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/AddBlock/Button/Button.tsx
@@ -91,7 +91,8 @@ export function Button({
                 borderColor: { xs: 'editor.divider', sm: 'primary.main' },
                 borderWidth: { xs: '1px', sm: '2px' },
                 '.plus2-icon': {
-                  display: 'flex'
+                  display: 'flex',
+                  opacity: { xs: 0, sm: 1 }
                 }
               }
             }}

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/AddBlock/Button/Button.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/AddBlock/Button/Button.tsx
@@ -44,7 +44,6 @@ export function Button({
   const handleClick = (): void => {
     onClick?.()
   }
-
   return (
     <Box
       onMouseDown={(e) => e.preventDefault()}
@@ -52,12 +51,7 @@ export function Button({
     >
       <StyledTooltip
         title={
-          <Typography
-            display={{ xs: 'none', sm: 'flex' }}
-            variant="caption"
-            lineHeight="12px"
-            sx={{ my: 1.25 }}
-          >
+          <Typography variant="caption" lineHeight="12px" sx={{ my: 1.25 }}>
             {t(
               disabled && value === 'Video'
                 ? 'Video Block cannot be placed on top of Blocks'
@@ -79,6 +73,7 @@ export function Button({
             ]
           }
         }}
+        sx={{ opacity: { xs: 0, sm: 1 } }}
       >
         <Box>
           <Card


### PR DESCRIPTION
# Description

### Issue

plus icon appearing on mobile when tapping as well as broken tooltips

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7292062030)

### Solution

remove icon and tooltips on mobile resolutions
