### PR TITLE
fix: video detail drawer

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Goals/GoalsList/GoalsListItem/GoalsListItem.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Goals/GoalsList/GoalsListItem/GoalsListItem.stories.tsx
@@ -67,7 +67,7 @@ export const Selected = {
       goalType: GoalType.Chat
     }
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement)
     await userEvent.click(canvas.getByText('https://www.ClickedSelected.com/'))
   }

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/ActionButton/ActionButton.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/ActionButton/ActionButton.tsx
@@ -47,7 +47,9 @@ export function ActionButton({ block, step }: ActionButtonProps): ReactElement {
   const [navigateToBlockActionUpdate] = useNavigateToBlockActionUpdateMutation()
   const { journey } = useJourney()
 
-  async function handleSourceConnect(params): Promise<void> {
+  async function handleSourceConnect(params: {
+    target: string
+  }): Promise<void> {
     if (journey == null) return
 
     await navigateToBlockActionUpdate(block, params.target)

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/StepBlockNode.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/StepBlockNode.stories.tsx
@@ -885,7 +885,7 @@ export const Hover = {
       activeContent: ActiveContent.Canvas
     }
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement)
 
     await waitFor(async () => {

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { SnackbarProvider } from 'notistack'
 
 import type { TreeBlock } from '@core/journeys/ui/block'
+import { EditorProvider } from '@core/journeys/ui/EditorProvider'
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 
 import {
@@ -222,7 +223,9 @@ describe('BackgroundMediaVideo', () => {
         >
           <ThemeProvider>
             <SnackbarProvider>
-              <BackgroundMediaVideo cardBlock={card} />
+              <EditorProvider initialState={{ selectedAttributeId: video.id }}>
+                <BackgroundMediaVideo cardBlock={card} />
+              </EditorProvider>
             </SnackbarProvider>
           </ThemeProvider>
         </JourneyProvider>
@@ -385,7 +388,11 @@ describe('BackgroundMediaVideo', () => {
           >
             <ThemeProvider>
               <SnackbarProvider>
-                <BackgroundMediaVideo cardBlock={existingCoverBlock} />
+                <EditorProvider
+                  initialState={{ selectedAttributeId: video.id }}
+                >
+                  <BackgroundMediaVideo cardBlock={existingCoverBlock} />
+                </EditorProvider>
               </SnackbarProvider>
             </ThemeProvider>
           </JourneyProvider>

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Video/Options/VideoOptions.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Video/Options/VideoOptions.spec.tsx
@@ -1,6 +1,6 @@
 import { InMemoryCache } from '@apollo/client'
 import { MockedProvider } from '@apollo/client/testing'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { SnackbarProvider } from 'notistack'
 
 import type { TreeBlock } from '@core/journeys/ui/block'
@@ -168,7 +168,7 @@ describe('VideoOptions', () => {
         duration: 144
       }
     }
-    const { getByRole, getByText } = render(
+    render(
       <MockedProvider
         mocks={[
           { ...getVideoMock, result },
@@ -191,7 +191,8 @@ describe('VideoOptions', () => {
           <ThemeProvider>
             <EditorProvider
               initialState={{
-                selectedBlock: { ...video, videoId: null }
+                selectedBlock: { ...video, videoId: null },
+                selectedAttributeId: video.id
               }}
             >
               <SnackbarProvider>
@@ -203,14 +204,16 @@ describe('VideoOptions', () => {
       </MockedProvider>
     )
     await waitFor(() =>
-      fireEvent.click(getByRole('button', { name: 'Select Video' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Select Video' }))
     )
-    await waitFor(() => expect(getByText('Brand Video')).toBeInTheDocument())
-    fireEvent.click(getByText('Brand Video'))
+    await waitFor(() =>
+      expect(screen.getByText('Brand Video')).toBeInTheDocument()
+    )
+    fireEvent.click(screen.getByText('Brand Video'))
     await waitFor(() =>
       expect(result).toHaveBeenCalledWith(getVideoMock.request.variables)
     )
-    fireEvent.click(getByRole('button', { name: 'Select' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
     await waitFor(() =>
       expect(videoBlockResult).toHaveBeenCalledWith(videoBlockUpdateVariables)
     )
@@ -265,7 +268,7 @@ describe('VideoOptions', () => {
 
     const getVideoResult = jest.fn().mockReturnValue(getVideoMock.result)
 
-    const { getByText, getByRole } = render(
+    render(
       <MockedProvider
         mocks={[
           { ...getVideoMock, result: getVideoResult },
@@ -322,7 +325,8 @@ describe('VideoOptions', () => {
             <EditorProvider
               initialState={{
                 selectedStep,
-                selectedBlock: { ...video, videoId: null }
+                selectedBlock: { ...video, videoId: null },
+                selectedAttributeId: video.id
               }}
             >
               <SnackbarProvider>
@@ -333,11 +337,15 @@ describe('VideoOptions', () => {
         </JourneyProvider>
       </MockedProvider>
     )
-    fireEvent.click(getByRole('button', { name: 'Select Video' }))
-    await waitFor(() => expect(getByText('Brand Video')).toBeInTheDocument())
-    fireEvent.click(getByText('Brand Video'))
+    await waitFor(() =>
+      fireEvent.click(screen.getByRole('button', { name: 'Select Video' }))
+    )
+    await waitFor(() =>
+      expect(screen.getByText('Brand Video')).toBeInTheDocument()
+    )
+    fireEvent.click(screen.getByText('Brand Video'))
     await waitFor(() => expect(getVideoResult).toHaveBeenCalled())
-    fireEvent.click(getByRole('button', { name: 'Select' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
     await waitFor(() => expect(result).toHaveBeenCalled())
     expect(cache.extract()['VideoBlock:video1.id']?.action).toEqual({
       gtmEventName: 'gtmEventName',

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/ImageBlockEditor/UnsplashGallery/UnsplashGallery.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/ImageBlockEditor/UnsplashGallery/UnsplashGallery.tsx
@@ -190,7 +190,7 @@ export function UnsplashGallery({
     setPage(newPage)
   }
 
-  function handleCollectionChange(id, query): void {
+  function handleCollectionChange(id: string, query: string): void {
     setCollectionId(id)
     setQuery(query)
   }

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/Source/Source.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/Source/Source.spec.tsx
@@ -1,6 +1,8 @@
 import { MockedProvider } from '@apollo/client/testing'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { NextRouter, useRouter } from 'next/router'
+
+import { EditorProvider } from '@core/journeys/ui/EditorProvider'
 
 import {
   VideoBlockSource,
@@ -103,19 +105,25 @@ describe('Source', () => {
       }
     } as unknown as NextRouter)
 
-    const { getByRole, getByText } = render(
+    render(
       <MockedProvider mocks={[getVideosMock, { ...getVideoMock, result }]}>
-        <Source selectedBlock={null} onChange={onChange} />
+        <EditorProvider initialState={{ selectedAttributeId: 'video1.id' }}>
+          <Source selectedBlock={null} onChange={onChange} />
+        </EditorProvider>
       </MockedProvider>
     )
     await waitFor(() =>
-      expect(getByRole('button', { name: 'Select Video' })).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'Select Video' })
+      ).toBeInTheDocument()
     )
-    fireEvent.click(getByRole('button', { name: 'Select Video' }))
-    await waitFor(() => expect(getByText('Brand Video')).toBeInTheDocument())
-    fireEvent.click(getByText('Brand Video'))
+    fireEvent.click(screen.getByRole('button', { name: 'Select Video' }))
+    await waitFor(() =>
+      expect(screen.getByText('Brand Video')).toBeInTheDocument()
+    )
+    fireEvent.click(screen.getByText('Brand Video'))
     await waitFor(() => expect(result).toHaveBeenCalled())
-    fireEvent.click(getByRole('button', { name: 'Select' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
     await waitFor(() =>
       expect(onChange).toHaveBeenCalledWith({
         duration: 144,
@@ -139,7 +147,7 @@ describe('Source', () => {
 
   it('shows YouTube video', async () => {
     const onChange = jest.fn()
-    const { getByRole } = render(
+    render(
       <MockedProvider>
         <Source
           selectedBlock={{
@@ -172,13 +180,13 @@ describe('Source', () => {
     )
     await waitFor(() =>
       expect(
-        getByRole('button', {
+        screen.getByRole('button', {
           name: 'What is the Bible? What is the Bible? YouTube'
         })
       ).toBeInTheDocument()
     )
     expect(
-      getByRole('img', {
+      screen.getByRole('img', {
         name: 'What is the Bible?'
       })
     ).toHaveAttribute('src', 'https://i.ytimg.com/vi/ak06MSETeo4/default.jpg')
@@ -186,7 +194,7 @@ describe('Source', () => {
 
   it('shows Cloudflare video', async () => {
     const onChange = jest.fn()
-    const { getByRole } = render(
+    render(
       <MockedProvider>
         <Source
           selectedBlock={{
@@ -219,15 +227,17 @@ describe('Source', () => {
     )
     await waitFor(() =>
       expect(
-        getByRole('button', {
+        screen.getByRole('button', {
           name: 'What is the Bible? What is the Bible? Custom Video'
         })
       ).toBeInTheDocument()
     )
     expect(
-      getByRole('img', {
-        name: 'What is the Bible?'
-      }).getAttribute('src')
+      screen
+        .getByRole('img', {
+          name: 'What is the Bible?'
+        })
+        .getAttribute('src')
     ).toMatch(
       /https:\/\/customer-.*\.cloudflarestream\.com\/videoId\/thumbnails\/thumbnail.jpg\?time=2s&height=55&width=55/
     )
@@ -243,7 +253,7 @@ describe('Source', () => {
       }
     } as unknown as NextRouter)
 
-    const { getByRole, getByText } = render(
+    render(
       <MockedProvider>
         <Source
           selectedBlock={{
@@ -276,17 +286,19 @@ describe('Source', () => {
     )
     await waitFor(() =>
       expect(
-        getByRole('button', {
+        screen.getByRole('button', {
           name: 'What is the Bible? What is the Bible? YouTube'
         })
       ).toBeInTheDocument()
     )
     fireEvent.click(
-      getByRole('button', {
+      screen.getByRole('button', {
         name: 'What is the Bible? What is the Bible? YouTube'
       })
     )
-    await waitFor(() => expect(getByText('Video Details')).toBeInTheDocument())
-    expect(getByText('What is the Bible?')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.getByText('Video Details')).toBeInTheDocument()
+    )
+    expect(screen.getByText('What is the Bible?')).toBeInTheDocument()
   })
 })

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/Source/Source.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/Source/Source.tsx
@@ -99,10 +99,10 @@ export function Source({ selectedBlock, onChange }: SourceProps): ReactElement {
   }
 
   useEffect(() => {
-    if (selectedAttributeId === undefined) {
+    if (selectedAttributeId === undefined && open === true) {
       setOpen(false)
     }
-  }, [selectedAttributeId])
+  }, [selectedAttributeId, open])
 
   return (
     <>

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/Source/Source.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/Source/Source.tsx
@@ -3,9 +3,10 @@ import CardActionArea from '@mui/material/CardActionArea'
 import Stack from '@mui/material/Stack'
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
-import { ReactElement, useState } from 'react'
+import { ReactElement, useEffect, useState } from 'react'
 
 import type { TreeBlock } from '@core/journeys/ui/block'
+import { useEditor } from '@core/journeys/ui/EditorProvider'
 
 import { BlockFields_VideoBlock as VideoBlock } from '../../../../../../../../__generated__/BlockFields'
 import {
@@ -62,6 +63,9 @@ interface SourceProps {
 export function Source({ selectedBlock, onChange }: SourceProps): ReactElement {
   const router = useRouter()
   const [open, setOpen] = useState<boolean | undefined>()
+  const {
+    state: { selectedAttributeId }
+  } = useEditor()
 
   let SourceContent
 
@@ -93,6 +97,12 @@ export function Source({ selectedBlock, onChange }: SourceProps): ReactElement {
       setBeaconPageViewed('video-library')
     })
   }
+
+  useEffect(() => {
+    if (selectedAttributeId === undefined) {
+      setOpen(false)
+    }
+  }, [selectedAttributeId])
 
   return (
     <>

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromLocal/LocalDetails/LocalDetails.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromLocal/LocalDetails/LocalDetails.tsx
@@ -142,11 +142,16 @@ export function LocalDetails({
       playerRef.current = videojs(videoRef.current, {
         ...defaultVideoJsOptions,
         fluid: true,
-        controls: true,
-        poster: data.video?.image ?? undefined
+        controls: true
       })
       playerRef.current.on('playing', () => {
         setPlaying(true)
+      })
+
+      playerRef.current.poster(data?.video?.image ?? undefined)
+      playerRef.current.src({
+        type: 'application/x-mpegURL',
+        src: data?.video?.variant?.hls ?? ''
       })
     }
   }, [data])

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoLibrary.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoLibrary.spec.tsx
@@ -1,11 +1,6 @@
 import { MockedProvider } from '@apollo/client/testing'
 import useMediaQuery from '@mui/material/useMediaQuery'
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor
-} from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { NextRouter, useRouter } from 'next/router'
 
 import {

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoLibrary.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoLibrary.spec.tsx
@@ -1,6 +1,11 @@
 import { MockedProvider } from '@apollo/client/testing'
 import useMediaQuery from '@mui/material/useMediaQuery'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor
+} from '@testing-library/react'
 import { NextRouter, useRouter } from 'next/router'
 
 import {
@@ -34,26 +39,28 @@ describe('VideoLibrary', () => {
     )
 
     it('should render the Video Library on the right', () => {
-      const { getByText, getByTestId } = render(
+      render(
         <MockedProvider>
           <VideoLibrary open />
         </MockedProvider>
       )
-      expect(getByText('Video Library')).toBeInTheDocument()
+      expect(screen.getByText('Video Library')).toBeInTheDocument()
       expect(
-        getByTestId('VideoLibrary').parentElement?.parentElement
+        screen.getByTestId('VideoLibrary').parentElement?.parentElement
       ).toHaveClass('MuiDrawer-paperAnchorRight')
     })
 
     it('should close VideoLibrary on close Icon click', () => {
       const onClose = jest.fn()
-      const { getAllByRole, getByTestId } = render(
+      render(
         <MockedProvider>
           <VideoLibrary open onClose={onClose} />
         </MockedProvider>
       )
-      expect(getAllByRole('button')[0]).toContainElement(getByTestId('X2Icon'))
-      fireEvent.click(getAllByRole('button')[0])
+      expect(screen.getAllByRole('button')[0]).toContainElement(
+        screen.getByTestId('X2Icon')
+      )
+      fireEvent.click(screen.getAllByRole('button')[0])
       expect(onClose).toHaveBeenCalled()
     })
   })
@@ -64,14 +71,14 @@ describe('VideoLibrary', () => {
     )
 
     it('should render the VideoLibrary from the bottom', () => {
-      const { getByText, getByTestId } = render(
+      render(
         <MockedProvider>
           <VideoLibrary open />
         </MockedProvider>
       )
-      expect(getByText('Video Library')).toBeInTheDocument()
+      expect(screen.getByText('Video Library')).toBeInTheDocument()
       expect(
-        getByTestId('VideoLibrary').parentElement?.parentElement
+        screen.getByTestId('VideoLibrary').parentElement?.parentElement
       ).toHaveClass('MuiDrawer-paperAnchorBottom')
     })
   })
@@ -82,7 +89,7 @@ describe('VideoLibrary', () => {
     )
 
     it('displays searched video', async () => {
-      const { getByRole, getByText } = render(
+      render(
         <MockedProvider
           mocks={[
             {
@@ -137,32 +144,32 @@ describe('VideoLibrary', () => {
           <VideoLibrary open />
         </MockedProvider>
       )
-      const textBox = getByRole('textbox')
+      const textBox = screen.getByRole('textbox')
       fireEvent.change(textBox, {
         target: { value: 'Andreas' }
       })
       await waitFor(() =>
-        expect(getByText("Andreas' Story")).toBeInTheDocument()
+        expect(screen.getByText("Andreas' Story")).toBeInTheDocument()
       )
     })
   })
 
   it('should render the Video Library on the right', () => {
-    const { getByText, getByTestId } = render(
+    render(
       <MockedProvider>
         <VideoLibrary open />
       </MockedProvider>
     )
-    expect(getByText('Video Library')).toBeInTheDocument()
+    expect(screen.getByText('Video Library')).toBeInTheDocument()
     expect(
-      getByTestId('VideoLibrary').parentElement?.parentElement
+      screen.getByTestId('VideoLibrary').parentElement?.parentElement
     ).toHaveClass('MuiDrawer-paperAnchorRight')
   })
 
   it('when video selected calls onSelect', async () => {
     const onSelect = jest.fn()
     const onClose = jest.fn()
-    const { getByRole, getByText } = render(
+    render(
       <MockedProvider
         mocks={[
           {
@@ -217,15 +224,17 @@ describe('VideoLibrary', () => {
         <VideoLibrary open onSelect={onSelect} onClose={onClose} />
       </MockedProvider>
     )
-    await waitFor(() => expect(getByText("Andreas' Story")).toBeInTheDocument())
+    await waitFor(() =>
+      expect(screen.getByText("Andreas' Story")).toBeInTheDocument()
+    )
     await waitFor(() =>
       fireEvent.click(
-        getByRole('button', {
+        screen.getByRole('button', {
           name: "Andreas' Story After living a life full of fighter planes and porsches, Andreas realizes something is missing. 03:06"
         })
       )
     )
-    fireEvent.click(getByRole('button', { name: 'Select' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }))
     expect(onSelect).toHaveBeenCalledWith({
       duration: 0,
       endAt: 0,
@@ -241,7 +250,7 @@ describe('VideoLibrary', () => {
     const onSelect = jest.fn()
     const onClose = jest.fn()
 
-    const { getByText } = render(
+    render(
       <MockedProvider>
         <VideoLibrary
           open
@@ -274,7 +283,8 @@ describe('VideoLibrary', () => {
         />
       </MockedProvider>
     )
-    await waitFor(() => expect(getByText('Video Details')).toBeInTheDocument())
+
+    await waitFor(() => expect(screen.getByText('Video Details')).toBeVisible())
   })
 
   it('should render YouTube', async () => {
@@ -286,14 +296,14 @@ describe('VideoLibrary', () => {
       }
     } as unknown as NextRouter)
 
-    const { getByText, getByRole } = render(
+    render(
       <MockedProvider>
         <VideoLibrary open />
       </MockedProvider>
     )
-    fireEvent.click(getByRole('tab', { name: 'YouTube' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'YouTube' }))
     await waitFor(() =>
-      expect(getByText('Paste any YouTube Link')).toBeInTheDocument()
+      expect(screen.getByText('Paste any YouTube Link')).toBeInTheDocument()
     )
     await waitFor(() => {
       expect(push).toHaveBeenCalledWith(
@@ -350,13 +360,13 @@ describe('VideoLibrary', () => {
       }
     } as unknown as NextRouter)
 
-    const { getByText, getByRole } = render(
+    render(
       <MockedProvider>
         <VideoLibrary open />
       </MockedProvider>
     )
-    fireEvent.click(getByRole('tab', { name: 'Upload' }))
-    expect(getByText('Drop a video here')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('tab', { name: 'Upload' }))
+    expect(screen.getByText('Drop a video here')).toBeInTheDocument()
     await waitFor(() => {
       expect(push).toHaveBeenCalledWith(
         {

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoLibrary.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoLibrary.tsx
@@ -4,7 +4,7 @@ import Tabs from '@mui/material/Tabs'
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
-import { ReactElement, SyntheticEvent, useEffect, useState } from 'react'
+import { ReactElement, SyntheticEvent, useState } from 'react'
 
 import { TreeBlock } from '@core/journeys/ui/block'
 import MediaStrip1Icon from '@core/shared/ui/icons/MediaStrip1'
@@ -55,17 +55,11 @@ export function VideoLibrary({
   selectedBlock,
   onSelect: handleSelect
 }: VideoLibraryProps): ReactElement {
-  const [openVideoDetails, setOpenVideoDetails] = useState(false)
+  const [openVideoDetails, setOpenVideoDetails] = useState(
+    selectedBlock?.videoId != null && open
+  )
   const [activeTab, setActiveTab] = useState(0)
   const router = useRouter()
-
-  useEffect(() => {
-    // opens video details if videoId is not null
-    // and video library is open
-    if (selectedBlock?.videoId != null && open) {
-      setOpenVideoDetails(true)
-    }
-  }, [selectedBlock, open])
 
   const TabParams = {
     0: 'video-library',

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoLibrary.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoLibrary.tsx
@@ -62,9 +62,7 @@ export function VideoLibrary({
   const router = useRouter()
 
   useEffect(() => {
-    if (selectedBlock?.videoId != null && open) {
-      setOpenVideoDetails(true)
-    }
+    setOpenVideoDetails(selectedBlock?.videoId != null && open)
   }, [open, selectedBlock?.videoId])
 
   const TabParams = {

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoLibrary.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoLibrary.tsx
@@ -4,7 +4,7 @@ import Tabs from '@mui/material/Tabs'
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
-import { ReactElement, SyntheticEvent, useState } from 'react'
+import { ReactElement, SyntheticEvent, useEffect, useState } from 'react'
 
 import { TreeBlock } from '@core/journeys/ui/block'
 import MediaStrip1Icon from '@core/shared/ui/icons/MediaStrip1'
@@ -60,6 +60,12 @@ export function VideoLibrary({
   )
   const [activeTab, setActiveTab] = useState(0)
   const router = useRouter()
+
+  useEffect(() => {
+    if (selectedBlock?.videoId != null && open) {
+      setOpenVideoDetails(true)
+    }
+  }, [open, selectedBlock?.videoId])
 
   const TabParams = {
     0: 'video-library',

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoList/VideoListItem/VideoListItem.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoList/VideoListItem/VideoListItem.tsx
@@ -47,6 +47,11 @@ export function VideoListItem({
     setOpen(false)
   }
 
+  const onSelect = (block: VideoBlockUpdateInput): void => {
+    if (handleSelect != null) handleSelect(block)
+    handleClose()
+  }
+
   const duration =
     time != null
       ? new Date(time * 1000).toISOString().substring(time < 3600 ? 14 : 11, 19)
@@ -112,7 +117,7 @@ export function VideoListItem({
           open={open}
           source={source}
           onClose={handleClose}
-          onSelect={handleSelect}
+          onSelect={onSelect}
         />
       )}
     </>

--- a/apps/journeys-admin/test/mockReactFlow.ts
+++ b/apps/journeys-admin/test/mockReactFlow.ts
@@ -45,12 +45,12 @@ export const mockReactFlow = (): void => {
   Object.defineProperties(global.HTMLElement.prototype, {
     offsetHeight: {
       get() {
-        return parseFloat(this.style.height)
+        return parseFloat(this.style.height as string)
       }
     },
     offsetWidth: {
       get() {
-        return parseFloat(this.style.width)
+        return parseFloat(this.style.width as string)
       }
     }
   })


### PR DESCRIPTION
# Description
Fixes video detail drawer showing incorrectly

### Issue
The video detail drawer shows when switching tabs in the video source drawer.

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7302308859)

### Solution
There was a useEffect in `VideoLibrary` that was setting the open state for `VideoDetails`. I just moved the logic in the useEffect to the default state value.

# External Changes
N/A

# Additional information
N/A
