### PR TITLE
fix: hide template filters with no background

### DIFF
--- a/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.tsx
@@ -112,7 +112,7 @@ export function NavigationDrawer({
         <ListItemButton
           onClick={handleClose}
           data-testid="NavigationListItemToggle"
-          aria-label='Navigation Drawer Toggle'
+          aria-label="Navigation Drawer Toggle"
         >
           <ListItemIcon
             sx={{

--- a/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/NavigationDrawer.tsx
@@ -112,6 +112,7 @@ export function NavigationDrawer({
         <ListItemButton
           onClick={handleClose}
           data-testid="NavigationListItemToggle"
+          aria-label='Navigation Drawer Toggle'
         >
           <ListItemIcon
             sx={{

--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/CollectionButton/CollectionButton.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/CollectionButton/CollectionButton.spec.tsx
@@ -20,7 +20,7 @@ describe('CollectionButton', () => {
       <CollectionButton item={tag} onClick={jest.fn()} />
     )
 
-    expect(getByRole('button', { name: 'NUA NUA NUA' })).toBeInTheDocument()
+    expect(getByRole('button', { name: 'NUA tag NUA NUA' })).toBeInTheDocument()
     expect(getByRole('img')).toBeInTheDocument()
   })
 
@@ -63,7 +63,7 @@ describe('CollectionButton', () => {
       <CollectionButton item={tag} onClick={onClick} />
     )
 
-    fireEvent.click(getByRole('button', { name: 'NUA NUA NUA' }))
+    fireEvent.click(getByRole('button', { name: 'NUA tag NUA NUA' }))
 
     expect(onClick).toHaveBeenCalledWith(tag.id)
   })

--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/CollectionButton/CollectionButton.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/CollectionButton/CollectionButton.tsx
@@ -91,7 +91,7 @@ export function CollectionButton({
                 priority
                 className="backgroundImageHover"
                 src={image.src}
-                alt={tagLabel ?? 'CollectionImage'}
+                alt={`${tagLabel} tag` ?? 'CollectionImage'}
                 width={64}
                 height={64}
               />

--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.spec.tsx
@@ -22,7 +22,7 @@ describe('FeltNeedsButton', () => {
     )
 
     expect(
-      getByRole('button', { name: 'Acceptance Acceptance Acceptance' })
+      getByRole('button', { name: 'Acceptance tag Acceptance Acceptance' })
     ).toBeInTheDocument()
     expect(queryByTestId('felt-needs-button-loading')).not.toBeInTheDocument()
   })
@@ -63,7 +63,7 @@ describe('FeltNeedsButton', () => {
     )
 
     fireEvent.click(
-      getByRole('button', { name: 'Acceptance Acceptance Acceptance' })
+      getByRole('button', { name: 'Acceptance tag Acceptance Acceptance' })
     )
 
     expect(onClick).toHaveBeenCalledWith(tag.id)

--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.spec.tsx
@@ -34,8 +34,8 @@ describe('FeltNeedsButton', () => {
     expect(getByTestId('felt-needs-button-loading')).toBeInTheDocument()
   })
 
-  it('should render without image', () => {
-    const { getByRole, queryByTestId } = render(
+  it('should not render unless it has an image', () => {
+    const { queryByRole, queryByTestId } = render(
       <FeltNeedsButton
         item={{
           ...tag,
@@ -51,8 +51,8 @@ describe('FeltNeedsButton', () => {
       />
     )
     expect(
-      getByRole('button', { name: 'invalid name invalid name' })
-    ).toBeInTheDocument()
+      queryByRole('button', { name: 'invalid name invalid name' })
+    ).not.toBeInTheDocument()
     expect(queryByTestId('felt-needs-button-loading')).not.toBeInTheDocument()
   })
 

--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.spec.tsx
@@ -34,8 +34,8 @@ describe('FeltNeedsButton', () => {
     expect(getByTestId('felt-needs-button-loading')).toBeInTheDocument()
   })
 
-  it('should not render unless it has an image', () => {
-    const { queryByRole, queryByTestId } = render(
+  it('should render without image', () => {
+    const { getByRole, queryByTestId } = render(
       <FeltNeedsButton
         item={{
           ...tag,
@@ -51,8 +51,8 @@ describe('FeltNeedsButton', () => {
       />
     )
     expect(
-      queryByRole('button', { name: 'invalid name invalid name' })
-    ).not.toBeInTheDocument()
+      getByRole('button', { name: 'invalid name invalid name' })
+    ).toBeInTheDocument()
     expect(queryByTestId('felt-needs-button-loading')).not.toBeInTheDocument()
   })
 

--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.tsx
@@ -33,7 +33,7 @@ function tagImage(tagLabel?: string):
         backgroundStyle:
           'linear-gradient(0deg, rgba(66, 66, 66, 0.8) 0%,rgba(66, 66, 66, 0) 60%,rgba(66, 66, 66, 0.0) 100%)'
       }
-    case 'Fear/Anxiety':
+    case 'Anxiety':
       return {
         tagImg: fearAnxietyImage,
         backgroundStyle:

--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.tsx
@@ -142,7 +142,7 @@ export function FeltNeedsButton({
           priority
           className="hoverStyles"
           src={image}
-          alt={tagLabel ?? 'FeltNeedsImage'}
+          alt={`${tagLabel} tag` ?? 'FeltNeedsImage'}
           sizes={`(max-width: ${
             theme.breakpoints.values.md - 0.5
           }px) 150px, 222px`}

--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.tsx
@@ -98,97 +98,103 @@ export function FeltNeedsButton({
   const tagImageData = tagImage(tagLabel)
   const image = tagImageData?.tagImg
 
-  return tag != null ? (
-    <ButtonBase
-      key={`${tagLabel ?? 'felt-needs'}-button}`}
-      sx={{
-        backgroundColor: 'grey',
-        padding: '32px 28px',
-        color: 'white',
-        borderRadius: '8px',
-        width: { xs: '150px', md: '222px' },
-        height: { xs: '56px', md: '110px' },
-        overflow: 'hidden',
-        '&:focus': {
-          outline: '2px solid',
-          outlineColor: theme.palette.primary.main,
-          outlineOffset: '2px'
-        },
-        '&:hover': {
-          '& .hoverStyles': {
-            transform: 'scale(1.05)'
-          }
-        },
-        '& .hoverStyles': {
-          transition: theme.transitions.create('transform')
-        }
-      }}
-      onClick={() => tag?.id != null && onClick(tag.id)}
-    >
-      <Box
-        data-testid="gradientLayer"
-        sx={{
-          position: 'absolute',
-          top: 0,
-          bottom: 0,
-          left: 0,
-          right: 0,
-          zIndex: 2,
-          background: tagImageData?.backgroundStyle
-        }}
-      />
-      {image != null && (
-        <NextImage
-          priority
-          className="hoverStyles"
-          src={image}
-          alt={tagLabel ?? 'FeltNeedsImage'}
-          sizes={`(max-width: ${
-            theme.breakpoints.values.md - 0.5
-          }px) 150px, 222px`}
-          fill
+  return (
+    <>
+      {tag != null ? (
+        tagImageData != null ? (
+          <ButtonBase
+            key={`${tagLabel ?? 'felt-needs'}-button}`}
+            sx={{
+              backgroundColor: 'grey',
+              padding: '32px 28px',
+              color: 'white',
+              borderRadius: '8px',
+              width: { xs: '150px', md: '222px' },
+              height: { xs: '56px', md: '110px' },
+              overflow: 'hidden',
+              '&:focus': {
+                outline: '2px solid',
+                outlineColor: theme.palette.primary.main,
+                outlineOffset: '2px'
+              },
+              '&:hover': {
+                '& .hoverStyles': {
+                  transform: 'scale(1.05)'
+                }
+              },
+              '& .hoverStyles': {
+                transition: theme.transitions.create('transform')
+              }
+            }}
+            onClick={() => tag?.id != null && onClick(tag.id)}
+          >
+            <Box
+              data-testid="gradientLayer"
+              sx={{
+                position: 'absolute',
+                top: 0,
+                bottom: 0,
+                left: 0,
+                right: 0,
+                zIndex: 2,
+                background: tagImageData?.backgroundStyle
+              }}
+            />
+            {image != null && (
+              <NextImage
+                priority
+                className="hoverStyles"
+                src={image}
+                alt={tagLabel ?? 'FeltNeedsImage'}
+                sizes={`(max-width: ${
+                  theme.breakpoints.values.md - 0.5
+                }px) 150px, 222px`}
+                fill
+              />
+            )}
+            <Typography
+              className="hoverStyles"
+              variant="h3"
+              sx={{
+                zIndex: 3,
+                display: { xs: 'none', md: 'flex' },
+                position: 'absolute',
+                opacity: '70%',
+                left: 12,
+                bottom: 8,
+                mixBlendMode: 'plus-lighter'
+              }}
+            >
+              {tagLabel ?? <Skeleton width={80} />}
+            </Typography>
+            <Typography
+              className="hoverStyles"
+              variant="subtitle2"
+              sx={{
+                zIndex: 1,
+                display: { md: 'none' },
+                position: 'absolute',
+                opacity: '70%',
+                left: 8,
+                bottom: 4,
+                mixBlendMode: 'plus-lighter'
+              }}
+            >
+              {tagLabel ?? <Skeleton width={80} />}
+            </Typography>
+          </ButtonBase>
+        ) : null
+      ) : (
+        <Skeleton
+          data-testid="felt-needs-button-loading"
+          variant="rounded"
+          sx={{
+            width: { xs: '150px', md: '222px' },
+            height: { xs: '56px', md: '110px' },
+            borderRadius: 2
+          }}
         />
       )}
-      <Typography
-        className="hoverStyles"
-        variant="h3"
-        sx={{
-          zIndex: 3,
-          display: { xs: 'none', md: 'flex' },
-          position: 'absolute',
-          opacity: '70%',
-          left: 12,
-          bottom: 8,
-          mixBlendMode: 'plus-lighter'
-        }}
-      >
-        {tagLabel ?? <Skeleton width={80} />}
-      </Typography>
-      <Typography
-        className="hoverStyles"
-        variant="subtitle2"
-        sx={{
-          zIndex: 1,
-          display: { md: 'none' },
-          position: 'absolute',
-          opacity: '70%',
-          left: 8,
-          bottom: 4,
-          mixBlendMode: 'plus-lighter'
-        }}
-      >
-        {tagLabel ?? <Skeleton width={80} />}
-      </Typography>
-    </ButtonBase>
-  ) : (
-    <Skeleton
-      data-testid="felt-needs-button-loading"
-      variant="rounded"
-      sx={{
-        width: { xs: '150px', md: '222px' },
-        height: { xs: '56px', md: '110px' },
-        borderRadius: 2
-      }}
-    />
+    </>
   )
 }

--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/FeltNeedsButton/FeltNeedsButton.tsx
@@ -98,103 +98,97 @@ export function FeltNeedsButton({
   const tagImageData = tagImage(tagLabel)
   const image = tagImageData?.tagImg
 
-  return (
-    <>
-      {tag != null ? (
-        tagImageData != null ? (
-          <ButtonBase
-            key={`${tagLabel ?? 'felt-needs'}-button}`}
-            sx={{
-              backgroundColor: 'grey',
-              padding: '32px 28px',
-              color: 'white',
-              borderRadius: '8px',
-              width: { xs: '150px', md: '222px' },
-              height: { xs: '56px', md: '110px' },
-              overflow: 'hidden',
-              '&:focus': {
-                outline: '2px solid',
-                outlineColor: theme.palette.primary.main,
-                outlineOffset: '2px'
-              },
-              '&:hover': {
-                '& .hoverStyles': {
-                  transform: 'scale(1.05)'
-                }
-              },
-              '& .hoverStyles': {
-                transition: theme.transitions.create('transform')
-              }
-            }}
-            onClick={() => tag?.id != null && onClick(tag.id)}
-          >
-            <Box
-              data-testid="gradientLayer"
-              sx={{
-                position: 'absolute',
-                top: 0,
-                bottom: 0,
-                left: 0,
-                right: 0,
-                zIndex: 2,
-                background: tagImageData?.backgroundStyle
-              }}
-            />
-            {image != null && (
-              <NextImage
-                priority
-                className="hoverStyles"
-                src={image}
-                alt={tagLabel ?? 'FeltNeedsImage'}
-                sizes={`(max-width: ${
-                  theme.breakpoints.values.md - 0.5
-                }px) 150px, 222px`}
-                fill
-              />
-            )}
-            <Typography
-              className="hoverStyles"
-              variant="h3"
-              sx={{
-                zIndex: 3,
-                display: { xs: 'none', md: 'flex' },
-                position: 'absolute',
-                opacity: '70%',
-                left: 12,
-                bottom: 8,
-                mixBlendMode: 'plus-lighter'
-              }}
-            >
-              {tagLabel ?? <Skeleton width={80} />}
-            </Typography>
-            <Typography
-              className="hoverStyles"
-              variant="subtitle2"
-              sx={{
-                zIndex: 1,
-                display: { md: 'none' },
-                position: 'absolute',
-                opacity: '70%',
-                left: 8,
-                bottom: 4,
-                mixBlendMode: 'plus-lighter'
-              }}
-            >
-              {tagLabel ?? <Skeleton width={80} />}
-            </Typography>
-          </ButtonBase>
-        ) : null
-      ) : (
-        <Skeleton
-          data-testid="felt-needs-button-loading"
-          variant="rounded"
-          sx={{
-            width: { xs: '150px', md: '222px' },
-            height: { xs: '56px', md: '110px' },
-            borderRadius: 2
-          }}
+  return tag != null ? (
+    <ButtonBase
+      key={`${tagLabel ?? 'felt-needs'}-button}`}
+      sx={{
+        backgroundColor: 'grey',
+        padding: '32px 28px',
+        color: 'white',
+        borderRadius: '8px',
+        width: { xs: '150px', md: '222px' },
+        height: { xs: '56px', md: '110px' },
+        overflow: 'hidden',
+        '&:focus': {
+          outline: '2px solid',
+          outlineColor: theme.palette.primary.main,
+          outlineOffset: '2px'
+        },
+        '&:hover': {
+          '& .hoverStyles': {
+            transform: 'scale(1.05)'
+          }
+        },
+        '& .hoverStyles': {
+          transition: theme.transitions.create('transform')
+        }
+      }}
+      onClick={() => tag?.id != null && onClick(tag.id)}
+    >
+      <Box
+        data-testid="gradientLayer"
+        sx={{
+          position: 'absolute',
+          top: 0,
+          bottom: 0,
+          left: 0,
+          right: 0,
+          zIndex: 2,
+          background: tagImageData?.backgroundStyle
+        }}
+      />
+      {image != null && (
+        <NextImage
+          priority
+          className="hoverStyles"
+          src={image}
+          alt={tagLabel ?? 'FeltNeedsImage'}
+          sizes={`(max-width: ${
+            theme.breakpoints.values.md - 0.5
+          }px) 150px, 222px`}
+          fill
         />
       )}
-    </>
+      <Typography
+        className="hoverStyles"
+        variant="h3"
+        sx={{
+          zIndex: 3,
+          display: { xs: 'none', md: 'flex' },
+          position: 'absolute',
+          opacity: '70%',
+          left: 12,
+          bottom: 8,
+          mixBlendMode: 'plus-lighter'
+        }}
+      >
+        {tagLabel ?? <Skeleton width={80} />}
+      </Typography>
+      <Typography
+        className="hoverStyles"
+        variant="subtitle2"
+        sx={{
+          zIndex: 1,
+          display: { md: 'none' },
+          position: 'absolute',
+          opacity: '70%',
+          left: 8,
+          bottom: 4,
+          mixBlendMode: 'plus-lighter'
+        }}
+      >
+        {tagLabel ?? <Skeleton width={80} />}
+      </Typography>
+    </ButtonBase>
+  ) : (
+    <Skeleton
+      data-testid="felt-needs-button-loading"
+      variant="rounded"
+      sx={{
+        width: { xs: '150px', md: '222px' },
+        height: { xs: '56px', md: '110px' },
+        borderRadius: 2
+      }}
+    />
   )
 }

--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/TagCarousels.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/TagCarousels.spec.tsx
@@ -22,15 +22,16 @@ describe('TagCarousels', () => {
     expect(getAllByTestId('collections-button-loading')).toHaveLength(2)
 
     await waitFor(async () => {
-      await expect(
+      expect(
         within(feltNeedsCarousel).getByRole('button', {
-          name: 'Acceptance Acceptance Acceptance'
+          // The name of the tag is the alt text + tag label + tag label
+          name: 'Acceptance tag Acceptance Acceptance'
         })
       ).toBeInTheDocument()
 
-      await expect(
+      expect(
         getByRole('button', {
-          name: 'NUA NUA NUA'
+          name: 'NUA tag NUA NUA'
         })
       ).toBeInTheDocument()
     })
@@ -45,16 +46,16 @@ describe('TagCarousels', () => {
     )
 
     await waitFor(async () => {
-      await expect(
+      expect(
         getByRole('button', {
-          name: 'Acceptance Acceptance Acceptance'
+          name: 'Acceptance tag Acceptance Acceptance'
         })
       ).toBeInTheDocument()
     })
 
     fireEvent.click(
       getByRole('button', {
-        name: 'Acceptance Acceptance Acceptance'
+        name: 'Acceptance tag Acceptance Acceptance'
       })
     )
 
@@ -71,16 +72,16 @@ describe('TagCarousels', () => {
 
     // Check that carousel has loaded properly
     await waitFor(async () => {
-      await expect(
+      expect(
         getByRole('button', {
-          name: 'Acceptance Acceptance Acceptance'
+          name: 'Acceptance tag Acceptance Acceptance'
         })
       ).toBeInTheDocument()
     })
 
     // Assert no background tag is filtered out
     await waitFor(async () => {
-      await expect(queryAllByText('Fear/Power')).toHaveLength(0)
+      expect(queryAllByText('Fear/Power')).toHaveLength(0)
     })
   })
 
@@ -93,16 +94,16 @@ describe('TagCarousels', () => {
     )
 
     await waitFor(async () => {
-      await expect(
+       expect(
         getByRole('button', {
-          name: 'NUA NUA NUA'
+          name: 'NUA tag NUA NUA'
         })
       ).toBeInTheDocument()
     })
 
     fireEvent.click(
       getByRole('button', {
-        name: 'NUA NUA NUA'
+        name: 'NUA tag NUA NUA'
       })
     )
 

--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/TagCarousels.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/TagCarousels.spec.tsx
@@ -94,7 +94,7 @@ describe('TagCarousels', () => {
     )
 
     await waitFor(async () => {
-       expect(
+      expect(
         getByRole('button', {
           name: 'NUA tag NUA NUA'
         })

--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/TagCarousels.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/TagCarousels.spec.tsx
@@ -70,7 +70,7 @@ describe('TagCarousels', () => {
       </MockedProvider>
     )
 
-    // Check that carousel has loaded properly
+    // Not for test but needed in order to ensure rendering is correct
     await waitFor(async () => {
       expect(
         getByRole('button', {
@@ -79,7 +79,7 @@ describe('TagCarousels', () => {
       ).toBeInTheDocument()
     })
 
-    // Assert no background tag is filtered out
+    // Assert tags without backgrounds are filtered out
     await waitFor(async () => {
       expect(queryAllByText('Fear/Power')).toHaveLength(0)
     })

--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/TagCarousels.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/TagCarousels.spec.tsx
@@ -61,6 +61,29 @@ describe('TagCarousels', () => {
     expect(onChange).toHaveBeenCalledWith('acceptanceTagId')
   })
 
+  it('should filter out felt needs tags that have no backgrounds', async () => {
+    const onChange = jest.fn()
+    const { getByRole, queryAllByText } = render(
+      <MockedProvider mocks={[getTagsMock]}>
+        <TagCarousels onChange={onChange} />
+      </MockedProvider>
+    )
+
+    // Check that carousel has loaded properly
+    await waitFor(async () => {
+      await expect(
+        getByRole('button', {
+          name: 'Acceptance Acceptance Acceptance'
+        })
+      ).toBeInTheDocument()
+    })
+
+    // Assert no background tag is filtered out
+    await waitFor(async () => {
+      await expect(queryAllByText('Fear/Power')).toHaveLength(0)
+    })
+  })
+
   it('should filter by collections tag', async () => {
     const onChange = jest.fn()
     const { getByRole } = render(

--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/TagCarousels.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/TagCarousels.tsx
@@ -101,7 +101,7 @@ function hasBgImg(tag: string): boolean {
   // (images currently hard-coded in FeltNeedsButton)
   return [
     'Depression',
-    'Fear/Anxiety',
+    'Anxiety',
     'Forgiveness',
     'Hope',
     'Loneliness',

--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/TagCarousels.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/TagCarousels.tsx
@@ -37,7 +37,8 @@ export function TagCarousels({
 
   const feltNeedsTags = useMemo(() => {
     return feltNeedsTagId != null
-      ? childTags.filter((tag) => tag.parentId === feltNeedsTagId)
+      ? childTags.filter((tag) => tag.parentId === feltNeedsTagId 
+        && hasBgImg(tag.name[0].value))
       : []
   }, [childTags, feltNeedsTagId])
 
@@ -91,4 +92,11 @@ export function TagCarousels({
       </Stack>
     </Stack>
   )
+}
+
+function hasBgImg(tag: string): boolean {
+  // Temporary fix: Only display these tags that have background images 
+  // (images currently hard-coded in FeltNeedsButton)
+  return ['Depression', 'Fear/Anxiety', 'Forgiveness', 'Hope', 'Loneliness', 
+  'Love', 'Security', 'Significance', 'Acceptance'].includes(tag)
 }

--- a/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/TagCarousels.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TagCarousels/TagCarousels.tsx
@@ -37,8 +37,10 @@ export function TagCarousels({
 
   const feltNeedsTags = useMemo(() => {
     return feltNeedsTagId != null
-      ? childTags.filter((tag) => tag.parentId === feltNeedsTagId 
-        && hasBgImg(tag.name[0].value))
+      ? childTags.filter(
+          (tag) =>
+            tag.parentId === feltNeedsTagId && hasBgImg(tag.name[0].value)
+        )
       : []
   }, [childTags, feltNeedsTagId])
 
@@ -95,8 +97,17 @@ export function TagCarousels({
 }
 
 function hasBgImg(tag: string): boolean {
-  // Temporary fix: Only display these tags that have background images 
+  // Temporary fix: Only display these tags that have background images
   // (images currently hard-coded in FeltNeedsButton)
-  return ['Depression', 'Fear/Anxiety', 'Forgiveness', 'Hope', 'Loneliness', 
-  'Love', 'Security', 'Significance', 'Acceptance'].includes(tag)
+  return [
+    'Depression',
+    'Fear/Anxiety',
+    'Forgiveness',
+    'Hope',
+    'Loneliness',
+    'Love',
+    'Security',
+    'Significance',
+    'Acceptance'
+  ].includes(tag)
 }

--- a/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.spec.tsx
@@ -168,12 +168,12 @@ describe('TemplateGallery', () => {
 
     await waitFor(() => {
       expect(
-        getByRole('button', { name: 'Acceptance Acceptance Acceptance' })
+        getByRole('button', { name: 'Acceptance tag Acceptance Acceptance' })
       ).toBeInTheDocument()
     })
 
     fireEvent.click(
-      getByRole('button', { name: 'Acceptance Acceptance Acceptance' })
+      getByRole('button', { name: 'Acceptance tag Acceptance Acceptance' })
     )
     await waitFor(() => {
       expect(push).toHaveBeenCalledWith({

--- a/apps/journeys-admin/src/components/TemplateGallery/data.ts
+++ b/apps/journeys-admin/src/components/TemplateGallery/data.ts
@@ -390,13 +390,13 @@ export const getTagsMock: MockedResponse<GetTags> = {
         },
         {
           __typename: 'Tag',
-          id: 'fearTagId',
+          id: 'anxietyTagId',
           service: null,
           parentId: 'parentId1',
           name: [
             {
               __typename: 'Translation',
-              value: 'Fear/Anxiety',
+              value: 'Anxiety',
               primary: true
             }
           ]

--- a/apps/journeys-admin/src/components/TemplateGallery/data.ts
+++ b/apps/journeys-admin/src/components/TemplateGallery/data.ts
@@ -481,6 +481,19 @@ export const getTagsMock: MockedResponse<GetTags> = {
         },
         {
           __typename: 'Tag',
+          id: 'fearPowerTagId',
+          service: null,
+          parentId: 'parentId1',
+          name: [
+            {
+              __typename: 'Translation',
+              value: 'Fear/Power',
+              primary: true
+            }
+          ]
+        },
+        {
+          __typename: 'Tag',
           id: 'parentId2',
           service: null,
           parentId: null,


### PR DESCRIPTION
# Description

### Issue

Filter card buttons (FeltNeedsButton.tsx) should only display if they have a background.

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071027/todos/7306953317)

### Solution

Initially tried to conditionally render the ButtonBase component iff the `tagImageData` variable is defined. However this lead to uneven spacing. 

Instead, let the TagCarousel filter out a fixed set of tags that are known to have valid backgrounds as hard-coded in FeltNeedsButton. 

<img width="1497" alt="image" src="https://github.com/JesusFilm/core/assets/26043376/cba53155-9f93-4fa3-b5db-1b1b695a0815">



# External Changes

n/a

# Additional information

UI test added took a long time to debug. Solution: I needed to make another button assertion so that jest would wait for the render to complete.
