### PR TITLE
revert: e2e tests from running

### DIFF
--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -149,37 +149,37 @@ jobs:
           state: ${{ job.status }}
           environment-url: ${{ steps.deployment-url.outputs.deployment-url }}
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-      - name: Store Playwright's Version
-        run: |
-          PLAYWRIGHT_VERSION=$(npm ls @playwright/test | grep @playwright | sed 's/.*@//')
-          echo "Playwright's Version: $PLAYWRIGHT_VERSION"
-          echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_ENV
-      - name: Cache Playwright Browsers for Playwright's Version
-        id: cache-playwright-browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-browsers-${{ env.PLAYWRIGHT_VERSION }}
-      - run: npx playwright install --with-deps
-        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-      - run: npx playwright install-deps
-        if: steps.cache-playwright-browsers.outputs.cache-hit == 'true'
-      - name: Run Playwright tests
-        run: npx nx run ${{ matrix.app }}-e2e:e2e
-        env:
-          DEPLOYMENT_URL: ${{ steps.deployment-url.outputs.deployment-url }}
-          PLAYWRIGHT_EMAIL: ${{ secrets.PLAYWRIGHT_EMAIL }}
-          PLAYWRIGHT_PASSWORD: ${{ secrets.PLAYWRIGHT_PASSWORD }}
-          PLAYWRIGHT_USER: ${{ secrets.PLAYWRIGHT_USER }}
-          PLAYWRIGHT_TEAM_NAME: ${{ secrets.PLAYWRIGHT_TEAM_NAME }}
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: ${{ matrix.app }}-playwright-report
-          path: |
-            playwright-report/
-            test-results/
-          retention-days: 30
+      # - name: Store Playwright's Version
+      #   run: |
+      #     PLAYWRIGHT_VERSION=$(npm ls @playwright/test | grep @playwright | sed 's/.*@//')
+      #     echo "Playwright's Version: $PLAYWRIGHT_VERSION"
+      #     echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_ENV
+      # - name: Cache Playwright Browsers for Playwright's Version
+      #   id: cache-playwright-browsers
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: ~/.cache/ms-playwright
+      #     key: playwright-browsers-${{ env.PLAYWRIGHT_VERSION }}
+      # - run: npx playwright install --with-deps
+      #   if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+      # - run: npx playwright install-deps
+      #   if: steps.cache-playwright-browsers.outputs.cache-hit == 'true'
+      # - name: Run Playwright tests
+      #   run: npx nx run ${{ matrix.app }}-e2e:e2e
+      #   env:
+      #     DEPLOYMENT_URL: ${{ steps.deployment-url.outputs.deployment-url }}
+      #     PLAYWRIGHT_EMAIL: ${{ secrets.PLAYWRIGHT_EMAIL }}
+      #     PLAYWRIGHT_PASSWORD: ${{ secrets.PLAYWRIGHT_PASSWORD }}
+      #     PLAYWRIGHT_USER: ${{ secrets.PLAYWRIGHT_USER }}
+      #     PLAYWRIGHT_TEAM_NAME: ${{ secrets.PLAYWRIGHT_TEAM_NAME }}
+      # - uses: actions/upload-artifact@v3
+      #   if: always()
+      #   with:
+      #     name: ${{ matrix.app }}-playwright-report
+      #     path: |
+      #       playwright-report/
+      #       test-results/
+      #     retention-days: 30
   deploy-status:
     runs-on: ubuntu-latest
     needs: [affected, deploy-preview]


### PR DESCRIPTION
# Description

### Issue

These tests were renabled without actually testing to see if they were passing

### Solution

Disable e2e tests from running. @kiran-redhat I think next time we re-enable these we should first make a minor change to each project to run the e2e tests before merging in.