### PR TITLE
fix: reset canvas focus when slider to journey flow

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Slider.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Slider.tsx
@@ -52,7 +52,7 @@ export function Slider(): ReactElement {
   function resetCanvasFocus(): void {
     if (isSlideChangingTo(ActiveSlide.JourneyFlow)) {
       dispatch({
-        type: 'SetSelectedBlockAction',
+        type: 'SetSelectedBlockOnlyAction',
         selectedBlock: selectedStep
       })
     }
@@ -79,12 +79,12 @@ export function Slider(): ReactElement {
       slidesPerView="auto"
       breakpoints={swiperBreakpoints}
       onActiveIndexChange={(swiper) => {
-        resetCanvasFocus()
         dispatch({
           type: 'SetActiveSlideAction',
           activeSlide: swiper.activeIndex
         })
       }}
+      onTransitionEnd={resetCanvasFocus}
       sx={{
         height: `calc(100svh - ${EDIT_TOOLBAR_HEIGHT}px)`
       }}

--- a/apps/journeys-admin/src/components/Editor/Slider/Slider.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Slider.tsx
@@ -25,7 +25,7 @@ export function Slider(): ReactElement {
   const { breakpoints } = useTheme()
   const swiperRef = useRef<SwiperRef>(null)
   const {
-    state: { activeSlide },
+    state: { activeSlide, selectedStep },
     dispatch
   } = useEditor()
 
@@ -40,21 +40,27 @@ export function Slider(): ReactElement {
     }
   }
 
+  useEffect(() => {
+    if (
+      swiperRef.current != null &&
+      swiperRef.current.swiper.activeIndex !== activeSlide
+    ) {
+      if (activeSlide === ActiveSlide.JourneyFlow) {
+        dispatch({
+          type: 'SetSelectedBlockAction',
+          selectedBlock: selectedStep
+        })
+      }
+      swiperRef.current.swiper.slideTo(activeSlide)
+    }
+  }, [activeSlide])
+
   function handlePrev(): void {
     dispatch({
       type: 'SetActiveSlideAction',
       activeSlide: activeSlide - 1
     })
   }
-
-  useEffect(() => {
-    if (
-      swiperRef.current != null &&
-      swiperRef.current.swiper.activeIndex !== activeSlide
-    ) {
-      swiperRef.current.swiper.slideTo(activeSlide)
-    }
-  }, [activeSlide])
 
   return (
     <StyledSwiper

--- a/apps/journeys-admin/src/components/Editor/Slider/Slider.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Slider.tsx
@@ -45,15 +45,25 @@ export function Slider(): ReactElement {
       swiperRef.current != null &&
       swiperRef.current.swiper.activeIndex !== activeSlide
     ) {
-      if (activeSlide === ActiveSlide.JourneyFlow) {
-        dispatch({
-          type: 'SetSelectedBlockAction',
-          selectedBlock: selectedStep
-        })
-      }
       swiperRef.current.swiper.slideTo(activeSlide)
     }
   }, [activeSlide])
+
+  function resetCanvasFocus(): void {
+    if (isSlideChangingTo(ActiveSlide.JourneyFlow)) {
+      dispatch({
+        type: 'SetSelectedBlockAction',
+        selectedBlock: selectedStep
+      })
+    }
+  }
+
+  function isSlideChangingTo(slide): boolean {
+    return (
+      swiperRef.current != null &&
+      swiperRef.current?.swiper.activeIndex === slide
+    )
+  }
 
   function handlePrev(): void {
     dispatch({
@@ -69,6 +79,7 @@ export function Slider(): ReactElement {
       slidesPerView="auto"
       breakpoints={swiperBreakpoints}
       onActiveIndexChange={(swiper) => {
+        resetCanvasFocus()
         dispatch({
           type: 'SetActiveSlideAction',
           activeSlide: swiper.activeIndex

--- a/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.spec.tsx
+++ b/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.spec.tsx
@@ -177,12 +177,41 @@ describe('EditorContext', () => {
         }
         expect(
           reducer(state, {
-            type: 'SetSelectedBlockAction',
+            type: 'SetSelectedBlockOnlyAction',
             selectedBlock: block
           })
         ).toEqual({
           ...state,
           selectedBlock: block
+        })
+      })
+
+      it('should change to content view when block selected', () => {
+        const block: TreeBlock = {
+          id: 'step0.id',
+          __typename: 'StepBlock',
+          parentBlockId: null,
+          parentOrder: 0,
+          locked: false,
+          nextBlockId: null,
+          children: []
+        }
+        const state: EditorState = {
+          steps: [block],
+          activeCanvasDetailsDrawer: ActiveCanvasDetailsDrawer.Properties,
+          activeFab: ActiveFab.Add,
+          activeSlide: ActiveSlide.JourneyFlow,
+          activeContent: ActiveContent.Canvas
+        }
+        expect(
+          reducer(state, {
+            type: 'SetSelectedBlockAction',
+            selectedBlock: block
+          })
+        ).toEqual({
+          ...state,
+          selectedBlock: block,
+          activeSlide: ActiveSlide.Content
         })
       })
     })

--- a/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
+++ b/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
@@ -101,6 +101,10 @@ interface SetSelectedBlockAction {
   type: 'SetSelectedBlockAction'
   selectedBlock?: TreeBlock
 }
+interface SetSelectedBlockOnlyAction {
+  type: 'SetSelectedBlockOnlyAction'
+  selectedBlock?: TreeBlock
+}
 export interface SetSelectedBlockByIdAction {
   type: 'SetSelectedBlockByIdAction'
   selectedBlockId?: string
@@ -128,6 +132,7 @@ type EditorAction =
   | SetActiveSlideAction
   | SetSelectedAttributeIdAction
   | SetSelectedBlockAction
+  | SetSelectedBlockOnlyAction
   | SetSelectedBlockByIdAction
   | SetSelectedGoalUrlAction
   | SetSelectedStepAction
@@ -172,6 +177,8 @@ export const reducer = (
         activeContent: ActiveContent.Canvas,
         activeSlide: ActiveSlide.Content
       }
+    case 'SetSelectedBlockOnlyAction':
+      return { ...state, selectedBlock: action.selectedBlock }
     case 'SetSelectedBlockByIdAction':
       return {
         ...state,


### PR DESCRIPTION
# Description

### Issue

When one selects any block that results in the QuickControls to appear, and then navigates to the journey flow slide, the QuickControls remain open. We want the parent card to be focused on and the QuickControls to close.

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7292062111)

### Solution

Add a dispatch on the slider useEffect function that sets the selected block value to the parent card block.

# External Changes

n/a

# Additional information

This fix seems to add some lagging in terms of rendering the canvas when the slider changes but the hope is that this can be resolved in another ticket. https://3.basecamp.com/3105655/buckets/37071143/todos/7307053111
