### PR TITLE
fix: open drawer on button press

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/CardWrapper/CardWrapper.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/CardWrapper/CardWrapper.tsx
@@ -9,7 +9,7 @@ import { MouseEvent, ReactElement } from 'react'
 
 import type { WrapperProps } from '@core/journeys/ui/BlockRenderer'
 import { Card } from '@core/journeys/ui/Card'
-import { useEditor } from '@core/journeys/ui/EditorProvider'
+import { ActiveSlide, useEditor } from '@core/journeys/ui/EditorProvider'
 
 export function CardWrapper({ block, children }: WrapperProps): ReactElement {
   const smUp = useMediaQuery((theme: Theme) => theme.breakpoints.up('sm'))
@@ -18,6 +18,7 @@ export function CardWrapper({ block, children }: WrapperProps): ReactElement {
     state: { selectedStep },
     dispatch
   } = useEditor()
+
   const openCardTemplates = (e: MouseEvent): void => {
     e.stopPropagation()
     dispatch({
@@ -27,6 +28,10 @@ export function CardWrapper({ block, children }: WrapperProps): ReactElement {
     dispatch({
       type: 'SetSelectedAttributeIdAction',
       selectedAttributeId: undefined
+    })
+    dispatch({
+      type: 'SetActiveSlideAction',
+      activeSlide: ActiveSlide.Drawer
     })
   }
 


### PR DESCRIPTION
# Description

### Issue

select template button did not bring drawer into focus

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7292725785)

### Solution

call dispatch to focus drawer

# Testing

to test, go on mobile, create new card, click select template button in card. templates drawer should be brought to focus