### PR TITLE
fix: active team on signin

### DIFF
--- a/apps/journeys-admin/src/components/SignIn/HomePage/HomePage.tsx
+++ b/apps/journeys-admin/src/components/SignIn/HomePage/HomePage.tsx
@@ -28,6 +28,7 @@ export function HomePage({
       .required(t('Please enter your email address')),
     password: string().min(6)
   })
+
   async function handleEmailSignIn(
     values: InferType<typeof validationSchema>
   ): Promise<void> {
@@ -53,6 +54,7 @@ export function HomePage({
     setUserEmail?.(values.email)
     setUserPassword?.(values.password ?? '')
   }
+
   return (
     <>
       <Box sx={{ pb: 3, mt: -4 }}>

--- a/apps/journeys-admin/src/components/SignIn/SignInServiceButton/SignInServiceButton.tsx
+++ b/apps/journeys-admin/src/components/SignIn/SignInServiceButton/SignInServiceButton.tsx
@@ -27,11 +27,7 @@ export function SignInServiceButton({
         ? new GoogleAuthProvider()
         : new FacebookAuthProvider()
     authProvider.setCustomParameters({ prompt: 'select_account' })
-    try {
-      await signInWithPopup(auth, authProvider)
-    } catch (err) {
-      console.error(err)
-    }
+    await signInWithPopup(auth, authProvider).catch(console.error)
   }
 
   return (

--- a/apps/journeys-admin/src/components/Team/TeamOnboarding/TeamOnboarding.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamOnboarding/TeamOnboarding.tsx
@@ -44,7 +44,7 @@ export function TeamOnboarding(): ReactElement {
           }
         }
       }),
-      await router.push(
+      router.push(
         router.query.redirect != null
           ? new URL(
               `${window.location.origin}${router.query.redirect as string}`

--- a/apps/journeys-admin/src/components/Team/TeamProvider/TeamProvider.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamProvider/TeamProvider.tsx
@@ -66,6 +66,7 @@ export function TeamProvider({ children }: TeamProviderProps): ReactElement {
   const query = useQuery<GetLastActiveTeamIdAndTeams>(
     GET_LAST_ACTIVE_TEAM_ID_AND_TEAMS,
     {
+      notifyOnNetworkStatusChange: true,
       onCompleted: (data) => {
         if (activeTeam != null || data.teams == null) return
         TagManager.dataLayer({

--- a/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.tsx
@@ -10,7 +10,7 @@ import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import sortBy from 'lodash/sortBy'
 import { useTranslation } from 'next-i18next'
-import { ReactElement, useRef, useState } from 'react'
+import { ReactElement, useEffect, useRef, useState } from 'react'
 
 import ChevronDownIcon from '@core/shared/ui/icons/ChevronDown'
 import UsersProfiles2Icon from '@core/shared/ui/icons/UsersProfiles2'
@@ -55,6 +55,12 @@ export function TeamSelect({ onboarding }: TeamSelectProps): ReactElement {
       }
     })
   }
+
+  useEffect(() => {
+    // TODO: remove once finished testing
+    console.log('I have refetched')
+    void query.refetch()
+  }, [])
 
   return (
     <>


### PR DESCRIPTION
# Description

### Issue

When you signin for the first time, all is well. After signin out (which sets activeTeam to null) and then signing back in again, it usually will default to the 'Shared with me'

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071027/todos/7337389239)

### Solution

Add the `notifyOnNetworkStatusChange: true` flag to the `TeamProvider`'s query which forces a re-render when the call is in flight. This seems to ensure that dropdown menus update when activeTeam has been correctly fetched.

# External Changes

n/a

# Additional information

n/a
