### PR TITLE
fix: flashing action menu

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/QuickControls/QuickControls.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/QuickControls/QuickControls.spec.tsx
@@ -10,11 +10,16 @@ import { GetAdminJourney_journey_blocks_VideoBlock as VideoBlock } from '../../.
 import { QuickControls } from '.'
 
 describe('QuickControls', () => {
+  const videoBlock = {
+    __typename: 'VideoBlock',
+    id: 'video1.id'
+  } as unknown as TreeBlock<VideoBlock>
+
   it('should render buttons', () => {
     render(
       <SnackbarProvider>
         <MockedProvider>
-          <QuickControls open anchorEl={null} />
+          <QuickControls open anchorEl={null} block={videoBlock} />
         </MockedProvider>
       </SnackbarProvider>
     )
@@ -26,16 +31,11 @@ describe('QuickControls', () => {
   })
 
   it('should disable duplicate block', () => {
-    const videoBlock = {
-      __typename: 'VideoBlock',
-      id: 'video1.id'
-    } as unknown as TreeBlock<VideoBlock>
-
     render(
       <SnackbarProvider>
         <MockedProvider>
           <EditorProvider initialState={{ selectedBlock: videoBlock }}>
-            <QuickControls open anchorEl={null} />
+            <QuickControls open anchorEl={null} block={videoBlock} />
           </EditorProvider>
         </MockedProvider>
       </SnackbarProvider>

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/QuickControls/QuickControls.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/QuickControls/QuickControls.stories.tsx
@@ -20,7 +20,7 @@ const Template: StoryObj<{ selectedBlock: TreeBlock<Block> }> = {
     <MockedProvider>
       <SnackbarProvider>
         <EditorProvider initialState={{ selectedBlock }}>
-          <QuickControls open anchorEl={null} />
+          <QuickControls open anchorEl={null} block={selectedBlock} />
         </EditorProvider>
       </SnackbarProvider>
     </MockedProvider>

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/QuickControls/QuickControls.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/QuickControls/QuickControls.tsx
@@ -4,19 +4,14 @@ import Popper from '@mui/material/Popper'
 import Stack from '@mui/material/Stack'
 import { MouseEvent, ReactElement } from 'react'
 
-import { useEditor } from '@core/journeys/ui/EditorProvider'
-
 import { ThemeProvider } from '../../../../../ThemeProvider'
 
 import { DeleteBlock } from './DeleteBlock'
 import { DuplicateBlock } from './DuplicateBlock'
 import { MoveBlock } from './MoveBlock'
 
-export function QuickControls({ open, anchorEl }): ReactElement {
-  const {
-    state: { selectedBlock }
-  } = useEditor()
-  const isVideoBlock = selectedBlock?.__typename === 'VideoBlock'
+export function QuickControls({ open, anchorEl, block }): ReactElement {
+  const isVideoBlock = block?.__typename === 'VideoBlock'
 
   function handleClick(e: MouseEvent<HTMLDivElement>): void {
     e.stopPropagation()

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/SelectableWrapper/SelectableWrapper.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/SelectableWrapper/SelectableWrapper.tsx
@@ -83,7 +83,7 @@ export function SelectableWrapper({
   }
 
   const videoOutlineStyles =
-    selectedBlock?.__typename === 'VideoBlock'
+    block?.__typename === 'VideoBlock'
       ? {
           width: '100%',
           height: '100%',
@@ -130,7 +130,11 @@ export function SelectableWrapper({
       onMouseDown={blockNonSelectionEvents}
     >
       {children}
-      <QuickControls open={open} anchorEl={selectableRef.current} />
+      <QuickControls
+        open={open}
+        anchorEl={selectableRef.current}
+        block={block}
+      />
     </Box>
   ) : (
     children

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Goals/GoalsList/GoalsListItem/GoalsListItem.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Goals/GoalsList/GoalsListItem/GoalsListItem.stories.tsx
@@ -67,7 +67,7 @@ export const Selected = {
       goalType: GoalType.Chat
     }
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement)
     await userEvent.click(canvas.getByText('https://www.ClickedSelected.com/'))
   }

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/ActionButton/ActionButton.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/ActionButton/ActionButton.tsx
@@ -47,7 +47,9 @@ export function ActionButton({ block, step }: ActionButtonProps): ReactElement {
   const [navigateToBlockActionUpdate] = useNavigateToBlockActionUpdateMutation()
   const { journey } = useJourney()
 
-  async function handleSourceConnect(params): Promise<void> {
+  async function handleSourceConnect(params: {
+    target: string
+  }): Promise<void> {
     if (journey == null) return
 
     await navigateToBlockActionUpdate(block, params.target)

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/StepBlockNode.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/StepBlockNode.stories.tsx
@@ -885,7 +885,7 @@ export const Hover = {
       activeContent: ActiveContent.Canvas
     }
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement)
 
     await waitFor(async () => {

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/ImageBlockEditor/UnsplashGallery/UnsplashGallery.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/ImageBlockEditor/UnsplashGallery/UnsplashGallery.tsx
@@ -190,7 +190,7 @@ export function UnsplashGallery({
     setPage(newPage)
   }
 
-  function handleCollectionChange(id, query): void {
+  function handleCollectionChange(id: string, query: string): void {
     setCollectionId(id)
     setQuery(query)
   }

--- a/apps/journeys-admin/test/mockReactFlow.ts
+++ b/apps/journeys-admin/test/mockReactFlow.ts
@@ -45,12 +45,12 @@ export const mockReactFlow = (): void => {
   Object.defineProperties(global.HTMLElement.prototype, {
     offsetHeight: {
       get() {
-        return parseFloat(this.style.height)
+        return parseFloat(this.style.height as string)
       }
     },
     offsetWidth: {
       get() {
-        return parseFloat(this.style.width)
+        return parseFloat(this.style.width as string)
       }
     }
   })


### PR DESCRIPTION
# Description
Fixes quick action menu layout shift when unselecting video blocks

### Issue
The styles for video blocks was being removed in the `SelectableWrapper` component.

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7302407694)

### Solution
Using the block instead does not remove the styles when selecting/unselecting but keeps the styles for the video block. The quick controls also requires the `block` property passed in from the `SelectableWrapper` to apply the styles correctly.

# External Changes
N/A

# Additional information
N/A