### PR TITLE
refactor: duplicate step block positions

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -1251,6 +1251,18 @@ type Mutation
 
     """drop this parameter after merging teams"""
     journeyId: ID
+
+    """
+    x is used to position a step block block horizontally in the journey flow diagram on
+    the editor.
+    """
+    x: Int
+
+    """
+    y is used to position a step block block vertically in the journey flow diagram on
+    the editor.
+    """
+    y: Int
   ): [Block!]! @join__field(graph: JOURNEYS)
   blockOrderUpdate(
     id: ID!

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -120,6 +120,18 @@ extend type Mutation {
 
     """drop this parameter after merging teams"""
     journeyId: ID
+
+    """
+    x is used to position a step block block horizontally in the journey flow diagram on
+    the editor.
+    """
+    x: Int
+
+    """
+    y is used to position a step block block vertically in the journey flow diagram on
+    the editor.
+    """
+    y: Int
   ): [Block!]!
   blockOrderUpdate(
     id: ID!

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -1519,7 +1519,7 @@ export abstract class IMutation {
 
     abstract blockDelete(id: string, journeyId?: Nullable<string>, parentBlockId?: Nullable<string>): Block[] | Promise<Block[]>;
 
-    abstract blockDuplicate(id: string, parentOrder?: Nullable<number>, journeyId?: Nullable<string>): Block[] | Promise<Block[]>;
+    abstract blockDuplicate(id: string, parentOrder?: Nullable<number>, journeyId?: Nullable<string>, x?: Nullable<number>, y?: Nullable<number>): Block[] | Promise<Block[]>;
 
     abstract blockOrderUpdate(id: string, parentOrder: number, journeyId?: Nullable<string>): Block[] | Promise<Block[]>;
 

--- a/apps/api-journeys/src/app/modules/block/block.graphql
+++ b/apps/api-journeys/src/app/modules/block/block.graphql
@@ -47,6 +47,16 @@ extend type Mutation {
     drop this parameter after merging teams
     """
     journeyId: ID
+    """
+    x is used to position a step block block horizontally in the journey flow diagram on
+    the editor.
+    """
+    x: Int
+    """
+    y is used to position a step block block vertically in the journey flow diagram on
+    the editor.
+    """
+    y: Int
   ): [Block!]!
   blockOrderUpdate(
     id: ID!

--- a/apps/api-journeys/src/app/modules/block/block.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/block.resolver.spec.ts
@@ -122,11 +122,15 @@ describe('BlockResolver', () => {
   describe('blockDuplicate', () => {
     it('duplicates the block and its children', async () => {
       prismaService.block.findUnique.mockResolvedValueOnce(blockWithUserTeam)
-      expect(await resolver.blockDuplicate(ability, 'blockId', 2)).toEqual([
+      expect(
+        await resolver.blockDuplicate(ability, 'blockId', 2, 3, 4)
+      ).toEqual([blockWithUserTeam, blockWithUserTeam])
+      expect(service.duplicateBlock).toHaveBeenCalledWith(
         blockWithUserTeam,
-        blockWithUserTeam
-      ])
-      expect(service.duplicateBlock).toHaveBeenCalledWith(blockWithUserTeam, 2)
+        2,
+        3,
+        4
+      )
     })
 
     it('throws error if not found', async () => {

--- a/apps/api-journeys/src/app/modules/block/block.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/block.resolver.ts
@@ -60,7 +60,9 @@ export class BlockResolver {
   async blockDuplicate(
     @CaslAbility() ability: AppAbility,
     @Args('id') id: string,
-    @Args('parentOrder') parentOrder?: number
+    @Args('parentOrder') parentOrder?: number,
+    @Args('x') x?: number,
+    @Args('y') y?: number
   ): Promise<Block[]> {
     const block = await this.prismaService.block.findUnique({
       where: { id },
@@ -74,6 +76,7 @@ export class BlockResolver {
         }
       }
     })
+
     if (block == null)
       throw new GraphQLError('block not found', {
         extensions: { code: 'NOT_FOUND' }
@@ -82,7 +85,7 @@ export class BlockResolver {
       throw new GraphQLError('user is not allowed to update block', {
         extensions: { code: 'FORBIDDEN' }
       })
-    return await this.blockService.duplicateBlock(block, parentOrder)
+    return await this.blockService.duplicateBlock(block, parentOrder, x, y)
   }
 
   @Mutation()

--- a/apps/api-journeys/src/app/modules/block/block.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/block.service.spec.ts
@@ -311,6 +311,33 @@ describe('BlockService', () => {
       ])
     })
 
+    it('should duplicate step block with new x and y', async () => {
+      const newStepBlock = {
+        ...stepBlock,
+        action: null,
+        x: 0,
+        y: 0
+      }
+      service.getDuplicateBlockAndChildren = jest
+        .fn()
+        .mockReturnValue([newStepBlock])
+
+      await service.duplicateBlock(newStepBlock, 1, 2, 3)
+      expect(prismaService.block.update).toHaveBeenCalledWith({
+        where: { id: newStepBlock.id },
+        include: { action: true },
+        data: {
+          action: undefined,
+          coverBlockId: newStepBlock.coverBlockId,
+          nextBlockId: newStepBlock.nextBlockId,
+          parentBlockId: undefined,
+          posterBlockId: newStepBlock.posterBlockId,
+          x: 2,
+          y: 3
+        }
+      })
+    })
+
     it('should add duplicated block at end by default', async () => {
       await service.duplicateBlock(block)
 


### PR DESCRIPTION
# Description

### Issue

Duplicating a step block should allow you to update the position of the step block on the journey flow

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

Update blockDuplicate mutation to allow x and y to be passed in, and updates it for step blocks

# External Changes

n/a

# Additional information

n/a