### PR TITLE
fix: fix encoding bug with share urls

### DIFF
--- a/apps/watch/pages/api/jf/watch.html/[videoId]/[languageId].ts
+++ b/apps/watch/pages/api/jf/watch.html/[videoId]/[languageId].ts
@@ -31,7 +31,8 @@ export default async function Handler(
   })
   if (data.video?.variant?.slug != null) {
     const [videoId, languageId] = data.video.variant.slug.split('/')
-    res.redirect(`/watch/${videoId}.html/${languageId}.html`)
+    const encodedVideoId =  encodeURIComponent(videoId)
+    res.redirect(`/watch/${encodedVideoId}.html/${languageId}.html`)
   } else {
     res.status(404).send({ error: 'video could not be found' })
   }

--- a/apps/watch/pages/api/jf/watch.html/[videoId]/[languageId].ts
+++ b/apps/watch/pages/api/jf/watch.html/[videoId]/[languageId].ts
@@ -31,7 +31,7 @@ export default async function Handler(
   })
   if (data.video?.variant?.slug != null) {
     const [videoId, languageId] = data.video.variant.slug.split('/')
-    const encodedVideoId =  encodeURIComponent(videoId)
+    const encodedVideoId = encodeURIComponent(videoId)
     res.redirect(`/watch/${encodedVideoId}.html/${languageId}.html`)
   } else {
     res.status(404).send({ error: 'video could not be found' })


### PR DESCRIPTION
# Description

### Issue

Share links from the app are broken on watch if the url has an special characters. See La Liberté De L’Interieur
https://arc.gt/s/2_0-La-Liberte/529?apiSessionId=7D56842ADC954A4FB5378FA9012042F0

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

Url encode the link before sending it to redirect to redirect to keep it from being utf-8 endoded.

# External Changes

_If you have made changes to external services, need to add additional values to Doppler, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc._

# Additional information

_Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc._
