### PR TITLE
fix: node menu style

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/StepBlockNodeMenu/StepBlockNodeMenu.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/StepBlockNodeMenu/StepBlockNodeMenu.tsx
@@ -42,8 +42,10 @@ export function StepBlockNodeMenu({
         onClick={handleClick}
         sx={{
           position: 'absolute',
-          top: -20,
-          right: -20
+          top: -14,
+          right: -20,
+          height: '28px',
+          color: 'rgba(0, 0, 0, 0.5)'
         }}
         data-testid="EditStepFab"
       >


### PR DESCRIPTION
# Description

### Issue

Styling of the StepBlockNodeMenu was not matching to design

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7370863138)

### Solution

Adjust the sx props styling

# External Changes

n/a

# Additional information

Popup used to look like
![image](https://github.com/JesusFilm/core/assets/26043376/e0a294b1-0864-4e7a-ab43-b7f0e9de062b)

Popup now looks like
![image](https://github.com/JesusFilm/core/assets/26043376/3ebd3b4d-e0d9-4580-9e42-45efa7a53e19)

