### PR TITLE
fix: add back button tooltip

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Toolbar/Toolbar.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Toolbar.spec.tsx
@@ -1,6 +1,7 @@
 import { MockedProvider } from '@apollo/client/testing'
-import { render } from '@testing-library/react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import { SnackbarProvider } from 'notistack'
+import { ReactElement } from 'react'
 
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 
@@ -15,33 +16,40 @@ jest.mock('@mui/material/useMediaQuery', () => ({
 }))
 
 describe('Toolbar', () => {
-  it('should render Toolbar', () => {
-    const { getByTestId, getByAltText, getByText } = render(
-      <SnackbarProvider>
-        <MockedProvider>
-          <JourneyProvider
-            value={{
-              journey: {
-                title: 'My Awesome Journey Title',
-                description: 'My Awesome Journey Description',
-                primaryImageBlock: null,
-                status: JourneyStatus.draft
-              } as unknown as Journey,
-              variant: 'admin'
-            }}
-          >
-            <Toolbar />
-          </JourneyProvider>
-        </MockedProvider>
-      </SnackbarProvider>
-    )
+  it('should render NextSteps logo on Toolbar', () => {
+    const { getByAltText } = render(toolbar())
     expect(getByAltText('Next Steps')).toBeInTheDocument() // NextSteps logo
-    expect(getByTestId('ToolbarBackButton')).toHaveAttribute('href', '/')
-    expect(getByTestId('ThumbsUpIcon')).toBeInTheDocument()
+  })
+
+  it('should render title & description on Toolbar', () => {
+    const { getByText } = render(toolbar())
     expect(getByText('My Awesome Journey Title')).toBeInTheDocument()
     expect(getByText('My Awesome Journey Description')).toBeInTheDocument()
+  })
+
+  it('should render items stack on Toolbar', () => {
+    const { getByTestId } = render(toolbar())
     expect(getByTestId('ItemsStack')).toBeInTheDocument()
+  })
+
+  it('should render menu button on Toolbar', () => {
+    const { getByTestId } = render(toolbar())
     expect(getByTestId('ToolbarMenuButton')).toBeInTheDocument()
+    expect(getByTestId('MoreIcon')).toBeInTheDocument()
+  })
+
+  it('should render all journeys button', () => {
+    const { getByTestId } = render(toolbar())
+    expect(getByTestId('ToolbarBackButton')).toHaveAttribute('href', '/')
+    expect(getByTestId('FormatListBulletedIcon')).toBeInTheDocument()
+  })
+
+  it('should render journeys tooltip on hover', async () => {
+    const { getByTestId, getByText } = render(toolbar())
+    fireEvent.mouseOver(getByTestId('ToolbarBackButton'))
+    await waitFor(() => {
+      expect(getByText('See all journeys')).toBeInTheDocument()
+    })
   })
 
   it('should render journey image', () => {
@@ -79,3 +87,25 @@ describe('Toolbar', () => {
     expect(queryByTestId('ThumbsUpIcon')).not.toBeInTheDocument()
   })
 })
+
+function toolbar(): ReactElement {
+  return (
+    <SnackbarProvider>
+      <MockedProvider>
+        <JourneyProvider
+          value={{
+            journey: {
+              title: 'My Awesome Journey Title',
+              description: 'My Awesome Journey Description',
+              primaryImageBlock: null,
+              status: JourneyStatus.draft
+            } as unknown as Journey,
+            variant: 'admin'
+          }}
+        >
+          <Toolbar />
+        </JourneyProvider>
+      </MockedProvider>
+    </SnackbarProvider>
+  )
+}

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Toolbar.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Toolbar.tsx
@@ -15,6 +15,7 @@ import { EDIT_TOOLBAR_HEIGHT } from '../constants'
 
 import { Items } from './Items'
 import { Menu } from './Menu'
+import { Tooltip } from '@mui/material'
 
 export function Toolbar(): ReactElement {
   const { journey } = useJourney()
@@ -42,9 +43,11 @@ export function Toolbar(): ReactElement {
         }}
       />
       <NextLink href="/" passHref legacyBehavior>
-        <IconButton data-testid="ToolbarBackButton">
-          <ChevronLeftIcon />
-        </IconButton>
+        <Tooltip title="See all journeys" placement="right" arrow>
+          <IconButton data-testid="ToolbarBackButton">
+            <ChevronLeftIcon />
+          </IconButton>
+        </Tooltip>
       </NextLink>
       {journey != null && (
         <>

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Toolbar.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Toolbar.tsx
@@ -1,13 +1,14 @@
+import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted'
 import Box from '@mui/material/Box'
 import IconButton from '@mui/material/IconButton'
 import Stack from '@mui/material/Stack'
+import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import Image from 'next/image'
 import NextLink from 'next/link'
 import { ReactElement } from 'react'
 
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
-import ChevronLeftIcon from '@core/shared/ui/icons/ChevronLeft'
 import ThumbsUpIcon from '@core/shared/ui/icons/ThumbsUp'
 
 import logo from '../../../../public/taskbar-icon.svg'
@@ -15,7 +16,6 @@ import { EDIT_TOOLBAR_HEIGHT } from '../constants'
 
 import { Items } from './Items'
 import { Menu } from './Menu'
-import { Tooltip } from '@mui/material'
 
 export function Toolbar(): ReactElement {
   const { journey } = useJourney()
@@ -45,7 +45,7 @@ export function Toolbar(): ReactElement {
       <NextLink href="/" passHref legacyBehavior>
         <Tooltip title="See all journeys" placement="right" arrow>
           <IconButton data-testid="ToolbarBackButton">
-            <ChevronLeftIcon />
+            <FormatListBulletedIcon />
           </IconButton>
         </Tooltip>
       </NextLink>


### PR DESCRIPTION
# Description

### Issue

Add a tooltip on the back button of the journey flow view.
Also change the icon to bullet list.

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7292062745)

### Solution

As above

# External Changes

n/a

# Additional information

Was:
<img width="323" alt="image" src="https://github.com/JesusFilm/core/assets/26043376/eda7d855-cb9b-48f6-a44c-7e573eac0744">

Changed to:
![image](https://github.com/JesusFilm/core/assets/26043376/e1e47b02-a829-4e39-8c0f-2c07f6488c74)

