### PR TITLE
feat: close icon on settings panel

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/AddBlock/AddBlock.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/AddBlock/AddBlock.spec.tsx
@@ -1,8 +1,9 @@
 import { MockedProvider } from '@apollo/client/testing'
-import { render } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import type { TreeBlock } from '@core/journeys/ui/block'
-import { EditorProvider } from '@core/journeys/ui/EditorProvider'
+import { ActiveSlide, EditorProvider } from '@core/journeys/ui/EditorProvider'
 import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 
 import { BlockFields_StepBlock as StepBlock } from '../../../../../../../__generated__/BlockFields'
@@ -11,6 +12,7 @@ import {
   TypographyColor,
   TypographyVariant
 } from '../../../../../../../__generated__/globalTypes'
+import { TestEditorState } from '../../../../../../libs/TestEditorState'
 import { ThemeProvider } from '../../../../../ThemeProvider'
 
 import { AddBlock } from '.'
@@ -112,5 +114,30 @@ describe('AddNewBlock', () => {
     const newVideoButton = newVideoButtonDiv.querySelector('button')
 
     expect(newVideoButton).toBeDisabled()
+  })
+
+  it('should return to journey map when close icon is clicked', async () => {
+    render(
+      <MockedProvider>
+        <ThemeProvider>
+          <EditorProvider
+            initialState={{ selectedStep, activeSlide: ActiveSlide.Content }}
+          >
+            <TestEditorState />
+            <AddBlock />
+          </EditorProvider>
+        </ThemeProvider>
+      </MockedProvider>
+    )
+
+    expect(screen.getByText('activeSlide: 1')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.getByTestId('X2Icon')).toBeInTheDocument()
+    )
+    await waitFor(
+      async () => await userEvent.click(screen.getByTestId('X2Icon'))
+    )
+
+    expect(screen.getByText('activeSlide: 0')).toBeInTheDocument()
   })
 })

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/AddBlock/AddBlock.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/AddBlock/AddBlock.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'next-i18next'
 import { ReactElement } from 'react'
 
 import { TreeBlock } from '@core/journeys/ui/block'
-import { useEditor } from '@core/journeys/ui/EditorProvider'
+import { ActiveSlide, useEditor } from '@core/journeys/ui/EditorProvider'
 import { useFlags } from '@core/shared/ui/FlagsProvider'
 
 import { BlockFields_CardBlock as CardBlock } from '../../../../../../../__generated__/BlockFields'
@@ -22,7 +22,8 @@ export function AddBlock(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   const { formiumForm } = useFlags()
   const {
-    state: { selectedStep }
+    state: { selectedStep },
+    dispatch
   } = useEditor()
 
   const cardBlock = selectedStep?.children.find(
@@ -33,8 +34,15 @@ export function AddBlock(): ReactElement {
     (block) => block.id !== cardBlock.coverBlockId
   )
 
+  function onClose(): void {
+    dispatch({
+      type: 'SetActiveSlideAction',
+      activeSlide: ActiveSlide.JourneyFlow
+    })
+  }
+
   return (
-    <Drawer title={t('Add a block')}>
+    <Drawer title={t('Add a block')} onClose={onClose}>
       <Grid p={5} container spacing={4}>
         <Grid item xs={6} sm={12}>
           <NewTypographyButton />

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Footer/Footer.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Footer/Footer.spec.tsx
@@ -1,5 +1,6 @@
 import { MockedProvider } from '@apollo/client/testing'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { SnackbarProvider } from 'notistack'
 
 import {
@@ -85,5 +86,29 @@ describe('Footer', () => {
       'aria-selected',
       'true'
     )
+  })
+
+  it('should return to journey map when close icon is clicked', async () => {
+    const contentState = { ...state, activeSlide: ActiveSlide.Content }
+    render(
+      <MockedProvider>
+        <SnackbarProvider>
+          <EditorProvider initialState={contentState}>
+            <TestEditorState />
+            <Footer />
+          </EditorProvider>
+        </SnackbarProvider>
+      </MockedProvider>
+    )
+
+    expect(screen.getByText('activeSlide: 1')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.getByTestId('X2Icon')).toBeInTheDocument()
+    )
+    await waitFor(
+      async () => await userEvent.click(screen.getByTestId('X2Icon'))
+    )
+
+    expect(screen.getByText('activeSlide: 0')).toBeInTheDocument()
   })
 })

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Footer/Footer.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Footer/Footer.tsx
@@ -5,7 +5,7 @@ import dynamic from 'next/dynamic'
 import { useTranslation } from 'next-i18next'
 import { ReactElement, SyntheticEvent, useEffect, useState } from 'react'
 
-import { useEditor } from '@core/journeys/ui/EditorProvider'
+import { ActiveSlide, useEditor } from '@core/journeys/ui/EditorProvider'
 import MessageChat1Icon from '@core/shared/ui/icons/MessageChat1'
 import UserProfileCircleIcon from '@core/shared/ui/icons/UserProfileCircle'
 import { TabPanel, tabA11yProps } from '@core/shared/ui/TabPanel'
@@ -40,6 +40,13 @@ export function Footer(): ReactElement {
     setTabValue(newValue)
   }
 
+  function onClose(): void {
+    dispatch({
+      type: 'SetActiveSlideAction',
+      activeSlide: ActiveSlide.JourneyFlow
+    })
+  }
+
   useEffect(() => {
     dispatch({
       type: 'SetSelectedAttributeIdAction',
@@ -49,7 +56,7 @@ export function Footer(): ReactElement {
   }, [dispatch])
 
   return (
-    <Drawer title={t('Footer Properties')}>
+    <Drawer title={t('Footer Properties')} onClose={onClose}>
       <Tabs
         value={tabValue}
         onChange={handleTabChange}

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/Properties.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/Properties.spec.tsx
@@ -1,9 +1,16 @@
 import { MockedProvider } from '@apollo/client/testing'
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { SnackbarProvider } from 'notistack'
 
 import { TreeBlock } from '@core/journeys/ui/block'
-import { EditorProvider, EditorState } from '@core/journeys/ui/EditorProvider'
+import {
+  ActiveSlide,
+  EditorProvider,
+  EditorState
+} from '@core/journeys/ui/EditorProvider'
+
+import { TestEditorState } from '../../../../../../libs/TestEditorState'
 
 import { Properties } from '.'
 
@@ -355,5 +362,42 @@ describe('Properties', () => {
     )
 
     await waitFor(() => expect(container.children[0].childElementCount).toBe(0))
+  })
+
+  it('should return to journey map when close icon is clicked', async () => {
+    const selectedBlock = {
+      __typename: 'CardBlock',
+      id: 'block.id',
+      fullscreen: false,
+      children: []
+    }
+    const selectedStep = {}
+
+    const state = {
+      selectedBlock,
+      selectedStep,
+      activeSlide: ActiveSlide.Content
+    } as unknown as EditorState
+
+    render(
+      <MockedProvider>
+        <SnackbarProvider>
+          <EditorProvider initialState={state}>
+            <TestEditorState />
+            <Properties />
+          </EditorProvider>
+        </SnackbarProvider>
+      </MockedProvider>
+    )
+
+    expect(screen.getByText('activeSlide: 1')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.getByTestId('X2Icon')).toBeInTheDocument()
+    )
+    await waitFor(
+      async () => await userEvent.click(screen.getByTestId('X2Icon'))
+    )
+
+    expect(screen.getByText('activeSlide: 0')).toBeInTheDocument()
   })
 })

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/Properties.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/Properties.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'next-i18next'
 import { ReactElement } from 'react'
 
 import { TreeBlock } from '@core/journeys/ui/block/TreeBlock'
-import { useEditor } from '@core/journeys/ui/EditorProvider'
+import { ActiveSlide, useEditor } from '@core/journeys/ui/EditorProvider'
 
 import { BlockFields as StepBlock } from '../../../../../../../__generated__/BlockFields'
 import { Drawer } from '../../Drawer'
@@ -105,9 +105,16 @@ interface PropertiesProps {
 
 export function Properties({ block, step }: PropertiesProps): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
-  const { state } = useEditor()
+  const { state, dispatch } = useEditor()
   const selectedBlock = block ?? state.selectedBlock
   const selectedStep = step ?? state.selectedStep
+
+  function onClose(): void {
+    dispatch({
+      type: 'SetActiveSlideAction',
+      activeSlide: ActiveSlide.JourneyFlow
+    })
+  }
 
   let component
   let title: string | undefined
@@ -173,7 +180,7 @@ export function Properties({ block, step }: PropertiesProps): ReactElement {
       break
   }
   return block == null && step == null ? (
-    <Drawer title={title}>
+    <Drawer title={title} onClose={onClose}>
       <Stack>{component}</Stack>
     </Drawer>
   ) : (

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Button/Button.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Button/Button.stories.tsx
@@ -1,3 +1,4 @@
+import { jest } from '@storybook/jest'
 import { Meta, StoryObj } from '@storybook/react'
 import { ComponentProps } from 'react'
 
@@ -25,6 +26,8 @@ const Demo: Meta<typeof Button> = {
     'Journeys-Admin/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Button'
 }
 
+const onClose = jest.fn()
+
 const block: TreeBlock<ButtonBlock> = {
   id: 'button.id',
   __typename: 'ButtonBlock',
@@ -44,7 +47,7 @@ const Template: StoryObj<ComponentProps<typeof Button>> = {
   render: (args) => {
     return (
       <EditorProvider>
-        <Drawer title="Button">
+        <Drawer title="Button" onClose={onClose}>
           <Button {...args} />
         </Drawer>
       </EditorProvider>
@@ -103,7 +106,7 @@ export const Filled: StoryObj<typeof Button> = {
     }
     return (
       <EditorProvider initialState={{ selectedBlock: block }}>
-        <Drawer title="Button">
+        <Drawer title="Button" onClose={onClose}>
           <Button {...block} />
         </Drawer>
       </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/Card.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/Card.stories.tsx
@@ -1,3 +1,4 @@
+import { jest } from '@storybook/jest'
 import { Meta, StoryObj } from '@storybook/react'
 import { ComponentProps } from 'react'
 
@@ -21,6 +22,8 @@ const Demo: Meta<typeof Card> = {
     'Journeys-Admin/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card'
 }
 
+const onClose = jest.fn()
+
 const block: TreeBlock<CardBlock> = {
   id: 'card1.id',
   __typename: 'CardBlock',
@@ -38,7 +41,7 @@ const Template: StoryObj<ComponentProps<typeof Card>> = {
   render: (args) => {
     return (
       <EditorProvider initialState={{ selectedBlock: args }}>
-        <Drawer title="Card Properties">
+        <Drawer title="Card Properties" onClose={onClose}>
           <Card {...args} />
         </Drawer>
       </EditorProvider>
@@ -83,7 +86,7 @@ export const Filled: StoryObj<typeof Card> = {
 
     return (
       <EditorProvider initialState={{ selectedBlock: block }}>
-        <Drawer title="Card Properties">
+        <Drawer title="Card Properties" onClose={onClose}>
           <Card {...block} />
         </Drawer>
       </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Form/Form.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Form/Form.stories.tsx
@@ -1,5 +1,6 @@
 import { MockedResponse } from '@apollo/client/testing'
 import { Form as FormType } from '@formium/types'
+import { jest } from '@storybook/jest'
 import { Meta, StoryObj } from '@storybook/react'
 import { ComponentProps } from 'react'
 
@@ -24,6 +25,8 @@ const Demo: Meta<typeof Form> = {
   title:
     'Journeys-Admin/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Form'
 }
+
+const onClose = jest.fn()
 
 const formBlock: TreeBlock<FormBlock> = {
   id: 'formBlock.id',
@@ -114,7 +117,7 @@ const getFilledFormBlockMock: MockedResponse<
 const Template: StoryObj<ComponentProps<typeof Form>> = {
   render: (block) => (
     <EditorProvider initialState={{ selectedBlock: { ...block } }}>
-      <Drawer title="Form Properties">
+      <Drawer title="Form Properties" onClose={onClose}>
         <Form {...block} />
       </Drawer>
     </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Image/Image.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Image/Image.stories.tsx
@@ -1,3 +1,4 @@
+import { jest } from '@storybook/jest'
 import { Meta, StoryObj } from '@storybook/react'
 import { ComponentProps } from 'react'
 
@@ -17,6 +18,8 @@ const Demo: Meta<typeof Image> = {
     'Journeys-Admin/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Image'
 }
 
+const onClose = jest.fn()
+
 const image: TreeBlock<ImageBlock> = {
   id: 'image1.id',
   __typename: 'ImageBlock',
@@ -35,7 +38,7 @@ const Template: StoryObj<ComponentProps<typeof Image>> = {
     /* eslint-disable */
     return (
       <EditorProvider initialState={{ selectedBlock: args }}>
-        <Drawer title="Image Properties">
+        <Drawer title="Image Properties" onClose={onClose}>
           <Image {...args} />
         </Drawer>
       </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Image/Options/ImageOptions.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Image/Options/ImageOptions.stories.tsx
@@ -1,4 +1,5 @@
 import { MockedProvider } from '@apollo/client/testing'
+import { jest } from '@storybook/jest'
 import { Meta, StoryObj } from '@storybook/react'
 
 import type { TreeBlock } from '@core/journeys/ui/block'
@@ -17,6 +18,8 @@ const Demo: Meta<typeof ImageOptions> = {
   title:
     'Journeys-Admin/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Image/ImageOptions'
 }
+
+const onClose = jest.fn()
 
 const image: TreeBlock<ImageBlock> = {
   id: 'image1.id',
@@ -41,7 +44,7 @@ const Template: StoryObj<{ block: TreeBlock<ImageBlock> }> = {
               selectedBlock: block
             }}
           >
-            <Drawer title="Image Options">
+            <Drawer title="Image Options" onClose={onClose}>
               <ImageOptions />
             </Drawer>
           </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/RadioOption/RadioOption.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/RadioOption/RadioOption.stories.tsx
@@ -1,3 +1,4 @@
+import { jest } from '@storybook/jest'
 import { Meta, StoryObj } from '@storybook/react'
 import { ComponentProps } from 'react'
 
@@ -17,6 +18,8 @@ const Demo: Meta<typeof RadioOption> = {
     'Journeys-Admin/Editor/Slider/Settings/CanvasDetails/Properties/blocks/RadioOption'
 }
 
+const onClose = jest.fn()
+
 const block: TreeBlock<RadioOptionBlock> = {
   id: 'radioOption1.id',
   __typename: 'RadioOptionBlock',
@@ -33,7 +36,7 @@ const Template: StoryObj<
   render: (block) => {
     return (
       <EditorProvider initialState={{ selectedBlock: { ...block } }}>
-        <Drawer title="Poll Option Properties">
+        <Drawer title="Poll Option Properties" onClose={onClose}>
           <RadioOption {...block} />
         </Drawer>
       </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/RadioQuestion/RadioQuestion.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/RadioQuestion/RadioQuestion.stories.tsx
@@ -1,3 +1,4 @@
+import { jest } from '@storybook/jest'
 import { Meta, StoryObj } from '@storybook/react'
 import { ComponentProps } from 'react'
 
@@ -17,6 +18,8 @@ const Demo: Meta<typeof RadioQuestion> = {
     'Journeys-Admin/Editor/Slider/Settings/CanvasDetails/Properties/blocks/RadioQuestion'
 }
 
+const onClose = jest.fn()
+
 const block: TreeBlock<RadioQuestionBlock> = {
   id: 'radioQuestion1.id',
   __typename: 'RadioQuestionBlock',
@@ -33,7 +36,7 @@ const Template: StoryObj<
   render: (block) => {
     return (
       <EditorProvider initialState={{ selectedBlock: { ...block } }}>
-        <Drawer title="Poll Block Selected">
+        <Drawer title="Poll Block Selected" onClose={onClose}>
           <RadioQuestion {...block} />
         </Drawer>
       </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/SignUp/SignUp.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/SignUp/SignUp.stories.tsx
@@ -1,3 +1,4 @@
+import { jest } from '@storybook/jest'
 import { Meta, StoryObj } from '@storybook/react'
 import { ComponentProps } from 'react'
 
@@ -22,6 +23,8 @@ const Demo: Meta<typeof SignUp> = {
     'Journeys-Admin/Editor/Slider/Settings/CanvasDetails/Properties/blocks/SignUp'
 }
 
+const onClose = jest.fn()
+
 const block: TreeBlock<SignUpBlock> = {
   id: 'signup.id',
   __typename: 'SignUpBlock',
@@ -37,7 +40,7 @@ const Template: StoryObj<ComponentProps<typeof SignUp>> = {
   render: (args) => {
     return (
       <EditorProvider initialState={{ selectedBlock: { ...args } }}>
-        <Drawer title="Subscribe Properties">
+        <Drawer title="Subscribe Properties" onClose={onClose}>
           <SignUp {...args} />
         </Drawer>
       </EditorProvider>
@@ -82,7 +85,7 @@ export const Filled: StoryObj<typeof SignUp> = {
     }
     return (
       <EditorProvider initialState={{ selectedBlock: { ...block } }}>
-        <Drawer title="Subscribe Properties">
+        <Drawer title="Subscribe Properties" onClose={onClose}>
           <SignUp {...block} />
         </Drawer>
       </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/TextResponse/TextResponse.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/TextResponse/TextResponse.stories.tsx
@@ -1,3 +1,4 @@
+import { jest } from '@storybook/jest'
 import { Meta, StoryObj } from '@storybook/react'
 import { ComponentProps } from 'react'
 
@@ -28,6 +29,8 @@ const Demo: Meta<typeof TextResponse> = {
   }
 }
 
+const onClose = jest.fn()
+
 const block: TreeBlock<TextResponseBlock> = {
   __typename: 'TextResponseBlock',
   id: 'textResponseBlock.id',
@@ -46,7 +49,7 @@ const Template: StoryObj<ComponentProps<typeof TextResponse>> = {
   render: ({ ...args }) => {
     return (
       <EditorProvider initialState={{ selectedBlock: { ...args } }}>
-        <Drawer title="Feedback Properties">
+        <Drawer title="Feedback Properties" onClose={onClose}>
           <TextResponse {...args} />
         </Drawer>
       </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Typography/Typography.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Typography/Typography.stories.tsx
@@ -1,3 +1,4 @@
+import { jest } from '@storybook/jest'
 import { Meta, StoryObj } from '@storybook/react'
 import { ComponentProps } from 'react'
 
@@ -28,6 +29,8 @@ const Demo: Meta<typeof Typography> = {
   }
 }
 
+const onClose = jest.fn()
+
 const block: TreeBlock<TypographyBlock> = {
   __typename: 'TypographyBlock',
   id: 'typographyBlock.id',
@@ -44,7 +47,7 @@ const Template: StoryObj<ComponentProps<typeof Typography>> = {
   render: ({ ...args }) => {
     return (
       <EditorProvider initialState={{ selectedBlock: { ...args } }}>
-        <Drawer title="Feedback Properties">
+        <Drawer title="Feedback Properties" onClose={onClose}>
           <Typography {...args} />
         </Drawer>
       </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Video/Video.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Video/Video.stories.tsx
@@ -1,3 +1,4 @@
+import { jest } from '@storybook/jest'
 import { Meta, StoryObj } from '@storybook/react'
 import { ComponentPropsWithoutRef } from 'react'
 
@@ -18,11 +19,13 @@ const VideoDemo: Meta<typeof Video> = {
     'Journeys-Admin/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Video'
 }
 
+const onClose = jest.fn()
+
 const Template: StoryObj<ComponentPropsWithoutRef<typeof Video>> = {
   render: ({ ...args }) => {
     return (
       <EditorProvider initialState={{ selectedBlock: { ...args } }}>
-        <Drawer title="Video Properties">
+        <Drawer title="Video Properties" onClose={onClose}>
           <Video {...args} />
         </Drawer>
       </EditorProvider>

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/GoalDetails/GoalDetails.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/GoalDetails/GoalDetails.spec.tsx
@@ -1,5 +1,6 @@
 import { MockedProvider } from '@apollo/client/testing'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import {
   ActiveCanvasDetailsDrawer,
@@ -100,5 +101,26 @@ describe('GoalDetails', () => {
         screen.getByText('selectedGoalUrl: https://newUrl.com')
       ).toBeInTheDocument()
     })
+  })
+
+  it('should navigate to journey map when close icon is clicked', async () => {
+    const contentState = { ...state, activeSlide: ActiveSlide.Content }
+    render(
+      <MockedProvider>
+        <EditorProvider initialState={contentState}>
+          <TestEditorState />
+          <GoalDetails />
+        </EditorProvider>
+      </MockedProvider>
+    )
+    expect(screen.getByText('activeSlide: 1')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.getByTestId('X2Icon')).toBeInTheDocument()
+    )
+    await waitFor(
+      async () => await userEvent.click(screen.getByTestId('X2Icon'))
+    )
+
+    expect(screen.getByText('activeSlide: 0')).toBeInTheDocument()
   })
 })

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/GoalDetails/GoalDetails.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/GoalDetails/GoalDetails.tsx
@@ -3,7 +3,7 @@ import Stack from '@mui/material/Stack'
 import { useTranslation } from 'next-i18next'
 import { ReactElement } from 'react'
 
-import { useEditor } from '@core/journeys/ui/EditorProvider'
+import { ActiveSlide, useEditor } from '@core/journeys/ui/EditorProvider'
 
 import { Drawer } from '../Drawer'
 
@@ -21,11 +21,18 @@ export function GoalDetails(): ReactElement {
   function setSelectedAction(url: string): void {
     dispatch({ type: 'SetSelectedGoalUrlAction', selectedGoalUrl: url })
   }
+  function onClose(): void {
+    dispatch({
+      type: 'SetActiveSlideAction',
+      activeSlide: ActiveSlide.JourneyFlow
+    })
+  }
 
   return (
     <Drawer
       data-testid="GoalDetails"
       title={selectedGoalUrl != null ? t('Goal Details') : t('Information')}
+      onClose={onClose}
     >
       <Box
         sx={{ overflow: 'auto', height: '100%' }}

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/SocialDetails.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/SocialDetails.spec.tsx
@@ -1,11 +1,14 @@
 import { MockedProvider } from '@apollo/client/testing'
 import useMediaQuery from '@mui/material/useMediaQuery'
-import { render } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
+import { ActiveSlide, EditorProvider } from '@core/journeys/ui/EditorProvider'
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 
 import { GetJourney_journey as Journey } from '../../../../../../__generated__/GetJourney'
 import { JourneyStatus } from '../../../../../../__generated__/globalTypes'
+import { TestEditorState } from '../../../../../libs/TestEditorState'
 
 import { SocialDetails } from '.'
 
@@ -34,5 +37,32 @@ describe('SocialDetails', () => {
     expect(getByText('Change')).toBeInTheDocument()
     expect(getByRole('textbox', { name: 'Title' })).toBeInTheDocument()
     expect(getByRole('textbox', { name: 'Description' })).toBeInTheDocument()
+  })
+
+  it('should navigate to journey map when close icon is clicked', async () => {
+    render(
+      <MockedProvider>
+        <JourneyProvider
+          value={{
+            journey: { status: JourneyStatus.published } as unknown as Journey,
+            variant: 'admin'
+          }}
+        >
+          <EditorProvider initialState={{ activeSlide: ActiveSlide.Content }}>
+            <TestEditorState />
+            <SocialDetails />
+          </EditorProvider>
+        </JourneyProvider>
+      </MockedProvider>
+    )
+    expect(screen.getByText('activeSlide: 1')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.getByTestId('X2Icon')).toBeInTheDocument()
+    )
+    await waitFor(
+      async () => await userEvent.click(screen.getByTestId('X2Icon'))
+    )
+
+    expect(screen.getByText('activeSlide: 0')).toBeInTheDocument()
   })
 })

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/SocialDetails.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/SocialDetails.tsx
@@ -3,6 +3,8 @@ import Typography from '@mui/material/Typography'
 import { useTranslation } from 'next-i18next'
 import { ReactElement } from 'react'
 
+import { ActiveSlide, useEditor } from '@core/journeys/ui/EditorProvider'
+
 import { Drawer } from '../Drawer'
 import { ImageEdit } from '../Drawer/ImageEdit'
 
@@ -10,9 +12,17 @@ import { DescriptionEdit } from './DescriptionEdit'
 import { TitleEdit } from './TitleEdit'
 
 export function SocialDetails(): ReactElement {
+  const { dispatch } = useEditor()
   const { t } = useTranslation('apps-journeys-admin')
+
+  function onClose(): void {
+    dispatch({
+      type: 'SetActiveSlideAction',
+      activeSlide: ActiveSlide.JourneyFlow
+    })
+  }
   return (
-    <Drawer title={t('Social Share Preview')}>
+    <Drawer title={t('Social Share Preview')} onClose={onClose}>
       <Box sx={{ px: 6, py: 4 }} data-testid="SocialShareAppearance">
         <Typography variant="subtitle2" sx={{ pb: 4 }}>
           {t('Social Image')}


### PR DESCRIPTION
# Description

### Issue

Add a close icon onto the settings panel, which takes the user back to the journey map

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7292062706#__recording_7375869126)

### Solution

Added an onClose method to the settings drawers, which creates the close icon, and sets the activeSlide to JourneyFlow when clicked

# Additional information

Also refactored the properties block stories to include the close icon