### PR TITLE
feat: add label for video nodes

### DIFF
--- a/apps/journeys-admin/__generated__/BlockFields.ts
+++ b/apps/journeys-admin/__generated__/BlockFields.ts
@@ -418,12 +418,25 @@ export interface BlockFields_VideoBlock_video_variant {
   hls: string | null;
 }
 
+export interface BlockFields_VideoBlock_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface BlockFields_VideoBlock_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: BlockFields_VideoBlock_video_variantLanguages_name[];
+}
+
 export interface BlockFields_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: BlockFields_VideoBlock_video_title[];
   image: string | null;
   variant: BlockFields_VideoBlock_video_variant | null;
+  variantLanguages: BlockFields_VideoBlock_video_variantLanguages[];
 }
 
 export interface BlockFields_VideoBlock_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/CardBlockVideoBlockCreate.ts
+++ b/apps/journeys-admin/__generated__/CardBlockVideoBlockCreate.ts
@@ -20,12 +20,25 @@ export interface CardBlockVideoBlockCreate_videoBlockCreate_video_variant {
   hls: string | null;
 }
 
+export interface CardBlockVideoBlockCreate_videoBlockCreate_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface CardBlockVideoBlockCreate_videoBlockCreate_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: CardBlockVideoBlockCreate_videoBlockCreate_video_variantLanguages_name[];
+}
+
 export interface CardBlockVideoBlockCreate_videoBlockCreate_video {
   __typename: "Video";
   id: string;
   title: CardBlockVideoBlockCreate_videoBlockCreate_video_title[];
   image: string | null;
   variant: CardBlockVideoBlockCreate_videoBlockCreate_video_variant | null;
+  variantLanguages: CardBlockVideoBlockCreate_videoBlockCreate_video_variantLanguages[];
 }
 
 export interface CardBlockVideoBlockCreate_videoBlockCreate_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/CardBlockVideoBlockUpdate.ts
+++ b/apps/journeys-admin/__generated__/CardBlockVideoBlockUpdate.ts
@@ -20,12 +20,25 @@ export interface CardBlockVideoBlockUpdate_videoBlockUpdate_video_variant {
   hls: string | null;
 }
 
+export interface CardBlockVideoBlockUpdate_videoBlockUpdate_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface CardBlockVideoBlockUpdate_videoBlockUpdate_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: CardBlockVideoBlockUpdate_videoBlockUpdate_video_variantLanguages_name[];
+}
+
 export interface CardBlockVideoBlockUpdate_videoBlockUpdate_video {
   __typename: "Video";
   id: string;
   title: CardBlockVideoBlockUpdate_videoBlockUpdate_video_title[];
   image: string | null;
   variant: CardBlockVideoBlockUpdate_videoBlockUpdate_video_variant | null;
+  variantLanguages: CardBlockVideoBlockUpdate_videoBlockUpdate_video_variantLanguages[];
 }
 
 export interface CardBlockVideoBlockUpdate_videoBlockUpdate_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/CardIntroCreate.ts
+++ b/apps/journeys-admin/__generated__/CardIntroCreate.ts
@@ -197,12 +197,25 @@ export interface CardIntroCreate_video_video_variant {
   hls: string | null;
 }
 
+export interface CardIntroCreate_video_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface CardIntroCreate_video_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: CardIntroCreate_video_video_variantLanguages_name[];
+}
+
 export interface CardIntroCreate_video_video {
   __typename: "Video";
   id: string;
   title: CardIntroCreate_video_video_title[];
   image: string | null;
   variant: CardIntroCreate_video_video_variant | null;
+  variantLanguages: CardIntroCreate_video_video_variantLanguages[];
 }
 
 export interface CardIntroCreate_video_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/CardVideoCreate.ts
+++ b/apps/journeys-admin/__generated__/CardVideoCreate.ts
@@ -20,12 +20,25 @@ export interface CardVideoCreate_video_video_variant {
   hls: string | null;
 }
 
+export interface CardVideoCreate_video_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface CardVideoCreate_video_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: CardVideoCreate_video_video_variantLanguages_name[];
+}
+
 export interface CardVideoCreate_video_video {
   __typename: "Video";
   id: string;
   title: CardVideoCreate_video_video_title[];
   image: string | null;
   variant: CardVideoCreate_video_video_variant | null;
+  variantLanguages: CardVideoCreate_video_video_variantLanguages[];
 }
 
 export interface CardVideoCreate_video_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/GetAdminJourney.ts
+++ b/apps/journeys-admin/__generated__/GetAdminJourney.ts
@@ -432,12 +432,25 @@ export interface GetAdminJourney_journey_blocks_VideoBlock_video_variant {
   hls: string | null;
 }
 
+export interface GetAdminJourney_journey_blocks_VideoBlock_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface GetAdminJourney_journey_blocks_VideoBlock_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: GetAdminJourney_journey_blocks_VideoBlock_video_variantLanguages_name[];
+}
+
 export interface GetAdminJourney_journey_blocks_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: GetAdminJourney_journey_blocks_VideoBlock_video_title[];
   image: string | null;
   variant: GetAdminJourney_journey_blocks_VideoBlock_video_variant | null;
+  variantLanguages: GetAdminJourney_journey_blocks_VideoBlock_video_variantLanguages[];
 }
 
 export interface GetAdminJourney_journey_blocks_VideoBlock_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/GetJourney.ts
+++ b/apps/journeys-admin/__generated__/GetJourney.ts
@@ -432,12 +432,25 @@ export interface GetJourney_journey_blocks_VideoBlock_video_variant {
   hls: string | null;
 }
 
+export interface GetJourney_journey_blocks_VideoBlock_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface GetJourney_journey_blocks_VideoBlock_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: GetJourney_journey_blocks_VideoBlock_video_variantLanguages_name[];
+}
+
 export interface GetJourney_journey_blocks_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: GetJourney_journey_blocks_VideoBlock_video_title[];
   image: string | null;
   variant: GetJourney_journey_blocks_VideoBlock_video_variant | null;
+  variantLanguages: GetJourney_journey_blocks_VideoBlock_video_variantLanguages[];
 }
 
 export interface GetJourney_journey_blocks_VideoBlock_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/GetPublisherTemplate.ts
+++ b/apps/journeys-admin/__generated__/GetPublisherTemplate.ts
@@ -432,12 +432,25 @@ export interface GetPublisherTemplate_publisherTemplate_blocks_VideoBlock_video_
   hls: string | null;
 }
 
+export interface GetPublisherTemplate_publisherTemplate_blocks_VideoBlock_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface GetPublisherTemplate_publisherTemplate_blocks_VideoBlock_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: GetPublisherTemplate_publisherTemplate_blocks_VideoBlock_video_variantLanguages_name[];
+}
+
 export interface GetPublisherTemplate_publisherTemplate_blocks_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: GetPublisherTemplate_publisherTemplate_blocks_VideoBlock_video_title[];
   image: string | null;
   variant: GetPublisherTemplate_publisherTemplate_blocks_VideoBlock_video_variant | null;
+  variantLanguages: GetPublisherTemplate_publisherTemplate_blocks_VideoBlock_video_variantLanguages[];
 }
 
 export interface GetPublisherTemplate_publisherTemplate_blocks_VideoBlock_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/JourneyFields.ts
+++ b/apps/journeys-admin/__generated__/JourneyFields.ts
@@ -432,12 +432,25 @@ export interface JourneyFields_blocks_VideoBlock_video_variant {
   hls: string | null;
 }
 
+export interface JourneyFields_blocks_VideoBlock_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface JourneyFields_blocks_VideoBlock_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: JourneyFields_blocks_VideoBlock_video_variantLanguages_name[];
+}
+
 export interface JourneyFields_blocks_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: JourneyFields_blocks_VideoBlock_video_title[];
   image: string | null;
   variant: JourneyFields_blocks_VideoBlock_video_variant | null;
+  variantLanguages: JourneyFields_blocks_VideoBlock_video_variantLanguages[];
 }
 
 export interface JourneyFields_blocks_VideoBlock_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/VideoBlockCreate.ts
+++ b/apps/journeys-admin/__generated__/VideoBlockCreate.ts
@@ -20,12 +20,25 @@ export interface VideoBlockCreate_videoBlockCreate_video_variant {
   hls: string | null;
 }
 
+export interface VideoBlockCreate_videoBlockCreate_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface VideoBlockCreate_videoBlockCreate_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: VideoBlockCreate_videoBlockCreate_video_variantLanguages_name[];
+}
+
 export interface VideoBlockCreate_videoBlockCreate_video {
   __typename: "Video";
   id: string;
   title: VideoBlockCreate_videoBlockCreate_video_title[];
   image: string | null;
   variant: VideoBlockCreate_videoBlockCreate_video_variant | null;
+  variantLanguages: VideoBlockCreate_videoBlockCreate_video_variantLanguages[];
 }
 
 export interface VideoBlockCreate_videoBlockCreate_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/VideoBlockUpdate.ts
+++ b/apps/journeys-admin/__generated__/VideoBlockUpdate.ts
@@ -20,12 +20,25 @@ export interface VideoBlockUpdate_videoBlockUpdate_video_variant {
   hls: string | null;
 }
 
+export interface VideoBlockUpdate_videoBlockUpdate_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface VideoBlockUpdate_videoBlockUpdate_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: VideoBlockUpdate_videoBlockUpdate_video_variantLanguages_name[];
+}
+
 export interface VideoBlockUpdate_videoBlockUpdate_video {
   __typename: "Video";
   id: string;
   title: VideoBlockUpdate_videoBlockUpdate_video_title[];
   image: string | null;
   variant: VideoBlockUpdate_videoBlockUpdate_video_variant | null;
+  variantLanguages: VideoBlockUpdate_videoBlockUpdate_video_variantLanguages[];
 }
 
 export interface VideoBlockUpdate_videoBlockUpdate_action_NavigateAction {

--- a/apps/journeys-admin/__generated__/VideoFields.ts
+++ b/apps/journeys-admin/__generated__/VideoFields.ts
@@ -20,12 +20,25 @@ export interface VideoFields_video_variant {
   hls: string | null;
 }
 
+export interface VideoFields_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface VideoFields_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: VideoFields_video_variantLanguages_name[];
+}
+
 export interface VideoFields_video {
   __typename: "Video";
   id: string;
   title: VideoFields_video_title[];
   image: string | null;
   variant: VideoFields_video_variant | null;
+  variantLanguages: VideoFields_video_variantLanguages[];
 }
 
 export interface VideoFields_action_NavigateAction {

--- a/apps/journeys-admin/src/components/CardPreview/CardList/CardList.spec.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardList/CardList.spec.tsx
@@ -90,7 +90,8 @@ describe('CardList', () => {
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
                 hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-              }
+              },
+              variantLanguages: []
             },
             endAt: null,
             startAt: null,

--- a/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
+++ b/apps/journeys-admin/src/components/CardPreview/CardPreview.stories.tsx
@@ -555,7 +555,8 @@ const steps: Array<TreeBlock<StepBlock>> = [
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
                 hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-              }
+              },
+              variantLanguages: []
             },
             startAt: null,
             endAt: null,
@@ -641,7 +642,8 @@ const steps: Array<TreeBlock<StepBlock>> = [
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
                 hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-              }
+              },
+              variantLanguages: []
             },
             startAt: null,
             endAt: null,

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/Canvas.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/Canvas.stories.tsx
@@ -434,7 +434,8 @@ const steps: Array<TreeBlock<StepBlock>> = [
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
                 hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-              }
+              },
+              variantLanguages: []
             },
             startAt: null,
             endAt: null,

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/StepBlockNode.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/StepBlockNode.tsx
@@ -202,26 +202,28 @@ export function StepBlockNode({ id }: NodeProps): ReactElement {
                       padding: 2
                     }}
                   >
-                    <Typography
-                      sx={{
-                        display: '-webkit-box',
-                        '-webkit-box-orient': 'vertical',
-                        '-webkit-line-clamp': '1',
-                        overflow: 'hidden',
-                        padding: 0,
-                        fontSize: 9,
-                        height: 'auto',
-                        flexDirection: 'column',
-                        justifyContent: 'flex-end',
-                        alignSelf: 'flex-start',
-                        marginBottom: 1,
-                        lineHeight: 1.3,
-                        alignItems: 'flex-end',
-                        color: '#444451'
-                      }}
-                    >
-                      {description !== '' ? description : ''}
-                    </Typography>
+                    {Boolean(description) && (
+                      <Typography
+                        sx={{
+                          display: '-webkit-box',
+                          '-webkit-box-orient': 'vertical',
+                          '-webkit-line-clamp': '1',
+                          overflow: 'ellipsis',
+                          padding: 0,
+                          fontSize: 9,
+                          height: 'auto',
+                          flexDirection: 'column',
+                          justifyContent: 'flex-end',
+                          alignSelf: 'flex-start',
+                          marginBottom: 1,
+                          lineHeight: 1.3,
+                          alignItems: 'flex-end',
+                          color: 'text.primary'
+                        }}
+                      >
+                        {description}
+                      </Typography>
+                    )}
                     <Typography
                       sx={{
                         display: '-webkit-box',
@@ -264,7 +266,7 @@ export function StepBlockNode({ id }: NodeProps): ReactElement {
                         fontSize: 10,
                         lineHeight: '1.2',
                         justifyContent: 'top',
-                        color: '#444451',
+                        color: 'text.primary',
                         overflow: 'hidden',
                         paddingBottom: '1px'
                       }}

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/libs/getBackgroundImage/getBackgroundImage.spec.ts
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/libs/getBackgroundImage/getBackgroundImage.spec.ts
@@ -69,7 +69,8 @@ const video: TreeBlock<VideoBlock> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    }
+    },
+    variantLanguages: []
   },
   posterBlockId: null,
   children: []

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/libs/getCardMetadata/getCardMetadata.spec.ts
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/libs/getCardMetadata/getCardMetadata.spec.ts
@@ -70,7 +70,7 @@ const video: TreeBlock<VideoBlock> = {
   image: null,
   objectFit: null,
   video: {
-    __typename: 'Video',
+    __typename: 'Video' as const,
     id: '2_0-FallingPlates',
     title: [
       {
@@ -84,7 +84,20 @@ const video: TreeBlock<VideoBlock> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    }
+    },
+    variantLanguages: [
+      {
+        __typename: 'Language',
+        id: '529',
+        name: [
+          {
+            __typename: 'Translation',
+            value: 'English',
+            primary: true
+          }
+        ]
+      }
+    ]
   },
   posterBlockId: null,
   children: []
@@ -114,13 +127,14 @@ describe('getCardMetadata', () => {
     })
   })
 
-  it('should return card metadata from videoblock', () => {
+  it('should return card metadata from internal videoblock', () => {
     const videoCard = {
       ...card,
       children: [video, image, typography1, typography2]
     }
     const cardMetadata = getCardMetadata(videoCard)
     expect(cardMetadata).toEqual({
+      description: 'English',
       title: 'FallingPlates',
       subtitle: '0:00-3:20',
       bgImage:

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/libs/getPriorityBlock/getPriorityBlock.spec.ts
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/libs/getPriorityBlock/getPriorityBlock.spec.ts
@@ -135,7 +135,8 @@ const video: TreeBlock<VideoBlock> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    }
+    },
+    variantLanguages: []
   },
   children: []
 }

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/BackgroundMedia.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/BackgroundMedia.spec.tsx
@@ -143,7 +143,8 @@ describe('BackgroundMedia', () => {
           __typename: 'VideoVariant',
           id: '2_0-FallingPlates-529',
           hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-        }
+        },
+        variantLanguages: []
       },
       posterBlockId: 'poster1.id',
       children: []

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/BackgroundMedia.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/BackgroundMedia.stories.tsx
@@ -125,7 +125,8 @@ const video: TreeBlock<VideoBlock> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    }
+    },
+    variantLanguages: []
   },
   posterBlockId: 'poster1.id',
   children: []

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
@@ -133,7 +133,8 @@ const video: TreeBlock<VideoBlock> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    }
+    },
+    variantLanguages: []
   },
   posterBlockId: null,
   children: []

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
@@ -76,7 +76,8 @@ const video: TreeBlock<VideoBlock> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/zbrvj'
-    }
+    },
+    variantLanguages: []
   },
   posterBlockId: null,
   children: []

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/Card.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/Card.spec.tsx
@@ -199,7 +199,8 @@ describe('Card', () => {
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
                 hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-              }
+              },
+              variantLanguages: []
             },
             posterBlockId: null,
             muted: true,
@@ -267,7 +268,8 @@ describe('Card', () => {
                 __typename: 'VideoVariant',
                 id: '2_0-FallingPlates-529',
                 hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-              }
+              },
+              variantLanguages: []
             },
             posterBlockId: null,
             muted: true,

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Video/Options/VideoOptions.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Video/Options/VideoOptions.spec.tsx
@@ -63,7 +63,8 @@ const video: TreeBlock<VideoBlock> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    }
+    },
+    variantLanguages: []
   },
   posterBlockId: null,
   children: []

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Video/Options/VideoOptions.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Video/Options/VideoOptions.stories.tsx
@@ -60,7 +60,8 @@ const video: TreeBlock<VideoBlock> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    }
+    },
+    variantLanguages: []
   },
   posterBlockId: 'poster1.id',
   children: []

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Video/Video.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Video/Video.spec.tsx
@@ -46,7 +46,8 @@ describe('Video', () => {
         __typename: 'VideoVariant',
         id: '2_0-FallingPlates-529',
         hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-      }
+      },
+      variantLanguages: []
     },
     posterBlockId: null,
     children: []

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/CardTemplates/Templates/CardIntro/CardIntro.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/CardTemplates/Templates/CardIntro/CardIntro.spec.tsx
@@ -241,6 +241,7 @@ describe('CardIntro', () => {
                 hls: 'https://arc.gt/j67rz',
                 __typename: 'VideoVariant'
               },
+              variantLanguages: [],
               __typename: 'Video'
             },
             action: {

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/Settings/Poster/Library/VideoBlockEditorSettingsPosterLibrary.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/Settings/Poster/Library/VideoBlockEditorSettingsPosterLibrary.spec.tsx
@@ -107,7 +107,8 @@ const video: TreeBlock<VideoBlock> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    }
+    },
+    variantLanguages: []
   },
   posterBlockId: null,
   children: []

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/Settings/Poster/VideoBlockEditorSettingsPoster.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/Settings/Poster/VideoBlockEditorSettingsPoster.spec.tsx
@@ -51,7 +51,8 @@ const video: VideoBlock = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    }
+    },
+    variantLanguages: []
   },
   posterBlockId: null
 }

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/Settings/VideoBlockEditorSettings.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/Settings/VideoBlockEditorSettings.spec.tsx
@@ -45,7 +45,8 @@ const video: TreeBlock = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    }
+    },
+    variantLanguages: []
   },
   posterBlockId: null,
   children: [],

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/VideoBlockEditor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/VideoBlockEditor.spec.tsx
@@ -47,7 +47,8 @@ const videoInternal: TreeBlock<VideoBlock> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    }
+    },
+    variantLanguages: []
   },
   posterBlockId: null,
   children: []

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/VideoBlockEditor.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/VideoBlockEditor.stories.tsx
@@ -84,7 +84,8 @@ const videoInternal: TreeBlock<VideoBlock> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    }
+    },
+    variantLanguages: []
   },
   posterBlockId: 'poster1.id',
   children: []

--- a/apps/journeys-admin/src/components/Editor/data.ts
+++ b/apps/journeys-admin/src/components/Editor/data.ts
@@ -291,7 +291,8 @@ export const blocks: Block[] = [
         __typename: 'VideoVariant',
         id: '2_0-FallingPlates-529',
         hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-      }
+      },
+      variantLanguages: []
     },
     startAt: null,
     endAt: null,
@@ -597,7 +598,8 @@ export const blocks: Block[] = [
         __typename: 'VideoVariant',
         id: '2_0-FallingPlates-529',
         hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-      }
+      },
+      variantLanguages: []
     },
     startAt: null,
     endAt: null,

--- a/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/data.ts
+++ b/apps/journeys-admin/src/components/TemplateView/TemplatePreviewTabs/data.ts
@@ -47,7 +47,8 @@ export const journeyVideoBlocks: Blocks[] = [
         __typename: 'VideoVariant',
         id: '1_529-0-TrainV_1Install',
         hls: 'https://arc.gt/zxqrt'
-      }
+      },
+      variantLanguages: []
     },
     action: {
       __typename: 'NavigateAction',
@@ -89,7 +90,8 @@ export const journeyVideoBlocks: Blocks[] = [
         __typename: 'VideoVariant',
         id: '1_529-0-TrainV_5Ministry',
         hls: 'https://arc.gt/rnfsp'
-      }
+      },
+      variantLanguages: []
     },
     action: {
       __typename: 'NavigateAction',
@@ -131,7 +133,8 @@ export const journeyVideoBlocks: Blocks[] = [
         __typename: 'VideoVariant',
         id: '1_529-cl1302-0-0',
         hls: 'https://arc.gt/7unjy'
-      }
+      },
+      variantLanguages: []
     },
     action: {
       __typename: 'NavigateAction',
@@ -220,7 +223,8 @@ export const journeyVideoBlocks: Blocks[] = [
         __typename: 'VideoVariant',
         id: '1_529-cl1305-0-0',
         hls: 'https://arc.gt/hmkwc'
-      }
+      },
+      variantLanguages: []
     }
   },
   {

--- a/apps/journeys-admin/src/libs/blockDeleteUpdate/blockDeleteUpdate.spec.ts
+++ b/apps/journeys-admin/src/libs/blockDeleteUpdate/blockDeleteUpdate.spec.ts
@@ -50,7 +50,8 @@ const video: TreeBlock<VideoBlock> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    }
+    },
+    variantLanguages: []
   },
   posterBlockId: null,
   children: []

--- a/apps/journeys/__generated__/BlockFields.ts
+++ b/apps/journeys/__generated__/BlockFields.ts
@@ -418,12 +418,25 @@ export interface BlockFields_VideoBlock_video_variant {
   hls: string | null;
 }
 
+export interface BlockFields_VideoBlock_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface BlockFields_VideoBlock_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: BlockFields_VideoBlock_video_variantLanguages_name[];
+}
+
 export interface BlockFields_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: BlockFields_VideoBlock_video_title[];
   image: string | null;
   variant: BlockFields_VideoBlock_video_variant | null;
+  variantLanguages: BlockFields_VideoBlock_video_variantLanguages[];
 }
 
 export interface BlockFields_VideoBlock_action_NavigateAction {

--- a/apps/journeys/__generated__/GetJourney.ts
+++ b/apps/journeys/__generated__/GetJourney.ts
@@ -432,12 +432,25 @@ export interface GetJourney_journey_blocks_VideoBlock_video_variant {
   hls: string | null;
 }
 
+export interface GetJourney_journey_blocks_VideoBlock_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface GetJourney_journey_blocks_VideoBlock_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: GetJourney_journey_blocks_VideoBlock_video_variantLanguages_name[];
+}
+
 export interface GetJourney_journey_blocks_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: GetJourney_journey_blocks_VideoBlock_video_title[];
   image: string | null;
   variant: GetJourney_journey_blocks_VideoBlock_video_variant | null;
+  variantLanguages: GetJourney_journey_blocks_VideoBlock_video_variantLanguages[];
 }
 
 export interface GetJourney_journey_blocks_VideoBlock_action_NavigateAction {

--- a/apps/journeys/__generated__/JourneyFields.ts
+++ b/apps/journeys/__generated__/JourneyFields.ts
@@ -432,12 +432,25 @@ export interface JourneyFields_blocks_VideoBlock_video_variant {
   hls: string | null;
 }
 
+export interface JourneyFields_blocks_VideoBlock_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface JourneyFields_blocks_VideoBlock_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: JourneyFields_blocks_VideoBlock_video_variantLanguages_name[];
+}
+
 export interface JourneyFields_blocks_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: JourneyFields_blocks_VideoBlock_video_title[];
   image: string | null;
   variant: JourneyFields_blocks_VideoBlock_video_variant | null;
+  variantLanguages: JourneyFields_blocks_VideoBlock_video_variantLanguages[];
 }
 
 export interface JourneyFields_blocks_VideoBlock_action_NavigateAction {

--- a/apps/journeys/__generated__/VideoFields.ts
+++ b/apps/journeys/__generated__/VideoFields.ts
@@ -20,12 +20,25 @@ export interface VideoFields_video_variant {
   hls: string | null;
 }
 
+export interface VideoFields_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface VideoFields_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: VideoFields_video_variantLanguages_name[];
+}
+
 export interface VideoFields_video {
   __typename: "Video";
   id: string;
   title: VideoFields_video_title[];
   image: string | null;
   variant: VideoFields_video_variant | null;
+  variantLanguages: VideoFields_video_variantLanguages[];
 }
 
 export interface VideoFields_action_NavigateAction {

--- a/apps/nexus-admin/__generated__/BlockFields.ts
+++ b/apps/nexus-admin/__generated__/BlockFields.ts
@@ -418,12 +418,25 @@ export interface BlockFields_VideoBlock_video_variant {
   hls: string | null;
 }
 
+export interface BlockFields_VideoBlock_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface BlockFields_VideoBlock_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: BlockFields_VideoBlock_video_variantLanguages_name[];
+}
+
 export interface BlockFields_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: BlockFields_VideoBlock_video_title[];
   image: string | null;
   variant: BlockFields_VideoBlock_video_variant | null;
+  variantLanguages: BlockFields_VideoBlock_video_variantLanguages[];
 }
 
 export interface BlockFields_VideoBlock_action_NavigateAction {

--- a/apps/nexus-admin/__generated__/JourneyFields.ts
+++ b/apps/nexus-admin/__generated__/JourneyFields.ts
@@ -432,12 +432,25 @@ export interface JourneyFields_blocks_VideoBlock_video_variant {
   hls: string | null;
 }
 
+export interface JourneyFields_blocks_VideoBlock_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface JourneyFields_blocks_VideoBlock_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: JourneyFields_blocks_VideoBlock_video_variantLanguages_name[];
+}
+
 export interface JourneyFields_blocks_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: JourneyFields_blocks_VideoBlock_video_title[];
   image: string | null;
   variant: JourneyFields_blocks_VideoBlock_video_variant | null;
+  variantLanguages: JourneyFields_blocks_VideoBlock_video_variantLanguages[];
 }
 
 export interface JourneyFields_blocks_VideoBlock_action_NavigateAction {

--- a/apps/nexus-admin/__generated__/VideoFields.ts
+++ b/apps/nexus-admin/__generated__/VideoFields.ts
@@ -20,12 +20,25 @@ export interface VideoFields_video_variant {
   hls: string | null;
 }
 
+export interface VideoFields_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface VideoFields_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: VideoFields_video_variantLanguages_name[];
+}
+
 export interface VideoFields_video {
   __typename: "Video";
   id: string;
   title: VideoFields_video_title[];
   image: string | null;
   variant: VideoFields_video_variant | null;
+  variantLanguages: VideoFields_video_variantLanguages[];
 }
 
 export interface VideoFields_action_NavigateAction {

--- a/apps/watch/__generated__/BlockFields.ts
+++ b/apps/watch/__generated__/BlockFields.ts
@@ -418,12 +418,25 @@ export interface BlockFields_VideoBlock_video_variant {
   hls: string | null;
 }
 
+export interface BlockFields_VideoBlock_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface BlockFields_VideoBlock_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: BlockFields_VideoBlock_video_variantLanguages_name[];
+}
+
 export interface BlockFields_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: BlockFields_VideoBlock_video_title[];
   image: string | null;
   variant: BlockFields_VideoBlock_video_variant | null;
+  variantLanguages: BlockFields_VideoBlock_video_variantLanguages[];
 }
 
 export interface BlockFields_VideoBlock_action_NavigateAction {

--- a/apps/watch/__generated__/JourneyFields.ts
+++ b/apps/watch/__generated__/JourneyFields.ts
@@ -432,12 +432,25 @@ export interface JourneyFields_blocks_VideoBlock_video_variant {
   hls: string | null;
 }
 
+export interface JourneyFields_blocks_VideoBlock_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface JourneyFields_blocks_VideoBlock_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: JourneyFields_blocks_VideoBlock_video_variantLanguages_name[];
+}
+
 export interface JourneyFields_blocks_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: JourneyFields_blocks_VideoBlock_video_title[];
   image: string | null;
   variant: JourneyFields_blocks_VideoBlock_video_variant | null;
+  variantLanguages: JourneyFields_blocks_VideoBlock_video_variantLanguages[];
 }
 
 export interface JourneyFields_blocks_VideoBlock_action_NavigateAction {

--- a/apps/watch/__generated__/VideoFields.ts
+++ b/apps/watch/__generated__/VideoFields.ts
@@ -20,12 +20,25 @@ export interface VideoFields_video_variant {
   hls: string | null;
 }
 
+export interface VideoFields_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface VideoFields_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: VideoFields_video_variantLanguages_name[];
+}
+
 export interface VideoFields_video {
   __typename: "Video";
   id: string;
   title: VideoFields_video_title[];
   image: string | null;
   variant: VideoFields_video_variant | null;
+  variantLanguages: VideoFields_video_variantLanguages[];
 }
 
 export interface VideoFields_action_NavigateAction {

--- a/libs/journeys/ui/src/components/BlockRenderer/BlockRenderer.spec.tsx
+++ b/libs/journeys/ui/src/components/BlockRenderer/BlockRenderer.spec.tsx
@@ -667,7 +667,8 @@ describe('BlockRenderer', () => {
           __typename: 'VideoVariant',
           id: '2_0-FallingPlates-529',
           hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-        }
+        },
+        variantLanguages: []
       },
       autoplay: false,
       muted: false,
@@ -717,7 +718,8 @@ describe('BlockRenderer', () => {
           __typename: 'VideoVariant',
           id: '2_0-FallingPlates-529',
           hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-        }
+        },
+        variantLanguages: []
       },
       autoplay: false,
       muted: false,

--- a/libs/journeys/ui/src/components/Card/Card.spec.tsx
+++ b/libs/journeys/ui/src/components/Card/Card.spec.tsx
@@ -204,7 +204,8 @@ describe('CardBlock', () => {
         __typename: 'VideoVariant',
         id: '2_0-FallingPlates-529',
         hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-      }
+      },
+      variantLanguages: []
     },
     children: [
       {

--- a/libs/journeys/ui/src/components/Card/Card.stories.tsx
+++ b/libs/journeys/ui/src/components/Card/Card.stories.tsx
@@ -130,7 +130,8 @@ const video: TreeBlock<VideoFields> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    }
+    },
+    variantLanguages: []
   },
   action: null,
   fullsize: null,

--- a/libs/journeys/ui/src/components/Card/ContainedCover/BackgroundVideo/BackgroundVideo.spec.tsx
+++ b/libs/journeys/ui/src/components/Card/ContainedCover/BackgroundVideo/BackgroundVideo.spec.tsx
@@ -43,7 +43,8 @@ const video: TreeBlock<VideoFields> = {
       __typename: 'VideoVariant',
       id: '5_0-NUA0201-0-0-529',
       hls: 'https://arc.gt/hls/5_0-NUA0201-0-0/529'
-    }
+    },
+    variantLanguages: []
   },
   posterBlockId: null,
   children: []

--- a/libs/journeys/ui/src/components/Card/ContainedCover/ContainedCover.spec.tsx
+++ b/libs/journeys/ui/src/components/Card/ContainedCover/ContainedCover.spec.tsx
@@ -61,7 +61,8 @@ describe('ContainedCover', () => {
         __typename: 'VideoVariant',
         id: '2_0-FallingPlates-529',
         hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-      }
+      },
+      variantLanguages: []
     },
     children: []
   }

--- a/libs/journeys/ui/src/components/Video/Video.spec.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.spec.tsx
@@ -49,7 +49,8 @@ const block: TreeBlock<VideoFields> = {
       __typename: 'VideoVariant',
       id: '2_0-FallingPlates-529',
       hls: 'https://arc.gt/hls/2_0-FallingPlates/529'
-    }
+    },
+    variantLanguages: []
   },
   children: [
     {

--- a/libs/journeys/ui/src/components/Video/__generated__/VideoFields.ts
+++ b/libs/journeys/ui/src/components/Video/__generated__/VideoFields.ts
@@ -20,12 +20,25 @@ export interface VideoFields_video_variant {
   hls: string | null;
 }
 
+export interface VideoFields_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface VideoFields_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: VideoFields_video_variantLanguages_name[];
+}
+
 export interface VideoFields_video {
   __typename: "Video";
   id: string;
   title: VideoFields_video_title[];
   image: string | null;
   variant: VideoFields_video_variant | null;
+  variantLanguages: VideoFields_video_variantLanguages[];
 }
 
 export interface VideoFields_action_NavigateAction {

--- a/libs/journeys/ui/src/components/Video/videoFields.ts
+++ b/libs/journeys/ui/src/components/Video/videoFields.ts
@@ -32,6 +32,13 @@ export const VIDEO_FIELDS = gql`
         id
         hls
       }
+      variantLanguages {
+        id
+        name {
+          value
+          primary
+        }
+      }
     }
     action {
       ...ActionFields

--- a/libs/journeys/ui/src/libs/JourneyProvider/__generated__/JourneyFields.ts
+++ b/libs/journeys/ui/src/libs/JourneyProvider/__generated__/JourneyFields.ts
@@ -432,12 +432,25 @@ export interface JourneyFields_blocks_VideoBlock_video_variant {
   hls: string | null;
 }
 
+export interface JourneyFields_blocks_VideoBlock_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface JourneyFields_blocks_VideoBlock_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: JourneyFields_blocks_VideoBlock_video_variantLanguages_name[];
+}
+
 export interface JourneyFields_blocks_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: JourneyFields_blocks_VideoBlock_video_title[];
   image: string | null;
   variant: JourneyFields_blocks_VideoBlock_video_variant | null;
+  variantLanguages: JourneyFields_blocks_VideoBlock_video_variantLanguages[];
 }
 
 export interface JourneyFields_blocks_VideoBlock_action_NavigateAction {

--- a/libs/journeys/ui/src/libs/block/__generated__/BlockFields.ts
+++ b/libs/journeys/ui/src/libs/block/__generated__/BlockFields.ts
@@ -418,12 +418,25 @@ export interface BlockFields_VideoBlock_video_variant {
   hls: string | null;
 }
 
+export interface BlockFields_VideoBlock_video_variantLanguages_name {
+  __typename: "Translation";
+  value: string;
+  primary: boolean;
+}
+
+export interface BlockFields_VideoBlock_video_variantLanguages {
+  __typename: "Language";
+  id: string;
+  name: BlockFields_VideoBlock_video_variantLanguages_name[];
+}
+
 export interface BlockFields_VideoBlock_video {
   __typename: "Video";
   id: string;
   title: BlockFields_VideoBlock_video_title[];
   image: string | null;
   variant: BlockFields_VideoBlock_video_variant | null;
+  variantLanguages: BlockFields_VideoBlock_video_variantLanguages[];
 }
 
 export interface BlockFields_VideoBlock_action_NavigateAction {


### PR DESCRIPTION
# Description

### Issue
Designs for video nodes required a label for video nodes. Internal videos are to display their language translation or fallback to "Internal Media", Youtube videos should say "YouTube Video", and uploaded videos to say "Uploaded Media"

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7292062679)

### Solution
- Added logic to pass the video label as the `description` option from `getCardMetaData`
- Adds `variantLanguages` to the `VideoFields` fragment
- Updates necessary files that were needing the `variantLanguages` field

# External Changes
N/A

# Additional information
<img width="368" alt="image" src="https://github.com/JesusFilm/core/assets/91484241/cb343d66-dc5f-4d80-8771-e7c6ba019a40">

