### PR TITLE
feat: video edition schema

### DIFF
--- a/apps/api-videos/db/migrations/20240508225808_20240508225807/migration.sql
+++ b/apps/api-videos/db/migrations/20240508225808_20240508225807/migration.sql
@@ -1,0 +1,50 @@
+-- AlterTable
+ALTER TABLE "VideoVariant" ADD COLUMN     "editionId" TEXT;
+
+-- CreateTable
+CREATE TABLE "Edition" (
+    "id" TEXT NOT NULL,
+
+    CONSTRAINT "Edition_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Subtitle" (
+    "id" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "primary" BOOLEAN NOT NULL,
+    "languageId" TEXT NOT NULL,
+    "editionId" TEXT NOT NULL,
+
+    CONSTRAINT "Subtitle_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_EditionToSubtitle" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateIndex
+CREATE INDEX "Subtitle_languageId_idx" ON "Subtitle"("languageId");
+
+-- CreateIndex
+CREATE INDEX "Subtitle_editionId_idx" ON "Subtitle"("editionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Subtitle_editionId_languageId_key" ON "Subtitle"("editionId", "languageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_EditionToSubtitle_AB_unique" ON "_EditionToSubtitle"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_EditionToSubtitle_B_index" ON "_EditionToSubtitle"("B");
+
+-- AddForeignKey
+ALTER TABLE "VideoVariant" ADD CONSTRAINT "VideoVariant_editionId_fkey" FOREIGN KEY ("editionId") REFERENCES "Edition"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_EditionToSubtitle" ADD CONSTRAINT "_EditionToSubtitle_A_fkey" FOREIGN KEY ("A") REFERENCES "Edition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_EditionToSubtitle" ADD CONSTRAINT "_EditionToSubtitle_B_fkey" FOREIGN KEY ("B") REFERENCES "Subtitle"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api-videos/db/schema.prisma
+++ b/apps/api-videos/db/schema.prisma
@@ -93,6 +93,8 @@ model VideoVariant {
   duration   Int?
   languageId String
   subtitle   VideoVariantSubtitle[]
+  editionId  String?
+  edition    Edition?               @relation(fields: [editionId], references: [id])
   slug       String                 @unique
   video      Video?                 @relation(fields: [videoId], references: [id], onDelete: Cascade)
   videoId    String?
@@ -100,6 +102,26 @@ model VideoVariant {
   @@unique([languageId, videoId])
   @@index(languageId)
   @@index(videoId)
+}
+
+model Edition {
+  id           String         @id
+  Subtitle     Subtitle[]
+  VideoVariant VideoVariant[]
+}
+
+model Subtitle {
+  id         String  @id @default(uuid())
+  value      String
+  primary    Boolean
+  languageId String
+  editionId  String
+
+  edition Edition[]
+
+  @@unique([editionId, languageId])
+  @@index(languageId)
+  @@index(editionId)
 }
 
 model VideoVariantSubtitle {

--- a/apps/api-videos/src/app/modules/video/video.resolver.spec.ts
+++ b/apps/api-videos/src/app/modules/video/video.resolver.spec.ts
@@ -41,6 +41,7 @@ describe('VideoResolver', () => {
       videoId: video.id,
       hls: '',
       slug: 'jesus/english',
+      editionId: '1',
       languageId: '529',
       duration: 0
     }


### PR DESCRIPTION
# Description

### Issue

No way to track arclight editions in core

### Solution

Add edition & subtitle tables to api-videos

# External Changes

Add edition & subtitle tables to api-videos

# Additional information

Existing subtitle tables will be removed in a future PR