### PR TITLE
ci: add helpful message git status check

### DIFF
--- a/tools/scripts/check-git-status.sh
+++ b/tools/scripts/check-git-status.sh
@@ -6,6 +6,9 @@
 if [[ `git status --porcelain` ]]; then
   # Changes
   git status --porcelain
+  if [[ `git status --porcelain | grep libs/locales/en` ]]; then
+    echo "🔶 - translation changes - try running \`nx extract-translations <project-name>\`"
+  fi
   echo "🛑 - run codegen and linting locally and commit changes"
   exit 1
 else


### PR DESCRIPTION
# Description

### Issue

Got failed CI/CD step as part of `check-git-status.sh` with no idea how to resolve.
<img width="421" alt="image" src="https://github.com/JesusFilm/core/assets/26043376/87e846ab-53da-4787-a247-38b0ca88c297">


### Solution

Add a helpful message
Now outputs:
<img width="544" alt="image" src="https://github.com/JesusFilm/core/assets/26043376/83ce9d17-a6c1-446e-8825-d83e575041a1">

# External Changes

Only temporarily adding blank line change to test that it works.

# Additional information

Note that originally I branched from the wrong parent branch (https://github.com/JesusFilm/core/pull/2726) so I have moved the change to new branch and PR here. 
