### PR TITLE
fix: stop playing local video after drawer closes

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromLocal/LocalDetails/LocalDetails.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromLocal/LocalDetails/LocalDetails.tsx
@@ -154,7 +154,7 @@ export function LocalDetails({
         src: data?.video?.variant?.hls ?? ''
       })
     }
-  }, [data])
+  }, [open, data])
 
   useEffect(() => {
     if (open) {


### PR DESCRIPTION
# Description

### Issue

Local videos continue to play after the drawer is closed.

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7380267444)

### Solution

Added open prop to the dependencies in the videojs useEffect


