### PR TITLE
refactor: deprecate NavigateToJourneyAction backend

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -57,7 +57,9 @@ enum ButtonAction
 {
   NavigateAction @join__enumValue(graph: JOURNEYS)
   NavigateToBlockAction @join__enumValue(graph: JOURNEYS)
-  NavigateToJourneyAction @join__enumValue(graph: JOURNEYS)
+
+  """DEPRECATED: use LinkAction instead."""
+  NavigateToJourneyAction @join__enumValue(graph: JOURNEYS) @deprecated(reason: "Journey flow now handles this. Use LinkAction.")
   LinkAction @join__enumValue(graph: JOURNEYS)
   EmailAction @join__enumValue(graph: JOURNEYS)
 }
@@ -128,7 +130,6 @@ type ButtonClickEvent implements Event
   The label for each corresponding action, mapping below:
   NavigateAction - null
   NavigateToBlockAction - StepName (generated in client) of the StepBlock
-  NavigateToJourneyAction - slug of the journey
   LinkAction - url of the link
   """
   actionValue: String
@@ -159,7 +160,6 @@ input ButtonClickEventCreateInput
   The label for each corresponding action, mapping below:
   NavigateAction - undefined
   NavigateToBlockAction - StepName (generated in client) of the StepBlock
-  NavigateToJourneyAction - slug of the journey
   LinkAction - url of the link
   """
   actionValue: String
@@ -1207,7 +1207,19 @@ type Mutation
   blockDeleteAction(id: ID!, journeyId: ID!): Block! @join__field(graph: JOURNEYS)
   blockUpdateNavigateAction(id: ID!, journeyId: ID!, input: NavigateActionInput!): NavigateAction! @join__field(graph: JOURNEYS)
   blockUpdateNavigateToBlockAction(id: ID!, journeyId: ID!, input: NavigateToBlockActionInput!): NavigateToBlockAction! @join__field(graph: JOURNEYS)
-  blockUpdateNavigateToJourneyAction(id: ID!, journeyId: ID!, input: NavigateToJourneyActionInput!): NavigateToJourneyAction! @join__field(graph: JOURNEYS)
+
+  """
+  DEPRECATED: NavigateToJourneyAction is being removed. Use blockUpdateLinkAction instead.
+  """
+  blockUpdateNavigateToJourneyAction(
+    id: ID!
+    journeyId: ID!
+
+    """
+    DEPRECATED: NavigateToJourneyAction is being removed. Use blockUpdateLinkAction and LinkActionInput instead.
+    """
+    input: NavigateToJourneyActionInput!
+  ): NavigateToJourneyAction! @join__field(graph: JOURNEYS)
   blockUpdateLinkAction(id: ID!, journeyId: ID!, input: LinkActionInput!): LinkAction! @join__field(graph: JOURNEYS)
   blockUpdateEmailAction(id: ID!, journeyId: ID!, input: EmailActionInput!): EmailAction! @join__field(graph: JOURNEYS)
 

--- a/apps/api-journeys/db/schema.prisma
+++ b/apps/api-journeys/db/schema.prisma
@@ -57,7 +57,7 @@ enum DeviceType {
 enum ButtonAction {
   NavigateAction
   NavigateToBlockAction
-  NavigateToJourneyAction
+  NavigateToJourneyAction /// @deprecated Use `LinkAction` instead.
   LinkAction
   EmailAction
 }

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -92,7 +92,19 @@ extend type Mutation {
   blockDeleteAction(id: ID!, journeyId: ID!): Block!
   blockUpdateNavigateAction(id: ID!, journeyId: ID!, input: NavigateActionInput!): NavigateAction!
   blockUpdateNavigateToBlockAction(id: ID!, journeyId: ID!, input: NavigateToBlockActionInput!): NavigateToBlockAction!
-  blockUpdateNavigateToJourneyAction(id: ID!, journeyId: ID!, input: NavigateToJourneyActionInput!): NavigateToJourneyAction!
+
+  """
+  DEPRECATED: NavigateToJourneyAction is being removed. Use blockUpdateLinkAction instead.
+  """
+  blockUpdateNavigateToJourneyAction(
+    id: ID!
+    journeyId: ID!
+
+    """
+    DEPRECATED: NavigateToJourneyAction is being removed. Use blockUpdateLinkAction and LinkActionInput instead.
+    """
+    input: NavigateToJourneyActionInput!
+  ): NavigateToJourneyAction!
   blockUpdateLinkAction(id: ID!, journeyId: ID!, input: LinkActionInput!): LinkAction!
   blockUpdateEmailAction(id: ID!, journeyId: ID!, input: EmailActionInput!): EmailAction!
 
@@ -1270,7 +1282,9 @@ type CustomDomainVerificationResponse {
 enum ButtonAction {
   NavigateAction
   NavigateToBlockAction
-  NavigateToJourneyAction
+
+  """DEPRECATED: use LinkAction instead."""
+  NavigateToJourneyAction @deprecated(reason: "Journey flow now handles this. Use LinkAction.")
   LinkAction
   EmailAction
 }
@@ -1298,7 +1312,6 @@ input ButtonClickEventCreateInput {
   The label for each corresponding action, mapping below:
   NavigateAction - undefined
   NavigateToBlockAction - StepName (generated in client) of the StepBlock
-  NavigateToJourneyAction - slug of the journey
   LinkAction - url of the link
   """
   actionValue: String
@@ -1326,7 +1339,6 @@ type ButtonClickEvent implements Event {
   The label for each corresponding action, mapping below:
   NavigateAction - null
   NavigateToBlockAction - StepName (generated in client) of the StepBlock
-  NavigateToJourneyAction - slug of the journey
   LinkAction - url of the link
   """
   actionValue: String

--- a/apps/api-journeys/src/app/modules/action/action.graphql
+++ b/apps/api-journeys/src/app/modules/action/action.graphql
@@ -74,9 +74,16 @@ extend type Mutation {
     journeyId: ID!
     input: NavigateToBlockActionInput!
   ): NavigateToBlockAction!
+
+  """
+  DEPRECATED: NavigateToJourneyAction is being removed. Use blockUpdateLinkAction instead.
+  """
   blockUpdateNavigateToJourneyAction(
     id: ID!
     journeyId: ID!
+    """
+    DEPRECATED: NavigateToJourneyAction is being removed. Use blockUpdateLinkAction and LinkActionInput instead.
+    """
     input: NavigateToJourneyActionInput!
   ): NavigateToJourneyAction!
   blockUpdateLinkAction(

--- a/apps/api-journeys/src/app/modules/event/button/button.graphql
+++ b/apps/api-journeys/src/app/modules/event/button/button.graphql
@@ -1,7 +1,13 @@
 enum ButtonAction {
   NavigateAction
   NavigateToBlockAction
+
+  """
+  DEPRECATED: use LinkAction instead.
+  """
   NavigateToJourneyAction
+    @deprecated(reason: "Journey flow now handles this. Use LinkAction.")
+
   LinkAction
   EmailAction
 }
@@ -32,7 +38,6 @@ input ButtonClickEventCreateInput {
   The label for each corresponding action, mapping below:
   NavigateAction - undefined
   NavigateToBlockAction - StepName (generated in client) of the StepBlock
-  NavigateToJourneyAction - slug of the journey
   LinkAction - url of the link
   """
   actionValue: String
@@ -64,7 +69,6 @@ type ButtonClickEvent implements Event {
   The label for each corresponding action, mapping below:
   NavigateAction - null
   NavigateToBlockAction - StepName (generated in client) of the StepBlock
-  NavigateToJourneyAction - slug of the journey
   LinkAction - url of the link
   """
   actionValue: String

--- a/apps/journeys-admin/__generated__/GetVisitorEvents.ts
+++ b/apps/journeys-admin/__generated__/GetVisitorEvents.ts
@@ -45,7 +45,6 @@ export interface GetVisitorEvents_visitor_events_ButtonClickEvent {
    * The label for each corresponding action, mapping below:
    * NavigateAction - null
    * NavigateToBlockAction - StepName (generated in client) of the StepBlock
-   * NavigateToJourneyAction - slug of the journey
    * LinkAction - url of the link
    */
   actionValue: string | null;

--- a/apps/journeys-admin/__generated__/NavigateToJourneyActionUpdate.ts
+++ b/apps/journeys-admin/__generated__/NavigateToJourneyActionUpdate.ts
@@ -22,6 +22,9 @@ export interface NavigateToJourneyActionUpdate_blockUpdateNavigateToJourneyActio
 }
 
 export interface NavigateToJourneyActionUpdate {
+  /**
+   * DEPRECATED: NavigateToJourneyAction is being removed. Use blockUpdateLinkAction instead.
+   */
   blockUpdateNavigateToJourneyAction: NavigateToJourneyActionUpdate_blockUpdateNavigateToJourneyAction;
 }
 


### PR DESCRIPTION
# Description

### Issue

`NavigateToJourneyAction` is no longer needed. It needs removed. This is the **_second_** in 3x PRs that will realise this.
1. Safely remove it from the frontend
2. **Mark it for deprecation in the backend**
3. Remove it from the backend

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7364835830)

### Solution

Mark the NavigateToJourneyAction field as deprecated and change from required to optional
Rerun codegen for api-journeys and journeys-admin

# External Changes

n/a

# Additional information

Behaviour of the backend should be unaffected.
You should however see a deprecation warning when trying to use original mutations.
<img width="448" alt="image" src="https://github.com/JesusFilm/core/assets/26043376/8fdb2a7c-6cf8-4660-9c98-007326946de6">

<img width="936" alt="image" src="https://github.com/JesusFilm/core/assets/26043376/0479fc8a-2338-4b77-bc48-f2da8ad41aea">

<img width="1040" alt="image" src="https://github.com/JesusFilm/core/assets/26043376/e68af4de-c0c2-4fe5-a7b8-de5dddd10e95">

<img width="966" alt="image" src="https://github.com/JesusFilm/core/assets/26043376/68359c4a-4000-4704-bc0d-8f9a5aaa1989">
