### PR TITLE
fix: canvas size on journeymap

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/Canvas.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/Canvas.tsx
@@ -163,7 +163,6 @@ export function Canvas(): ReactElement {
           data-testid="stack here"
         >
           <Box
-            data-testid="CardAndFabBox"
             sx={{
               display: 'flex',
               flexDirection: 'column',

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/Canvas.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/Canvas.tsx
@@ -163,6 +163,7 @@ export function Canvas(): ReactElement {
           data-testid="stack here"
         >
           <Box
+            data-testid="CardAndFabBox"
             sx={{
               display: 'flex',
               flexDirection: 'column',
@@ -176,10 +177,9 @@ export function Canvas(): ReactElement {
                 width: CARD_WIDTH,
                 height: CARD_HEIGHT,
                 transform: `scale(${scale})`,
-                margin: `${calculateScaledMargin(
-                  CARD_HEIGHT,
-                  scale
-                )} ${calculateScaledMargin(CARD_WIDTH, scale)}`,
+                margin: `calc(${calculateScaledMargin(CARD_HEIGHT, scale)} + ${
+                  scale < 0.65 ? '20px' : '0px'
+                }) ${calculateScaledMargin(CARD_WIDTH, scale)}`,
                 borderRadius: 6,
                 transition: (theme) =>
                   theme.transitions.create('border-color', {

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/utils/calculateDimensions/calculateDimensions.ts
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/utils/calculateDimensions/calculateDimensions.ts
@@ -12,8 +12,7 @@ export function calculateScale(ref: RefObject<HTMLDivElement>): number {
   if (current.clientWidth === 0) return 1
 
   const clientHeight = current.clientHeight / CARD_HEIGHT
-  const scale = clientHeight
-  return Math.min(scale, 1)
+  return Math.min(clientHeight, 1)
 }
 
 export function calculateScaledMargin(

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/utils/calculateDimensions/calculateDimensions.ts
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/utils/calculateDimensions/calculateDimensions.ts
@@ -11,10 +11,8 @@ export function calculateScale(ref: RefObject<HTMLDivElement>): number {
   // which is done intentionally for the swiper
   if (current.clientWidth === 0) return 1
 
-  const clientWidth = current.clientWidth / CARD_WIDTH
   const clientHeight = current.clientHeight / CARD_HEIGHT
-  const scale = Math.min(clientWidth, clientHeight)
-
+  const scale = clientHeight
   return Math.min(scale, 1)
 }
 


### PR DESCRIPTION
# Description

### Issue

Issue #1 on the below basecamp ticket. When the user shrinks the screen vertically, the canvas width and height will reduce. However, if you then bring the screen back to normal size, the canvas size does not adjust back to normal. 

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7356029597)

### Solution

Removed clientWidth from the scale calculations. 

# Additional information

When shrinking the screen vertically, the top of the card(on the canvas) would go up behind the toolbar. To fix this, I added some extra margin height when the scale value has reduced below .65.
