### PR TITLE
feat: delete nodes and edges on keypress

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/InlineEditWrapper/InlineEditWrapper.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/InlineEditWrapper/InlineEditWrapper.tsx
@@ -1,11 +1,9 @@
-import { useMutation } from '@apollo/client'
 import { ReactElement } from 'react'
 
 import { WrapperProps } from '@core/journeys/ui/BlockRenderer'
 import { ActiveFab, useEditor } from '@core/journeys/ui/EditorProvider'
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 
-import { BlockDelete } from '../../../../../../../__generated__/BlockDelete'
 import { ButtonFields } from '../../../../../../../__generated__/ButtonFields'
 import { RadioOptionFields } from '../../../../../../../__generated__/RadioOptionFields'
 import { RadioQuestionFields } from '../../../../../../../__generated__/RadioQuestionFields'
@@ -13,7 +11,7 @@ import { SignUpFields } from '../../../../../../../__generated__/SignUpFields'
 import { TextResponseFields } from '../../../../../../../__generated__/TextResponseFields'
 import { TypographyFields } from '../../../../../../../__generated__/TypographyFields'
 import { blockDeleteUpdate } from '../../../../../../libs/blockDeleteUpdate'
-import { BLOCK_DELETE } from '../QuickControls/DeleteBlock/DeleteBlock'
+import { useBlockDeleteMutation } from '../../../../../../libs/useBlockDeleteMutation'
 import getSelected from '../QuickControls/DeleteBlock/utils/getSelected'
 
 import { ButtonEdit } from './ButtonEdit'
@@ -37,7 +35,7 @@ export function InlineEditWrapper({
   block,
   children
 }: InlineEditWrapperProps): ReactElement {
-  const [blockDelete] = useMutation<BlockDelete>(BLOCK_DELETE)
+  const [blockDelete] = useBlockDeleteMutation()
 
   const {
     state: { selectedBlock, activeFab, selectedStep, steps },
@@ -59,12 +57,7 @@ export function InlineEditWrapper({
     const stepsBeforeDelete = steps
     const stepBeforeDelete = selectedStep
 
-    await blockDelete({
-      variables: {
-        id: selectedBlock.id,
-        journeyId: journey.id,
-        parentBlockId: selectedBlock.parentBlockId
-      },
+    await blockDelete(selectedBlock, {
       update(cache, { data }) {
         if (data?.blockDelete != null && deletedBlockParentOrder != null) {
           const selected = getSelected({

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/QuickControls/DeleteBlock/DeleteBlock.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/QuickControls/DeleteBlock/DeleteBlock.spec.tsx
@@ -20,8 +20,10 @@ import {
   TypographyVariant
 } from '../../../../../../../../__generated__/globalTypes'
 import { TestEditorState } from '../../../../../../../libs/TestEditorState'
+import { BLOCK_DELETE } from '../../../../../../../libs/useBlockDeleteMutation'
+import { deleteBlockMock } from '../../../../../../../libs/useBlockDeleteMutation/useBlockDeleteMutation.mock'
 
-import { BLOCK_DELETE, DeleteBlock } from './DeleteBlock'
+import { DeleteBlock } from './DeleteBlock'
 
 jest.mock('@mui/material/useMediaQuery', () => ({
   __esModule: true,
@@ -72,28 +74,6 @@ describe('DeleteBlock', () => {
         children: [selectedBlock, block1, block2]
       }
     ]
-  }
-
-  const deleteBlockMock: MockedResponse<BlockDelete> = {
-    request: {
-      query: BLOCK_DELETE,
-      variables: {
-        id: selectedBlock.id,
-        parentBlockId: selectedBlock.parentBlockId,
-        journeyId: 'journeyId'
-      }
-    },
-    result: {
-      data: {
-        blockDelete: [
-          {
-            __typename: 'TypographyBlock',
-            id: selectedBlock.id,
-            parentOrder: selectedBlock.parentOrder
-          }
-        ]
-      }
-    }
   }
 
   const deleteCardMock: MockedResponse<BlockDelete> = {

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/QuickControls/DeleteBlock/DeleteBlock.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/QuickControls/DeleteBlock/DeleteBlock.spec.tsx
@@ -56,7 +56,7 @@ describe('DeleteBlock', () => {
   const selectedStep: TreeBlock<StepBlock> = {
     __typename: 'StepBlock',
     id: 'stepId',
-    parentBlockId: 'journeyId',
+    parentBlockId: 'journey-id',
     parentOrder: 0,
     locked: true,
     nextBlockId: null,
@@ -82,7 +82,7 @@ describe('DeleteBlock', () => {
       variables: {
         id: selectedStep.id,
         parentBlockId: selectedStep.parentBlockId,
-        journeyId: 'journeyId'
+        journeyId: 'journey-id'
       }
     },
     result: {
@@ -102,12 +102,12 @@ describe('DeleteBlock', () => {
   it('should delete a block on button click', async () => {
     const cache = new InMemoryCache()
     cache.restore({
-      'Journey:journeyId': {
+      'Journey:journey-id': {
         blocks: [
           { __ref: `CardBlock:card1.id` },
           { __ref: `TypographyBlock:typography0.id` }
         ],
-        id: 'journeyId',
+        id: 'journey-id',
         __typename: 'Journey'
       },
       'CardBlock:card1.id': {
@@ -126,7 +126,7 @@ describe('DeleteBlock', () => {
         >
           <JourneyProvider
             value={{
-              journey: { id: 'journeyId' } as unknown as Journey,
+              journey: { id: 'journey-id' } as unknown as Journey,
               variant: 'admin'
             }}
           >
@@ -142,7 +142,7 @@ describe('DeleteBlock', () => {
     )
     await userEvent.click(screen.getByRole('button'))
     await waitFor(() => expect(deleteBlockResultMock).toHaveBeenCalled())
-    expect(cache.extract()['Journey:journeyId']?.blocks).toEqual([
+    expect(cache.extract()['Journey:journey-id']?.blocks).toEqual([
       { __ref: 'CardBlock:card1.id' }
     ])
   })
@@ -150,12 +150,12 @@ describe('DeleteBlock', () => {
   it('should delete a block on menu item click', async () => {
     const cache = new InMemoryCache()
     cache.restore({
-      'Journey:journeyId': {
+      'Journey:journey-id': {
         blocks: [
           { __ref: `CardBlock:card1.id` },
           { __ref: `TypographyBlock:typography0.id` }
         ],
-        id: 'journeyId',
+        id: 'journey-id',
         __typename: 'Journey'
       },
       'CardBlock:card1.id': {
@@ -174,7 +174,7 @@ describe('DeleteBlock', () => {
         >
           <JourneyProvider
             value={{
-              journey: { id: 'journeyId' } as unknown as Journey,
+              journey: { id: 'journey-id' } as unknown as Journey,
               variant: 'admin'
             }}
           >
@@ -189,7 +189,7 @@ describe('DeleteBlock', () => {
       screen.getByRole('menuitem', { name: 'Delete Block' })
     )
     await waitFor(() => expect(deleteBlockResultMock).toHaveBeenCalled())
-    expect(cache.extract()['Journey:journeyId']?.blocks).toEqual([
+    expect(cache.extract()['Journey:journey-id']?.blocks).toEqual([
       { __ref: 'CardBlock:card1.id' }
     ])
   })
@@ -199,13 +199,13 @@ describe('DeleteBlock', () => {
 
     const cache = new InMemoryCache()
     cache.restore({
-      'Journey:journeyId': {
+      'Journey:journey-id': {
         blocks: [
           { __ref: `StepBlock:stepId` },
           { __ref: `CardBlock:card1.id` },
           { __ref: `TypographyBlock:typography0.id` }
         ],
-        id: 'journeyId',
+        id: 'journey-id',
         __typename: 'Journey'
       },
       'StepBlock:stepId': {
@@ -227,7 +227,7 @@ describe('DeleteBlock', () => {
         >
           <JourneyProvider
             value={{
-              journey: { id: 'journeyId' } as unknown as Journey,
+              journey: { id: 'journey-id' } as unknown as Journey,
               variant: 'admin'
             }}
           >
@@ -251,7 +251,7 @@ describe('DeleteBlock', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
 
     await waitFor(() => expect(deleteCardResultMock).toHaveBeenCalled())
-    expect(cache.extract()['Journey:journeyId']?.blocks).toEqual([])
+    expect(cache.extract()['Journey:journey-id']?.blocks).toEqual([])
   })
 
   it('should delete card on menu click', async () => {
@@ -259,13 +259,13 @@ describe('DeleteBlock', () => {
 
     const cache = new InMemoryCache()
     cache.restore({
-      'Journey:journeyId': {
+      'Journey:journey-id': {
         blocks: [
           { __ref: `StepBlock:stepId` },
           { __ref: `CardBlock:card1.id` },
           { __ref: `TypographyBlock:typography0.id` }
         ],
-        id: 'journeyId',
+        id: 'journey-id',
         __typename: 'Journey'
       },
       'StepBlock:stepId': {
@@ -287,7 +287,7 @@ describe('DeleteBlock', () => {
         >
           <JourneyProvider
             value={{
-              journey: { id: 'journeyId' } as unknown as Journey,
+              journey: { id: 'journey-id' } as unknown as Journey,
               variant: 'admin'
             }}
           >
@@ -307,7 +307,7 @@ describe('DeleteBlock', () => {
     )
     await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
     await waitFor(() => expect(deleteCardResultMock).toHaveBeenCalled())
-    expect(cache.extract()['Journey:journeyId']?.blocks).toEqual([])
+    expect(cache.extract()['Journey:journey-id']?.blocks).toEqual([])
     await waitFor(() =>
       expect(screen.queryByRole('menu')).not.toBeInTheDocument()
     )
@@ -342,7 +342,7 @@ describe('DeleteBlock', () => {
     const passedInStep: TreeBlock<StepBlock> = {
       __typename: 'StepBlock',
       id: 'passedInStepId',
-      parentBlockId: 'journeyId',
+      parentBlockId: 'journey-id',
       parentOrder: 0,
       locked: true,
       nextBlockId: null,
@@ -368,7 +368,7 @@ describe('DeleteBlock', () => {
         variables: {
           id: passedInStep.id,
           parentBlockId: passedInStep.parentBlockId,
-          journeyId: 'journeyId'
+          journeyId: 'journey-id'
         }
       },
       result: jest.fn(() => ({
@@ -387,13 +387,13 @@ describe('DeleteBlock', () => {
 
     const cache = new InMemoryCache()
     cache.restore({
-      'Journey:journeyId': {
+      'Journey:journey-id': {
         blocks: [
           { __ref: `StepBlock:passedInStepId` },
           { __ref: `CardBlock:card1.id` },
           { __ref: `TypographyBlock:typography0.id` }
         ],
-        id: 'journeyId',
+        id: 'journey-id',
         __typename: 'Journey'
       }
     })
@@ -410,7 +410,7 @@ describe('DeleteBlock', () => {
         >
           <JourneyProvider
             value={{
-              journey: { id: 'journeyId' } as unknown as Journey,
+              journey: { id: 'journey-id' } as unknown as Journey,
               variant: 'admin'
             }}
           >
@@ -434,7 +434,7 @@ describe('DeleteBlock', () => {
       expect(passedInStepDeleteMock.result).toHaveBeenCalled()
     )
     await waitFor(() => expect(deleteCardResultMock).not.toHaveBeenCalled())
-    expect(cache.extract()['Journey:journeyId']?.blocks).toEqual([])
+    expect(cache.extract()['Journey:journey-id']?.blocks).toEqual([])
 
     expect(
       screen.getByText(`selectedBlock: ${selectedStep.id}`)

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/QuickControls/DeleteBlock/DeleteBlock.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/QuickControls/DeleteBlock/DeleteBlock.tsx
@@ -1,4 +1,3 @@
-import { gql, useMutation } from '@apollo/client'
 import IconButton from '@mui/material/IconButton'
 import Typography from '@mui/material/Typography'
 import { useTranslation } from 'next-i18next'
@@ -11,23 +10,11 @@ import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import { Dialog } from '@core/shared/ui/Dialog'
 import Trash2Icon from '@core/shared/ui/icons/Trash2'
 
-import { BlockDelete } from '../../../../../../../../__generated__/BlockDelete'
 import { blockDeleteUpdate } from '../../../../../../../libs/blockDeleteUpdate'
+import { useBlockDeleteMutation } from '../../../../../../../libs/useBlockDeleteMutation'
 import { MenuItem } from '../../../../../../MenuItem'
 
 import getSelected from './utils/getSelected'
-
-export const BLOCK_DELETE = gql`
-  mutation BlockDelete($id: ID!, $journeyId: ID!, $parentBlockId: ID) {
-    blockDelete(id: $id, journeyId: $journeyId, parentBlockId: $parentBlockId) {
-      id
-      parentOrder
-      ... on StepBlock {
-        nextBlockId
-      }
-    }
-  }
-`
 
 interface DeleteBlockProps {
   variant: 'button' | 'list-item'
@@ -43,7 +30,7 @@ export function DeleteBlock({
   block
 }: DeleteBlockProps): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
-  const [blockDelete] = useMutation<BlockDelete>(BLOCK_DELETE)
+  const [blockDelete] = useBlockDeleteMutation()
   const { enqueueSnackbar } = useSnackbar()
   const { journey } = useJourney()
   const {
@@ -70,12 +57,7 @@ export function DeleteBlock({
     const stepsBeforeDelete = steps
     const stepBeforeDelete = selectedStep
 
-    await blockDelete({
-      variables: {
-        id: currentBlock.id,
-        journeyId: journey.id,
-        parentBlockId: currentBlock.parentBlockId
-      },
+    await blockDelete(currentBlock, {
       update(cache, { data }) {
         if (
           data?.blockDelete != null &&

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/JourneyFlow.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/JourneyFlow.tsx
@@ -44,6 +44,7 @@ import { PositionMap, arrangeSteps } from './libs/arrangeSteps'
 import { transformSteps } from './libs/transformSteps'
 import { useCreateStep } from './libs/useCreateStep'
 import { useDeleteEdge } from './libs/useDeleteEdge'
+import { useDeleteOnKeyPress } from './libs/useDeleteOnKeyPress'
 import { useUpdateEdge } from './libs/useUpdateEdge'
 import { NewStepButton } from './NewStepButton'
 import { SocialPreviewNode } from './nodes/SocialPreviewNode'
@@ -85,6 +86,7 @@ export function JourneyFlow(): ReactElement {
   const createStep = useCreateStep()
   const updateEdge = useUpdateEdge()
   const deleteEdge = useDeleteEdge()
+  const { onSelectionChange } = useDeleteOnKeyPress()
   const [stepBlockPositionUpdate] = useStepBlockPositionUpdateMutation()
 
   async function blockPositionsUpdate(positions: PositionMap): Promise<void> {
@@ -183,7 +185,7 @@ export function JourneyFlow(): ReactElement {
     connectingParams.current = params
   }, [])
   const onConnectEnd = useCallback<OnConnectEnd>(
-    (event) => {
+    async (event) => {
       if (
         reactFlowInstance == null ||
         connectingParams.current == null ||
@@ -293,12 +295,14 @@ export function JourneyFlow(): ReactElement {
         onEdgeUpdate={onEdgeUpdate}
         onEdgeUpdateStart={onEdgeUpdateStart}
         onEdgeUpdateEnd={onEdgeUpdateEnd}
+        onSelectionChange={onSelectionChange}
         fitView
         fitViewOptions={{ nodes: [nodes[0]], minZoom: 1, maxZoom: 0.7 }}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
         proOptions={{ hideAttribution: true }}
         onInit={setReactFlowInstance}
+        deleteKeyCode={[]}
         connectionLineStyle={{
           stroke: theme.palette.primary.main,
           strokeWidth: 2

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/libs/useDeleteOnKeyPress/index.ts
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/libs/useDeleteOnKeyPress/index.ts
@@ -1,0 +1,1 @@
+export { useDeleteOnKeyPress } from './useDeleteOnKeyPress'

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/libs/useDeleteOnKeyPress/useDeleteOnKeyPress.ts
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/libs/useDeleteOnKeyPress/useDeleteOnKeyPress.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react'
+import { Edge, OnSelectionChangeFunc, useKeyPress } from 'reactflow'
+
+import { ActiveSlide, useEditor } from '@core/journeys/ui/EditorProvider'
+
+import { BlockFields } from '../../../../../../../__generated__/BlockFields'
+import { useBlockDeleteMutation } from '../../../../../../libs/useBlockDeleteMutation'
+import { useDeleteEdge } from '../useDeleteEdge'
+
+const isEdge = (element: Edge | BlockFields): element is Edge =>
+  'source' in element && 'target' in element
+
+export function useDeleteOnKeyPress(): {
+  onSelectionChange: OnSelectionChangeFunc
+} {
+  const {
+    state: { selectedBlock, activeSlide }
+  } = useEditor()
+  const deleteEdge = useDeleteEdge()
+  const [blockDelete] = useBlockDeleteMutation()
+  const [selected, setSelected] = useState<Edge | BlockFields | undefined>()
+
+  // Set selected node or edge using selectedBlock and reactflow OnSelectionChange
+  const onSelectionChange: OnSelectionChangeFunc = ({ edges }) => {
+    if (edges.length > 0) {
+      setSelected(edges[0])
+    }
+  }
+
+  // Uses selected block for determining the current selected item.
+  // Important to set the selected item when creating a node
+  useEffect(() => {
+    if (selectedBlock == null) {
+      setSelected(undefined)
+    } else if (selectedBlock.__typename === 'StepBlock') {
+      setSelected(selectedBlock)
+    }
+  }, [selectedBlock])
+
+  const deleteEvent = useKeyPress(['Delete', 'Backspace'])
+
+  useEffect(
+    function handleDeleteEvent() {
+      if (
+        deleteEvent &&
+        selected != null &&
+        activeSlide === ActiveSlide.JourneyFlow
+      ) {
+        if (isEdge(selected)) {
+          void deleteEdge({
+            source: selected.source,
+            sourceHandle: selected.sourceHandle
+          })
+        } else {
+          void blockDelete(selected)
+        }
+
+        setSelected(undefined)
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [deleteEvent]
+  )
+
+  return { onSelectionChange }
+}

--- a/apps/journeys-admin/src/libs/useBlockDeleteMutation/index.ts
+++ b/apps/journeys-admin/src/libs/useBlockDeleteMutation/index.ts
@@ -1,1 +1,1 @@
-export { useBlockDeleteMutation } from './useBlockDeleteMutation'
+export { useBlockDeleteMutation, BLOCK_DELETE } from './useBlockDeleteMutation'

--- a/apps/journeys-admin/src/libs/useBlockDeleteMutation/index.ts
+++ b/apps/journeys-admin/src/libs/useBlockDeleteMutation/index.ts
@@ -1,0 +1,1 @@
+export { useBlockDeleteMutation } from './useBlockDeleteMutation'

--- a/apps/journeys-admin/src/libs/useBlockDeleteMutation/useBlockDeleteMutation.mock.ts
+++ b/apps/journeys-admin/src/libs/useBlockDeleteMutation/useBlockDeleteMutation.mock.ts
@@ -9,8 +9,8 @@ export const deleteBlockMock: MockedResponse<BlockDelete> = {
     query: BLOCK_DELETE,
     variables: {
       id: 'typography0.id',
-      parentBlockId: 'card1.id',
-      journeyId: 'journeyId'
+      journeyId: 'journey-id',
+      parentBlockId: 'card1.id'
     }
   },
   result: {

--- a/apps/journeys-admin/src/libs/useBlockDeleteMutation/useBlockDeleteMutation.mock.ts
+++ b/apps/journeys-admin/src/libs/useBlockDeleteMutation/useBlockDeleteMutation.mock.ts
@@ -1,0 +1,27 @@
+import { MockedResponse } from '@apollo/client/testing'
+
+import { BlockDelete } from '../../../__generated__/BlockDelete'
+
+import { BLOCK_DELETE } from './useBlockDeleteMutation'
+
+export const deleteBlockMock: MockedResponse<BlockDelete> = {
+  request: {
+    query: BLOCK_DELETE,
+    variables: {
+      id: 'typography0.id',
+      parentBlockId: 'card1.id',
+      journeyId: 'journeyId'
+    }
+  },
+  result: {
+    data: {
+      blockDelete: [
+        {
+          __typename: 'TypographyBlock',
+          id: 'block1.id',
+          parentOrder: 0
+        }
+      ]
+    }
+  }
+}

--- a/apps/journeys-admin/src/libs/useBlockDeleteMutation/useBlockDeleteMutation.spec.tsx
+++ b/apps/journeys-admin/src/libs/useBlockDeleteMutation/useBlockDeleteMutation.spec.tsx
@@ -1,0 +1,91 @@
+import { MockedProvider } from '@apollo/client/testing'
+import { renderHook, waitFor } from '@testing-library/react'
+import { act } from 'react-dom/test-utils'
+
+import { TreeBlock } from '@core/journeys/ui/block'
+import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
+
+import { GetJourney_journey_blocks_TypographyBlock as TypographyBlock } from '../../../__generated__/GetJourney'
+import { defaultJourney } from '../../components/Editor/data'
+
+import { deleteBlockMock } from './useBlockDeleteMutation.mock'
+
+import { BLOCK_DELETE, useBlockDeleteMutation } from '.'
+
+describe('useBlockDeleteMutation', () => {
+  const block: TreeBlock<TypographyBlock> = {
+    id: 'typography0.id',
+    __typename: 'TypographyBlock',
+    parentBlockId: 'card1.id',
+    parentOrder: 0,
+    align: null,
+    color: null,
+    content: 'block',
+    variant: null,
+    children: []
+  }
+
+  it('returns a function which deletes a block', async () => {
+    const { result } = renderHook(() => useBlockDeleteMutation(), {
+      wrapper: ({ children }) => (
+        <MockedProvider mocks={[deleteBlockMock]}>
+          <JourneyProvider value={{ journey: defaultJourney }}>
+            {children}
+          </JourneyProvider>
+        </MockedProvider>
+      )
+    })
+
+    await act(async () => {
+      await waitFor(async () => {
+        expect(await result.current[0](block)).toMatchObject({
+          data: {
+            blockDelete: [
+              {
+                __typename: 'TypographyBlock',
+                id: 'block1.id',
+                parentOrder: 0
+              }
+            ]
+          }
+        })
+      })
+    })
+  })
+
+  it('returns a function which returns undefined if error', async () => {
+    const emptyBlock = {} as unknown as TypographyBlock
+
+    const { result } = renderHook(() => useBlockDeleteMutation(), {
+      wrapper: ({ children }) => (
+        <MockedProvider
+          mocks={[
+            {
+              request: {
+                query: BLOCK_DELETE,
+                variables: {
+                  id: undefined,
+                  journeyId: undefined,
+                  parentBlockId: undefined
+                }
+              },
+              result: {
+                data: {}
+              }
+            }
+          ]}
+        >
+          <JourneyProvider value={{ journey: defaultJourney }}>
+            {children}
+          </JourneyProvider>
+        </MockedProvider>
+      )
+    })
+
+    await act(async () => {
+      await waitFor(async () => {
+        expect(await result.current[0](emptyBlock)).toBeUndefined()
+      })
+    })
+  })
+})

--- a/apps/journeys-admin/src/libs/useBlockDeleteMutation/useBlockDeleteMutation.ts
+++ b/apps/journeys-admin/src/libs/useBlockDeleteMutation/useBlockDeleteMutation.ts
@@ -48,19 +48,23 @@ export function useBlockDeleteMutation(
     block: TreeBlock,
     options: MutationFunctionOptions<BlockDelete, BlockDeleteVariables>
   ): Promise<FetchResult<BlockDelete> | undefined> {
-    if (journey == null) return
+    try {
+      if (journey == null) return
 
-    return await blockDeleteMutation({
-      variables: {
-        id: block.id,
-        journeyId: journey.id,
-        parentBlockId: block.parentBlockId
-      },
-      update(cache, { data }) {
-        blockDeleteUpdate(block, data?.blockDelete, cache, journey.id)
-      },
-      ...options
-    })
+      return await blockDeleteMutation({
+        variables: {
+          id: block.id,
+          journeyId: journey.id,
+          parentBlockId: block.parentBlockId
+        },
+        update(cache, { data }) {
+          blockDeleteUpdate(block, data?.blockDelete, cache, journey.id)
+        },
+        ...options
+      })
+    } catch (e) {
+      return undefined
+    }
   }
 
   return [wrappedBlockDeleteMutation, result]

--- a/apps/journeys-admin/src/libs/useBlockDeleteMutation/useBlockDeleteMutation.ts
+++ b/apps/journeys-admin/src/libs/useBlockDeleteMutation/useBlockDeleteMutation.ts
@@ -1,0 +1,67 @@
+import {
+  FetchResult,
+  MutationFunctionOptions,
+  MutationHookOptions,
+  MutationResult,
+  gql,
+  useMutation
+} from '@apollo/client'
+
+import { TreeBlock } from '@core/journeys/ui/block'
+import { useJourney } from '@core/journeys/ui/JourneyProvider'
+
+import {
+  BlockDelete,
+  BlockDeleteVariables
+} from '../../../__generated__/BlockDelete'
+import { BlockFields } from '../../../__generated__/BlockFields'
+import { blockDeleteUpdate } from '../blockDeleteUpdate'
+
+export const BLOCK_DELETE = gql`
+  mutation BlockDelete($id: ID!, $journeyId: ID!, $parentBlockId: ID) {
+    blockDelete(id: $id, journeyId: $journeyId, parentBlockId: $parentBlockId) {
+      id
+      parentOrder
+      ... on StepBlock {
+        nextBlockId
+      }
+    }
+  }
+`
+
+export function useBlockDeleteMutation(
+  options?: MutationHookOptions<BlockDelete, BlockDeleteVariables>
+): [
+  (
+    block: BlockFields,
+    options?: MutationFunctionOptions<BlockDelete, BlockDeleteVariables>
+  ) => Promise<FetchResult<BlockDelete> | undefined>,
+  MutationResult<BlockDelete>
+] {
+  const { journey } = useJourney()
+  const [blockDeleteMutation, result] = useMutation<
+    BlockDelete,
+    BlockDeleteVariables
+  >(BLOCK_DELETE, options)
+
+  async function wrappedBlockDeleteMutation(
+    block: TreeBlock,
+    options: MutationFunctionOptions<BlockDelete, BlockDeleteVariables>
+  ): Promise<FetchResult<BlockDelete> | undefined> {
+    if (journey == null) return
+
+    return await blockDeleteMutation({
+      variables: {
+        id: block.id,
+        journeyId: journey.id,
+        parentBlockId: block.parentBlockId
+      },
+      update(cache, { data }) {
+        blockDeleteUpdate(block, data?.blockDelete, cache, journey.id)
+      },
+      ...options
+    })
+  }
+
+  return [wrappedBlockDeleteMutation, result]
+}


### PR DESCRIPTION
# Description

### Issue
Allow users to delete nodes and edges when pressing backspace or delete

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7364539792)

### Solution
- created a custom hook `useDeleteOnKeyPress` to perform various logic to delete a selected node or edge when pressing the backspace or delete key

# External Changes
N/A

# Additional information
- The original suggestion was to use reactflow's `onEdgesDelete` and `onNodesDelete` functions, but since some edges or nodes should not be deletable I had to use the `useKeyPress` helper as an override.