### PR TITLE
feat: languages bq import support part 1

### DIFF
--- a/apps/api-languages/db/migrations/20240510220947_20240510220946/migration.sql
+++ b/apps/api-languages/db/migrations/20240510220947_20240510220946/migration.sql
@@ -1,0 +1,34 @@
+-- CreateTable
+CREATE TABLE "LanguageName" (
+    "id" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "languageId" TEXT NOT NULL,
+    "primary" BOOLEAN NOT NULL,
+    "parentLanguageId" TEXT NOT NULL,
+
+    CONSTRAINT "LanguageName_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "LanguageName_parentLanguageId_idx" ON "LanguageName"("parentLanguageId");
+
+-- CreateIndex
+CREATE INDEX "LanguageName_primary_idx" ON "LanguageName"("primary");
+
+-- CreateIndex
+CREATE INDEX "LanguageName_languageId_idx" ON "LanguageName"("languageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LanguageName_parentLanguageId_languageId_key" ON "LanguageName"("parentLanguageId", "languageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LanguageName_parentLanguageId_primary_key" ON "LanguageName"("parentLanguageId", "primary");
+
+-- CreateIndex
+CREATE INDEX "Language_bcp47_idx" ON "Language"("bcp47");
+
+-- AddForeignKey
+ALTER TABLE "LanguageName" ADD CONSTRAINT "LanguageName_languageId_fkey" FOREIGN KEY ("languageId") REFERENCES "Language"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LanguageName" ADD CONSTRAINT "LanguageName_parentLanguageId_fkey" FOREIGN KEY ("parentLanguageId") REFERENCES "Language"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api-languages/db/schema.prisma
+++ b/apps/api-languages/db/schema.prisma
@@ -19,10 +19,30 @@ datasource db {
 }
 
 model Language {
-  id        String   @id
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  name      Json[]
-  bcp47     String?
-  iso3      String?
+  id           String         @id
+  createdAt    DateTime       @default(now())
+  updatedAt    DateTime       @updatedAt
+  name         Json[]
+  bcp47        String?
+  iso3         String?
+  languageName LanguageName[] @relation(name: "name") // TODO: rename to name after migration
+  nameLanguage LanguageName[] @relation(name: "nameLanguage")
+
+  @@index(bcp47(type: Hash))
+}
+
+model LanguageName {
+  id               String   @id @default(uuid())
+  value            String
+  languageId       String
+  primary          Boolean
+  parentLanguageId String
+  language         Language @relation(name: "nameLanguage", fields: [languageId], references: [id])
+  parent           Language @relation(name: "name", fields: [parentLanguageId], references: [id])
+
+  @@unique([parentLanguageId, languageId])
+  @@unique([parentLanguageId, primary])
+  @@index(parentLanguageId(type: Hash))
+  @@index(primary(type: Hash))
+  @@index(languageId(type: Hash))
 }


### PR DESCRIPTION
# Description

### Issue

Name field is in a Json Blob array

### Solution

Incrementally move name to a table relation

# External Changes

Adds new model & relations, as well as seed for new model

# Additional information

Once complete, this should allow us to import languages from BQ.
Additionally it should make for better caching down the line and reduce cpu usage of filtering json. Especially once we if/when we add WESS data
