### PR TITLE
refactor: convert NavigateToJourney -> Link in DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ testem.log
 **/public/locales
 apps/api-gateway/router
 /**/tsconfig.tsbuildinfo
+.history/
 
 # System Files
 .DS_Store

--- a/apps/api-journeys/db/seeds/remediateNavigateToJourney.ts
+++ b/apps/api-journeys/db/seeds/remediateNavigateToJourney.ts
@@ -2,144 +2,57 @@
  * NavigateToJourneyAction is being removed. This script is to convert all
  * usages of the property to the LinkAction instead.
  */
-import get from 'lodash/get'
-import sortBy from 'lodash/sortBy'
-
-import {
-  Action,
-  Block,
-  Journey,
-  PrismaClient
-} from '.prisma/api-journeys-client'
+import { Journey, PrismaClient } from '.prisma/api-journeys-client'
 
 const prisma = new PrismaClient()
 
-type BlockWithAction = Array<Block & { action: Action }>
-type JourneyWithBlocks = Journey & { blocks: BlockWithAction }
-interface LinkActionUpdate {
-  target: null
-  gtmEventName: string
-  url: string
+function urlFromJourneySlug(journey: Journey | null): string {
+  if (journey?.slug == null) throw new Error('Journey slug is missing!')
+
+  return `https://your.nextstep.is/${journey.slug}`
 }
 
-function findParentStepBlock(blocks, parentBlockId): string {
-  const block = blocks.find((block) => block.id === parentBlockId)
-  if (block != null && block.typename === 'StepBlock') return block.id
-  return findParentStepBlock(blocks, block.parentBlockId)
-}
-
-function urlFromJourneySlug(journey: Journey): string {
-  if (journey.slug == null) {
-    console.error('Journey slug is missing!')
-    return ``
-  } else {
-    return `https://your.nextstep.is/${journey.slug}`
-  }
-}
-
-function createLinkActionForJourney(journey: Journey): LinkActionUpdate {
-  return {
-    gtmEventName: 'LinkAction',
-    url: urlFromJourneySlug(journey),
-    target: null
-  }
-}
-
-async function updateNextStepId(
-  stepBlockId: string,
-  nextStepBlockId: string
-): Promise<void> {
-  // many nextBlockIds are null - therefore update them
-  await prisma.block.update({
-    where: { id: stepBlockId },
-    data: { nextBlockId: nextStepBlockId }
-  })
-}
-
-function actionType(obj: Action): string {
-  if (get(obj, 'blockId') != null) return 'NavigateToBlockAction'
-  if (get(obj, 'journeyId') != null) return 'NavigateToJourneyAction'
-  if (get(obj, 'url') != null) return 'LinkAction'
-  if (get(obj, 'email') != null) return 'EmailAction'
-  return 'NavigateAction'
-}
-
-function getNavigateToJourneyBlocks(blocks: BlockWithAction): Block[] {
-  return blocks.filter(
-    (block): boolean =>
-      block.action != null &&
-      actionType(block.action) === 'NavigateToJourneyAction'
-  )
-}
-
-function getStepBlocks(blocks: Block[]): Block[] {
-  return blocks.filter((block) => block.typename === 'StepBlock')
-}
-
-async function updateBlockAction(id: string, linkAction): Promise<void> {
-  console.log({
-    where: { id: id },
-    data: { action: { update: linkAction } }
-  })
-  // await prisma.block.update({
-  //   where: { id: id },
-  //   data: { action: { update: linkAction } }
-  // })
-}
-
-async function convertStepBlocksAndActions(
-  journey: JourneyWithBlocks
-): Promise<void> {
-  const blocks = journey.blocks
-  const stepBlocks = sortBy(getStepBlocks(blocks), 'parentOrder')
-  const navigateToJourneyBlocks = getNavigateToJourneyBlocks(blocks)
-  const linkAction = createLinkActionForJourney(journey)
-
-  await Promise.all(
-    stepBlocks.map(async (stepBlock, index) => {
-      const nextIndex = index + 1
-      const hasNextStep = nextIndex < stepBlocks.length
-      const nextStepBlock = stepBlocks[nextIndex]
-
-      if (hasNextStep) {
-        console.log(
-          'Updating next block ID: ',
-          stepBlock.nextBlockId,
-          ' to ',
-          nextStepBlock.id
-        )
-        // await updateNextStepId(stepBlock.id, nextStepBlock.id)
-
-        const childActionBlocks = navigateToJourneyBlocks.filter(
-          (actionBlock) =>
-            actionBlock.parentBlockId != null &&
-            findParentStepBlock(blocks, actionBlock.parentBlockId) ===
-              stepBlock.id
-        )
-
-        await Promise.all(
-          childActionBlocks.map(
-            async (block) => await updateBlockAction(block.id, linkAction)
-          )
-        )
-      }
-    })
-  )
-}
-
-export async function remediateNavigateToJourney(): Promise<void> {
+async function remediateNavigateToJourney(): Promise<void> {
   let offset = 0
   while (true) {
-    const journeys = await prisma.journey.findMany({
+    const actions = await prisma.action.findMany({
       take: 100,
       skip: offset,
-      include: { blocks: { include: { action: true } } }
+      include: { journey: true },
+      where: { journeyId: { not: null } }
     })
 
-    if (journeys.length === 0) break
+    await Promise.all(
+      actions.map(async (action) => {
+        console.log(
+          `transform NavigateToJourneyAction (parentBlockId: ${
+            action.parentBlockId
+          }, journeyId: ${
+            action.journey?.id
+          }) to LinkAction with url ${urlFromJourneySlug(action.journey)}`
+        )
+        return await prisma.action.update({
+          where: { parentBlockId: action.parentBlockId },
+          data: {
+            gtmEventName: 'LinkAction',
+            journeyId: null,
+            url: urlFromJourneySlug(action.journey),
+            target: null
+          }
+        })
+      })
+    )
 
-    await Promise.all(journeys.map(convertStepBlocksAndActions))
+    if (actions.length === 0) break
 
     offset += 100
   }
 }
+
+async function main(): Promise<void> {
+  await remediateNavigateToJourney()
+}
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/apps/api-journeys/db/seeds/remediateNavigateToJourney.ts
+++ b/apps/api-journeys/db/seeds/remediateNavigateToJourney.ts
@@ -77,10 +77,14 @@ function getStepBlocks(blocks: Block[]): Block[] {
 }
 
 async function updateBlockAction(id: string, linkAction): Promise<void> {
-  await prisma.block.update({
+  console.log({
     where: { id: id },
     data: { action: { update: linkAction } }
   })
+  // await prisma.block.update({
+  //   where: { id: id },
+  //   data: { action: { update: linkAction } }
+  // })
 }
 
 async function convertStepBlocksAndActions(
@@ -98,7 +102,13 @@ async function convertStepBlocksAndActions(
       const nextStepBlock = stepBlocks[nextIndex]
 
       if (hasNextStep) {
-        await updateNextStepId(stepBlock.id, nextStepBlock.id)
+        console.log(
+          'Updating next block ID: ',
+          stepBlock.nextBlockId,
+          ' to ',
+          nextStepBlock.id
+        )
+        // await updateNextStepId(stepBlock.id, nextStepBlock.id)
 
         const childActionBlocks = navigateToJourneyBlocks.filter(
           (actionBlock) =>

--- a/apps/api-journeys/db/seeds/remediateNavigateToJourney.ts
+++ b/apps/api-journeys/db/seeds/remediateNavigateToJourney.ts
@@ -1,0 +1,130 @@
+/**
+ * NavigateToJourneyAction is being removed. This script is to convert all
+ * usages of the property to the LinkAction instead.
+ */
+import sortBy from 'lodash/sortBy'
+
+import {
+  PrismaClient,
+  Block,
+  Action,
+  Journey
+} from '.prisma/api-journeys-client'
+
+import { get } from 'lodash'
+
+const prisma = new PrismaClient()
+
+type BlockWithAction = Array<Block & { action: Action }>
+type JourneyWithBlocks = Journey & { blocks: BlockWithAction }
+
+function findParentStepBlock(blocks, parentBlockId): string {
+  const block = blocks.find((block) => block.id === parentBlockId)
+  if (block != null && block.typename === 'StepBlock') return block.id
+  return findParentStepBlock(blocks, block.parentBlockId)
+}
+
+function urlFromJourneySlug(journey: Journey) {
+  if (!journey.slug) {
+    console.error('Journey slug is missing!')
+    return ``
+  } else {
+    return `https://your.nextstep.is/${journey.slug}`
+  }
+}
+
+function createLinkActionForJourney(journey: Journey) {
+  return {
+    gtmEventName: 'LinkAction',
+    url: urlFromJourneySlug(journey),
+    target: null
+  }
+}
+
+async function updateNextStepId(
+  stepBlockId: string,
+  nextStepBlockId: string
+): Promise<void> {
+  await prisma.block.update({
+    where: { id: stepBlockId },
+    data: { nextBlockId: nextStepBlockId }
+  })
+}
+
+function actionType(obj: Action): string {
+  if (get(obj, 'blockId') != null) return 'NavigateToBlockAction'
+  if (get(obj, 'journeyId') != null) return 'NavigateToJourneyAction'
+  if (get(obj, 'url') != null) return 'LinkAction'
+  if (get(obj, 'email') != null) return 'EmailAction'
+  return 'NavigateAction'
+}
+
+function getNavigateToJourneyBlocks(blocks: BlockWithAction): Block[] {
+  return blocks.filter(
+    (block): boolean =>
+      block.action != null &&
+      actionType(block.action) === 'NavigateToJourneyAction'
+  )
+}
+
+function getStepBlocks(blocks: Block[]): Block[] {
+  return blocks.filter((block) => block.typename === 'StepBlock')
+}
+
+async function updateBlockAction(id: string, linkAction): Promise<void> {
+  await prisma.block.update({
+    where: { id: id },
+    data: { action: { update: linkAction } }
+  })
+}
+
+async function convertStepBlocksAndActions(
+  journey: JourneyWithBlocks
+): Promise<void> {
+  const blocks = journey.blocks
+  const stepBlocks = sortBy(getStepBlocks(blocks), 'parentOrder')
+  const navigateToJourneyBlocks = getNavigateToJourneyBlocks(blocks)
+  const linkAction = createLinkActionForJourney(journey)
+
+  await Promise.all(
+    stepBlocks.map(async (stepBlock, index) => {
+      const nextIndex = index + 1
+      const hasNextStep = nextIndex < stepBlocks.length
+      const nextStepBlock = stepBlocks[nextIndex]
+
+      if (hasNextStep) {
+        await updateNextStepId(stepBlock.id, nextStepBlock.id)
+
+        const childActionBlocks = navigateToJourneyBlocks.filter(
+          (actionBlock) =>
+            actionBlock.parentBlockId != null &&
+            findParentStepBlock(blocks, actionBlock.parentBlockId) ===
+              stepBlock.id
+        )
+
+        await Promise.all(
+          childActionBlocks.map(
+            async (block) => await updateBlockAction(block.id, linkAction)
+          )
+        )
+      }
+    })
+  )
+}
+
+export async function remediateNavigateToJourney(): Promise<void> {
+  let offset = 0
+  while (true) {
+    const journeys = await prisma.journey.findMany({
+      take: 100,
+      skip: offset,
+      include: { blocks: { include: { action: true } } }
+    })
+
+    if (journeys.length === 0) break
+
+    await Promise.all(journeys.map(convertStepBlocksAndActions))
+
+    offset += 100
+  }
+}

--- a/apps/api-journeys/db/seeds/remediateNavigateToJourney.ts
+++ b/apps/api-journeys/db/seeds/remediateNavigateToJourney.ts
@@ -13,11 +13,9 @@ function urlFromJourneySlug(journey: Journey | null): string {
 }
 
 async function remediateNavigateToJourney(): Promise<void> {
-  let offset = 0
   while (true) {
     const actions = await prisma.action.findMany({
       take: 100,
-      skip: offset,
       include: { journey: true },
       where: { journeyId: { not: null } }
     })
@@ -44,8 +42,6 @@ async function remediateNavigateToJourney(): Promise<void> {
     )
 
     if (actions.length === 0) break
-
-    offset += 100
   }
 }
 

--- a/apps/api-journeys/project.json
+++ b/apps/api-journeys/project.json
@@ -124,6 +124,12 @@
         ]
       }
     },
+    "remediate-navigate-to-journey": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm run ts-node apps/api-journeys/db/seeds/remediateNavigateToJourney.ts"
+      }
+    },
     "prisma-seed": {
       "executor": "nx:run-commands",
       "options": {


### PR DESCRIPTION
# Description

### Issue

`NavigateToJourneyAction` is no longer needed. It needs removed. This is the **_third_** in 4x PRs that will realise this.
1. Safely remove it from the frontend
2. Mark it for deprecation in the backend
3. **Migrate data in prod**
4. Remove it from the backend

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7364835830)

### Solution

Add a script that selects all the block actions that have the action type 'NavigateToJourneyAction' and convert them to 'LinkAction' type instead.
Also update the nextBlockId of those set to null.
Tries to remain aligned with similar PR https://github.com/JesusFilm/core/pull/2707

# External Changes

Ignore .history/ folders 

# Additional information

This script has been run on the staging DB today approximately 3:30pm and seems to have the desired affect.
<img width="1309" alt="image" src="https://github.com/JesusFilm/core/assets/26043376/7d0a95b1-74db-487d-a332-21ee03c3d2c2">
Left side shows the updates performed, i.e. 152c1650-21ce-48b7-8a73-66d3a7178a44 is converted. The right side shows a second attempt of the script which does not update any data.

# How to test
## Acceptance Criteria
* All `NavigateToJourneyAction`'s on a journey should be converted to `LinkAction` after the script is run
* All `nextBlockId` props on an updated journey should correctly point to their next block after the script is run

## Steps to test
* Create some blocks with the action type in one or more journeys
* Modify the actions to use the NavigateToJourneyAction implimentation over anything else
* Ensure some nextBlockId's have been set to null
* Run the script
* Ensure both acceptance criteria are met