### PR TITLE
fix: casl permissions update

### DIFF
--- a/apps/api-journeys/src/app/modules/customDomain/customDomain.acl.spec.ts
+++ b/apps/api-journeys/src/app/modules/customDomain/customDomain.acl.spec.ts
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability'
 import { Test, TestingModule } from '@nestjs/testing'
 
-import { UserTeamRole } from '../../__generated__/graphql'
+import { UserJourneyRole, UserTeamRole } from '../../__generated__/graphql'
 import { Action, AppAbility, AppCaslFactory } from '../../lib/casl/caslFactory'
 
 describe('customDomainAcl', () => {
@@ -183,7 +183,7 @@ describe('customDomainAcl', () => {
       ).toBe(true)
     })
 
-    it('should not allow when user is not team member', () => {
+    it('should not allow when user is not team member, journey owner or journey editor', () => {
       expect(
         ability.can(
           Action.Read,
@@ -193,6 +193,52 @@ describe('customDomainAcl', () => {
           })
         )
       ).toBe(false)
+    })
+
+    it('should  allow when user is journey owner', () => {
+      expect(
+        ability.can(
+          Action.Read,
+          subject('CustomDomain', {
+            ...customDomain,
+            team: {
+              journeys: [
+                {
+                  userJourneys: [
+                    {
+                      userId: 'userId',
+                      role: UserJourneyRole.editor
+                    }
+                  ]
+                }
+              ]
+            }
+          })
+        )
+      ).toBe(true)
+    })
+
+    it('should  allow when user is journey editor', () => {
+      expect(
+        ability.can(
+          Action.Read,
+          subject('CustomDomain', {
+            ...customDomain,
+            team: {
+              journeys: [
+                {
+                  userJourneys: [
+                    {
+                      userId: 'userId',
+                      role: UserJourneyRole.editor
+                    }
+                  ]
+                }
+              ]
+            }
+          })
+        )
+      ).toBe(true)
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/customDomain/customDomain.acl.spec.ts
+++ b/apps/api-journeys/src/app/modules/customDomain/customDomain.acl.spec.ts
@@ -143,4 +143,56 @@ describe('customDomainAcl', () => {
       ).toBe(false)
     })
   })
+
+  describe('Read', () => {
+    it('should allow when user is team manager', () => {
+      expect(
+        ability.can(
+          Action.Read,
+          subject('CustomDomain', {
+            ...customDomain,
+            team: {
+              userTeams: [
+                {
+                  userId: 'userId',
+                  role: UserTeamRole.manager
+                }
+              ]
+            }
+          })
+        )
+      ).toBe(true)
+    })
+
+    it('should allow when user is team member', () => {
+      expect(
+        ability.can(
+          Action.Read,
+          subject('CustomDomain', {
+            ...customDomain,
+            team: {
+              userTeams: [
+                {
+                  userId: 'userId',
+                  role: UserTeamRole.member
+                }
+              ]
+            }
+          })
+        )
+      ).toBe(true)
+    })
+
+    it('should not allow when user is not team member', () => {
+      expect(
+        ability.can(
+          Action.Read,
+          subject('CustomDomain', {
+            ...customDomain,
+            team: {}
+          })
+        )
+      ).toBe(false)
+    })
+  })
 })

--- a/apps/api-journeys/src/app/modules/customDomain/customDomain.acl.ts
+++ b/apps/api-journeys/src/app/modules/customDomain/customDomain.acl.ts
@@ -16,4 +16,16 @@ export const customDomainAcl: AppAclFn = ({ can, user }: AppAclParameters) => {
       }
     }
   })
+  can(Action.Read, 'CustomDomain', {
+    team: {
+      is: {
+        userTeams: {
+          some: {
+            userId: user.id,
+            role: { in: [UserTeamRole.manager, UserTeamRole.member] }
+          }
+        }
+      }
+    }
+  })
 }

--- a/apps/api-journeys/src/app/modules/customDomain/customDomain.acl.ts
+++ b/apps/api-journeys/src/app/modules/customDomain/customDomain.acl.ts
@@ -1,5 +1,6 @@
 import { UserTeamRole } from '.prisma/api-journeys-client'
 
+import { UserJourneyRole } from '../../__generated__/graphql'
 import { Action, AppAclFn, AppAclParameters } from '../../lib/casl/caslFactory'
 
 export const customDomainAcl: AppAclFn = ({ can, user }: AppAclParameters) => {
@@ -16,6 +17,7 @@ export const customDomainAcl: AppAclFn = ({ can, user }: AppAclParameters) => {
       }
     }
   })
+  // read as manager or member of team
   can(Action.Read, 'CustomDomain', {
     team: {
       is: {
@@ -23,6 +25,25 @@ export const customDomainAcl: AppAclFn = ({ can, user }: AppAclParameters) => {
           some: {
             userId: user.id,
             role: { in: [UserTeamRole.manager, UserTeamRole.member] }
+          }
+        }
+      }
+    }
+  })
+  // read as editor or owner of journey
+  can(Action.Read, 'CustomDomain', {
+    team: {
+      is: {
+        journeys: {
+          some: {
+            userJourneys: {
+              some: {
+                userId: user.id,
+                role: {
+                  in: [UserJourneyRole.owner, UserJourneyRole.editor]
+                }
+              }
+            }
           }
         }
       }

--- a/apps/api-journeys/src/app/modules/customDomain/customDomain.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/customDomain/customDomain.resolver.spec.ts
@@ -78,7 +78,18 @@ describe('CustomDomainResolver', () => {
       )
       expect(prismaService.customDomain.findUnique).toHaveBeenCalledWith({
         where: { id: 'customDomainId' },
-        include: { team: { include: { userTeams: true } } }
+        include: {
+          team: {
+            include: {
+              userTeams: true,
+              journeys: {
+                include: {
+                  userJourneys: true
+                }
+              }
+            }
+          }
+        }
       })
     })
 

--- a/apps/api-journeys/src/app/modules/customDomain/customDomain.resolver.ts
+++ b/apps/api-journeys/src/app/modules/customDomain/customDomain.resolver.ts
@@ -47,7 +47,14 @@ export class CustomDomainResolver {
   ): Promise<CustomDomain> {
     const customDomain = await this.prismaService.customDomain.findUnique({
       where: { id },
-      include: { team: { include: { userTeams: true } } }
+      include: {
+        team: {
+          include: {
+            userTeams: true,
+            journeys: { include: { userJourneys: true } }
+          }
+        }
+      }
     })
     if (customDomain == null)
       throw new GraphQLError('custom domain not found', {


### PR DESCRIPTION
# Description

### Issue

team members cannot see custom domain and hence preview button does not work

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071027/todos/7400237676)

### Solution

added read permissions for team members to see custom 