### PR TITLE
build: ignore history folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ testem.log
 **/public/locales
 apps/api-gateway/router
 /**/tsconfig.tsbuildinfo
+.history/
 
 # System Files
 .DS_Store


### PR DESCRIPTION
# Description

### Issue

`.history/` folder is used by [Local History](https://marketplace.visualstudio.com/items?itemName=xyz.local-history). This should be ignored.

### Solution

Add to git ignore

# External Changes

n/a

# Additional information

n/a
