### PR TITLE
fix: add more languages to templates

### DIFF
--- a/apps/journeys-admin/pages/templates/index.tsx
+++ b/apps/journeys-admin/pages/templates/index.tsx
@@ -84,7 +84,10 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
             '7083', // Japanese
             '16639', // Bahasa Indonesia
             '3887', // Vietnamese
-            '13169' // Thai
+            '13169', // Thai
+            '6464', // Hindi
+            '12876', // Ukrainian
+            '53441' // Arabic, Egyptian Modern Standard
           ]
         }
       }

--- a/apps/journeys-admin/src/components/TemplateGallery/HeaderAndLanguageFilter/HeaderAndLanguageFilter.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/HeaderAndLanguageFilter/HeaderAndLanguageFilter.tsx
@@ -186,7 +186,10 @@ export function HeaderAndLanguageFilter({
         '7083', // Japanese
         '16639', // Bahasa Indonesia
         '3887', // Vietnamese
-        '13169' // Thai
+        '13169', // Thai
+        '6464', // Hindi
+        '12876', // Ukrainian
+        '53441' // Arabic, Egyptian Modern Standard
       ]
     }
   })

--- a/apps/journeys-admin/src/components/TemplateGallery/HeaderAndLanguageFilter/LanguagesFilterPopper/LanguagesFilterPopper.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/HeaderAndLanguageFilter/LanguagesFilterPopper/LanguagesFilterPopper.tsx
@@ -26,8 +26,7 @@ const StyledPopperOption = styled(ButtonBase)(() => ({
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'flex-start',
-  alignItems: 'center',
-  flexGrow: 1
+  alignItems: 'center'
 }))
 
 export function LanguagesFilterPopper({
@@ -85,7 +84,7 @@ export function LanguagesFilterPopper({
                     backgroundColor: 'background.paper',
                     borderRadius: 1,
                     boxShadow: 2,
-                    minWidth: 250,
+                    minWidth: 200,
                     width: { xs: '100%', md: anchorEl?.clientWidth }
                   }}
                   placement="bottom-start"
@@ -118,10 +117,33 @@ export function LanguagesFilterPopper({
                               (language) => language.id === id
                             )}
                           />
-                          <Stack alignItems="flex-start" sx={{ pr: 2 }}>
-                            <Typography>{localName ?? nativeName}</Typography>
+                          <Stack
+                            alignItems="flex-start"
+                            sx={{
+                              width: 200,
+                              pr: 1,
+                              flexGrow: 1
+                            }}
+                          >
+                            <Typography
+                              sx={{
+                                textAlign: 'start',
+                                width: '100%',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                                overflow: 'hidden'
+                              }}
+                            >
+                              {localName ?? nativeName}
+                            </Typography>
+
                             {localName != null && nativeName != null && (
                               <Typography
+                                sx={{
+                                  textOverflow: 'ellipsis',
+                                  whiteSpace: 'nowrap',
+                                  overflow: 'hidden'
+                                }}
                                 variant="body2"
                                 color="text.secondary"
                               >

--- a/apps/journeys-admin/src/components/TemplateGallery/data.ts
+++ b/apps/journeys-admin/src/components/TemplateGallery/data.ts
@@ -286,7 +286,10 @@ export const getLanguagesMock: MockedResponse<GetLanguages> = {
           '7083',
           '16639',
           '3887',
-          '13169'
+          '13169',
+          '6464',
+          '12876',
+          '53441'
         ]
       }
     }


### PR DESCRIPTION
# Description

### Issue

Needed more languages for `LanguagesFilterPopper` on templates page.

[Link to Basecamp Todo]()

### Solution

Languages added:

- Hindi
- Ukrainian
- Arabic, Egyptian Modern Standard

Included a fix for long language names to be truncated with ellipsis.

# External Changes

_If you have made changes to external services, need to add additional values to Doppler, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc._

# Additional information

_Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc._
