### PR TITLE
fix: remove router changes

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/ImageBlockEditor/ImageBlockEditor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/ImageBlockEditor/ImageBlockEditor.spec.tsx
@@ -1,18 +1,10 @@
 import { MockedProvider } from '@apollo/client/testing'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { NextRouter, useRouter } from 'next/router'
 import { SnackbarProvider } from 'notistack'
 
 import { BlockFields_ImageBlock as ImageBlock } from '../../../../../../../__generated__/BlockFields'
 
 import { ImageBlockEditor } from '.'
-
-jest.mock('next/router', () => ({
-  __esModule: true,
-  useRouter: jest.fn(() => ({ query: { tab: 'active' } }))
-}))
-
-const mockedUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
 
 describe('ImageBlockEditor', () => {
   const imageBlock: ImageBlock = {
@@ -42,17 +34,6 @@ describe('ImageBlockEditor', () => {
   })
 
   it('should switch tabs', async () => {
-    const push = jest.fn()
-    const on = jest.fn()
-
-    mockedUseRouter.mockReturnValue({
-      query: { param: null },
-      push,
-      events: {
-        on
-      }
-    } as unknown as NextRouter)
-
     const { getByText, getByRole } = render(
       <SnackbarProvider>
         <MockedProvider>
@@ -61,54 +42,14 @@ describe('ImageBlockEditor', () => {
       </SnackbarProvider>
     )
     expect(getByRole('tab', { name: 'Gallery' })).toBeInTheDocument()
-    expect(getByText('Unsplash')).toBeInTheDocument()
+    await waitFor(() => expect(getByText('Unsplash')).toBeInTheDocument())
     fireEvent.click(getByRole('tab', { name: 'Custom' }))
-    await waitFor(() => {
-      expect(push).toHaveBeenCalledWith(
-        {
-          query: { param: 'custom-image' },
-          push,
-          events: {
-            on
-          }
-        },
-        undefined,
-        { shallow: true }
-      )
-    })
-
-    expect(getByText('Add image by URL')).toBeInTheDocument()
-    await fireEvent.click(getByRole('tab', { name: 'AI' }))
+    await waitFor(() =>
+      expect(getByText('Add image by URL')).toBeInTheDocument()
+    )
+    fireEvent.click(getByRole('tab', { name: 'AI' }))
     await waitFor(() =>
       expect(getByRole('button', { name: 'Prompt' })).toBeInTheDocument()
     )
-    await waitFor(() => {
-      expect(push).toHaveBeenCalledWith(
-        {
-          query: { param: 'ai-image' },
-          push,
-          events: {
-            on
-          }
-        },
-        undefined,
-        { shallow: true }
-      )
-    })
-
-    fireEvent.click(getByRole('tab', { name: 'Gallery' }))
-    await waitFor(() => {
-      expect(push).toHaveBeenCalledWith(
-        {
-          query: { param: 'unsplash-image' },
-          push,
-          events: {
-            on
-          }
-        },
-        undefined,
-        { shallow: true }
-      )
-    })
   })
 })

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/ImageBlockEditor/ImageBlockEditor.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/ImageBlockEditor/ImageBlockEditor.tsx
@@ -3,7 +3,6 @@ import Tab from '@mui/material/Tab'
 import Tabs from '@mui/material/Tabs'
 import Typography from '@mui/material/Typography'
 import dynamic from 'next/dynamic'
-import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import { ReactElement, SyntheticEvent, useState } from 'react'
 import { object, string } from 'yup'
@@ -14,7 +13,6 @@ import StarsIcon from '@core/shared/ui/icons/Stars'
 import { TabPanel, tabA11yProps } from '@core/shared/ui/TabPanel'
 
 import { BlockFields_ImageBlock as ImageBlock } from '../../../../../../../__generated__/BlockFields'
-import { setBeaconPageViewed } from '../../../../../../libs/setBeaconPageViewed'
 import { ImageBlockHeader } from '../ImageBlockHeader'
 
 import { UnsplashAuthor } from './UnsplashGallery'
@@ -61,29 +59,15 @@ export function ImageBlockEditor({
   error
 }: ImageBlockEditorProps): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
-  const router = useRouter()
   const [tabValue, setTabValue] = useState(0)
   const [unsplashAuthor, setUnsplashAuthor] = useState<UnsplashAuthor>()
   const [uploading, setUploading] = useState<boolean>()
-
-  const TabParams = { 0: 'unsplash-image', 1: 'custom-image', 2: 'ai-image' }
-
-  function setRoute(param: string): void {
-    router.query.param = param
-    void router.push(router, undefined, { shallow: true })
-    router.events.on('routeChangeComplete', () => {
-      setBeaconPageViewed(param)
-    })
-  }
 
   const handleTabChange = (
     _event: SyntheticEvent<Element, Event>,
     newValue: number
   ): void => {
     setTabValue(newValue)
-    const route: 'unsplash-image' | 'custom-image' | 'ai-image' =
-      TabParams[newValue]
-    if (route != null) setRoute(route)
   }
 
   const srcSchema = object().shape({

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoLibrary.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoLibrary.spec.tsx
@@ -1,7 +1,6 @@
 import { MockedProvider } from '@apollo/client/testing'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { NextRouter, useRouter } from 'next/router'
 
 import {
   VideoBlockSource,
@@ -17,17 +16,7 @@ jest.mock('@mui/material/useMediaQuery', () => ({
   default: jest.fn()
 }))
 
-jest.mock('next/router', () => ({
-  __esModule: true,
-  useRouter: jest.fn(() => ({ query: { tab: 'active' } }))
-}))
-
-const mockedUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
-
 describe('VideoLibrary', () => {
-  const push = jest.fn()
-  const on = jest.fn()
-
   describe('smUp', () => {
     beforeEach(() =>
       (useMediaQuery as jest.Mock).mockImplementation(() => true)
@@ -283,14 +272,6 @@ describe('VideoLibrary', () => {
   })
 
   it('should render YouTube', async () => {
-    mockedUseRouter.mockReturnValue({
-      query: { param: null },
-      push,
-      events: {
-        on
-      }
-    } as unknown as NextRouter)
-
     render(
       <MockedProvider>
         <VideoLibrary open />
@@ -300,80 +281,17 @@ describe('VideoLibrary', () => {
     await waitFor(() =>
       expect(screen.getByText('Paste any YouTube Link')).toBeInTheDocument()
     )
-    await waitFor(() => {
-      expect(push).toHaveBeenCalledWith(
-        {
-          query: { param: 'video-youtube' },
-          push,
-          events: {
-            on
-          }
-        },
-        undefined,
-        { shallow: true }
-      )
-    })
-  })
-
-  it('should update url params on library tab click', async () => {
-    mockedUseRouter.mockReturnValue({
-      query: { param: null },
-      push,
-      events: {
-        on
-      }
-    } as unknown as NextRouter)
-
-    const { getByRole } = render(
-      <MockedProvider>
-        <VideoLibrary open />
-      </MockedProvider>
-    )
-    fireEvent.click(getByRole('tab', { name: 'Upload' }))
-    fireEvent.click(getByRole('tab', { name: 'Library' }))
-    await waitFor(() => {
-      expect(push).toHaveBeenCalledWith(
-        {
-          query: { param: 'video-library' },
-          push,
-          events: {
-            on
-          }
-        },
-        undefined,
-        { shallow: true }
-      )
-    })
   })
 
   it('should render Cloudflare', async () => {
-    mockedUseRouter.mockReturnValue({
-      query: { param: null },
-      push,
-      events: {
-        on
-      }
-    } as unknown as NextRouter)
-
     render(
       <MockedProvider>
         <VideoLibrary open />
       </MockedProvider>
     )
     fireEvent.click(screen.getByRole('tab', { name: 'Upload' }))
-    expect(screen.getByText('Drop a video here')).toBeInTheDocument()
-    await waitFor(() => {
-      expect(push).toHaveBeenCalledWith(
-        {
-          query: { param: 'video-upload' },
-          push,
-          events: {
-            on
-          }
-        },
-        undefined,
-        { shallow: true }
-      )
-    })
+    await waitFor(() =>
+      expect(screen.getByText('Drop a video here')).toBeInTheDocument()
+    )
   })
 })

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoLibrary.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoLibrary.tsx
@@ -2,7 +2,6 @@ import Box from '@mui/material/Box'
 import Tab from '@mui/material/Tab'
 import Tabs from '@mui/material/Tabs'
 import dynamic from 'next/dynamic'
-import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import { ReactElement, SyntheticEvent, useEffect, useState } from 'react'
 
@@ -14,7 +13,6 @@ import { TabPanel, tabA11yProps } from '@core/shared/ui/TabPanel'
 
 import { BlockFields_VideoBlock as VideoBlock } from '../../../../../../../__generated__/BlockFields'
 import { VideoBlockUpdateInput } from '../../../../../../../__generated__/globalTypes'
-import { setBeaconPageViewed } from '../../../../../../libs/setBeaconPageViewed'
 import { Drawer } from '../Drawer'
 
 import { VideoFromLocal } from './VideoFromLocal'
@@ -59,34 +57,16 @@ export function VideoLibrary({
     selectedBlock?.videoId != null && open
   )
   const [activeTab, setActiveTab] = useState(0)
-  const router = useRouter()
 
   useEffect(() => {
     setOpenVideoDetails(selectedBlock?.videoId != null && open)
   }, [open, selectedBlock?.videoId])
-
-  const TabParams = {
-    0: 'video-library',
-    1: 'video-youtube',
-    2: 'video-upload'
-  }
-
-  function setRoute(param: string): void {
-    router.query.param = param
-    void router.push(router, undefined, { shallow: true })
-    router.events.on('routeChangeComplete', () => {
-      setBeaconPageViewed(param)
-    })
-  }
 
   const handleChange = (
     _event: SyntheticEvent<Element, Event>,
     newValue: number
   ): void => {
     setActiveTab(newValue)
-    const route: 'unsplash-image' | 'custom-image' | 'ai-image' =
-      TabParams[newValue]
-    if (route != null) setRoute(route)
   }
 
   const onSelect = (block: VideoBlockUpdateInput): void => {


### PR DESCRIPTION
# Description

### Issue

Router changes cause back and forward navigation events to break executing javascript. 

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7400797879)

### Solution

Remove the route changes. This will break helpscout workflows that use the URLs. We should find another workaround for that.