### PR TITLE
fix: router opentelemetry

### DIFF
--- a/apps/api-gateway/infrastructure/locals.tf
+++ b/apps/api-gateway/infrastructure/locals.tf
@@ -3,6 +3,7 @@ locals {
   environment_variables = [
     "APOLLO_GRAPH_REF",
     "APOLLO_KEY",
+    "DATADOG_AGENT_HOST",
     "GOOGLE_APPLICATION_JSON",
   ]
   service_config = {

--- a/apps/api-gateway/router.prod.yaml
+++ b/apps/api-gateway/router.prod.yaml
@@ -50,6 +50,7 @@ telemetry:
       otlp:
         enabled: true
         temporality: delta
+        endpoint: '${env.DATADOG_AGENT_HOST}:4317'
 experimental_batching:
   enabled: true
   mode: batch_http_link


### PR DESCRIPTION
# Description

### Issue

Open telemetry isn't working

### Solution

add DD agent hostname to apollo config

# External Changes

Adds env to doppler and terraform

# Additional information

