### PR TITLE
fix: update edges immediately

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/JourneyFlow.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/JourneyFlow.tsx
@@ -260,7 +260,7 @@ export function JourneyFlow(): ReactElement {
       }
       edgeUpdateSuccessful.current = true
     },
-    [deleteEdge]
+    [deleteEdge, setEdges]
   )
 
   const nodeTypes = useMemo(

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/JourneyFlow.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/JourneyFlow.tsx
@@ -24,9 +24,9 @@ import {
   ReactFlow,
   ReactFlowInstance,
   ReactFlowProps,
+  updateEdge as reactFlowUpdateEdge,
   useEdgesState,
-  useNodesState,
-  updateEdge as reactFlowUpdateEdge
+  useNodesState
 } from 'reactflow'
 
 import { useEditor } from '@core/journeys/ui/EditorProvider'
@@ -252,8 +252,10 @@ export function JourneyFlow(): ReactElement {
   const onEdgeUpdateEnd = useCallback<
     NonNullable<ReactFlowProps['onEdgeUpdateEnd']>
   >(
-    (_, { source, sourceHandle }) => {
+    (_, edge) => {
+      const { source, sourceHandle } = edge
       if (edgeUpdateSuccessful.current === false) {
+        setEdges((eds) => eds.filter((e) => e.id !== edge.id))
         void deleteEdge({ source, sourceHandle })
       }
       edgeUpdateSuccessful.current = true

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/JourneyFlow.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/JourneyFlow.tsx
@@ -25,7 +25,8 @@ import {
   ReactFlowInstance,
   ReactFlowProps,
   useEdgesState,
-  useNodesState
+  useNodesState,
+  updateEdge as reactFlowUpdateEdge
 } from 'reactflow'
 
 import { useEditor } from '@core/journeys/ui/EditorProvider'
@@ -239,7 +240,9 @@ export function JourneyFlow(): ReactElement {
   }, [])
 
   const onEdgeUpdate = useCallback<OnEdgeUpdateFunc>(
-    (_, { source, sourceHandle, target }) => {
+    (oldEdge, newConnection) => {
+      const { source, sourceHandle, target } = newConnection
+      setEdges((prev) => reactFlowUpdateEdge(oldEdge, newConnection, prev))
       edgeUpdateSuccessful.current = true
       void updateEdge({ source, sourceHandle, target })
     },

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/JourneyFlow.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/JourneyFlow.tsx
@@ -246,7 +246,7 @@ export function JourneyFlow(): ReactElement {
       edgeUpdateSuccessful.current = true
       void updateEdge({ source, sourceHandle, target })
     },
-    [updateEdge]
+    [updateEdge, setEdges]
   )
 
   const onEdgeUpdateEnd = useCallback<


### PR DESCRIPTION
# Description

### Issue

edges were not updating properly causing glitching UI when connecting from one handle to another

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7400975158)

### Solution

employed ReactFlow's in built state manager to update the UI immediately 

