### PR TITLE
fix: next step text

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/ActionButton/ActionButton.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/ActionButton/ActionButton.tsx
@@ -94,7 +94,7 @@ export function ActionButton({
       isSourceConnected = hasConnection(block)
       break
     case 'StepBlock':
-      title = t('Next Step →')
+      title = t('Default Next Step →')
       isSourceConnected = block.nextBlockId != null
       break
   }

--- a/libs/locales/en/apps-journeys-admin.json
+++ b/libs/locales/en/apps-journeys-admin.json
@@ -125,7 +125,7 @@
   "Subscribe": "Subscribe",
   "Feedback": "Feedback",
   "Video": "Video",
-  "Next Step →": "Next Step →",
+  "Default Next Step →": "Default Next Step →",
   "Click to edit or drag": "Click to edit or drag",
   "Card Duplicated": "Card Duplicated",
   "Duplicate Card": "Duplicate Card",


### PR DESCRIPTION
# Description

### Issue

Change the text "Next Step ->" within the action button to become "Default Next Step ->"

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

Update the text to the desired new text and run extract translations
