### PR TITLE
feat: hide self connecting edges

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/libs/transformSteps/transformSteps.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/libs/transformSteps/transformSteps.spec.tsx
@@ -1,8 +1,17 @@
-import { defaultEdgeProps, hiddenEdge, hiddenNode } from './transformSteps'
+import { TreeBlock } from '@core/journeys/ui/block'
+
+import { BlockFields_StepBlock as StepBlock } from '../../../../../../../__generated__/BlockFields'
+
+import {
+  defaultEdgeProps,
+  hiddenEdge,
+  hiddenNode,
+  socialNode
+} from './transformSteps'
 
 import { transformSteps } from '.'
 
-describe('tranformSteps', () => {
+describe('transformSteps', () => {
   it('should handle multiple steps without navigation actions', () => {
     const steps = [
       {
@@ -43,6 +52,8 @@ describe('tranformSteps', () => {
     const { nodes, edges } = transformSteps(steps, positions)
 
     expect(nodes).toEqual([
+      socialNode,
+      hiddenNode,
       {
         data: {},
         id: 'step1.id',
@@ -60,21 +71,11 @@ describe('tranformSteps', () => {
         id: 'step3.id',
         position: { x: 0, y: 20 },
         type: 'StepBlock'
-      },
-      {
-        data: {},
-        draggable: false,
-        id: 'SocialPreview',
-        position: {
-          x: -365,
-          y: -46
-        },
-        type: 'SocialPreview'
-      },
-      hiddenNode
+      }
     ])
 
     expect(edges).toEqual([
+      hiddenEdge,
       {
         id: 'step1.id->step2.id',
         source: 'step1.id',
@@ -100,8 +101,7 @@ describe('tranformSteps', () => {
         source: 'SocialPreview',
         target: 'step1.id',
         type: 'Start'
-      },
-      hiddenEdge
+      }
     ])
   })
 
@@ -123,5 +123,184 @@ describe('tranformSteps', () => {
     ])
 
     expect(edges).toEqual([hiddenEdge])
+  })
+
+  it('should handle action blocks', () => {
+    const steps: Array<TreeBlock<StepBlock>> = [
+      {
+        __typename: 'StepBlock' as const,
+        id: 'step1.id',
+        parentBlockId: null,
+        parentOrder: 0,
+        locked: false,
+        nextBlockId: null,
+        children: [
+          {
+            __typename: 'CardBlock',
+            id: 'card1.id',
+            parentBlockId: 'step1.id',
+            parentOrder: 0,
+            backgroundColor: null,
+            coverBlockId: null,
+            themeName: null,
+            themeMode: null,
+            fullscreen: false,
+            children: [
+              {
+                __typename: 'ButtonBlock',
+                id: 'button1.id',
+                parentBlockId: 'card1.id',
+                parentOrder: 0,
+                label: 'button1',
+                buttonVariant: null,
+                buttonColor: null,
+                size: null,
+                startIconId: null,
+                endIconId: null,
+                action: {
+                  __typename: 'NavigateToBlockAction',
+                  parentBlockId: 'button1.id',
+                  gtmEventName: null,
+                  blockId: 'step2.id'
+                },
+                children: []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        __typename: 'StepBlock' as const,
+        id: 'step2.id',
+        parentBlockId: null,
+        parentOrder: 0,
+        locked: false,
+        nextBlockId: null,
+        children: []
+      }
+    ]
+    const positions = {
+      'step1.id': { x: 0, y: 0 },
+      'step2.id': { x: 0, y: 10 }
+    }
+    const { nodes, edges } = transformSteps(steps, positions)
+
+    expect(nodes).toEqual([
+      socialNode,
+      hiddenNode,
+      {
+        data: {},
+        id: 'step1.id',
+        position: { x: 0, y: 0 },
+        type: 'StepBlock'
+      },
+      {
+        data: {},
+        id: 'step2.id',
+        position: { x: 0, y: 10 },
+        type: 'StepBlock'
+      }
+    ])
+
+    expect(edges).toEqual([
+      hiddenEdge,
+      {
+        id: 'button1.id->step2.id',
+        source: 'step1.id',
+        sourceHandle: 'button1.id',
+        target: 'step2.id',
+        ...defaultEdgeProps
+      },
+      {
+        id: 'SocialPreview->step1.id',
+        markerEnd: {
+          color: 'rgb(111, 111, 112)',
+          height: 10,
+          type: 'arrowclosed',
+          width: 10
+        },
+        source: 'SocialPreview',
+        target: 'step1.id',
+        type: 'Start'
+      }
+    ])
+  })
+
+  it('should not return edges that connects back the parent step', () => {
+    const steps: Array<TreeBlock<StepBlock>> = [
+      {
+        __typename: 'StepBlock' as const,
+        id: 'step1.id',
+        parentBlockId: null,
+        parentOrder: 0,
+        locked: false,
+        nextBlockId: 'step1.id',
+        children: [
+          {
+            __typename: 'CardBlock',
+            id: 'card1.id',
+            parentBlockId: 'step1.id',
+            parentOrder: 0,
+            backgroundColor: null,
+            coverBlockId: null,
+            themeName: null,
+            themeMode: null,
+            fullscreen: false,
+            children: [
+              {
+                __typename: 'ButtonBlock',
+                id: 'button1.id',
+                parentBlockId: 'card1.id',
+                parentOrder: 0,
+                label: 'button1',
+                buttonVariant: null,
+                buttonColor: null,
+                size: null,
+                startIconId: null,
+                endIconId: null,
+                action: {
+                  __typename: 'NavigateToBlockAction',
+                  parentBlockId: 'button1.id',
+                  gtmEventName: null,
+                  blockId: 'step1.id'
+                },
+                children: []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+    const positions = {
+      'step1.id': { x: 0, y: 0 }
+    }
+    const { nodes, edges } = transformSteps(steps, positions)
+
+    expect(nodes).toEqual([
+      socialNode,
+      hiddenNode,
+      {
+        data: {},
+        id: 'step1.id',
+        position: { x: 0, y: 0 },
+        type: 'StepBlock'
+      }
+    ])
+
+    expect(edges).toEqual([
+      hiddenEdge,
+      {
+        id: 'SocialPreview->step1.id',
+        markerEnd: {
+          color: 'rgb(111, 111, 112)',
+          height: 10,
+          type: 'arrowclosed',
+          width: 10
+        },
+        source: 'SocialPreview',
+        target: 'step1.id',
+        type: 'Start'
+      }
+    ])
   })
 })

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/libs/transformSteps/transformSteps.ts
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/libs/transformSteps/transformSteps.ts
@@ -4,10 +4,7 @@ import { Edge, MarkerType, Node } from 'reactflow'
 
 import { TreeBlock } from '@core/journeys/ui/block'
 
-import {
-  BlockFields,
-  BlockFields_StepBlock as StepBlock
-} from '../../../../../../../__generated__/BlockFields'
+import { BlockFields_StepBlock as StepBlock } from '../../../../../../../__generated__/BlockFields'
 import { adminLight } from '../../../../../ThemeProvider/admin/theme'
 import { PositionMap } from '../arrangeSteps'
 import { filterActionBlocks } from '../filterActionBlocks'
@@ -23,6 +20,15 @@ export const defaultEdgeProps = {
     color: MARKER_END_DEFAULT_COLOR
   }
 }
+
+export const socialNode = {
+  id: 'SocialPreview',
+  type: 'SocialPreview',
+  data: {},
+  position: { x: -365, y: -46 },
+  draggable: false
+}
+
 export const hiddenEdge = {
   id: 'SocialPreview->hidden',
   source: 'SocialPreview',
@@ -45,12 +51,6 @@ export const hiddenNode = {
   hidden: true
 }
 
-interface Connection<T = BlockFields> {
-  block: TreeBlock<T>
-  step: TreeBlock<StepBlock>
-  steps: Array<TreeBlock<StepBlock>>
-}
-
 type TreeStepBlock = TreeBlock<StepBlock>
 
 export function transformSteps(
@@ -60,27 +60,37 @@ export function transformSteps(
   nodes: Node[]
   edges: Edge[]
 } {
-  const nodes: Node[] = []
-  const edges: Edge[] = []
+  const nodes: Node[] = [socialNode, hiddenNode]
+  const edges: Edge[] = [hiddenEdge]
 
-  function connectBlockToNextBlock({ block, step, steps }: Connection): void {
+  function connectStepToNextBlock(
+    step: TreeBlock<StepBlock>,
+    steps: Array<TreeBlock<StepBlock>>
+  ): void {
     const index = findIndex(steps, (child) => child.id === step.id)
     if (index < 0) return
+
     if (step.nextBlockId != null && step.nextBlockId !== step.id) {
       edges.push({
-        id: `${block.id}->${step.nextBlockId}`,
+        id: `${step.id}->${step.nextBlockId}`,
         source: step.id,
-        sourceHandle: block.id !== step.id ? block.id : undefined,
+        sourceHandle: undefined,
         target: step.nextBlockId,
         ...defaultEdgeProps
       })
     }
   }
 
-  function processActionBlock(block, step, steps): void {
-    if (block.action == null) return
+  function processActionBlock(
+    block: TreeBlock,
+    step: TreeBlock<StepBlock>
+  ): void {
+    if (!('action' in block) || block.action == null) return
 
-    if (block.action.__typename === 'NavigateToBlockAction') {
+    if (
+      block.action.__typename === 'NavigateToBlockAction' &&
+      block.action.blockId !== step.id
+    ) {
       edges.push({
         id: `${block.id}->${block.action.blockId}`,
         source: step.id,
@@ -92,23 +102,15 @@ export function transformSteps(
   }
 
   steps.forEach((step) => {
-    connectBlockToNextBlock({ block: step, step, steps })
+    connectStepToNextBlock(step, steps)
     const actionBlocks = filterActionBlocks(step)
-    actionBlocks.forEach((block) => processActionBlock(block, step, steps))
+    actionBlocks.forEach((block) => processActionBlock(block, step))
     nodes.push({
       id: step.id,
       type: 'StepBlock',
       data: {},
       position: positions[step.id]
     })
-  })
-
-  nodes.push({
-    id: 'SocialPreview',
-    type: 'SocialPreview',
-    data: {},
-    position: { x: -365, y: -46 },
-    draggable: false
   })
 
   if (steps[0] != null) {
@@ -119,12 +121,6 @@ export function transformSteps(
       ...defaultEdgeProps,
       type: 'Start'
     })
-  }
-
-  // hidden edge so the markerEnd style can be used
-  if (nodes.find((node) => node.id === 'hidden') == null) {
-    nodes.push(hiddenNode)
-    edges.push(hiddenEdge)
   }
 
   return { nodes, edges }


### PR DESCRIPTION
# Description

### Issue

Partners have cards that connected to itself. This functionality has been removed now, but is still getting reported as a bug

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

- Restricts steps and actions that connect to itself from creating edges. 
- Added some minor refactors and tests

# External Changes

n/a

# Additional information

- This only removes the visual representation as we deemed it not worth it to do a full migration removing this. 
- You can still see the NavigateToStepAction still showing the self connection if you manually look at the action update.
