### PR TITLE
fix: edge arrow color

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/libs/transformSteps/transformSteps.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/libs/transformSteps/transformSteps.spec.tsx
@@ -93,7 +93,7 @@ describe('transformSteps', () => {
       {
         id: 'SocialPreview->step1.id',
         markerEnd: {
-          color: 'rgb(111, 111, 112)',
+          color: '#d9d9dc',
           height: 10,
           type: 'arrowclosed',
           width: 10
@@ -214,7 +214,7 @@ describe('transformSteps', () => {
       {
         id: 'SocialPreview->step1.id',
         markerEnd: {
-          color: 'rgb(111, 111, 112)',
+          color: '#d9d9dc',
           height: 10,
           type: 'arrowclosed',
           width: 10
@@ -292,7 +292,7 @@ describe('transformSteps', () => {
       {
         id: 'SocialPreview->step1.id',
         markerEnd: {
-          color: 'rgb(111, 111, 112)',
+          color: '#d9d9dc',
           height: 10,
           type: 'arrowclosed',
           width: 10

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/libs/transformSteps/transformSteps.ts
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/libs/transformSteps/transformSteps.ts
@@ -1,4 +1,4 @@
-import { darken } from '@mui/system/colorManipulator'
+import { lighten, rgbToHex } from '@mui/system/colorManipulator'
 import findIndex from 'lodash/findIndex'
 import { Edge, MarkerType, Node } from 'reactflow'
 
@@ -9,7 +9,9 @@ import { adminLight } from '../../../../../ThemeProvider/admin/theme'
 import { PositionMap } from '../arrangeSteps'
 import { filterActionBlocks } from '../filterActionBlocks'
 
-export const MARKER_END_DEFAULT_COLOR = darken(adminLight.palette.divider, 0.5)
+export const MARKER_END_DEFAULT_COLOR = rgbToHex(
+  lighten(adminLight.palette.secondary.main, 0.8)
+)
 export const MARKER_END_SELECTED_COLOR = adminLight.palette.primary.main
 export const defaultEdgeProps = {
   type: 'Custom',


### PR DESCRIPTION
# Description

### Issue
The color for edge arrows was missing.

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7403576506)

### Solution
The rgb value returned from the mui `lighten` function did not work with the marker end color property. Updating the value returned from `lighten` using the mui `rgbToHex` function to convert the value into digestible hex value.

# External Changes
N/A

# Additional information
N/A