### PR TITLE
refactor: remove default nexstep action for video blocks

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Video/Options/VideoOptions.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Video/Options/VideoOptions.tsx
@@ -3,14 +3,11 @@ import { useTranslation } from 'next-i18next'
 import { useSnackbar } from 'notistack'
 import { ReactElement } from 'react'
 
-import type { TreeBlock } from '@core/journeys/ui/block'
 import { useEditor } from '@core/journeys/ui/EditorProvider'
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import { VIDEO_FIELDS } from '@core/journeys/ui/Video/videoFields'
 
-import { BlockFields_VideoBlock as VideoBlock } from '../../../../../../../../../../__generated__/BlockFields'
 import { VideoBlockUpdateInput } from '../../../../../../../../../../__generated__/globalTypes'
-import { UpdateVideoBlockNextStep } from '../../../../../../../../../../__generated__/UpdateVideoBlockNextStep'
 import { VideoBlockUpdate } from '../../../../../../../../../../__generated__/VideoBlockUpdate'
 import { VideoBlockEditor } from '../../../../../Drawer/VideoBlockEditor'
 
@@ -48,43 +45,11 @@ export const UPDATE_VIDEO_BLOCK_NEXT_STEP = gql`
 export function VideoOptions(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   const {
-    state: { selectedStep, selectedBlock }
+    state: { selectedBlock }
   } = useEditor()
   const { journey } = useJourney()
   const { enqueueSnackbar } = useSnackbar()
   const [videoBlockUpdate] = useMutation<VideoBlockUpdate>(VIDEO_BLOCK_UPDATE)
-  const [updateVideoBlockNextStep] = useMutation<UpdateVideoBlockNextStep>(
-    UPDATE_VIDEO_BLOCK_NEXT_STEP
-  )
-
-  const updateDefaultNextStep = async (): Promise<void> => {
-    const nextStepId = selectedStep?.nextBlockId
-    const currentBlock = selectedBlock as TreeBlock<VideoBlock> | undefined
-    if (nextStepId != null && currentBlock != null && journey != null) {
-      await updateVideoBlockNextStep({
-        variables: {
-          id: currentBlock.id,
-          journeyId: journey.id,
-          input: {
-            blockId: nextStepId
-          }
-        },
-        update(cache, { data }) {
-          if (data?.blockUpdateNavigateToBlockAction != null) {
-            cache.modify({
-              id: cache.identify({
-                __typename: 'VideoBlock',
-                id: currentBlock.id
-              }),
-              fields: {
-                action: () => data?.blockUpdateNavigateToBlockAction
-              }
-            })
-          }
-        }
-      })
-    }
-  }
 
   const handleChange = async (input: VideoBlockUpdateInput): Promise<void> => {
     if (selectedBlock == null || journey == null) return
@@ -97,7 +62,6 @@ export function VideoOptions(): ReactElement {
           input
         }
       })
-      await updateDefaultNextStep()
       enqueueSnackbar(t('Video Updated'), {
         variant: 'success',
         preventDuplicate: true


### PR DESCRIPTION
# Description

### Issue
When assigning a video block source, a next step action is applied to the block. Charles has requested to remove this action to be more cohesive with the rest of the action blocks and video block behaviors.

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7410145983)

### Solution
I have removed the function and request to add a next block for the video block when assigning a source.

# External Changes
N/A

# Additional information
N/A