### PR TITLE
fix: double tap needed on select node

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/edges/BaseEdge/BaseEdge.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/edges/BaseEdge/BaseEdge.tsx
@@ -26,16 +26,16 @@ export function BaseEdge({
   const [isHovering, setIsHovering] = useState(false)
   const theme = useTheme()
 
-  useOnSelectionChange({
-    onChange: (selected) => {
-      const selectedEdge = selected.edges.find((edge) => edge.id === id)
-      if (selectedEdge != null) {
-        setEdgeSelected(true)
-      } else {
-        setEdgeSelected(false)
-      }
-    }
-  })
+  // useOnSelectionChange({
+  //   onChange: (selected) => {
+  //     const selectedEdge = selected.edges.find((edge) => edge.id === id)
+  //     if (selectedEdge != null) {
+  //       setEdgeSelected(true)
+  //     } else {
+  //       setEdgeSelected(false)
+  //     }
+  //   }
+  // })
 
   const props = !hasTouchScreen() && {
     onMouseOver: () => setIsHovering(true),

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/edges/CustomEdge/CustomEdge.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/edges/CustomEdge/CustomEdge.tsx
@@ -36,10 +36,10 @@ export function CustomEdge({
     targetPosition
   })
 
-  useOnSelectionChange({
-    onChange: (selected) =>
-      setSelected(selected.edges.find((edge) => edge.id === id) != null)
-  })
+  // useOnSelectionChange({
+  //   onChange: (selected) =>
+  //     setSelected(selected.edges.find((edge) => edge.id === id) != null)
+  // })
 
   const onEdgeClick = (): void => {
     void deleteEdge({

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/BaseNode/BaseNode.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/BaseNode/BaseNode.tsx
@@ -25,6 +25,7 @@ import {
 } from '../StepBlockNode/libs/sizes'
 
 import { PulseWrapper } from './PulseWrapper'
+import { useSnackbar } from 'notistack'
 
 const StyledHandle = styled(Handle)(() => ({}))
 const connectionHandleIdSelector = (state): string | null =>
@@ -67,18 +68,23 @@ export function BaseNode({
     id !== connectionNodeId
   const [targetSelected, setTargetSelected] = useState(false)
   const [sourceSelected, setSourceSelected] = useState(false)
+  const { enqueueSnackbar } = useSnackbar()
 
-  useOnSelectionChange({
-    onChange: (selected) => {
-      const selectedEdge = selected.edges[0]
-      setTargetSelected(selectedEdge?.target === id)
-      setSourceSelected(
-        selectedEdge?.sourceHandle != null
-          ? selectedEdge.sourceHandle === id
-          : selectedEdge?.source === id
-      )
-    }
-  })
+  // useOnSelectionChange({
+  //   onChange: (selected) => {
+  //     enqueueSnackbar(t('useOnSelectionChange'), {
+  //       variant: 'default',
+  //       preventDuplicate: true
+  //     })
+  //     const selectedEdge = selected.edges[0]
+  //     setTargetSelected(selectedEdge?.target === id)
+  //     setSourceSelected(
+  //       selectedEdge?.sourceHandle != null
+  //         ? selectedEdge.sourceHandle === id
+  //         : selectedEdge?.source === id
+  //     )
+  //   }
+  // })
 
   return (
     <Box
@@ -89,46 +95,46 @@ export function BaseNode({
         '.arrow': {
           opacity: 0,
           transition: 'right 0.5s, opacity 0.4s'
-        },
-        ':hover .arrow': {
-          opacity: isSourceConnected ? 0 : 1,
-          right: -22 // animation travel length
         }
+        // ':hover .arrow': {
+        //   opacity: isSourceConnected ? 0 : 1,
+        //   right: -22 // animation travel length
+        // }
       }}
     >
       {isFunction(children) ? children({ selected }) : children}
       {isTargetConnectable && (
-        <PulseWrapper show={isConnecting}>
-          <StyledHandle
-            type="target"
-            data-testid="BaseNodeLeftHandle"
-            position={Position.Left}
-            isConnectableStart={isConnecting}
-            isConnectable={id !== connectionNodeId}
-            sx={{
-              width: HANDLE_DIAMETER + HANDLE_BORDER_WIDTH,
-              height: HANDLE_DIAMETER + HANDLE_BORDER_WIDTH,
-              left: -HANDLE_WITH_BORDER_DIAMETER / 2,
-              top: (STEP_NODE_CARD_HEIGHT + HANDLE_WITH_BORDER_DIAMETER) / 2,
-              background: (theme) => theme.palette.background.default,
-              border: (theme) =>
-                isConnecting || targetSelected
-                  ? `${HANDLE_BORDER_WIDTH}px solid ${theme.palette.primary.main}`
-                  : `${HANDLE_BORDER_WIDTH}px solid ${theme.palette.secondary.light}80`,
+        // <PulseWrapper show={isConnecting}>
+        <StyledHandle
+          type="target"
+          data-testid="BaseNodeLeftHandle"
+          position={Position.Left}
+          isConnectableStart={isConnecting}
+          isConnectable={id !== connectionNodeId}
+          sx={{
+            width: HANDLE_DIAMETER + HANDLE_BORDER_WIDTH,
+            height: HANDLE_DIAMETER + HANDLE_BORDER_WIDTH,
+            left: -HANDLE_WITH_BORDER_DIAMETER / 2,
+            top: (STEP_NODE_CARD_HEIGHT + HANDLE_WITH_BORDER_DIAMETER) / 2,
+            background: (theme) => theme.palette.background.default,
+            border: (theme) =>
+              isConnecting || targetSelected
+                ? `${HANDLE_BORDER_WIDTH}px solid ${theme.palette.primary.main}`
+                : `${HANDLE_BORDER_WIDTH}px solid ${theme.palette.secondary.light}80`,
 
-              '&:after': {
-                display: isConnecting ? 'block' : 'none',
-                position: 'absolute',
-                content: '""',
-                width: STEP_NODE_WIDTH + NODE_EXTRA_DETECTION_WIDTH,
-                height: STEP_NODE_CARD_HEIGHT,
-                top: -STEP_NODE_CARD_HEIGHT / 2,
-                left: -NODE_EXTRA_DETECTION_WIDTH,
-                backgroundColor: 'transparent'
-              }
-            }}
-          />
-        </PulseWrapper>
+            '&:after': {
+              display: isConnecting ? 'block' : 'none',
+              position: 'absolute',
+              content: '""',
+              width: STEP_NODE_WIDTH + NODE_EXTRA_DETECTION_WIDTH,
+              height: STEP_NODE_CARD_HEIGHT,
+              top: -STEP_NODE_CARD_HEIGHT / 2,
+              left: -NODE_EXTRA_DETECTION_WIDTH,
+              backgroundColor: 'transparent'
+            }
+          }}
+        />
+        // </PulseWrapper>
       )}
       {isSourceConnectable && (
         <StyledHandle

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/StepBlockNodeCard/StepBlockNodeCard.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/StepBlockNodeCard/StepBlockNodeCard.tsx
@@ -16,6 +16,7 @@ import {
 import { getCardMetadata } from '../libs/getCardMetadata'
 import { STEP_NODE_CARD_HEIGHT, STEP_NODE_CARD_WIDTH } from '../libs/sizes'
 import { StepBlockNodeIcon } from '../StepBlockNodeIcon'
+import { useSnackbar } from 'notistack'
 
 interface StepBlockNodeCardProps {
   step: TreeBlock<StepBlock>
@@ -31,13 +32,23 @@ export function StepBlockNodeCard({
     dispatch
   } = useEditor()
   const { t } = useTranslation('apps-journeys-admin')
+  const { enqueueSnackbar } = useSnackbar()
 
   const card = step?.children[0] as TreeBlock<CardBlock> | undefined
   const { title, subtitle, description, priorityBlock, bgImage } =
     getCardMetadata(card)
 
   function handleClick(): void {
+    enqueueSnackbar(t('Handling click'), {
+      variant: 'success',
+      preventDuplicate: false
+    })
     if (selectedStep?.id === step?.id) {
+      enqueueSnackbar(t('Dispatching'), {
+        variant: 'warning',
+        preventDuplicate: false
+      })
+      // TODO: could these be replaced by one dispatch?
       dispatch({
         type: 'SetSelectedBlockAction',
         selectedBlock: selectedStep
@@ -60,10 +71,10 @@ export function StepBlockNodeCard({
       onClick={handleClick}
       sx={{
         width: STEP_NODE_CARD_WIDTH,
-        m: 1.5,
-        '&:hover': {
-          boxShadow: selected ? 6 : 3
-        }
+        m: 1.5
+        // '&:hover': {
+        //   boxShadow: selected ? 6 : 3
+        // }
       }}
     >
       <CardContent


### PR DESCRIPTION
# Description

### Issue

On iPhone it takes a double tap to select a node in the journey flow view. This should match all other devices in only taking 1x tap to select, and a second tap to move to the editor view.

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7422986305)

### Solution

TODO

# External Changes

TODO

# Additional information

TODO
