### PR TITLE
feat: hide step button and controls

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/JourneyFlow.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/JourneyFlow.tsx
@@ -29,7 +29,7 @@ import {
   useNodesState
 } from 'reactflow'
 
-import { useEditor } from '@core/journeys/ui/EditorProvider'
+import { ActiveSlide, useEditor } from '@core/journeys/ui/EditorProvider'
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import ArrowRefresh6Icon from '@core/shared/ui/icons/ArrowRefresh6'
 
@@ -75,7 +75,7 @@ export function JourneyFlow(): ReactElement {
   const { journey } = useJourney()
   const theme = useTheme()
   const {
-    state: { steps }
+    state: { steps, activeSlide }
   } = useEditor()
   const [reactFlowInstance, setReactFlowInstance] =
     useState<ReactFlowInstance | null>(null)
@@ -314,14 +314,20 @@ export function JourneyFlow(): ReactElement {
         }}
         elevateEdgesOnSelect
       >
-        <Panel position="top-right">
-          <NewStepButton />
-        </Panel>
-        <Controls showInteractive={false}>
-          <ControlButton onClick={async () => await blockPositionsUpdate({})}>
-            <ArrowRefresh6Icon />
-          </ControlButton>
-        </Controls>
+        {activeSlide === ActiveSlide.JourneyFlow && (
+          <>
+            <Panel position="top-right">
+              <NewStepButton />
+            </Panel>
+            <Controls showInteractive={false}>
+              <ControlButton
+                onClick={async () => await blockPositionsUpdate({})}
+              >
+                <ArrowRefresh6Icon />
+              </ControlButton>
+            </Controls>
+          </>
+        )}
         <Background color="#aaa" gap={16} />
       </ReactFlow>
     </Box>


### PR DESCRIPTION
# Description

### Issue
Lyuba requested to hide the new step button and the react flow controls when editing a block.

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7422849800)

### Solution
Conditionally render `NewStepButton` and react flow `Controls` when the activeSlide is set to Journeyflow

# External Changes
N/A

# Additional information
N/A
