### PR TITLE
test: add hook tests

### DIFF
--- a/apps/journeys-admin/src/libs/useBlockActionDeleteMutation/useBlockActionDeleteMutation.spec.tsx
+++ b/apps/journeys-admin/src/libs/useBlockActionDeleteMutation/useBlockActionDeleteMutation.spec.tsx
@@ -1,0 +1,89 @@
+import { InMemoryCache } from '@apollo/client'
+import { MockedProvider } from '@apollo/client/testing'
+import { act, renderHook, waitFor } from '@testing-library/react'
+
+import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
+
+import { BlockFields_ButtonBlock as ButtonBlock } from '../../../__generated__/BlockFields'
+import { JourneyFields as Journey } from '../../../__generated__/JourneyFields'
+
+import { blockActionDeleteMock } from './useBlockActionDeleteMutation.mock'
+
+import { useBlockActionDeleteMutation } from '.'
+
+describe('useBlockActionDeleteMutation', () => {
+  const journey = {
+    id: 'journey-id'
+  } as unknown as Journey
+
+  const block1: ButtonBlock = {
+    __typename: 'ButtonBlock',
+    id: 'block1.id',
+    parentBlockId: 'card1.id',
+    parentOrder: 0,
+    label: 'button',
+    buttonVariant: null,
+    buttonColor: null,
+    size: null,
+    startIconId: null,
+    endIconId: null,
+    action: {
+      __typename: 'NavigateToBlockAction',
+      gtmEventName: null,
+      parentBlockId: 'step1.id',
+      blockId: 'step2.id'
+    }
+  }
+
+  it('should delete block action', async () => {
+    const mockResult = jest.fn().mockReturnValue(blockActionDeleteMock.result)
+
+    const { result } = renderHook(() => useBlockActionDeleteMutation(), {
+      wrapper: ({ children }) => (
+        <JourneyProvider value={{ journey }}>
+          <MockedProvider
+            mocks={[{ ...blockActionDeleteMock, result: mockResult }]}
+          >
+            {children}
+          </MockedProvider>
+        </JourneyProvider>
+      )
+    })
+
+    await act(async () => {
+      await result.current[0](block1)
+
+      expect(mockResult).toHaveBeenCalled()
+    })
+  })
+
+  it('should update cache', async () => {
+    const cache = new InMemoryCache()
+    cache.restore({
+      'ButtonBlock:block1.id': {
+        ...block1
+      }
+    })
+
+    const { result } = renderHook(() => useBlockActionDeleteMutation(), {
+      wrapper: ({ children }) => (
+        <JourneyProvider value={{ journey }}>
+          <MockedProvider mocks={[blockActionDeleteMock]} cache={cache}>
+            {children}
+          </MockedProvider>
+        </JourneyProvider>
+      )
+    })
+
+    await act(async () => {
+      await result.current[0](block1)
+
+      await waitFor(() =>
+        expect(cache.extract()['ButtonBlock:block1.id']).toEqual({
+          ...block1,
+          action: null
+        })
+      )
+    })
+  })
+})

--- a/apps/journeys-admin/src/libs/useNavigateToBlockActionUpdateMutation/useNavigateToBlockActionUpdateMutation.spec.tsx
+++ b/apps/journeys-admin/src/libs/useNavigateToBlockActionUpdateMutation/useNavigateToBlockActionUpdateMutation.spec.tsx
@@ -1,0 +1,103 @@
+import { InMemoryCache } from '@apollo/client'
+import { MockedProvider } from '@apollo/client/testing'
+import { renderHook, waitFor } from '@testing-library/react'
+import { act } from 'react'
+
+import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
+
+import { BlockFields_ButtonBlock as ButtonBlock } from '../../../__generated__/BlockFields'
+import { JourneyFields as Journey } from '../../../__generated__/JourneyFields'
+
+import { navigateToBlockActionUpdateMock } from './useNavigateToBlockActionUpdate.mock'
+
+import { useNavigateToBlockActionUpdateMutation } from '.'
+
+describe('useNavigateToBlockActionUpdateMutation', () => {
+  const journey = {
+    id: 'journey-id'
+  } as unknown as Journey
+
+  const block1: ButtonBlock = {
+    __typename: 'ButtonBlock',
+    id: 'block1.id',
+    parentBlockId: 'card1.id',
+    parentOrder: 0,
+    label: 'button',
+    buttonVariant: null,
+    buttonColor: null,
+    size: null,
+    startIconId: null,
+    endIconId: null,
+    action: null
+  }
+
+  it('should update block action', async () => {
+    const mockResult = jest
+      .fn()
+      .mockReturnValue(navigateToBlockActionUpdateMock.result)
+
+    const { result } = renderHook(
+      () => useNavigateToBlockActionUpdateMutation(),
+      {
+        wrapper: ({ children }) => (
+          <JourneyProvider value={{ journey }}>
+            <MockedProvider
+              mocks={[
+                { ...navigateToBlockActionUpdateMock, result: mockResult }
+              ]}
+            >
+              {children}
+            </MockedProvider>
+          </JourneyProvider>
+        )
+      }
+    )
+
+    await act(async () => {
+      await result.current[0](block1, 'step2.id')
+
+      expect(mockResult).toHaveBeenCalled()
+    })
+  })
+
+  it('should update cache', async () => {
+    const cache = new InMemoryCache()
+    cache.restore({
+      'ButtonBlock:block1.id': {
+        ...block1
+      }
+    })
+
+    const { result } = renderHook(
+      () => useNavigateToBlockActionUpdateMutation(),
+      {
+        wrapper: ({ children }) => (
+          <JourneyProvider value={{ journey }}>
+            <MockedProvider
+              mocks={[navigateToBlockActionUpdateMock]}
+              cache={cache}
+            >
+              {children}
+            </MockedProvider>
+          </JourneyProvider>
+        )
+      }
+    )
+
+    await act(async () => {
+      await result.current[0](block1, 'step2.id')
+
+      await waitFor(() =>
+        expect(cache.extract()['ButtonBlock:block1.id']).toEqual({
+          ...block1,
+          action: {
+            __typename: 'NavigateToBlockAction',
+            gtmEventName: null,
+            parentBlockId: 'step1.id',
+            blockId: 'block1.id'
+          }
+        })
+      )
+    })
+  })
+})

--- a/apps/journeys-admin/src/libs/useStepAndCardBlockCreateMutation/useStepAndCardBlockCreateMutation.spec.tsx
+++ b/apps/journeys-admin/src/libs/useStepAndCardBlockCreateMutation/useStepAndCardBlockCreateMutation.spec.tsx
@@ -1,0 +1,109 @@
+import { InMemoryCache } from '@apollo/client'
+import { MockedProvider } from '@apollo/client/testing'
+import { act, renderHook } from '@testing-library/react'
+
+import { ThemeMode, ThemeName } from '../../../__generated__/globalTypes'
+
+import { stepAndCardBlockCreateMock } from './useStepAndCardBlockCreateMutation.mock'
+
+import { useStepAndCardBlockCreateMutation } from '.'
+
+describe('useStepAndCardBlockCreateMutation', () => {
+  it('should create step and card block', async () => {
+    const mockResult = jest
+      .fn()
+      .mockReturnValue(stepAndCardBlockCreateMock.result)
+
+    const { result } = renderHook(() => useStepAndCardBlockCreateMutation(), {
+      wrapper: ({ children }) => (
+        <MockedProvider
+          mocks={[{ ...stepAndCardBlockCreateMock, result: mockResult }]}
+        >
+          {children}
+        </MockedProvider>
+      )
+    })
+
+    await act(async () => {
+      await result.current[0]({
+        variables: {
+          stepBlockCreateInput: {
+            id: 'newStep.id',
+            journeyId: 'journey-id',
+            x: -200,
+            y: 38
+          },
+          cardBlockCreateInput: {
+            id: 'newCard.id',
+            journeyId: 'journey-id',
+            parentBlockId: 'newStep.id',
+            themeMode: ThemeMode.dark,
+            themeName: ThemeName.base
+          }
+        }
+      })
+      expect(mockResult).toHaveBeenCalled()
+    })
+  })
+
+  it('should update the cache', async () => {
+    const cache = new InMemoryCache()
+    cache.restore({
+      'Journey:journey-id': {
+        id: 'journey-id',
+        __typename: 'Journey',
+        blocks: []
+      }
+    })
+
+    const { result } = renderHook(() => useStepAndCardBlockCreateMutation(), {
+      wrapper: ({ children }) => (
+        <MockedProvider cache={cache} mocks={[stepAndCardBlockCreateMock]}>
+          {children}
+        </MockedProvider>
+      )
+    })
+
+    await act(async () => {
+      await result.current[0]({
+        variables: {
+          stepBlockCreateInput: {
+            id: 'newStep.id',
+            journeyId: 'journey-id',
+            x: -200,
+            y: 38
+          },
+          cardBlockCreateInput: {
+            id: 'newCard.id',
+            journeyId: 'journey-id',
+            parentBlockId: 'newStep.id',
+            themeMode: ThemeMode.dark,
+            themeName: ThemeName.base
+          }
+        }
+      })
+
+      expect(cache.extract()['StepBlock:newStep.id']).toEqual({
+        __typename: 'StepBlock',
+        id: 'newStep.id',
+        locked: false,
+        nextBlockId: null,
+        parentBlockId: null,
+        parentOrder: null,
+        x: -200,
+        y: 38
+      })
+      expect(cache.extract()['CardBlock:newCard.id']).toEqual({
+        __typename: 'CardBlock',
+        id: 'newCard.id',
+        backgroundColor: null,
+        coverBlockId: null,
+        fullscreen: false,
+        parentBlockId: 'newStep.id',
+        parentOrder: 0,
+        themeMode: ThemeMode.dark,
+        themeName: ThemeName.base
+      })
+    })
+  })
+})


### PR DESCRIPTION
# Description

### Issue

Normally mutation hook do not need tests, but because of the added logic in for cache updates, tests are now required

[- Action Delete Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7390573979)
[- Action update Basecamp Todo](https://3.basecamp.com/3105655/buckets/37071143/todos/7390574649)

### Solution

add tests

# External Changes
n/a

# Additional information

Also added missing test for `stepAndCardBlockCreate` hook mutation
