### PR TITLE
fix: form block update back end

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -2052,6 +2052,8 @@ type TextResponseSubmissionEvent implements Event
 
   """response from the TextResponseBlock form"""
   value: String
+
+  """the id of the block this event orignates from"""
   blockId: String
 }
 

--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -2053,7 +2053,7 @@ type TextResponseSubmissionEvent implements Event
   """response from the TextResponseBlock form"""
   value: String
 
-  """the id of the block this event orignates from"""
+  """the id of the block this event originates from"""
   blockId: String
 }
 

--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -2052,6 +2052,7 @@ type TextResponseSubmissionEvent implements Event
 
   """response from the TextResponseBlock form"""
   value: String
+  blockId: String
 }
 
 input TextResponseSubmissionEventCreateInput

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -1596,7 +1596,7 @@ type TextResponseSubmissionEvent implements Event {
   """response from the TextResponseBlock form"""
   value: String
 
-  """the id of the block this event orignates from"""
+  """the id of the block this event originates from"""
   blockId: String
 }
 

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -1595,6 +1595,7 @@ type TextResponseSubmissionEvent implements Event {
 
   """response from the TextResponseBlock form"""
   value: String
+  blockId: String
 }
 
 input VideoStartEventCreateInput {

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -1595,6 +1595,8 @@ type TextResponseSubmissionEvent implements Event {
 
   """response from the TextResponseBlock form"""
   value: String
+
+  """the id of the block this event orignates from"""
   blockId: String
 }
 

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -1179,6 +1179,7 @@ export class TextResponseSubmissionEvent implements Event {
     createdAt: DateTime;
     label?: Nullable<string>;
     value?: Nullable<string>;
+    blockId?: Nullable<string>;
 }
 
 export class VideoStartEvent implements Event {

--- a/apps/api-journeys/src/app/modules/event/textResponse/textResponse.graphql
+++ b/apps/api-journeys/src/app/modules/event/textResponse/textResponse.graphql
@@ -36,6 +36,9 @@ type TextResponseSubmissionEvent implements Event {
   response from the TextResponseBlock form
   """
   value: String
+  """
+  the id of the block this event orignates from
+  """
   blockId: String
 }
 

--- a/apps/api-journeys/src/app/modules/event/textResponse/textResponse.graphql
+++ b/apps/api-journeys/src/app/modules/event/textResponse/textResponse.graphql
@@ -37,7 +37,7 @@ type TextResponseSubmissionEvent implements Event {
   """
   value: String
   """
-  the id of the block this event orignates from
+  the id of the block this event originates from
   """
   blockId: String
 }

--- a/apps/api-journeys/src/app/modules/event/textResponse/textResponse.graphql
+++ b/apps/api-journeys/src/app/modules/event/textResponse/textResponse.graphql
@@ -36,6 +36,7 @@ type TextResponseSubmissionEvent implements Event {
   response from the TextResponseBlock form
   """
   value: String
+  blockId: String
 }
 
 extend type Mutation {

--- a/apps/journeys-admin/__generated__/GetJourneyVisitors.ts
+++ b/apps/journeys-admin/__generated__/GetJourneyVisitors.ts
@@ -35,33 +35,13 @@ export interface GetJourneyVisitors_visitors_edges_node_visitor {
   referrer: string | null;
 }
 
-export interface GetJourneyVisitors_visitors_edges_node_events_ButtonClickEvent {
-  __typename: "ButtonClickEvent" | "ChatOpenEvent" | "JourneyViewEvent" | "RadioQuestionSubmissionEvent" | "SignUpSubmissionEvent" | "StepViewEvent" | "StepNextEvent" | "StepPreviousEvent" | "VideoStartEvent" | "VideoPlayEvent" | "VideoPauseEvent" | "VideoCompleteEvent" | "VideoExpandEvent" | "VideoCollapseEvent" | "VideoProgressEvent";
+export interface GetJourneyVisitors_visitors_edges_node_events {
+  __typename: "ButtonClickEvent" | "ChatOpenEvent" | "JourneyViewEvent" | "RadioQuestionSubmissionEvent" | "SignUpSubmissionEvent" | "StepViewEvent" | "StepNextEvent" | "StepPreviousEvent" | "TextResponseSubmissionEvent" | "VideoStartEvent" | "VideoPlayEvent" | "VideoPauseEvent" | "VideoCompleteEvent" | "VideoExpandEvent" | "VideoCollapseEvent" | "VideoProgressEvent";
   id: string;
   createdAt: any;
   label: string | null;
   value: string | null;
 }
-
-export interface GetJourneyVisitors_visitors_edges_node_events_TextResponseSubmissionEvent {
-  __typename: "TextResponseSubmissionEvent";
-  id: string;
-  /**
-   * time event was created
-   */
-  createdAt: any;
-  /**
-   * stepName of the parent stepBlock
-   */
-  label: string | null;
-  /**
-   * response from the TextResponseBlock form
-   */
-  value: string | null;
-  blockId: string | null;
-}
-
-export type GetJourneyVisitors_visitors_edges_node_events = GetJourneyVisitors_visitors_edges_node_events_ButtonClickEvent | GetJourneyVisitors_visitors_edges_node_events_TextResponseSubmissionEvent;
 
 export interface GetJourneyVisitors_visitors_edges_node {
   __typename: "JourneyVisitor";

--- a/apps/journeys-admin/__generated__/GetJourneyVisitors.ts
+++ b/apps/journeys-admin/__generated__/GetJourneyVisitors.ts
@@ -35,13 +35,33 @@ export interface GetJourneyVisitors_visitors_edges_node_visitor {
   referrer: string | null;
 }
 
-export interface GetJourneyVisitors_visitors_edges_node_events {
-  __typename: "ButtonClickEvent" | "ChatOpenEvent" | "JourneyViewEvent" | "RadioQuestionSubmissionEvent" | "SignUpSubmissionEvent" | "StepViewEvent" | "StepNextEvent" | "StepPreviousEvent" | "TextResponseSubmissionEvent" | "VideoStartEvent" | "VideoPlayEvent" | "VideoPauseEvent" | "VideoCompleteEvent" | "VideoExpandEvent" | "VideoCollapseEvent" | "VideoProgressEvent";
+export interface GetJourneyVisitors_visitors_edges_node_events_ButtonClickEvent {
+  __typename: "ButtonClickEvent" | "ChatOpenEvent" | "JourneyViewEvent" | "RadioQuestionSubmissionEvent" | "SignUpSubmissionEvent" | "StepViewEvent" | "StepNextEvent" | "StepPreviousEvent" | "VideoStartEvent" | "VideoPlayEvent" | "VideoPauseEvent" | "VideoCompleteEvent" | "VideoExpandEvent" | "VideoCollapseEvent" | "VideoProgressEvent";
   id: string;
   createdAt: any;
   label: string | null;
   value: string | null;
 }
+
+export interface GetJourneyVisitors_visitors_edges_node_events_TextResponseSubmissionEvent {
+  __typename: "TextResponseSubmissionEvent";
+  id: string;
+  /**
+   * time event was created
+   */
+  createdAt: any;
+  /**
+   * stepName of the parent stepBlock
+   */
+  label: string | null;
+  /**
+   * response from the TextResponseBlock form
+   */
+  value: string | null;
+  blockId: string | null;
+}
+
+export type GetJourneyVisitors_visitors_edges_node_events = GetJourneyVisitors_visitors_edges_node_events_ButtonClickEvent | GetJourneyVisitors_visitors_edges_node_events_TextResponseSubmissionEvent;
 
 export interface GetJourneyVisitors_visitors_edges_node {
   __typename: "JourneyVisitor";


### PR DESCRIPTION
# Description

### Issue

we need to filter duplicate text response events and return the most recent text response in the front end on a per text response block basis

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37663186/todos/7439519537)

### Solution

add the blockId of the originating text response event

# External Changes

_If you have made changes to external services, need to add additional values to Doppler, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc._

# Additional information

_Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc._
