### PR TITLE
feat: get plausible stats breakdown

### DIFF
--- a/apps/journeys-admin/__generated__/GetPlausibleStatsBreakdown.ts
+++ b/apps/journeys-admin/__generated__/GetPlausibleStatsBreakdown.ts
@@ -1,0 +1,66 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { PlausibleStatsBreakdownFilter, IdType } from "./globalTypes";
+
+// ====================================================
+// GraphQL query operation: GetPlausibleStatsBreakdown
+// ====================================================
+
+export interface GetPlausibleStatsBreakdown_journeysPlausibleStatsBreakdown {
+  __typename: "PlausibleStatsResponse";
+  /**
+   * On breakdown queries, this is the property that was broken down by.
+   * On aggregate queries, this is the date the stats are for.
+   */
+  property: string;
+  /**
+   * The number of visits/sessions.
+   */
+  visits: number | null;
+  /**
+   * The number of pageview events.
+   */
+  pageviews: number | null;
+  /**
+   * Bounce rate percentage.
+   */
+  bounceRate: number | null;
+  /**
+   * Visit duration in seconds.
+   */
+  visitDuration: number | null;
+}
+
+export interface GetPlausibleStatsBreakdown {
+  /**
+   * This endpoint allows you to break down your stats by some property.
+   * If you are familiar with SQL family databases, this endpoint corresponds to
+   * running `GROUP BY` on a certain property in your stats, then ordering by the
+   * count.
+   * 
+   * Check out the [properties](https: // plausible.io/docs/stats-api#properties)
+   * section for a reference of all the properties you can use in this query.
+   * 
+   * This endpoint can be used to fetch data for `Top sources`, `Top pages`,
+   * `Top countries` and similar reports.
+   * 
+   * Currently, it is only possible to break down on one property at a time.
+   * Using a list of properties with one query is not supported. So if you want
+   * a breakdown by both `event:page` and `visit:source` for example, you would
+   * have to make multiple queries (break down on one property and filter on
+   * another) and then manually/programmatically group the results together in one
+   * report. This also applies for breaking down by time periods. To get a daily
+   * breakdown for every page, you would have to break down on `event:page` and
+   * make multiple queries for each date.
+   */
+  journeysPlausibleStatsBreakdown: GetPlausibleStatsBreakdown_journeysPlausibleStatsBreakdown[];
+}
+
+export interface GetPlausibleStatsBreakdownVariables {
+  where: PlausibleStatsBreakdownFilter;
+  id: string;
+  idType?: IdType | null;
+}

--- a/apps/journeys-admin/__generated__/StatsBreakdownFields.ts
+++ b/apps/journeys-admin/__generated__/StatsBreakdownFields.ts
@@ -1,0 +1,33 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: StatsBreakdownFields
+// ====================================================
+
+export interface StatsBreakdownFields {
+  __typename: "PlausibleStatsResponse";
+  /**
+   * On breakdown queries, this is the property that was broken down by.
+   * On aggregate queries, this is the date the stats are for.
+   */
+  property: string;
+  /**
+   * The number of visits/sessions.
+   */
+  visits: number | null;
+  /**
+   * The number of pageview events.
+   */
+  pageviews: number | null;
+  /**
+   * Bounce rate percentage.
+   */
+  bounceRate: number | null;
+  /**
+   * Visit duration in seconds.
+   */
+  visitDuration: number | null;
+}

--- a/apps/journeys-admin/__generated__/globalTypes.ts
+++ b/apps/journeys-admin/__generated__/globalTypes.ts
@@ -71,6 +71,11 @@ export enum IconSize {
   xl = "xl",
 }
 
+export enum IdType {
+  databaseId = "databaseId",
+  slug = "slug",
+}
+
 export enum JourneyStatus {
   archived = "archived",
   deleted = "deleted",
@@ -444,6 +449,15 @@ export interface MeInput {
 export interface NavigateToBlockActionInput {
   gtmEventName?: string | null;
   blockId: string;
+}
+
+export interface PlausibleStatsBreakdownFilter {
+  property: string;
+  period?: string | null;
+  date?: string | null;
+  limit?: number | null;
+  page?: number | null;
+  filters?: string | null;
 }
 
 export interface RadioOptionBlockCreateInput {

--- a/apps/journeys-admin/src/components/Editor/Editor.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.tsx
@@ -7,12 +7,12 @@ import { transformer } from '@core/journeys/ui/transformer'
 
 import { BlockFields_StepBlock as StepBlock } from '../../../__generated__/BlockFields'
 import { GetJourney_journey as Journey } from '../../../__generated__/GetJourney'
+import { IdType } from '../../../__generated__/globalTypes'
+import { usePlausibleStatsBreakdownQuery } from '../../libs/usePlausibleStatsBreakdownQuery'
 
 import { Fab } from './Fab'
 import { Slider } from './Slider'
 import { Toolbar } from './Toolbar'
-import { usePlausibleStatsBreakdownQuery } from '../../libs/usePlausibleStatsBreakdownQuery'
-import { IdType } from '../../../__generated__/globalTypes'
 
 interface EditorProps {
   journey?: Journey
@@ -40,7 +40,7 @@ export function Editor({
       : undefined
 
   const { data } = usePlausibleStatsBreakdownQuery({
-    id: journey!.id,
+    id: journey?.id ?? '',
     where: { property: 'event:page' },
     idType: IdType.databaseId
   })

--- a/apps/journeys-admin/src/components/Editor/Editor.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.tsx
@@ -11,6 +11,8 @@ import { GetJourney_journey as Journey } from '../../../__generated__/GetJourney
 import { Fab } from './Fab'
 import { Slider } from './Slider'
 import { Toolbar } from './Toolbar'
+import { usePlausibleStatsBreakdownQuery } from '../../libs/usePlausibleStatsBreakdownQuery'
+import { IdType } from '../../../__generated__/globalTypes'
 
 interface EditorProps {
   journey?: Journey
@@ -37,12 +39,19 @@ export function Editor({
       ? steps.find(({ id }) => id === selectedStepId)
       : undefined
 
+  const { data } = usePlausibleStatsBreakdownQuery({
+    id: journey!.id,
+    where: { property: 'event:page' },
+    idType: IdType.databaseId
+  })
+
   return (
     <JourneyProvider value={{ journey, variant: 'admin' }}>
       <EditorProvider
         initialState={{
           steps,
           selectedStep,
+          journeyStatsBreakdown: data?.journeysPlausibleStatsBreakdown ?? [],
           ...initialState
         }}
       >

--- a/apps/journeys-admin/src/components/Editor/Fab/Fab.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Fab/Fab.spec.tsx
@@ -24,7 +24,7 @@ jest.mock('@mui/material/useMediaQuery', () => ({
 }))
 
 describe('Fab', () => {
-  const state: EditorState = {
+  const state: Partial<EditorState> = {
     activeFab: ActiveFab.Add,
     activeSlide: ActiveSlide.Content,
     activeContent: ActiveContent.Canvas,

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/Canvas.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/Canvas.spec.tsx
@@ -59,7 +59,7 @@ describe('Canvas', () => {
     nextBlockId: null,
     children: []
   }
-  const initialState: EditorState = {
+  const initialState: Partial<EditorState> = {
     steps: [step0, step1],
     selectedStep: step0,
     selectedBlock: step0,

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Goals/GoalsList/GoalsList.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Goals/GoalsList/GoalsList.spec.tsx
@@ -41,7 +41,7 @@ describe('GoalsList', () => {
     }
   ]
 
-  const state: EditorState = {
+  const state: Partial<EditorState> = {
     activeFab: ActiveFab.Add,
     activeSlide: ActiveSlide.JourneyFlow,
     activeContent: ActiveContent.Goals,

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Goals/GoalsList/GoalsListItem/GoalListItem.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Goals/GoalsList/GoalsListItem/GoalListItem.spec.tsx
@@ -66,7 +66,7 @@ describe('GoalListItem', () => {
   })
 
   it('should handle click', () => {
-    const state: EditorState = {
+    const state: Partial<EditorState> = {
       activeFab: ActiveFab.Add,
       activeSlide: ActiveSlide.JourneyFlow,
       activeContent: ActiveContent.Goals,

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Social/SocialPreview.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Social/SocialPreview.spec.tsx
@@ -54,7 +54,7 @@ describe('SocialPreview', () => {
   })
 
   it('should dispatch active slide action on click', () => {
-    const state: EditorState = {
+    const state: Partial<EditorState> = {
       activeFab: ActiveFab.Add,
       activeSlide: ActiveSlide.JourneyFlow,
       activeContent: ActiveContent.Social,

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/SocialPreviewNode/SocialPreviewNode.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/SocialPreviewNode/SocialPreviewNode.spec.tsx
@@ -129,7 +129,7 @@ describe('SocialPreviewNode', () => {
   })
 
   it('calls select social media node on click', async () => {
-    const state: EditorState = {
+    const state: Partial<EditorState> = {
       activeFab: ActiveFab.Add,
       activeSlide: ActiveSlide.JourneyFlow,
       activeContent: ActiveContent.Canvas,

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Footer/Footer.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Footer/Footer.spec.tsx
@@ -24,7 +24,7 @@ jest.mock('@mui/material/useMediaQuery', () => ({
 }))
 
 describe('Footer', () => {
-  const state: EditorState = {
+  const state: Partial<EditorState> = {
     steps: [],
     activeFab: ActiveFab.Add,
     activeSlide: ActiveSlide.JourneyFlow,

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Form/Credentials/Credentials.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Form/Credentials/Credentials.spec.tsx
@@ -27,7 +27,7 @@ const block: TreeBlock<FormBlock> = {
   children: []
 }
 
-const state: EditorState = {
+const state: Partial<EditorState> = {
   selectedBlock: block,
   activeFab: ActiveFab.Add,
   activeSlide: ActiveSlide.Drawer,

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Step/Step.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Step/Step.spec.tsx
@@ -25,8 +25,7 @@ jest.mock('@mui/material/useMediaQuery', () => ({
 }))
 
 describe('Step', () => {
-  const state: EditorState = {
-    steps: [],
+  const state: Partial<EditorState> = {
     activeFab: ActiveFab.Add,
     activeSlide: ActiveSlide.JourneyFlow,
     activeContent: ActiveContent.Canvas,

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/GoalDetails/GoalDetails.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/GoalDetails/GoalDetails.spec.tsx
@@ -25,7 +25,7 @@ jest.mock('@mui/material/useMediaQuery', () => ({
 }))
 
 describe('GoalDetails', () => {
-  const state: EditorState = {
+  const state: Partial<EditorState> = {
     activeFab: ActiveFab.Add,
     activeSlide: ActiveSlide.JourneyFlow,
     activeContent: ActiveContent.Goals,

--- a/apps/journeys-admin/src/components/Editor/Slider/Slider.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Slider.spec.tsx
@@ -61,7 +61,9 @@ describe('Slider', () => {
       activeCanvasDetailsDrawer: ActiveCanvasDetailsDrawer.AddBlock,
       activeContent: ActiveContent.Canvas,
       activeFab: ActiveFab.Add,
-      activeSlide: ActiveSlide.JourneyFlow
+      activeSlide: ActiveSlide.JourneyFlow,
+      journeyStatsBreakdown: [],
+      showJourneyFlowAnalytics: false
     }
     mockUseMediaQuery.mockImplementation(() => true)
     mockReactFlow()

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/StrategyItem/StrategyItem.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/StrategyItem/StrategyItem.spec.tsx
@@ -21,7 +21,7 @@ import { StrategyItem } from '.'
 
 describe('StrategyItem', () => {
   it('should navigate to goals and close menu on click', async () => {
-    const state: EditorState = {
+    const state: Partial<EditorState> = {
       activeFab: ActiveFab.Add,
       activeSlide: ActiveSlide.JourneyFlow,
       activeContent: ActiveContent.Canvas,

--- a/apps/journeys-admin/src/libs/usePlausibleStatsBreakdownQuery/index.ts
+++ b/apps/journeys-admin/src/libs/usePlausibleStatsBreakdownQuery/index.ts
@@ -1,0 +1,1 @@
+export { usePlausibleStatsBreakdownQuery } from './usePlausibleStatsBreakdownQuery'

--- a/apps/journeys-admin/src/libs/usePlausibleStatsBreakdownQuery/usePlausibleStatsBreakdownQuery.ts
+++ b/apps/journeys-admin/src/libs/usePlausibleStatsBreakdownQuery/usePlausibleStatsBreakdownQuery.ts
@@ -3,19 +3,17 @@ import {
   GetPlausibleStatsBreakdown,
   GetPlausibleStatsBreakdownVariables
 } from '../../../__generated__/GetPlausibleStatsBreakdown'
+import { STATS_BREAKDOWN_FIELDS } from '@core/journeys/ui/plausible/StatsBreakdownFields'
 
 export const GET_PLAUSIBLE_STATS_BREAKDOWN = gql`
+  ${STATS_BREAKDOWN_FIELDS}
   query GetPlausibleStatsBreakdown(
     $where: PlausibleStatsBreakdownFilter!
     $id: ID!
     $idType: IdType
   ) {
     journeysPlausibleStatsBreakdown(where: $where, id: $id, idType: $idType) {
-      property
-      visits
-      pageviews
-      bounceRate
-      visitDuration
+      ...StatsBreakdownFields
     }
   }
 `

--- a/apps/journeys-admin/src/libs/usePlausibleStatsBreakdownQuery/usePlausibleStatsBreakdownQuery.ts
+++ b/apps/journeys-admin/src/libs/usePlausibleStatsBreakdownQuery/usePlausibleStatsBreakdownQuery.ts
@@ -1,9 +1,11 @@
-import { gql, useQuery } from '@apollo/client'
+import { QueryResult, gql, useQuery } from '@apollo/client'
+
+import { STATS_BREAKDOWN_FIELDS } from '@core/journeys/ui/plausible/StatsBreakdownFields'
+
 import {
   GetPlausibleStatsBreakdown,
   GetPlausibleStatsBreakdownVariables
 } from '../../../__generated__/GetPlausibleStatsBreakdown'
-import { STATS_BREAKDOWN_FIELDS } from '@core/journeys/ui/plausible/StatsBreakdownFields'
 
 export const GET_PLAUSIBLE_STATS_BREAKDOWN = gql`
   ${STATS_BREAKDOWN_FIELDS}
@@ -20,7 +22,10 @@ export const GET_PLAUSIBLE_STATS_BREAKDOWN = gql`
 
 export function usePlausibleStatsBreakdownQuery(
   variables: GetPlausibleStatsBreakdownVariables
-) {
+): QueryResult<
+  GetPlausibleStatsBreakdown,
+  GetPlausibleStatsBreakdownVariables
+> {
   return useQuery<
     GetPlausibleStatsBreakdown,
     GetPlausibleStatsBreakdownVariables

--- a/apps/journeys-admin/src/libs/usePlausibleStatsBreakdownQuery/usePlausibleStatsBreakdownQuery.ts
+++ b/apps/journeys-admin/src/libs/usePlausibleStatsBreakdownQuery/usePlausibleStatsBreakdownQuery.ts
@@ -1,0 +1,30 @@
+import { gql, useQuery } from '@apollo/client'
+import {
+  GetPlausibleStatsBreakdown,
+  GetPlausibleStatsBreakdownVariables
+} from '../../../__generated__/GetPlausibleStatsBreakdown'
+
+export const GET_PLAUSIBLE_STATS_BREAKDOWN = gql`
+  query GetPlausibleStatsBreakdown(
+    $where: PlausibleStatsBreakdownFilter!
+    $id: ID!
+    $idType: IdType
+  ) {
+    journeysPlausibleStatsBreakdown(where: $where, id: $id, idType: $idType) {
+      property
+      visits
+      pageviews
+      bounceRate
+      visitDuration
+    }
+  }
+`
+
+export function usePlausibleStatsBreakdownQuery(
+  variables: GetPlausibleStatsBreakdownVariables
+) {
+  return useQuery<
+    GetPlausibleStatsBreakdown,
+    GetPlausibleStatsBreakdownVariables
+  >(GET_PLAUSIBLE_STATS_BREAKDOWN, { variables })
+}

--- a/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.spec.tsx
+++ b/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.spec.tsx
@@ -38,7 +38,9 @@ describe('EditorContext', () => {
           activeCanvasDetailsDrawer: ActiveCanvasDetailsDrawer.Properties,
           activeFab: ActiveFab.Edit,
           activeSlide: ActiveSlide.JourneyFlow,
-          activeContent: ActiveContent.Canvas
+          activeContent: ActiveContent.Canvas,
+          journeyStatsBreakdown: [],
+          showJourneyFlowAnalytics: false
         }
         expect(
           reducer(state, {
@@ -60,7 +62,9 @@ describe('EditorContext', () => {
           activeCanvasDetailsDrawer: ActiveCanvasDetailsDrawer.Properties,
           activeFab: ActiveFab.Add,
           activeSlide: ActiveSlide.JourneyFlow,
-          activeContent: ActiveContent.Canvas
+          activeContent: ActiveContent.Canvas,
+          journeyStatsBreakdown: [],
+          showJourneyFlowAnalytics: false
         }
         expect(
           reducer(state, {
@@ -81,7 +85,9 @@ describe('EditorContext', () => {
           activeCanvasDetailsDrawer: ActiveCanvasDetailsDrawer.Properties,
           activeFab: ActiveFab.Add,
           activeSlide: ActiveSlide.JourneyFlow,
-          activeContent: ActiveContent.Canvas
+          activeContent: ActiveContent.Canvas,
+          journeyStatsBreakdown: [],
+          showJourneyFlowAnalytics: false
         }
         expect(
           reducer(state, {
@@ -102,7 +108,9 @@ describe('EditorContext', () => {
           activeCanvasDetailsDrawer: ActiveCanvasDetailsDrawer.Properties,
           activeFab: ActiveFab.Add,
           activeSlide: ActiveSlide.Content,
-          activeContent: ActiveContent.Social
+          activeContent: ActiveContent.Social,
+          journeyStatsBreakdown: [],
+          showJourneyFlowAnalytics: false
         }
         expect(
           reducer(state, {
@@ -122,7 +130,9 @@ describe('EditorContext', () => {
           activeCanvasDetailsDrawer: ActiveCanvasDetailsDrawer.Properties,
           activeFab: ActiveFab.Add,
           activeSlide: ActiveSlide.Content,
-          activeContent: ActiveContent.Canvas
+          activeContent: ActiveContent.Canvas,
+          journeyStatsBreakdown: [],
+          showJourneyFlowAnalytics: false
         }
         expect(
           reducer(state, {
@@ -143,7 +153,9 @@ describe('EditorContext', () => {
           activeCanvasDetailsDrawer: ActiveCanvasDetailsDrawer.Properties,
           activeFab: ActiveFab.Add,
           activeSlide: ActiveSlide.JourneyFlow,
-          activeContent: ActiveContent.Canvas
+          activeContent: ActiveContent.Canvas,
+          journeyStatsBreakdown: [],
+          showJourneyFlowAnalytics: false
         }
         expect(
           reducer(state, {
@@ -173,7 +185,9 @@ describe('EditorContext', () => {
           activeCanvasDetailsDrawer: ActiveCanvasDetailsDrawer.Properties,
           activeFab: ActiveFab.Edit,
           activeSlide: ActiveSlide.Content,
-          activeContent: ActiveContent.Canvas
+          activeContent: ActiveContent.Canvas,
+          journeyStatsBreakdown: [],
+          showJourneyFlowAnalytics: false
         }
         expect(
           reducer(state, {
@@ -201,7 +215,9 @@ describe('EditorContext', () => {
           activeCanvasDetailsDrawer: ActiveCanvasDetailsDrawer.Properties,
           activeFab: ActiveFab.Add,
           activeSlide: ActiveSlide.JourneyFlow,
-          activeContent: ActiveContent.Canvas
+          activeContent: ActiveContent.Canvas,
+          journeyStatsBreakdown: [],
+          showJourneyFlowAnalytics: false
         }
         expect(
           reducer(state, {
@@ -244,7 +260,9 @@ describe('EditorContext', () => {
           activeCanvasDetailsDrawer: ActiveCanvasDetailsDrawer.Footer,
           activeFab: ActiveFab.Edit,
           activeSlide: ActiveSlide.JourneyFlow,
-          activeContent: ActiveContent.Canvas
+          activeContent: ActiveContent.Canvas,
+          journeyStatsBreakdown: [],
+          showJourneyFlowAnalytics: false
         }
         expect(
           reducer(state, {
@@ -285,7 +303,9 @@ describe('EditorContext', () => {
           activeCanvasDetailsDrawer: ActiveCanvasDetailsDrawer.Properties,
           activeFab: ActiveFab.Add,
           activeSlide: ActiveSlide.JourneyFlow,
-          activeContent: ActiveContent.Canvas
+          activeContent: ActiveContent.Canvas,
+          journeyStatsBreakdown: [],
+          showJourneyFlowAnalytics: false
         }
         expect(
           reducer(state, {
@@ -304,7 +324,9 @@ describe('EditorContext', () => {
           activeCanvasDetailsDrawer: ActiveCanvasDetailsDrawer.Properties,
           activeContent: ActiveContent.Canvas,
           activeFab: ActiveFab.Add,
-          activeSlide: ActiveSlide.JourneyFlow
+          activeSlide: ActiveSlide.JourneyFlow,
+          journeyStatsBreakdown: [],
+          showJourneyFlowAnalytics: false
         }
         expect(
           reducer(state, {
@@ -324,7 +346,9 @@ describe('EditorContext', () => {
           activeCanvasDetailsDrawer: ActiveCanvasDetailsDrawer.Properties,
           activeFab: ActiveFab.Add,
           activeSlide: ActiveSlide.JourneyFlow,
-          activeContent: ActiveContent.Canvas
+          activeContent: ActiveContent.Canvas,
+          journeyStatsBreakdown: [],
+          showJourneyFlowAnalytics: false
         }
         expect(
           reducer(state, {
@@ -354,7 +378,9 @@ describe('EditorContext', () => {
           activeCanvasDetailsDrawer: ActiveCanvasDetailsDrawer.Properties,
           activeFab: ActiveFab.Add,
           activeSlide: ActiveSlide.JourneyFlow,
-          activeContent: ActiveContent.Canvas
+          activeContent: ActiveContent.Canvas,
+          journeyStatsBreakdown: [],
+          showJourneyFlowAnalytics: false
         }
         expect(
           reducer(state, {
@@ -386,7 +412,9 @@ describe('EditorContext', () => {
           activeCanvasDetailsDrawer: ActiveCanvasDetailsDrawer.Properties,
           activeFab: ActiveFab.Add,
           activeSlide: ActiveSlide.JourneyFlow,
-          activeContent: ActiveContent.Canvas
+          activeContent: ActiveContent.Canvas,
+          journeyStatsBreakdown: [],
+          showJourneyFlowAnalytics: false
         }
         expect(
           reducer(state, {
@@ -438,7 +466,9 @@ describe('EditorContext', () => {
           activeSlide: ActiveSlide.JourneyFlow,
           selectedBlock: block,
           selectedStep: step,
-          activeContent: ActiveContent.Canvas
+          activeContent: ActiveContent.Canvas,
+          journeyStatsBreakdown: [],
+          showJourneyFlowAnalytics: false
         }
         expect(
           reducer(state, {
@@ -487,7 +517,9 @@ describe('EditorContext', () => {
         activeCanvasDetailsDrawer: ActiveCanvasDetailsDrawer.Properties,
         activeFab: ActiveFab.Add,
         activeSlide: ActiveSlide.Content,
-        activeContent: ActiveContent.Canvas
+        activeContent: ActiveContent.Canvas,
+        journeyStatsBreakdown: [],
+        showJourneyFlowAnalytics: false
       })
     })
   })

--- a/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
+++ b/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
@@ -13,7 +13,6 @@ import {
 import type { TreeBlock } from '../block'
 import { BlockFields_StepBlock as StepBlock } from '../block/__generated__/BlockFields'
 import { searchBlocks } from '../searchBlocks'
-import { GetPlausibleStatsBreakdown_journeysPlausibleStatsBreakdown as StatsBreakdown } from '../../../../../../apps/journeys-admin/__generated__/GetPlausibleStatsBreakdown'
 import { StatsBreakdownFields } from '../plausible/__generated__/StatsBreakdownFields'
 
 export enum ActiveContent {
@@ -140,7 +139,7 @@ interface SetShowJourneyFlowAnalyticsAction {
 
 interface SetStatsBreakdownAction {
   type: 'SetStatsBreakdownAction'
-  journeyStatsBreakdown: Array<StatsBreakdown>
+  journeyStatsBreakdown: Array<StatsBreakdownFields>
 }
 
 type EditorAction =

--- a/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
+++ b/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
@@ -12,8 +12,8 @@ import {
 
 import type { TreeBlock } from '../block'
 import { BlockFields_StepBlock as StepBlock } from '../block/__generated__/BlockFields'
-import { searchBlocks } from '../searchBlocks'
 import { StatsBreakdownFields } from '../plausible/__generated__/StatsBreakdownFields'
+import { searchBlocks } from '../searchBlocks'
 
 export enum ActiveContent {
   Canvas = 'canvas',
@@ -139,7 +139,7 @@ interface SetShowJourneyFlowAnalyticsAction {
 
 interface SetStatsBreakdownAction {
   type: 'SetStatsBreakdownAction'
-  journeyStatsBreakdown: Array<StatsBreakdownFields>
+  journeyStatsBreakdown: StatsBreakdownFields[]
 }
 
 type EditorAction =

--- a/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
+++ b/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
@@ -14,6 +14,7 @@ import type { TreeBlock } from '../block'
 import { BlockFields_StepBlock as StepBlock } from '../block/__generated__/BlockFields'
 import { searchBlocks } from '../searchBlocks'
 import { GetPlausibleStatsBreakdown_journeysPlausibleStatsBreakdown as StatsBreakdown } from '../../../../../../apps/journeys-admin/__generated__/GetPlausibleStatsBreakdown'
+import { StatsBreakdownFields } from '../plausible/__generated__/StatsBreakdownFields'
 
 export enum ActiveContent {
   Canvas = 'canvas',
@@ -86,7 +87,7 @@ export interface EditorState {
    */
   selectedStep?: TreeBlock<StepBlock>
   steps?: Array<TreeBlock<StepBlock>>
-  journeyStatsBreakdown: Array<StatsBreakdown>
+  journeyStatsBreakdown: StatsBreakdownFields[]
 }
 interface SetActiveContentAction {
   type: 'SetActiveContentAction'

--- a/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
+++ b/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
@@ -13,6 +13,7 @@ import {
 import type { TreeBlock } from '../block'
 import { BlockFields_StepBlock as StepBlock } from '../block/__generated__/BlockFields'
 import { searchBlocks } from '../searchBlocks'
+import { GetPlausibleStatsBreakdown_journeysPlausibleStatsBreakdown as StatsBreakdown } from '../../../../../../apps/journeys-admin/__generated__/GetPlausibleStatsBreakdown'
 
 export enum ActiveContent {
   Canvas = 'canvas',
@@ -85,6 +86,7 @@ export interface EditorState {
    */
   selectedStep?: TreeBlock<StepBlock>
   steps?: Array<TreeBlock<StepBlock>>
+  journeyStatsBreakdown: Array<StatsBreakdown>
 }
 interface SetActiveContentAction {
   type: 'SetActiveContentAction'
@@ -134,6 +136,12 @@ interface SetShowJourneyFlowAnalyticsAction {
   type: 'SetShowJourneyFlowAnalyticsAction'
   showJourneyFlowAnalytics: boolean
 }
+
+interface SetStatsBreakdownAction {
+  type: 'SetStatsBreakdownAction'
+  journeyStatsBreakdown: Array<StatsBreakdown>
+}
+
 type EditorAction =
   | SetActiveCanvasDetailsDrawerAction
   | SetActiveContentAction
@@ -147,6 +155,7 @@ type EditorAction =
   | SetSelectedStepAction
   | SetStepsAction
   | SetShowJourneyFlowAnalyticsAction
+  | SetStatsBreakdownAction
 
 export const reducer = (
   state: EditorState,
@@ -227,6 +236,12 @@ export const reducer = (
         ...state,
         showJourneyFlowAnalytics: action.showJourneyFlowAnalytics
       }
+    case 'SetStatsBreakdownAction': {
+      return {
+        ...state,
+        journeyStatsBreakdown: action.journeyStatsBreakdown
+      }
+    }
   }
 }
 
@@ -240,7 +255,8 @@ export const EditorContext = createContext<{
     activeFab: ActiveFab.Add,
     activeSlide: ActiveSlide.JourneyFlow,
     activeContent: ActiveContent.Canvas,
-    showJourneyFlowAnalytics: false
+    showJourneyFlowAnalytics: false,
+    journeyStatsBreakdown: []
   },
   dispatch: () => null
 })
@@ -268,6 +284,7 @@ export function EditorProvider({
     activeSlide: ActiveSlide.JourneyFlow,
     activeContent: ActiveContent.Canvas,
     showJourneyFlowAnalytics: false,
+    journeyStatsBreakdown: [],
     ...initialState
   })
 
@@ -275,6 +292,15 @@ export function EditorProvider({
     if (initialState?.steps != null)
       dispatch({ type: 'SetStepsAction', steps: initialState.steps })
   }, [initialState?.steps])
+
+  useEffect(() => {
+    if (initialState?.journeyStatsBreakdown != null) {
+      dispatch({
+        type: 'SetStatsBreakdownAction',
+        journeyStatsBreakdown: initialState.journeyStatsBreakdown
+      })
+    }
+  }, [initialState?.journeyStatsBreakdown])
 
   // only run once
   const stepRef = useRef(false)

--- a/libs/journeys/ui/src/libs/isActionBlock/isActionBlock.spec.tsx
+++ b/libs/journeys/ui/src/libs/isActionBlock/isActionBlock.spec.tsx
@@ -1,28 +1,21 @@
+import { TreeBlock } from '../block'
+import { BlockFields } from '../block/__generated__/BlockFields'
+
 import { isActionBlock } from '.'
 
 describe('isActionBlock', () => {
   it('should return true for valid action block', () => {
-    const block = { action: 'action' }
+    const block = { action: 'action' } as unknown as TreeBlock<BlockFields>
     expect(isActionBlock(block)).toBe(true)
   })
 
   it('should return false for a non-action block', () => {
-    const block = { text: 'some text' }
+    const block = { text: 'some text' } as unknown as TreeBlock<BlockFields>
     expect(isActionBlock(block)).toBe(false)
   })
 
   it('should return false for an empty block', () => {
-    const block = {}
-    expect(isActionBlock(block)).toBe(false)
-  })
-
-  it('should return false for null', () => {
-    const block = null
-    expect(isActionBlock(block)).toBe(false)
-  })
-
-  it('should return false for undefined', () => {
-    const block = undefined
+    const block = {} as unknown as TreeBlock<BlockFields>
     expect(isActionBlock(block)).toBe(false)
   })
 })

--- a/libs/journeys/ui/src/libs/isActionBlock/isActionBlock.ts
+++ b/libs/journeys/ui/src/libs/isActionBlock/isActionBlock.ts
@@ -19,4 +19,4 @@ export type ActionBlock =
 
 export const isActionBlock = (
   block: TreeBlock<BlockFields>
-): block is ActionBlock => (block as ActionBlock).action !== undefined
+): block is ActionBlock => (block as ActionBlock)?.action !== undefined

--- a/libs/journeys/ui/src/libs/isActionBlock/isActionBlock.ts
+++ b/libs/journeys/ui/src/libs/isActionBlock/isActionBlock.ts
@@ -1,5 +1,6 @@
 import { TreeBlock } from '../block'
 import {
+  BlockFields,
   BlockFields_ButtonBlock as ButtonBlock,
   BlockFields_FormBlock as FormBlock,
   BlockFields_RadioOptionBlock as RadioOptionBlock,
@@ -16,5 +17,6 @@ export type ActionBlock =
   | TreeBlock<FormBlock>
   | TreeBlock<VideoBlock>
 
-export const isActionBlock = (block: TreeBlock<any>): block is ActionBlock =>
-  block?.action !== undefined
+export const isActionBlock = (
+  block: TreeBlock<BlockFields>
+): block is ActionBlock => (block as ActionBlock).action !== undefined

--- a/libs/journeys/ui/src/libs/plausible/StatsBreakdownFields.ts
+++ b/libs/journeys/ui/src/libs/plausible/StatsBreakdownFields.ts
@@ -1,0 +1,11 @@
+import { gql } from '@apollo/client'
+
+export const STATS_BREAKDOWN_FIELDS = gql`
+  fragment StatsBreakdownFields on PlausibleStatsResponse {
+    property
+    visits
+    pageviews
+    bounceRate
+    visitDuration
+  }
+`

--- a/libs/journeys/ui/src/libs/plausible/__generated__/StatsBreakdownFields.ts
+++ b/libs/journeys/ui/src/libs/plausible/__generated__/StatsBreakdownFields.ts
@@ -1,0 +1,33 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: StatsBreakdownFields
+// ====================================================
+
+export interface StatsBreakdownFields {
+  __typename: "PlausibleStatsResponse";
+  /**
+   * On breakdown queries, this is the property that was broken down by.
+   * On aggregate queries, this is the date the stats are for.
+   */
+  property: string;
+  /**
+   * The number of visits/sessions.
+   */
+  visits: number | null;
+  /**
+   * The number of pageview events.
+   */
+  pageviews: number | null;
+  /**
+   * Bounce rate percentage.
+   */
+  bounceRate: number | null;
+  /**
+   * Visit duration in seconds.
+   */
+  visitDuration: number | null;
+}

--- a/libs/journeys/ui/src/libs/plausibleHelpers/index.ts
+++ b/libs/journeys/ui/src/libs/plausibleHelpers/index.ts
@@ -1,1 +1,1 @@
-export { JourneyPlausibleEvents, keyify } from './plausibleHelpers'
+export { type JourneyPlausibleEvents, keyify } from './plausibleHelpers'


### PR DESCRIPTION
# Description

### Issue
Need to fetch the plausible analytic stats for a journey's steps and pass the data to the editor context
_Provide a brief summary of why this task is needed_

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37663055/todos/7446780139)

### Solution
- Created `usePlausibleStatsBreakdownQuery` hook
- Fetch stats break down and pass into editor context

# External Changes
n/a

# Additional information
n/a