### PR TITLE
feat: step analytics overlay

### DIFF
--- a/apps/journeys-admin/__generated__/GetPlausibleStatsBreakdown.ts
+++ b/apps/journeys-admin/__generated__/GetPlausibleStatsBreakdown.ts
@@ -1,0 +1,66 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { PlausibleStatsBreakdownFilter, IdType } from "./globalTypes";
+
+// ====================================================
+// GraphQL query operation: GetPlausibleStatsBreakdown
+// ====================================================
+
+export interface GetPlausibleStatsBreakdown_journeysPlausibleStatsBreakdown {
+  __typename: "PlausibleStatsResponse";
+  /**
+   * On breakdown queries, this is the property that was broken down by.
+   * On aggregate queries, this is the date the stats are for.
+   */
+  property: string;
+  /**
+   * The number of visits/sessions.
+   */
+  visits: number | null;
+  /**
+   * The number of pageview events.
+   */
+  pageviews: number | null;
+  /**
+   * Bounce rate percentage.
+   */
+  bounceRate: number | null;
+  /**
+   * Visit duration in seconds.
+   */
+  visitDuration: number | null;
+}
+
+export interface GetPlausibleStatsBreakdown {
+  /**
+   * This endpoint allows you to break down your stats by some property.
+   * If you are familiar with SQL family databases, this endpoint corresponds to
+   * running `GROUP BY` on a certain property in your stats, then ordering by the
+   * count.
+   * 
+   * Check out the [properties](https: // plausible.io/docs/stats-api#properties)
+   * section for a reference of all the properties you can use in this query.
+   * 
+   * This endpoint can be used to fetch data for `Top sources`, `Top pages`,
+   * `Top countries` and similar reports.
+   * 
+   * Currently, it is only possible to break down on one property at a time.
+   * Using a list of properties with one query is not supported. So if you want
+   * a breakdown by both `event:page` and `visit:source` for example, you would
+   * have to make multiple queries (break down on one property and filter on
+   * another) and then manually/programmatically group the results together in one
+   * report. This also applies for breaking down by time periods. To get a daily
+   * breakdown for every page, you would have to break down on `event:page` and
+   * make multiple queries for each date.
+   */
+  journeysPlausibleStatsBreakdown: GetPlausibleStatsBreakdown_journeysPlausibleStatsBreakdown[];
+}
+
+export interface GetPlausibleStatsBreakdownVariables {
+  where: PlausibleStatsBreakdownFilter;
+  id: string;
+  idType?: IdType | null;
+}

--- a/apps/journeys-admin/__generated__/StatsBreakdownFields.ts
+++ b/apps/journeys-admin/__generated__/StatsBreakdownFields.ts
@@ -1,0 +1,33 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: StatsBreakdownFields
+// ====================================================
+
+export interface StatsBreakdownFields {
+  __typename: "PlausibleStatsResponse";
+  /**
+   * On breakdown queries, this is the property that was broken down by.
+   * On aggregate queries, this is the date the stats are for.
+   */
+  property: string;
+  /**
+   * The number of visits/sessions.
+   */
+  visits: number | null;
+  /**
+   * The number of pageview events.
+   */
+  pageviews: number | null;
+  /**
+   * Bounce rate percentage.
+   */
+  bounceRate: number | null;
+  /**
+   * Visit duration in seconds.
+   */
+  visitDuration: number | null;
+}

--- a/apps/journeys-admin/__generated__/globalTypes.ts
+++ b/apps/journeys-admin/__generated__/globalTypes.ts
@@ -71,6 +71,11 @@ export enum IconSize {
   xl = "xl",
 }
 
+export enum IdType {
+  databaseId = "databaseId",
+  slug = "slug",
+}
+
 export enum JourneyStatus {
   archived = "archived",
   deleted = "deleted",
@@ -444,6 +449,15 @@ export interface MeInput {
 export interface NavigateToBlockActionInput {
   gtmEventName?: string | null;
   blockId: string;
+}
+
+export interface PlausibleStatsBreakdownFilter {
+  property: string;
+  period?: string | null;
+  date?: string | null;
+  limit?: number | null;
+  page?: number | null;
+  filters?: string | null;
 }
 
 export interface RadioOptionBlockCreateInput {

--- a/apps/journeys-admin/src/components/Editor/Editor.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.tsx
@@ -7,12 +7,12 @@ import { transformer } from '@core/journeys/ui/transformer'
 
 import { BlockFields_StepBlock as StepBlock } from '../../../__generated__/BlockFields'
 import { GetJourney_journey as Journey } from '../../../__generated__/GetJourney'
+import { IdType } from '../../../__generated__/globalTypes'
+import { usePlausibleStatsBreakdownQuery } from '../../libs/usePlausibleStatsBreakdownQuery'
 
 import { Fab } from './Fab'
 import { Slider } from './Slider'
 import { Toolbar } from './Toolbar'
-import { usePlausibleStatsBreakdownQuery } from '../../libs/usePlausibleStatsBreakdownQuery'
-import { IdType } from '../../../__generated__/globalTypes'
 
 interface EditorProps {
   journey?: Journey
@@ -40,7 +40,7 @@ export function Editor({
       : undefined
 
   const { data } = usePlausibleStatsBreakdownQuery({
-    id: journey!.id,
+    id: journey?.id ?? '',
     where: { property: 'event:page' },
     idType: IdType.databaseId
   })

--- a/apps/journeys-admin/src/components/Editor/Editor.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.tsx
@@ -11,6 +11,8 @@ import { GetJourney_journey as Journey } from '../../../__generated__/GetJourney
 import { Fab } from './Fab'
 import { Slider } from './Slider'
 import { Toolbar } from './Toolbar'
+import { usePlausibleStatsBreakdownQuery } from '../../libs/usePlausibleStatsBreakdownQuery'
+import { IdType } from '../../../__generated__/globalTypes'
 
 interface EditorProps {
   journey?: Journey
@@ -37,12 +39,19 @@ export function Editor({
       ? steps.find(({ id }) => id === selectedStepId)
       : undefined
 
+  const { data } = usePlausibleStatsBreakdownQuery({
+    id: journey!.id,
+    where: { property: 'event:page' },
+    idType: IdType.databaseId
+  })
+
   return (
     <JourneyProvider value={{ journey, variant: 'admin' }}>
       <EditorProvider
         initialState={{
           steps,
           selectedStep,
+          journeyStatsBreakdown: data?.journeysPlausibleStatsBreakdown ?? [],
           ...initialState
         }}
       >

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/StepBlockNode.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/StepBlockNode.tsx
@@ -9,7 +9,9 @@ import { filterActionBlocks } from '@core/journeys/ui/filterActionBlocks'
 import { BaseNode } from '../BaseNode'
 
 import { ActionButton } from './ActionButton'
+import { getStepAnalytics } from './libs/getStepAnalytics'
 import { STEP_NODE_WIDTH } from './libs/sizes'
+import { StepBlockNodeAnalytics } from './StepBlockNodeAnalytics'
 import { StepBlockNodeCard } from './StepBlockNodeCard'
 import { StepBlockNodeMenu } from './StepBlockNodeMenu'
 
@@ -20,16 +22,29 @@ export function StepBlockNode({
   dragging
 }: NodeProps): ReactElement {
   const {
-    state: { steps, selectedStep, activeContent, showJourneyFlowAnalytics }
+    state: {
+      steps,
+      selectedStep,
+      activeContent,
+      showJourneyFlowAnalytics,
+      journeyStatsBreakdown
+    }
   } = useEditor()
   const step = steps?.find((step) => step.id === id)
   const actionBlocks = filterActionBlocks(step)
+
+  const stepAnalytics = getStepAnalytics(
+    journeyStatsBreakdown?.find((step) => step.property.includes(id))
+  )
 
   const isSelected =
     activeContent === ActiveContent.Canvas && selectedStep?.id === step?.id
 
   return step != null ? (
-    <>
+    <Stack sx={{ position: 'relative' }}>
+      {showJourneyFlowAnalytics && (
+        <StepBlockNodeAnalytics {...stepAnalytics} />
+      )}
       {!showJourneyFlowAnalytics && (
         <StepBlockNodeMenu
           in={isSelected}
@@ -74,7 +89,7 @@ export function StepBlockNode({
           ))}
         </Stack>
       </Stack>
-    </>
+    </Stack>
   ) : (
     <></>
   )

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/StepBlockNodeAnalytics/StepBlockNodeAnalytics.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/StepBlockNodeAnalytics/StepBlockNodeAnalytics.tsx
@@ -1,0 +1,74 @@
+import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import SvgIcon from '@mui/material/SvgIcon'
+import Typography from '@mui/material/Typography'
+import { ReactElement } from 'react'
+
+import Clock1 from '@core/shared/ui/icons/Clock1'
+import EyeOpen from '@core/shared/ui/icons/EyeOpen'
+
+interface DataPointProps {
+  children: string | number
+  Icon?: typeof SvgIcon
+}
+
+function DataPoint({ children, Icon }: DataPointProps): ReactElement {
+  return (
+    <Stack
+      direction="row"
+      spacing={1}
+      sx={{ alignItems: 'center', color: 'info.main' }}
+    >
+      {Icon != null && <Icon fontSize="small" />}
+      <Typography sx={{ fontWeight: 800 }}>{children}</Typography>
+    </Stack>
+  )
+}
+
+interface StepBlockNodeAnalyticsProps {
+  visitDuration?: string
+  views?: number
+  bouncePercentage?: number | null
+}
+
+export function StepBlockNodeAnalytics({
+  visitDuration = '0:00',
+  views = 0,
+  bouncePercentage
+}: StepBlockNodeAnalyticsProps): ReactElement {
+  return (
+    <>
+      <Stack
+        direction="row"
+        sx={{
+          alignItems: 'center',
+          gap: 6,
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          transform: 'translateY(-100%)'
+        }}
+        data-testid="AnalyticsOverlay"
+      >
+        <DataPoint Icon={Clock1}>{visitDuration}</DataPoint>
+        <DataPoint Icon={EyeOpen}>{views}</DataPoint>
+      </Stack>
+      {bouncePercentage != null && (
+        <Box
+          sx={{
+            position: 'absolute',
+            bottom: 0,
+            right: 32,
+            transform: 'translateY(50%)',
+            px: 1,
+            borderRadius: 1,
+            backgroundColor: '#ffcdcd',
+            boxShadow: 1
+          }}
+        >
+          <Typography variant="body2">{bouncePercentage}%</Typography>
+        </Box>
+      )}
+    </>
+  )
+}

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/StepBlockNodeAnalytics/index.ts
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/StepBlockNodeAnalytics/index.ts
@@ -1,0 +1,1 @@
+export { StepBlockNodeAnalytics } from './StepBlockNodeAnalytics'

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/libs/getStepAnalytics/getStepAnalytics.ts
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/libs/getStepAnalytics/getStepAnalytics.ts
@@ -1,0 +1,33 @@
+import { secondsToTimeFormat } from '@core/shared/ui/timeFormat'
+
+import { GetPlausibleStatsBreakdown_journeysPlausibleStatsBreakdown as StatsBreakdown } from '../../../../../../../../../__generated__/GetPlausibleStatsBreakdown'
+
+interface StepAnalytics {
+  views: number
+  visitDuration: string
+  bouncePercentage: number | null
+}
+
+export function getStepAnalytics(
+  page: StatsBreakdown | undefined
+): StepAnalytics | undefined {
+  if (page == null) {
+    return undefined
+  }
+
+  const { pageviews, visitDuration, bounceRate } = page
+
+  const stats: StepAnalytics = {
+    views: pageviews ?? 0,
+    visitDuration: secondsToTimeFormat(visitDuration ?? 0, {
+      trimZeroes: true
+    }),
+    bouncePercentage: null
+  }
+
+  if (bounceRate != null && stats.views > 0) {
+    stats.bouncePercentage = Math.trunc(bounceRate / stats.views) / 100
+  }
+
+  return stats
+}

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/libs/getStepAnalytics/index.ts
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/libs/getStepAnalytics/index.ts
@@ -1,0 +1,1 @@
+export { getStepAnalytics } from './getStepAnalytics'

--- a/apps/journeys-admin/src/libs/usePlausibleStatsBreakdownQuery/index.ts
+++ b/apps/journeys-admin/src/libs/usePlausibleStatsBreakdownQuery/index.ts
@@ -1,0 +1,1 @@
+export { usePlausibleStatsBreakdownQuery } from './usePlausibleStatsBreakdownQuery'

--- a/apps/journeys-admin/src/libs/usePlausibleStatsBreakdownQuery/usePlausibleStatsBreakdownQuery.ts
+++ b/apps/journeys-admin/src/libs/usePlausibleStatsBreakdownQuery/usePlausibleStatsBreakdownQuery.ts
@@ -3,19 +3,17 @@ import {
   GetPlausibleStatsBreakdown,
   GetPlausibleStatsBreakdownVariables
 } from '../../../__generated__/GetPlausibleStatsBreakdown'
+import { STATS_BREAKDOWN_FIELDS } from '@core/journeys/ui/plausible/StatsBreakdownFields'
 
 export const GET_PLAUSIBLE_STATS_BREAKDOWN = gql`
+  ${STATS_BREAKDOWN_FIELDS}
   query GetPlausibleStatsBreakdown(
     $where: PlausibleStatsBreakdownFilter!
     $id: ID!
     $idType: IdType
   ) {
     journeysPlausibleStatsBreakdown(where: $where, id: $id, idType: $idType) {
-      property
-      visits
-      pageviews
-      bounceRate
-      visitDuration
+      ...StatsBreakdownFields
     }
   }
 `

--- a/apps/journeys-admin/src/libs/usePlausibleStatsBreakdownQuery/usePlausibleStatsBreakdownQuery.ts
+++ b/apps/journeys-admin/src/libs/usePlausibleStatsBreakdownQuery/usePlausibleStatsBreakdownQuery.ts
@@ -1,9 +1,11 @@
-import { gql, useQuery } from '@apollo/client'
+import { QueryResult, gql, useQuery } from '@apollo/client'
+
+import { STATS_BREAKDOWN_FIELDS } from '@core/journeys/ui/plausible/StatsBreakdownFields'
+
 import {
   GetPlausibleStatsBreakdown,
   GetPlausibleStatsBreakdownVariables
 } from '../../../__generated__/GetPlausibleStatsBreakdown'
-import { STATS_BREAKDOWN_FIELDS } from '@core/journeys/ui/plausible/StatsBreakdownFields'
 
 export const GET_PLAUSIBLE_STATS_BREAKDOWN = gql`
   ${STATS_BREAKDOWN_FIELDS}
@@ -20,7 +22,10 @@ export const GET_PLAUSIBLE_STATS_BREAKDOWN = gql`
 
 export function usePlausibleStatsBreakdownQuery(
   variables: GetPlausibleStatsBreakdownVariables
-) {
+): QueryResult<
+  GetPlausibleStatsBreakdown,
+  GetPlausibleStatsBreakdownVariables
+> {
   return useQuery<
     GetPlausibleStatsBreakdown,
     GetPlausibleStatsBreakdownVariables

--- a/apps/journeys-admin/src/libs/usePlausibleStatsBreakdownQuery/usePlausibleStatsBreakdownQuery.ts
+++ b/apps/journeys-admin/src/libs/usePlausibleStatsBreakdownQuery/usePlausibleStatsBreakdownQuery.ts
@@ -1,0 +1,30 @@
+import { gql, useQuery } from '@apollo/client'
+import {
+  GetPlausibleStatsBreakdown,
+  GetPlausibleStatsBreakdownVariables
+} from '../../../__generated__/GetPlausibleStatsBreakdown'
+
+export const GET_PLAUSIBLE_STATS_BREAKDOWN = gql`
+  query GetPlausibleStatsBreakdown(
+    $where: PlausibleStatsBreakdownFilter!
+    $id: ID!
+    $idType: IdType
+  ) {
+    journeysPlausibleStatsBreakdown(where: $where, id: $id, idType: $idType) {
+      property
+      visits
+      pageviews
+      bounceRate
+      visitDuration
+    }
+  }
+`
+
+export function usePlausibleStatsBreakdownQuery(
+  variables: GetPlausibleStatsBreakdownVariables
+) {
+  return useQuery<
+    GetPlausibleStatsBreakdown,
+    GetPlausibleStatsBreakdownVariables
+  >(GET_PLAUSIBLE_STATS_BREAKDOWN, { variables })
+}

--- a/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
+++ b/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
@@ -13,7 +13,6 @@ import {
 import type { TreeBlock } from '../block'
 import { BlockFields_StepBlock as StepBlock } from '../block/__generated__/BlockFields'
 import { searchBlocks } from '../searchBlocks'
-import { GetPlausibleStatsBreakdown_journeysPlausibleStatsBreakdown as StatsBreakdown } from '../../../../../../apps/journeys-admin/__generated__/GetPlausibleStatsBreakdown'
 import { StatsBreakdownFields } from '../plausible/__generated__/StatsBreakdownFields'
 
 export enum ActiveContent {
@@ -140,7 +139,7 @@ interface SetShowJourneyFlowAnalyticsAction {
 
 interface SetStatsBreakdownAction {
   type: 'SetStatsBreakdownAction'
-  journeyStatsBreakdown: Array<StatsBreakdown>
+  journeyStatsBreakdown: Array<StatsBreakdownFields>
 }
 
 type EditorAction =

--- a/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
+++ b/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
@@ -12,8 +12,8 @@ import {
 
 import type { TreeBlock } from '../block'
 import { BlockFields_StepBlock as StepBlock } from '../block/__generated__/BlockFields'
-import { searchBlocks } from '../searchBlocks'
 import { StatsBreakdownFields } from '../plausible/__generated__/StatsBreakdownFields'
+import { searchBlocks } from '../searchBlocks'
 
 export enum ActiveContent {
   Canvas = 'canvas',
@@ -139,7 +139,7 @@ interface SetShowJourneyFlowAnalyticsAction {
 
 interface SetStatsBreakdownAction {
   type: 'SetStatsBreakdownAction'
-  journeyStatsBreakdown: Array<StatsBreakdownFields>
+  journeyStatsBreakdown: StatsBreakdownFields[]
 }
 
 type EditorAction =

--- a/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
+++ b/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
@@ -14,6 +14,7 @@ import type { TreeBlock } from '../block'
 import { BlockFields_StepBlock as StepBlock } from '../block/__generated__/BlockFields'
 import { searchBlocks } from '../searchBlocks'
 import { GetPlausibleStatsBreakdown_journeysPlausibleStatsBreakdown as StatsBreakdown } from '../../../../../../apps/journeys-admin/__generated__/GetPlausibleStatsBreakdown'
+import { StatsBreakdownFields } from '../plausible/__generated__/StatsBreakdownFields'
 
 export enum ActiveContent {
   Canvas = 'canvas',
@@ -86,7 +87,7 @@ export interface EditorState {
    */
   selectedStep?: TreeBlock<StepBlock>
   steps?: Array<TreeBlock<StepBlock>>
-  journeyStatsBreakdown: Array<StatsBreakdown>
+  journeyStatsBreakdown: StatsBreakdownFields[]
 }
 interface SetActiveContentAction {
   type: 'SetActiveContentAction'

--- a/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
+++ b/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
@@ -13,6 +13,7 @@ import {
 import type { TreeBlock } from '../block'
 import { BlockFields_StepBlock as StepBlock } from '../block/__generated__/BlockFields'
 import { searchBlocks } from '../searchBlocks'
+import { GetPlausibleStatsBreakdown_journeysPlausibleStatsBreakdown as StatsBreakdown } from '../../../../../../apps/journeys-admin/__generated__/GetPlausibleStatsBreakdown'
 
 export enum ActiveContent {
   Canvas = 'canvas',
@@ -85,6 +86,7 @@ export interface EditorState {
    */
   selectedStep?: TreeBlock<StepBlock>
   steps?: Array<TreeBlock<StepBlock>>
+  journeyStatsBreakdown: Array<StatsBreakdown>
 }
 interface SetActiveContentAction {
   type: 'SetActiveContentAction'
@@ -134,6 +136,12 @@ interface SetShowJourneyFlowAnalyticsAction {
   type: 'SetShowJourneyFlowAnalyticsAction'
   showJourneyFlowAnalytics: boolean
 }
+
+interface SetStatsBreakdownAction {
+  type: 'SetStatsBreakdownAction'
+  journeyStatsBreakdown: Array<StatsBreakdown>
+}
+
 type EditorAction =
   | SetActiveCanvasDetailsDrawerAction
   | SetActiveContentAction
@@ -147,6 +155,7 @@ type EditorAction =
   | SetSelectedStepAction
   | SetStepsAction
   | SetShowJourneyFlowAnalyticsAction
+  | SetStatsBreakdownAction
 
 export const reducer = (
   state: EditorState,
@@ -227,6 +236,12 @@ export const reducer = (
         ...state,
         showJourneyFlowAnalytics: action.showJourneyFlowAnalytics
       }
+    case 'SetStatsBreakdownAction': {
+      return {
+        ...state,
+        journeyStatsBreakdown: action.journeyStatsBreakdown
+      }
+    }
   }
 }
 
@@ -240,7 +255,8 @@ export const EditorContext = createContext<{
     activeFab: ActiveFab.Add,
     activeSlide: ActiveSlide.JourneyFlow,
     activeContent: ActiveContent.Canvas,
-    showJourneyFlowAnalytics: false
+    showJourneyFlowAnalytics: false,
+    journeyStatsBreakdown: []
   },
   dispatch: () => null
 })
@@ -268,6 +284,7 @@ export function EditorProvider({
     activeSlide: ActiveSlide.JourneyFlow,
     activeContent: ActiveContent.Canvas,
     showJourneyFlowAnalytics: false,
+    journeyStatsBreakdown: [],
     ...initialState
   })
 
@@ -275,6 +292,15 @@ export function EditorProvider({
     if (initialState?.steps != null)
       dispatch({ type: 'SetStepsAction', steps: initialState.steps })
   }, [initialState?.steps])
+
+  useEffect(() => {
+    if (initialState?.journeyStatsBreakdown != null) {
+      dispatch({
+        type: 'SetStatsBreakdownAction',
+        journeyStatsBreakdown: initialState.journeyStatsBreakdown
+      })
+    }
+  }, [initialState?.journeyStatsBreakdown])
 
   // only run once
   const stepRef = useRef(false)

--- a/libs/journeys/ui/src/libs/isActionBlock/isActionBlock.ts
+++ b/libs/journeys/ui/src/libs/isActionBlock/isActionBlock.ts
@@ -1,5 +1,6 @@
 import { TreeBlock } from '../block'
 import {
+  BlockFields,
   BlockFields_ButtonBlock as ButtonBlock,
   BlockFields_FormBlock as FormBlock,
   BlockFields_RadioOptionBlock as RadioOptionBlock,
@@ -16,5 +17,6 @@ export type ActionBlock =
   | TreeBlock<FormBlock>
   | TreeBlock<VideoBlock>
 
-export const isActionBlock = (block: TreeBlock<any>): block is ActionBlock =>
-  block?.action !== undefined
+export const isActionBlock = (
+  block: TreeBlock<BlockFields>
+): block is ActionBlock => (block as ActionBlock).action !== undefined

--- a/libs/journeys/ui/src/libs/plausible/StatsBreakdownFields.ts
+++ b/libs/journeys/ui/src/libs/plausible/StatsBreakdownFields.ts
@@ -1,0 +1,11 @@
+import { gql } from '@apollo/client'
+
+export const STATS_BREAKDOWN_FIELDS = gql`
+  fragment StatsBreakdownFields on PlausibleStatsResponse {
+    property
+    visits
+    pageviews
+    bounceRate
+    visitDuration
+  }
+`

--- a/libs/journeys/ui/src/libs/plausible/__generated__/StatsBreakdownFields.ts
+++ b/libs/journeys/ui/src/libs/plausible/__generated__/StatsBreakdownFields.ts
@@ -1,0 +1,33 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: StatsBreakdownFields
+// ====================================================
+
+export interface StatsBreakdownFields {
+  __typename: "PlausibleStatsResponse";
+  /**
+   * On breakdown queries, this is the property that was broken down by.
+   * On aggregate queries, this is the date the stats are for.
+   */
+  property: string;
+  /**
+   * The number of visits/sessions.
+   */
+  visits: number | null;
+  /**
+   * The number of pageview events.
+   */
+  pageviews: number | null;
+  /**
+   * Bounce rate percentage.
+   */
+  bounceRate: number | null;
+  /**
+   * Visit duration in seconds.
+   */
+  visitDuration: number | null;
+}


### PR DESCRIPTION
# Description

### Issue
Need to add the analytics overlay for step blocks
- Display view count and visit duration
- Display bounce rate stat

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37663055/todos/7446834029)

### Solution
- Added `getStepAnalytics` helper function
- Added `StepBlockNodeAnalytics` component which displays the view count, visit duration, and bounce rate

# External Changes
N/A

# Additional information
N/A
