### PR TITLE
chore: add new believer course to watch and videos page

### DIFF
--- a/apps/watch/pages/index.tsx
+++ b/apps/watch/pages/index.tsx
@@ -39,6 +39,7 @@ const videoIds = [
   'GOMarkCollection',
   'GOLukeCollection',
   'GOJohnCollection',
+  '8_NBC',
   '1_cl1309-0-0',
   '1_jf6102-0-0',
   '2_0-FallingPlates',

--- a/apps/watch/pages/videos.tsx
+++ b/apps/watch/pages/videos.tsx
@@ -44,6 +44,7 @@ const videoIds = [
   '1_cl-0-0',
   'Wonder',
   'Nua',
+  '8_NBC',
   'GoodStory',
   '2_FileZero-0-0',
   '1_fj-0-0',


### PR DESCRIPTION
# Description

### Issue
Urgent request from Melissa
"Is it possible to turn on visibility for the new believer course on the website immediately? Right now it is only searchable and not visible. I'm going into meetings with them Monday evening and all day Tuesday. It's kind of embarrassing that we've had it licensed for over a year and had it up on ArcLight for 6 months but they can't see it"


[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

_Provide a detailed description of how exactly this task will be accomplished. This can be something technical. What specific steps will be taken to achieve the goal? This should include details on service integration, job logic, implementation, etc._

# External Changes

_If you have made changes to external services, need to add additional values to Doppler, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc._

# Additional information

_Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc._
