### PR TITLE
fix: language switcher encoding for watch

### DIFF
--- a/apps/watch/pages/[part1]/[part2].tsx
+++ b/apps/watch/pages/[part1]/[part2].tsx
@@ -72,7 +72,7 @@ export const getStaticProps: GetStaticProps<Part2PageProps> = async (
     return {
       redirect: {
         permanent: false,
-        destination: `/${contentId}.html/${languageId}.html`
+        destination: `/${encodeURIComponent(contentId)}.html/${languageId}.html`
       }
     }
   }


### PR DESCRIPTION
# Description

### Issue

Watch language switching for videos with non standard characters was broken in production but working locally.

The issue was the videoId string not being properly url encoded when sending the redirect leading to a 400 locally and a 404 redirect on production.


### Solution

I added the proper encoding before sending the redirect.

# External Changes

None

# Additional information

None
