### PR TITLE
fix: team creation updates journey list

### DIFF
--- a/apps/journeys-admin/src/components/Team/TeamCreateForm/TeamCreateForm.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamCreateForm/TeamCreateForm.tsx
@@ -1,4 +1,4 @@
-import { ApolloError } from '@apollo/client'
+import { ApolloError, useMutation } from '@apollo/client'
 import { Formik, FormikConfig, FormikHelpers } from 'formik'
 import { useTranslation } from 'next-i18next'
 import { useSnackbar } from 'notistack'
@@ -7,7 +7,9 @@ import { ObjectSchema, object, string } from 'yup'
 
 import { TeamCreateInput } from '../../../../__generated__/globalTypes'
 import { TeamCreate } from '../../../../__generated__/TeamCreate'
+import { UpdateLastActiveTeamId } from '../../../../__generated__/UpdateLastActiveTeamId'
 import { useTeamCreateMutation } from '../../../libs/useTeamCreateMutation'
+import { UPDATE_LAST_ACTIVE_TEAM_ID } from '../TeamSelect/TeamSelect'
 
 interface TeamCreateFormProps {
   onSubmit?: (
@@ -32,6 +34,8 @@ export function TeamCreateForm({
   })
   const [teamCreate] = useTeamCreateMutation()
   const { enqueueSnackbar } = useSnackbar()
+  const [updateLastActiveTeamId, { client }] =
+    useMutation<UpdateLastActiveTeamId>(UPDATE_LAST_ACTIVE_TEAM_ID)
 
   async function handleSubmit(
     input: TeamCreateInput,
@@ -40,6 +44,16 @@ export function TeamCreateForm({
     try {
       const { data } = await teamCreate({
         variables: { input }
+      })
+      void updateLastActiveTeamId({
+        variables: {
+          input: {
+            lastActiveTeamId: data?.teamCreate.id ?? null
+          }
+        },
+        onCompleted() {
+          void client.refetchQueries({ include: ['GetAdminJourneys'] })
+        }
       })
       enqueueSnackbar(
         data !== null && data !== undefined && data?.teamCreate.title !== ''


### PR DESCRIPTION
# Description

### Issue

Fixes issue where team creation did not update journeys list - leading to misleading team journeys

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37663057/todos/7475799222)

### Solution

Run mutation query to update latest team on team create.

# External Changes

_If you have made changes to external services, need to add additional values to Doppler, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc._

# Additional information

_Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc._
