### PR TITLE
fix: reload page after updating url

### DIFF
--- a/libs/journeys/ui/src/libs/action/action.ts
+++ b/libs/journeys/ui/src/libs/action/action.ts
@@ -28,7 +28,7 @@ export function handleAction(
       } else if (action.url === '') {
         break
       } else {
-        void router.push(action.url).then(() => window.location.reload())
+        void router.push(action.url)?.then(() => window.location.reload())
       }
       break
     case 'EmailAction':

--- a/libs/journeys/ui/src/libs/action/action.ts
+++ b/libs/journeys/ui/src/libs/action/action.ts
@@ -28,7 +28,7 @@ export function handleAction(
       } else if (action.url === '') {
         break
       } else {
-        void router.push(action.url)
+        void router.push(action.url).then(() => window.location.reload())
       }
       break
     case 'EmailAction':


### PR DESCRIPTION
# Description

### Issue

Currently navigating from journey to journey is causing an issue. The journey you're going to updates the title and everything else but the blocks doesn't get updated

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

The quickest fix is to reload the page so that the blockHistory gets a good refresh of data