### PR TITLE
feat: add turkish to template language filter

### DIFF
--- a/apps/journeys-admin/pages/templates/index.tsx
+++ b/apps/journeys-admin/pages/templates/index.tsx
@@ -87,7 +87,8 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
             '13169', // Thai
             '6464', // Hindi
             '12876', // Ukrainian
-            '53441' // Arabic, Egyptian Modern Standard
+            '53441', // Arabic, Egyptian Modern Standard
+            '1942' // Türkçe, Turkish
           ]
         }
       }

--- a/apps/journeys-admin/src/components/TemplateGallery/HeaderAndLanguageFilter/HeaderAndLanguageFilter.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/HeaderAndLanguageFilter/HeaderAndLanguageFilter.tsx
@@ -189,7 +189,8 @@ export function HeaderAndLanguageFilter({
         '13169', // Thai
         '6464', // Hindi
         '12876', // Ukrainian
-        '53441' // Arabic, Egyptian Modern Standard
+        '53441', // Arabic, Egyptian Modern Standard
+        '1942' // Türkçe, Turkish
       ]
     }
   })

--- a/apps/journeys-admin/src/components/TemplateGallery/data.ts
+++ b/apps/journeys-admin/src/components/TemplateGallery/data.ts
@@ -289,7 +289,8 @@ export const getLanguagesMock: MockedResponse<GetLanguages> = {
           '13169',
           '6464',
           '12876',
-          '53441'
+          '53441',
+          '1942'
         ]
       }
     }


### PR DESCRIPTION
# Description

### Issue

A partner is planning to provide templates in Turkish and need a way to filter for them

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

Update the query that fetches available languages to filter by

# External Changes

n/a

# Additional information

n/a