### PR TITLE
feat: event email notification on delete cascade

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -457,7 +457,22 @@ type EventEmailNotifications
   id: ID!
   userId: ID!
   journeyId: ID!
+  teamId: ID
   value: Boolean!
+}
+
+input EventEmailNotificationsDeleteByTeamInput
+  @join__type(graph: JOURNEYS)
+{
+  userId: ID!
+  teamId: ID!
+}
+
+input EventEmailNotificationsDeleteInput
+  @join__type(graph: JOURNEYS)
+{
+  userId: ID!
+  journeyId: ID!
 }
 
 input EventEmailNotificationsUpdateInput
@@ -465,6 +480,7 @@ input EventEmailNotificationsUpdateInput
 {
   userId: ID!
   journeyId: ID!
+  teamId: ID
   value: Boolean!
 }
 
@@ -1375,8 +1391,9 @@ type Mutation
   videoExpandEventCreate(input: VideoExpandEventCreateInput!): VideoExpandEvent! @join__field(graph: JOURNEYS)
   videoCollapseEventCreate(input: VideoCollapseEventCreateInput!): VideoCollapseEvent! @join__field(graph: JOURNEYS)
   videoProgressEventCreate(input: VideoProgressEventCreateInput!): VideoProgressEvent! @join__field(graph: JOURNEYS)
-  eventEmailNotificationsUpdate(input: EventEmailNotificationsUpdateInput!, id: ID): EventEmailNotifications! @join__field(graph: JOURNEYS)
-  eventEmailNotificationsDelete(input: EventEmailNotificationsUpdateInput!, id: ID): EventEmailNotifications! @join__field(graph: JOURNEYS)
+  eventEmailNotificationsUpdate(input: EventEmailNotificationsUpdateInput!): EventEmailNotifications! @join__field(graph: JOURNEYS)
+  eventEmailNotificationsDelete(input: EventEmailNotificationsDeleteInput!): EventEmailNotifications! @join__field(graph: JOURNEYS)
+  eventEmailNotificationsDeleteByTeamId(input: EventEmailNotificationsDeleteByTeamInput!): [EventEmailNotifications!]! @join__field(graph: JOURNEYS)
   hostCreate(teamId: ID!, input: HostCreateInput!): Host! @join__field(graph: JOURNEYS)
   hostUpdate(id: ID!, teamId: ID!, input: HostUpdateInput): Host! @join__field(graph: JOURNEYS)
   hostDelete(id: ID!, teamId: ID!): Host! @join__field(graph: JOURNEYS)

--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -457,22 +457,9 @@ type EventEmailNotifications
   id: ID!
   userId: ID!
   journeyId: ID!
-  teamId: ID
+  userTeamId: ID
+  userJourneyId: ID
   value: Boolean!
-}
-
-input EventEmailNotificationsDeleteByTeamInput
-  @join__type(graph: JOURNEYS)
-{
-  userId: ID!
-  teamId: ID!
-}
-
-input EventEmailNotificationsDeleteInput
-  @join__type(graph: JOURNEYS)
-{
-  userId: ID!
-  journeyId: ID!
 }
 
 input EventEmailNotificationsUpdateInput
@@ -480,7 +467,8 @@ input EventEmailNotificationsUpdateInput
 {
   userId: ID!
   journeyId: ID!
-  teamId: ID
+  userTeamId: ID
+  userJourneyId: ID
   value: Boolean!
 }
 
@@ -1392,8 +1380,6 @@ type Mutation
   videoCollapseEventCreate(input: VideoCollapseEventCreateInput!): VideoCollapseEvent! @join__field(graph: JOURNEYS)
   videoProgressEventCreate(input: VideoProgressEventCreateInput!): VideoProgressEvent! @join__field(graph: JOURNEYS)
   eventEmailNotificationsUpdate(input: EventEmailNotificationsUpdateInput!): EventEmailNotifications! @join__field(graph: JOURNEYS)
-  eventEmailNotificationsDelete(input: EventEmailNotificationsDeleteInput!): EventEmailNotifications! @join__field(graph: JOURNEYS)
-  eventEmailNotificationsDeleteByTeamId(input: EventEmailNotificationsDeleteByTeamInput!): [EventEmailNotifications!]! @join__field(graph: JOURNEYS)
   hostCreate(teamId: ID!, input: HostCreateInput!): Host! @join__field(graph: JOURNEYS)
   hostUpdate(id: ID!, teamId: ID!, input: HostUpdateInput): Host! @join__field(graph: JOURNEYS)
   hostDelete(id: ID!, teamId: ID!): Host! @join__field(graph: JOURNEYS)

--- a/apps/api-journeys/db/migrations/20240611034043_20240611034041/migration.sql
+++ b/apps/api-journeys/db/migrations/20240611034043_20240611034041/migration.sql
@@ -1,2 +1,0 @@
--- AlterTable
-ALTER TABLE "EventEmailNotifications" ADD COLUMN     "teamId" TEXT;

--- a/apps/api-journeys/db/migrations/20240611034043_20240611034041/migration.sql
+++ b/apps/api-journeys/db/migrations/20240611034043_20240611034041/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "EventEmailNotifications" ADD COLUMN     "teamId" TEXT;

--- a/apps/api-journeys/db/migrations/20240611215915_20240611215913/migration.sql
+++ b/apps/api-journeys/db/migrations/20240611215915_20240611215913/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "EventEmailNotifications" ADD COLUMN     "userJourneyId" TEXT,
+ADD COLUMN     "userTeamId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "EventEmailNotifications" ADD CONSTRAINT "EventEmailNotifications_userTeamId_fkey" FOREIGN KEY ("userTeamId") REFERENCES "UserTeam"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EventEmailNotifications" ADD CONSTRAINT "EventEmailNotifications_userJourneyId_fkey" FOREIGN KEY ("userJourneyId") REFERENCES "UserJourney"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api-journeys/db/schema.prisma
+++ b/apps/api-journeys/db/schema.prisma
@@ -481,6 +481,7 @@ model EventEmailNotifications {
   id        String  @id @default(uuid())
   userId    String
   journeyId String
+  teamId    String?
   value     Boolean @default(true)
 
   @@unique([userId, journeyId])

--- a/apps/api-journeys/db/schema.prisma
+++ b/apps/api-journeys/db/schema.prisma
@@ -208,13 +208,14 @@ model Team {
 }
 
 model UserTeam {
-  id        String       @id @default(uuid())
-  teamId    String
-  team      Team         @relation(fields: [teamId], references: [id], onDelete: Cascade)
-  userId    String
-  role      UserTeamRole @default(member)
-  createdAt DateTime     @default(now())
-  updatedAt DateTime     @updatedAt
+  id                      String                    @id @default(uuid())
+  teamId                  String
+  team                    Team                      @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  userId                  String
+  role                    UserTeamRole              @default(member)
+  createdAt               DateTime                  @default(now())
+  updatedAt               DateTime                  @updatedAt
+  EventEmailNotifications EventEmailNotifications[]
 
   @@unique([teamId, userId])
   @@index(role)
@@ -251,13 +252,14 @@ enum UserJourneyRole {
 }
 
 model UserJourney {
-  id        String          @id @default(uuid())
-  userId    String
-  journeyId String
-  updatedAt DateTime        @default(now()) @updatedAt
-  journey   Journey         @relation(fields: [journeyId], references: [id], onDelete: Cascade)
-  role      UserJourneyRole
-  openedAt  DateTime?
+  id                      String                    @id @default(uuid())
+  userId                  String
+  journeyId               String
+  updatedAt               DateTime                  @default(now()) @updatedAt
+  journey                 Journey                   @relation(fields: [journeyId], references: [id], onDelete: Cascade)
+  role                    UserJourneyRole
+  openedAt                DateTime?
+  EventEmailNotifications EventEmailNotifications[]
 
   @@unique([journeyId, userId])
   @@index(journeyId)
@@ -478,11 +480,14 @@ model JourneysEmailPreference {
 }
 
 model EventEmailNotifications {
-  id        String  @id @default(uuid())
-  userId    String
-  journeyId String
-  teamId    String?
-  value     Boolean @default(true)
+  id            String       @id @default(uuid())
+  userId        String
+  journeyId     String
+  userTeamId    String?
+  userJourneyId String?
+  userTeam      UserTeam?    @relation(fields: [userTeamId], references: [id], onDelete: Cascade)
+  userJourney   UserJourney? @relation(fields: [userJourneyId], references: [id], onDelete: Cascade)
+  value         Boolean      @default(true)
 
   @@unique([userId, journeyId])
   @@index(userId)

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -226,8 +226,9 @@ type Mutation {
   videoExpandEventCreate(input: VideoExpandEventCreateInput!): VideoExpandEvent!
   videoCollapseEventCreate(input: VideoCollapseEventCreateInput!): VideoCollapseEvent!
   videoProgressEventCreate(input: VideoProgressEventCreateInput!): VideoProgressEvent!
-  eventEmailNotificationsUpdate(input: EventEmailNotificationsUpdateInput!, id: ID): EventEmailNotifications!
-  eventEmailNotificationsDelete(input: EventEmailNotificationsUpdateInput!, id: ID): EventEmailNotifications!
+  eventEmailNotificationsUpdate(input: EventEmailNotificationsUpdateInput!): EventEmailNotifications!
+  eventEmailNotificationsDelete(input: EventEmailNotificationsDeleteInput!): EventEmailNotifications!
+  eventEmailNotificationsDeleteByTeamId(input: EventEmailNotificationsDeleteByTeamInput!): [EventEmailNotifications!]!
   hostCreate(teamId: ID!, input: HostCreateInput!): Host!
   hostUpdate(id: ID!, teamId: ID!, input: HostUpdateInput): Host!
   hostDelete(id: ID!, teamId: ID!): Host!
@@ -1908,13 +1909,25 @@ type EventEmailNotifications {
   id: ID!
   userId: ID!
   journeyId: ID!
+  teamId: ID
   value: Boolean!
 }
 
 input EventEmailNotificationsUpdateInput {
   userId: ID!
   journeyId: ID!
+  teamId: ID
   value: Boolean!
+}
+
+input EventEmailNotificationsDeleteInput {
+  userId: ID!
+  journeyId: ID!
+}
+
+input EventEmailNotificationsDeleteByTeamInput {
+  userId: ID!
+  teamId: ID!
 }
 
 type Host {

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -227,8 +227,6 @@ type Mutation {
   videoCollapseEventCreate(input: VideoCollapseEventCreateInput!): VideoCollapseEvent!
   videoProgressEventCreate(input: VideoProgressEventCreateInput!): VideoProgressEvent!
   eventEmailNotificationsUpdate(input: EventEmailNotificationsUpdateInput!): EventEmailNotifications!
-  eventEmailNotificationsDelete(input: EventEmailNotificationsDeleteInput!): EventEmailNotifications!
-  eventEmailNotificationsDeleteByTeamId(input: EventEmailNotificationsDeleteByTeamInput!): [EventEmailNotifications!]!
   hostCreate(teamId: ID!, input: HostCreateInput!): Host!
   hostUpdate(id: ID!, teamId: ID!, input: HostUpdateInput): Host!
   hostDelete(id: ID!, teamId: ID!): Host!
@@ -1909,25 +1907,17 @@ type EventEmailNotifications {
   id: ID!
   userId: ID!
   journeyId: ID!
-  teamId: ID
+  userTeamId: ID
+  userJourneyId: ID
   value: Boolean!
 }
 
 input EventEmailNotificationsUpdateInput {
   userId: ID!
   journeyId: ID!
-  teamId: ID
+  userTeamId: ID
+  userJourneyId: ID
   value: Boolean!
-}
-
-input EventEmailNotificationsDeleteInput {
-  userId: ID!
-  journeyId: ID!
-}
-
-input EventEmailNotificationsDeleteByTeamInput {
-  userId: ID!
-  teamId: ID!
 }
 
 type Host {

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -597,18 +597,9 @@ export class VideoProgressEventCreateInput {
 export class EventEmailNotificationsUpdateInput {
     userId: string;
     journeyId: string;
-    teamId?: Nullable<string>;
+    userTeamId?: Nullable<string>;
+    userJourneyId?: Nullable<string>;
     value: boolean;
-}
-
-export class EventEmailNotificationsDeleteInput {
-    userId: string;
-    journeyId: string;
-}
-
-export class EventEmailNotificationsDeleteByTeamInput {
-    userId: string;
-    teamId: string;
 }
 
 export class HostUpdateInput {
@@ -896,10 +887,6 @@ export abstract class IMutation {
     abstract videoProgressEventCreate(input: VideoProgressEventCreateInput): VideoProgressEvent | Promise<VideoProgressEvent>;
 
     abstract eventEmailNotificationsUpdate(input: EventEmailNotificationsUpdateInput): EventEmailNotifications | Promise<EventEmailNotifications>;
-
-    abstract eventEmailNotificationsDelete(input: EventEmailNotificationsDeleteInput): EventEmailNotifications | Promise<EventEmailNotifications>;
-
-    abstract eventEmailNotificationsDeleteByTeamId(input: EventEmailNotificationsDeleteByTeamInput): EventEmailNotifications[] | Promise<EventEmailNotifications[]>;
 
     abstract hostCreate(teamId: string, input: HostCreateInput): Host | Promise<Host>;
 
@@ -1478,7 +1465,8 @@ export class EventEmailNotifications {
     id: string;
     userId: string;
     journeyId: string;
-    teamId?: Nullable<string>;
+    userTeamId?: Nullable<string>;
+    userJourneyId?: Nullable<string>;
     value: boolean;
 }
 

--- a/apps/api-journeys/src/app/__generated__/graphql.ts
+++ b/apps/api-journeys/src/app/__generated__/graphql.ts
@@ -597,7 +597,18 @@ export class VideoProgressEventCreateInput {
 export class EventEmailNotificationsUpdateInput {
     userId: string;
     journeyId: string;
+    teamId?: Nullable<string>;
     value: boolean;
+}
+
+export class EventEmailNotificationsDeleteInput {
+    userId: string;
+    journeyId: string;
+}
+
+export class EventEmailNotificationsDeleteByTeamInput {
+    userId: string;
+    teamId: string;
 }
 
 export class HostUpdateInput {
@@ -884,9 +895,11 @@ export abstract class IMutation {
 
     abstract videoProgressEventCreate(input: VideoProgressEventCreateInput): VideoProgressEvent | Promise<VideoProgressEvent>;
 
-    abstract eventEmailNotificationsUpdate(input: EventEmailNotificationsUpdateInput, id?: Nullable<string>): EventEmailNotifications | Promise<EventEmailNotifications>;
+    abstract eventEmailNotificationsUpdate(input: EventEmailNotificationsUpdateInput): EventEmailNotifications | Promise<EventEmailNotifications>;
 
-    abstract eventEmailNotificationsDelete(input: EventEmailNotificationsUpdateInput, id?: Nullable<string>): EventEmailNotifications | Promise<EventEmailNotifications>;
+    abstract eventEmailNotificationsDelete(input: EventEmailNotificationsDeleteInput): EventEmailNotifications | Promise<EventEmailNotifications>;
+
+    abstract eventEmailNotificationsDeleteByTeamId(input: EventEmailNotificationsDeleteByTeamInput): EventEmailNotifications[] | Promise<EventEmailNotifications[]>;
 
     abstract hostCreate(teamId: string, input: HostCreateInput): Host | Promise<Host>;
 
@@ -1465,6 +1478,7 @@ export class EventEmailNotifications {
     id: string;
     userId: string;
     journeyId: string;
+    teamId?: Nullable<string>;
     value: boolean;
 }
 

--- a/apps/api-journeys/src/app/modules/eventEmailNotifications/evenEmailNotifications.graphql
+++ b/apps/api-journeys/src/app/modules/eventEmailNotifications/evenEmailNotifications.graphql
@@ -2,37 +2,23 @@ type EventEmailNotifications {
   id: ID!
   userId: ID!
   journeyId: ID!
-  teamId: ID
+  userTeamId: ID
+  userJourneyId: ID
   value: Boolean!
 }
 
 input EventEmailNotificationsUpdateInput {
   userId: ID!
   journeyId: ID!
-  teamId: ID
+  userTeamId: ID
+  userJourneyId: ID
   value: Boolean!
-}
-
-input EventEmailNotificationsDeleteInput {
-  userId: ID!
-  journeyId: ID!
-}
-
-input EventEmailNotificationsDeleteByTeamInput {
-  userId: ID!
-  teamId: ID!
 }
 
 type Mutation {
   eventEmailNotificationsUpdate(
     input: EventEmailNotificationsUpdateInput!
   ): EventEmailNotifications!
-  eventEmailNotificationsDelete(
-    input: EventEmailNotificationsDeleteInput!
-  ): EventEmailNotifications!
-  eventEmailNotificationsDeleteByTeamId(
-    input: EventEmailNotificationsDeleteByTeamInput!
-  ): [EventEmailNotifications!]!
 }
 
 type Query {

--- a/apps/api-journeys/src/app/modules/eventEmailNotifications/evenEmailNotifications.graphql
+++ b/apps/api-journeys/src/app/modules/eventEmailNotifications/evenEmailNotifications.graphql
@@ -2,24 +2,37 @@ type EventEmailNotifications {
   id: ID!
   userId: ID!
   journeyId: ID!
+  teamId: ID
   value: Boolean!
 }
 
 input EventEmailNotificationsUpdateInput {
   userId: ID!
   journeyId: ID!
+  teamId: ID
   value: Boolean!
+}
+
+input EventEmailNotificationsDeleteInput {
+  userId: ID!
+  journeyId: ID!
+}
+
+input EventEmailNotificationsDeleteByTeamInput {
+  userId: ID!
+  teamId: ID!
 }
 
 type Mutation {
   eventEmailNotificationsUpdate(
     input: EventEmailNotificationsUpdateInput!
-    id: ID
   ): EventEmailNotifications!
   eventEmailNotificationsDelete(
-    input: EventEmailNotificationsUpdateInput!
-    id: ID
+    input: EventEmailNotificationsDeleteInput!
   ): EventEmailNotifications!
+  eventEmailNotificationsDeleteByTeamId(
+    input: EventEmailNotificationsDeleteByTeamInput!
+  ): [EventEmailNotifications!]!
 }
 
 type Query {

--- a/apps/api-journeys/src/app/modules/eventEmailNotifications/eventEmailNotifications.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/eventEmailNotifications/eventEmailNotifications.resolver.spec.ts
@@ -38,7 +38,8 @@ describe('EventEmailNotifications', () => {
     id: '1',
     journeyId: 'journeyId',
     userId: 'userId1',
-    teamId: 'teamId',
+    userJourneyId: 'userJourneyId',
+    userTeamId: null,
     value: false
   }
   const input = {
@@ -78,7 +79,8 @@ describe('EventEmailNotifications', () => {
         id: '1',
         journeyId: 'journeyId',
         userId: 'userId1',
-        teamId: 'teamId',
+        userJourneyId: 'userJourneyId',
+        userTeamId: null,
         value: true
       })
       expect(prismaService.eventEmailNotifications.upsert).toHaveBeenCalledWith(
@@ -90,48 +92,6 @@ describe('EventEmailNotifications', () => {
           update: input
         }
       )
-    })
-  })
-
-  describe('eventEmailNotificationsDelete', () => {
-    it('should delete an event email notification by userId and journeyId', async () => {
-      prismaService.eventEmailNotifications.delete.mockResolvedValueOnce(
-        eventEmailNotification
-      )
-      expect(await resolver.eventEmailNotificationsDelete(input)).toEqual(
-        eventEmailNotification
-      )
-      expect(prismaService.eventEmailNotifications.delete).toHaveBeenCalledWith(
-        {
-          where: {
-            userId_journeyId: { userId: 'userId1', journeyId: 'journeyId' }
-          }
-        }
-      )
-    })
-  })
-
-  describe('eventEmailNotificationsDeleteByTeamId', () => {
-    it('should delete all event email notification by userId and teamId', async () => {
-      prismaService.eventEmailNotifications.findMany.mockResolvedValueOnce(
-        eventEmailNotifications
-      )
-      prismaService.eventEmailNotifications.deleteMany.mockResolvedValueOnce({
-        count: 2
-      })
-      expect(
-        await resolver.eventEmailNotificationsDeleteByTeamId(input)
-      ).toEqual(eventEmailNotifications)
-      expect(
-        prismaService.eventEmailNotifications.findMany
-      ).toHaveBeenCalledWith({
-        where: { teamId: 'teamId', userId: 'userId1' }
-      })
-      expect(
-        prismaService.eventEmailNotifications.deleteMany
-      ).toHaveBeenCalledWith({
-        where: { teamId: 'teamId', userId: 'userId1' }
-      })
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/eventEmailNotifications/eventEmailNotifications.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/eventEmailNotifications/eventEmailNotifications.resolver.spec.ts
@@ -1,7 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
 
-import { EventEmailNotifications } from '../../__generated__/graphql'
+import { EventEmailNotifications } from '.prisma/api-journeys-client'
+
 import { PrismaService } from '../../lib/prisma.service'
 
 import { EventEmailNotificationsResolver } from './eventEmailNotifications.resolver'
@@ -37,17 +38,23 @@ describe('EventEmailNotifications', () => {
     id: '1',
     journeyId: 'journeyId',
     userId: 'userId1',
+    teamId: 'teamId',
     value: false
   }
-  const input = { journeyId: 'journeyId', userId: 'userId1', value: true }
+  const input = {
+    journeyId: 'journeyId',
+    userId: 'userId1',
+    value: true,
+    teamId: 'teamId'
+  }
+
+  const eventEmailNotifications: EventEmailNotifications[] = [
+    eventEmailNotification,
+    { ...eventEmailNotification, id: '2' }
+  ]
 
   describe('eventEmailNotificationsByJourney', () => {
     it('should return an array of event email notifications', async () => {
-      const eventEmailNotifications: EventEmailNotifications[] = [
-        eventEmailNotification,
-        { ...eventEmailNotification, id: '2' }
-      ]
-
       prismaService.eventEmailNotifications.findMany.mockResolvedValueOnce(
         eventEmailNotifications
       )
@@ -62,26 +69,6 @@ describe('EventEmailNotifications', () => {
   })
 
   describe('eventEmailNotificationsUpdate', () => {
-    it('should upsert an event email notification by id', async () => {
-      prismaService.eventEmailNotifications.upsert.mockResolvedValueOnce({
-        ...eventEmailNotification,
-        value: true
-      })
-      expect(await resolver.eventEmailNotificationsUpdate(input, '1')).toEqual({
-        id: '1',
-        journeyId: 'journeyId',
-        userId: 'userId1',
-        value: true
-      })
-      expect(prismaService.eventEmailNotifications.upsert).toHaveBeenCalledWith(
-        {
-          where: { id: '1' },
-          create: input,
-          update: input
-        }
-      )
-    })
-
     it('should upsert an event email notification by userId and journeyId', async () => {
       prismaService.eventEmailNotifications.upsert.mockResolvedValueOnce({
         ...eventEmailNotification,
@@ -91,6 +78,7 @@ describe('EventEmailNotifications', () => {
         id: '1',
         journeyId: 'journeyId',
         userId: 'userId1',
+        teamId: 'teamId',
         value: true
       })
       expect(prismaService.eventEmailNotifications.upsert).toHaveBeenCalledWith(
@@ -106,22 +94,6 @@ describe('EventEmailNotifications', () => {
   })
 
   describe('eventEmailNotificationsDelete', () => {
-    it('should delete an event email notification by id', async () => {
-      prismaService.eventEmailNotifications.delete.mockResolvedValueOnce(
-        eventEmailNotification
-      )
-      expect(await resolver.eventEmailNotificationsDelete(input, '1')).toEqual(
-        eventEmailNotification
-      )
-      expect(prismaService.eventEmailNotifications.delete).toHaveBeenCalledWith(
-        {
-          where: {
-            id: '1'
-          }
-        }
-      )
-    })
-
     it('should delete an event email notification by userId and journeyId', async () => {
       prismaService.eventEmailNotifications.delete.mockResolvedValueOnce(
         eventEmailNotification
@@ -136,6 +108,30 @@ describe('EventEmailNotifications', () => {
           }
         }
       )
+    })
+  })
+
+  describe('eventEmailNotificationsDeleteByTeamId', () => {
+    it('should delete all event email notification by userId and teamId', async () => {
+      prismaService.eventEmailNotifications.findMany.mockResolvedValueOnce(
+        eventEmailNotifications
+      )
+      prismaService.eventEmailNotifications.deleteMany.mockResolvedValueOnce({
+        count: 2
+      })
+      expect(
+        await resolver.eventEmailNotificationsDeleteByTeamId(input)
+      ).toEqual(eventEmailNotifications)
+      expect(
+        prismaService.eventEmailNotifications.findMany
+      ).toHaveBeenCalledWith({
+        where: { teamId: 'teamId', userId: 'userId1' }
+      })
+      expect(
+        prismaService.eventEmailNotifications.deleteMany
+      ).toHaveBeenCalledWith({
+        where: { teamId: 'teamId', userId: 'userId1' }
+      })
     })
   })
 })

--- a/apps/api-journeys/src/app/modules/eventEmailNotifications/eventEmailNotifications.resolver.ts
+++ b/apps/api-journeys/src/app/modules/eventEmailNotifications/eventEmailNotifications.resolver.ts
@@ -4,10 +4,7 @@ import { Args, Mutation, Query, Resolver } from '@nestjs/graphql'
 import { EventEmailNotifications } from '.prisma/api-journeys-client'
 import { GqlAuthGuard } from '@core/nest/gqlAuthGuard/GqlAuthGuard'
 
-import {
-  EventEmailNotificationsDeleteByTeamInput,
-  EventEmailNotificationsUpdateInput
-} from '../../__generated__/graphql'
+import { EventEmailNotificationsUpdateInput } from '../../__generated__/graphql'
 import { PrismaService } from '../../lib/prisma.service'
 
 @Resolver('EventEmailNotifications')
@@ -34,34 +31,5 @@ export class EventEmailNotificationsResolver {
       update: input,
       create: input
     })
-  }
-
-  @Mutation()
-  @UseGuards(GqlAuthGuard)
-  async eventEmailNotificationsDelete(
-    @Args('input') input: EventEmailNotificationsUpdateInput
-  ): Promise<EventEmailNotifications> {
-    const { userId, journeyId } = input
-    return await this.prismaService.eventEmailNotifications.delete({
-      where: { userId_journeyId: { userId, journeyId } }
-    })
-  }
-
-  @Mutation()
-  @UseGuards(GqlAuthGuard)
-  async eventEmailNotificationsDeleteByTeamId(
-    @Args('input') input: EventEmailNotificationsDeleteByTeamInput
-  ): Promise<EventEmailNotifications[]> {
-    const { teamId, userId } = input
-    const eventEmailNotifications =
-      await this.prismaService.eventEmailNotifications.findMany({
-        where: { teamId, userId }
-      })
-
-    await this.prismaService.eventEmailNotifications.deleteMany({
-      where: { teamId, userId }
-    })
-
-    return eventEmailNotifications
   }
 }

--- a/apps/api-journeys/src/app/modules/eventEmailNotifications/eventEmailNotifications.resolver.ts
+++ b/apps/api-journeys/src/app/modules/eventEmailNotifications/eventEmailNotifications.resolver.ts
@@ -4,7 +4,10 @@ import { Args, Mutation, Query, Resolver } from '@nestjs/graphql'
 import { EventEmailNotifications } from '.prisma/api-journeys-client'
 import { GqlAuthGuard } from '@core/nest/gqlAuthGuard/GqlAuthGuard'
 
-import { EventEmailNotificationsUpdateInput } from '../../__generated__/graphql'
+import {
+  EventEmailNotificationsDeleteByTeamInput,
+  EventEmailNotificationsUpdateInput
+} from '../../__generated__/graphql'
 import { PrismaService } from '../../lib/prisma.service'
 
 @Resolver('EventEmailNotifications')
@@ -23,14 +26,11 @@ export class EventEmailNotificationsResolver {
   @Mutation()
   @UseGuards(GqlAuthGuard)
   async eventEmailNotificationsUpdate(
-    @Args('input') input: EventEmailNotificationsUpdateInput,
-    @Args('id') id?: string
+    @Args('input') input: EventEmailNotificationsUpdateInput
   ): Promise<EventEmailNotifications> {
     const { userId, journeyId } = input
-    const where =
-      id != null ? { id } : { userId_journeyId: { userId, journeyId } }
     return await this.prismaService.eventEmailNotifications.upsert({
-      where,
+      where: { userId_journeyId: { userId, journeyId } },
       update: input,
       create: input
     })
@@ -39,14 +39,29 @@ export class EventEmailNotificationsResolver {
   @Mutation()
   @UseGuards(GqlAuthGuard)
   async eventEmailNotificationsDelete(
-    @Args('input') input: EventEmailNotificationsUpdateInput,
-    @Args('id') id?: string
+    @Args('input') input: EventEmailNotificationsUpdateInput
   ): Promise<EventEmailNotifications> {
     const { userId, journeyId } = input
-    const where =
-      id != null ? { id } : { userId_journeyId: { userId, journeyId } }
     return await this.prismaService.eventEmailNotifications.delete({
-      where
+      where: { userId_journeyId: { userId, journeyId } }
     })
+  }
+
+  @Mutation()
+  @UseGuards(GqlAuthGuard)
+  async eventEmailNotificationsDeleteByTeamId(
+    @Args('input') input: EventEmailNotificationsDeleteByTeamInput
+  ): Promise<EventEmailNotifications[]> {
+    const { teamId, userId } = input
+    const eventEmailNotifications =
+      await this.prismaService.eventEmailNotifications.findMany({
+        where: { teamId, userId }
+      })
+
+    await this.prismaService.eventEmailNotifications.deleteMany({
+      where: { teamId, userId }
+    })
+
+    return eventEmailNotifications
   }
 }


### PR DESCRIPTION
# Description

### Issue

need to be able to delete all the users eventUserNotifications if they get removed from the team

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

if user is part of the journey's team then the team id can be stored. Then we can delete all by userId and teamId

