### PR TITLE
fix: encode contentid on page 3

### DIFF
--- a/apps/watch/pages/watch/[part1]/[part2]/[part3].tsx
+++ b/apps/watch/pages/watch/[part1]/[part2]/[part3].tsx
@@ -70,7 +70,9 @@ export const getStaticProps: GetStaticProps<Part3PageProps> = async (
     return {
       redirect: {
         permanent: false,
-        destination: `/watch/${containerId}.html/${contentId}/${languageId}.html`
+        destination: `/watch/${containerId}.html/${encodeURIComponent(
+          contentId
+        )}/${languageId}.html`
       }
     }
   }


### PR DESCRIPTION
# Description

### Issue

Switching languages goes to 404 for videos with special characters inside of a collection.

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

Encode the contentid in the url

# External Changes

_If you have made changes to external services, need to add additional values to Doppler, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc._

# Additional information

_Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc._
