### PR TITLE
feat: devcontainer updates

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,14 @@
 # Update the VARIANT arg in docker-compose.yml to pick a Node version
-ARG VARIANT=20
-FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:${VARIANT}-bullseye
+ARG VARIANT=20 
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:${VARIANT}-bullseye AS base
 
 # Update args in docker-compose.yaml to set the UID/GID of the "node" user.
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then groupmod --gid $USER_GID node && usermod --uid $USER_UID --gid $USER_GID node; fi
+
+
+FROM base as final
 
 # solves "failed to fetch URL Hash Sum mismatch error"
 # see: https://github.com/docker/for-mac/issues/7025
@@ -16,9 +19,15 @@ RUN echo 'Acquire::http::Pipeline-Depth 0;\nAcquire::http::No-Cache true;\nAcqui
 RUN sh -c 'echo "deb [signed-by=/usr/share/keyrings/postgresql-archive.keyring.gpg] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /usr/share/keyrings/postgresql-archive.keyring.gpg
 
+# doppler
+RUN curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key' | apt-key add -
+RUN echo "deb https://packages.doppler.com/public/cli/deb/debian any-version main" | tee /etc/apt/sources.list.d/doppler-cli.list
+    
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends gnupg2 libpixman-1-dev libcairo2-dev libpango1.0-dev postgresql-client-13 chromium
+    && apt-get -y install --no-install-recommends gnupg2 libpixman-1-dev libcairo2-dev \
+    libpango1.0-dev postgresql-client-13 chromium apt-transport-https ca-certificates curl \
+    gnupg doppler
 
 # [Optional] Uncomment if you want to install an additional version of node using nvm
 # ARG EXTRA_NODE_VERSION=20
@@ -26,6 +35,13 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 
 # [Optional] Uncomment if you want to install more global node modules
 RUN su node -c "npm install -g npm@latest"
+
+WORKDIR /home/node
+
+# install github action runner
+RUN curl https://raw.githubusercontent.com/nektos/act/master/install.sh | bash
+RUN mv bin/act /usr/bin/
+RUN rm -rf bin
 
 RUN mkdir /home/node/.doppler \
     && chown -R node /home/node/.doppler

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   app:
     build:
       context: .
+      target: final
       dockerfile: Dockerfile
       args:
         VARIANT: 20
@@ -10,7 +11,7 @@ services:
         USER_GID: 1000
     volumes:
       - ..:/workspaces:delegated
-      - core-node-doppler:/home/node/.doppler
+      - core-node-user:/home/node
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
     # Uncomment the next line to use a non-root user for all processes.
@@ -64,6 +65,6 @@ services:
       - 1080:1080
       - 1025:1025
 volumes:
-  core-node-doppler:
+  core-node-user:
   postgres-data:
   redis-data:

--- a/.devcontainer/post-create-command.sh
+++ b/.devcontainer/post-create-command.sh
@@ -27,11 +27,6 @@ npm install -g apollo graphql
 # install all dependencies
 npm i
 
-# install github action runner
-curl https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
-sudo mv bin/act /usr/bin/
-rm -rf bin
-
 # install router to api gateways
 # when updating router version you'll need to:
 # - update .devcontainer/post-create-command.sh apollo router version (...nix/vX.X.X)
@@ -40,8 +35,3 @@ rm -rf bin
 curl -sSL https://router.apollo.dev/download/nix/v1.43.1 | sh
 mv router apps/api-gateway/
 
-# install doppler
-sudo apt-get update && sudo apt-get install -y apt-transport-https ca-certificates curl gnupg
-curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key' | sudo apt-key add -
-echo "deb https://packages.doppler.com/public/cli/deb/debian any-version main" | sudo tee /etc/apt/sources.list.d/doppler-cli.list
-sudo apt-get update && sudo apt-get install doppler


### PR DESCRIPTION
# Description

### Issue

Several user configs and caches are lost on rebuild
Upcoming changes will store even more in the home/node directory

### Solution

Save All home/node data as a docker volume

# External Changes


# Additional information

Will require a new doppler login
Personal vscode extensions will now persist through rebuild
Also moved several post-install scripts into the docker image for less apt churn on build
Made Docker image Multi-stage to allow for caching layers requiring less rebuild
