### PR TITLE
fix: template languages selected text

### DIFF
--- a/libs/locales/en/apps-journeys-admin.json
+++ b/libs/locales/en/apps-journeys-admin.json
@@ -649,7 +649,7 @@
   "New members get access instantly. Team members can see all analytics, edit any journey, and delete and copy journey.": "New members get access instantly. Team members can see all analytics, edit any journey, and delete and copy journey.",
   "<0>Journey Templates</0><1>in</1><2>{{firstLanguage}} {{secondLanguage}}</2>": "<0>Journey Templates</0><1>in</1><2>{{firstLanguage}} {{secondLanguage}}</2>",
   "<0>Journey Templates</0><1>in</1><2>{{firstLanguage}}</2>_one": "<0>Journey Templates</0><1>in</1><2>{{firstLanguage}}</2>",
-  "<0>Journey Templates</0><1>in</1><2>{{firstLanguage}}</2>_other": "<0>Journey Templates</0><1>in</1><2>{{firstLanguage}}</2>",
+  "<0>Journey Templates</0><1>in</1><2>{{firstLanguage}}</2>_other": "<0>Journey Templates</0><1>in</1><2>{{count}} languages</2>",
   "Topics, holidays, felt needs, collections": "Topics, holidays, felt needs, collections",
   "Audience": "Audience",
   "Genre": "Genre",

--- a/libs/locales/en/apps-journeys-admin.json
+++ b/libs/locales/en/apps-journeys-admin.json
@@ -647,7 +647,7 @@
   "Save": "Save",
   "Only a manager can invite new members to the team": "Only a manager can invite new members to the team",
   "New members get access instantly. Team members can see all analytics, edit any journey, and delete and copy journey.": "New members get access instantly. Team members can see all analytics, edit any journey, and delete and copy journey.",
-  "<0>Journey Templates</0><1>in</1><2>{{firstLanguage}} {{secondLanguage}}</2>": "<0>Journey Templates</0><1>in</1><2>{{firstLanguage}} {{secondLanguage}}</2>",
+  "<0>Journey Templates</0><1>in</1><2>{{firstLanguage}} {{secondLanguage}}</2>": "<0>Journey Templates</0><1>in</1><2>{{firstLanguage}}, {{secondLanguage}}</2>",
   "<0>Journey Templates</0><1>in</1><2>{{firstLanguage}}</2>_one": "<0>Journey Templates</0><1>in</1><2>{{firstLanguage}}</2>",
   "<0>Journey Templates</0><1>in</1><2>{{firstLanguage}}</2>_other": "<0>Journey Templates</0><1>in</1><2>{{count}} languages</2>",
   "Topics, holidays, felt needs, collections": "Topics, holidays, felt needs, collections",


### PR DESCRIPTION
# Description

### Issue

Currently selecting multiple languages in the templates doesn't get reflected properly in the text

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

Update text to be representing multiple selected languages
