### PR TITLE
feat: add analytics ui algorithm

### DIFF
--- a/libs/journeys/ui/src/components/VideoTrigger/VideoTrigger.tsx
+++ b/libs/journeys/ui/src/components/VideoTrigger/VideoTrigger.tsx
@@ -7,7 +7,7 @@ import Player from 'video.js/dist/types/player'
 import { isIPhone } from '@core/shared/ui/deviceUtils'
 
 import { handleAction } from '../../libs/action'
-import { type TreeBlock, useBlocks } from '../../libs/block'
+import { type TreeBlock } from '../../libs/block'
 import { useJourney } from '../../libs/JourneyProvider'
 import { JourneyPlausibleEvents, keyify } from '../../libs/plausibleHelpers'
 
@@ -29,11 +29,8 @@ export function VideoTrigger({
 }: VideoTriggerProps): ReactElement {
   const router = useRouter()
   const { variant } = useJourney()
-  const { blockHistory } = useBlocks()
   const [triggered, setTriggered] = useState(false)
   const plausible = usePlausible<JourneyPlausibleEvents>()
-  const activeBlock = blockHistory[blockHistory.length - 1]
-  const stepId = activeBlock?.id
 
   useEffect(() => {
     if (player != null && !triggered) {
@@ -87,7 +84,7 @@ export function VideoTrigger({
               props: {
                 ...input,
                 key: keyify({
-                  stepId,
+                  stepId: input.blockId,
                   event: 'videoTrigger',
                   blockId: input.blockId,
                   target: triggerAction

--- a/libs/journeys/ui/src/components/VideoTrigger/VideoTrigger.tsx
+++ b/libs/journeys/ui/src/components/VideoTrigger/VideoTrigger.tsx
@@ -105,8 +105,7 @@ export function VideoTrigger({
     triggered,
     variant,
     blockId,
-    plausible,
-    stepId
+    plausible
   ])
 
   return <></>

--- a/libs/journeys/ui/src/components/VideoTrigger/VideoTrigger.tsx
+++ b/libs/journeys/ui/src/components/VideoTrigger/VideoTrigger.tsx
@@ -7,7 +7,7 @@ import Player from 'video.js/dist/types/player'
 import { isIPhone } from '@core/shared/ui/deviceUtils'
 
 import { handleAction } from '../../libs/action'
-import type { TreeBlock } from '../../libs/block'
+import { type TreeBlock, useBlocks } from '../../libs/block'
 import { useJourney } from '../../libs/JourneyProvider'
 import { JourneyPlausibleEvents, keyify } from '../../libs/plausibleHelpers'
 
@@ -29,8 +29,11 @@ export function VideoTrigger({
 }: VideoTriggerProps): ReactElement {
   const router = useRouter()
   const { variant } = useJourney()
+  const { blockHistory } = useBlocks()
   const [triggered, setTriggered] = useState(false)
   const plausible = usePlausible<JourneyPlausibleEvents>()
+  const activeBlock = blockHistory[blockHistory.length - 1]
+  const stepId = activeBlock?.id
 
   useEffect(() => {
     if (player != null && !triggered) {
@@ -84,7 +87,7 @@ export function VideoTrigger({
               props: {
                 ...input,
                 key: keyify({
-                  stepId: input.blockId,
+                  stepId,
                   event: 'videoTrigger',
                   blockId: input.blockId,
                   target: triggerAction
@@ -105,7 +108,8 @@ export function VideoTrigger({
     triggered,
     variant,
     blockId,
-    plausible
+    plausible,
+    stepId
   ])
 
   return <></>

--- a/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.spec.tsx
+++ b/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.spec.tsx
@@ -487,7 +487,8 @@ describe('EditorContext', () => {
         chatsStarted: 0,
         linksVisited: 0,
         referrers: [],
-        stepsStats: []
+        stepsStats: [],
+        actionEventMap: {}
       }
 
       expect(

--- a/libs/journeys/ui/src/libs/plausibleHelpers/plausibleHelpers.ts
+++ b/libs/journeys/ui/src/libs/plausibleHelpers/plausibleHelpers.ts
@@ -16,9 +16,6 @@ import {
   VideoStartEventCreateInput
 } from '../../../__generated__/globalTypes'
 import { ActionFields as Action } from '../action/__generated__/ActionFields'
-import { TreeBlock } from '../block'
-import { BlockFields_StepBlock } from '../block/__generated__/BlockFields'
-import { ActionBlock, isActionBlock } from '../isActionBlock'
 import { PlausibleEvent } from '../transformPlausibleBreakdown/transformPlausibleBreakdown'
 
 interface Props {
@@ -73,16 +70,7 @@ export interface BlockAnalytics {
   event: PlausibleEvent
 }
 
-interface StepAnalytics {
-  blockAnalyticsMap: Record<string, BlockAnalytics>
-  totalActiveEvents: number
-}
-
-interface ActionEvent extends PlausibleEvent {
-  target: string
-}
-
-function generateActionTargetKey(action: Action): string {
+export function generateActionTargetKey(action: Action): string {
   switch (action.__typename) {
     case 'NavigateToBlockAction':
       return action.blockId
@@ -122,71 +110,4 @@ export function reverseKeyify(key: string): {
   target?: string
 } {
   return JSON.parse(key)
-}
-
-export function formatEventKey(from: string, to: string): string {
-  return `${from}->${to}`
-}
-
-export function getBlockEventKey(block?: TreeBlock): string {
-  let key = ''
-
-  if (block == null) {
-    return key
-  }
-
-  if (block?.__typename === 'StepBlock') {
-    // Get a key for Steps that have a next block
-    if (block.nextBlockId != null && block.nextBlockId !== '') {
-      key = formatEventKey(block.id, block.nextBlockId)
-    }
-  }
-
-  // Get a key for actions blocks that have an action
-  if (isActionBlock(block) && block.action != null) {
-    const target = generateActionTargetKey(block.action)
-    key = formatEventKey(block.action.parentBlockId, target)
-  }
-
-  return key
-}
-
-export function isActiveActionEvent(
-  event: PlausibleEvent
-): event is ActionEvent {
-  return event.target != null && event.event !== 'navigatePreviousStep'
-}
-
-export function getStepAnalytics(
-  blocks: Array<TreeBlock<BlockFields_StepBlock> | ActionBlock>,
-  eventMap?: Record<string, PlausibleEvent>
-): StepAnalytics {
-  let totalActiveEvents = 0
-  const blockAnalyticsMap: { [key: string]: BlockAnalytics } = {}
-
-  // Iterate over action blocks to populate blockAnalyticsMap and totalActiveEvents
-  blocks.forEach((block) => {
-    if (block == null) return
-
-    const key = getBlockEventKey(block)
-    const event = eventMap?.[key]
-
-    if (event != null) {
-      totalActiveEvents += event.events
-      blockAnalyticsMap[block.id] = { event, percentOfStepEvents: 0 }
-    }
-  })
-
-  // Calculate
-  blocks.forEach((block) => {
-    const analytics = blockAnalyticsMap[block.id]
-
-    if (analytics == null) return
-
-    const percentage = analytics.event.events / totalActiveEvents
-
-    blockAnalyticsMap[block.id].percentOfStepEvents = percentage
-  })
-
-  return { blockAnalyticsMap, totalActiveEvents }
 }

--- a/libs/journeys/ui/src/libs/transformPlausibleBreakdown/transformPlausibleBreakdown.spec.ts
+++ b/libs/journeys/ui/src/libs/transformPlausibleBreakdown/transformPlausibleBreakdown.spec.ts
@@ -231,13 +231,6 @@ describe('transformPlausibleBreakdown', () => {
           stepId: 'step1.id',
           target: 'link:https://bible.com'
         },
-        'step1.id->': {
-          blockId: 'step1.id',
-          event: 'pageview',
-          events: 5,
-          stepId: 'step1.id',
-          target: ''
-        },
         'step1.id->link:https://m.me/test': {
           blockId: 'step1.id',
           event: 'chatButtonClick',

--- a/libs/journeys/ui/src/libs/transformPlausibleBreakdown/transformPlausibleBreakdown.spec.ts
+++ b/libs/journeys/ui/src/libs/transformPlausibleBreakdown/transformPlausibleBreakdown.spec.ts
@@ -208,7 +208,51 @@ describe('transformPlausibleBreakdown', () => {
           visitorsExitAtStep: 2,
           stepEvents: []
         }
-      ]
+      ],
+      actionEventMap: {
+        'button1.id->step2.id': {
+          blockId: 'button1.id',
+          event: 'buttonClick',
+          events: 5,
+          stepId: 'step1.id',
+          target: 'step2.id'
+        },
+        'radioOption1.id->link:https://google.com': {
+          blockId: 'radioOption1.id',
+          event: 'radioQuestionSubmit',
+          events: 5,
+          stepId: 'step1.id',
+          target: 'link:https://google.com'
+        },
+        'signUp1.id->link:https://bible.com': {
+          blockId: 'signUp1.id',
+          event: 'signUpSubmit',
+          events: 5,
+          stepId: 'step1.id',
+          target: 'link:https://bible.com'
+        },
+        'step1.id->': {
+          blockId: 'step1.id',
+          event: 'pageview',
+          events: 5,
+          stepId: 'step1.id',
+          target: ''
+        },
+        'step1.id->link:https://m.me/test': {
+          blockId: 'step1.id',
+          event: 'chatButtonClick',
+          events: 5,
+          stepId: 'step1.id',
+          target: 'link:https://m.me/test'
+        },
+        'step1.id->step2,id': {
+          blockId: 'step1.id',
+          event: 'navigateNextStep',
+          events: 5,
+          stepId: 'step1.id',
+          target: 'step2,id'
+        }
+      }
     }
 
     expect(

--- a/libs/journeys/ui/src/libs/transformPlausibleBreakdown/transformPlausibleBreakdown.ts
+++ b/libs/journeys/ui/src/libs/transformPlausibleBreakdown/transformPlausibleBreakdown.ts
@@ -67,12 +67,12 @@ interface TransformPlausibleBreakdownProps {
 
 const ACTION_EVENTS: Array<keyof JourneyPlausibleEvents> = [
   'navigateNextStep',
-  'videoTrigger',
   'buttonClick',
   'textResponseSubmit',
   'signUpSubmit',
   'radioQuestionSubmit',
-  'chatButtonClick'
+  'chatButtonClick',
+  'videoComplete'
 ]
 
 export function transformPlausibleBreakdown({
@@ -178,7 +178,7 @@ function getLinkClicks(journeyEvents: PlausibleEvent[]): {
   }
 }
 
-export function formatEventKey(from: string, to: string): string {
+function formatEventKey(from: string, to: string): string {
   return `${from}->${to}`
 }
 
@@ -237,7 +237,10 @@ export function getStepAnalytics(
 
     if (analytics == null) return
 
-    const percentage = analytics.event.events / totalActiveEvents
+    const percentage =
+      Math.round(
+        (analytics.event.events / totalActiveEvents + Number.EPSILON) * 100
+      ) / 100
 
     blockAnalyticsMap[block.id].percentOfStepEvents = percentage
   })


### PR DESCRIPTION
# Description

### Issue
Needed a way to use the data returned from plausible on a step/block/link level
[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution
The algorithm has a few key points
- Adds `actionEventMap` which stores all next step events under their "event key" (key generated using the block and target of an action). This would be nextstep, link, and email actions.
- Provides `getStepAnalytics` that will return the `totalActiveEvent` count and the `blockAnalyticsMap`. `blockAnalyticsMap` is keyed by the blockId rather than the "event key"


# External Changes
N/A


# Additional information
N/A

