### PR TITLE
refactor: i18next

### DIFF
--- a/apps/journeys-admin/setupTests.tsx
+++ b/apps/journeys-admin/setupTests.tsx
@@ -6,7 +6,7 @@ import crypto from 'crypto'
 import { configure } from '@testing-library/react'
 
 import { mswServer } from './test/mswServer'
-import '../../libs/journeys/ui/test/i18n'
+import '@core/journeys/ui/test/i18n'
 
 configure({ asyncUtilTimeout: 2500 })
 

--- a/apps/journeys-admin/setupTests.tsx
+++ b/apps/journeys-admin/setupTests.tsx
@@ -6,7 +6,7 @@ import crypto from 'crypto'
 import { configure } from '@testing-library/react'
 
 import { mswServer } from './test/mswServer'
-import './test/i18n'
+import '../../libs/journeys/ui/test/i18n'
 
 configure({ asyncUtilTimeout: 2500 })
 

--- a/apps/journeys-admin/src/components/JourneyList/ActiveJourneyList/ActivePriorityList/ActivePriorityList.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/ActiveJourneyList/ActivePriorityList/ActivePriorityList.spec.tsx
@@ -13,7 +13,7 @@ import {
   pendingActionJourney
 } from './ActiveJourneyListData'
 import { ActivePriorityList } from './ActivePriorityList'
-import '../../../../../test/i18n'
+import '../../../../../../../libs/journeys/ui/test/i18n'
 
 describe('ActivePriorityList', () => {
   it('should show journeyCard in default priority for owners', () => {

--- a/apps/journeys-admin/src/components/JourneyList/ActiveJourneyList/ActivePriorityList/ActivePriorityList.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/ActiveJourneyList/ActivePriorityList/ActivePriorityList.spec.tsx
@@ -13,7 +13,7 @@ import {
   pendingActionJourney
 } from './ActiveJourneyListData'
 import { ActivePriorityList } from './ActivePriorityList'
-import '../../../../../../../libs/journeys/ui/test/i18n'
+import '@core/journeys/ui/test/i18n'
 
 describe('ActivePriorityList', () => {
   it('should show journeyCard in default priority for owners', () => {

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCard.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCard.stories.tsx
@@ -22,7 +22,7 @@ import {
 import { JourneyCard } from './JourneyCard'
 import { JourneyCardVariant } from './journeyCardVariant'
 
-import '../../../../../../libs/journeys/ui/test/i18n'
+import '@core/journeys/ui/test/i18n'
 
 const TestStory: Meta<typeof JourneyCard> = {
   ...journeysAdminConfig,

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCard.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCard.stories.tsx
@@ -22,7 +22,7 @@ import {
 import { JourneyCard } from './JourneyCard'
 import { JourneyCardVariant } from './journeyCardVariant'
 
-import '../../../../test/i18n'
+import '../../../../../../libs/journeys/ui/test/i18n'
 
 const TestStory: Meta<typeof JourneyCard> = {
   ...journeysAdminConfig,

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardInfo/JourneyCardInfo.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardInfo/JourneyCardInfo.spec.tsx
@@ -11,7 +11,7 @@ import { publishedJourney } from '../../journeyListData'
 import { JourneyCardVariant } from '../journeyCardVariant'
 
 import { JourneyCardInfo } from '.'
-import '../../../../../test/i18n'
+import '../../../../../../../libs/journeys/ui/test/i18n'
 
 describe('JourneyCardInfo', () => {
   it('should show the langauge name', () => {

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardInfo/JourneyCardInfo.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardInfo/JourneyCardInfo.spec.tsx
@@ -11,7 +11,7 @@ import { publishedJourney } from '../../journeyListData'
 import { JourneyCardVariant } from '../journeyCardVariant'
 
 import { JourneyCardInfo } from '.'
-import '../../../../../../../libs/journeys/ui/test/i18n'
+import '@core/journeys/ui/test/i18n'
 
 describe('JourneyCardInfo', () => {
   it('should show the langauge name', () => {

--- a/apps/journeys-admin/src/components/JourneyVisitorsList/JourneyVisitorsList.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyVisitorsList/JourneyVisitorsList.stories.tsx
@@ -6,7 +6,7 @@ import { journeysAdminConfig } from '@core/shared/ui/storybook'
 import { VisitorStatus } from '../../../__generated__/globalTypes'
 
 import { JourneyVisitorsList } from '.'
-import '../../../test/i18n'
+import '../../../../../libs/journeys/ui/test/i18n'
 
 const JourneyVisitorsListStory: Meta<typeof JourneyVisitorsList> = {
   ...journeysAdminConfig,

--- a/apps/journeys-admin/src/components/JourneyVisitorsList/JourneyVisitorsList.stories.tsx
+++ b/apps/journeys-admin/src/components/JourneyVisitorsList/JourneyVisitorsList.stories.tsx
@@ -6,7 +6,7 @@ import { journeysAdminConfig } from '@core/shared/ui/storybook'
 import { VisitorStatus } from '../../../__generated__/globalTypes'
 
 import { JourneyVisitorsList } from '.'
-import '../../../../../libs/journeys/ui/test/i18n'
+import '@core/journeys/ui/test/i18n'
 
 const JourneyVisitorsListStory: Meta<typeof JourneyVisitorsList> = {
   ...journeysAdminConfig,

--- a/apps/journeys-admin/src/components/Team/TeamUpdateDialog/TeamUpdateDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamUpdateDialog/TeamUpdateDialog.spec.tsx
@@ -13,7 +13,7 @@ import {
 import { TEAM_UPDATE } from './TeamUpdateDialog'
 
 import { TeamUpdateDialog } from '.'
-import '../../../../../../libs/journeys/ui/test/i18n'
+import '@core/journeys/ui/test/i18n'
 
 describe('TeamUpdateDialog', () => {
   const getTeamsMock: MockedResponse<GetLastActiveTeamIdAndTeams> = {

--- a/apps/journeys-admin/src/components/Team/TeamUpdateDialog/TeamUpdateDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamUpdateDialog/TeamUpdateDialog.spec.tsx
@@ -13,7 +13,7 @@ import {
 import { TEAM_UPDATE } from './TeamUpdateDialog'
 
 import { TeamUpdateDialog } from '.'
-import '../../../../test/i18n'
+import '../../../../../../libs/journeys/ui/test/i18n'
 
 describe('TeamUpdateDialog', () => {
   const getTeamsMock: MockedResponse<GetLastActiveTeamIdAndTeams> = {

--- a/apps/journeys-admin/src/components/TemplateGallery/HeaderAndLanguageFilter/HeaderAndLanguageFilter.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/HeaderAndLanguageFilter/HeaderAndLanguageFilter.stories.tsx
@@ -3,7 +3,7 @@ import { screen, userEvent } from '@storybook/testing-library'
 import noop from 'lodash/noop'
 import { ComponentProps } from 'react'
 
-import '../../../../test/i18n'
+import '@core/journeys/ui/test/i18n'
 
 import { journeysAdminConfig } from '@core/shared/ui/storybook'
 

--- a/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateGallery/TemplateGallery.stories.tsx
@@ -13,7 +13,7 @@ import {
 
 import { TemplateGallery } from '.'
 
-import '../../../test/i18n'
+import '@core/journeys/ui/test/i18n'
 
 const TemplateGalleryStory: Meta<typeof TemplateGallery> = {
   ...journeysAdminConfig,

--- a/apps/journeys-admin/src/components/TemplateList/ActiveTemplateList/ActiveTemplateList.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateList/ActiveTemplateList/ActiveTemplateList.stories.tsx
@@ -17,7 +17,7 @@ import {
 
 import { ActiveTemplateList } from '.'
 
-import '../../../../test/i18n'
+import '../../../../../../libs/journeys/ui/test/i18n'
 
 const ActiveTemplateListStory: Meta<typeof ActiveTemplateList> = {
   component: ActiveTemplateList,

--- a/apps/journeys-admin/src/components/TemplateList/ActiveTemplateList/ActiveTemplateList.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateList/ActiveTemplateList/ActiveTemplateList.stories.tsx
@@ -17,7 +17,7 @@ import {
 
 import { ActiveTemplateList } from '.'
 
-import '../../../../../../libs/journeys/ui/test/i18n'
+import '@core/journeys/ui/test/i18n'
 
 const ActiveTemplateListStory: Meta<typeof ActiveTemplateList> = {
   component: ActiveTemplateList,

--- a/apps/journeys-admin/src/components/TemplateList/ArchivedTemplateList/ArchivedTemplateList.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateList/ArchivedTemplateList/ArchivedTemplateList.stories.tsx
@@ -17,7 +17,7 @@ import {
 
 import { ArchivedTemplateList } from '.'
 
-import '../../../../../../libs/journeys/ui/test/i18n'
+import '@core/journeys/ui/test/i18n'
 
 const ArchivedTemplatesStory: Meta<typeof ArchivedTemplateList> = {
   component: ArchivedTemplateList,

--- a/apps/journeys-admin/src/components/TemplateList/ArchivedTemplateList/ArchivedTemplateList.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateList/ArchivedTemplateList/ArchivedTemplateList.stories.tsx
@@ -17,7 +17,7 @@ import {
 
 import { ArchivedTemplateList } from '.'
 
-import '../../../../test/i18n'
+import '../../../../../../libs/journeys/ui/test/i18n'
 
 const ArchivedTemplatesStory: Meta<typeof ArchivedTemplateList> = {
   component: ArchivedTemplateList,

--- a/apps/journeys-admin/src/components/TemplateList/TemplateList.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateList/TemplateList.stories.tsx
@@ -14,7 +14,7 @@ import {
 } from './data'
 
 import { TemplateList } from '.'
-import '../../../test/i18n'
+import '../../../../../libs/journeys/ui/test/i18n'
 
 const TemplateListStory: Meta<typeof TemplateList> = {
   ...journeysAdminConfig,

--- a/apps/journeys-admin/src/components/TemplateList/TemplateList.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateList/TemplateList.stories.tsx
@@ -14,7 +14,7 @@ import {
 } from './data'
 
 import { TemplateList } from '.'
-import '../../../../../libs/journeys/ui/test/i18n'
+import '@core/journeys/ui/test/i18n'
 
 const TemplateListStory: Meta<typeof TemplateList> = {
   ...journeysAdminConfig,

--- a/apps/journeys-admin/src/components/TemplateList/TemplateListItem/TemplateListItem.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateList/TemplateListItem/TemplateListItem.stories.tsx
@@ -8,7 +8,7 @@ import { descriptiveTemplate } from '../data'
 
 import { TemplateListItem } from '.'
 
-import '../../../../../../libs/journeys/ui/test/i18n'
+import '@core/journeys/ui/test/i18n'
 
 const TemplateListItemStory: Meta<typeof TemplateListItem> = {
   ...journeysAdminConfig,

--- a/apps/journeys-admin/src/components/TemplateList/TemplateListItem/TemplateListItem.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateList/TemplateListItem/TemplateListItem.stories.tsx
@@ -8,7 +8,7 @@ import { descriptiveTemplate } from '../data'
 
 import { TemplateListItem } from '.'
 
-import '../../../../test/i18n'
+import '../../../../../../libs/journeys/ui/test/i18n'
 
 const TemplateListItemStory: Meta<typeof TemplateListItem> = {
   ...journeysAdminConfig,

--- a/apps/journeys-admin/src/components/TemplateList/TrashedTemplateList/TrashedTemplateList.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateList/TrashedTemplateList/TrashedTemplateList.stories.tsx
@@ -18,7 +18,7 @@ import {
 
 import { TrashedTemplateList } from '.'
 
-import '../../../../../../libs/journeys/ui/test/i18n'
+import '@core/journeys/ui/test/i18n'
 
 const TrashedTemplateListStory: Meta<typeof TrashedTemplateList> = {
   component: TrashedTemplateList,

--- a/apps/journeys-admin/src/components/TemplateList/TrashedTemplateList/TrashedTemplateList.stories.tsx
+++ b/apps/journeys-admin/src/components/TemplateList/TrashedTemplateList/TrashedTemplateList.stories.tsx
@@ -18,7 +18,7 @@ import {
 
 import { TrashedTemplateList } from '.'
 
-import '../../../../test/i18n'
+import '../../../../../../libs/journeys/ui/test/i18n'
 
 const TrashedTemplateListStory: Meta<typeof TrashedTemplateList> = {
   component: TrashedTemplateList,

--- a/apps/journeys-admin/src/components/VisitorInfo/VisitorJourneysList/EventsCard/EventsCard.spec.tsx
+++ b/apps/journeys-admin/src/components/VisitorInfo/VisitorJourneysList/EventsCard/EventsCard.spec.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render } from '@testing-library/react'
 import { journey } from '../utils/data'
 
 import { EventsCard } from '.'
-import '../../../../../../../libs/journeys/ui/test/i18n'
+import '@core/journeys/ui/test/i18n'
 
 describe('EventsCard', () => {
   it('should show card header', () => {

--- a/apps/journeys-admin/src/components/VisitorInfo/VisitorJourneysList/EventsCard/EventsCard.spec.tsx
+++ b/apps/journeys-admin/src/components/VisitorInfo/VisitorJourneysList/EventsCard/EventsCard.spec.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render } from '@testing-library/react'
 import { journey } from '../utils/data'
 
 import { EventsCard } from '.'
-import '../../../../../test/i18n'
+import '../../../../../../../libs/journeys/ui/test/i18n'
 
 describe('EventsCard', () => {
   it('should show card header', () => {

--- a/apps/journeys-admin/src/components/VisitorInfo/VisitorJourneysList/EventsCard/EventsCard.stories.tsx
+++ b/apps/journeys-admin/src/components/VisitorInfo/VisitorJourneysList/EventsCard/EventsCard.stories.tsx
@@ -7,7 +7,7 @@ import { journey } from '../utils/data'
 
 import { EventsCard } from '.'
 
-import '../../../../../../../libs/journeys/ui/test/i18n'
+import '@core/journeys/ui/test/i18n'
 
 const EventsCardStory: Meta<typeof EventsCard> = {
   ...journeysAdminConfig,

--- a/apps/journeys-admin/src/components/VisitorInfo/VisitorJourneysList/EventsCard/EventsCard.stories.tsx
+++ b/apps/journeys-admin/src/components/VisitorInfo/VisitorJourneysList/EventsCard/EventsCard.stories.tsx
@@ -7,7 +7,7 @@ import { journey } from '../utils/data'
 
 import { EventsCard } from '.'
 
-import '../../../../../test/i18n'
+import '../../../../../../../libs/journeys/ui/test/i18n'
 
 const EventsCardStory: Meta<typeof EventsCard> = {
   ...journeysAdminConfig,

--- a/apps/journeys-admin/src/components/VisitorInfo/VisitorJourneysList/EventsCard/TimelineEvent/TimelineEvent.spec.tsx
+++ b/apps/journeys-admin/src/components/VisitorInfo/VisitorJourneysList/EventsCard/TimelineEvent/TimelineEvent.spec.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../utils/data'
 
 import { TimelineEvent } from '.'
-import '../../../../../../../../libs/journeys/ui/test/i18n'
+import '@core/journeys/ui/test/i18n'
 
 describe('TimelineEvent', () => {
   it('shows journeyViewEvent', () => {

--- a/apps/journeys-admin/src/components/VisitorInfo/VisitorJourneysList/EventsCard/TimelineEvent/TimelineEvent.spec.tsx
+++ b/apps/journeys-admin/src/components/VisitorInfo/VisitorJourneysList/EventsCard/TimelineEvent/TimelineEvent.spec.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../utils/data'
 
 import { TimelineEvent } from '.'
-import '../../../../../../test/i18n'
+import '../../../../../../../../libs/journeys/ui/test/i18n'
 
 describe('TimelineEvent', () => {
   it('shows journeyViewEvent', () => {

--- a/apps/journeys-admin/src/components/VisitorInfo/VisitorJourneysList/EventsCard/TimelineEvent/TimelineEvent.stories.tsx
+++ b/apps/journeys-admin/src/components/VisitorInfo/VisitorJourneysList/EventsCard/TimelineEvent/TimelineEvent.stories.tsx
@@ -3,7 +3,7 @@ import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { Meta, StoryObj } from '@storybook/react'
 import { ReactElement } from 'react'
-import '../../../../../../../../libs/journeys/ui/test/i18n'
+import '@core/journeys/ui/test/i18n'
 
 import { journeysAdminConfig } from '@core/shared/ui/storybook'
 

--- a/apps/journeys-admin/src/components/VisitorInfo/VisitorJourneysList/EventsCard/TimelineEvent/TimelineEvent.stories.tsx
+++ b/apps/journeys-admin/src/components/VisitorInfo/VisitorJourneysList/EventsCard/TimelineEvent/TimelineEvent.stories.tsx
@@ -3,7 +3,7 @@ import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { Meta, StoryObj } from '@storybook/react'
 import { ReactElement } from 'react'
-import '../../../../../../test/i18n'
+import '../../../../../../../../libs/journeys/ui/test/i18n'
 
 import { journeysAdminConfig } from '@core/shared/ui/storybook'
 

--- a/libs/journeys/ui/test/i18n.ts
+++ b/libs/journeys/ui/test/i18n.ts
@@ -3,7 +3,7 @@ import i18next, { use } from 'i18next'
 import { initReactI18next } from 'react-i18next'
 
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import appJourneysAdminTranslations from '../../../libs/locales/en/apps-journeys-admin.json'
+import appJourneysAdminTranslations from '../../../locales/en/apps-journeys-admin.json'
 
 void use(initReactI18next).init({
   fallbackLng: 'en',

--- a/libs/journeys/ui/tsconfig.json
+++ b/libs/journeys/ui/tsconfig.json
@@ -5,6 +5,7 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
     "strict": true,
     "noFallthroughCasesInSwitch": true
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,6 +21,7 @@
         "libs/journeys/ui/src/components/*",
         "libs/journeys/ui/src/libs/*"
       ],
+      "@core/journeys/ui/test/*": ["libs/journeys/ui/test/*"],
       "@core/nest/common/*": ["libs/nest/common/src/lib/*"],
       "@core/nest/decorators/*": ["libs/nest/decorators/src/lib/*"],
       "@core/nest/gqlAuthGuard/*": ["libs/nest/gqlAuthGuard/src/lib/*"],


### PR DESCRIPTION
# Description

### Issue

Components needed for the resources hub need refactored out into the shared space to be used by both journeys-admin and watch. 

We need to refactor out i18next query because it is needed by many stories and spec files which will be refactored out in a future PR.

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37663178/todos/7452920587)

### Solution

This PR refactors the i18next function into the journeys/ui/ space. 

# External Changes

n/a

# Additional information

Big-bang discovery branch is here https://github.com/JesusFilm/core/pull/2810.

## How To Test
There should be no behavioural impact so ensure application still performs as expected. These components are currently only being used in journeys-admin so regression test as appropriate.
One should be able to use the i18n function in another project.
