### PR TITLE
fix: access item check url

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/AccessItem/AccessItem.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/AccessItem/AccessItem.tsx
@@ -1,7 +1,7 @@
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
-import { ComponentProps, ReactElement, useState } from 'react'
+import { ComponentProps, ReactElement, useEffect, useState } from 'react'
 
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import UsersProfiles2Icon from '@core/shared/ui/icons/UsersProfiles2'
@@ -52,6 +52,18 @@ export function AccessItem({
   function handleClose(): void {
     setAccessDialogOpen(false)
   }
+
+  useEffect(() => {
+    const manageAccessQuery = router.query.manageAccess as string
+    if (manageAccessQuery === 'true') {
+      setAccessDialogOpen(true)
+      void router.replace(
+        { query: { ...router.query, manageAccess: undefined } },
+        undefined,
+        { shallow: true }
+      )
+    }
+  }, [router])
 
   return (
     <>


### PR DESCRIPTION
# Description

### Issue

Users need the ability to unsubscribe from getting email events notifications

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

Add a URL check to see if manageAccess is true within the URL param, if it is we open the accessItem dialog. This should only occur once or from the email unsubscribe button click
