### PR TITLE
fix: chat button not crashing on click

### DIFF
--- a/apps/api-journeys/src/app/modules/event/event.service.ts
+++ b/apps/api-journeys/src/app/modules/event/event.service.ts
@@ -68,10 +68,8 @@ export class EventService {
 
   @FromPostgresql()
   async save<T>(input: Prisma.EventCreateInput): Promise<T> {
-    return (await this.prismaService.event.upsert({
-      where: { id: input.id },
-      update: { ...input },
-      create: input
+    return (await this.prismaService.event.create({
+      data: input
     })) as unknown as T
   }
 }

--- a/apps/api-journeys/src/app/modules/event/event.service.ts
+++ b/apps/api-journeys/src/app/modules/event/event.service.ts
@@ -69,8 +69,8 @@ export class EventService {
   @FromPostgresql()
   async save<T>(input: Prisma.EventCreateInput): Promise<T> {
     return (await this.prismaService.event.upsert({
-      where: { id: input.id},
-      update: { ...input}, 
+      where: { id: input.id },
+      update: { ...input },
       create: input
     })) as unknown as T
   }

--- a/apps/api-journeys/src/app/modules/event/event.service.ts
+++ b/apps/api-journeys/src/app/modules/event/event.service.ts
@@ -68,8 +68,10 @@ export class EventService {
 
   @FromPostgresql()
   async save<T>(input: Prisma.EventCreateInput): Promise<T> {
-    return (await this.prismaService.event.create({
-      data: input
+    return (await this.prismaService.event.upsert({
+      where: { id: input.id},
+      update: { ...input}, 
+      create: input
     })) as unknown as T
   }
 }

--- a/biome.json
+++ b/biome.json
@@ -33,7 +33,7 @@
         "useMediaCaption": "info"
       },
       "complexity": {
-        "noForEach": "warn",
+        "noForEach": "off",
         "noUselessFragments": "info",
         "noUselessSwitchCase": "info",
         "useArrowFunction": "info",

--- a/libs/journeys/ui/src/components/StepFooter/ChatButtons/ChatButtons.spec.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/ChatButtons/ChatButtons.spec.tsx
@@ -98,7 +98,6 @@ describe('ChatButtons', () => {
         query: CHAT_BUTTON_EVENT_CREATE,
         variables: {
           input: {
-            id: chatButtons[0]?.id,
             blockId: stepBlock?.id,
             stepId: stepBlock?.id,
             value: chatButtons[0].platform

--- a/libs/journeys/ui/src/components/StepFooter/ChatButtons/ChatButtons.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/ChatButtons/ChatButtons.tsx
@@ -71,7 +71,6 @@ export function ChatButtons(): ReactElement {
       void chatButtonEventCreate({
         variables: {
           input: {
-            id: chatButton?.id,
             blockId: activeBlock?.id,
             stepId: activeBlock?.id,
             value: chatButton?.platform


### PR DESCRIPTION
# Description

### Issue

Clicking on chat button crashes admin-stage or pretty much the api-journeys server. This is happening because it's trying to create a event but the ID for that event already exists

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

Use upsert instead of create to support cases when the event already exists