### PR TITLE
fix: remove header divider on watch

### DIFF
--- a/apps/watch/src/components/Header/Header.tsx
+++ b/apps/watch/src/components/Header/Header.tsx
@@ -17,6 +17,7 @@ import { MouseEventHandler, ReactElement, forwardRef, useState } from 'react'
 import { ThemeProvider } from '@core/shared/ui/ThemeProvider'
 import { ThemeMode, ThemeName } from '@core/shared/ui/themes'
 
+import { light } from '@mui/material/styles/createPalette'
 import { HeaderMenuPanel } from './HeaderMenuPanel'
 import { HeaderTabButtons } from './HeaderTabButtons'
 import minimalLogo from './assets/minimal-logo.png'
@@ -122,6 +123,8 @@ export function Header({
   const trigger = useScrollTrigger()
   const [drawerOpen, setDrawerOpen] = useState(false)
 
+  const lightTheme = themeMode === ThemeMode.light
+
   return (
     <>
       {hideSpacer !== true && <Box data-testid="HeaderSpacer" height={128} />}
@@ -141,7 +144,7 @@ export function Header({
               background: 'transparent',
               boxShadow: 'none'
             }}
-            showDivider
+            showDivider={lightTheme}
             onMenuClick={() => setDrawerOpen(true)}
           />
         </Fade>

--- a/apps/watch/src/components/Header/Header.tsx
+++ b/apps/watch/src/components/Header/Header.tsx
@@ -17,7 +17,6 @@ import { MouseEventHandler, ReactElement, forwardRef, useState } from 'react'
 import { ThemeProvider } from '@core/shared/ui/ThemeProvider'
 import { ThemeMode, ThemeName } from '@core/shared/ui/themes'
 
-import { light } from '@mui/material/styles/createPalette'
 import { HeaderMenuPanel } from './HeaderMenuPanel'
 import { HeaderTabButtons } from './HeaderTabButtons'
 import minimalLogo from './assets/minimal-logo.png'

--- a/apps/watch/src/components/Header/Header.tsx
+++ b/apps/watch/src/components/Header/Header.tsx
@@ -122,8 +122,6 @@ export function Header({
   const trigger = useScrollTrigger()
   const [drawerOpen, setDrawerOpen] = useState(false)
 
-  const lightTheme = themeMode === ThemeMode.light
-
   return (
     <>
       {hideSpacer !== true && <Box data-testid="HeaderSpacer" height={128} />}
@@ -143,7 +141,7 @@ export function Header({
               background: 'transparent',
               boxShadow: 'none'
             }}
-            showDivider={lightTheme}
+            showDivider={themeMode === ThemeMode.light}
             onMenuClick={() => setDrawerOpen(true)}
           />
         </Fade>


### PR DESCRIPTION
# Description

### Issue

Header divider line was showing up on watch page, which meant there was a line going through the background content

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37663178/todos/7439735805)

### Solution

Added a check to only show divider on light theme


