### PR TITLE
fix: plausible resolver fragments

### DIFF
--- a/apps/api-journeys/src/app/modules/journey/journey.module.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.module.ts
@@ -8,7 +8,6 @@ import { DateTimeScalar } from '../../lib/dateTime/dateTime.provider'
 import { PrismaService } from '../../lib/prisma.service'
 import { BlockService } from '../block/block.service'
 import { ChatButtonResolver } from '../chatButton/chatButton.resolver'
-import { PlausibleService } from '../plausible/plausible.service'
 
 import { JourneyResolver } from './journey.resolver'
 
@@ -22,8 +21,7 @@ import { JourneyResolver } from './journey.resolver'
     BlockService,
     DateTimeScalar,
     ChatButtonResolver,
-    PrismaService,
-    PlausibleService
+    PrismaService
   ]
 })
 export class JourneyModule {}

--- a/apps/api-journeys/src/app/modules/plausible/plausible.module.ts
+++ b/apps/api-journeys/src/app/modules/plausible/plausible.module.ts
@@ -6,7 +6,6 @@ import { CaslAuthModule } from '@core/nest/common/CaslAuthModule'
 import { AppCaslFactory } from '../../lib/casl/caslFactory'
 import { PrismaService } from '../../lib/prisma.service'
 
-import { PlausibleConsumer } from './plausible.consumer'
 import { PlausibleResolver } from './plausible.resolver'
 import { PlausibleService } from './plausible.service'
 
@@ -15,11 +14,6 @@ import { PlausibleService } from './plausible.service'
     CaslAuthModule.register(AppCaslFactory),
     BullModule.registerQueue({ name: 'api-journeys-plausible' })
   ],
-  providers: [
-    PlausibleResolver,
-    PlausibleService,
-    PrismaService
-    // PlausibleConsumer
-  ]
+  providers: [PlausibleResolver, PlausibleService, PrismaService]
 })
 export class PlausibleModule {}

--- a/apps/api-journeys/src/app/modules/plausible/plausible.module.ts
+++ b/apps/api-journeys/src/app/modules/plausible/plausible.module.ts
@@ -18,8 +18,8 @@ import { PlausibleService } from './plausible.service'
   providers: [
     PlausibleResolver,
     PlausibleService,
-    PrismaService,
-    PlausibleConsumer
+    PrismaService
+    // PlausibleConsumer
   ]
 })
 export class PlausibleModule {}

--- a/apps/api-journeys/src/app/modules/plausible/plausible.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/plausible/plausible.resolver.spec.ts
@@ -22,6 +22,7 @@ import {
 import { AppAbility, AppCaslFactory } from '../../lib/casl/caslFactory'
 import { PrismaService } from '../../lib/prisma.service'
 
+import { GraphQLResolveInfo, Kind } from 'graphql'
 import { PlausibleResolver } from './plausible.resolver'
 import { PlausibleService } from './plausible.service'
 
@@ -170,7 +171,7 @@ describe('PlausibleResolver', () => {
   })
 
   describe('journeysPlausibleStatsAggregate', () => {
-    it('should return aggregate stats', async () => {
+    it('should return aggregate stats for field', async () => {
       prismaService.journey.findUnique.mockResolvedValue(journeyWithUserTeam)
       const mockAggregateValue: PlausibleStatsAggregateValue = {
         __typename: 'PlausibleStatsAggregateValue',
@@ -195,13 +196,139 @@ describe('PlausibleResolver', () => {
             selectionSet: {
               selections: [
                 {
-                  name: { value: '' }
+                  kind: Kind.FIELD,
+                  name: { value: 'events' }
+                },
+                {
+                  kind: Kind.FIELD,
+                  name: { value: 'property' }
+                },
+                {
+                  kind: Kind.FIELD,
+                  name: { value: '__typename' }
                 }
               ]
             }
           }
         ]
+      } as unknown as GraphQLResolveInfo
+      const where: PlausibleStatsAggregateFilter = {}
+
+      const actual = await resolver.journeysPlausibleStatsAggregate(
+        ability,
+        'id',
+        IdType.slug,
+        info,
+        where
+      )
+
+      expect(plausibleService.getStatsAggregate).toHaveBeenCalledWith(
+        journey.id,
+        'journey',
+        {
+          metrics: 'events'
+        }
+      )
+      expect(actual).toEqual(result)
+    })
+    it('should return aggregate stats for fragment spread', async () => {
+      prismaService.journey.findUnique.mockResolvedValue(journeyWithUserTeam)
+      const mockAggregateValue: PlausibleStatsAggregateValue = {
+        __typename: 'PlausibleStatsAggregateValue',
+        value: 5
       }
+      const result: PlausibleStatsAggregateResponse = {
+        __typename: 'PlausibleStatsAggregateResponse',
+        visitors: mockAggregateValue,
+        visits: mockAggregateValue,
+        pageviews: mockAggregateValue,
+        viewsPerVisit: mockAggregateValue,
+        bounceRate: mockAggregateValue,
+        visitDuration: mockAggregateValue,
+        events: mockAggregateValue,
+        conversionRate: mockAggregateValue,
+        timeOnPage: mockAggregateValue
+      }
+      plausibleService.getStatsAggregate.mockResolvedValue(result)
+      const info = {
+        fieldNodes: [
+          {
+            selectionSet: {
+              selections: [
+                {
+                  kind: Kind.FRAGMENT_SPREAD,
+                  name: { value: 'fragmentSpread' }
+                }
+              ]
+            }
+          }
+        ],
+        fragments: {
+          fragmentSpread: {
+            selectionSet: {
+              selections: [
+                {
+                  kind: Kind.FIELD,
+                  name: { value: 'visits' }
+                }
+              ]
+            }
+          }
+        }
+      } as unknown as GraphQLResolveInfo
+      const where: PlausibleStatsAggregateFilter = {}
+
+      const actual = await resolver.journeysPlausibleStatsAggregate(
+        ability,
+        'id',
+        IdType.slug,
+        info,
+        where
+      )
+
+      expect(plausibleService.getStatsAggregate).toHaveBeenCalledWith(
+        journey.id,
+        'journey',
+        {
+          metrics: 'visits'
+        }
+      )
+      expect(actual).toEqual(result)
+    })
+
+    it('should return aggregate stats for inline fragment', async () => {
+      prismaService.journey.findUnique.mockResolvedValue(journeyWithUserTeam)
+      const mockAggregateValue: PlausibleStatsAggregateValue = {
+        __typename: 'PlausibleStatsAggregateValue',
+        value: 5
+      }
+      const result: PlausibleStatsAggregateResponse = {
+        __typename: 'PlausibleStatsAggregateResponse',
+        visitors: mockAggregateValue,
+        visits: mockAggregateValue,
+        pageviews: mockAggregateValue,
+        viewsPerVisit: mockAggregateValue,
+        bounceRate: mockAggregateValue,
+        visitDuration: mockAggregateValue,
+        events: mockAggregateValue,
+        conversionRate: mockAggregateValue,
+        timeOnPage: mockAggregateValue
+      }
+      plausibleService.getStatsAggregate.mockResolvedValue(result)
+      const info = {
+        fieldNodes: [
+          {
+            selectionSet: {
+              selections: [
+                {
+                  kind: Kind.INLINE_FRAGMENT,
+                  name: { value: 'inlineFragment' }
+                }
+              ]
+            }
+          }
+        ]
+      } as unknown as GraphQLResolveInfo
       const where: PlausibleStatsAggregateFilter = {}
 
       const actual = await resolver.journeysPlausibleStatsAggregate(
@@ -248,13 +375,14 @@ describe('PlausibleResolver', () => {
             selectionSet: {
               selections: [
                 {
+                  kind: Kind.FIELD,
                   name: { value: 'events' }
                 }
               ]
             }
           }
         ]
-      }
+      } as unknown as GraphQLResolveInfo
       const where: PlausibleStatsBreakdownFilter = {
         property: 'property'
       }
@@ -304,13 +432,14 @@ describe('PlausibleResolver', () => {
             selectionSet: {
               selections: [
                 {
-                  name: { value: '' }
+                  kind: Kind.FIELD,
+                  name: { value: 'property' }
                 }
               ]
             }
           }
         ]
-      }
+      } as unknown as GraphQLResolveInfo
       const where: PlausibleStatsTimeseriesFilter = {}
 
       const actual = await resolver.journeysPlausibleStatsTimeseries(

--- a/apps/api-journeys/src/app/modules/plausible/plausible.resolver.ts
+++ b/apps/api-journeys/src/app/modules/plausible/plausible.resolver.ts
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability'
 import { UseGuards } from '@nestjs/common'
 import { Args, Info, Query, Resolver } from '@nestjs/graphql'
-import { GraphQLError } from 'graphql'
+import { GraphQLError, GraphQLResolveInfo, Kind, SelectionNode } from 'graphql'
 import pull from 'lodash/pull'
 import snakeCase from 'lodash/snakeCase'
 
@@ -50,7 +50,7 @@ export class PlausibleResolver {
     @CaslAbility() ability: AppAbility,
     @Args('id') id: string,
     @Args('idType') idType: IdType = IdType.slug,
-    @Info() info,
+    @Info() info: GraphQLResolveInfo,
     @Args('where') where: PlausibleStatsAggregateFilter
   ): Promise<PlausibleStatsAggregateResponse> {
     const journey = await this.loadJourney(ability, id, idType)
@@ -69,7 +69,7 @@ export class PlausibleResolver {
     @CaslAbility() ability: AppAbility,
     @Args('id') id: string,
     @Args('idType') idType: IdType = IdType.slug,
-    @Info() info,
+    @Info() info: GraphQLResolveInfo,
     @Args('where') where: PlausibleStatsBreakdownFilter
   ): Promise<PlausibleStatsResponse[]> {
     const journey = await this.loadJourney(ability, id, idType)
@@ -88,7 +88,7 @@ export class PlausibleResolver {
     @CaslAbility() ability: AppAbility,
     @Args('id') id: string,
     @Args('idType') idType: IdType = IdType.slug,
-    @Info() info,
+    @Info() info: GraphQLResolveInfo,
     @Args('where') where: PlausibleStatsTimeseriesFilter
   ): Promise<PlausibleStatsResponse[]> {
     const journey = await this.loadJourney(ability, id, idType)
@@ -101,16 +101,35 @@ export class PlausibleResolver {
     return result
   }
 
-  private getMetrics(info): string {
+  private getMetrics(info: GraphQLResolveInfo): string {
     const metrics = pull(
-      info.fieldNodes[0].selectionSet.selections.map((item) =>
-        snakeCase(item.name.value as string)
-      ) as string[],
+      this.getFieldNames(
+        info,
+        info.fieldNodes[0].selectionSet?.selections ?? []
+      ),
       'property',
-      'typename',
-      'plausible_journey_referrer_fields'
+      'typename'
     ).join(',')
     return metrics === '' ? 'visitors' : metrics
+  }
+
+  private getFieldNames(
+    info: GraphQLResolveInfo,
+    selections: readonly SelectionNode[]
+  ): string[] {
+    return selections.flatMap((item) => {
+      switch (item.kind) {
+        case Kind.FIELD:
+          return snakeCase(item.name.value)
+        case Kind.FRAGMENT_SPREAD:
+          return this.getFieldNames(
+            info,
+            info.fragments[item.name.value].selectionSet.selections
+          )
+        default:
+          return ''
+      }
+    })
   }
 
   private async loadJourney(


### PR DESCRIPTION
# Description

### Issue

plausible resolver get metrics only handled the case if info is type `field`

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

- getMetrics also handle types `fragment spread` and `inline fragment`
- Remove some redundant module dependencies

# External Changes
n/a

# Additional information
n/a
