### PR TITLE
feat: express settings subscribe to journey updates

### DIFF
--- a/apps/journeys-admin/pages/templates/[journeyId]/quick.tsx
+++ b/apps/journeys-admin/pages/templates/[journeyId]/quick.tsx
@@ -1,16 +1,20 @@
+import { gql } from '@apollo/client'
 import { AuthAction, withUser, withUserTokenSSR } from 'next-firebase-auth'
+import { useRouter } from 'next/router'
 import { ReactElement, useEffect } from 'react'
 
-import { gql } from '@apollo/client'
-import { useRouter } from 'next/router'
 import { GetTeams } from '../../../__generated__/GetTeams'
 import {
   JourneyDuplicate,
   JourneyDuplicateVariables
 } from '../../../__generated__/JourneyDuplicate'
-import { UserTeamRole } from '../../../__generated__/globalTypes'
+import {
+  JourneyNotificationUpdate,
+  JourneyNotificationUpdateVariables
+} from '../../../__generated__/JourneyNotificationUpdate'
 import { initAndAuthApp } from '../../../src/libs/initAndAuthApp'
 import { JOURNEY_DUPLICATE } from '../../../src/libs/useJourneyDuplicateMutation'
+import { JOURNEY_NOTIFICATION_UPDATE } from '../../../src/libs/useJourneyNotificationUpdate/useJourneyNotificationUpdate'
 
 export const GET_TEAMS = gql`
   query GetTeams {
@@ -57,6 +61,18 @@ export const getServerSideProps = withUserTokenSSR({
       }
     })
     if (journeyDuplicate?.journeyDuplicate.id) {
+      await apolloClient.mutate<
+        JourneyNotificationUpdate,
+        JourneyNotificationUpdateVariables
+      >({
+        mutation: JOURNEY_NOTIFICATION_UPDATE,
+        variables: {
+          input: {
+            journeyId: journeyDuplicate.journeyDuplicate.id,
+            visitorInteractionEmail: true
+          }
+        }
+      })
       return {
         redirect: {
           destination: `/journeys/${journeyDuplicate.journeyDuplicate.id}/quick`,


### PR DESCRIPTION
# Description

### Issue

When a  journey is duplicated using 'quick', the user is not opted in for journey email updates.

Opt in for journey email updates after journey is duplicated on the `templates/:id/quick` page.