### PR TITLE
fix: static date

### DIFF
--- a/apps/api-journeys/src/app/emails/stories/VisitorInteraction.stories.tsx
+++ b/apps/api-journeys/src/app/emails/stories/VisitorInteraction.stories.tsx
@@ -56,7 +56,7 @@ export const Default = {
   args: {
     title: 'Journey Title',
     visitor: {
-      createdAt: new Date(),
+      createdAt: new Date('2024-05-27T23:39:28.000Z'),
       duration: 10,
       events: [
         {


### PR DESCRIPTION
# Description

### Issue

New date in storybook causing to stories to be regenerated

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

Make date static
