### PR TITLE
fix: watch film link

### DIFF
--- a/apps/watch/src/components/VideoContentPage/VideoHeading/VideoHeading.spec.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHeading/VideoHeading.spec.tsx
@@ -22,11 +22,11 @@ describe('VideoHeading', () => {
     )
     expect(getByRole('link', { name: 'JESUS' })).toHaveAttribute(
       'href',
-      `/jesus/english`
+      '/watch/jesus/english'
     )
     expect(getByRole('link', { name: 'Watch Full Film' })).toHaveAttribute(
       'href',
-      `/jesus/english`
+      '/watch/jesus/english'
     )
   })
 
@@ -46,13 +46,13 @@ describe('VideoHeading', () => {
     await waitFor(() =>
       expect(getByRole('link', { name: 'LUMO' })).toHaveAttribute(
         'href',
-        `/lumo/english`
+        '/watch/lumo/english'
       )
     )
 
     expect(getByRole('link', { name: 'See All' })).toHaveAttribute(
       'href',
-      `/lumo/english`
+      '/watch/lumo/english'
     )
   })
 

--- a/apps/watch/src/components/VideoContentPage/VideoHeading/VideoHeading.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHeading/VideoHeading.tsx
@@ -74,7 +74,7 @@ export function VideoHeading({
             >
               <Stack direction="row" alignItems="center" spacing={2}>
                 <NextLink
-                  href={`/${container.variant?.slug as string}`}
+                  href={`/watch/${container.variant?.slug as string}`}
                   passHref
                   legacyBehavior
                 >
@@ -111,7 +111,7 @@ export function VideoHeading({
                 </Typography>
               </Stack>
               <NextLink
-                href={`/${container.variant?.slug as string}`}
+                href={`/watch/${container.variant?.slug as string}`}
                 passHref
                 legacyBehavior
               >


### PR DESCRIPTION
# Description

### Issue

Next links on the sub page of watch a film were leading to 404.

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37663057/todos/7540358832)

### Solution

Prepend links with /watch

# External Changes

n/a

# Additional information

n/a
