### PR TITLE
feat: canvas footer analytics

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/Canvas.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/Canvas.tsx
@@ -22,6 +22,7 @@ import { setBeaconPageViewed } from '../../../../../libs/setBeaconPageViewed'
 import { FramePortal } from '../../../../FramePortal'
 import { Fab } from '../../../Fab'
 
+import { FooterAnalytics } from './CardAnalytics'
 import { CardWrapper } from './CardWrapper'
 import { FormWrapper } from './FormWrapper'
 import { InlineEditWrapper } from './InlineEditWrapper'
@@ -295,17 +296,26 @@ export function Canvas(): ReactElement {
                 </ThemeProvider>
               </FramePortal>
             </Box>
-            {showAnalytics !== true && (
-              <Box
-                sx={{
-                  mt: 4,
-                  alignSelf: 'end',
-                  transform: `scale(${scale})`
-                }}
-              >
-                <Fab variant="canvas" />
-              </Box>
-            )}
+            <Box
+              sx={{
+                mt: 4,
+                display: 'flex',
+                height: 48
+              }}
+            >
+              {showAnalytics ? (
+                <FooterAnalytics />
+              ) : (
+                <Box
+                  sx={{
+                    ml: 'auto',
+                    transform: `scale(${scale})`
+                  }}
+                >
+                  <Fab variant="canvas" />
+                </Box>
+              )}
+            </Box>
           </Box>
         </Stack>
       )}

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/CardAnalytics/FooterAnalytics.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/CardAnalytics/FooterAnalytics.spec.tsx
@@ -1,0 +1,44 @@
+import { EditorProvider } from '@core/journeys/ui/EditorProvider'
+import { TreeBlock } from '@core/journeys/ui/block'
+import { BlockFields_StepBlock } from '@core/journeys/ui/block/__generated__/BlockFields'
+import { JourneyAnalytics } from '@core/journeys/ui/useJourneyAnalyticsQuery'
+import { render, screen } from '@testing-library/react'
+import { FooterAnalytics } from '.'
+
+describe('FooterAnalytics', () => {
+  it('should render', () => {
+    const initialState = {
+      selectedStep: {
+        id: 'step1.id'
+      } as unknown as TreeBlock<BlockFields_StepBlock>,
+      showAnalytics: true,
+      analytics: {
+        stepMap: new Map([
+          [
+            'step1.id',
+            {
+              eventMap: new Map([
+                ['footerThumbsUpButtonClick', 10],
+                ['footerThumbsDownButtonClick', 2],
+                ['footerChatButtonClick', 5]
+              ])
+            }
+          ]
+        ])
+      } as unknown as JourneyAnalytics
+    }
+
+    render(
+      <EditorProvider initialState={initialState}>
+        <FooterAnalytics />
+      </EditorProvider>
+    )
+
+    expect(screen.getByTestId('ThumbsUpIcon')).toBeInTheDocument()
+    expect(screen.getByText('10')).toBeInTheDocument()
+    expect(screen.getByTestId('ThumbsDownIcon')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+    expect(screen.getByTestId('FacebookIcon')).toBeInTheDocument()
+    expect(screen.getByText('5')).toBeInTheDocument()
+  })
+})

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/CardAnalytics/FooterAnalytics.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/CardAnalytics/FooterAnalytics.stories.tsx
@@ -1,0 +1,47 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { FooterAnalytics } from '.'
+
+import { EditorProvider } from '@core/journeys/ui/EditorProvider'
+import { simpleComponentConfig } from '../../../../../../libs/storybook'
+
+const Demo: Meta<typeof FooterAnalytics> = {
+  ...simpleComponentConfig,
+  component: FooterAnalytics,
+  title: 'Journeys-Admin/Editor/Slider/Content/Canvas/FooterAnalytics'
+}
+
+const Template: StoryObj<typeof FooterAnalytics> = {
+  render: (args) => (
+    <EditorProvider initialState={args.initialState}>
+      <FooterAnalytics />
+    </EditorProvider>
+  )
+}
+
+export const Default = {
+  ...Template,
+  args: {
+    initialState: {
+      selectedStep: {
+        id: 'step1.id'
+      },
+      showAnalytics: true,
+      analytics: {
+        stepMap: new Map([
+          [
+            'step1.id',
+            {
+              eventMap: new Map([
+                ['footerThumbsUpButtonClick', 10],
+                ['footerThumbsDownButtonClick', 2],
+                ['footerChatButtonClick', 5]
+              ])
+            }
+          ]
+        ])
+      }
+    }
+  }
+}
+
+export default Demo

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/CardAnalytics/FooterAnalytics.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/CardAnalytics/FooterAnalytics.tsx
@@ -1,0 +1,78 @@
+import { useEditor } from '@core/journeys/ui/EditorProvider'
+import Facebook from '@core/shared/ui/icons/Facebook'
+import ThumbsDown from '@core/shared/ui/icons/ThumbsDown'
+import ThumbsUp from '@core/shared/ui/icons/ThumbsUp'
+import { Fade, Tooltip } from '@mui/material'
+import Divider from '@mui/material/Divider'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+
+function DataPoint({ value, Icon, tooltipTitle }) {
+  return (
+    <Tooltip
+      title={tooltipTitle}
+      placement="bottom"
+      slotProps={{
+        popper: {
+          modifiers: [
+            {
+              name: 'offset',
+              options: {
+                offset: [0, -8]
+              }
+            }
+          ]
+        }
+      }}
+    >
+      <Stack
+        direction="row"
+        spacing={3}
+        sx={{
+          px: 4,
+          flex: 1,
+          height: 48,
+          justifyContent: 'center',
+          alignItems: 'center'
+        }}
+      >
+        {Icon}
+        <Typography variant="subtitle1">{value}</Typography>
+      </Stack>
+    </Tooltip>
+  )
+}
+
+export function FooterAnalytics(props) {
+  const {
+    state: { selectedStep, showAnalytics, analytics }
+  } = useEditor()
+
+  const eventMap = analytics?.stepMap.get(selectedStep?.id ?? '')?.eventMap
+
+  return (
+    <Fade in={showAnalytics}>
+      <Stack
+        direction="row"
+        divider={<Divider orientation="vertical" flexItem />}
+        sx={{ flex: 1 }}
+      >
+        <DataPoint
+          Icon={<ThumbsUp />}
+          value={eventMap?.get('footerThumbsUpButtonClick') ?? 0}
+          tooltipTitle="Likes"
+        />
+        <DataPoint
+          Icon={<ThumbsDown />}
+          value={eventMap?.get('footerThumbsDownButtonClick') ?? 0}
+          tooltipTitle="Dislikes"
+        />
+        <DataPoint
+          Icon={<Facebook />}
+          value={eventMap?.get('footerChatButtonClick') ?? 0}
+          tooltipTitle="Widget clicks"
+        />
+      </Stack>
+    </Fade>
+  )
+}

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/CardAnalytics/index.ts
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/CardAnalytics/index.ts
@@ -1,0 +1,1 @@
+export { FooterAnalytics } from './FooterAnalytics'


### PR DESCRIPTION
# Description

### Issue
Add the footer analytics under the canvas element on admin journeys

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37663055/todos/7545010559)

### Solution
Created the `FooterAnalytics` component to display the 'footer' analytics for a card

# External Changes

# Additional information

