### PR TITLE
fix: links and chats calc

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/AnalyticsOverlaySwitch/AnalyticsOverlaySwitch.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/AnalyticsOverlaySwitch/AnalyticsOverlaySwitch.spec.tsx
@@ -44,7 +44,7 @@ describe('AnalyticsOverlaySwitch', () => {
     expect(JSON.parse(analytics.textContent ?? '')).toMatchObject({
       totalVisitors: 10,
       chatsStarted: 5,
-      linksVisited: 0,
+      linksVisited: 10,
       referrers: expect.any(Array),
       stepsStats: expect.any(Array),
       stepMap: {},

--- a/libs/journeys/ui/src/libs/useJourneyAnalyticsQuery/transformJourneyAnalytics/transformJourneyAnalytics.spec.ts
+++ b/libs/journeys/ui/src/libs/useJourneyAnalyticsQuery/transformJourneyAnalytics/transformJourneyAnalytics.spec.ts
@@ -158,7 +158,7 @@ describe('transformJourneyAnalytics', () => {
     const result = {
       totalVisitors: 10,
       chatsStarted: 5,
-      linksVisited: 0,
+      linksVisited: 10,
       referrers: [
         {
           __typename: 'PlausibleStatsResponse',

--- a/libs/journeys/ui/src/libs/useJourneyAnalyticsQuery/transformJourneyAnalytics/transformJourneyAnalytics.ts
+++ b/libs/journeys/ui/src/libs/useJourneyAnalyticsQuery/transformJourneyAnalytics/transformJourneyAnalytics.ts
@@ -1,5 +1,6 @@
 import replace from 'lodash/replace'
 
+import { messagePlatforms } from '../../../components/Button/utils/findMessagePlatform'
 import { JourneyPlausibleEvents, reverseKeyify } from '../../plausibleHelpers'
 import {
   GetJourneyAnalytics,
@@ -155,14 +156,12 @@ function getLinkClicks(journeyEvents: PlausibleEvent[]): {
 
   journeyEvents.forEach((plausibleEvent) => {
     const { event, target, events } = plausibleEvent
-    const isChatEvent = event === 'chatButtonClick'
-    const isLinkEvent =
-      event === 'buttonClick' && target != null && target.includes('link')
-
-    if (isChatEvent) {
-      chatsStarted += events
-    } else if (isLinkEvent) {
-      linksVisited += events
+    if (target != null && target.includes('link')) {
+      if (messagePlatforms.find(({ url }) => target.includes(url))) {
+        chatsStarted += events
+      } else {
+        linksVisited += events
+      }
     }
   })
 


### PR DESCRIPTION
# Description

### Issue

Total links clicked and chats started was not being calculated correctly

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

Update the code that was calculating this

# External Changes

n/a

# Additional information

n/a