### PR TITLE
fix: journeyflow deadspace

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/JourneyFlow.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/JourneyFlow.tsx
@@ -362,7 +362,7 @@ export function JourneyFlow(): ReactElement {
               <Panel position="top-left">
                 <>
                   <AnalyticsOverlaySwitch />
-                  <Fade in={showAnalytics}>
+                  <Fade in={showAnalytics} unmountOnExit>
                     <Box>
                       <JourneyAnalyticsCard />
                     </Box>


### PR DESCRIPTION
# Description

### Issue
The journey analytics card was blocking the interactivity of journey flow when not active

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37663055/todos/7549579156)

### Solution
Unmounting the journey analytics card when it should not be visible solves the issue

# External Changes

# Additional information
