### PR TITLE
feat: filter stats by all time

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/AnalyticsOverlaySwitch/AnalyticsOverlaySwitch.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/AnalyticsOverlaySwitch/AnalyticsOverlaySwitch.spec.tsx
@@ -5,16 +5,35 @@ import { getJourneyAnalytics } from '@core/journeys/ui/useJourneyAnalyticsQuery/
 import { render, screen, waitFor } from '@testing-library/react'
 import { AnalyticsOverlaySwitch } from '.'
 import { GetJourney_journey } from '../../../../../../__generated__/GetJourney'
+import { earliestStatsCollected } from './AnalyticsOverlaySwitch'
+
+const mockCurrentDate = '2024-06-02'
 
 describe('AnalyticsOverlaySwitch', () => {
+  beforeAll(() => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2024-06-02'))
+  })
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
   it('toggles showAnalytics', async () => {
     const result = jest.fn().mockReturnValue(getJourneyAnalytics.result)
     const journey = { id: 'journeyId' } as unknown as GetJourney_journey
+    const request = {
+      ...getJourneyAnalytics.request,
+      variables: {
+        ...getJourneyAnalytics.request.variables,
+        period: 'custom',
+        date: `${earliestStatsCollected},${mockCurrentDate}`
+      }
+    }
     render(
       <MockedProvider
         mocks={[
           {
-            ...getJourneyAnalytics,
+            request,
             result
           }
         ]}

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/AnalyticsOverlaySwitch/AnalyticsOverlaySwitch.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/AnalyticsOverlaySwitch/AnalyticsOverlaySwitch.tsx
@@ -7,6 +7,10 @@ import { ReactElement } from 'react'
 import { useEditor } from '@core/journeys/ui/EditorProvider'
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import { useJourneyAnalyticsQuery } from '@core/journeys/ui/useJourneyAnalyticsQuery'
+import { formatISO } from 'date-fns'
+
+// Used to for filter all time stats
+export const earliestStatsCollected = '2024-06-01'
 
 export function AnalyticsOverlaySwitch(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
@@ -15,10 +19,13 @@ export function AnalyticsOverlaySwitch(): ReactElement {
     state: { showAnalytics },
     dispatch
   } = useEditor()
+  const currentDate = formatISO(new Date(), { representation: 'date' })
 
   useJourneyAnalyticsQuery({
     variables: {
-      id: journey?.id ?? ''
+      id: journey?.id ?? '',
+      period: 'custom',
+      date: `${earliestStatsCollected},${currentDate}`
     },
     skip: journey?.id == null || showAnalytics !== true,
     onCompleted: (analytics) => {


### PR DESCRIPTION
# Description

### Issue

Stats default time filter to 30 days unless specified 

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

specify custom date to when stats were first collected to get all time stats

# External Changes

n/a

# Additional information

n/a
