### PR TITLE
fix: alb ssl forward

### DIFF
--- a/infrastructure/modules/aws/locals.tf
+++ b/infrastructure/modules/aws/locals.tf
@@ -49,6 +49,12 @@ locals {
         to_port     = 443
         protocol    = "tcp"
         cidr_blocks = ["0.0.0.0/0"]
+      },
+      {
+        from_port   = 80
+        to_port     = 80
+        protocol    = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
       }
     ]
     egress_rules = local.egress_rules

--- a/infrastructure/modules/aws/main.tf
+++ b/infrastructure/modules/aws/main.tf
@@ -111,6 +111,21 @@ module "public_alb_listener" {
   protocol        = "HTTPS"
   certificate_arn = var.certificate_arn
 }
+resource "aws_lb_listener" "ssl_forwarder" {
+  load_balancer_arn = module.public_alb.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
 
 resource "aws_lb_listener_certificate" "acm_nextstep_is" {
   listener_arn    = module.public_alb_listener.arn


### PR DESCRIPTION
# Description

### Issue

AWS hosted sites did not offer forwarding from http requests

### Solution

Open port 80 for ingress on public alb
Add port 80 to 443 forward in public alb listeners

# External Changes

Changes are implemented in AWS

# Additional information

Changes are live, PR is just updating terraform in main
