### PR TITLE
fix: referrer styles

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/ReferrerNode/BaseReferrer/BaseReferrer.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/ReferrerNode/BaseReferrer/BaseReferrer.tsx
@@ -1,8 +1,12 @@
 import ChevronDown from '@core/shared/ui/icons/ChevronDown'
 import { FacebookIcon } from '@core/shared/ui/icons/FacebookIcon'
 import LinkAngled from '@core/shared/ui/icons/LinkAngled'
+import { Tooltip } from '@mui/material'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
+
+const iconStyles = { fontSize: '18px' }
+const textStyles = { fontSize: '12px', lineHeight: '20px' }
 
 export function BaseReferrer({ property, visitors }) {
   let Icon
@@ -12,33 +16,65 @@ export function BaseReferrer({ property, visitors }) {
       Icon = <FacebookIcon />
       break
     case 'Direct / None':
-      Icon = <LinkAngled fontSize="small" />
+      Icon = <LinkAngled sx={iconStyles} />
       break
     case 'Other sources':
-      Icon = <ChevronDown />
+      Icon = <ChevronDown sx={iconStyles} />
       break
     default:
-      Icon = <LinkAngled fontSize="small" />
+      Icon = <LinkAngled sx={iconStyles} />
   }
 
   return (
     <Box
       sx={{
-        display: 'flex',
-        justifyContent: 'space-between',
+        display: 'grid',
+        gridTemplateColumns: 'min-content auto 1fr',
+        alignItems: 'center',
+        padding: '8px 12px',
         gap: 2,
-        padding: '3px 6px',
         ':hover': {
           cursor: 'default'
         }
       }}
       data-testid="BaseReferrer"
     >
-      <Box sx={{ display: 'flex', alignItems: 'center' }}>
-        {Icon}
-        <Typography variant="body2">{property}</Typography>
-      </Box>
-      <Typography variant="body2">{visitors}</Typography>
+      {Icon}
+      <Tooltip
+        title={property}
+        placement="top"
+        slotProps={{
+          popper: {
+            modifiers: [
+              {
+                name: 'offset',
+                options: {
+                  offset: [0, -8]
+                }
+              }
+            ]
+          },
+          tooltip: {
+            sx: {
+              py: 0
+            }
+          }
+        }}
+      >
+        <Typography noWrap sx={textStyles}>
+          {property}
+        </Typography>
+      </Tooltip>
+      <Typography
+        variant="body2"
+        sx={{
+          ...textStyles,
+          fontWeight: 600,
+          placeSelf: 'end'
+        }}
+      >
+        {visitors}
+      </Typography>
     </Box>
   )
 }

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/ReferrerNode/BaseReferrer/BaseReferrer.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/ReferrerNode/BaseReferrer/BaseReferrer.tsx
@@ -28,8 +28,7 @@ export function BaseReferrer({ property, visitors }) {
   return (
     <Box
       sx={{
-        display: 'grid',
-        gridTemplateColumns: 'min-content auto 1fr',
+        display: 'flex',
         alignItems: 'center',
         padding: '8px 12px',
         gap: 2,
@@ -40,41 +39,51 @@ export function BaseReferrer({ property, visitors }) {
       data-testid="BaseReferrer"
     >
       {Icon}
-      <Tooltip
-        title={property}
-        placement="top"
-        slotProps={{
-          popper: {
-            modifiers: [
-              {
-                name: 'offset',
-                options: {
-                  offset: [0, -8]
-                }
-              }
-            ]
-          },
-          tooltip: {
-            sx: {
-              py: 0
-            }
-          }
-        }}
-      >
-        <Typography noWrap sx={textStyles}>
-          {property}
-        </Typography>
-      </Tooltip>
-      <Typography
-        variant="body2"
+      <Box
         sx={{
-          ...textStyles,
-          fontWeight: 600,
-          placeSelf: 'end'
+          flex: 1,
+          display: 'grid',
+          gridTemplateColumns: 'auto 1fr',
+          alignItems: 'inherit',
+          gap: 2
         }}
       >
-        {visitors}
-      </Typography>
+        <Tooltip
+          title={property}
+          placement="top"
+          slotProps={{
+            popper: {
+              modifiers: [
+                {
+                  name: 'offset',
+                  options: {
+                    offset: [0, -8]
+                  }
+                }
+              ]
+            },
+            tooltip: {
+              sx: {
+                py: 0
+              }
+            }
+          }}
+        >
+          <Typography noWrap sx={textStyles}>
+            {property}
+          </Typography>
+        </Tooltip>
+        <Typography
+          variant="body2"
+          sx={{
+            ...textStyles,
+            fontWeight: 600,
+            placeSelf: 'end'
+          }}
+        >
+          {visitors}
+        </Typography>
+      </Box>
     </Box>
   )
 }

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/ReferrerNode/OtherReferrer/OtherReferrer.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/ReferrerNode/OtherReferrer/OtherReferrer.tsx
@@ -29,7 +29,7 @@ export function OtherReferrer({ referrers }: { referrers: JourneyReferrer[] }) {
         onMouseEnter={handlePopoverOpen}
         onMouseLeave={handlePopoverClose}
         sx={{
-          width: 160,
+          width: 180,
           backgroundColor: 'background.paper',
           borderRadius: 50,
           boxShadow: 3

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/ReferrerNode/ReferrerNode.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/ReferrerNode/ReferrerNode.tsx
@@ -31,7 +31,7 @@ export function ReferrerNode({ data }: ReferrerNodeProps) {
         ) : (
           <Box
             sx={{
-              width: 160,
+              width: 180,
               backgroundColor: 'background.paper',
               borderRadius: 50,
               boxShadow: 3

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/ReferrerNode/ReferrerNode.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/ReferrerNode/ReferrerNode.tsx
@@ -33,7 +33,7 @@ export function ReferrerNode({ data }: ReferrerNodeProps) {
             sx={{
               width: 180,
               backgroundColor: 'background.paper',
-              borderRadius: 50,
+              borderRadius: 5,
               boxShadow: 3
             }}
           >

--- a/libs/journeys/ui/src/libs/useJourneyAnalyticsQuery/transformJourneyAnalytics/transformJourneyAnalytics.spec.ts
+++ b/libs/journeys/ui/src/libs/useJourneyAnalyticsQuery/transformJourneyAnalytics/transformJourneyAnalytics.spec.ts
@@ -194,7 +194,7 @@ describe('transformJourneyAnalytics', () => {
             id: 'Direct / None',
             position: {
               x: -600,
-              y: -18
+              y: -46
             },
             type: 'Referrer'
           },
@@ -208,7 +208,7 @@ describe('transformJourneyAnalytics', () => {
             id: 'tiktok',
             position: {
               x: -600,
-              y: 24
+              y: 19
             },
             type: 'Referrer'
           },
@@ -222,7 +222,7 @@ describe('transformJourneyAnalytics', () => {
             id: 'facebook',
             position: {
               x: -600,
-              y: 66
+              y: 84
             },
             type: 'Referrer'
           }

--- a/libs/journeys/ui/src/libs/useJourneyAnalyticsQuery/transformReferrers/transformReferrers.spec.ts
+++ b/libs/journeys/ui/src/libs/useJourneyAnalyticsQuery/transformReferrers/transformReferrers.spec.ts
@@ -31,14 +31,14 @@ describe('transformReferrers', () => {
           id: 'Facebook',
           type: 'Referrer',
           data: referrers[0],
-          position: { x: -600, y: -18 },
+          position: { x: -600, y: -46 },
           draggable: false
         },
         {
           id: 'Google',
           type: 'Referrer',
           data: referrers[2],
-          position: { x: -600, y: 24 },
+          position: { x: -600, y: 19 },
           draggable: false
         },
         {
@@ -48,7 +48,7 @@ describe('transformReferrers', () => {
             property: 'Other sources',
             referrers: [referrers[1], referrers[3]]
           },
-          position: { x: -600, y: 66 },
+          position: { x: -600, y: 84 },
           draggable: false
         }
       ],
@@ -103,21 +103,21 @@ describe('transformReferrers', () => {
           id: 'Facebook',
           type: 'Referrer',
           data: referrers[0],
-          position: { x: -600, y: -18 },
+          position: { x: -600, y: -46 },
           draggable: false
         },
         {
           id: 'Google',
           type: 'Referrer',
           data: referrers[2],
-          position: { x: -600, y: 24 },
+          position: { x: -600, y: 19 },
           draggable: false
         },
         {
           id: 'Direct / None',
           type: 'Referrer',
           data: referrers[1],
-          position: { x: -600, y: 66 },
+          position: { x: -600, y: 84 },
           draggable: false
         }
       ],
@@ -167,14 +167,14 @@ describe('transformReferrers', () => {
           id: 'Facebook',
           type: 'Referrer',
           data: referrers[0],
-          position: { x: -600, y: -4 },
+          position: { x: -600, y: -9 },
           draggable: false
         },
         {
           id: 'Direct / None',
           type: 'Referrer',
           data: referrers[1],
-          position: { x: -600, y: 52 },
+          position: { x: -600, y: 47 },
           draggable: false
         }
       ],
@@ -212,7 +212,7 @@ describe('transformReferrers', () => {
           id: 'Direct / None',
           type: 'Referrer',
           data: referrers[0],
-          position: { x: -600, y: 24 },
+          position: { x: -600, y: 19 },
           draggable: false
         }
       ],

--- a/libs/journeys/ui/src/libs/useJourneyAnalyticsQuery/transformReferrers/transformReferrers.ts
+++ b/libs/journeys/ui/src/libs/useJourneyAnalyticsQuery/transformReferrers/transformReferrers.ts
@@ -1,8 +1,22 @@
 import { GetJourneyAnalytics_journeyReferrer as JourneyReferrer } from '@core/journeys/ui/useJourneyAnalyticsQuery/__generated__/GetJourneyAnalytics'
 import { Edge, Node } from 'reactflow'
 
+interface OtherSource {
+  property: 'Other sources'
+  referrers: JourneyReferrer[]
+}
+
 const SOCIAL_PREVIEW_CARD_HEIGHT = 168
-const START_OF_SOCIAL_PREVIEW = -60
+const START_OF_SOCIAL_PREVIEW = -46
+const REFERRER_NODE_HEIGHT = 38
+
+const THREE_NODE_Y_POSITIONS = [
+  START_OF_SOCIAL_PREVIEW,
+  START_OF_SOCIAL_PREVIEW +
+    SOCIAL_PREVIEW_CARD_HEIGHT / 2 -
+    REFERRER_NODE_HEIGHT / 2,
+  START_OF_SOCIAL_PREVIEW + SOCIAL_PREVIEW_CARD_HEIGHT - REFERRER_NODE_HEIGHT
+]
 
 function sortReferrers(a: JourneyReferrer, b: JourneyReferrer) {
   if (a.visitors === null) {
@@ -22,24 +36,24 @@ export function transformReferrers(referrers?: JourneyReferrer[]) {
 
   if (referrers == null || referrers.length === 0) return { nodes, edges }
 
-  const sortedReferrers = [...referrers].sort(sortReferrers)
+  const sortedReferrers: Array<JourneyReferrer | OtherSource> = [
+    ...referrers
+  ].sort(sortReferrers)
 
-  if (referrers.length > 3) {
-    const topReferrers = sortedReferrers.slice(0, 2)
-    const otherReferrers = sortedReferrers.slice(2, referrers.length)
-
-    function getYPos(idx: number) {
-      return (
-        START_OF_SOCIAL_PREVIEW + ((idx + 1) / 4) * SOCIAL_PREVIEW_CARD_HEIGHT
-      )
+  if (sortedReferrers.length >= 3) {
+    if (sortedReferrers.length > 3) {
+      sortedReferrers.splice(2, Number.POSITIVE_INFINITY, {
+        property: 'Other sources',
+        referrers: sortedReferrers.slice(2) as JourneyReferrer[]
+      })
     }
 
-    topReferrers.forEach((referrer, idx) => {
+    sortedReferrers.forEach((referrer, idx) => {
       nodes.push({
         id: referrer.property,
         type: 'Referrer',
         data: referrer,
-        position: { x: -600, y: getYPos(idx) },
+        position: { x: -600, y: THREE_NODE_Y_POSITIONS[idx] },
         draggable: false
       })
 
@@ -51,26 +65,12 @@ export function transformReferrers(referrers?: JourneyReferrer[]) {
         updatable: false
       })
     })
-
-    nodes.push({
-      id: 'Other sources',
-      type: 'Referrer',
-      data: { property: 'Other sources', referrers: otherReferrers },
-      position: { x: -600, y: getYPos(2) },
-      draggable: false
-    })
-
-    edges.push({
-      id: 'Other sources->SocialPreview',
-      source: 'Other sources',
-      target: 'SocialPreview',
-      type: 'Referrer',
-      updatable: false
-    })
   } else {
     sortedReferrers.forEach((referrer, idx) => {
       const yPos =
-        -60 + ((idx + 1) / (referrers.length + 1)) * SOCIAL_PREVIEW_CARD_HEIGHT
+        START_OF_SOCIAL_PREVIEW +
+        ((idx + 1) / (referrers.length + 1)) * SOCIAL_PREVIEW_CARD_HEIGHT -
+        REFERRER_NODE_HEIGHT / 2
 
       nodes.push({
         id: referrer.property,


### PR DESCRIPTION
# Description

### Issue
Long referrer names would overflow outside their container.
Styles for referrer nodes did not match.

[Long referrer names](https://3.basecamp.com/3105655/buckets/37663055/todos/7551057416)
[Referrer styles](https://3.basecamp.com/3105655/buckets/37663055/todos/7556307794)

### Solution
- Updated the layout for the referrer node so that long names would no longer overflow outside their container. The text should now overflow to ellipsis and a tooltip is available to view the full referrer name.
- Update the styles for the referrer node
- Updated the referrer node layout algorithm

# External Changes

# Additional information
