### PR TITLE
fix: use forwarded headers on k8s ingress

### DIFF
--- a/infrastructure/kube/ingress/deploy.yaml
+++ b/infrastructure/kube/ingress/deploy.yaml
@@ -321,6 +321,7 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: 'false'
+  use-forwarded-headers: 'true'
 kind: ConfigMap
 metadata:
   labels:


### PR DESCRIPTION
# Description

### Issue

When Vercel is acting as a proxy between the user and the plausible server the correct client IP address is not being passed to plausible. This is causing every event to plausible to be logged as a unique user due to each event call being executed as a lambda function on vercel. Vercel however is already passing the correct X-Forwarded-* headers.

### Solution

Add use-forwarded-headers config for nginx ingress controller.

I have already applied this to K8s. This is just so that the repo is up to date.