### PR TITLE
fix: onboarding template preview

### DIFF
--- a/apps/journeys-admin/src/components/OnboardingPageWrapper/OnboardingDrawer/OnboardingTemplateCard/OnboardingTemplateCard.spec.tsx
+++ b/apps/journeys-admin/src/components/OnboardingPageWrapper/OnboardingDrawer/OnboardingTemplateCard/OnboardingTemplateCard.spec.tsx
@@ -1,15 +1,16 @@
 import { MockedProvider } from '@apollo/client/testing'
-import { render, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 
 import { GET_JOURNEY } from '@core/journeys/ui/useJourneyQuery'
 
-import { GetJourneys_journeys as Journey } from '../../../../../__generated__/GetJourneys'
+import type { GetJourneys_journeys as Journey } from '../../../../../__generated__/GetJourneys'
 import {
   JourneyStatus,
   ThemeMode,
   ThemeName
 } from '../../../../../__generated__/globalTypes'
 
+import { IdType } from 'libs/journeys/ui/__generated__/globalTypes'
 import { OnboardingTemplateCard } from './OnboardingTemplateCard'
 
 describe('OnboardingTemplateCard', () => {
@@ -58,14 +59,15 @@ describe('OnboardingTemplateCard', () => {
   it('should render OnboardingTemplateCard', async () => {
     const result = jest.fn(() => ({ data: { journey } }))
 
-    const { getByRole, getAllByText } = render(
+    render(
       <MockedProvider
         mocks={[
           {
             request: {
               query: GET_JOURNEY,
               variables: {
-                id: 'template-id'
+                id: 'template-id',
+                idType: IdType.databaseId
               }
             },
             result
@@ -77,12 +79,14 @@ describe('OnboardingTemplateCard', () => {
     )
 
     await waitFor(() => expect(result).toHaveBeenCalled())
-    expect(getAllByText('Journey Template')[0]).toBeInTheDocument()
+    expect(screen.getAllByText('Journey Template')[0]).toBeInTheDocument()
     await waitFor(() =>
-      expect(getByRole('img').attributes.getNamedItem('src')?.value).toBe(
+      expect(
+        screen.getByRole('img').attributes.getNamedItem('src')?.value
+      ).toBe(
         '/_next/image?url=https%3A%2F%2Fimages.unsplash.com%2Fphoto-1508363778367-af363f107cbb%3Fixlib%3Drb-1.2.1%26q%3D80%26fm%3Djpg%26crop%3Dentropy%26cs%3Dtinysrgb%26dl%3Dchester-wade-hLP7lVm4KUE-unsplash.jpg%26w%3D1920&w=3840&q=75'
       )
     )
-    expect(getAllByText('A Template Heading')[0]).toBeInTheDocument()
+    expect(screen.getAllByText('A Template Heading')[0]).toBeInTheDocument()
   })
 })

--- a/apps/journeys-admin/src/components/OnboardingPageWrapper/OnboardingDrawer/OnboardingTemplateCard/OnboardingTemplateCard.tsx
+++ b/apps/journeys-admin/src/components/OnboardingPageWrapper/OnboardingDrawer/OnboardingTemplateCard/OnboardingTemplateCard.tsx
@@ -8,6 +8,7 @@ import { useJourneyQuery } from '@core/journeys/ui/useJourneyQuery'
 import { NextImage } from '@core/shared/ui/NextImage'
 import GridEmptyIcon from '@core/shared/ui/icons/GridEmpty'
 
+import { IdType } from 'libs/journeys/ui/__generated__/globalTypes'
 import { JourneyFields as Journey } from '../../../../../__generated__/JourneyFields'
 
 interface OnboardingTemplateCardProps {
@@ -17,7 +18,10 @@ interface OnboardingTemplateCardProps {
 export function OnboardingTemplateCard({
   templateId
 }: OnboardingTemplateCardProps): ReactElement {
-  const { data } = useJourneyQuery({ id: templateId ?? '' })
+  const { data } = useJourneyQuery({
+    id: templateId ?? '',
+    idType: IdType.databaseId
+  })
 
   return (
     <>


### PR DESCRIPTION
# Description

### Issue
The onboarding template preview is not displaying. The template preview is falling back to the skeleton placeholder.
[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/37663057/todos/7578126352)

### Solution
The query to fetch the journey was using the slug instead of the journey id. Just had to query by the journey id and it returns the template properly.

# External Changes


# Additional information
