### PR TITLE
ci: update visual test run condition

### DIFF
--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -14,7 +14,7 @@ jobs:
   visual-test:
     if: >
       contains(github.event.pull_request.labels.*.name, 'chromatic') ||
-      (github.event_name == 'merge_group' && contains(github.ref, 'refs/heads/main'))
+      (github.event_name == 'enqueued' && contains(github.ref, 'refs/heads/main'))
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   visual-test:
-    if: contains(github.event.pull_request.labels.*.name, 'chromatic') || github.event_name == 'enqueued'
+    if: contains(github.event.pull_request.labels.*.name, 'chromatic') || github.event.action == 'enqueued'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -12,7 +12,9 @@ concurrency:
   cancel-in-progress: true
 jobs:
   visual-test:
-    if: contains(github.event.pull_request.labels.*.name, 'chromatic')
+    if: >
+      contains(github.event.pull_request.labels.*.name, 'chromatic') ||
+      (github.event_name == 'push' && contains(github.ref, 'refs/heads/main'))
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -12,9 +12,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   visual-test:
-    if: >
-      contains(github.event.pull_request.labels.*.name, 'chromatic') ||
-      (github.event_name == 'enqueued' && contains(github.ref, 'refs/heads/main'))
+    if: contains(github.event.pull_request.labels.*.name, 'chromatic') || github.event_name == 'enqueued'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -14,7 +14,7 @@ jobs:
   visual-test:
     if: >
       contains(github.event.pull_request.labels.*.name, 'chromatic') ||
-      (github.event_name == 'push' && contains(github.ref, 'refs/heads/main'))
+      (github.event_name == 'merge_group' && contains(github.ref, 'refs/heads/main'))
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   visual-test:
-    if: contains(github.event.pull_request.labels.*.name, 'chromatic') || github.event.action == 'enqueued'
+    if: contains(github.event.pull_request.labels.*.name, 'chromatic') || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
# Description

### Issue

Visual tests are not running during merge queue as it's expecting the chromatic label. We are to add support that it runs without the label only during merge queue

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

Update the conditional statement which runs the visual test. Run the visual test if it's going to be pushed to main