### PR TITLE
fix: default english templates

### DIFF
--- a/libs/journeys/ui/src/components/TemplateGallery/TemplateGallery.tsx
+++ b/libs/journeys/ui/src/components/TemplateGallery/TemplateGallery.tsx
@@ -5,7 +5,7 @@ import castArray from 'lodash/castArray'
 import difference from 'lodash/difference'
 import { useTranslation } from 'next-i18next'
 import { useRouter } from 'next/router'
-import { ReactElement } from 'react'
+import { ReactElement, useEffect } from 'react'
 
 import { TemplateSections } from '../TemplateSections'
 
@@ -24,6 +24,10 @@ export function TemplateGallery({
   const router = useRouter()
   const selectedLanguageIds = castArray(router.query.languageIds ?? [])
   const selectedTagIds = castArray(router.query.tagIds ?? [])
+
+  useEffect(() => {
+    handleLanguageIdsChange(['529'])
+  }, [])
 
   function handleTagIdsChange(
     newSelectedTagIds: string[],

--- a/libs/journeys/ui/src/components/TemplateGallery/TemplateGallery.tsx
+++ b/libs/journeys/ui/src/components/TemplateGallery/TemplateGallery.tsx
@@ -22,7 +22,7 @@ export function TemplateGallery({
 }: TemplateGalleryProps): ReactElement {
   const { t } = useTranslation('libs-journeys-ui')
   const router = useRouter()
-  const selectedLanguageIds = castArray(router.query.languageIds ?? ['529'])
+  const selectedLanguageIds = castArray(router.query.languageIds ?? ['529']) // Defaults to English language
   const selectedTagIds = castArray(router.query.tagIds ?? [])
 
   function handleTagIdsChange(

--- a/libs/journeys/ui/src/components/TemplateGallery/TemplateGallery.tsx
+++ b/libs/journeys/ui/src/components/TemplateGallery/TemplateGallery.tsx
@@ -5,7 +5,7 @@ import castArray from 'lodash/castArray'
 import difference from 'lodash/difference'
 import { useTranslation } from 'next-i18next'
 import { useRouter } from 'next/router'
-import { ReactElement, useEffect } from 'react'
+import { ReactElement } from 'react'
 
 import { TemplateSections } from '../TemplateSections'
 

--- a/libs/journeys/ui/src/components/TemplateGallery/TemplateGallery.tsx
+++ b/libs/journeys/ui/src/components/TemplateGallery/TemplateGallery.tsx
@@ -22,12 +22,8 @@ export function TemplateGallery({
 }: TemplateGalleryProps): ReactElement {
   const { t } = useTranslation('libs-journeys-ui')
   const router = useRouter()
-  const selectedLanguageIds = castArray(router.query.languageIds ?? [])
+  const selectedLanguageIds = castArray(router.query.languageIds ?? ['529'])
   const selectedTagIds = castArray(router.query.tagIds ?? [])
-
-  useEffect(() => {
-    handleLanguageIdsChange(['529'])
-  }, [])
 
   function handleTagIdsChange(
     newSelectedTagIds: string[],


### PR DESCRIPTION
# Description

### Issue

Currently the default when languages are not specified is "All Languages". This is replaced with English as the default here.

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/38213939/todos/7585497434)

### Solution

_Provide a detailed description of how exactly this task will be accomplished. This can be something technical. What specific steps will be taken to achieve the goal? This should include details on service integration, job logic, implementation, etc._

# External Changes

_If you have made changes to external services, need to add additional values to Doppler, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc._

# Additional information

_Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc._
