### PR TITLE
feat: add enable reinitialize prop to text label forms

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/TextResponse/TextResponseFields/Hint/Hint.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/TextResponse/TextResponseFields/Hint/Hint.tsx
@@ -68,7 +68,11 @@ export function Hint(): ReactElement {
   return (
     <Box sx={{ p: 4, pt: 0 }} data-testid="Hint">
       {initialValues != null ? (
-        <Formik initialValues={initialValues} onSubmit={noop}>
+        <Formik
+          initialValues={initialValues}
+          onSubmit={noop}
+          enableReinitialize
+        >
           {({ values, errors, handleChange, handleBlur }) => (
             <Form>
               <TextField

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/TextResponse/TextResponseFields/Label/Label.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/TextResponse/TextResponseFields/Label/Label.tsx
@@ -65,7 +65,11 @@ export function Label(): ReactElement {
   return (
     <Box sx={{ p: 4, pt: 0 }} data-testid="Label">
       {selectedBlock != null ? (
-        <Formik initialValues={initialValues} onSubmit={noop}>
+        <Formik
+          initialValues={initialValues}
+          onSubmit={noop}
+          enableReinitialize
+        >
           {({ values, errors, handleChange, handleBlur, setValues }) => (
             <Form>
               <TextField


### PR DESCRIPTION
# Description

### Issue

When switching between two text label blocks on the same step, the label and hint forms do not change. This is because the initial values were not switching from state changes. 

[Link to Basecamp Todo](hhttps://3.basecamp.com/3105655/buckets/38213939/todos/7581970138)

### Solution

_Provide a detailed description of how exactly this task will be accomplished. This can be something technical. What specific steps will be taken to achieve the goal? This should include details on service integration, job logic, implementation, etc._

# External Changes

_If you have made changes to external services, need to add additional values to Doppler, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc._

# Additional information

_Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc._
