### PR TITLE
refactor: redirect to templates

### DIFF
--- a/apps/journeys-admin/pages/templates/[journeyId].tsx
+++ b/apps/journeys-admin/pages/templates/[journeyId].tsx
@@ -53,7 +53,6 @@ function TemplateDetailsPage(): ReactElement {
           title={t('Journey Template')}
           user={user}
           backHref="/templates"
-          backHrefHistory
           mainBodyPadding={false}
           showMainHeader={user?.id != null}
           showAppHeader={user?.id != null}


### PR DESCRIPTION
# Description

### Issue
The back button on the templates page redirects to previous history rather than the templates page

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/38213939/todos/7594990078)

### Solution
Updated the back button so it will redirect to the templates page instead of previous history

# External Changes

# Additional information
