### PR TITLE
fix: card preview not displaying on firefox

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/Canvas.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/Canvas.tsx
@@ -235,7 +235,7 @@ export function Canvas(): ReactElement {
                         },
                         position: 'relative',
                         width: 'calc(100% - 8px)',
-                        height: 'calc(100% - 8px)',
+                        height: 'calc(100vh - 8px)',
                         m: '4px'
                       }}
                     >


### PR DESCRIPTION
# Description

### Issue
The journey flow card preview was not displaying properly on firefox

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/38213939/todos/7595172063)

### Solution
Updated the container height inside the iframe to use `vh` instead of `100%`

# External Changes

# Additional information

