### PR TITLE
fix: add key for background color

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/Card.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/Card.tsx
@@ -13,6 +13,7 @@ import PaletteIcon from '@core/shared/ui/icons/Palette'
 import VideoOnIcon from '@core/shared/ui/icons/VideoOn'
 import { ThemeMode, ThemeName, getTheme } from '@core/shared/ui/themes'
 
+import { useEditor } from '@core/journeys/ui/EditorProvider'
 import { BlockFields_CardBlock as CardBlock } from '../../../../../../../../../__generated__/BlockFields'
 import { Accordion } from '../../Accordion'
 
@@ -58,6 +59,9 @@ export function Card({
   children
 }: TreeBlock<CardBlock>): ReactElement {
   const { journey } = useJourney()
+  const {
+    state: { selectedStep }
+  } = useEditor()
   const { rtl, locale } = getJourneyRTL(journey)
   const { t } = useTranslation('apps-journeys-admin')
 
@@ -93,7 +97,7 @@ export function Card({
         name={t('Color')}
         value={selectedCardColor.toUpperCase()}
       >
-        <BackgroundColor />
+        <BackgroundColor key={selectedStep?.id} />
       </Accordion>
 
       {coverBlock?.__typename === 'ImageBlock' && coverBlock.src != null && (


### PR DESCRIPTION
# Description

### Issue

Changing background color on a selected card, changed the background color of the previously selected card instead

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/38213939/todos/7613969491)

### Solution

Add key for `BackgroundColor` so it references the currently selected step

# External Changes

n/a

# Additional information

n/a