### PR TITLE
fix: duplicate journey error

### DIFF
--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -458,7 +458,7 @@ export class JourneyResolver {
     const duplicateJourneyId = uuidv4()
 
     const originalBlocks = await this.prismaService.block.findMany({
-      where: { journeyId: journey.id, typename: 'StepBlock' },
+      where: { journeyId: journey.id, typename: 'StepBlock', deletedAt: null },
       orderBy: { parentOrder: 'asc' },
       include: { action: true }
     })


### PR DESCRIPTION
# Description

### Issue
Journeys were failing to duplicate properly
_Provide a brief summary of why this task is needed_

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/38213939/todos/7612339832)

### Solution
Soft deleted blocks were not being properly handled in the duplication logic

# External Changes

# Additional information

