### PR TITLE
feat: add set editor focus to editor provider

### DIFF
--- a/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.spec.tsx
+++ b/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.spec.tsx
@@ -455,7 +455,7 @@ describe('EditorContext', () => {
       })
     })
 
-    describe('SetCommandStateAction', () => {
+    describe('SetEditorFocusAction', () => {
       it('should set editor state with given overrides', () => {
         const step: TreeBlock = {
           id: 'step0.id',
@@ -487,17 +487,21 @@ describe('EditorContext', () => {
         }
         expect(
           reducer(state, {
-            type: 'SetCommandStateAction',
-            selectedBlock: block,
-            selectedStep: step,
+            activeCanvasDetailsDrawer: ActiveCanvasDetailsDrawer.Footer,
             activeContent: ActiveContent.Canvas,
-            activeSlide: ActiveSlide.Content
+            activeSlide: ActiveSlide.Content,
+            selectedAttributeId: 'selectedAttributeId',
+            selectedBlock: block,
+            selectedGoalUrl: 'https://www.example.com',
+            selectedStep: step,
+            type: 'SetEditorFocusAction'
           })
         ).toEqual({
-          activeCanvasDetailsDrawer: 0,
+          activeCanvasDetailsDrawer: ActiveCanvasDetailsDrawer.Footer,
           activeContent: 'canvas',
-          activeFab: 0,
-          activeSlide: 1,
+          activeFab: ActiveFab.Add,
+          activeSlide: ActiveSlide.Content,
+          selectedAttributeId: 'selectedAttributeId',
           selectedBlock: {
             __typename: 'CardBlock',
             backgroundColor: null,
@@ -510,6 +514,7 @@ describe('EditorContext', () => {
             themeMode: null,
             themeName: null
           },
+          selectedGoalUrl: 'https://www.example.com',
           selectedStep: {
             __typename: 'StepBlock',
             children: [],
@@ -559,13 +564,7 @@ describe('EditorContext', () => {
           selectedStep: step,
           activeContent: ActiveContent.Canvas
         }
-        expect(
-          reducer(state, {
-            type: 'SetCommandStateAction'
-          })
-        ).toEqual({
-          ...state
-        })
+        expect(reducer(state, { type: 'SetEditorFocusAction' })).toEqual(state)
       })
     })
 

--- a/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
+++ b/libs/journeys/ui/src/libs/EditorProvider/EditorProvider.tsx
@@ -145,12 +145,20 @@ interface SetAnalyticsAction {
   analytics?: JourneyAnalytics
 }
 
-interface SetCommandStateAction {
-  type: 'SetCommandStateAction'
-  selectedBlock?: TreeBlock
-  selectedStep?: TreeBlock<StepBlock>
+/**
+ * SetEditorFocusAction is a special action that allows setting multiple state
+ * properties at once. This is primarily used to set the UI position of the
+ * editor.
+ */
+interface SetEditorFocusAction {
+  type: 'SetEditorFocusAction'
+  activeCanvasDetailsDrawer?: ActiveCanvasDetailsDrawer
   activeContent?: ActiveContent
   activeSlide?: ActiveSlide
+  selectedAttributeId?: string
+  selectedBlock?: TreeBlock
+  selectedGoalUrl?: string
+  selectedStep?: TreeBlock<StepBlock>
 }
 export type EditorAction =
   | SetActiveCanvasDetailsDrawerAction
@@ -166,7 +174,7 @@ export type EditorAction =
   | SetStepsAction
   | SetShowAnalyticsAction
   | SetAnalyticsAction
-  | SetCommandStateAction
+  | SetEditorFocusAction
 
 export const reducer = (
   state: EditorState,
@@ -191,11 +199,13 @@ export const reducer = (
     case 'SetActiveSlideAction':
       return {
         ...state,
-        activeContent: state.activeContent,
         activeSlide: action.activeSlide
       }
     case 'SetSelectedAttributeIdAction':
-      return { ...state, selectedAttributeId: action.selectedAttributeId }
+      return {
+        ...state,
+        selectedAttributeId: action.selectedAttributeId
+      }
     case 'SetSelectedBlockAction':
       return {
         ...state,
@@ -205,7 +215,10 @@ export const reducer = (
         activeSlide: ActiveSlide.Content
       }
     case 'SetSelectedBlockOnlyAction':
-      return { ...state, selectedBlock: action.selectedBlock }
+      return {
+        ...state,
+        selectedBlock: action.selectedBlock
+      }
     case 'SetSelectedBlockByIdAction':
       return {
         ...state,
@@ -247,30 +260,58 @@ export const reducer = (
         ...state,
         showAnalytics: action.showAnalytics
       }
-    case 'SetAnalyticsAction': {
+    case 'SetAnalyticsAction':
       return {
         ...state,
         analytics: action.analytics
       }
-    }
-    case 'SetCommandStateAction': {
-      return {
-        ...state,
-        selectedBlock:
-          action.selectedBlock != null
-            ? action.selectedBlock
-            : state.selectedBlock,
-        activeContent:
-          action.activeContent != null
-            ? action.activeContent
-            : state.activeContent,
-        selectedStep:
-          action.selectedStep != null
-            ? action.selectedStep
-            : state.selectedStep,
-        activeSlide:
-          action.activeSlide != null ? action.activeSlide : state.activeSlide
-      }
+    case 'SetEditorFocusAction': {
+      let stateCopy = { ...state }
+      const {
+        activeCanvasDetailsDrawer,
+        activeContent,
+        activeSlide,
+        selectedAttributeId,
+        selectedGoalUrl,
+        selectedBlock,
+        selectedStep
+      } = action
+      if (selectedStep != null)
+        stateCopy = reducer(stateCopy, {
+          type: 'SetSelectedStepAction',
+          selectedStep
+        })
+      if (selectedBlock != null)
+        stateCopy = reducer(stateCopy, {
+          type: 'SetSelectedBlockAction',
+          selectedBlock
+        })
+      if (activeSlide != null)
+        stateCopy = reducer(stateCopy, {
+          type: 'SetActiveSlideAction',
+          activeSlide
+        })
+      if (activeContent != null)
+        stateCopy = reducer(stateCopy, {
+          type: 'SetActiveContentAction',
+          activeContent
+        })
+      if (activeCanvasDetailsDrawer != null)
+        stateCopy = reducer(stateCopy, {
+          type: 'SetActiveCanvasDetailsDrawerAction',
+          activeCanvasDetailsDrawer
+        })
+      if (selectedAttributeId != null)
+        stateCopy = reducer(stateCopy, {
+          type: 'SetSelectedAttributeIdAction',
+          selectedAttributeId
+        })
+      if (selectedGoalUrl != null)
+        stateCopy = reducer(stateCopy, {
+          type: 'SetSelectedGoalUrlAction',
+          selectedGoalUrl
+        })
+      return stateCopy
     }
   }
 }


### PR DESCRIPTION
# Description

### Issue

changing what the editor is primarily focused on requires a number of dispatches to be issued.

### Solution

Add a new SetEditorFocusAction which uses the existing reducer function to combine actions to manage focus. This solution works down the editor state tree. See [Journeys Admin - Editor](https://www.figma.com/board/etPSAXYPE8pbWcKL9gej19/Journeys-Admin---Editor?node-id=0-1&t=CJuiW95WWVCOKoHn-1) documentation for more details on the state tree.