### PR TITLE
fix: plausible site creation

### DIFF
--- a/apps/api-analytics/src/schema/site/siteCreate.mutation.spec.ts
+++ b/apps/api-analytics/src/schema/site/siteCreate.mutation.spec.ts
@@ -277,4 +277,99 @@ describe('siteCreateMutation', () => {
       }
     })
   })
+
+  it('should return the existing site if a user creates a site with a existing domain', async () => {
+    const site = {
+      id: 'siteId',
+      domain: 'https://test-site.com',
+      site_memberships: [
+        {
+          id: 'membershipId',
+          role: 'owner'
+        }
+      ],
+      goals: [
+        {
+          id: 'goalId',
+          event_name: 'test-goal'
+        }
+      ],
+      shared_links: [
+        {
+          id: 'sharedLinkId',
+          name: 'api-analytics',
+          slug: 'test-slug'
+        }
+      ]
+    }
+    prismaMock.sites.create.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError(
+        'Unique constraint failed on the fields: (`domain`)',
+        {
+          code: 'P2002',
+          clientVersion: 'prismaVersion'
+        }
+      )
+    )
+    prismaMock.sites.findUnique.mockResolvedValue(site)
+
+    const data = await client({
+      document: SITE_CREATE_MUTATION,
+      variables: {
+        input: {
+          domain: 'https://test-site.com',
+          goals: ['test-goal']
+        }
+      }
+    })
+
+    expect(prismaMock.sites.findUnique).toHaveBeenCalledWith({
+      include: {
+        goals: true,
+        shared_links: true,
+        site_memberships: {
+          where: {
+            role: 'owner',
+            user_id: 1
+          }
+        }
+      },
+      where: {
+        domain: 'https://test-site.com'
+      }
+    })
+
+    expect(data).toEqual({
+      data: {
+        siteCreate: {
+          data: {
+            __typename: 'Site',
+            domain: 'https://test-site.com',
+            goals: [
+              {
+                __typename: 'SiteGoal',
+                id: 'goalId',
+                eventName: 'test-goal'
+              }
+            ],
+            id: 'siteId',
+            memberships: [
+              {
+                __typename: 'SiteMembership',
+                id: 'membershipId',
+                role: 'owner'
+              }
+            ],
+            sharedLinks: [
+              {
+                __typename: 'SiteSharedLink',
+                id: 'sharedLinkId',
+                slug: 'test-slug'
+              }
+            ]
+          }
+        }
+      }
+    })
+  })
 })

--- a/apps/api-analytics/src/schema/site/siteCreate.mutation.ts
+++ b/apps/api-analytics/src/schema/site/siteCreate.mutation.ts
@@ -74,8 +74,31 @@ builder.mutationType({
             error.message.includes(
               'Unique constraint failed on the fields: (`domain`)'
             )
-          )
+          ) {
+            if (context.currentUser?.id != null) {
+              const site = await prisma.sites.findUnique({
+                ...query,
+                include: {
+                  ...query.include,
+                  site_memberships: {
+                    where: {
+                      role: 'owner',
+                      user_id: context.currentUser.id
+                    }
+                  }
+                },
+                where: {
+                  domain: input.domain
+                }
+              })
+              if (
+                site?.site_memberships != null &&
+                site?.site_memberships.length > 0
+              )
+                return site
+            }
             throw new Error('domain already exists')
+          }
 
           throw error
         }


### PR DESCRIPTION
# Description

### Issue

When seed is ran, plausible attempts to create sites for the seeded teams and journeys. Since the teams and journeys still exist, the code enters into an infinite loop.

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

- Remove while loop that was causing the infinite loop issue with a chunked array.
- siteCreation returns the existing site when the owner tries to create a site with an existing domain

# External Changes

n/a

# Additional information

n/a
