### PR TITLE
fix: resize image used for blurhash

### DIFF
--- a/apps/api-journeys/src/app/modules/block/image/transformInput.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/image/transformInput.spec.ts
@@ -17,15 +17,21 @@ const mockFetch = fetch as jest.MockedFunction<typeof fetch>
 jest.mock('sharp', () => () => ({
   raw: () => ({
     ensureAlpha: () => ({
-      toBuffer: () => ({
-        data: new Uint8ClampedArray([]),
-        info: {
-          width: 640,
-          height: 425
-        }
+      resize: () => ({
+        toBuffer: () => ({
+          data: new Uint8ClampedArray([]),
+          info: {
+            width: 32,
+            height: 32
+          }
+        })
       })
     })
-  })
+  }),
+  metadata: jest.fn(() => ({
+    width: 640,
+    height: 425
+  }))
 }))
 
 jest.mock('blurhash', () => {


### PR DESCRIPTION
# Description

### Issue

blurhash is super slow because we are using a fullsize image to calculate the blurhash.

### Solution

resize image to 32x32 before calculating the blurhash.