### PR TITLE
fix: video subtitle primary field

### DIFF
--- a/apps/api-videos/src/app/modules/importer/importerVideoSubtitle/importerVideoSubtitle.service.spec.ts
+++ b/apps/api-videos/src/app/modules/importer/importerVideoSubtitle/importerVideoSubtitle.service.spec.ts
@@ -32,7 +32,6 @@ describe('ImporterVideoSubtitlesService', () => {
     it('should update video subtitle', async () => {
       importerVideosService.ids = ['mockVideoId']
       await service.import({
-        primary: 1,
         languageId: 529,
         video: 'mockVideoId',
         vttSrc: 'mockVttSrc',
@@ -70,7 +69,6 @@ describe('ImporterVideoSubtitlesService', () => {
       await service.importMany([
         {
           value: 'mockValue',
-          primary: 1,
           languageId: 529,
           video: 'mockVideoId',
           vttSrc: 'mockVttSrc',
@@ -79,7 +77,6 @@ describe('ImporterVideoSubtitlesService', () => {
         },
         {
           value: 'mockValue1',
-          primary: 1,
           languageId: 529,
           video: 'mockVideoId1',
           vttSrc: 'mockVttSrc',
@@ -122,7 +119,6 @@ describe('ImporterVideoSubtitlesService', () => {
       importerVideosService.ids = []
       await expect(
         service.import({
-          primary: 1,
           languageId: 529,
           video: 'mockVideoId',
           vttSrc: 'mockVttSrc',

--- a/apps/api-videos/src/app/modules/importer/importerVideoSubtitle/importerVideoSubtitle.service.ts
+++ b/apps/api-videos/src/app/modules/importer/importerVideoSubtitle/importerVideoSubtitle.service.ts
@@ -14,7 +14,6 @@ const videoSubtitlesSchema = z
       .transform((value) => value ?? 'base'),
     vttSrc: z.string().nullable(),
     srtSrc: z.string().nullable(),
-    primary: z.number().transform(Boolean),
     languageId: z.number().transform(String)
   })
   .transform((data) => ({

--- a/apps/api-videos/src/app/modules/importer/importerVideoSubtitle/importerVideoSubtitle.service.ts
+++ b/apps/api-videos/src/app/modules/importer/importerVideoSubtitle/importerVideoSubtitle.service.ts
@@ -18,8 +18,9 @@ const videoSubtitlesSchema = z
     languageId: z.number().transform(String)
   })
   .transform((data) => ({
-    ...omit(data, 'video'),
-    videoId: data.video
+    ...omit(data, 'video', 'primary'),
+    videoId: data.video,
+    primary: data.languageId === '529'
   }))
 
 type VideoSubtitles = z.infer<typeof videoSubtitlesSchema>


### PR DESCRIPTION
# Description

### Issue

Primary is not properly filled in bq data, but easy to ascertain

### Solution

Make 529 primary on import

# External Changes


# Additional information

