### PR TITLE
feat: add responses navigation

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/Items.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/Items.tsx
@@ -6,6 +6,7 @@ import { AnalyticsItem } from './AnalyticsItem'
 import { CommandRedoItem } from './CommandRedoItem'
 import { CommandUndoItem } from './CommandUndoItem'
 import { PreviewItem } from './PreviewItem'
+import { ResponsesItem } from './ResponsesItem'
 import { ShareItem } from './ShareItem'
 import { StrategyItem } from './StrategyItem'
 
@@ -24,6 +25,7 @@ export function Items(): ReactElement {
           <CommandRedoItem variant="icon-button" />
         </>
       )}
+      <ResponsesItem variant="button" />
       <AnalyticsItem variant="icon-button" />
       <StrategyItem variant="button" />
       <ShareItem variant="button" />

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/ResponsesItem/ResponsesItem.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/ResponsesItem/ResponsesItem.tsx
@@ -1,0 +1,37 @@
+import Inbox2 from '@core/shared/ui/icons/Inbox2'
+import { useTranslation } from 'next-i18next'
+import NextLink from 'next/link'
+import { ComponentProps } from 'react'
+import { Item } from '../Item'
+
+import { useJourney } from '@core/journeys/ui/JourneyProvider'
+import Box from '@mui/material/Box'
+
+interface ResponsesItemProps {
+  variant: ComponentProps<typeof Item>['variant']
+}
+
+export function ResponsesItem({ variant }: ResponsesItemProps) {
+  const { t } = useTranslation('apps-journeys-admin')
+  const { journey } = useJourney()
+
+  return (
+    <Box data-testid="ResponsesItem">
+      <NextLink
+        href={`/journeys/${journey?.id}/reports/visitors`}
+        passHref
+        legacyBehavior
+        prefetch={false}
+      >
+        <Item
+          variant={variant}
+          label={25}
+          icon={<Inbox2 />}
+          ButtonProps={{
+            variant: 'text'
+          }}
+        />
+      </NextLink>
+    </Box>
+  )
+}

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/ResponsesItem/index.ts
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/ResponsesItem/index.ts
@@ -1,0 +1,1 @@
+export { ResponsesItem } from './ResponsesItem'

--- a/libs/shared/ui/src/components/icons/Icon.tsx
+++ b/libs/shared/ui/src/components/icons/Icon.tsx
@@ -99,6 +99,7 @@ import Home3 from './Home3'
 import Home4 from './Home4'
 import Image3 from './Image3'
 import ImageX from './ImageX'
+import Inbox2 from './Inbox2'
 import InformationCircleContained from './InformationCircleContained'
 import InformationSquareContained from './InformationSquareContained'
 import Instagram from './Instagram'
@@ -306,6 +307,7 @@ export type IconName =
   | 'Home4'
   | 'Image3'
   | 'ImageX'
+  | 'Inbox2'
   | 'InformationCircleContained'
   | 'InformationSquareContained'
   | 'Instagram'
@@ -517,6 +519,7 @@ const iconComponents: IconComponents = {
   Home4,
   Image3,
   ImageX,
+  Inbox2,
   InformationCircleContained,
   InformationSquareContained,
   Instagram,

--- a/libs/shared/ui/src/components/icons/Inbox2.tsx
+++ b/libs/shared/ui/src/components/icons/Inbox2.tsx
@@ -1,0 +1,10 @@
+import { createSvgIcon } from '@mui/material/utils'
+
+export default createSvgIcon(
+  <path
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M4.5 4.8a3.4 3.4 0 0 1 3.2-2.2h8.6c1.5 0 2.7.9 3.2 2.2l3 8 .1.4V18c0 1.9-1.5 3.4-3.4 3.4H4.8A3.4 3.4 0 0 1 1.4 18v-5.2l3-8Zm3.2-.2c-.6 0-1.1.4-1.3 1l-2.6 6.6h3.4c.3 0 .5.1.7.3L9.2 14h5.6l1.3-1.4c.2-.2.4-.3.7-.3h3.4l-2.6-6.7c-.2-.5-.7-.9-1.3-.9H7.7Zm12.9 9.6h-3.4L16 15.6a1 1 0 0 1-.7.3H8.8a1 1 0 0 1-.7-.3l-1.3-1.4H3.4V18c0 .8.6 1.4 1.4 1.4h14.4c.8 0 1.4-.6 1.4-1.4v-3.8Z"
+  />,
+  'Inbox2'
+)


### PR DESCRIPTION
# Description

### Issue
Design has requested to have a navigation item from the editor to the visitors page with responses

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/38213939/todos/7616348706)

### Solution
Added the `ResponsesItem` to the editor toolbar.

# External Changes

# Additional information

