### PR TITLE
feat: insights watch

### DIFF
--- a/apps/watch/pages/_app.tsx
+++ b/apps/watch/pages/_app.tsx
@@ -114,7 +114,13 @@ function WatchApp({
             themeName={ThemeName.website}
             themeMode={ThemeMode.light}
           >
-            <InstantSearch searchClient={searchClient}>
+            <InstantSearch
+              searchClient={searchClient}
+              future={{
+                preserveSharedStateOnUnmount: true
+              }}
+              insights={true}
+            >
               <Component {...pageProps} />
             </InstantSearch>
           </ThemeProvider>

--- a/apps/watch/pages/watch/[part1]/[part2].tsx
+++ b/apps/watch/pages/watch/[part1]/[part2].tsx
@@ -52,7 +52,7 @@ const searchClient = algoliasearch(
 
 export default function Part2Page({ content }: Part2PageProps): ReactElement {
   return (
-    <InstantSearch searchClient={searchClient}>
+    <InstantSearch insights searchClient={searchClient}>
       <SnackbarProvider>
         <LanguageProvider>
           <VideoProvider value={{ content }}>

--- a/apps/watch/src/components/VideoCard/VideoCard.spec.tsx
+++ b/apps/watch/src/components/VideoCard/VideoCard.spec.tsx
@@ -3,8 +3,21 @@ import { render } from '@testing-library/react'
 import { videos } from '../Videos/__generated__/testData'
 
 import { VideoCard } from '.'
+import { useHits } from 'react-instantsearch'
+import { HitsRenderState } from 'instantsearch.js/es/connectors/hits/connectHits'
+
+jest.mock('react-instantsearch')
+
+const mockUseHits = useHits as jest.MockedFunction<typeof useHits>
 
 describe('VideoCard', () => {
+  beforeEach(() => {
+    mockUseHits.mockReturnValue({
+      hits: videos,
+      sendEvent: jest.fn()
+    } as unknown as HitsRenderState)
+  })
+
   describe('video contained', () => {
     it('displays image', () => {
       const { getByRole } = render(

--- a/apps/watch/src/components/VideoCard/VideoCard.tsx
+++ b/apps/watch/src/components/VideoCard/VideoCard.tsx
@@ -12,7 +12,7 @@ import NextLink from 'next/link'
 import { ReactElement } from 'react'
 
 import { secondsToTimeFormat } from '@core/shared/ui/timeFormat'
-
+import { useHits } from 'react-instantsearch'
 import { VideoChildFields } from '../../../__generated__/VideoChildFields'
 import { VideoLabel } from '../../../__generated__/globalTypes'
 import { getLabelDetails } from '../../libs/utils/getLabelDetails/getLabelDetails'
@@ -73,6 +73,9 @@ export function VideoCard({
   )
   const href = getSlug(containerSlug, video?.label, video?.variant?.slug)
 
+  const { hits, sendEvent } = useHits()
+  const hit = hits.filter((hit) => hit.videoId === video?.id)
+
   const { t } = useTranslation('apps-watch')
   return (
     <NextLink href={href} passHref legacyBehavior>
@@ -83,6 +86,10 @@ export function VideoCard({
         sx={{ pointerEvents: video != null ? 'auto' : 'none' }}
         aria-label="VideoCard"
         data-testid={video != null ? `VideoCard-${video.id}` : 'VideoCard'}
+        onClick={(event) => {
+          event.stopPropagation()
+          sendEvent('click', hit, 'Video Clicked')
+        }}
       >
         <Stack spacing={3}>
           <ImageButton


### PR DESCRIPTION
# Description

### Issue

Need insights turned on for algolia searches

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/38213804/todos/7634025419)

### Solution

Add send event call on each video card
Note that an event now sends for viewing a hit on any page, and when one is clicked.

<img width="654" alt="image" src="https://github.com/user-attachments/assets/de671041-50f3-4125-a3d9-e97b8d28c56f">

# External Changes

Fixed a bug in ID of strategy

# Additional information

## How to test
Should have hits viewed and video clicked events in algolia dashboard

