### PR TITLE
fix: restore resolver should also return siblings

### DIFF
--- a/apps/api-journeys/src/app/modules/block/block.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/block.resolver.spec.ts
@@ -307,6 +307,16 @@ describe('BlockResolver', () => {
       )
     })
 
+    it('should throw error if block does not have a parent order', async () => {
+      prismaService.block.findUnique.mockResolvedValue({
+        ...blockWithUserTeam,
+        parentOrder: null
+      })
+      await expect(resolver.blockRestore('1', ability)).rejects.toThrow(
+        'updated block has no parent order'
+      )
+    })
+
     it('should throw error if user does not have the correct permissions', async () => {
       prismaService.block.findUnique.mockResolvedValue(block)
       prismaService.block.update.mockResolvedValue(block)

--- a/apps/api-journeys/src/app/modules/block/block.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/block.resolver.ts
@@ -216,12 +216,16 @@ export class BlockResolver {
           action: true
         }
       })
-      if (updatedBlock.parentOrder != null)
-        await this.blockService.reorderBlock(
-          updatedBlock,
-          updatedBlock.parentOrder,
-          tx
-        )
+      if (updatedBlock?.parentOrder == null)
+        throw new GraphQLError('updated block has no parent order', {
+          extensions: { code: 'INTERNAL_SERVER_ERROR' }
+        })
+
+      const updatedBlockAndSiblings = await this.blockService.reorderBlock(
+        updatedBlock,
+        updatedBlock.parentOrder,
+        tx
+      )
       const blocks = await tx.block.findMany({
         where: {
           journeyId: updatedBlock.journeyId,
@@ -234,7 +238,7 @@ export class BlockResolver {
         updatedBlock.id,
         blocks
       )
-      return [updatedBlock, ...children]
+      return [...updatedBlockAndSiblings, ...children]
     })
   }
 }


### PR DESCRIPTION
# Description

### Issue

returning the correct parent order of siblings of the restored block along with its descendants 
this is needed to automatically set correct parent order in the fe cache along with making sure the optimistic update parent order is not overridden

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)


