### PR TITLE
fix: language name for selector

### DIFF
--- a/apps/api-languages/src/bigquery/importers/languageNames/languageNames.ts
+++ b/apps/api-languages/src/bigquery/importers/languageNames/languageNames.ts
@@ -13,7 +13,7 @@ const languageNameSchema = z
   })
   .transform((value) => ({
     ...value,
-    primary: value.languageId === '529'
+    primary: value.languageId === value.parentLanguageId
   }))
 
 const bigQueryTableName =

--- a/apps/api-languages/src/schema/language/language.spec.ts
+++ b/apps/api-languages/src/schema/language/language.spec.ts
@@ -65,7 +65,8 @@ describe('language', () => {
     })
     expect(prismaMock.languageName.findMany).toHaveBeenCalledWith({
       where: {
-        parentLanguageId: '20615'
+        parentLanguageId: '20615',
+        OR: [{ languageId: '529' }, { primary: true }]
       },
       include: { language: true },
       orderBy: { primary: 'desc' }

--- a/apps/api-languages/src/schema/language/language.ts
+++ b/apps/api-languages/src/schema/language/language.ts
@@ -50,7 +50,10 @@ export const Language = builder.prismaObject('Language', {
       resolve: async (query, language, { languageId, primary }) => {
         const where: Prisma.LanguageNameWhereInput = {
           parentLanguageId: language.id,
-          OR: languageId == null && primary == null ? undefined : []
+          OR:
+            languageId == null && primary == null
+              ? [{ languageId: '529' }, { primary: true }]
+              : []
         }
         if (languageId != null) where.OR?.push({ languageId })
         if (primary != null) where.OR?.push({ primary })
@@ -104,9 +107,7 @@ builder.queryFields((t) => ({
       where: t.arg({ type: LanguagesFilter, required: false })
     },
     resolve: async (query, _parent, { offset, limit, where }) => {
-      const filter: Prisma.LanguageWhereInput = {
-        hasVideos: true
-      }
+      const filter: Prisma.LanguageWhereInput = {}
       if (where?.ids != null) filter.id = { in: where?.ids }
       return await prisma.language.findMany({
         ...query,

--- a/apps/api-languages/src/schema/language/language.ts
+++ b/apps/api-languages/src/schema/language/language.ts
@@ -107,7 +107,9 @@ builder.queryFields((t) => ({
       where: t.arg({ type: LanguagesFilter, required: false })
     },
     resolve: async (query, _parent, { offset, limit, where }) => {
-      const filter: Prisma.LanguageWhereInput = {}
+      const filter: Prisma.LanguageWhereInput = {
+        hasVideos: true
+      }
       if (where?.ids != null) filter.id = { in: where?.ids }
       return await prisma.language.findMany({
         ...query,

--- a/apps/api-languages/src/schema/language/languages.spec.ts
+++ b/apps/api-languages/src/schema/language/languages.spec.ts
@@ -35,7 +35,9 @@ describe('language', () => {
       document: LANGUAGES_QUERY
     })
     expect(prismaMock.language.findMany).toHaveBeenCalledWith({
-      where: {}
+      where: {
+        hasVideos: true
+      }
     })
     expect(prismaMock.languageName.findMany).toHaveBeenCalledWith({
       where: {
@@ -66,7 +68,9 @@ describe('language', () => {
       }
     })
     expect(prismaMock.language.findMany).toHaveBeenCalledWith({
-      where: {}
+      where: {
+        hasVideos: true
+      }
     })
     expect(prismaMock.languageName.findMany).toHaveBeenCalledWith({
       where: {

--- a/apps/api-languages/src/schema/language/languages.spec.ts
+++ b/apps/api-languages/src/schema/language/languages.spec.ts
@@ -35,13 +35,12 @@ describe('language', () => {
       document: LANGUAGES_QUERY
     })
     expect(prismaMock.language.findMany).toHaveBeenCalledWith({
-      where: {
-        hasVideos: true
-      }
+      where: {}
     })
     expect(prismaMock.languageName.findMany).toHaveBeenCalledWith({
       where: {
-        parentLanguageId: '20615'
+        parentLanguageId: '20615',
+        OR: [{ languageId: '529' }, { primary: true }]
       },
       include: { language: true },
       orderBy: { primary: 'desc' }
@@ -67,9 +66,7 @@ describe('language', () => {
       }
     })
     expect(prismaMock.language.findMany).toHaveBeenCalledWith({
-      where: {
-        hasVideos: true
-      }
+      where: {}
     })
     expect(prismaMock.languageName.findMany).toHaveBeenCalledWith({
       where: {


### PR DESCRIPTION
# Description

### Issue

Language name primary was calculated incorrectly in the new seed
Row ordering changed the output of language names

### Solution

correct importer primary calculation
add a default resolver for native and english 

