### PR TITLE
fix: include action in children block restore

### DIFF
--- a/apps/api-journeys/src/app/modules/block/block.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/block.resolver.spec.ts
@@ -293,6 +293,9 @@ describe('BlockResolver', () => {
           journeyId: block.journeyId,
           deletedAt: null,
           NOT: { id: block.id }
+        },
+        include: {
+          action: true
         }
       })
       expect(service.getDescendants).toHaveBeenCalledWith(block.id, [

--- a/apps/api-journeys/src/app/modules/block/block.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/block.resolver.ts
@@ -231,7 +231,8 @@ export class BlockResolver {
           journeyId: updatedBlock.journeyId,
           deletedAt: null,
           NOT: { id: updatedBlock.id }
-        }
+        },
+        include: { action: true }
       })
 
       const children: Block[] = await this.blockService.getDescendants(


### PR DESCRIPTION
# Description

### Issue

actions need to be included so that the edges do not get overwritten incorrectly in the cache for a block restore

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)