### PR TITLE
fix: step block node second line clipped

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/StepBlockNodeCard/StepBlockNodeCard.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/StepBlockNodeCard/StepBlockNodeCard.tsx
@@ -22,12 +22,6 @@ interface StepBlockNodeCardProps {
   selected: boolean
 }
 
-const analyticStyles = {
-  opacity: 0.8,
-  boxShadow: 'none',
-  bgcolor: 'transparent'
-}
-
 export function StepBlockNodeCard({
   step,
   selected
@@ -147,7 +141,8 @@ export function StepBlockNodeCard({
                 '-webkit-box-orient': 'vertical',
                 '-webkit-line-clamp': '1',
                 overflow: 'hidden',
-                fontSize: 9
+                fontSize: 9,
+                lineHeight: 2
               }}
             >
               {description !== '' ? description : ''}
@@ -163,7 +158,7 @@ export function StepBlockNodeCard({
               fontSize: 11,
               fontWeight: 'bold',
               alignSelf: 'flex-start',
-              lineHeight: 1.3
+              lineHeight: 1.2
             }}
           >
             {title != null && title !== '' ? (
@@ -187,7 +182,7 @@ export function StepBlockNodeCard({
               '-webkit-box-orient': 'vertical',
               '-webkit-line-clamp': '2',
               fontSize: 10,
-              lineHeight: '1.2',
+              lineHeight: 1.2,
               overflow: 'hidden'
             }}
           >


### PR DESCRIPTION
# Description

### Issue

For the step block node card, the title of the node would cut off partially if it was long enough. This has been fixed now by slightly tweaking the padding and line heights.

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/38213939/todos/7586174799)

### Solution

_Provide a detailed description of how exactly this task will be accomplished. This can be something technical. What specific steps will be taken to achieve the goal? This should include details on service integration, job logic, implementation, etc._

# External Changes

_If you have made changes to external services, need to add additional values to Doppler, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc._

# Additional information

_Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc._
