### PR TITLE
fix: stop text overflow on nodes

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/StepBlockNodeCard/StepBlockNodeCard.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/StepBlockNode/StepBlockNodeCard/StepBlockNodeCard.tsx
@@ -146,7 +146,7 @@ export function StepBlockNodeCard({
                 lineHeight: 2
               }}
             >
-               {description !== '' ? description : ''}
+              {description !== '' ? description : ''}
             </Typography>
           )}
           <Typography


### PR DESCRIPTION
# Description

### Issue

text is overflowing when title is too long

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/38213939/todos/7586174664)

### Solution
add wordBreak: 'break-word', 
