### PR TITLE
fix: video trigger when on first step

### DIFF
--- a/libs/journeys/ui/src/components/VideoTrigger/VideoTrigger.tsx
+++ b/libs/journeys/ui/src/components/VideoTrigger/VideoTrigger.tsx
@@ -31,11 +31,13 @@ export function VideoTrigger({
   const { journey, variant } = useJourney()
   const [triggered, setTriggered] = useState(false)
   const { blockHistory } = useBlocks()
-  const activeBlock = blockHistory[blockHistory.length - 1]
+  const activeBlock = blockHistory[blockHistory.length - 1] as
+    | TreeBlock
+    | undefined
   const plausible = usePlausible<JourneyPlausibleEvents>()
 
   useEffect(() => {
-    if (player != null && !triggered) {
+    if (player != null && !triggered && activeBlock?.id != null) {
       const handleTimeUpdate = (): void => {
         if (
           (player.currentTime() ?? 0) >= triggerStart - 0.25 &&
@@ -99,7 +101,7 @@ export function VideoTrigger({
     blockId,
     plausible,
     journey?.id,
-    activeBlock.id
+    activeBlock?.id
   ])
 
   return <></>


### PR DESCRIPTION
# Description

https://3.basecamp.com/3105655/buckets/38213939/todos/7686470036

### Issue

activeBlock can be undefined on page initialization.

### Solution

Don't run useEffect when activeBlock is undefined.