### PR TITLE
fix: handle null parentorder on block restore

### DIFF
--- a/apps/api-journeys/src/app/modules/block/block.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/block/block.resolver.spec.ts
@@ -340,14 +340,18 @@ describe('BlockResolver', () => {
       )
     })
 
-    it('should throw error if block does not have a parent order', async () => {
-      prismaService.block.findUnique.mockResolvedValue({
+    it('should only return the updated block without its siblings if parent order is null', async () => {
+      const blockWithoutParentOrder = {
         ...blockWithUserTeam,
         parentOrder: null
-      })
-      await expect(resolver.blockRestore('1', ability)).rejects.toThrow(
-        'updated block has no parent order'
-      )
+      }
+
+      prismaService.block.findUnique.mockResolvedValue(blockWithoutParentOrder)
+      prismaService.block.update.mockResolvedValue(blockWithoutParentOrder)
+
+      expect(await resolver.blockRestore('1', ability)).toEqual([
+        blockWithoutParentOrder
+      ])
     })
 
     it('should throw error if user does not have the correct permissions', async () => {

--- a/apps/api-journeys/src/app/modules/block/block.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/block.resolver.ts
@@ -11,7 +11,7 @@ import { Action, AppAbility } from '../../lib/casl/caslFactory'
 import { AppCaslGuard } from '../../lib/casl/caslGuard'
 import { PrismaService } from '../../lib/prisma.service'
 
-import { BlockService } from './block.service'
+import { BlockService, BlockWithAction } from './block.service'
 
 @Resolver('Block')
 export class BlockResolver {
@@ -215,6 +215,7 @@ export class BlockResolver {
       })
 
     return await this.prismaService.$transaction(async (tx) => {
+      let res: BlockWithAction[] | undefined
       const updatedBlock = await tx.block.update({
         where: { id },
         data: {
@@ -224,16 +225,13 @@ export class BlockResolver {
           action: true
         }
       })
-      if (updatedBlock?.parentOrder == null)
-        throw new GraphQLError('updated block has no parent order', {
-          extensions: { code: 'INTERNAL_SERVER_ERROR' }
-        })
+      if (updatedBlock?.parentOrder != null)
+        res = await this.blockService.reorderBlock(
+          updatedBlock,
+          updatedBlock.parentOrder,
+          tx
+        )
 
-      const updatedBlockAndSiblings = await this.blockService.reorderBlock(
-        updatedBlock,
-        updatedBlock.parentOrder,
-        tx
-      )
       const blocks = await tx.block.findMany({
         where: {
           journeyId: updatedBlock.journeyId,
@@ -247,7 +245,9 @@ export class BlockResolver {
         updatedBlock.id,
         blocks
       )
-      return [...updatedBlockAndSiblings, ...children]
+
+      if (res == null) res = [updatedBlock]
+      return [...res, ...children]
     })
   }
 }

--- a/apps/api-journeys/src/app/modules/block/block.resolver.ts
+++ b/apps/api-journeys/src/app/modules/block/block.resolver.ts
@@ -215,7 +215,6 @@ export class BlockResolver {
       })
 
     return await this.prismaService.$transaction(async (tx) => {
-      let res: BlockWithAction[] | undefined
       const updatedBlock = await tx.block.update({
         where: { id },
         data: {
@@ -225,8 +224,9 @@ export class BlockResolver {
           action: true
         }
       })
+      let siblings: BlockWithAction[] = [updatedBlock]
       if (updatedBlock?.parentOrder != null)
-        res = await this.blockService.reorderBlock(
+        siblings = await this.blockService.reorderBlock(
           updatedBlock,
           updatedBlock.parentOrder,
           tx
@@ -246,8 +246,7 @@ export class BlockResolver {
         blocks
       )
 
-      if (res == null) res = [updatedBlock]
-      return [...res, ...children]
+      return [...siblings, ...children]
     })
   }
 }


### PR DESCRIPTION
# Description

### Issue

block restore can now handle blocks that has a null parentOrder

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)
