### PR TITLE
fix: rely on use effect to populate positions

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/JourneyFlow.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/JourneyFlow.tsx
@@ -126,31 +126,14 @@ export function JourneyFlow(): ReactElement {
     notifyOnNetworkStatusChange: true,
     variables: { journeyIds: journey?.id != null ? [journey.id] : undefined },
     onCompleted: (data) => {
-      if (steps == null || journey == null) return
-      const positions: PositionMap = {}
       if (
         data.blocks.some(
           (block) =>
             block.__typename === 'StepBlock' &&
             (block.x == null || block.y == null)
         )
-      ) {
-        // some steps have no x or y coordinates
+      )
         void allBlockPositionUpdate(true)
-      } else {
-        data.blocks.forEach((block) => {
-          if (
-            block.__typename === 'StepBlock' &&
-            block.x != null &&
-            block.y != null
-          ) {
-            positions[block.id] = { x: block.x, y: block.y }
-          }
-        })
-      }
-      const { nodes, edges } = transformSteps(steps ?? [], positions)
-      setEdges(edges)
-      setNodes(nodes)
     }
   })
 


### PR DESCRIPTION
# Description

### Issue

When block has no x or y the page throws an error

### Solution

Edges and nodes should be set when use effect runs not when position data returns. They should only be set when there are positions for all the visible steps.