### PR TITLE
fix: filter invalid root block types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -138,7 +138,7 @@
         "@typescript-eslint/prefer-nullish-coalescing": "off",
         "@typescript-eslint/prefer-optional-chain": "off",
         "@typescript-eslint/non-nullable-type-assertion-style": "off",
-        "@typescript-eslint/no-extra-semi": "error",
+        "@typescript-eslint/no-extra-semi": "off",
         "no-extra-semi": "off"
       }
     },
@@ -146,7 +146,7 @@
       "files": ["*.js", "*.jsx"],
       "extends": ["plugin:@nx/javascript", "standard", "prettier"],
       "rules": {
-        "@typescript-eslint/no-extra-semi": "error",
+        "@typescript-eslint/no-extra-semi": "off",
         "no-extra-semi": "off"
       }
     },

--- a/.github/workflows/autofix.ci.yml
+++ b/.github/workflows/autofix.ci.yml
@@ -63,7 +63,10 @@ jobs:
       - name: Run Prettier
         run: npm run prettier:fix
       - name: Run ESLint
-        run: npm run lint:fix
+        uses: mansagroup/nrwl-nx-action@v3
+        with:
+          targets: lint
+          args: --fix
       - name: type-check, extract-translations, subgraph-check
         uses: mansagroup/nrwl-nx-action@v3
         with:

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,6 @@ schema.graphql
 .storybook/static/mockServiceWorker.js
 /.nx/cache
 /.nx/workspace-data
+.next/
+.terraform/
+playwright-report/

--- a/apps/api-videos/src/app/modules/importer/importerVideos/importerVideos.service.ts
+++ b/apps/api-videos/src/app/modules/importer/importerVideos/importerVideos.service.ts
@@ -95,7 +95,7 @@ export class ImporterVideosService extends ImporterService<Video> {
     })
     this.ids = [...this.ids, ...transformedVideos.map(({ id }) => id)]
     for (const video of transformedVideos) {
-      (this.usedSlugs as Record<string, string>)[video.id] = video.slug
+      ;(this.usedSlugs as Record<string, string>)[video.id] = video.slug
     }
   }
 }

--- a/apps/journeys-admin/src/components/Editor/Editor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.spec.tsx
@@ -126,7 +126,7 @@ describe('Editor', () => {
   })
 
   it('should render the Fab', async () => {
-    (useMediaQuery as jest.Mock).mockImplementation(() => true)
+    ;(useMediaQuery as jest.Mock).mockImplementation(() => true)
 
     render(
       <MockedProvider>

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/CanvasFooter/CanvasFooter.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/CanvasFooter/CanvasFooter.spec.tsx
@@ -17,7 +17,7 @@ jest.mock('@mui/material/useMediaQuery', () => ({
 
 describe('CanvasFooter', () => {
   it('should render fab when not in analytics mode', () => {
-    (useMediaQuery as jest.Mock).mockImplementation(() => true)
+    ;(useMediaQuery as jest.Mock).mockImplementation(() => true)
 
     const initialState = {
       showAnalytics: false

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
@@ -131,7 +131,7 @@ describe('BackgroundMediaImage', () => {
   let originalEnv
 
   beforeEach(() => {
-    (useMediaQuery as jest.Mock).mockImplementation(() => true)
+    ;(useMediaQuery as jest.Mock).mockImplementation(() => true)
     originalEnv = process.env
     process.env = {
       ...originalEnv,

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Image/Options/ImageOptions.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Image/Options/ImageOptions.spec.tsx
@@ -28,7 +28,7 @@ describe('ImageOptions', () => {
   let originalEnv
 
   beforeEach(() => {
-    (useMediaQuery as jest.Mock).mockImplementation(() => true)
+    ;(useMediaQuery as jest.Mock).mockImplementation(() => true)
     originalEnv = process.env
     process.env = {
       ...originalEnv,

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/ImageSource/ImageSource.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/ImageSource/ImageSource.spec.tsx
@@ -29,7 +29,7 @@ describe('ImageSource', () => {
   let originalEnv
 
   beforeEach(() => {
-    (useMediaQuery as jest.Mock).mockImplementation(() => true)
+    ;(useMediaQuery as jest.Mock).mockImplementation(() => true)
     originalEnv = process.env
     process.env = {
       ...originalEnv,

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/Settings/Poster/Library/VideoBlockEditorSettingsPosterLibrary.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/Settings/Poster/Library/VideoBlockEditorSettingsPosterLibrary.spec.tsx
@@ -160,7 +160,7 @@ describe('VideoBlockEditorSettingsPosterLibrary', () => {
   let originalEnv
 
   beforeEach(() => {
-    (useMediaQuery as jest.Mock).mockImplementation(() => true)
+    ;(useMediaQuery as jest.Mock).mockImplementation(() => true)
     originalEnv = process.env
     process.env = {
       ...originalEnv,

--- a/apps/journeys-admin/src/components/PageWrapper/PageWrapper.spec.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/PageWrapper.spec.tsx
@@ -113,7 +113,7 @@ describe('PageWrapper', () => {
     })
 
     it('should show the side nav bar', () => {
-      (useMediaQuery as jest.Mock).mockImplementation(() => true)
+      ;(useMediaQuery as jest.Mock).mockImplementation(() => true)
 
       const { getByTestId, getByText, queryByRole } = render(
         <MockedProvider>

--- a/apps/journeys-admin/src/components/Team/TeamCreateDialog/TeamCreateDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamCreateDialog/TeamCreateDialog.spec.tsx
@@ -25,7 +25,7 @@ jest.mock('@mui/material/useMediaQuery', () => ({
 
 describe('TeamCreateDialog', () => {
   beforeEach(() => {
-    (useMediaQuery as jest.Mock).mockImplementation(() => true)
+    ;(useMediaQuery as jest.Mock).mockImplementation(() => true)
   })
 
   const teamCreateMock: MockedResponse<TeamCreate> = {

--- a/apps/journeys-admin/src/components/Team/TeamMenu/TeamMenu.spec.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamMenu/TeamMenu.spec.tsx
@@ -30,7 +30,7 @@ describe('TeamMenu', () => {
   const on = jest.fn()
 
   beforeEach(() => {
-    (useMediaQuery as jest.Mock).mockImplementation(() => true)
+    ;(useMediaQuery as jest.Mock).mockImplementation(() => true)
     jest.clearAllMocks()
   })
 

--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoControls/VideoControls.spec.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoControls/VideoControls.spec.tsx
@@ -122,7 +122,7 @@ describe('VideoControls', () => {
   })
 
   it('fullscreens the video player on fullscreen icon click when mobile', () => {
-    (global.navigator.userAgent as unknown as string) = 'iPhone'
+    ;(global.navigator.userAgent as unknown as string) = 'iPhone'
     const fullscreenStub = jest
       .spyOn(player, 'requestFullscreen')
       .mockImplementation(() => ({
@@ -140,7 +140,7 @@ describe('VideoControls', () => {
   })
 
   it('fullscreens the video player on fullscreen icon click when desktop', async () => {
-    (global.navigator.userAgent as unknown as string) = 'Mac'
+    ;(global.navigator.userAgent as unknown as string) = 'Mac'
     const { getByTestId } = render(
       <MockedProvider>
         <VideoProvider value={{ content: videos[0] }}>

--- a/libs/journeys/ui/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.spec.tsx
+++ b/libs/journeys/ui/src/components/TemplateView/TemplatePreviewTabs/TemplateCardPreview/TemplateCardPreview.spec.tsx
@@ -15,7 +15,7 @@ jest.mock('@mui/material/useMediaQuery', () => ({
 
 describe('TemplateCardPreview', () => {
   it('renders correct number of cards', async () => {
-    (useMediaQuery as unknown as jest.Mock).mockReturnValue(false)
+    ;(useMediaQuery as unknown as jest.Mock).mockReturnValue(false)
     const steps = [
       { id: '1', children: [{ __typename: 'CardBlock' }] },
       { id: '2', children: [{ __typename: 'CardBlock' }] },
@@ -68,7 +68,7 @@ describe('TemplateCardPreview', () => {
   })
 
   it('renders correct number of cards on small breakpoints', async () => {
-    (useMediaQuery as unknown as jest.Mock).mockReturnValue(true)
+    ;(useMediaQuery as unknown as jest.Mock).mockReturnValue(true)
     const steps = [
       { id: '1', children: [{ __typename: 'CardBlock' }] },
       { id: '2', children: [{ __typename: 'CardBlock' }] },

--- a/libs/journeys/ui/src/components/Video/VideoControls/VideoControls.spec.tsx
+++ b/libs/journeys/ui/src/components/Video/VideoControls/VideoControls.spec.tsx
@@ -189,7 +189,7 @@ describe('VideoControls', () => {
   })
 
   it('should show pause after unmuting via region click', async () => {
-    (useMediaQuery as unknown as jest.Mock).mockReturnValue(true)
+    ;(useMediaQuery as unknown as jest.Mock).mockReturnValue(true)
     jest.spyOn(player, 'on').mockImplementation((type, fn) => {
       if (type === 'play') fn()
     })

--- a/libs/journeys/ui/src/libs/transformer/transformer.spec.ts
+++ b/libs/journeys/ui/src/libs/transformer/transformer.spec.ts
@@ -21,6 +21,17 @@ describe('transformer', () => {
           locked: false
         },
         {
+          __typename: 'CardBlock',
+          backgroundColor: '#30313D',
+          coverBlockId: '404-imageBlock-id',
+          fullscreen: false,
+          id: 'invalidRoot',
+          parentBlockId: null,
+          parentOrder: 0,
+          themeMode: null,
+          themeName: null
+        },
+        {
           __typename: 'RadioQuestionBlock',
           id: 'Question1',
           parentBlockId: 'Root1',

--- a/libs/journeys/ui/src/libs/transformer/transformer.ts
+++ b/libs/journeys/ui/src/libs/transformer/transformer.ts
@@ -22,5 +22,5 @@ export function transformer(data: BlockFields[]): TreeBlock[] {
       tree.push(newNode)
     }
   })
-  return tree
+  return tree.filter(({ __typename: typename }) => typename === 'StepBlock')
 }


### PR DESCRIPTION
# Description

### Issue

all our logic expects steps to be of type StepBlock. I am pretty surprised tbh this hasn't caused more issues. There are some journeys with orphaned blocks. This stops them from being visible on the frontend and admin sites.

Also quick lint fix.