### PR TITLE
fix: goals overflow to scroll

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Goals/GoalsList/GoalsList.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Goals/GoalsList/GoalsList.tsx
@@ -42,7 +42,8 @@ export function GoalsList({
       <Stack
         sx={{
           gap: { xs: 4, sm: variant !== 'minimal' ? 12 : 4 },
-          mx: { xs: 0, sm: variant !== 'minimal' ? 8 : 0 }
+          mx: { xs: 0, sm: variant !== 'minimal' ? 8 : 0 },
+          overflow: 'hidden'
         }}
         data-testid="GoalsList"
       >
@@ -89,13 +90,17 @@ export function GoalsList({
           sx={{
             boxShadow: 'none',
             border: variant !== 'minimal' ? '1px solid #DEDFE0' : 0,
-            backgroundColor: 'transparent'
+            backgroundColor: 'transparent',
+            overflowY: 'auto'
           }}
         >
-          <Table>
+          <Table stickyHeader>
             <TableHead
               sx={{
-                borderBottom: variant !== 'minimal' ? '1.5px solid #DEDFE0' : 0
+                '& .MuiTableCell-stickyHeader': {
+                    bgcolor: 'background.paper',
+                    borderBottom: ({ palette }) => variant !== 'minimal' ? `1.5px solid ${palette.divider}` : 0
+                  }
               }}
             >
               <TableRow sx={{ backgroundColor: 'background.paper' }}>

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Goals/GoalsList/GoalsList.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Goals/GoalsList/GoalsList.tsx
@@ -98,9 +98,10 @@ export function GoalsList({
             <TableHead
               sx={{
                 '& .MuiTableCell-stickyHeader': {
-                    bgcolor: 'background.paper',
-                    borderBottom: ({ palette }) => variant !== 'minimal' ? `1.5px solid ${palette.divider}` : 0
-                  }
+                  bgcolor: 'background.paper',
+                  borderBottom: ({ palette }) =>
+                    variant !== 'minimal' ? `1.5px solid ${palette.divider}` : 0
+                }
               }}
             >
               <TableRow sx={{ backgroundColor: 'background.paper' }}>


### PR DESCRIPTION
# Description

### Issue
Goals list was not scrollable causing some goals to not be viewable

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/38213939/todos/7683170757)

### Solution
Corrected the styles for the goals list table to switch to overflow scroll instead of overflowing the parent container

# External Changes
N/A

# Additional information
N/A