### PR TITLE
fix: editor mobile swipe

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Slider.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Slider.tsx
@@ -107,7 +107,7 @@ export function Slider(): ReactElement {
 
   useEffect(() => {
     if (swiperRef.current != null) {
-      swiperRef.current.swiper.allowTouchMove = showAnalytics === false
+      swiperRef.current.swiper.allowTouchMove = showAnalytics === false || showAnalytics == null
       swiperRef.current.swiper.setGrabCursor()
     }
   }, [showAnalytics])

--- a/apps/journeys-admin/src/components/Editor/Slider/Slider.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Slider.tsx
@@ -107,7 +107,8 @@ export function Slider(): ReactElement {
 
   useEffect(() => {
     if (swiperRef.current != null) {
-      swiperRef.current.swiper.allowTouchMove = showAnalytics === false || showAnalytics == null
+      swiperRef.current.swiper.allowTouchMove =
+        showAnalytics === false || showAnalytics == null
       swiperRef.current.swiper.setGrabCursor()
     }
   }, [showAnalytics])

--- a/apps/journeys-admin/src/components/Editor/Slider/Slider.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Slider.tsx
@@ -107,8 +107,7 @@ export function Slider(): ReactElement {
 
   useEffect(() => {
     if (swiperRef.current != null) {
-      swiperRef.current.swiper.allowTouchMove =
-        showAnalytics === false || showAnalytics == null
+      swiperRef.current.swiper.allowTouchMove = showAnalytics !== true
       swiperRef.current.swiper.setGrabCursor()
     }
   }, [showAnalytics])


### PR DESCRIPTION
# Description

### Issue
Could not swipe up on the card preview for mobile devices. Caused by the logic to set the swiper `allowTouchMove` property not handling the undefined case for `showAnalytics`

[Link to Basecamp Todo](https://3.basecamp.com/3105655/buckets/38213939/todos/7700139780)

### Solution
Updated the logic for the swiper property to properly handle the necessary `showAnalytics` cases

# External Changes

# Additional information
