### PR TITLE
fix: add api key for build time

### DIFF
--- a/apps/watch/pages/strategies/index.tsx
+++ b/apps/watch/pages/strategies/index.tsx
@@ -19,7 +19,9 @@ import { getFlags } from '../../src/libs/getFlags'
 
 const searchClient = algoliasearch(
   process.env.NEXT_PUBLIC_ALGOLIA_APP_ID ?? '',
-  process.env.NEXT_PUBLIC_ALGOLIA_API_KEY ?? ''
+  process.env.ALGOLIA_SERVER_API_KEY ??
+    process.env.NEXT_PUBLIC_ALGOLIA_API_KEY ??
+    ''
 )
 
 interface StrategiesPageProps {


### PR DESCRIPTION
# Description
 
Https referrers don't exists during build. Added a new API key that doesn't have https referrers to only be used during build 