### PR TITLE
perf: improve image size

### DIFF
--- a/apps/watch/src/components/VideoCard/VideoCard.tsx
+++ b/apps/watch/src/components/VideoCard/VideoCard.tsx
@@ -4,7 +4,7 @@ import ButtonBase from '@mui/material/ButtonBase'
 import Link from '@mui/material/Link'
 import Skeleton from '@mui/material/Skeleton'
 import Stack from '@mui/material/Stack'
-import { SxProps, styled } from '@mui/material/styles'
+import { type SxProps, styled, useTheme } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
 import Image from 'next/image'
 import NextLink from 'next/link'
@@ -67,13 +67,15 @@ export function VideoCard({
   active,
   imageSx
 }: VideoCardProps): ReactElement {
+  const { t } = useTranslation('apps-watch')
+  const theme = useTheme()
+
   const { label, color, childCountLabel } = getLabelDetails(
     video?.label,
     video?.childrenCount ?? 0
   )
   const href = getSlug(containerSlug, video?.label, video?.variant?.slug)
 
-  const { t } = useTranslation('apps-watch')
   return (
     <NextLink href={href} passHref legacyBehavior>
       <Link
@@ -116,7 +118,11 @@ export function VideoCard({
                   src={video.image}
                   alt={video.title[0].value}
                   fill
-                  sizes="100vw"
+                  sizes={`(max-width: ${
+                    theme.breakpoints.values.md - 0.5
+                  }) 100vw, (max-width: ${
+                    theme.breakpoints.values.xl - 0.5
+                  }) 33vw, 20vw`}
                   style={{
                     objectFit: 'cover',
                     objectPosition: 'left top'


### PR DESCRIPTION
# Description

### Issue

Warning errors in the console complaining about needlessly fetching full resolution images when not needed.

<img width="404" alt="image" src="https://github.com/user-attachments/assets/9cea81e9-ef3a-47a5-9327-a25e1dd10642">


### Solution

When the viewport is less than md, the image will need to render 100% viewport width
When the viewport is less than xl, the image will only be max 33% viewport width
When the viewport is larger than xl, the image will only be max 20% viewport width

Should should also in turn reduce the payload size on network calls which is already quite heavy for this page.

# External Changes

n/a

# Additional information

n/a
