### PR TITLE
fix: video match right language

### DIFF
--- a/apps/api-videos/src/schema/video/video.ts
+++ b/apps/api-videos/src/schema/video/video.ts
@@ -178,9 +178,9 @@ const Video = builder.prismaObject('Video', {
 
         const journeysLanguageIdForBlock = (
           info.variableValues as {
-            representations: Array<{ primaryLanguageId: string }>
+            representations: Array<{ id: string; primaryLanguageId: string }>
           }
-        ).representations?.[0].primaryLanguageId
+        ).representations?.find(({ id }) => id === parent.id)?.primaryLanguageId
 
         if (
           info.variableValues.idType !== IdTypeShape.databaseId &&


### PR DESCRIPTION
# Description

if two video blocks existed it would make the video variant selected be in the same language.