### PR TITLE
feat: add chat buttons to drawer

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Footer/Footer.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Footer/Footer.spec.tsx
@@ -16,6 +16,9 @@ import {
 import { TestEditorState } from '../../../../../../libs/TestEditorState'
 
 import { Footer } from './Footer'
+import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
+import { defaultJourney } from '@core/journeys/ui/TemplateView/data'
+import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 
 jest.mock('@mui/material/useMediaQuery', () => ({
   __esModule: true,
@@ -34,24 +37,26 @@ describe('Footer', () => {
     jest.resetAllMocks()
   })
 
-  it('should display Footer attributes', async () => {
+  it('should display Footer attributes for Journey mode', async () => {
     render(
       <MockedProvider>
         <SnackbarProvider>
-          <EditorProvider initialState={state}>
-            <Footer />
-          </EditorProvider>
+          <FlagsProvider flags={{ websiteMode: true }}>
+            <JourneyProvider value={{ journey: defaultJourney }}>
+              <EditorProvider initialState={state}>
+                <Footer />
+              </EditorProvider>
+            </JourneyProvider>
+          </FlagsProvider>
         </SnackbarProvider>
       </MockedProvider>
     )
 
     expect(screen.getByText('Journey Appearance')).toBeInTheDocument()
 
-    await waitFor(() =>
-      expect(
-        screen.getByRole('button', { name: 'Hosted By' })
-      ).toBeInTheDocument()
-    )
+    const toggleBtn = screen.getByRole('button', { name: 'Journey' })
+    expect(toggleBtn).toBeInTheDocument()
+    expect(toggleBtn).toHaveAttribute('aria-pressed', 'true')
 
     const reactions = await waitFor(() =>
       screen.getByRole('button', { name: 'Reactions' })
@@ -66,6 +71,36 @@ describe('Footer', () => {
 
     expect(reactions).toBeInTheDocument()
     expect(details).toBeInTheDocument()
+    expect(chat).toBeInTheDocument()
+  })
+
+  it('should display Footer attributes for Website mode', async () => {
+    render(
+      <MockedProvider>
+        <SnackbarProvider>
+          <FlagsProvider flags={{ websiteMode: true }}>
+            <JourneyProvider
+              value={{ journey: { ...defaultJourney, website: true } }}
+            >
+              <EditorProvider initialState={state}>
+                <Footer />
+              </EditorProvider>
+            </JourneyProvider>
+          </FlagsProvider>
+        </SnackbarProvider>
+      </MockedProvider>
+    )
+
+    expect(screen.getByText('Journey Appearance')).toBeInTheDocument()
+
+    const toggleBtn = screen.getByRole('button', { name: 'Website' })
+    expect(toggleBtn).toBeInTheDocument()
+    expect(toggleBtn).toHaveAttribute('aria-pressed', 'true')
+
+    const chat = await waitFor(() =>
+      screen.getByRole('button', { name: 'Chat Widget' })
+    )
+
     expect(chat).toBeInTheDocument()
   })
 

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Footer/Footer.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Footer/Footer.spec.tsx
@@ -12,13 +12,13 @@ import {
   ActiveCanvasDetailsDrawer,
   ActiveSlide
 } from '@core/journeys/ui/EditorProvider/EditorProvider'
+import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
+import { defaultJourney } from '@core/journeys/ui/TemplateView/data'
+import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 
 import { TestEditorState } from '../../../../../../libs/TestEditorState'
 
 import { Footer } from './Footer'
-import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
-import { defaultJourney } from '@core/journeys/ui/TemplateView/data'
-import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
 
 jest.mock('@mui/material/useMediaQuery', () => ({
   __esModule: true,

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Footer/Footer.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Footer/Footer.tsx
@@ -8,7 +8,6 @@ import { useFlags } from '@core/shared/ui/FlagsProvider'
 
 import { Drawer } from '../../Drawer'
 import { WebsiteToggle } from '../WebsiteToggle'
-<<<<<<< HEAD
 
 const Reactions = dynamic(
   async () =>
@@ -17,8 +16,6 @@ const Reactions = dynamic(
     ).then((mod) => mod.Reactions),
   { ssr: false }
 )
-=======
->>>>>>> e4469d8a4 (fix: lint)
 
 const Host = dynamic(
   async () =>

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Footer/Footer.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Footer/Footer.tsx
@@ -8,6 +8,7 @@ import { useFlags } from '@core/shared/ui/FlagsProvider'
 
 import { Drawer } from '../../Drawer'
 import { WebsiteToggle } from '../WebsiteToggle'
+<<<<<<< HEAD
 
 const Reactions = dynamic(
   async () =>
@@ -16,6 +17,8 @@ const Reactions = dynamic(
     ).then((mod) => mod.Reactions),
   { ssr: false }
 )
+=======
+>>>>>>> e4469d8a4 (fix: lint)
 
 const Host = dynamic(
   async () =>
@@ -56,7 +59,7 @@ export function Footer(): ReactElement {
   return (
     <Drawer title={t('Journey Appearance')} onClose={onClose}>
       {websiteMode && <WebsiteToggle />}
-      {journey?.website ? (
+      {journey?.website === true ? (
         <>
           <Chat />
         </>

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Footer/Footer.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Footer/Footer.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'next-i18next'
 import { ReactElement, useEffect } from 'react'
 
 import { ActiveSlide, useEditor } from '@core/journeys/ui/EditorProvider'
+import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import { useFlags } from '@core/shared/ui/FlagsProvider'
 
 import { Drawer } from '../../Drawer'
@@ -36,6 +37,7 @@ export function Footer(): ReactElement {
   const { dispatch } = useEditor()
   const { t } = useTranslation('apps-journeys-admin')
   const { websiteMode } = useFlags()
+  const { journey } = useJourney()
 
   function onClose(): void {
     dispatch({
@@ -54,9 +56,17 @@ export function Footer(): ReactElement {
   return (
     <Drawer title={t('Journey Appearance')} onClose={onClose}>
       {websiteMode && <WebsiteToggle />}
-      <Reactions />
-      <Host />
-      <Chat />
+      {journey?.website ? (
+        <>
+          <Chat />
+        </>
+      ) : (
+        <>
+          <Reactions />
+          <Host />
+          <Chat />
+        </>
+      )}
     </Drawer>
   )
 }


### PR DESCRIPTION
# Description

### Issue
Needed to show the different drawer properties based on journey or website mode

### Solution
- Updated `Footer` component to conditionally render drawer properties by journey or website mode
- Update `Footer` tests
