### PR TITLE
fix: blank journey seo title upon creation

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/TitleEdit/TitleEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/TitleEdit/TitleEdit.tsx
@@ -50,7 +50,7 @@ export function TitleEdit(): ReactElement {
   const initialValues =
     journey != null
       ? {
-          seoTitle: journey.seoTitle ?? journey.title
+          seoTitle: journey.seoTitle
         }
       : null
 

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/TitleEdit/TitleEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/TitleEdit/TitleEdit.tsx
@@ -50,7 +50,7 @@ export function TitleEdit(): ReactElement {
   const initialValues =
     journey != null
       ? {
-          seoTitle: journey.seoTitle ?? ""
+          seoTitle: journey.seoTitle ?? ''
         }
       : null
 

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/TitleEdit/TitleEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/TitleEdit/TitleEdit.tsx
@@ -50,7 +50,7 @@ export function TitleEdit(): ReactElement {
   const initialValues =
     journey != null
       ? {
-          seoTitle: journey.seoTitle
+          seoTitle: journey.seoTitle ?? ""
         }
       : null
 


### PR DESCRIPTION
# Description

### Issue

Seo title shouldn't default to journey title name.

[Link to Linear Todo](https://linear.app/jesus-film-project/issue/ENG-730/social-media-title-matches-journey-admin-title-upon-journey-creation)

### Solution

_Provide a detailed description of how exactly this task will be accomplished. This can be something technical. What specific steps will be taken to achieve the goal? This should include details on service integration, job logic, implementation, etc._

# External Changes

_If you have made changes to external services, need to add additional values to Doppler, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc._

# Additional information

_Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc._
