### PR TITLE
Tannerfleming/eng 758 brazilian portuguese magdalena incorrect

### DIFF
--- a/apps/watch/src/libs/slugMap.ts
+++ b/apps/watch/src/libs/slugMap.ts
@@ -41,7 +41,7 @@ export const slugMap = {
   'creole-french-guyanese': 'guyanese-creole',
   'mixe-atitlan': 'atitlan-mixe',
   'nahuatl-guerrero-aztec': 'aztec-nahuatl-guerrero',
-  'portuguese-brazil': 'spanish-castilian',
+  'portuguese-brazil': 'portuguese-brazil',
   'motu-hiri': 'hiri-motu',
   'chinese-hui': 'hui',
   'karen-pao': 'pao',

--- a/apps/watch/src/libs/slugMap.ts
+++ b/apps/watch/src/libs/slugMap.ts
@@ -41,7 +41,6 @@ export const slugMap = {
   'creole-french-guyanese': 'guyanese-creole',
   'mixe-atitlan': 'atitlan-mixe',
   'nahuatl-guerrero-aztec': 'aztec-nahuatl-guerrero',
-  'portuguese-brazil': 'portuguese-brazil',
   'motu-hiri': 'hiri-motu',
   'chinese-hui': 'hui',
   'karen-pao': 'pao',


### PR DESCRIPTION
# Description

### Issue

Portuguese Brazil redirecting to spanish, castilian

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

Remove Portuguese Brazil from the language slug map.

# External Changes

_If you have made changes to external services, need to add additional values to Doppler, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc._

# Additional information

_Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc._
