### PR TITLE
fix: card duplicate

### DIFF
--- a/apps/api-journeys/src/app/modules/block/block.service.ts
+++ b/apps/api-journeys/src/app/modules/block/block.service.ts
@@ -136,7 +136,8 @@ export class BlockService {
           'posterBlockId',
           'coverBlockId',
           'nextBlockId',
-          'action'
+          'action',
+          'slug'
         ]),
         journey: {
           connect: { id: block.journeyId }


### PR DESCRIPTION
# Description

Omit card slug when duplicating
