### PR TITLE
fix: remove dependencies that triggers default selection

### DIFF
--- a/libs/journeys/ui/src/components/SearchBar/SearchDropdown/SearchbarDropdown.tsx
+++ b/libs/journeys/ui/src/components/SearchBar/SearchDropdown/SearchbarDropdown.tsx
@@ -86,7 +86,8 @@ export function SearchbarDropdown({
         })
       }
     }
-  }, [refinements.items, continentLanguages, dispatch, languages])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refinements.items, dispatch])
 
   useEffect(() => {
     updateDefaultLanguageContinent()


### PR DESCRIPTION
Some of the dependencies within the useEffect triggers the default language selection function. Removed those dependencies and have made the useEffect to only call the default function depending on `refinements`
