### PR TITLE
feat: watch middleware

### DIFF
--- a/apps/watch/middleware.spec.ts
+++ b/apps/watch/middleware.spec.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { middleware } from './middleware'
+
+describe('middleware', () => {
+  const url = 'http://localhost:4300/'
+
+  it('should set the NEXT_COUNTRY cookie if country is available', async () => {
+    const request = new Request(url)
+    const req = new NextRequest(request, {
+      geo: { country: 'US' }
+    })
+    const response = await middleware(req)
+
+    expect(response?.cookies.get('NEXT_COUNTRY')?.value).toBe('00001---US')
+  })
+
+  it('should not set the NEXT_COUNTRY cookie if country is unknown', () => {
+    const request = new NextRequest(url, {
+      geo: { country: undefined }
+    })
+    const response = middleware(request) as NextResponse
+
+    expect(response.cookies.get('NEXT_COUNTRY')).toBeUndefined()
+  })
+})

--- a/apps/watch/middleware.ts
+++ b/apps/watch/middleware.ts
@@ -1,8 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+const PUBLIC_FILE_REGEX = /\.(.*)$/
+
 const COOKIE_FINGERPRINT = '00001'
 
+// geo information is available on projects that is hosted on Vercel
+// https://nextjs.org/docs/pages/api-reference/functions/next-request#geo
 export function middleware(req: NextRequest): NextResponse | undefined {
+  if (
+    req.nextUrl.pathname.startsWith('/_next') ||
+    req.nextUrl.pathname.includes('/api/') ||
+    PUBLIC_FILE_REGEX.test(req.nextUrl.pathname)
+  )
+    return
+
   const country = req.geo?.country ?? 'unknown'
   const response = NextResponse.next()
   if (country !== 'unknown') {

--- a/apps/watch/middleware.ts
+++ b/apps/watch/middleware.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const COOKIE_FINGERPRINT = '00001'
+
+export function middleware(req: NextRequest): NextResponse | undefined {
+  const country = req.geo?.country ?? 'unknown'
+  const response = NextResponse.next()
+  if (country !== 'unknown') {
+    response.cookies.set('NEXT_COUNTRY', `${COOKIE_FINGERPRINT}---${country}`)
+  }
+  return response
+}

--- a/apps/watch/setupTests.tsx
+++ b/apps/watch/setupTests.tsx
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom'
+import 'isomorphic-fetch'
 import { configure } from '@testing-library/react'
 
 configure({ asyncUtilTimeout: 2500 })


### PR DESCRIPTION
# Description

### Issue

The purpose of this middleware is to figure out the country the user is in. We are to later use this information to render necessary information within the watch client

### Solution

Create a middleware in watch where we save the users country as a cookie. We're using the geo property that we can call from `NextRequest`. 

Things to keep in mind is that geo property comes out of the box for projects hosted on Vercel. If by any point we choose to run watch on a different hosting platform we are to update the configuration accordingly. Read more here: https://nextjs.org/docs/pages/api-reference/functions/next-request#geo
