### PR TITLE
feat: add a loading state to languages dropdown

### DIFF
--- a/libs/journeys/ui/src/components/SearchBar/SearchDropdown/RefinementGroups/RefinementGroups.spec.tsx
+++ b/libs/journeys/ui/src/components/SearchBar/SearchDropdown/RefinementGroups/RefinementGroups.spec.tsx
@@ -137,4 +137,13 @@ describe('RefinementGroups', () => {
     fireEvent.click(seeAllButton)
     expect(toggleShowMore).toHaveBeenCalled()
   })
+
+  it('should show loading when loading languages', () => {
+    render(
+      <SearchBarProvider>
+        <RefinementGroups refinements={refinements} languages={{}} />
+      </SearchBarProvider>
+    )
+    expect(screen.getByText('Loading...')).toBeVisible()
+  })
 })

--- a/libs/journeys/ui/src/components/SearchBar/SearchDropdown/RefinementGroups/RefinementGroups.tsx
+++ b/libs/journeys/ui/src/components/SearchBar/SearchDropdown/RefinementGroups/RefinementGroups.tsx
@@ -32,12 +32,16 @@ export function RefinementGroups({
 }: RefinementGroupsProps): ReactElement {
   const { t } = useTranslation('apps-watch')
 
+  const languageEntries = Object.entries(languages)
+
   const { canToggleShowMore, isShowingMore, toggleShowMore } = refinements
   const shouldFade = canToggleShowMore && !isShowingMore
+  const isLoading = languageEntries.length === 0
+  const hasRefinements = refinements.items.length > 0
 
   return (
     <>
-      {refinements.items.length > 0 ? (
+      {!isLoading && hasRefinements ? (
         <>
           <Grid
             container
@@ -59,26 +63,24 @@ export function RefinementGroups({
                 : 'none'
             }}
           >
-            {Object.entries(languages).map(
-              ([continent, continentLanguages]) => {
-                const items = refinements.items.filter((item) =>
-                  continentLanguages.some((language) => language === item.label)
-                )
-                return items.length > 0 ? (
-                  <Grid key={continent} size={1}>
-                    <RefinementGroup
-                      title={continent}
-                      refinement={{
-                        ...refinements,
-                        items
-                      }}
-                    />
-                  </Grid>
-                ) : (
-                  <></>
-                )
-              }
-            )}
+            {languageEntries.map(([continent, continentLanguages]) => {
+              const items = refinements.items.filter((item) =>
+                continentLanguages.some((language) => language === item.label)
+              )
+              return items.length > 0 ? (
+                <Grid key={continent} size={1}>
+                  <RefinementGroup
+                    title={continent}
+                    refinement={{
+                      ...refinements,
+                      items
+                    }}
+                  />
+                </Grid>
+              ) : (
+                <></>
+              )
+            })}
           </Grid>
           {canToggleShowMore && (
             <Box display="flex" flexDirection="column" alignItems="center">
@@ -94,11 +96,25 @@ export function RefinementGroups({
           )}
         </>
       ) : (
-        <Typography>
-          {t(
-            `Sorry, there are no languages available for this search. Try removing some of your search criteria!`
+        <>
+          {!hasRefinements && (
+            <Typography mb={5}>
+              {t(
+                `Sorry, there are no languages available for this search. Try removing some of your search criteria!`
+              )}
+            </Typography>
           )}
-        </Typography>
+          {isLoading && (
+            <Box
+              display="flex"
+              flexDirection="column"
+              alignItems="center"
+              mb={5}
+            >
+              <Typography>{t(`Loading...`)}</Typography>
+            </Box>
+          )}
+        </>
       )}
     </>
   )


### PR DESCRIPTION
# Description

### Issue
It takes up to 2 seconds to load the languages and sort the refinements into continents in the languages dropdown.

[Link to Linear Todo](https://linear.app/jesus-film-project/issue/ENG-873/languages-loading)

### Solution
When languages are empty, display a loading state
![image](https://github.com/user-attachments/assets/09cf5963-279a-4fed-90b9-ae0ef84733ee)

# How to test

- Should show a loading state when a user first opens the dropdown in languages tab
- Should still show no refinements state when a user has too specific a search
- Should still show refinements when they have loaded