### PR TITLE
feat: use country query

### DIFF
--- a/apps/journeys-admin/__generated__/GetCountry.ts
+++ b/apps/journeys-admin/__generated__/GetCountry.ts
@@ -1,0 +1,40 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: GetCountry
+// ====================================================
+
+export interface GetCountry_country_countryLanguages_language_name {
+  __typename: "LanguageName";
+  primary: boolean;
+  value: string;
+}
+
+export interface GetCountry_country_countryLanguages_language {
+  __typename: "Language";
+  name: GetCountry_country_countryLanguages_language_name[];
+}
+
+export interface GetCountry_country_countryLanguages {
+  __typename: "CountryLanguage";
+  language: GetCountry_country_countryLanguages_language;
+  speakers: number;
+}
+
+export interface GetCountry_country {
+  __typename: "Country";
+  id: string;
+  flagPngSrc: string | null;
+  countryLanguages: GetCountry_country_countryLanguages[];
+}
+
+export interface GetCountry {
+  country: GetCountry_country | null;
+}
+
+export interface GetCountryVariables {
+  countryId: string;
+}

--- a/apps/journeys/__generated__/GetCountry.ts
+++ b/apps/journeys/__generated__/GetCountry.ts
@@ -1,0 +1,40 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: GetCountry
+// ====================================================
+
+export interface GetCountry_country_countryLanguages_language_name {
+  __typename: "LanguageName";
+  primary: boolean;
+  value: string;
+}
+
+export interface GetCountry_country_countryLanguages_language {
+  __typename: "Language";
+  name: GetCountry_country_countryLanguages_language_name[];
+}
+
+export interface GetCountry_country_countryLanguages {
+  __typename: "CountryLanguage";
+  language: GetCountry_country_countryLanguages_language;
+  speakers: number;
+}
+
+export interface GetCountry_country {
+  __typename: "Country";
+  id: string;
+  flagPngSrc: string | null;
+  countryLanguages: GetCountry_country_countryLanguages[];
+}
+
+export interface GetCountry {
+  country: GetCountry_country | null;
+}
+
+export interface GetCountryVariables {
+  countryId: string;
+}

--- a/apps/watch/__generated__/GetCountry.ts
+++ b/apps/watch/__generated__/GetCountry.ts
@@ -1,0 +1,40 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: GetCountry
+// ====================================================
+
+export interface GetCountry_country_countryLanguages_language_name {
+  __typename: "LanguageName";
+  primary: boolean;
+  value: string;
+}
+
+export interface GetCountry_country_countryLanguages_language {
+  __typename: "Language";
+  name: GetCountry_country_countryLanguages_language_name[];
+}
+
+export interface GetCountry_country_countryLanguages {
+  __typename: "CountryLanguage";
+  language: GetCountry_country_countryLanguages_language;
+  speakers: number;
+}
+
+export interface GetCountry_country {
+  __typename: "Country";
+  id: string;
+  flagPngSrc: string | null;
+  countryLanguages: GetCountry_country_countryLanguages[];
+}
+
+export interface GetCountry {
+  country: GetCountry_country | null;
+}
+
+export interface GetCountryVariables {
+  countryId: string;
+}

--- a/libs/journeys/ui/src/libs/useCountryQuery/__generated__/GetCountry.ts
+++ b/libs/journeys/ui/src/libs/useCountryQuery/__generated__/GetCountry.ts
@@ -1,0 +1,40 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: GetCountry
+// ====================================================
+
+export interface GetCountry_country_countryLanguages_language_name {
+  __typename: "LanguageName";
+  primary: boolean;
+  value: string;
+}
+
+export interface GetCountry_country_countryLanguages_language {
+  __typename: "Language";
+  name: GetCountry_country_countryLanguages_language_name[];
+}
+
+export interface GetCountry_country_countryLanguages {
+  __typename: "CountryLanguage";
+  language: GetCountry_country_countryLanguages_language;
+  speakers: number;
+}
+
+export interface GetCountry_country {
+  __typename: "Country";
+  id: string;
+  flagPngSrc: string | null;
+  countryLanguages: GetCountry_country_countryLanguages[];
+}
+
+export interface GetCountry {
+  country: GetCountry_country | null;
+}
+
+export interface GetCountryVariables {
+  countryId: string;
+}

--- a/libs/journeys/ui/src/libs/useCountryQuery/data.ts
+++ b/libs/journeys/ui/src/libs/useCountryQuery/data.ts
@@ -2,7 +2,7 @@ import { GetCountry_country as Country } from './__generated__/GetCountry'
 
 export const country: Country = {
   __typename: 'Country',
-  id: 'country.id',
+  id: 'US',
   flagPngSrc: 'https://example.flag.com',
   countryLanguages: [
     {

--- a/libs/journeys/ui/src/libs/useCountryQuery/data.ts
+++ b/libs/journeys/ui/src/libs/useCountryQuery/data.ts
@@ -1,0 +1,42 @@
+import { GetCountry_country as Country } from './__generated__/GetCountry'
+
+export const country: Country = {
+  __typename: 'Country',
+  id: 'country.id',
+  flagPngSrc: 'https://example.flag.com',
+  countryLanguages: [
+    {
+      __typename: 'CountryLanguage',
+      language: {
+        __typename: 'Language',
+        name: [
+          {
+            __typename: 'LanguageName',
+            primary: false,
+            value: 'English'
+          }
+        ]
+      },
+      speakers: 100
+    },
+    {
+      __typename: 'CountryLanguage',
+      language: {
+        __typename: 'Language',
+        name: [
+          {
+            __typename: 'LanguageName',
+            primary: true,
+            value: 'Spanish'
+          },
+          {
+            __typename: 'LanguageName',
+            primary: true,
+            value: 'Spanish'
+          }
+        ]
+      },
+      speakers: 200
+    }
+  ]
+}

--- a/libs/journeys/ui/src/libs/useCountryQuery/index.ts
+++ b/libs/journeys/ui/src/libs/useCountryQuery/index.ts
@@ -1,0 +1,1 @@
+export { useCountryQuery } from './useCountryQuery'

--- a/libs/journeys/ui/src/libs/useCountryQuery/useCountryQuery.mock.ts
+++ b/libs/journeys/ui/src/libs/useCountryQuery/useCountryQuery.mock.ts
@@ -1,0 +1,57 @@
+import { MockedResponse } from '@apollo/client/testing'
+
+import { GetCountry } from './__generated__/GetCountry'
+import { GET_COUNTRY } from './useCountryQuery'
+
+export const getCountryMock: MockedResponse<GetCountry> = {
+  request: {
+    query: GET_COUNTRY,
+    variables: {
+      countryId: 'country.id'
+    }
+  },
+  result: {
+    data: {
+      country: {
+        __typename: 'Country',
+        id: 'country.id',
+        flagPngSrc: 'https://example.flag.com',
+        countryLanguages: [
+          {
+            __typename: 'CountryLanguage',
+            language: {
+              __typename: 'Language',
+              name: [
+                {
+                  __typename: 'LanguageName',
+                  primary: false,
+                  value: 'English'
+                }
+              ]
+            },
+            speakers: 100
+          },
+          {
+            __typename: 'CountryLanguage',
+            language: {
+              __typename: 'Language',
+              name: [
+                {
+                  __typename: 'LanguageName',
+                  primary: true,
+                  value: 'Spanish'
+                },
+                {
+                  __typename: 'LanguageName',
+                  primary: true,
+                  value: 'Spanish'
+                }
+              ]
+            },
+            speakers: 200
+          }
+        ]
+      }
+    }
+  }
+}

--- a/libs/journeys/ui/src/libs/useCountryQuery/useCountryQuery.mock.ts
+++ b/libs/journeys/ui/src/libs/useCountryQuery/useCountryQuery.mock.ts
@@ -1,6 +1,7 @@
 import { MockedResponse } from '@apollo/client/testing'
 
 import { GetCountry } from './__generated__/GetCountry'
+import { country } from './data'
 import { GET_COUNTRY } from './useCountryQuery'
 
 export const getCountryMock: MockedResponse<GetCountry> = {
@@ -12,46 +13,7 @@ export const getCountryMock: MockedResponse<GetCountry> = {
   },
   result: {
     data: {
-      country: {
-        __typename: 'Country',
-        id: 'country.id',
-        flagPngSrc: 'https://example.flag.com',
-        countryLanguages: [
-          {
-            __typename: 'CountryLanguage',
-            language: {
-              __typename: 'Language',
-              name: [
-                {
-                  __typename: 'LanguageName',
-                  primary: false,
-                  value: 'English'
-                }
-              ]
-            },
-            speakers: 100
-          },
-          {
-            __typename: 'CountryLanguage',
-            language: {
-              __typename: 'Language',
-              name: [
-                {
-                  __typename: 'LanguageName',
-                  primary: true,
-                  value: 'Spanish'
-                },
-                {
-                  __typename: 'LanguageName',
-                  primary: true,
-                  value: 'Spanish'
-                }
-              ]
-            },
-            speakers: 200
-          }
-        ]
-      }
+      country
     }
   }
 }

--- a/libs/journeys/ui/src/libs/useCountryQuery/useCountryQuery.mock.ts
+++ b/libs/journeys/ui/src/libs/useCountryQuery/useCountryQuery.mock.ts
@@ -8,7 +8,7 @@ export const getCountryMock: MockedResponse<GetCountry> = {
   request: {
     query: GET_COUNTRY,
     variables: {
-      countryId: 'country.id'
+      countryId: 'US'
     }
   },
   result: {

--- a/libs/journeys/ui/src/libs/useCountryQuery/useCountryQuery.spec.tsx
+++ b/libs/journeys/ui/src/libs/useCountryQuery/useCountryQuery.spec.tsx
@@ -1,0 +1,24 @@
+import { MockedProvider } from '@apollo/client/testing'
+import { renderHook, waitFor } from '@testing-library/react'
+import { act } from 'react'
+
+import { useCountryQuery } from './useCountryQuery'
+import { getCountryMock } from './useCountryQuery.mock'
+
+describe('useCountryQuery', () => {
+  it('should get country based on countryId', async () => {
+    const result = jest.fn().mockReturnValue(getCountryMock.result)
+
+    renderHook(() => useCountryQuery({ countryId: 'country.id' }), {
+      wrapper: ({ children }) => (
+        <MockedProvider mocks={[{ ...getCountryMock, result }]}>
+          {children}
+        </MockedProvider>
+      )
+    })
+
+    await act(
+      async () => await waitFor(() => expect(result).toHaveBeenCalled())
+    )
+  })
+})

--- a/libs/journeys/ui/src/libs/useCountryQuery/useCountryQuery.spec.tsx
+++ b/libs/journeys/ui/src/libs/useCountryQuery/useCountryQuery.spec.tsx
@@ -9,7 +9,7 @@ describe('useCountryQuery', () => {
   it('should get country based on countryId', async () => {
     const result = jest.fn().mockReturnValue(getCountryMock.result)
 
-    renderHook(() => useCountryQuery({ countryId: 'country.id' }), {
+    renderHook(() => useCountryQuery({ countryId: 'US' }), {
       wrapper: ({ children }) => (
         <MockedProvider mocks={[{ ...getCountryMock, result }]}>
           {children}

--- a/libs/journeys/ui/src/libs/useCountryQuery/useCountryQuery.ts
+++ b/libs/journeys/ui/src/libs/useCountryQuery/useCountryQuery.ts
@@ -1,0 +1,29 @@
+import { QueryResult, gql, useQuery } from '@apollo/client'
+
+import { GetCountry, GetCountryVariables } from './__generated__/GetCountry'
+
+export const GET_COUNTRY = gql`
+  query GetCountry($countryId: ID!) {
+    country(id: $countryId) {
+      id
+      flagPngSrc
+      countryLanguages {
+        language {
+          name {
+            primary
+            value
+          }
+        }
+        speakers
+      }
+    }
+  }
+`
+
+export function useCountryQuery(
+  variables?: GetCountryVariables
+): QueryResult<GetCountry, GetCountryVariables> {
+  return useQuery<GetCountry, GetCountryVariables>(GET_COUNTRY, {
+    variables
+  })
+}

--- a/libs/journeys/ui/src/libs/useCountryQuery/useCountryQuery.ts
+++ b/libs/journeys/ui/src/libs/useCountryQuery/useCountryQuery.ts
@@ -21,7 +21,7 @@ export const GET_COUNTRY = gql`
 `
 
 export function useCountryQuery(
-  variables?: GetCountryVariables
+  variables: GetCountryVariables
 ): QueryResult<GetCountry, GetCountryVariables> {
   return useQuery<GetCountry, GetCountryVariables>(GET_COUNTRY, {
     variables


### PR DESCRIPTION
# Description

### Issue

We need the ability to grab a country information, this information would be used to render the languages a user can choose from in the CountryLanguageSelector

### Solution

Created the a useCountryQuery hook that enables us to call data for a country

it should return the following details: 

- flagPngSrc - image link to country flag
- countryLanguages
      - returns the language(s) spoken by that country
      - returns the amount of speakers of that language
