### PR TITLE
fix: disable add block fab for video block steps

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Fab/Fab.tsx
+++ b/apps/journeys-admin/src/components/Editor/Fab/Fab.tsx
@@ -67,9 +67,8 @@ export function Fab({ variant }: FabProps): ReactElement {
     (block) =>
       block.__typename === 'VideoBlock' && cardBlock.coverBlockId !== block.id
   )
-  const disabled =
-    steps == null ||
-    (videoBlock != null && activeSlide !== ActiveSlide.JourneyFlow)
+
+  const disabled = steps == null || videoBlock != null
 
   const fabIn =
     variant === 'mobile'


### PR DESCRIPTION
# Description

### Issue

Add block is still enabled for steps that are video blocks when the user is on the JourneyFlow view. This allows the user to keep adding other blocks ontop of the video block.

### Solution

Disable the add block fab when the user is on JourneyFlow view for video blocks.

