### PR TITLE
fix: github danger workflow

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -18,6 +18,10 @@ on:
 jobs:
   danger:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      repository-projects: write
     strategy:
       matrix:
         node-version: [20]


### PR DESCRIPTION
# Description

### Issue

Github danger keeps failing

### Solution

Add recommended permissions to danger workflow

