### PR TITLE
feat: enter key closes the dropdown

### DIFF
--- a/libs/journeys/ui/src/components/SearchBar/SearchBar.spec.tsx
+++ b/libs/journeys/ui/src/components/SearchBar/SearchBar.spec.tsx
@@ -206,4 +206,33 @@ describe('SearchBar', () => {
 
     await waitFor(() => expect(screen.getByText('Cantonese')).toBeVisible())
   })
+
+  const enterKey = {
+    key: 'Enter',
+    code: 'Enter',
+    charCode: 13
+  }
+
+  it('should close dropdown on key enter', async () => {
+    render(
+      <MockedProvider mocks={[getLanguagesContinentsMock]}>
+        <SearchBar showLanguageButton />
+      </MockedProvider>
+    )
+    await clickOnSearchBar()
+    fireEvent.keyDown(screen.getByDisplayValue('Hello World!'), enterKey)
+    expect(screen.queryByTestId('SearchBarDropdown')).not.toBeInTheDocument()
+  })
+
+  it('should open dropdown again after closing on key enter', async () => {
+    render(
+      <MockedProvider mocks={[getLanguagesContinentsMock]}>
+        <SearchBar showLanguageButton />
+      </MockedProvider>
+    )
+    await clickOnSearchBar()
+    fireEvent.keyDown(screen.getByDisplayValue('Hello World!'), enterKey)
+    await clickOnSearchBar()
+    expect(screen.getByTestId('SearchBarDropdown')).toBeInTheDocument()
+  })
 })

--- a/libs/journeys/ui/src/components/SearchBar/SearchBar.tsx
+++ b/libs/journeys/ui/src/components/SearchBar/SearchBar.tsx
@@ -125,6 +125,10 @@ export function SearchBar({
                     onChange={handleChange}
                     onBlur={handleBlur}
                     onFocus={openSuggestionsDropdown}
+                    onClick={openSuggestionsDropdown}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') setOpen(false)
+                    }}
                     InputProps={{
                       startAdornment: (
                         <InputAdornment position="start">


### PR DESCRIPTION
# Description

### Issue

Users want the dropdown to disapear on enter key

[Link to Linear Todo](https://linear.app/jesus-film-project/issue/ENG-817/enter-on-searchbar)

# How to test

Should close on desktop keyboard enter
Should close on mobil keyboard enter
Should open on searchbar click