### PR TITLE
fix: language buttons hydration error

### DIFF
--- a/apps/watch/next-env.d.ts
+++ b/apps/watch/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/libs/journeys/ui/src/components/SearchBar/LanguageButtons/LanguageButtons.tsx
+++ b/libs/journeys/ui/src/components/SearchBar/LanguageButtons/LanguageButtons.tsx
@@ -40,7 +40,8 @@ export function LanguageButtons({
 
   return (
     <Box
-      component="button"
+      component="div"
+      role="button"
       onClick={onClick}
       data-testid="LanguageSelect"
       sx={{


### PR DESCRIPTION
# Description

### Issue

On developer environment, we're getting a hydration error for Language Buttons

### Solution

Update the Box that's causing the error, from Material UI to stick with being a `div` but have a role of a `button`