### PR TITLE
feat: grab all the languages from algolia

### DIFF
--- a/libs/journeys/ui/src/components/SearchBar/SearchBar.tsx
+++ b/libs/journeys/ui/src/components/SearchBar/SearchBar.tsx
@@ -71,7 +71,7 @@ export function SearchBar({
   const refinements = useRefinementList({
     attribute: 'languageEnglishName',
     showMore: true,
-    limit: 5,
+    limit: 1000,
     showMoreLimit: 5000
   })
 

--- a/libs/journeys/ui/src/components/SearchBar/SearchDropdown/RefinementGroups/RefinementGroups.spec.tsx
+++ b/libs/journeys/ui/src/components/SearchBar/SearchDropdown/RefinementGroups/RefinementGroups.spec.tsx
@@ -92,61 +92,23 @@ describe('RefinementGroups', () => {
     ).toBeInTheDocument()
   })
 
-  it('should render a see all button', () => {
-    const showMoreRefinements = {
-      ...refinements,
-      canToggleShowMore: true,
-      isShowingMore: false,
-      toggleShowMore: jest.fn()
-    }
+  it('should render a see all button', async () => {
     render(
       <SearchBarProvider>
-        <RefinementGroups
-          refinements={showMoreRefinements}
-          languages={languages}
-        />
+        <RefinementGroups refinements={refinements} languages={languages} />
       </SearchBarProvider>
     )
-    expect(screen.getByText('See All')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'See All' })).toBeInTheDocument()
   })
 
   it('should render a see less button', () => {
-    const showMoreRefinements = {
-      ...refinements,
-      canToggleShowMore: true,
-      isShowingMore: true,
-      toggleShowMore: jest.fn()
-    }
     render(
       <SearchBarProvider>
-        <RefinementGroups
-          refinements={showMoreRefinements}
-          languages={languages}
-        />
+        <RefinementGroups refinements={refinements} languages={languages} />
       </SearchBarProvider>
     )
+    fireEvent.click(screen.getByRole('button', { name: 'See All' }))
     expect(screen.getByText('See Less')).toBeInTheDocument()
-  })
-
-  it('should call toggleShowMore when see all button clicked', () => {
-    const toggleShowMore = jest.fn()
-    const showMoreRefinements = {
-      ...refinements,
-      canToggleShowMore: true,
-      isShowingMore: false,
-      toggleShowMore
-    }
-    render(
-      <SearchBarProvider>
-        <RefinementGroups
-          refinements={showMoreRefinements}
-          languages={languages}
-        />
-      </SearchBarProvider>
-    )
-    const seeAllButton = screen.getByText('See All')
-    fireEvent.click(seeAllButton)
-    expect(toggleShowMore).toHaveBeenCalled()
   })
 
   it('should not show clear all button if cannot clear refinements', () => {

--- a/libs/journeys/ui/src/components/SearchBar/SearchDropdown/RefinementGroups/RefinementGroups.tsx
+++ b/libs/journeys/ui/src/components/SearchBar/SearchDropdown/RefinementGroups/RefinementGroups.tsx
@@ -6,7 +6,7 @@ import { styled, useTheme } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
 import { RefinementListRenderState } from 'instantsearch.js/es/connectors/refinement-list/connectRefinementList'
 import { useTranslation } from 'next-i18next'
-import { ReactElement } from 'react'
+import { ReactElement, useState } from 'react'
 import { useClearRefinements } from 'react-instantsearch'
 
 import ChevronDown from '@core/shared/ui/icons/ChevronDown'
@@ -40,14 +40,13 @@ export function RefinementGroups({
 }: RefinementGroupsProps): ReactElement {
   const { t } = useTranslation('apps-watch')
   const theme = useTheme()
+  const [isOpen, setIsOpen] = useState(false)
 
   const { refine: clearRefinements, canRefine: canClearRefinements } =
     useClearRefinements()
 
   const languageEntries = Object.entries(languages)
 
-  const { canToggleShowMore, isShowingMore, toggleShowMore } = refinements
-  const shouldFade = canToggleShowMore && !isShowingMore
   const isLoading = languageEntries.length === 0
   const hasRefinements = refinements.items.length > 0
 
@@ -61,13 +60,16 @@ export function RefinementGroups({
             columns={{ xs: 1, lg: 6 }}
             direction={{ xs: 'column', lg: 'row' }}
             sx={{
-              '-webkit-mask-image': shouldFade
+              minHeight: 344,
+              height: isOpen ? 'auto' : 344,
+              overflow: 'hidden',
+              '-webkit-mask-image': !isOpen
                 ? {
                     xs: 'linear-gradient(to bottom, black 85%, transparent 100%)',
                     lg: 'linear-gradient(to bottom, black 60%, transparent 60%)'
                   }
                 : 'none',
-              'mask-image': shouldFade
+              'mask-image': !isOpen
                 ? {
                     xs: 'linear-gradient(to bottom, black 85%, transparent 100%)',
                     lg: 'linear-gradient(to bottom, black 60%, transparent 85%)'
@@ -96,16 +98,13 @@ export function RefinementGroups({
           </Grid>
           <Box sx={{ justifyContent: 'center', display: 'flex' }}>
             <Stack direction="row" spacing={3}>
-              {canToggleShowMore && (
-                <StyledButton
-                  size="small"
-                  onClick={toggleShowMore}
-                  disabled={!canToggleShowMore}
-                  endIcon={isShowingMore ? <ChevronUp /> : <ChevronDown />}
-                >
-                  {t(isShowingMore ? 'See Less' : 'See All')}
-                </StyledButton>
-              )}
+              <StyledButton
+                size="small"
+                onClick={() => setIsOpen(!isOpen)}
+                endIcon={isOpen ? <ChevronUp /> : <ChevronDown />}
+              >
+                {t(isOpen ? 'See Less' : 'See All')}
+              </StyledButton>
               {canClearRefinements && (
                 <StyledButton
                   size="small"

--- a/libs/journeys/ui/src/components/SearchBar/SearchDropdown/RefinementGroups/RefinementGroups.tsx
+++ b/libs/journeys/ui/src/components/SearchBar/SearchDropdown/RefinementGroups/RefinementGroups.tsx
@@ -40,7 +40,7 @@ export function RefinementGroups({
 }: RefinementGroupsProps): ReactElement {
   const { t } = useTranslation('apps-watch')
   const theme = useTheme()
-  const [isOpen, setIsOpen] = useState(false)
+  const [isCollapsed, setIsCollapsed] = useState(false)
 
   const { refine: clearRefinements, canRefine: canClearRefinements } =
     useClearRefinements()
@@ -61,15 +61,15 @@ export function RefinementGroups({
             direction={{ xs: 'column', lg: 'row' }}
             sx={{
               minHeight: 344,
-              height: isOpen ? 'auto' : 344,
+              height: isCollapsed ? 'auto' : 344,
               overflow: 'hidden',
-              '-webkit-mask-image': !isOpen
+              '-webkit-mask-image': !isCollapsed
                 ? {
                     xs: 'linear-gradient(to bottom, black 85%, transparent 100%)',
                     lg: 'linear-gradient(to bottom, black 60%, transparent 60%)'
                   }
                 : 'none',
-              'mask-image': !isOpen
+              'mask-image': !isCollapsed
                 ? {
                     xs: 'linear-gradient(to bottom, black 85%, transparent 100%)',
                     lg: 'linear-gradient(to bottom, black 60%, transparent 85%)'
@@ -100,10 +100,10 @@ export function RefinementGroups({
             <Stack direction="row" spacing={3}>
               <StyledButton
                 size="small"
-                onClick={() => setIsOpen(!isOpen)}
-                endIcon={isOpen ? <ChevronUp /> : <ChevronDown />}
+                onClick={() => setIsCollapsed(!isCollapsed)}
+                endIcon={isCollapsed ? <ChevronUp /> : <ChevronDown />}
               >
-                {t(isOpen ? 'See Less' : 'See All')}
+                {t(isCollapsed ? 'See Less' : 'See All')}
               </StyledButton>
               {canClearRefinements && (
                 <StyledButton


### PR DESCRIPTION
# Description

### Issue

Currently we set a limit for the languageEnglishName refinement to only return 5 at the start, this doesn't reflect all the languages that we currently have

### Solution

Up the limit of the refinement to be 1000 and update RefinementGroup to show the rest of the languages through CSS
