### PR TITLE
fix: swap analytics chat widget icon order

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/CanvasFooter/CardAnalytics/CardAnalytics.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/CanvasFooter/CardAnalytics/CardAnalytics.tsx
@@ -61,18 +61,6 @@ export function CardAnalytics(): ReactElement {
           value={thumbsDownClicks}
           icon={<ThumbsDownIcon sx={{ fontSize: 24 }} />}
         />
-        {primaryChat != null && (
-          <Analytic
-            title={t('widget clicks')}
-            value={primaryChatClicks}
-            icon={
-              <MessageChatIcon
-                platform={primaryChat.platform ?? MessagePlatform.custom}
-                sx={{ fontSize: 24 }}
-              />
-            }
-          />
-        )}
         {secondaryChat != null && (
           <Analytic
             title={t('widget clicks')}
@@ -80,6 +68,18 @@ export function CardAnalytics(): ReactElement {
             icon={
               <MessageChatIcon
                 platform={secondaryChat.platform ?? MessagePlatform.custom}
+                sx={{ fontSize: 24 }}
+              />
+            }
+          />
+        )}
+        {primaryChat != null && (
+          <Analytic
+            title={t('widget clicks')}
+            value={primaryChatClicks}
+            icon={
+              <MessageChatIcon
+                platform={primaryChat.platform ?? MessagePlatform.custom}
                 sx={{ fontSize: 24 }}
               />
             }


### PR DESCRIPTION
# Description

### Issue

Chat widget analytics order is not the same as on the card.

### Solution

Swap them around


