### PR TITLE
fix: update strategies to consume excerpt

### DIFF
--- a/apps/watch/next-env.d.ts
+++ b/apps/watch/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/apps/watch/src/components/StrategiesView/StrategySections/StrategySection/data.ts
+++ b/apps/watch/src/components/StrategiesView/StrategySections/StrategySection/data.ts
@@ -7,6 +7,7 @@ const strategyItem = {
   post_title: 'London Bridges 1 One Week',
   post_date: 1671059126,
   post_date_formatted: '12/14/2022',
+  post_excerpt: '<p>description from excerpt</p>',
   post_modified: 1717597535,
   images: {
     thumbnail: {

--- a/apps/watch/src/libs/algolia/useAlgoliaStrategies/useAlgoliaStrategies.spec.ts
+++ b/apps/watch/src/libs/algolia/useAlgoliaStrategies/useAlgoliaStrategies.spec.ts
@@ -5,6 +5,7 @@ import { useHits } from 'react-instantsearch'
 
 import {
   StrategyItem,
+  removeExcerptPTags,
   transformAlgoliaStrategies,
   useAlgoliaStrategies
 } from './useAlgoliaStrategies'
@@ -12,6 +13,13 @@ import {
 jest.mock('react-instantsearch')
 
 const mockUseHits = useHits as jest.MockedFunction<typeof useHits>
+
+describe('removeExcerptPTags', () => {
+  it('should remove p tags from excerpt', () => {
+    const result = removeExcerptPTags('<p>description</p>')
+    expect(result).toBe('description')
+  })
+})
 
 describe('useAlgoliaStrategies', () => {
   const algoliaStrategyItem = {
@@ -21,6 +29,7 @@ describe('useAlgoliaStrategies', () => {
     post_title: 'title',
     post_date: 1671059126,
     post_date_formatted: '12/14/2022',
+    post_excerpt: '<p>description from excerpt</p>',
     post_modified: 1717597535,
     images: {
       thumbnail: {
@@ -37,7 +46,7 @@ describe('useAlgoliaStrategies', () => {
   const strategyItem = {
     id: '1',
     title: 'title',
-    description: 'description',
+    description: 'description from excerpt',
     imageUrl: 'https://example.com/image.jpg',
     link: 'https://example.com/test-page/'
   } as unknown as StrategyItem

--- a/apps/watch/src/libs/algolia/useAlgoliaStrategies/useAlgoliaStrategies.spec.ts
+++ b/apps/watch/src/libs/algolia/useAlgoliaStrategies/useAlgoliaStrategies.spec.ts
@@ -19,6 +19,21 @@ describe('removeExcerptPTags', () => {
     const result = removeExcerptPTags('<p>description</p>')
     expect(result).toBe('description')
   })
+
+  it('should remove multiple p tags from excerpt', () => {
+    const result = removeExcerptPTags('<p>description</p><p>description</p>')
+    expect(result).toBe('descriptiondescription')
+  })
+
+  it('should handle nested p tags', () => {
+    const result = removeExcerptPTags('<p><p>description</p><p>')
+    expect(result).toBe('description')
+  })
+
+  it('should handle no p tags', () => {
+    const result = removeExcerptPTags('description')
+    expect(result).toBe('description')
+  })
 })
 
 describe('useAlgoliaStrategies', () => {

--- a/apps/watch/src/libs/algolia/useAlgoliaStrategies/useAlgoliaStrategies.ts
+++ b/apps/watch/src/libs/algolia/useAlgoliaStrategies/useAlgoliaStrategies.ts
@@ -1,6 +1,10 @@
 import { BaseHit, Hit } from 'instantsearch.js'
 import { useHits } from 'react-instantsearch'
 
+export function removeExcerptPTags(excerpt: string): string {
+  return excerpt.replace(/<\/?p>/g, '')
+}
+
 export interface StrategyItem extends Hit<BaseHit> {
   id: string
   title: string
@@ -13,7 +17,7 @@ export function transformAlgoliaStrategies(hits: Hit[]): StrategyItem[] {
   return hits.map((hit) => ({
     id: hit.objectID,
     title: hit.post_title,
-    description: hit.content,
+    description: removeExcerptPTags(hit.post_excerpt),
     imageUrl: hit.images.thumbnail?.url,
     link: hit.permalink
   })) as unknown as StrategyItem[]


### PR DESCRIPTION
# Description

### Issue

Strategy card items are currently consuming all of the content for description. This won't do as it's not very descriptive

### Solution

Update the hook useAlgoliaStrategies to be consuming the excerpt from Wordpress. The value comes with `p` tags we are to ensure the tag doesn't get renderd in strategies