### PR TITLE
feat: videojs image improvements

### DIFF
--- a/libs/shared/ui/src/libs/defaultVideoJsOptions/defaultVideoJsOptions.spec.ts
+++ b/libs/shared/ui/src/libs/defaultVideoJsOptions/defaultVideoJsOptions.spec.ts
@@ -1,11 +1,67 @@
 import { defaultVideoJsOptions } from './defaultVideoJsOptions'
 
 describe('defaultVideoJsOptions', () => {
-  it('should have useDevicePixelRatio set to true', () => {
-    expect(defaultVideoJsOptions.html5.hls.useDevicePixelRatio).toBe(true)
+  it('should have enableSmoothSeeking set to true', () => {
+    expect(defaultVideoJsOptions.enableSmoothSeeking).toBe(true)
   })
 
-  it('should have bandwidth set to 1e9', () => {
-    expect(defaultVideoJsOptions.html5.hls.bandwidth).toBe(1e9)
+  it('should have experimentalSvgIcons set to true', () => {
+    expect(defaultVideoJsOptions.experimentalSvgIcons).toBe(true)
+  })
+
+  describe('hls', () => {
+    it('should have useDevicePixelRatio set to true', () => {
+      expect(defaultVideoJsOptions.html5.hls.useDevicePixelRatio).toBe(true)
+    })
+
+    it('should have bandwidth set to 1e9', () => {
+      expect(defaultVideoJsOptions.html5.hls.bandwidth).toBe(1e9)
+    })
+
+    it('should have useBandwidthFromLocalStorage set to true', () => {
+      expect(defaultVideoJsOptions.html5.hls.useBandwidthFromLocalStorage).toBe(
+        true
+      )
+    })
+
+    it('should have useNetworkInformationApi set to true', () => {
+      expect(defaultVideoJsOptions.html5.hls.useNetworkInformationApi).toBe(
+        true
+      )
+    })
+
+    it('should have limitRenditionByPlayerDimensions set to false', () => {
+      expect(
+        defaultVideoJsOptions.html5.hls.limitRenditionByPlayerDimensions
+      ).toBe(false)
+    })
+  })
+
+  describe('vhs', () => {
+    it('should have useDevicePixelRatio set to true', () => {
+      expect(defaultVideoJsOptions.html5.vhs.useDevicePixelRatio).toBe(true)
+    })
+
+    it('should have bandwidth set to 1e9', () => {
+      expect(defaultVideoJsOptions.html5.vhs.bandwidth).toBe(1e9)
+    })
+
+    it('should have useBandwidthFromLocalStorage set to true', () => {
+      expect(defaultVideoJsOptions.html5.vhs.useBandwidthFromLocalStorage).toBe(
+        true
+      )
+    })
+
+    it('should have useNetworkInformationApi set to true', () => {
+      expect(defaultVideoJsOptions.html5.vhs.useNetworkInformationApi).toBe(
+        true
+      )
+    })
+
+    it('should have limitRenditionByPlayerDimensions set to false', () => {
+      expect(
+        defaultVideoJsOptions.html5.vhs.limitRenditionByPlayerDimensions
+      ).toBe(false)
+    })
   })
 })

--- a/libs/shared/ui/src/libs/defaultVideoJsOptions/defaultVideoJsOptions.ts
+++ b/libs/shared/ui/src/libs/defaultVideoJsOptions/defaultVideoJsOptions.ts
@@ -1,8 +1,20 @@
 // note: all video.js players import these options, so take care with what is added here
 
 export const defaultVideoJsOptions = {
+  enableSmoothSeeking: true,
+  experimentalSvgIcons: true,
   html5: {
+    vhs: {
+      limitRenditionByPlayerDimensions: false,
+      useBandwidthFromLocalStorage: true,
+      useNetworkInformationApi: true,
+      bandwidth: 1e9, // used to set initial bandwidth before calculation for abr video
+      useDevicePixelRatio: true
+    },
     hls: {
+      limitRenditionByPlayerDimensions: false,
+      useBandwidthFromLocalStorage: true,
+      useNetworkInformationApi: true,
       useDevicePixelRatio: true,
       bandwidth: 1e9 // used to set initial bandwidth before calculation for abr video
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,7 +161,7 @@
         "unsplash-js": "^7.0.19",
         "util": "^0.12.4",
         "vercel": "^32.1.0",
-        "video.js": "^8.6.1",
+        "video.js": "^8.17.4",
         "videojs-youtube": "^3.0.1",
         "xliff": "^6.2.1",
         "yup": "^1.0.0",
@@ -24152,17 +24152,18 @@
       }
     },
     "node_modules/@videojs/http-streaming": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.7.0.tgz",
-      "integrity": "sha512-5uLFKBL8CvD56dxxJyuxqB5CY0tdoa4SE9KbXakeiAy6iFBUEPvTr2YGLKEWvQ8Lojs1wl+FQndLdv+GO7t9Fw==",
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.13.3.tgz",
+      "integrity": "sha512-L7H+iTeqHeZ5PylzOx+pT3CVyzn4TALWYTJKkIc1pDaV/cTVfNGtG+9/vXPAydD+wR/xH1M9/t2JH8tn/DCT4w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "4.0.0",
         "aes-decrypter": "4.0.1",
         "global": "^4.4.0",
         "m3u8-parser": "^7.1.0",
-        "mpd-parser": "^1.2.2",
-        "mux.js": "7.0.1",
+        "mpd-parser": "^1.3.0",
+        "mux.js": "7.0.3",
         "video.js": "^7 || ^8"
       },
       "engines": {
@@ -24170,23 +24171,26 @@
         "npm": ">=5"
       },
       "peerDependencies": {
-        "video.js": "^7 || ^8"
+        "video.js": "^8.14.0"
       }
     },
-    "node_modules/@videojs/http-streaming/node_modules/m3u8-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-7.1.0.tgz",
-      "integrity": "sha512-7N+pk79EH4oLKPEYdgRXgAsKDyA/VCo0qCHlUwacttQA0WqsjZQYmNfywMvjlY9MpEBVZEt0jKFd73Kv15EBYQ==",
+    "node_modules/@videojs/http-streaming/node_modules/aes-decrypter": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-4.0.1.tgz",
+      "integrity": "sha512-H1nh/P9VZXUf17AA5NQfJML88CFjVBDuGkp5zDHa7oEhYN9TTpNLJknRY1ie0iSKWlDf6JRnJKaZVDSQdPy6Cg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "^3.0.5",
-        "global": "^4.4.0"
+        "global": "^4.4.0",
+        "pkcs7": "^1.0.4"
       }
     },
-    "node_modules/@videojs/http-streaming/node_modules/m3u8-parser/node_modules/@videojs/vhs-utils": {
+    "node_modules/@videojs/http-streaming/node_modules/aes-decrypter/node_modules/@videojs/vhs-utils": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
       "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "global": "^4.4.0",
@@ -24201,6 +24205,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.0.0.tgz",
       "integrity": "sha512-xJp7Yd4jMLwje2vHCUmi8MOUU76nxiwII3z4Eg3Ucb+6rrkFVGosrXlMgGnaLjq724j3wzNElRZ71D/CKrTtxg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "global": "^4.4.0",
@@ -24212,9 +24217,10 @@
       }
     },
     "node_modules/@videojs/xhr": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@videojs/xhr/-/xhr-2.6.0.tgz",
-      "integrity": "sha512-7J361GiN1tXpm+gd0xz2QWr3xNWBE+rytvo8J3KuggFaLg+U37gZQ2BuPLcnkfGffy2e+ozY70RHC8jt7zjA6Q==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@videojs/xhr/-/xhr-2.7.0.tgz",
+      "integrity": "sha512-giab+EVRanChIupZK7gXjHy90y3nncA2phIOyG3Ne5fvpiMJzvqYwiTOnEVW2S4CoYcuKJkomat7bMXA/UoUZQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "global": "~4.4.0",
@@ -24776,24 +24782,25 @@
       }
     },
     "node_modules/aes-decrypter": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-4.0.1.tgz",
-      "integrity": "sha512-H1nh/P9VZXUf17AA5NQfJML88CFjVBDuGkp5zDHa7oEhYN9TTpNLJknRY1ie0iSKWlDf6JRnJKaZVDSQdPy6Cg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-4.0.2.tgz",
+      "integrity": "sha512-lc+/9s6iJvuaRe5qDlMTpCFjnwpkeOXp8qP3oiZ5jsj1MRg+SBVUmmICrhxHvc8OELSmc+fEyyxAuppY6hrWzw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.5",
+        "@videojs/vhs-utils": "^4.1.1",
         "global": "^4.4.0",
         "pkcs7": "^1.0.4"
       }
     },
     "node_modules/aes-decrypter/node_modules/@videojs/vhs-utils": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
-      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.1.1.tgz",
+      "integrity": "sha512-5iLX6sR2ownbv4Mtejw6Ax+naosGvoT9kY+gcuHzANyUZZ+4NpeNdKMUhb6ag0acYej1Y7cmr/F2+4PrggMiVA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "global": "^4.4.0",
-        "url-toolkit": "^2.2.1"
+        "global": "^4.4.0"
       },
       "engines": {
         "node": ">=8",
@@ -39379,11 +39386,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/individual": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/individual/-/individual-2.0.0.tgz",
-      "integrity": "sha512-pWt8hBCqJsUWI/HtcfWod7+N9SgAqyPEaF7JQjwzjn5vGrpg6aQ5qeAFQ7dx//UH4J1O+7xqew+gCeeFt6xN/g=="
-    },
     "node_modules/infima": {
       "version": "0.2.0-alpha.43",
       "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.43.tgz",
@@ -39864,7 +39866,8 @@
     "node_modules/is-function": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
+      "license": "MIT"
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
@@ -42520,11 +42523,6 @@
         "node": ">= 12"
       }
     },
-    "node_modules/keycode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
-      "integrity": "sha512-ps3I9jAdNtRpJrbBvQjpzyFbss/skHqzS+eu4RxKLaEAtFqkjZaB6TZMSivPbLxf4K7VI4SjR0P5mRCX5+Q25A=="
-    },
     "node_modules/keygrip": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
@@ -43789,23 +43787,24 @@
       }
     },
     "node_modules/m3u8-parser": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-6.2.0.tgz",
-      "integrity": "sha512-qlC00JTxYOxawcqg+RB8jbyNwL3foY/nCY61kyWP+RCuJE9APLeqB/nSlTjb4Mg0yRmyERgjswpdQxMvkeoDrg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-7.2.0.tgz",
+      "integrity": "sha512-CRatFqpjVtMiMaKXxNvuI3I++vUumIXVVT/JpCpdU/FynV/ceVw1qpPyyBNindL+JlPMSesx+WX1QJaZEJSaMQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.5",
+        "@videojs/vhs-utils": "^4.1.1",
         "global": "^4.4.0"
       }
     },
     "node_modules/m3u8-parser/node_modules/@videojs/vhs-utils": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
-      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.1.1.tgz",
+      "integrity": "sha512-5iLX6sR2ownbv4Mtejw6Ax+naosGvoT9kY+gcuHzANyUZZ+4NpeNdKMUhb6ag0acYej1Y7cmr/F2+4PrggMiVA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "global": "^4.4.0",
-        "url-toolkit": "^2.2.1"
+        "global": "^4.4.0"
       },
       "engines": {
         "node": ">=8",
@@ -47640,31 +47639,18 @@
       "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
     },
     "node_modules/mpd-parser": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-1.2.2.tgz",
-      "integrity": "sha512-QCfB1koOoZw6E5La1cx+W/Yd0EZlRhHMqMr4TAJez0eRTuPDzPM5FWoiOqjyo37W+ISPLzmfJACSbJFEBjbL4Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-1.3.0.tgz",
+      "integrity": "sha512-WgeIwxAqkmb9uTn4ClicXpEQYCEduDqRKfmUdp4X8vmghKfBNXZLYpREn9eqrDx/Tf5LhzRcJLSpi4ohfV742Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.5",
+        "@videojs/vhs-utils": "^4.0.0",
         "@xmldom/xmldom": "^0.8.3",
         "global": "^4.4.0"
       },
       "bin": {
         "mpd-to-m3u8-json": "bin/parse.js"
-      }
-    },
-    "node_modules/mpd-parser/node_modules/@videojs/vhs-utils": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
-      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "global": "^4.4.0",
-        "url-toolkit": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
       }
     },
     "node_modules/mqtt": {
@@ -48007,9 +47993,10 @@
       "dev": true
     },
     "node_modules/mux.js": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.1.tgz",
-      "integrity": "sha512-Omz79uHqYpMP1V80JlvEdCiOW1hiw4mBvDh9gaZEpxvB+7WYb2soZSzfuSRrK2Kh9Pm6eugQNrIpY/Bnyhk4hw==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.3.tgz",
+      "integrity": "sha512-gzlzJVEGFYPtl2vvEiJneSWAWD4nfYRHD5XgxmB2gWvXraMPOYk+sxfvexmNfjQUFpmk6hwLR5C6iSFmuwCHdQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "global": "^4.4.0"
@@ -53185,6 +53172,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/pkcs7/-/pkcs7-1.0.4.tgz",
       "integrity": "sha512-afRERtHn54AlwaF2/+LFszyAANTCggGilmcmILUzEjvs3XgFZT+xE6+QWQcAGmu4xajy+Xtj7acLOPdx5/eXWQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.5.5"
       },
@@ -58974,14 +58962,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rust-result": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rust-result/-/rust-result-1.0.0.tgz",
-      "integrity": "sha512-6cJzSBU+J/RJCF063onnQf0cDUOHs9uZI1oroSGnHOph+CQTIJ5Pp2hK5kEQq1+7yE/EEWfulSNXAQ2jikPthA==",
-      "dependencies": {
-        "individual": "^2.0.0"
-      }
-    },
     "node_modules/rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
@@ -59040,14 +59020,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/safe-json-parse": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-4.0.0.tgz",
-      "integrity": "sha512-RjZPPHugjK0TOzFrLZ8inw44s9bKox99/0AZW9o/BEQVrJfhI+fIHMErnPyRa89/yRXUUr93q+tiN6zhoVV4wQ==",
-      "dependencies": {
-        "rust-result": "^1.0.0"
-      }
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",
@@ -63513,7 +63485,8 @@
     "node_modules/url-toolkit": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.5.tgz",
-      "integrity": "sha512-mtN6xk+Nac+oyJ/PrI7tzfmomRVNFIWKUbG8jdYFt52hxbiReFAXIjYskvu64/dvuW71IcB7lV8l0HvZMac6Jg=="
+      "integrity": "sha512-mtN6xk+Nac+oyJ/PrI7tzfmomRVNFIWKUbG8jdYFt52hxbiReFAXIjYskvu64/dvuW71IcB7lV8l0HvZMac6Jg==",
+      "license": "Apache-2.0"
     },
     "node_modules/urlpattern-polyfill": {
       "version": "10.0.0",
@@ -63881,45 +63854,46 @@
       "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
     },
     "node_modules/video.js": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.6.1.tgz",
-      "integrity": "sha512-CNYVJ5WWIZ7bOhbkkfcKqLGoc6WsE3Ft2RfS1lXdQTWk8UiSsPW2Ssk2JzPCA8qnIlUG9os/faCFsYWjyu4JcA==",
+      "version": "8.17.4",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.17.4.tgz",
+      "integrity": "sha512-AECieAxKMKB/QgYK36ci50phfpWys6bFT6+pGMpSafeFYSoZaQ2Vpl83T9Qqcesv4TO7oNtiycnVeaBnrva2oA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/http-streaming": "3.7.0",
+        "@videojs/http-streaming": "3.13.3",
         "@videojs/vhs-utils": "^4.0.0",
-        "@videojs/xhr": "2.6.0",
+        "@videojs/xhr": "2.7.0",
         "aes-decrypter": "^4.0.1",
         "global": "4.4.0",
-        "keycode": "2.2.0",
-        "m3u8-parser": "^6.0.0",
-        "mpd-parser": "^1.0.1",
+        "m3u8-parser": "^7.1.0",
+        "mpd-parser": "^1.2.2",
         "mux.js": "^7.0.1",
-        "safe-json-parse": "4.0.0",
-        "videojs-contrib-quality-levels": "4.0.0",
-        "videojs-font": "4.1.0",
+        "videojs-contrib-quality-levels": "4.1.0",
+        "videojs-font": "4.2.0",
         "videojs-vtt.js": "0.15.5"
       }
     },
     "node_modules/videojs-contrib-quality-levels": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/videojs-contrib-quality-levels/-/videojs-contrib-quality-levels-4.0.0.tgz",
-      "integrity": "sha512-u5rmd8BjLwANp7XwuQ0Q/me34bMe6zg9PQdHfTS7aXgiVRbNTb4djcmfG7aeSrkpZjg+XCLezFNenlJaCjBHKw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/videojs-contrib-quality-levels/-/videojs-contrib-quality-levels-4.1.0.tgz",
+      "integrity": "sha512-TfrXJJg1Bv4t6TOCMEVMwF/CoS8iENYsWNKip8zfhB5kTcegiFYezEA0eHAJPU64ZC8NQbxQgOwAsYU8VXbOWA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "global": "^4.4.0"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6"
+        "node": ">=16",
+        "npm": ">=8"
       },
       "peerDependencies": {
         "video.js": "^8"
       }
     },
     "node_modules/videojs-font": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-4.1.0.tgz",
-      "integrity": "sha512-X1LuPfLZPisPLrANIAKCknZbZu5obVM/ylfd1CN+SsCmPZQ3UMDPcvLTpPBJxcBuTpHQq2MO1QCFt7p8spnZ/w=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-4.2.0.tgz",
+      "integrity": "sha512-YPq+wiKoGy2/M7ccjmlvwi58z2xsykkkfNMyIg4xb7EZQQNwB71hcSsB3o75CqQV7/y5lXkXhI/rsGAS7jfEmQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/videojs-vtt.js": {
       "version": "0.15.5",

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "unsplash-js": "^7.0.19",
     "util": "^0.12.4",
     "vercel": "^32.1.0",
-    "video.js": "^8.6.1",
+    "video.js": "^8.17.4",
     "videojs-youtube": "^3.0.1",
     "xliff": "^6.2.1",
     "yup": "^1.0.0",


### PR DESCRIPTION
# Description

### Issue

Brightcove videos are lower resolution than possible and often start with the lowest resolution


### Solution

Change vhs & hls settings to set and remember bandwidth
Use browser bandwidth calculation where possible
Don't limit resolution based on player size, but rather on bandwidth
Switch from webfont to svg to reduce package size
Enable new smoothseeking feature

