### PR TITLE
fix: drop dev indices strategy sections

### DIFF
--- a/apps/watch/next.config.js
+++ b/apps/watch/next.config.js
@@ -20,6 +20,7 @@ const nextConfig = {
       // jesusfilm wordpress website
       { protocol: 'https', hostname: 'develop.jesusfilm.org' },
       { protocol: 'https', hostname: 'jesusfilm.org' },
+      { protocol: 'https', hostname: 'www.jesusfilm.org' },
       // arclight image provider - cloudfront
       { protocol: 'https', hostname: 'd1wl257kev7hsz.cloudfront.net' },
       { protocol: 'https', hostname: 'd3s4plubcuq0w9.cloudfront.net' },

--- a/apps/watch/src/components/StrategiesView/StrategySections/StrategySections.tsx
+++ b/apps/watch/src/components/StrategiesView/StrategySections/StrategySections.tsx
@@ -6,27 +6,6 @@ import { EmptySearch } from '@core/journeys/ui/EmptySearch'
 
 import { StrategySection } from './StrategySection/StrategySection'
 
-const PROD_INDEXES = [
-  'wp_prd_posts_equipment',
-  'wp_prd_posts_training_strategies',
-  'wp_prd_posts_outreach_resources',
-  'wp_prd_posts_prayer_resources',
-  'wp_prd_posts_digital_strategies'
-]
-
-const DEV_INDEXES = [
-  'wp_dev_posts_equipment',
-  'wp_dev_posts_training_strategies',
-  'wp_dev_posts_outreach_resources',
-  'wp_dev_posts_prayer_resources',
-  'wp_dev_posts_digital_strategies'
-]
-
-function getIndexes(): string[] {
-  const isProd = process.env.DOPPLER_ENVIRONMENT === 'prd'
-  return isProd ? PROD_INDEXES : DEV_INDEXES
-}
-
 interface StrategySectionsProps {
   includeIndex?: boolean
 }
@@ -34,7 +13,14 @@ interface StrategySectionsProps {
 export function StrategySections({
   includeIndex = false
 }: StrategySectionsProps): ReactElement {
-  const indexes = getIndexes()
+  const indexes = [
+    'wp_prd_posts_equipment',
+    'wp_prd_posts_training_strategies',
+    'wp_prd_posts_outreach_resources',
+    'wp_prd_posts_prayer_resources',
+    'wp_prd_posts_digital_strategies'
+  ]
+
   const [hasResult, setHasResult] = useState<boolean>(true)
 
   const resultsMap = new Map<number, boolean>()


### PR DESCRIPTION
# Description

### Issue

It looks like that we might not be using the dev indices in the near future or not at all

### Solution

Drop the use of dev indices and enable it to be used in all environments
