### PR TITLE
fix: support cf country header

### DIFF
--- a/apps/watch/pages/api/geolocation.ts
+++ b/apps/watch/pages/api/geolocation.ts
@@ -4,13 +4,19 @@ export default async function Handler(
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void> {
-  // Log all headers
-  console.log('headers', {
-    headers: Object.fromEntries(Object.entries(req.headers))
-  })
+  const cloudflareIPCountry = req.headers['cf-ipcountry']
+  const vercelIPCountry = req.headers['x-vercel-ip-country']
+
+  console.log(
+    'Using:',
+    cloudflareIPCountry != null
+      ? `Cloudflare Country: ${cloudflareIPCountry as string}`
+      : `Vercel Country: ${vercelIPCountry as string}`
+  )
+
+  const country = cloudflareIPCountry ?? vercelIPCountry
+
   res.status(200).send({
-    country: req.headers['x-vercel-ip-country'],
-    region: req.headers['x-vercel-ip-country-region'],
-    city: req.headers['x-vercel-ip-city']
+    country
   })
 }

--- a/apps/watch/pages/api/geolocation.ts
+++ b/apps/watch/pages/api/geolocation.ts
@@ -1,18 +1,13 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import pino from 'pino'
-
-const logger = pino({ level: 'info' })
 
 export default async function Handler(
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void> {
   // Log all headers
-  logger.info(
-    { headers: Object.fromEntries(Object.entries(req.headers)) },
-    'Request Headers'
-  )
-
+  console.log('headers', {
+    headers: Object.fromEntries(Object.entries(req.headers))
+  })
   res.status(200).send({
     country: req.headers['x-vercel-ip-country'],
     region: req.headers['x-vercel-ip-country-region'],

--- a/apps/watch/pages/api/geolocation.ts
+++ b/apps/watch/pages/api/geolocation.ts
@@ -4,10 +4,7 @@ export default async function Handler(
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void> {
-  const country =
-    req.headers['cf-ipcountry'] ?? req.headers['x-vercel-ip-country']
-
   res.status(200).send({
-    country
+    country: req.headers['cf-ipcountry'] ?? req.headers['x-vercel-ip-country']
   })
 }

--- a/apps/watch/pages/api/geolocation.ts
+++ b/apps/watch/pages/api/geolocation.ts
@@ -4,17 +4,8 @@ export default async function Handler(
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void> {
-  const cloudflareIPCountry = req.headers['cf-ipcountry']
-  const vercelIPCountry = req.headers['x-vercel-ip-country']
-
-  console.log(
-    'Using:',
-    cloudflareIPCountry != null
-      ? `Cloudflare Country: ${cloudflareIPCountry as string}`
-      : `Vercel Country: ${vercelIPCountry as string}`
-  )
-
-  const country = cloudflareIPCountry ?? vercelIPCountry
+  const country =
+    req.headers['cf-ipcountry'] ?? req.headers['x-vercel-ip-country']
 
   res.status(200).send({
     country

--- a/apps/watch/pages/api/geolocation.ts
+++ b/apps/watch/pages/api/geolocation.ts
@@ -1,9 +1,18 @@
 import { NextApiRequest, NextApiResponse } from 'next'
+import pino from 'pino'
+
+const logger = pino({ level: 'info' })
 
 export default async function Handler(
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void> {
+  // Log all headers
+  logger.info(
+    { headers: Object.fromEntries(Object.entries(req.headers)) },
+    'Request Headers'
+  )
+
   res.status(200).send({
     country: req.headers['x-vercel-ip-country'],
     region: req.headers['x-vercel-ip-country-region'],


### PR DESCRIPTION
# Description

### Issue

Using `x-vercel-ip-country` returns inconsistent results when it comes to detecting the users location. This is due to 

### Solution

Instead we are to use `x-vercel-ip-country` as a fallback and use `cf-ipcountry` to detect the users location or users country. `cf-ipcountry` returns a more consistent result in terms of location.