### PR TITLE
fix: disable page side scroll

### DIFF
--- a/apps/watch/src/components/PageWrapper/PageWrapper.tsx
+++ b/apps/watch/src/components/PageWrapper/PageWrapper.tsx
@@ -1,6 +1,6 @@
 import Box from '@mui/material/Box'
 import Container from '@mui/material/Container'
-import Stack from '@mui/material/Stack'
+import Stack, { StackProps } from '@mui/material/Stack'
 import { ReactElement, ReactNode } from 'react'
 import Div100vh from 'react-div-100vh'
 
@@ -11,7 +11,7 @@ import { ThemeMode, ThemeName } from '@core/shared/ui/themes'
 import { Footer } from '../Footer'
 import { Header } from '../Header'
 
-interface PageWrapperProps {
+interface PageWrapperProps extends StackProps {
   hero?: ReactNode
   children?: ReactNode
   hideHeader?: boolean
@@ -26,7 +26,8 @@ export function PageWrapper({
   hideHeader,
   hideHeaderSpacer,
   testId,
-  headerThemeMode
+  headerThemeMode,
+  ...props
 }: PageWrapperProps): ReactElement {
   return (
     <Div100vh>
@@ -37,6 +38,7 @@ export function PageWrapper({
         justifyContent="space-between"
         sx={{ width: '100%', height: '100%' }}
         data-testid={testId}
+        {...props}
       >
         <Container maxWidth={false} disableGutters>
           <ThemeProvider

--- a/apps/watch/src/components/PageWrapper/PageWrapper.tsx
+++ b/apps/watch/src/components/PageWrapper/PageWrapper.tsx
@@ -1,6 +1,7 @@
 import Box from '@mui/material/Box'
 import Container from '@mui/material/Container'
-import Stack, { StackProps } from '@mui/material/Stack'
+import Stack from '@mui/material/Stack'
+import { SxProps } from '@mui/material/styles'
 import { ReactElement, ReactNode } from 'react'
 import Div100vh from 'react-div-100vh'
 
@@ -11,13 +12,14 @@ import { ThemeMode, ThemeName } from '@core/shared/ui/themes'
 import { Footer } from '../Footer'
 import { Header } from '../Header'
 
-interface PageWrapperProps extends StackProps {
+interface PageWrapperProps {
   hero?: ReactNode
   children?: ReactNode
   hideHeader?: boolean
   hideHeaderSpacer?: boolean
   testId?: string
   headerThemeMode?: ThemeMode
+  sx?: SxProps
 }
 
 export function PageWrapper({
@@ -27,7 +29,7 @@ export function PageWrapper({
   hideHeaderSpacer,
   testId,
   headerThemeMode,
-  ...props
+  sx
 }: PageWrapperProps): ReactElement {
   return (
     <Div100vh>
@@ -36,9 +38,8 @@ export function PageWrapper({
       )}
       <Stack
         justifyContent="space-between"
-        sx={{ width: '100%', height: '100%' }}
+        sx={{ width: '100%', height: '100%', overflowX: 'clip', ...sx }}
         data-testid={testId}
-        {...props}
       >
         <Container maxWidth={false} disableGutters>
           <ThemeProvider

--- a/apps/watch/src/components/PageWrapper/PageWrapper.tsx
+++ b/apps/watch/src/components/PageWrapper/PageWrapper.tsx
@@ -1,7 +1,6 @@
 import Box from '@mui/material/Box'
 import Container from '@mui/material/Container'
 import Stack from '@mui/material/Stack'
-import { SxProps } from '@mui/material/styles'
 import { ReactElement, ReactNode } from 'react'
 import Div100vh from 'react-div-100vh'
 
@@ -19,7 +18,6 @@ interface PageWrapperProps {
   hideHeaderSpacer?: boolean
   testId?: string
   headerThemeMode?: ThemeMode
-  sx?: SxProps
 }
 
 export function PageWrapper({
@@ -28,8 +26,7 @@ export function PageWrapper({
   hideHeader,
   hideHeaderSpacer,
   testId,
-  headerThemeMode,
-  sx
+  headerThemeMode
 }: PageWrapperProps): ReactElement {
   return (
     <Div100vh>
@@ -38,7 +35,7 @@ export function PageWrapper({
       )}
       <Stack
         justifyContent="space-between"
-        sx={{ width: '100%', height: '100%', overflowX: 'clip', ...sx }}
+        sx={{ width: '100%', height: '100%', overflowX: 'clip' }}
         data-testid={testId}
       >
         <Container maxWidth={false} disableGutters>

--- a/apps/watch/src/components/ResourcesView/ResourcesView.tsx
+++ b/apps/watch/src/components/ResourcesView/ResourcesView.tsx
@@ -12,7 +12,10 @@ import { ResourceSections } from './ResourceSections'
 export function ResourcesView(): ReactElement {
   return (
     <PageWrapper>
-      <Container maxWidth="xxl" sx={{ px: { xs: 0 }, py: { xs: 6, sm: 9 } }}>
+      <Container
+        maxWidth="xxl"
+        sx={{ px: { xs: 0 }, py: { xs: 6, sm: 9 }, overflowX: 'hidden' }}
+      >
         <Stack sx={{ p: 0, gap: 10 }}>
           <ResourceHeading heading="Resources" />
           <SearchBar />

--- a/apps/watch/src/components/ResourcesView/ResourcesView.tsx
+++ b/apps/watch/src/components/ResourcesView/ResourcesView.tsx
@@ -11,7 +11,7 @@ import { ResourceSections } from './ResourceSections'
 
 export function ResourcesView(): ReactElement {
   return (
-    <PageWrapper sx={{ overflowX: 'clip' }}>
+    <PageWrapper>
       <Container maxWidth="xxl" sx={{ px: { xs: 0 }, py: { xs: 6, sm: 9 } }}>
         <Stack sx={{ p: 0, gap: 10 }}>
           <ResourceHeading heading="Resources" />

--- a/apps/watch/src/components/ResourcesView/ResourcesView.tsx
+++ b/apps/watch/src/components/ResourcesView/ResourcesView.tsx
@@ -11,11 +11,8 @@ import { ResourceSections } from './ResourceSections'
 
 export function ResourcesView(): ReactElement {
   return (
-    <PageWrapper>
-      <Container
-        maxWidth="xxl"
-        sx={{ px: { xs: 0 }, py: { xs: 6, sm: 9 }, overflowX: 'hidden' }}
-      >
+    <PageWrapper sx={{ overflowX: 'clip' }}>
+      <Container maxWidth="xxl" sx={{ px: { xs: 0 }, py: { xs: 6, sm: 9 } }}>
         <Stack sx={{ p: 0, gap: 10 }}>
           <ResourceHeading heading="Resources" />
           <SearchBar />


### PR DESCRIPTION
# Description

### Issue

Entire resources page is able to scroll to the right

[Link to Linear Todo](https://linear.app/jesus-film-project/issue/ENG-976/disable-x-scroll-resources-page)

### Solution

Use overflow-x: clip on all watch page wrapper containers

### How to test
* Ensure the carousels overflow right to the edge of the screen
* Ensure the resources page cannot be scrolled to the right or left
* Ensure all other watch pages look and scroll as expected