### PR TITLE
fix: select options not displaying

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/Properties.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/Properties.tsx
@@ -181,7 +181,12 @@ export function Properties({ block, step }: PropertiesProps): ReactElement {
       data-testId="SettingsDrawer"
     >
       <DrawerTitle title={title} onClose={onClose} />
-      <Stack flexGrow={1} sx={{ overflow: 'auto' }}>
+      <Stack
+        data-testid="SettingsDrawerContent"
+        className="swiper-no-swiping"
+        flexGrow={1}
+        sx={{ overflow: 'auto' }}
+      >
         {component}
       </Stack>
     </Stack>


### PR DESCRIPTION
# Description

### Issue
- Options for select inputs are not displaying in the properties drawer

### Solution
- Add the swiper class to prevent event capture for the drawer