### PR TITLE
fix: use name instead of namelanguage in slug filter

### DIFF
--- a/apps/api-languages/src/workers/bigQuery/importers/languageSlugs/languageSlugs.ts
+++ b/apps/api-languages/src/workers/bigQuery/importers/languageSlugs/languageSlugs.ts
@@ -50,7 +50,7 @@ export async function importLanguageSlugs(logger?: Logger): Promise<void> {
   const emptySlugs = await prisma.language.findMany({
     where: {
       slug: null,
-      nameLanguage: { some: { languageId: '529' } }
+      name: { some: { languageId: '529' } }
     }
   })
 


### PR DESCRIPTION
# Description

### Issue

Language slugs are not getting populated causing some videoVariants to not get imported.

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

fix the prisma call to use name instead of nameLanguage

# External Changes
# Additional information
