### PR TITLE
fix: disable preview button if no href

### DIFF
--- a/apps/journeys-admin-e2e/src/pages/journey-page.ts
+++ b/apps/journeys-admin-e2e/src/pages/journey-page.ts
@@ -930,7 +930,10 @@ export class JourneyPage {
   }
 
   async clickPreviewBtnInCustomJourneyPage() {
-    await this.page.getByTestId('ItemsStack').getByLabel('Preview').click()
+    await this.page
+      .getByTestId('ItemsStack')
+      .getByRole('link', { name: 'Preview' })
+      .click()
   }
 
   async verifyPreviewFromCustomJourneyPage() {

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/Item/Item.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/Item/Item.spec.tsx
@@ -23,35 +23,6 @@ describe('Item', () => {
       expect(IconButtonItem.getAttribute('href')).toBe('https://test.com/')
       expect(IconButtonItem.getAttribute('target')).toBe('_blank')
     })
-
-    it('should be disabled if no href provided', async () => {
-      const { getByRole } = render(
-        <Item
-          variant="icon-button"
-          label="Icon Button"
-          href={undefined}
-          icon={<Edit2Icon />}
-        />
-      )
-      const IconButtonItem = getByRole('button', { name: 'Icon Button' })
-      expect(IconButtonItem).toBeDisabled()
-    })
-
-    it('should not be able to click button', async () => {
-      const handleClick = jest.fn()
-      const { getByRole } = render(
-        <Item
-          variant="icon-button"
-          label="Icon Button"
-          href={undefined}
-          icon={<Edit2Icon />}
-          onClick={handleClick}
-        />
-      )
-      const IconButtonItem = getByRole('button', { name: 'Icon Button' })
-      fireEvent.click(IconButtonItem)
-      await waitFor(() => expect(handleClick).not.toHaveBeenCalled())
-    })
   })
 
   describe('button variant', () => {

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/Item/Item.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/Item/Item.spec.tsx
@@ -5,57 +5,92 @@ import Edit2Icon from '@core/shared/ui/icons/Edit2'
 import { Item } from './Item'
 
 describe('Item', () => {
-  it('handles icon button item click', async () => {
-    const handleClick = jest.fn()
-    const { getByRole } = render(
-      <Item
-        variant="icon-button"
-        label="Icon Button"
-        href="https://test.com/"
-        icon={<Edit2Icon />}
-        onClick={handleClick}
-      />
-    )
-    const IconButtonItem = getByRole('link', { name: 'Icon Button' })
-    fireEvent.click(IconButtonItem)
-    await waitFor(() => expect(handleClick).toHaveBeenCalled())
-    expect(IconButtonItem.getAttribute('href')).toBe('https://test.com/')
-    expect(IconButtonItem.getAttribute('target')).toBe('_blank')
+  describe('icon button variant', () => {
+    it('should handle icon button click', async () => {
+      const handleClick = jest.fn()
+      const { getByRole } = render(
+        <Item
+          variant="icon-button"
+          label="Icon Button"
+          href="https://test.com/"
+          icon={<Edit2Icon />}
+          onClick={handleClick}
+        />
+      )
+      const IconButtonItem = getByRole('link', { name: 'Icon Button' })
+      fireEvent.click(IconButtonItem)
+      await waitFor(() => expect(handleClick).toHaveBeenCalled())
+      expect(IconButtonItem.getAttribute('href')).toBe('https://test.com/')
+      expect(IconButtonItem.getAttribute('target')).toBe('_blank')
+    })
+
+    it('should be disabled if no href provided', async () => {
+      const { getByRole } = render(
+        <Item
+          variant="icon-button"
+          label="Icon Button"
+          href={undefined}
+          icon={<Edit2Icon />}
+        />
+      )
+      const IconButtonItem = getByRole('button', { name: 'Icon Button' })
+      expect(IconButtonItem).toBeDisabled()
+    })
+
+    it('should not be able to click button', async () => {
+      const handleClick = jest.fn()
+      const { getByRole } = render(
+        <Item
+          variant="icon-button"
+          label="Icon Button"
+          href={undefined}
+          icon={<Edit2Icon />}
+          onClick={handleClick}
+        />
+      )
+      const IconButtonItem = getByRole('button', { name: 'Icon Button' })
+      fireEvent.click(IconButtonItem)
+      await waitFor(() => expect(handleClick).not.toHaveBeenCalled())
+    })
   })
 
-  it('handles button item click', async () => {
-    const handleClick = jest.fn()
-    const { getByRole } = render(
-      <Item
-        variant="button"
-        label="Button"
-        href="https://test.com/"
-        icon={<Edit2Icon />}
-        onClick={handleClick}
-      />
-    )
-    const ButtonItem = getByRole('link', { name: 'Button' })
-    fireEvent.click(ButtonItem)
-    await waitFor(() => expect(handleClick).toHaveBeenCalled())
-    expect(ButtonItem.getAttribute('href')).toBe('https://test.com/')
-    expect(ButtonItem.getAttribute('target')).toBe('_blank')
+  describe('button variant', () => {
+    it('handles button click', async () => {
+      const handleClick = jest.fn()
+      const { getByRole } = render(
+        <Item
+          variant="button"
+          label="Button"
+          href="https://test.com/"
+          icon={<Edit2Icon />}
+          onClick={handleClick}
+        />
+      )
+      const ButtonItem = getByRole('link', { name: 'Button' })
+      fireEvent.click(ButtonItem)
+      await waitFor(() => expect(handleClick).toHaveBeenCalled())
+      expect(ButtonItem.getAttribute('href')).toBe('https://test.com/')
+      expect(ButtonItem.getAttribute('target')).toBe('_blank')
+    })
   })
 
-  it('handles menu item click', async () => {
-    const handleClick = jest.fn()
-    const { getByRole } = render(
-      <Item
-        variant="menu-item"
-        label="Menu"
-        href="https://test.com/"
-        icon={<Edit2Icon />}
-        onClick={handleClick}
-      />
-    )
-    const MenuItem = getByRole('menuitem', { name: 'Menu' })
-    fireEvent.click(MenuItem)
-    await waitFor(() => expect(handleClick).toHaveBeenCalled())
-    expect(MenuItem.getAttribute('href')).toBe('https://test.com/')
-    expect(MenuItem.getAttribute('target')).toBe('_blank')
+  describe('menu item variant', () => {
+    it('handles menu item click', async () => {
+      const handleClick = jest.fn()
+      const { getByRole } = render(
+        <Item
+          variant="menu-item"
+          label="Menu"
+          href="https://test.com/"
+          icon={<Edit2Icon />}
+          onClick={handleClick}
+        />
+      )
+      const MenuItem = getByRole('menuitem', { name: 'Menu' })
+      fireEvent.click(MenuItem)
+      await waitFor(() => expect(handleClick).toHaveBeenCalled())
+      expect(MenuItem.getAttribute('href')).toBe('https://test.com/')
+      expect(MenuItem.getAttribute('target')).toBe('_blank')
+    })
   })
 })

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/Item/Item.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/Item/Item.tsx
@@ -41,15 +41,19 @@ export function Item({
             ]
           }}
         >
-          <IconButton
-            component={href != null ? 'a' : 'button'}
-            target={href != null ? '_blank' : undefined}
-            href={href}
-            onClick={onClick}
-            {...ButtonProps}
-          >
-            {icon}
-          </IconButton>
+          <span>
+            <IconButton
+              component={href != null ? 'a' : 'button'}
+              target={href != null ? '_blank' : undefined}
+              disabled={href == null}
+              href={href}
+              onClick={onClick}
+              aria-label={label}
+              {...ButtonProps}
+            >
+              {icon}
+            </IconButton>
+          </span>
         </Tooltip>
       )
     case 'button':

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/Item/Item.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/Item/Item.tsx
@@ -45,7 +45,6 @@ export function Item({
             <IconButton
               component={href != null ? 'a' : 'button'}
               target={href != null ? '_blank' : undefined}
-              disabled={href == null}
               href={href}
               onClick={onClick}
               aria-label={label}

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/PreviewItem/PreviewItem.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/PreviewItem/PreviewItem.spec.tsx
@@ -26,7 +26,7 @@ describe('PreviewItem', () => {
   it('should call onclick', async () => {
     const mockOnClick = jest.fn()
     const { getByRole } = render(
-      <MockedProvider>
+      <MockedProvider mocks={[getCustomDomainMock]}>
         <SnackbarProvider>
           <JourneyProvider value={{ journey: mockJourney }}>
             <PreviewItem variant="icon-button" onClick={mockOnClick} />
@@ -39,9 +39,25 @@ describe('PreviewItem', () => {
     await waitFor(() => expect(mockOnClick).toHaveBeenCalled())
   })
 
+  it('should not call onclick when no journey id', async () => {
+    const mockOnClick = jest.fn()
+    const { getByRole } = render(
+      <MockedProvider mocks={[getCustomDomainMock]}>
+        <SnackbarProvider>
+          <JourneyProvider value={{ journey: undefined }}>
+            <PreviewItem variant="icon-button" onClick={mockOnClick} />
+          </JourneyProvider>
+        </SnackbarProvider>
+      </MockedProvider>
+    )
+
+    fireEvent.click(getByRole('button'))
+    await waitFor(() => expect(mockOnClick).not.toHaveBeenCalled())
+  })
+
   it('should have correct link', async () => {
     const { getByRole } = render(
-      <MockedProvider>
+      <MockedProvider mocks={[getCustomDomainMock]}>
         <SnackbarProvider>
           <JourneyProvider value={{ journey: mockJourney }}>
             <PreviewItem variant="icon-button" />

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/PreviewItem/PreviewItem.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/PreviewItem/PreviewItem.tsx
@@ -37,6 +37,9 @@ export function PreviewItem({
         label={t('Preview')}
         icon={<Play3Icon />}
         onClick={onClick}
+        ButtonProps={{
+          disabled: href == null
+        }}
       />
     </Box>
   )

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/PreviewItem/PreviewItem.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/PreviewItem/PreviewItem.tsx
@@ -24,13 +24,16 @@ export function PreviewItem({
     skip: journey?.team?.id == null
   })
 
+  const journeyPath = `/api/preview?slug=${journey?.slug}`
+  const customDomainParam = hostname != null ? `&hostname=${hostname}` : ''
+  const href =
+    journey?.slug != null ? journeyPath + customDomainParam : undefined
+
   return (
     <Box data-testid="PreviewItem">
       <Item
         variant={variant}
-        href={`/api/preview?slug=${journey?.slug}${
-          hostname != null ? `&hostname=${hostname}` : ''
-        }`}
+        href={href}
         label={t('Preview')}
         icon={<Play3Icon />}
         onClick={onClick}


### PR DESCRIPTION
# Description

### Issue

If a button is to always be displayed, we need to at least disable it during loading states.
If you load the journey flow, and you are quick, you can click the preview button before the journey loads which sends you to an undefined url.

[Link to Linear Todo](https://linear.app/jesus-film-project/issue/ENG-1121/preview-button-undefined)

### Solution

Disable the button if the href is undefined.

# External Changes

Added a span around the IconButton because tooltips cannot take disabled buttons.
Refactored out href string building into named const's for code cleanliness.

# How to test

Open a large journey and try to click the preview button as soon as it shows. You may try using network throttling or use on a mobile. At no point should you be able to click the preview button until the journey has loaded. 
When clicking the preview button, you should never be navigated to undefined
