### PR TITLE
chore: add jwt to authorization header

### DIFF
--- a/apps/journeys-admin/src/libs/apolloClient/apolloClient.ts
+++ b/apps/journeys-admin/src/libs/apolloClient/apolloClient.ts
@@ -33,7 +33,7 @@ export function createApolloClient(
     return {
       headers: {
         ...(!ssrMode ? headers : []),
-        Authorization: firebaseToken
+        Authorization: `JWT ${firebaseToken}`
       }
     }
   })

--- a/apps/journeys-admin/src/libs/apolloClient/apolloClient.ts
+++ b/apps/journeys-admin/src/libs/apolloClient/apolloClient.ts
@@ -33,7 +33,8 @@ export function createApolloClient(
     return {
       headers: {
         ...(!ssrMode ? headers : []),
-        Authorization: `JWT ${firebaseToken}`
+        Authorization:
+          firebaseToken != null ? `JWT ${firebaseToken}` : undefined
       }
     }
   })

--- a/apps/journeys/src/libs/apolloClient/apolloClient.ts
+++ b/apps/journeys/src/libs/apolloClient/apolloClient.ts
@@ -27,7 +27,7 @@ const authLink = setContext(async (_, { headers }) => {
   return {
     headers: {
       ...headers,
-      Authorization: token != null ? `JWT ${token}` : ''
+      Authorization: token != null ? `JWT ${token}` : undefined
     }
   }
 })

--- a/apps/journeys/src/libs/apolloClient/apolloClient.ts
+++ b/apps/journeys/src/libs/apolloClient/apolloClient.ts
@@ -27,7 +27,7 @@ const authLink = setContext(async (_, { headers }) => {
   return {
     headers: {
       ...headers,
-      Authorization: token ?? ''
+      Authorization: token != null ? `JWT ${token}` : ''
     }
   }
 })

--- a/apps/videos-admin/src/app/[locale]/_ApolloProvider/ApolloProvider.tsx
+++ b/apps/videos-admin/src/app/[locale]/_ApolloProvider/ApolloProvider.tsx
@@ -29,7 +29,7 @@ const authLink = setContext(async (_, { headers }) => {
   return {
     headers: {
       ...headers,
-      Authorization: token != null ? `JWT ${token}` : ''
+      Authorization: token != null ? `JWT ${token}` : undefined
     }
   }
 })

--- a/apps/videos-admin/src/app/[locale]/_ApolloProvider/ApolloProvider.tsx
+++ b/apps/videos-admin/src/app/[locale]/_ApolloProvider/ApolloProvider.tsx
@@ -29,7 +29,7 @@ const authLink = setContext(async (_, { headers }) => {
   return {
     headers: {
       ...headers,
-      Authorization: token ?? ''
+      Authorization: token != null ? `JWT ${token}` : ''
     }
   }
 })

--- a/apps/videos-admin/src/app/[locale]/users/unauthorized/page.tsx
+++ b/apps/videos-admin/src/app/[locale]/users/unauthorized/page.tsx
@@ -28,7 +28,7 @@ export default async function UnauthorizedPage(): Promise<ReactNode> {
   const t = await getTranslations()
   const user = await getUser()
   const { data } = await makeClient({
-    headers: { Authorization: user?.token ?? '' }
+    headers: { Authorization: user?.token != null ? `JWT ${user.token}` : '' }
   }).query({
     query: GET_AUTH
   })

--- a/apps/videos-admin/src/libs/apollo/apolloClient.ts
+++ b/apps/videos-admin/src/libs/apollo/apolloClient.ts
@@ -10,7 +10,9 @@ export const { getClient: getApolloClient, query } = registerApolloClient(
   async () => {
     const token = await getTokens(cookies(), authConfig)
     return makeClient({
-      headers: { Authorization: token?.token ?? '' }
+      headers: {
+        Authorization: token?.token != null ? `JWT ${token?.token}` : ''
+      }
     })
   }
 )

--- a/apps/videos-admin/src/middleware.ts
+++ b/apps/videos-admin/src/middleware.ts
@@ -62,7 +62,7 @@ export default async function middleware(
     },
     handleValidToken: async (token) => {
       const { data } = await makeClient({
-        headers: { Authorization: token.token }
+        headers: { Authorization: `JWT ${token.token}` }
       }).query({
         query: GET_AUTH
       })

--- a/apps/watch/src/libs/apolloClient/apolloClient.ts
+++ b/apps/watch/src/libs/apolloClient/apolloClient.ts
@@ -33,7 +33,7 @@ export function createApolloClient({
     return {
       headers: {
         ...(!isSsrMode ? headers : []),
-        Authorization: token ?? ''
+        Authorization: token != null ? `JWT ${token}` : ''
       }
     }
   })

--- a/apps/watch/src/libs/apolloClient/apolloClient.ts
+++ b/apps/watch/src/libs/apolloClient/apolloClient.ts
@@ -33,7 +33,7 @@ export function createApolloClient({
     return {
       headers: {
         ...(!isSsrMode ? headers : []),
-        Authorization: token != null ? `JWT ${token}` : ''
+        Authorization: token != null ? `JWT ${token}` : undefined
       }
     }
   })


### PR DESCRIPTION
This pull request updates the authorization headers in multiple Apollo Client configurations to use JWT tokens. The changes ensure that the `Authorization` header is correctly formatted as a JWT token string.

Authorization header updates:

* [`apps/journeys-admin/src/libs/apolloClient/apolloClient.ts`](diffhunk://#diff-5623b21681bed5ef22e6a41f3d69a4a8ee99d0addc268e3d051276f9ab22adc2L36-R36): Changed `Authorization` header to use `JWT ${firebaseToken}`.
* [`apps/journeys/src/libs/apolloClient/apolloClient.ts`](diffhunk://#diff-7b2e1ab77fe34d2e404a989dea996285fe9c8aca582f7f9ccf325e33f7d9fd4dL30-R30): Updated `Authorization` header to use `JWT ${token}` if `token` is not null.
* `apps/videos-admin/src/app/[locale]/_ApolloProvider/ApolloProvider.tsx`: Modified `Authorization` header to use `JWT ${token}` if `token` is not null. ([apps/videos-admin/src/app/[locale]/_ApolloProvider/ApolloProvider.tsxL32-R32](diffhunk://#diff-69fce40bb5fc39e503b36f6de87c88287fae9b228d259b39f6b006ea22bdae24L32-R32))
* [`apps/watch/src/libs/apolloClient/apolloClient.ts`](diffhunk://#diff-a1de3faf70d48b8794a55e4203d105a9542aa6bf68ea91fbdee196012b5307b1L36-R36): Adjusted `Authorization` header to use `JWT ${token}` if `token` is not null.