### PR TITLE
fix: pic needs to be nullish

### DIFF
--- a/libs/nest/common/src/lib/firebaseClient/firebaseClient.ts
+++ b/libs/nest/common/src/lib/firebaseClient/firebaseClient.ts
@@ -30,7 +30,7 @@ export const auth = getAuth(firebaseClient)
 const payloadSchema = z
   .object({
     name: z.string(),
-    picture: z.string().nullable(),
+    picture: z.string().nullish(),
     user_id: z.string(),
     email: z.string(),
     email_verified: z.boolean()

--- a/libs/yoga/src/firebaseClient/firebaseClient.ts
+++ b/libs/yoga/src/firebaseClient/firebaseClient.ts
@@ -26,7 +26,7 @@ export const firebaseClient = initializeApp(
 const payloadSchema = z
   .object({
     name: z.string(),
-    picture: z.string().nullable(),
+    picture: z.string().nullish(),
     user_id: z.string(),
     email: z.string(),
     email_verified: z.boolean()


### PR DESCRIPTION
This pull request includes changes to the payload schema in two different files to improve consistency and handle null values more flexibly. The most important changes include replacing the `.nullable()` method with `.nullish()` for the `picture` field.

Schema updates for consistency:

* [`libs/nest/common/src/lib/firebaseClient/firebaseClient.ts`](diffhunk://#diff-2cb825a00ad967c021e9b36e02a8f9b87795b7b13f95efc07f89666221ea4703L33-R33): Changed the `picture` field from `z.string().nullable()` to `z.string().nullish()` to handle null values more flexibly.
* [`libs/yoga/src/firebaseClient/firebaseClient.ts`](diffhunk://#diff-f705e44b0588a69d6e742f65bf921a01a74c4eb41a07837f00c8b557227b8057L29-R29): Updated the `picture` field from `z.string().nullable()` to `z.string().nullish()` for consistency with other schema definitions.