### PR TITLE
fix: clear cache on logout

### DIFF
--- a/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/UserNavigation/UserMenu/UserMenu.spec.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/UserNavigation/UserMenu/UserMenu.spec.tsx
@@ -1,3 +1,4 @@
+import { ApolloClient, useApolloClient } from '@apollo/client'
 import { MockedProvider, MockedResponse } from '@apollo/client/testing'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { NextRouter, useRouter } from 'next/router'
@@ -17,7 +18,16 @@ jest.mock('next/router', () => ({
   useRouter: jest.fn()
 }))
 
+jest.mock('@apollo/client', () => ({
+  __esModule: true,
+  ...jest.requireActual('@apollo/client'),
+  useApolloClient: jest.fn()
+}))
+
 const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
+const mockUseApolloClient = useApolloClient as jest.MockedFunction<
+  typeof useApolloClient
+>
 
 describe('UserMenu', () => {
   const handleProfileClose = jest.fn()
@@ -108,6 +118,10 @@ describe('UserMenu', () => {
   })
 
   it('should call signOut on logout click', async () => {
+    const clearStore = jest.fn()
+    mockUseApolloClient.mockReturnValue({
+      clearStore
+    } as unknown as ApolloClient<object>)
     const getTeams: MockedResponse<GetLastActiveTeamIdAndTeams> = {
       request: {
         query: GET_LAST_ACTIVE_TEAM_ID_AND_TEAMS
@@ -171,6 +185,7 @@ describe('UserMenu', () => {
       expect(getByText('Logout successful')).toBeInTheDocument()
     )
     expect(getTeams.result).toHaveBeenCalled()
+    expect(clearStore).toHaveBeenCalled()
   })
 
   it('should open language selector', async () => {

--- a/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/UserNavigation/UserMenu/UserMenu.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/UserNavigation/UserMenu/UserMenu.tsx
@@ -102,7 +102,7 @@ export function UserMenu({
           icon={<Logout2Icon fontSize="small" />}
           onClick={async () => {
             handleProfileClose()
-            await client.resetStore()
+            await client.clearStore()
             await user.signOut()
             await enqueueSnackbar(t('Logout successful'), {
               variant: 'success',


### PR DESCRIPTION
# Description

### Issue

`resetStore` refetches the active queries. changed function to `clearStore` which removes cache without refetch of queries

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)


