### PR TITLE
fix: nullish email address

### DIFF
--- a/apps/api-journeys/src/app/emails/templates/JourneyAccessRequest/JourneyAccessRequest.tsx
+++ b/apps/api-journeys/src/app/emails/templates/JourneyAccessRequest/JourneyAccessRequest.tsx
@@ -87,7 +87,7 @@ export const JourneyAccessRequestEmail = ({
           </ActionCard>
         </BodyWrapper>
         <Footer />
-        <UnsubscribeLink recipientEmail={recipient.email} />
+        <UnsubscribeLink recipientEmail={recipient.email ?? ''} />
       </EmailContainer>
     </>
   )

--- a/apps/api-journeys/src/app/emails/templates/JourneyShared/JourneyShared.tsx
+++ b/apps/api-journeys/src/app/emails/templates/JourneyShared/JourneyShared.tsx
@@ -83,7 +83,7 @@ export const JourneySharedEmail = ({
           </ActionCard>
         </BodyWrapper>
         <Footer />
-        <UnsubscribeLink recipientEmail={recipient.email} />
+        <UnsubscribeLink recipientEmail={recipient.email ?? ''} />
       </EmailContainer>
     </>
   )

--- a/apps/api-journeys/src/app/emails/templates/TeamInvite/TeamInvite.tsx
+++ b/apps/api-journeys/src/app/emails/templates/TeamInvite/TeamInvite.tsx
@@ -70,7 +70,7 @@ export const TeamInviteEmail = ({
           </ActionCard>
         </BodyWrapper>
         <Footer />
-        <UnsubscribeLink recipientEmail={recipient.email} />
+        <UnsubscribeLink recipientEmail={recipient.email ?? ''} />
       </EmailContainer>
     </>
   )

--- a/apps/api-journeys/src/app/emails/templates/TeamInviteAccepted/TeamInviteAccepted.tsx
+++ b/apps/api-journeys/src/app/emails/templates/TeamInviteAccepted/TeamInviteAccepted.tsx
@@ -70,7 +70,7 @@ export const TeamInviteAcceptedEmail = ({
           </ActionCard>
         </BodyWrapper>
         <Footer />
-        <UnsubscribeLink recipientEmail={recipient.email} />
+        <UnsubscribeLink recipientEmail={recipient.email ?? ''} />
       </EmailContainer>
     </>
   )

--- a/apps/api-journeys/src/app/emails/templates/TeamRemoved/TeamRemoved.tsx
+++ b/apps/api-journeys/src/app/emails/templates/TeamRemoved/TeamRemoved.tsx
@@ -70,7 +70,7 @@ export const TeamRemovedEmail = ({
           </ActionCard>
         </BodyWrapper>
         <Footer />
-        <UnsubscribeLink recipientEmail={recipient.email} />
+        <UnsubscribeLink recipientEmail={recipient.email ?? ''} />
       </EmailContainer>
     </>
   )

--- a/apps/api-journeys/src/app/emails/templates/VisitorInteraction/VisitorInteraction.tsx
+++ b/apps/api-journeys/src/app/emails/templates/VisitorInteraction/VisitorInteraction.tsx
@@ -156,7 +156,7 @@ export const VisitorInteraction = ({
           </ActionCard>
         </BodyWrapper>
         <UnsubscribeLink
-          recipientEmail={recipient.email}
+          recipientEmail={recipient.email ?? ''}
           url={unsubscribeUrl}
         />
       </EmailContainer>

--- a/apps/api-journeys/src/app/modules/mailChimp/mailChimp.service.ts
+++ b/apps/api-journeys/src/app/modules/mailChimp/mailChimp.service.ts
@@ -14,6 +14,8 @@ export class MailChimpService {
       })
       if (process.env.MAILCHIMP_AUDIENCE_ID == null)
         throw new Error('Mailchimp Audience ID is undefined')
+      if (user.email == null)
+        throw new Error('User must have an email to receive marketing emails')
       // upsert operation
       await mailchimp.lists.setListMember(
         process.env.MAILCHIMP_AUDIENCE_ID,

--- a/apps/api-journeys/src/app/modules/userInvite/userInvite.resolver.ts
+++ b/apps/api-journeys/src/app/modules/userInvite/userInvite.resolver.ts
@@ -129,6 +129,10 @@ export class UserInviteResolver {
   @Mutation()
   @UseGuards(AppCaslGuard)
   async userInviteAcceptAll(@CurrentUser() user: User): Promise<UserInvite[]> {
+    if (user.email == null)
+      throw new GraphQLError('User must have an email to accept invites', {
+        extensions: { code: 'BAD_REQUEST' }
+      })
     const userInvites = await this.prismaService.userInvite.findMany({
       where: {
         email: user.email,

--- a/apps/api-journeys/src/app/modules/userTeamInvite/userTeamInvite.resolver.ts
+++ b/apps/api-journeys/src/app/modules/userTeamInvite/userTeamInvite.resolver.ts
@@ -123,6 +123,10 @@ export class UserTeamInviteResolver {
     @CurrentUser()
     user: User
   ): Promise<UserTeamInvite[]> {
+    if (user.email == null)
+      throw new GraphQLError('User must have an email to accept invites', {
+        extensions: { code: 'BAD_REQUEST' }
+      })
     const userTeamInvites = await this.prismaService.userTeamInvite.findMany({
       where: {
         email: user.email,

--- a/apps/api-users/src/schema/user/user.ts
+++ b/apps/api-users/src/schema/user/user.ts
@@ -113,6 +113,11 @@ builder.mutationFields((t) => ({
         throw new GraphQLError('User not found', {
           extensions: { code: '404' }
         })
+      if (ctx.currentUser.email == null)
+        // only satifies typescript null check
+        throw new GraphQLError('User email not found', {
+          extensions: { code: '404' }
+        })
 
       await verifyUser(
         ctx.currentUser.id,

--- a/libs/nest/common/src/lib/firebaseClient/firebaseClient.ts
+++ b/libs/nest/common/src/lib/firebaseClient/firebaseClient.ts
@@ -9,7 +9,7 @@ export interface User {
   id: string
   firstName: string
   lastName?: string
-  email: string
+  email?: string | null
   imageUrl?: string | null
   emailVerified: boolean
 }
@@ -32,7 +32,7 @@ const payloadSchema = z
     name: z.string().nullish(),
     picture: z.string().nullish(),
     user_id: z.string(),
-    email: z.string(),
+    email: z.string().nullish(),
     email_verified: z.boolean().nullish()
   })
   .transform((data) => ({

--- a/libs/yoga/src/firebaseClient/firebaseClient.ts
+++ b/libs/yoga/src/firebaseClient/firebaseClient.ts
@@ -7,7 +7,7 @@ export interface User {
   id: string
   firstName: string
   lastName?: string
-  email: string
+  email?: string | null
   imageUrl?: string | null
   emailVerified: boolean
 }
@@ -29,7 +29,7 @@ const payloadSchema = z
     name: z.string().nullish(),
     picture: z.string().nullish(),
     user_id: z.string(),
-    email: z.string(),
+    email: z.string().nullish(),
     email_verified: z.boolean().nullish()
   })
   .transform((data) => ({


### PR DESCRIPTION
This pull request includes several changes to handle cases where a user's email might be null or undefined. The changes ensure that the application gracefully handles these scenarios without causing errors.

### Email Template Updates:
* Updated `UnsubscribeLink` components to handle cases where `recipient.email` might be null or undefined in various email templates. (`JourneyAccessRequest.tsx` [[1]](diffhunk://#diff-28c71da0aa1853a9ea32d92706fe2afb9c367e72f1730aa3e08dbc403a45804eL90-R90) `JourneyShared.tsx` [[2]](diffhunk://#diff-a18a43cb6c86b62ea53c56ba7e519e67cf1549dd8269b68de35f875a581bfc80L86-R86) `TeamInvite.tsx` [[3]](diffhunk://#diff-268d5fcec0e44c408eb67cc1eb5e8615245d1c0a6fb86df1baae97e1fdbd8d8dL73-R73) `TeamInviteAccepted.tsx` [[4]](diffhunk://#diff-e230b6da7520ac990e54906f99d7fd9a882d28573f0496e32407f27e9919bec4L73-R73) `TeamRemoved.tsx` [[5]](diffhunk://#diff-777f371fec5676ada147581ad6487aac6d6b2b7e1412a1701ac38192a57a1740L73-R73) `VisitorInteraction.tsx` [[6]](diffhunk://#diff-4ccb9f4461bc9e8c104d80ade0f8d9b2bf72ef0e7ff5fede89bf34dedcd4fe83L159-R159)

### Service and Resolver Updates:
* Added checks to ensure `user.email` is not null before performing operations in `MailChimpService`. (`mailChimp.service.ts` [apps/api-journeys/src/app/modules/mailChimp/mailChimp.service.tsR17-R18](diffhunk://#diff-9af531b1bcca53d71748a0b0fdfa9556e2c64c1255eb1a4f5358b4f5629a0be8R17-R18))
* Added validation to ensure `user.email` is not null before accepting invites in `UserInviteResolver` and `UserTeamInviteResolver`. (`userInvite.resolver.ts` [[1]](diffhunk://#diff-bc5cc6088373037d92ed3ee63e4f2bec9ca58024f6544a1822b6c01d78f4d93cR132-R135) `userTeamInvite.resolver.ts` [[2]](diffhunk://#diff-036f06ba47b1cbecc61ae3aeb09a1667a4655c0487e456ccdb6538ac794dc628R126-R129)

### Schema and Interface Updates:
* Updated the `User` interface and corresponding schema to allow `email` to be null or undefined. (`firebaseClient.ts` [[1]](diffhunk://#diff-2cb825a00ad967c021e9b36e02a8f9b87795b7b13f95efc07f89666221ea4703L12-R12) [[2]](diffhunk://#diff-2cb825a00ad967c021e9b36e02a8f9b87795b7b13f95efc07f89666221ea4703L35-R35) [[3]](diffhunk://#diff-f705e44b0588a69d6e742f65bf921a01a74c4eb41a07837f00c8b557227b8057L10-R10) [[4]](diffhunk://#diff-f705e44b0588a69d6e742f65bf921a01a74c4eb41a07837f00c8b557227b8057L32-R32)
* Added a check for null `ctx.currentUser.email` in the `user.ts` schema to satisfy TypeScript null checks. (`user.ts` [apps/api-users/src/schema/user/user.tsR116-R120](diffhunk://#diff-90424905f3b2a2f652169f528f9da3c453ec63149e63f6ef9958976e3dbb491bR116-R120))