### PR TITLE
feat: deprecate video image prisma fields

### DIFF
--- a/apps/api-media/db/schema.prisma
+++ b/apps/api-media/db/schema.prisma
@@ -81,13 +81,13 @@ model Video {
   snippet                VideoSnippet[]
   description            VideoDescription[]
   studyQuestions         VideoStudyQuestion[]
-  image                  String?
+  image                  String? /// @deprecated Use images aspectRatio banner
   imageAlt               VideoImageAlt[]
-  thumbnail              String?
-  videoStill             String?
-  mobileCinematicHigh    String?
-  mobileCinematicLow     String?
-  mobileCinematicVeryLow String?
+  thumbnail              String? /// @deprecated Use images aspectRatio hd
+  videoStill             String? /// @deprecated Use images aspectRatio hd
+  mobileCinematicHigh    String? /// @deprecated Use images aspectRatio banner
+  mobileCinematicLow     String? /// @deprecated Use images aspectRatio banner
+  mobileCinematicVeryLow String? /// @deprecated Use images aspectRatio banner
   slug                   String?              @unique
   noIndex                Boolean?
   childIds               String[] // needed for child sort order


### PR DESCRIPTION
# Description

### Issue

Deprecate unused prisma video image fields

### Solution

add deprecated jsdoc tag to alert that the fields are deprecated

