### PR TITLE
chore: bq video image fields to cf

### DIFF
--- a/apps/api-media/src/workers/bigQuery/importers/videoImages/videoImages.spec.ts
+++ b/apps/api-media/src/workers/bigQuery/importers/videoImages/videoImages.spec.ts
@@ -52,14 +52,14 @@ describe('bigQuery/importers/videoImages', () => {
 
     it('should get existing images for videos', async () => {
       prismaMock.video.findMany.mockResolvedValue([
-        { id: 'mockVideoId', image: null, videoStill: null } as unknown as Video
+        { id: 'mockVideoId', images: [] } as unknown as Video
       ])
       prismaMock.cloudflareImage.create.mockResolvedValue(
         {} as unknown as CloudflareImage
       )
       await importVideoImages()
       expect(prismaMock.video.findMany).toHaveBeenCalledWith({
-        select: { id: true, image: true, videoStill: true },
+        select: { id: true },
         where: { images: { none: {} } }
       })
       expect(getClient().images.v1.get).toHaveBeenCalledWith(
@@ -114,33 +114,6 @@ describe('bigQuery/importers/videoImages', () => {
           uploadUrl:
             'https://d1wl257kev7hsz.cloudfront.net/cinematics/mockVideoId.videoStill.jpg',
           userId: 'system'
-        }
-      })
-    })
-
-    it('should fix broken images', async () => {
-      prismaMock.video.findMany.mockResolvedValue([
-        {
-          id: 'mockVideoId',
-          mobileCinematicHigh: null,
-          videoStill: null
-        } as unknown as Video
-      ])
-      prismaMock.video.update.mockResolvedValue({} as unknown as Video)
-      await importVideoImages()
-      expect(prismaMock.video.update).toHaveBeenCalledWith({
-        data: {
-          mobileCinematicHigh:
-            'https://d1wl257kev7hsz.cloudfront.net/cinematics/mockVideoId.mobileCinematicHigh.jpg',
-          mobileCinematicLow: null,
-          mobileCinematicVeryLow: null,
-          thumbnail:
-            'https://d1wl257kev7hsz.cloudfront.net/cinematics/mockVideoId.thumbnail.jpg',
-          videoStill:
-            'https://d1wl257kev7hsz.cloudfront.net/cinematics/mockVideoId.videoStill.jpg'
-        },
-        where: {
-          id: 'mockVideoId'
         }
       })
     })

--- a/apps/api-media/src/workers/bigQuery/importers/videoImages/videoImages.ts
+++ b/apps/api-media/src/workers/bigQuery/importers/videoImages/videoImages.ts
@@ -8,20 +8,25 @@ import { client as bqClient } from '../../importer'
 
 enum fields {
   videoStill = 'videoStill',
-  image = 'image'
+  mobileCinematicHigh = 'mobileCinematicHigh'
 }
 
 export async function importVideoImages(logger?: Logger): Promise<void> {
-  logger?.info('check for broken video images')
+  logger?.info('imageSeed started')
   const brokenVideos = await prisma.video.findMany({
-    select: { id: true, mobileCinematicHigh: true },
+    select: { id: true },
     where: {
-      mobileCinematicHigh: null
+      images: { none: {} }
     }
   })
   if (brokenVideos.length > 0)
     logger?.info(`found ${brokenVideos.length} broken video images`)
+  else {
+    logger?.info('imageSeed finished')
+    return
+  }
 
+  const client = getClient()
   for (const video of brokenVideos) {
     const bqResult = await bqClient.query({
       query: `SELECT * FROM \`jfp-data-warehouse.jfp_mmdb_prod.core_video_arclight_data\` WHERE id = @id`,
@@ -36,31 +41,10 @@ export async function importVideoImages(logger?: Logger): Promise<void> {
       continue
     }
 
-    await prisma.video.update({
-      where: { id: video.id },
-      data: {
-        mobileCinematicHigh: bqVideo.mobileCinematicHigh,
-        mobileCinematicLow: bqVideo.mobileCinematicLow,
-        mobileCinematicVeryLow: bqVideo.mobileCinematicVeryLow,
-        thumbnail: bqVideo.thumbnail,
-        videoStill: bqVideo.videoStill
-      }
-    })
-  }
-
-  logger?.info('imageSeed started')
-  const newVideos = await prisma.video.findMany({
-    select: { id: true, videoStill: true, image: true },
-    where: { images: { none: {} } }
-  })
-
-  const client = getClient()
-  for (const video of newVideos) {
-    logger?.info(`imageSeed started for video: ${video.id}`)
     const editions = [
       {
         fileName: `${video.id}.mobileCinematicHigh.jpg`,
-        field: fields.image,
+        field: fields.mobileCinematicHigh,
         aspectRatio: ImageAspectRatio.banner
       },
       {
@@ -69,10 +53,11 @@ export async function importVideoImages(logger?: Logger): Promise<void> {
         aspectRatio: ImageAspectRatio.hd
       }
     ]
+
     for (const edition of editions) {
       try {
         const url =
-          video[edition.field] ??
+          bqVideo[edition.field] ??
           `https://d1wl257kev7hsz.cloudfront.net/cinematics/${edition.fileName}`
         try {
           await client.images.v1.get(edition.fileName, {


### PR DESCRIPTION
# Description

### Issue

Video image fields are no longer needed on bq import

### Solution

Change importer to create cloudflare images and not require video image fields
