### PR TITLE
fix: delay fetching of analytics counts until after journey loads

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/AnalyticsItem/AnalyticsItem.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/AnalyticsItem/AnalyticsItem.spec.tsx
@@ -73,11 +73,12 @@ describe('AnalyticsItem', () => {
         </MockedProvider>
       </SnackbarProvider>
     )
-    expect(getByRole('menuitem', { name: 'Analytics' })).toBeInTheDocument()
-    expect(getByRole('menuitem', { name: 'Analytics' })).toHaveAttribute(
-      'href',
-      '/journeys/journey-id/reports'
-    )
+    expect(
+      getByRole('menuitem', { name: 'Analytics 0 visitors' })
+    ).toBeInTheDocument()
+    expect(
+      getByRole('menuitem', { name: 'Analytics 0 visitors' })
+    ).toHaveAttribute('href', '/journeys/journey-id/reports')
   })
 
   it('should link to journey reports page as an icon button', async () => {
@@ -121,13 +122,13 @@ describe('AnalyticsItem', () => {
                 variant: 'admin'
               }}
             >
-              <AnalyticsItem variant="button" />
+              <AnalyticsItem variant="icon-button" />
             </JourneyProvider>
           </TeamProvider>
         </MockedProvider>
       </SnackbarProvider>
     )
     await waitFor(() => expect(result).toHaveBeenCalled())
-    expect(getByRole('paragraph')).toHaveTextContent('10')
+    expect(getByRole('link')).toHaveTextContent('10')
   })
 })

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/AnalyticsItem/AnalyticsItem.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/AnalyticsItem/AnalyticsItem.tsx
@@ -1,10 +1,8 @@
-import { gql, useQuery } from '@apollo/client'
-import Stack from '@mui/material/Stack'
-import Typography from '@mui/material/Typography'
+import { gql, useLazyQuery } from '@apollo/client'
 import { formatISO } from 'date-fns'
 import NextLink from 'next/link'
 import { useTranslation } from 'next-i18next'
-import { ComponentProps, ReactElement } from 'react'
+import { ComponentProps, ReactElement, useEffect } from 'react'
 
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import BarChartSquare3Icon from '@core/shared/ui/icons/BarChartSquare3'
@@ -37,35 +35,39 @@ export const GET_JOURNEY_PLAUSIBLE_VISITORS = gql`
 export function AnalyticsItem({ variant }: AnalyticsItemProps): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   const { journey } = useJourney()
-  const currentDate = formatISO(new Date(), { representation: 'date' })
 
-  const { data } = useQuery<
+  const [loadPlausibleVisitors, { data }] = useLazyQuery<
     GetJourneyPlausibleVisitors,
     GetJourneyPlausibleVisitorsVariables
-  >(GET_JOURNEY_PLAUSIBLE_VISITORS, {
-    variables: {
-      date: `${earliestStatsCollected},${currentDate}`,
-      id: journey?.id ?? ''
-    }
-  })
+  >(GET_JOURNEY_PLAUSIBLE_VISITORS)
+  useEffect(() => {
+    if (journey?.id != null)
+      void loadPlausibleVisitors({
+        variables: {
+          date: `${earliestStatsCollected},${formatISO(new Date(), {
+            representation: 'date'
+          })}`,
+          id: journey.id
+        }
+      })
+  }, [journey?.id, loadPlausibleVisitors])
 
   return (
-    <Stack data-testid="AnalyticsItem" direction="row" alignItems="center">
-      <NextLink
-        href={`/journeys/${journey?.id}/reports`}
-        passHref
-        legacyBehavior
-        prefetch={false}
-      >
-        <Item
-          variant={variant}
-          label={t('Analytics')}
-          icon={<BarChartSquare3Icon />}
-        />
-      </NextLink>
-      <Typography variant="body2">
-        {data?.journeyAggregateVisitors?.visitors?.value ?? ''}
-      </Typography>
-    </Stack>
+    <NextLink
+      href={`/journeys/${journey?.id}/reports`}
+      passHref
+      legacyBehavior
+      prefetch={false}
+    >
+      <Item
+        variant={variant}
+        label={t('Analytics')}
+        icon={<BarChartSquare3Icon />}
+        count={data?.journeyAggregateVisitors?.visitors?.value ?? 0}
+        countLabel={t('{{count}} visitors', {
+          count: data?.journeyAggregateVisitors?.visitors?.value ?? 0
+        })}
+      />
+    </NextLink>
   )
 }

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/Item/Item.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/Item/Item.stories.tsx
@@ -45,4 +45,15 @@ export const IconButtonItem = {
   }
 }
 
+export const IconButtonWithCountItem = {
+  ...Template,
+  args: {
+    variant: 'icon-button',
+    icon: <BarChartSquare3Icon />,
+    label: 'Icon Button Item',
+    count: 5,
+    countLabel: '5 visitors'
+  }
+}
+
 export default Demo

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/Item/Item.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/Item/Item.tsx
@@ -14,6 +14,8 @@ interface ItemProps {
   href?: string
   ButtonProps?: ComponentProps<typeof Button>
   onClick?: (event: MouseEvent<HTMLElement>) => void
+  count?: number
+  countLabel?: string
 }
 
 export function Item({
@@ -22,7 +24,9 @@ export function Item({
   label,
   href,
   ButtonProps,
-  onClick
+  onClick,
+  count,
+  countLabel
 }: ItemProps): ReactElement {
   switch (variant) {
     case 'icon-button':
@@ -42,17 +46,39 @@ export function Item({
           }}
         >
           <span>
-            <IconButton
-              component={href != null ? 'a' : 'button'}
-              target={href != null ? '_blank' : undefined}
-              href={href}
-              onClick={onClick}
-              aria-label={label}
-              {...ButtonProps}
-              sx={{ px: 1 }}
-            >
-              {icon}
-            </IconButton>
+            {count != null ? (
+              <Button
+                startIcon={icon}
+                component={href != null ? 'a' : 'button'}
+                target={href != null ? '_blank' : undefined}
+                href={href}
+                onClick={onClick}
+                aria-label={label}
+                color="secondary"
+                sx={{
+                  fontWeight: 'normal',
+                  color: 'text.secondary',
+                  '& > .MuiButton-startIcon > .MuiSvgIcon-root': {
+                    fontSize: '24px'
+                  },
+                  ...ButtonProps?.sx
+                }}
+                {...ButtonProps}
+              >
+                {count.toLocaleString()}
+              </Button>
+            ) : (
+              <IconButton
+                component={href != null ? 'a' : 'button'}
+                target={href != null ? '_blank' : undefined}
+                href={href}
+                onClick={onClick}
+                aria-label={label}
+                {...ButtonProps}
+              >
+                {icon}
+              </IconButton>
+            )}
           </span>
         </Tooltip>
       )
@@ -85,7 +111,9 @@ export function Item({
           }}
         >
           <ListItemIcon>{icon}</ListItemIcon>
-          <ListItemText>{label}</ListItemText>
+          <ListItemText secondary={countLabel ?? count?.toLocaleString()}>
+            {label}
+          </ListItemText>
         </MenuItem>
       )
   }

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/Items.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/Items.tsx
@@ -16,7 +16,7 @@ export function Items(): ReactElement {
       data-testid="ItemsStack"
       alignItems="center"
     >
-      <ResponsesItem />
+      <ResponsesItem variant="icon-button" />
       <AnalyticsItem variant="icon-button" />
       <StrategyItem variant="button" />
       <ShareItem variant="button" />

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/ResponsesItem/ResponsesItem.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/ResponsesItem/ResponsesItem.spec.tsx
@@ -22,7 +22,7 @@ describe('ResponsesItem', () => {
               variant: 'admin'
             }}
           >
-            <ResponsesItem />
+            <ResponsesItem variant="icon-button" />
           </JourneyProvider>
         </MockedProvider>
       </SnackbarProvider>
@@ -54,7 +54,7 @@ describe('ResponsesItem', () => {
               variant: 'admin'
             }}
           >
-            <ResponsesItem />
+            <ResponsesItem variant="icon-button" />
           </JourneyProvider>
         </MockedProvider>
       </SnackbarProvider>

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/ResponsesItem/ResponsesItem.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/ResponsesItem/ResponsesItem.stories.tsx
@@ -46,7 +46,7 @@ const Template: StoryObj<typeof ResponsesItem> = {
           backgroundColor: 'background.paper'
         }}
       >
-        <ResponsesItem />
+        <ResponsesItem variant="icon-button" />
       </Box>
     </JourneyProvider>
   )

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/ResponsesItem/ResponsesItem.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/ResponsesItem/ResponsesItem.tsx
@@ -1,9 +1,7 @@
 import { gql, useLazyQuery } from '@apollo/client'
-import Stack from '@mui/material/Stack'
-import Typography from '@mui/material/Typography'
 import NextLink from 'next/link'
 import { useTranslation } from 'next-i18next'
-import { ReactElement, useEffect } from 'react'
+import { ComponentProps, ReactElement, useEffect } from 'react'
 
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import Inbox2Icon from '@core/shared/ui/icons/Inbox2'
@@ -14,6 +12,10 @@ import {
 } from '../../../../../../__generated__/GetJourneyVisitorsCountWithTextResponses'
 import { Item } from '../Item'
 
+interface ResponseItemProps {
+  variant: ComponentProps<typeof Item>['variant']
+}
+
 export const GET_JOURNEY_VISITORS_COUNT_WITH_TEXT_RESPONSES = gql`
   query GetJourneyVisitorsCountWithTextResponses(
     $filter: JourneyVisitorFilter!
@@ -22,7 +24,7 @@ export const GET_JOURNEY_VISITORS_COUNT_WITH_TEXT_RESPONSES = gql`
   }
 `
 
-export function ResponsesItem(): ReactElement {
+export function ResponsesItem({ variant }: ResponseItemProps): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   const { journey } = useJourney()
 
@@ -41,20 +43,21 @@ export function ResponsesItem(): ReactElement {
   }, [journey?.id, loadVisitorsResponseCount, data])
 
   return (
-    <Stack direction="row" alignItems="center" data-testid="ResponsesItem">
-      <NextLink
-        href={`/journeys/${journey?.id}/reports/visitors?withSubmittedText=true`}
-        passHref
-        legacyBehavior
-        prefetch={false}
-      >
-        <Item
-          variant="icon-button"
-          label={t('Responses')}
-          icon={<Inbox2Icon />}
-        />
-      </NextLink>
-      <Typography variant="body2">{data?.journeyVisitorCount ?? ''}</Typography>
-    </Stack>
+    <NextLink
+      href={`/journeys/${journey?.id}/reports/visitors?withSubmittedText=true`}
+      passHref
+      legacyBehavior
+      prefetch={false}
+    >
+      <Item
+        variant={variant}
+        label={t('Responses')}
+        icon={<Inbox2Icon />}
+        count={data?.journeyVisitorCount ?? 0}
+        countLabel={t('{{count}} responses', {
+          count: data?.journeyVisitorCount ?? 0
+        })}
+      />
+    </NextLink>
   )
 }


### PR DESCRIPTION
This pull request includes changes to the `AnalyticsItem` and `ResponsesItem` components in the `apps/journeys-admin` project. The main focus is on improving the user interface by adding visitor counts to the toolbar items and updating test cases accordingly.

### Enhancements to Toolbar Items:

* [`apps/journeys-admin/src/components/Editor/Toolbar/Items/Item/Item.tsx`](diffhunk://#diff-abc491b6d849d6b59674fc10f25b5475ad7d595350368291b461097dd71e5ecfR17-R18): Added `count` and `countLabel` properties to the `Item` component to display visitor counts. Updated the rendering logic to include these properties for `icon-button` variants. [[1]](diffhunk://#diff-abc491b6d849d6b59674fc10f25b5475ad7d595350368291b461097dd71e5ecfR17-R18) [[2]](diffhunk://#diff-abc491b6d849d6b59674fc10f25b5475ad7d595350368291b461097dd71e5ecfL25-R29) [[3]](diffhunk://#diff-abc491b6d849d6b59674fc10f25b5475ad7d595350368291b461097dd71e5ecfR49-R81) [[4]](diffhunk://#diff-abc491b6d849d6b59674fc10f25b5475ad7d595350368291b461097dd71e5ecfL88-R116)

### Updates to AnalyticsItem:

* [`apps/journeys-admin/src/components/Editor/Toolbar/Items/AnalyticsItem/AnalyticsItem.tsx`](diffhunk://#diff-cba0a555725ad3aad9aff210bad1d9f63414be43e36442f7f302873ecd0bbb1eL1-R5): Switched from `useQuery` to `useLazyQuery` for fetching visitor data and added `useEffect` to load data when the journey ID changes. Updated the component to use the new `count` and `countLabel` properties. [[1]](diffhunk://#diff-cba0a555725ad3aad9aff210bad1d9f63414be43e36442f7f302873ecd0bbb1eL1-R5) [[2]](diffhunk://#diff-cba0a555725ad3aad9aff210bad1d9f63414be43e36442f7f302873ecd0bbb1eL40-L53) [[3]](diffhunk://#diff-cba0a555725ad3aad9aff210bad1d9f63414be43e36442f7f302873ecd0bbb1eR66-L69)
* [`apps/journeys-admin/src/components/Editor/Toolbar/Items/AnalyticsItem/AnalyticsItem.spec.tsx`](diffhunk://#diff-6b20415932510b75dc661a3d814339713b9e73e2be9f6a6bdbba7d46ace9b944L76-R81): Updated test cases to reflect changes in the `AnalyticsItem` component, including the new visitor count display and the `icon-button` variant. [[1]](diffhunk://#diff-6b20415932510b75dc661a3d814339713b9e73e2be9f6a6bdbba7d46ace9b944L76-R81) [[2]](diffhunk://#diff-6b20415932510b75dc661a3d814339713b9e73e2be9f6a6bdbba7d46ace9b944L124-R132)

### Updates to ResponsesItem:

* [`apps/journeys-admin/src/components/Editor/Toolbar/Items/ResponsesItem/ResponsesItem.tsx`](diffhunk://#diff-b68c412887b5ae71c98339e393090c16ef0f4474b917a8884b15638d33cdef07L2-R4): Added a `variant` prop to allow different button styles and updated the component to use the new `count` and `countLabel` properties. [[1]](diffhunk://#diff-b68c412887b5ae71c98339e393090c16ef0f4474b917a8884b15638d33cdef07L2-R4) [[2]](diffhunk://#diff-b68c412887b5ae71c98339e393090c16ef0f4474b917a8884b15638d33cdef07R15-R18) [[3]](diffhunk://#diff-b68c412887b5ae71c98339e393090c16ef0f4474b917a8884b15638d33cdef07L25-R27) [[4]](diffhunk://#diff-b68c412887b5ae71c98339e393090c16ef0f4474b917a8884b15638d33cdef07L44-L58)
* [`apps/journeys-admin/src/components/Editor/Toolbar/Items/ResponsesItem/ResponsesItem.spec.tsx`](diffhunk://#diff-f48a81bcfe16cdfb3ec5327c7607f6607383321a31e91ad072c67d7ae7bf10d7L25-R25): Updated test cases to reflect changes in the `ResponsesItem` component, including the new visitor count display and the `icon-button` variant. [[1]](diffhunk://#diff-f48a81bcfe16cdfb3ec5327c7607f6607383321a31e91ad072c67d7ae7bf10d7L25-R25) [[2]](diffhunk://#diff-f48a81bcfe16cdfb3ec5327c7607f6607383321a31e91ad072c67d7ae7bf10d7L57-R57)

### Storybook Updates:

* [`apps/journeys-admin/src/components/Editor/Toolbar/Items/Item/Item.stories.tsx`](diffhunk://#diff-3382b007d14f7943a3b14a56669d025797eb98a220da9a0718b232ac015f5d1dR48-R58): Added a new story for `IconButtonWithCountItem` to demonstrate the new `count` and `countLabel` properties.
* [`apps/journeys-admin/src/components/Editor/Toolbar/Items/ResponsesItem/ResponsesItem.stories.tsx`](diffhunk://#diff-436e87da0bb4731b25adf0b30dff43c316e38166fc99e7d31ee3fb224f1ec90fL49-R49): Updated the story to use the `icon-button` variant.

These changes enhance the user interface by providing more informative toolbar items and ensuring the components are well-tested.