### PR TITLE
feat: add expiration to completed bullmq jobs-no-qa

### DIFF
--- a/apps/api-journeys/src/app/modules/event/event.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/event/event.service.spec.ts
@@ -155,7 +155,7 @@ describe('EventService', () => {
           delay: 120000,
           jobId: 'visitor-event-journey-id-visitor-id',
           removeOnComplete: true,
-          removeOnFail: { age: 864000 }
+          removeOnFail: { age: 86400, count: 50 }
         }
       )
     })
@@ -174,7 +174,7 @@ describe('EventService', () => {
           delay: 120000,
           jobId: 'visitor-event-journey-id-visitor-id',
           removeOnComplete: true,
-          removeOnFail: { age: 864000 }
+          removeOnFail: { age: 86400, count: 50 }
         }
       )
     })

--- a/apps/api-journeys/src/app/modules/event/event.service.ts
+++ b/apps/api-journeys/src/app/modules/event/event.service.ts
@@ -16,6 +16,9 @@ import { BlockService } from '../block/block.service'
 import { EventsNotificationJob } from '../email/emailEvents/emailEvents.consumer'
 import { VisitorService } from '../visitor/visitor.service'
 
+const TWO_MINUTES = 2 * 60 * 1000 // in milliseconds
+const ONE_DAY = 24 * 60 * 60 // in seconds
+
 @Injectable()
 export class EventService {
   constructor(
@@ -98,9 +101,9 @@ export class EventService {
         },
         {
           jobId,
-          delay: 2 * 60 * 1000, // delay for 2 minutes
+          delay: TWO_MINUTES,
           removeOnComplete: true,
-          removeOnFail: { age: 24 * 36000 } // keep up to 24 hours
+          removeOnFail: { age: ONE_DAY, count: 50 }
         }
       )
     } else {
@@ -112,9 +115,9 @@ export class EventService {
         },
         {
           jobId,
-          delay: 2 * 60 * 1000, // delay for 2 minutes
+          delay: TWO_MINUTES,
           removeOnComplete: true,
-          removeOnFail: { age: 24 * 36000 } // keep up to 24 hours
+          removeOnFail: { age: ONE_DAY, count: 50 }
         }
       )
     }
@@ -129,7 +132,7 @@ export class EventService {
     const visitorEmailJob = await this.emailQueue.getJob(jobId)
 
     if (visitorEmailJob != null) {
-      const baseDelay = 2 * 60 * 1000
+      const baseDelay = TWO_MINUTES
       const delayInMilliseconds = (delay ?? 0) * 1000
       const delayTimer = Math.max(delayInMilliseconds, baseDelay)
       await visitorEmailJob.changeDelay(delayTimer)

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -825,14 +825,28 @@ describe('JourneyResolver', () => {
           'teamId'
         )
       ).toEqual(journeyWithUserTeam)
-      expect(plausibleQueue.add).toHaveBeenCalledWith('create-journey-site', {
-        __typename: 'plausibleCreateJourneySite',
-        journeyId: 'journeyId'
-      })
-      expect(plausibleQueue.add).toHaveBeenCalledWith('create-team-site', {
-        __typename: 'plausibleCreateTeamSite',
-        teamId: 'teamId'
-      })
+      expect(plausibleQueue.add).toHaveBeenCalledWith(
+        'create-journey-site',
+        {
+          __typename: 'plausibleCreateJourneySite',
+          journeyId: 'journeyId'
+        },
+        {
+          removeOnComplete: true,
+          removeOnFail: { age: 432000, count: 50 }
+        }
+      )
+      expect(plausibleQueue.add).toHaveBeenCalledWith(
+        'create-team-site',
+        {
+          __typename: 'plausibleCreateTeamSite',
+          teamId: 'teamId'
+        },
+        {
+          removeOnComplete: true,
+          removeOnFail: { age: 432000, count: 50 }
+        }
+      )
       expect(prismaService.journey.create).toHaveBeenCalledWith({
         data: {
           id: 'journeyId',
@@ -1170,14 +1184,28 @@ describe('JourneyResolver', () => {
 
     it('duplicates your journey', async () => {
       await resolver.journeyDuplicate(ability, 'journeyId', 'userId', 'teamId')
-      expect(plausibleQueue.add).toHaveBeenCalledWith('create-journey-site', {
-        __typename: 'plausibleCreateJourneySite',
-        journeyId: 'duplicateJourneyId'
-      })
-      expect(plausibleQueue.add).toHaveBeenCalledWith('create-team-site', {
-        __typename: 'plausibleCreateTeamSite',
-        teamId: 'teamId'
-      })
+      expect(plausibleQueue.add).toHaveBeenCalledWith(
+        'create-journey-site',
+        {
+          __typename: 'plausibleCreateJourneySite',
+          journeyId: 'duplicateJourneyId'
+        },
+        {
+          removeOnComplete: true,
+          removeOnFail: { age: 432000, count: 50 }
+        }
+      )
+      expect(plausibleQueue.add).toHaveBeenCalledWith(
+        'create-team-site',
+        {
+          __typename: 'plausibleCreateTeamSite',
+          teamId: 'teamId'
+        },
+        {
+          removeOnComplete: true,
+          removeOnFail: { age: 432000, count: 50 }
+        }
+      )
       expect(prismaService.journey.create).toHaveBeenCalledWith({
         data: {
           ...omit(journey, [
@@ -1278,14 +1306,28 @@ describe('JourneyResolver', () => {
         }
       }
 
-      expect(plausibleQueue.add).toHaveBeenCalledWith('create-journey-site', {
-        __typename: 'plausibleCreateJourneySite',
-        journeyId: 'duplicateJourneyId'
-      })
-      expect(plausibleQueue.add).toHaveBeenCalledWith('create-team-site', {
-        __typename: 'plausibleCreateTeamSite',
-        teamId: 'teamId'
-      })
+      expect(plausibleQueue.add).toHaveBeenCalledWith(
+        'create-journey-site',
+        {
+          __typename: 'plausibleCreateJourneySite',
+          journeyId: 'duplicateJourneyId'
+        },
+        {
+          removeOnComplete: true,
+          removeOnFail: { age: 432000, count: 50 }
+        }
+      )
+      expect(plausibleQueue.add).toHaveBeenCalledWith(
+        'create-team-site',
+        {
+          __typename: 'plausibleCreateTeamSite',
+          teamId: 'teamId'
+        },
+        {
+          removeOnComplete: true,
+          removeOnFail: { age: 432000, count: 50 }
+        }
+      )
 
       expect(prismaService.journey.create).toHaveBeenNthCalledWith(1, { data })
       expect(prismaService.journey.create).toHaveBeenLastCalledWith({

--- a/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apps/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -56,6 +56,8 @@ import { PlausibleJob } from '../plausible/plausible.consumer'
 
 type BlockWithAction = Block & { action: BlockAction | null }
 
+const FIVE_DAYS = 5 * 24 * 60 * 60 // in seconds
+
 @Resolver('Journey')
 export class JourneyResolver {
   constructor(
@@ -377,14 +379,28 @@ export class JourneyResolver {
           return journey
         })
         retry = false
-        await this.plausibleQueue.add('create-journey-site', {
-          __typename: 'plausibleCreateJourneySite',
-          journeyId: journey.id
-        })
-        await this.plausibleQueue.add('create-team-site', {
-          __typename: 'plausibleCreateTeamSite',
-          teamId: journey.teamId
-        })
+        await this.plausibleQueue.add(
+          'create-journey-site',
+          {
+            __typename: 'plausibleCreateJourneySite',
+            journeyId: journey.id
+          },
+          {
+            removeOnComplete: true,
+            removeOnFail: { age: FIVE_DAYS, count: 50 }
+          }
+        )
+        await this.plausibleQueue.add(
+          'create-team-site',
+          {
+            __typename: 'plausibleCreateTeamSite',
+            teamId: journey.teamId
+          },
+          {
+            removeOnComplete: true,
+            removeOnFail: { age: FIVE_DAYS, count: 50 }
+          }
+        )
         return journey
       } catch (err) {
         if (err.code === ERROR_PSQL_UNIQUE_CONSTRAINT_VIOLATED) {
@@ -672,14 +688,28 @@ export class JourneyResolver {
           })
         }
         retry = false
-        await this.plausibleQueue.add('create-journey-site', {
-          __typename: 'plausibleCreateJourneySite',
-          journeyId: duplicateJourneyId
-        })
-        await this.plausibleQueue.add('create-team-site', {
-          __typename: 'plausibleCreateTeamSite',
-          teamId
-        })
+        await this.plausibleQueue.add(
+          'create-journey-site',
+          {
+            __typename: 'plausibleCreateJourneySite',
+            journeyId: duplicateJourneyId
+          },
+          {
+            removeOnComplete: true,
+            removeOnFail: { age: FIVE_DAYS, count: 50 }
+          }
+        )
+        await this.plausibleQueue.add(
+          'create-team-site',
+          {
+            __typename: 'plausibleCreateTeamSite',
+            teamId
+          },
+          {
+            removeOnComplete: true,
+            removeOnFail: { age: FIVE_DAYS, count: 50 }
+          }
+        )
         return duplicateJourney
       } catch (err) {
         if (err.code === ERROR_PSQL_UNIQUE_CONSTRAINT_VIOLATED) {

--- a/apps/api-journeys/src/app/modules/plausible/plausible.service.ts
+++ b/apps/api-journeys/src/app/modules/plausible/plausible.service.ts
@@ -63,6 +63,8 @@ export const SITE_CREATE = gql(`
   }
 `)
 
+const FIVE_DAYS = 5 * 24 * 60 * 60 // in seconds
+
 export const goals: Array<keyof JourneyPlausibleEvents> = [
   'footerThumbsUpButtonClick',
   'footerThumbsDownButtonClick',
@@ -151,9 +153,16 @@ export class PlausibleService implements OnModuleInit {
   }
 
   async onModuleInit(): Promise<void> {
-    await this.plausibleQueue.add('plausibleCreateSites', {
-      __typename: 'plausibleCreateSites'
-    })
+    await this.plausibleQueue.add(
+      'plausibleCreateSites',
+      {
+        __typename: 'plausibleCreateSites'
+      },
+      {
+        removeOnComplete: true,
+        removeOnFail: { age: FIVE_DAYS, count: 50 }
+      }
+    )
   }
 
   async createSites(): Promise<void> {

--- a/apps/api-media/src/workers/server.ts
+++ b/apps/api-media/src/workers/server.ts
@@ -44,7 +44,7 @@ function run({
     {},
     {
       removeOnComplete: { age: ONE_HOUR },
-      removeOnFail: { age: ONE_DAY },
+      removeOnFail: { age: ONE_DAY, count: 50 },
       repeat: repeat != null ? { pattern: repeat } : undefined
     }
   )


### PR DESCRIPTION
# Description

### Issue

Our bullmq redis servers are filling with completed junk, causing the volatile lru to handle deletions.

### Solution

Remove completed tasks and add expiration to failed ones

