### PR TITLE
fix: catch error when no video found

### DIFF
--- a/apps/api-media/src/schema/video/video.spec.ts
+++ b/apps/api-media/src/schema/video/video.spec.ts
@@ -1,10 +1,12 @@
 import { ResultOf } from 'gql.tada'
+import { GraphQLError } from 'graphql'
 
 import {
   BibleCitation,
   CloudflareImage,
   ImageAspectRatio,
   Keyword,
+  Prisma,
   Video,
   VideoDescription,
   VideoImageAlt,
@@ -861,6 +863,26 @@ describe('video', () => {
         }
       })
       expect(data).toHaveProperty('data.video', { id: 'videoId' })
+    })
+
+    it('should throw error when not found', async () => {
+      prismaMock.video.findFirstOrThrow.mockRejectedValueOnce(
+        new Prisma.PrismaClientKnownRequestError('No Video found', {
+          code: 'P2025',
+          clientVersion: 'prismaVersion'
+        })
+      )
+      const data = await client({
+        document: VIDEO_QUERY,
+        variables: {
+          id: 'slug',
+          idType: 'slug'
+        }
+      })
+
+      expect(data).toHaveProperty('errors', [
+        new GraphQLError('Video not found with id slug:slug')
+      ])
     })
   })
 


### PR DESCRIPTION
This pull request introduces error handling for cases where a video is not found in the database. The changes include importing necessary libraries, adding error handling in the video query resolver, and updating tests to cover the new error scenario.

Error handling improvements:

* [`apps/api-media/src/schema/video/video.ts`](diffhunk://#diff-7333027db0b1ac5a75be38f49d0b888174a854e4ac103b154fe9f228d7fe6fc4R404): Added error handling in the video query resolver to throw a `GraphQLError` when a video is not found. This involves catching `PrismaClientKnownRequestError` and rethrowing it as a `GraphQLError` with a specific message. [[1]](diffhunk://#diff-7333027db0b1ac5a75be38f49d0b888174a854e4ac103b154fe9f228d7fe6fc4R404) [[2]](diffhunk://#diff-7333027db0b1ac5a75be38f49d0b888174a854e4ac103b154fe9f228d7fe6fc4R414-R422)

Testing enhancements:

* [`apps/api-media/src/schema/video/video.spec.ts`](diffhunk://#diff-839e90f574572f320dfe98d0cb2f6dfabf0424aa3c6a27955608935910952bf7R867-R886): Added a test case to ensure that a `GraphQLError` is thrown when a video is not found. This includes mocking the `prisma.video.findFirstOrThrow` method to simulate the error scenario.

Library imports:

* [`apps/api-media/src/schema/video/video.ts`](diffhunk://#diff-7333027db0b1ac5a75be38f49d0b888174a854e4ac103b154fe9f228d7fe6fc4R1-R7): Imported `GraphQLError` from `graphql` and `Prisma` from the Prisma client to support the new error handling logic.
* [`apps/api-media/src/schema/video/video.spec.ts`](diffhunk://#diff-839e90f574572f320dfe98d0cb2f6dfabf0424aa3c6a27955608935910952bf7R2-R9): Imported `GraphQLError` from `graphql` to use in the new test case.