### PR TITLE
fix: allow error video not found

### DIFF
--- a/apps/watch/pages/watch/[part1]/[part2].tsx
+++ b/apps/watch/pages/watch/[part1]/[part2].tsx
@@ -128,7 +128,9 @@ export const getStaticProps: GetStaticProps<Part2PageProps> = async (
     if (
       error instanceof ApolloError &&
       error.graphQLErrors.some(
-        ({ extensions }) => extensions?.code === 'NOT_FOUND'
+        ({ extensions, message }) =>
+          extensions?.code === 'NOT_FOUND' ||
+          message?.startsWith('Video not found')
       )
     )
       return {

--- a/apps/watch/pages/watch/[part1]/[part2]/[part3].tsx
+++ b/apps/watch/pages/watch/[part1]/[part2]/[part3].tsx
@@ -128,7 +128,9 @@ export const getStaticProps: GetStaticProps<Part3PageProps> = async (
     if (
       error instanceof ApolloError &&
       error.graphQLErrors.some(
-        ({ extensions }) => extensions?.code === 'NOT_FOUND'
+        ({ extensions, message }) =>
+          extensions?.code === 'NOT_FOUND' ||
+          message?.startsWith('Video not found')
       )
     )
       return {


### PR DESCRIPTION
This pull request makes updates to error handling in two different files to improve the robustness of the `getStaticProps` function. The changes ensure that the function can handle additional error messages related to video not being found.

Error handling improvements:

* `apps/watch/pages/watch/[part1]/[part2].tsx`: Enhanced the error handling in `getStaticProps` to check if the error message starts with 'Video not found' in addition to checking the `extensions.code` for 'NOT_FOUND'. ([apps/watch/pages/watch/[part1]/[part2].tsxL131-R133](diffhunk://#diff-cd96fa06ac6d9e612355d56a84a6dc31c8ab4ce0daba81d34dd80d9ccf13d659L131-R133))
* `apps/watch/pages/watch/[part1]/[part2]/[part3].tsx`: Similar enhancement to the error handling in `getStaticProps` to include a check for error messages starting with 'Video not found'. ([apps/watch/pages/watch/[part1]/[part2]/[part3].tsxL131-R133](diffhunk://#diff-3d9a5bd894937ba419a23bf72d1927fdeedf18d46d31c8ff0fba30f8205ec7e5L131-R133))