### PR TITLE
fix: update vercel environment variables for deployments

### DIFF
--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -106,7 +106,7 @@ jobs:
           JOURNEYS_ADMIN_VERCEL_PROJECT_ID: ${{ secrets.JOURNEYS_ADMIN_VERCEL_PROJECT_ID }}
           WATCH_VERCEL_PROJECT_ID: ${{ secrets.WATCH_VERCEL_PROJECT_ID }}
           VIDEOS_ADMIN_VERCEL_PROJECT_ID: ${{ secrets.VIDEOS_ADMIN_VERCEL_PROJECT_ID }}
-          NEXT_PUBLIC_VERCEL_ENV: preview
+          NEXT_PUBLIC_VERCEL_ENV: stage
           NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA: ${{ github.sha }}
         # use run-namy to avoid case where deploy command doesn't exist for a project
         run: npx nx run-many --target=deploy --projects=${{ matrix.app }}
@@ -258,7 +258,7 @@ jobs:
           JOURNEYS_ADMIN_VERCEL_PROJECT_ID: ${{ secrets.JOURNEYS_ADMIN_VERCEL_PROJECT_ID }}
           WATCH_VERCEL_PROJECT_ID: ${{ secrets.WATCH_VERCEL_PROJECT_ID }}
           VIDEOS_ADMIN_VERCEL_PROJECT_ID: ${{ secrets.VIDEOS_ADMIN_VERCEL_PROJECT_ID }}
-          NEXT_PUBLIC_VERCEL_ENV: production
+          NEXT_PUBLIC_VERCEL_ENV: prod
           NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA: ${{ github.sha }}
         # use run-namy to avoid case where deploy command doesn't exist for a project
         run: npx nx run-many --target=deploy --projects=${{ matrix.app }} --prod

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -106,7 +106,7 @@ jobs:
           JOURNEYS_ADMIN_VERCEL_PROJECT_ID: ${{ secrets.JOURNEYS_ADMIN_VERCEL_PROJECT_ID }}
           WATCH_VERCEL_PROJECT_ID: ${{ secrets.WATCH_VERCEL_PROJECT_ID }}
           VIDEOS_ADMIN_VERCEL_PROJECT_ID: ${{ secrets.VIDEOS_ADMIN_VERCEL_PROJECT_ID }}
-          NEXT_PUBLIC_VERCEL_ENV: stage
+          NEXT_PUBLIC_VERCEL_ENV: ${{ github.event_name == 'push' && github.ref == 'refs/heads/stage' && 'stage' || 'preview' }}
           NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA: ${{ github.sha }}
         # use run-namy to avoid case where deploy command doesn't exist for a project
         run: npx nx run-many --target=deploy --projects=${{ matrix.app }}

--- a/.github/workflows/ecs-frontend-deploy-prod-worker.yml
+++ b/.github/workflows/ecs-frontend-deploy-prod-worker.yml
@@ -117,6 +117,8 @@ jobs:
           DOPPLER_WATCH_TOKEN: ${{ secrets.DOPPLER_WATCH_TOKEN }}
           DOPPLER_WATCH_ADMIN_TOKEN: ${{ secrets.DOPPLER_WATCH_ADMIN_TOKEN }}
           DOPPLER_GITHUB_SERVICE_TOKEN: ${{ secrets.DOPPLER_GITHUB_SERVICE_TOKEN }}
+          NEXT_PUBLIC_VERCEL_ENV: prod
+          NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA: ${{ github.sha }}
         with:
           targets: fetch-secrets, extract-translations, build
           projects: ${{ inputs.name }}

--- a/.github/workflows/ecs-frontend-deploy-stage-worker.yml
+++ b/.github/workflows/ecs-frontend-deploy-stage-worker.yml
@@ -111,11 +111,14 @@ jobs:
           DOPPLER_API_USERS_TOKEN: ${{ secrets.DOPPLER_API_USERS_TOKEN }}
           DOPPLER_API_MEDIA_TOKEN: ${{ secrets.DOPPLER_API_MEDIA_TOKEN }}
           DOPPLER_ARCLIGHT_TOKEN: ${{ secrets.DOPPLER_ARCLIGHT_TOKEN }}
+          DOPPLER_DOCS_TOKEN: ${{ secrets.DOPPLER_DOCS_TOKEN }}
           DOPPLER_JOURNEYS_TOKEN: ${{ secrets.DOPPLER_JOURNEYS_TOKEN }}
           DOPPLER_JOURNEYS_ADMIN_TOKEN: ${{ secrets.DOPPLER_JOURNEYS_ADMIN_TOKEN }}
           DOPPLER_WATCH_TOKEN: ${{ secrets.DOPPLER_WATCH_TOKEN }}
           DOPPLER_WATCH_ADMIN_TOKEN: ${{ secrets.DOPPLER_WATCH_ADMIN_TOKEN }}
           DOPPLER_GITHUB_SERVICE_TOKEN: ${{ secrets.DOPPLER_GITHUB_SERVICE_TOKEN }}
+          NEXT_PUBLIC_VERCEL_ENV: stage
+          NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA: ${{ github.sha }}
         with:
           targets: fetch-secrets, extract-translations, build
           projects: ${{ inputs.name }}

--- a/apps/arclight/project.json
+++ b/apps/arclight/project.json
@@ -37,6 +37,8 @@
       "options": {
         "commands": [
           "VERCEL_PROJECT_ID=$ARCLIGHT_VERCEL_PROJECT_ID npx vercel pull --environment=preview --token=$VERCEL_TOKEN",
+          "echo \"VERCEL_ENV=\\\"$NEXT_PUBLIC_VERCEL_ENV\\\"\" >> .vercel/.env.preview.local",
+          "echo \"VERCEL_GIT_COMMIT_SHA=\\\"$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA\\\"\" >> .vercel/.env.preview.local",
           "npx vercel build",
           "VERCEL_PROJECT_ID=$ARCLIGHT_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --token=$VERCEL_TOKEN --archive=tgz > apps/arclight/.vercel-url"
         ],
@@ -46,6 +48,8 @@
         "production": {
           "commands": [
             "VERCEL_PROJECT_ID=$ARCLIGHT_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
+            "echo \"VERCEL_ENV=\\\"$NEXT_PUBLIC_VERCEL_ENV\\\"\" >> .vercel/.env.production.local",
+            "echo \"VERCEL_GIT_COMMIT_SHA=\\\"$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA\\\"\" >> .vercel/.env.production.local",
             "npx vercel build --prod",
             "VERCEL_PROJECT_ID=$ARCLIGHT_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --archive=tgz > apps/arclight/.vercel-url"
           ]

--- a/apps/docs/project.json
+++ b/apps/docs/project.json
@@ -16,6 +16,8 @@
       "options": {
         "commands": [
           "VERCEL_PROJECT_ID=$DOCS_VERCEL_PROJECT_ID npx vercel pull --environment=preview --token=$VERCEL_TOKEN",
+          "echo \"VERCEL_ENV=\\\"$NEXT_PUBLIC_VERCEL_ENV\\\"\" >> .vercel/.env.preview.local",
+          "echo \"VERCEL_GIT_COMMIT_SHA=\\\"$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA\\\"\" >> .vercel/.env.preview.local",
           "npx vercel build",
           "VERCEL_PROJECT_ID=$DOCS_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --token=$VERCEL_TOKEN --archive=tgz > apps/docs/.vercel-url"
         ],
@@ -25,6 +27,8 @@
         "production": {
           "commands": [
             "VERCEL_PROJECT_ID=$DOCS_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
+            "echo \"VERCEL_ENV=\\\"$NEXT_PUBLIC_VERCEL_ENV\\\"\" >> .vercel/.env.production.local",
+            "echo \"VERCEL_GIT_COMMIT_SHA=\\\"$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA\\\"\" >> .vercel/.env.production.local",
             "npx vercel build --prod",
             "VERCEL_PROJECT_ID=$DOCS_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --archive=tgz > apps/docs/.vercel-url"
           ]

--- a/apps/journeys-admin/project.json
+++ b/apps/journeys-admin/project.json
@@ -40,6 +40,8 @@
       "options": {
         "commands": [
           "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel pull --environment=preview --token=$VERCEL_TOKEN",
+          "echo \"VERCEL_ENV=\\\"$NEXT_PUBLIC_VERCEL_ENV\\\"\" >> .vercel/.env.preview.local",
+          "echo \"VERCEL_GIT_COMMIT_SHA=\\\"$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA\\\"\" >> .vercel/.env.preview.local",
           "npx vercel build",
           "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --token=$VERCEL_TOKEN --archive=tgz > apps/journeys-admin/.vercel-url"
         ],
@@ -49,6 +51,8 @@
         "production": {
           "commands": [
             "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
+            "echo \"VERCEL_ENV=\\\"$NEXT_PUBLIC_VERCEL_ENV\\\"\" >> .vercel/.env.production.local",
+            "echo \"VERCEL_GIT_COMMIT_SHA=\\\"$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA\\\"\" >> .vercel/.env.production.local",
             "npx vercel build --prod",
             "VERCEL_PROJECT_ID=$JOURNEYS_ADMIN_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --archive=tgz > apps/journeys-admin/.vercel-url"
           ]

--- a/apps/journeys-admin/src/libs/firebaseClient/initAuth.ts
+++ b/apps/journeys-admin/src/libs/firebaseClient/initAuth.ts
@@ -33,7 +33,8 @@ export function initAuth(): void {
       path: '/',
       sameSite: 'strict',
       secure:
-        process.env.NEXT_PUBLIC_VERCEL_ENV === 'production' ||
+        process.env.NEXT_PUBLIC_VERCEL_ENV === 'prod' ||
+        process.env.NEXT_PUBLIC_VERCEL_ENV === 'stage' ||
         process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview',
       signed: true
     },

--- a/apps/journeys/project.json
+++ b/apps/journeys/project.json
@@ -38,6 +38,8 @@
       "options": {
         "commands": [
           "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel pull --environment=preview --token=$VERCEL_TOKEN",
+          "echo \"VERCEL_ENV=\\\"$NEXT_PUBLIC_VERCEL_ENV\\\"\" >> .vercel/.env.preview.local",
+          "echo \"VERCEL_GIT_COMMIT_SHA=\\\"$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA\\\"\" >> .vercel/.env.preview.local",
           "npx vercel build",
           "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --token=$VERCEL_TOKEN --archive=tgz > apps/journeys/.vercel-url"
         ],
@@ -47,6 +49,8 @@
         "production": {
           "commands": [
             "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
+            "echo \"VERCEL_ENV=\\\"$NEXT_PUBLIC_VERCEL_ENV\\\"\" >> .vercel/.env.production.local",
+            "echo \"VERCEL_GIT_COMMIT_SHA=\\\"$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA\\\"\" >> .vercel/.env.production.local",
             "npx vercel build --prod",
             "VERCEL_PROJECT_ID=$JOURNEYS_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --archive=tgz > apps/journeys/.vercel-url"
           ]

--- a/apps/videos-admin/project.json
+++ b/apps/videos-admin/project.json
@@ -39,6 +39,8 @@
       "options": {
         "commands": [
           "VERCEL_PROJECT_ID=$VIDEOS_ADMIN_VERCEL_PROJECT_ID npx vercel pull --environment=preview --token=$VERCEL_TOKEN",
+          "echo \"VERCEL_ENV=\\\"$NEXT_PUBLIC_VERCEL_ENV\\\"\" >> .vercel/.env.preview.local",
+          "echo \"VERCEL_GIT_COMMIT_SHA=\\\"$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA\\\"\" >> .vercel/.env.preview.local",
           "npx vercel build",
           "VERCEL_PROJECT_ID=$VIDEOS_ADMIN_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --token=$VERCEL_TOKEN --archive=tgz > apps/videos-admin/.vercel-url"
         ],
@@ -48,6 +50,8 @@
         "production": {
           "commands": [
             "VERCEL_PROJECT_ID=$VIDEOS_ADMIN_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
+            "echo \"VERCEL_ENV=\\\"$NEXT_PUBLIC_VERCEL_ENV\\\"\" >> .vercel/.env.production.local",
+            "echo \"VERCEL_GIT_COMMIT_SHA=\\\"$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA\\\"\" >> .vercel/.env.production.local",
             "npx vercel build --prod",
             "VERCEL_PROJECT_ID=$VIDEOS_ADMIN_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --archive=tgz > apps/videos-admin/.vercel-url"
           ]

--- a/apps/watch/project.json
+++ b/apps/watch/project.json
@@ -35,6 +35,8 @@
       "options": {
         "commands": [
           "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel pull --environment=preview --token=$VERCEL_TOKEN",
+          "echo \"VERCEL_ENV=\\\"$NEXT_PUBLIC_VERCEL_ENV\\\"\" >> .vercel/.env.preview.local",
+          "echo \"VERCEL_GIT_COMMIT_SHA=\\\"$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA\\\"\" >> .vercel/.env.preview.local",
           "npx vercel build",
           "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --token=$VERCEL_TOKEN --archive=tgz > apps/watch/.vercel-url"
         ],
@@ -44,6 +46,8 @@
         "production": {
           "commands": [
             "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel pull --environment=production --token=$VERCEL_TOKEN",
+            "echo \"VERCEL_ENV=\\\"$NEXT_PUBLIC_VERCEL_ENV\\\"\" >> .vercel/.env.production.local",
+            "echo \"VERCEL_GIT_COMMIT_SHA=\\\"$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA\\\"\" >> .vercel/.env.production.local",
             "npx vercel build --prod",
             "VERCEL_PROJECT_ID=$WATCH_VERCEL_PROJECT_ID npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --archive=tgz > apps/watch/.vercel-url"
           ]


### PR DESCRIPTION
This pull request includes updates to environment variables and deployment configurations across multiple files to standardize and ensure consistency in the deployment process.

### Environment Variable Updates

* [`.github/workflows/app-deploy.yml`](diffhunk://#diff-9e0c9c0f4afe54c489ddc47b38619a84a911c7fdae64ac8e5a48dd7bde43b95cL109-R109): Changed `NEXT_PUBLIC_VERCEL_ENV` values from `preview` to `stage` and from `production` to `prod` for different deployment jobs. [[1]](diffhunk://#diff-9e0c9c0f4afe54c489ddc47b38619a84a911c7fdae64ac8e5a48dd7bde43b95cL109-R109) [[2]](diffhunk://#diff-9e0c9c0f4afe54c489ddc47b38619a84a911c7fdae64ac8e5a48dd7bde43b95cL261-R261)
* [`.github/workflows/ecs-frontend-deploy-prod-worker.yml`](diffhunk://#diff-ea1f935e5945a5982d5434211256fd1e5d9167c7fba02333cb7b633cfbf83548R120-R121): Added `NEXT_PUBLIC_VERCEL_ENV` and `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA` environment variables.
* [`.github/workflows/ecs-frontend-deploy-stage-worker.yml`](diffhunk://#diff-52158f8574e227f9b8f8fdc17c73f66b2c206ada2ac3cbfd511075da04ce700cR114-R121): Added `DOPPLER_DOCS_TOKEN`, `NEXT_PUBLIC_VERCEL_ENV`, and `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA` environment variables.

### Deployment Command Updates

* [`apps/arclight/project.json`](diffhunk://#diff-2ee72abfb359f27ab80ff116e1da8ead663c7dda6b8586b30f6fe3a9ce2529a2R40-R41): Added commands to set `VERCEL_ENV` and `VERCEL_GIT_COMMIT_SHA` in `.env.preview.local` and `.env.production.local` files. [[1]](diffhunk://#diff-2ee72abfb359f27ab80ff116e1da8ead663c7dda6b8586b30f6fe3a9ce2529a2R40-R41) [[2]](diffhunk://#diff-2ee72abfb359f27ab80ff116e1da8ead663c7dda6b8586b30f6fe3a9ce2529a2R51-R52)
* [`apps/docs/project.json`](diffhunk://#diff-92d9997980c0871325f1a46a6d363cc28da597bd19ed327e979774d9e7838cabR19-R20): Added commands to set `VERCEL_ENV` and `VERCEL_GIT_COMMIT_SHA` in `.env.preview.local` and `.env.production.local` files. [[1]](diffhunk://#diff-92d9997980c0871325f1a46a6d363cc28da597bd19ed327e979774d9e7838cabR19-R20) [[2]](diffhunk://#diff-92d9997980c0871325f1a46a6d363cc28da597bd19ed327e979774d9e7838cabR30-R31)
* [`apps/journeys-admin/project.json`](diffhunk://#diff-6db2543346cb5deb37fb15d46779760691a5c6aa003df54659bd35d74f85a661R43-R44): Added commands to set `VERCEL_ENV` and `VERCEL_GIT_COMMIT_SHA` in `.env.preview.local` and `.env.production.local` files. [[1]](diffhunk://#diff-6db2543346cb5deb37fb15d46779760691a5c6aa003df54659bd35d74f85a661R43-R44) [[2]](diffhunk://#diff-6db2543346cb5deb37fb15d46779760691a5c6aa003df54659bd35d74f85a661R54-R55)
* [`apps/journeys/project.json`](diffhunk://#diff-3efedbfcf2a27083cc54397746311aa1b491e5d469b75b9012baa4aca66e0b69R41-R42): Added commands to set `VERCEL_ENV` and `VERCEL_GIT_COMMIT_SHA` in `.env.preview.local` and `.env.production.local` files. [[1]](diffhunk://#diff-3efedbfcf2a27083cc54397746311aa1b491e5d469b75b9012baa4aca66e0b69R41-R42) [[2]](diffhunk://#diff-3efedbfcf2a27083cc54397746311aa1b491e5d469b75b9012baa4aca66e0b69R52-R53)
* [`apps/videos-admin/project.json`](diffhunk://#diff-d47f6101b7f91cebe4d9000eb1d92853918529b8dbaddeec2d367522244cfb4aR42-R43): Added commands to set `VERCEL_ENV` and `VERCEL_GIT_COMMIT_SHA` in `.env.preview.local` and `.env.production.local` files. [[1]](diffhunk://#diff-d47f6101b7f91cebe4d9000eb1d92853918529b8dbaddeec2d367522244cfb4aR42-R43) [[2]](diffhunk://#diff-d47f6101b7f91cebe4d9000eb1d92853918529b8dbaddeec2d367522244cfb4aR53-R54)
* [`apps/watch/project.json`](diffhunk://#diff-b08d4e805876fecd32fd77a4785c9ac3cbfe0500d0ad536f024dc697a261cc6cR38-R39): Added commands to set `VERCEL_ENV` and `VERCEL_GIT_COMMIT_SHA` in `.env.preview.local` and `.env.production.local` files. [[1]](diffhunk://#diff-b08d4e805876fecd32fd77a4785c9ac3cbfe0500d0ad536f024dc697a261cc6cR38-R39) [[2]](diffhunk://#diff-b08d4e805876fecd32fd77a4785c9ac3cbfe0500d0ad536f024dc697a261cc6cR49-R50)