### PR TITLE
chore: update to hive gateway 1-2-0

### DIFF
--- a/apps/api-gateway/Dockerfile
+++ b/apps/api-gateway/Dockerfile
@@ -2,7 +2,7 @@
 # - update Dockerfile image version (ghcr.io/ardatan/hive-gateway:X.X.X)
 # - update package.json ("@graphql-hive/gateway": "^X.X.X")
 # - inform all developers to run npm i
-FROM  ghcr.io/ardatan/hive-gateway:1.0.5
+FROM  ghcr.io/ardatan/hive-gateway:1.2.0
 ARG SERVICE_VERSION=0.0.1
 ENV OTEL_RESOURCE_ATTRIBUTES="service.version=$SERVICE_VERSION"
 EXPOSE 4000

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,7 +126,6 @@
         "next-logger": "^4.0.0",
         "next-plausible": "^3.12.0",
         "next-seo": "^6.4.0",
-        "node-libcurl": "^4.0.0",
         "nodemailer": "^6.9.9",
         "notistack": "^3.0.1",
         "pino": "^9.3.2",
@@ -7228,9 +7227,9 @@
       }
     },
     "node_modules/@envelop/extended-validation/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -7276,9 +7275,9 @@
       }
     },
     "node_modules/@envelop/generic-auth/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -7375,9 +7374,9 @@
       }
     },
     "node_modules/@envelop/rate-limiter/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -11780,26 +11779,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@graphql-hive/cli/node_modules/@graphql-hive/core": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/core/-/core-0.8.2.tgz",
-      "integrity": "sha512-wIOq0EMtfBojZrOdlvITlKmlHHwhxxsU9XZ+D82W0vC81sB2koO1G7HiCZIJPrgUREDpuZgT662lNfhfNggDlQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.0.0",
-        "@whatwg-node/fetch": "0.9.21",
-        "async-retry": "1.3.3",
-        "lodash.sortby": "4.7.0",
-        "tiny-lru": "8.0.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/@graphql-hive/cli/node_modules/@graphql-inspector/core": {
       "version": "5.1.0-alpha-20231208113249-34700c8a",
       "resolved": "https://registry.npmjs.org/@graphql-inspector/core/-/core-5.1.0-alpha-20231208113249-34700c8a.tgz",
@@ -11892,20 +11871,6 @@
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^3.26.6"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@graphql-hive/cli/node_modules/@whatwg-node/fetch": {
-      "version": "0.9.21",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.21.tgz",
-      "integrity": "sha512-Wt0jPb+04JjobK0pAAN7mEHxVHcGA9HoP3OyCsZtyAecNQeADXCZ1MihFwVwjsgaRYuGVmNlsCmLxlG6mor8Gw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@whatwg-node/node-fetch": "^0.5.23",
-        "urlpattern-polyfill": "^10.0.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -12074,13 +12039,13 @@
       "license": "0BSD"
     },
     "node_modules/@graphql-hive/core": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/core/-/core-0.8.0.tgz",
-      "integrity": "sha512-3qMMfEPk9CMBcV6KqCqk+5bZm3ktyJuwTy/g5DotBeDi+0aRZlr6LAMEBHSrlipJv/xk5qyERt/JmRfnrjj9vQ==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@graphql-hive/core/-/core-0.8.2.tgz",
+      "integrity": "sha512-wIOq0EMtfBojZrOdlvITlKmlHHwhxxsU9XZ+D82W0vC81sB2koO1G7HiCZIJPrgUREDpuZgT662lNfhfNggDlQ==",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/utils": "^10.0.0",
-        "@whatwg-node/fetch": "0.9.20",
+        "@whatwg-node/fetch": "0.9.21",
         "async-retry": "1.3.3",
         "lodash.sortby": "4.7.0",
         "tiny-lru": "8.0.2"
@@ -12093,9 +12058,9 @@
       }
     },
     "node_modules/@graphql-hive/core/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -12123,23 +12088,20 @@
       }
     },
     "node_modules/@graphql-hive/gateway": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.0.7.tgz",
-      "integrity": "sha512-7Y3NP2uQ/KK3Nz3eahRmaKf0qzxuLBv9TG8I2Dil9C5xjbC8Z9Tjq3JryOEjgJDzkSH80v9kUqMgCZ1g9umXkw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-hive/gateway/-/gateway-1.2.0.tgz",
+      "integrity": "sha512-LxPi2c0v5X6qe4WYla7+iBhi+PeN1TgmwChmeBElc/9xYGOaAkLemrVzgp7bErAy7WsMhjqVAXQbPEGcw6R0MA==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-mesh/serve-cli": "^1.0.6",
-        "@graphql-mesh/serve-runtime": "^1.0.4",
-        "@graphql-mesh/utils": "^0.102.5"
+        "@graphql-mesh/serve-cli": "^1.2.0",
+        "@graphql-mesh/serve-runtime": "^1.1.1",
+        "@graphql-mesh/utils": "^0.102.7"
       },
       "bin": {
         "hive-gateway": "esm/bin.js"
       },
       "engines": {
         "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "uWebSockets.js": "uNetworking/uWebSockets.js#semver:^20"
       },
       "peerDependencies": {
         "@parcel/watcher": "^2.1.0",
@@ -12152,9 +12114,9 @@
       }
     },
     "node_modules/@graphql-hive/gateway/node_modules/@graphql-mesh/cross-helpers": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/cross-helpers/-/cross-helpers-0.4.6.tgz",
-      "integrity": "sha512-jCwVoZ/90vGsqafBk6NlgzIwQime7y1PpDjY/cnoqITjF8+znviff+gc70Oqgjget+wF7vrvWveWu7KeB9gddg==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/cross-helpers/-/cross-helpers-0.4.7.tgz",
+      "integrity": "sha512-r/mIYVKiFJukPJleytYjCVSklB/5/XWzm2sApcVHUIi+UPXK5AQkdCNMUUIvQvPMlZo+bqVFwUhqPvsOjNxW5w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -12164,14 +12126,14 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*"
       }
     },
     "node_modules/@graphql-hive/gateway/node_modules/@graphql-mesh/store": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/store/-/store-0.102.5.tgz",
-      "integrity": "sha512-szzwC9UdKM4MT0wu0c0qoHkCKI3b/Yr8/G64wL+bFa61b0WC0I6VOCePiVYHrE1ORTRCF6LyaUkh9d0ZC2qr+g==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/store/-/store-0.102.7.tgz",
+      "integrity": "sha512-gUktpEQu2Y1XZdwClbP9naaKi0Ri6blSXOng+srBT7I0gVm88exMI2aVXYMCk8n7KUDvwohjcO/Yx7SIeGHBkw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -12181,43 +12143,43 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-hive/gateway/node_modules/@graphql-mesh/types": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/types/-/types-0.102.5.tgz",
-      "integrity": "sha512-bFcPZQVrNF4+QLk+O3IqXASsl0mNtss18aD0UzaDLI5ai5MkS7vXO222oGUcxC1sGc8poyZJwL/nlIYnv4HoPA==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/types/-/types-0.102.7.tgz",
+      "integrity": "sha512-15fRGOERUugl/XMZiVG0FqVqz3Ugmk7hxKu52HEa6HGJsDNjy+7WRZIvWuCjqftDGnCzZ0mspkcZixfPU73guA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@graphql-tools/batch-delegate": "^9.0.3",
-        "@graphql-tools/delegate": "^10.0.21",
+        "@graphql-tools/batch-delegate": "^9.0.5",
+        "@graphql-tools/delegate": "^10.0.23",
         "@graphql-typed-document-node/core": "^3.2.0"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/store": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/store": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-hive/gateway/node_modules/@graphql-mesh/utils": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/utils/-/utils-0.102.5.tgz",
-      "integrity": "sha512-7rAFz7Y2/gzPmWNMc1vloiS5KJ+MhlxMuweu4/htCBmHARv04pBzAcRW3TfV3sSuqM/3g2C08xNEXQn9+TlMmQ==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/utils/-/utils-0.102.7.tgz",
+      "integrity": "sha512-48wd6ozcR/XIsiap/T9Dq1EZ4yA2XCIbMZ86Rybsx29baB6drJH0LJfzIfxPOCDyF2NCnu5xOBt2ASERrnEO4A==",
       "license": "MIT",
       "dependencies": {
         "@graphql-mesh/string-interpolation": "^0.5.6",
-        "@graphql-tools/delegate": "^10.0.21",
+        "@graphql-tools/delegate": "^10.0.23",
         "@whatwg-node/disposablestack": "^0.0.5",
         "@whatwg-node/fetch": "^0.9.13",
         "dset": "^3.1.2",
@@ -12230,17 +12192,17 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-hive/gateway/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -12279,12 +12241,12 @@
       }
     },
     "node_modules/@graphql-hive/yoga": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@graphql-hive/yoga/-/yoga-0.38.0.tgz",
-      "integrity": "sha512-mg7IxzG95LG0VCw5P0nsAHQeeaebZhjg8MMiH98wkn41rZkw1lmeGG76ZmaUDYz5EZw+0bwP5KXPwT2zZWwLLg==",
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@graphql-hive/yoga/-/yoga-0.38.2.tgz",
+      "integrity": "sha512-gVYWQERt/bTNeflMQDdSyWzFPM6cAyk/5dPE3YMt1OulgAsssYbJi5HbrjIdoZK50Y4uAhryxmGix6B+NsA6kw==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-hive/core": "0.8.0",
+        "@graphql-hive/core": "0.8.2",
         "@graphql-yoga/plugin-persisted-operations": "^3.3.1",
         "tiny-lru": "8.0.2"
       },
@@ -12297,9 +12259,9 @@
       }
     },
     "node_modules/@graphql-hive/yoga/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -12378,24 +12340,24 @@
       "peer": true
     },
     "node_modules/@graphql-mesh/fusion-runtime": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/fusion-runtime/-/fusion-runtime-0.8.13.tgz",
-      "integrity": "sha512-C9ofHPHLsWydvKmLzKHdYHUN4Lvyty1284WUdTwasgmhqJJRfiOS/MEMwBKMHWZXP4iScqF0fbne/r49Ftr0ag==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/fusion-runtime/-/fusion-runtime-0.9.1.tgz",
+      "integrity": "sha512-2oVKXVbr8+lFGR/7Z2nsjcvNHf5ZGJF2Nm7mwKALUBd4BQsjTczBTvSjPI2sAIzfboiQ9EYMfn/gv9Jf1ERrjA==",
       "license": "MIT",
       "dependencies": {
         "@envelop/core": "^5.0.1",
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/runtime": "^0.103.6",
-        "@graphql-mesh/transport-common": "^0.7.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
-        "@graphql-tools/delegate": "^10.0.21",
-        "@graphql-tools/executor": "^1.3.1",
-        "@graphql-tools/federation": "^2.2.10",
-        "@graphql-tools/stitch": "^9.2.10",
-        "@graphql-tools/stitching-directives": "^3.1.2",
-        "@graphql-tools/utils": "^10.5.3",
-        "@graphql-tools/wrap": "^10.0.5",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/runtime": "^0.103.8",
+        "@graphql-mesh/transport-common": "^0.7.8",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
+        "@graphql-tools/delegate": "^10.0.23",
+        "@graphql-tools/executor": "^1.3.2",
+        "@graphql-tools/federation": "^2.2.12",
+        "@graphql-tools/stitch": "^9.2.12",
+        "@graphql-tools/stitching-directives": "^3.1.4",
+        "@graphql-tools/utils": "^10.5.5",
+        "@graphql-tools/wrap": "^10.0.7",
         "@whatwg-node/disposablestack": "^0.0.5",
         "change-case": "^4.1.2",
         "graphql-yoga": "^5.7.0",
@@ -12409,9 +12371,9 @@
       }
     },
     "node_modules/@graphql-mesh/fusion-runtime/node_modules/@graphql-mesh/cross-helpers": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/cross-helpers/-/cross-helpers-0.4.6.tgz",
-      "integrity": "sha512-jCwVoZ/90vGsqafBk6NlgzIwQime7y1PpDjY/cnoqITjF8+znviff+gc70Oqgjget+wF7vrvWveWu7KeB9gddg==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/cross-helpers/-/cross-helpers-0.4.7.tgz",
+      "integrity": "sha512-r/mIYVKiFJukPJleytYjCVSklB/5/XWzm2sApcVHUIi+UPXK5AQkdCNMUUIvQvPMlZo+bqVFwUhqPvsOjNxW5w==",
       "license": "MIT",
       "dependencies": {
         "path-browserify": "1.0.1"
@@ -12420,24 +12382,24 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*"
       }
     },
     "node_modules/@graphql-mesh/fusion-runtime/node_modules/@graphql-mesh/runtime": {
-      "version": "0.103.6",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/runtime/-/runtime-0.103.6.tgz",
-      "integrity": "sha512-mTqyqKWeHF7b/ZFyyc0lHUqYkCXaNUugtp66pgp1lg5fvqn/2B7GPYteeVCCerJD2kpqLp0R3Zpb3Atb/8Fifg==",
+      "version": "0.103.8",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/runtime/-/runtime-0.103.8.tgz",
+      "integrity": "sha512-YoPC++X0zxjG39DhKNGnggbLW+9WIQ5/Pw8zjrHszFZtlsP1wWeskxyxm6U5j95CO4ZOVr27CEr1Z+B7EToI/g==",
       "license": "MIT",
       "dependencies": {
         "@envelop/core": "^5.0.0",
         "@envelop/extended-validation": "^4.0.0",
         "@envelop/graphql-jit": "^8.0.0",
         "@graphql-mesh/string-interpolation": "^0.5.6",
-        "@graphql-tools/batch-delegate": "^9.0.3",
-        "@graphql-tools/delegate": "^10.0.21",
-        "@graphql-tools/executor": "^1.3.1",
-        "@graphql-tools/wrap": "^10.0.5",
+        "@graphql-tools/batch-delegate": "^9.0.5",
+        "@graphql-tools/delegate": "^10.0.23",
+        "@graphql-tools/executor": "^1.3.2",
+        "@graphql-tools/wrap": "^10.0.7",
         "@whatwg-node/fetch": "^0.9.0",
         "graphql-jit": "0.8.6"
       },
@@ -12445,18 +12407,18 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/fusion-runtime/node_modules/@graphql-mesh/store": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/store/-/store-0.102.5.tgz",
-      "integrity": "sha512-szzwC9UdKM4MT0wu0c0qoHkCKI3b/Yr8/G64wL+bFa61b0WC0I6VOCePiVYHrE1ORTRCF6LyaUkh9d0ZC2qr+g==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/store/-/store-0.102.7.tgz",
+      "integrity": "sha512-gUktpEQu2Y1XZdwClbP9naaKi0Ri6blSXOng+srBT7I0gVm88exMI2aVXYMCk8n7KUDvwohjcO/Yx7SIeGHBkw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -12466,61 +12428,61 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/fusion-runtime/node_modules/@graphql-mesh/transport-common": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/transport-common/-/transport-common-0.7.6.tgz",
-      "integrity": "sha512-flhu4bxwWhO6awj0bDCqBtDQVGG+AcIsAhO5MHFGOviwKG4sSqNUiK4O0YoEJ6oNbs26MCPea+DwWXhSQ5EVRA==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/transport-common/-/transport-common-0.7.8.tgz",
+      "integrity": "sha512-oZ5bB2mFaItL3MGAeVzBuswzHVsbefV8lALbmtoaifE93ybmqfggAU3i8Yxksa+h7kkwKiPrP8H4RJsogxM6nA==",
       "license": "MIT",
       "dependencies": {
         "@envelop/core": "^5.0.1",
-        "@graphql-tools/delegate": "^10.0.21",
-        "@graphql-tools/utils": "^10.5.3"
+        "@graphql-tools/delegate": "^10.0.23",
+        "@graphql-tools/utils": "^10.5.5"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/types": "^0.102.5",
+        "@graphql-mesh/types": "^0.102.7",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/fusion-runtime/node_modules/@graphql-mesh/types": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/types/-/types-0.102.5.tgz",
-      "integrity": "sha512-bFcPZQVrNF4+QLk+O3IqXASsl0mNtss18aD0UzaDLI5ai5MkS7vXO222oGUcxC1sGc8poyZJwL/nlIYnv4HoPA==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/types/-/types-0.102.7.tgz",
+      "integrity": "sha512-15fRGOERUugl/XMZiVG0FqVqz3Ugmk7hxKu52HEa6HGJsDNjy+7WRZIvWuCjqftDGnCzZ0mspkcZixfPU73guA==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/batch-delegate": "^9.0.3",
-        "@graphql-tools/delegate": "^10.0.21",
+        "@graphql-tools/batch-delegate": "^9.0.5",
+        "@graphql-tools/delegate": "^10.0.23",
         "@graphql-typed-document-node/core": "^3.2.0"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/store": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/store": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/fusion-runtime/node_modules/@graphql-mesh/utils": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/utils/-/utils-0.102.5.tgz",
-      "integrity": "sha512-7rAFz7Y2/gzPmWNMc1vloiS5KJ+MhlxMuweu4/htCBmHARv04pBzAcRW3TfV3sSuqM/3g2C08xNEXQn9+TlMmQ==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/utils/-/utils-0.102.7.tgz",
+      "integrity": "sha512-48wd6ozcR/XIsiap/T9Dq1EZ4yA2XCIbMZ86Rybsx29baB6drJH0LJfzIfxPOCDyF2NCnu5xOBt2ASERrnEO4A==",
       "license": "MIT",
       "dependencies": {
         "@graphql-mesh/string-interpolation": "^0.5.6",
-        "@graphql-tools/delegate": "^10.0.21",
+        "@graphql-tools/delegate": "^10.0.23",
         "@whatwg-node/disposablestack": "^0.0.5",
         "@whatwg-node/fetch": "^0.9.13",
         "dset": "^3.1.2",
@@ -12533,17 +12495,17 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/fusion-runtime/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -12595,36 +12557,34 @@
       }
     },
     "node_modules/@graphql-mesh/serve-cli": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/serve-cli/-/serve-cli-1.0.6.tgz",
-      "integrity": "sha512-7XlYV0+NaFmYRGwbZOo7NcaJwEYOJETG3wGA3vwuCRTCwggSW78YR+5kzzx8vT1xxSc5Ws5UJDanGZV/4MEYQg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/serve-cli/-/serve-cli-1.2.0.tgz",
+      "integrity": "sha512-BgXj+mqAAGfOm3MvFJVu9NIRsyxb2PhAABE93/+4HIa/nLpNqqd9zXGmaycG4PsFxGRrnTBNYs/qhyVBbtwL1Q==",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^12.1.0",
-        "@graphql-mesh/cache-cfw-kv": "^0.102.5",
-        "@graphql-mesh/cache-localforage": "^0.102.5",
-        "@graphql-mesh/cache-redis": "^0.102.5",
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/hmac-upstream-signature": "^1.0.4",
+        "@graphql-mesh/cache-cfw-kv": "^0.102.7",
+        "@graphql-mesh/cache-localforage": "^0.102.7",
+        "@graphql-mesh/cache-redis": "^0.102.7",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/hmac-upstream-signature": "^1.1.1",
         "@graphql-mesh/include": "^0.2.2",
-        "@graphql-mesh/plugin-deduplicate-request": "^0.102.5",
-        "@graphql-mesh/plugin-http-cache": "^0.102.5",
-        "@graphql-mesh/plugin-jwt-auth": "^1.0.4",
-        "@graphql-mesh/plugin-mock": "^0.102.6",
-        "@graphql-mesh/plugin-opentelemetry": "^1.0.4",
-        "@graphql-mesh/plugin-prometheus": "^1.0.4",
-        "@graphql-mesh/plugin-rate-limit": "^0.102.5",
-        "@graphql-mesh/plugin-snapshot": "^0.102.5",
-        "@graphql-mesh/serve-runtime": "^1.0.4",
-        "@graphql-mesh/transport-http-callback": "^0.4.0",
-        "@graphql-mesh/transport-ws": "^0.3.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/plugin-deduplicate-request": "^0.102.7",
+        "@graphql-mesh/plugin-http-cache": "^0.102.7",
+        "@graphql-mesh/plugin-jwt-auth": "^1.1.1",
+        "@graphql-mesh/plugin-mock": "^0.102.8",
+        "@graphql-mesh/plugin-opentelemetry": "^1.2.0",
+        "@graphql-mesh/plugin-prometheus": "^1.1.1",
+        "@graphql-mesh/plugin-rate-limit": "^0.102.7",
+        "@graphql-mesh/plugin-snapshot": "^0.102.7",
+        "@graphql-mesh/serve-runtime": "^1.1.1",
+        "@graphql-mesh/transport-http-callback": "^0.4.2",
+        "@graphql-mesh/transport-ws": "^0.3.8",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "commander": "^12.0.0",
         "dotenv": "^16.3.1",
-        "json-bigint-patch": "^0.0.8",
-        "node-libcurl": "npm:@ardatan/node-libcurl@^4.0.2",
         "parse-duration": "^1.1.0"
       },
       "bin": {
@@ -12632,9 +12592,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      },
-      "optionalDependencies": {
-        "uWebSockets.js": "uNetworking/uWebSockets.js#semver:^20"
       },
       "peerDependencies": {
         "@parcel/watcher": "^2.1.0",
@@ -12656,24 +12613,24 @@
       }
     },
     "node_modules/@graphql-mesh/serve-cli/node_modules/@graphql-mesh/cache-cfw-kv": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/cache-cfw-kv/-/cache-cfw-kv-0.102.5.tgz",
-      "integrity": "sha512-/f4uxdraI0blme4rgic1pOn2A7Ftu9w7YJmwUB0FpVS9IU1Fg4iyKiJO33ixH6zjMci8PzUQVF0xR7CygZOiVQ==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/cache-cfw-kv/-/cache-cfw-kv-0.102.7.tgz",
+      "integrity": "sha512-bsvfU/NL4llZPz61kssU4nn9Haei/l1Y0hTq78rjnRYbh+LJkWZQw8BIsMINnreEdiIsizZXiWj4296i9nXl7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-cli/node_modules/@graphql-mesh/cache-localforage": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/cache-localforage/-/cache-localforage-0.102.5.tgz",
-      "integrity": "sha512-VL8RRAR6ccpy83GQpT8kFW0G+DDC3efzaVu/XmqvtHYiUflC+CGDm6K9svPgHcsadcQ1mVLbByEGoLSoOq8UXw==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/cache-localforage/-/cache-localforage-0.102.7.tgz",
+      "integrity": "sha512-zm1UL46Vmc/KX55LLTw2gYNcyxkgou+Vwa6FDA8ppLV8xk1DyfFH7mgrlk+v+rL7j2WI/ZaaggjQWzirSqJZJg==",
       "license": "MIT",
       "dependencies": {
         "localforage": "1.10.0"
@@ -12682,16 +12639,16 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-cli/node_modules/@graphql-mesh/cache-redis": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/cache-redis/-/cache-redis-0.102.5.tgz",
-      "integrity": "sha512-U1DNgx5XT1z7xNL2EduXZToqZgLe3VZL5MVB1K+XU0+joAeHuxLVSFA/GfjqO0tsGSyiToL47TKgE1EBXTB7SQ==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/cache-redis/-/cache-redis-0.102.7.tgz",
+      "integrity": "sha512-xWTKODCA3oaYeAup0C8NtcZuluCf5IiiIJCKeQlOBLIvj7rNr1bP7Q/Vpfje5QA1ccblpTIw1vYSixFRvsWoBg==",
       "license": "MIT",
       "dependencies": {
         "@graphql-mesh/string-interpolation": "0.5.6",
@@ -12703,17 +12660,17 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-cli/node_modules/@graphql-mesh/cross-helpers": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/cross-helpers/-/cross-helpers-0.4.6.tgz",
-      "integrity": "sha512-jCwVoZ/90vGsqafBk6NlgzIwQime7y1PpDjY/cnoqITjF8+znviff+gc70Oqgjget+wF7vrvWveWu7KeB9gddg==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/cross-helpers/-/cross-helpers-0.4.7.tgz",
+      "integrity": "sha512-r/mIYVKiFJukPJleytYjCVSklB/5/XWzm2sApcVHUIi+UPXK5AQkdCNMUUIvQvPMlZo+bqVFwUhqPvsOjNxW5w==",
       "license": "MIT",
       "dependencies": {
         "path-browserify": "1.0.1"
@@ -12722,48 +12679,48 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*"
       }
     },
     "node_modules/@graphql-mesh/serve-cli/node_modules/@graphql-mesh/hmac-upstream-signature": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/hmac-upstream-signature/-/hmac-upstream-signature-1.0.4.tgz",
-      "integrity": "sha512-70HRq8rrfu5KbijkNa5Wa1q+MU57CUBthLUpSLirZUJFndoCeeWVgqbD89LEyT3j8LjvS+DAIvAjUjf67lQpgg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/hmac-upstream-signature/-/hmac-upstream-signature-1.1.1.tgz",
+      "integrity": "sha512-76VAwwgvpFThfqLYMchfBqqQ82t+9ezzW6r4Rg58tdtLutoDRtXiOBreuEQnYQNp2ETdyIvebrSAPsZWwCOUyQ==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-mesh/transport-common": "^0.7.6",
+        "@graphql-mesh/transport-common": "^0.7.8",
         "json-stable-stringify": "^1.1.1"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-cli/node_modules/@graphql-mesh/plugin-deduplicate-request": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/plugin-deduplicate-request/-/plugin-deduplicate-request-0.102.5.tgz",
-      "integrity": "sha512-C15cL0hpYj185+RLO6E9ftjB+6AWOE3hehWOLOf7e49RY6Pu3tkB66jHQGDUb8IuVu9fEosStXIkRzfb6iEvug==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/plugin-deduplicate-request/-/plugin-deduplicate-request-0.102.7.tgz",
+      "integrity": "sha512-vdHc4t3fbAmx2+7cER1Q/23w+7x56NoTl5vb+P7f2c+ashqcFfEdgM1WZ8sIwlday3gxFK4SpJv/wFsEwoeQIg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-cli/node_modules/@graphql-mesh/plugin-http-cache": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/plugin-http-cache/-/plugin-http-cache-0.102.5.tgz",
-      "integrity": "sha512-fkaA5HyfWzmMhHDil53r32cJzp5p9nbo8a0InV/pUPHa1GYiF8WFLC2XMX1ZUUEfiOkf3zE75BI9/f4rPYfn1w==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/plugin-http-cache/-/plugin-http-cache-0.102.7.tgz",
+      "integrity": "sha512-j/NRPRmFYGUxNH/7YJ/tXTcNjCEhNY/r63jGEXa7TAFolZ/E12Ln2+6BYAGugKmowHTxqoXzxnuUZzQT/mxx8w==",
       "license": "MIT",
       "dependencies": {
         "@whatwg-node/fetch": "^0.9.0",
@@ -12773,16 +12730,16 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-cli/node_modules/@graphql-mesh/plugin-jwt-auth": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/plugin-jwt-auth/-/plugin-jwt-auth-1.0.4.tgz",
-      "integrity": "sha512-h9drL+Dt6gs01l+/UYhJmwq4p2u587Jadbw9KT9iQMDtve9IkujivQaiYlA0qPJGVcmTuldVTdy8gj6vDMrg/w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/plugin-jwt-auth/-/plugin-jwt-auth-1.1.1.tgz",
+      "integrity": "sha512-gUwbkj2e1h1hLCx5EDMnnwt+3hGFmkFzuhA4LQso/ru49L6wjDn0E+/PFydZc5KtOBNhcofrpNrnsTwHCEYlpQ==",
       "license": "MIT",
       "dependencies": {
         "@graphql-yoga/plugin-jwt": "^3.0.2"
@@ -12791,16 +12748,16 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-cli/node_modules/@graphql-mesh/plugin-mock": {
-      "version": "0.102.6",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/plugin-mock/-/plugin-mock-0.102.6.tgz",
-      "integrity": "sha512-WMSmAK/UECuLkbB9tdfWjpkxb+hC5+RMKYWCStyxNqsdOBh+EVbmfKAYG1eeHXE8ft45MB9kI/NKaZajPZWGWw==",
+      "version": "0.102.8",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/plugin-mock/-/plugin-mock-0.102.8.tgz",
+      "integrity": "sha512-7ql3lWk4LmqZhHBNvJrUfbYclNn2eQBGkiF91NhaBowzHzGllyx6VNYNyvW3Fc/TXlbQMoovQJUq4lgfR5SC2g==",
       "license": "MIT",
       "dependencies": {
         "@graphql-mesh/string-interpolation": "^0.5.6",
@@ -12813,23 +12770,23 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-cli/node_modules/@graphql-mesh/plugin-opentelemetry": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/plugin-opentelemetry/-/plugin-opentelemetry-1.0.4.tgz",
-      "integrity": "sha512-eeTscF/M8fmhf8B1w6w9oBTj9J33LXCkswqUJswSO1YWERhffWmS/I1LFazHJM5Sob//2jB0lJS+mI5nV41HQw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/plugin-opentelemetry/-/plugin-opentelemetry-1.2.0.tgz",
+      "integrity": "sha512-zl1JBdXhHdYUJXyxF+QsGxDQKcjFXsNBDHZ3S6qJ6kQhRvZgwu7CsFNDkLCKYc+9FUkZXiXOlzdixaiempc28A==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-mesh/serve-runtime": "^1.0.4",
-        "@graphql-mesh/transport-common": "^0.7.6",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/serve-runtime": "^1.1.1",
+        "@graphql-mesh/transport-common": "^0.7.8",
+        "@graphql-tools/utils": "^10.5.5",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-node": "^0.50.0",
         "@opentelemetry/context-async-hooks": "^1.25.1",
@@ -12847,19 +12804,19 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-cli/node_modules/@graphql-mesh/plugin-prometheus": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/plugin-prometheus/-/plugin-prometheus-1.0.4.tgz",
-      "integrity": "sha512-ZgzBTJgbj9fo01JGnGqMuv7z4LoXqagO2EIF7DxL0Zfq0qkfxs8TPLE4xhB2M/xDhunahgTbui+gQq7l0rfKHQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/plugin-prometheus/-/plugin-prometheus-1.1.1.tgz",
+      "integrity": "sha512-EqgpYquU9zz4d8PWNkbGUxI109K0NOaCO7N+CUvTcfTqj6yFojTSXLNZfmTAT9jnuPpxsZsvl3ZJjYDnLzmW6Q==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-mesh/serve-runtime": "^1.0.4",
+        "@graphql-mesh/serve-runtime": "^1.1.1",
         "@graphql-yoga/plugin-prometheus": "^6.1.0",
         "prom-client": "^15.0.0"
       },
@@ -12867,8 +12824,8 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
         "graphql": "*",
         "graphql-yoga": "^4.0.5 || ^5.0.0",
         "prom-client": "^13 || ^14.0.0 || ^15.0.0",
@@ -12876,9 +12833,9 @@
       }
     },
     "node_modules/@graphql-mesh/serve-cli/node_modules/@graphql-mesh/plugin-rate-limit": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/plugin-rate-limit/-/plugin-rate-limit-0.102.5.tgz",
-      "integrity": "sha512-5Va1AFLN3p8U56+c5EKteBiGK9+QZHfA6tec4m4pRdcOOFMyVaPQMA172baqF1SYmysb88unCE0jm6kwQ1HkVQ==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/plugin-rate-limit/-/plugin-rate-limit-0.102.7.tgz",
+      "integrity": "sha512-CO3X0Rqzo4wYt0tMpu5TzuLg3jWdPckEexdheX8zh1xrh8bwzzpNcxN0tLesAhYmSfcsYQgsvmaaKrDBEqT1FA==",
       "license": "MIT",
       "dependencies": {
         "@envelop/rate-limiter": "^6.2.0",
@@ -12888,18 +12845,18 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-cli/node_modules/@graphql-mesh/plugin-snapshot": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/plugin-snapshot/-/plugin-snapshot-0.102.5.tgz",
-      "integrity": "sha512-LiPhtgI1ivw/6ukW+kq9zy7sNUi3GwHG99jiFCHo0POpCQ3j8pgyx5Kc44ZjaHHRqoixcABsdm82KfEU/gQF5g==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/plugin-snapshot/-/plugin-snapshot-0.102.7.tgz",
+      "integrity": "sha512-/kHyAPNn4nTaqT8V2WgsgEIspxD9AzGYzWjdQ2OELVMB80j8zpCttl92zgb93RI82r50+H+N7uPhca6AigILfA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-mesh/string-interpolation": "0.5.6",
@@ -12910,17 +12867,17 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-cli/node_modules/@graphql-mesh/store": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/store/-/store-0.102.5.tgz",
-      "integrity": "sha512-szzwC9UdKM4MT0wu0c0qoHkCKI3b/Yr8/G64wL+bFa61b0WC0I6VOCePiVYHrE1ORTRCF6LyaUkh9d0ZC2qr+g==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/store/-/store-0.102.7.tgz",
+      "integrity": "sha512-gUktpEQu2Y1XZdwClbP9naaKi0Ri6blSXOng+srBT7I0gVm88exMI2aVXYMCk8n7KUDvwohjcO/Yx7SIeGHBkw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -12930,61 +12887,61 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-cli/node_modules/@graphql-mesh/transport-common": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/transport-common/-/transport-common-0.7.6.tgz",
-      "integrity": "sha512-flhu4bxwWhO6awj0bDCqBtDQVGG+AcIsAhO5MHFGOviwKG4sSqNUiK4O0YoEJ6oNbs26MCPea+DwWXhSQ5EVRA==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/transport-common/-/transport-common-0.7.8.tgz",
+      "integrity": "sha512-oZ5bB2mFaItL3MGAeVzBuswzHVsbefV8lALbmtoaifE93ybmqfggAU3i8Yxksa+h7kkwKiPrP8H4RJsogxM6nA==",
       "license": "MIT",
       "dependencies": {
         "@envelop/core": "^5.0.1",
-        "@graphql-tools/delegate": "^10.0.21",
-        "@graphql-tools/utils": "^10.5.3"
+        "@graphql-tools/delegate": "^10.0.23",
+        "@graphql-tools/utils": "^10.5.5"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/types": "^0.102.5",
+        "@graphql-mesh/types": "^0.102.7",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-cli/node_modules/@graphql-mesh/types": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/types/-/types-0.102.5.tgz",
-      "integrity": "sha512-bFcPZQVrNF4+QLk+O3IqXASsl0mNtss18aD0UzaDLI5ai5MkS7vXO222oGUcxC1sGc8poyZJwL/nlIYnv4HoPA==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/types/-/types-0.102.7.tgz",
+      "integrity": "sha512-15fRGOERUugl/XMZiVG0FqVqz3Ugmk7hxKu52HEa6HGJsDNjy+7WRZIvWuCjqftDGnCzZ0mspkcZixfPU73guA==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/batch-delegate": "^9.0.3",
-        "@graphql-tools/delegate": "^10.0.21",
+        "@graphql-tools/batch-delegate": "^9.0.5",
+        "@graphql-tools/delegate": "^10.0.23",
         "@graphql-typed-document-node/core": "^3.2.0"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/store": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/store": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-cli/node_modules/@graphql-mesh/utils": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/utils/-/utils-0.102.5.tgz",
-      "integrity": "sha512-7rAFz7Y2/gzPmWNMc1vloiS5KJ+MhlxMuweu4/htCBmHARv04pBzAcRW3TfV3sSuqM/3g2C08xNEXQn9+TlMmQ==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/utils/-/utils-0.102.7.tgz",
+      "integrity": "sha512-48wd6ozcR/XIsiap/T9Dq1EZ4yA2XCIbMZ86Rybsx29baB6drJH0LJfzIfxPOCDyF2NCnu5xOBt2ASERrnEO4A==",
       "license": "MIT",
       "dependencies": {
         "@graphql-mesh/string-interpolation": "^0.5.6",
-        "@graphql-tools/delegate": "^10.0.21",
+        "@graphql-tools/delegate": "^10.0.23",
         "@whatwg-node/disposablestack": "^0.0.5",
         "@whatwg-node/fetch": "^0.9.13",
         "dset": "^3.1.2",
@@ -12997,20 +12954,20 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-cli/node_modules/@graphql-tools/merge": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.7.tgz",
-      "integrity": "sha512-lbTrIuXIbUSmSumHkPRY1QX0Z8JEtmRhnIrkH7vkfeEmf0kNn/nCWvJwqokm5U7L+a+DA1wlRM4slIlbfXjJBA==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.8.tgz",
+      "integrity": "sha512-RG9NEp4fi0MoFi0te4ahqTMYuavQnXlpEZxxMomdCa6CI5tfekcVm/rsLF5Zt8O4HY+esDt9+4dCL+aOKvG79w==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.5.4",
+        "@graphql-tools/utils": "^10.5.5",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -13021,13 +12978,13 @@
       }
     },
     "node_modules/@graphql-mesh/serve-cli/node_modules/@graphql-tools/schema": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.6.tgz",
-      "integrity": "sha512-EIJgPRGzpvDFEjVp+RF1zNNYIC36BYuIeZ514jFoJnI6IdxyVyIRDLx/ykgMdaa1pKQerpfdqDnsF4JnZoDHSQ==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.7.tgz",
+      "integrity": "sha512-Cz1o+rf9cd3uMgG+zI9HlM5mPlnHQUlk/UQRZyUlPDfT+944taLaokjvj7AI6GcOFVf4f2D11XthQp+0GY31jQ==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/merge": "^9.0.6",
-        "@graphql-tools/utils": "^10.5.4",
+        "@graphql-tools/merge": "^9.0.8",
+        "@graphql-tools/utils": "^10.5.5",
         "tslib": "^2.4.0",
         "value-or-promise": "^1.0.12"
       },
@@ -13039,9 +12996,9 @@
       }
     },
     "node_modules/@graphql-mesh/serve-cli/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -13054,6 +13011,18 @@
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-mesh/serve-cli/node_modules/@opentelemetry/api-logs": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.1.tgz",
+      "integrity": "sha512-qnSqB2DQ9TPP96dl8cDubDvrUyWc0/sK81xHTK8eSUspzDM3bsewX903qclQFvVhgStjRWdC5bLb3kQqMkfV5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@graphql-mesh/serve-cli/node_modules/@opentelemetry/core": {
@@ -13080,25 +13049,6 @@
         "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.25.1",
         "@opentelemetry/otlp-grpc-exporter-base": "0.52.1",
-        "@opentelemetry/otlp-transformer": "0.52.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@graphql-mesh/serve-cli/node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.52.1.tgz",
-      "integrity": "sha512-05HcNizx0BxcFKKnS5rwOV+2GevLTVIRA0tRgWYyw4yCgR53Ic/xk83toYKts7kbzcI+dswInUg/4s8oyA+tqg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/otlp-exporter-base": "0.52.1",
         "@opentelemetry/otlp-transformer": "0.52.1",
         "@opentelemetry/resources": "1.25.1",
         "@opentelemetry/sdk-trace-base": "1.25.1"
@@ -13190,15 +13140,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@graphql-mesh/serve-cli/node_modules/abbrev": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
-      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/@graphql-mesh/serve-cli/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -13229,74 +13170,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@graphql-mesh/serve-cli/node_modules/env-paths": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@graphql-mesh/serve-cli/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@graphql-mesh/serve-cli/node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@graphql-mesh/serve-cli/node_modules/isexe": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@graphql-mesh/serve-cli/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
     "node_modules/@graphql-mesh/serve-cli/node_modules/minimatch": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
@@ -13307,98 +13180,6 @@
       },
       "engines": {
         "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@graphql-mesh/serve-cli/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/@graphql-mesh/serve-cli/node_modules/node-gyp": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-10.2.0.tgz",
-      "integrity": "sha512-sp3FonBAaFe4aYTcFdZUn2NYkbP7xroPGYvQmP4Nl5PxamznItBnNCgjrVTKrEfQynInMsJvZrdmqUnysCJ8rw==",
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.0",
-        "exponential-backoff": "^3.1.1",
-        "glob": "^10.3.10",
-        "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^13.0.0",
-        "nopt": "^7.0.0",
-        "proc-log": "^4.1.0",
-        "semver": "^7.3.5",
-        "tar": "^6.2.1",
-        "which": "^4.0.0"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@graphql-mesh/serve-cli/node_modules/node-libcurl": {
-      "name": "@ardatan/node-libcurl",
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@ardatan/node-libcurl/-/node-libcurl-4.0.2.tgz",
-      "integrity": "sha512-H1XB1bFiAxA5dc8vRnQEGC4hsbVVATAdhR8trUcG+MivG98aPB3BrkE2j3qEE3RMHoo3uWx5tzctTnoCXIM8fA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.11",
-        "env-paths": "2.2.0",
-        "nan": "^2.20.0",
-        "node-gyp": "^10.2.0",
-        "npmlog": "^7.0.1",
-        "rimraf": "^5.0.5",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@graphql-mesh/serve-cli/node_modules/nopt": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
-      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "^2.0.0"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@graphql-mesh/serve-cli/node_modules/proc-log": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
-      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@graphql-mesh/serve-cli/node_modules/rimraf": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^10.3.7"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -13425,46 +13206,31 @@
         "node": ">=12"
       }
     },
-    "node_modules/@graphql-mesh/serve-cli/node_modules/which": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/@graphql-mesh/serve-runtime": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/serve-runtime/-/serve-runtime-1.0.4.tgz",
-      "integrity": "sha512-lPXbPwy9D+vWJS90DsZcMtbsMPQiJhAFhDXNM6Au8K/Qq3WG3MR+ArCR4teriaeEoUm028v2Uj6pWOv/kLgl4A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/serve-runtime/-/serve-runtime-1.1.1.tgz",
+      "integrity": "sha512-lkQPz+H92AUhXfir4D3FQ9r8n+9ei+HAUqa+gv1r4c1RqX6ymPV9KOWOZtfetxg5fAePP5EnsoGTjEjRED70aw==",
       "license": "MIT",
       "dependencies": {
         "@envelop/core": "^5.0.0",
         "@envelop/disable-introspection": "^6.0.0",
         "@envelop/generic-auth": "^8.0.0",
-        "@graphql-hive/core": "^0.8.0",
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/fusion-runtime": "^0.8.13",
-        "@graphql-mesh/hmac-upstream-signature": "^1.0.4",
-        "@graphql-mesh/plugin-hive": "^0.102.6",
-        "@graphql-mesh/plugin-response-cache": "^0.102.5",
-        "@graphql-mesh/transport-common": "^0.7.6",
-        "@graphql-mesh/transport-http": "^0.6.6",
-        "@graphql-mesh/utils": "^0.102.5",
-        "@graphql-tools/batch-delegate": "^9.0.3",
-        "@graphql-tools/delegate": "^10.0.21",
+        "@graphql-hive/core": "^0.8.1",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/fusion-runtime": "^0.9.1",
+        "@graphql-mesh/hmac-upstream-signature": "^1.1.1",
+        "@graphql-mesh/plugin-hive": "^0.102.9",
+        "@graphql-mesh/plugin-response-cache": "^0.102.7",
+        "@graphql-mesh/transport-common": "^0.7.8",
+        "@graphql-mesh/transport-http": "^0.6.8",
+        "@graphql-mesh/utils": "^0.102.7",
+        "@graphql-tools/batch-delegate": "^9.0.5",
+        "@graphql-tools/delegate": "^10.0.23",
         "@graphql-tools/executor-http": "^1.1.5",
-        "@graphql-tools/federation": "^2.2.10",
-        "@graphql-tools/stitch": "^9.2.10",
-        "@graphql-tools/utils": "^10.5.3",
-        "@graphql-tools/wrap": "^10.0.5",
+        "@graphql-tools/federation": "^2.2.12",
+        "@graphql-tools/stitch": "^9.2.12",
+        "@graphql-tools/utils": "^10.5.5",
+        "@graphql-tools/wrap": "^10.0.7",
         "@graphql-yoga/plugin-apollo-usage-report": "^0.1.0",
         "@graphql-yoga/plugin-csrf-prevention": "^3.7.0",
         "@graphql-yoga/plugin-defer-stream": "^3.7.0",
@@ -13481,9 +13247,9 @@
       }
     },
     "node_modules/@graphql-mesh/serve-runtime/node_modules/@graphql-mesh/cross-helpers": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/cross-helpers/-/cross-helpers-0.4.6.tgz",
-      "integrity": "sha512-jCwVoZ/90vGsqafBk6NlgzIwQime7y1PpDjY/cnoqITjF8+znviff+gc70Oqgjget+wF7vrvWveWu7KeB9gddg==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/cross-helpers/-/cross-helpers-0.4.7.tgz",
+      "integrity": "sha512-r/mIYVKiFJukPJleytYjCVSklB/5/XWzm2sApcVHUIi+UPXK5AQkdCNMUUIvQvPMlZo+bqVFwUhqPvsOjNxW5w==",
       "license": "MIT",
       "dependencies": {
         "path-browserify": "1.0.1"
@@ -13492,54 +13258,54 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*"
       }
     },
     "node_modules/@graphql-mesh/serve-runtime/node_modules/@graphql-mesh/hmac-upstream-signature": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/hmac-upstream-signature/-/hmac-upstream-signature-1.0.4.tgz",
-      "integrity": "sha512-70HRq8rrfu5KbijkNa5Wa1q+MU57CUBthLUpSLirZUJFndoCeeWVgqbD89LEyT3j8LjvS+DAIvAjUjf67lQpgg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/hmac-upstream-signature/-/hmac-upstream-signature-1.1.1.tgz",
+      "integrity": "sha512-76VAwwgvpFThfqLYMchfBqqQ82t+9ezzW6r4Rg58tdtLutoDRtXiOBreuEQnYQNp2ETdyIvebrSAPsZWwCOUyQ==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-mesh/transport-common": "^0.7.6",
+        "@graphql-mesh/transport-common": "^0.7.8",
         "json-stable-stringify": "^1.1.1"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-runtime/node_modules/@graphql-mesh/plugin-hive": {
-      "version": "0.102.6",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/plugin-hive/-/plugin-hive-0.102.6.tgz",
-      "integrity": "sha512-Mrf3E9oFhlaS30XDgVEPcf3ZXpgWOOeF2EDskbF0IgKX+rEIoAvoWkpp82ETIgPUXaPhWcf7s5ot8nkr3wLYzg==",
+      "version": "0.102.9",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/plugin-hive/-/plugin-hive-0.102.9.tgz",
+      "integrity": "sha512-HuLD7XqRtzcqchE4gDwINQu0sFMaJwmqopKFNoa9VLYPeGmaNwYIDaSt8LlLSWG0fSD8Mq/um19nGRRCDpx0lw==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-hive/core": "^0.8.0",
-        "@graphql-hive/yoga": "^0.38.0",
+        "@graphql-hive/core": "^0.8.1",
+        "@graphql-hive/yoga": "^0.38.1",
         "@graphql-mesh/string-interpolation": "0.5.6"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-runtime/node_modules/@graphql-mesh/plugin-response-cache": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/plugin-response-cache/-/plugin-response-cache-0.102.5.tgz",
-      "integrity": "sha512-ygHc2vwEhDsczPDJsdezJpAG2mRzVfsCoxm2XcNQOefqAAg1idpIm6IxCIUrfueGgDH5TYaGGgWNErCFO3q6+Q==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/plugin-response-cache/-/plugin-response-cache-0.102.7.tgz",
+      "integrity": "sha512-k9nPuQiNa6s+n5DcxD8FZMVzsno8Z67oxFV6BFYIh4qjkLz/FuEhhiZTnFDDRXdTlukpes4e5KpNg0p3xs/PKg==",
       "license": "MIT",
       "dependencies": {
         "@envelop/core": "^5.0.0",
@@ -13552,17 +13318,17 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-runtime/node_modules/@graphql-mesh/store": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/store/-/store-0.102.5.tgz",
-      "integrity": "sha512-szzwC9UdKM4MT0wu0c0qoHkCKI3b/Yr8/G64wL+bFa61b0WC0I6VOCePiVYHrE1ORTRCF6LyaUkh9d0ZC2qr+g==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/store/-/store-0.102.7.tgz",
+      "integrity": "sha512-gUktpEQu2Y1XZdwClbP9naaKi0Ri6blSXOng+srBT7I0gVm88exMI2aVXYMCk8n7KUDvwohjcO/Yx7SIeGHBkw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -13572,62 +13338,62 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-runtime/node_modules/@graphql-mesh/transport-common": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/transport-common/-/transport-common-0.7.6.tgz",
-      "integrity": "sha512-flhu4bxwWhO6awj0bDCqBtDQVGG+AcIsAhO5MHFGOviwKG4sSqNUiK4O0YoEJ6oNbs26MCPea+DwWXhSQ5EVRA==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/transport-common/-/transport-common-0.7.8.tgz",
+      "integrity": "sha512-oZ5bB2mFaItL3MGAeVzBuswzHVsbefV8lALbmtoaifE93ybmqfggAU3i8Yxksa+h7kkwKiPrP8H4RJsogxM6nA==",
       "license": "MIT",
       "dependencies": {
         "@envelop/core": "^5.0.1",
-        "@graphql-tools/delegate": "^10.0.21",
-        "@graphql-tools/utils": "^10.5.3"
+        "@graphql-tools/delegate": "^10.0.23",
+        "@graphql-tools/utils": "^10.5.5"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/types": "^0.102.5",
+        "@graphql-mesh/types": "^0.102.7",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-runtime/node_modules/@graphql-mesh/types": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/types/-/types-0.102.5.tgz",
-      "integrity": "sha512-bFcPZQVrNF4+QLk+O3IqXASsl0mNtss18aD0UzaDLI5ai5MkS7vXO222oGUcxC1sGc8poyZJwL/nlIYnv4HoPA==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/types/-/types-0.102.7.tgz",
+      "integrity": "sha512-15fRGOERUugl/XMZiVG0FqVqz3Ugmk7hxKu52HEa6HGJsDNjy+7WRZIvWuCjqftDGnCzZ0mspkcZixfPU73guA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@graphql-tools/batch-delegate": "^9.0.3",
-        "@graphql-tools/delegate": "^10.0.21",
+        "@graphql-tools/batch-delegate": "^9.0.5",
+        "@graphql-tools/delegate": "^10.0.23",
         "@graphql-typed-document-node/core": "^3.2.0"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/store": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/store": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-runtime/node_modules/@graphql-mesh/utils": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/utils/-/utils-0.102.5.tgz",
-      "integrity": "sha512-7rAFz7Y2/gzPmWNMc1vloiS5KJ+MhlxMuweu4/htCBmHARv04pBzAcRW3TfV3sSuqM/3g2C08xNEXQn9+TlMmQ==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/utils/-/utils-0.102.7.tgz",
+      "integrity": "sha512-48wd6ozcR/XIsiap/T9Dq1EZ4yA2XCIbMZ86Rybsx29baB6drJH0LJfzIfxPOCDyF2NCnu5xOBt2ASERrnEO4A==",
       "license": "MIT",
       "dependencies": {
         "@graphql-mesh/string-interpolation": "^0.5.6",
-        "@graphql-tools/delegate": "^10.0.21",
+        "@graphql-tools/delegate": "^10.0.23",
         "@whatwg-node/disposablestack": "^0.0.5",
         "@whatwg-node/fetch": "^0.9.13",
         "dset": "^3.1.2",
@@ -13640,17 +13406,17 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/serve-runtime/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -13759,16 +13525,16 @@
       }
     },
     "node_modules/@graphql-mesh/transport-http": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/transport-http/-/transport-http-0.6.6.tgz",
-      "integrity": "sha512-mOwBKOdCPA5qFCz/wc5+212mQaxVSBQs/vngL9ZscvfIJQAFSXp8yEO00Y+4ch1TDD8Yh3GwTrYZvixwkCzWew==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/transport-http/-/transport-http-0.6.8.tgz",
+      "integrity": "sha512-S2jnYFsIVKixZ4J3gwE9bp9ZtopdQjZ4T9zWDQwGAQNkoRjitOnZIXga37jqjjeyfwRjrx3nhVwOS44d4rB9hw==",
       "license": "MIT",
       "dependencies": {
         "@graphql-mesh/string-interpolation": "^0.5.6",
-        "@graphql-mesh/transport-common": "^0.7.6",
-        "@graphql-mesh/utils": "^0.102.5",
+        "@graphql-mesh/transport-common": "^0.7.8",
+        "@graphql-mesh/utils": "^0.102.7",
         "@graphql-tools/executor-http": "^1.1.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql-ws": "^5.16.0",
         "ws": "^8.18.0"
       },
@@ -13781,16 +13547,16 @@
       }
     },
     "node_modules/@graphql-mesh/transport-http-callback": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/transport-http-callback/-/transport-http-callback-0.4.0.tgz",
-      "integrity": "sha512-HssJD5WMON8by6RLaeVJEFbb0rx44MCaRX8ziy38M/lxvRwKMxiUpu1fnomNy3RoZi8MH9OqzuKrtRW7BUs6gQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/transport-http-callback/-/transport-http-callback-0.4.2.tgz",
+      "integrity": "sha512-6tPNVfG3GP6WSFGuRYuUbEVX+HzP9FiFPegGzFvmUOiShwqgFdRljYu+b3DcHdPohZelVpr12v33X/+ShrH6fw==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
         "@graphql-mesh/string-interpolation": "^0.5.6",
-        "@graphql-mesh/transport-common": "^0.7.6",
-        "@graphql-mesh/utils": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/transport-common": "^0.7.8",
+        "@graphql-mesh/utils": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "@repeaterjs/repeater": "^3.0.6",
         "@whatwg-node/fetch": "^0.9.18"
       },
@@ -13803,9 +13569,9 @@
       }
     },
     "node_modules/@graphql-mesh/transport-http-callback/node_modules/@graphql-mesh/cross-helpers": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/cross-helpers/-/cross-helpers-0.4.6.tgz",
-      "integrity": "sha512-jCwVoZ/90vGsqafBk6NlgzIwQime7y1PpDjY/cnoqITjF8+znviff+gc70Oqgjget+wF7vrvWveWu7KeB9gddg==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/cross-helpers/-/cross-helpers-0.4.7.tgz",
+      "integrity": "sha512-r/mIYVKiFJukPJleytYjCVSklB/5/XWzm2sApcVHUIi+UPXK5AQkdCNMUUIvQvPMlZo+bqVFwUhqPvsOjNxW5w==",
       "license": "MIT",
       "dependencies": {
         "path-browserify": "1.0.1"
@@ -13814,14 +13580,14 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*"
       }
     },
     "node_modules/@graphql-mesh/transport-http-callback/node_modules/@graphql-mesh/store": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/store/-/store-0.102.5.tgz",
-      "integrity": "sha512-szzwC9UdKM4MT0wu0c0qoHkCKI3b/Yr8/G64wL+bFa61b0WC0I6VOCePiVYHrE1ORTRCF6LyaUkh9d0ZC2qr+g==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/store/-/store-0.102.7.tgz",
+      "integrity": "sha512-gUktpEQu2Y1XZdwClbP9naaKi0Ri6blSXOng+srBT7I0gVm88exMI2aVXYMCk8n7KUDvwohjcO/Yx7SIeGHBkw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -13831,62 +13597,62 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/transport-http-callback/node_modules/@graphql-mesh/transport-common": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/transport-common/-/transport-common-0.7.6.tgz",
-      "integrity": "sha512-flhu4bxwWhO6awj0bDCqBtDQVGG+AcIsAhO5MHFGOviwKG4sSqNUiK4O0YoEJ6oNbs26MCPea+DwWXhSQ5EVRA==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/transport-common/-/transport-common-0.7.8.tgz",
+      "integrity": "sha512-oZ5bB2mFaItL3MGAeVzBuswzHVsbefV8lALbmtoaifE93ybmqfggAU3i8Yxksa+h7kkwKiPrP8H4RJsogxM6nA==",
       "license": "MIT",
       "dependencies": {
         "@envelop/core": "^5.0.1",
-        "@graphql-tools/delegate": "^10.0.21",
-        "@graphql-tools/utils": "^10.5.3"
+        "@graphql-tools/delegate": "^10.0.23",
+        "@graphql-tools/utils": "^10.5.5"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/types": "^0.102.5",
+        "@graphql-mesh/types": "^0.102.7",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/transport-http-callback/node_modules/@graphql-mesh/types": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/types/-/types-0.102.5.tgz",
-      "integrity": "sha512-bFcPZQVrNF4+QLk+O3IqXASsl0mNtss18aD0UzaDLI5ai5MkS7vXO222oGUcxC1sGc8poyZJwL/nlIYnv4HoPA==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/types/-/types-0.102.7.tgz",
+      "integrity": "sha512-15fRGOERUugl/XMZiVG0FqVqz3Ugmk7hxKu52HEa6HGJsDNjy+7WRZIvWuCjqftDGnCzZ0mspkcZixfPU73guA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@graphql-tools/batch-delegate": "^9.0.3",
-        "@graphql-tools/delegate": "^10.0.21",
+        "@graphql-tools/batch-delegate": "^9.0.5",
+        "@graphql-tools/delegate": "^10.0.23",
         "@graphql-typed-document-node/core": "^3.2.0"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/store": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/store": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/transport-http-callback/node_modules/@graphql-mesh/utils": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/utils/-/utils-0.102.5.tgz",
-      "integrity": "sha512-7rAFz7Y2/gzPmWNMc1vloiS5KJ+MhlxMuweu4/htCBmHARv04pBzAcRW3TfV3sSuqM/3g2C08xNEXQn9+TlMmQ==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/utils/-/utils-0.102.7.tgz",
+      "integrity": "sha512-48wd6ozcR/XIsiap/T9Dq1EZ4yA2XCIbMZ86Rybsx29baB6drJH0LJfzIfxPOCDyF2NCnu5xOBt2ASERrnEO4A==",
       "license": "MIT",
       "dependencies": {
         "@graphql-mesh/string-interpolation": "^0.5.6",
-        "@graphql-tools/delegate": "^10.0.21",
+        "@graphql-tools/delegate": "^10.0.23",
         "@whatwg-node/disposablestack": "^0.0.5",
         "@whatwg-node/fetch": "^0.9.13",
         "dset": "^3.1.2",
@@ -13899,17 +13665,17 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/transport-http-callback/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -13946,9 +13712,9 @@
       }
     },
     "node_modules/@graphql-mesh/transport-http/node_modules/@graphql-mesh/cross-helpers": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/cross-helpers/-/cross-helpers-0.4.6.tgz",
-      "integrity": "sha512-jCwVoZ/90vGsqafBk6NlgzIwQime7y1PpDjY/cnoqITjF8+znviff+gc70Oqgjget+wF7vrvWveWu7KeB9gddg==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/cross-helpers/-/cross-helpers-0.4.7.tgz",
+      "integrity": "sha512-r/mIYVKiFJukPJleytYjCVSklB/5/XWzm2sApcVHUIi+UPXK5AQkdCNMUUIvQvPMlZo+bqVFwUhqPvsOjNxW5w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -13958,14 +13724,14 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*"
       }
     },
     "node_modules/@graphql-mesh/transport-http/node_modules/@graphql-mesh/store": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/store/-/store-0.102.5.tgz",
-      "integrity": "sha512-szzwC9UdKM4MT0wu0c0qoHkCKI3b/Yr8/G64wL+bFa61b0WC0I6VOCePiVYHrE1ORTRCF6LyaUkh9d0ZC2qr+g==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/store/-/store-0.102.7.tgz",
+      "integrity": "sha512-gUktpEQu2Y1XZdwClbP9naaKi0Ri6blSXOng+srBT7I0gVm88exMI2aVXYMCk8n7KUDvwohjcO/Yx7SIeGHBkw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -13975,62 +13741,62 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/transport-http/node_modules/@graphql-mesh/transport-common": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/transport-common/-/transport-common-0.7.6.tgz",
-      "integrity": "sha512-flhu4bxwWhO6awj0bDCqBtDQVGG+AcIsAhO5MHFGOviwKG4sSqNUiK4O0YoEJ6oNbs26MCPea+DwWXhSQ5EVRA==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/transport-common/-/transport-common-0.7.8.tgz",
+      "integrity": "sha512-oZ5bB2mFaItL3MGAeVzBuswzHVsbefV8lALbmtoaifE93ybmqfggAU3i8Yxksa+h7kkwKiPrP8H4RJsogxM6nA==",
       "license": "MIT",
       "dependencies": {
         "@envelop/core": "^5.0.1",
-        "@graphql-tools/delegate": "^10.0.21",
-        "@graphql-tools/utils": "^10.5.3"
+        "@graphql-tools/delegate": "^10.0.23",
+        "@graphql-tools/utils": "^10.5.5"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/types": "^0.102.5",
+        "@graphql-mesh/types": "^0.102.7",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/transport-http/node_modules/@graphql-mesh/types": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/types/-/types-0.102.5.tgz",
-      "integrity": "sha512-bFcPZQVrNF4+QLk+O3IqXASsl0mNtss18aD0UzaDLI5ai5MkS7vXO222oGUcxC1sGc8poyZJwL/nlIYnv4HoPA==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/types/-/types-0.102.7.tgz",
+      "integrity": "sha512-15fRGOERUugl/XMZiVG0FqVqz3Ugmk7hxKu52HEa6HGJsDNjy+7WRZIvWuCjqftDGnCzZ0mspkcZixfPU73guA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@graphql-tools/batch-delegate": "^9.0.3",
-        "@graphql-tools/delegate": "^10.0.21",
+        "@graphql-tools/batch-delegate": "^9.0.5",
+        "@graphql-tools/delegate": "^10.0.23",
         "@graphql-typed-document-node/core": "^3.2.0"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/store": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/store": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/transport-http/node_modules/@graphql-mesh/utils": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/utils/-/utils-0.102.5.tgz",
-      "integrity": "sha512-7rAFz7Y2/gzPmWNMc1vloiS5KJ+MhlxMuweu4/htCBmHARv04pBzAcRW3TfV3sSuqM/3g2C08xNEXQn9+TlMmQ==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/utils/-/utils-0.102.7.tgz",
+      "integrity": "sha512-48wd6ozcR/XIsiap/T9Dq1EZ4yA2XCIbMZ86Rybsx29baB6drJH0LJfzIfxPOCDyF2NCnu5xOBt2ASERrnEO4A==",
       "license": "MIT",
       "dependencies": {
         "@graphql-mesh/string-interpolation": "^0.5.6",
-        "@graphql-tools/delegate": "^10.0.21",
+        "@graphql-tools/delegate": "^10.0.23",
         "@whatwg-node/disposablestack": "^0.0.5",
         "@whatwg-node/fetch": "^0.9.13",
         "dset": "^3.1.2",
@@ -14043,17 +13809,17 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/transport-http/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -14126,17 +13892,17 @@
       }
     },
     "node_modules/@graphql-mesh/transport-ws": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/transport-ws/-/transport-ws-0.3.6.tgz",
-      "integrity": "sha512-pIE7Qg8/1mytpkW1pFgQloqBCy5LlAzz+8N7iFJr1uLAOZOqWeQkcK6jbe5Rq2NbZXIh+okuvYbDK3oxa+m5NQ==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/transport-ws/-/transport-ws-0.3.8.tgz",
+      "integrity": "sha512-i7TqHMKwPzHrNcO4Z0K9T/9CDuvtvkJuLxcCacEklXrT85hZpFn42GG966zwFm5YOySU0pB3Pu3UPeaaMcOQRg==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-mesh/cross-helpers": "0.4.6",
+        "@graphql-mesh/cross-helpers": "0.4.7",
         "@graphql-mesh/string-interpolation": "^0.5.6",
-        "@graphql-mesh/transport-common": "^0.7.6",
-        "@graphql-mesh/utils": "^0.102.5",
+        "@graphql-mesh/transport-common": "^0.7.8",
+        "@graphql-mesh/utils": "^0.102.7",
         "@graphql-tools/executor-graphql-ws": "^1.2.0",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql-ws": "^5.16.0",
         "ws": "^8.18.0"
       },
@@ -14149,9 +13915,9 @@
       }
     },
     "node_modules/@graphql-mesh/transport-ws/node_modules/@graphql-mesh/cross-helpers": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/cross-helpers/-/cross-helpers-0.4.6.tgz",
-      "integrity": "sha512-jCwVoZ/90vGsqafBk6NlgzIwQime7y1PpDjY/cnoqITjF8+znviff+gc70Oqgjget+wF7vrvWveWu7KeB9gddg==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/cross-helpers/-/cross-helpers-0.4.7.tgz",
+      "integrity": "sha512-r/mIYVKiFJukPJleytYjCVSklB/5/XWzm2sApcVHUIi+UPXK5AQkdCNMUUIvQvPMlZo+bqVFwUhqPvsOjNxW5w==",
       "license": "MIT",
       "dependencies": {
         "path-browserify": "1.0.1"
@@ -14160,14 +13926,14 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*"
       }
     },
     "node_modules/@graphql-mesh/transport-ws/node_modules/@graphql-mesh/store": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/store/-/store-0.102.5.tgz",
-      "integrity": "sha512-szzwC9UdKM4MT0wu0c0qoHkCKI3b/Yr8/G64wL+bFa61b0WC0I6VOCePiVYHrE1ORTRCF6LyaUkh9d0ZC2qr+g==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/store/-/store-0.102.7.tgz",
+      "integrity": "sha512-gUktpEQu2Y1XZdwClbP9naaKi0Ri6blSXOng+srBT7I0gVm88exMI2aVXYMCk8n7KUDvwohjcO/Yx7SIeGHBkw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14177,62 +13943,62 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-mesh/utils": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-mesh/utils": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/transport-ws/node_modules/@graphql-mesh/transport-common": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/transport-common/-/transport-common-0.7.6.tgz",
-      "integrity": "sha512-flhu4bxwWhO6awj0bDCqBtDQVGG+AcIsAhO5MHFGOviwKG4sSqNUiK4O0YoEJ6oNbs26MCPea+DwWXhSQ5EVRA==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/transport-common/-/transport-common-0.7.8.tgz",
+      "integrity": "sha512-oZ5bB2mFaItL3MGAeVzBuswzHVsbefV8lALbmtoaifE93ybmqfggAU3i8Yxksa+h7kkwKiPrP8H4RJsogxM6nA==",
       "license": "MIT",
       "dependencies": {
         "@envelop/core": "^5.0.1",
-        "@graphql-tools/delegate": "^10.0.21",
-        "@graphql-tools/utils": "^10.5.3"
+        "@graphql-tools/delegate": "^10.0.23",
+        "@graphql-tools/utils": "^10.5.5"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/types": "^0.102.5",
+        "@graphql-mesh/types": "^0.102.7",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/transport-ws/node_modules/@graphql-mesh/types": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/types/-/types-0.102.5.tgz",
-      "integrity": "sha512-bFcPZQVrNF4+QLk+O3IqXASsl0mNtss18aD0UzaDLI5ai5MkS7vXO222oGUcxC1sGc8poyZJwL/nlIYnv4HoPA==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/types/-/types-0.102.7.tgz",
+      "integrity": "sha512-15fRGOERUugl/XMZiVG0FqVqz3Ugmk7hxKu52HEa6HGJsDNjy+7WRZIvWuCjqftDGnCzZ0mspkcZixfPU73guA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@graphql-tools/batch-delegate": "^9.0.3",
-        "@graphql-tools/delegate": "^10.0.21",
+        "@graphql-tools/batch-delegate": "^9.0.5",
+        "@graphql-tools/delegate": "^10.0.23",
         "@graphql-typed-document-node/core": "^3.2.0"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/store": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/store": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/transport-ws/node_modules/@graphql-mesh/utils": {
-      "version": "0.102.5",
-      "resolved": "https://registry.npmjs.org/@graphql-mesh/utils/-/utils-0.102.5.tgz",
-      "integrity": "sha512-7rAFz7Y2/gzPmWNMc1vloiS5KJ+MhlxMuweu4/htCBmHARv04pBzAcRW3TfV3sSuqM/3g2C08xNEXQn9+TlMmQ==",
+      "version": "0.102.7",
+      "resolved": "https://registry.npmjs.org/@graphql-mesh/utils/-/utils-0.102.7.tgz",
+      "integrity": "sha512-48wd6ozcR/XIsiap/T9Dq1EZ4yA2XCIbMZ86Rybsx29baB6drJH0LJfzIfxPOCDyF2NCnu5xOBt2ASERrnEO4A==",
       "license": "MIT",
       "dependencies": {
         "@graphql-mesh/string-interpolation": "^0.5.6",
-        "@graphql-tools/delegate": "^10.0.21",
+        "@graphql-tools/delegate": "^10.0.23",
         "@whatwg-node/disposablestack": "^0.0.5",
         "@whatwg-node/fetch": "^0.9.13",
         "dset": "^3.1.2",
@@ -14245,17 +14011,17 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@graphql-mesh/cross-helpers": "^0.4.6",
-        "@graphql-mesh/types": "^0.102.5",
-        "@graphql-tools/utils": "^10.5.3",
+        "@graphql-mesh/cross-helpers": "^0.4.7",
+        "@graphql-mesh/types": "^0.102.7",
+        "@graphql-tools/utils": "^10.5.5",
         "graphql": "*",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-mesh/transport-ws/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -14364,13 +14130,13 @@
       }
     },
     "node_modules/@graphql-tools/batch-delegate": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-delegate/-/batch-delegate-9.0.3.tgz",
-      "integrity": "sha512-wYYbDLQeXU+lEUQJDjylN/e1V3OTVkeJSZYgroDniBfg3etDuOJruAIWZ6S6skKB1PZBy1emEbs6HjrziHeX0A==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-delegate/-/batch-delegate-9.0.8.tgz",
+      "integrity": "sha512-VDxa6O72j6i7GEhuPF3n+4dd5GWjLHUGj09GTSmNhp7z6lPxgXEyBlmi0JhfpLmmemCnTExicL6CSgtP6TlRuQ==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/delegate": "^10.0.11",
-        "@graphql-tools/utils": "^10.2.1",
+        "@graphql-tools/delegate": "^10.0.26",
+        "@graphql-tools/utils": "^10.5.5",
         "dataloader": "2.2.2",
         "tslib": "^2.4.0",
         "value-or-promise": "^1.0.12"
@@ -14383,9 +14149,9 @@
       }
     },
     "node_modules/@graphql-tools/batch-delegate/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -14413,11 +14179,12 @@
       }
     },
     "node_modules/@graphql-tools/batch-execute": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.4.tgz",
-      "integrity": "sha512-kkebDLXgDrep5Y0gK1RN3DMUlLqNhg60OAz0lTCqrYeja6DshxLtLkj+zV4mVbBA4mQOEoBmw6g1LZs3dA84/w==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.5.tgz",
+      "integrity": "sha512-wkHLqBNtprKuNk+6ZoOw/RthsnGDycIjtOo976K8f0IgbE7fRNO9SnyhjSziHaIWVDjOuP3XaJD5v/i3vQsa5Q==",
+      "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.0.13",
+        "@graphql-tools/utils": "^10.5.5",
         "dataloader": "^2.2.2",
         "tslib": "^2.4.0",
         "value-or-promise": "^1.0.12"
@@ -14430,12 +14197,13 @@
       }
     },
     "node_modules/@graphql-tools/batch-execute/node_modules/@graphql-tools/utils": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.2.2.tgz",
-      "integrity": "sha512-ueoplzHIgFfxhFrF4Mf/niU/tYHuO6Uekm2nCYU72qpI+7Hn9dA2/o5XOBvFXDk27Lp5VSvQY5WfmRbqwVxaYQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
+      "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
-        "cross-inspect": "1.0.0",
+        "cross-inspect": "1.0.1",
         "dset": "^3.1.2",
         "tslib": "^2.4.0"
       },
@@ -14444,6 +14212,18 @@
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/batch-execute/node_modules/cross-inspect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.1.tgz",
+      "integrity": "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@graphql-tools/code-file-loader": {
@@ -14484,15 +14264,15 @@
       }
     },
     "node_modules/@graphql-tools/delegate": {
-      "version": "10.0.21",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.0.21.tgz",
-      "integrity": "sha512-UytyYVvDfLQbCYG1aQo8Vc67c1WhEjzW9ytYKEEqMJSdlwfMCujHmCz7EyH5DNjTAKapDHuQcN5VivKGap/Beg==",
+      "version": "10.0.26",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.0.26.tgz",
+      "integrity": "sha512-8KaphA86onhO8h9WJeu7YpRNwYDkbbD+KctV6LPJ99vK3w+rQuWkZoxrL1H2nN2FwDBP/9OXposeE7z5C6cv8w==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/batch-execute": "^9.0.4",
-        "@graphql-tools/executor": "^1.3.1",
-        "@graphql-tools/schema": "^10.0.4",
-        "@graphql-tools/utils": "^10.3.4",
+        "@graphql-tools/batch-execute": "^9.0.5",
+        "@graphql-tools/executor": "^1.3.2",
+        "@graphql-tools/schema": "^10.0.7",
+        "@graphql-tools/utils": "^10.5.5",
         "@repeaterjs/repeater": "^3.0.6",
         "dataloader": "^2.2.2",
         "tslib": "^2.5.0"
@@ -14505,11 +14285,12 @@
       }
     },
     "node_modules/@graphql-tools/delegate/node_modules/@graphql-tools/merge": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.4.tgz",
-      "integrity": "sha512-MivbDLUQ+4Q8G/Hp/9V72hbn810IJDEZQ57F01sHnlrrijyadibfVhaQfW/pNH+9T/l8ySZpaR/DpL5i+ruZ+g==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.8.tgz",
+      "integrity": "sha512-RG9NEp4fi0MoFi0te4ahqTMYuavQnXlpEZxxMomdCa6CI5tfekcVm/rsLF5Zt8O4HY+esDt9+4dCL+aOKvG79w==",
+      "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.0.13",
+        "@graphql-tools/utils": "^10.5.5",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -14520,12 +14301,13 @@
       }
     },
     "node_modules/@graphql-tools/delegate/node_modules/@graphql-tools/schema": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.4.tgz",
-      "integrity": "sha512-HuIwqbKxPaJujox25Ra4qwz0uQzlpsaBOzO6CVfzB/MemZdd+Gib8AIvfhQArK0YIN40aDran/yi+E5Xf0mQww==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.7.tgz",
+      "integrity": "sha512-Cz1o+rf9cd3uMgG+zI9HlM5mPlnHQUlk/UQRZyUlPDfT+944taLaokjvj7AI6GcOFVf4f2D11XthQp+0GY31jQ==",
+      "license": "MIT",
       "dependencies": {
-        "@graphql-tools/merge": "^9.0.3",
-        "@graphql-tools/utils": "^10.2.1",
+        "@graphql-tools/merge": "^9.0.8",
+        "@graphql-tools/utils": "^10.5.5",
         "tslib": "^2.4.0",
         "value-or-promise": "^1.0.12"
       },
@@ -14537,9 +14319,9 @@
       }
     },
     "node_modules/@graphql-tools/delegate/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -14583,12 +14365,12 @@
       }
     },
     "node_modules/@graphql-tools/executor": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.3.1.tgz",
-      "integrity": "sha512-tgJDdGf9SCAm64ofEMZdv925u6/J+eTmv36TGNLxgP2DpCJsZ6gnJ4A+0D28EazDXqJIvMiPd+3d+o3cCRCAnQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.3.2.tgz",
+      "integrity": "sha512-U8nAR709IPNjwf0aLG6U9FlX0t7vA4cdWvL4RtMR/L/Ll4OHZ39OqUtq6moy+kLRRwLTqLif6iiUYrxnWpUGXw==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.3.4",
+        "@graphql-tools/utils": "^10.5.5",
         "@graphql-typed-document-node/core": "3.2.0",
         "@repeaterjs/repeater": "^3.0.4",
         "tslib": "^2.4.0",
@@ -14782,9 +14564,9 @@
       }
     },
     "node_modules/@graphql-tools/executor/node_modules/@graphql-tools/utils": {
-      "version": "10.5.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.3.tgz",
-      "integrity": "sha512-XVyYptHEB7OeYwLTvG0092r5+a5SptTdOB0Ppov2nr6MrMZuyDLzEUNUapD75EdiOZzrVpO3JcHZ7FdRxiIyrw==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -14812,18 +14594,18 @@
       }
     },
     "node_modules/@graphql-tools/federation": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/federation/-/federation-2.2.10.tgz",
-      "integrity": "sha512-MF7/TUl+v+dzb8+mutVvivB4sAOmKHK+mJc0TZoM0rCpYNJAIxjp8NIg64z8jImjEPCRmPpxI4uH0kFH3ErWMQ==",
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/federation/-/federation-2.2.16.tgz",
+      "integrity": "sha512-BvUw4tiGb8ESK75HDVbAeeZkqpFVE1IK4rXjq22yhPXrlYp9vXjecM1T9ky6Esu9xMwJ1FnYCj95gpeJHcXx5w==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/delegate": "^10.0.20",
-        "@graphql-tools/executor-http": "^1.1.5",
-        "@graphql-tools/merge": "^9.0.5",
-        "@graphql-tools/schema": "^10.0.5",
-        "@graphql-tools/stitch": "^9.2.10",
-        "@graphql-tools/utils": "^10.4.0",
-        "@graphql-tools/wrap": "^10.0.3",
+        "@graphql-tools/delegate": "^10.0.26",
+        "@graphql-tools/executor-http": "^1.1.7",
+        "@graphql-tools/merge": "^9.0.8",
+        "@graphql-tools/schema": "^10.0.7",
+        "@graphql-tools/stitch": "^9.2.15",
+        "@graphql-tools/utils": "^10.5.5",
+        "@graphql-tools/wrap": "^10.0.10",
         "@whatwg-node/fetch": "^0.9.17",
         "tslib": "^2.4.0",
         "value-or-promise": "^1.0.12"
@@ -14839,12 +14621,12 @@
       }
     },
     "node_modules/@graphql-tools/federation/node_modules/@graphql-tools/merge": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.7.tgz",
-      "integrity": "sha512-lbTrIuXIbUSmSumHkPRY1QX0Z8JEtmRhnIrkH7vkfeEmf0kNn/nCWvJwqokm5U7L+a+DA1wlRM4slIlbfXjJBA==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.8.tgz",
+      "integrity": "sha512-RG9NEp4fi0MoFi0te4ahqTMYuavQnXlpEZxxMomdCa6CI5tfekcVm/rsLF5Zt8O4HY+esDt9+4dCL+aOKvG79w==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.5.4",
+        "@graphql-tools/utils": "^10.5.5",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -14855,13 +14637,13 @@
       }
     },
     "node_modules/@graphql-tools/federation/node_modules/@graphql-tools/schema": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.6.tgz",
-      "integrity": "sha512-EIJgPRGzpvDFEjVp+RF1zNNYIC36BYuIeZ514jFoJnI6IdxyVyIRDLx/ykgMdaa1pKQerpfdqDnsF4JnZoDHSQ==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.7.tgz",
+      "integrity": "sha512-Cz1o+rf9cd3uMgG+zI9HlM5mPlnHQUlk/UQRZyUlPDfT+944taLaokjvj7AI6GcOFVf4f2D11XthQp+0GY31jQ==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/merge": "^9.0.6",
-        "@graphql-tools/utils": "^10.5.4",
+        "@graphql-tools/merge": "^9.0.8",
+        "@graphql-tools/utils": "^10.5.5",
         "tslib": "^2.4.0",
         "value-or-promise": "^1.0.12"
       },
@@ -14873,9 +14655,9 @@
       }
     },
     "node_modules/@graphql-tools/federation/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -15209,13 +14991,13 @@
       }
     },
     "node_modules/@graphql-tools/mock": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/mock/-/mock-9.0.4.tgz",
-      "integrity": "sha512-/pfrBoL6QkKBrJcaOZ/2FtfoAYmiQE+L6Up3hWbSWjg1XJfecjqptLTcM2Wf0dmHAFkjCK1k4QVNHMmGJ94IOA==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/mock/-/mock-9.0.5.tgz",
+      "integrity": "sha512-hn1F2UM05Y8U80lt8dW/xcPA78KS/FtpV1zvsEsiw+InO3teR1BGXoqKVxcKzM1XmNp0c2Ijk07YaDV34Y2QQA==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/schema": "^10.0.4",
-        "@graphql-tools/utils": "^10.2.1",
+        "@graphql-tools/schema": "^10.0.7",
+        "@graphql-tools/utils": "^10.5.5",
         "fast-json-stable-stringify": "^2.1.0",
         "tslib": "^2.4.0"
       },
@@ -15227,12 +15009,12 @@
       }
     },
     "node_modules/@graphql-tools/mock/node_modules/@graphql-tools/merge": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.7.tgz",
-      "integrity": "sha512-lbTrIuXIbUSmSumHkPRY1QX0Z8JEtmRhnIrkH7vkfeEmf0kNn/nCWvJwqokm5U7L+a+DA1wlRM4slIlbfXjJBA==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.8.tgz",
+      "integrity": "sha512-RG9NEp4fi0MoFi0te4ahqTMYuavQnXlpEZxxMomdCa6CI5tfekcVm/rsLF5Zt8O4HY+esDt9+4dCL+aOKvG79w==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.5.4",
+        "@graphql-tools/utils": "^10.5.5",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -15243,13 +15025,13 @@
       }
     },
     "node_modules/@graphql-tools/mock/node_modules/@graphql-tools/schema": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.6.tgz",
-      "integrity": "sha512-EIJgPRGzpvDFEjVp+RF1zNNYIC36BYuIeZ514jFoJnI6IdxyVyIRDLx/ykgMdaa1pKQerpfdqDnsF4JnZoDHSQ==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.7.tgz",
+      "integrity": "sha512-Cz1o+rf9cd3uMgG+zI9HlM5mPlnHQUlk/UQRZyUlPDfT+944taLaokjvj7AI6GcOFVf4f2D11XthQp+0GY31jQ==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/merge": "^9.0.6",
-        "@graphql-tools/utils": "^10.5.4",
+        "@graphql-tools/merge": "^9.0.8",
+        "@graphql-tools/utils": "^10.5.5",
         "tslib": "^2.4.0",
         "value-or-promise": "^1.0.12"
       },
@@ -15261,9 +15043,9 @@
       }
     },
     "node_modules/@graphql-tools/mock/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -15453,18 +15235,18 @@
       }
     },
     "node_modules/@graphql-tools/stitch": {
-      "version": "9.2.10",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/stitch/-/stitch-9.2.10.tgz",
-      "integrity": "sha512-p4BOr6YTYZ9xjnHtrd6AsNR9Y2XtRSroSEEdOwv3KTHQLFhOD9wiLxb+UlKiHYm2jtTvL4wl6+TWV9dKCeNQ3g==",
+      "version": "9.2.15",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/stitch/-/stitch-9.2.15.tgz",
+      "integrity": "sha512-NOnmymAaXxH0ZM3t1dP9MyPsOsmKGiCayBUjjn4Ej0TgUgZoSxjn78KQaXWcQ/FwxXPLmRdJ7bpwXe3aYzG/rA==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/batch-delegate": "^9.0.3",
-        "@graphql-tools/delegate": "^10.0.12",
-        "@graphql-tools/executor": "^1.2.8",
-        "@graphql-tools/merge": "^9.0.4",
-        "@graphql-tools/schema": "^10.0.4",
-        "@graphql-tools/utils": "^10.2.3",
-        "@graphql-tools/wrap": "^10.0.2",
+        "@graphql-tools/batch-delegate": "^9.0.8",
+        "@graphql-tools/delegate": "^10.0.26",
+        "@graphql-tools/executor": "^1.3.2",
+        "@graphql-tools/merge": "^9.0.8",
+        "@graphql-tools/schema": "^10.0.7",
+        "@graphql-tools/utils": "^10.5.5",
+        "@graphql-tools/wrap": "^10.0.10",
         "tslib": "^2.4.0",
         "value-or-promise": "^1.0.11"
       },
@@ -15476,12 +15258,12 @@
       }
     },
     "node_modules/@graphql-tools/stitch/node_modules/@graphql-tools/merge": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.7.tgz",
-      "integrity": "sha512-lbTrIuXIbUSmSumHkPRY1QX0Z8JEtmRhnIrkH7vkfeEmf0kNn/nCWvJwqokm5U7L+a+DA1wlRM4slIlbfXjJBA==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.8.tgz",
+      "integrity": "sha512-RG9NEp4fi0MoFi0te4ahqTMYuavQnXlpEZxxMomdCa6CI5tfekcVm/rsLF5Zt8O4HY+esDt9+4dCL+aOKvG79w==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.5.4",
+        "@graphql-tools/utils": "^10.5.5",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -15492,13 +15274,13 @@
       }
     },
     "node_modules/@graphql-tools/stitch/node_modules/@graphql-tools/schema": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.6.tgz",
-      "integrity": "sha512-EIJgPRGzpvDFEjVp+RF1zNNYIC36BYuIeZ514jFoJnI6IdxyVyIRDLx/ykgMdaa1pKQerpfdqDnsF4JnZoDHSQ==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.7.tgz",
+      "integrity": "sha512-Cz1o+rf9cd3uMgG+zI9HlM5mPlnHQUlk/UQRZyUlPDfT+944taLaokjvj7AI6GcOFVf4f2D11XthQp+0GY31jQ==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/merge": "^9.0.6",
-        "@graphql-tools/utils": "^10.5.4",
+        "@graphql-tools/merge": "^9.0.8",
+        "@graphql-tools/utils": "^10.5.5",
         "tslib": "^2.4.0",
         "value-or-promise": "^1.0.12"
       },
@@ -15510,9 +15292,9 @@
       }
     },
     "node_modules/@graphql-tools/stitch/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -15540,13 +15322,13 @@
       }
     },
     "node_modules/@graphql-tools/stitching-directives": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/stitching-directives/-/stitching-directives-3.1.2.tgz",
-      "integrity": "sha512-c+udtRV+9IROJhbanoWH15Esb65E9VK5/VTVkV7XbhTpK+Id2X9qAUMCYTxHjexAOnZ8H+hGQpfNAHKdZ4F1QQ==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/stitching-directives/-/stitching-directives-3.1.7.tgz",
+      "integrity": "sha512-SVnQeU9IlOAceNyR+7TRlNVaqeksRwkOYoCz0lx4Wds2L9K+u4cPeMpPVCXVuJ1Qcl1fgWpfQmBJZLzyVVRVCA==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/delegate": "^10.0.4",
-        "@graphql-tools/utils": "^10.0.13",
+        "@graphql-tools/delegate": "^10.0.26",
+        "@graphql-tools/utils": "^10.5.5",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -15557,9 +15339,9 @@
       }
     },
     "node_modules/@graphql-tools/stitching-directives/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -15644,13 +15426,14 @@
       }
     },
     "node_modules/@graphql-tools/wrap": {
-      "version": "10.0.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.5.tgz",
-      "integrity": "sha512-Cbr5aYjr3HkwdPvetZp1cpDWTGdD1Owgsb3z/ClzhmrboiK86EnQDxDvOJiQkDCPWE9lNBwj8Y4HfxroY0D9DQ==",
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.10.tgz",
+      "integrity": "sha512-3f1CUM+EpsALjt/HofzSWCLyfY65o9VpmqCTvIwVWGOnaP82cWbZE1Ytwb+t7yAZBKqCCc+1ginp+COIPD3ULw==",
+      "license": "MIT",
       "dependencies": {
-        "@graphql-tools/delegate": "^10.0.4",
-        "@graphql-tools/schema": "^10.0.3",
-        "@graphql-tools/utils": "^10.1.1",
+        "@graphql-tools/delegate": "^10.0.26",
+        "@graphql-tools/schema": "^10.0.7",
+        "@graphql-tools/utils": "^10.5.5",
         "tslib": "^2.4.0",
         "value-or-promise": "^1.0.12"
       },
@@ -15662,11 +15445,12 @@
       }
     },
     "node_modules/@graphql-tools/wrap/node_modules/@graphql-tools/merge": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.4.tgz",
-      "integrity": "sha512-MivbDLUQ+4Q8G/Hp/9V72hbn810IJDEZQ57F01sHnlrrijyadibfVhaQfW/pNH+9T/l8ySZpaR/DpL5i+ruZ+g==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.8.tgz",
+      "integrity": "sha512-RG9NEp4fi0MoFi0te4ahqTMYuavQnXlpEZxxMomdCa6CI5tfekcVm/rsLF5Zt8O4HY+esDt9+4dCL+aOKvG79w==",
+      "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.0.13",
+        "@graphql-tools/utils": "^10.5.5",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -15677,12 +15461,13 @@
       }
     },
     "node_modules/@graphql-tools/wrap/node_modules/@graphql-tools/schema": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.4.tgz",
-      "integrity": "sha512-HuIwqbKxPaJujox25Ra4qwz0uQzlpsaBOzO6CVfzB/MemZdd+Gib8AIvfhQArK0YIN40aDran/yi+E5Xf0mQww==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.7.tgz",
+      "integrity": "sha512-Cz1o+rf9cd3uMgG+zI9HlM5mPlnHQUlk/UQRZyUlPDfT+944taLaokjvj7AI6GcOFVf4f2D11XthQp+0GY31jQ==",
+      "license": "MIT",
       "dependencies": {
-        "@graphql-tools/merge": "^9.0.3",
-        "@graphql-tools/utils": "^10.2.1",
+        "@graphql-tools/merge": "^9.0.8",
+        "@graphql-tools/utils": "^10.5.5",
         "tslib": "^2.4.0",
         "value-or-promise": "^1.0.12"
       },
@@ -15694,12 +15479,13 @@
       }
     },
     "node_modules/@graphql-tools/wrap/node_modules/@graphql-tools/utils": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.2.2.tgz",
-      "integrity": "sha512-ueoplzHIgFfxhFrF4Mf/niU/tYHuO6Uekm2nCYU72qpI+7Hn9dA2/o5XOBvFXDk27Lp5VSvQY5WfmRbqwVxaYQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
+      "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
-        "cross-inspect": "1.0.0",
+        "cross-inspect": "1.0.1",
         "dset": "^3.1.2",
         "tslib": "^2.4.0"
       },
@@ -15708,6 +15494,18 @@
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/wrap/node_modules/cross-inspect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.1.tgz",
+      "integrity": "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@graphql-typed-document-node/core": {
@@ -15758,9 +15556,9 @@
       }
     },
     "node_modules/@graphql-yoga/plugin-defer-stream/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -19650,90 +19448,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@npmcli/agent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.2.2.tgz",
-      "integrity": "sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==",
-      "license": "ISC",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.1",
-        "lru-cache": "^10.0.1",
-        "socks-proxy-agent": "^8.0.3"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@npmcli/agent/node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@npmcli/agent/node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@npmcli/agent/node_modules/https-proxy-agent": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@npmcli/agent/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
-    },
-    "node_modules/@npmcli/fs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
-      "integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
-      "license": "ISC",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@npmcli/fs/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@nrwl/cypress": {
@@ -25071,9 +24785,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.1.tgz",
-      "integrity": "sha512-qnSqB2DQ9TPP96dl8cDubDvrUyWc0/sK81xHTK8eSUspzDM3bsewX903qclQFvVhgStjRWdC5bLb3kQqMkfV5A==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
+      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
@@ -25083,14 +24797,14 @@
       }
     },
     "node_modules/@opentelemetry/auto-instrumentations-node": {
-      "version": "0.50.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.50.0.tgz",
-      "integrity": "sha512-LqoSiWrOM4Cnr395frDHL4R/o5c2fuqqrqW8sZwhxvkasImmVlyL66YMPHllM2O5xVj2nP2ANUKHZSd293meZA==",
+      "version": "0.50.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.50.2.tgz",
+      "integrity": "sha512-l1JWvNp5gt5Fze8X68+zjzBqiviB5B8zeepsbfpFgdDxoCVjmixg8gcMt/AmqI9Qntw2qaeXah84V14fCbVuMg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/instrumentation-amqplib": "^0.42.0",
-        "@opentelemetry/instrumentation-aws-lambda": "^0.44.0",
+        "@opentelemetry/instrumentation-aws-lambda": "^0.45.0",
         "@opentelemetry/instrumentation-aws-sdk": "^0.44.0",
         "@opentelemetry/instrumentation-bunyan": "^0.41.0",
         "@opentelemetry/instrumentation-cassandra-driver": "^0.41.0",
@@ -25098,8 +24812,8 @@
         "@opentelemetry/instrumentation-cucumber": "^0.9.0",
         "@opentelemetry/instrumentation-dataloader": "^0.12.0",
         "@opentelemetry/instrumentation-dns": "^0.39.0",
-        "@opentelemetry/instrumentation-express": "^0.42.0",
-        "@opentelemetry/instrumentation-fastify": "^0.39.0",
+        "@opentelemetry/instrumentation-express": "^0.43.0",
+        "@opentelemetry/instrumentation-fastify": "^0.40.0",
         "@opentelemetry/instrumentation-fs": "^0.15.0",
         "@opentelemetry/instrumentation-generic-pool": "^0.39.0",
         "@opentelemetry/instrumentation-graphql": "^0.43.0",
@@ -25118,21 +24832,21 @@
         "@opentelemetry/instrumentation-mysql2": "^0.41.0",
         "@opentelemetry/instrumentation-nestjs-core": "^0.40.0",
         "@opentelemetry/instrumentation-net": "^0.39.0",
-        "@opentelemetry/instrumentation-pg": "^0.44.0",
+        "@opentelemetry/instrumentation-pg": "^0.45.1",
         "@opentelemetry/instrumentation-pino": "^0.42.0",
         "@opentelemetry/instrumentation-redis": "^0.42.0",
-        "@opentelemetry/instrumentation-redis-4": "^0.42.0",
+        "@opentelemetry/instrumentation-redis-4": "^0.42.1",
         "@opentelemetry/instrumentation-restify": "^0.41.0",
         "@opentelemetry/instrumentation-router": "^0.40.0",
         "@opentelemetry/instrumentation-socket.io": "^0.42.0",
         "@opentelemetry/instrumentation-tedious": "^0.14.0",
         "@opentelemetry/instrumentation-undici": "^0.6.0",
         "@opentelemetry/instrumentation-winston": "^0.40.0",
-        "@opentelemetry/resource-detector-alibaba-cloud": "^0.29.1",
-        "@opentelemetry/resource-detector-aws": "^1.6.1",
+        "@opentelemetry/resource-detector-alibaba-cloud": "^0.29.3",
+        "@opentelemetry/resource-detector-aws": "^1.6.2",
         "@opentelemetry/resource-detector-azure": "^0.2.11",
-        "@opentelemetry/resource-detector-container": "^0.4.1",
-        "@opentelemetry/resource-detector-gcp": "^0.29.11",
+        "@opentelemetry/resource-detector-container": "^0.4.3",
+        "@opentelemetry/resource-detector-gcp": "^0.29.12",
         "@opentelemetry/resources": "^1.24.0",
         "@opentelemetry/sdk-node": "^0.53.0"
       },
@@ -25143,16 +24857,23 @@
         "@opentelemetry/api": "^1.4.1"
       }
     },
-    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/api-logs": {
+    "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/exporter-trace-otlp-http": {
       "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
-      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.53.0.tgz",
+      "integrity": "sha512-m7F5ZTq+V9mKGWYpX8EnZ7NjoqAU7VemQ1E2HAG+W/u0wpY1x0OmbxAXfGKFHCspdJk8UKlwPGrpcB8nay3P8A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-exporter-base": "0.53.0",
+        "@opentelemetry/otlp-transformer": "0.53.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0"
       },
       "engines": {
         "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
       }
     },
     "node_modules/@opentelemetry/auto-instrumentations-node/node_modules/@opentelemetry/exporter-trace-otlp-proto": {
@@ -25304,18 +25025,6 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/api-logs": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
-      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/otlp-transformer": {
       "version": "0.53.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.53.0.tgz",
@@ -25371,18 +25080,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/api-logs": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
-      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/otlp-exporter-base": {
@@ -25460,18 +25157,6 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/api-logs": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
-      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/otlp-exporter-base": {
       "version": "0.53.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.53.0.tgz",
@@ -25546,18 +25231,6 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/api-logs": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
-      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/otlp-transformer": {
       "version": "0.53.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.53.0.tgz",
@@ -25597,16 +25270,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.53.0.tgz",
-      "integrity": "sha512-m7F5ZTq+V9mKGWYpX8EnZ7NjoqAU7VemQ1E2HAG+W/u0wpY1x0OmbxAXfGKFHCspdJk8UKlwPGrpcB8nay3P8A==",
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.52.1.tgz",
+      "integrity": "sha512-05HcNizx0BxcFKKnS5rwOV+2GevLTVIRA0tRgWYyw4yCgR53Ic/xk83toYKts7kbzcI+dswInUg/4s8oyA+tqg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.26.0",
-        "@opentelemetry/otlp-exporter-base": "0.53.0",
-        "@opentelemetry/otlp-transformer": "0.53.0",
-        "@opentelemetry/resources": "1.26.0",
-        "@opentelemetry/sdk-trace-base": "1.26.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1"
       },
       "engines": {
         "node": ">=14"
@@ -25615,70 +25288,61 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/api-logs": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
-      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.53.0.tgz",
-      "integrity": "sha512-UCWPreGQEhD6FjBaeDuXhiMf6kkBODF0ZQzrk/tuQcaVDJ+dDQ/xhJp192H9yWnKxVpEjFrSSLnpqmX4VwX+eA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "1.26.0",
-        "@opentelemetry/otlp-transformer": "0.53.0"
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.53.0.tgz",
-      "integrity": "sha512-rM0sDA9HD8dluwuBxLetUmoqGJKSAbWenwD65KY9iZhUxdBHRLrIdrABfNDP7aiTjcgK8XFyTn5fhDz7N+W6DA==",
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.53.0",
-        "@opentelemetry/core": "1.26.0",
-        "@opentelemetry/resources": "1.26.0",
-        "@opentelemetry/sdk-logs": "0.53.0",
-        "@opentelemetry/sdk-metrics": "1.26.0",
-        "@opentelemetry/sdk-trace-base": "1.26.0",
-        "protobufjs": "^7.3.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.53.0.tgz",
-      "integrity": "sha512-dhSisnEgIj/vJZXZV6f6KcTnyLDx/VuQ6l3ejuZpMpPlh9S1qMHiZU9NMmOkVkwwHkMy3G6mEBwdP23vUZVr4g==",
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+      "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.53.0",
-        "@opentelemetry/core": "1.26.0",
-        "@opentelemetry/resources": "1.26.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
@@ -25813,9 +25477,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-lambda": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.44.0.tgz",
-      "integrity": "sha512-6vmr7FJIuopZzsQjEQTp4xWtF6kBp7DhD7pPIN8FN0dKUKyuVraABIpgWjMfelaUPy4rTYUGkYqPluhG0wx8Dw==",
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.45.0.tgz",
+      "integrity": "sha512-22ZnmYftKjFoiqC1k3tu2AVKiXSZv+ohuHWk4V4MdJpPuNkadY624aDkv5BmwDeavDxVFgqE9nGgDM9s3Q94mg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.53.0",
@@ -25864,18 +25528,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-bunyan/node_modules/@opentelemetry/api-logs": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
-      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/instrumentation-cassandra-driver": {
@@ -25972,9 +25624,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-express": {
-      "version": "0.42.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.42.0.tgz",
-      "integrity": "sha512-YNcy7ZfGnLsVEqGXQPT+S0G1AE46N21ORY7i7yUQyfhGAL4RBjnZUqefMI0NwqIl6nGbr1IpF0rZGoN8Q7x12Q==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.43.0.tgz",
+      "integrity": "sha512-bxTIlzn9qPXJgrhz8/Do5Q3jIlqfpoJrSUtVGqH+90eM1v2PkPHc+SdE+zSqe4q9Y1UQJosmZ4N4bm7Zj/++MA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
@@ -25989,9 +25641,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fastify": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.39.0.tgz",
-      "integrity": "sha512-SS9uSlKcsWZabhBp2szErkeuuBDgxOUlllwkS92dVaWRnMmwysPhcEgHKB8rUe3BHg/GnZC1eo1hbTZv4YhfoA==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.40.0.tgz",
+      "integrity": "sha512-74qj4nG3zPtU7g2x4sm2T4R3/pBMyrYstTsqSZwdlhQk1SD4l8OSY9sPRX1qkhfxOuW3U4KZQAV/Cymb3fB6hg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
@@ -26313,13 +25965,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pg": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.44.0.tgz",
-      "integrity": "sha512-oTWVyzKqXud1BYEGX1loo2o4k4vaU1elr3vPO8NZolrBtFvQ34nx4HgUaexUDuEog00qQt+MLR5gws/p+JXMLQ==",
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.45.1.tgz",
+      "integrity": "sha512-GHUvPv7CQEK3RKHH3YAj6mjgJ3nZb6wRQS+t0yaRgKZzX2ggGsLN6OhRT04+IjqmMg9aIRUy1CzqwzgqAxjYbw==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/core": "^1.26.0",
         "@opentelemetry/instrumentation": "^0.53.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "1.27.0",
         "@opentelemetry/sql-common": "^0.40.1",
         "@types/pg": "8.6.1",
         "@types/pg-pool": "2.0.6"
@@ -26348,18 +26001,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-pino/node_modules/@opentelemetry/api-logs": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
-      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-redis": {
       "version": "0.42.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.42.0.tgz",
@@ -26378,9 +26019,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis-4": {
-      "version": "0.42.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.42.0.tgz",
-      "integrity": "sha512-NaD+t2JNcOzX/Qa7kMy68JbmoVIV37fT/fJYzLKu2Wwd+0NCxt+K2OOsOakA8GVg8lSpFdbx4V/suzZZ2Pvdjg==",
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.42.1.tgz",
+      "integrity": "sha512-xm17LJhDfQzQo4wkM/zFwh6wk3SNN/FBFGkscI9Kj4efrb/o5p8Z3yE6ldBPNdIZ6RAwg2p3DL7fvE3DuUDJWA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.53.0",
@@ -26492,30 +26133,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-winston/node_modules/@opentelemetry/api-logs": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
-      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation/node_modules/@opentelemetry/api-logs": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
-      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation/node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -26584,18 +26201,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/api-logs": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
-      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/otlp-exporter-base": {
@@ -26671,6 +26276,18 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-logs": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.1.tgz",
+      "integrity": "sha512-qnSqB2DQ9TPP96dl8cDubDvrUyWc0/sK81xHTK8eSUspzDM3bsewX903qclQFvVhgStjRWdC5bLb3kQqMkfV5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
@@ -26814,12 +26431,13 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-alibaba-cloud": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.29.1.tgz",
-      "integrity": "sha512-Qshebw6azBuKUqGkVgambZlLS6Xh+LCoLXep1oqW1RSzSOHQxGYDsPs99v8NzO65eJHHOu8wc2yKsWZQAgYsSw==",
+      "version": "0.29.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.29.3.tgz",
+      "integrity": "sha512-jdnG/cYItxwKGRj2n3YsJn1+j3QsMRUfaH/mQSj2b6yULo7bKO4turvASwxy3GuSDH55VwrK+F8oIbanJk69ng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/resources": "^1.0.0",
+        "@opentelemetry/core": "^1.26.0",
+        "@opentelemetry/resources": "^1.10.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "engines": {
@@ -26830,9 +26448,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-aws": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.6.1.tgz",
-      "integrity": "sha512-A/3lqx9xoew7sFi+AVUUVr6VgB7UJ5qqddkKR3gQk9hWLm1R7HUXVJG09cLcZ7DMNpX13DohPRGmHE/vp1vafw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.6.2.tgz",
+      "integrity": "sha512-xxT6PVmcBTtCo0rf4Bv/mnDMpVRITVt13bDX8mOqKVb0kr5EwIMabZS5EGJhXjP4nljrOIA7ZlOJgSX0Kehfkw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
@@ -26864,11 +26482,12 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-container": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.4.1.tgz",
-      "integrity": "sha512-v0bvO6RxYtbxvY/HwqrPQnZ4UtP4nBq4AOyS30iqV2vEtiLTY1gNTbNvTF1lwN/gg/g5CY1tRSrHcYODDOv0vw==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.4.4.tgz",
+      "integrity": "sha512-ZEN2mq7lIjQWJ8NTt1umtr6oT/Kb89856BOmESLSvgSHbIwOFYs7cSfSRH5bfiVw6dXTQAVbZA/wLgCHKrebJA==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/core": "^1.26.0",
         "@opentelemetry/resources": "^1.10.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
@@ -26880,13 +26499,13 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-gcp": {
-      "version": "0.29.11",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.29.11.tgz",
-      "integrity": "sha512-07wJx4nyxD/c2z3n70OQOg8fmoO/baTsq8uU+f7tZaehRNQx76MPkRbV2L902N40Z21SPIG8biUZ30OXE9tOIg==",
+      "version": "0.29.12",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.29.12.tgz",
+      "integrity": "sha512-liFG9XTaFVyY9YdFy4r2qVNa4a+Mg3k+XoWzzq2F+/xR0hFLfL0H4k7CsMW+T4Vl+1Cvc9W9WEVt5VCF4u/SYw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/resources": "^1.0.0",
+        "@opentelemetry/resources": "^1.10.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "gcp-metadata": "^6.0.0"
       },
@@ -26928,6 +26547,18 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/api-logs": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.1.tgz",
+      "integrity": "sha512-qnSqB2DQ9TPP96dl8cDubDvrUyWc0/sK81xHTK8eSUspzDM3bsewX903qclQFvVhgStjRWdC5bLb3kQqMkfV5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
@@ -27013,6 +26644,18 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/api-logs": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.1.tgz",
+      "integrity": "sha512-qnSqB2DQ9TPP96dl8cDubDvrUyWc0/sK81xHTK8eSUspzDM3bsewX903qclQFvVhgStjRWdC5bLb3kQqMkfV5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/context-async-hooks": {
       "version": "1.25.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.25.1.tgz",
@@ -27049,25 +26692,6 @@
         "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.25.1",
         "@opentelemetry/otlp-grpc-exporter-base": "0.52.1",
-        "@opentelemetry/otlp-transformer": "0.52.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.52.1.tgz",
-      "integrity": "sha512-05HcNizx0BxcFKKnS5rwOV+2GevLTVIRA0tRgWYyw4yCgR53Ic/xk83toYKts7kbzcI+dswInUg/4s8oyA+tqg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/otlp-exporter-base": "0.52.1",
         "@opentelemetry/otlp-transformer": "0.52.1",
         "@opentelemetry/resources": "1.25.1",
         "@opentelemetry/sdk-trace-base": "1.25.1"
@@ -35178,12 +34802,12 @@
       }
     },
     "node_modules/@whatwg-node/fetch": {
-      "version": "0.9.20",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.20.tgz",
-      "integrity": "sha512-bayE8tJBVw3QRg5vDqGIOfBmdxCV6HHUqCxMhZ1pOHukUk1TrfNH3tViivJErhmtSN0bbvjWaBQpJllAOpgSxA==",
+      "version": "0.9.21",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.21.tgz",
+      "integrity": "sha512-Wt0jPb+04JjobK0pAAN7mEHxVHcGA9HoP3OyCsZtyAecNQeADXCZ1MihFwVwjsgaRYuGVmNlsCmLxlG6mor8Gw==",
       "license": "MIT",
       "dependencies": {
-        "@whatwg-node/node-fetch": "^0.5.22",
+        "@whatwg-node/node-fetch": "^0.5.23",
         "urlpattern-polyfill": "^10.0.0"
       },
       "engines": {
@@ -35869,16 +35493,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-4.0.2.tgz",
-      "integrity": "sha512-ncSWAawFhKMJDTdoAeOV+jyW1VCMj5QIAwULIBV0SSR7B/RLPPEQiknKcg/RIIZlUQrxELpsxMiTUoAQ4sIUyg==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
     },
     "node_modules/arg": {
       "version": "5.0.2",
@@ -37647,115 +37261,6 @@
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/cacache": {
-      "version": "18.0.4",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.4.tgz",
-      "integrity": "sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==",
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^3.1.0",
-        "fs-minipass": "^3.0.0",
-        "glob": "^10.2.2",
-        "lru-cache": "^10.0.1",
-        "minipass": "^7.0.3",
-        "minipass-collect": "^2.0.1",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "p-map": "^4.0.0",
-        "ssri": "^10.0.0",
-        "tar": "^6.1.11",
-        "unique-filename": "^3.0.0"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/cacache/node_modules/fs-minipass": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
-      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/cacache/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/cacache/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/cacache/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
-    },
-    "node_modules/cacache/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/cacache/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/cache-content-type": {
@@ -40228,6 +39733,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.0.tgz",
       "integrity": "sha512-4PFfn4b5ZN6FMNGSZlyb7wUhuN8wvj8t/VQHZdM4JsDcruGJ8L2kf9zao98QIrBPFCpdk27qst/AGTl7pL3ypQ==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -43821,6 +43327,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -43830,12 +43337,6 @@
       "resolved": "https://registry.npmjs.org/eol/-/eol-0.9.1.tgz",
       "integrity": "sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg==",
       "dev": true
-    },
-    "node_modules/err-code": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-      "license": "MIT"
     },
     "node_modules/errno": {
       "version": "0.1.8",
@@ -45874,12 +45375,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/exponential-backoff": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz",
-      "integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==",
-      "license": "Apache-2.0"
-    },
     "node_modules/express": {
       "version": "4.20.0",
       "resolved": "https://registry.npmjs.org/express/-/express-4.20.0.tgz",
@@ -46354,10 +45849,10 @@
       }
     },
     "node_modules/fast-json-stringify/node_modules/ajv/node_modules/fast-uri": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.2.tgz",
-      "integrity": "sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row==",
-      "license": "MIT"
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
+      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-json-stringify/node_modules/fast-uri": {
       "version": "2.4.0",
@@ -47912,38 +47407,6 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gauge": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-5.0.2.tgz",
-      "integrity": "sha512-pMaFftXPtiGIHCJHdcUUx9Rby/rFT/Kkt3fIIGCs+9PMDIljSyRiqraTlxNtBReJRDfUefpa263RQ3vnp5G/LQ==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.3",
-        "console-control-strings": "^1.1.0",
-        "has-unicode": "^2.0.1",
-        "signal-exit": "^4.0.1",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.5"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/gauge/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gaxios": {
@@ -52224,25 +51687,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/ip-address/node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "license": "MIT"
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -52776,12 +52220,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/is-lambda": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-      "license": "MIT"
     },
     "node_modules/is-lower-case": {
       "version": "2.0.2",
@@ -54860,12 +54298,6 @@
         "bignumber.js": "^9.0.0"
       }
     },
-    "node_modules/json-bigint-patch": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/json-bigint-patch/-/json-bigint-patch-0.0.8.tgz",
-      "integrity": "sha512-xa0LTQsyaq8awYyZyuUsporWisZFiyqzxGW8CKM3t7oouf0GFAKYJnqAm6e9NLNBQOCtOLvy614DEiRX/rPbnA==",
-      "license": "MIT"
-    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -56719,47 +56151,6 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
-    },
-    "node_modules/make-fetch-happen": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
-      "integrity": "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==",
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/agent": "^2.0.0",
-        "cacache": "^18.0.0",
-        "http-cache-semantics": "^4.1.1",
-        "is-lambda": "^1.0.1",
-        "minipass": "^7.0.2",
-        "minipass-fetch": "^3.0.0",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.3",
-        "proc-log": "^4.2.0",
-        "promise-retry": "^2.0.1",
-        "ssri": "^10.0.0"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/proc-log": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
-      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -59927,89 +59318,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/minipass-collect": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
-      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/minipass-collect/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/minipass-fetch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.5.tgz",
-      "integrity": "sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==",
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.0.3",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.1.2"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.13"
-      }
-    },
-    "node_modules/minipass-fetch/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/minipass-flush": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minipass-pipeline": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-sized": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
-      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/minipass/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -61547,30 +60855,6 @@
         "node": ">= 6.13.0"
       }
     },
-    "node_modules/node-gyp": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-10.0.1.tgz",
-      "integrity": "sha512-gg3/bHehQfZivQVfqIyy8wTdSymF9yTyP4CJifK73imyNMU8AIGQE2pUa7dNWfmMeG9cDVF2eehiRMv0LC1iAg==",
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.0",
-        "exponential-backoff": "^3.1.1",
-        "glob": "^10.3.10",
-        "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^13.0.0",
-        "nopt": "^7.0.0",
-        "proc-log": "^3.0.0",
-        "semver": "^7.3.5",
-        "tar": "^6.1.2",
-        "which": "^4.0.0"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
     "node_modules/node-gyp-build": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
@@ -61592,265 +60876,11 @@
         "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
-    "node_modules/node-gyp/node_modules/abbrev": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
-      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/node-gyp/node_modules/isexe": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/node-gyp/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/node-gyp/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/node-gyp/node_modules/nopt": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
-      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "^2.0.0"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-gyp/node_modules/which": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true
-    },
-    "node_modules/node-libcurl": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/node-libcurl/-/node-libcurl-4.0.0.tgz",
-      "integrity": "sha512-v+u+OgSq6ldvf8MrdjieAy/mv8WeTN94nrTomh62zhItF2HH0Ckin/QEqs8+35DWyYrE5nBM2480UtWVXktzbQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mapbox/node-pre-gyp": "1.0.11",
-        "env-paths": "2.2.0",
-        "nan": "2.18.0",
-        "node-gyp": "10.0.1",
-        "npmlog": "7.0.1",
-        "rimraf": "5.0.5",
-        "tslib": "2.6.2"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/node-libcurl/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/node-libcurl/node_modules/env-paths": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/node-libcurl/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/node-libcurl/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/node-libcurl/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/node-libcurl/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/node-libcurl/node_modules/nan": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
-      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
-      "license": "MIT"
-    },
-    "node_modules/node-libcurl/node_modules/rimraf": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
-      "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^10.3.7"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/node-libcurl/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "license": "0BSD"
     },
     "node_modules/node-machine-id": {
       "version": "1.1.12",
@@ -64815,22 +63845,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC"
-    },
-    "node_modules/npmlog": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-7.0.1.tgz",
-      "integrity": "sha512-uJ0YFk/mCQpLBt+bxN88AKd+gyqZvZDbtiNxk6Waqcj2aPRyfVx8ITawkyQynxUagInjdYT1+qj4NfA5KJJUxg==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "^4.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^5.0.0",
-        "set-blocking": "^2.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
     },
     "node_modules/nprogress": {
       "version": "0.2.0",
@@ -68092,6 +67106,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
       "integrity": "sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -68152,28 +67167,6 @@
       "dev": true,
       "engines": {
         "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/promise-retry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/promise-retry/node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/prompts": {
@@ -73849,16 +72842,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
     "node_modules/snake-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
@@ -73947,46 +72930,6 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^9.0.5",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
-      "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.1",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/socks-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/sonic-boom": {
@@ -74275,27 +73218,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ssri": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
-      "integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/ssri/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/stable": {
@@ -76957,30 +75879,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/unique-filename": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
-      "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/unique-slug": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
-      "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/unique-stream": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
@@ -77756,12 +76654,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/uWebSockets.js": {
-      "version": "20.49.0",
-      "resolved": "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#442087c0a01bf146acb7386910739ec81df06700",
-      "license": "Apache-2.0",
-      "optional": true
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,6 @@
     "next-logger": "^4.0.0",
     "next-plausible": "^3.12.0",
     "next-seo": "^6.4.0",
-    "node-libcurl": "^4.0.0",
     "nodemailer": "^6.9.9",
     "notistack": "^3.0.1",
     "pino": "^9.3.2",


### PR DESCRIPTION
This pull request includes updates to the Docker image version and the removal of an unused package from `package.json`. These changes aim to keep dependencies up-to-date and clean up the project.

Dependency updates:

* [`apps/api-gateway/Dockerfile`](diffhunk://#diff-948323ae264c213f9ef92d63425f2f77b495ad8804cf520ebaf4f8153f883b40L5-R5): Updated the Docker image version from `ghcr.io/ardatan/hive-gateway:1.0.5` to `ghcr.io/ardatan/hive-gateway:1.2.0`.

Code cleanup:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L154): Removed the unused `node-libcurl` package to clean up dependencies.