### PR TITLE
fix: part3 container error on watch

### DIFF
--- a/apps/watch/__generated__/GetVideoContainerAndVideoContent.ts
+++ b/apps/watch/__generated__/GetVideoContainerAndVideoContent.ts
@@ -9,91 +9,6 @@ import { VideoLabel, VideoVariantDownloadQuality } from "./globalTypes";
 // GraphQL query operation: GetVideoContainerAndVideoContent
 // ====================================================
 
-export interface GetVideoContainerAndVideoContent_container_images {
-  __typename: "CloudflareImage";
-  mobileCinematicHigh: string | null;
-}
-
-export interface GetVideoContainerAndVideoContent_container_imageAlt {
-  __typename: "VideoImageAlt";
-  value: string;
-}
-
-export interface GetVideoContainerAndVideoContent_container_snippet {
-  __typename: "VideoSnippet";
-  value: string;
-}
-
-export interface GetVideoContainerAndVideoContent_container_description {
-  __typename: "VideoDescription";
-  value: string;
-}
-
-export interface GetVideoContainerAndVideoContent_container_studyQuestions {
-  __typename: "VideoStudyQuestion";
-  value: string;
-}
-
-export interface GetVideoContainerAndVideoContent_container_title {
-  __typename: "VideoTitle";
-  value: string;
-}
-
-export interface GetVideoContainerAndVideoContent_container_variant_downloads {
-  __typename: "VideoVariantDownload";
-  quality: VideoVariantDownloadQuality;
-  size: number;
-  url: string;
-}
-
-export interface GetVideoContainerAndVideoContent_container_variant_language_name {
-  __typename: "LanguageName";
-  value: string;
-  primary: boolean;
-}
-
-export interface GetVideoContainerAndVideoContent_container_variant_language {
-  __typename: "Language";
-  id: string;
-  name: GetVideoContainerAndVideoContent_container_variant_language_name[];
-}
-
-export interface GetVideoContainerAndVideoContent_container_variant {
-  __typename: "VideoVariant";
-  id: string;
-  duration: number;
-  hls: string | null;
-  downloads: GetVideoContainerAndVideoContent_container_variant_downloads[];
-  language: GetVideoContainerAndVideoContent_container_variant_language;
-  /**
-   * slug is a permanent link to the video variant.
-   */
-  slug: string;
-  subtitleCount: number;
-}
-
-export interface GetVideoContainerAndVideoContent_container {
-  __typename: "Video";
-  id: string;
-  label: VideoLabel;
-  images: GetVideoContainerAndVideoContent_container_images[];
-  imageAlt: GetVideoContainerAndVideoContent_container_imageAlt[];
-  snippet: GetVideoContainerAndVideoContent_container_snippet[];
-  description: GetVideoContainerAndVideoContent_container_description[];
-  studyQuestions: GetVideoContainerAndVideoContent_container_studyQuestions[];
-  title: GetVideoContainerAndVideoContent_container_title[];
-  variant: GetVideoContainerAndVideoContent_container_variant | null;
-  variantLanguagesCount: number;
-  /**
-   * slug is a permanent link to the video.
-   */
-  slug: string;
-  /**
-   * the number value of the amount of children on a video
-   */
-  childrenCount: number;
-}
-
 export interface GetVideoContainerAndVideoContent_content_images {
   __typename: "CloudflareImage";
   mobileCinematicHigh: string | null;
@@ -179,9 +94,94 @@ export interface GetVideoContainerAndVideoContent_content {
   childrenCount: number;
 }
 
+export interface GetVideoContainerAndVideoContent_container_images {
+  __typename: "CloudflareImage";
+  mobileCinematicHigh: string | null;
+}
+
+export interface GetVideoContainerAndVideoContent_container_imageAlt {
+  __typename: "VideoImageAlt";
+  value: string;
+}
+
+export interface GetVideoContainerAndVideoContent_container_snippet {
+  __typename: "VideoSnippet";
+  value: string;
+}
+
+export interface GetVideoContainerAndVideoContent_container_description {
+  __typename: "VideoDescription";
+  value: string;
+}
+
+export interface GetVideoContainerAndVideoContent_container_studyQuestions {
+  __typename: "VideoStudyQuestion";
+  value: string;
+}
+
+export interface GetVideoContainerAndVideoContent_container_title {
+  __typename: "VideoTitle";
+  value: string;
+}
+
+export interface GetVideoContainerAndVideoContent_container_variant_downloads {
+  __typename: "VideoVariantDownload";
+  quality: VideoVariantDownloadQuality;
+  size: number;
+  url: string;
+}
+
+export interface GetVideoContainerAndVideoContent_container_variant_language_name {
+  __typename: "LanguageName";
+  value: string;
+  primary: boolean;
+}
+
+export interface GetVideoContainerAndVideoContent_container_variant_language {
+  __typename: "Language";
+  id: string;
+  name: GetVideoContainerAndVideoContent_container_variant_language_name[];
+}
+
+export interface GetVideoContainerAndVideoContent_container_variant {
+  __typename: "VideoVariant";
+  id: string;
+  duration: number;
+  hls: string | null;
+  downloads: GetVideoContainerAndVideoContent_container_variant_downloads[];
+  language: GetVideoContainerAndVideoContent_container_variant_language;
+  /**
+   * slug is a permanent link to the video variant.
+   */
+  slug: string;
+  subtitleCount: number;
+}
+
+export interface GetVideoContainerAndVideoContent_container {
+  __typename: "Video";
+  id: string;
+  label: VideoLabel;
+  images: GetVideoContainerAndVideoContent_container_images[];
+  imageAlt: GetVideoContainerAndVideoContent_container_imageAlt[];
+  snippet: GetVideoContainerAndVideoContent_container_snippet[];
+  description: GetVideoContainerAndVideoContent_container_description[];
+  studyQuestions: GetVideoContainerAndVideoContent_container_studyQuestions[];
+  title: GetVideoContainerAndVideoContent_container_title[];
+  variant: GetVideoContainerAndVideoContent_container_variant | null;
+  variantLanguagesCount: number;
+  /**
+   * slug is a permanent link to the video.
+   */
+  slug: string;
+  /**
+   * the number value of the amount of children on a video
+   */
+  childrenCount: number;
+}
+
 export interface GetVideoContainerAndVideoContent {
-  container: GetVideoContainerAndVideoContent_container;
   content: GetVideoContainerAndVideoContent_content;
+  container: GetVideoContainerAndVideoContent_container;
 }
 
 export interface GetVideoContainerAndVideoContentVariables {

--- a/apps/watch/pages/watch/[part1]/[part2]/[part3].tsx
+++ b/apps/watch/pages/watch/[part1]/[part2]/[part3].tsx
@@ -25,10 +25,10 @@ export const GET_VIDEO_CONTAINER_AND_VIDEO_CONTENT = gql`
     $contentId: ID!
     $languageId: ID
   ) {
-    container: video(id: $containerId, idType: slug) {
+    content: video(id: $contentId, idType: slug) {
       ...VideoContentFields
     }
-    content: video(id: $contentId, idType: slug) {
+    container: video(id: $containerId, idType: slug) {
       ...VideoContentFields
     }
   }
@@ -97,6 +97,8 @@ export const getStaticProps: GetStaticProps<Part3PageProps> = async (
     }
 
   const client = createApolloClient()
+  console.log('containerId', `${containerId}/${languageId}`)
+  console.log('contentId', `${contentId}/${languageId}`)
   try {
     const { data } = await client.query<GetVideoContainerAndVideoContent>({
       query: GET_VIDEO_CONTAINER_AND_VIDEO_CONTENT,

--- a/apps/watch/pages/watch/[part1]/[part2]/[part3].tsx
+++ b/apps/watch/pages/watch/[part1]/[part2]/[part3].tsx
@@ -97,8 +97,6 @@ export const getStaticProps: GetStaticProps<Part3PageProps> = async (
     }
 
   const client = createApolloClient()
-  console.log('containerId', `${containerId}/${languageId}`)
-  console.log('contentId', `${contentId}/${languageId}`)
   try {
     const { data } = await client.query<GetVideoContainerAndVideoContent>({
       query: GET_VIDEO_CONTAINER_AND_VIDEO_CONTENT,


### PR DESCRIPTION
This pull request includes changes to the GraphQL query and debugging improvements in the `apps/watch/pages/watch/[part1]/[part2]/[part3].tsx` file. The most important changes include swapping the `container` and `content` fields in the GraphQL query and adding console logs for debugging purposes.

GraphQL Query Changes:

* `apps/watch/pages/watch/[part1]/[part2]/[part3].tsx`: Swapped the `container` and `content` fields in the `GET_VIDEO_CONTAINER_AND_VIDEO_CONTENT` GraphQL query. (`[apps/watch/pages/watch/[part1]/[part2]/[part3].tsxL28-R31](diffhunk://#diff-3d9a5bd894937ba419a23bf72d1927fdeedf18d46d31c8ff0fba30f8205ec7e5L28-R31)`)

Debugging Improvements:

* `apps/watch/pages/watch/[part1]/[part2]/[part3].tsx`: Added console logs to print `containerId` and `contentId` with `languageId` for debugging purposes. (`[apps/watch/pages/watch/[part1]/[part2]/[part3].tsxR100-R101](diffhunk://#diff-3d9a5bd894937ba419a23bf72d1927fdeedf18d46d31c8ff0fba30f8205ec7e5R100-R101)`)