### PR TITLE
test: run watch monitoring redirect test separately

### DIFF
--- a/apps/watch-e2e/src/monitoring/watch-redirection.monitor.ts
+++ b/apps/watch-e2e/src/monitoring/watch-redirection.monitor.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@playwright/test'
+
+/*  
+Check https://arc.gt/s/1_jf-0-0/529 is redirected to
+https://www.jesusfilm.org/watch/jesus.html/english.html 
+*/
+
+test('Check https://arc.gt/s/1_jf-0-0/529 is redirected to https://www.jesusfilm.org/watch/jesus.html/english.html', async ({
+  page
+}) => {
+  const response = await page.goto('https://arc.gt/s/1_jf-0-0/529')
+  expect(response?.status()).toEqual(200)
+  expect(response?.url()).toEqual(
+    'https://www.jesusfilm.org/watch/jesus.html/english.html'
+  )
+})

--- a/apps/watch-e2e/src/monitoring/watch.monitor.ts
+++ b/apps/watch-e2e/src/monitoring/watch.monitor.ts
@@ -15,16 +15,3 @@ test('Homepage checks', async ({ page }) => {
 
   await expect(videoTitle).toHaveText('Jesus Calms the StormChapter1:59')
 })
-
-/*  
-Check https://arc.gt/s/1_jf-0-0/529 is redirected to
-https://www.jesusfilm.org/watch/jesus.html/english.html 
-*/
-
-test('Check redirect', async ({ page }) => {
-  const response = await page.goto('https://arc.gt/s/1_jf-0-0/529')
-  expect(response?.status()).toEqual(200)
-  expect(response?.url()).toEqual(
-    'https://www.jesusfilm.org/watch/jesus.html/english.html'
-  )
-})

--- a/package-lock.json
+++ b/package-lock.json
@@ -247,7 +247,7 @@
         "babel-jest": "29.7.0",
         "babel-loader": "^9.1.3",
         "chalk": "^4.1.2",
-        "checkly": "^4.7.0",
+        "checkly": "^4.9.1",
         "chromatic": "^7.1.0",
         "copy-webpack-plugin": "^10.2.4",
         "cosmiconfig": "^8.3.4",

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "babel-jest": "29.7.0",
     "babel-loader": "^9.1.3",
     "chalk": "^4.1.2",
-    "checkly": "^4.7.0",
+    "checkly": "^4.9.1",
     "chromatic": "^7.1.0",
     "copy-webpack-plugin": "^10.2.4",
     "cosmiconfig": "^8.3.4",


### PR DESCRIPTION
# Description
Running watch monitoring redirect separately. So, we can identify which test failed during alert.
### Issue

_Provide a brief summary of why this task is needed_

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

_Provide a detailed description of how exactly this task will be accomplished. This can be something technical. What specific steps will be taken to achieve the goal? This should include details on service integration, job logic, implementation, etc._

# External Changes

_If you have made changes to external services, need to add additional values to Doppler, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc._

# Additional information

_Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc._
