### PR TITLE
fix: enable reinitialize on dialog

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Toolbar/JourneyDetails/JourneyDetailsDialog/JourneyDetailsDialog.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/JourneyDetails/JourneyDetailsDialog/JourneyDetailsDialog.tsx
@@ -132,6 +132,7 @@ export function JourneyDetailsDialog({
           }}
           onSubmit={handleUpdateJourneyDetails}
           validationSchema={titleSchema}
+          enableReinitialize
         >
           {({
             values,


### PR DESCRIPTION
# Description

### Issue

When editing a title and description using the 3-dot menu, the changes do not appear in the text box when using the joint title and description editor. For instance, after making an update, the new title (e.g., "edit 2") appears correctly in the header, but the text box below only shows the previous version (e.g., "edit")

### Solution

The issue occurs because the initial values in the form are not updating when changes are made. Adding enableReinitialize to the form ensures the values are updated automatically whenever a change is detected.

### Additional information

[Enable Reinitialize](https://formik.org/docs/api/formik#enablereinitialize-boolean) - Controls whether Formik should reset the form if `initial values` changes
