### PR TITLE
fix: detect step not found on ssr

### DIFF
--- a/apps/journeys/pages/[hostname]/[journeySlug]/[stepSlug].tsx
+++ b/apps/journeys/pages/[hostname]/[journeySlug]/[stepSlug].tsx
@@ -39,10 +39,6 @@ function HostStepPage({ journey, locale, rtl }: StepPageProps): ReactElement {
       (block.slug === stepSlug || block.id === stepSlug)
   )
 
-  if (stepBlock == null) {
-    void router.push('/404')
-  }
-
   return (
     <>
       <Head>
@@ -117,6 +113,23 @@ export const getStaticProps: GetStaticProps<StepPageProps> = async (
       }
     })
     const { rtl, locale } = getJourneyRTL(data.journey)
+
+    const stepBlock = data.journey?.blocks?.find(
+      (block) =>
+        block.__typename === 'StepBlock' &&
+        (block.slug === context.params?.stepSlug ||
+          block.id === context.params?.stepSlug)
+    )
+
+    if (stepBlock == null)
+      return {
+        redirect: {
+          destination: `/${data.journey.slug}`,
+          permanent: false
+        },
+        revalidate: 1
+      }
+
     return {
       props: {
         ...(await serverSideTranslations(
@@ -140,7 +153,8 @@ export const getStaticProps: GetStaticProps<StepPageProps> = async (
             i18nConfig
           ))
         },
-        notFound: true
+        notFound: true,
+        revalidate: 1
       }
     }
     throw e

--- a/apps/journeys/pages/home/[journeySlug]/[stepSlug].tsx
+++ b/apps/journeys/pages/home/[journeySlug]/[stepSlug].tsx
@@ -128,7 +128,8 @@ export const getStaticProps: GetStaticProps<StepPageProps> = async (
         redirect: {
           destination: `/${data.journey.slug}`,
           permanent: false
-        }
+        },
+        revalidate: 1
       }
 
     return {
@@ -154,7 +155,8 @@ export const getStaticProps: GetStaticProps<StepPageProps> = async (
             i18nConfig
           ))
         },
-        notFound: true
+        notFound: true,
+        revalidate: 1
       }
     }
     throw e

--- a/apps/journeys/pages/home/[journeySlug]/[stepSlug].tsx
+++ b/apps/journeys/pages/home/[journeySlug]/[stepSlug].tsx
@@ -39,10 +39,6 @@ function StepPage({ journey, locale, rtl }: StepPageProps): ReactElement {
       (block.slug === stepSlug || block.id === stepSlug)
   )
 
-  if (stepBlock == null) {
-    void router.push('/404')
-  }
-
   return (
     <>
       <Head>
@@ -119,6 +115,22 @@ export const getStaticProps: GetStaticProps<StepPageProps> = async (
       }
     })
     const { rtl, locale } = getJourneyRTL(data.journey)
+
+    const stepBlock = data.journey?.blocks?.find(
+      (block) =>
+        block.__typename === 'StepBlock' &&
+        (block.slug === context.params?.stepSlug ||
+          block.id === context.params?.stepSlug)
+    )
+
+    if (stepBlock == null)
+      return {
+        redirect: {
+          destination: `/${data.journey.slug}`,
+          permanent: false
+        }
+      }
+
     return {
       props: {
         ...(await serverSideTranslations(


### PR DESCRIPTION
This pull request to `apps/journeys/pages/home/[journeySlug]/[stepSlug].tsx` includes changes to improve the handling of invalid step slugs and to add revalidation for static props. The most important changes include moving the step block validation to `getStaticProps` and adding revalidation logic.

Improvements to step block validation:

* `apps/journeys/pages/home/[journeySlug]/[stepSlug].tsx`: Removed the step block validation from the `StepPage` component. ([apps/journeys/pages/home/[journeySlug]/[stepSlug].tsxL42-L45](diffhunk://#diff-ec3d15b9703e427a4d071e770d0ddacd02fabd900324a43a787d9a90ff02dba8L42-L45))
* `apps/journeys/pages/home/[journeySlug]/[stepSlug].tsx`: Added step block validation in `getStaticProps` to redirect to the journey's main page if the step block is not found. ([apps/journeys/pages/home/[journeySlug]/[stepSlug].tsxR118-R134](diffhunk://#diff-ec3d15b9703e427a4d071e770d0ddacd02fabd900324a43a787d9a90ff02dba8R118-R134))

Revalidation logic:

* `apps/journeys/pages/home/[journeySlug]/[stepSlug].tsx`: Added `revalidate: 1` to the return object in `getStaticProps` to ensure the page is revalidated every second. ([apps/journeys/pages/home/[journeySlug]/[stepSlug].tsxL145-R159](diffhunk://#diff-ec3d15b9703e427a4d071e770d0ddacd02fabd900324a43a787d9a90ff02dba8L145-R159))