### PR TITLE
fix: prevent zoom when editing blocks on ios safari

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/InlineEditWrapper/ButtonEdit/ButtonEdit.tsx
@@ -125,9 +125,6 @@ export function ButtonEdit({
           fullWidth
           multiline
           autoFocus
-          inputRef={(ref) => {
-            if (ref != null) ref.focus()
-          }}
           onFocus={(e) =>
             e.currentTarget.setSelectionRange(
               e.currentTarget.value.length,

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/InlineEditWrapper/InlineEditInput/InlineEditInput.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Canvas/InlineEditWrapper/InlineEditInput/InlineEditInput.tsx
@@ -1,6 +1,7 @@
 import InputBase, { InputBaseProps } from '@mui/material/InputBase'
 import { SimplePaletteColorOptions, styled } from '@mui/material/styles'
 
+import { isIOSTouchScreen as checkIsIOSTouchScreen } from '@core/shared/ui/deviceUtils'
 import { adminTheme } from '@core/shared/ui/themes/journeysAdmin/theme'
 
 interface StyledInputProps extends InputBaseProps {}
@@ -8,17 +9,20 @@ interface StyledInputProps extends InputBaseProps {}
 const adminPrimaryColor = adminTheme.palette
   .primary as SimplePaletteColorOptions
 
-export const InlineEditInput = styled(InputBase)<StyledInputProps>(() => ({
-  '& .MuiInputBase-input': {
-    textAlign: 'inherit',
-    textTransform: 'inherit'
-  },
-  color: 'inherit',
-  fontSize: 'inherit',
-  fontWeight: 'inherit',
-  fontFamily: 'inherit',
-  lineHeight: 'inherit',
-  letterSpacing: 'inherit',
-  padding: '0px',
-  caretColor: adminPrimaryColor.main
-}))
+export const InlineEditInput = styled(InputBase)<StyledInputProps>(() => {
+  const isIOSTouchScreen = checkIsIOSTouchScreen()
+  return {
+    '& .MuiInputBase-input': {
+      textAlign: 'inherit',
+      textTransform: 'inherit'
+    },
+    color: 'inherit',
+    fontSize: isIOSTouchScreen ? '1rem' : 'inherit',
+    fontWeight: 'inherit',
+    fontFamily: 'inherit',
+    lineHeight: 'inherit',
+    letterSpacing: 'inherit',
+    padding: '0px',
+    caretColor: adminPrimaryColor.main
+  }
+})


### PR DESCRIPTION
# Description

### Issue

tapping on a button element is zooming in on the button. Editing it's properties keeps bringing up the keyboard

### Solution

remove unnecessary ref.focus() as focus i already being controlled by autofocus prop. this programmatic focus was bringing up the keyboard on every state change.

on IOS - set the font-size to be relative to the document, preventing safari from zooming in on focus
