### PR TITLE
fix: add protocol check

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/JourneyAppearance/Chat/ChatOption/Details/Details.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/JourneyAppearance/Chat/ChatOption/Details/Details.spec.tsx
@@ -84,6 +84,56 @@ describe('Details', () => {
     await waitFor(() => expect(result).toHaveBeenCalled())
   })
 
+  it('should update link with a protocol', async () => {
+    const props = {
+      ...defaultProps,
+      currentPlatform: MessagePlatform.telegram
+    }
+
+    const result = jest.fn(() => ({
+      data: {
+        chatButtonUpdate: {
+          __typename: 'ChatButton',
+          id: 'chat.id',
+          link: 'newlink.com',
+          platform: MessagePlatform.telegram
+        }
+      }
+    }))
+
+    const { getByRole } = render(
+      <MockedProvider
+        mocks={[
+          {
+            request: {
+              query: JOURNEY_CHAT_BUTTON_UPDATE,
+              variables: {
+                chatButtonUpdateId: 'chat.id',
+                journeyId: 'journeyId',
+                input: {
+                  link: 'https://newlink.com',
+                  platform: MessagePlatform.telegram
+                }
+              }
+            },
+            result
+          }
+        ]}
+      >
+        <SnackbarProvider>
+          <Details {...props} />
+        </SnackbarProvider>
+      </MockedProvider>
+    )
+
+    fireEvent.change(getByRole('textbox'), {
+      target: { value: 'https://newlink.com' }
+    })
+    fireEvent.blur(getByRole('textbox'))
+
+    await waitFor(() => expect(result).toHaveBeenCalled())
+  })
+
   it('should update platform', async () => {
     const props = {
       ...defaultProps,

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/JourneyAppearance/Chat/ChatOption/Details/Details.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/JourneyAppearance/Chat/ChatOption/Details/Details.tsx
@@ -261,11 +261,17 @@ export function Details({
   ): Promise<void> {
     let input
     if (type === 'link') {
+      const hasProtocolPrefix = /^\w+:\/\//
+      const link =
+        value != null && hasProtocolPrefix.test(value)
+          ? value
+          : `https://${value}`
+
       input = {
-        link: value,
+        link,
         platform: currentPlatform
       }
-      setCurrentLink(value ?? '')
+      setCurrentLink(link ?? '')
     } else {
       input = {
         link: currentLink,
@@ -323,14 +329,12 @@ export function Details({
             </Select>
           </FormControl>
         )}
-
         <TextFieldForm
           id={currentPlatform as string}
           label={t('Paste URL here')}
           initialValue={currentLink}
           onSubmit={async (value) => await handleUpdate('link', value)}
         />
-
         {helperInfo != null && (
           <Typography variant="caption">{helperInfo}</Typography>
         )}

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/JourneyAppearance/Chat/ChatOption/Details/Details.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/JourneyAppearance/Chat/ChatOption/Details/Details.tsx
@@ -73,6 +73,7 @@ interface DetailsProps {
   setCurrentLink: (value: string) => void
   helperInfo?: string
   enableIconSelect: boolean
+  active?: boolean
 }
 
 interface MessagePlatformOptions {
@@ -89,7 +90,8 @@ export function Details({
   setCurrentPlatform,
   setCurrentLink,
   helperInfo,
-  enableIconSelect
+  enableIconSelect,
+  active
 }: DetailsProps): ReactElement {
   const { enqueueSnackbar } = useSnackbar()
   const { t } = useTranslation('apps-journeys-admin')
@@ -263,7 +265,9 @@ export function Details({
     if (type === 'link') {
       const hasProtocolPrefix = /^\w+:\/\//
       const link =
-        value != null && hasProtocolPrefix.test(value)
+        value === ''
+          ? ''
+          : hasProtocolPrefix.test(value ?? '')
           ? value
           : `https://${value}`
 

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/JourneyAppearance/Chat/ChatOption/Details/Details.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/JourneyAppearance/Chat/ChatOption/Details/Details.tsx
@@ -73,7 +73,6 @@ interface DetailsProps {
   setCurrentLink: (value: string) => void
   helperInfo?: string
   enableIconSelect: boolean
-  active?: boolean
 }
 
 interface MessagePlatformOptions {
@@ -90,8 +89,7 @@ export function Details({
   setCurrentPlatform,
   setCurrentLink,
   helperInfo,
-  enableIconSelect,
-  active
+  enableIconSelect
 }: DetailsProps): ReactElement {
   const { enqueueSnackbar } = useSnackbar()
   const { t } = useTranslation('apps-journeys-admin')
@@ -268,8 +266,8 @@ export function Details({
         value === ''
           ? ''
           : hasProtocolPrefix.test(value ?? '')
-            ? value
-            : `https://${value}`
+          ? value
+          : `https://${value}`
 
       input = {
         link,

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/JourneyAppearance/Chat/ChatOption/Details/Details.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/JourneyAppearance/Chat/ChatOption/Details/Details.tsx
@@ -268,8 +268,8 @@ export function Details({
         value === ''
           ? ''
           : hasProtocolPrefix.test(value ?? '')
-          ? value
-          : `https://${value}`
+            ? value
+            : `https://${value}`
 
       input = {
         link,

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/JourneyAppearance/Chat/ChatOption/Details/Details.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/JourneyAppearance/Chat/ChatOption/Details/Details.tsx
@@ -266,8 +266,8 @@ export function Details({
         value === ''
           ? ''
           : hasProtocolPrefix.test(value ?? '')
-          ? value
-          : `https://${value}`
+            ? value
+            : `https://${value}`
 
       input = {
         link,


### PR DESCRIPTION
# Description

### Issue

Adding URLs to the chat platforms accepts the string as is and doesn't support adding the HTTPS protocol. Causing the user to visit your.nextstep.is/[chat link]

### Solution

Add a protocol check before Chat button link update. If it already has a protocol proceed to update. Otherwise we are to append the HTTPS protocol to the URL

