### PR TITLE
fix: edition seed

### DIFF
--- a/apps/api-media/src/workers/bigQuery/importers/videoSubtitles/videoSubtitles.spec.ts
+++ b/apps/api-media/src/workers/bigQuery/importers/videoSubtitles/videoSubtitles.spec.ts
@@ -43,6 +43,11 @@ describe('bigQuery/importers/videoSubtitles', () => {
         srtSrc: 'mockSrtSrc',
         edition: null
       })
+      expect(prismaMock.videoEdition.upsert).toHaveBeenCalledWith({
+        where: { id: 'base' },
+        update: {},
+        create: { id: 'base' }
+      })
       expect(prismaMock.videoSubtitle.upsert).toHaveBeenCalledWith({
         where: {
           videoId_edition_languageId: {
@@ -103,6 +108,17 @@ describe('bigQuery/importers/videoSubtitles', () => {
           edition: 'ct'
         }
       ])
+      expect(prismaMock.videoEdition.upsert).toHaveBeenCalledWith({
+        where: { id: 'base' },
+        update: {},
+        create: { id: 'base' }
+      })
+      expect(prismaMock.videoEdition.upsert).toHaveBeenCalledWith({
+        where: { id: 'ct' },
+        update: {},
+        create: { id: 'ct' }
+      })
+      expect(prismaMock.videoEdition.upsert).toHaveBeenCalledTimes(2)
       expect(prismaMock.videoSubtitle.createMany).toHaveBeenCalledWith({
         data: [
           {

--- a/apps/api-media/src/workers/bigQuery/importers/videoVariants/videoVariants.spec.ts
+++ b/apps/api-media/src/workers/bigQuery/importers/videoVariants/videoVariants.spec.ts
@@ -70,6 +70,11 @@ describe('bigQuery/importers/videoVariants', () => {
         someValue: 'otherValue',
         edition: 'mockEdition'
       })
+      expect(prismaMock.videoEdition.upsert).toHaveBeenCalledWith({
+        where: { id: 'mockEdition' },
+        update: {},
+        create: { id: 'mockEdition' }
+      })
       expect(prismaMock.videoVariant.upsert).toHaveBeenCalledWith({
         where: { id: '1' },
         create: {
@@ -149,6 +154,12 @@ describe('bigQuery/importers/videoVariants', () => {
           edition: 'mockEdition'
         }
       ])
+      expect(prismaMock.videoEdition.upsert).toHaveBeenCalledWith({
+        where: { id: 'mockEdition' },
+        update: {},
+        create: { id: 'mockEdition' }
+      })
+      expect(prismaMock.videoEdition.upsert).toHaveBeenCalledTimes(1)
       expect(prismaMock.videoVariant.createMany).toHaveBeenCalledWith({
         data: [
           {

--- a/apps/api-media/src/workers/seed/service/edition/edition.spec.ts
+++ b/apps/api-media/src/workers/seed/service/edition/edition.spec.ts
@@ -6,9 +6,26 @@ describe('seed/edition', () => {
   it('should seed editions', async () => {
     prismaMock.videoEdition.findFirst.mockResolvedValue(null)
     prismaMock.videoEdition.createMany.mockImplementation()
+    prismaMock.$queryRaw
+      .mockResolvedValueOnce([
+        {
+          edition: 'base'
+        },
+        {
+          edition: 'abc'
+        }
+      ])
+      .mockResolvedValueOnce([
+        {
+          edition: 'base'
+        },
+        {
+          edition: 'def'
+        }
+      ])
     await seedEditions()
     expect(prismaMock.videoEdition.createMany).toHaveBeenCalledWith({
-      data: EDITIONS.map((edition) => ({
+      data: [...EDITIONS, 'abc', 'def'].map((edition) => ({
         id: edition
       }))
     })


### PR DESCRIPTION
# Description

### Issue

Edition seed could miss outliers or prevent new biquery insertions

### Solution

Fix edition seed for upcoming prisma references
