### PR TITLE
feat: grid empty icon for blank social appearance

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Toolbar/Toolbar.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Toolbar.tsx
@@ -29,7 +29,6 @@ import {
 } from '@core/journeys/ui/EditorProvider'
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import { useFlags } from '@core/shared/ui/FlagsProvider'
-import ThumbsUpIcon from '@core/shared/ui/icons/ThumbsUp'
 
 import { GetPlausibleJourneyFlowViewed } from '../../../../__generated__/GetPlausibleJourneyFlowViewed'
 import {
@@ -47,6 +46,7 @@ import { CommandUndoItem } from './Items/CommandUndoItem'
 import { PreviewItem } from './Items/PreviewItem'
 import { JourneyDetails } from './JourneyDetails'
 import { Menu } from './Menu'
+import GridEmptyIcon from '@core/shared/ui/icons/GridEmpty'
 
 const JourneyDetailsDialog = dynamic(
   async () =>
@@ -241,7 +241,7 @@ export function Toolbar({ user }: ToolbarProps): ReactElement {
               sx={{ display: { xs: 'none', sm: 'flex' } }}
             >
               {journey?.primaryImageBlock?.src == null ? (
-                <ThumbsUpIcon color="error" />
+                <GridEmptyIcon color="error" />
               ) : (
                 <Image
                   src={journey.primaryImageBlock.src}


### PR DESCRIPTION
# Description

### Issue

Icon for empty social media apperance on toolbar changed for better intuitiveness.

### Solution

Icon ThumbsUpIcon changed to EmptyGridIcon. 

