### PR TITLE
fix: page view events after menu card

### DIFF
--- a/.storybook/static/mockServiceWorker.js
+++ b/.storybook/static/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.5.2'
+const PACKAGE_VERSION = '2.6.0'
 const INTEGRITY_CHECKSUM = '07a8241b182f8a246a7cd39894799a9e'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/apps/journeys/src/components/WebView/WebView.tsx
+++ b/apps/journeys/src/components/WebView/WebView.tsx
@@ -47,7 +47,7 @@ export function WebView({ blocks, stepBlock }: WebViewProps): ReactElement {
     blockHistoryVar([stepBlock])
     // multiple re-renders causes block history to be incorrect so do not pass in 'blocks' variable to deps array
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [setTreeBlocks])
+  }, [stepBlock, setTreeBlocks])
 
   useEffect(() => {
     if ((variant === 'default' || variant === 'embed') && journey != null) {


### PR DESCRIPTION
# Description

### Issue

Analytics incorrect after menu card

### Solution

Refactor a useEffect to update the blockHistory so the page changes are detected for analytics

