### PR TITLE
refactor: linear gradient for OverlayContent

### DIFF
--- a/libs/journeys/ui/src/components/Card/ExpandedCover/ExpandedCover.tsx
+++ b/libs/journeys/ui/src/components/Card/ExpandedCover/ExpandedCover.tsx
@@ -23,7 +23,7 @@ export function ExpandedCover({
   backgroundBlur,
   hasFullscreenVideo = false
 }: ExpandedCoverProps): ReactElement {
-  const { variant } = useJourney()
+  const { journey, variant } = useJourney()
   const enableVerticalScroll = {
     overflowY: 'scroll',
     // Hide on Firefox https://caniuse.com/?search=scrollbar-width
@@ -74,7 +74,7 @@ export function ExpandedCover({
           justifyContent="center"
           sx={{
             flexGrow: 1,
-            pt: { xs: 10, sm: 8 },
+            pt: journey?.website === true ? 0 : { xs: 10, sm: 8 },
             ...enableVerticalScroll
           }}
         >

--- a/libs/journeys/ui/src/components/Card/OverlayContent/OverlayContent.tsx
+++ b/libs/journeys/ui/src/components/Card/OverlayContent/OverlayContent.tsx
@@ -95,7 +95,7 @@ export function OverlayContent({
       data-testid="CardOverlayContent"
       sx={{
         ...enableVerticalScroll,
-        // ...topBottomEdgeFadeEffect,
+        ...topBottomEdgeFadeEffect,
         ...conditionalWebsiteStyles,
         ...mobileNotchPadding,
         ...sx

--- a/libs/journeys/ui/src/components/Card/OverlayContent/OverlayContent.tsx
+++ b/libs/journeys/ui/src/components/Card/OverlayContent/OverlayContent.tsx
@@ -4,6 +4,7 @@ import { ReactElement, ReactNode } from 'react'
 
 import { useJourney } from '../../../libs/JourneyProvider'
 import { getFooterMobileSpacing } from '../utils/getFooterElements'
+import { showHeader } from '../utils/getHeaderElements'
 
 interface OverlayContentProps {
   children: ReactNode
@@ -73,15 +74,30 @@ export function OverlayContent({
     mb: { xs: footerMobileSpacing, sm: 10 }
   }
 
+  const hasHeader = showHeader(journey, variant)
+
+  const conditionalWebsiteStyles =
+    journey?.website === true
+      ? {
+          mb: 0,
+          '& > *': {
+            '&:first-child': { mt: hasHeader ? 20 : 6 },
+            '&:last-child': { mb: 20 }
+          }
+        }
+      : {
+          ...topBottomMarginsOnContent,
+          ...footerSpacing
+        }
+
   return (
     <Box
       data-testid="CardOverlayContent"
       sx={{
         ...enableVerticalScroll,
-        ...topBottomEdgeFadeEffect,
-        ...topBottomMarginsOnContent,
+        // ...topBottomEdgeFadeEffect,
+        ...conditionalWebsiteStyles,
         ...mobileNotchPadding,
-        ...footerSpacing,
         ...sx
       }}
     >

--- a/libs/journeys/ui/src/components/Card/OverlayContent/OverlayContent.tsx
+++ b/libs/journeys/ui/src/components/Card/OverlayContent/OverlayContent.tsx
@@ -29,8 +29,14 @@ export function OverlayContent({
 
   const topBottomEdgeFadeEffect: SxProps = !hasFullscreenVideo
     ? {
-        WebkitMask: `linear-gradient(transparent 0%, #0000001a 4%, #000000 8%, #000000 90%, #0000001a 98%, transparent 100%)`,
-        mask: `linear-gradient(transparent 0%, #0000001a 4%, #000000 8%, #000000 90%, #0000001a 98%, transparent 100%)`
+        WebkitMask: {
+          xs: `linear-gradient(transparent 0px, #0000001a 12px, #000000 32px, #000000 calc(100% - 24px), #0000001a calc(100% - 8px), transparent 100%)`,
+          lg: `linear-gradient(transparent 0px, #0000001a 12px, #000000 32px, #000000 calc(100% - 32px), #0000001a calc(100% - 12px), transparent 100%)`
+        },
+        mask: {
+          xs: `linear-gradient(transparent 0px, #0000001a 12px, #000000 32px, #000000 calc(100% - 24px), #0000001a calc(100% - 8px), transparent 100%)`,
+          lg: `linear-gradient(transparent 0px, #0000001a 12px, #000000 32px, #000000 calc(100% - 32px), #0000001a calc(100% - 12px), transparent 100%)`
+        }
       }
     : {}
 

--- a/libs/journeys/ui/src/components/Card/utils/getHeaderElements/getHeaderElements.spec.ts
+++ b/libs/journeys/ui/src/components/Card/utils/getHeaderElements/getHeaderElements.spec.ts
@@ -1,5 +1,6 @@
-import { showHeader } from '.'
 import { defaultJourney } from '../../../TemplateView/data'
+
+import { showHeader } from '.'
 
 describe('getHeaderElements', () => {
   describe('showHeader', () => {

--- a/libs/journeys/ui/src/components/Card/utils/getHeaderElements/getHeaderElements.spec.ts
+++ b/libs/journeys/ui/src/components/Card/utils/getHeaderElements/getHeaderElements.spec.ts
@@ -1,0 +1,40 @@
+import { showHeader } from '.'
+import { defaultJourney } from '../../../TemplateView/data'
+
+describe('getHeaderElements', () => {
+  describe('showHeader', () => {
+    it('should return false if journey or variant are nullish', () => {
+      expect(showHeader(undefined, undefined)).toBe(false)
+    })
+
+    it('should return true if variant is admin', () => {
+      expect(showHeader(defaultJourney, 'admin')).toBe(true)
+    })
+
+    it('should return false if logo and menu are missing', () => {
+      expect(showHeader(defaultJourney, 'default')).toBe(false)
+    })
+
+    it('should return true if logo or menu are present', () => {
+      const journey = {
+        ...defaultJourney,
+        logoImageBlock: {
+          __typename: 'ImageBlock' as const,
+          id: 'logoImageBlockId',
+          src: 'https://example.com/logo.png',
+          alt: 'Logo',
+          parentBlockId: null,
+          parentOrder: null,
+          height: 10,
+          width: 10,
+          blurhash: 'blurhash',
+          scale: 1,
+          focalLeft: 50,
+          focalTop: 50
+        }
+      }
+
+      expect(showHeader(journey, 'default')).toBe(true)
+    })
+  })
+})

--- a/libs/journeys/ui/src/components/Card/utils/getHeaderElements/getHeaderElements.ts
+++ b/libs/journeys/ui/src/components/Card/utils/getHeaderElements/getHeaderElements.ts
@@ -1,0 +1,14 @@
+import { JourneyFields } from '../../../../libs/JourneyProvider/__generated__/JourneyFields'
+
+export function showHeader(
+  journey?: JourneyFields,
+  variant?: 'admin' | 'embed' | 'default'
+): boolean {
+  if (journey == null || variant == null) return false
+
+  if (variant === 'admin') {
+    return true
+  } else {
+    return journey.menuButtonIcon != null || journey.logoImageBlock != null
+  }
+}

--- a/libs/journeys/ui/src/components/Card/utils/getHeaderElements/index.ts
+++ b/libs/journeys/ui/src/components/Card/utils/getHeaderElements/index.ts
@@ -1,0 +1,1 @@
+export { showHeader } from './getHeaderElements'


### PR DESCRIPTION
# Description

### Issue
The linear gradient could cover the last block for a journey card in certain cases. This issue mainly applies cards with the last element being a button, causing the button to look disabled.

### Solution
I updated the linear gradient to use a fixed height instead of a dynamic width of the container. The new fixed widths should match the margins applied to the first and last elements inside `OverlayContent` so that the gradient will only be visible on overflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled an edge fade effect on card overlays for enhanced visual transitions.
	- Introduced dynamic header visibility, ensuring headers are displayed only when pertinent.
	- Adjusted expanded cover layout spacing based on content settings for a more tailored user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->