### PR TITLE
fix: pass  jwt to backend

### DIFF
--- a/apps/videos-admin/src/app/[locale]/layout.tsx
+++ b/apps/videos-admin/src/app/[locale]/layout.tsx
@@ -23,7 +23,7 @@ export default async function LocaleLayout({
       <body>
         <AuthProvider user={user}>
           <NextIntlClientProvider messages={messages}>
-            <ApolloProvider>
+            <ApolloProvider user={user}>
               <AppRouterCacheProvider>{children}</AppRouterCacheProvider>
             </ApolloProvider>
           </NextIntlClientProvider>


### PR DESCRIPTION
# Description

### Issue

anonymous user token were being passed to gql endpoints instead of actual user token, causing forbidden error.

[Link to Linear Todo](https://linear.app/jesus-film-project/issue/ENG-1318/jwt-token-not-being-passed-to-backend-properly)

### Solution

removed signInAnonymously function and replaced with getting the user from auth context and passing to apollo provider context to be sent as headers on every request.
