### PR TITLE
feat: add helper text for react flow controls

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/Controls/Controls.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/Controls/Controls.spec.tsx
@@ -1,0 +1,36 @@
+import { MockedProvider } from '@apollo/client/testing'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { ReactFlowProvider } from 'reactflow'
+
+import { Controls } from '.'
+
+describe('Controls', () => {
+  it('should render', () => {
+    render(
+      <MockedProvider>
+        <ReactFlowProvider>
+          <Controls handleReset={jest.fn()} />
+        </ReactFlowProvider>
+      </MockedProvider>
+    )
+
+    expect(screen.getByTestId('Plus1Icon')).toBeInTheDocument()
+    expect(screen.getByTestId('DashIcon')).toBeInTheDocument()
+    expect(screen.getByTestId('Maximise2Icon')).toBeInTheDocument()
+    expect(screen.getByTestId('ArrowRefresh6Icon')).toBeInTheDocument()
+  })
+
+  it('should call reset function on click', () => {
+    const handleReset = jest.fn()
+    render(
+      <MockedProvider>
+        <ReactFlowProvider>
+          <Controls handleReset={handleReset} />
+        </ReactFlowProvider>
+      </MockedProvider>
+    )
+
+    fireEvent.click(screen.getByTestId('ArrowRefresh6Icon'))
+    expect(handleReset).toHaveBeenCalled()
+  })
+})

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/Controls/Controls.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/Controls/Controls.tsx
@@ -1,0 +1,43 @@
+import Tooltip from '@mui/material/Tooltip'
+import { useTranslation } from 'next-i18next'
+import { ReactElement } from 'react'
+import { Controls as Control, ControlButton, useReactFlow } from 'reactflow'
+
+import ArrowRefresh6Icon from '@core/shared/ui/icons/ArrowRefresh6'
+import Dash from '@core/shared/ui/icons/Dash'
+import Maximise2 from '@core/shared/ui/icons/Maximise2'
+import Plus1 from '@core/shared/ui/icons/Plus1'
+
+interface ControlsProps {
+  handleReset: (boolean?) => Promise<void>
+}
+
+export function Controls({ handleReset }: ControlsProps): ReactElement {
+  const { zoomIn, zoomOut, fitView } = useReactFlow()
+  const { t } = useTranslation('apps-journeys-admin')
+
+  return (
+    <Control showInteractive={false} showFitView={false} showZoom={false}>
+      <Tooltip title={t('Zoom in')} arrow placement="right">
+        <ControlButton onClick={() => zoomIn()}>
+          <Plus1 />
+        </ControlButton>
+      </Tooltip>
+      <Tooltip title={t('Zoom out')} arrow placement="right">
+        <ControlButton onClick={() => zoomOut()}>
+          <Dash />
+        </ControlButton>
+      </Tooltip>
+      <Tooltip title={t('Recenter')} arrow placement="right">
+        <ControlButton onClick={() => fitView()}>
+          <Maximise2 />
+        </ControlButton>
+      </Tooltip>
+      <Tooltip title={t('Reset layout')} arrow placement="right">
+        <ControlButton onClick={async () => await handleReset()}>
+          <ArrowRefresh6Icon />
+        </ControlButton>
+      </Tooltip>
+    </Control>
+  )
+}

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/Controls/index.ts
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/Controls/index.ts
@@ -1,0 +1,1 @@
+export { Controls } from './Controls'

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/JourneyFlow.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/JourneyFlow.tsx
@@ -14,8 +14,6 @@ import {
 } from 'react'
 import {
   Background,
-  ControlButton,
-  Controls,
   type Edge,
   type Node,
   type NodeDragHandler,
@@ -40,7 +38,6 @@ import { isActionBlock } from '@core/journeys/ui/isActionBlock'
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import { searchBlocks } from '@core/journeys/ui/searchBlocks'
 import { useFlags } from '@core/shared/ui/FlagsProvider'
-import ArrowRefresh6Icon from '@core/shared/ui/icons/ArrowRefresh6'
 
 import type {
   GetStepBlocksWithPosition,
@@ -50,6 +47,7 @@ import type {
 import { useStepBlockPositionUpdateMutation } from '../../../../libs/useStepBlockPositionUpdateMutation'
 
 import { AnalyticsOverlaySwitch } from './AnalyticsOverlaySwitch'
+import { Controls } from './Controls'
 import { CustomEdge } from './edges/CustomEdge'
 import { ReferrerEdge } from './edges/ReferrerEdge'
 import { StartEdge } from './edges/StartEdge'
@@ -533,13 +531,7 @@ export function JourneyFlow(): ReactElement {
                 </>
               </Panel>
             )}
-            <Controls showInteractive={false}>
-              <ControlButton
-                onClick={async () => await allBlockPositionUpdate()}
-              >
-                <ArrowRefresh6Icon />
-              </ControlButton>
-            </Controls>
+            <Controls handleReset={allBlockPositionUpdate} />
           </>
         )}
         <Background


### PR DESCRIPTION
# Description

React flow control icons (especially the recenter view, and reset layout, are not intuitive for users. Added tooltip indicators for users to see which buttons are which. 

### Solution

Wrap all control buttons in tooltips. 
Refactor controls component (which was abstracted as a Reactflow component) and extract individual buttons so that they could be wrapped in tooltips. 
