### PR TITLE
fix: seo issues on videos page

### DIFF
--- a/apps/watch/pages/watch/[part1]/[part2].tsx
+++ b/apps/watch/pages/watch/[part1]/[part2].tsx
@@ -4,9 +4,6 @@ import dynamic from 'next/dynamic'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { SnackbarProvider } from 'notistack'
 import type { ReactElement } from 'react'
-import { InstantSearch } from 'react-instantsearch'
-
-import { useInstantSearchClient } from '@core/journeys/ui/algolia/InstantSearchProvider'
 
 import type {
   GetVideoContent,
@@ -51,23 +48,18 @@ const DynamicVideoContainerPage = dynamic(
 )
 
 export default function Part2Page({ content }: Part2PageProps): ReactElement {
-  const searchClient = useInstantSearchClient()
-  const indexName = process.env.NEXT_PUBLIC_ALGOLIA_INDEX ?? ''
-
   return (
-    <InstantSearch searchClient={searchClient} indexName={indexName} insights>
-      <SnackbarProvider>
-        <LanguageProvider>
-          <VideoProvider value={{ content }}>
-            {content.variant?.hls != null ? (
-              <DynamicVideoContentPage />
-            ) : (
-              <DynamicVideoContainerPage />
-            )}
-          </VideoProvider>
-        </LanguageProvider>
-      </SnackbarProvider>
-    </InstantSearch>
+    <SnackbarProvider>
+      <LanguageProvider>
+        <VideoProvider value={{ content }}>
+          {content.variant?.hls != null ? (
+            <DynamicVideoContentPage />
+          ) : (
+            <DynamicVideoContainerPage />
+          )}
+        </VideoProvider>
+      </LanguageProvider>
+    </SnackbarProvider>
   )
 }
 

--- a/apps/watch/src/components/VideoCard/VideoCard.tsx
+++ b/apps/watch/src/components/VideoCard/VideoCard.tsx
@@ -9,17 +9,12 @@ import Typography from '@mui/material/Typography'
 import Image from 'next/image'
 import NextLink from 'next/link'
 import { useTranslation } from 'next-i18next'
-import type { ReactElement } from 'react'
+import type { MouseEvent, ReactElement } from 'react'
 
-import { useAlgoliaVideos } from '@core/journeys/ui/algolia/useAlgoliaVideos'
 import { secondsToTimeFormat } from '@core/shared/ui/timeFormat'
 
 import { VideoLabel } from '../../../__generated__/globalTypes'
 import type { VideoChildFields } from '../../../__generated__/VideoChildFields'
-import {
-  type CoreVideo,
-  transformAlgoliaVideos as transformItems
-} from '../../libs/algolia/transformAlgoliaVideos'
 import { getLabelDetails } from '../../libs/utils/getLabelDetails/getLabelDetails'
 
 interface VideoCardProps {
@@ -29,6 +24,7 @@ interface VideoCardProps {
   index?: number
   active?: boolean
   imageSx?: SxProps
+  onClick?: (videoId?: string) => (event: MouseEvent<HTMLElement>) => void
 }
 
 const ImageButton = styled(ButtonBase)(() => ({
@@ -70,7 +66,8 @@ export function VideoCard({
   variant = 'expanded',
   index,
   active,
-  imageSx
+  imageSx,
+  onClick: handleClick
 }: VideoCardProps): ReactElement {
   const { t } = useTranslation('apps-watch')
 
@@ -79,14 +76,6 @@ export function VideoCard({
     video?.childrenCount ?? 0
   )
   const href = getSlug(containerSlug, video?.label, video?.variant?.slug)
-
-  const { items, sendEvent } = useAlgoliaVideos<CoreVideo>({ transformItems })
-  const item = items.filter((item) => item.id === video?.id)
-
-  const handleClick = (event): void => {
-    event.stopPropagation()
-    sendEvent('click', item, 'Video Clicked')
-  }
 
   return (
     <NextLink href={href} passHref legacyBehavior>
@@ -97,7 +86,7 @@ export function VideoCard({
         sx={{ pointerEvents: video != null ? 'auto' : 'none' }}
         aria-label="VideoCard"
         data-testid={video != null ? `VideoCard-${video.id}` : 'VideoCard'}
-        onClick={handleClick}
+        onClick={handleClick?.(video?.id)}
       >
         <Stack spacing={3}>
           <ImageButton

--- a/apps/watch/src/components/VideoCard/VideoCard.tsx
+++ b/apps/watch/src/components/VideoCard/VideoCard.tsx
@@ -24,7 +24,7 @@ interface VideoCardProps {
   index?: number
   active?: boolean
   imageSx?: SxProps
-  onClick?: (videoId?: string) => (event: MouseEvent<HTMLElement>) => void
+  onClick?: (videoId?: string) => (event: MouseEvent) => void
 }
 
 const ImageButton = styled(ButtonBase)(() => ({

--- a/apps/watch/src/components/VideoGrid/AlgoliaVideoGrid/AlgoliaVideoGrid.tsx
+++ b/apps/watch/src/components/VideoGrid/AlgoliaVideoGrid/AlgoliaVideoGrid.tsx
@@ -20,7 +20,7 @@ export function AlgoliaVideoGrid(props: VideoGridProps): ReactElement {
 
   const handleClick =
     (videoId?: string) =>
-    (event: MouseEvent<HTMLAnchorElement>): void => {
+    (event: MouseEvent): void => {
       event.stopPropagation()
       if (videoId == null) return
       const item = algoliaVideos.filter((item) => item.id === videoId)

--- a/apps/watch/src/components/VideoGrid/AlgoliaVideoGrid/AlgoliaVideoGrid.tsx
+++ b/apps/watch/src/components/VideoGrid/AlgoliaVideoGrid/AlgoliaVideoGrid.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react'
+import type { MouseEvent, ReactElement } from 'react'
 
 import { useAlgoliaVideos } from '@core/journeys/ui/algolia/useAlgoliaVideos'
 
@@ -14,8 +14,20 @@ export function AlgoliaVideoGrid(props: VideoGridProps): ReactElement {
     showMore,
     isLastPage,
     loading,
-    noResults
+    noResults,
+    sendEvent
   } = useAlgoliaVideos<CoreVideo>({ transformItems })
+
+  const handleClick =
+    (videoId?: string) =>
+    (event: MouseEvent<HTMLAnchorElement>): void => {
+      event.stopPropagation()
+      if (videoId == null) return
+      const item = algoliaVideos.filter((item) => item.id === videoId)
+      sendEvent('click', item, 'Video Clicked')
+      console.log('I got called', item)
+    }
+
   return (
     <VideoGrid
       videos={algoliaVideos}
@@ -23,6 +35,7 @@ export function AlgoliaVideoGrid(props: VideoGridProps): ReactElement {
       showMore={showMore}
       hasNextPage={!isLastPage}
       hasNoResults={noResults}
+      onCardClick={handleClick}
       {...props}
     />
   )

--- a/apps/watch/src/components/VideoGrid/AlgoliaVideoGrid/AlgoliaVideoGrid.tsx
+++ b/apps/watch/src/components/VideoGrid/AlgoliaVideoGrid/AlgoliaVideoGrid.tsx
@@ -25,7 +25,6 @@ export function AlgoliaVideoGrid(props: VideoGridProps): ReactElement {
       if (videoId == null) return
       const item = algoliaVideos.filter((item) => item.id === videoId)
       sendEvent('click', item, 'Video Clicked')
-      console.log('I got called', item)
     }
 
   return (

--- a/apps/watch/src/components/VideoGrid/VideoGrid.tsx
+++ b/apps/watch/src/components/VideoGrid/VideoGrid.tsx
@@ -2,7 +2,7 @@ import AddRounded from '@mui/icons-material/AddRounded'
 import LoadingButton from '@mui/lab/LoadingButton'
 import Box from '@mui/material/Box'
 import Grid from '@mui/material/Grid'
-import type { ComponentProps, ReactElement } from 'react'
+import type { ComponentProps, MouseEvent, ReactElement } from 'react'
 
 import { EmptySearch } from '@core/journeys/ui/EmptySearch'
 
@@ -18,6 +18,7 @@ export interface VideoGridProps {
   showMore?: () => void
   hasNextPage?: boolean
   hasNoResults?: boolean
+  onCardClick?: (videoId?: string) => (event: MouseEvent<HTMLElement>) => void
 }
 
 export function VideoGrid({
@@ -28,7 +29,8 @@ export function VideoGrid({
   loading = false,
   showMore,
   hasNextPage = true,
-  hasNoResults = false
+  hasNoResults = false,
+  onCardClick
 }: VideoGridProps): ReactElement {
   return (
     <Grid
@@ -44,6 +46,7 @@ export function VideoGrid({
               video={video}
               containerSlug={containerSlug}
               variant={variant}
+              onClick={onCardClick}
             />
           </Grid>
         ))}

--- a/apps/watch/src/components/VideoGrid/VideoGrid.tsx
+++ b/apps/watch/src/components/VideoGrid/VideoGrid.tsx
@@ -18,7 +18,7 @@ export interface VideoGridProps {
   showMore?: () => void
   hasNextPage?: boolean
   hasNoResults?: boolean
-  onCardClick?: (videoId?: string) => (event: MouseEvent<HTMLElement>) => void
+  onCardClick?: (videoId?: string) => (event: MouseEvent) => void
 }
 
 export function VideoGrid({


### PR DESCRIPTION
# Description

The Single Video/Container page SEO is impacted due to the recent Algolia changes. The issue arises because VideoCard uses `sendEvent` (from Algolia) for tracking video selections, requiring pages that uses VideoCard to be wrapped in `InstantSearchProvider` - even non-search pages.

## Solution

Added an `onClick` prop to VideoCard to handle tracking externally, removing the direct dependency on Algolia's provider. This preserves analytics on search page while fixing SEO in the Single Video/Container Page.