### PR TITLE
fix: disable study questions when not in edit mode

### DIFF
--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Metadata/StudyQuestionsList/StudyQuestionsList.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Metadata/StudyQuestionsList/StudyQuestionsList.tsx
@@ -10,6 +10,7 @@ import Plus2 from '@core/shared/ui/icons/Plus2'
 import { OrderedList } from '../../../../../../../../components/OrderedList'
 import { OrderedItem } from '../../../../../../../../components/OrderedList/OrderedItem'
 import { GetAdminVideo_AdminVideo_StudyQuestions as StudyQuestions } from '../../../../../../../../libs/useAdminVideo/useAdminVideo'
+import { useEdit } from '../../../_EditProvider'
 import { Section } from '../../Section'
 
 export const UPDATE_STUDY_QUESTION_ORDER = graphql(`
@@ -35,6 +36,9 @@ interface StudyQuestionsListProps {
 export function StudyQuestionsList({
   studyQuestions
 }: StudyQuestionsListProps): ReactElement | null {
+  const {
+    state: { isEdit }
+  } = useEdit()
   const t = useTranslations()
   const [studyQuestionItems, setStudyQuestionItems] = useState(studyQuestions)
   const [updateStudyQuestionOrder] = useMutation(UPDATE_STUDY_QUESTION_ORDER)
@@ -82,11 +86,15 @@ export function StudyQuestionsList({
   return (
     <Section
       title={t('Study Questions')}
-      action={{
-        label: t('Add Question'),
-        startIcon: <Plus2 />,
-        onClick: () => alert('Create new Question')
-      }}
+      action={
+        isEdit
+          ? {
+              label: t('Add Question'),
+              startIcon: <Plus2 />,
+              onClick: () => alert('Create new Question')
+            }
+          : undefined
+      }
     >
       {totalQuestions > 0 ? (
         <OrderedList

--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/VideoView.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/VideoView.tsx
@@ -13,6 +13,7 @@ import { ReactElement, SyntheticEvent, useState } from 'react'
 
 import { PublishedChip } from '../../../../../../components/PublishedChip'
 import { useAdminVideo } from '../../../../../../libs/useAdminVideo'
+import { useEdit } from '../_EditProvider'
 
 import { Children } from './Children'
 import { Editions } from './Editions'
@@ -23,17 +24,20 @@ import { TabLabel } from './Tabs/TabLabel'
 import { Variants } from './Variants'
 
 export function VideoView(): ReactElement {
+  const {
+    state: { isEdit },
+    dispatch
+  } = useEdit()
   const t = useTranslations()
   const params = useParams<{ videoId: string; locale: string }>()
   const [tabValue, setTabValue] = useState(0)
-  const [isEdit, setIsEdit] = useState(false)
   const { data, loading } = useAdminVideo({
     variables: { videoId: params?.videoId as string }
   })
   const video = data?.adminVideo
 
   function handleEdit(): void {
-    setIsEdit(!isEdit)
+    dispatch({ type: 'SetEditStateAction', isEdit: !isEdit })
   }
 
   function handleTabChange(e: SyntheticEvent, newValue: number): void {

--- a/apps/videos-admin/src/components/OrderedList/OrderedItem/Actions/Actions.tsx
+++ b/apps/videos-admin/src/components/OrderedList/OrderedItem/Actions/Actions.tsx
@@ -6,12 +6,17 @@ import { MouseEvent, ReactElement, useState } from 'react'
 
 import More from '@core/shared/ui/icons/More'
 
+import { useEdit } from '../../../../app/[locale]/(dashboard)/videos/[videoId]/_EditProvider'
+
 interface ActionsProps {
   id: string
   actions: Array<{ label: string; handler: (id: string) => void }>
 }
 
 export function Actions({ id, actions }: ActionsProps): ReactElement {
+  const {
+    state: { isEdit }
+  } = useEdit()
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
   const open = Boolean(anchorEl)
 
@@ -27,6 +32,7 @@ export function Actions({ id, actions }: ActionsProps): ReactElement {
   return (
     <Box>
       <IconButton
+        disabled={!isEdit}
         aria-label="ordered-item-actions"
         size="small"
         onClick={handleClick}

--- a/apps/videos-admin/src/components/OrderedList/OrderedItem/DropDown/DropDown.tsx
+++ b/apps/videos-admin/src/components/OrderedList/OrderedItem/DropDown/DropDown.tsx
@@ -6,6 +6,8 @@ import Typography from '@mui/material/Typography'
 import { useTranslations } from 'next-intl'
 import { ReactElement } from 'react'
 
+import { useEdit } from '../../../../app/[locale]/(dashboard)/videos/[videoId]/_EditProvider'
+
 interface DropdownProps {
   id: string
   idx: number
@@ -19,6 +21,9 @@ export function DropDown({
   total,
   onChange
 }: DropdownProps): ReactElement {
+  const {
+    state: { isEdit }
+  } = useEdit()
   const t = useTranslations()
   function handleChange(e: SelectChangeEvent<number>): void {
     let newOrder = e.target.value
@@ -32,7 +37,12 @@ export function DropDown({
   return (
     <FormControl sx={{ ml: 'auto' }}>
       <InputLabel>{t('Order')}</InputLabel>
-      <Select value={idx} size="small" onChange={handleChange}>
+      <Select
+        value={idx}
+        size="small"
+        onChange={handleChange}
+        disabled={!isEdit}
+      >
         {[...Array(total)].map((_, i) => (
           <MenuItem key={i} value={i}>
             <Typography>{i + 1}</Typography>

--- a/apps/videos-admin/src/components/OrderedList/OrderedItem/OrderedItem.tsx
+++ b/apps/videos-admin/src/components/OrderedList/OrderedItem/OrderedItem.tsx
@@ -8,6 +8,8 @@ import { MouseEvent, ReactElement } from 'react'
 
 import Drag from '@core/shared/ui/icons/Drag'
 
+import { useEdit } from '../../../app/[locale]/(dashboard)/videos/[videoId]/_EditProvider'
+
 import { Actions } from './Actions'
 import { DropDown } from './DropDown'
 
@@ -43,7 +45,9 @@ export function OrderedItem({
     transition,
     setActivatorNodeRef
   } = useSortable({ id })
-
+  const {
+    state: { isEdit }
+  } = useEdit()
   const style =
     transform != null
       ? { transform: `translate3d(0px, ${transform.y}px, 0)`, transition }
@@ -75,6 +79,7 @@ export function OrderedItem({
       }}
     >
       <IconButton
+        disabled={!isEdit}
         data-testid={`OrderedItemDragHandle-${idx}`}
         sx={{ cursor: 'move' }}
         aria-label="ordered-item-drag-handle"
@@ -84,7 +89,7 @@ export function OrderedItem({
         <Drag fontSize="large" />
       </IconButton>
       <Typography variant="subtitle2">{`${idx + 1}. ${label}`}</Typography>
-      {onChange != null && (
+      {onChange != null && isEdit && (
         <DropDown id={id} idx={idx} total={total} onChange={onChange} />
       )}
       {img != null && (
@@ -107,7 +112,7 @@ export function OrderedItem({
           />
         </Box>
       )}
-      {actions != null && actions.length > 0 && (
+      {actions != null && actions.length > 0 && isEdit && (
         <Actions actions={actions} id={id} />
       )}
     </Stack>

--- a/apps/videos-admin/src/components/OrderedList/OrderedList.tsx
+++ b/apps/videos-admin/src/components/OrderedList/OrderedList.tsx
@@ -11,6 +11,8 @@ import { SortableContext, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 import Stack from '@mui/material/Stack'
 import { ReactElement, ReactNode } from 'react'
 
+import { useEdit } from '../../app/[locale]/(dashboard)/videos/[videoId]/_EditProvider'
+
 interface BaseItem {
   id: string
 }
@@ -26,6 +28,10 @@ export function OrderedList<T extends BaseItem>({
   items,
   children
 }: OrderedListProps<T>): ReactElement {
+  const {
+    state: { isEdit }
+  } = useEdit()
+
   async function handleDragEnd(e: DragEndEvent): Promise<void> {
     await onOrderUpdate(e)
   }
@@ -40,7 +46,7 @@ export function OrderedList<T extends BaseItem>({
 
   return (
     <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
-      <SortableContext items={items}>
+      <SortableContext items={items} disabled={!isEdit}>
         <Stack gap={1}>{children}</Stack>
       </SortableContext>
     </DndContext>


### PR DESCRIPTION
# Description

### Issue

study questions are editable at all times 

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

ran dispatch to change state on edit button click
add disabled states to interactive buttons
stripped ui in view only mode
