### PR TITLE
feat: allow publishers to delete media items 

### DIFF
--- a/apps/api-media/src/schema/cloudflare/image/image.spec.ts
+++ b/apps/api-media/src/schema/cloudflare/image/image.spec.ts
@@ -399,6 +399,9 @@ describe('cloudflareImage', () => {
           userId: 'userId',
           roles: ['publisher']
         })
+        prismaMock.cloudflareImage.findUniqueOrThrow.mockResolvedValue({
+          userId: 'notUser'
+        })
         const result = await authClient({
           document: DELETE_CLOUDFLARE_IMAGE_MUTATION
         })
@@ -407,7 +410,7 @@ describe('cloudflareImage', () => {
         ).toHaveBeenCalledWith({
           where: { id: 'testId' }
         })
-        expect(mockDeleteImage).toHaveBeenCalledWith('testId')
+        expect(mockDeleteImage).not.toHaveBeenCalled()
         expect(result).toEqual({
           data: {
             deleteCloudflareImage: true
@@ -419,6 +422,9 @@ describe('cloudflareImage', () => {
       })
 
       it('should return true if not publisher', async () => {
+        prismaMock.cloudflareImage.findUniqueOrThrow.mockResolvedValue({
+          userId: 'testUserId'
+        })
         const result = await client({
           document: DELETE_CLOUDFLARE_IMAGE_MUTATION
         })

--- a/apps/api-media/src/schema/cloudflare/image/image.spec.ts
+++ b/apps/api-media/src/schema/cloudflare/image/image.spec.ts
@@ -1,6 +1,6 @@
 import { Response } from 'node-fetch'
 
-import { ImageAspectRatio } from '.prisma/api-media-client'
+import { CloudflareImage, ImageAspectRatio } from '.prisma/api-media-client'
 
 import { getClient } from '../../../../test/client'
 import { prismaMock } from '../../../../test/prismaMock'
@@ -401,7 +401,7 @@ describe('cloudflareImage', () => {
         })
         prismaMock.cloudflareImage.findUniqueOrThrow.mockResolvedValue({
           userId: 'notUser'
-        })
+        } as unknown as CloudflareImage)
         const result = await authClient({
           document: DELETE_CLOUDFLARE_IMAGE_MUTATION
         })
@@ -424,7 +424,7 @@ describe('cloudflareImage', () => {
       it('should return true if not publisher', async () => {
         prismaMock.cloudflareImage.findUniqueOrThrow.mockResolvedValue({
           userId: 'testUserId'
-        })
+        } as unknown as CloudflareImage)
         const result = await client({
           document: DELETE_CLOUDFLARE_IMAGE_MUTATION
         })

--- a/apps/api-media/src/schema/cloudflare/image/image.ts
+++ b/apps/api-media/src/schema/cloudflare/image/image.ts
@@ -183,11 +183,12 @@ builder.mutationFields((t) => ({
       if (!currentRoles.includes('publisher')) {
         where.userId = user.id
       }
-      await prisma.cloudflareImage.findUniqueOrThrow({
+      const image = await prisma.cloudflareImage.findUniqueOrThrow({
         where
       })
 
-      await deleteImage(id)
+      // only delete cloudflare asset if original user
+      if (image.userId === user.id) await deleteImage(id)
 
       await prisma.cloudflareImage.delete({ where: { id } })
       return true

--- a/apps/api-media/src/schema/cloudflare/image/image.ts
+++ b/apps/api-media/src/schema/cloudflare/image/image.ts
@@ -178,9 +178,13 @@ builder.mutationFields((t) => ({
     args: {
       id: t.arg({ type: 'ID', required: true })
     },
-    resolve: async (_root, { id }, { user }) => {
+    resolve: async (_root, { id }, { user, currentRoles }) => {
+      const where = { id }
+      if (!currentRoles.includes('publisher')) {
+        where.userId = user.id
+      }
       await prisma.cloudflareImage.findUniqueOrThrow({
-        where: { id, userId: user.id }
+        where
       })
 
       await deleteImage(id)

--- a/apps/api-media/src/schema/cloudflare/image/image.ts
+++ b/apps/api-media/src/schema/cloudflare/image/image.ts
@@ -1,3 +1,5 @@
+import { Prisma } from '.prisma/api-media-client'
+
 import { prisma } from '../../../lib/prisma'
 import { builder } from '../../builder'
 
@@ -179,7 +181,7 @@ builder.mutationFields((t) => ({
       id: t.arg({ type: 'ID', required: true })
     },
     resolve: async (_root, { id }, { user, currentRoles }) => {
-      const where = { id }
+      const where: Prisma.CloudflareImageWhereUniqueInput = { id }
       if (!currentRoles.includes('publisher')) {
         where.userId = user.id
       }

--- a/apps/api-media/src/schema/cloudflare/video/video.spec.ts
+++ b/apps/api-media/src/schema/cloudflare/video/video.spec.ts
@@ -1,5 +1,7 @@
 import { Video } from 'cloudflare/resources/stream/stream'
 
+import { CloudflareVideo } from '.prisma/api-media-client'
+
 import { getClient } from '../../../../test/client'
 import { prismaMock } from '../../../../test/prismaMock'
 import { graphql } from '../../../lib/graphql/subgraphGraphql'
@@ -347,7 +349,7 @@ describe('cloudflareVideo', () => {
         })
         prismaMock.cloudflareVideo.findUniqueOrThrow.mockResolvedValue({
           userId: 'notUser'
-        })
+        } as unknown as CloudflareVideo)
         const result = await authClient({
           document: DELETE_CLOUDFLARE_VIDEO_MUTATION
         })
@@ -377,7 +379,7 @@ describe('cloudflareVideo', () => {
         })
         prismaMock.cloudflareVideo.findUniqueOrThrow.mockResolvedValue({
           userId: 'testUserId'
-        })
+        } as unknown as CloudflareVideo)
         const result = await authClient({
           document: DELETE_CLOUDFLARE_VIDEO_MUTATION
         })

--- a/apps/api-media/src/schema/cloudflare/video/video.spec.ts
+++ b/apps/api-media/src/schema/cloudflare/video/video.spec.ts
@@ -329,7 +329,12 @@ describe('cloudflareVideo', () => {
         }
       `)
 
-      it('should return true', async () => {
+      it('should return true if publisher', async () => {
+        prismaMock.userMediaRole.findUnique.mockResolvedValue({
+          id: 'testUserId',
+          userId: 'userId',
+          roles: ['publisher']
+        })
         const result = await client({
           document: DELETE_CLOUDFLARE_VIDEO_MUTATION
         })
@@ -337,6 +342,41 @@ describe('cloudflareVideo', () => {
         expect(result).toEqual({
           data: {
             deleteCloudflareVideo: true
+          }
+        })
+        expect(
+          prismaMock.cloudflareVideo.findUniqueOrThrow
+        ).toHaveBeenCalledWith({
+          where: {
+            id: 'testId'
+          }
+        })
+        expect(prismaMock.cloudflareVideo.delete).toHaveBeenCalledWith({
+          where: { id: 'testId' }
+        })
+      })
+
+      it('should return true if not publisher', async () => {
+        prismaMock.userMediaRole.findUnique.mockResolvedValue({
+          id: 'testUserId',
+          userId: 'userId',
+          roles: []
+        })
+        const result = await client({
+          document: DELETE_CLOUDFLARE_VIDEO_MUTATION
+        })
+        expect(mockDeleteVideo).toHaveBeenCalledWith('testId')
+        expect(result).toEqual({
+          data: {
+            deleteCloudflareVideo: true
+          }
+        })
+        expect(
+          prismaMock.cloudflareVideo.findUniqueOrThrow
+        ).toHaveBeenCalledWith({
+          where: {
+            id: 'testId',
+            userId: 'testUserId'
           }
         })
         expect(prismaMock.cloudflareVideo.delete).toHaveBeenCalledWith({

--- a/apps/api-media/src/schema/cloudflare/video/video.spec.ts
+++ b/apps/api-media/src/schema/cloudflare/video/video.spec.ts
@@ -33,6 +33,16 @@ jest.mock('./service', () => ({
 
 describe('cloudflareVideo', () => {
   const client = getClient()
+  const authClient = getClient({
+    headers: {
+      authorization: 'token'
+    },
+    context: {
+      currentUser: {
+        id: 'userId'
+      }
+    }
+  })
 
   describe('queries', () => {
     describe('getMyCloudflareVideos', () => {
@@ -335,10 +345,13 @@ describe('cloudflareVideo', () => {
           userId: 'userId',
           roles: ['publisher']
         })
-        const result = await client({
+        prismaMock.cloudflareVideo.findUniqueOrThrow.mockResolvedValue({
+          userId: 'notUser'
+        })
+        const result = await authClient({
           document: DELETE_CLOUDFLARE_VIDEO_MUTATION
         })
-        expect(mockDeleteVideo).toHaveBeenCalledWith('testId')
+        expect(mockDeleteVideo).not.toHaveBeenCalled()
         expect(result).toEqual({
           data: {
             deleteCloudflareVideo: true
@@ -362,7 +375,10 @@ describe('cloudflareVideo', () => {
           userId: 'userId',
           roles: []
         })
-        const result = await client({
+        prismaMock.cloudflareVideo.findUniqueOrThrow.mockResolvedValue({
+          userId: 'testUserId'
+        })
+        const result = await authClient({
           document: DELETE_CLOUDFLARE_VIDEO_MUTATION
         })
         expect(mockDeleteVideo).toHaveBeenCalledWith('testId')

--- a/apps/api-media/src/schema/cloudflare/video/video.ts
+++ b/apps/api-media/src/schema/cloudflare/video/video.ts
@@ -1,3 +1,5 @@
+import { Prisma } from '.prisma/api-media-client'
+
 import { prisma } from '../../../lib/prisma'
 import { builder } from '../../builder'
 
@@ -122,7 +124,7 @@ builder.mutationFields((t) => ({
       id: t.arg({ type: 'ID', required: true })
     },
     resolve: async (_root, { id }, { user, currentRoles }) => {
-      const where = { id }
+      const where: Prisma.CloudflareVideoWhereUniqueInput = { id }
       if (!currentRoles.includes('publisher')) {
         where.userId = user.id
       }

--- a/apps/api-media/src/schema/cloudflare/video/video.ts
+++ b/apps/api-media/src/schema/cloudflare/video/video.ts
@@ -126,11 +126,12 @@ builder.mutationFields((t) => ({
       if (!currentRoles.includes('publisher')) {
         where.userId = user.id
       }
-      await prisma.cloudflareVideo.findUniqueOrThrow({
+      const video = await prisma.cloudflareVideo.findUniqueOrThrow({
         where
       })
 
-      await deleteVideo(id)
+      // only delete cloudflare asset if original user
+      if (video.userId === user.id) await deleteVideo(id)
 
       await prisma.cloudflareVideo.delete({ where: { id } })
 

--- a/apps/api-media/src/schema/cloudflare/video/video.ts
+++ b/apps/api-media/src/schema/cloudflare/video/video.ts
@@ -121,9 +121,13 @@ builder.mutationFields((t) => ({
     args: {
       id: t.arg({ type: 'ID', required: true })
     },
-    resolve: async (_root, { id }, { user }) => {
+    resolve: async (_root, { id }, { user, currentRoles }) => {
+      const where = { id }
+      if (!currentRoles.includes('publisher')) {
+        where.userId = user.id
+      }
       await prisma.cloudflareVideo.findUniqueOrThrow({
-        where: { id, userId: user.id }
+        where
       })
 
       await deleteVideo(id)

--- a/apps/api-media/src/schema/mux/video/video.spec.ts
+++ b/apps/api-media/src/schema/mux/video/video.spec.ts
@@ -3,8 +3,6 @@ import { graphql } from 'gql.tada'
 import { getClient } from '../../../../test/client'
 import { prismaMock } from '../../../../test/prismaMock'
 
-import { deleteVideo } from './service'
-
 jest.mock('./service', () => ({
   createVideoByDirectUpload: jest.fn().mockResolvedValue({
     id: 'videoId',
@@ -269,14 +267,11 @@ describe('mux/video', () => {
         }
       `)
 
-      it('should return true if publisher', async () => {
+      it('should return true IF publisher', async () => {
         prismaMock.userMediaRole.findUnique.mockResolvedValue({
           id: 'userId',
           userId: 'userId',
           roles: ['publisher']
-        })
-        prismaMock.muxVideo.findUniqueOrThrow.mockResolvedValue({
-          userId: 'notUser'
         })
         prismaMock.muxVideo.delete.mockResolvedValue({
           id: 'videoId',
@@ -297,7 +292,6 @@ describe('mux/video', () => {
         expect(prismaMock.muxVideo.findUniqueOrThrow).toHaveBeenCalledWith({
           where: { id: 'videoId' }
         })
-        expect(deleteVideo).not.toHaveBeenCalled()
         expect(prismaMock.muxVideo.delete).toHaveBeenCalledWith({
           where: { id: 'videoId' }
         })
@@ -309,9 +303,6 @@ describe('mux/video', () => {
           id: 'testUserId',
           userId: 'userId',
           roles: []
-        })
-        prismaMock.muxVideo.findUniqueOrThrow.mockResolvedValue({
-          userId: 'testUserId'
         })
         prismaMock.muxVideo.delete.mockResolvedValue({
           id: 'videoId',
@@ -332,7 +323,6 @@ describe('mux/video', () => {
         expect(prismaMock.muxVideo.findUniqueOrThrow).toHaveBeenCalledWith({
           where: { id: 'videoId', userId: 'testUserId' }
         })
-        expect(deleteVideo).toHaveBeenCalledWith('videoId')
         expect(prismaMock.muxVideo.delete).toHaveBeenCalledWith({
           where: { id: 'videoId' }
         })

--- a/apps/api-media/src/schema/mux/video/video.spec.ts
+++ b/apps/api-media/src/schema/mux/video/video.spec.ts
@@ -3,6 +3,8 @@ import { graphql } from 'gql.tada'
 import { getClient } from '../../../../test/client'
 import { prismaMock } from '../../../../test/prismaMock'
 
+import { deleteVideo } from './service'
+
 jest.mock('./service', () => ({
   createVideoByDirectUpload: jest.fn().mockResolvedValue({
     id: 'videoId',
@@ -273,6 +275,9 @@ describe('mux/video', () => {
           userId: 'userId',
           roles: ['publisher']
         })
+        prismaMock.muxVideo.findUniqueOrThrow.mockResolvedValue({
+          userId: 'notUser'
+        })
         prismaMock.muxVideo.delete.mockResolvedValue({
           id: 'videoId',
           name: 'videoName',
@@ -292,6 +297,7 @@ describe('mux/video', () => {
         expect(prismaMock.muxVideo.findUniqueOrThrow).toHaveBeenCalledWith({
           where: { id: 'videoId' }
         })
+        expect(deleteVideo).not.toHaveBeenCalled()
         expect(prismaMock.muxVideo.delete).toHaveBeenCalledWith({
           where: { id: 'videoId' }
         })
@@ -303,6 +309,9 @@ describe('mux/video', () => {
           id: 'testUserId',
           userId: 'userId',
           roles: []
+        })
+        prismaMock.muxVideo.findUniqueOrThrow.mockResolvedValue({
+          userId: 'testUserId'
         })
         prismaMock.muxVideo.delete.mockResolvedValue({
           id: 'videoId',
@@ -323,6 +332,7 @@ describe('mux/video', () => {
         expect(prismaMock.muxVideo.findUniqueOrThrow).toHaveBeenCalledWith({
           where: { id: 'videoId', userId: 'testUserId' }
         })
+        expect(deleteVideo).toHaveBeenCalledWith('videoId')
         expect(prismaMock.muxVideo.delete).toHaveBeenCalledWith({
           where: { id: 'videoId' }
         })

--- a/apps/api-media/src/schema/mux/video/video.spec.ts
+++ b/apps/api-media/src/schema/mux/video/video.spec.ts
@@ -267,7 +267,7 @@ describe('mux/video', () => {
         }
       `)
 
-      it('should return true', async () => {
+      it('should return true if publisher', async () => {
         prismaMock.userMediaRole.findUnique.mockResolvedValue({
           id: 'userId',
           userId: 'userId',
@@ -288,6 +288,40 @@ describe('mux/video', () => {
           variables: {
             id: 'videoId'
           }
+        })
+        expect(prismaMock.muxVideo.findUniqueOrThrow).toHaveBeenCalledWith({
+          where: { id: 'videoId' }
+        })
+        expect(prismaMock.muxVideo.delete).toHaveBeenCalledWith({
+          where: { id: 'videoId' }
+        })
+        expect(result).toHaveProperty('data.deleteMuxVideo', true)
+      })
+
+      it('should return true if not publisher', async () => {
+        prismaMock.userMediaRole.findUnique.mockResolvedValue({
+          id: 'testUserId',
+          userId: 'userId',
+          roles: []
+        })
+        prismaMock.muxVideo.delete.mockResolvedValue({
+          id: 'videoId',
+          name: 'videoName',
+          uploadUrl: null,
+          userId: 'testUserId',
+          createdAt: new Date(),
+          readyToStream: true,
+          downloadable: false,
+          updatedAt: new Date()
+        })
+        const result = await authClient({
+          document: DELETE_MUX_VIDEO,
+          variables: {
+            id: 'videoId'
+          }
+        })
+        expect(prismaMock.muxVideo.findUniqueOrThrow).toHaveBeenCalledWith({
+          where: { id: 'videoId', userId: 'testUserId' }
         })
         expect(prismaMock.muxVideo.delete).toHaveBeenCalledWith({
           where: { id: 'videoId' }

--- a/apps/api-media/src/schema/mux/video/video.ts
+++ b/apps/api-media/src/schema/mux/video/video.ts
@@ -122,11 +122,15 @@ builder.mutationFields((t) => ({
     args: {
       id: t.arg({ type: 'ID', required: true })
     },
-    resolve: async (_root, { id }, { user }) => {
+    resolve: async (_root, { id }, { user, currentRoles }) => {
       if (user == null) throw new Error('User not found')
 
+      const where = { id }
+      if (!currentRoles.includes('publisher')) {
+        where.userId = user.id
+      }
       await prisma.muxVideo.findUniqueOrThrow({
-        where: { id, userId: user.id }
+        where
       })
 
       await deleteVideo(id)

--- a/apps/api-media/src/schema/mux/video/video.ts
+++ b/apps/api-media/src/schema/mux/video/video.ts
@@ -1,3 +1,5 @@
+import { Prisma } from '.prisma/api-media-client'
+
 import { prisma } from '../../../lib/prisma'
 import { builder } from '../../builder'
 
@@ -125,7 +127,7 @@ builder.mutationFields((t) => ({
     resolve: async (_root, { id }, { user, currentRoles }) => {
       if (user == null) throw new Error('User not found')
 
-      const where = { id }
+      const where: Prisma.MuxVideoWhereUniqueInput = { id }
       if (!currentRoles.includes('publisher')) {
         where.userId = user.id
       }

--- a/apps/api-media/src/schema/mux/video/video.ts
+++ b/apps/api-media/src/schema/mux/video/video.ts
@@ -129,12 +129,11 @@ builder.mutationFields((t) => ({
       if (!currentRoles.includes('publisher')) {
         where.userId = user.id
       }
-      const video = await prisma.muxVideo.findUniqueOrThrow({
+      await prisma.muxVideo.findUniqueOrThrow({
         where
       })
 
-      // only delete mux asset if original user
-      if (video.userId === user.id) await deleteVideo(id)
+      await deleteVideo(id)
 
       await prisma.muxVideo.delete({ where: { id } })
 

--- a/apps/api-media/src/schema/mux/video/video.ts
+++ b/apps/api-media/src/schema/mux/video/video.ts
@@ -129,11 +129,12 @@ builder.mutationFields((t) => ({
       if (!currentRoles.includes('publisher')) {
         where.userId = user.id
       }
-      await prisma.muxVideo.findUniqueOrThrow({
+      const video = await prisma.muxVideo.findUniqueOrThrow({
         where
       })
 
-      await deleteVideo(id)
+      // only delete mux asset if original user
+      if (video.userId === user.id) await deleteVideo(id)
 
       await prisma.muxVideo.delete({ where: { id } })
 


### PR DESCRIPTION
# Description

### Issue

Publishers need to be able to change media assets


### Solution

Allow deletion of cloudflare images/videos in db for publishers (due to cf mixing environments. will be later addressed with custom ids)
Allow deletion of mux videos by publishers

