### PR TITLE
fix: add optimistic response to journey update

### DIFF
--- a/apps/journeys-admin/__generated__/UpdateLastActiveTeamId.ts
+++ b/apps/journeys-admin/__generated__/UpdateLastActiveTeamId.ts
@@ -12,6 +12,7 @@ import { JourneyProfileUpdateInput } from "./globalTypes";
 export interface UpdateLastActiveTeamId_journeyProfileUpdate {
   __typename: "JourneyProfile";
   id: string;
+  lastActiveTeamId: string | null;
 }
 
 export interface UpdateLastActiveTeamId {

--- a/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.tsx
@@ -22,10 +22,10 @@ interface TeamSelectProps {
 }
 
 export function TeamSelect({ onboarding }: TeamSelectProps): ReactElement {
-  const { query, activeTeam, setActiveTeam } = useTeam()
   const { t } = useTranslation('apps-journeys-admin')
   const anchorRef = useRef(null)
   const currentRef = anchorRef.current
+  const { query, activeTeam, setActiveTeam } = useTeam()
   const [open, setOpen] = useState(onboarding ?? false)
 
   const [updateLastActiveTeamId, { client }] =
@@ -44,7 +44,8 @@ export function TeamSelect({ onboarding }: TeamSelectProps): ReactElement {
       },
       optimisticResponse: {
         journeyProfileUpdate: {
-          id: team?.id as string,
+          id: query.data?.getJourneyProfile?.id as string,
+          lastActiveTeamId: team?.id ?? null,
           __typename: 'JourneyProfile'
         }
       },

--- a/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.tsx
@@ -42,6 +42,12 @@ export function TeamSelect({ onboarding }: TeamSelectProps): ReactElement {
           lastActiveTeamId: team?.id ?? null
         }
       },
+      optimisticResponse: {
+        journeyProfileUpdate: {
+          id: team?.id as string,
+          __typename: 'JourneyProfile'
+        }
+      },
       onCompleted() {
         void client.refetchQueries({ include: ['GetAdminJourneys'] })
       }

--- a/libs/journeys/ui/src/libs/useUpdateLastActiveTeamIdMutation/useUpdateLastActiveTeamIdMutation.ts
+++ b/libs/journeys/ui/src/libs/useUpdateLastActiveTeamIdMutation/useUpdateLastActiveTeamIdMutation.ts
@@ -14,6 +14,7 @@ export const UPDATE_LAST_ACTIVE_TEAM_ID = gql`
   mutation UpdateLastActiveTeamId($input: JourneyProfileUpdateInput!) {
     journeyProfileUpdate(input: $input) {
       id
+      lastActiveTeamId
     }
   }
 `


### PR DESCRIPTION
# Description

### Issue

For low bandwidth connections, changing teams can take more than 3 seconds. 

### Solution

Look into adding an optimistic response to the `JourneyUpdate` mutation