### PR TITLE
fix: fix test for video details page

### DIFF
--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_tests/page.spec.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_tests/page.spec.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'next/navigation'
 import { NextIntlClientProvider } from 'next-intl'
 
 import { useAdminVideoMock } from '../../../../../../libs/useAdminVideo/useAdminVideo.mock'
+import { EditProvider } from '../_EditProvider'
 import VideoViewPage from '../page'
 
 jest.mock('next/navigation', () => ({
@@ -16,13 +17,14 @@ const mockUseParams = useParams as jest.MockedFunction<typeof mockUseParams>
 describe('VideoViewPage', () => {
   it('should display video view component', async () => {
     mockUseParams.mockReturnValue({ videoId: 'someId' })
-
     const result = jest.fn().mockReturnValue(useAdminVideoMock.result)
 
     render(
       <MockedProvider mocks={[{ ...useAdminVideoMock, result }]}>
         <NextIntlClientProvider locale="en">
-          <VideoViewPage />
+          <EditProvider>
+            <VideoViewPage />
+          </EditProvider>
         </NextIntlClientProvider>
       </MockedProvider>
     )


### PR DESCRIPTION
# Description

### Issue

Broken tests in `apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_tests/page.spec.tsx`

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

- Added `EditProvider`

