### PR TITLE
fix: change components to list items and clean up children

### DIFF
--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Children/Children.spec.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Children/Children.spec.tsx
@@ -35,7 +35,7 @@ describe('Children', () => {
     expect(screen.getByTestId('OrderedItem-2')).toBeInTheDocument()
   })
 
-  it('should handle view click', async () => {
+  it('should direct to video view of the child video on click', async () => {
     const push = jest.fn()
     mockRouter.mockReturnValue({ push } as unknown as AppRouterInstance)
     mockUsePathname.mockReturnValue('/en/videos/1_jf6101-0-0')
@@ -49,29 +49,9 @@ describe('Children', () => {
     )
 
     expect(screen.getByTestId('OrderedItem-0')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'View' }))
+    fireEvent.click(screen.getByTestId('OrderedItem-0'))
     await waitFor(() =>
       expect(push).toHaveBeenCalledWith('/en/videos/1_jf6101-0-0')
-    )
-  })
-
-  it('should handle edit click', async () => {
-    const push = jest.fn()
-    mockRouter.mockReturnValue({ push } as unknown as AppRouterInstance)
-    mockUsePathname.mockReturnValue('/en/videos/1_jf6101-0-0')
-    const oneChildVideo = [childVideos[0]]
-    render(
-      <NextIntlClientProvider locale="en">
-        <MockedProvider>
-          <Children childVideos={oneChildVideo} />
-        </MockedProvider>
-      </NextIntlClientProvider>
-    )
-
-    expect(screen.getByTestId('OrderedItem-0')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
-    await waitFor(() =>
-      expect(push).toHaveBeenCalledWith('/en/videos/1_jf6101-0-0?isEdit=true')
     )
   })
 

--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Children/Children.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Children/Children.tsx
@@ -7,10 +7,6 @@ import { usePathname, useRouter } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import { ReactElement, useState } from 'react'
 
-import Edit2 from '@core/shared/ui/icons/Edit2'
-import EyeOpen from '@core/shared/ui/icons/EyeOpen'
-import Trash2 from '@core/shared/ui/icons/Trash2'
-
 import { OrderedList } from '../../../../../../../components/OrderedList'
 import { OrderedItem } from '../../../../../../../components/OrderedList/OrderedItem'
 import { GetAdminVideo_AdminVideo_Children as VideoChildren } from '../../../../../../../libs/useAdminVideo'
@@ -44,16 +40,10 @@ export function Children({ childVideos }: ChildrenProps): ReactElement {
     return <Typography>{t('No children to show')}</Typography>
   }
 
-  function view(id: string): void {
+  function handleClick(id: string): void {
     if (pathname == null) return
     const [, locale, entity] = pathname.split('/')
     router.push(`/${locale}/${entity}/${id}`)
-  }
-
-  function edit(id: string): void {
-    if (pathname == null) return
-    const [, locale, entity] = pathname.split('/')
-    router.push(`/${locale}/${entity}/${id}?isEdit=true`)
   }
 
   async function updateOrderOnDrag(e: DragEndEvent): Promise<void> {
@@ -89,42 +79,16 @@ export function Children({ childVideos }: ChildrenProps): ReactElement {
               key={id}
               id={id}
               label={title[0].value}
+              subtitle={id}
               idx={i}
-              iconButtons={[
-                {
-                  Icon: EyeOpen,
-                  events: {
-                    onClick: () => view(id)
-                  },
-                  name: 'View'
-                },
-                {
-                  Icon: Edit2,
-                  events: {
-                    onClick: () => edit(id)
-                  },
-                  name: 'Edit'
-                },
-                {
-                  Icon: Trash2,
-                  events: {
-                    onClick: () => alert('Delete child')
-                  },
-                  name: 'Delete',
-                  slotProps: {
-                    button: {
-                      color: 'error'
-                    },
-                    icon: {
-                      color: 'error'
-                    }
-                  }
-                }
-              ]}
               img={{
                 src: images?.[0]?.mobileCinematicHigh as string,
                 alt: imageAlt[0].value
               }}
+              sx={{
+                cursor: 'pointer'
+              }}
+              onClick={handleClick}
             />
           ))}
         </OrderedList>

--- a/apps/videos-admin/src/components/OrderedList/OrderedItem/OrderedItem.tsx
+++ b/apps/videos-admin/src/components/OrderedList/OrderedItem/OrderedItem.tsx
@@ -1,11 +1,13 @@
 import { useSortable } from '@dnd-kit/sortable'
 import Box from '@mui/material/Box'
 import IconButton, { IconButtonProps } from '@mui/material/IconButton'
+import ListItem from '@mui/material/ListItem'
 import Stack from '@mui/material/Stack'
+import { SxProps } from '@mui/material/styles'
 import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon'
 import Typography from '@mui/material/Typography'
 import Image from 'next/image'
-import { CSSProperties, MouseEvent, ReactElement, useMemo } from 'react'
+import { MouseEvent, ReactElement, useMemo } from 'react'
 
 import Drag from '@core/shared/ui/icons/Drag'
 
@@ -15,6 +17,7 @@ import { OrderedItemMenu } from './OrderedItemMenu'
 interface OrderedItemProps {
   id: string
   label: string
+  subtitle?: string
   idx: number
   img?: { src: string; alt: string }
   onClick?: (id: string) => void
@@ -31,18 +34,19 @@ interface OrderedItemProps {
       icon?: SvgIconProps
     }
   }>
-  virtualStyles?: CSSProperties
+  sx?: SxProps
 }
 
 export function OrderedItem({
   id,
   label,
+  subtitle,
   idx,
   img,
   onClick,
   menuActions,
   iconButtons,
-  virtualStyles
+  sx
 }: OrderedItemProps): ReactElement {
   const {
     attributes,
@@ -62,7 +66,7 @@ export function OrderedItem({
       ? { transform: `translate3d(0px, ${transform.y}px, 0)`, transition }
       : undefined
 
-  function handleClick(e: MouseEvent<HTMLDivElement>): void {
+  function handleClick(e: MouseEvent<HTMLLIElement>): void {
     if (e.currentTarget !== e.target) return
     onClick?.(id)
   }
@@ -78,16 +82,17 @@ export function OrderedItem({
   )
 
   return (
-    <Stack
+    <ListItem
       onClick={handleClick}
       data-testid={`OrderedItem-${idx}`}
       id={id}
       ref={setNodeRef}
       {...attributes}
-      direction="row"
-      gap={2}
       sx={{
         ...style,
+        display: 'flex',
+        flexDirection: 'row',
+        gap: 2,
         alignItems: 'center',
         border: '1px solid',
         borderColor: 'divider',
@@ -95,18 +100,26 @@ export function OrderedItem({
         p: 1,
         borderRadius: 1,
         width: '100%',
-        ...virtualStyles
+        ...sx
       }}
     >
       <IconButton
+        size="large"
+        disableRipple
         data-testid={`OrderedItemDragHandle-${idx}`}
-        sx={{ cursor: 'move' }}
+        sx={{
+          cursor: 'move',
+          border: '0px',
+          '&:active': { backgroundColor: 'transparent' },
+          '&:hover': { backgroundColor: 'transparent' }
+        }}
         aria-label="ordered-item-drag-handle"
         ref={setActivatorNodeRef}
         {...listeners}
       >
         <Drag fontSize="large" />
       </IconButton>
+
       {img != null && (
         <Box
           sx={{
@@ -127,7 +140,15 @@ export function OrderedItem({
           />
         </Box>
       )}
-      <Typography variant="subtitle2">{`${idx + 1}. ${label}`}</Typography>
+      <Box>
+        <Typography variant="subtitle2">{`${idx + 1}. ${label}`}</Typography>
+        {subtitle != null && (
+          <Typography
+            variant="caption"
+            color="text.secondary"
+          >{`${subtitle}`}</Typography>
+        )}
+      </Box>
       <Stack sx={{ ml: 'auto' }} flexDirection="row">
         {iconMemoButtons != null && iconMemoButtons.length > 0 && (
           <OrderedItemIcons iconButtons={iconMemoButtons} />
@@ -136,6 +157,6 @@ export function OrderedItem({
           <OrderedItemMenu actions={menuActionButtons} id={id} />
         )}
       </Stack>
-    </Stack>
+    </ListItem>
   )
 }

--- a/apps/videos-admin/src/components/OrderedList/OrderedList.stories.tsx
+++ b/apps/videos-admin/src/components/OrderedList/OrderedList.stories.tsx
@@ -55,14 +55,4 @@ export const Default: Story = {
   }
 }
 
-export const Editable: Story = {
-  ...Template,
-  args: {
-    items: [
-      { id: 'OrderedItem.1', value: 'Ordered row 1' } as BaseItem,
-      { id: 'OrderedItem.2', value: 'Ordered row 2' } as BaseItem
-    ]
-  }
-}
-
 export default meta

--- a/apps/videos-admin/src/components/OrderedList/OrderedList.tsx
+++ b/apps/videos-admin/src/components/OrderedList/OrderedList.tsx
@@ -8,7 +8,7 @@ import {
   useSensors
 } from '@dnd-kit/core'
 import { SortableContext, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
-import Stack from '@mui/material/Stack'
+import List from '@mui/material/List'
 import { ReactElement, ReactNode } from 'react'
 
 export interface BaseItem {
@@ -41,7 +41,7 @@ export function OrderedList<T extends BaseItem>({
   return (
     <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
       <SortableContext items={items}>
-        <Stack gap={1}>{children}</Stack>
+        <List sx={{ gap: 1 }}>{children}</List>
       </SortableContext>
     </DndContext>
   )


### PR DESCRIPTION
# Description

### Issue

lists need to be converted to list item component
children cards need a clean up
styles of the drag handle need adjusting

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

converted all lists to list items
dropped unnecessary buttons from children cards and made the onClick function handle what the buttons were doing
fixed the styles of the drag handle

