### PR TITLE
fix: remove editing label

### DIFF
--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Variants/Variants.spec.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Variants/Variants.spec.tsx
@@ -30,7 +30,7 @@ describe('Variants', () => {
     ).toBeInTheDocument()
   })
 
-  it('should open variant modal when variant is clicked', () => {
+  it('should open variant modal when variant is clicked', async () => {
     render(
       <MockedProvider>
         <NextIntlClientProvider locale="en">
@@ -40,9 +40,11 @@ describe('Variants', () => {
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'Munukutuba 4334' }))
-    expect(
-      screen.getByRole('heading', { level: 4, name: 'Downloads' })
-    ).toBeInTheDocument()
+    await waitFor(() =>
+      expect(
+        screen.getByRole('heading', { level: 4, name: 'Downloads' })
+      ).toBeInTheDocument()
+    )
   })
 
   it('should close variant modal', async () => {

--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/VideoView.spec.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/VideoView.spec.tsx
@@ -30,7 +30,7 @@ describe('VideoView', () => {
 
     await waitFor(() => expect(result).toHaveBeenCalled())
     expect(
-      screen.getByRole('heading', { level: 4, name: 'titleEdit' })
+      screen.getByRole('heading', { level: 4, name: 'videoTitle' })
     ).toBeInTheDocument()
     expect(screen.getByRole('textbox', { name: 'Title' })).toHaveValue('JESUS')
     expect(screen.getByRole('textbox', { name: 'Image Alt' })).toHaveValue(

--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/VideoView.spec.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/VideoView.spec.tsx
@@ -30,7 +30,7 @@ describe('VideoView', () => {
 
     await waitFor(() => expect(result).toHaveBeenCalled())
     expect(
-      screen.getByRole('heading', { level: 4, name: 'videoTitle' })
+      screen.getByRole('heading', { level: 4, name: 'JESUS' })
     ).toBeInTheDocument()
     expect(screen.getByRole('textbox', { name: 'Title' })).toHaveValue('JESUS')
     expect(screen.getByRole('textbox', { name: 'Image Alt' })).toHaveValue(

--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/VideoView.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/VideoView.tsx
@@ -48,7 +48,7 @@ export function VideoView(): ReactElement {
         }}
       >
         <Typography variant="h4">
-          {t('titleEdit', { value: videoTitle })}
+          {t('videoTitle', { value: videoTitle })}
         </Typography>
         <PublishedChip published={data?.adminVideo.published ?? false} />
       </Stack>

--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/VideoView.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/VideoView.tsx
@@ -47,9 +47,7 @@ export function VideoView(): ReactElement {
           flexDirection: { xs: 'col', sm: 'row' }
         }}
       >
-        <Typography variant="h4">
-          {t('videoTitle', { value: videoTitle })}
-        </Typography>
+        <Typography variant="h4">{videoTitle}</Typography>
         <PublishedChip published={data?.adminVideo.published ?? false} />
       </Stack>
       <Stack gap={2} sx={{ flexDirection: { xs: 'column', sm: 'row' } }}>

--- a/libs/locales/en/apps-videos-admin.json
+++ b/libs/locales/en/apps-videos-admin.json
@@ -40,7 +40,6 @@
   "URL": "URL",
   "Variant": "Variant",
   "Variants": "Variants",
-  "videoTitle": "{value}",
   "Loading...": "Loading...",
   "Email": "Email",
   "Password": "Password",

--- a/libs/locales/en/apps-videos-admin.json
+++ b/libs/locales/en/apps-videos-admin.json
@@ -40,7 +40,7 @@
   "URL": "URL",
   "Variant": "Variant",
   "Variants": "Variants",
-  "titleEdit": "Editing: {value}",
+  "videoTitle": "{value}",
   "Loading...": "Loading...",
   "Email": "Email",
   "Password": "Password",


### PR DESCRIPTION
# Description

### Issue

No need for the "Editing:" label.

### Solution

- Removed "Editing:" from the video title
- Fixed broken test in `Variants.spec.tsx`