### PR TITLE
fix: icon sizing

### DIFF
--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Children/Children.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Children/Children.tsx
@@ -69,7 +69,7 @@ export function Children({ childVideos }: ChildrenProps): ReactElement {
     <Section
       title={t('Children')}
       boxProps={{
-        sx: { p: 0, height: 'calc(100vh - 400px)', overflowY: 'scroll' }
+        sx: { p: 2, height: 'calc(100vh - 400px)', overflowY: 'scroll' }
       }}
       variant="contained"
     >

--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Variants/Variants.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Variants/Variants.tsx
@@ -43,7 +43,7 @@ export function Variants({
       {variants != null && (
         <Section
           boxProps={{
-            sx: { p: 0, height: 'calc(100vh - 400px)' }
+            sx: { p: 2, height: 'calc(100vh - 400px)' }
           }}
           title={t('Variants')}
           variant="contained"

--- a/apps/videos-admin/src/components/OrderedList/OrderedItem/OrderedItem.tsx
+++ b/apps/videos-admin/src/components/OrderedList/OrderedItem/OrderedItem.tsx
@@ -118,7 +118,15 @@ export function OrderedItem({
         ref={setActivatorNodeRef}
         {...listeners}
       >
-        <Drag fontSize="large" />
+        <Drag
+          fontSize="large"
+          sx={{
+            '&.MuiSvgIcon-root': {
+              width: '30px !important',
+              height: '30px !important'
+            }
+          }}
+        />
       </IconButton>
 
       {img != null && (

--- a/apps/videos-admin/src/components/OrderedList/OrderedList.tsx
+++ b/apps/videos-admin/src/components/OrderedList/OrderedList.tsx
@@ -41,7 +41,7 @@ export function OrderedList<T extends BaseItem>({
   return (
     <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
       <SortableContext items={items}>
-        <List sx={{ gap: 1 }}>{children}</List>
+        <List sx={{ gap: 1, px: 0 }}>{children}</List>
       </SortableContext>
     </DndContext>
   )


### PR DESCRIPTION
# Description

### Issue

drag handle sizing was too small - was being overriden by list item styles
study questions need to be left aligned properly

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

added important rule to width and property styles to stop them from being overridden by list item styles at run time
removed left and right padding from list items
adding padding to boxes where the sx prop was overriden, thus removing default styles in the component

