### PR TITLE
fix: make save button smaller

### DIFF
--- a/apps/videos-admin/src/components/SaveButton/SaveButton.tsx
+++ b/apps/videos-admin/src/components/SaveButton/SaveButton.tsx
@@ -14,13 +14,10 @@ export function SaveButton({
   return (
     <Button
       variant="contained"
-      size="medium"
+      size="small"
       color={disabled ? 'info' : 'secondary'}
       type="submit"
       disabled={disabled}
-      sx={{
-        width: 80
-      }}
     >
       {t('Save')}
     </Button>


### PR DESCRIPTION
# Description

### Issue

save button is too big

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

remove width from css styles and added size=small prop
