### PR TITLE
fix: set description text to block

### DIFF
--- a/apps/journeys-admin/src/components/MediaListItem/MediaListItem.tsx
+++ b/apps/journeys-admin/src/components/MediaListItem/MediaListItem.tsx
@@ -146,7 +146,10 @@ export function MediaListItem({
                     variant="caption"
                     color="secondary.light"
                     className="overflow-text"
-                    sx={{ ...fadeOverflowText('caption') }}
+                    sx={{
+                      ...fadeOverflowText('caption'),
+                      display: 'block'
+                    }}
                   >
                     {loading === true ? <Skeleton width={128} /> : description}
                   </Typography>


### PR DESCRIPTION
# Description

### Issue

Fixed broken overflow for onboarding journeys using caption font. 