### PR TITLE
chore: deprecate video field

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -290,6 +290,11 @@ type Mutation @join__type(graph: API_ANALYTICS)  @join__type(graph: API_JOURNEYS
   customDomainCheck(id: ID!) : CustomDomainCheck! @join__field(graph: API_JOURNEYS) 
   buttonClickEventCreate(input: ButtonClickEventCreateInput!) : ButtonClickEvent! @join__field(graph: API_JOURNEYS) 
   chatOpenEventCreate(input: ChatOpenEventCreateInput!) : ChatOpenEvent! @join__field(graph: API_JOURNEYS) 
+  """
+  Creates a JourneyViewEvent, returns null if attempting to create another
+  JourneyViewEvent with the same userId, journeyId, and within the same 24hr
+  period of the previous JourneyViewEvent
+  """
   journeyViewEventCreate(input: JourneyViewEventCreateInput!) : JourneyViewEvent @join__field(graph: API_JOURNEYS) 
   radioQuestionSubmissionEventCreate(input: RadioQuestionSubmissionEventCreateInput!) : RadioQuestionSubmissionEvent! @join__field(graph: API_JOURNEYS) 
   signUpSubmissionEventCreate(input: SignUpSubmissionEventCreateInput!) : SignUpSubmissionEvent! @join__field(graph: API_JOURNEYS) 
@@ -1019,7 +1024,7 @@ type VideoBlock implements Block @join__type(graph: API_JOURNEYS)  @join__type(
   internal source videos: video is only populated when videoID and
   videoVariantLanguageId are present
   """
-  video: Video @join__field(graph: API_JOURNEYS) 
+  video: Video @join__field(graph: API_JOURNEYS)  @deprecated(reason: "use mediaVideo union instead") 
   """
   internal source videos: videoId and videoVariantLanguageId both need to be set
   to select a video.

--- a/apps/api-journeys/schema.graphql
+++ b/apps/api-journeys/schema.graphql
@@ -281,6 +281,12 @@ type Mutation {
   customDomainCheck(id: ID!): CustomDomainCheck!
   buttonClickEventCreate(input: ButtonClickEventCreateInput!): ButtonClickEvent!
   chatOpenEventCreate(input: ChatOpenEventCreateInput!): ChatOpenEvent!
+
+  """
+  Creates a JourneyViewEvent, returns null if attempting to create another
+  JourneyViewEvent with the same userId, journeyId, and within the same 24hr
+  period of the previous JourneyViewEvent
+  """
   journeyViewEventCreate(input: JourneyViewEventCreateInput!): JourneyViewEvent
   radioQuestionSubmissionEventCreate(input: RadioQuestionSubmissionEventCreateInput!): RadioQuestionSubmissionEvent!
   signUpSubmissionEventCreate(input: SignUpSubmissionEventCreateInput!): SignUpSubmissionEvent!
@@ -1130,7 +1136,7 @@ type VideoBlock implements Block {
   internal source videos: video is only populated when videoID and
   videoVariantLanguageId are present
   """
-  video: Video
+  video: Video @deprecated(reason: "use mediaVideo union instead")
 
   """
   internal source videos: videoId and videoVariantLanguageId both need to be set

--- a/apps/api-journeys/src/__generated__/graphql.ts
+++ b/apps/api-journeys/src/__generated__/graphql.ts
@@ -1299,6 +1299,11 @@ export type Mutation = {
   /** Updates template */
   journeyTemplate: Journey;
   journeyUpdate: Journey;
+  /**
+   * Creates a JourneyViewEvent, returns null if attempting to create another
+   * JourneyViewEvent with the same userId, journeyId, and within the same 24hr
+   * period of the previous JourneyViewEvent
+   */
   journeyViewEventCreate?: Maybe<JourneyViewEvent>;
   /** Sets journeys statuses to archived */
   journeysArchive?: Maybe<Array<Maybe<Journey>>>;
@@ -3985,6 +3990,7 @@ export type VideoBlock = Block & {
   /**
    * internal source videos: video is only populated when videoID and
    * videoVariantLanguageId are present
+   * @deprecated use mediaVideo union instead
    */
   video?: Maybe<Video>;
   /**

--- a/apps/api-journeys/src/app/modules/block/video/video.graphql
+++ b/apps/api-journeys/src/app/modules/block/video/video.graphql
@@ -60,7 +60,7 @@ type VideoBlock implements Block {
   internal source videos: video is only populated when videoID and
   videoVariantLanguageId are present
   """
-  video: Video
+  video: Video @deprecated(reason: "use mediaVideo union instead")
   """
   internal source videos: videoId and videoVariantLanguageId both need to be set
   to select a video.

--- a/apps/journeys/__generated__/JourneyViewEventCreate.ts
+++ b/apps/journeys/__generated__/JourneyViewEventCreate.ts
@@ -15,6 +15,11 @@ export interface JourneyViewEventCreate_journeyViewEventCreate {
 }
 
 export interface JourneyViewEventCreate {
+  /**
+   * Creates a JourneyViewEvent, returns null if attempting to create another
+   * JourneyViewEvent with the same userId, journeyId, and within the same 24hr
+   * period of the previous JourneyViewEvent
+   */
   journeyViewEventCreate: JourneyViewEventCreate_journeyViewEventCreate | null;
 }
 


### PR DESCRIPTION
# Description

### Issue

Video field is no longer the correct field for videoblocks

### Solution

Deprecate video field in favor of mediaVideo


