### PR TITLE
feat: add ability to cancel edits to video admin fields

### DIFF
--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Metadata/VideoDescription/VideoDescription.spec.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Metadata/VideoDescription/VideoDescription.spec.tsx
@@ -1,5 +1,6 @@
 import { MockedProvider } from '@apollo/client/testing'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import unescape from 'lodash/unescape'
 import { NextIntlClientProvider } from 'next-intl'
 
@@ -48,7 +49,7 @@ describe('VideoDescription', () => {
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
   })
 
-  it('should enable save button if description has been changed', async () => {
+  it('should enable form buttons if description has been changed', async () => {
     render(
       <MockedProvider>
         <NextIntlClientProvider locale="en">
@@ -58,6 +59,9 @@ describe('VideoDescription', () => {
     )
 
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+    expect(
+      screen.queryByRole('button', { name: 'Cancel' })
+    ).not.toBeInTheDocument()
     expect(screen.getByRole('textbox')).toHaveValue(
       unescape(mockVideoDescriptions[0].value).replace(/&#13;/g, '\n')
     )
@@ -66,6 +70,7 @@ describe('VideoDescription', () => {
     })
     expect(screen.getByRole('textbox')).toHaveValue('Hello')
     expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
   })
 
   it('should update video description on submit', async () => {
@@ -112,5 +117,33 @@ describe('VideoDescription', () => {
       expect(screen.getByText('Description is required')).toBeInTheDocument()
     )
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+
+  it('should reset form when cancel is clicked', async () => {
+    render(
+      <MockedProvider>
+        <NextIntlClientProvider locale="en">
+          <VideoDescription videoDescriptions={mockVideoDescriptions} />
+        </NextIntlClientProvider>
+      </MockedProvider>
+    )
+    const user = userEvent.setup()
+
+    const textbox = screen.getByRole('textbox')
+
+    expect(textbox).toHaveValue(
+      unescape(mockVideoDescriptions[0].value).replace(/&#13;/g, '\n')
+    )
+
+    await user.clear(textbox)
+    await user.type(textbox, 'Hello')
+
+    expect(screen.getByRole('textbox')).toHaveValue('Hello')
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(screen.getByRole('textbox')).toHaveValue(
+      unescape(mockVideoDescriptions[0].value).replace(/&#13;/g, '\n')
+    )
   })
 })

--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Metadata/VideoDescription/VideoDescription.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Metadata/VideoDescription/VideoDescription.tsx
@@ -8,6 +8,7 @@ import { useTranslations } from 'next-intl'
 import { ReactElement } from 'react'
 import { object, string } from 'yup'
 
+import { CancelButton } from '../../../../../../../../components/CancelButton'
 import { ResizableTextField } from '../../../../../../../../components/ResizableTextField'
 import { SaveButton } from '../../../../../../../../components/SaveButton'
 import { GetAdminVideo_AdminVideo_VideoDescriptions as VideoDescriptions } from '../../../../../../../../libs/useAdminVideo/useAdminVideo'
@@ -62,7 +63,15 @@ export function VideoDescription({
       validationSchema={validationSchema}
       enableReinitialize
     >
-      {({ values, errors, handleChange, isValid, isSubmitting, dirty }) => (
+      {({
+        values,
+        errors,
+        handleChange,
+        isValid,
+        isSubmitting,
+        dirty,
+        resetForm
+      }) => (
         <Form>
           <Stack gap={2}>
             <ResizableTextField
@@ -76,7 +85,8 @@ export function VideoDescription({
               maxRows={6}
             />
             <Divider sx={{ mx: -4 }} />
-            <Stack direction="row" justifyContent="flex-end">
+            <Stack direction="row" justifyContent="flex-end" gap={1}>
+              <CancelButton show={dirty} handleCancel={() => resetForm()} />
               <SaveButton disabled={!isValid || isSubmitting || !dirty} />
             </Stack>
           </Stack>

--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Metadata/VideoImageAlt/VideoImageAlt.spec.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Metadata/VideoImageAlt/VideoImageAlt.spec.tsx
@@ -1,5 +1,6 @@
 import { MockedProvider } from '@apollo/client/testing'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { NextIntlClientProvider } from 'next-intl'
 
 import { GetAdminVideo_AdminVideo_VideoImageAlts as VideoImageAlts } from '../../../../../../../../libs/useAdminVideo/useAdminVideo'
@@ -35,7 +36,7 @@ describe('VideoImageAlt', () => {
     jest.clearAllMocks()
   })
 
-  it('should show disabled save button if values have not been changed', () => {
+  it('should disable form buttons if values have not been changed', () => {
     render(
       <MockedProvider>
         <NextIntlClientProvider locale="en">
@@ -45,9 +46,12 @@ describe('VideoImageAlt', () => {
     )
 
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+    expect(
+      screen.queryByRole('button', { name: 'Cancel' })
+    ).not.toBeInTheDocument()
   })
 
-  it('should enable save button if image alt has been changed', async () => {
+  it('should enable form buttons if alt has changed', async () => {
     render(
       <MockedProvider>
         <NextIntlClientProvider locale="en">
@@ -63,6 +67,7 @@ describe('VideoImageAlt', () => {
     })
     expect(screen.getByRole('textbox')).toHaveValue('Hello')
     expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
   })
 
   it('should update video image alt on submit', async () => {
@@ -105,5 +110,26 @@ describe('VideoImageAlt', () => {
       expect(screen.getByText('Image Alt is required')).toBeInTheDocument()
     )
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+
+  it('should reset form when cancel button is clicked', async () => {
+    render(
+      <MockedProvider>
+        <NextIntlClientProvider locale="en">
+          <VideoImageAlt videoImageAlts={mockVideoImageAlt} />
+        </NextIntlClientProvider>
+      </MockedProvider>
+    )
+
+    const user = userEvent.setup()
+
+    const textbox = screen.getByRole('textbox')
+    expect(textbox).toHaveValue('JESUS')
+
+    await user.type(textbox, ' Video')
+    expect(textbox).toHaveValue('JESUS Video')
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(textbox).toHaveValue('JESUS')
   })
 })

--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Metadata/VideoImageAlt/VideoImageAlt.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Metadata/VideoImageAlt/VideoImageAlt.tsx
@@ -8,6 +8,7 @@ import { useTranslations } from 'next-intl'
 import { ReactElement } from 'react'
 import { object, string } from 'yup'
 
+import { CancelButton } from '../../../../../../../../components/CancelButton'
 import { SaveButton } from '../../../../../../../../components/SaveButton'
 import { GetAdminVideo_AdminVideo_VideoImageAlts as VideoImageAlts } from '../../../../../../../../libs/useAdminVideo/useAdminVideo'
 
@@ -56,7 +57,15 @@ export function VideoImageAlt({
       validationSchema={validationSchema}
       enableReinitialize
     >
-      {({ values, errors, handleChange, isValid, isSubmitting, dirty }) => (
+      {({
+        values,
+        errors,
+        handleChange,
+        isValid,
+        isSubmitting,
+        dirty,
+        resetForm
+      }) => (
         <Form>
           <Stack gap={2}>
             <Stack direction="row" gap={2}>
@@ -73,7 +82,8 @@ export function VideoImageAlt({
               />
             </Stack>
             <Divider sx={{ mx: -4 }} />
-            <Stack direction="row" justifyContent="flex-end">
+            <Stack direction="row" justifyContent="flex-end" gap={1}>
+              <CancelButton show={dirty} handleCancel={() => resetForm()} />
               <SaveButton disabled={!isValid || isSubmitting || !dirty} />
             </Stack>
           </Stack>

--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Metadata/VideoInformation/VideoInfomation.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Metadata/VideoInformation/VideoInfomation.tsx
@@ -14,6 +14,7 @@ import { useTranslations } from 'next-intl'
 import { ReactElement } from 'react'
 import { object, string } from 'yup'
 
+import { CancelButton } from '../../../../../../../../components/CancelButton'
 import { SaveButton } from '../../../../../../../../components/SaveButton'
 import { GetAdminVideo_AdminVideo as AdminVideo } from '../../../../../../../../libs/useAdminVideo/useAdminVideo'
 
@@ -101,7 +102,15 @@ export function VideoInformation({
       validationSchema={validationSchema}
       enableReinitialize
     >
-      {({ values, errors, handleChange, isValid, isSubmitting, dirty }) => (
+      {({
+        values,
+        errors,
+        handleChange,
+        isValid,
+        isSubmitting,
+        dirty,
+        resetForm
+      }) => (
         <Form>
           <Stack gap={2}>
             <Stack
@@ -204,7 +213,8 @@ export function VideoInformation({
               </FormControl>
             </Stack>
             <Divider sx={{ mx: -4 }} />
-            <Stack direction="row" justifyContent="flex-end">
+            <Stack direction="row" justifyContent="flex-end" gap={1}>
+              <CancelButton show={dirty} handleCancel={() => resetForm()} />
               <SaveButton disabled={!isValid || isSubmitting || !dirty} />
             </Stack>
           </Stack>

--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Metadata/VideoInformation/VideoInformation.spec.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Metadata/VideoInformation/VideoInformation.spec.tsx
@@ -1,5 +1,6 @@
 import { MockedProvider } from '@apollo/client/testing'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { NextIntlClientProvider } from 'next-intl'
 
 import { GetAdminVideo_AdminVideo as AdminVideo } from '../../../../../../../../libs/useAdminVideo/useAdminVideo'
@@ -69,12 +70,16 @@ describe('VideoInformation', () => {
     )
 
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+    expect(
+      screen.queryByRole('button', { name: 'Cancel' })
+    ).not.toBeInTheDocument()
     expect(screen.getByRole('textbox', { name: 'Title' })).toHaveValue('JESUS')
     fireEvent.change(screen.getByRole('textbox', { name: 'Title' }), {
       target: { value: 'Hello' }
     })
     expect(screen.getByRole('textbox', { name: 'Title' })).toHaveValue('Hello')
     expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
   })
 
   it('should enable save button if status has been changed', async () => {
@@ -87,15 +92,19 @@ describe('VideoInformation', () => {
     )
 
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+    expect(
+      screen.queryByRole('button', { name: 'Cancel' })
+    ).not.toBeInTheDocument()
     fireEvent.mouseDown(screen.getByRole('combobox', { name: 'Status' }))
     fireEvent.click(screen.getByRole('option', { name: 'Draft' }))
     expect(screen.getByRole('combobox', { name: 'Status' })).toHaveTextContent(
       'Draft'
     )
     expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
   })
 
-  it('should enable save button if label has been changed', async () => {
+  it('should enable form buttons if label has been changed', async () => {
     render(
       <MockedProvider>
         <NextIntlClientProvider locale="en">
@@ -105,12 +114,16 @@ describe('VideoInformation', () => {
     )
 
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+    expect(
+      screen.queryByRole('button', { name: 'Cancel' })
+    ).not.toBeInTheDocument()
     fireEvent.mouseDown(screen.getByRole('combobox', { name: 'Label' }))
     fireEvent.click(screen.getByRole('option', { name: 'Short Film' }))
     expect(screen.getByRole('combobox', { name: 'Label' })).toHaveTextContent(
       'Short Film'
     )
     expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
   })
 
   it('should update video information on submit', async () => {
@@ -155,5 +168,44 @@ describe('VideoInformation', () => {
       expect(screen.getByText('Title is required')).toBeInTheDocument()
     )
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+
+  it('should reset form when cancel button is clicked', async () => {
+    render(
+      <MockedProvider>
+        <NextIntlClientProvider locale="en">
+          <VideoInformation video={mockVideo} />
+        </NextIntlClientProvider>
+      </MockedProvider>
+    )
+
+    const user = userEvent.setup()
+
+    const title = screen.getByRole('textbox', { name: 'Title' })
+    const status = screen.getByRole('combobox', { name: 'Status' })
+    const label = screen.getByRole('combobox', { name: 'Label' })
+
+    expect(title).toHaveValue('JESUS')
+    expect(status).toHaveTextContent('Published')
+    expect(label).toHaveTextContent('Feature Film')
+
+    await user.clear(title)
+    await user.type(title, 'Title')
+
+    await user.click(status)
+    await user.click(screen.getByRole('option', { name: 'Draft' }))
+
+    await user.click(label)
+    await user.click(screen.getByRole('option', { name: 'Short Film' }))
+
+    expect(title).toHaveValue('Title')
+    expect(status).toHaveTextContent('Draft')
+    expect(label).toHaveTextContent('Short Film')
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(title).toHaveValue('JESUS')
+    expect(status).toHaveTextContent('Published')
+    expect(label).toHaveTextContent('Feature Film')
   })
 })

--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Metadata/VideoSnippet/VideoSnippet.spec.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Metadata/VideoSnippet/VideoSnippet.spec.tsx
@@ -1,5 +1,6 @@
 import { MockedProvider } from '@apollo/client/testing'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { NextIntlClientProvider } from 'next-intl'
 
 import { GetAdminVideo_AdminVideo_VideoSnippets as VideoSnippets } from '../../../../../../../../libs/useAdminVideo/useAdminVideo'
@@ -47,7 +48,7 @@ describe('VideoSnippet', () => {
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
   })
 
-  it('should enable save button if snippet has been changed', async () => {
+  it('should enable form buttons if snippet has been changed', async () => {
     render(
       <MockedProvider>
         <NextIntlClientProvider locale="en">
@@ -57,6 +58,9 @@ describe('VideoSnippet', () => {
     )
 
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+    expect(
+      screen.queryByRole('button', { name: 'Cancel' })
+    ).not.toBeInTheDocument()
     expect(screen.getByRole('textbox')).toHaveValue(
       'Jesus constantly surprises and confounds people, from His miraculous birth to His rise from the grave. Follow His life through excerpts from the Book of Luke, all the miracles, the teachings, and the passion.'
     )
@@ -65,6 +69,7 @@ describe('VideoSnippet', () => {
     })
     expect(screen.getByRole('textbox')).toHaveValue('Hello')
     expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
   })
 
   it('should update video snippet on submit', async () => {
@@ -111,5 +116,31 @@ describe('VideoSnippet', () => {
       expect(screen.getByText('Snippet is required')).toBeInTheDocument()
     )
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+
+  it('should reset form when cancel is clicked', async () => {
+    render(
+      <MockedProvider>
+        <NextIntlClientProvider locale="en">
+          <VideoSnippet videoSnippets={mockVideoSnippets} />
+        </NextIntlClientProvider>
+      </MockedProvider>
+    )
+    const user = userEvent.setup()
+
+    const textbox = screen.getByRole('textbox')
+    expect(textbox).toHaveValue(
+      'Jesus constantly surprises and confounds people, from His miraculous birth to His rise from the grave. Follow His life through excerpts from the Book of Luke, all the miracles, the teachings, and the passion.'
+    )
+
+    await user.clear(textbox)
+    await user.type(textbox, 'Hello')
+    expect(screen.getByRole('textbox')).toHaveValue('Hello')
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(textbox).toHaveValue(
+      'Jesus constantly surprises and confounds people, from His miraculous birth to His rise from the grave. Follow His life through excerpts from the Book of Luke, all the miracles, the teachings, and the passion.'
+    )
   })
 })

--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Metadata/VideoSnippet/VideoSnippet.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Metadata/VideoSnippet/VideoSnippet.tsx
@@ -8,6 +8,7 @@ import { useTranslations } from 'next-intl'
 import { ReactElement } from 'react'
 import { object, string } from 'yup'
 
+import { CancelButton } from '../../../../../../../../components/CancelButton'
 import { ResizableTextField } from '../../../../../../../../components/ResizableTextField'
 import { SaveButton } from '../../../../../../../../components/SaveButton'
 import { GetAdminVideo_AdminVideo_VideoSnippets as VideoSnippets } from '../../../../../../../../libs/useAdminVideo/useAdminVideo'
@@ -58,7 +59,15 @@ export function VideoSnippet({
       validationSchema={validationSchema}
       enableReinitialize
     >
-      {({ values, errors, handleChange, isValid, isSubmitting, dirty }) => (
+      {({
+        values,
+        errors,
+        handleChange,
+        isValid,
+        isSubmitting,
+        dirty,
+        resetForm
+      }) => (
         <Form>
           <Stack gap={2}>
             <ResizableTextField
@@ -72,7 +81,8 @@ export function VideoSnippet({
               maxRows={6}
             />
             <Divider sx={{ mx: -4 }} />
-            <Stack direction="row" justifyContent="flex-end">
+            <Stack direction="row" justifyContent="flex-end" gap={1}>
+              <CancelButton show={dirty} handleCancel={() => resetForm()} />
               <SaveButton disabled={!isValid || isSubmitting || !dirty} />
             </Stack>
           </Stack>

--- a/apps/videos-admin/src/components/CancelButton/CancelButton.spec.tsx
+++ b/apps/videos-admin/src/components/CancelButton/CancelButton.spec.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { NextIntlClientProvider } from 'next-intl'
+
+import { CancelButton } from './CancelButton'
+
+const mockCancel = jest.fn()
+
+describe('CancelButton', () => {
+  it('should render cancel button', () => {
+    render(
+      <NextIntlClientProvider locale="en">
+        <CancelButton show handleCancel={mockCancel} />
+      </NextIntlClientProvider>
+    )
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+  })
+
+  it('should not render save button if show is false', () => {
+    render(
+      <NextIntlClientProvider locale="en">
+        <CancelButton show={false} handleCancel={mockCancel} />
+      </NextIntlClientProvider>
+    )
+
+    expect(
+      screen.queryByRole('button', { name: 'Cancel' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('should call handleCancel callback when clicked', async () => {
+    render(
+      <NextIntlClientProvider locale="en">
+        <CancelButton show handleCancel={mockCancel} />
+      </NextIntlClientProvider>
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(mockCancel).toHaveBeenCalled()
+  })
+})

--- a/apps/videos-admin/src/components/CancelButton/CancelButton.stories.tsx
+++ b/apps/videos-admin/src/components/CancelButton/CancelButton.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import noop from 'lodash/noop'
+import { ComponentPropsWithoutRef } from 'react'
+
+import { videosAdminConfig } from '../../libs/storybookConfig'
+
+import { CancelButton } from './CancelButton'
+
+type StoryArgs = ComponentPropsWithoutRef<typeof CancelButton>
+
+const meta = {
+  ...videosAdminConfig,
+  component: CancelButton,
+  title: 'Videos-Admin/CancelButton'
+} satisfies Meta<StoryArgs>
+
+type Story = StoryObj<typeof meta>
+
+export const Hidden: Story = {
+  args: { show: false, handleCancel: noop }
+}
+
+export const Disabled: Story = {
+  args: { show: true, handleCancel: noop }
+}
+
+export default meta

--- a/apps/videos-admin/src/components/CancelButton/CancelButton.tsx
+++ b/apps/videos-admin/src/components/CancelButton/CancelButton.tsx
@@ -1,0 +1,17 @@
+import Button from '@mui/material/Button'
+import { useTranslations } from 'next-intl'
+import { ReactElement } from 'react'
+
+export function CancelButton({ show, handleCancel }): ReactElement | null {
+  const t = useTranslations()
+
+  if (!show) {
+    return null
+  }
+
+  return (
+    <Button variant="outlined" size="small" onClick={handleCancel}>
+      {t('Cancel')}
+    </Button>
+  )
+}

--- a/apps/videos-admin/src/components/CancelButton/index.ts
+++ b/apps/videos-admin/src/components/CancelButton/index.ts
@@ -1,0 +1,1 @@
+export { CancelButton } from './CancelButton'

--- a/apps/videos-admin/src/components/SaveButton/SaveButton.stories.tsx
+++ b/apps/videos-admin/src/components/SaveButton/SaveButton.stories.tsx
@@ -1,34 +1,25 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { NextIntlClientProvider } from 'next-intl'
-import { ComponentProps } from 'react'
+import { ComponentPropsWithoutRef } from 'react'
 
 import { videosAdminConfig } from '../../libs/storybookConfig'
 
 import { SaveButton } from './SaveButton'
 
-const meta: Meta<typeof SaveButton> = {
+type StoryArgs = ComponentPropsWithoutRef<typeof SaveButton>
+
+const meta = {
   ...videosAdminConfig,
   component: SaveButton,
   title: 'Videos-Admin/SaveButton'
-}
+} satisfies Meta<StoryArgs>
 
-type Story = StoryObj<ComponentProps<typeof SaveButton>>
+type Story = StoryObj<typeof meta>
 
-const Template: Story = {
-  render: ({ disabled }) => (
-    <NextIntlClientProvider locale="en">
-      <SaveButton disabled={disabled} />
-    </NextIntlClientProvider>
-  )
-}
-
-export const Default = {
-  ...Template,
+export const Default: Story = {
   args: { disabled: false }
 }
 
-export const Disabled = {
-  ...Template,
+export const Disabled: Story = {
   args: { disabled: true }
 }
 


### PR DESCRIPTION
# Description

### Issue
It was requested to add the ability to reset forms when canceling edits to the video admin forms

### Solution
- Added `CancelButton` component, stories, and tests
- Added cancel button to video admin forms and reset forms on click
- Updated relevant tests to include the cancel button functionality