### PR TITLE
feat: hide published label while data is loading

### DIFF
--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/VideoView.spec.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/VideoView.spec.tsx
@@ -257,4 +257,17 @@ describe('VideoView', () => {
     await waitFor(() => expect(result).toHaveBeenCalled())
     expect(screen.getAllByRole('tab')).toHaveLength(2)
   })
+
+  it('should render loading ui', async () => {
+    render(
+      <MockedProvider mocks={[]}>
+        <NextIntlClientProvider locale="en">
+          <VideoView />
+        </NextIntlClientProvider>
+      </MockedProvider>
+    )
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+    expect(screen.queryByTestId('PublishedChip')).not.toBeInTheDocument()
+  })
 })

--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/VideoView.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/VideoView.tsx
@@ -47,17 +47,19 @@ export function VideoView(): ReactElement {
       sx={{ width: '100%', maxWidth: 1700 }}
       data-testid="VideoView"
     >
-      <Stack
-        gap={2}
-        sx={{
-          mb: 2,
-          alignItems: { xs: 'start', sm: 'center' },
-          flexDirection: { xs: 'col', sm: 'row' }
-        }}
-      >
-        <Typography variant="h4">{videoTitle}</Typography>
-        <PublishedChip published={data?.adminVideo.published ?? false} />
-      </Stack>
+      {data != null && (
+        <Stack
+          gap={2}
+          sx={{
+            mb: 2,
+            alignItems: { xs: 'start', sm: 'center' },
+            flexDirection: { xs: 'col', sm: 'row' }
+          }}
+        >
+          <Typography variant="h4">{videoTitle}</Typography>
+          <PublishedChip published={data.adminVideo.published} />
+        </Stack>
+      )}
       <Stack gap={2} sx={{ flexDirection: { xs: 'column', sm: 'row' } }}>
         <Box width="100%">
           {loading ? (

--- a/apps/videos-admin/src/components/PublishedChip/PublishedChip.tsx
+++ b/apps/videos-admin/src/components/PublishedChip/PublishedChip.tsx
@@ -11,6 +11,7 @@ export function PublishedChip({ published }: PublishedChipProps): ReactElement {
 
   return (
     <Chip
+      data-testid="PublishedChip"
       label={published ? t('Published') : t('Draft')}
       color={published ? 'success' : 'warning'}
     />


### PR DESCRIPTION
# Description

### Issue
Requested to hide the status label while the data is loading

### Solution
- Conditionally render video header while data is loading
- Add test for loading ui

