### PR TITLE
fix: remove ache slug mapping

### DIFF
--- a/apps/watch/src/libs/slugMap.ts
+++ b/apps/watch/src/libs/slugMap.ts
@@ -31,7 +31,6 @@ export const slugMap = {
   'malay-central-pasemah': 'pasemah',
   'malay-central-ogan': 'ogan',
   'arabic-moroccan': 'arabic-moroccan-spoken',
-  ache: 'ache-2',
   banyamulenge: 'kinyamulenge',
   'javanese-cirebon': 'cirebon',
   lango: 'lango-uganda',


### PR DESCRIPTION
# Description

### Issue

Ache and A Che are routing to same video but are two seperate videos.

### Solution

Remove slug mapping so languages have seperate slugs.