### PR TITLE
fix: updating slug with no url

### DIFF
--- a/apps/api-journeys/src/app/modules/qrCode/qrCode.service.spec.ts
+++ b/apps/api-journeys/src/app/modules/qrCode/qrCode.service.spec.ts
@@ -383,7 +383,7 @@ describe('QrCodeService', () => {
 
   describe('updateJourneyShortLink', () => {
     it('updates short link', async () => {
-      prismaService.qrCode.findFirstOrThrow.mockResolvedValue(qrCode)
+      prismaService.qrCode.findFirst.mockResolvedValue(qrCode)
       jest.spyOn(service, 'getTo').mockResolvedValue('to')
 
       jest.spyOn(ApolloClient.prototype, 'mutate').mockImplementation(
@@ -402,15 +402,15 @@ describe('QrCodeService', () => {
       expect(ApolloClient.prototype.mutate).toHaveBeenCalledTimes(1)
     })
 
-    it('throws qr code not found not found error', async () => {
-      prismaService.qrCode.findFirstOrThrow.mockRejectedValue(
-        new Error('QrCode not found')
-      )
+    // it('throws qr code not found not found error', async () => {
+    //   prismaService.qrCode.findFirstOrThrow.mockRejectedValue(
+    //     new Error('QrCode not found')
+    //   )
 
-      await expect(service.updateJourneyShortLink('qrCodeId')).rejects.toThrow(
-        'QrCode not found'
-      )
-    })
+    //   await expect(service.updateJourneyShortLink('qrCodeId')).rejects.toThrow(
+    //     'QrCode not found'
+    //   )
+    // })
   })
 
   describe('parseAndVerifyTo', () => {

--- a/apps/api-journeys/src/app/modules/qrCode/qrCode.service.ts
+++ b/apps/api-journeys/src/app/modules/qrCode/qrCode.service.ts
@@ -311,9 +311,11 @@ export class QrCodeService {
       cache: new InMemoryCache()
     })
 
-    const qrCode = await this.prismaService.qrCode.findFirstOrThrow({
+    const qrCode = await this.prismaService.qrCode.findFirst({
       where: { toJourneyId }
     })
+
+    if (qrCode == null) return
 
     const to = await this.getTo(
       qrCode.id,


### PR DESCRIPTION
# Description

### Issue

automatic qr code update on slug change was throwing error when no qr code

### Solution

Remove throw error if no qr code exists
