### PR TITLE
fix: fix missing mux video type for video templates

### DIFF
--- a/libs/journeys/ui/src/components/TemplateView/TemplatePreviewTabs/TemplateVideoPreview/TemplateVideoPlayer/TemplateVideoPlayer.tsx
+++ b/libs/journeys/ui/src/components/TemplateView/TemplatePreviewTabs/TemplateVideoPreview/TemplateVideoPlayer/TemplateVideoPlayer.tsx
@@ -4,9 +4,11 @@ import videojs from 'video.js'
 import Player from 'video.js/dist/types/player'
 
 import { VideoBlockSource } from '../../../../../../__generated__/globalTypes'
+import { VideoFields_mediaVideo } from '../../../../Video/__generated__/VideoFields'
 
 export interface TemplateVideoPlayerProps {
   id?: string | null
+  mediaVideo?: VideoFields_mediaVideo | null
   source?: VideoBlockSource
   poster?: string
   startAt: number
@@ -18,7 +20,8 @@ export function TemplateVideoPlayer({
   source,
   poster,
   startAt = 0,
-  endAt
+  endAt,
+  mediaVideo
 }: TemplateVideoPlayerProps): ReactElement {
   const videoRef = useRef<HTMLVideoElement>(null)
   const [player, setPlayer] = useState<Player>()
@@ -113,6 +116,13 @@ export function TemplateVideoPlayer({
             type="video/youtube"
           />
         )}
+        {mediaVideo?.__typename === 'MuxVideo' &&
+          mediaVideo?.playbackId != null && (
+            <source
+              src={`https://stream.mux.com/${mediaVideo.playbackId}.m3u8`}
+              type="application/x-mpegURL"
+            />
+          )}
       </video>
     </Box>
   )

--- a/libs/journeys/ui/src/components/TemplateView/TemplatePreviewTabs/TemplateVideoPreview/TemplateVideoPreview.tsx
+++ b/libs/journeys/ui/src/components/TemplateView/TemplatePreviewTabs/TemplateVideoPreview/TemplateVideoPreview.tsx
@@ -76,6 +76,7 @@ function TemplateVideoPreviewItem({
           }
           startAt={block?.startAt ?? 0}
           endAt={block?.endAt ?? 10000}
+          mediaVideo={block?.mediaVideo}
         />
       ) : (
         <Image


### PR DESCRIPTION
# Description

### Issue

It looks like a mux player type was missed for templates. Will be needed after mux migrations

### Solution

Add missing lines from other video template



