### PR TITLE
feat: performance testing for videos

### DIFF
--- a/apps/journeys/src/components/Conductor/DynamicCardList/DynamicCardList.tsx
+++ b/apps/journeys/src/components/Conductor/DynamicCardList/DynamicCardList.tsx
@@ -1,6 +1,6 @@
 import Box from '@mui/material/Box'
 import Fade from '@mui/material/Fade'
-import { ReactElement, forwardRef, useEffect } from 'react'
+import { ReactElement, forwardRef, useEffect, useState } from 'react'
 
 import { TreeBlock, useBlocks } from '@core/journeys/ui/block'
 import { BlockRenderer } from '@core/journeys/ui/BlockRenderer'
@@ -63,6 +63,15 @@ interface DynamicCardProps {
 const DynamicCard = forwardRef<HTMLDivElement, DynamicCardProps>(
   function DynamicCard({ isCurrent, isPreRender, block }, ref) {
     const { setShowNavigation } = useBlocks()
+    const [isCurrentLoaded, setIsCurrentLoaded] = useState(false)
+
+    // Callback for when the isCurrent block is fully loaded
+    const handleContentLoaded = () => {
+      setIsCurrentLoaded(true)
+      console.log('Current block has fully loaded!')
+    }
+
+    //if prerender and if block is video block...
 
     return (
       <Box
@@ -76,14 +85,17 @@ const DynamicCard = forwardRef<HTMLDivElement, DynamicCardProps>(
           display: isCurrent ? 'block' : 'none'
         }}
       >
-        {isCurrent || isPreRender ? (
+        {isCurrent || (isPreRender && isCurrentLoaded) ? (
           <Box
             data-testid={`journey-card-${block.id}`}
             sx={{
               height: '100%'
             }}
           >
-            <BlockRenderer block={block} />
+            <BlockRenderer
+              block={block}
+              onContentLoaded={handleContentLoaded}
+            />
           </Box>
         ) : (
           <></>

--- a/libs/journeys/ui/src/components/BlockRenderer/BlockRenderer.tsx
+++ b/libs/journeys/ui/src/components/BlockRenderer/BlockRenderer.tsx
@@ -120,13 +120,15 @@ const DynamicTypography = dynamic<TreeBlock<TypographyBlock>>(
 interface BlockRenderProps {
   block?: TreeBlock
   wrappers?: WrappersProps
+  onContentLoaded?: () => void
 }
 
 const DefaultWrapper: WrapperFn = ({ children }) => children
 
 export function BlockRenderer({
   block,
-  wrappers
+  wrappers,
+  onContentLoaded
 }: BlockRenderProps): ReactElement {
   const Wrapper = wrappers?.Wrapper ?? DefaultWrapper
   const ButtonWrapper = wrappers?.ButtonWrapper ?? DefaultWrapper

--- a/libs/journeys/ui/src/components/Video/InitAndPlay/InitAndPlay.tsx
+++ b/libs/journeys/ui/src/components/Video/InitAndPlay/InitAndPlay.tsx
@@ -53,8 +53,9 @@ export function InitAndPlay({
   setLoading,
   setShowPoster,
   setVideoEndTime,
-  activeStep = false
-}: InitAndPlayProps): ReactElement {
+  activeStep = false,
+  onLoadedData
+}: InitAndPlayProps & { onLoadedData?: () => void }): ReactElement {
   const { variant } = useJourney()
   const { blockHistory } = useBlocks()
   const activeBlock = blockHistory[blockHistory.length - 1]
@@ -84,6 +85,10 @@ export function InitAndPlay({
             source === VideoBlockSource.youTube
         })
       )
+      // Trigger the onLoadedData callback when video is loaded
+      player?.on('loadeddata', () => {
+        if (onLoadedData) onLoadedData() // ✅ Trigger callback
+      })
     }
   }, [
     startAt,
@@ -94,7 +99,9 @@ export function InitAndPlay({
     videoRef,
     autoplay,
     activeStep,
-    source
+    source,
+    onLoadedData,
+    player
   ])
 
   // Initiate video player listeners

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -74,8 +74,9 @@ export function Video({
   posterBlockId,
   children,
   action,
-  objectFit
-}: TreeBlock<VideoFields>): ReactElement {
+  objectFit,
+  onLoadedData
+}: TreeBlock<VideoFields> & { onLoadedData?: () => void }): ReactElement {
   const theme = useTheme()
   const hundredVh = use100vh()
 
@@ -235,6 +236,7 @@ export function Video({
               className="video-js vjs-tech"
               playsInline
               preload="auto"
+              onLoadedData={onLoadedData}
               sx={{
                 '&.video-js.vjs-youtube.vjs-fill': {
                   transform: 'scale(1.01)'


### PR DESCRIPTION
# Description

### Issue

Dummy PR to test performance of pre-rendering cards. **Do not merge**

### Solution

Delay the second card loading until the first cards video has loaded

# External Changes

None

# Additional information

This is an investigation ticket


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved content loading controls in dynamic display components, ensuring that information appears only once fully ready.
  - Enhanced video components with callback triggers for when video data is loaded, promoting smoother playback integration.
  - Added support for notifying when content load events complete, enabling more responsive interactions during media rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->