### PR TITLE
fix: adjust position and visibility of DynamicCard

### DIFF
--- a/apps/journeys/src/components/Conductor/DynamicCardList/DynamicCardList.tsx
+++ b/apps/journeys/src/components/Conductor/DynamicCardList/DynamicCardList.tsx
@@ -74,8 +74,7 @@ const DynamicCard = forwardRef<HTMLDivElement, DynamicCardProps>(
           position: isPreRender ? 'absolute' : 'relative',
           height: '100%',
           display: 'block',
-          // opacity: isPreRender ? 0 : 1,
-          visibility: isPreRender ? 'hidden' : 'visible'
+          opacity: isPreRender ? 0 : 1
         }}
       >
         {isCurrent || isPreRender ? (

--- a/apps/journeys/src/components/Conductor/DynamicCardList/DynamicCardList.tsx
+++ b/apps/journeys/src/components/Conductor/DynamicCardList/DynamicCardList.tsx
@@ -71,9 +71,11 @@ const DynamicCard = forwardRef<HTMLDivElement, DynamicCardProps>(
         onClick={() => setShowNavigation(true)}
         sx={{
           width: 'inherit',
-          position: 'relative',
+          position: isPreRender ? 'absolute' : 'relative',
           height: '100%',
-          display: isCurrent ? 'block' : 'none'
+          display: 'block',
+          // opacity: isPreRender ? 0 : 1,
+          visibility: isPreRender ? 'hidden' : 'visible'
         }}
       >
         {isCurrent || isPreRender ? (

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -234,7 +234,7 @@ export function Video({
               ref={videoRef}
               className="video-js vjs-tech"
               playsInline
-              preload="auto"
+              preload="preload"
               sx={{
                 '&.video-js.vjs-youtube.vjs-fill': {
                   transform: 'scale(1.01)'

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -235,6 +235,11 @@ export function Video({
               className="video-js vjs-tech"
               playsInline
               preload="preload"
+              onLoadedMetadata={() => {
+                if (videoRef.current) {
+                  videoRef.current.currentTime = startAt ?? 30
+                }
+              }}
               sx={{
                 '&.video-js.vjs-youtube.vjs-fill': {
                   transform: 'scale(1.01)'


### PR DESCRIPTION


# Description

Updating display and position of pre-rendered card as videos/images will not load in the browser when display = none

Updated DynamicCardList to pre render the next card. **DO NOT MERGE**

### Issue

https://linear.app/jesus-film-project/issue/ENG-1847/image-loading-discovery

### Solution


# External Changes

N/A

# Additional information

Testing rendering changes in staging


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined card element layout and styling to create a more consistent visual presentation.
- **Refactor**
  - Streamlined the rendering logic to improve the handling of transitional display states for cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->