### PR TITLE
refactor: remove hardcoded bandwidth settings in video player options

### DIFF
--- a/libs/shared/ui/src/libs/defaultVideoJsOptions/defaultVideoJsOptions.spec.ts
+++ b/libs/shared/ui/src/libs/defaultVideoJsOptions/defaultVideoJsOptions.spec.ts
@@ -14,10 +14,6 @@ describe('defaultVideoJsOptions', () => {
       expect(defaultVideoJsOptions.html5.hls.useDevicePixelRatio).toBe(true)
     })
 
-    it('should have bandwidth set to 1e9', () => {
-      expect(defaultVideoJsOptions.html5.hls.bandwidth).toBe(1e9)
-    })
-
     it('should have useBandwidthFromLocalStorage set to true', () => {
       expect(defaultVideoJsOptions.html5.hls.useBandwidthFromLocalStorage).toBe(
         true
@@ -40,10 +36,6 @@ describe('defaultVideoJsOptions', () => {
   describe('vhs', () => {
     it('should have useDevicePixelRatio set to true', () => {
       expect(defaultVideoJsOptions.html5.vhs.useDevicePixelRatio).toBe(true)
-    })
-
-    it('should have bandwidth set to 1e9', () => {
-      expect(defaultVideoJsOptions.html5.vhs.bandwidth).toBe(1e9)
     })
 
     it('should have useBandwidthFromLocalStorage set to true', () => {

--- a/libs/shared/ui/src/libs/defaultVideoJsOptions/defaultVideoJsOptions.ts
+++ b/libs/shared/ui/src/libs/defaultVideoJsOptions/defaultVideoJsOptions.ts
@@ -8,15 +8,13 @@ export const defaultVideoJsOptions = {
       limitRenditionByPlayerDimensions: false,
       useBandwidthFromLocalStorage: true,
       useNetworkInformationApi: true,
-      bandwidth: 1e9, // used to set initial bandwidth before calculation for abr video
       useDevicePixelRatio: true
     },
     hls: {
       limitRenditionByPlayerDimensions: false,
       useBandwidthFromLocalStorage: true,
       useNetworkInformationApi: true,
-      useDevicePixelRatio: true,
-      bandwidth: 1e9 // used to set initial bandwidth before calculation for abr video
+      useDevicePixelRatio: true
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined video playback settings by removing the `bandwidth` property from configurations, ensuring adaptive bitrate streaming performs more efficiently.
  
- **Tests**
  - Removed test cases related to the `bandwidth` property to reflect the updated configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->