### PR TITLE
feat: add seed for available languages

### DIFF
--- a/apis/api-media/src/workers/seed/service/service.spec.ts
+++ b/apis/api-media/src/workers/seed/service/service.spec.ts
@@ -1,6 +1,7 @@
 import { service } from './service'
 import { seedTags } from './tag'
 import { seedTaxonomies } from './taxonomy'
+import { seedVideoLanguages } from './videoLanguage'
 
 jest.mock('./tag', () => ({
   seedTags: jest.fn()
@@ -15,5 +16,6 @@ describe('seed/service', () => {
     await service()
     expect(seedTags).toHaveBeenCalled()
     expect(seedTaxonomies).toHaveBeenCalled()
+    expect(seedVideoLanguages).toHaveBeenCalled()
   })
 })

--- a/apis/api-media/src/workers/seed/service/service.spec.ts
+++ b/apis/api-media/src/workers/seed/service/service.spec.ts
@@ -11,6 +11,10 @@ jest.mock('./taxonomy', () => ({
   seedTaxonomies: jest.fn()
 }))
 
+jest.mock('./videoLanguage', () => ({
+  seedVideoLanguages: jest.fn()
+}))
+
 describe('seed/service', () => {
   it('should seed', async () => {
     await service()

--- a/apis/api-media/src/workers/seed/service/service.ts
+++ b/apis/api-media/src/workers/seed/service/service.ts
@@ -1,6 +1,6 @@
 import { seedTags } from './tag'
 import { seedTaxonomies } from './taxonomy'
-import { seedVideoLanguages } from './videoLanguage/videoLanguage'
+import { seedVideoLanguages } from './videoLanguage'
 
 export async function service(): Promise<void> {
   await seedTags()

--- a/apis/api-media/src/workers/seed/service/service.ts
+++ b/apis/api-media/src/workers/seed/service/service.ts
@@ -1,7 +1,9 @@
 import { seedTags } from './tag'
 import { seedTaxonomies } from './taxonomy'
+import { seedVideoLanguages } from './videoLanguage/videoLanguage'
 
 export async function service(): Promise<void> {
   await seedTags()
   await seedTaxonomies()
+  await seedVideoLanguages()
 }

--- a/apis/api-media/src/workers/seed/service/videoLanguage/index.ts
+++ b/apis/api-media/src/workers/seed/service/videoLanguage/index.ts
@@ -1,0 +1,1 @@
+export { seedVideoLanguages } from './videoLanguage'

--- a/apis/api-media/src/workers/seed/service/videoLanguage/videoLanguage.ts
+++ b/apis/api-media/src/workers/seed/service/videoLanguage/videoLanguage.ts
@@ -1,0 +1,30 @@
+import { prisma } from '../../../../lib/prisma'
+
+export async function seedVideoLanguages(): Promise<void> {
+  const videos = await prisma.video.findMany({
+    select: {
+      id: true,
+      availableLanguages: true,
+      variants: {
+        select: {
+          languageId: true
+        }
+      }
+    }
+  })
+
+  for (const video of videos) {
+    const availableLanguages = Array.from(
+      new Set(video.variants.map((variant) => variant.languageId))
+    )
+
+    try {
+      await prisma.video.update({
+        where: { id: video.id },
+        data: { availableLanguages }
+      })
+    } catch (error) {
+      console.error(`Error updating video ${video.id}:`, error)
+    }
+  }
+}

--- a/apis/api-media/src/workers/seed/service/videoLanguage/videoLanguage.ts
+++ b/apis/api-media/src/workers/seed/service/videoLanguage/videoLanguage.ts
@@ -1,5 +1,31 @@
 import { prisma } from '../../../../lib/prisma'
 
+const BATCH_SIZE = 100
+const MAX_RETRIES = 3
+
+async function updateBatch(
+  videos: { id: string; availableLanguages: string[] }[],
+  retries = 0
+): Promise<void> {
+  try {
+    await prisma.$transaction(
+      videos.map(({ id, availableLanguages }) =>
+        prisma.video.update({
+          where: { id },
+          data: { availableLanguages }
+        })
+      )
+    )
+  } catch (error) {
+    if (retries < MAX_RETRIES) {
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+      return updateBatch(videos, retries + 1)
+    }
+    console.error('Failed to update batch after retries:', error)
+    throw error
+  }
+}
+
 export async function seedVideoLanguages(): Promise<void> {
   const videos = await prisma.video.findMany({
     select: {
@@ -13,18 +39,19 @@ export async function seedVideoLanguages(): Promise<void> {
     }
   })
 
-  for (const video of videos) {
-    const availableLanguages = Array.from(
+  const updates = videos.map((video) => ({
+    id: video.id,
+    availableLanguages: Array.from(
       new Set(video.variants.map((variant) => variant.languageId))
     )
+  }))
 
+  for (let i = 0; i < updates.length; i += BATCH_SIZE) {
+    const batch = updates.slice(i, i + BATCH_SIZE)
     try {
-      await prisma.video.update({
-        where: { id: video.id },
-        data: { availableLanguages }
-      })
+      await updateBatch(batch)
     } catch (error) {
-      console.error(`Error updating video ${video.id}:`, error)
+      console.error(`Failed to process batch ${i / BATCH_SIZE + 1}:`, error)
     }
   }
 }


### PR DESCRIPTION
# Description

### Issue

Need to seed available languages in prod and stage.

### Solution

Add a temp seed to Videos table


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced video language management. Media content now benefits from improved processing of language details, ensuring that language options for videos are updated consistently and accurately. This upgrade helps deliver a more reliable and enriched user experience when accessing video content.
  - Introduced a new function for seeding video languages, enhancing the overall functionality of the media service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->