### PR TITLE
fix: use correct query to get series count

### DIFF
--- a/apps/arclight/src/app/v2/[...route]/_media-languages/index.ts
+++ b/apps/arclight/src/app/v2/[...route]/_media-languages/index.ts
@@ -62,9 +62,11 @@ const GET_LANGUAGES = graphql(`
         primary
         suggested
       }
-      seriesCount
-      featureFilmCount
-      shortFilmCount
+      labeledVideoCounts {
+        seriesCount
+        featureFilmCount
+        shortFilmCount
+      }
     }
   }
 `)
@@ -158,26 +160,26 @@ mediaLanguages.get(
             ).length,
             description: 'Number of countries'
           },
-          ...(language.seriesCount != 0
+          ...(language.labeledVideoCounts.seriesCount != 0
             ? {
                 series: {
-                  value: language.seriesCount,
+                  value: language.labeledVideoCounts.seriesCount,
                   description: 'Series'
                 }
               }
             : {}),
-          ...(language.featureFilmCount != 0
+          ...(language.labeledVideoCounts.featureFilmCount != 0
             ? {
                 featureFilm: {
-                  value: language.featureFilmCount,
+                  value: language.labeledVideoCounts.featureFilmCount,
                   description: 'Feature Film'
                 }
               }
             : {}),
-          ...(language.shortFilmCount != 0
+          ...(language.labeledVideoCounts.shortFilmCount != 0
             ? {
                 shortFilm: {
-                  value: language.shortFilmCount,
+                  value: language.labeledVideoCounts.shortFilmCount,
                   description: 'Short Film'
                 }
               }


### PR DESCRIPTION
# Description

### Issue

Fix internal server error on prod

### Solution

Use the correct Graphql query to get counts for the videos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Consolidated video counts for series, feature films, and short films into a unified structure for more consistent and streamlined data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->