### PR TITLE
fix: broken test in CI

### DIFF
--- a/libs/journeys/ui/src/libs/blurImage/blurImage.spec.ts
+++ b/libs/journeys/ui/src/libs/blurImage/blurImage.spec.ts
@@ -1,10 +1,39 @@
 import { blurImage } from './blurImage'
 
+// Mock blurhash decode function
 jest.mock('blurhash', () => ({
   decode: () => new Uint8ClampedArray(32 * 32 * 4).fill(128)
 }))
 
 describe('blurImage', () => {
+  // Mock canvas and context before each test
+  beforeEach(() => {
+    // Create a mock canvas context
+    const mockContext = {
+      createImageData: () => ({
+        data: new Uint8ClampedArray(32 * 32 * 4)
+      }),
+      putImageData: jest.fn(),
+      fillStyle: '',
+      fillRect: jest.fn()
+    }
+
+    // Create a mock canvas element
+    const mockCanvas = {
+      getContext: () => mockContext,
+      setAttribute: jest.fn(),
+      toDataURL: () => 'data:image/png;base64,mockImageData'
+    }
+
+    // Mock document.createElement
+    document.createElement = jest.fn((tagName) => {
+      if (tagName === 'canvas') {
+        return mockCanvas as unknown as HTMLCanvasElement
+      }
+      return {} as HTMLElement
+    })
+  })
+
   const image = {
     id: 'image1.id',
     __typename: 'ImageBlock',
@@ -25,19 +54,16 @@ describe('blurImage', () => {
   })
 
   it('returns undefined as fallback', () => {
-    // Prevent 2d canvas from being generated
-    const createElement = document.createElement.bind(document)
-    document.createElement = <K extends keyof HTMLElementTagNameMap>(
-      tagName: K
-    ) => {
+    // Override the mock to return null context
+    document.createElement = jest.fn((tagName) => {
       if (tagName === 'canvas') {
         return {
           getContext: () => null,
-          setAttribute: () => ({})
-        }
+          setAttribute: jest.fn()
+        } as unknown as HTMLCanvasElement
       }
-      return createElement(tagName)
-    }
+      return {} as HTMLElement
+    })
 
     expect(blurImage(image.blurhash, '#000000')).toBeUndefined()
   })

--- a/libs/journeys/ui/src/libs/blurImage/blurImage.spec.ts
+++ b/libs/journeys/ui/src/libs/blurImage/blurImage.spec.ts
@@ -1,5 +1,9 @@
 import { blurImage } from './blurImage'
 
+jest.mock('blurhash', () => ({
+  decode: () => new Uint8ClampedArray(32 * 32 * 4).fill(128)
+}))
+
 describe('blurImage', () => {
   const image = {
     id: 'image1.id',
@@ -15,10 +19,9 @@ describe('blurImage', () => {
   }
 
   it('returns url of blurred image', () => {
-    const result = blurImage(image.blurhash, '#000000')
-    expect(result).toBeDefined()
-    expect(typeof result).toBe('string')
-    expect(result).toMatch(/^data:image\/png;base64,[A-Za-z0-9+/]+=*$/)
+    expect(
+      blurImage(image.blurhash, '#000000')?.startsWith('data:image/png;base64,')
+    ).toBeTruthy()
   })
 
   it('returns undefined as fallback', () => {

--- a/libs/journeys/ui/src/libs/blurImage/blurImage.spec.ts
+++ b/libs/journeys/ui/src/libs/blurImage/blurImage.spec.ts
@@ -15,9 +15,10 @@ describe('blurImage', () => {
   }
 
   it('returns url of blurred image', () => {
-    expect(
-      blurImage(image.blurhash, '#000000')?.startsWith('data:image/png;base64,')
-    ).toBeTruthy()
+    const result = blurImage(image.blurhash, '#000000')
+    expect(result).toBeDefined()
+    expect(typeof result).toBe('string')
+    expect(result).toMatch(/^data:image\/png;base64,[A-Za-z0-9+/]+=*$/)
   })
 
   it('returns undefined as fallback', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Introduced a mock for the `blurhash` module in the test file to simulate decoding behavior for controlled testing of the `blurImage` function.
  - Added setup for mock canvas and context objects to ensure proper testing of the `blurImage` function under various conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->