### PR TITLE
fix: update jf-proxy configuration for production routes and environments

### DIFF
--- a/workers/jf-proxy/project.json
+++ b/workers/jf-proxy/project.json
@@ -26,7 +26,7 @@
         "env": "stage"
       },
       "configurations": {
-        "prod": {
+        "production": {
           "env": "prod"
         }
       }

--- a/workers/jf-proxy/src/index.spec.ts
+++ b/workers/jf-proxy/src/index.spec.ts
@@ -65,46 +65,6 @@ describe('test the worker', () => {
     expect(await res.text()).toBe('not found content')
   })
 
-  it('should handle 301 response', async () => {
-    fetchMock
-      .get('http://test.example.com')
-      .intercept({ path: '/test-path%aa' })
-      .reply(301, 'redirect content', {
-        headers: { location: 'http://test.example.com/redirected-path%AA' }
-      })
-
-    const res = await app.request(
-      'http://localhost/test-path%AA',
-      {},
-      { PROXY_DEST: 'test.example.com' }
-    )
-    expect(res.status).toBe(301)
-    expect(await res.text()).toBe('redirect content')
-    expect(res.headers.get('location')).toBe(
-      'http://localhost/redirected-path%aa'
-    )
-  })
-
-  it('should handle 302 response', async () => {
-    fetchMock
-      .get('http://test.example.com')
-      .intercept({ path: '/test-path%aa' })
-      .reply(302, 'redirect content', {
-        headers: { location: 'http://test.example.com/redirected-path%AA' }
-      })
-
-    const res = await app.request(
-      'http://localhost/test-path%AA',
-      {},
-      { PROXY_DEST: 'test.example.com' }
-    )
-    expect(res.status).toBe(302)
-    expect(await res.text()).toBe('redirect content')
-    expect(res.headers.get('location')).toBe(
-      'http://localhost/redirected-path%aa'
-    )
-  })
-
   it('should handle network error in main fetch', async () => {
     fetchMock
       .get('http://test.example.com')
@@ -138,42 +98,6 @@ describe('test the worker', () => {
     )
     expect(res.status).toBe(404)
     expect(await res.text()).toBe('Not Found')
-  })
-
-  it('should handle invalid URLs in redirect location header', async () => {
-    fetchMock
-      .get('http://test.example.com')
-      .intercept({ path: '/test-path%aa' })
-      .reply(301, 'redirect content', {
-        headers: { location: 'invalid-url' }
-      })
-
-    const res = await app.request(
-      'http://localhost/test-path%AA',
-      {},
-      { PROXY_DEST: 'test.example.com' }
-    )
-    expect(res.status).toBe(301)
-    expect(await res.text()).toBe('redirect content')
-    expect(res.headers.get('location')).toBe('invalid-url')
-  })
-
-  it('should handle missing location header in redirect', async () => {
-    fetchMock
-      .get('http://test.example.com')
-      .intercept({ path: '/test-path%aa' })
-      .reply(301, 'redirect content', {
-        headers: {} // No location header
-      })
-
-    const res = await app.request(
-      'http://localhost/test-path%AA',
-      {},
-      { PROXY_DEST: 'test.example.com' }
-    )
-    expect(res.status).toBe(301)
-    expect(await res.text()).toBe('redirect content')
-    expect(res.headers.has('location')).toBe(false)
   })
 
   it('should handle missing PROXY_DEST binding', async () => {

--- a/workers/jf-proxy/src/index.ts
+++ b/workers/jf-proxy/src/index.ts
@@ -19,35 +19,7 @@ app.get('*', async (c) => {
     return new Response('Service Unavailable', { status: 503 })
   }
 
-  if (response.status == 301 || response.status == 302) {
-    const locationHeader = response.headers.get('location')
-    if (!locationHeader) {
-      // If no location header, pass through the response as-is
-      return response
-    }
-
-    try {
-      const respUrl = new URL(locationHeader)
-      const origUrl = new URL(c.req.url)
-      if (respUrl.hostname !== origUrl.hostname) {
-        respUrl.hostname = origUrl.hostname
-        const modifiedResp = new Response(response.body, {
-          status: response.status,
-          headers: {
-            ...Object.fromEntries(response.headers.entries()),
-            location: respUrl
-              .toString()
-              .replace(/(%[0-9A-F][0-9A-F])/g, (match) => match.toLowerCase())
-          }
-        })
-        return modifiedResp
-      }
-    } catch (error) {
-      // If location URL is invalid, pass through the response as-is
-      console.warn('Invalid redirect location:', locationHeader)
-      return response
-    }
-  } else if (response.status == 404 || response.status == 500) {
+  if (response.status == 404 || response.status == 500) {
     const notFoundUrl = new URL(c.req.url)
     notFoundUrl.pathname = '/not-found.html'
     try {
@@ -61,7 +33,7 @@ app.get('*', async (c) => {
   // Sanitize response headers
   const sanitizedHeaders = Object.fromEntries(
     Array.from(response.headers.entries()).filter(
-      ([_, value]) => value !== undefined && value !== null
+      ([, value]) => value !== undefined && value !== null
     )
   )
 

--- a/workers/jf-proxy/wrangler.toml
+++ b/workers/jf-proxy/wrangler.toml
@@ -1,4 +1,4 @@
-name = "jf-proxy"
+name = "jf-proxy-dev"
 compatibility_date = "2024-01-01"
 compatibility_flags = ["nodejs_compat"]
 main = "src/index.ts"
@@ -25,10 +25,10 @@ PROXY_DEST = "c89a34d4-4b06-4219-ad8b-c7289106424d.jesusfilm.org"
 [env.prod]
 name = "jf-proxy-prod"
 routes = [
-  { pattern = "jesusfilm.org/watch*", zone_name = "jesusfilm.org" },
-  { pattern = "jesusfilm.org/bin/*", zone_name = "jesusfilm.org" },
-  { pattern = "jesusfilm.org/api/*", zone_name = "jesusfilm.org" },
-  { pattern = "jesusfilm.org/_next/*", zone_name = "jesusfilm.org" }
+  { pattern = "www.jesusfilm.org/watch*", zone_name = "jesusfilm.org" },
+  { pattern = "www.jesusfilm.org/bin/*", zone_name = "jesusfilm.org" },
+  { pattern = "www.jesusfilm.org/api/*", zone_name = "jesusfilm.org" },
+  { pattern = "www.jesusfilm.org/_next/*", zone_name = "jesusfilm.org" }
 ]
 
 [env.prod.vars]


### PR DESCRIPTION
This PR updates the JF proxy configuration to: (1) Rename configuration from 'prod' to 'production' (2) Add www prefix to production routes (3) Update dev proxy name for clarity [ENG-1927]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Renamed the deployment environment key for improved clarity.
  - Updated the project identifier to reflect a development version.
  - Adjusted URL routing by prepending "www." to key web addresses for consistent access.
- **Bug Fixes**
  - Removed handling logic for HTTP redirect responses (301 and 302), simplifying response management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->