### PR TITLE
eng-1934: Add README documentation for workers

### DIFF
--- a/workers/arclight-canary/README.md
+++ b/workers/arclight-canary/README.md
@@ -1,0 +1,135 @@
+# Arclight Canary Worker
+
+A Cloudflare worker that implements canary routing between core and arclight endpoints. This worker allows for gradual traffic migration and A/B testing between services.
+
+## How It Works
+
+The worker sits in front of two endpoints (core and arclight) and routes incoming requests based on three rules:
+
+1. **Path-Based Core Routing**: Requests to `/_next/*` paths are always routed to the core endpoint
+2. **Path-Based Arclight Routing**: Requests to `/build/v1harness/images/primary.png` are always routed to the arclight endpoint
+3. **Weight-Based Routing**: All other requests are randomly routed based on a configurable weight percentage
+
+### Request Flow
+
+1. Request comes in to the worker
+2. Worker checks if the path matches any fixed routing rules
+3. If no fixed rules match, applies weight-based routing
+4. Forwards the request to the chosen endpoint
+5. Returns the response with an `x-routed-to` header indicating which endpoint was used
+
+## Configuration
+
+The worker is configured through environment variables:
+
+```toml
+# Required
+ENDPOINT_CORE="https://core.example.com"      # Base URL for core endpoint
+ENDPOINT_ARCLIGHT="https://api.example.com"   # Base URL for arclight endpoint
+ENDPOINT_ARCLIGHT_WEIGHT="90"                 # Percentage of requests to route to arclight (0-100)
+
+# Optional
+TIMEOUT="30000"                               # Request timeout in milliseconds (default: 30000)
+```
+
+### Environment-Specific Configuration
+
+The worker supports different configurations for development, staging, and production environments. Each environment can specify:
+
+- Custom routes and domains
+- Different endpoint URLs
+- Different weight percentages
+- Environment-specific timeouts
+
+## Development
+
+### Prerequisites
+
+- Node.js
+- nx CLI
+- Wrangler CLI (Cloudflare Workers)
+
+### Local Development
+
+1. Start the worker locally:
+
+   ```bash
+   nx serve workers/arclight-canary
+   ```
+
+2. Run tests:
+   ```bash
+   nx test workers/arclight-canary
+   ```
+
+### Adding New Routes
+
+To add new path-based routing rules:
+
+1. Update the constants in `src/index.ts`:
+
+   ```typescript
+   // For core-only paths (uses startsWith)
+   const CORE_ONLY_PATHS = ['/_next/']
+
+   // For arclight-only paths (uses exact match)
+   const ARCLIGHT_ONLY_PATHS = ['/build/v1harness/images/primary.png']
+   ```
+
+2. Add corresponding tests in `src/index.spec.ts`
+
+### Error Handling
+
+The worker handles several types of errors:
+
+- **Weight Validation** (400): Invalid weight configuration
+- **Request Timeout** (503): Request exceeded timeout
+- **Network Errors** (503): Connection or DNS issues
+- **Missing Configuration** (500): Required environment variables not set
+- **Unexpected Errors** (500): All other errors
+
+### Deployment
+
+The worker is automatically deployed using GitHub Actions:
+
+- **Staging Environment**:
+
+  - Triggered by: Pushes to the `stage` branch
+  - Deploys to: `canary-stage.arclight.org`
+  - Configuration: Uses staging environment variables
+
+- **Production Environment**:
+  - Triggered by: Pushes to the `main` branch
+  - Deploys to: `canary.arclight.org`
+  - Configuration: Uses production environment variables
+
+The GitHub Actions workflow:
+
+1. Runs tests
+2. Builds the worker
+3. Deploys to the appropriate environment
+
+## Monitoring
+
+The worker adds an `x-routed-to` header to all responses with either:
+
+- `core`: Request was routed to the core endpoint
+- `arclight`: Request was routed to the arclight endpoint
+
+This header can be used for monitoring and debugging routing decisions.
+
+## Testing
+
+The test suite covers:
+
+- Weight-based routing
+- Path-based routing rules
+- Request/response preservation
+- Error handling
+- Timeout handling
+
+Run the tests with:
+
+```bash
+nx test workers/arclight-canary
+```

--- a/workers/jf-proxy/README.md
+++ b/workers/jf-proxy/README.md
@@ -1,0 +1,128 @@
+# JF Proxy Worker
+
+A Cloudflare worker that acts as a proxy server for the Jesus Film website, handling requests and managing failover to error pages.
+
+## How It Works
+
+The worker sits in front of the Jesus Film website and:
+
+1. Forwards incoming requests to the configured destination
+2. Handles error cases (404, 500) by serving a custom error page
+3. Preserves request properties (method, headers, body)
+4. Sanitizes response headers
+
+### Request Flow
+
+1. Request comes in to the worker
+2. Worker modifies the hostname to the configured `PROXY_DEST`
+3. Worker forwards the request with all original properties
+4. If the response is a 404 or 500:
+   - Attempts to serve `/not-found.html`
+   - Falls back to a basic error message if that fails
+5. Returns the response with sanitized headers
+
+## Configuration
+
+The worker is configured through environment variables:
+
+```toml
+# Required
+PROXY_DEST="www.example.com"  # The destination hostname to proxy requests to
+```
+
+### Environment-Specific Configuration
+
+The worker supports different configurations for development, staging, and production environments. Each environment can specify:
+
+- Custom routes and domains
+- Different proxy destinations
+- Environment-specific settings
+
+The worker handles routing for various website sections including:
+
+- Watch pages
+- Journeys
+- Calendar
+- Products
+- Resources
+- Binary files
+- API endpoints
+- Next.js assets
+
+## Development
+
+### Prerequisites
+
+- Node.js
+- nx CLI
+- Wrangler CLI (Cloudflare Workers)
+
+### Local Development
+
+1. Start the worker locally:
+
+   ```bash
+   nx serve workers/jf-proxy
+   ```
+
+2. Run tests:
+   ```bash
+   nx test workers/jf-proxy
+   ```
+
+### Error Handling
+
+The worker handles several types of errors:
+
+- **404 Not Found**: Attempts to serve `/not-found.html`
+- **500 Server Error**: Attempts to serve `/not-found.html`
+- **Network Errors**: Returns 503 Service Unavailable
+- **Not Found Page Errors**: Returns basic 404 message
+
+### Deployment
+
+The worker is automatically deployed using GitHub Actions:
+
+- **Staging Environment**:
+
+  - Triggered by: Pushes to the `stage` branch
+  - Deploys to: `develop.jesusfilm.org`
+  - Configuration: Uses staging environment variables
+
+- **Production Environment**:
+  - Triggered by: Pushes to the `main` branch
+  - Deploys to: `www.jesusfilm.org`
+  - Configuration: Uses production environment variables
+
+The GitHub Actions workflow:
+
+1. Runs tests
+2. Builds the worker
+3. Deploys to the appropriate environment
+
+## Testing
+
+The test suite covers:
+
+- Basic request proxying
+- Error handling (404, 500)
+- Network error handling
+- Missing configuration handling
+- Header sanitization
+
+Run the tests with:
+
+```bash
+nx test workers/jf-proxy
+```
+
+### Test Cases
+
+The test suite includes verification for:
+
+- Successful proxying of requests
+- Handling of 404 responses with custom error page
+- Handling of 500 responses with custom error page
+- Network errors during main request
+- Network errors during error page fetch
+- Missing PROXY_DEST configuration


### PR DESCRIPTION
## Description\n\nAdded comprehensive README documentation for both arclight-canary and jf-proxy workers. The documentation includes:\n\n- Detailed explanation of how each worker functions\n- Configuration options and environment variables\n- Development setup and prerequisites\n- Error handling and testing information\n- Deployment process via GitHub Actions\n\n## Changes\n\n- Added README.md for arclight-canary worker\n- Added README.md for jf-proxy worker\n- Documented configuration, deployment, and testing for both workers\n\n## Testing\n\nDocumentation has been reviewed for accuracy and completeness.