### PR TITLE
fix: limit and page type issue

### DIFF
--- a/apps/arclight-e2e/src/e2e/media-components/index.spec.ts
+++ b/apps/arclight-e2e/src/e2e/media-components/index.spec.ts
@@ -148,6 +148,24 @@ test.describe('media components', () => {
     expect(data._links).toHaveProperty('next')
   })
 
+  test('handles string values for numeric parameters', async ({ request }) => {
+    // This test specifically verifies that string values for numeric parameters are handled correctly
+    const params = createQueryParams({
+      page: '3',
+      limit: '2'
+    })
+
+    const response = await request.get(
+      `${await getBaseUrl()}/v2/media-components?${params}`
+    )
+
+    expect(response.ok()).toBeTruthy()
+    const data = await response.json()
+    expect(data.page).toBe(3)
+    expect(data.limit).toBe(2)
+    expect(data._embedded.mediaComponents.length).toBeLessThanOrEqual(2)
+  })
+
   test('media components returns 400 for invalid language with no fallback content', async ({
     request
   }) => {

--- a/apps/arclight-e2e/src/e2e/media-components/index.spec.ts
+++ b/apps/arclight-e2e/src/e2e/media-components/index.spec.ts
@@ -149,7 +149,6 @@ test.describe('media components', () => {
   })
 
   test('handles string values for numeric parameters', async ({ request }) => {
-    // This test specifically verifies that string values for numeric parameters are handled correctly
     const params = createQueryParams({
       page: '3',
       limit: '2'

--- a/apps/arclight-e2e/src/e2e/media-countries/index.spec.ts
+++ b/apps/arclight-e2e/src/e2e/media-countries/index.spec.ts
@@ -103,4 +103,20 @@ test.describe('GET /v2/media-countries', () => {
     const unitedStates = data._embedded.mediaCountries[0]
     expect(unitedStates.metadataLanguageTag).toBe('es')
   })
+
+  test('handles string values for numeric parameters', async ({ request }) => {
+    const response = await getMediaCountries(request, {
+      ids: ['US'],
+      page: '2',
+      limit: '1'
+    })
+
+    expect(response.ok()).toBeTruthy()
+    const data = await response.json()
+
+    expect(data.page).toBe(2)
+    expect(data.limit).toBe(1)
+    expect(data._links).toHaveProperty('previous')
+    expect(data._embedded.mediaCountries.length).toBeLessThanOrEqual(1)
+  })
 })

--- a/apps/arclight-e2e/src/e2e/media-languages/index.spec.ts
+++ b/apps/arclight-e2e/src/e2e/media-languages/index.spec.ts
@@ -159,4 +159,22 @@ test.describe('GET /v2/media-languages', () => {
     expect(english.languageId).toBe(529)
     expect(english.metadataLanguageTag).toBe('es')
   })
+
+  test('handles string values for numeric parameters', async ({ request }) => {
+    const response = await getMediaLanguages(request, {
+      page: '2',
+      limit: '3'
+    })
+
+    expect(response.ok()).toBeTruthy()
+    const data = await response.json()
+
+    expect(data.page).toBe(2)
+    expect(data.limit).toBe(3)
+    expect(data._embedded.mediaLanguages.length).toBeLessThanOrEqual(3)
+
+    // Verify pagination links are correct
+    expect(data._links).toHaveProperty('previous')
+    expect(data._links.previous.href).toContain('page=1')
+  })
 })

--- a/apps/arclight/src/app/v2/[...route]/_media-components/index.ts
+++ b/apps/arclight/src/app/v2/[...route]/_media-components/index.ts
@@ -109,8 +109,8 @@ const GET_VIDEOS_WITH_FALLBACK = graphql(`
 `)
 
 const QuerySchema = z.object({
-  page: z.string().optional(),
-  limit: z.string().optional(),
+  page: z.coerce.number().optional(),
+  limit: z.coerce.number().optional(),
   subTypes: z.string().optional(),
   languageIds: z.string().optional(),
   ids: z.string().optional()

--- a/apps/arclight/src/app/v2/[...route]/_media-countries/index.ts
+++ b/apps/arclight/src/app/v2/[...route]/_media-countries/index.ts
@@ -49,8 +49,8 @@ export const mediaCountries = new OpenAPIHono()
 mediaCountries.route('/:countryId', mediaCountry)
 
 const QuerySchema = z.object({
-  page: z.number().optional(),
-  limit: z.number().optional(),
+  page: z.coerce.number().optional(),
+  limit: z.coerce.number().optional(),
   ids: z.string().optional(),
   expand: z.string().optional(),
   metadataLanguageTags: z.string().optional()
@@ -72,6 +72,11 @@ const ResponseSchema = z.object({
       href: z.string()
     }),
     next: z
+      .object({
+        href: z.string()
+      })
+      .optional(),
+    previous: z
       .object({
         href: z.string()
       })
@@ -182,6 +187,10 @@ mediaCountries.openapi(route, async (c) => {
     ...queryObject,
     page: (page + 1).toString()
   }).toString()
+  const previousQueryString = new URLSearchParams({
+    ...queryObject,
+    page: (page - 1).toString()
+  }).toString()
 
   const mediaCountries = data.countries
     .slice(offset, offset + limit)
@@ -255,6 +264,12 @@ mediaCountries.openapi(route, async (c) => {
         page < totalPages
           ? {
               href: `http://api.arclight.org/v2/media-countries?${nextQueryString}`
+            }
+          : undefined,
+      previous:
+        page > 1
+          ? {
+              href: `http://api.arclight.org/v2/media-countries?${previousQueryString}`
             }
           : undefined
     },

--- a/apps/arclight/src/app/v2/[...route]/_media-languages/index.ts
+++ b/apps/arclight/src/app/v2/[...route]/_media-languages/index.ts
@@ -79,8 +79,8 @@ const GET_LANGUAGES_DATA = graphql(`
 
 const QuerySchema = z.object({
   apiKey: z.string().optional().describe('API key'),
-  page: z.string().optional().describe('Page number'),
-  limit: z.string().optional().describe('Number of items per page'),
+  page: z.coerce.number().optional().describe('Page number'),
+  limit: z.coerce.number().optional().describe('Number of items per page'),
   ids: z.string().optional().describe('Filter by language IDs'),
   bcp47: z.string().optional().describe('Filter by BCP-47 language codes'),
   iso3: z.string().optional().describe('Filter by ISO-3 language codes'),


### PR DESCRIPTION
# Description

### Issue

Issues with page and limit

### Solution

Coerce page and limit to number and add previous link for media countries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced media API endpoints now automatically convert string inputs for numeric query parameters, ensuring accurate pagination and improved navigation with appropriate links.

- **Tests**
  - Added validation tests across media endpoints to confirm that numeric parameters provided as strings are correctly interpreted, ensuring reliable and consistent API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->