### PR TITLE
feat: create base edition on video create

### DIFF
--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Editions/EditionDialog/EditionCreate/EditionCreate.spec.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Editions/EditionDialog/EditionCreate/EditionCreate.spec.tsx
@@ -1,4 +1,4 @@
-import { MockedProvider, MockedResponse } from '@apollo/client/testing'
+import { MockedProvider } from '@apollo/client/testing'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { GraphQLError } from 'graphql'
@@ -6,39 +6,17 @@ import { NextIntlClientProvider } from 'next-intl'
 
 import { SnackbarProvider } from '../../../../../../../../../libs/SnackbarProvider'
 import { useAdminVideoMock } from '../../../../../../../../../libs/useAdminVideo/useAdminVideo.mock'
+import { getCreateEditionMock } from '../../../../../../../../../libs/useCreateEdition/useCreateEdition.mock'
 import { VideoProvider } from '../../../../../../../../../libs/VideoProvider'
 
-import {
-  CREATE_VIDEO_EDITION,
-  CreateVideoEdition,
-  CreateVideoEditionVariables,
-  EditionCreate
-} from './EditionCreate'
+import { EditionCreate } from './EditionCreate'
 
 const mockVideo = useAdminVideoMock['result']?.['data']?.['adminVideo']
 
-const createEditionMock: MockedResponse<
-  CreateVideoEdition,
-  CreateVideoEditionVariables
-> = {
-  request: {
-    query: CREATE_VIDEO_EDITION,
-    variables: {
-      input: {
-        videoId: mockVideo.id,
-        name: 'New edition'
-      }
-    }
-  },
-  result: {
-    data: {
-      videoEditionCreate: {
-        id: 'edition.id',
-        name: 'New edition'
-      }
-    }
-  }
-}
+const createEditionMock = getCreateEditionMock({
+  videoId: mockVideo.id,
+  name: 'New edition'
+})
 
 describe('EditionCreate', () => {
   it('should render', () => {
@@ -60,16 +38,11 @@ describe('EditionCreate', () => {
 
   it('should create an edition', async () => {
     const close = jest.fn()
-    const createEditionMockResult = jest
-      .fn()
-      .mockReturnValue(createEditionMock.result)
 
     render(
       <NextIntlClientProvider locale="en">
         <SnackbarProvider>
-          <MockedProvider
-            mocks={[{ ...createEditionMock, result: createEditionMockResult }]}
-          >
+          <MockedProvider mocks={[createEditionMock]}>
             <VideoProvider video={mockVideo}>
               <EditionCreate close={close} />
             </VideoProvider>
@@ -85,7 +58,7 @@ describe('EditionCreate', () => {
     await user.click(screen.getByRole('button', { name: 'Create' }))
 
     await waitFor(() => {
-      expect(createEditionMockResult).toHaveBeenCalled()
+      expect(createEditionMock.result).toHaveBeenCalled()
     })
     expect(
       screen.getByText('Successfully created edition.')

--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Editions/EditionDialog/EditionCreate/EditionCreate.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Editions/EditionDialog/EditionCreate/EditionCreate.tsx
@@ -1,25 +1,11 @@
-import { gql, useMutation } from '@apollo/client'
-import { ResultOf, VariablesOf, graphql } from 'gql.tada'
+import { gql } from '@apollo/client'
 import { useTranslations } from 'next-intl'
 import { useSnackbar } from 'notistack'
 import { ReactElement } from 'react'
 
+import { useCreateEditionMutation } from '../../../../../../../../../libs/useCreateEdition'
 import { useVideo } from '../../../../../../../../../libs/VideoProvider'
 import { EditionForm, EditionValidationSchema } from '../../EditionForm'
-
-export const CREATE_VIDEO_EDITION = graphql(`
-  mutation CreateVideoEdition($input: VideoEditionCreateInput!) {
-    videoEditionCreate(input: $input) {
-      id
-      name
-    }
-  }
-`)
-
-export type CreateVideoEditionVariables = VariablesOf<
-  typeof CREATE_VIDEO_EDITION
->
-export type CreateVideoEdition = ResultOf<typeof CREATE_VIDEO_EDITION>
 
 interface EditionCreateProps {
   close: () => void
@@ -30,7 +16,7 @@ export function EditionCreate({ close }: EditionCreateProps): ReactElement {
   const { enqueueSnackbar } = useSnackbar()
   const video = useVideo()
 
-  const [createEdition] = useMutation(CREATE_VIDEO_EDITION, {
+  const [createEdition] = useCreateEditionMutation({
     update(cache, { data }) {
       if (data?.videoEditionCreate == null) return
 

--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/_VideoList/VideoCreateForm/VideoCreateForm.spec.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/_VideoList/VideoCreateForm/VideoCreateForm.spec.tsx
@@ -7,6 +7,7 @@ import { NextIntlClientProvider } from 'next-intl'
 import { getLanguagesMock } from '@core/journeys/ui/useLanguagesQuery/useLanguagesQuery.mock'
 
 import { SnackbarProvider } from '../../../../../../libs/SnackbarProvider'
+import { getCreateEditionMock } from '../../../../../../libs/useCreateEdition/useCreateEdition.mock'
 
 import {
   CREATE_VIDEO,
@@ -43,14 +44,18 @@ const createVideoMock: MockedResponse<CreateVideo, CreateVideoVariables> = {
       }
     }
   },
-  result: {
+  result: jest.fn(() => ({
     data: {
       videoCreate: {
         id: 'test_video'
       }
     }
-  }
+  }))
 }
+const createEditionMock = getCreateEditionMock({
+  videoId: 'test_video',
+  name: 'base'
+})
 
 describe('VideoCreateForm', () => {
   const mockCancel = jest.fn()
@@ -113,16 +118,14 @@ describe('VideoCreateForm', () => {
     const getLanguagesMockResult = jest
       .fn()
       .mockReturnValue(getLanguagesMock.result)
-    const createVideoMockResult = jest
-      .fn()
-      .mockReturnValue(createVideoMock.result)
 
     render(
       <NextIntlClientProvider locale="en">
         <MockedProvider
           mocks={[
             { ...getLanguagesMock, result: getLanguagesMockResult },
-            { ...createVideoMock, result: createVideoMockResult }
+            createVideoMock,
+            createEditionMock
           ]}
         >
           <VideoCreateForm close={mockCancel} />
@@ -150,7 +153,10 @@ describe('VideoCreateForm', () => {
 
     await user.click(screen.getByRole('button', { name: 'Create' }))
 
-    expect(createVideoMockResult).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(createVideoMock.result).toHaveBeenCalled()
+    })
+    expect(createEditionMock.result).toHaveBeenCalled()
     expect(mockUseRouter).toHaveBeenCalledWith('/en/videos/test_video')
   })
 

--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/_VideoList/VideoCreateForm/VideoCreateForm.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/_VideoList/VideoCreateForm/VideoCreateForm.tsx
@@ -19,6 +19,7 @@ import {
 import { FormSelectField } from '../../../../../../components/FormSelectField'
 import { FormTextField } from '../../../../../../components/FormTextField'
 import { videoLabels } from '../../../../../../constants'
+import { useCreateEditionMutation } from '../../../../../../libs/useCreateEdition'
 
 enum VideoLabel {
   behindTheScenes = 'behindTheScenes',
@@ -96,6 +97,7 @@ export function VideoCreateForm({ close }: VideoCreateFormProps): ReactElement {
   const pathname = usePathname()
 
   const [createVideo] = useMutation(CREATE_VIDEO)
+  const [createEdition] = useCreateEditionMutation()
 
   const handleSubmit = async (values: InferType<typeof validationSchema>) => {
     await createVideo({
@@ -110,12 +112,29 @@ export function VideoCreateForm({ close }: VideoCreateFormProps): ReactElement {
           childIds: []
         }
       },
-      onCompleted: () => {
-        enqueueSnackbar(t('Successfully created video.'), {
-          variant: 'success'
+      onCompleted: async (data) => {
+        const videoId = data.videoCreate.id
+
+        await createEdition({
+          variables: {
+            input: {
+              videoId,
+              name: 'base'
+            }
+          },
+          onCompleted: () => {
+            enqueueSnackbar(t('Successfully created video.'), {
+              variant: 'success'
+            })
+            close()
+            router.push(`${pathname}/${values.id}`)
+          },
+          onError: () => {
+            enqueueSnackbar(t('Failed to create video edition.'), {
+              variant: 'error'
+            })
+          }
         })
-        close()
-        router.push(`${pathname}/${values.id}`)
       },
       onError: () => {
         // TODO: proper error handling for specific errors

--- a/apps/videos-admin/src/libs/useCreateEdition/index.ts
+++ b/apps/videos-admin/src/libs/useCreateEdition/index.ts
@@ -1,0 +1,1 @@
+export { useCreateEditionMutation } from './useCreateEdition'

--- a/apps/videos-admin/src/libs/useCreateEdition/useCreateEdition.mock.tsx
+++ b/apps/videos-admin/src/libs/useCreateEdition/useCreateEdition.mock.tsx
@@ -1,0 +1,26 @@
+import { MockedResponse } from '@apollo/client/testing'
+
+import {
+  CREATE_VIDEO_EDITION,
+  CreateVideoEdition,
+  CreateVideoEditionVariables
+} from './useCreateEdition'
+
+export const getCreateEditionMock = <
+  T extends CreateVideoEditionVariables['input']
+>(
+  input: T
+): MockedResponse<CreateVideoEdition, CreateVideoEditionVariables> => ({
+  request: {
+    query: CREATE_VIDEO_EDITION,
+    variables: { input }
+  },
+  result: jest.fn(() => ({
+    data: {
+      videoEditionCreate: {
+        id: 'edition.id',
+        name: input.name
+      }
+    }
+  }))
+})

--- a/apps/videos-admin/src/libs/useCreateEdition/useCreateEdition.spec.tsx
+++ b/apps/videos-admin/src/libs/useCreateEdition/useCreateEdition.spec.tsx
@@ -1,0 +1,33 @@
+import { MockedProvider } from '@apollo/client/testing'
+import { act, renderHook } from '@testing-library/react'
+
+import { useCreateEditionMutation } from './useCreateEdition'
+import { getCreateEditionMock } from './useCreateEdition.mock'
+
+const createEditionMock = getCreateEditionMock({
+  videoId: 'video.id',
+  name: 'base'
+})
+
+describe('useCreateEdition', () => {
+  it('should create an edition', async () => {
+    const { result } = renderHook(() => useCreateEditionMutation(), {
+      wrapper: ({ children }) => (
+        <MockedProvider mocks={[createEditionMock]}>{children}</MockedProvider>
+      )
+    })
+
+    await act(async () => {
+      await result.current[0]({
+        variables: {
+          input: {
+            videoId: 'video.id',
+            name: 'base'
+          }
+        }
+      })
+    })
+
+    expect(createEditionMock.result).toHaveBeenCalled()
+  })
+})

--- a/apps/videos-admin/src/libs/useCreateEdition/useCreateEdition.tsx
+++ b/apps/videos-admin/src/libs/useCreateEdition/useCreateEdition.tsx
@@ -1,0 +1,24 @@
+import { MutationHookOptions, MutationTuple, useMutation } from '@apollo/client'
+import { ResultOf, VariablesOf, graphql } from 'gql.tada'
+
+export const CREATE_VIDEO_EDITION = graphql(`
+  mutation CreateVideoEdition($input: VideoEditionCreateInput!) {
+    videoEditionCreate(input: $input) {
+      id
+      name
+    }
+  }
+`)
+
+export type CreateVideoEditionVariables = VariablesOf<
+  typeof CREATE_VIDEO_EDITION
+>
+export type CreateVideoEdition = ResultOf<typeof CREATE_VIDEO_EDITION>
+
+export function useCreateEditionMutation(
+  options?: MutationHookOptions<CreateVideoEdition, CreateVideoEditionVariables>
+): MutationTuple<CreateVideoEdition, CreateVideoEditionVariables> {
+  const mutation = useMutation(CREATE_VIDEO_EDITION, options)
+
+  return mutation
+}

--- a/libs/locales/en/apps-videos-admin.json
+++ b/libs/locales/en/apps-videos-admin.json
@@ -6,6 +6,7 @@
   "Primary language is required": "Primary language is required",
   "Label is required": "Label is required",
   "Successfully created video.": "Successfully created video.",
+  "Failed to create video edition.": "Failed to create video edition.",
   "Something went wrong.": "Something went wrong.",
   "ID": "ID",
   "Slug": "Slug",


### PR DESCRIPTION
# Description

### Issue

_Provide a brief summary of why this task is needed_

[Link to Basecamp Todo](https://3.basecamp.com/3105655/projects)

### Solution

_Provide a detailed description of how exactly this task will be accomplished. This can be something technical. What specific steps will be taken to achieve the goal? This should include details on service integration, job logic, implementation, etc._

# External Changes

_If you have made changes to external services, need to add additional values to Doppler, or need to add something new to the database, explain it here. This may include updates to third-party services, changes to infrastructure configuration, integration with external APIs, etc._

# Additional information

_Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a custom hook for creating video editions, enhancing the video creation flow with automatic edition generation and improved error messaging.
- **Bug Fixes**
	- Added localized error messages for failed video edition creation.
- **Tests**
	- Enhanced test coverage for the new edition creation functionality, simplifying mock setups and ensuring accurate assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->