### PR TITLE
chore: update worker to handle new routes on prod

### DIFF
--- a/workers/jf-proxy/wrangler.toml
+++ b/workers/jf-proxy/wrangler.toml
@@ -11,8 +11,6 @@ name = "jf-proxy-stage"
 routes = [
   { pattern = "develop.jesusfilm.org/watch*", zone_name = "jesusfilm.org" },
   { pattern = "develop.jesusfilm.org/journeys*", zone_name = "jesusfilm.org" },
-  { pattern = "develop.jesusfilm.org/calendar", zone_name = "jesusfilm.org" },
-  { pattern = "develop.jesusfilm.org/products", zone_name = "jesusfilm.org" },
   { pattern = "develop.jesusfilm.org/resources", zone_name = "jesusfilm.org" },
   { pattern = "develop.jesusfilm.org/bin/*", zone_name = "jesusfilm.org" },
   { pattern = "develop.jesusfilm.org/api/*", zone_name = "jesusfilm.org" },
@@ -26,6 +24,8 @@ PROXY_DEST = "c89a34d4-4b06-4219-ad8b-c7289106424d.jesusfilm.org"
 name = "jf-proxy-prod"
 routes = [
   { pattern = "www.jesusfilm.org/watch*", zone_name = "jesusfilm.org" },
+  { pattern = "www.jesusfilm.org/journeys*", zone_name = "jesusfilm.org" },
+  { pattern = "www.jesusfilm.org/resources", zone_name = "jesusfilm.org" },
   { pattern = "www.jesusfilm.org/bin/*", zone_name = "jesusfilm.org" },
   { pattern = "www.jesusfilm.org/api/*", zone_name = "jesusfilm.org" },
   { pattern = "www.jesusfilm.org/_next/*", zone_name = "jesusfilm.org" }


### PR DESCRIPTION
This PR updates the Cloudflare worker configuration to handle new routes on production environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new endpoints for accessing journeys and resources, enhancing your navigation experience.

- **Chores**
  - Removed outdated routes for calendar and products to streamline service delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->