### PR TITLE
fix: fallback to iso3 if no bcp47

### DIFF
--- a/apps/arclight/src/app/v2/[...route]/_resources/index.ts
+++ b/apps/arclight/src/app/v2/[...route]/_resources/index.ts
@@ -434,7 +434,7 @@ resources.openapi(searchRoute, async (c) => {
     const transformedLanguages = languageHits.map((hit) => ({
       languageId: Number(hit.objectID),
       iso3: hit.iso3,
-      bcp47: hit.bcp47,
+      bcp47: hit.bcp47 ?? hit.iso3 ?? '',
       primaryCountryId: hit.primaryCountryId,
       name:
         hit.names.find((n) => n.bcp47 === metadataLanguageTags[0])?.value ??


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved language code handling: If the primary language code isn’t available, the system now falls back to a secondary code or defaults to an empty value, ensuring more reliable language mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->