### PR TITLE
fix(watch): show three lines on desktop

### DIFF
--- a/apps/watch/src/components/ResourcesView/ResourceSections/ResourceCard/ResourceCard.tsx
+++ b/apps/watch/src/components/ResourcesView/ResourceSections/ResourceCard/ResourceCard.tsx
@@ -127,7 +127,7 @@ export function ResourceCard({
             <Box
               sx={{
                 display: { xs: 'none', md: '-webkit-box' },
-                height: '66px',
+                height: 86,
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
                 WebkitBoxOrient: 'vertical',
@@ -137,7 +137,7 @@ export function ResourceCard({
               <Typography
                 variant="body1"
                 sx={{
-                  my: 1
+                  py: 1
                 }}
               >
                 {item?.description ?? ''}
@@ -156,7 +156,7 @@ export function ResourceCard({
               <Typography
                 variant="body2"
                 sx={{
-                  my: 1
+                  py: 1
                 }}
               >
                 {item?.description ?? ''}


### PR DESCRIPTION
This PR provides a fix to give the description of `ResourceCard` on desktop to have ellipsis after 3 lines of text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the visual layout of resource display cards by increasing the vertical space for a more balanced design.
  - Replaced margin settings with padding adjustments to create a consistent and refined spacing across text elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->