### PR TITLE
fix(watch): side menu overscroll behaviour

### DIFF
--- a/apps/watch/src/components/Header/Header.tsx
+++ b/apps/watch/src/components/Header/Header.tsx
@@ -90,7 +90,8 @@ export function Header({
               width: '100%',
               background: 'transparent',
               boxShadow: 'none',
-              overflowX: 'hidden'
+              overflowX: 'hidden',
+              overscrollBehaviorY: 'none'
             },
             onClick: () => setDrawerOpen(false)
           }}
@@ -106,7 +107,10 @@ export function Header({
             }}
           >
             <Box
-              sx={{ minHeight: '100%', width: { xs: '100%', lg: 530 } }}
+              sx={{
+                minHeight: '100%',
+                width: { xs: '100%', lg: 530 }
+              }}
               onClick={(e) => e.stopPropagation()}
             >
               <HeaderMenuPanel onClose={() => setDrawerOpen(false)} />

--- a/apps/watch/src/components/Header/HeaderMenuPanel/HeaderMenuPanel.tsx
+++ b/apps/watch/src/components/Header/HeaderMenuPanel/HeaderMenuPanel.tsx
@@ -57,7 +57,16 @@ export function HeaderMenuPanel({
             position: 'fixed',
             width: { xs: '100%', lg: 530 },
             zIndex: (theme) => theme.zIndex.drawer + 1,
-            backgroundColor: 'background.default'
+            backgroundColor: 'background.default',
+            '&::after': {
+              content: '""',
+              position: 'absolute',
+              top: 0,
+              bottom: 0,
+              left: '100%',
+              width: '100vw',
+              backgroundColor: 'background.default'
+            }
           }}
         >
           <Button


### PR DESCRIPTION
This PR provides a fix to disable the overscroll behaviour of the side menu. It also makes sure that the header portion of the side menu extends further right on desktop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced header component styling for smoother scroll interactions.
	- Introduced a refined overlay effect in the header menu for a more cohesive visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->