### PR TITLE
fix(watch): video hero height calculation

### DIFF
--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoHero.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoHero.tsx
@@ -64,11 +64,11 @@ export function VideoHero({ onPlay, hasPlayed }: VideoHeroProps): ReactElement {
         hideSpacer
         themeMode={ThemeMode.dark}
       />
-      <Div100vh
+      <Box
         css={{
+          height: '100svh',
           marginBottom: isFullscreen ? 0 : -VIDEO_HERO_BOTTOM_SPACING,
-          paddingBottom: isFullscreen ? 0 : VIDEO_HERO_BOTTOM_SPACING,
-          minHeight: 560
+          paddingBottom: isFullscreen ? 0 : VIDEO_HERO_BOTTOM_SPACING
         }}
       >
         <Box
@@ -93,7 +93,7 @@ export function VideoHero({ onPlay, hasPlayed }: VideoHeroProps): ReactElement {
             !isPlaying && <VideoHeroOverlay handlePlay={handlePlay} />
           )}
         </Box>
-      </Div100vh>
+      </Box>
     </>
   )
 }


### PR DESCRIPTION
This PR fixes the sudden resizing of the `VideoHero` on the video page when the user scrolls down on iOS safari.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the primary container element in the video display component for a more consistent layout.
- **Style**
  - Applied a full viewport height property to enhance the component's visual presentation.
  - Removed a fixed minimum height to allow for more flexible scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->