### PR TITLE
chore: replace objectfit on next image

### DIFF
--- a/apps/arclight/src/app/page.tsx
+++ b/apps/arclight/src/app/page.tsx
@@ -12,7 +12,12 @@ export default function Index(): ReactElement {
         margin: '0 auto'
       }}
     >
-      <Image src="/arclight.png" alt="logo" fill objectFit="contain" />
+      <Image
+        src="/arclight.png"
+        alt="logo"
+        fill
+        style={{ objectFit: 'contain' }}
+      />
     </Box>
   )
 }

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/Image/FocalPoint/FocalPoint.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/Image/FocalPoint/FocalPoint.tsx
@@ -117,7 +117,7 @@ export function FocalPoint({
                 src={imageBlock.src}
                 alt={imageBlock?.alt ?? ''}
                 layout="fill"
-                objectFit="cover"
+                style={{ objectFit: 'cover' }}
               />
               <Box
                 sx={{

--- a/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Metadata/VideoImage/VideoImage.tsx
+++ b/apps/videos-admin/src/app/[locale]/(dashboard)/videos/[videoId]/_VideoView/Metadata/VideoImage/VideoImage.tsx
@@ -67,7 +67,7 @@ export function VideoImage({ video }: VideoImageProps): ReactElement {
             src={src}
             alt={alt ?? t('video image')}
             layout="fill"
-            objectFit="cover"
+            style={{ objectFit: 'cover' }}
             priority
           />
         ) : (

--- a/apps/videos-admin/src/components/OrderedList/OrderedItem/OrderedItem.tsx
+++ b/apps/videos-admin/src/components/OrderedList/OrderedItem/OrderedItem.tsx
@@ -145,7 +145,7 @@ export function OrderedItem({
             alt={img.alt}
             loading="lazy"
             layout="fill"
-            objectFit="cover"
+            style={{ objectFit: 'cover' }}
           />
         </Box>
       )}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the way image styling is applied across several views. Images continue to fill their containers as before, ensuring a consistent display with no visible changes in appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->