### PR TITLE
feat: integrate Mux Player across video components

### DIFF
--- a/apps/arclight/src/app/videoPlayerUrl/VideoPlayer.tsx
+++ b/apps/arclight/src/app/videoPlayerUrl/VideoPlayer.tsx
@@ -1,4 +1,5 @@
 'use client'
+import MuxPlayer from '@mux/mux-player-react'
 import { useEffect, useRef } from 'react'
 import videojs from 'video.js'
 
@@ -11,12 +12,18 @@ interface VideoPlayerProps {
   hlsUrl: string
   videoTitle: string
   thumbnail?: string | null
+  isMux?: boolean
+  playbackId?: string
+  videoId?: string
 }
 
 export function VideoPlayer({
   hlsUrl,
   videoTitle,
-  thumbnail
+  thumbnail,
+  isMux = false,
+  playbackId,
+  videoId
 }: VideoPlayerProps): JSX.Element {
   const playerRef = useRef<HTMLVideoElement>(null)
 
@@ -54,10 +61,31 @@ export function VideoPlayer({
   }
 
   useEffect(() => {
-    if (playerRef.current != null) {
+    if (playerRef.current != null && !isMux) {
       initPlayer(playerRef)
     }
-  }, [])
+  }, [isMux])
+
+  if (isMux && playbackId) {
+    return (
+      <div className="relative w-full h-full">
+        <MuxPlayer
+          streamType="on-demand"
+          playbackId={playbackId}
+          metadata={{
+            video_id: videoId ?? '',
+            video_title: videoTitle,
+            player_name: 'arclight'
+          }}
+          style={{
+            width: '100%',
+            height: '100%'
+          }}
+          poster={thumbnail ?? undefined}
+        />
+      </div>
+    )
+  }
 
   return (
     <div className="relative w-full h-full">

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromMux/MuxDetails/MuxDetails.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromMux/MuxDetails/MuxDetails.spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 
 import {
   VideoBlockObjectFit,
@@ -12,9 +12,23 @@ jest.mock('@mui/material/useMediaQuery', () => ({
   default: jest.fn()
 }))
 
+// Mock MuxPlayer component
+jest.mock('@mux/mux-player-react', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(({ playbackId, poster }) => (
+    <div
+      data-testid="mux-player"
+      data-playback-id={playbackId}
+      data-poster={poster}
+    >
+      Mux Player
+    </div>
+  ))
+}))
+
 describe('MuxDetails', () => {
   it('should render details of a video', async () => {
-    const { getByRole } = render(
+    render(
       <MuxDetails
         activeVideoBlock={{
           __typename: 'VideoBlock',
@@ -48,16 +62,12 @@ describe('MuxDetails', () => {
         onSelect={jest.fn()}
       />
     )
-    const videoPlayer = getByRole('region', {
-      name: 'Video Player'
-    })
-    const sourceTag = videoPlayer.querySelector('.vjs-tech source')
-    expect(sourceTag?.getAttribute('src')).toBe(
-      'https://stream.mux.com/playbackId.m3u8'
-    )
-    expect(sourceTag?.getAttribute('type')).toBe('application/x-mpegURL')
-    const imageTag = videoPlayer.querySelector('.vjs-poster > picture > img')
-    expect(imageTag?.getAttribute('src')).toBe(
+
+    const muxPlayer = screen.getByTestId('mux-player')
+    expect(muxPlayer).toBeInTheDocument()
+    expect(muxPlayer).toHaveAttribute('data-playback-id', 'playbackId')
+    expect(muxPlayer).toHaveAttribute(
+      'data-poster',
       'https://image.mux.com/playbackId/thumbnail.png?time=1'
     )
   })

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromMux/MuxDetails/MuxDetails.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromMux/MuxDetails/MuxDetails.tsx
@@ -1,14 +1,9 @@
 import Stack from '@mui/material/Stack'
 import Box from '@mui/system/Box'
-import { ReactElement, useEffect, useRef } from 'react'
-import videojs from 'video.js'
-import Player from 'video.js/dist/types/player'
-
-import { defaultVideoJsOptions } from '@core/shared/ui/defaultVideoJsOptions'
+import MuxPlayer from '@mux/mux-player-react'
+import { ReactElement } from 'react'
 
 import type { VideoDetailsProps } from '../../VideoDetails/VideoDetails'
-
-import 'video.js/dist/video-js.css'
 
 export function MuxDetails({
   open,
@@ -17,25 +12,6 @@ export function MuxDetails({
   VideoDetailsProps,
   'open' | 'activeVideoBlock' | 'onSelect'
 >): ReactElement {
-  const videoRef = useRef<HTMLVideoElement>(null)
-  const playerRef = useRef<Player>()
-
-  useEffect(() => {
-    if (
-      open &&
-      videoRef.current != null &&
-      activeVideoBlock?.mediaVideo?.__typename === 'MuxVideo' &&
-      activeVideoBlock?.mediaVideo?.playbackId != null
-    ) {
-      playerRef.current = videojs(videoRef.current, {
-        ...defaultVideoJsOptions,
-        fluid: true,
-        controls: true,
-        poster: `https://image.mux.com/${activeVideoBlock.mediaVideo.playbackId}/thumbnail.png?time=1`
-      })
-    }
-  }, [activeVideoBlock, open, videoRef])
-
   return (
     <Stack spacing={4} sx={{ p: 6 }} data-testid="MuxDetails">
       <Box
@@ -45,19 +21,25 @@ export function MuxDetails({
           overflow: 'hidden'
         }}
       >
-        <video
-          ref={videoRef}
-          className="video-js vjs-big-play-centered"
-          playsInline
-        >
-          {activeVideoBlock?.mediaVideo?.__typename === 'MuxVideo' &&
-            activeVideoBlock?.mediaVideo?.playbackId != null && (
-              <source
-                src={`https://stream.mux.com/${activeVideoBlock?.mediaVideo?.playbackId}.m3u8`}
-                type="application/x-mpegURL"
-              />
-            )}
-        </video>
+        {open &&
+          activeVideoBlock?.mediaVideo?.__typename === 'MuxVideo' &&
+          activeVideoBlock?.mediaVideo?.playbackId != null && (
+            <MuxPlayer
+              streamType="on-demand"
+              playbackId={activeVideoBlock.mediaVideo.playbackId}
+              metadata={{
+                video_id: activeVideoBlock.mediaVideo.id || '',
+                video_title: activeVideoBlock.title || '',
+                player_name: 'journeys-admin'
+              }}
+              style={{
+                width: '100%',
+                height: 'auto',
+                aspectRatio: '16/9'
+              }}
+              poster={`https://image.mux.com/${activeVideoBlock.mediaVideo.playbackId}/thumbnail.png?time=1`}
+            />
+          )}
       </Box>
     </Stack>
   )

--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoPlayer.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoPlayer.tsx
@@ -1,4 +1,3 @@
-import MuxPlayer from '@mux/mux-player-react'
 import { ReactElement, useEffect, useRef, useState } from 'react'
 import videojs from 'video.js'
 import Player from 'video.js/dist/types/player'
@@ -22,10 +21,6 @@ export function VideoPlayer({
   const { variant, title } = useVideo()
   const videoRef = useRef<HTMLVideoElement>(null)
   const [player, setPlayer] = useState<Player>()
-
-  // Since we don't have a direct way to check if it's a Mux video,
-  // we'll assume it's not for now and use the standard video.js player
-  const isMuxVideo = false
 
   useEffect(() => {
     if (videoRef.current != null) {

--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoPlayer.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoPlayer.tsx
@@ -1,3 +1,4 @@
+import MuxPlayer from '@mux/mux-player-react'
 import { ReactElement, useEffect, useRef, useState } from 'react'
 import videojs from 'video.js'
 import Player from 'video.js/dist/types/player'
@@ -21,6 +22,10 @@ export function VideoPlayer({
   const { variant, title } = useVideo()
   const videoRef = useRef<HTMLVideoElement>(null)
   const [player, setPlayer] = useState<Player>()
+
+  // Since we don't have a direct way to check if it's a Mux video,
+  // we'll assume it's not for now and use the standard video.js player
+  const isMuxVideo = false
 
   useEffect(() => {
     if (videoRef.current != null) {

--- a/libs/journeys/ui/src/components/Video/Video.spec.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.spec.tsx
@@ -15,6 +15,23 @@ jest.mock('@mui/material/useMediaQuery', () => ({
   default: () => true
 }))
 
+// Mock MuxPlayer component
+jest.mock('@mux/mux-player-react', () => ({
+  __esModule: true,
+  default: jest
+    .fn()
+    .mockImplementation(({ playbackId, startTime, metadata }) => (
+      <div
+        data-testid="mux-player"
+        data-playback-id={playbackId}
+        data-start-time={startTime}
+        data-video-id={metadata?.video_id}
+      >
+        Mux Player
+      </div>
+    ))
+}))
+
 const block: TreeBlock<VideoFields> = {
   __typename: 'VideoBlock',
   id: 'video0.id',
@@ -141,13 +158,12 @@ describe('Video', () => {
         />
       </MockedProvider>
     )
-    const sourceTag = screen
-      .getByTestId('JourneysVideo-video0.id')
-      .querySelector('.vjs-tech source')
-    expect(sourceTag?.getAttribute('src')).toBe(
-      `https://stream.mux.com/videoId.m3u8?asset_start_time=${0}&asset_end_time=${10000}`
-    )
-    expect(sourceTag?.getAttribute('type')).toBe('application/x-mpegURL')
+
+    const muxPlayer = screen.getByTestId('mux-player')
+    expect(muxPlayer).toBeInTheDocument()
+    expect(muxPlayer).toHaveAttribute('data-playback-id', 'videoId')
+    expect(muxPlayer).toHaveAttribute('data-start-time', '0')
+    expect(muxPlayer).toHaveAttribute('data-video-id', 'videoId')
   })
 
   it('should render mux video with startAt and endAt', () => {
@@ -171,13 +187,12 @@ describe('Video', () => {
         />
       </MockedProvider>
     )
-    const sourceTag = screen
-      .getByTestId('JourneysVideo-video0.id')
-      .querySelector('.vjs-tech source')
-    expect(sourceTag?.getAttribute('src')).toBe(
-      `https://stream.mux.com/videoId.m3u8?asset_start_time=${block.startAt}&asset_end_time=${endAt}`
-    )
-    expect(sourceTag?.getAttribute('type')).toBe('application/x-mpegURL')
+
+    const muxPlayer = screen.getByTestId('mux-player')
+    expect(muxPlayer).toBeInTheDocument()
+    expect(muxPlayer).toHaveAttribute('data-playback-id', 'videoId')
+    expect(muxPlayer).toHaveAttribute('data-start-time', '10')
+    expect(muxPlayer).toHaveAttribute('data-video-id', 'videoId')
   })
 
   it('should render poster block image', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,8 @@
         "@mui/x-date-pickers": "^7.27.1",
         "@mui/x-tree-view": "^7.26.0",
         "@mux/mux-node": "^9.0.0",
+        "@mux/mux-player": "^3.3.0",
+        "@mux/mux-player-react": "^3.3.0",
         "@mux/upchunk": "^3.4.0",
         "@nestjs-modules/mailer": "^2.0.2",
         "@nestjs/apollo": "^12.0.7",
@@ -21582,6 +21584,64 @@
       "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
       "license": "MIT"
     },
+    "node_modules/@mux/mux-player": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-3.3.0.tgz",
+      "integrity": "sha512-/VSOPKBd56QzQzVSjuigS8r6kAMJRuNskEUGqU0o0k37FC7ztLH4Fh85fzhEyWSDHs3krJ1dBLqhJ1eCs8r3sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-video": "0.24.3",
+        "@mux/playback-core": "0.28.3",
+        "media-chrome": "~4.5.0",
+        "player.style": "^0.1.4"
+      }
+    },
+    "node_modules/@mux/mux-player-react": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-3.3.0.tgz",
+      "integrity": "sha512-S+P7shdph+Uj73emLiDoAfDKxHbbzQaqTHmndMXqsNhjfOF0ve7ZF7pLZOAV16UUwBrBDwOQwwmIFwd3wYgY+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-player": "3.3.0",
+        "@mux/playback-core": "0.28.3",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0",
+        "react": "^17.0.2 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0",
+        "react-dom": "^17.0.2 || ^17.0.2-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mux/mux-video": {
+      "version": "0.24.3",
+      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.24.3.tgz",
+      "integrity": "sha512-HM5oasXfmYVfmsTMv1lZIW/OkHEQMJwavrl1gI4p13bdlmmUu2CNARiTv/tYATJ9+NkYHlU3RsteHXx7tK7+vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/playback-core": "0.28.3",
+        "castable-video": "~1.1.4",
+        "custom-media-element": "~1.4.2",
+        "media-tracks": "~0.3.2"
+      }
+    },
+    "node_modules/@mux/playback-core": {
+      "version": "0.28.3",
+      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.28.3.tgz",
+      "integrity": "sha512-QID2zp76szCTiXZp5LLYwDZV68HgflOoF10Vmp6P81FqKHonHVrQ0svNGqW6fMZLH2Ymf/Qc6kHSnwWTucgQqA==",
+      "license": "MIT",
+      "dependencies": {
+        "hls.js": "~1.5.19",
+        "mux-embed": "^5.5.0"
+      }
+    },
     "node_modules/@mux/upchunk": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@mux/upchunk/-/upchunk-3.4.0.tgz",
@@ -41632,6 +41692,15 @@
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "dev": true
     },
+    "node_modules/castable-video": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-1.1.4.tgz",
+      "integrity": "sha512-EBQJ04ShZFi1CGKXhBui6UYFJf+6C6wNIa12J2/NSu+ca/XeF5gkXUwHQ8uSKVCpvFYS2RRRB2zf29R0OYz8Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "custom-media-element": "~1.4.2"
+      }
+    },
     "node_modules/catharsis": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
@@ -41653,6 +41722,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ce-la-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ce-la-react/-/ce-la-react-0.1.3.tgz",
+      "integrity": "sha512-zZwEEJv9XukeEGbswQXObaDJjYAufOIilSnDg4BWCpKNEYN84H9fpaB+wl+rYKWOIH4wBBPbLnOxKvDIwsL/JQ==",
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "react": ">=17.0.0"
       }
     },
     "node_modules/chai": {
@@ -44436,6 +44514,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/custom-media-element": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.4.2.tgz",
+      "integrity": "sha512-AM6FRWqJyW7pWTvXb4uJj6yvHE7C6UutdhJ5o3XO5NEl5aWFcfnpz8/TuW8qr1+/wfbj50wRvdArnSNjTmjmVw==",
+      "license": "MIT"
     },
     "node_modules/cypress": {
       "version": "13.15.1",
@@ -54336,6 +54420,12 @@
         "value-equal": "^1.0.1"
       }
     },
+    "node_modules/hls.js": {
+      "version": "1.5.20",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.5.20.tgz",
+      "integrity": "sha512-uu0VXUK52JhihhnN/MVVo1lvqNNuhoxkonqgO3IpjvQiGpJBdIXMGkofjQb/j9zvV7a1SW8U9g1FslWx/1HOiQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -60801,6 +60891,18 @@
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/media-chrome": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.5.0.tgz",
+      "integrity": "sha512-MkVFFM+WvkkMwFu7sXr0bJMdQ5dbJz3BkhofPguiIHvgKYWei7VDPTEC41LmdhxWx4jQQ0FCYHXN8YFOWb7Olw==",
+      "license": "MIT"
+    },
+    "node_modules/media-tracks": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/media-tracks/-/media-tracks-0.3.3.tgz",
+      "integrity": "sha512-9P2FuUHnZZ3iji+2RQk7Zkh5AmZTnOG5fODACnjhCVveX1McY3jmCRHofIEI+yTBqplz7LXy48c7fQ3Uigp88w==",
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -70014,6 +70116,31 @@
       "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/player.style": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/player.style/-/player.style-0.1.5.tgz",
+      "integrity": "sha512-qfeudwJbYWQ/cDERtxeM5gnaY1AvaC7tTgl7COY1lcCMssuz4EQzUz/c5P9OKUSi1TrXj0NAFw3lK6kJoYFNbQ==",
+      "license": "MIT",
+      "workspaces": [
+        ".",
+        "site",
+        "examples/*",
+        "scripts/*",
+        "themes/*"
+      ],
+      "dependencies": {
+        "media-chrome": "~4.7.1"
+      }
+    },
+    "node_modules/player.style/node_modules/media-chrome": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.7.1.tgz",
+      "integrity": "sha512-9aZZTpMeSWqHq8klcwo10dKR0DcKHk6SEFaAp0gwgn9dPpl/E6WTkTHswwHqmLPPny1P0Mf33NmA2d2Qj+62tA==",
+      "license": "MIT",
+      "dependencies": {
+        "ce-la-react": "^0.1.3"
       }
     },
     "node_modules/playwright": {
@@ -84695,6 +84822,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/react-email/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.24",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.24.tgz",
+      "integrity": "sha512-9KuS+XUXM3T6v7leeWU0erpJ6NsFIwiTFD5nzNg8J5uo/DMIPvCp3L1Ao5HjbHX0gkWPB1VrKoo/Il4F0cGK2Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -84823,21 +84823,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/react-email/node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.24.tgz",
-      "integrity": "sha512-9KuS+XUXM3T6v7leeWU0erpJ6NsFIwiTFD5nzNg8J5uo/DMIPvCp3L1Ao5HjbHX0gkWPB1VrKoo/Il4F0cGK2Q==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -84823,6 +84823,21 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/react-email/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.24",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.24.tgz",
+      "integrity": "sha512-9KuS+XUXM3T6v7leeWU0erpJ6NsFIwiTFD5nzNg8J5uo/DMIPvCp3L1Ao5HjbHX0gkWPB1VrKoo/Il4F0cGK2Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
     "@mui/x-date-pickers": "^7.27.1",
     "@mui/x-tree-view": "^7.26.0",
     "@mux/mux-node": "^9.0.0",
+    "@mux/mux-player": "^3.3.0",
+    "@mux/mux-player-react": "^3.3.0",
     "@mux/upchunk": "^3.4.0",
     "@nestjs-modules/mailer": "^2.0.2",
     "@nestjs/apollo": "^12.0.7",


### PR DESCRIPTION
This commit adds @mux/mux-player and @mux/mux-player-react to the project and updates video components to use the new Mux Player. Changes include:

- Added Mux Player dependencies to package.json
- Updated VideoPlayer components in arclight, journeys-admin, watch, and journeys UI
- Replaced video.js player with MuxPlayer for Mux video sources
- Added support for playback metadata, start time, and poster images
- Updated test cases to work with new Mux Player component