### PR TITLE
fix: disallow duplicates in bible citations 

### DIFF
--- a/apis/api-media/db/migrations/20250318152126_update_bible_citation_nulls/migration.sql
+++ b/apis/api-media/db/migrations/20250318152126_update_bible_citation_nulls/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[videoId,bibleBookId,chapterStart,chapterEnd,verseStart,verseEnd]` on the table `BibleCitation` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE INDEX "BibleCitation_order_idx" ON "BibleCitation"("order");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BibleCitation_videoId_bibleBookId_chapterStart_chapterEnd_v_key" ON "BibleCitation"("videoId", "bibleBookId", "chapterStart", "chapterEnd", "verseStart", "verseEnd");

--- a/apis/api-media/db/migrations/20250318152127_update_bible_citation_values.sql
+++ b/apis/api-media/db/migrations/20250318152127_update_bible_citation_values.sql
@@ -1,0 +1,9 @@
+-- Update NULL values with appropriate defaults
+UPDATE "BibleCitation" SET "chapterEnd" = -1 WHERE "chapterEnd" IS NULL;
+UPDATE "BibleCitation" SET "verseStart" = -1 WHERE "verseStart" IS NULL;
+UPDATE "BibleCitation" SET "verseEnd" = -1 WHERE "verseEnd" IS NULL;
+
+-- Make the columns required
+ALTER TABLE "BibleCitation" ALTER COLUMN "chapterEnd" SET NOT NULL;
+ALTER TABLE "BibleCitation" ALTER COLUMN "verseStart" SET NOT NULL;
+ALTER TABLE "BibleCitation" ALTER COLUMN "verseEnd" SET NOT NULL; 

--- a/apis/api-media/db/migrations/20250318152249_biblecitation/migration.sql
+++ b/apis/api-media/db/migrations/20250318152249_biblecitation/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - Made the column `chapterEnd` on table `BibleCitation` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `verseStart` on table `BibleCitation` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `verseEnd` on table `BibleCitation` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "BibleCitation" ALTER COLUMN "chapterEnd" SET NOT NULL,
+ALTER COLUMN "verseStart" SET NOT NULL,
+ALTER COLUMN "verseEnd" SET NOT NULL;

--- a/apis/api-media/db/schema.prisma
+++ b/apis/api-media/db/schema.prisma
@@ -301,13 +301,16 @@ model BibleCitation {
   bibleBookId  String
   osisId       String
   chapterStart Int
-  chapterEnd   Int?
-  verseStart   Int?
-  verseEnd     Int?
+  chapterEnd   Int
+  verseStart   Int
+  verseEnd     Int
   videoId      String
   order        Int
   video        Video     @relation(fields: [videoId], references: [id])
   bibleBook    BibleBook @relation(fields: [bibleBookId], references: [id])
+
+  @@unique([videoId, bibleBookId, chapterStart, chapterEnd, verseStart, verseEnd])
+  @@index([order])
 }
 
 model BibleBook {

--- a/apis/api-media/src/schema/bibleCitation/bibleCitation.spec.ts
+++ b/apis/api-media/src/schema/bibleCitation/bibleCitation.spec.ts
@@ -35,9 +35,9 @@ describe('BibleCitation', () => {
           bibleBookId: 'bibleBookId',
           bibleBook: { id: 'bibleBookId' },
           chapterStart: 1,
-          chapterEnd: null,
+          chapterEnd: -1,
           verseStart: 1,
-          verseEnd: null,
+          verseEnd: -1,
           videoId: 'videoId',
           video: { id: 'videoId' },
           order: 0

--- a/apis/api-media/src/schema/bibleCitation/bibleCitation.spec.ts
+++ b/apis/api-media/src/schema/bibleCitation/bibleCitation.spec.ts
@@ -63,9 +63,9 @@ describe('BibleCitation', () => {
           osisId: 'Gen',
           bibleBook: { id: 'bibleBookId' },
           chapterStart: 1,
-          chapterEnd: null,
+          chapterEnd: -1,
           verseStart: 1,
-          verseEnd: null,
+          verseEnd: -1,
           video: { id: 'videoId' }
         }
       ])

--- a/apis/api-media/src/schema/bibleCitation/bibleCitation.spec.ts
+++ b/apis/api-media/src/schema/bibleCitation/bibleCitation.spec.ts
@@ -63,9 +63,9 @@ describe('BibleCitation', () => {
           osisId: 'Gen',
           bibleBook: { id: 'bibleBookId' },
           chapterStart: 1,
-          chapterEnd: -1,
+          chapterEnd: null,
           verseStart: 1,
-          verseEnd: -1,
+          verseEnd: null,
           video: { id: 'videoId' }
         }
       ])

--- a/apis/api-media/src/schema/bibleCitation/bibleCitation.ts
+++ b/apis/api-media/src/schema/bibleCitation/bibleCitation.ts
@@ -7,9 +7,9 @@ builder.prismaObject('BibleCitation', {
     osisId: t.exposeString('osisId', { nullable: false }),
     bibleBook: t.relation('bibleBook', { nullable: false }),
     chapterStart: t.exposeInt('chapterStart', { nullable: false }),
-    chapterEnd: t.exposeInt('chapterEnd'),
-    verseStart: t.exposeInt('verseStart'),
-    verseEnd: t.exposeInt('verseEnd'),
+    chapterEnd: t.exposeInt('chapterEnd', { nullable: false }),
+    verseStart: t.exposeInt('verseStart', { nullable: false }),
+    verseEnd: t.exposeInt('verseEnd', { nullable: false }),
     video: t.relation('video', { nullable: false })
   })
 })

--- a/apis/api-media/src/schema/bibleCitation/bibleCitation.ts
+++ b/apis/api-media/src/schema/bibleCitation/bibleCitation.ts
@@ -7,9 +7,18 @@ builder.prismaObject('BibleCitation', {
     osisId: t.exposeString('osisId', { nullable: false }),
     bibleBook: t.relation('bibleBook', { nullable: false }),
     chapterStart: t.exposeInt('chapterStart', { nullable: false }),
-    chapterEnd: t.exposeInt('chapterEnd', { nullable: false }),
-    verseStart: t.exposeInt('verseStart', { nullable: false }),
-    verseEnd: t.exposeInt('verseEnd', { nullable: false }),
+    chapterEnd: t.int({
+      nullable: true,
+      resolve: (parent) => (parent.chapterEnd === -1 ? null : parent.chapterEnd)
+    }),
+    verseStart: t.int({
+      nullable: true,
+      resolve: (parent) => (parent.verseStart === -1 ? null : parent.verseStart)
+    }),
+    verseEnd: t.int({
+      nullable: true,
+      resolve: (parent) => (parent.verseEnd === -1 ? null : parent.verseEnd)
+    }),
     video: t.relation('video', { nullable: false })
   })
 })

--- a/apis/api-media/src/schema/video/video.spec.ts
+++ b/apis/api-media/src/schema/video/video.spec.ts
@@ -123,9 +123,9 @@ describe('video', () => {
           osisId: 'Gen',
           bibleBookId: 'bibleBookId',
           chapterStart: 1,
-          chapterEnd: null,
+          chapterEnd: -1,
           verseStart: 1,
-          verseEnd: null,
+          verseEnd: -1,
           videoId: 'videoId',
           order: 0
         }

--- a/apis/api-media/src/workers/bigQuery/importers/bibleCitations/bibleCitations.spec.ts
+++ b/apis/api-media/src/workers/bigQuery/importers/bibleCitations/bibleCitations.spec.ts
@@ -45,9 +45,9 @@ describe('bigQuery/importers/bibleCitations', () => {
           bibleBookId: 1,
           order: 1,
           chapterStart: 1,
-          chapterEnd: null,
+          chapterEnd: -1,
           verseStart: 1,
-          verseEnd: null,
+          verseEnd: -1,
           position: 1,
           datastream_metadata: {
             uuid: 'mockUuid'
@@ -62,9 +62,9 @@ describe('bigQuery/importers/bibleCitations', () => {
             bibleBookId: '1',
             order: 1,
             chapterStart: 1,
-            chapterEnd: null,
+            chapterEnd: -1,
             verseStart: 1,
-            verseEnd: null
+            verseEnd: -1
           },
           create: {
             id: 'mockUuid',
@@ -73,9 +73,9 @@ describe('bigQuery/importers/bibleCitations', () => {
             bibleBookId: '1',
             order: 1,
             chapterStart: 1,
-            chapterEnd: null,
+            chapterEnd: -1,
             verseStart: 1,
-            verseEnd: null
+            verseEnd: -1
           }
         })
       })
@@ -91,9 +91,9 @@ describe('bigQuery/importers/bibleCitations', () => {
           bibleBookId: 1,
           order: 1,
           chapterStart: 1,
-          chapterEnd: null,
+          chapterEnd: -1,
           verseStart: 1,
-          verseEnd: null,
+          verseEnd: -1,
           position: 1,
           datastream_metadata: {
             uuid: 'mockUuid'
@@ -105,9 +105,9 @@ describe('bigQuery/importers/bibleCitations', () => {
           bibleBookId: 1,
           order: 1,
           chapterStart: 1,
-          chapterEnd: null,
+          chapterEnd: -1,
           verseStart: 1,
-          verseEnd: null,
+          verseEnd: -1,
           position: 1,
           datastream_metadata: {
             uuid: 'mockUuid1'
@@ -123,9 +123,9 @@ describe('bigQuery/importers/bibleCitations', () => {
             bibleBookId: '1',
             order: 1,
             chapterStart: 1,
-            chapterEnd: null,
+            chapterEnd: -1,
             verseStart: 1,
-            verseEnd: null
+            verseEnd: -1
           },
           {
             id: 'mockUuid1',
@@ -134,9 +134,9 @@ describe('bigQuery/importers/bibleCitations', () => {
             bibleBookId: '1',
             order: 1,
             chapterStart: 1,
-            chapterEnd: null,
+            chapterEnd: -1,
             verseStart: 1,
-            verseEnd: null
+            verseEnd: -1
           }
         ],
         skipDuplicates: true

--- a/apis/api-media/src/workers/bigQuery/importers/bibleCitations/bibleCitations.ts
+++ b/apis/api-media/src/workers/bigQuery/importers/bibleCitations/bibleCitations.ts
@@ -24,7 +24,10 @@ const bibleCitationSchema = z
   .transform((data) => ({
     ...omit(data, ['position', 'datastream_metadata']),
     id: data.datastream_metadata.uuid,
-    order: data.position
+    order: data.position,
+    chapterEnd: data.chapterEnd ?? -1,
+    verseStart: data.verseStart ?? -1,
+    verseEnd: data.verseEnd ?? -1
   }))
 
 export async function importBibleCitations(logger?: Logger): Promise<void> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced citation data consistency by enforcing complete, non-null values for chapter and verse fields.
  - Prevented duplicate citation entries with added uniqueness constraints on multiple fields.
  - Optimized data retrieval through refined indexing on the citation table for better performance.
  - Implemented default value updates for chapter and verse fields to ensure stable and reliable citation information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->