### PR TITLE
fix: omit journeyId from input when saving JourneyViewEvent

### DIFF
--- a/apis/api-journeys/src/app/modules/event/journey/journey.resolver.spec.ts
+++ b/apis/api-journeys/src/app/modules/event/journey/journey.resolver.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing'
+import omit from 'lodash/omit'
 
 import { keyAsId } from '@core/nest/decorators/KeyAsId'
 
@@ -92,7 +93,7 @@ describe('JourneyViewEventResolver', () => {
       expect(
         await resolver.journeyViewEventCreate('user.id', userAgent, input)
       ).toEqual({
-        ...input,
+        ...omit(input, 'journeyId'),
         typename: 'JourneyViewEvent',
         visitor: {
           connect: { id: visitorWithId.id }

--- a/apis/api-journeys/src/app/modules/event/journey/journey.resolver.ts
+++ b/apis/api-journeys/src/app/modules/event/journey/journey.resolver.ts
@@ -3,6 +3,7 @@
 import { UseGuards } from '@nestjs/common'
 import { Args, Mutation, Parent, ResolveField, Resolver } from '@nestjs/graphql'
 import { GraphQLError } from 'graphql'
+import { omit } from 'lodash'
 
 import { CurrentUserAgent } from '@core/nest/decorators/CurrentUserAgent'
 import { CurrentUserId } from '@core/nest/decorators/CurrentUserId'
@@ -64,7 +65,7 @@ export class JourneyViewEventResolver {
     if (existingEvent == null) {
       const promises = [
         this.eventService.save({
-          ...input,
+          ...omit(input, 'journeyId'),
           id: input.id ?? undefined,
           typename: 'JourneyViewEvent',
           visitor: { connect: { id: visitor.id } },

--- a/apis/api-journeys/src/app/modules/event/journey/journey.resolver.ts
+++ b/apis/api-journeys/src/app/modules/event/journey/journey.resolver.ts
@@ -3,7 +3,7 @@
 import { UseGuards } from '@nestjs/common'
 import { Args, Mutation, Parent, ResolveField, Resolver } from '@nestjs/graphql'
 import { GraphQLError } from 'graphql'
-import { omit } from 'lodash'
+import omit from 'lodash/omit'
 
 import { CurrentUserAgent } from '@core/nest/decorators/CurrentUserAgent'
 import { CurrentUserId } from '@core/nest/decorators/CurrentUserId'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the journey event processing by excluding the `journeyId` from the data saved during event creation, promoting more accurate event tracking and association within the system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->