### PR TITLE
fix: add ga to autoplay start

### DIFF
--- a/apps/watch/src/components/CollectionsPage/CollectionVideoPlayer/CollectionVideoPlayer.tsx
+++ b/apps/watch/src/components/CollectionsPage/CollectionVideoPlayer/CollectionVideoPlayer.tsx
@@ -297,6 +297,19 @@ export function CollectionVideoPlayer({
       if (isVisible) {
         player.muted(mutePage)
         setIsMuted(mutePage)
+        eventToDataLayer(
+          `video_autoplay_starts`,
+          videoData?.content.id,
+          videoData?.content.variant?.language.id,
+          videoData?.content.title[0].value,
+          videoData?.content.variant?.language?.name.find(
+            ({ primary }) => !primary
+          )?.value ?? videoData?.content.variant?.language?.name[0]?.value,
+          Math.round(player.currentTime() ?? 0),
+          Math.round(
+            ((player.currentTime() ?? 0) / (player.duration() ?? 1)) * 100
+          )
+        )
         void player.play()
         setIsPlaying(true)
       } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced video player behavior: Videos now trigger a background logging event when they autoplay upon visibility. This improvement supports better analytics on playback performance, paving the way for future enhancements to your video viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->