### PR TITLE
fix: hide sign up from add block

### DIFF
--- a/apps/journeys-admin-e2e/src/e2e/discover/card-level-actions.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/card-level-actions.spec.ts
@@ -141,23 +141,6 @@ test.describe('verify card level actions', () => {
     await cardLevelActionPage.verifyFeedBackDeletedFromCard() // verifying the feedback section is deleted from the card
   })
 
-  // Subscribe - create, update & delete
-  test('Subscribe - create, update & delete', async ({ page }) => {
-    const cardLevelActionPage = new CardLevelActionPage(page)
-    await cardLevelActionPage.clickAddBlockBtn() // clicking on add block button
-    await cardLevelActionPage.clickBtnInAddBlockDrawer('Subscribe') // clicking on subscribe button in add block drawer
-    await cardLevelActionPage.verifySubscribeAddedToCard() // verify subscribe section is added to the card
-    await cardLevelActionPage.clickActionOfFeedBackProperties() // clicking the action property dropdown in the subscribe properties drawer
-    await cardLevelActionPage.selectEmailOptionInPrepertiesOptions() // selecting the 'Selected card' option in 'navigate to' options and below the selecting the card for navigation
-    await cardLevelActionPage.clickSubscribePropertiesDropDown('Button Icon') // clicking the 'button icon' property dropdown in the subscribe properties drawer
-    await cardLevelActionPage.selectIconForProperties() // seleting an icon for the subscribe button section
-    await cardLevelActionPage.verifySelecetdIconInCardBelowSubscribe() // veriying the Selected icon is updated in the subscribe section of the card
-    await cardLevelActionPage.selectWholeSubscribeSectionInCard() // selecting the whole subscribe section
-    await cardLevelActionPage.clickDeleteBtnInToolTipBar() // clicking delete button in the tooltip bar
-    await cardLevelActionPage.verifyToastMessage() // verifying the toast message
-    await cardLevelActionPage.verifySubscribeDeletedFromCard() //  verifying the subscribe section is deleted from the card
-  })
-
   // Footer properties - Hosted By & Chat Widget
   test('Footer properties - create, update & delete', async ({ page }) => {
     const cardLevelActionPage = new CardLevelActionPage(page)

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/AddBlock/AddBlock.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/AddBlock/AddBlock.spec.tsx
@@ -76,9 +76,6 @@ describe('AddBlock', () => {
     expect(
       getByTestId('JourneysAdminButtonNewRadioQuestionButton')
     ).toBeInTheDocument()
-    expect(
-      getByTestId('JourneysAdminButtonNewSignUpButton')
-    ).toBeInTheDocument()
     expect(getByTestId('JourneysAdminButtonNewButton')).toBeInTheDocument()
   })
 

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/AddBlock/AddBlock.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/AddBlock/AddBlock.tsx
@@ -14,7 +14,6 @@ import { Drawer } from '../../Drawer'
 import { NewButtonButton } from './NewButtonButton'
 import { NewImageButton } from './NewImageButton'
 import { NewRadioQuestionButton } from './NewRadioQuestionButton'
-import { NewSignUpButton } from './NewSignUpButton'
 import { NewSpacerButton } from './NewSpacerButton'
 import { NewTextResponseButton } from './NewTextResponseButton'
 import { NewTypographyButton } from './NewTypographyButton'
@@ -58,9 +57,6 @@ export function AddBlock(): ReactElement {
         </Grid>
         <Grid item xs={6} md={12}>
           <NewTextResponseButton />
-        </Grid>
-        <Grid item xs={6} md={12}>
-          <NewSignUpButton />
         </Grid>
         <Grid item xs={6} md={12}>
           <NewButtonButton />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Removed the "New Sign Up" option from the block addition interface, streamlining the available choices to five instead of six.
  
- **Bug Fixes**
  - Removed obsolete test cases related to the "New Sign Up" button and "Subscribe" functionality, ensuring the test suite reflects current features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->