### PR TITLE
fix: journey background video playback on safari

### DIFF
--- a/libs/journeys/ui/src/components/Card/ContainedCover/BackgroundVideo/BackgroundVideo.tsx
+++ b/libs/journeys/ui/src/components/Card/ContainedCover/BackgroundVideo/BackgroundVideo.tsx
@@ -4,7 +4,7 @@ import { CSSProperties, ReactElement, useEffect, useRef } from 'react'
 import videojs from 'video.js'
 import Player from 'video.js/dist/types/player'
 
-import { defaultVideoJsOptions } from '@core/shared/ui/defaultVideoJsOptions'
+import { defaultBackgroundVideoJsOptions } from '@core/shared/ui/defaultVideoJsOptions'
 
 import {
   VideoBlockObjectFit,
@@ -41,7 +41,7 @@ export function BackgroundVideo({
   useEffect(() => {
     if (videoRef.current != null) {
       playerRef.current = videojs(videoRef.current, {
-        ...defaultVideoJsOptions,
+        ...defaultBackgroundVideoJsOptions,
         autoplay: true,
         controls: false,
         controlBar: false,

--- a/libs/shared/ui/src/libs/defaultVideoJsOptions/defaultVideoJsOptions.spec.ts
+++ b/libs/shared/ui/src/libs/defaultVideoJsOptions/defaultVideoJsOptions.spec.ts
@@ -1,4 +1,7 @@
-import { defaultBackgroundVideoJsOptions, defaultVideoJsOptions } from './defaultVideoJsOptions'
+import {
+  defaultBackgroundVideoJsOptions,
+  defaultVideoJsOptions
+} from './defaultVideoJsOptions'
 
 describe('defaultVideoJsOptions', () => {
   it('should have enableSmoothSeeking set to true', () => {
@@ -69,43 +72,67 @@ describe('defaultBackgroundVideoJsOptions', () => {
 
   describe('hls', () => {
     it('should have useDevicePixelRatio set to true', () => {
-      expect(defaultBackgroundVideoJsOptions.html5.hls.useDevicePixelRatio).toBe(true)
+      expect(
+        defaultBackgroundVideoJsOptions.html5.hls.useDevicePixelRatio
+      ).toBe(true)
     })
 
     it('should have useBandwidthFromLocalStorage set to true', () => {
-      expect(defaultBackgroundVideoJsOptions.html5.hls.useBandwidthFromLocalStorage).toBe(true)
+      expect(
+        defaultBackgroundVideoJsOptions.html5.hls.useBandwidthFromLocalStorage
+      ).toBe(true)
     })
 
     it('should have useNetworkInformationApi set to true', () => {
-      expect(defaultBackgroundVideoJsOptions.html5.hls.useNetworkInformationApi).toBe(true)
+      expect(
+        defaultBackgroundVideoJsOptions.html5.hls.useNetworkInformationApi
+      ).toBe(true)
     })
 
     it('should have limitRenditionByPlayerDimensions set to false', () => {
-      expect(defaultBackgroundVideoJsOptions.html5.hls.limitRenditionByPlayerDimensions).toBe(false)
+      expect(
+        defaultBackgroundVideoJsOptions.html5.hls
+          .limitRenditionByPlayerDimensions
+      ).toBe(false)
     })
   })
 
   describe('vhs', () => {
     it('should have useDevicePixelRatio set to true', () => {
-      expect(defaultBackgroundVideoJsOptions.html5.vhs.useDevicePixelRatio).toBe(true)
+      expect(
+        defaultBackgroundVideoJsOptions.html5.vhs.useDevicePixelRatio
+      ).toBe(true)
     })
 
     it('should have useBandwidthFromLocalStorage set to true', () => {
-      expect(defaultBackgroundVideoJsOptions.html5.vhs.useBandwidthFromLocalStorage).toBe(true)
+      expect(
+        defaultBackgroundVideoJsOptions.html5.vhs.useBandwidthFromLocalStorage
+      ).toBe(true)
     })
 
     it('should have useNetworkInformationApi set to true', () => {
-      expect(defaultBackgroundVideoJsOptions.html5.vhs.useNetworkInformationApi).toBe(true)
+      expect(
+        defaultBackgroundVideoJsOptions.html5.vhs.useNetworkInformationApi
+      ).toBe(true)
     })
 
     it('should have limitRenditionByPlayerDimensions set to false', () => {
-      expect(defaultBackgroundVideoJsOptions.html5.vhs.limitRenditionByPlayerDimensions).toBe(false)
+      expect(
+        defaultBackgroundVideoJsOptions.html5.vhs
+          .limitRenditionByPlayerDimensions
+      ).toBe(false)
     })
   })
 
   it('should not have native track options', () => {
-    expect((defaultBackgroundVideoJsOptions.html5 as any).nativeAudioTracks).toBeUndefined()
-    expect((defaultBackgroundVideoJsOptions.html5 as any).nativeVideoTracks).toBeUndefined()
-    expect((defaultBackgroundVideoJsOptions.html5.vhs as any).overrideNative).toBeUndefined()
+    expect(
+      (defaultBackgroundVideoJsOptions.html5 as any).nativeAudioTracks
+    ).toBeUndefined()
+    expect(
+      (defaultBackgroundVideoJsOptions.html5 as any).nativeVideoTracks
+    ).toBeUndefined()
+    expect(
+      (defaultBackgroundVideoJsOptions.html5.vhs as any).overrideNative
+    ).toBeUndefined()
   })
 })

--- a/libs/shared/ui/src/libs/defaultVideoJsOptions/defaultVideoJsOptions.spec.ts
+++ b/libs/shared/ui/src/libs/defaultVideoJsOptions/defaultVideoJsOptions.spec.ts
@@ -1,4 +1,4 @@
-import { defaultVideoJsOptions } from './defaultVideoJsOptions'
+import { defaultBackgroundVideoJsOptions, defaultVideoJsOptions } from './defaultVideoJsOptions'
 
 describe('defaultVideoJsOptions', () => {
   it('should have enableSmoothSeeking set to true', () => {
@@ -55,5 +55,57 @@ describe('defaultVideoJsOptions', () => {
         defaultVideoJsOptions.html5.vhs.limitRenditionByPlayerDimensions
       ).toBe(false)
     })
+  })
+})
+
+describe('defaultBackgroundVideoJsOptions', () => {
+  it('should have enableSmoothSeeking set to true', () => {
+    expect(defaultBackgroundVideoJsOptions.enableSmoothSeeking).toBe(true)
+  })
+
+  it('should have experimentalSvgIcons set to true', () => {
+    expect(defaultBackgroundVideoJsOptions.experimentalSvgIcons).toBe(true)
+  })
+
+  describe('hls', () => {
+    it('should have useDevicePixelRatio set to true', () => {
+      expect(defaultBackgroundVideoJsOptions.html5.hls.useDevicePixelRatio).toBe(true)
+    })
+
+    it('should have useBandwidthFromLocalStorage set to true', () => {
+      expect(defaultBackgroundVideoJsOptions.html5.hls.useBandwidthFromLocalStorage).toBe(true)
+    })
+
+    it('should have useNetworkInformationApi set to true', () => {
+      expect(defaultBackgroundVideoJsOptions.html5.hls.useNetworkInformationApi).toBe(true)
+    })
+
+    it('should have limitRenditionByPlayerDimensions set to false', () => {
+      expect(defaultBackgroundVideoJsOptions.html5.hls.limitRenditionByPlayerDimensions).toBe(false)
+    })
+  })
+
+  describe('vhs', () => {
+    it('should have useDevicePixelRatio set to true', () => {
+      expect(defaultBackgroundVideoJsOptions.html5.vhs.useDevicePixelRatio).toBe(true)
+    })
+
+    it('should have useBandwidthFromLocalStorage set to true', () => {
+      expect(defaultBackgroundVideoJsOptions.html5.vhs.useBandwidthFromLocalStorage).toBe(true)
+    })
+
+    it('should have useNetworkInformationApi set to true', () => {
+      expect(defaultBackgroundVideoJsOptions.html5.vhs.useNetworkInformationApi).toBe(true)
+    })
+
+    it('should have limitRenditionByPlayerDimensions set to false', () => {
+      expect(defaultBackgroundVideoJsOptions.html5.vhs.limitRenditionByPlayerDimensions).toBe(false)
+    })
+  })
+
+  it('should not have native track options', () => {
+    expect((defaultBackgroundVideoJsOptions.html5 as any).nativeAudioTracks).toBeUndefined()
+    expect((defaultBackgroundVideoJsOptions.html5 as any).nativeVideoTracks).toBeUndefined()
+    expect((defaultBackgroundVideoJsOptions.html5.vhs as any).overrideNative).toBeUndefined()
   })
 })

--- a/libs/shared/ui/src/libs/defaultVideoJsOptions/defaultVideoJsOptions.ts
+++ b/libs/shared/ui/src/libs/defaultVideoJsOptions/defaultVideoJsOptions.ts
@@ -12,6 +12,28 @@ export const defaultVideoJsOptions = {
       // allows vhs to be used in Safari - will not work for IOS
       overrideNative: true
     },
+    // disable native audio and video tracks to force hls-supported browsers to use vjs
+    nativeAudioTracks: false,
+    nativeVideoTracks: false,
+    hls: {
+      limitRenditionByPlayerDimensions: false,
+      useBandwidthFromLocalStorage: true,
+      useNetworkInformationApi: true,
+      useDevicePixelRatio: true
+    }
+  }
+}
+
+export const defaultBackgroundVideoJsOptions = {
+  enableSmoothSeeking: true,
+  experimentalSvgIcons: true,
+  html5: {
+    vhs: {
+      limitRenditionByPlayerDimensions: false,
+      useBandwidthFromLocalStorage: true,
+      useNetworkInformationApi: true,
+      useDevicePixelRatio: true,
+    },
     hls: {
       limitRenditionByPlayerDimensions: false,
       useBandwidthFromLocalStorage: true,

--- a/libs/shared/ui/src/libs/defaultVideoJsOptions/defaultVideoJsOptions.ts
+++ b/libs/shared/ui/src/libs/defaultVideoJsOptions/defaultVideoJsOptions.ts
@@ -32,7 +32,7 @@ export const defaultBackgroundVideoJsOptions = {
       limitRenditionByPlayerDimensions: false,
       useBandwidthFromLocalStorage: true,
       useNetworkInformationApi: true,
-      useDevicePixelRatio: true,
+      useDevicePixelRatio: true
     },
     hls: {
       limitRenditionByPlayerDimensions: false,

--- a/libs/shared/ui/src/libs/defaultVideoJsOptions/index.ts
+++ b/libs/shared/ui/src/libs/defaultVideoJsOptions/index.ts
@@ -1,1 +1,1 @@
-export { defaultVideoJsOptions } from './defaultVideoJsOptions'
+export { defaultBackgroundVideoJsOptions, defaultVideoJsOptions } from './defaultVideoJsOptions'

--- a/libs/shared/ui/src/libs/defaultVideoJsOptions/index.ts
+++ b/libs/shared/ui/src/libs/defaultVideoJsOptions/index.ts
@@ -1,1 +1,4 @@
-export { defaultBackgroundVideoJsOptions, defaultVideoJsOptions } from './defaultVideoJsOptions'
+export {
+  defaultBackgroundVideoJsOptions,
+  defaultVideoJsOptions
+} from './defaultVideoJsOptions'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new video player configuration option for background videos, providing enhanced control over playback settings.

- **Bug Fixes**
  - Improved handling of video playback by disabling native audio and video tracks in certain configurations to ensure consistent behavior.

- **Tests**
  - Added comprehensive tests for the new background video configuration to verify correct settings and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->