### PR TITLE
fix: remove stack of gray cards

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/ShareItem/EmbedJourneyDialog/EmbedCardPreview/EmbedCardPreview.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/ShareItem/EmbedJourneyDialog/EmbedCardPreview/EmbedCardPreview.tsx
@@ -41,26 +41,6 @@ export function EmbedCardPreview(): ReactElement {
             transformOrigin: smUp ? 'top left' : '22.5% top'
           }}
         >
-          <Box
-            sx={{
-              ml: 7,
-              mb: '-3.5px',
-              height: 12,
-              width: CARD_WIDTH - 55,
-              backgroundColor: '#DCDDE5',
-              borderRadius: '16px 16px 0 0'
-            }}
-          />
-          <Box
-            sx={{
-              ml: 3.5,
-              mb: '-3.5px',
-              height: 12,
-              width: CARD_WIDTH - 30,
-              backgroundColor: '#AAACBB',
-              borderRadius: '16px 16px 0 0'
-            }}
-          />
           <FramePortal
             width={340}
             height={520}
@@ -71,7 +51,7 @@ export function EmbedCardPreview(): ReactElement {
               themeName={journey?.themeName ?? ThemeName.base}
               themeMode={journey?.themeMode ?? ThemeMode.light}
             >
-              <Box sx={{ height: '100%' }}>
+              <Box sx={{ height: '100%', borderRadius: 4 }}>
                 <BlockRenderer
                   block={block}
                   wrappers={{

--- a/apps/journeys/src/components/EmbeddedPreview/ClickableCard/ClickableCard.tsx
+++ b/apps/journeys/src/components/EmbeddedPreview/ClickableCard/ClickableCard.tsx
@@ -46,32 +46,6 @@ export function ClickableCard({
           height: '100%'
         }}
       >
-        {fullscreen === false && (
-          <>
-            <Box
-              sx={{
-                mx: 'auto',
-                mb: 0,
-                height: 6.5,
-                width: '82.5%',
-                backgroundColor: '#AAACBB',
-                borderRadius: '16px 16px 0 0',
-                opacity: 0.3
-              }}
-            />
-            <Box
-              sx={{
-                mx: 'auto',
-                mb: 0,
-                height: 6.5,
-                width: '90%',
-                backgroundColor: '#AAACBB',
-                borderRadius: '16px 16px 0 0',
-                opacity: 0.6
-              }}
-            />
-          </>
-        )}
         <Box
           sx={{
             height: '100%',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Removed decorative horizontal bars from card previews and embedded cards for a cleaner appearance.
  - Added rounded corners to the content container in the embed card preview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->