### PR TITLE
feat: easter banner on inner video pages

### DIFF
--- a/apps/watch/src/components/VideoContentPage/VideoContent/VideoContent.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoContent/VideoContent.tsx
@@ -1,4 +1,6 @@
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import Box from '@mui/material/Box'
+import ButtonBase from '@mui/material/ButtonBase'
 import Stack from '@mui/material/Stack'
 import Tab from '@mui/material/Tab'
 import Tabs from '@mui/material/Tabs'
@@ -28,6 +30,64 @@ export function VideoContent(): ReactElement {
 
   return (
     <Box width="100%" data-testid="VideoContent">
+      <ButtonBase
+        component="a"
+        href="https://www.jesusfilm.org/watch/easter.html/english.html?utm=easter2025"
+        sx={{
+          width: '100%',
+          mb: 3,
+          p: 4,
+          borderRadius: 3,
+          border: '2px solid',
+          borderColor: 'primary.main',
+          bgcolor: 'transparent',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          cursor: 'pointer',
+          textDecoration: 'none',
+          '&:hover': {
+            bgcolor: 'primary.main',
+            '& .banner-text': {
+              color: 'primary.contrastText'
+            },
+            '& .banner-icon': {
+              color: 'primary.contrastText'
+            }
+          }
+        }}
+      >
+        <Typography
+          variant="h5"
+          sx={{
+            lineHeight: 1.125,
+            fontWeight: 600,
+            fontSize: { md: '18px' },
+            width: '100%'
+          }}
+          className="banner-text"
+          color="primary.main"
+        >
+          {t('Experience and Share the Joy of Easter with Powerful Videos')}
+        </Typography>
+        <ArrowForwardIcon
+          sx={{ color: 'primary.main', ml: 4 }}
+          className="banner-icon"
+        />
+        <Typography
+          variant="h3"
+          sx={{
+            whiteSpace: 'nowrap',
+            ml: 4,
+            mr: 1,
+            fontSize: { md: '27px' }
+          }}
+          className="banner-text"
+          color="primary.main"
+        >
+          {t('Easter 2025')}
+        </Typography>
+      </ButtonBase>
       <Tabs
         value={tabValue}
         onChange={handleTabChange}

--- a/libs/locales/en/apps-watch.json
+++ b/libs/locales/en/apps-watch.json
@@ -25,6 +25,8 @@
   "Copy Code": "Copy Code",
   "Playing now": "Playing now",
   "{{ languageCount }} Languages": "{{ languageCount }} Languages",
+  "Experience and Share the Joy of Easter with Powerful Videos": "Experience and Share the Joy of Easter with Powerful Videos",
+  "Easter 2025": "Easter 2025",
   "Description": "Description",
   "Discussion": "Discussion",
   "Discussion Questions": "Discussion Questions",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a clickable banner above the video content tabs, promoting Easter 2025 with localized text and a direct link.
  - Enhanced user experience with interactive styling and prominent visual elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->