### PR TITLE
feat: enhance enableDownload function to support custom video resolut…

### DIFF
--- a/apis/api-gateway/schema.graphql
+++ b/apis/api-gateway/schema.graphql
@@ -415,7 +415,7 @@ type Mutation @join__type(graph: API_ANALYTICS)  @join__type(graph: API_JOURNEYS
   triggerUnsplashDownload(url: String!) : Boolean! @join__field(graph: API_MEDIA) 
   createMuxVideoUploadByFile(name: String!, userGenerated: Boolean) : MuxVideo! @join__field(graph: API_MEDIA) 
   createMuxVideoUploadByUrl(url: String!, userGenerated: Boolean) : MuxVideo! @join__field(graph: API_MEDIA) 
-  enableMuxDownload(id: ID!) : MuxVideo @join__field(graph: API_MEDIA) 
+  enableMuxDownload(id: ID!, resolution: String) : MuxVideo @join__field(graph: API_MEDIA) 
   deleteMuxVideo(id: ID!, userGenerated: Boolean) : Boolean! @join__field(graph: API_MEDIA) 
   """
   Create a new short link domain that can be used for short links (this domain must have a CNAME record pointing to the short link service)

--- a/apis/api-journeys/src/__generated__/graphql.ts
+++ b/apis/api-journeys/src/__generated__/graphql.ts
@@ -1714,6 +1714,7 @@ export type MutationDeleteMuxVideoArgs = {
 
 export type MutationEnableMuxDownloadArgs = {
   id: Scalars['ID']['input'];
+  resolution?: InputMaybe<Scalars['String']['input']>;
 };
 
 

--- a/apis/api-media/schema.graphql
+++ b/apis/api-media/schema.graphql
@@ -166,7 +166,7 @@ type Mutation {
   triggerUnsplashDownload(url: String!): Boolean!
   createMuxVideoUploadByFile(name: String!, userGenerated: Boolean): MuxVideo!
   createMuxVideoUploadByUrl(url: String!, userGenerated: Boolean): MuxVideo!
-  enableMuxDownload(id: ID!): MuxVideo
+  enableMuxDownload(id: ID!, resolution: String): MuxVideo
   deleteMuxVideo(id: ID!, userGenerated: Boolean): Boolean!
 
   """

--- a/apis/api-media/src/schema/mux/video/service.ts
+++ b/apis/api-media/src/schema/mux/video/service.ts
@@ -98,12 +98,24 @@ export async function deleteVideo(
 }
 
 export async function enableDownload(
-  videoId: string,
+  assetId: string,
   userGenerated: boolean,
   resolution: string
 ): Promise<void> {
+  // get existing static renditions
+  const existingAsset =
+    await getClient(userGenerated).video.assets.retrieve(assetId)
+
+  // skip if the resolution already exists
+  if (
+    existingAsset.static_renditions?.files?.some(
+      (file) => file.resolution === resolution
+    )
+  )
+    return
+
   await getClient(userGenerated).post(
-    `/video/v1/assets/${videoId}/static_renditions`,
+    `/video/v1/assets/${assetId}/static-renditions`,
     {
       body: {
         resolution

--- a/apis/api-media/src/schema/mux/video/service.ts
+++ b/apis/api-media/src/schema/mux/video/service.ts
@@ -99,9 +99,15 @@ export async function deleteVideo(
 
 export async function enableDownload(
   videoId: string,
-  userGenerated: boolean
+  userGenerated: boolean,
+  resolution: string
 ): Promise<void> {
-  await getClient(userGenerated).video.assets.updateMP4Support(videoId, {
-    mp4_support: 'capped-1080p'
-  })
+  await getClient(userGenerated).post(
+    `/video/v1/assets/${videoId}/static_renditions`,
+    {
+      body: {
+        resolution
+      }
+    }
+  )
 }

--- a/apis/api-media/src/schema/mux/video/video.spec.ts
+++ b/apis/api-media/src/schema/mux/video/video.spec.ts
@@ -17,7 +17,9 @@ jest.mock('./service', () => ({
   }),
   getVideo: jest.fn().mockResolvedValue({
     id: 'assetId',
-    status: 'ready'
+    status: 'ready',
+    playback_ids: [{ id: 'playbackId' }],
+    duration: 10
   }),
   deleteVideo: jest.fn().mockResolvedValue({
     id: 'assetId'
@@ -55,8 +57,8 @@ describe('mux/video', () => {
   describe('queries', () => {
     describe('getMyMuxVideos', () => {
       const GET_MY_MUX_VIDEOS = graphql(`
-        query GetMyMuxVideos {
-          getMyMuxVideos {
+        query GetMyMuxVideos($offset: Int, $limit: Int) {
+          getMyMuxVideos(offset: $offset, limit: $limit) {
             id
             playbackId
             uploadUrl
@@ -95,7 +97,8 @@ describe('mux/video', () => {
         const data = await authClient({
           document: GET_MY_MUX_VIDEOS,
           variables: {
-            userGenerated: false
+            offset: 0,
+            limit: 10
           }
         })
         expect(data).toHaveProperty('data.getMyMuxVideos', [
@@ -114,7 +117,8 @@ describe('mux/video', () => {
         const data = await client({
           document: GET_MY_MUX_VIDEOS,
           variables: {
-            userGenerated: false
+            offset: 0,
+            limit: 10
           }
         })
         expect(data).toHaveProperty('data', null)
@@ -157,7 +161,8 @@ describe('mux/video', () => {
         const data = await authClient({
           document: GET_MY_MUX_VIDEO,
           variables: {
-            id: 'videoId'
+            id: 'videoId',
+            userGenerated: true
           }
         })
         expect(data).toHaveProperty('data.getMyMuxVideo', {
@@ -173,7 +178,8 @@ describe('mux/video', () => {
         const data = await client({
           document: GET_MY_MUX_VIDEO,
           variables: {
-            id: 'videoId'
+            id: 'videoId',
+            userGenerated: true
           }
         })
         expect(data).toHaveProperty('data', null)
@@ -182,8 +188,8 @@ describe('mux/video', () => {
 
     describe('getMuxVideo', () => {
       const GET_MUX_VIDEO = graphql(`
-        query GetMuxVideo($id: ID!) {
-          getMuxVideo(id: $id) {
+        query GetMuxVideo($id: ID!, $userGenerated: Boolean) {
+          getMuxVideo(id: $id, userGenerated: $userGenerated) {
             id
             playbackId
             uploadUrl
@@ -216,7 +222,8 @@ describe('mux/video', () => {
         const data = await client({
           document: GET_MUX_VIDEO,
           variables: {
-            id: 'videoId'
+            id: 'videoId',
+            userGenerated: false
           }
         })
         expect(data).toHaveProperty('data.getMuxVideo', {
@@ -233,8 +240,14 @@ describe('mux/video', () => {
   describe('mutations', () => {
     describe('createMuxVideoUploadByFile', () => {
       const CREATE_MUX_VIDEO_UPLOAD_BY_FILE = graphql(`
-        mutation CreateMuxVideoUploadByFile($name: String!) {
-          createMuxVideoUploadByFile(name: $name) {
+        mutation CreateMuxVideoUploadByFile(
+          $name: String!
+          $userGenerated: Boolean
+        ) {
+          createMuxVideoUploadByFile(
+            name: $name
+            userGenerated: $userGenerated
+          ) {
             id
             playbackId
             uploadUrl
@@ -267,7 +280,8 @@ describe('mux/video', () => {
         const result = await authClient({
           document: CREATE_MUX_VIDEO_UPLOAD_BY_FILE,
           variables: {
-            name: 'videoName'
+            name: 'videoName',
+            userGenerated: true
           }
         })
         expect(prismaMock.muxVideo.create).toHaveBeenCalledWith({
@@ -291,7 +305,8 @@ describe('mux/video', () => {
         const result = await client({
           document: CREATE_MUX_VIDEO_UPLOAD_BY_FILE,
           variables: {
-            name: 'videoName'
+            name: 'videoName',
+            userGenerated: true
           }
         })
         expect(result).toHaveProperty('data', null)
@@ -300,8 +315,11 @@ describe('mux/video', () => {
 
     describe('createMuxVideoUploadByUrl', () => {
       const CREATE_MUX_VIDEO_UPLOAD_BY_URL = graphql(`
-        mutation CreateMuxVideoUploadByUrl($url: String!) {
-          createMuxVideoUploadByUrl(url: $url) {
+        mutation CreateMuxVideoUploadByUrl(
+          $url: String!
+          $userGenerated: Boolean
+        ) {
+          createMuxVideoUploadByUrl(url: $url, userGenerated: $userGenerated) {
             id
             playbackId
             uploadUrl
@@ -334,7 +352,8 @@ describe('mux/video', () => {
         const result = await authClient({
           document: CREATE_MUX_VIDEO_UPLOAD_BY_URL,
           variables: {
-            url: 'https://example.com/video.mp4'
+            url: 'https://example.com/video.mp4',
+            userGenerated: true
           }
         })
         expect(prismaMock.muxVideo.create).toHaveBeenCalledWith({
@@ -356,7 +375,8 @@ describe('mux/video', () => {
         const result = await client({
           document: CREATE_MUX_VIDEO_UPLOAD_BY_URL,
           variables: {
-            url: 'https://example.com/video.mp4'
+            url: 'https://example.com/video.mp4',
+            userGenerated: true
           }
         })
         expect(result).toHaveProperty('data', null)
@@ -365,8 +385,8 @@ describe('mux/video', () => {
 
     describe('deleteMuxVideo', () => {
       const DELETE_MUX_VIDEO = graphql(`
-        mutation DeleteMuxVideo($id: ID!) {
-          deleteMuxVideo(id: $id)
+        mutation DeleteMuxVideo($id: ID!, $userGenerated: Boolean) {
+          deleteMuxVideo(id: $id, userGenerated: $userGenerated)
         }
       `)
 
@@ -393,7 +413,8 @@ describe('mux/video', () => {
         const result = await authClient({
           document: DELETE_MUX_VIDEO,
           variables: {
-            id: 'videoId'
+            id: 'videoId',
+            userGenerated: false
           }
         })
         expect(prismaMock.muxVideo.findUniqueOrThrow).toHaveBeenCalledWith({
@@ -428,7 +449,8 @@ describe('mux/video', () => {
         const result = await authClient({
           document: DELETE_MUX_VIDEO,
           variables: {
-            id: 'videoId'
+            id: 'videoId',
+            userGenerated: true
           }
         })
         expect(prismaMock.muxVideo.findUniqueOrThrow).toHaveBeenCalledWith({
@@ -457,6 +479,20 @@ describe('mux/video', () => {
           userId: 'userId',
           roles: ['publisher']
         })
+        prismaMock.muxVideo.findUniqueOrThrow.mockResolvedValue({
+          id: 'videoId',
+          playbackId: 'playbackId',
+          uploadId: 'uploadId',
+          assetId: 'assetId',
+          duration: 10,
+          name: 'videoName',
+          uploadUrl: null,
+          userId: 'testUserId',
+          createdAt: new Date(),
+          readyToStream: true,
+          downloadable: false,
+          updatedAt: new Date()
+        })
         prismaMock.muxVideo.update.mockResolvedValue({
           id: 'videoId',
           playbackId: 'playbackId',
@@ -478,7 +514,7 @@ describe('mux/video', () => {
           }
         })
 
-        expect(enableDownload).toHaveBeenCalledWith('videoId', false, '1080p')
+        expect(enableDownload).toHaveBeenCalledWith('assetId', false, '1080p')
 
         // Check that the database was updated
         expect(prismaMock.muxVideo.update).toHaveBeenCalledWith({
@@ -500,6 +536,20 @@ describe('mux/video', () => {
           id: 'userId',
           userId: 'userId',
           roles: ['publisher']
+        })
+        prismaMock.muxVideo.findUniqueOrThrow.mockResolvedValue({
+          id: 'videoId',
+          playbackId: 'playbackId',
+          uploadId: 'uploadId',
+          assetId: 'assetId',
+          duration: 10,
+          name: 'videoName',
+          uploadUrl: null,
+          userId: 'testUserId',
+          createdAt: new Date(),
+          readyToStream: true,
+          downloadable: false,
+          updatedAt: new Date()
         })
         prismaMock.muxVideo.update.mockResolvedValue({
           id: 'videoId',
@@ -523,7 +573,7 @@ describe('mux/video', () => {
           }
         })
 
-        expect(enableDownload).toHaveBeenCalledWith('videoId', false, '720p')
+        expect(enableDownload).toHaveBeenCalledWith('assetId', false, '720p')
 
         // Check that the database was updated
         expect(prismaMock.muxVideo.update).toHaveBeenCalledWith({
@@ -538,6 +588,43 @@ describe('mux/video', () => {
           id: 'videoId',
           downloadable: true
         })
+      })
+
+      it('should throw an error for invalid resolution', async () => {
+        prismaMock.userMediaRole.findUnique.mockResolvedValue({
+          id: 'userId',
+          userId: 'userId',
+          roles: ['publisher']
+        })
+        prismaMock.muxVideo.findUniqueOrThrow.mockResolvedValue({
+          id: 'videoId',
+          playbackId: 'playbackId',
+          uploadId: 'uploadId',
+          assetId: 'assetId',
+          duration: 10,
+          name: 'videoName',
+          uploadUrl: null,
+          userId: 'testUserId',
+          createdAt: new Date(),
+          readyToStream: true,
+          downloadable: false,
+          updatedAt: new Date()
+        })
+
+        const result = (await publisherClient({
+          document: ENABLE_MUX_DOWNLOAD,
+          variables: {
+            id: 'videoId',
+            resolution: 'invalid'
+          }
+        })) as {
+          data: any
+          errors?: { message: string; extensions?: { code: string } }[]
+        }
+
+        expect(result.errors).toBeDefined()
+        expect(result.errors?.[0]?.message).toBe('Invalid resolution')
+        expect(result.errors?.[0]?.extensions?.code).toBe('BAD_REQUEST')
       })
 
       it('should fail if not authenticated', async () => {

--- a/apis/api-media/src/schema/mux/video/video.ts
+++ b/apis/api-media/src/schema/mux/video/video.ts
@@ -271,7 +271,15 @@ builder.mutationFields((t) => ({
           extensions: { code: 'BAD_REQUEST' }
         })
       }
-      await enableDownload(id, false, res)
+      const video = await prisma.muxVideo.findUniqueOrThrow({
+        where: { id }
+      })
+      if (video.assetId == null) {
+        throw new GraphQLError('Asset not found', {
+          extensions: { code: 'NOT_FOUND' }
+        })
+      }
+      await enableDownload(video.assetId, false, res)
       return await prisma.muxVideo.update({
         ...query,
         where: { id },


### PR DESCRIPTION
…ions

- Updated enableDownload function to accept a resolution parameter.
- Modified GraphQL mutation to include resolution argument.
- Added validation for resolution input in the resolver.
- Updated tests to cover scenarios for both default and custom resolutions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to specify a video resolution when enabling downloads. Supported resolutions include 1080p, 720p, and 270p.
  - Introduced pagination support for fetching user videos.
  - Added support for marking videos as user-generated in various video operations.

- **Bug Fixes**
  - Improved validation to ensure only allowed resolutions can be selected when enabling video downloads.

- **Tests**
  - Added and updated test cases to verify correct behavior for both default and custom resolution selections when enabling downloads.
  - Included tests for pagination and user-generated content flags in video queries and mutations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->