### PR TITLE
feat: add existing child

### DIFF
--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/children/add/_ExistingVideoByIdSelector/ExistingVideoByIdSelector.spec.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/children/add/_ExistingVideoByIdSelector/ExistingVideoByIdSelector.spec.tsx
@@ -1,0 +1,174 @@
+import { MockedProvider } from '@apollo/client/testing'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { graphql } from 'gql.tada'
+
+import { ExistingVideoByIdSelector } from './ExistingVideoByIdSelector'
+
+const GET_VIDEO_BY_ID = graphql(`
+  query GetVideoById($id: ID!) {
+    adminVideo(id: $id) {
+      id
+      title {
+        primary
+        value
+      }
+    }
+  }
+`)
+
+describe('ExistingVideoByIdSelector', () => {
+  const handleSelect = jest.fn()
+  const handleCancel = jest.fn()
+
+  const mocks = [
+    {
+      request: {
+        query: GET_VIDEO_BY_ID,
+        variables: { id: 'video123' }
+      },
+      result: {
+        data: {
+          adminVideo: {
+            id: 'video123',
+            title: [{ primary: true, value: 'Test Video' }]
+          }
+        }
+      }
+    },
+    {
+      request: {
+        query: GET_VIDEO_BY_ID,
+        variables: { id: 'nonexistent' }
+      },
+      error: new Error('Video not found')
+    }
+  ]
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders the component correctly', () => {
+    render(
+      <MockedProvider mocks={mocks}>
+        <ExistingVideoByIdSelector
+          onSelect={handleSelect}
+          onCancel={handleCancel}
+        />
+      </MockedProvider>
+    )
+
+    expect(screen.getByLabelText('Video ID')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+
+  it('shows an error message when trying to submit without an ID', async () => {
+    render(
+      <MockedProvider mocks={mocks}>
+        <ExistingVideoByIdSelector
+          onSelect={handleSelect}
+          onCancel={handleCancel}
+        />
+      </MockedProvider>
+    )
+
+    const submitButton = screen.getByRole('button', { name: 'Save' })
+
+    // Button should be disabled when ID is empty
+    expect(submitButton).toBeDisabled()
+
+    // Enter an ID to enable the button
+    const idInput = screen.getByLabelText('Video ID')
+    await userEvent.type(idInput, ' ')
+    await userEvent.clear(idInput)
+
+    // Button should be disabled again
+    expect(submitButton).toBeDisabled()
+  })
+
+  it('fetches and displays video details when a valid ID is entered', async () => {
+    render(
+      <MockedProvider mocks={mocks}>
+        <ExistingVideoByIdSelector
+          onSelect={handleSelect}
+          onCancel={handleCancel}
+        />
+      </MockedProvider>
+    )
+
+    const idInput = screen.getByLabelText('Video ID')
+    await userEvent.type(idInput, 'video123')
+
+    const submitButton = screen.getByRole('button', { name: 'Save' })
+    expect(submitButton).not.toBeDisabled()
+
+    await userEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('Video found:')).toBeInTheDocument()
+      expect(screen.getByText('Test Video')).toBeInTheDocument()
+    })
+  })
+
+  it('shows an error message when video is not found', async () => {
+    render(
+      <MockedProvider mocks={mocks}>
+        <ExistingVideoByIdSelector
+          onSelect={handleSelect}
+          onCancel={handleCancel}
+        />
+      </MockedProvider>
+    )
+
+    const idInput = screen.getByLabelText('Video ID')
+    await userEvent.type(idInput, 'nonexistent')
+
+    const submitButton = screen.getByRole('button', { name: 'Save' })
+    await userEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Video not found. Please check the ID and try again.')
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('calls onSelect when a valid video is found', async () => {
+    render(
+      <MockedProvider mocks={mocks}>
+        <ExistingVideoByIdSelector
+          onSelect={handleSelect}
+          onCancel={handleCancel}
+        />
+      </MockedProvider>
+    )
+
+    const idInput = screen.getByLabelText('Video ID')
+    await userEvent.type(idInput, 'video123')
+
+    const submitButton = screen.getByRole('button', { name: 'Save' })
+    await userEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(handleSelect).toHaveBeenCalledWith('video123')
+    })
+  })
+
+  it('calls onCancel when clicking the Cancel button', async () => {
+    render(
+      <MockedProvider mocks={mocks}>
+        <ExistingVideoByIdSelector
+          onSelect={handleSelect}
+          onCancel={handleCancel}
+        />
+      </MockedProvider>
+    )
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' })
+    await userEvent.click(cancelButton)
+
+    expect(handleCancel).toHaveBeenCalled()
+  })
+})

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/children/add/_ExistingVideoByIdSelector/ExistingVideoByIdSelector.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/children/add/_ExistingVideoByIdSelector/ExistingVideoByIdSelector.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { useLazyQuery } from '@apollo/client'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import CircularProgress from '@mui/material/CircularProgress'
+import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+import Typography from '@mui/material/Typography'
+import { graphql } from 'gql.tada'
+import { useState } from 'react'
+
+const GET_VIDEO_BY_ID = graphql(`
+  query GetVideoById($id: ID!) {
+    adminVideo(id: $id) {
+      id
+      title {
+        primary
+        value
+      }
+    }
+  }
+`)
+
+export interface ExistingVideoByIdSelectorProps {
+  onSelect: (videoId: string) => Promise<void>
+  onCancel?: () => void
+}
+
+export function ExistingVideoByIdSelector({
+  onSelect,
+  onCancel
+}: ExistingVideoByIdSelectorProps): JSX.Element {
+  const [videoId, setVideoId] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [fetchVideo, { loading, data }] = useLazyQuery(GET_VIDEO_BY_ID, {
+    onError: () => {
+      setError('Video not found. Please check the ID and try again.')
+    }
+  })
+
+  const handleSubmit = async (): Promise<void> => {
+    if (!videoId.trim()) {
+      setError('Please enter a video ID')
+      return
+    }
+
+    setError(null)
+    setIsSubmitting(true)
+
+    try {
+      const result = await fetchVideo({ variables: { id: videoId.trim() } })
+
+      if (result.data?.adminVideo) {
+        void onSelect(videoId.trim())
+      }
+    } catch (err) {
+      // Error is handled in the onError callback of the query
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleCancel = (): void => {
+    if (onCancel) {
+      onCancel()
+    }
+  }
+
+  const videoTitle = data?.adminVideo?.title.find((t) => t.primary)?.value
+
+  return (
+    <Stack spacing={2} sx={{ p: 2 }}>
+      <TextField
+        fullWidth
+        label="Video ID"
+        value={videoId}
+        onChange={(e) => {
+          setVideoId(e.target.value)
+          setError(null)
+        }}
+        error={!!error}
+        helperText={error}
+        disabled={isSubmitting || loading}
+      />
+
+      {data?.adminVideo && (
+        <Box sx={{ mt: 2, p: 2, bgcolor: 'background.paper', borderRadius: 1 }}>
+          <Typography variant="subtitle1">Video found:</Typography>
+          <Typography variant="body1">{videoTitle || 'Untitled'}</Typography>
+          <Typography variant="caption" color="text.secondary">
+            ID: {data.adminVideo.id}
+          </Typography>
+        </Box>
+      )}
+
+      <Stack direction="row" sx={{ gap: 1, mt: 2 }}>
+        <Button
+          variant="outlined"
+          onClick={handleCancel}
+          disabled={isSubmitting}
+          sx={{ flex: 1 }}
+        >
+          <Typography>Cancel</Typography>
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={!videoId.trim() || isSubmitting || loading}
+          sx={{ flex: 1 }}
+        >
+          {loading ? (
+            <CircularProgress size={24} color="inherit" />
+          ) : isSubmitting ? (
+            <CircularProgress size={24} color="inherit" />
+          ) : (
+            <Typography>Save</Typography>
+          )}
+        </Button>
+      </Stack>
+    </Stack>
+  )
+}

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/children/add/_ExistingVideoByIdSelector/index.ts
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/children/add/_ExistingVideoByIdSelector/index.ts
@@ -1,0 +1,1 @@
+export { ExistingVideoByIdSelector } from './ExistingVideoByIdSelector'

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/children/add/_ExistingVideoSelector/ExistingVideoSelector.spec.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/children/add/_ExistingVideoSelector/ExistingVideoSelector.spec.tsx
@@ -1,0 +1,128 @@
+import { MockedProvider } from '@apollo/client/testing'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { graphql } from 'gql.tada'
+
+import { ExistingVideoSelector } from './ExistingVideoSelector'
+
+const SEARCH_VIDEOS = graphql(`
+  query SearchVideos($title: String!) {
+    adminVideos(where: { title: $title }, limit: 20) {
+      id
+      title {
+        primary
+        value
+      }
+    }
+  }
+`)
+
+describe('ExistingVideoSelector', () => {
+  const handleSelect = jest.fn()
+  const handleCancel = jest.fn()
+
+  const mocks = [
+    {
+      request: {
+        query: SEARCH_VIDEOS,
+        variables: { title: 'test' }
+      },
+      result: {
+        data: {
+          adminVideos: [
+            {
+              id: 'video1',
+              title: [{ primary: true, value: 'Test Video 1' }]
+            },
+            {
+              id: 'video2',
+              title: [{ primary: true, value: 'Test Video 2' }]
+            }
+          ]
+        }
+      }
+    }
+  ]
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders the component correctly', () => {
+    render(
+      <MockedProvider mocks={mocks}>
+        <ExistingVideoSelector
+          onSelect={handleSelect}
+          onCancel={handleCancel}
+        />
+      </MockedProvider>
+    )
+
+    expect(screen.getByLabelText('Search videos by title')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+
+  it('searches for videos when typing in the search field', async () => {
+    render(
+      <MockedProvider mocks={mocks}>
+        <ExistingVideoSelector
+          onSelect={handleSelect}
+          onCancel={handleCancel}
+        />
+      </MockedProvider>
+    )
+
+    const searchInput = screen.getByLabelText('Search videos by title')
+    await userEvent.type(searchInput, 'test')
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Video 1')).toBeInTheDocument()
+      expect(screen.getByText('Test Video 2')).toBeInTheDocument()
+    })
+  })
+
+  it('calls onSelect when clicking the Save button after selecting a video', async () => {
+    render(
+      <MockedProvider mocks={mocks}>
+        <ExistingVideoSelector
+          onSelect={handleSelect}
+          onCancel={handleCancel}
+        />
+      </MockedProvider>
+    )
+
+    const searchInput = screen.getByLabelText('Search videos by title')
+    await userEvent.type(searchInput, 'test')
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Video 1')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByText('Test Video 1'))
+
+    // Button should be enabled now
+    const saveButton = screen.getByRole('button', { name: 'Save' })
+    expect(saveButton).not.toBeDisabled()
+
+    await userEvent.click(saveButton)
+
+    expect(handleSelect).toHaveBeenCalledWith('video1')
+  })
+
+  it('calls onCancel when clicking the Cancel button', async () => {
+    render(
+      <MockedProvider mocks={mocks}>
+        <ExistingVideoSelector
+          onSelect={handleSelect}
+          onCancel={handleCancel}
+        />
+      </MockedProvider>
+    )
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' })
+    await userEvent.click(cancelButton)
+
+    expect(handleCancel).toHaveBeenCalled()
+  })
+})

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/children/add/_ExistingVideoSelector/ExistingVideoSelector.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/children/add/_ExistingVideoSelector/ExistingVideoSelector.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import { useLazyQuery } from '@apollo/client'
+import Autocomplete from '@mui/material/Autocomplete'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import CircularProgress from '@mui/material/CircularProgress'
+import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+import Typography from '@mui/material/Typography'
+import { graphql } from 'gql.tada'
+import { useState } from 'react'
+
+const SEARCH_VIDEOS = graphql(`
+  query SearchVideos($title: String!) {
+    adminVideos(where: { title: $title }, limit: 20) {
+      id
+      title {
+        primary
+        value
+      }
+    }
+  }
+`)
+
+export interface ExistingVideoSelectorProps {
+  onSelect: (videoId: string) => Promise<void>
+  onCancel?: () => void
+}
+
+interface VideoOption {
+  id: string
+  title: string
+}
+
+export function ExistingVideoSelector({
+  onSelect,
+  onCancel
+}: ExistingVideoSelectorProps): JSX.Element {
+  const [searchTerm, setSearchTerm] = useState('')
+  const [selectedVideo, setSelectedVideo] = useState<VideoOption | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const [searchVideos, { loading, data }] = useLazyQuery(SEARCH_VIDEOS)
+
+  const handleInputChange = (
+    _event: React.SyntheticEvent,
+    value: string
+  ): void => {
+    setSearchTerm(value)
+    if (value.length >= 2) {
+      void searchVideos({ variables: { title: value } })
+    }
+  }
+
+  const handleSubmit = async (): Promise<void> => {
+    if (selectedVideo) {
+      setIsSubmitting(true)
+      try {
+        await onSelect(selectedVideo.id)
+      } finally {
+        setIsSubmitting(false)
+      }
+    }
+  }
+
+  const handleCancel = (): void => {
+    if (onCancel) {
+      onCancel()
+    }
+  }
+
+  const options: VideoOption[] =
+    data?.adminVideos.map((video) => ({
+      id: video.id,
+      title: video.title.find((t) => t.primary)?.value || 'Untitled'
+    })) || []
+
+  return (
+    <Stack spacing={2} sx={{ p: 2 }}>
+      <Autocomplete
+        fullWidth
+        options={options}
+        loading={loading}
+        onInputChange={handleInputChange}
+        onChange={(_event, newValue) => setSelectedVideo(newValue)}
+        getOptionLabel={(option) => option.title}
+        isOptionEqualToValue={(option, value) => option.id === value.id}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label="Search videos by title"
+            fullWidth
+            InputProps={{
+              ...params.InputProps,
+              endAdornment: (
+                <>
+                  {loading ? (
+                    <CircularProgress color="inherit" size={20} />
+                  ) : null}
+                  {params.InputProps.endAdornment}
+                </>
+              )
+            }}
+          />
+        )}
+        renderOption={(props, option) => (
+          <Box component="li" {...props}>
+            <Typography variant="body1">{option.title}</Typography>
+            <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+              ({option.id})
+            </Typography>
+          </Box>
+        )}
+        noOptionsText={
+          searchTerm.length < 2
+            ? 'Type at least 2 characters to search'
+            : 'No videos found'
+        }
+      />
+      <Stack direction="row" sx={{ gap: 1, mt: 2 }}>
+        <Button
+          variant="outlined"
+          onClick={handleCancel}
+          disabled={isSubmitting}
+          sx={{ flex: 1 }}
+        >
+          <Typography>Cancel</Typography>
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={!selectedVideo || isSubmitting}
+          sx={{ flex: 1 }}
+        >
+          {isSubmitting ? (
+            <CircularProgress size={24} color="inherit" />
+          ) : (
+            <Typography>Save</Typography>
+          )}
+        </Button>
+      </Stack>
+    </Stack>
+  )
+}

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/children/add/_ExistingVideoSelector/index.ts
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/children/add/_ExistingVideoSelector/index.ts
@@ -1,0 +1,1 @@
+export { ExistingVideoSelector } from './ExistingVideoSelector'


### PR DESCRIPTION
…n methods

- Introduced a selection mechanism for adding child videos, allowing users to choose between creating a new video, finding an existing video by title, or adding an existing video by ID.
- Updated the dialog title to reflect the new functionality.
- Integrated new components for selecting existing videos and handling their addition as children.