### PR TITLE
fix: move revalidation to backend

### DIFF
--- a/apis/api-journeys-modern/src/workers/revalidate/config.ts
+++ b/apis/api-journeys-modern/src/workers/revalidate/config.ts
@@ -1,0 +1,2 @@
+export const queueName = 'api-journeys-revalidate'
+export const jobName = `${queueName}-job`

--- a/apis/api-journeys-modern/src/workers/revalidate/index.ts
+++ b/apis/api-journeys-modern/src/workers/revalidate/index.ts
@@ -1,0 +1,2 @@
+export { jobName, queueName } from './config'
+export { service } from './service'

--- a/apis/api-journeys-modern/src/workers/revalidate/queue.ts
+++ b/apis/api-journeys-modern/src/workers/revalidate/queue.ts
@@ -1,0 +1,7 @@
+import { Queue } from 'bullmq'
+
+import { connection } from '../lib/connection'
+
+import { queueName } from './config'
+
+export const queue = new Queue(queueName, { connection })

--- a/apis/api-journeys-modern/src/workers/revalidate/service/index.ts
+++ b/apis/api-journeys-modern/src/workers/revalidate/service/index.ts
@@ -1,0 +1,1 @@
+export { service } from './service'

--- a/apis/api-journeys-modern/src/workers/revalidate/service/service.spec.ts
+++ b/apis/api-journeys-modern/src/workers/revalidate/service/service.spec.ts
@@ -1,0 +1,171 @@
+import { Job } from 'bullmq'
+import FormData from 'form-data'
+import fetch from 'node-fetch'
+import { Logger } from 'pino'
+
+import { generateFacebookAppAccessToken, revalidate, service } from './service'
+
+jest.mock('node-fetch')
+
+const mockFetch = fetch as jest.MockedFunction<typeof fetch>
+const mockLogger = {
+  error: jest.fn()
+}
+
+describe('RevalidateService', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    process.env = {
+      ...originalEnv,
+      JOURNEYS_URL: 'https://example.com',
+      JOURNEYS_REVALIDATE_ACCESS_TOKEN: 'test-token',
+      FACEBOOK_APP_ID: 'fb-app-id',
+      FACEBOOK_APP_SECRET: 'fb-app-secret'
+    }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    jest.useRealTimers()
+  })
+
+  describe('service', () => {
+    it('should handle revalidate job', async () => {
+      const job = {
+        name: 'revalidate',
+        data: { slug: 'test-journey' }
+      } as Job
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true
+      } as any)
+
+      await service(job)
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://example.com/api/revalidate?accessToken=test-token&slug=test-journey'
+      )
+    })
+  })
+
+  describe('revalidate', () => {
+    it('should throw error if environment variables are missing', async () => {
+      delete process.env.JOURNEYS_URL
+      delete process.env.JOURNEYS_REVALIDATE_ACCESS_TOKEN
+
+      const job = {
+        data: { slug: 'test-journey' }
+      } as Job
+
+      await revalidate(job, mockLogger as unknown as Logger)
+      await expect(mockLogger.error).toHaveBeenCalledWith(
+        'JOURNEYS_URL or JOURNEYS_REVALIDATE_ACCESS_TOKEN not configured'
+      )
+    })
+
+    it('should revalidate journey with custom hostname', async () => {
+      const job = {
+        data: { slug: 'test-journey', hostname: 'custom.example.com' }
+      } as Job
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true
+      } as any)
+
+      await revalidate(job)
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://example.com/api/revalidate?accessToken=test-token&slug=test-journey&hostname=custom.example.com'
+      )
+    })
+
+    it('should handle Facebook re-scraping when enabled', async () => {
+      const job = {
+        data: { slug: 'test-journey', fbReScrape: true }
+      } as Job
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ access_token: 'fb-token' })
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true
+        } as any)
+
+      await revalidate(job)
+
+      expect(mockFetch).toHaveBeenCalledTimes(3)
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        'https://graph.facebook.com/oauth/access_token?client_id=fb-app-id&client_secret=fb-app-secret&grant_type=client_credentials'
+      )
+
+      const thirdCallArgs = mockFetch.mock.calls[2]
+      expect(thirdCallArgs[0]).toBe(
+        'https://graph.facebook.com/v19.0/?access_token=fb-token'
+      )
+      expect(thirdCallArgs[1]).toHaveProperty('method', 'POST')
+      expect(thirdCallArgs[1]).toHaveProperty('body')
+
+      const formData = thirdCallArgs[1]?.body as FormData
+      const formDataString = formData.getBuffer().toString()
+      expect(formDataString).toContain('https://example.com/home/test-journey')
+      expect(formDataString).toContain('true')
+    })
+
+    it('should handle revalidation errors', async () => {
+      const job = {
+        data: { slug: 'test-journey' }
+      } as Job
+
+      mockFetch.mockRejectedValueOnce(new Error('Network error'))
+
+      await revalidate(job, mockLogger as unknown as Logger)
+      await expect(mockLogger.error).toHaveBeenCalledWith(
+        'Failed to revalidate: Error: Network error'
+      )
+    })
+  })
+
+  describe('generateFacebookAppAccessToken', () => {
+    it('should throw error if Facebook credentials are missing', async () => {
+      delete process.env.FACEBOOK_APP_ID
+      delete process.env.FACEBOOK_APP_SECRET
+
+      await expect(generateFacebookAppAccessToken()).rejects.toThrow(
+        'Facebook App ID or App Secret not configured'
+      )
+    })
+
+    it('should return access token when credentials are valid', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ access_token: 'fb-token' })
+      } as any)
+
+      const token = await generateFacebookAppAccessToken()
+
+      expect(token).toBe('fb-token')
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://graph.facebook.com/oauth/access_token?client_id=fb-app-id&client_secret=fb-app-secret&grant_type=client_credentials'
+      )
+    })
+
+    it('should handle Facebook API errors', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        statusText: 'Bad Request'
+      } as any)
+
+      await expect(generateFacebookAppAccessToken()).rejects.toThrow(
+        'Failed to generate access token: Bad Request'
+      )
+    })
+  })
+})

--- a/apis/api-journeys-modern/src/workers/revalidate/service/service.ts
+++ b/apis/api-journeys-modern/src/workers/revalidate/service/service.ts
@@ -1,0 +1,98 @@
+import { Job } from 'bullmq'
+import FormData from 'form-data'
+import fetch from 'node-fetch'
+import { Logger } from 'pino'
+
+import { ApiRevalidateJobs, RevalidateJob } from './types'
+
+async function sleep(ms: number | undefined): Promise<void> {
+  return await new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+export async function generateFacebookAppAccessToken(): Promise<string> {
+  const appId = process.env.FACEBOOK_APP_ID
+  const appSecret = process.env.FACEBOOK_APP_SECRET
+
+  if (!appId || !appSecret) {
+    throw new Error('Facebook App ID or App Secret not configured')
+  }
+
+  const response = await fetch(
+    `https://graph.facebook.com/oauth/access_token?client_id=${appId}&client_secret=${appSecret}&grant_type=client_credentials`
+  )
+
+  if (!response.ok) {
+    throw new Error(`Failed to generate access token: ${response.statusText}`)
+  }
+
+  const data = await response.json()
+  return data.access_token
+}
+
+export async function service(
+  job: Job<ApiRevalidateJobs>,
+  logger?: Logger
+): Promise<void> {
+  switch (job.name) {
+    case 'revalidate':
+      await revalidate(job, logger)
+      break
+  }
+}
+
+export async function revalidate(job: Job<RevalidateJob>, logger?: Logger) {
+  if (
+    process.env.JOURNEYS_URL == null ||
+    process.env.JOURNEYS_REVALIDATE_ACCESS_TOKEN == null
+  ) {
+    logger?.error(
+      'JOURNEYS_URL or JOURNEYS_REVALIDATE_ACCESS_TOKEN not configured'
+    )
+    return
+  }
+
+  const { slug, hostname } = job.data
+  const path = hostname != null ? `/${slug}` : `/home/${slug}`
+  const journeyUrl =
+    hostname != null
+      ? `https://${hostname}${path}`
+      : `${process.env.JOURNEYS_URL}${path}`
+
+  const params: { accessToken: string; slug: string; hostname?: string } = {
+    accessToken: process.env.JOURNEYS_REVALIDATE_ACCESS_TOKEN,
+    slug
+  }
+
+  if (hostname != null) params.hostname = hostname
+
+  try {
+    await fetch(
+      `${process.env.JOURNEYS_URL}/api/revalidate?${new URLSearchParams(
+        params
+      ).toString()}`
+    )
+    // 300ms required to invalidate edge caches
+    await sleep(300)
+
+    if (job.data.fbReScrape === true) {
+      const fbAccessToken = await generateFacebookAppAccessToken()
+      const formData = new FormData()
+      formData.append('id', journeyUrl)
+      formData.append('scrape', 'true')
+
+      await fetch(
+        `https://graph.facebook.com/v19.0/?access_token=${fbAccessToken}`,
+        {
+          method: 'POST',
+          body: formData
+        }
+      )
+    }
+    return
+  } catch (error) {
+    logger?.error(`Failed to revalidate: ${error as Error}`)
+    return
+  }
+}

--- a/apis/api-journeys-modern/src/workers/revalidate/service/types.ts
+++ b/apis/api-journeys-modern/src/workers/revalidate/service/types.ts
@@ -1,0 +1,7 @@
+export type ApiRevalidateJobs = RevalidateJob
+
+export type RevalidateJob = {
+  slug: string
+  hostname?: string
+  fbReScrape: boolean
+}

--- a/apis/api-journeys-modern/src/workers/server.ts
+++ b/apis/api-journeys-modern/src/workers/server.ts
@@ -43,6 +43,12 @@ async function main(): Promise<void> {
       './emailEvents'
     )
   )
+  run(
+    await import(
+      /* webpackChunkName: "revalidate" */
+      './revalidate'
+    )
+  )
 }
 
 // avoid running on test environment

--- a/apis/api-journeys/src/app/lib/prisma.types.ts
+++ b/apis/api-journeys/src/app/lib/prisma.types.ts
@@ -75,3 +75,9 @@ export interface VerifyUserJob {
   token: string
   redirect: string | undefined
 }
+
+export interface RevalidateJob {
+  slug: string
+  hostname?: string
+  fbReScrape?: boolean
+}

--- a/apis/api-journeys/src/app/modules/journey/journey.module.ts
+++ b/apis/api-journeys/src/app/modules/journey/journey.module.ts
@@ -17,7 +17,10 @@ import { JourneyResolver } from './journey.resolver'
 @Module({
   imports: [
     CaslAuthModule.register(AppCaslFactory),
-    BullModule.registerQueue({ name: 'api-journeys-plausible' })
+    BullModule.registerQueue(
+      { name: 'api-journeys-plausible' },
+      { name: 'api-journeys-revalidate' }
+    )
   ],
   providers: [
     JourneyResolver,

--- a/apis/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apis/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -8,6 +8,7 @@ import {
   Action,
   Block,
   ChatButton,
+  CustomDomain,
   Host,
   Journey,
   JourneyCollection,
@@ -61,7 +62,8 @@ describe('JourneyResolver', () => {
     prismaService: DeepMockProxy<PrismaService>,
     ability: AppAbility,
     abilityWithPublisher: AppAbility,
-    plausibleQueue: { add: jest.Mock }
+    plausibleQueue: { add: jest.Mock },
+    revalidateQueue: { add: jest.Mock }
 
   const journey: Journey = {
     id: 'journeyId',
@@ -135,11 +137,15 @@ describe('JourneyResolver', () => {
     plausibleQueue = {
       add: jest.fn()
     }
+    revalidateQueue = {
+      add: jest.fn()
+    }
 
     const module: TestingModule = await Test.createTestingModule({
       imports: [
         CaslAuthModule.register(AppCaslFactory),
-        BullModule.registerQueue({ name: 'api-journeys-plausible' })
+        BullModule.registerQueue({ name: 'api-journeys-plausible' }),
+        BullModule.registerQueue({ name: 'api-journeys-revalidate' })
       ],
       providers: [
         JourneyResolver,
@@ -162,6 +168,8 @@ describe('JourneyResolver', () => {
     })
       .overrideProvider(getQueueToken('api-journeys-plausible'))
       .useValue(plausibleQueue)
+      .overrideProvider(getQueueToken('api-journeys-revalidate'))
+      .useValue(revalidateQueue)
       .compile()
     resolver = module.get<JourneyResolver>(JourneyResolver)
     blockService = module.get<BlockService>(
@@ -1798,6 +1806,13 @@ describe('JourneyResolver', () => {
 
       expect(prismaService.journey.update).toHaveBeenCalledWith({
         where: { id: 'journeyId' },
+        include: {
+          team: {
+            include: {
+              customDomains: true
+            }
+          }
+        },
         data: {
           title: 'new title',
           languageId: '529',
@@ -1821,12 +1836,59 @@ describe('JourneyResolver', () => {
       })
       expect(prismaService.journey.update).toHaveBeenCalledWith({
         where: { id: 'journeyId' },
+        include: {
+          team: {
+            include: {
+              customDomains: true
+            }
+          }
+        },
         data: {
           title: undefined,
           languageId: undefined,
           slug: undefined,
           journeyTags: undefined
         }
+      })
+    })
+
+    it('revalidates a journey when SEO fields are updated', async () => {
+      prismaService.journey.findUnique.mockResolvedValueOnce(
+        journeyWithUserTeam
+      )
+
+      prismaService.journey.update.mockResolvedValueOnce({
+        ...journeyWithUserTeam,
+        team: {
+          ...journeyWithUserTeam.team,
+          customDomains: [{ name: 'teamId.joinslash.com' }] as CustomDomain[]
+        }
+      } as unknown as Journey)
+      await resolver.journeyUpdate(ability, 'journeyId', {
+        seoTitle: 'new seo title',
+        seoDescription: 'new seo description',
+        primaryImageBlockId: 'primaryImageBlockId'
+      })
+      expect(prismaService.journey.update).toHaveBeenCalledWith({
+        where: { id: 'journeyId' },
+        include: {
+          team: {
+            include: {
+              customDomains: true
+            }
+          }
+        },
+        data: {
+          seoTitle: 'new seo title',
+          seoDescription: 'new seo description',
+          primaryImageBlockId: 'primaryImageBlockId'
+        }
+      })
+
+      expect(revalidateQueue.add).toHaveBeenCalledWith('revalidate', {
+        slug: 'journey-slug',
+        hostname: 'teamId.joinslash.com',
+        fbReScrape: true
       })
     })
 

--- a/apis/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apis/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -50,6 +50,7 @@ import {
 import { Action, AppAbility } from '../../lib/casl/caslFactory'
 import { AppCaslGuard } from '../../lib/casl/caslGuard'
 import { PrismaService } from '../../lib/prisma.service'
+import { RevalidateJob } from '../../lib/prisma.types'
 import { ERROR_PSQL_UNIQUE_CONSTRAINT_VIOLATED } from '../../lib/prismaErrors'
 import { BlockService } from '../block/block.service'
 import { PlausibleJob } from '../plausible/plausible.consumer'
@@ -62,6 +63,8 @@ const FIVE_DAYS = 5 * 24 * 60 * 60 // in seconds
 @Resolver('Journey')
 export class JourneyResolver {
   constructor(
+    @InjectQueue('api-journeys-revalidate')
+    private readonly revalidateQueue: Queue<RevalidateJob>,
     @InjectQueue('api-journeys-plausible')
     private readonly plausibleQueue: Queue<PlausibleJob>,
     private readonly blockService: BlockService,
@@ -782,6 +785,13 @@ export class JourneyResolver {
 
         const updatedJourney = await tx.journey.update({
           where: { id },
+          include: {
+            team: {
+              include: {
+                customDomains: true
+              }
+            }
+          },
           data: {
             ...omit(input, ['tagIds']),
             title: input.title ?? undefined,
@@ -799,6 +809,19 @@ export class JourneyResolver {
             updatedJourney.id,
             input.slug
           )
+        }
+
+        if (
+          input.seoTitle != null ||
+          input.seoDescription != null ||
+          input.primaryImageBlockId != null
+        ) {
+          console.log('here 1asasdfasdf')
+          await this.revalidateQueue.add('revalidate', {
+            slug: updatedJourney.slug,
+            hostname: updatedJourney.team.customDomains[0]?.name,
+            fbReScrape: true
+          })
         }
 
         return updatedJourney

--- a/apis/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apis/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -816,7 +816,6 @@ export class JourneyResolver {
           input.seoDescription != null ||
           input.primaryImageBlockId != null
         ) {
-          console.log('here 1asasdfasdf')
           await this.revalidateQueue.add('revalidate', {
             slug: updatedJourney.slug,
             hostname: updatedJourney.team.customDomains[0]?.name,

--- a/package-lock.json
+++ b/package-lock.json
@@ -83999,21 +83999,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/react-email/node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.26.tgz",
-      "integrity": "sha512-GQWg/Vbz9zUGi9X80lOeGsz1rMH/MtFO/XqigDznhhhTfDlDoynCM6982mPCbSlxJ/aveZcKtTlwfAjwhyxDpg==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -83999,6 +83999,21 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/react-email/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.26.tgz",
+      "integrity": "sha512-GQWg/Vbz9zUGi9X80lOeGsz1rMH/MtFO/XqigDznhhhTfDlDoynCM6982mPCbSlxJ/aveZcKtTlwfAjwhyxDpg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced automated revalidation for journeys when SEO-related fields are updated, ensuring that changes are reflected promptly.
  - Added support for Facebook re-scraping as part of the revalidation process when applicable.
- **Bug Fixes**
  - None.
- **Tests**
  - Added comprehensive tests to verify revalidation logic, including Facebook integration and error handling.
- **Chores**
  - Registered a new queue for revalidation tasks and updated relevant configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->