### PR TITLE
fix: add '360p' resolution option to video validation logic

### DIFF
--- a/apis/api-media/src/schema/mux/video/video.ts
+++ b/apis/api-media/src/schema/mux/video/video.ts
@@ -266,7 +266,7 @@ builder.mutationFields((t) => ({
           extensions: { code: 'NOT_FOUND' }
         })
       const res = resolution ?? '1080p'
-      if (!['1080p', '720p', '270p'].includes(res)) {
+      if (!['1080p', '720p', '360p', '270p'].includes(res)) {
         throw new GraphQLError('Invalid resolution', {
           extensions: { code: 'BAD_REQUEST' }
         })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for "360p" video resolution when enabling video downloads.

- **Bug Fixes**
  - Improved validation to ensure only supported video resolutions can be selected. Unsupported resolutions now return a clear error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->