### PR TITLE
feat: add support for forcing requests to arclight or core based on API key lists in canary

### DIFF
--- a/workers/arclight-canary/wrangler.toml
+++ b/workers/arclight-canary/wrangler.toml
@@ -4,7 +4,9 @@ compatibility_flags = ["nodejs_compat"]
 main = "src/index.ts"
 
 [vars]
+# endpoint of the core service
 ENDPOINT_CORE = "http://localhost:4600"
+# endpoint of the arclight service
 ENDPOINT_ARCLIGHT = "https://preprod.arclight.org"
 # percentage of requests that will be sent to the arclight endpoint
 ENDPOINT_ARCLIGHT_WEIGHT = "50"
@@ -16,10 +18,16 @@ routes = [
 ]
 
 [env.stage.vars]
+# endpoint of the core service
 ENDPOINT_CORE = "https://core-stage.arclight.org"
+# endpoint of the arclight service
 ENDPOINT_ARCLIGHT = "https://preprod.arclight.org"
 # percentage of requests that will be sent to the arclight endpoint
 ENDPOINT_ARCLIGHT_WEIGHT = "50"
+# api keys that will be forced to the arclight endpoint
+FORCE_API_KEYS_TO_ARCLIGHT = "607f41540b2ca6.32427244"
+# api keys that will be forced to the core endpoint
+FORCE_API_KEYS_TO_CORE = "1234567890"
 
 [env.prod]
 name = "arclight-canary-prod"
@@ -28,7 +36,13 @@ routes = [
 ]
 
 [env.prod.vars]
+# endpoint of the core service
 ENDPOINT_CORE = "https://core.arclight.org"
+# endpoint of the arclight service
 ENDPOINT_ARCLIGHT = "https://api.arclight.org"
 # percentage of requests that will be sent to the arclight endpoint
 ENDPOINT_ARCLIGHT_WEIGHT = "90"
+# api keys that will be forced to the arclight endpoint
+FORCE_API_KEYS_TO_ARCLIGHT = "607f41540b2ca6.32427244"
+# api keys that will be forced to the core endpoint
+FORCE_API_KEYS_TO_CORE = "1234567890"


### PR DESCRIPTION
Added support for FORCE_API_KEYS_TO_ARCLIGHT and FORCE_API_KEYS_TO_CORE as comma-separated lists to force routing. https://linear.app/jesusfilm/issue/PRJ-2579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for forcing specific API keys to route requests to either the Arclight or Core endpoints using new environment variables.
- **Tests**
  - Introduced test cases to verify correct routing behavior based on API keys, including handling of comma-separated lists, whitespace, and order variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->