### PR TITLE
feat: add path mapping for shared AI library in TypeScript configuration

### DIFF
--- a/libs/shared/ai/.babelrc
+++ b/libs/shared/ai/.babelrc
@@ -1,0 +1,11 @@
+{
+  "presets": [
+    [
+      "@nx/react/babel",
+      {
+        "runtime": "automatic",
+        "useBuiltIns": "usage"
+      }
+    ]
+  ]
+}

--- a/libs/shared/ai/README.md
+++ b/libs/shared/ai/README.md
@@ -1,0 +1,11 @@
+# shared-ai
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test shared-ai` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running storybook
+
+Run `nx demo shared-ui` for storybook server. Navigate to http://localhost:4400/. The app will automatically reload if you change any of the source files.

--- a/libs/shared/ai/eslint.config.mjs
+++ b/libs/shared/ai/eslint.config.mjs
@@ -1,0 +1,12 @@
+import baseConfig from '../../../eslint.config.mjs'
+
+export default [
+  ...baseConfig,
+  {
+    ignores: [
+      'libs/shared/ai/eslint.config.js',
+      'libs/shared/ai/jest.config.ts',
+      'libs/shared/ai/apollo.config.js'
+    ]
+  }
+]

--- a/libs/shared/ai/jest.config.ts
+++ b/libs/shared/ai/jest.config.ts
@@ -1,0 +1,17 @@
+import type { Config } from 'jest'
+
+const config: Config = {
+  displayName: 'ai',
+  transform: {
+    '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
+    '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }]
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../coverage/libs/shared/ai',
+  setupFilesAfterEnv: ['<rootDir>setupTests.ts'],
+  collectCoverage: true,
+  coverageReporters: ['cobertura'],
+  preset: '../../../jest.preset.js'
+}
+
+export default config

--- a/libs/shared/ai/project.json
+++ b/libs/shared/ai/project.json
@@ -1,0 +1,49 @@
+{
+  "name": "shared-ai",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/shared/ai/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "cache": true,
+        "cacheLocation": ".cache/ai/eslint",
+        "cacheStrategy": "content"
+      }
+    },
+    "type-check": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npx tsc -b libs/shared/ai/tsconfig.json"
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/libs/shared/ai"],
+      "options": {
+        "jestConfig": "libs/shared/ai/jest.config.ts"
+      }
+    },
+    "demo": {
+      "executor": "@nx/storybook:storybook",
+      "options": {
+        "port": 4400,
+        "configDir": ".storybook"
+      },
+      "configurations": {
+        "ci": {
+          "quiet": true
+        }
+      }
+    },
+    "codecov": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "codecov -f coverage/libs/ai/cobertura-coverage.xml -F libs.ai"
+      }
+    }
+  }
+}

--- a/libs/shared/ai/project.json
+++ b/libs/shared/ai/project.json
@@ -42,7 +42,7 @@
     "codecov": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "codecov -f coverage/libs/ai/cobertura-coverage.xml -F libs.ai"
+        "command": "codecov -f coverage/libs/shared/ai/cobertura-coverage.xml -F libs.ai"
       }
     }
   }

--- a/libs/shared/ai/setupTests.ts
+++ b/libs/shared/ai/setupTests.ts
@@ -1,0 +1,4 @@
+import '@testing-library/jest-dom'
+
+if (process.env.CI === 'true')
+  jest.retryTimes(3, { logErrorsBeforeRetry: true })

--- a/libs/shared/ai/src/index.ts
+++ b/libs/shared/ai/src/index.ts
@@ -1,0 +1,1 @@
+export * from './prompts'

--- a/libs/shared/ai/src/prompts/index.ts
+++ b/libs/shared/ai/src/prompts/index.ts
@@ -1,0 +1,1 @@
+export { systemPrompt } from './system'

--- a/libs/shared/ai/src/prompts/system.ts
+++ b/libs/shared/ai/src/prompts/system.ts
@@ -1,0 +1,3 @@
+export const systemPrompt = `
+You are a helpful assistant that can answer questions and help with tasks.
+`

--- a/libs/shared/ai/tsconfig.json
+++ b/libs/shared/ai/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "incremental": true,
+    "tsBuildInfoFile": "../../../.cache/shared-ai/tsc/.tsbuildinfo"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/shared/ai/tsconfig.lib.json
+++ b/libs/shared/ai/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "types": ["node"]
+  },
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "jest.config.ts"],
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+}

--- a/libs/shared/ai/tsconfig.spec.json
+++ b/libs/shared/ai/tsconfig.spec.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx",
+    "**/*.d.ts",
+    "setupTests.ts",
+    "jest.config.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -25,6 +25,7 @@
       "@core/nest/decorators/*": ["libs/nest/decorators/src/lib/*"],
       "@core/nest/gqlAuthGuard/*": ["libs/nest/gqlAuthGuard/src/lib/*"],
       "@core/nest/powerBi/*": ["libs/nest/powerBi/src/lib/*"],
+      "@core/shared/ai/*": ["libs/shared/ai/src/*"],
       "@core/shared/ui-dynamic/*": [
         "libs/shared/ui-dynamic/src/components/*",
         "libs/shared/ui-dynamic/src/libs/*"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the `shared-ai` library, providing a system prompt for AI assistant functionality.
  - Added TypeScript path alias for easier imports of the `shared-ai` library.

- **Chores**
  - Added configuration files for Babel, ESLint, Jest, and TypeScript to support development, testing, and linting.
  - Included project metadata and build targets for linting, testing, Storybook demos, and code coverage.
  - Added a README with usage and testing instructions.

- **Documentation**
  - Added a README file with setup and usage guidance for the `shared-ai` library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->