### PR TITLE
fix: buttons on call to action card template 

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/CardTemplates/Templates/CardCta/CardCta.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/CardTemplates/Templates/CardCta/CardCta.spec.tsx
@@ -122,7 +122,8 @@ describe('CardCta', () => {
           parentBlockId: 'cardId',
           label: 'Chat with us',
           variant: ButtonVariant.contained,
-          size: ButtonSize.large
+          size: ButtonSize.large,
+          submitEnabled: null
         },
         startIcon1Input: {
           id: 'startIcon1Id',
@@ -146,7 +147,8 @@ describe('CardCta', () => {
           parentBlockId: 'cardId',
           label: 'Email us',
           variant: ButtonVariant.contained,
-          size: ButtonSize.large
+          size: ButtonSize.large,
+          submitEnabled: null
         },
         startIcon2Input: {
           id: 'startIcon2Id',
@@ -171,7 +173,8 @@ describe('CardCta', () => {
           label: 'More about us',
           variant: ButtonVariant.text,
           color: ButtonColor.secondary,
-          size: ButtonSize.large
+          size: ButtonSize.large,
+          submitEnabled: null
         },
         startIcon3Input: {
           id: 'startIcon3Id',

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/CardTemplates/Templates/CardCta/CardCta.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/CardTemplates/Templates/CardCta/CardCta.tsx
@@ -485,7 +485,13 @@ export function CardCta(): ReactElement {
             },
             button1Id: buttonBlock1.id,
             button1Input: {
-              ...pick(buttonBlock1, ['id', 'parentBlockId', 'label', 'size']),
+              ...pick(buttonBlock1, [
+                'id',
+                'parentBlockId',
+                'label',
+                'size',
+                'submitEnabled'
+              ]),
               journeyId: journey.id,
               variant: buttonBlock1.buttonVariant
             },
@@ -504,7 +510,13 @@ export function CardCta(): ReactElement {
             },
             button2Id: buttonBlock2.id,
             button2Input: {
-              ...pick(buttonBlock2, ['id', 'parentBlockId', 'label', 'size']),
+              ...pick(buttonBlock2, [
+                'id',
+                'parentBlockId',
+                'label',
+                'size',
+                'submitEnabled'
+              ]),
               journeyId: journey.id,
               variant: buttonBlock2.buttonVariant
             },
@@ -523,7 +535,13 @@ export function CardCta(): ReactElement {
             },
             button3Id: buttonBlock3.id,
             button3Input: {
-              ...pick(buttonBlock3, ['id', 'parentBlockId', 'label', 'size']),
+              ...pick(buttonBlock3, [
+                'id',
+                'parentBlockId',
+                'label',
+                'size',
+                'submitEnabled'
+              ]),
               journeyId: journey.id,
               variant: buttonBlock3.buttonVariant,
               color: buttonBlock3.buttonColor

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/CardTemplates/Templates/CardForm/CardForm.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/CardTemplates/Templates/CardForm/CardForm.tsx
@@ -388,7 +388,7 @@ export function CardForm(): ReactElement {
               variant: buttonBlock.buttonVariant,
               color: buttonBlock.buttonColor,
               size: buttonBlock.size,
-              submitEnabled: true
+              submitEnabled: buttonBlock.submitEnabled
             },
             buttonId: buttonBlock.id,
             buttonUpdateInput: {


### PR DESCRIPTION
The buttons on the call to action card template were incorrectly being created as submit buttons. Fixed this to make sure they were normal buttons

### Additional

Changed submitenabled field on card form create, so that it was using the value from the button block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The submit button state for card CTA and form buttons now accurately reflects the configuration, allowing for more dynamic control over button behavior.

- **Tests**
  - Updated test data to include the new submit button state property for improved test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->