### PR TITLE
fix: populate session ids and child link fix

### DIFF
--- a/apps/arclight/src/app/v2/[...route]/_media-components/[mediaComponentId]/languages/[languageId]/index.ts
+++ b/apps/arclight/src/app/v2/[...route]/_media-components/[mediaComponentId]/languages/[languageId]/index.ts
@@ -219,7 +219,7 @@ mediaComponentLanguage.openapi(route, async (c) => {
     }
   })
 
-  const apiSessionId = '6622f10d2260a8.05128925'
+  const apiSessionId = c.req.query('apiSessionId') ?? '6622f10d2260a8.05128925'
 
   const video = data.video
 
@@ -403,7 +403,9 @@ mediaComponentLanguage.openapi(route, async (c) => {
               low: child.variant?.downloads?.find(
                 (d) => d.quality === 'low'
               ) && {
-                url: `https://arc.gt/${Math.random().toString(36).substring(2, 7)}?apiSessionId=${apiSessionId}`,
+                url:
+                  child.variant.downloads.find((d) => d.quality === 'low')
+                    ?.url ?? '',
                 height:
                   child.variant.downloads.find((d) => d.quality === 'low')
                     ?.height ?? 240,
@@ -417,7 +419,9 @@ mediaComponentLanguage.openapi(route, async (c) => {
               high: child.variant?.downloads?.find(
                 (d) => d.quality === 'high'
               ) && {
-                url: `https://arc.gt/${Math.random().toString(36).substring(2, 7)}?apiSessionId=${apiSessionId}`,
+                url:
+                  child.variant.downloads.find((d) => d.quality === 'high')
+                    ?.url ?? '',
                 height:
                   child.variant.downloads.find((d) => d.quality === 'high')
                     ?.height ?? 720,
@@ -439,7 +443,7 @@ mediaComponentLanguage.openapi(route, async (c) => {
               ],
               http: []
             },
-            shareUrl: `https://arc.gt/${Math.random().toString(36).substring(2, 7)}?apiSessionId=${apiSessionId}`,
+            shareUrl: child.variant?.share ?? '',
             socialMediaUrls: {},
             _links: {
               self: {

--- a/apps/arclight/src/app/v2/[...route]/_media-components/[mediaComponentId]/languages/[languageId]/index.ts
+++ b/apps/arclight/src/app/v2/[...route]/_media-components/[mediaComponentId]/languages/[languageId]/index.ts
@@ -44,6 +44,7 @@ const GET_VIDEO_VARIANT = graphql(`
         primaryLanguageId
         variant {
           hls
+          share
           lengthInMilliseconds
           downloadable
           downloads {
@@ -52,6 +53,7 @@ const GET_VIDEO_VARIANT = graphql(`
             quality
             size
             bitrate
+            url
           }
           subtitle {
             language {

--- a/apps/arclight/src/app/v2/[...route]/_media-components/[mediaComponentId]/languages/index.ts
+++ b/apps/arclight/src/app/v2/[...route]/_media-components/[mediaComponentId]/languages/index.ts
@@ -113,7 +113,7 @@ mediaComponentLanguages.openapi(route, async (c) => {
   }
 
   const languageIds = c.req.query('languageIds')?.split(',') ?? []
-  const apiSessionId = '6622f10d2260a8.05128925'
+  const apiSessionId = c.req.query('apiSessionId') ?? '6622f10d2260a8.05128925'
 
   const { data } = await getApolloClient().query<
     ResultOf<typeof GET_VIDEO_LANGUAGES>

--- a/apps/arclight/src/app/v2/[...route]/_media-components/index.ts
+++ b/apps/arclight/src/app/v2/[...route]/_media-components/index.ts
@@ -233,6 +233,7 @@ mediaComponents.openapi(route, async (c) => {
       : c.req.query('ids')?.split(',').filter(Boolean)
   const metadataLanguageTags =
     c.req.query('metadataLanguageTags')?.split(',').filter(Boolean) ?? []
+  const apiSessionId = c.req.query('apiSessionId') ?? '6622f10d2260a8.05128925'
 
   const languageResult = await getLanguageIdsFromTags(metadataLanguageTags)
   if (languageResult instanceof HTTPException) {
@@ -385,7 +386,7 @@ mediaComponents.openapi(route, async (c) => {
         limit,
         pages: lastPage,
         total,
-        apiSessionId: '',
+        apiSessionId: apiSessionId,
         _links: {
           self: {
             href: `http://api.arclight.org/v2/media-components?${queryString}`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The application now accepts an optional apiSessionId query parameter, allowing users to specify their session ID for certain endpoints.
  - Download and share URLs for media components now use actual variant data, providing accurate links for each item.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->