### PR TITLE
fix: partner issues in arclight facade

### DIFF
--- a/apps/arclight-e2e/src/e2e/media-component-links/[mediaComponentId]/index.spec.ts
+++ b/apps/arclight-e2e/src/e2e/media-component-links/[mediaComponentId]/index.spec.ts
@@ -148,12 +148,12 @@ test.describe('single media component link', () => {
     expect(data).toMatchObject({
       mediaComponentId: '10_DarkroomFaith',
       linkedMediaComponentIds: expect.any(Object),
-      __embedded: {
+      _embedded: {
         contains: expect.any(Array)
       }
     })
 
-    const component = data.__embedded.contains[0]
+    const component = data._embedded.contains[0]
     expect(component).toMatchObject({
       mediaComponentId: expect.any(String),
       componentType: expect.any(String),

--- a/apps/arclight-e2e/src/e2e/media-components/[mediaComponentId]/index.spec.ts
+++ b/apps/arclight-e2e/src/e2e/media-components/[mediaComponentId]/index.spec.ts
@@ -128,19 +128,16 @@ test('media component returns 400 for non-existent ID', async ({ request }) => {
   })
 })
 
-test('media component returns 400 for invalid language with no fallback content', async ({
+test('media component returns 200 and defaults to english for invalid language with no fallback content', async ({
   request
 }) => {
   const response = await request.get(
     `${await getBaseUrl()}/v2/media-components/${mediaComponentId}?${createQueryParams({ metadataLanguageTags: 'xx' })}`
   )
 
-  expect(response.status()).toBe(400)
+  expect(response.ok()).toBeTruthy()
+  expect(response.status()).toBe(200)
   const data = await response.json()
-  expect(data).toMatchObject({
-    message: expect.stringContaining(
-      'Not acceptable metadata language tag(s): xx'
-    ),
-    logref: 400
-  })
+  expect(data).toHaveProperty('metadataLanguageTag')
+  expect(data.metadataLanguageTag).toBe('en')
 })

--- a/apps/arclight-e2e/src/e2e/media-components/index.spec.ts
+++ b/apps/arclight-e2e/src/e2e/media-components/index.spec.ts
@@ -165,7 +165,7 @@ test.describe('media components', () => {
     expect(data._embedded.mediaComponents.length).toBeLessThanOrEqual(2)
   })
 
-  test('media components returns 400 for invalid language with no fallback content', async ({
+  test('media components returns 200 and defaults to english for invalid language with no fallback content', async ({
     request
   }) => {
     const response = await request.get(
@@ -175,11 +175,13 @@ test.describe('media components', () => {
       })}`
     )
 
-    expect(response.status()).toBe(400)
+    expect(response.ok()).toBeTruthy()
+    expect(response.status()).toBe(200)
     const data = await response.json()
-    expect(data).toMatchObject({
-      message: expect.any(String),
-      logref: 400
-    })
+    expect(data._embedded.mediaComponents.length).toBeGreaterThan(0)
+    expect(data._embedded.mediaComponents[0]).toHaveProperty(
+      'metadataLanguageTag'
+    )
+    expect(data._embedded.mediaComponents[0].metadataLanguageTag).toBe('en')
   })
 })

--- a/apps/arclight-e2e/src/e2e/media-languages/[languageId]/index.spec.ts
+++ b/apps/arclight-e2e/src/e2e/media-languages/[languageId]/index.spec.ts
@@ -101,20 +101,19 @@ test.describe('GET /v2/media-languages/[languageId]', () => {
     })
   })
 
-  test('returns 400 for invalid metadata language', async ({ request }) => {
+  test('returns 200 and defaults to english for invalid metadata language', async ({
+    request
+  }) => {
     const response = await getMediaLanguage(request, {
       languageId: '529',
       params: { metadataLanguageTags: 'invalid' }
     })
 
-    expect(response.ok()).toBeFalsy()
-    expect(response.status()).toBe(400)
+    expect(response.ok()).toBeTruthy()
+    expect(response.status()).toBe(200)
     const data = await response.json()
     expect(data).toMatchObject({
-      message: expect.stringContaining(
-        'Not acceptable metadata language tag(s): invalid'
-      ),
-      logref: 400
+      languageId: 529
     })
   })
 })

--- a/apps/arclight/src/app/v2/[...route]/_media-component-links/[mediaComponentId]/index.ts
+++ b/apps/arclight/src/app/v2/[...route]/_media-component-links/[mediaComponentId]/index.ts
@@ -319,7 +319,12 @@ mediaComponentLinksWithId.openapi(route, async (c) => {
                   lengthInMilliseconds: variant?.lengthInMilliseconds ?? 0,
                   containsCount: childrenCount,
                   isDownloadable: variant?.downloadable ?? false,
-                  downloadSizes: {},
+                  downloadSizes: {
+                    approximateSmallDownloadSizeInBytes:
+                      variant?.downloads[0]?.size ?? 0,
+                    approximateLargeDownloadSizeInBytes:
+                      variant?.downloads[1]?.size ?? 0
+                  },
                   bibleCitations: bibleCitations.map((citation) => ({
                     osisBibleBook: citation.osisId,
                     chapterStart: citation.chapterStart,
@@ -398,7 +403,12 @@ mediaComponentLinksWithId.openapi(route, async (c) => {
                           variant?.lengthInMilliseconds ?? 0,
                         containsCount: childrenCount,
                         isDownloadable: variant?.downloadable ?? false,
-                        downloadSizes: {},
+                        downloadSizes: {
+                          approximateSmallDownloadSizeInBytes:
+                            variant?.downloads[0]?.size ?? 0,
+                          approximateLargeDownloadSizeInBytes:
+                            variant?.downloads[1]?.size ?? 0
+                        },
                         bibleCitations: bibleCitations.map((citation) => ({
                           osisBibleBook: citation.osisId,
                           chapterStart: citation.chapterStart,

--- a/apps/arclight/src/app/v2/[...route]/_media-component-links/[mediaComponentId]/index.ts
+++ b/apps/arclight/src/app/v2/[...route]/_media-component-links/[mediaComponentId]/index.ts
@@ -269,7 +269,7 @@ mediaComponentLinksWithId.openapi(route, async (c) => {
     },
     ...(expand.includes('mediaComponents')
       ? {
-          __embedded: {
+          _embedded: {
             contains: video.children
               .filter(
                 ({ availableLanguages }) =>

--- a/apps/arclight/src/app/v2/[...route]/_media-component-links/[mediaComponentId]/index.ts
+++ b/apps/arclight/src/app/v2/[...route]/_media-component-links/[mediaComponentId]/index.ts
@@ -55,7 +55,7 @@ const GET_VIDEO_CHILDREN = graphql(`
         availableLanguages
         variant {
           hls
-          duration
+          lengthInMilliseconds
           language {
             bcp47
           }
@@ -114,7 +114,7 @@ const GET_VIDEO_CHILDREN = graphql(`
         availableLanguages
         variant {
           hls
-          duration
+          lengthInMilliseconds
           language {
             bcp47
           }
@@ -316,7 +316,7 @@ mediaComponentLinksWithId.openapi(route, async (c) => {
                         (image) => image.mobileCinematicVeryLow != null
                       )?.mobileCinematicVeryLow ?? ''
                   },
-                  lengthInMilliseconds: variant?.duration ?? 0,
+                  lengthInMilliseconds: variant?.lengthInMilliseconds ?? 0,
                   containsCount: childrenCount,
                   isDownloadable: variant?.downloadable ?? false,
                   downloadSizes: {},
@@ -394,7 +394,8 @@ mediaComponentLinksWithId.openapi(route, async (c) => {
                               (image) => image.mobileCinematicVeryLow != null
                             )?.mobileCinematicVeryLow ?? ''
                         },
-                        lengthInMilliseconds: variant?.duration ?? 0,
+                        lengthInMilliseconds:
+                          variant?.lengthInMilliseconds ?? 0,
                         containsCount: childrenCount,
                         isDownloadable: variant?.downloadable ?? false,
                         downloadSizes: {},

--- a/apps/arclight/src/app/v2/[...route]/_media-components/[mediaComponentId]/index.ts
+++ b/apps/arclight/src/app/v2/[...route]/_media-components/[mediaComponentId]/index.ts
@@ -282,7 +282,7 @@ mediaComponent.openapi(route, async (c) => {
         video.studyQuestions.length > 0
           ? video.studyQuestions.map((question) => question.value)
           : video.fallbackStudyQuestions.map((question) => question.value),
-      metadataLanguageTag: metadataLanguageTags[0] ?? 'en',
+      metadataLanguageTag: video.title[0]?.language.bcp47 ?? 'en',
       _links: {
         sampleMediaComponentLanguage: {
           href: `http://api.arclight.org/v2/media-components/${mediaComponentId}/languages/529?platform=${platform}&apiKey=${apiKey}`

--- a/apps/arclight/src/app/v2/[...route]/_media-components/index.ts
+++ b/apps/arclight/src/app/v2/[...route]/_media-components/index.ts
@@ -95,7 +95,6 @@ const GET_VIDEOS_WITH_FALLBACK = graphql(`
       availableLanguages
       variant {
         hls
-        duration
         lengthInMilliseconds
         language {
           bcp47

--- a/apps/arclight/src/lib/getLanguageIdsFromTags.ts
+++ b/apps/arclight/src/lib/getLanguageIdsFromTags.ts
@@ -1,5 +1,4 @@
 import { ResultOf, graphql } from 'gql.tada'
-import { HTTPException } from 'hono/http-exception'
 
 import { getApolloClient } from './apolloClient'
 
@@ -63,28 +62,26 @@ async function fetchLanguageId(languageTag: string): Promise<string> {
 
 export async function getLanguageIdsFromTags(
   metadataLanguageTags: string[]
-): Promise<LanguageIds | HTTPException> {
+): Promise<LanguageIds> {
   const DEFAULT_LANGUAGE_ID = '529'
+  let metadataLanguageId = DEFAULT_LANGUAGE_ID
+  const fallbackLanguageId = DEFAULT_LANGUAGE_ID
 
   if (metadataLanguageTags.length === 0) {
     return {
-      metadataLanguageId: DEFAULT_LANGUAGE_ID,
-      fallbackLanguageId: DEFAULT_LANGUAGE_ID
+      metadataLanguageId,
+      fallbackLanguageId
     }
   }
 
   const metadataLanguageTag =
     matchLocales(metadataLanguageTags) ?? metadataLanguageTags[0]
 
-  const metadataLanguageId = await fetchLanguageId(metadataLanguageTag)
+  metadataLanguageId = await fetchLanguageId(metadataLanguageTag)
 
   if (!metadataLanguageId) {
-    throw new HTTPException(400, {
-      message: `Not acceptable metadata language tag(s): ${metadataLanguageTag}`
-    })
+    metadataLanguageId = DEFAULT_LANGUAGE_ID
   }
-
-  const fallbackLanguageId = DEFAULT_LANGUAGE_ID
 
   return { metadataLanguageId, fallbackLanguageId }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected response key naming from `__embedded` to `_embedded` for improved consistency.
	- Updated to use `lengthInMilliseconds` instead of the deprecated `duration` field in video data, ensuring accurate time information.

- **Refactor**
	- Improved language ID resolution by defaulting to a standard value when a language cannot be determined, preventing errors and ensuring smoother operation.

- **Enhancements**
	- Media content now defaults to English for invalid or missing language tags, improving user experience by avoiding errors.
	- Language tags in media responses are derived from video titles for more accurate metadata representation.
	- Added download size metadata for video components, providing users with information on approximate file sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->