### PR TITLE
fix: mark language field as shareable in journey schema

### DIFF
--- a/apis/api-journeys/schema.graphql
+++ b/apis/api-journeys/schema.graphql
@@ -396,7 +396,7 @@ type Journey
 
   """private title for creators"""
   title: String! @shareable
-  language: Language!
+  language: Language! @shareable
   languageId: String! @shareable
   themeMode: ThemeMode!
   themeName: ThemeName!

--- a/apis/api-journeys/src/app/modules/journey/journey.graphql
+++ b/apis/api-journeys/src/app/modules/journey/journey.graphql
@@ -23,7 +23,7 @@ type Journey @key(fields: "id") {
   private title for creators
   """
   title: String! @shareable
-  language: Language!
+  language: Language! @shareable
   languageId: String! @shareable
   themeMode: ThemeMode!
   themeName: ThemeName!


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The `language` field in the Journey GraphQL type is now shareable across federated services, improving interoperability in multi-service environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->