### PR TITLE
feat: enhance journey translation subscription to include SEO fields

### DIFF
--- a/apis/api-journeys-modern/src/schema/journeyAiTranslate/journeyAiTranslate.spec.ts
+++ b/apis/api-journeys-modern/src/schema/journeyAiTranslate/journeyAiTranslate.spec.ts
@@ -4,7 +4,7 @@ import { hardenPrompt, preSystemPrompt } from '@core/shared/ai/prompts'
 
 import { getClient } from '../../../test/client'
 import { prismaMock } from '../../../test/prismaMock'
-import { Action, ability } from '../../lib/auth/ability'
+import { Action, ability, subject } from '../../lib/auth/ability'
 import { graphql } from '../../lib/graphql/subgraphGraphql'
 
 import { getCardBlocksContent } from './getCardBlocksContent'
@@ -29,7 +29,7 @@ jest.mock('../../lib/auth/ability', () => ({
     Update: 'update'
   },
   ability: jest.fn(),
-  subject: jest.fn()
+  subject: jest.fn((type, object) => ({ subject: type, object }))
 }))
 
 jest.mock('./getCardBlocksContent', () => ({
@@ -55,6 +55,7 @@ function createMockAsyncIterator<T>(items: T[]): AsyncIterable<T> {
 
 describe('journeyAiTranslateCreate mutation', () => {
   const mockAbility = ability as jest.MockedFunction<typeof ability>
+  const mockSubject = subject as jest.MockedFunction<typeof subject>
   const mockGenerateObject = generateObject as jest.MockedFunction<
     typeof generateObject
   >
@@ -248,7 +249,11 @@ describe('journeyAiTranslateCreate mutation', () => {
     })
 
     // Verify permissions were checked
-    expect(mockAbility).toHaveBeenCalledWith(Action.Update, undefined, mockUser)
+    expect(mockAbility).toHaveBeenCalledWith(
+      Action.Update,
+      { subject: 'Journey', object: mockJourney },
+      mockUser
+    )
 
     // Verify AI analysis was requested
     expect(mockGenerateObject).toHaveBeenCalledWith(
@@ -534,6 +539,7 @@ describe('journeyAiTranslateCreate mutation', () => {
 
 describe('journeyAiTranslateCreateSubscription', () => {
   const mockAbility = ability as jest.MockedFunction<typeof ability>
+  const mockSubject = subject as jest.MockedFunction<typeof subject>
   const mockGenerateObject = generateObject as jest.MockedFunction<
     typeof generateObject
   >

--- a/apis/api-journeys-modern/src/schema/journeyAiTranslate/journeyAiTranslate.ts
+++ b/apis/api-journeys-modern/src/schema/journeyAiTranslate/journeyAiTranslate.ts
@@ -157,7 +157,7 @@ Also suggest ways to culturally adapt this content for the target language: ${ha
 Then, translate the following journey title and description to ${hardenPrompt(input.textLanguageName)}.
 If a description is not provided, do not create one.
 
-If possible, find a populare translation of the Bible in the target language to use in follow up steps.
+If possible, find a popular translation of the Bible in the target language for Bible translations and include it in the analysis.
 
 ${hardenPrompt(`
 The source language is: ${input.journeyLanguageName}.
@@ -605,7 +605,7 @@ Also suggest ways to culturally adapt this content for the target language: ${ha
 Then, translate the following journey title and description to ${hardenPrompt(requestedLanguageName)}.
 If a description is not provided, do not create one.
 
-If possible, find a populare translation of the Bible in the target language to use in follow up steps.
+If possible, find a popular translation of the Bible in the target language to use in follow up steps.
 
 ${hardenPrompt(`
 The source language is: ${sourceLanguageName}.
@@ -639,13 +639,7 @@ Return in this format:
             { role: 'system', content: preSystemPrompt },
             { role: 'user', content: combinedPrompt }
           ],
-          schema: z.object({
-            analysis: z.string(),
-            title: z.string(),
-            description: z.string(),
-            seoTitle: z.string(),
-            seoDescription: z.string()
-          })
+          schema: JourneyAnalysisSchema
         })
 
         if (!analysisAndTranslation.title)


### PR DESCRIPTION
- Added support for translating SEO title and description in the journeyAiTranslateCreateSubscription.
- Updated the schema to validate and handle SEO fields conditionally.
- Refactored the translation prompt to include SEO considerations.
- Improved test coverage for SEO field handling in journey translations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for translating and updating SEO title and SEO description fields during journey translation.
  - Enhanced translation process to include cultural adaptation suggestions and SEO fields in a single step.

- **Bug Fixes**
  - Improved validation to ensure SEO fields are only updated if present and successfully translated.

- **Tests**
  - Introduced comprehensive tests for the new subscription functionality, including scenarios with and without SEO fields.
  - Updated permission checks in existing tests for more accurate authorization handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->