### PR TITLE
feat: implement cache update for video creation in Apollo Client

### DIFF
--- a/apps/videos-admin/src/app/(dashboard)/videos/_VideoCreateForm/VideoCreateForm.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/_VideoCreateForm/VideoCreateForm.tsx
@@ -113,6 +113,15 @@ export function VideoCreateForm({
           childIds: []
         }
       },
+      update: (cache, { data }) => {
+        if (!data?.videoCreate) return
+
+        // Invalidate all adminVideos and adminVideosCount queries in the cache
+        // This ensures that any active queries will refetch and show the new video
+        cache.evict({ fieldName: 'adminVideos' })
+        cache.evict({ fieldName: 'adminVideosCount' })
+        cache.gc()
+      },
       onCompleted: async (data) => {
         const videoId = data.videoCreate.id
 

--- a/apps/videos-admin/src/libs/apollo/cache.ts
+++ b/apps/videos-admin/src/libs/apollo/cache.ts
@@ -32,6 +32,19 @@ export const cache = {
             ) as VideoData[]
           }
         },
+        adminVideos: {
+          ...offsetLimitPagination(['where']),
+          read(existing, { args }) {
+            // A read function should always return undefined if existing is
+            // undefined. Returning undefined signals that the field is
+            // missing from the cache, which instructs Apollo Client to
+            // fetch its value from your GraphQL server.
+            return existing?.slice(
+              args?.offset ?? 0,
+              (args?.offset ?? 0) + (args?.limit ?? 100)
+            ) as VideoData[]
+          }
+        },
         // Always fetch the video from the network
         adminVideo: {
           read(_, { args, toReference }) {


### PR DESCRIPTION
- Added cache eviction for adminVideos and adminVideosCount upon video creation to ensure updated data is fetched.
- Introduced a read function for adminVideos to handle pagination in the Apollo cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved cache management to ensure the video list and count update correctly after creating a new video.

- **New Features**
	- Enhanced pagination support for the admin video list, providing more accurate and responsive data updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->