### PR TITLE
chore: upgrade EKS Kubernetes version to 1.31

### DIFF
--- a/infrastructure/modules/aws/eks/main.tf
+++ b/infrastructure/modules/aws/eks/main.tf
@@ -46,7 +46,7 @@ resource "aws_security_group" "eks-cluster" {
 resource "aws_eks_cluster" "this" {
   name     = "${var.name}-${var.env}"
   role_arn = aws_iam_role.eks-cluster.arn
-  version  = "1.30"
+  version  = "1.31"
 
   vpc_config {
     security_group_ids = concat([aws_security_group.eks-cluster.id], var.security_group_ids)


### PR DESCRIPTION
This PR upgrades the AWS EKS Kubernetes cluster version from 1.30 to 1.31 in the Terraform configuration. Please review for compatibility and staged rollout as needed.