### PR TITLE
fix: journey theme update filter by journeyId

### DIFF
--- a/apis/api-journeys/src/app/modules/journeyTheme/journeyTheme.resolver.spec.ts
+++ b/apis/api-journeys/src/app/modules/journeyTheme/journeyTheme.resolver.spec.ts
@@ -262,7 +262,7 @@ describe('JourneyThemeResolver', () => {
       ).resolves.toEqual(updatedJourneyTheme)
 
       expect(prismaService.journeyTheme.update).toHaveBeenCalledWith({
-        where: { id: 'journeyThemeId' },
+        where: { journeyId: 'journeyThemeId' },
         data: {
           headerFont: 'Helvetica',
           bodyFont: 'Times New Roman',

--- a/apis/api-journeys/src/app/modules/journeyTheme/journeyTheme.resolver.ts
+++ b/apis/api-journeys/src/app/modules/journeyTheme/journeyTheme.resolver.ts
@@ -95,7 +95,7 @@ export class JourneyThemeResolver {
     @Args('input') input: JourneyThemeUpdateInput
   ): Promise<JourneyTheme> {
     const journeyTheme = await this.prismaService.journeyTheme.findUnique({
-      where: { id },
+      where: { journeyId: id },
       include: {
         journey: {
           include: {
@@ -119,7 +119,7 @@ export class JourneyThemeResolver {
     }
 
     return await this.prismaService.journeyTheme.update({
-      where: { id },
+      where: { journeyId: id },
       data: {
         headerFont: input.headerFont ?? undefined,
         bodyFont: input.bodyFont ?? undefined,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the logic for updating JourneyTheme settings to use the journey's identifier instead of the theme's identifier, ensuring changes are correctly applied to the intended journey.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->