### PR TITLE
fix: add duration and lengthInMilliseconds to video variant data

### DIFF
--- a/apps/videos-admin/src/app/_UploadVideoVariantProvider/UploadVideoVariantProvider.spec.tsx
+++ b/apps/videos-admin/src/app/_UploadVideoVariantProvider/UploadVideoVariantProvider.spec.tsx
@@ -72,7 +72,8 @@ const getMyMuxVideoMock = {
         id: 'mux-id',
         assetId: 'asset-id',
         playbackId: 'playback-id',
-        readyToStream: true
+        readyToStream: true,
+        duration: 120
       }
     }
   }
@@ -91,7 +92,9 @@ const createVideoVariantMock = {
         downloadable: true,
         published: true,
         muxVideoId: 'mux-id',
-        hls: 'https://stream.mux.com/playback-id.m3u8'
+        hls: 'https://stream.mux.com/playback-id.m3u8',
+        duration: 120,
+        lengthInMilliseconds: 120000
       }
     }
   },
@@ -172,7 +175,9 @@ const createVideoVariantErrorMock = {
         downloadable: true,
         published: true,
         muxVideoId: 'mux-id',
-        hls: 'https://stream.mux.com/playback-id.m3u8'
+        hls: 'https://stream.mux.com/playback-id.m3u8',
+        duration: 120,
+        lengthInMilliseconds: 120000
       }
     }
   },

--- a/apps/videos-admin/src/app/_UploadVideoVariantProvider/UploadVideoVariantProvider.tsx
+++ b/apps/videos-admin/src/app/_UploadVideoVariantProvider/UploadVideoVariantProvider.tsx
@@ -49,6 +49,7 @@ export const GET_MY_MUX_VIDEO = graphql(`
       assetId
       playbackId
       readyToStream
+      duration
     }
   }
 `)
@@ -180,7 +181,8 @@ export function UploadVideoVariantProvider({
         stopPolling()
         await handleCreateVideoVariant(
           data.getMyMuxVideo.id,
-          data.getMyMuxVideo.playbackId
+          data.getMyMuxVideo.playbackId,
+          data.getMyMuxVideo.duration
         )
       }
     },
@@ -194,7 +196,8 @@ export function UploadVideoVariantProvider({
 
   const handleCreateVideoVariant = async (
     muxId: string,
-    playbackId: string
+    playbackId: string,
+    duration?: number | null
   ) => {
     if (
       state.videoId == null ||
@@ -204,6 +207,10 @@ export function UploadVideoVariantProvider({
       state.videoSlug == null
     )
       return
+
+    // Calculate lengthInMilliseconds from duration (duration is in seconds)
+    const durationInSeconds = duration ?? 0
+    const lengthInMilliseconds = durationInSeconds * 1000
 
     try {
       await createVideoVariant({
@@ -217,7 +224,9 @@ export function UploadVideoVariantProvider({
             downloadable: true,
             published: true,
             muxVideoId: muxId,
-            hls: `https://stream.mux.com/${playbackId}.m3u8`
+            hls: `https://stream.mux.com/${playbackId}.m3u8`,
+            duration: durationInSeconds,
+            lengthInMilliseconds: lengthInMilliseconds
           }
         },
         onCompleted: () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video uploads now include duration metadata, providing more detailed information about each video variant.
* **Tests**
  * Enhanced test coverage to validate the inclusion of video duration and length in milliseconds for uploaded video variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->