### PR TITLE
feat: allow cursor branches in linting

### DIFF
--- a/validate-branch-name.config.js
+++ b/validate-branch-name.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   pattern:
-    /^(\(HEAD detached at pull\/[0-9]+\/merge\)|(00-00-RB-.*)|stage|main|([0-9]{2}-[0-9]{2}-[A-Z]{2}-(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)-[a-z0-9-]+[a-z0-9])|(feature\/[0-9]{2}-[0-9]{2}-[A-Z]{2}-[a-z0-9-]+[a-z0-9])|[a-z0-9]{3}-[0-9]+-[a-z0-9-]+|[a-z]+\/[a-z0-9]{3}-[0-9]+-[a-z0-9-]+)$/,
+    /^(\(HEAD detached at pull\/[0-9]+\/merge\)|(00-00-RB-.*)|stage|main|([0-9]{2}-[0-9]{2}-[A-Z]{2}-(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)-[a-z0-9-]+[a-z0-9])|(feature\/[0-9]{2}-[0-9]{2}-[A-Z]{2}-[a-z0-9-]+[a-z0-9])|[a-z0-9]{3}-[0-9]+-[a-z0-9-]+|[a-z]+\/[a-z0-9]{3}-[0-9]+-[a-z0-9-]+|(cursor\/.*))$/,
   errorMsg:
     'Your branch does not match the naming convention (https://github.com/JesusFilm/core/wiki/Repository-Best-Practice#naming-your-branch)'
 }


### PR DESCRIPTION
Update branch name linting to allow `cursor/*` branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated branch name validation to allow branch names starting with "cursor/" in addition to existing formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->