### PR TITLE
fix: add rangeStrategy to renovatebot config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,6 @@
   "reviewers": ["mikeallisonJS", "tataihono"],
   "assignees": ["mikeallisonJS"],
   "labels": ["effort: 1", "priority: 2day", "type: chore"],
-  "prConcurrentLimit": 4
+  "prConcurrentLimit": 4,
+  "rangeStrategy": "bump"
 }


### PR DESCRIPTION
Add `rangeStrategy: "bump"` to Renovate config to update dependencies by bumping within semver ranges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to specify version update strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->