### PR TITLE
fix: implement streaming SQL file preprocessing in data-import script

### DIFF
--- a/apis/api-media/src/scripts/data-import.spec.ts
+++ b/apis/api-media/src/scripts/data-import.spec.ts
@@ -1,11 +1,9 @@
 import { spawn } from 'child_process'
 import fs, { promises as fsPromises } from 'fs'
-import { join } from 'path'
-import { Readable } from 'stream'
-import { pipeline } from 'stream/promises'
+import { createInterface } from 'readline'
 import { createGunzip } from 'zlib'
 
-import main from './data-import'
+import main, { preprocessSqlFile } from './data-import'
 
 // Mock fs functions
 jest.mock('fs', () => ({
@@ -21,7 +19,14 @@ jest.mock('fs', () => ({
   }),
   createWriteStream: jest.fn().mockReturnValue({
     write: jest.fn(),
-    end: jest.fn()
+    end: jest.fn(),
+    on: jest.fn((event, handler) => {
+      if (event === 'finish') {
+        // Simulate write stream finishing
+        setTimeout(() => handler(), 0)
+      }
+      return { write: jest.fn(), end: jest.fn(), on: jest.fn() }
+    })
   }),
   promises: {
     mkdir: jest.fn().mockResolvedValue(undefined),
@@ -56,6 +61,29 @@ jest.mock('stream/promises', () => ({
 jest.mock('zlib', () => ({
   createGunzip: jest.fn().mockReturnValue({
     pipe: jest.fn().mockReturnThis()
+  })
+}))
+
+// Mock readline
+jest.mock('readline', () => ({
+  createInterface: jest.fn().mockReturnValue({
+    [Symbol.asyncIterator]: jest.fn().mockReturnValue({
+      next: jest
+        .fn()
+        .mockResolvedValueOnce({
+          value: 'CREATE TABLE test (id INT);',
+          done: false
+        })
+        .mockResolvedValueOnce({
+          value: 'CREATE PUBLICATION pub FOR ALL TABLES;',
+          done: false
+        })
+        .mockResolvedValueOnce({
+          value: 'INSERT INTO test VALUES (1);',
+          done: false
+        })
+        .mockResolvedValueOnce({ done: true })
+    })
   })
 }))
 
@@ -160,9 +188,9 @@ describe('data-import script', () => {
     // Verify decompression was executed
     expect(createGunzip).toHaveBeenCalled()
 
-    // Verify SQL file was preprocessed
-    expect(fsPromises.readFile).toHaveBeenCalled()
-    expect(fsPromises.writeFile).toHaveBeenCalled()
+    // Verify SQL file was preprocessed using streaming
+    expect(fs.createReadStream).toHaveBeenCalled()
+    expect(fs.createWriteStream).toHaveBeenCalled()
 
     // Verify psql command was executed with the preprocessed file
     expect(spawn).toHaveBeenCalledWith(
@@ -246,5 +274,76 @@ describe('data-import script', () => {
 
     expect(console.error).toHaveBeenCalled()
     expect(process.exit).toHaveBeenCalledWith(1)
+  })
+
+  describe('preprocessSqlFile', () => {
+    it('should process SQL files using streaming and filter out CREATE PUBLICATION statements', async () => {
+      // Mock createInterface to return lines including CREATE PUBLICATION statements
+      const mockLines = [
+        'CREATE TABLE test (id INT);',
+        'CREATE PUBLICATION pub1 FOR ALL TABLES;',
+        'INSERT INTO test VALUES (1);',
+        'CREATE PUBLICATION pub2 FOR TABLE test;',
+        'SELECT * FROM test;'
+      ]
+
+      const mockReadlineInterface = {
+        [Symbol.asyncIterator]: jest.fn().mockReturnValue({
+          next: jest
+            .fn()
+            .mockResolvedValueOnce({ value: mockLines[0], done: false })
+            .mockResolvedValueOnce({ value: mockLines[1], done: false })
+            .mockResolvedValueOnce({ value: mockLines[2], done: false })
+            .mockResolvedValueOnce({ value: mockLines[3], done: false })
+            .mockResolvedValueOnce({ value: mockLines[4], done: false })
+            .mockResolvedValueOnce({ done: true })
+        })
+      }
+
+      ;(createInterface as jest.Mock).mockReturnValueOnce(mockReadlineInterface)
+
+      const mockWriteStream: any = {
+        write: jest.fn(),
+        end: jest.fn(),
+        on: jest.fn((event: string, handler: () => void) => {
+          if (event === 'finish') {
+            setTimeout(() => handler(), 0)
+          }
+          return mockWriteStream
+        })
+      }
+
+      ;(fs.createWriteStream as jest.Mock).mockReturnValueOnce(mockWriteStream)
+
+      await preprocessSqlFile('/input/test.sql', '/output/test.sql')
+
+      // Verify createInterface was called
+      expect(createInterface).toHaveBeenCalled()
+
+      // Verify write stream was created
+      expect(fs.createWriteStream).toHaveBeenCalledWith('/output/test.sql')
+
+      // Verify only non-publication statements were written
+      expect(mockWriteStream.write).toHaveBeenCalledWith(
+        'CREATE TABLE test (id INT);\n'
+      )
+      expect(mockWriteStream.write).toHaveBeenCalledWith(
+        'INSERT INTO test VALUES (1);\n'
+      )
+      expect(mockWriteStream.write).toHaveBeenCalledWith(
+        'SELECT * FROM test;\n'
+      )
+
+      // Verify CREATE PUBLICATION statements were NOT written
+      expect(mockWriteStream.write).not.toHaveBeenCalledWith(
+        'CREATE PUBLICATION pub1 FOR ALL TABLES;\n'
+      )
+      expect(mockWriteStream.write).not.toHaveBeenCalledWith(
+        'CREATE PUBLICATION pub2 FOR TABLE test;\n'
+      )
+
+      // Verify stream was properly closed
+      expect(mockWriteStream.end).toHaveBeenCalled()
+    })
   })
 })

--- a/apis/api-media/src/scripts/data-import.ts
+++ b/apis/api-media/src/scripts/data-import.ts
@@ -1,6 +1,11 @@
 import { spawn } from 'child_process'
-import fs, { promises as fsPromises } from 'fs'
+import fs, {
+  createReadStream,
+  createWriteStream,
+  promises as fsPromises
+} from 'fs'
 import { join } from 'path'
+import { createInterface } from 'readline'
 import { Readable } from 'stream'
 import { pipeline } from 'stream/promises'
 import { TransformStream } from 'stream/web'
@@ -160,6 +165,7 @@ async function decompressFile(
 
 /**
  * Preprocesses the SQL file to ensure compatibility with existing database
+ * Uses streaming to handle large files without loading them entirely into memory
  */
 async function preprocessSqlFile(
   inputFile: string,
@@ -168,16 +174,75 @@ async function preprocessSqlFile(
   console.log('Preprocessing SQL file for compatibility')
 
   try {
-    const sqlContent = await fsPromises.readFile(inputFile, 'utf8')
-
-    // Remove all CREATE PUBLICATION statements completely
-    const processedContent = sqlContent.replace(
-      /CREATE PUBLICATION .* FOR .*;(\r?\n)?/g,
-      ''
+    // Get file size for progress reporting
+    const stats = await fsPromises.stat(inputFile)
+    const totalSize = stats.size
+    const fileName = inputFile.split('/').pop() || inputFile
+    console.log(
+      `Processing ${fileName} (${(totalSize / 1024 / 1024).toFixed(2)} MB)`
     )
 
-    await fsPromises.writeFile(outputFile, processedContent)
-    console.log('SQL file preprocessing completed')
+    const startTime = Date.now()
+    let processedBytes = 0
+    let linesProcessed = 0
+    let publicationStatementsRemoved = 0
+
+    // Create read and write streams
+    const readStream = createReadStream(inputFile)
+    const writeStream = createWriteStream(outputFile)
+
+    // Create readline interface for line-by-line processing
+    const rl = createInterface({
+      input: readStream,
+      crlfDelay: Infinity // Handle Windows line endings
+    })
+
+    // Progress reporting
+    const progressInterval = setInterval(() => {
+      const percent =
+        totalSize > 0 ? Math.round((processedBytes / totalSize) * 100) : 0
+      console.log(
+        `Processing: ${percent}% (${linesProcessed.toLocaleString()} lines, ${publicationStatementsRemoved} publication statements removed)`
+      )
+    }, 3000)
+
+    // Process each line
+    for await (const line of rl) {
+      linesProcessed++
+      processedBytes += Buffer.byteLength(line, 'utf8') + 1 // +1 for newline
+
+      // Check if this line contains a CREATE PUBLICATION statement
+      if (/CREATE PUBLICATION .* FOR .*;/.test(line)) {
+        publicationStatementsRemoved++
+        // Skip this line (don't write it to output)
+        continue
+      }
+
+      // Write the line to output file
+      writeStream.write(line + '\n')
+    }
+
+    // Close the write stream
+    writeStream.end()
+
+    // Wait for the write stream to finish
+    await new Promise<void>((resolve, reject) => {
+      writeStream.on('finish', resolve)
+      writeStream.on('error', reject)
+    })
+
+    clearInterval(progressInterval)
+
+    // Verify the output file exists and has content
+    const outputStats = await fsPromises.stat(outputFile)
+    if (outputStats.size === 0) {
+      throw new Error('Processed file is empty')
+    }
+
+    const duration = ((Date.now() - startTime) / 1000).toFixed(1)
+    console.log(
+      `SQL file preprocessing completed: ${fileName} -> ${(outputStats.size / 1024 / 1024).toFixed(2)} MB (${linesProcessed.toLocaleString()} lines processed, ${publicationStatementsRemoved} publication statements removed, took ${duration}s)`
+    )
   } catch (error) {
     console.error('Error preprocessing SQL file:', error)
     throw error
@@ -470,3 +535,4 @@ if (require.main === module) {
 }
 
 export default main
+export { preprocessSqlFile }


### PR DESCRIPTION
- Added streaming support to preprocessSqlFile for handling large SQL files without loading them entirely into memory.
- Removed CREATE PUBLICATION statements during processing.
- Enhanced progress reporting during file processing.
- Updated tests to verify new functionality and ensure correct behavior of the preprocessing logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved SQL file preprocessing for large files, now processing files line-by-line for better efficiency and memory usage.
  * Progress updates are displayed during processing, including percentage complete, lines processed, and statements removed.

* **Bug Fixes**
  * SQL statements related to publication creation are now correctly filtered out during preprocessing.

* **Tests**
  * Enhanced and expanded test coverage for SQL preprocessing, ensuring correct filtering and improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->