### PR TITLE
fix: variable values

### DIFF
--- a/apis/api-media/src/schema/video/video.spec.ts
+++ b/apis/api-media/src/schema/video/video.spec.ts
@@ -966,6 +966,49 @@ describe('video', () => {
       })
       expect(data).toHaveProperty('data.videos', result)
     })
+
+    it('should query videoVariants with different variable precedence', async () => {
+      prismaMock.video.findMany.mockResolvedValueOnce(videos)
+      // children
+      prismaMock.video.findMany.mockResolvedValueOnce(children)
+      // parents
+      prismaMock.video.findMany.mockResolvedValueOnce(parents)
+      // variantLanguages
+      prismaMock.videoVariant.findMany.mockResolvedValueOnce([
+        { languageId: 'languageId' } as unknown as VideoVariant
+      ])
+      // variantLanguagesCount
+      prismaMock.videoVariant.count.mockResolvedValueOnce(1)
+      // childrenCount
+      prismaMock.video.count.mockResolvedValueOnce(1)
+      // variantLanguagesWithSlug
+      prismaMock.videoVariant.findMany.mockResolvedValueOnce([
+        { languageId: 'languageId', slug: 'slug' } as unknown as VideoVariant
+      ])
+      // variant - test the precedence logic
+      prismaMock.videoVariant.findUnique.mockResolvedValueOnce({
+        id: 'variantId'
+      } as unknown as VideoVariant)
+
+      prismaMock.videoVariant.findMany.mockResolvedValueOnce([
+        {
+          id: 'variantId1',
+          languageId: 'languageId1'
+        } as unknown as VideoVariant,
+        {
+          id: 'variantId2',
+          languageId: 'languageId2'
+        } as unknown as VideoVariant
+      ])
+
+      const data = await client({
+        document: VIDEOS_QUERY,
+        variables: {
+          languageId: '987'
+        }
+      })
+      expect(data).toHaveProperty('data.videos', result)
+    })
   })
 
   describe('video', () => {

--- a/apis/api-media/src/schema/video/video.ts
+++ b/apis/api-media/src/schema/video/video.ts
@@ -355,6 +355,8 @@ const Video = builder.prismaObject('Video', {
           (info.variableValues.id as string | undefined) ??
           (info.variableValues.contentId as string | undefined) ??
           (info.variableValues._1_contentId as string | undefined) ??
+          (info.variableValues.containerId as string | undefined) ??
+          (info.variableValues._1_containerId as string | undefined) ??
           ''
         const requestedLanguage = variableValueId.includes('/')
           ? variableValueId.substring(variableValueId.lastIndexOf('/') + 1)


### PR DESCRIPTION
On watch [part3] pages. VideoChildren (in carousel) were incorrectly using english videoVariants even if the container was in another language. This change makes the video variants use the same language as the video container

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new test to verify correct selection of video variants when different variables are provided.
* **Bug Fixes**
  * Improved handling of variable precedence when selecting video variants, ensuring more reliable fallback to alternative variable keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->