### PR TITLE
refactor: journeySimpleTypes schemas for flexible get

### DIFF
--- a/apis/api-journeys-modern/src/schema/journey/simple/getSimpleJourney.ts
+++ b/apis/api-journeys-modern/src/schema/journey/simple/getSimpleJourney.ts
@@ -1,3 +1,5 @@
+import { GraphQLError } from 'graphql'
+
 import {
   JourneySimple,
   journeySimpleSchema
@@ -28,8 +30,13 @@ export async function getSimpleJourney(
       'Zod validation error in getSimpleJourney:',
       result.error.format()
     )
-    throw new Error(
-      'Transformed journey data is invalid. Please contact support.'
+    throw new GraphQLError(
+      'Transformed journey data is invalid. Please contact support.',
+      {
+        extensions: {
+          code: 'INTERNAL_SERVER_ERROR'
+        }
+      }
     )
   }
   return result.data

--- a/apis/api-journeys-modern/src/schema/journey/simple/simplifyJourney.ts
+++ b/apis/api-journeys-modern/src/schema/journey/simple/simplifyJourney.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '.prisma/api-journeys-modern-client'
+import type { Prisma } from '.prisma/api-journeys-modern-client'
 import {
   JourneySimple,
   JourneySimpleCard

--- a/apis/api-journeys-modern/src/schema/journey/simple/updateSimpleJourney.ts
+++ b/apis/api-journeys-modern/src/schema/journey/simple/updateSimpleJourney.ts
@@ -1,10 +1,10 @@
-import { JourneySimple } from '@core/shared/ai/journeySimpleTypes'
+import { JourneySimpleUpdate } from '@core/shared/ai/journeySimpleTypes'
 
 import { prisma } from '../../../lib/prisma'
 
 export async function updateSimpleJourney(
   journeyId: string,
-  simple: JourneySimple
+  simple: JourneySimpleUpdate
 ) {
   return prisma.$transaction(async (tx) => {
     // Mark all non-deleted blocks for this journey as deleted

--- a/libs/shared/ai/src/journeySimpleTypes.spec.ts
+++ b/libs/shared/ai/src/journeySimpleTypes.spec.ts
@@ -1,12 +1,15 @@
 import {
   journeySimpleButtonSchema,
+  journeySimpleButtonSchemaUpdate,
   journeySimpleCardSchema,
-  journeySimplePollOptionSchema
+  journeySimpleCardSchemaUpdate,
+  journeySimplePollOptionSchema,
+  journeySimplePollOptionSchemaUpdate
 } from './journeySimpleTypes'
 
 // journeySimplePollOptionSchema tests
 
-describe('journeySimplePollOptionSchema', () => {
+describe('journeySimplePollOptionSchema (base, permissive)', () => {
   it('validates with only nextCard', () => {
     expect(
       journeySimplePollOptionSchema.safeParse({ text: 'A', nextCard: 'card-1' })
@@ -23,8 +26,44 @@ describe('journeySimplePollOptionSchema', () => {
     ).toBe(true)
   })
 
-  it('fails with both nextCard and url', () => {
-    const result = journeySimplePollOptionSchema.safeParse({
+  it('validates with both nextCard and url (permissive)', () => {
+    expect(
+      journeySimplePollOptionSchema.safeParse({
+        text: 'A',
+        nextCard: 'card-1',
+        url: 'https://a.com'
+      }).success
+    ).toBe(true)
+  })
+
+  it('validates with neither nextCard nor url (permissive)', () => {
+    expect(journeySimplePollOptionSchema.safeParse({ text: 'A' }).success).toBe(
+      true
+    )
+  })
+})
+
+describe('journeySimplePollOptionSchemaUpdate (strict)', () => {
+  it('validates with only nextCard', () => {
+    expect(
+      journeySimplePollOptionSchemaUpdate.safeParse({
+        text: 'A',
+        nextCard: 'card-1'
+      }).success
+    ).toBe(true)
+  })
+
+  it('validates with only url', () => {
+    expect(
+      journeySimplePollOptionSchemaUpdate.safeParse({
+        text: 'A',
+        url: 'https://a.com'
+      }).success
+    ).toBe(true)
+  })
+
+  it('fails with both nextCard and url (strict)', () => {
+    const result = journeySimplePollOptionSchemaUpdate.safeParse({
       text: 'A',
       nextCard: 'card-1',
       url: 'https://a.com'
@@ -35,8 +74,8 @@ describe('journeySimplePollOptionSchema', () => {
     }
   })
 
-  it('fails with neither nextCard nor url', () => {
-    const result = journeySimplePollOptionSchema.safeParse({ text: 'A' })
+  it('fails with neither nextCard nor url (strict)', () => {
+    const result = journeySimplePollOptionSchemaUpdate.safeParse({ text: 'A' })
     expect(result.success).toBe(false)
     if (!result.success) {
       expect(result.error.issues[0].message).toMatch(/Exactly one/)
@@ -46,7 +85,7 @@ describe('journeySimplePollOptionSchema', () => {
 
 // journeySimpleButtonSchema tests
 
-describe('journeySimpleButtonSchema', () => {
+describe('journeySimpleButtonSchema (base, permissive)', () => {
   it('validates with only nextCard', () => {
     expect(
       journeySimpleButtonSchema.safeParse({ text: 'B', nextCard: 'card-2' })
@@ -61,8 +100,44 @@ describe('journeySimpleButtonSchema', () => {
     ).toBe(true)
   })
 
-  it('fails with both nextCard and url', () => {
-    const result = journeySimpleButtonSchema.safeParse({
+  it('validates with both nextCard and url (permissive)', () => {
+    expect(
+      journeySimpleButtonSchema.safeParse({
+        text: 'B',
+        nextCard: 'card-2',
+        url: 'https://b.com'
+      }).success
+    ).toBe(true)
+  })
+
+  it('validates with neither nextCard nor url (permissive)', () => {
+    expect(journeySimpleButtonSchema.safeParse({ text: 'B' }).success).toBe(
+      true
+    )
+  })
+})
+
+describe('journeySimpleButtonSchemaUpdate (strict)', () => {
+  it('validates with only nextCard', () => {
+    expect(
+      journeySimpleButtonSchemaUpdate.safeParse({
+        text: 'B',
+        nextCard: 'card-2'
+      }).success
+    ).toBe(true)
+  })
+
+  it('validates with only url', () => {
+    expect(
+      journeySimpleButtonSchemaUpdate.safeParse({
+        text: 'B',
+        url: 'https://b.com'
+      }).success
+    ).toBe(true)
+  })
+
+  it('fails with both nextCard and url (strict)', () => {
+    const result = journeySimpleButtonSchemaUpdate.safeParse({
       text: 'B',
       nextCard: 'card-2',
       url: 'https://b.com'
@@ -73,8 +148,8 @@ describe('journeySimpleButtonSchema', () => {
     }
   })
 
-  it('fails with neither nextCard nor url', () => {
-    const result = journeySimpleButtonSchema.safeParse({ text: 'B' })
+  it('fails with neither nextCard nor url (strict)', () => {
+    const result = journeySimpleButtonSchemaUpdate.safeParse({ text: 'B' })
     expect(result.success).toBe(false)
     if (!result.success) {
       expect(result.error.issues[0].message).toMatch(/Exactly one/)
@@ -84,7 +159,7 @@ describe('journeySimpleButtonSchema', () => {
 
 // journeySimpleCardSchema tests
 
-describe('journeySimpleCardSchema', () => {
+describe('journeySimpleCardSchema (base, permissive)', () => {
   const base = { id: 'card-1' }
 
   it('validates with button', () => {
@@ -112,11 +187,73 @@ describe('journeySimpleCardSchema', () => {
     ).toBe(true)
   })
 
-  it('fails with none of button, poll, defaultNextCard', () => {
+  it('validates with none of button, poll, defaultNextCard (permissive)', () => {
     const result = journeySimpleCardSchema.safeParse(base)
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('journeySimpleCardSchemaUpdate (strict)', () => {
+  const base = { id: 'card-1' }
+
+  it('validates with button', () => {
+    expect(
+      journeySimpleCardSchemaUpdate.safeParse({
+        ...base,
+        button: { text: 'B', nextCard: 'card-2' }
+      }).success
+    ).toBe(true)
+  })
+
+  it('validates with poll', () => {
+    expect(
+      journeySimpleCardSchemaUpdate.safeParse({
+        ...base,
+        poll: [{ text: 'A', nextCard: 'card-2' }]
+      }).success
+    ).toBe(true)
+  })
+
+  it('validates with defaultNextCard', () => {
+    expect(
+      journeySimpleCardSchemaUpdate.safeParse({
+        ...base,
+        defaultNextCard: 'card-2'
+      }).success
+    ).toBe(true)
+  })
+
+  it('fails with none of button, poll, defaultNextCard (strict)', () => {
+    const result = journeySimpleCardSchemaUpdate.safeParse(base)
     expect(result.success).toBe(false)
     if (!result.success) {
       expect(result.error.issues[0].message).toMatch(/At least one/)
+    }
+  })
+
+  it('fails with invalid button (both nextCard and url, strict)', () => {
+    const result = journeySimpleCardSchemaUpdate.safeParse({
+      ...base,
+      button: { text: 'B', nextCard: 'card-2', url: 'https://b.com' }
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) => /Exactly one/.test(issue.message))
+      ).toBe(true)
+    }
+  })
+
+  it('fails with invalid poll option (neither nextCard nor url, strict)', () => {
+    const result = journeySimpleCardSchemaUpdate.safeParse({
+      ...base,
+      poll: [{ text: 'A' }]
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) => /Exactly one/.test(issue.message))
+      ).toBe(true)
     }
   })
 })

--- a/libs/shared/ai/src/journeySimpleTypes.ts
+++ b/libs/shared/ai/src/journeySimpleTypes.ts
@@ -1,23 +1,24 @@
 import { z } from 'zod'
 
-// Poll option type
-export const journeySimplePollOptionSchema = z
-  .object({
-    text: z.string().describe('The text label for the poll option.'),
-    nextCard: z
-      .string()
-      .optional()
-      .describe(
-        'The id of the card to navigate to if this option is selected. Something like card-1, card-2, etc. Should only provide one of url or nextCard.'
-      ),
-    url: z
-      .string()
-      .optional()
-      .describe(
-        'A URL to navigate to when the poll option is selected. Should only provide one of url or nextCard.'
-      )
-  })
-  .superRefine((data, ctx) => {
+// --- Poll Option Schemas ---
+export const journeySimplePollOptionSchema = z.object({
+  text: z.string().describe('The text label for the poll option.'),
+  nextCard: z
+    .string()
+    .optional()
+    .describe(
+      'The id of the card to navigate to if this option is selected. Something like card-1, card-2, etc. Should only provide one of url or nextCard.'
+    ),
+  url: z
+    .string()
+    .optional()
+    .describe(
+      'A URL to navigate to when the poll option is selected. Should only provide one of url or nextCard.'
+    )
+})
+
+export const journeySimplePollOptionSchemaUpdate =
+  journeySimplePollOptionSchema.superRefine((data, ctx) => {
     const hasNextCard = !!data.nextCard
     const hasUrl = !!data.url
     if (hasNextCard === hasUrl) {
@@ -27,28 +28,33 @@ export const journeySimplePollOptionSchema = z
       })
     }
   })
+
 export type JourneySimplePollOption = z.infer<
   typeof journeySimplePollOptionSchema
 >
+export type JourneySimplePollOptionUpdate = z.infer<
+  typeof journeySimplePollOptionSchemaUpdate
+>
 
-// Button type
-export const journeySimpleButtonSchema = z
-  .object({
-    text: z.string().describe('The text label displayed on the button.'),
-    nextCard: z
-      .string()
-      .optional()
-      .describe(
-        'The id of the card to navigate to when the button is pressed. Something like card-1, card-2, etc. Should only provide one of url or nextCard.'
-      ),
-    url: z
-      .string()
-      .optional()
-      .describe(
-        'A URL to navigate to when the button is pressed. Should only provide one of url or nextCard.'
-      )
-  })
-  .superRefine((data, ctx) => {
+// --- Button Schemas ---
+export const journeySimpleButtonSchema = z.object({
+  text: z.string().describe('The text label displayed on the button.'),
+  nextCard: z
+    .string()
+    .optional()
+    .describe(
+      'The id of the card to navigate to when the button is pressed. Something like card-1, card-2, etc. Should only provide one of url or nextCard.'
+    ),
+  url: z
+    .string()
+    .optional()
+    .describe(
+      'A URL to navigate to when the button is pressed. Should only provide one of url or nextCard.'
+    )
+})
+
+export const journeySimpleButtonSchemaUpdate =
+  journeySimpleButtonSchema.superRefine((data, ctx) => {
     const hasNextCard = !!data.nextCard
     const hasUrl = !!data.url
     if (hasNextCard === hasUrl) {
@@ -58,9 +64,13 @@ export const journeySimpleButtonSchema = z
       })
     }
   })
-export type JourneySimpleButton = z.infer<typeof journeySimpleButtonSchema>
 
-// Image type
+export type JourneySimpleButton = z.infer<typeof journeySimpleButtonSchema>
+export type JourneySimpleButtonUpdate = z.infer<
+  typeof journeySimpleButtonSchemaUpdate
+>
+
+// --- Image Schema (shared, no update/default distinction needed) ---
 export const journeySimpleImageSchema = z.object({
   src: z.string().describe('A URL for the image.'),
   alt: z.string().describe('Alt text for the image for accessibility.'),
@@ -76,36 +86,41 @@ export const journeySimpleImageSchema = z.object({
 })
 export type JourneySimpleImage = z.infer<typeof journeySimpleImageSchema>
 
-// Card type
-export const journeySimpleCardSchema = z
-  .object({
-    id: z
-      .string()
-      .describe('The id of the card. Something like card-1, card-2, etc.'),
-    heading: z
-      .string()
-      .optional()
-      .describe('A heading for the card, if present.'),
-    text: z.string().optional().describe('The main text content of the card.'),
-    button: journeySimpleButtonSchema
-      .optional()
-      .describe('A button object for this card, if present.'),
-    poll: z
-      .array(journeySimplePollOptionSchema)
-      .optional()
-      .describe('An array of poll options for this card, if present.'),
-    image: journeySimpleImageSchema
-      .optional()
-      .describe('Image object for the card.'),
-    backgroundImage: journeySimpleImageSchema
-      .optional()
-      .describe('Background image object for the card.'),
-    defaultNextCard: z
-      .string()
-      .optional()
-      .describe(
-        'The id of the card to navigate to after this card by default. Something like card-1, card-2, etc.'
-      )
+// --- Card Schemas ---
+export const journeySimpleCardSchema = z.object({
+  id: z
+    .string()
+    .describe('The id of the card. Something like card-1, card-2, etc.'),
+  heading: z
+    .string()
+    .optional()
+    .describe('A heading for the card, if present.'),
+  text: z.string().optional().describe('The main text content of the card.'),
+  button: journeySimpleButtonSchema
+    .optional()
+    .describe('A button object for this card, if present.'),
+  poll: z
+    .array(journeySimplePollOptionSchema)
+    .optional()
+    .describe('An array of poll options for this card, if present.'),
+  image: journeySimpleImageSchema
+    .optional()
+    .describe('Image object for the card.'),
+  backgroundImage: journeySimpleImageSchema
+    .optional()
+    .describe('Background image object for the card.'),
+  defaultNextCard: z
+    .string()
+    .optional()
+    .describe(
+      'The id of the card to navigate to after this card by default. Something like card-1, card-2, etc.'
+    )
+})
+
+export const journeySimpleCardSchemaUpdate = journeySimpleCardSchema
+  .extend({
+    button: journeySimpleButtonSchemaUpdate.optional(),
+    poll: z.array(journeySimplePollOptionSchemaUpdate).optional()
   })
   .superRefine((data, ctx) => {
     const hasButton = !!data.button
@@ -119,9 +134,13 @@ export const journeySimpleCardSchema = z
       })
     }
   })
-export type JourneySimpleCard = z.infer<typeof journeySimpleCardSchema>
 
-// Journey type
+export type JourneySimpleCard = z.infer<typeof journeySimpleCardSchema>
+export type JourneySimpleCardUpdate = z.infer<
+  typeof journeySimpleCardSchemaUpdate
+>
+
+// --- Journey Schemas ---
 export const journeySimpleSchema = z.object({
   title: z.string().describe('The title of the journey.'),
   description: z.string().describe('A description of the journey.'),
@@ -129,4 +148,10 @@ export const journeySimpleSchema = z.object({
     .array(journeySimpleCardSchema)
     .describe('An array of cards that make up the journey.')
 })
+
+export const journeySimpleSchemaUpdate = journeySimpleSchema.extend({
+  cards: z.array(journeySimpleCardSchemaUpdate)
+})
+
 export type JourneySimple = z.infer<typeof journeySimpleSchema>
+export type JourneySimpleUpdate = z.infer<typeof journeySimpleSchemaUpdate>


### PR DESCRIPTION
## Summary

Refactored the Zod schemas in `libs/shared/ai/src/journeySimpleTypes.ts` to support both permissive (base) and strict (Update) validation for journey, card, button, and poll option types. The base schemas are now permissive for reads, while the Update schemas enforce stricter validation for updates/creates. All nested fields in the Update schemas use their strict counterparts. Tests in `journeySimpleTypes.spec.ts` were updated to clearly distinguish between base and Update schema behaviors.

## Details
- Used `.extend()` to override only the necessary fields in Update schemas.
- Removed journey-level `.superRefine` from the Update schema.
- Updated and clarified all test descriptions.
- Ensured all validation logic is thoroughly tested for both read and update scenarios.

---

Closes [ENG-3056](https://linear.app/jesus-film-project/issue/ENG-3056/refactor-journeysimpletypes-schemas-for-strict-vs-permissive)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced stricter validation for journey updates, ensuring that poll options and buttons require exactly one of `nextCard` or `url`, and that cards require at least one navigation field.
  * Added new validation schemas and types specifically for update operations.

* **Bug Fixes**
  * Improved error handling for invalid journey data, providing more structured and informative error messages.

* **Tests**
  * Expanded test coverage to distinguish between permissive (base) and strict (update) validation scenarios for journeys, poll options, buttons, and cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->