### PR TITLE
feat: add video block support to journeySimpleTypes and simplifyJourney function [ENG-3057]

### DIFF
--- a/apis/api-journeys-modern/src/schema/journey/simple/simplifyJourney.ts
+++ b/apis/api-journeys-modern/src/schema/journey/simple/simplifyJourney.ts
@@ -23,6 +23,31 @@ export function simplifyJourney(
       (block) => block.parentBlockId === cardBlock.id
     )
 
+    // --- VIDEO BLOCK HANDLING ---
+    const videoBlock = childBlocks.find(
+      (block) => block.typename === 'VideoBlock' && block.source === 'youTube'
+    )
+    if (videoBlock) {
+      const card: JourneySimpleCard = {
+        id: `card-${index + 1}`,
+        video: {
+          url: `https://youtube.com/watch?v=${videoBlock.videoId}`,
+          startAt: videoBlock.startAt ?? undefined,
+          endAt: videoBlock.endAt ?? undefined
+        }
+      }
+      if (stepBlock.nextBlockId) {
+        const nextStepBlockIndex = stepBlocks.findIndex(
+          (s) => s.id === stepBlock.nextBlockId
+        )
+        if (nextStepBlockIndex >= 0) {
+          card.defaultNextCard = `card-${nextStepBlockIndex + 1}`
+        }
+      }
+      return card
+    }
+
+    // --- NON-VIDEO CARDS (existing logic) ---
     const card: JourneySimpleCard = {
       id: `card-${index + 1}`
     }

--- a/libs/shared/ai/src/journeySimpleTypes.ts
+++ b/libs/shared/ai/src/journeySimpleTypes.ts
@@ -86,6 +86,44 @@ export const journeySimpleImageSchema = z.object({
 })
 export type JourneySimpleImage = z.infer<typeof journeySimpleImageSchema>
 
+// --- Video Schema ---
+export const journeySimpleVideoSchema = z.object({
+  url: z.string().describe('The YouTube video URL.'),
+  startAt: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe('Start time in seconds. If not provided, defaults to 0.'),
+  endAt: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe(
+      'End time in seconds. If not provided, defaults to the video duration.'
+    )
+})
+export type JourneySimpleVideo = z.infer<typeof journeySimpleVideoSchema>
+
+// --- Video Update Schema (with stricter validation) ---
+export const journeySimpleVideoSchemaUpdate =
+  journeySimpleVideoSchema.superRefine((data, ctx) => {
+    if (
+      data.startAt !== undefined &&
+      data.endAt !== undefined &&
+      data.endAt <= data.startAt
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'endAt must be greater than startAt if both are provided.'
+      })
+    }
+  })
+export type JourneySimpleVideoUpdate = z.infer<
+  typeof journeySimpleVideoSchemaUpdate
+>
+
 // --- Card Schemas ---
 export const journeySimpleCardSchema = z.object({
   id: z
@@ -109,6 +147,11 @@ export const journeySimpleCardSchema = z.object({
   backgroundImage: journeySimpleImageSchema
     .optional()
     .describe('Background image object for the card.'),
+  video: journeySimpleVideoSchema
+    .optional()
+    .describe(
+      'Video segment for this card, if present. If present, only "id", "video", and (optionally) "defaultNextCard" should be set on this card. All other content fields (heading, text, button, poll, image, backgroundImage, etc.) must be omitted.'
+    ),
   defaultNextCard: z
     .string()
     .optional()
@@ -120,18 +163,47 @@ export const journeySimpleCardSchema = z.object({
 export const journeySimpleCardSchemaUpdate = journeySimpleCardSchema
   .extend({
     button: journeySimpleButtonSchemaUpdate.optional(),
-    poll: z.array(journeySimplePollOptionSchemaUpdate).optional()
+    poll: z.array(journeySimplePollOptionSchemaUpdate).optional(),
+    video: journeySimpleVideoSchemaUpdate.optional()
   })
   .superRefine((data, ctx) => {
-    const hasButton = !!data.button
-    const hasPoll = Array.isArray(data.poll) && data.poll.length > 0
-    const hasDefaultNextCard = !!data.defaultNextCard
-    if (!hasButton && !hasPoll && !hasDefaultNextCard) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message:
-          'At least one of button, poll, or defaultNextCard must be present to provide navigation.'
-      })
+    if (data.video !== undefined) {
+      // Enforce only id, video, and defaultNextCard are present
+      const forbiddenFields = [
+        'heading',
+        'text',
+        'button',
+        'poll',
+        'image',
+        'backgroundImage'
+      ]
+      for (const field of forbiddenFields) {
+        if ((data as Record<string, unknown>)[field] !== undefined) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `If video is present, ${field} must not be set.`
+          })
+        }
+      }
+      // Enforce defaultNextCard is required for video cards
+      if (data.defaultNextCard === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'If video is present, defaultNextCard is required.'
+        })
+      }
+    } else {
+      // For non-video cards, require at least one navigation option
+      const hasButton = !!data.button
+      const hasPoll = Array.isArray(data.poll) && data.poll.length > 0
+      const hasDefaultNextCard = !!data.defaultNextCard
+      if (!hasButton && !hasPoll && !hasDefaultNextCard) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'At least one of button, poll, or defaultNextCard must be present to provide navigation.'
+        })
+      }
     }
   })
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive video block support to the journey simple types and transformation logic, enabling YouTube video content in simplified journey structures.

## Changes Made

### `libs/shared/ai/src/journeySimpleTypes.ts`
- ✅ Added `journeySimpleVideoSchema` with `url`, `startAt`, and `endAt` fields for YouTube video content
- ✅ Added `journeySimpleVideoSchemaUpdate` with validation ensuring `endAt > startAt` when both are provided
- ✅ Enhanced `journeySimpleCardSchema` to include optional `video` field
- ✅ Updated `journeySimpleCardSchemaUpdate` with strict validation rules for video cards:
  - Video cards can only have `id`, `video`, and `defaultNextCard` fields
  - All other content fields (`heading`, `text`, `button`, `poll`, `image`, `backgroundImage`) are forbidden
  - `defaultNextCard` is required for video cards to ensure navigation

### `apis/api-journeys-modern/src/schema/journey/simple/simplifyJourney.ts`
- ✅ Added video block detection logic for YouTube video blocks
- ✅ Creates video cards with proper YouTube URL formatting (`https://youtube.com/watch?v=${videoId}`)
- ✅ Handles `startAt` and `endAt` time segments
- ✅ Ensures video cards have navigation via `defaultNextCard`
- ✅ Maintains existing non-video card logic unchanged

## Technical Details

### Video Schema Validation
- **Base Schema**: Permissive, allows any combination of video timing
- **Update Schema**: Strict validation ensures logical time ranges (endAt > startAt)
- **Card Integration**: Video field seamlessly integrates with existing card structure

### Transformation Logic
- Detects `VideoBlock` with `source === 'youTube'`
- Transforms `videoId` into full YouTube URL
- Preserves optional `startAt`/`endAt` timing
- Ensures navigation consistency with step block relationships

### Validation Rules for Video Cards
- **Minimal Content**: Only `id`, `video`, and `defaultNextCard` allowed
- **Navigation Required**: `defaultNextCard` is mandatory for video cards
- **Content Restrictions**: No text, images, buttons, or polls allowed on video cards

## Testing Notes

This implementation maintains backward compatibility with existing non-video cards while adding robust video support. The strict validation ensures video cards follow the intended minimal structure.

## Related

- **Linear Issue**: [ENG-3057](https://linear.app/jesus-film-project/issue/ENG-3057)
- **Branch**: `tataihono/eng-3057-add-video-block-support-to-journeysimpletypes-and`