### PR TITLE
feat: implement chapter-based validation for end verse in CitationForm

### DIFF
--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/citation/_CitationForm/CitationForm.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/citation/_CitationForm/CitationForm.tsx
@@ -171,8 +171,10 @@ export function CitationForm({
         'greaterThanVerseStart',
         'End verse must be greater than or equal to start verse',
         function (value) {
-          const { verseStart } = this.parent
-          return !value || !verseStart || value >= verseStart
+          const { verseStart, chapterStart, chapterEnd } = this.parent
+          // Only validate end verse against start verse if chapters are the same
+          const isSameChapter = !chapterEnd || chapterEnd === chapterStart
+          return !value || !verseStart || !isSameChapter || value >= verseStart
         }
       )
   })


### PR DESCRIPTION
- Updated validation logic to ensure end verse is only compared to start verse when chapters are the same.
- Added new test cases to cover various scenarios for end verse validation, including same and different chapters.