### PR TITLE
feat: add script to update arc.gt URLs to new API endpoint

### DIFF
--- a/apis/api-media/project.json
+++ b/apis/api-media/project.json
@@ -217,6 +217,12 @@
       "options": {
         "command": "npm run ts-node apis/api-media/src/scripts/copy-distro-downloads.ts"
       }
+    },
+    "update-arcgt-urls": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm run ts-node apis/api-media/src/scripts/update-arcgt-urls.ts"
+      }
     }
   }
 }

--- a/apis/api-media/src/scripts/README.md
+++ b/apis/api-media/src/scripts/README.md
@@ -133,3 +133,49 @@ The script includes error handling for:
 - Progress tracking and reporting
 
 If any error occurs, the script will exit with a non-zero code and display an appropriate error message.
+
+## Update Arc.gt URLs Script
+
+The update arc.gt URLs script updates VideoVariantDownload URLs from `https://arc.gt` to `https://api-v1.arclight.org` for specific distribution qualities.
+
+### Usage
+
+```bash
+nx run api-media:update-arcgt-urls
+```
+
+### Process
+
+The script will:
+
+1. Find all VideoVariantDownloads with qualities: `distroLow`, `distroSd`, `distroHigh`
+2. Filter for downloads with URLs starting with `https://arc.gt`
+3. Update each URL by replacing `https://arc.gt` with `https://api-v1.arclight.org`
+4. Process downloads in batches of 1000 for optimal performance
+5. Preserve all URL paths and query parameters after the domain
+
+### Target Qualities
+
+The script only updates URLs for these specific qualities:
+
+- `distroLow` - Distribution center low quality downloads
+- `distroSd` - Distribution center SD quality downloads
+- `distroHigh` - Distribution center high quality downloads
+
+### URL Transformation
+
+| Before                                          | After                                                        |
+| ----------------------------------------------- | ------------------------------------------------------------ |
+| `https://arc.gt/video.mp4`                      | `https://api-v1.arclight.org/video.mp4`                      |
+| `https://arc.gt/path/to/video.mp4?params=value` | `https://api-v1.arclight.org/path/to/video.mp4?params=value` |
+
+### Error Handling
+
+The script includes error handling for:
+
+- Database connection issues
+- Batch processing failures
+- Progress tracking and reporting
+- Individual update failures
+
+If any error occurs, the script will exit with a non-zero code and display an appropriate error message.

--- a/apis/api-media/src/scripts/update-arcgt-urls.spec.ts
+++ b/apis/api-media/src/scripts/update-arcgt-urls.spec.ts
@@ -1,0 +1,210 @@
+import { VideoVariantDownloadQuality } from '.prisma/api-media-client'
+
+import { updateArcGtUrls } from './update-arcgt-urls'
+
+// Mock prisma
+const prismaMock = {
+  videoVariantDownload: {
+    count: jest.fn(),
+    findMany: jest.fn(),
+    update: jest.fn()
+  },
+  $disconnect: jest.fn()
+}
+
+jest.mock('../lib/prisma', () => ({
+  prisma: prismaMock
+}))
+
+describe('updateArcGtUrls', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    prismaMock.$disconnect.mockResolvedValue(undefined)
+  })
+
+  it('should update URLs from arc.gt to api-v1.arclight.org for distro qualities', async () => {
+    // Mock count query
+    prismaMock.videoVariantDownload.count.mockResolvedValue(2)
+
+    // Mock findMany query - this is called in a loop until no more records
+    prismaMock.videoVariantDownload.findMany
+      .mockResolvedValueOnce([
+        {
+          id: 'download1',
+          quality: VideoVariantDownloadQuality.distroLow,
+          url: 'https://arc.gt/video1.mp4',
+          size: 1000,
+          height: 720,
+          width: 1280,
+          bitrate: 2500,
+          version: 1,
+          assetId: 'asset1',
+          videoVariantId: 'variant1'
+        },
+        {
+          id: 'download2',
+          quality: VideoVariantDownloadQuality.distroSd,
+          url: 'https://arc.gt/video2.mp4',
+          size: 500,
+          height: 360,
+          width: 640,
+          bitrate: 1000,
+          version: 1,
+          assetId: 'asset2',
+          videoVariantId: 'variant2'
+        }
+      ])
+      .mockResolvedValueOnce([]) // Empty array to end the loop
+
+    // Mock update
+    prismaMock.videoVariantDownload.update.mockResolvedValue({})
+
+    await updateArcGtUrls()
+
+    // Verify count was called with correct filter
+    expect(prismaMock.videoVariantDownload.count).toHaveBeenCalledWith({
+      where: {
+        quality: {
+          in: [
+            VideoVariantDownloadQuality.distroLow,
+            VideoVariantDownloadQuality.distroSd,
+            VideoVariantDownloadQuality.distroHigh
+          ]
+        },
+        url: {
+          startsWith: 'https://arc.gt'
+        }
+      }
+    })
+
+    // Verify findMany was called with correct filter
+    expect(prismaMock.videoVariantDownload.findMany).toHaveBeenCalledWith({
+      where: {
+        quality: {
+          in: [
+            VideoVariantDownloadQuality.distroLow,
+            VideoVariantDownloadQuality.distroSd,
+            VideoVariantDownloadQuality.distroHigh
+          ]
+        },
+        url: {
+          startsWith: 'https://arc.gt'
+        }
+      },
+      take: 1000,
+      skip: 0,
+      orderBy: {
+        id: 'asc'
+      }
+    })
+
+    // Verify update was called for each download with correct URL transformation
+    expect(prismaMock.videoVariantDownload.update).toHaveBeenCalledWith({
+      where: { id: 'download1' },
+      data: { url: 'https://api-v1.arclight.org/video1.mp4' }
+    })
+
+    expect(prismaMock.videoVariantDownload.update).toHaveBeenCalledWith({
+      where: { id: 'download2' },
+      data: { url: 'https://api-v1.arclight.org/video2.mp4' }
+    })
+
+    expect(prismaMock.videoVariantDownload.update).toHaveBeenCalledTimes(2)
+  })
+
+  it('should handle case when no downloads need updating', async () => {
+    // Mock count query to return 0
+    prismaMock.videoVariantDownload.count.mockResolvedValue(0)
+
+    await updateArcGtUrls()
+
+    // Verify count was called
+    expect(prismaMock.videoVariantDownload.count).toHaveBeenCalled()
+
+    // Verify findMany was not called since count is 0
+    expect(prismaMock.videoVariantDownload.findMany).not.toHaveBeenCalled()
+
+    // Verify update was not called
+    expect(prismaMock.videoVariantDownload.update).not.toHaveBeenCalled()
+  })
+
+  it('should only target specific qualities', async () => {
+    // Mock count query
+    prismaMock.videoVariantDownload.count.mockResolvedValue(1)
+
+    // Mock findMany query with distroHigh quality
+    prismaMock.videoVariantDownload.findMany
+      .mockResolvedValueOnce([
+        {
+          id: 'download3',
+          quality: VideoVariantDownloadQuality.distroHigh,
+          url: 'https://arc.gt/video3.mp4',
+          size: 2000,
+          height: 720,
+          width: 1280,
+          bitrate: 3000,
+          version: 1,
+          assetId: 'asset3',
+          videoVariantId: 'variant3'
+        }
+      ])
+      .mockResolvedValueOnce([]) // Empty array to end the loop
+
+    // Mock update
+    prismaMock.videoVariantDownload.update.mockResolvedValue({})
+
+    await updateArcGtUrls()
+
+    // Verify the quality filter includes only the target qualities
+    expect(prismaMock.videoVariantDownload.count).toHaveBeenCalledWith({
+      where: {
+        quality: {
+          in: [
+            VideoVariantDownloadQuality.distroLow,
+            VideoVariantDownloadQuality.distroSd,
+            VideoVariantDownloadQuality.distroHigh
+          ]
+        },
+        url: {
+          startsWith: 'https://arc.gt'
+        }
+      }
+    })
+  })
+
+  it('should preserve the path after the domain', async () => {
+    // Mock count query
+    prismaMock.videoVariantDownload.count.mockResolvedValue(1)
+
+    // Mock findMany query with complex URL path
+    prismaMock.videoVariantDownload.findMany
+      .mockResolvedValueOnce([
+        {
+          id: 'download4',
+          quality: VideoVariantDownloadQuality.distroLow,
+          url: 'https://arc.gt/path/to/video/file.mp4?param=value',
+          size: 1000,
+          height: 240,
+          width: 426,
+          bitrate: 500,
+          version: 1,
+          assetId: 'asset4',
+          videoVariantId: 'variant4'
+        }
+      ])
+      .mockResolvedValueOnce([]) // Empty array to end the loop
+
+    // Mock update
+    prismaMock.videoVariantDownload.update.mockResolvedValue({})
+
+    await updateArcGtUrls()
+
+    // Verify the URL transformation preserves the path and query parameters
+    expect(prismaMock.videoVariantDownload.update).toHaveBeenCalledWith({
+      where: { id: 'download4' },
+      data: {
+        url: 'https://api-v1.arclight.org/path/to/video/file.mp4?param=value'
+      }
+    })
+  })
+})

--- a/apis/api-media/src/scripts/update-arcgt-urls.ts
+++ b/apis/api-media/src/scripts/update-arcgt-urls.ts
@@ -1,0 +1,125 @@
+import { VideoVariantDownloadQuality } from '.prisma/api-media-client'
+
+import { prisma } from '../lib/prisma'
+
+// Target qualities to update
+const TARGET_QUALITIES: VideoVariantDownloadQuality[] = [
+  VideoVariantDownloadQuality.distroLow,
+  VideoVariantDownloadQuality.distroSd,
+  VideoVariantDownloadQuality.distroHigh
+]
+
+const BATCH_SIZE = 1000
+const OLD_URL_PREFIX = 'https://arc.gt'
+const NEW_URL_PREFIX = 'https://api-v1.arclight.org'
+
+/**
+ * Updates URLs in VideoVariantDownload from https://arc.gt to https://api-v1.arclight.org
+ * for distroLow, distroSd, and distroHigh qualities
+ */
+async function updateArcGtUrls(): Promise<void> {
+  console.log('Starting URL update for arc.gt -> api-v1.arclight.org...')
+  console.log(`Target qualities: ${TARGET_QUALITIES.join(', ')}`)
+
+  try {
+    // Get count of downloads that need updating
+    const totalCount = await prisma.videoVariantDownload.count({
+      where: {
+        quality: {
+          in: TARGET_QUALITIES
+        },
+        url: {
+          startsWith: OLD_URL_PREFIX
+        }
+      }
+    })
+
+    console.log(`Found ${totalCount} downloads to update`)
+
+    if (totalCount === 0) {
+      console.log('No downloads found to update. Exiting.')
+      return
+    }
+
+    let processed = 0
+    let updated = 0
+
+    // Process in batches
+    while (processed < totalCount) {
+      console.log(
+        `Processing batch ${Math.floor(processed / BATCH_SIZE) + 1}...`
+      )
+
+      // Get batch of downloads to update
+      const downloads = await prisma.videoVariantDownload.findMany({
+        where: {
+          quality: {
+            in: TARGET_QUALITIES
+          },
+          url: {
+            startsWith: OLD_URL_PREFIX
+          }
+        },
+        take: BATCH_SIZE,
+        skip: processed,
+        orderBy: {
+          id: 'asc'
+        }
+      })
+
+      if (downloads.length === 0) {
+        break
+      }
+
+      // Update URLs in batch
+      for (const download of downloads) {
+        const newUrl = download.url.replace(OLD_URL_PREFIX, NEW_URL_PREFIX)
+
+        await prisma.videoVariantDownload.update({
+          where: { id: download.id },
+          data: { url: newUrl }
+        })
+
+        updated++
+
+        if (updated % 100 === 0) {
+          console.log(`Updated ${updated} URLs so far...`)
+        }
+      }
+
+      processed += downloads.length
+      console.log(`Progress: ${processed}/${totalCount} downloads processed`)
+    }
+
+    console.log('\n=== Update Complete ===')
+    console.log(`Total processed: ${processed}`)
+    console.log(`Total updated: ${updated}`)
+    console.log(`URLs changed from: ${OLD_URL_PREFIX}`)
+    console.log(`URLs changed to: ${NEW_URL_PREFIX}`)
+  } catch (error) {
+    console.error('Error updating arc.gt URLs:', error)
+    throw error
+  }
+}
+
+/**
+ * Main function to run the script
+ */
+async function main(): Promise<void> {
+  try {
+    await updateArcGtUrls()
+    console.log('Script completed successfully!')
+  } catch (error) {
+    console.error('Script failed:', error)
+    process.exit(1)
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+// Run the script if called directly
+if (require.main === module) {
+  void main()
+}
+
+export { updateArcGtUrls }


### PR DESCRIPTION
- Introduced a new script to update VideoVariantDownload URLs from `https://arc.gt` to `https://api-v1.arclight.org`.
- Updated project.json to include a command for running the new script.
- Enhanced README.md with usage instructions and details on the URL transformation process.