### PR TITLE
chore: disable error display in video.js options across components

### DIFF
--- a/apps/arclight/src/app/videoPlayerUrl/VideoPlayer.tsx
+++ b/apps/arclight/src/app/videoPlayerUrl/VideoPlayer.tsx
@@ -50,6 +50,7 @@ export function VideoPlayer({
 
       // Configure videojs options
       const vjsOptions = {
+        errorDisplay: false,
         enableSmoothSeeking: true,
         experimentalSvgIcons: true,
         preload: 'auto',

--- a/libs/journeys/ui/src/components/TemplateView/TemplatePreviewTabs/TemplateVideoPreview/TemplateVideoPlayer/TemplateVideoPlayer.tsx
+++ b/libs/journeys/ui/src/components/TemplateView/TemplatePreviewTabs/TemplateVideoPreview/TemplateVideoPlayer/TemplateVideoPlayer.tsx
@@ -30,6 +30,7 @@ export function TemplateVideoPlayer({
     if (videoRef.current != null) {
       setPlayer(
         videojs(videoRef.current, {
+          errorDisplay: false,
           autoplay: true,
           controls: true,
           bigPlayButton: false,

--- a/libs/shared/ui/src/libs/defaultVideoJsOptions/defaultVideoJsOptions.ts
+++ b/libs/shared/ui/src/libs/defaultVideoJsOptions/defaultVideoJsOptions.ts
@@ -1,6 +1,7 @@
 // note: all video.js players import these options, so take care with what is added here
 
 export const defaultVideoJsOptions = {
+  errorDisplay: false,
   enableSmoothSeeking: true,
   experimentalSvgIcons: true,
   html5: {
@@ -25,6 +26,7 @@ export const defaultVideoJsOptions = {
 }
 
 export const defaultBackgroundVideoJsOptions = {
+  errorDisplay: false,
   enableSmoothSeeking: true,
   experimentalSvgIcons: true,
   html5: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Disabled the default error display UI in video players across the app for a cleaner viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->