### PR TITLE
[watch-modern] drop jsdoc and constant extraction rules

### DIFF
--- a/.cursor/rules/watch-modern.mdc
+++ b/.cursor/rules/watch-modern.mdc
@@ -62,7 +62,6 @@ Follow these rules when you write code:
 
 ## Documentation Guidelines
 
-- All components must have JSDoc comments, including examples and prop documentation.
 - Keep documentation up to date with code changes.
 
 ## Layout Component Patterns
@@ -77,7 +76,6 @@ Follow these rules when you write code:
 
 - Use semantic names: `PageLayout`, `Header`, `Footer`
 - Prefix interface names with component name: `PageLayoutProps`
-- Use descriptive JSDoc with @example blocks
 
 **CSS Class Patterns**:
 
@@ -87,7 +85,6 @@ Follow these rules when you write code:
 
 **Linting Requirements**:
 
-- Extract string literals to constants (avoid inline string literals)
 - Use type-only imports for React types: `import type { ReactElement }`
 - Maintain alphabetical import order
 
@@ -95,10 +92,8 @@ Follow these rules when you write code:
 
 **React Component Structure**:
 
-- Always include comprehensive JSDoc with @param and @example blocks
 - Define interfaces above the component function
 - Use destructured props with default values
-- Extract constants for all text content to avoid literal string errors
 
 **Component Props Patterns**:
 

--- a/apps/watch-modern/AGENTS.md
+++ b/apps/watch-modern/AGENTS.md
@@ -1,0 +1,27 @@
+# Watch-Modern Contributor Guide
+
+This document summarizes key rules for Codex when working inside the `apps/watch-modern` application. It draws from `.cursor/rules/watch-modern.mdc` and the `prds/watch-modern` folder.
+
+## Environment
+- Run the dev server from the repo root with **both** `nf start` and `nx run watch-modern:serve` running in parallel.
+- Wait until `✓ Ready` appears in the console before continuing development.
+
+## Testing
+- Follow Test Driven Development.
+- Run tests with `npm test watch-modern`.
+- You may run a specific test using `npm test watch-modern -- --testNamePattern="<name>"`.
+
+## Coding Standards
+- **Never** use MUI components. Prefer Shadcn/ui, then Tailwind, then semantic HTML+Tailwind.
+- All code must be typed with TypeScript.
+- Use early returns and descriptive names.
+- Maintain alphabetical import order and use type-only React imports.
+- Layout components live in `src/components/Layout/` and are exported via `index.ts`.
+- Use i18next via `useTranslation('apps-watch')` for user-facing text.
+- Follow a server-first architecture: use `'use client'` components only when necessary.
+
+## Workflow
+- Keep Git operations (commits, branches, PRs) in human control.
+- Follow the Red → Green → Refactor cycle.
+- Update or create tests for any code changes and ensure they pass before delivery.
+


### PR DESCRIPTION
## Summary
- update watch-modern guidelines to prefer inline strings
- drop jsdoc requirement from watch-modern rules
- keep i18next usage instruction

## Testing
- `npm test watch-modern`

------
https://chatgpt.com/codex/tasks/task_e_6885171fba848328a02a3949d1d38f6b