### PR TITLE
fix(e2e): adjust Playwright config and enhance feature film tests

### DIFF
--- a/apps/journeys-admin-e2e/playwright.config.ts
+++ b/apps/journeys-admin-e2e/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 3 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? Math.min(15, require('os').cpus().length * 3) : 1,
+  workers: process.env.CI ? 10 : 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/apps/watch-e2e/src/e2e/chapter.spec.ts
+++ b/apps/watch-e2e/src/e2e/chapter.spec.ts
@@ -16,18 +16,21 @@ test('Chapter', async ({ page }) => {
   const jesusCalmsStormButton = page.getByRole('button', {
     name: 'Jesus Calms the Storm Jesus Calms the Storm Chapter 1:59'
   })
-  
+
   // Wait for the element to be properly interactive
   await jesusCalmsStormButton.waitFor({ state: 'visible' })
   await expect(jesusCalmsStormButton).toBeEnabled()
-  
+
   await jesusCalmsStormButton.click()
 
   // Wait for navigation to complete
   await page.waitForURL('**/jesus-calms-the-storm.html/**', { timeout: 60000 })
 
   // check it's navigated to the correct URL
-  await expect(page).toHaveURL('/watch/jesus-calms-the-storm.html/english.html', {
-    timeout: 60000
-  })
+  await expect(page).toHaveURL(
+    '/watch/jesus-calms-the-storm.html/english.html',
+    {
+      timeout: 60000
+    }
+  )
 })

--- a/apps/watch-e2e/src/e2e/chapter.spec.ts
+++ b/apps/watch-e2e/src/e2e/chapter.spec.ts
@@ -9,16 +9,25 @@ Verify URL is correct
 */
 test('Chapter', async ({ page }) => {
   // Set test time out as it has video
-  test.setTimeout(7 * 60 * 1000)
+  test.setTimeout(3 * 60 * 1000)
 
   await page.goto('/watch')
 
-  await page
-    .getByRole('button', {
-      name: 'Jesus Calms the Storm Jesus Calms the Storm Chapter 1:59'
-    })
-    .click()
+  const jesusCalmsStormButton = page.getByRole('button', {
+    name: 'Jesus Calms the Storm Jesus Calms the Storm Chapter 1:59'
+  })
+  
+  // Wait for the element to be properly interactive
+  await jesusCalmsStormButton.waitFor({ state: 'visible' })
+  await expect(jesusCalmsStormButton).toBeEnabled()
+  
+  await jesusCalmsStormButton.click()
+
+  // Wait for navigation to complete
+  await page.waitForURL('**/jesus-calms-the-storm.html/**', { timeout: 60000 })
 
   // check it's navigated to the correct URL
-  await expect(page).toHaveURL('/watch/jesus-calms-the-storm.html/english.html')
+  await expect(page).toHaveURL('/watch/jesus-calms-the-storm.html/english.html', {
+    timeout: 60000
+  })
 })

--- a/apps/watch-e2e/src/e2e/feature-film.spec.ts
+++ b/apps/watch-e2e/src/e2e/feature-film.spec.ts
@@ -13,7 +13,7 @@ Expect page to have URL: /watch/jesus.html/birth-of-jesus/english.html
 test.describe('Feature film', () => {
   test('Feature film navigation and video playback', async ({ page }) => {
     // Set longer timeout for CI environments
-    test.setTimeout(90000)
+    test.setTimeout(180000)
 
     // Navigate to the watch page using daily-e2e deployment
     await page.goto('/watch')
@@ -27,6 +27,9 @@ test.describe('Feature film', () => {
     })
     await jesusButton.waitFor({ timeout: 30000 })
     await jesusButton.click()
+
+    // Wait for navigation to complete
+    await page.waitForURL('**/jesus.html/**', { timeout: 60000 })
 
     // Wait for navigation and verify URL with longer timeout
     await expect(page).toHaveURL('/watch/jesus.html/english.html', {
@@ -42,8 +45,15 @@ test.describe('Feature film', () => {
     )
     await birthOfJesusButton.waitFor({ timeout: 30000 })
 
+    // Wait for the element to be properly interactive
+    await birthOfJesusButton.waitFor({ state: 'visible' })
+    await expect(birthOfJesusButton).toBeEnabled()
+
     // Click on 'CHAPTER Birth of Jesus'
     await birthOfJesusButton.click()
+
+    // Wait for navigation to complete
+    await page.waitForURL('**/birth-of-jesus/**', { timeout: 60000 })
 
     // Wait for page to load after clicking chapter
     await page.waitForLoadState('domcontentloaded')
@@ -51,7 +61,7 @@ test.describe('Feature film', () => {
     // Verify URL changed to Birth of Jesus chapter
     await expect(page).toHaveURL(
       '/watch/jesus.html/birth-of-jesus/english.html',
-      { timeout: 30000 }
+      { timeout: 60000 }
     )
   })
 })

--- a/apps/watch-e2e/src/e2e/feature-film.spec.ts
+++ b/apps/watch-e2e/src/e2e/feature-film.spec.ts
@@ -13,7 +13,7 @@ Expect page to have URL: /watch/jesus.html/birth-of-jesus/english.html
 test.describe('Feature film', () => {
   test('Feature film navigation and video playback', async ({ page }) => {
     // Set longer timeout for CI environments
-    test.setTimeout(180000)
+    test.setTimeout(4 * 60 * 1000)
 
     // Navigate to the watch page using daily-e2e deployment
     await page.goto('/watch')
@@ -38,12 +38,15 @@ test.describe('Feature film', () => {
 
     // Wait for page to be fully loaded after navigation
     await page.waitForLoadState('domcontentloaded')
+    
+    // Wait for the JESUS page content to load (look for elements that indicate we're on the JESUS page)
+    await page.waitForSelector('h1:has-text("JESUS")', { timeout: 60000 })
 
     // Wait for Birth of Jesus chapter to be available - try multiple selectors
     const birthOfJesusButton = page.locator(
       '[data-testid="VideoCardButton-birth-of-jesus"]'
     )
-    await birthOfJesusButton.waitFor({ timeout: 30000 })
+    await birthOfJesusButton.waitFor({ timeout: 60000 })
 
     // Wait for the element to be properly interactive
     await birthOfJesusButton.waitFor({ state: 'visible' })

--- a/apps/watch-e2e/src/e2e/feature-film.spec.ts
+++ b/apps/watch-e2e/src/e2e/feature-film.spec.ts
@@ -38,7 +38,7 @@ test.describe('Feature film', () => {
 
     // Wait for page to be fully loaded after navigation
     await page.waitForLoadState('domcontentloaded')
-    
+
     // Wait for the JESUS page content to load (look for elements that indicate we're on the JESUS page)
     await page.waitForSelector('h1:has-text("JESUS")', { timeout: 60000 })
 


### PR DESCRIPTION
- Reduced the number of workers in Playwright config for CI to 10.
- Increased timeout for feature film navigation and video playback tests to 180 seconds.
- Added waits for navigation and element visibility to improve test reliability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of end-to-end tests by adding explicit waits and adjusting timeouts for navigation and button interactions.
  * Reduced test timeout for chapter navigation tests and increased timeout for feature film tests to better match expected execution times.
  * Synchronized test steps to ensure pages and elements are fully loaded before assertions, enhancing test stability.

* **Chores**
  * Updated test runner configuration to use a fixed number of parallel workers during CI runs for more consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->