### PR TITLE
fix: subtitle redirect

### DIFF
--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/editions/[editionId]/page.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/editions/[editionId]/page.tsx
@@ -237,14 +237,14 @@ export default function EditEditionPage({
                       actions={{
                         edit: () =>
                           router.push(
-                            `/videos/${videoId}/editions/${editionId}/subtitles/${subtitle.id}`,
+                            `/videos/${videoId}/editions/${editionId}/subtitle/${subtitle.id}`,
                             {
                               scroll: false
                             }
                           ),
                         delete: () =>
                           router.push(
-                            `/videos/${videoId}/editions/${editionId}/subtitles/${subtitle.id}/delete`,
+                            `/videos/${videoId}/editions/${editionId}/subtitle/${subtitle.id}/delete`,
                             {
                               scroll: false
                             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the URLs for subtitle editing and deletion actions to use the singular form "subtitle" instead of "subtitles" in the navigation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->