### PR TITLE
chore: increase memory and desired count for ECS service in locals.tf

### DIFF
--- a/apis/api-gateway/infrastructure/locals.tf
+++ b/apis/api-gateway/infrastructure/locals.tf
@@ -15,15 +15,15 @@ locals {
     container_port = local.port
     host_port      = local.port
     cpu            = 1024
-    memory         = 2048
-    desired_count  = 1
+    memory         = 4096
+    desired_count  = 2
     zone_id        = var.ecs_config.zone_id
     alb_target_group = merge(var.ecs_config.alb_target_group, {
       port = local.port
     })
     auto_scaling = {
       max_capacity = 4
-      min_capacity = 1
+      min_capacity = 2
       cpu = {
         target_value = 75
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased memory allocation and default container count for the API gateway service to improve capacity.
  * Updated auto-scaling settings to raise the minimum number of running instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->