### PR TITLE
chore: update health check endpoint to '/readiness' in API gateway 

### DIFF
--- a/apis/api-gateway/src/common.config.ts
+++ b/apis/api-gateway/src/common.config.ts
@@ -13,7 +13,7 @@ export const commonConfig = defineConfig({
   logging: logger,
   port: 4000,
   graphqlEndpoint: '/',
-  healthCheckEndpoint: '/health',
+  healthCheckEndpoint: '/readiness',
   propagateHeaders: {
     fromClientToSubgraphs: ({ request, subgraphName }) => {
       const headers: Record<string, string> = {

--- a/apis/api-gateway/src/common.config.ts
+++ b/apis/api-gateway/src/common.config.ts
@@ -13,7 +13,7 @@ export const commonConfig = defineConfig({
   logging: logger,
   port: 4000,
   graphqlEndpoint: '/',
-  healthCheckEndpoint: '/readiness',
+  healthCheckEndpoint: '/health',
   propagateHeaders: {
     fromClientToSubgraphs: ({ request, subgraphName }) => {
       const headers: Record<string, string> = {

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -42,8 +42,13 @@ locals {
 }
 
 module "api-gateway" {
-  source           = "../../../apis/api-gateway/infrastructure"
-  ecs_config       = local.public_ecs_config
+  source = "../../../apis/api-gateway/infrastructure"
+  ecs_config = merge(local.public_ecs_config, {
+    alb_target_group = merge(local.alb_target_group, {
+      health_check_path = "/readiness"
+      health_check_port = "4000"
+    })
+  })
   doppler_token    = data.aws_ssm_parameter.doppler_api_gateway_prod_token.value
   alb_listener_arn = module.prod.public_alb.alb_listener.arn
   alb_dns_name     = module.prod.public_alb.dns_name

--- a/infrastructure/environments/stage/main.tf
+++ b/infrastructure/environments/stage/main.tf
@@ -72,8 +72,13 @@ locals {
 }
 
 module "api-gateway-stage" {
-  source           = "../../../apis/api-gateway/infrastructure"
-  ecs_config       = local.public_ecs_config
+  source = "../../../apis/api-gateway/infrastructure"
+  ecs_config = merge(local.public_ecs_config, {
+    alb_target_group = merge(local.alb_target_group, {
+      health_check_path = "/readiness"
+      health_check_port = "4000"
+    })
+  })
   env              = "stage"
   doppler_token    = data.aws_ssm_parameter.doppler_api_gateway_stage_token.value
   alb_listener_arn = module.stage.public_alb.alb_listener.arn


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated health check endpoint from "/health" to "/readiness" for the API Gateway service.
  * Adjusted health check settings for load balancer target groups in production and staging environments to use the new readiness endpoint and port 4000.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->