### PR TITLE
feat: add alb logging into datadog

### DIFF
--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -1,9 +1,11 @@
 module "prod" {
-  source            = "../../modules/aws"
-  certificate_arn   = data.aws_acm_certificate.acm_central_jesusfilm_org.arn
-  env               = "prod"
-  cidr              = "10.10.0.0/16"
-  internal_url_name = "service.internal"
+  source                                 = "../../modules/aws"
+  certificate_arn                        = data.aws_acm_certificate.acm_central_jesusfilm_org.arn
+  env                                    = "prod"
+  cidr                                   = "10.10.0.0/16"
+  internal_url_name                      = "service.internal"
+  datadog_forwarder_lambda_arn           = var.datadog_forwarder_lambda_arn
+  datadog_forwarder_lambda_function_name = var.datadog_forwarder_lambda_function_name
 }
 
 locals {

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -1,11 +1,10 @@
 module "prod" {
-  source                                 = "../../modules/aws"
-  certificate_arn                        = data.aws_acm_certificate.acm_central_jesusfilm_org.arn
-  env                                    = "prod"
-  cidr                                   = "10.10.0.0/16"
-  internal_url_name                      = "service.internal"
-  datadog_forwarder_lambda_arn           = var.datadog_forwarder_lambda_arn
-  datadog_forwarder_lambda_function_name = var.datadog_forwarder_lambda_function_name
+  source                       = "../../modules/aws"
+  certificate_arn              = data.aws_acm_certificate.acm_central_jesusfilm_org.arn
+  env                          = "prod"
+  cidr                         = "10.10.0.0/16"
+  internal_url_name            = "service.internal"
+  datadog_forwarder_lambda_arn = var.datadog_forwarder_lambda_arn
 }
 
 locals {

--- a/infrastructure/environments/prod/variables.tf
+++ b/infrastructure/environments/prod/variables.tf
@@ -1,0 +1,9 @@
+variable "datadog_forwarder_lambda_arn" {
+  type = string
+}
+
+variable "datadog_forwarder_lambda_function_name" {
+  type = string
+}
+
+

--- a/infrastructure/environments/prod/variables.tf
+++ b/infrastructure/environments/prod/variables.tf
@@ -2,8 +2,6 @@ variable "datadog_forwarder_lambda_arn" {
   type = string
 }
 
-variable "datadog_forwarder_lambda_function_name" {
-  type = string
-}
+
 
 

--- a/infrastructure/environments/stage/main.tf
+++ b/infrastructure/environments/stage/main.tf
@@ -1,11 +1,10 @@
 module "stage" {
-  source                                 = "../../modules/aws"
-  env                                    = "stage"
-  cidr                                   = "10.11.0.0/16"
-  internal_url_name                      = "stage.internal"
-  certificate_arn                        = aws_acm_certificate.stage.arn
-  datadog_forwarder_lambda_arn           = var.datadog_forwarder_lambda_arn
-  datadog_forwarder_lambda_function_name = var.datadog_forwarder_lambda_function_name
+  source                       = "../../modules/aws"
+  env                          = "stage"
+  cidr                         = "10.11.0.0/16"
+  internal_url_name            = "stage.internal"
+  certificate_arn              = aws_acm_certificate.stage.arn
+  datadog_forwarder_lambda_arn = var.datadog_forwarder_lambda_arn
 }
 
 module "route53_stage_central_jesusfilm_org" {

--- a/infrastructure/environments/stage/main.tf
+++ b/infrastructure/environments/stage/main.tf
@@ -1,9 +1,11 @@
 module "stage" {
-  source            = "../../modules/aws"
-  env               = "stage"
-  cidr              = "10.11.0.0/16"
-  internal_url_name = "stage.internal"
-  certificate_arn   = aws_acm_certificate.stage.arn
+  source                                 = "../../modules/aws"
+  env                                    = "stage"
+  cidr                                   = "10.11.0.0/16"
+  internal_url_name                      = "stage.internal"
+  certificate_arn                        = aws_acm_certificate.stage.arn
+  datadog_forwarder_lambda_arn           = var.datadog_forwarder_lambda_arn
+  datadog_forwarder_lambda_function_name = var.datadog_forwarder_lambda_function_name
 }
 
 module "route53_stage_central_jesusfilm_org" {

--- a/infrastructure/environments/stage/variables.tf
+++ b/infrastructure/environments/stage/variables.tf
@@ -1,0 +1,9 @@
+variable "datadog_forwarder_lambda_arn" {
+  type = string
+}
+
+variable "datadog_forwarder_lambda_function_name" {
+  type = string
+}
+
+

--- a/infrastructure/environments/stage/variables.tf
+++ b/infrastructure/environments/stage/variables.tf
@@ -2,8 +2,6 @@ variable "datadog_forwarder_lambda_arn" {
   type = string
 }
 
-variable "datadog_forwarder_lambda_function_name" {
-  type = string
-}
+
 
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -20,11 +20,15 @@ module "acm_central_jesusfilm_org" {
 }
 
 module "prod" {
-  source = "./environments/prod"
+  source                                 = "./environments/prod"
+  datadog_forwarder_lambda_arn           = module.datadog.log_forwarder_lambda_arn
+  datadog_forwarder_lambda_function_name = module.datadog.log_forwarder_lambda_function_name
 }
 
 module "stage" {
-  source = "./environments/stage"
+  source                                 = "./environments/stage"
+  datadog_forwarder_lambda_arn           = module.datadog.log_forwarder_lambda_arn
+  datadog_forwarder_lambda_function_name = module.datadog.log_forwarder_lambda_function_name
 }
 
 module "datadog" {

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -20,15 +20,13 @@ module "acm_central_jesusfilm_org" {
 }
 
 module "prod" {
-  source                                 = "./environments/prod"
-  datadog_forwarder_lambda_arn           = module.datadog.log_forwarder_lambda_arn
-  datadog_forwarder_lambda_function_name = module.datadog.log_forwarder_lambda_function_name
+  source                       = "./environments/prod"
+  datadog_forwarder_lambda_arn = module.datadog.log_forwarder_lambda_arn
 }
 
 module "stage" {
-  source                                 = "./environments/stage"
-  datadog_forwarder_lambda_arn           = module.datadog.log_forwarder_lambda_arn
-  datadog_forwarder_lambda_function_name = module.datadog.log_forwarder_lambda_function_name
+  source                       = "./environments/stage"
+  datadog_forwarder_lambda_arn = module.datadog.log_forwarder_lambda_arn
 }
 
 module "datadog" {

--- a/infrastructure/modules/aws/alb/main.tf
+++ b/infrastructure/modules/aws/alb/main.tf
@@ -4,4 +4,13 @@ resource "aws_alb" "alb" {
   load_balancer_type = "application"
   subnets            = var.subnets
   security_groups    = var.security_groups
+
+  dynamic "access_logs" {
+    for_each = var.access_logs_enabled ? [1] : []
+    content {
+      bucket  = var.access_logs_bucket
+      prefix  = var.access_logs_prefix
+      enabled = var.access_logs_enabled
+    }
+  }
 }

--- a/infrastructure/modules/aws/alb/variables.tf
+++ b/infrastructure/modules/aws/alb/variables.tf
@@ -37,3 +37,21 @@ variable "forwards" {
   }))
   default = {}
 }
+
+variable "access_logs_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable ALB access logs"
+}
+
+variable "access_logs_bucket" {
+  type        = string
+  default     = ""
+  description = "S3 bucket for ALB access logs"
+}
+
+variable "access_logs_prefix" {
+  type        = string
+  default     = ""
+  description = "S3 prefix for ALB access logs"
+}

--- a/infrastructure/modules/aws/data.tf
+++ b/infrastructure/modules/aws/data.tf
@@ -17,3 +17,7 @@ data "aws_acm_certificate" "acm_arclight_org" {
 data "aws_acm_certificate" "acm_arc_gt" {
   domain = "arc.gt"
 }
+
+# Data sources for ALB logging
+data "aws_elb_service_account" "main" {}
+data "aws_caller_identity" "current" {}

--- a/infrastructure/modules/aws/datadog/main.tf
+++ b/infrastructure/modules/aws/datadog/main.tf
@@ -132,3 +132,66 @@ module "datadog_rds_enhanced_monitoring_forwarder" {
   version    = "5.1.0"
   dd_api_key = data.aws_ssm_parameter.datadog_api_key.value
 }
+
+# Grant the Datadog forwarder Lambda role permission to read ALB logs from S3
+data "aws_iam_role" "datadog_log_forwarder" {
+  name = "datadog-log-forwarder"
+}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+  s3_read_resources = [
+    # Stage buckets
+    "arn:aws:s3:::jfp-public-alb-logs-stage-${local.account_id}",
+    "arn:aws:s3:::jfp-public-alb-logs-stage-${local.account_id}/AWSLogs/${local.account_id}/*",
+    "arn:aws:s3:::jfp-internal-alb-logs-stage-${local.account_id}",
+    "arn:aws:s3:::jfp-internal-alb-logs-stage-${local.account_id}/AWSLogs/${local.account_id}/*",
+    # Prod buckets
+    "arn:aws:s3:::jfp-public-alb-logs-prod-${local.account_id}",
+    "arn:aws:s3:::jfp-public-alb-logs-prod-${local.account_id}/AWSLogs/${local.account_id}/*",
+    "arn:aws:s3:::jfp-internal-alb-logs-prod-${local.account_id}",
+    "arn:aws:s3:::jfp-internal-alb-logs-prod-${local.account_id}/AWSLogs/${local.account_id}/*",
+  ]
+}
+
+resource "aws_iam_policy" "datadog_forwarder_s3_read" {
+  name        = "DatadogForwarderS3Read"
+  description = "Allow Datadog forwarder to read ALB access logs from S3"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "S3ListBuckets"
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket"
+        ]
+        Resource = [
+          "arn:aws:s3:::jfp-public-alb-logs-stage-${local.account_id}",
+          "arn:aws:s3:::jfp-internal-alb-logs-stage-${local.account_id}",
+          "arn:aws:s3:::jfp-public-alb-logs-prod-${local.account_id}",
+          "arn:aws:s3:::jfp-internal-alb-logs-prod-${local.account_id}"
+        ]
+      },
+      {
+        Sid    = "S3GetObjects"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject"
+        ]
+        Resource = [
+          "arn:aws:s3:::jfp-public-alb-logs-stage-${local.account_id}/AWSLogs/${local.account_id}/*",
+          "arn:aws:s3:::jfp-internal-alb-logs-stage-${local.account_id}/AWSLogs/${local.account_id}/*",
+          "arn:aws:s3:::jfp-public-alb-logs-prod-${local.account_id}/AWSLogs/${local.account_id}/*",
+          "arn:aws:s3:::jfp-internal-alb-logs-prod-${local.account_id}/AWSLogs/${local.account_id}/*"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "datadog_forwarder_s3_read" {
+  role       = data.aws_iam_role.datadog_log_forwarder.name
+  policy_arn = aws_iam_policy.datadog_forwarder_s3_read.arn
+}

--- a/infrastructure/modules/aws/datadog/outputs.tf
+++ b/infrastructure/modules/aws/datadog/outputs.tf
@@ -2,8 +2,4 @@ output "log_forwarder_lambda_arn" {
   value = module.datadog_log_forwarder.lambda_arn
 }
 
-output "log_forwarder_lambda_function_name" {
-  value = module.datadog_log_forwarder.lambda_function_name
-}
-
 

--- a/infrastructure/modules/aws/datadog/outputs.tf
+++ b/infrastructure/modules/aws/datadog/outputs.tf
@@ -1,5 +1,5 @@
 output "log_forwarder_lambda_arn" {
-  value = module.datadog_log_forwarder.lambda_function_arn
+  value = module.datadog_log_forwarder.lambda_arn
 }
 
 output "log_forwarder_lambda_function_name" {

--- a/infrastructure/modules/aws/datadog/outputs.tf
+++ b/infrastructure/modules/aws/datadog/outputs.tf
@@ -1,0 +1,9 @@
+output "log_forwarder_lambda_arn" {
+  value = module.datadog_log_forwarder.lambda_function_arn
+}
+
+output "log_forwarder_lambda_function_name" {
+  value = module.datadog_log_forwarder.lambda_function_name
+}
+
+

--- a/infrastructure/modules/aws/main.tf
+++ b/infrastructure/modules/aws/main.tf
@@ -86,12 +86,15 @@ module "public_bastion_security_group" {
 }
 
 module "internal_alb" {
-  source          = "./alb"
-  name            = "jfp-internal-alb-${var.env}"
-  subnets         = module.vpc.internal_subnets
-  vpc_id          = module.vpc.vpc_id
-  internal        = true
-  security_groups = [module.internal_alb_security_group.security_group_id]
+  source              = "./alb"
+  name                = "jfp-internal-alb-${var.env}"
+  subnets             = module.vpc.internal_subnets
+  vpc_id              = module.vpc.vpc_id
+  internal            = true
+  security_groups     = [module.internal_alb_security_group.security_group_id]
+  access_logs_enabled = true
+  access_logs_bucket  = aws_s3_bucket.internal_alb_logs.bucket
+  access_logs_prefix  = ""
 }
 
 module "internal_alb_listener" {
@@ -102,13 +105,16 @@ module "internal_alb_listener" {
 }
 
 module "public_alb" {
-  source          = "./alb"
-  name            = "jfp-public-alb-${var.env}"
-  subnets         = module.vpc.public_subnets
-  vpc_id          = module.vpc.vpc_id
-  internal        = false
-  redirects       = local.public_alb_config.redirects
-  security_groups = [module.public_alb_security_group.security_group_id]
+  source              = "./alb"
+  name                = "jfp-public-alb-${var.env}"
+  subnets             = module.vpc.public_subnets
+  vpc_id              = module.vpc.vpc_id
+  internal            = false
+  redirects           = local.public_alb_config.redirects
+  security_groups     = [module.public_alb_security_group.security_group_id]
+  access_logs_enabled = true
+  access_logs_bucket  = aws_s3_bucket.public_alb_logs.bucket
+  access_logs_prefix  = ""
 }
 
 module "public_alb_listener" {

--- a/infrastructure/modules/aws/main.tf
+++ b/infrastructure/modules/aws/main.tf
@@ -216,7 +216,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "public_alb_logs" {
   rule {
     id     = "expire-logs"
     status = "Enabled"
-    expiration { days = 90 }
+    expiration { days = 14 }
   }
 }
 
@@ -262,7 +262,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "internal_alb_logs" {
   rule {
     id     = "expire-logs"
     status = "Enabled"
-    expiration { days = 90 }
+    expiration { days = 14 }
   }
 }
 

--- a/infrastructure/modules/aws/main.tf
+++ b/infrastructure/modules/aws/main.tf
@@ -332,7 +332,7 @@ resource "aws_s3_bucket_policy" "internal_alb_logs" {
 
 # Permission for S3 to invoke Datadog Lambda for public ALB logs
 resource "aws_lambda_permission" "allow_s3_public_alb_logs" {
-  statement_id  = "AllowS3PublicALBLogs"
+  statement_id  = "AllowS3PublicALBLogs-${var.env}"
   action        = "lambda:InvokeFunction"
   function_name = var.datadog_forwarder_lambda_arn
   principal     = "s3.amazonaws.com"
@@ -341,7 +341,7 @@ resource "aws_lambda_permission" "allow_s3_public_alb_logs" {
 
 # Permission for S3 to invoke Datadog Lambda for internal ALB logs
 resource "aws_lambda_permission" "allow_s3_internal_alb_logs" {
-  statement_id  = "AllowS3InternalALBLogs"
+  statement_id  = "AllowS3InternalALBLogs-${var.env}"
   action        = "lambda:InvokeFunction"
   function_name = var.datadog_forwarder_lambda_arn
   principal     = "s3.amazonaws.com"

--- a/infrastructure/modules/aws/variables.tf
+++ b/infrastructure/modules/aws/variables.tf
@@ -17,3 +17,14 @@ variable "certificate_arn" {
   type = string
 }
 
+
+variable "datadog_forwarder_lambda_arn" {
+  type        = string
+  description = "ARN of the Datadog log forwarder Lambda function"
+}
+
+variable "datadog_forwarder_lambda_function_name" {
+  type        = string
+  description = "Name of the Datadog log forwarder Lambda function"
+}
+

--- a/infrastructure/modules/aws/variables.tf
+++ b/infrastructure/modules/aws/variables.tf
@@ -23,8 +23,5 @@ variable "datadog_forwarder_lambda_arn" {
   description = "ARN of the Datadog log forwarder Lambda function"
 }
 
-variable "datadog_forwarder_lambda_function_name" {
-  type        = string
-  description = "Name of the Datadog log forwarder Lambda function"
-}
+
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional ALB access logging with configurable bucket and prefix.
  * Environment-scoped S3 log buckets for ALB logs with encryption, public-access protections, ownership controls, and 14-day retention.
  * S3 notifications forward ALB logs to Datadog; Datadog forwarder ARN exposed and wired for environments.
  * IAM policy granting Datadog read access to ALB log buckets.

* **Bug Fixes**
  * Updated bastion ingress IP.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->