### PR TITLE
refactor: remove max resolution from videos-admin

### DIFF
--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/audio/add/page.spec.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/audio/add/page.spec.tsx
@@ -268,16 +268,9 @@ describe('AddAudioLanguageDialog', () => {
       })
     })
 
-    // Select Max Resolution
-    await act(async () => {
-      fireEvent.change(screen.getAllByTestId('mui-select')[1], {
-        target: { value: 'fhd' }
-      })
-    })
-
     // Select Status
     await act(async () => {
-      fireEvent.change(screen.getAllByTestId('mui-select')[2], {
+      fireEvent.change(screen.getAllByTestId('mui-select')[1], {
         target: { value: 'published' }
       })
     })

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/audio/add/page.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/audio/add/page.tsx
@@ -34,16 +34,14 @@ interface AddAudioLanguageDialogProps {
 const validationSchema = object().shape({
   edition: string().required('Edition is required'),
   language: object().nullable().required('Language is required'),
-  file: mixed().required('Video file is required'),
-  maxResolution: string().required('Max resolution is required')
+  file: mixed().required('Video file is required')
 })
 
 const initialValues: FormikValues = {
   edition: 'base',
   language: null,
   file: null,
-  published: 'unpublished',
-  maxResolution: 'fhd'
+  published: 'unpublished'
 }
 
 const GET_ADMIN_VIDEO_VARIANTS = graphql(`
@@ -100,7 +98,6 @@ export default function AddAudioLanguageDialog({
       values.edition,
       values.published === 'published',
       videoSlug,
-      values.maxResolution,
       () => {
         router.push(returnUrl, {
           scroll: false
@@ -202,38 +199,6 @@ export default function AddAudioLanguageDialog({
                     )}
                   />
                 </Box>
-                <FormControl
-                  fullWidth
-                  error={touched.maxResolution && errors.maxResolution != null}
-                >
-                  <InputLabel id="max-resolution-label">
-                    Max Resolution
-                  </InputLabel>
-                  <Select
-                    labelId="max-resolution-label"
-                    data-testid="MaxResolutionSelect"
-                    id="maxResolution"
-                    name="maxResolution"
-                    label="Video Resolution"
-                    error={
-                      touched.maxResolution && errors.maxResolution != null
-                    }
-                    value={values.maxResolution}
-                    onChange={async (event) => {
-                      await setFieldValue('maxResolution', event.target.value)
-                    }}
-                    disabled={isUploadInProgress}
-                  >
-                    <MenuItem value="fhd">Up to 1K - Full HD (1080p)</MenuItem>
-                    <MenuItem value="qhd">2K - Quad HD (1440p)</MenuItem>
-                    <MenuItem value="uhd">4K - Ultra HD (2160p)</MenuItem>
-                  </Select>
-                  <FormHelperText>
-                    {touched.maxResolution && errors.maxResolution
-                      ? (errors.maxResolution as string)
-                      : undefined}
-                  </FormHelperText>
-                </FormControl>
                 <FormControl variant="standard">
                   <InputLabel id="status-select-label">Status</InputLabel>
                   <Select
@@ -279,8 +244,7 @@ export default function AddAudioLanguageDialog({
                       isUploadInProgress ||
                       values.language == null ||
                       values.edition === '' ||
-                      values.file == null ||
-                      values.maxResolution === ''
+                      values.file == null
                     }
                   >
                     Add

--- a/apps/videos-admin/src/app/_UploadVideoVariantProvider/UploadVideoVariantProvider.spec.tsx
+++ b/apps/videos-admin/src/app/_UploadVideoVariantProvider/UploadVideoVariantProvider.spec.tsx
@@ -53,7 +53,7 @@ const createMuxVideoUploadByUrlMock = {
       url: 'https://mock.cloudflare-domain.com/video-id/variants/language-id/videos/uuidv4/language-id_video-id.mp4',
       userGenerated: false,
       downloadable: true,
-      maxResolution: undefined
+      maxResolution: 'uhd'
     }
   },
   result: {
@@ -170,7 +170,7 @@ const createMuxVideoUploadByUrlErrorMock = {
       url: 'https://mock.cloudflare-domain.com/video-id/variants/language-id/videos/uuidv4/language-id_video-id.mp4',
       userGenerated: false,
       downloadable: true,
-      maxResolution: undefined
+      maxResolution: 'uhd'
     }
   },
   error: new Error('Mux creation failed')
@@ -593,8 +593,7 @@ describe('UploadVideoVariantContext', () => {
           'en',
           'base',
           false,
-          'video-slug',
-          undefined
+          'video-slug'
         )
       })
 

--- a/apps/videos-admin/src/app/_UploadVideoVariantProvider/UploadVideoVariantProvider.tsx
+++ b/apps/videos-admin/src/app/_UploadVideoVariantProvider/UploadVideoVariantProvider.tsx
@@ -7,8 +7,6 @@ import { ReactNode, createContext, useContext, useReducer } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
 import { graphql } from '@core/shared/gql'
-// Remove the invalid import for MaxResolutionTier
-// import { MaxResolutionTier } from '@core/shared/gql/__generated__/graphql'
 
 import { getExtension } from '../(dashboard)/videos/[videoId]/audio/add/_utils/getExtension'
 import { useCreateR2AssetMutation } from '../../libs/useCreateR2Asset/useCreateR2Asset'
@@ -92,7 +90,6 @@ interface UploadVideoVariantContextType {
     edition: string,
     published: boolean,
     videoSlug?: string,
-    maxResolution?: 'fhd' | 'qhd' | 'uhd',
     onComplete?: () => void
   ) => Promise<void>
   clearUploadState: () => void
@@ -299,7 +296,6 @@ export function UploadVideoVariantProvider({
     edition: string,
     published: boolean,
     videoSlug?: string,
-    maxResolution?: 'fhd' | 'qhd' | 'uhd',
     onComplete?: () => void
   ) => {
     try {
@@ -358,7 +354,7 @@ export function UploadVideoVariantProvider({
           url: r2Response.data.cloudflareR2Create.publicUrl,
           userGenerated: false,
           downloadable: true,
-          maxResolution: maxResolution || undefined
+          maxResolution: 'uhd'
         }
       })
 


### PR DESCRIPTION
Forces max to 4k. Mux handles the rest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Simplified Add Audio Language flow: removed the Max Resolution selection. Uploads now default to Ultra HD (UHD). Other steps (edition, language, file, publish) remain unchanged.
- Refactor
  - Streamlined upload process by standardizing resolution handling behind the scenes.
- Tests
  - Updated tests to reflect the removal of the Max Resolution option and the adjusted field order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->