### PR TITLE
fix: reorder locale resolution priorities in middleware

### DIFF
--- a/apps/watch/middleware.spec.ts
+++ b/apps/watch/middleware.spec.ts
@@ -60,34 +60,10 @@ describe('middleware', () => {
   })
 
   describe('locale detection', () => {
-    it('should ignore cookie locale and rely on path only', () => {
-      const req = createMockRequest('/watch/jesus.html', {
-        cookies: [{ name: 'NEXT_LOCALE', value: 'fingerprint---fr' }]
-      })
-      const result = middleware(req)
-      expect(result).toEqual(NextResponse.next())
-    })
-
-    it('should use URL path locale if no cookie', () => {
+    it('should use URL path locale', () => {
       const req = createMockRequest('/watch/jesus.html/french.html')
       const result = middleware(req) as NextResponse
       expect(result?.headers.get('x-middleware-rewrite')).toContain('/fr/')
-    })
-
-    it('should not use browser language when no path locale', () => {
-      const req = createMockRequest('/watch/jesus.html', {
-        headers: { 'accept-language': 'fr-FR,fr;q=0.9,en;q=0.8' }
-      })
-      const result = middleware(req)
-      expect(result).toEqual(NextResponse.next())
-    })
-
-    it('should not use geolocation when no path locale', () => {
-      const req = createMockRequest('/watch/jesus.html', {
-        headers: { 'cf-ipcountry': 'FR' }
-      })
-      const result = middleware(req)
-      expect(result).toEqual(NextResponse.next())
     })
 
     it('should fallback to default locale if no locale detected', () => {
@@ -102,7 +78,7 @@ describe('middleware', () => {
       const req = createMockRequest('/watch/jesus.html/french.html')
       const result = middleware(req) as NextResponse
       expect(result?.headers.get('x-middleware-rewrite')).toBe(
-        'http://localhost/fr/watch/jesus.html'
+        'http://localhost/fr/watch/jesus.html/french.html'
       )
     })
 
@@ -116,7 +92,7 @@ describe('middleware', () => {
       const req = createMockRequest('/watch/jesus.html/french.html?param=value')
       const result = middleware(req) as NextResponse
       expect(result?.headers.get('x-middleware-rewrite')).toBe(
-        'http://localhost/fr/watch/jesus.html?param=value'
+        'http://localhost/fr/watch/jesus.html/french.html?param=value'
       )
     })
   })

--- a/apps/watch/middleware.ts
+++ b/apps/watch/middleware.ts
@@ -88,13 +88,13 @@ function getBrowserLanguage(req: NextRequest): string {
 }
 
 function getLocale(req: NextRequest): string {
-  // Priority 1: Cookie
-  const cookieLocale = req.cookies.get('NEXT_LOCALE')?.value?.split('---')[1]
-  if (cookieLocale != null) return cookieLocale
-
-  // Priority 2: URL Path
+  // Priority 1: URL Path
   const pathLocale = getLocaleFromPath(req.nextUrl.pathname)
   if (pathLocale != null) return pathLocale
+
+  // Priority 2: Cookie
+  const cookieLocale = req.cookies.get('NEXT_LOCALE')?.value?.split('---')[1]
+  if (cookieLocale != null) return cookieLocale
 
   // Priority 3: Browser Language
   const browserLocale = getBrowserLanguage(req)

--- a/apps/watch/middleware.ts
+++ b/apps/watch/middleware.ts
@@ -88,21 +88,11 @@ function getBrowserLanguage(req: NextRequest): string {
 }
 
 function getLocale(req: NextRequest): string {
-  // Priority 1: URL Path
+  // Only URL Path should determine language
   const pathLocale = getLocaleFromPath(req.nextUrl.pathname)
   if (pathLocale != null) return pathLocale
 
-  // Priority 2: Cookie
-  const cookieLocale = req.cookies.get('NEXT_LOCALE')?.value?.split('---')[1]
-  if (cookieLocale != null) return cookieLocale
-
-  // Priority 3: Browser Language
-  const browserLocale = getBrowserLanguage(req)
-  if (browserLocale !== DEFAULT_LOCALE) return browserLocale
-
-  // Priority 4: Geolocation (only check if no other locale found)
-  const geoLocale = getLocaleFromGeoHeaders(req)
-  return geoLocale ?? DEFAULT_LOCALE
+  return DEFAULT_LOCALE
 }
 
 export function middleware(req: NextRequest): NextResponse | undefined {

--- a/apps/watch/middleware.ts
+++ b/apps/watch/middleware.ts
@@ -1,90 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-import {
-  DEFAULT_LOCALE,
-  LANGUAGE_MAPPINGS,
-  SUPPORTED_LOCALES
-} from './src/libs/localeMapping'
-
-interface LanguagePriority {
-  code: string
-  priority: number
-}
-
-function parseAcceptLanguageHeader(header: string): LanguagePriority[] {
-  return header.split(',').map((item) => {
-    const [code, priority] = item.trim().split(';')
-    const langPriority =
-      priority != null ? Number.parseFloat(priority.split('=')[1]) : 1
-    return { code, priority: langPriority }
-  })
-}
-
-function getPreferredLanguage(
-  languages: LanguagePriority[] | undefined
-): string | undefined {
-  const preferredLanguage = languages?.find(
-    (language) =>
-      SUPPORTED_LOCALES.includes(language.code) ||
-      SUPPORTED_LOCALES.includes(language.code.split('-')[0])
-  )
-
-  if (preferredLanguage == null) return
-  return getSupportedLocale(preferredLanguage?.code)
-}
-
-function getSupportedLocale(input?: string): string {
-  if (input == null) return DEFAULT_LOCALE
-
-  const languageCode = input.split('-')[0]
-
-  const isSupported = (code: string): boolean =>
-    SUPPORTED_LOCALES.includes(code)
-
-  return isSupported(input)
-    ? input
-    : isSupported(languageCode)
-      ? languageCode
-      : DEFAULT_LOCALE
-}
+import { DEFAULT_LOCALE, LANGUAGE_MAPPINGS } from './src/libs/localeMapping'
 
 function getLocaleFromPath(pathname: string): string | undefined {
   const parts = pathname.split('/').filter(Boolean)
   const pathParts = parts.slice(1)
-  const lastPart = pathParts[pathParts.length - 1]
+  const lastPart = pathParts[pathParts.length - 1]?.split('?')[0]
 
   const localeEntry = Object.values(LANGUAGE_MAPPINGS).find((mapping) =>
     mapping.languageSlugs.includes(lastPart)
   )
 
   return localeEntry?.locale
-}
-
-function getLocaleFromGeoHeaders(req: NextRequest): string | undefined {
-  const country =
-    req.headers.get('cf-ipcountry') ||
-    req.headers.get('x-vercel-ip-country') ||
-    undefined
-
-  if (!country) return undefined
-
-  const countryCode = country.toUpperCase()
-  const localeEntry = Object.values(LANGUAGE_MAPPINGS).find((mapping) =>
-    mapping.geoLocations.includes(countryCode)
-  )
-
-  return localeEntry?.locale
-}
-
-function getBrowserLanguage(req: NextRequest): string {
-  const acceptedLanguagesHeader = req.headers.get('accept-language')
-  if (acceptedLanguagesHeader == null) return DEFAULT_LOCALE
-
-  const acceptedLanguages = parseAcceptLanguageHeader(acceptedLanguagesHeader)
-  const sortedLanguages = acceptedLanguages?.sort(
-    (a, b) => b.priority - a.priority
-  )
-  return getPreferredLanguage(sortedLanguages) ?? DEFAULT_LOCALE
 }
 
 function getLocale(req: NextRequest): string {
@@ -111,6 +38,7 @@ export function middleware(req: NextRequest): NextResponse | undefined {
     const rewriteUrl = req.nextUrl.clone()
     const cleanPathname = req.nextUrl.pathname.split('?')[0]
     rewriteUrl.pathname = `/${locale}${cleanPathname}`
+
     return NextResponse.rewrite(rewriteUrl)
   }
 

--- a/apps/watch/src/components/LanguageSwitchDialog/LanguageSwitchDialog.spec.tsx
+++ b/apps/watch/src/components/LanguageSwitchDialog/LanguageSwitchDialog.spec.tsx
@@ -138,27 +138,6 @@ describe('LanguageSwitchDialog', () => {
     })
   })
 
-  describe('component structure', () => {
-    it('should render components in correct order with separators', () => {
-      render(
-        <MockedProvider mocks={[]} addTypename={false}>
-          <WatchProvider initialState={defaultWatchState}>
-            <LanguageSwitchDialog open={true} handleClose={mockHandleClose} />
-          </WatchProvider>
-        </MockedProvider>
-      )
-
-      const dialog = screen.getByRole('dialog')
-
-      // Verify horizontal rule separator exists
-      const separator = dialog.querySelector('hr')
-      expect(separator).toBeInTheDocument()
-
-      // Verify dialog contains the main content structure
-      expect(dialog).toBeInTheDocument()
-    })
-  })
-
   describe('GraphQL integration', () => {
     it('should call getAllLanguages query and update state with SetAllLanguages dispatch', async () => {
       render(

--- a/apps/watch/src/components/LanguageSwitchDialog/LanguageSwitchDialog.tsx
+++ b/apps/watch/src/components/LanguageSwitchDialog/LanguageSwitchDialog.tsx
@@ -3,7 +3,6 @@ import CloseIcon from '@mui/icons-material/Close'
 import Box from '@mui/material/Box'
 import Dialog from '@mui/material/Dialog'
 import DialogContent from '@mui/material/DialogContent'
-import Divider from '@mui/material/Divider'
 import IconButton from '@mui/material/IconButton'
 import Stack from '@mui/material/Stack'
 import { ThemeProvider } from '@mui/material/styles'
@@ -16,7 +15,6 @@ import { GetAllLanguages } from '../../../__generated__/GetAllLanguages'
 import { useWatch } from '../../libs/watchContext'
 
 import { AudioTrackSelect } from './AudioTrackSelect'
-import { SiteLanguageSelect } from './SiteLanguageSelect'
 import { SubtitlesSelect } from './SubtitlesSelect'
 
 export const GET_ALL_LANGUAGES = gql`
@@ -97,8 +95,6 @@ export const LanguageSwitchDialog = memo(function LanguageSwitchDialog({
 
         <DialogContent sx={{ pt: 0, pb: 6, px: 0 }}>
           <Stack gap={8}>
-            <SiteLanguageSelect />
-            <Divider />
             <AudioTrackSelect />
             <SubtitlesSelect />
           </Stack>

--- a/apps/watch/src/libs/watchContext/useLanguageActions/useLanguageActions.spec.tsx
+++ b/apps/watch/src/libs/watchContext/useLanguageActions/useLanguageActions.spec.tsx
@@ -90,10 +90,9 @@ describe('useLanguageActions', () => {
         result.current.actions.updateSiteLanguage('es')
       })
 
-      expect(mockSetCookie).toHaveBeenCalledWith('NEXT_LOCALE', 'es')
       expect(mockSetCookie).toHaveBeenCalledWith('AUDIO_LANGUAGE', '530')
       expect(mockSetCookie).toHaveBeenCalledWith('SUBTITLE_LANGUAGE', '530')
-      expect(mockSetCookie).toHaveBeenCalledTimes(3)
+      expect(mockSetCookie).toHaveBeenCalledTimes(2)
     })
 
     it('should fallback to current language IDs when selected language not found', async () => {
@@ -126,7 +125,6 @@ describe('useLanguageActions', () => {
         result.current.actions.updateSiteLanguage('de')
       })
 
-      expect(mockSetCookie).toHaveBeenCalledWith('NEXT_LOCALE', 'de')
       expect(mockSetCookie).toHaveBeenCalledWith('AUDIO_LANGUAGE', '529') // fallback to current
       expect(mockSetCookie).toHaveBeenCalledWith('SUBTITLE_LANGUAGE', '529') // fallback to current
     })
@@ -207,7 +205,6 @@ describe('useLanguageActions', () => {
         result.current.actions.updateSiteLanguage('es')
       })
 
-      expect(mockSetCookie).toHaveBeenCalledWith('NEXT_LOCALE', 'es')
       expect(mockSetCookie).toHaveBeenCalledWith('AUDIO_LANGUAGE', '529')
       expect(mockSetCookie).toHaveBeenCalledWith('SUBTITLE_LANGUAGE', '529')
     })

--- a/apps/watch/src/libs/watchContext/useLanguageActions/useLanguageActions.ts
+++ b/apps/watch/src/libs/watchContext/useLanguageActions/useLanguageActions.ts
@@ -38,8 +38,7 @@ export function useLanguageActions() {
       const newAudioLanguage = selectedLangObj?.id ?? state.audioLanguage
       const newSubtitleLanguage = selectedLangObj?.id ?? state.subtitleLanguage
 
-      // Set all affected cookies
-      setCookie('NEXT_LOCALE', language)
+      // Set affected cookies (exclude site language cookie; language defined by URL)
       setCookie('AUDIO_LANGUAGE', newAudioLanguage)
       setCookie('SUBTITLE_LANGUAGE', newSubtitleLanguage)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Locale is now determined exclusively by the page URL; bookmarked/shared URLs always open in the URL-specified language.
  - Rewrites occur only when a non-default locale is present in the path; default-locale requests are unchanged.

- **Behavior Change**
  - Updating site language no longer sets a site-language cookie; audio/subtitle preferences still persist.

- **Tests / UI**
  - Tests updated to reflect path-only locale behavior; a site-language selector UI was removed from the language dialog and related tests adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->