### PR TITLE
fix: language detection priority locale on watch

### DIFF
--- a/apps/watch/middleware.spec.ts
+++ b/apps/watch/middleware.spec.ts
@@ -60,34 +60,10 @@ describe('middleware', () => {
   })
 
   describe('locale detection', () => {
-    it('should ignore cookie locale and rely on path only', () => {
-      const req = createMockRequest('/watch/jesus.html', {
-        cookies: [{ name: 'NEXT_LOCALE', value: 'fingerprint---fr' }]
-      })
-      const result = middleware(req)
-      expect(result).toEqual(NextResponse.next())
-    })
-
-    it('should use URL path locale if no cookie', () => {
+    it('should use URL path locale', () => {
       const req = createMockRequest('/watch/jesus.html/french.html')
       const result = middleware(req) as NextResponse
       expect(result?.headers.get('x-middleware-rewrite')).toContain('/fr/')
-    })
-
-    it('should not use browser language when no path locale', () => {
-      const req = createMockRequest('/watch/jesus.html', {
-        headers: { 'accept-language': 'fr-FR,fr;q=0.9,en;q=0.8' }
-      })
-      const result = middleware(req)
-      expect(result).toEqual(NextResponse.next())
-    })
-
-    it('should not use geolocation when no path locale', () => {
-      const req = createMockRequest('/watch/jesus.html', {
-        headers: { 'cf-ipcountry': 'FR' }
-      })
-      const result = middleware(req)
-      expect(result).toEqual(NextResponse.next())
     })
 
     it('should fallback to default locale if no locale detected', () => {
@@ -102,7 +78,7 @@ describe('middleware', () => {
       const req = createMockRequest('/watch/jesus.html/french.html')
       const result = middleware(req) as NextResponse
       expect(result?.headers.get('x-middleware-rewrite')).toBe(
-        'http://localhost/fr/watch/jesus.html'
+        'http://localhost/fr/watch/jesus.html/french.html'
       )
     })
 
@@ -116,7 +92,7 @@ describe('middleware', () => {
       const req = createMockRequest('/watch/jesus.html/french.html?param=value')
       const result = middleware(req) as NextResponse
       expect(result?.headers.get('x-middleware-rewrite')).toBe(
-        'http://localhost/fr/watch/jesus.html?param=value'
+        'http://localhost/fr/watch/jesus.html/french.html?param=value'
       )
     })
   })

--- a/apps/watch/middleware.ts
+++ b/apps/watch/middleware.ts
@@ -1,46 +1,136 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { DEFAULT_LOCALE, LANGUAGE_MAPPINGS } from './src/libs/localeMapping'
+import languagesData from './src/libs/localeMapping/languages.json'
 
-function getLocaleFromPath(pathname: string): string | undefined {
-  const parts = pathname.split('/').filter(Boolean)
-  const pathParts = parts.slice(1)
-  const lastPart = pathParts[pathParts.length - 1]?.split('?')[0]
-
-  const localeEntry = Object.values(LANGUAGE_MAPPINGS).find((mapping) =>
-    mapping.languageSlugs.includes(lastPart)
-  )
-
-  return localeEntry?.locale
+type LanguageName = {
+  value: string
+  primary: boolean
+  language: {
+    id: string
+  }
 }
 
-function getLocale(req: NextRequest): string {
-  // Only URL Path should determine language
-  const pathLocale = getLocaleFromPath(req.nextUrl.pathname)
-  if (pathLocale != null) return pathLocale
+type Language = {
+  slug: string
+  bcp47: string | null
+  iso3: string
+  id: string
+  name: LanguageName[]
+}
 
-  return DEFAULT_LOCALE
+type LanguagesData = {
+  languages: Language[]
+}
+
+type LangHit = { locale: string; index: number }
+
+// Collect known locales so we can detect if the path is already prefixed
+const KNOWN_LOCALES = new Set(
+  Object.values(LANGUAGE_MAPPINGS).map((m: any) => m.locale)
+)
+
+/**
+ * Find the English name for a language slug from the languages.json data
+ */
+function getEnglishNameFromSlug(slug: string): string | undefined {
+  const language = (languagesData as LanguagesData).languages.find((lang: Language) => lang.slug === slug)
+  if (!language) return undefined
+  
+  // Find the English name (primary=false, language.id="529" which is English)
+  const englishName = language.name.find((name: LanguageName) => 
+    name.primary === false && name.language.id === "529"
+  )
+  
+  return englishName?.value
+}
+
+/**
+ * Scan all path segments and find the first segment that matches a configured languageSlug.
+ * Returns the locale and the index of that segment within the path.
+ */
+function findLanguageSlug(pathname: string): LangHit | undefined {
+  const segments = pathname.split('/').filter(Boolean)
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i]
+    const mapping = Object.values(LANGUAGE_MAPPINGS).find((m: any) =>
+      m.languageSlugs.includes(seg)
+    ) as { locale: string } | undefined
+
+    if (mapping) return { locale: mapping.locale, index: i }
+  }
+  return undefined
 }
 
 export function middleware(req: NextRequest): NextResponse | undefined {
-  const isNextInternal = req.nextUrl.pathname.startsWith('/_next')
-  const isApi = req.nextUrl.pathname.includes('/api/')
-  const isWatchRoute = req.nextUrl.pathname.startsWith('/watch')
-  const isAsset = req.nextUrl.pathname.includes('/assets/')
+  const { pathname } = req.nextUrl
 
-  if (isNextInternal || isApi || !isWatchRoute || isAsset) {
+  const isNextInternal = pathname.startsWith('/_next')
+  const isApi = pathname.includes('/api/')
+  const isAsset = pathname.includes('/assets/')
+  const isWatchRoute = pathname.startsWith('/watch')
+
+  if (isNextInternal || isApi || isAsset || !isWatchRoute) {
     return
   }
 
-  const locale = getLocale(req)
+  const segments = pathname.split('/').filter(Boolean)
 
-  if (locale !== DEFAULT_LOCALE) {
-    const rewriteUrl = req.nextUrl.clone()
-    const cleanPathname = req.nextUrl.pathname.split('?')[0]
-    rewriteUrl.pathname = `/${locale}${cleanPathname}`
+  // If already prefixed with a known locale, let it through untouched
+  if (segments.length && KNOWN_LOCALES.has(segments[0])) {
+    return NextResponse.next()
+  }
+
+  const hit = findLanguageSlug(pathname)
+  if (!hit) {
+    return NextResponse.next()
+  }
+
+  const { locale, index: langIdx } = hit
+  const watchIdx = segments.indexOf('watch')
+
+  if (watchIdx === -1) {
+    return NextResponse.next()
+  }
+
+  const rewriteUrl = req.nextUrl.clone()
+
+  // MAIN PAGE legacy format:
+  //   /watch/{languageSlug}.html/…  ->  /{locale?}/watch/…  (drop the languageSlug segment)
+  if (langIdx === watchIdx + 1) {
+    // Ensure the URL has the language refinement param (visible to the user)
+    const langSeg = segments[langIdx]
+    const englishName = getEnglishNameFromSlug(langSeg) || langSeg.replace(/\.html$/, '').replace(/-/g, ' ')
+
+    const paramKey = 'refinementList[languageEnglishName][0]'
+    const hasParam = req.nextUrl.searchParams.has(paramKey)
+
+    if (!hasParam && englishName) {
+      const redirectUrl = req.nextUrl.clone()
+      redirectUrl.searchParams.set(paramKey, englishName)
+      return NextResponse.redirect(redirectUrl)
+    }
+
+    const withoutLang = segments.slice(0, langIdx).concat(segments.slice(langIdx + 1))
+
+    // Default locale: no prefix. Non-default: prefix with /{locale}
+    if (locale !== DEFAULT_LOCALE) {
+      rewriteUrl.pathname = '/' + [locale, ...withoutLang].join('/')
+    } else {
+      rewriteUrl.pathname = '/' + withoutLang.join('/')
+    }
 
     return NextResponse.rewrite(rewriteUrl)
   }
 
+  // INNER PAGE legacy format:
+  //   /watch/{page}.html/{languageSlug}.html/…  ->  /{locale?}/watch/{page}.html/{languageSlug}.html/…
+  // Keep the full path, only add locale prefix for non-default locales.
+  if (locale !== DEFAULT_LOCALE) {
+    rewriteUrl.pathname = '/' + [locale, ...segments].join('/')
+    return NextResponse.rewrite(rewriteUrl)
+  }
+
+  // Default-locale inner pages can pass through unchanged
   return NextResponse.next()
 }

--- a/apps/watch/middleware.ts
+++ b/apps/watch/middleware.ts
@@ -88,13 +88,13 @@ function getBrowserLanguage(req: NextRequest): string {
 }
 
 function getLocale(req: NextRequest): string {
-  // Priority 1: Cookie
-  const cookieLocale = req.cookies.get('NEXT_LOCALE')?.value?.split('---')[1]
-  if (cookieLocale != null) return cookieLocale
-
-  // Priority 2: URL Path
+  // Priority 1: URL Path
   const pathLocale = getLocaleFromPath(req.nextUrl.pathname)
   if (pathLocale != null) return pathLocale
+
+  // Priority 2: Cookie
+  const cookieLocale = req.cookies.get('NEXT_LOCALE')?.value?.split('---')[1]
+  if (cookieLocale != null) return cookieLocale
 
   // Priority 3: Browser Language
   const browserLocale = getBrowserLanguage(req)

--- a/apps/watch/middleware.ts
+++ b/apps/watch/middleware.ts
@@ -34,15 +34,17 @@ const KNOWN_LOCALES = new Set(
  * Find the English name for a language slug from the languages.json data
  */
 function getEnglishNameFromSlug(slug: string): string | undefined {
-  const language = (languagesData as LanguagesData).languages.find((lang: Language) => lang.slug === slug)
-  
-  if (!language) return undefined
-  
-  // Find the English name (primary=false, language.id="529" which is English)
-  const englishName = language.name.find((name: LanguageName) => 
-    name.primary === false
+  const language = (languagesData as LanguagesData).languages.find(
+    (lang: Language) => lang.slug === slug
   )
-  
+
+  if (!language) return undefined
+
+  // Find the English name (primary=false, language.id="529" which is English)
+  const englishName = language.name.find(
+    (name: LanguageName) => name.primary === false
+  )
+
   return englishName?.value
 }
 
@@ -78,7 +80,7 @@ export function middleware(req: NextRequest): NextResponse | undefined {
 
   const segments = pathname.split('/').filter(Boolean)
 
-    // If already prefixed with a known locale, let it through untouched
+  // If already prefixed with a known locale, let it through untouched
   if (segments.length && KNOWN_LOCALES.has(segments[0])) {
     return NextResponse.next()
   }
@@ -106,9 +108,9 @@ export function middleware(req: NextRequest): NextResponse | undefined {
     // Extract language slug from URL (e.g., "spanish" from "spanish.html")
     const langSeg = segments[langIdx]
     const cleanLangSeg = langSeg.replace(/\.html$/, '')
-    
+
     // Convert slug to English name (e.g., "spanish" -> "Spanish, Latin American")
-    const englishName = getEnglishNameFromSlug(cleanLangSeg)  // Keep original slug
+    const englishName = getEnglishNameFromSlug(cleanLangSeg) // Keep original slug
 
     // Check if search param already exists to avoid duplicate redirects
     const paramKey = 'refinementList[languageEnglishName][0]'
@@ -123,7 +125,9 @@ export function middleware(req: NextRequest): NextResponse | undefined {
     }
 
     // Remove language slug from path segments for URL rewrite
-    const withoutLang = segments.slice(0, langIdx).concat(segments.slice(langIdx + 1))
+    const withoutLang = segments
+      .slice(0, langIdx)
+      .concat(segments.slice(langIdx + 1))
 
     // Default locale: no prefix. Non-default: prefix with /{locale}
     const isNonDefaultLocale = locale !== DEFAULT_LOCALE

--- a/apps/watch/middleware.ts
+++ b/apps/watch/middleware.ts
@@ -88,21 +88,11 @@ function getBrowserLanguage(req: NextRequest): string {
 }
 
 function getLocale(req: NextRequest): string {
-  // Priority 1: URL Path
+  // Only URL Path should determine language
   const pathLocale = getLocaleFromPath(req.nextUrl.pathname)
   if (pathLocale != null) return pathLocale
 
-  // Priority 2: Cookie
-  const cookieLocale = req.cookies.get('NEXT_LOCALE')?.value?.split('---')[1]
-  if (cookieLocale != null) return cookieLocale
-
-  // Priority 3: Browser Language
-  const browserLocale = getBrowserLanguage(req)
-  if (browserLocale !== DEFAULT_LOCALE) return browserLocale
-
-  // Priority 4: Geolocation (only check if no other locale found)
-  const geoLocale = getLocaleFromGeoHeaders(req)
-  return geoLocale ?? DEFAULT_LOCALE
+  return DEFAULT_LOCALE
 }
 
 export function middleware(req: NextRequest): NextResponse | undefined {

--- a/apps/watch/middleware.ts
+++ b/apps/watch/middleware.ts
@@ -1,90 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-import {
-  DEFAULT_LOCALE,
-  LANGUAGE_MAPPINGS,
-  SUPPORTED_LOCALES
-} from './src/libs/localeMapping'
-
-interface LanguagePriority {
-  code: string
-  priority: number
-}
-
-function parseAcceptLanguageHeader(header: string): LanguagePriority[] {
-  return header.split(',').map((item) => {
-    const [code, priority] = item.trim().split(';')
-    const langPriority =
-      priority != null ? Number.parseFloat(priority.split('=')[1]) : 1
-    return { code, priority: langPriority }
-  })
-}
-
-function getPreferredLanguage(
-  languages: LanguagePriority[] | undefined
-): string | undefined {
-  const preferredLanguage = languages?.find(
-    (language) =>
-      SUPPORTED_LOCALES.includes(language.code) ||
-      SUPPORTED_LOCALES.includes(language.code.split('-')[0])
-  )
-
-  if (preferredLanguage == null) return
-  return getSupportedLocale(preferredLanguage?.code)
-}
-
-function getSupportedLocale(input?: string): string {
-  if (input == null) return DEFAULT_LOCALE
-
-  const languageCode = input.split('-')[0]
-
-  const isSupported = (code: string): boolean =>
-    SUPPORTED_LOCALES.includes(code)
-
-  return isSupported(input)
-    ? input
-    : isSupported(languageCode)
-      ? languageCode
-      : DEFAULT_LOCALE
-}
+import { DEFAULT_LOCALE, LANGUAGE_MAPPINGS } from './src/libs/localeMapping'
 
 function getLocaleFromPath(pathname: string): string | undefined {
   const parts = pathname.split('/').filter(Boolean)
   const pathParts = parts.slice(1)
-  const lastPart = pathParts[pathParts.length - 1]
+  const lastPart = pathParts[pathParts.length - 1]?.split('?')[0]
 
   const localeEntry = Object.values(LANGUAGE_MAPPINGS).find((mapping) =>
     mapping.languageSlugs.includes(lastPart)
   )
 
   return localeEntry?.locale
-}
-
-function getLocaleFromGeoHeaders(req: NextRequest): string | undefined {
-  const country =
-    req.headers.get('cf-ipcountry') ||
-    req.headers.get('x-vercel-ip-country') ||
-    undefined
-
-  if (!country) return undefined
-
-  const countryCode = country.toUpperCase()
-  const localeEntry = Object.values(LANGUAGE_MAPPINGS).find((mapping) =>
-    mapping.geoLocations.includes(countryCode)
-  )
-
-  return localeEntry?.locale
-}
-
-function getBrowserLanguage(req: NextRequest): string {
-  const acceptedLanguagesHeader = req.headers.get('accept-language')
-  if (acceptedLanguagesHeader == null) return DEFAULT_LOCALE
-
-  const acceptedLanguages = parseAcceptLanguageHeader(acceptedLanguagesHeader)
-  const sortedLanguages = acceptedLanguages?.sort(
-    (a, b) => b.priority - a.priority
-  )
-  return getPreferredLanguage(sortedLanguages) ?? DEFAULT_LOCALE
 }
 
 function getLocale(req: NextRequest): string {
@@ -111,6 +38,7 @@ export function middleware(req: NextRequest): NextResponse | undefined {
     const rewriteUrl = req.nextUrl.clone()
     const cleanPathname = req.nextUrl.pathname.split('?')[0]
     rewriteUrl.pathname = `/${locale}${cleanPathname}`
+
     return NextResponse.rewrite(rewriteUrl)
   }
 

--- a/apps/watch/next-i18next.config.js
+++ b/apps/watch/next-i18next.config.js
@@ -30,7 +30,8 @@ const i18nConfig = {
       'tr', // Turkish
       'zh', // Chinese
       'zh-Hans-CN' // Chinese, Simplified
-    ]
+    ],
+    localeDetection: false
   },
   localePath,
   fallbackLng: {

--- a/apps/watch/src/components/Header/HeaderTabButtons/HeaderTabButtons.tsx
+++ b/apps/watch/src/components/Header/HeaderTabButtons/HeaderTabButtons.tsx
@@ -28,17 +28,18 @@ import { LANGUAGE_MAPPINGS } from '../../../libs/localeMapping'
 function getVideosLink(query: Record<string, string | string[]>): string {
   // Check all query values for language slugs
   const queryValues = Object.values(query).flat()
-  
+
   // Find if there's a language slug in the query values
   for (const value of queryValues) {
     if (typeof value === 'string') {
+      const cleanValue = value.replace(/\.html$/, '')
       const mapping = Object.values(LANGUAGE_MAPPINGS).find((m) =>
-        m.languageSlugs.includes(value)
+        m.languageSlugs.includes(cleanValue)
       )
       
       if (mapping) {
         // Found a language slug, return the watch path with that language
-        return `/watch/${value}`
+        return `/watch/${cleanValue}`
       }
     }
   }
@@ -51,8 +52,7 @@ export function HeaderTabButtons(): ReactElement {
   const { strategies, journeys } = useFlags()
   const { t } = useTranslation('apps-watch')
   const router = useRouter()
-  console.log('>>>>>>> router', {router})
-  const videosLink = router?.query ? getVideosLink(router.query) : '/watch'
+  const videosLink = router?.query ? getVideosLink(router.query as Record<string, string | string[]>) : '/watch'
 
   const headerItems = compact([
     strategies

--- a/apps/watch/src/components/Header/HeaderTabButtons/HeaderTabButtons.tsx
+++ b/apps/watch/src/components/Header/HeaderTabButtons/HeaderTabButtons.tsx
@@ -18,10 +18,41 @@ import JourneysIcon from '@core/shared/ui/icons/Journeys'
 import Play1Icon from '@core/shared/ui/icons/Play1'
 import TerminalIcon from '@core/shared/ui/icons/Terminal'
 
+import { LANGUAGE_MAPPINGS } from '../../../libs/localeMapping'
+
+/**
+ * Determines the correct Videos link based on the current URL query parameters.
+ * For inner pages with language slugs, returns /watch/{languageSlug}
+ * Otherwise returns /watch
+ */
+function getVideosLink(query: Record<string, string | string[]>): string {
+  // Check all query values for language slugs
+  const queryValues = Object.values(query).flat()
+  
+  // Find if there's a language slug in the query values
+  for (const value of queryValues) {
+    if (typeof value === 'string') {
+      const mapping = Object.values(LANGUAGE_MAPPINGS).find((m) =>
+        m.languageSlugs.includes(value)
+      )
+      
+      if (mapping) {
+        // Found a language slug, return the watch path with that language
+        return `/watch/${value}`
+      }
+    }
+  }
+  
+  // No language slug found, return /watch
+  return '/watch'
+}
+
 export function HeaderTabButtons(): ReactElement {
   const { strategies, journeys } = useFlags()
   const { t } = useTranslation('apps-watch')
   const router = useRouter()
+  console.log('>>>>>>> router', {router})
+  const videosLink = router?.query ? getVideosLink(router.query) : '/watch'
 
   const headerItems = compact([
     strategies
@@ -38,7 +69,7 @@ export function HeaderTabButtons(): ReactElement {
           href: '/journeys'
         }
       : undefined,
-    { label: t('Videos', { lng: 'en' }), icon: <Play1Icon />, href: '/watch' }
+    { label: t('Videos', { lng: 'en' }), icon: <Play1Icon />, href: videosLink }
   ])
 
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)

--- a/apps/watch/src/components/Header/HeaderTabButtons/HeaderTabButtons.tsx
+++ b/apps/watch/src/components/Header/HeaderTabButtons/HeaderTabButtons.tsx
@@ -36,14 +36,14 @@ function getVideosLink(query: Record<string, string | string[]>): string {
       const mapping = Object.values(LANGUAGE_MAPPINGS).find((m) =>
         m.languageSlugs.includes(cleanValue)
       )
-      
+
       if (mapping) {
         // Found a language slug, return the watch path with that language
         return `/watch/${cleanValue}`
       }
     }
   }
-  
+
   // No language slug found, return /watch
   return '/watch'
 }
@@ -52,7 +52,9 @@ export function HeaderTabButtons(): ReactElement {
   const { strategies, journeys } = useFlags()
   const { t } = useTranslation('apps-watch')
   const router = useRouter()
-  const videosLink = router?.query ? getVideosLink(router.query as Record<string, string | string[]>) : '/watch'
+  const videosLink = router?.query
+    ? getVideosLink(router.query as Record<string, string | string[]>)
+    : '/watch'
 
   const headerItems = compact([
     strategies

--- a/apps/watch/src/components/NewVideoContentPage/VideoContentHero/ContentHeader/ContentHeader.spec.tsx
+++ b/apps/watch/src/components/NewVideoContentPage/VideoContentHero/ContentHeader/ContentHeader.spec.tsx
@@ -59,7 +59,7 @@ describe('ContentHeader', () => {
     expect(header).toBeInTheDocument()
 
     const link = screen.getByRole('link')
-    expect(link).toHaveAttribute('href', '/watch/russian.html')
+    expect(link).toHaveAttribute('href', '/watch/russian')
   })
 
   it('renders the header with a logo linking to /watch when router is not available (SSR)', () => {

--- a/apps/watch/src/components/NewVideoContentPage/VideoContentHero/ContentHeader/ContentHeader.spec.tsx
+++ b/apps/watch/src/components/NewVideoContentPage/VideoContentHero/ContentHeader/ContentHeader.spec.tsx
@@ -1,6 +1,7 @@
 import { MockedProvider } from '@apollo/client/testing'
 import { userEvent } from '@storybook/test'
 import { render, screen, waitFor } from '@testing-library/react'
+import { useRouter } from 'next/router'
 
 import {
   PlayerProvider,
@@ -11,12 +12,62 @@ import { videos } from '../../../Videos/__generated__/testData'
 
 import { ContentHeader } from './ContentHeader'
 
+// Mock next/router
+jest.mock('next/router', () => ({
+  useRouter: jest.fn()
+}))
+
 describe('ContentHeader', () => {
+  const mockUseRouter = useRouter as jest.Mock
+
   beforeEach(() => {
     jest.clearAllMocks()
+    // Default mock for useRouter
+    mockUseRouter.mockReturnValue({
+      pathname: '/watch',
+      asPath: '/watch'
+    })
   })
 
-  it('renders the header with a logo', () => {
+  it('renders the header with a logo for default path', () => {
+    render(
+      <VideoProvider value={{ content: videos[0] }}>
+        <ContentHeader />
+      </VideoProvider>
+    )
+
+    const header = screen.getByRole('img', { name: 'JesusFilm Project' })
+    expect(header).toBeInTheDocument()
+
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', '/watch')
+  })
+
+  it('renders the header with a logo linking to language-specific page for inner pages with language slug', () => {
+    mockUseRouter.mockReturnValue({
+      pathname: '/ru/watch/jesus-calms-the-storm.html/russian.html',
+      asPath: '/watch/jesus-calms-the-storm.html/russian.html'
+    })
+
+    render(
+      <VideoProvider value={{ content: videos[0] }}>
+        <ContentHeader />
+      </VideoProvider>
+    )
+
+    const header = screen.getByRole('img', { name: 'JesusFilm Project' })
+    expect(header).toBeInTheDocument()
+
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', '/watch/russian.html')
+  })
+
+  it('renders the header with a logo linking to /watch when router is not available (SSR)', () => {
+    mockUseRouter.mockReturnValue({
+      pathname: '/watch/some-video.html',
+      asPath: undefined
+    })
+
     render(
       <VideoProvider value={{ content: videos[0] }}>
         <ContentHeader />

--- a/apps/watch/src/components/NewVideoContentPage/VideoContentHero/ContentHeader/ContentHeader.tsx
+++ b/apps/watch/src/components/NewVideoContentPage/VideoContentHero/ContentHeader/ContentHeader.tsx
@@ -14,20 +14,20 @@ import { AudioLanguageButton } from '../../../VideoContentPage/AudioLanguageButt
  */
 function getLogoLink(pathname: string): string {
   const segments = pathname.split('/').filter(Boolean)
-  
+
   // Find if there's a language slug in the path
   for (const segment of segments) {
     const cleanSegment = segment.replace(/\.html$/, '')
     const mapping = Object.values(LANGUAGE_MAPPINGS).find((m) =>
       m.languageSlugs.includes(cleanSegment)
     )
-    
+
     if (mapping) {
       // Found a language slug, return the watch path with that language
       return `/watch/${cleanSegment}`
     }
   }
-  
+
   // No language slug found, return /watch
   return '/watch'
 }

--- a/apps/watch/src/components/NewVideoContentPage/VideoContentHero/ContentHeader/ContentHeader.tsx
+++ b/apps/watch/src/components/NewVideoContentPage/VideoContentHero/ContentHeader/ContentHeader.tsx
@@ -17,13 +17,14 @@ function getLogoLink(pathname: string): string {
   
   // Find if there's a language slug in the path
   for (const segment of segments) {
+    const cleanSegment = segment.replace(/\.html$/, '')
     const mapping = Object.values(LANGUAGE_MAPPINGS).find((m) =>
-      m.languageSlugs.includes(segment)
+      m.languageSlugs.includes(cleanSegment)
     )
     
     if (mapping) {
       // Found a language slug, return the watch path with that language
-      return `/watch/${segment}`
+      return `/watch/${cleanSegment}`
     }
   }
   

--- a/apps/watch/src/components/NewVideoContentPage/VideoContentHero/ContentHeader/ContentHeader.tsx
+++ b/apps/watch/src/components/NewVideoContentPage/VideoContentHero/ContentHeader/ContentHeader.tsx
@@ -1,14 +1,42 @@
 import Image from 'next/image'
 import NextLink from 'next/link'
+import { useRouter } from 'next/router'
 import { ReactElement } from 'react'
 
+import { LANGUAGE_MAPPINGS } from '../../../../libs/localeMapping'
 import { usePlayer } from '../../../../libs/playerContext/PlayerContext'
 import { AudioLanguageButton } from '../../../VideoContentPage/AudioLanguageButton'
+
+/**
+ * Determines the correct logo link based on the current URL path.
+ * For inner pages with language slugs, returns /watch/{languageSlug}.html
+ * Otherwise returns /watch
+ */
+function getLogoLink(pathname: string): string {
+  const segments = pathname.split('/').filter(Boolean)
+  
+  // Find if there's a language slug in the path
+  for (const segment of segments) {
+    const mapping = Object.values(LANGUAGE_MAPPINGS).find((m) =>
+      m.languageSlugs.includes(segment)
+    )
+    
+    if (mapping) {
+      // Found a language slug, return the watch path with that language
+      return `/watch/${segment}`
+    }
+  }
+  
+  // No language slug found, return /watch
+  return '/watch'
+}
 
 export function ContentHeader(): ReactElement {
   const {
     state: { play, active, loading }
   } = usePlayer()
+  const router = useRouter()
+  const logoLink = router?.asPath ? getLogoLink(router.asPath) : '/watch'
   const visible = !play || active || loading
   return (
     <div
@@ -20,7 +48,7 @@ export function ContentHeader(): ReactElement {
           visible ? 'opacity-100' : 'opacity-0'
         } ${visible ? 'delay-0' : 'delay-[2000ms]'}`}
     >
-      <NextLink href="/watch">
+      <NextLink href={logoLink}>
         <Image
           src="/watch/assets/jesusfilm-sign.svg"
           alt="JesusFilm Project"

--- a/apps/watch/src/components/VideosPage/FilterList/FilterList.spec.tsx
+++ b/apps/watch/src/components/VideosPage/FilterList/FilterList.spec.tsx
@@ -36,7 +36,8 @@ describe('FilterList', () => {
   const useAlgoliaRouter: FilterParams = {
     query: null,
     languageId: null,
-    subtitleId: null
+    subtitleId: null,
+    languageEnglishName: null
   }
 
   beforeEach(() => {

--- a/apps/watch/src/libs/algolia/useAlgoliaRouter/useAlgoliaRouter.ts
+++ b/apps/watch/src/libs/algolia/useAlgoliaRouter/useAlgoliaRouter.ts
@@ -14,7 +14,11 @@ export function extractQueryParams(url: string): FilterParams {
   const query = params.get('query')
   const languageId = params.get('menu[languageId]')
   const subtitleId = params.get('menu[subtitles]')
-  const languageEnglishName = params.get('languageEnglishName')
+  
+  // Fix: Handle the correct parameter format for languageEnglishName
+  const languageEnglishName = params.get('refinementList[languageEnglishName][0]') || 
+                             params.get('languageEnglishName') // fallback for backward compatibility
+  
   return { query, languageId, subtitleId, languageEnglishName }
 }
 

--- a/apps/watch/src/libs/algolia/useAlgoliaRouter/useAlgoliaRouter.ts
+++ b/apps/watch/src/libs/algolia/useAlgoliaRouter/useAlgoliaRouter.ts
@@ -6,6 +6,7 @@ export interface FilterParams {
   query: string | null
   languageId: string | null
   subtitleId: string | null
+  languageEnglishName: string | null
 }
 
 export function extractQueryParams(url: string): FilterParams {
@@ -13,15 +14,20 @@ export function extractQueryParams(url: string): FilterParams {
   const query = params.get('query')
   const languageId = params.get('menu[languageId]')
   const subtitleId = params.get('menu[subtitles]')
-  return { query, languageId, subtitleId }
+  const languageEnglishName = params.get('languageEnglishName')
+  return { query, languageId, subtitleId, languageEnglishName }
 }
 
-export function useAlgoliaRouter(): FilterParams {
+export function useAlgoliaRouter(languageEnglishName?: string): FilterParams {
   const router = useRouter()
   const decodedUrl = decodeURIComponent(router?.asPath ?? '')
-  const { query, languageId, subtitleId } = extractQueryParams(decodedUrl)
+  const { query, languageId, subtitleId, languageEnglishName: urlLanguageEnglishName } = extractQueryParams(decodedUrl)
+  
+  // Use provided parameter or fall back to URL parameter
+  const finalLanguageEnglishName = languageEnglishName ?? urlLanguageEnglishName
+  
   const hasQueryParams =
-    query != null || languageId != null || subtitleId != null
+    query != null || languageId != null || subtitleId != null || finalLanguageEnglishName != null
 
   const { refresh } = useInstantSearch()
   useEffect(() => {
@@ -32,5 +38,5 @@ export function useAlgoliaRouter(): FilterParams {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  return { query, languageId, subtitleId }
+  return { query, languageId, subtitleId, languageEnglishName: finalLanguageEnglishName }
 }

--- a/apps/watch/src/libs/algolia/useAlgoliaRouter/useAlgoliaRouter.ts
+++ b/apps/watch/src/libs/algolia/useAlgoliaRouter/useAlgoliaRouter.ts
@@ -14,24 +14,33 @@ export function extractQueryParams(url: string): FilterParams {
   const query = params.get('query')
   const languageId = params.get('menu[languageId]')
   const subtitleId = params.get('menu[subtitles]')
-  
+
   // Fix: Handle the correct parameter format for languageEnglishName
-  const languageEnglishName = params.get('refinementList[languageEnglishName][0]') || 
-                             params.get('languageEnglishName') // fallback for backward compatibility
-  
+  const languageEnglishName =
+    params.get('refinementList[languageEnglishName][0]') ||
+    params.get('languageEnglishName') // fallback for backward compatibility
+
   return { query, languageId, subtitleId, languageEnglishName }
 }
 
 export function useAlgoliaRouter(languageEnglishName?: string): FilterParams {
   const router = useRouter()
   const decodedUrl = decodeURIComponent(router?.asPath ?? '')
-  const { query, languageId, subtitleId, languageEnglishName: urlLanguageEnglishName } = extractQueryParams(decodedUrl)
-  
+  const {
+    query,
+    languageId,
+    subtitleId,
+    languageEnglishName: urlLanguageEnglishName
+  } = extractQueryParams(decodedUrl)
+
   // Use provided parameter or fall back to URL parameter
   const finalLanguageEnglishName = languageEnglishName ?? urlLanguageEnglishName
-  
+
   const hasQueryParams =
-    query != null || languageId != null || subtitleId != null || finalLanguageEnglishName != null
+    query != null ||
+    languageId != null ||
+    subtitleId != null ||
+    finalLanguageEnglishName != null
 
   const { refresh } = useInstantSearch()
   useEffect(() => {
@@ -42,5 +51,10 @@ export function useAlgoliaRouter(languageEnglishName?: string): FilterParams {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  return { query, languageId, subtitleId, languageEnglishName: finalLanguageEnglishName }
+  return {
+    query,
+    languageId,
+    subtitleId,
+    languageEnglishName: finalLanguageEnglishName
+  }
 }

--- a/apps/watch/src/libs/localeMapping/languages.json
+++ b/apps/watch/src/libs/localeMapping/languages.json
@@ -1,0 +1,36078 @@
+{
+  "languages": [
+    {
+      "slug": "san-andres-islander-creole",
+      "bcp47": "icr",
+      "iso3": "icr",
+      "id": "184519",
+      "name": [
+        {
+          "value": "San Andres Islander Creole",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "danish",
+      "bcp47": "da",
+      "iso3": "dan",
+      "id": "4454",
+      "name": [
+        {
+          "value": "Dansk",
+          "primary": true,
+          "language": {
+            "id": "4454"
+          }
+        },
+        {
+          "value": "Danish",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chachi",
+      "bcp47": "cbi",
+      "iso3": "cbi",
+      "id": "4501",
+      "name": [
+        {
+          "value": "Chachi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "estonian",
+      "bcp47": "et",
+      "iso3": "ekk",
+      "id": "4601",
+      "name": [
+        {
+          "value": "Eesti Keel",
+          "primary": true,
+          "language": {
+            "id": "4601"
+          }
+        },
+        {
+          "value": "Estonian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gofa",
+      "bcp47": "gof",
+      "iso3": "gof",
+      "id": "4634",
+      "name": [
+        {
+          "value": "Gofa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gamo",
+      "bcp47": "gmv",
+      "iso3": "gmv",
+      "id": "4635",
+      "name": [
+        {
+          "value": "Gamo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sidamo",
+      "bcp47": null,
+      "iso3": "sid",
+      "id": "4644",
+      "name": [
+        {
+          "value": "Sidámo 'Afó",
+          "primary": true,
+          "language": {
+            "id": "4644"
+          }
+        },
+        {
+          "value": "Sidamo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kambaata",
+      "bcp47": "ktb",
+      "iso3": "ktb",
+      "id": "4655",
+      "name": [
+        {
+          "value": "Kambaata",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "koorete",
+      "bcp47": "kqy",
+      "iso3": "kqy",
+      "id": "4656",
+      "name": [
+        {
+          "value": "Koorete",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hadiyya",
+      "bcp47": "hdy",
+      "iso3": "hdy",
+      "id": "4667",
+      "name": [
+        {
+          "value": "Hadiyya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gurage-west",
+      "bcp47": "sgw",
+      "iso3": "sgw",
+      "id": "4676",
+      "name": [
+        {
+          "value": "Gurage, West",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gurage-sodo",
+      "bcp47": "gru",
+      "iso3": "gru",
+      "id": "4684",
+      "name": [
+        {
+          "value": "Gurage, Sodo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dirasha",
+      "bcp47": "gdl",
+      "iso3": "gdl",
+      "id": "4694",
+      "name": [
+        {
+          "value": "Dirasha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "oromo-west-central",
+      "bcp47": "gaz",
+      "iso3": "gaz",
+      "id": "4695",
+      "name": [
+        {
+          "value": "Oromo, West-Central",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "guji",
+      "bcp47": null,
+      "iso3": "gax",
+      "id": "4699",
+      "name": [
+        {
+          "value": "Guji",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "oromo-borana-arsi-guji",
+      "bcp47": "gax",
+      "iso3": "gax",
+      "id": "4700",
+      "name": [
+        {
+          "value": "Oromo, Borana-Arsi-Guji",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "wolaytta",
+      "bcp47": "wal",
+      "iso3": "wal",
+      "id": "4734",
+      "name": [
+        {
+          "value": "Wolaytta",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "suri-tirmaga-chai",
+      "bcp47": "suq",
+      "iso3": "suq",
+      "id": "4739",
+      "name": [
+        {
+          "value": "Suri, Tirmaga-Chai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nuer",
+      "bcp47": "nus",
+      "iso3": "nus",
+      "id": "4752",
+      "name": [
+        {
+          "value": "Nuer",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "magahi",
+      "bcp47": "mag",
+      "iso3": "mag",
+      "id": "6186",
+      "name": [
+        {
+          "value": "मगही",
+          "primary": true,
+          "language": {
+            "id": "6186"
+          }
+        },
+        {
+          "value": "Magahi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "maithili",
+      "bcp47": "mai",
+      "iso3": "mai",
+      "id": "6199",
+      "name": [
+        {
+          "value": "मैथिली",
+          "primary": true,
+          "language": {
+            "id": "6199"
+          }
+        },
+        {
+          "value": "Maithili",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "marwari",
+      "bcp47": "rwr",
+      "iso3": "rwr",
+      "id": "6209",
+      "name": [
+        {
+          "value": "Marwari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mal-paharia",
+      "bcp47": "mkb",
+      "iso3": "mkb",
+      "id": "6210",
+      "name": [
+        {
+          "value": "Mal Paharia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sauria-paharia",
+      "bcp47": null,
+      "iso3": "mjt",
+      "id": "6222",
+      "name": [
+        {
+          "value": "Sauria Paharia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mandeali",
+      "bcp47": "mjl",
+      "iso3": "mjl",
+      "id": "6242",
+      "name": [
+        {
+          "value": "Mandeali",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "limbu",
+      "bcp47": "lif",
+      "iso3": "lif",
+      "id": "6259",
+      "name": [
+        {
+          "value": "Limbu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ladakhi",
+      "bcp47": "lbj",
+      "iso3": "lbj",
+      "id": "6271",
+      "name": [
+        {
+          "value": "ལ་དྭགས་སྐད།",
+          "primary": true,
+          "language": {
+            "id": "6271"
+          }
+        },
+        {
+          "value": "Ladakhi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gedeo",
+      "bcp47": "drs",
+      "iso3": "drs",
+      "id": "4704",
+      "name": [
+        {
+          "value": "Gedeo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malagasy-northern-betsimisaraka",
+      "bcp47": "mg-bmm",
+      "iso3": "bmm",
+      "id": "26664",
+      "name": [
+        {
+          "value": "Fiteny Malagasy",
+          "primary": true,
+          "language": {
+            "id": "26664"
+          }
+        },
+        {
+          "value": "Malagasy, Northern Betsimisaraka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "imbongu",
+      "bcp47": "imo",
+      "iso3": "imo",
+      "id": "12040",
+      "name": [
+        {
+          "value": "Imbongu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kandawo",
+      "bcp47": "gam",
+      "iso3": "gam",
+      "id": "12151",
+      "name": [
+        {
+          "value": "Kandawo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "guarani-paraguayan",
+      "bcp47": "gug",
+      "iso3": "gug",
+      "id": "12327",
+      "name": [
+        {
+          "value": "Avañe'ẽ",
+          "primary": true,
+          "language": {
+            "id": "12327"
+          }
+        },
+        {
+          "value": "Guarani, Paraguayan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kankanaey",
+      "bcp47": "kne",
+      "iso3": "kne",
+      "id": "12682",
+      "name": [
+        {
+          "value": "Kankanaey",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "awutu",
+      "bcp47": null,
+      "iso3": "afu",
+      "id": "19468",
+      "name": [
+        {
+          "value": "Awutu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "western-garame",
+      "bcp47": null,
+      "iso3": "acz",
+      "id": "179190",
+      "name": [
+        {
+          "value": "Western Garame",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dawro",
+      "bcp47": "dwr",
+      "iso3": "dwr",
+      "id": "4633",
+      "name": [
+        {
+          "value": "Dawro",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kinaray-a",
+      "bcp47": "krj",
+      "iso3": "krj",
+      "id": "12672",
+      "name": [
+        {
+          "value": "Kinaray-A",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kiribati",
+      "bcp47": "gil",
+      "iso3": "gil",
+      "id": "4812",
+      "name": [
+        {
+          "value": "Taetae Ni Kiribati",
+          "primary": true,
+          "language": {
+            "id": "4812"
+          }
+        },
+        {
+          "value": "Kiribati",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "finnish",
+      "bcp47": "fi",
+      "iso3": "fin",
+      "id": "4820",
+      "name": [
+        {
+          "value": "Suomi",
+          "primary": true,
+          "language": {
+            "id": "4820"
+          }
+        },
+        {
+          "value": "Finnish",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "swedish",
+      "bcp47": "sv",
+      "iso3": "swe",
+      "id": "4823",
+      "name": [
+        {
+          "value": "Svenska",
+          "primary": true,
+          "language": {
+            "id": "4823"
+          }
+        },
+        {
+          "value": "Swedish",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "karelian",
+      "bcp47": "krl",
+      "iso3": "krl",
+      "id": "4835",
+      "name": [
+        {
+          "value": "Karjalan Kieli",
+          "primary": true,
+          "language": {
+            "id": "4835"
+          }
+        },
+        {
+          "value": "Karelian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tahitian",
+      "bcp47": "ty",
+      "iso3": "tah",
+      "id": "4950",
+      "name": [
+        {
+          "value": "Reo Mā'ohi",
+          "primary": true,
+          "language": {
+            "id": "4950"
+          }
+        },
+        {
+          "value": "Tahitian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tsogo",
+      "bcp47": "tsv",
+      "iso3": "tsv",
+      "id": "5019",
+      "name": [
+        {
+          "value": "Tsogo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mansoanka",
+      "bcp47": "msw",
+      "iso3": "msw",
+      "id": "5038",
+      "name": [
+        {
+          "value": "Mansoanka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mandinka",
+      "bcp47": "mnk",
+      "iso3": "mnk",
+      "id": "5040",
+      "name": [
+        {
+          "value": "لغة مندنكا",
+          "primary": true,
+          "language": {
+            "id": "5040"
+          }
+        },
+        {
+          "value": "Mandinka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mankanya",
+      "bcp47": "knf",
+      "iso3": "knf",
+      "id": "5042",
+      "name": [
+        {
+          "value": "Mankanya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fulfulde-pulaar",
+      "bcp47": "fuc-x-Fulfulde",
+      "iso3": "fuc",
+      "id": "5048",
+      "name": [
+        {
+          "value": "Fulfulde, Pulaar",
+          "primary": true,
+          "language": {
+            "id": "5048"
+          }
+        },
+        {
+          "value": "Fulfulde, Pulaar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "serere-sine",
+      "bcp47": "srr",
+      "iso3": "srr",
+      "id": "5058",
+      "name": [
+        {
+          "value": "Seereer",
+          "primary": true,
+          "language": {
+            "id": "5058"
+          }
+        },
+        {
+          "value": "Serere-Sine",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "crioulo-upper-guinea",
+      "bcp47": "pov",
+      "iso3": "pov",
+      "id": "5059",
+      "name": [
+        {
+          "value": "Crioulo, Upper Guinea",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "osetin",
+      "bcp47": "os",
+      "iso3": "oss",
+      "id": "5089",
+      "name": [
+        {
+          "value": "ирон ӕвзаг",
+          "primary": true,
+          "language": {
+            "id": "5089"
+          }
+        },
+        {
+          "value": "Osetin",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "georgian",
+      "bcp47": "ka",
+      "iso3": "kat",
+      "id": "5112",
+      "name": [
+        {
+          "value": "ქართული",
+          "primary": true,
+          "language": {
+            "id": "5112"
+          }
+        },
+        {
+          "value": "Georgian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ahanta",
+      "bcp47": "aha",
+      "iso3": "aha",
+      "id": "5170",
+      "name": [
+        {
+          "value": "Ahanta",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ntcham",
+      "bcp47": "bud",
+      "iso3": "bud",
+      "id": "5171",
+      "name": [
+        {
+          "value": "Ntcham",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bimoba",
+      "bcp47": "bim",
+      "iso3": "bim",
+      "id": "5174",
+      "name": [
+        {
+          "value": "Bimoba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fulfulde-maasina",
+      "bcp47": "ffm",
+      "iso3": "ffm",
+      "id": "5183",
+      "name": [
+        {
+          "value": "Fulfulde",
+          "primary": true,
+          "language": {
+            "id": "5183"
+          }
+        },
+        {
+          "value": "Fulfulde, Maasina",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gonja",
+      "bcp47": "gjn",
+      "iso3": "gjn",
+      "id": "5187",
+      "name": [
+        {
+          "value": "Gonja",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dagaari-southern",
+      "bcp47": "dga",
+      "iso3": "dga",
+      "id": "5188",
+      "name": [
+        {
+          "value": "Dagaari, Southern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sisaala-tumulung",
+      "bcp47": "sil",
+      "iso3": "sil",
+      "id": "5206",
+      "name": [
+        {
+          "value": "Sisaala, Tumulung",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pasaale",
+      "bcp47": null,
+      "iso3": "sig",
+      "id": "5209",
+      "name": [
+        {
+          "value": "Pasaale",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sehwi",
+      "bcp47": null,
+      "iso3": "sfw",
+      "id": "5210",
+      "name": [
+        {
+          "value": "Sehwi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nzema",
+      "bcp47": "nzi",
+      "iso3": "nzi",
+      "id": "5213",
+      "name": [
+        {
+          "value": "Nzema",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chumburung",
+      "bcp47": "ncu",
+      "iso3": "ncu",
+      "id": "5232",
+      "name": [
+        {
+          "value": "Chumburung",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mampruli",
+      "bcp47": "maw",
+      "iso3": "maw",
+      "id": "5240",
+      "name": [
+        {
+          "value": "Mampruli",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lelemi",
+      "bcp47": "lef",
+      "iso3": "lef",
+      "id": "5251",
+      "name": [
+        {
+          "value": "Lelemi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kusaal-eastern",
+      "bcp47": "kus",
+      "iso3": "kus",
+      "id": "5261",
+      "name": [
+        {
+          "value": "Kusaal, Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "wali",
+      "bcp47": "wlx",
+      "iso3": "wlx",
+      "id": "5276",
+      "name": [
+        {
+          "value": "Wali",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "vagla",
+      "bcp47": "vag",
+      "iso3": "vag",
+      "id": "5279",
+      "name": [
+        {
+          "value": "Vagla",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fante",
+      "bcp47": "fat",
+      "iso3": "aka",
+      "id": "5288",
+      "name": [
+        {
+          "value": "Fante",
+          "primary": true,
+          "language": {
+            "id": "5288"
+          }
+        },
+        {
+          "value": "Fante",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "akposo",
+      "bcp47": "kpo",
+      "iso3": "kpo",
+      "id": "5296",
+      "name": [
+        {
+          "value": "Akposo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "konni",
+      "bcp47": "kma",
+      "iso3": "kma",
+      "id": "5303",
+      "name": [
+        {
+          "value": "Konni",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hanga",
+      "bcp47": "hag",
+      "iso3": "hag",
+      "id": "5319",
+      "name": [
+        {
+          "value": "Hanga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ewe",
+      "bcp47": "ee",
+      "iso3": "ewe",
+      "id": "5331",
+      "name": [
+        {
+          "value": "Èʋegbe",
+          "primary": true,
+          "language": {
+            "id": "5331"
+          }
+        },
+        {
+          "value": "Ewe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "adele",
+      "bcp47": "ade",
+      "iso3": "ade",
+      "id": "5338",
+      "name": [
+        {
+          "value": "Adele",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cakchiquel-western",
+      "bcp47": "cak",
+      "iso3": "cak",
+      "id": "5392",
+      "name": [
+        {
+          "value": "Cakchiquel, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cakchiquel-eastern",
+      "bcp47": null,
+      "iso3": "cak",
+      "id": "5397",
+      "name": [
+        {
+          "value": "Cakchiquel, Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mam-central",
+      "bcp47": "mam-x-Central",
+      "iso3": "mam",
+      "id": "5408",
+      "name": [
+        {
+          "value": "Mam, Central",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mam-tajumulco",
+      "bcp47": "mam-x-Tajumulco",
+      "iso3": "mam",
+      "id": "5410",
+      "name": [
+        {
+          "value": "Mam, Tajumulco",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ixil-nebaj",
+      "bcp47": "ixl",
+      "iso3": "ixl",
+      "id": "5420",
+      "name": [
+        {
+          "value": "Ixil, Nebaj",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quiche-west-central",
+      "bcp47": null,
+      "iso3": "quc",
+      "id": "5425",
+      "name": [
+        {
+          "value": "Qhichwa",
+          "primary": true,
+          "language": {
+            "id": "5425"
+          }
+        },
+        {
+          "value": "Quiche, West Central",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "huli",
+      "bcp47": "hui",
+      "iso3": "hui",
+      "id": "12053",
+      "name": [
+        {
+          "value": "Huli",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "qena",
+      "bcp47": null,
+      "iso3": "alw",
+      "id": "156595",
+      "name": [
+        {
+          "value": "Qena",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "shilluk",
+      "bcp47": "shk",
+      "iso3": "shk",
+      "id": "13848",
+      "name": [
+        {
+          "value": "Shilluk",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mbula",
+      "bcp47": null,
+      "iso3": "mbu",
+      "id": "9490",
+      "name": [
+        {
+          "value": "Mbula",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ikizu",
+      "bcp47": "ikz",
+      "iso3": "ikz",
+      "id": "14188",
+      "name": [
+        {
+          "value": "Ikizu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ndamba",
+      "bcp47": "ndj",
+      "iso3": "ndj",
+      "id": "14117",
+      "name": [
+        {
+          "value": "Ndamba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "konongo-2",
+      "bcp47": null,
+      "iso3": "kcz",
+      "id": "14165",
+      "name": [
+        {
+          "value": "Konongo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kituba",
+      "bcp47": "ktu",
+      "iso3": "ktu",
+      "id": "15639",
+      "name": [
+        {
+          "value": "Kituba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "csango",
+      "bcp47": "hu",
+      "iso3": "hun",
+      "id": "108102",
+      "name": [
+        {
+          "value": "Csango",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "huasteco-veracruz",
+      "bcp47": "hus",
+      "iso3": "hus",
+      "id": "8272",
+      "name": [
+        {
+          "value": "Huasteco, Veracruz",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "acateco",
+      "bcp47": null,
+      "iso3": "knj",
+      "id": "5428",
+      "name": [
+        {
+          "value": "Acateco",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "uspanteco",
+      "bcp47": "usp",
+      "iso3": "usp",
+      "id": "5431",
+      "name": [
+        {
+          "value": "Uspanteco",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cakchiquel-south-central",
+      "bcp47": "cak",
+      "iso3": "cak",
+      "id": "5437",
+      "name": [
+        {
+          "value": "Cakchiquel, South Central",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "achi-rabinal",
+      "bcp47": "acr",
+      "iso3": "acr",
+      "id": "5441",
+      "name": [
+        {
+          "value": "Achi, Rabinal",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "susu",
+      "bcp47": "sus",
+      "iso3": "sus",
+      "id": "5470",
+      "name": [
+        {
+          "value": "Susu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kissi-northern",
+      "bcp47": "kqs",
+      "iso3": "kqs",
+      "id": "5481",
+      "name": [
+        {
+          "value": "Kissi, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "warao",
+      "bcp47": "wba",
+      "iso3": "wba",
+      "id": "5500",
+      "name": [
+        {
+          "value": "Warao",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hindi-caribbean",
+      "bcp47": "hns",
+      "iso3": "hns",
+      "id": "5511",
+      "name": [
+        {
+          "value": "Hindi, Caribbean",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "miskito",
+      "bcp47": "miq",
+      "iso3": "miq",
+      "id": "5527",
+      "name": [
+        {
+          "value": "Miskito",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "serbian",
+      "bcp47": "sr",
+      "iso3": "srp",
+      "id": "5541",
+      "name": [
+        {
+          "value": "Српски",
+          "primary": true,
+          "language": {
+            "id": "5541"
+          }
+        },
+        {
+          "value": "Serbian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "slovak",
+      "bcp47": "sk",
+      "iso3": "slk",
+      "id": "5545",
+      "name": [
+        {
+          "value": "Slovenčina",
+          "primary": true,
+          "language": {
+            "id": "5545"
+          }
+        },
+        {
+          "value": "Slovak",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "romanian",
+      "bcp47": "ro",
+      "iso3": "ron",
+      "id": "5546",
+      "name": [
+        {
+          "value": "Română",
+          "primary": true,
+          "language": {
+            "id": "5546"
+          }
+        },
+        {
+          "value": "Romanian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "icelandic",
+      "bcp47": "is",
+      "iso3": "isl",
+      "id": "5563",
+      "name": [
+        {
+          "value": "Íslenska",
+          "primary": true,
+          "language": {
+            "id": "5563"
+          }
+        },
+        {
+          "value": "Icelandic",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "awadhi",
+      "bcp47": "awa",
+      "iso3": "awa",
+      "id": "5603",
+      "name": [
+        {
+          "value": "Awadhi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "braj-bhasha",
+      "bcp47": "bra",
+      "iso3": "bra",
+      "id": "5611",
+      "name": [
+        {
+          "value": "Braj Bhasha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tetun-dili",
+      "bcp47": null,
+      "iso3": "tdt",
+      "id": "17224",
+      "name": [
+        {
+          "value": "Tetun Dili",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kangri",
+      "bcp47": "xnr",
+      "iso3": "xnr",
+      "id": "5625",
+      "name": [
+        {
+          "value": "Kangri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "churahi",
+      "bcp47": null,
+      "iso3": "cdj",
+      "id": "5647",
+      "name": [
+        {
+          "value": "Churahi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "adygey",
+      "bcp47": "ady",
+      "iso3": "ady",
+      "id": "20522",
+      "name": [
+        {
+          "value": "Адыгэбзэ",
+          "primary": true,
+          "language": {
+            "id": "20522"
+          }
+        },
+        {
+          "value": "Adygey",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chodri",
+      "bcp47": "cdi",
+      "iso3": "cdi",
+      "id": "5648",
+      "name": [
+        {
+          "value": "Chodri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chambeali",
+      "bcp47": "cdh",
+      "iso3": "cdh",
+      "id": "5652",
+      "name": [
+        {
+          "value": "Chambeali",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "balochi-eastern",
+      "bcp47": "bgp",
+      "iso3": "bgp",
+      "id": "5700",
+      "name": [
+        {
+          "value": "بلوچی",
+          "primary": true,
+          "language": {
+            "id": "5700"
+          }
+        },
+        {
+          "value": "Balochi, Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "wagdi",
+      "bcp47": "wbr",
+      "iso3": "wbr",
+      "id": "5766",
+      "name": [
+        {
+          "value": "Wagdi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "waddar",
+      "bcp47": "wbq",
+      "iso3": "wbq",
+      "id": "5767",
+      "name": [
+        {
+          "value": "Waddar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "varli",
+      "bcp47": null,
+      "iso3": "vav",
+      "id": "5771",
+      "name": [
+        {
+          "value": "Varli",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "vasavi",
+      "bcp47": "vas",
+      "iso3": "vas",
+      "id": "5772",
+      "name": [
+        {
+          "value": "Vasavi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tulu",
+      "bcp47": "tcy",
+      "iso3": "tcy",
+      "id": "5829",
+      "name": [
+        {
+          "value": "ತುಳು ಬಾಸೆ",
+          "primary": true,
+          "language": {
+            "id": "5829"
+          }
+        },
+        {
+          "value": "Tulu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tamil",
+      "bcp47": "ta",
+      "iso3": "tam",
+      "id": "5871",
+      "name": [
+        {
+          "value": "தமிழ்",
+          "primary": true,
+          "language": {
+            "id": "5871"
+          }
+        },
+        {
+          "value": "Tamil",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tamang-eastern",
+      "bcp47": "taj",
+      "iso3": "taj",
+      "id": "5872",
+      "name": [
+        {
+          "value": "तामाङ",
+          "primary": true,
+          "language": {
+            "id": "5872"
+          }
+        },
+        {
+          "value": "Tamang, Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "saraiki",
+      "bcp47": "skr",
+      "iso3": "skr",
+      "id": "5907",
+      "name": [
+        {
+          "value": "سرائیکی",
+          "primary": true,
+          "language": {
+            "id": "5907"
+          }
+        },
+        {
+          "value": "Saraiki",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "shina",
+      "bcp47": null,
+      "iso3": "scl",
+      "id": "5918",
+      "name": [
+        {
+          "value": "Shina",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "saurashtra",
+      "bcp47": "saz",
+      "iso3": "saz",
+      "id": "5920",
+      "name": [
+        {
+          "value": "Saurashtra",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "rawang",
+      "bcp47": "raw",
+      "iso3": "raw",
+      "id": "5930",
+      "name": [
+        {
+          "value": "Rawang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "rabha",
+      "bcp47": "rah",
+      "iso3": "rah",
+      "id": "5934",
+      "name": [
+        {
+          "value": "Rabha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mirgan",
+      "bcp47": "zrg",
+      "iso3": "zrg",
+      "id": "5935",
+      "name": [
+        {
+          "value": "Mirgan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chin-paite",
+      "bcp47": "pck",
+      "iso3": "pck",
+      "id": "5961",
+      "name": [
+        {
+          "value": "Chin, Paite",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tangshang-shecyu-cyamcyang",
+      "bcp47": "nst",
+      "iso3": "nst",
+      "id": "6007",
+      "name": [
+        {
+          "value": "Tangshang, Shecyu-Cyamcyang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "naga-tangkhul",
+      "bcp47": "nmf",
+      "iso3": "nmf",
+      "id": "6044",
+      "name": [
+        {
+          "value": "Naga, Tangkhul",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "naga-angami",
+      "bcp47": "njm",
+      "iso3": "njm",
+      "id": "6071",
+      "name": [
+        {
+          "value": "Naga, Angami",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "naga-lotha",
+      "bcp47": "njh",
+      "iso3": "njh",
+      "id": "6079",
+      "name": [
+        {
+          "value": "Naga, Lotha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "newari",
+      "bcp47": "new",
+      "iso3": "new",
+      "id": "6093",
+      "name": [
+        {
+          "value": "नेपाल भाषा",
+          "primary": true,
+          "language": {
+            "id": "6093"
+          }
+        },
+        {
+          "value": "Newari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tharaka",
+      "bcp47": "thk",
+      "iso3": "thk",
+      "id": "20269",
+      "name": [
+        {
+          "value": "Tharaka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "guarani-bolivian-eastern",
+      "bcp47": "gui",
+      "iso3": "gui",
+      "id": "20631",
+      "name": [
+        {
+          "value": "Avañe'ẽ",
+          "primary": true,
+          "language": {
+            "id": "20631"
+          }
+        },
+        {
+          "value": "Guarani, Bolivian, Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "buol",
+      "bcp47": null,
+      "iso3": "blf",
+      "id": "17373",
+      "name": [
+        {
+          "value": "Buol",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "naga-mao",
+      "bcp47": "nbi",
+      "iso3": "nbi",
+      "id": "6110",
+      "name": [
+        {
+          "value": "Naga, Mao",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malvi",
+      "bcp47": "mup",
+      "iso3": "mup",
+      "id": "6171",
+      "name": [
+        {
+          "value": "Malvi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "marathi",
+      "bcp47": "mr",
+      "iso3": "mar",
+      "id": "6174",
+      "name": [
+        {
+          "value": "मराठी",
+          "primary": true,
+          "language": {
+            "id": "6174"
+          }
+        },
+        {
+          "value": "Marathi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chuvash",
+      "bcp47": "cv",
+      "iso3": "chv",
+      "id": "18574",
+      "name": [
+        {
+          "value": "Чӑвашла",
+          "primary": true,
+          "language": {
+            "id": "18574"
+          }
+        },
+        {
+          "value": "Chuvash",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bima",
+      "bcp47": "bhp",
+      "iso3": "bhp",
+      "id": "19537",
+      "name": [
+        {
+          "value": "Nggahi Mbojo",
+          "primary": true,
+          "language": {
+            "id": "19537"
+          }
+        },
+        {
+          "value": "Bima",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "giryama",
+      "bcp47": "nyf",
+      "iso3": "nyf",
+      "id": "20117",
+      "name": [
+        {
+          "value": "Giryama",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "karanga",
+      "bcp47": "sn-kth",
+      "iso3": "sna",
+      "id": "20211",
+      "name": [
+        {
+          "value": "Karanga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "balangao",
+      "bcp47": null,
+      "iso3": "blw",
+      "id": "12808",
+      "name": [
+        {
+          "value": "Balangao",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "balantak",
+      "bcp47": "blz",
+      "iso3": "blz",
+      "id": "97403",
+      "name": [
+        {
+          "value": "Balantak",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bembe",
+      "bcp47": null,
+      "iso3": "bmb",
+      "id": "19571",
+      "name": [
+        {
+          "value": "Bembe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zoque-francisco-leon",
+      "bcp47": "zos",
+      "iso3": "zos",
+      "id": "7988",
+      "name": [
+        {
+          "value": "Zoque, Francisco Leon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zapoteco-isthmus",
+      "bcp47": "zai",
+      "iso3": "zai",
+      "id": "8014",
+      "name": [
+        {
+          "value": "Zapoteco, Isthmus",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kabwa",
+      "bcp47": "cwa",
+      "iso3": "cwa",
+      "id": "14274",
+      "name": [
+        {
+          "value": "Kabwa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kuvi",
+      "bcp47": "kxv",
+      "iso3": "kxv",
+      "id": "6275",
+      "name": [
+        {
+          "value": "Kuvi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kui",
+      "bcp47": "kxu",
+      "iso3": "uki",
+      "id": "6278",
+      "name": [
+        {
+          "value": "Kui",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "koraku",
+      "bcp47": "ksz",
+      "iso3": "ksz",
+      "id": "6282",
+      "name": [
+        {
+          "value": "Koraku",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kashmiri",
+      "bcp47": "ks",
+      "iso3": "kas",
+      "id": "6298",
+      "name": [
+        {
+          "value": "كٲشُر",
+          "primary": true,
+          "language": {
+            "id": "6298"
+          }
+        },
+        {
+          "value": "Kashmiri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kannada",
+      "bcp47": "kn",
+      "iso3": "kan",
+      "id": "6318",
+      "name": [
+        {
+          "value": "ಕನ್ನಡ",
+          "primary": true,
+          "language": {
+            "id": "6318"
+          }
+        },
+        {
+          "value": "Kannada",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kharia",
+      "bcp47": "khr",
+      "iso3": "khr",
+      "id": "6326",
+      "name": [
+        {
+          "value": "Kharia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ahirani",
+      "bcp47": null,
+      "iso3": "ahr",
+      "id": "6330",
+      "name": [
+        {
+          "value": "Ahirani",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kanjari",
+      "bcp47": null,
+      "iso3": "kft",
+      "id": "6362",
+      "name": [
+        {
+          "value": "Kanjari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "korku",
+      "bcp47": "kfq",
+      "iso3": "kfq",
+      "id": "6370",
+      "name": [
+        {
+          "value": "Korku",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "korwa",
+      "bcp47": "kfp",
+      "iso3": "kfp",
+      "id": "6372",
+      "name": [
+        {
+          "value": "Korwa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kinnauri",
+      "bcp47": "kfk",
+      "iso3": "kfk",
+      "id": "6383",
+      "name": [
+        {
+          "value": "Kinnauri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "koya",
+      "bcp47": "kff",
+      "iso3": "kff",
+      "id": "6400",
+      "name": [
+        {
+          "value": "Koya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kukna",
+      "bcp47": "kex",
+      "iso3": "kex",
+      "id": "6414",
+      "name": [
+        {
+          "value": "Kukna",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "juray",
+      "bcp47": "juy",
+      "iso3": "juy",
+      "id": "6425",
+      "name": [
+        {
+          "value": "Juray",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "juang",
+      "bcp47": "jun",
+      "iso3": "jun",
+      "id": "6426",
+      "name": [
+        {
+          "value": "Juang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "irula",
+      "bcp47": "iru",
+      "iso3": "iru",
+      "id": "6440",
+      "name": [
+        {
+          "value": "Irula",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yaqui",
+      "bcp47": "yaq",
+      "iso3": "yaq",
+      "id": "8026",
+      "name": [
+        {
+          "value": "Yaqui",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "otomi-mezquital",
+      "bcp47": "ote",
+      "iso3": "ote",
+      "id": "8158",
+      "name": [
+        {
+          "value": "Otomi, Mezquital",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mixteco-alacatlatzala",
+      "bcp47": "mim",
+      "iso3": "mim",
+      "id": "8299",
+      "name": [
+        {
+          "value": "Mixteco, Alacatlatzala",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chol-tumbala",
+      "bcp47": "ctu",
+      "iso3": "ctu",
+      "id": "8315",
+      "name": [
+        {
+          "value": "Chol, Tumbala",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "amuzgo-oaxaca",
+      "bcp47": "azg",
+      "iso3": "azg",
+      "id": "8338",
+      "name": [
+        {
+          "value": "Amuzgo, Oaxaca",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yapese",
+      "bcp47": "yap",
+      "iso3": "yap",
+      "id": "8381",
+      "name": [
+        {
+          "value": "Yapese",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "manyika",
+      "bcp47": "mxc",
+      "iso3": "mxc",
+      "id": "8456",
+      "name": [
+        {
+          "value": "Manyika",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "shona",
+      "bcp47": "sn",
+      "iso3": "sna",
+      "id": "8506",
+      "name": [
+        {
+          "value": "chiShona",
+          "primary": true,
+          "language": {
+            "id": "8506"
+          }
+        },
+        {
+          "value": "Shona",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sena",
+      "bcp47": "seh",
+      "iso3": "seh",
+      "id": "8513",
+      "name": [
+        {
+          "value": "Sena",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "aztec-nahuatl-guerrero",
+      "bcp47": "ngu",
+      "iso3": "ngu",
+      "id": "20843",
+      "name": [
+        {
+          "value": "Aztec Nahuatl Guerrero",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "teso-kenyan",
+      "bcp47": null,
+      "iso3": "teo",
+      "id": "20964",
+      "name": [
+        {
+          "value": "Teso, Kenyan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ge",
+      "bcp47": "hmj",
+      "iso3": "hmj",
+      "id": "22819",
+      "name": [
+        {
+          "value": "Ge",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bakairi",
+      "bcp47": "bkq",
+      "iso3": "bkq",
+      "id": "1884",
+      "name": [
+        {
+          "value": "Bakairi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "blaan-koronadal",
+      "bcp47": "bpr",
+      "iso3": "bpr",
+      "id": "12816",
+      "name": [
+        {
+          "value": "Blaan, Koronadal",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "blaan-sarangani",
+      "bcp47": "bps",
+      "iso3": "bps",
+      "id": "12815",
+      "name": [
+        {
+          "value": "Blaan, Sarangani",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nosu-yinuo",
+      "bcp47": null,
+      "iso3": "iii",
+      "id": "22929",
+      "name": [
+        {
+          "value": "Nosu, Yinuo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bwazza",
+      "bcp47": "mbu",
+      "iso3": "mbu",
+      "id": "9491",
+      "name": [
+        {
+          "value": "Bwazza",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kwere",
+      "bcp47": "cwe",
+      "iso3": "cwe",
+      "id": "14273",
+      "name": [
+        {
+          "value": "Kwere",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kwatay",
+      "bcp47": "cwt",
+      "iso3": "cwt",
+      "id": "13063",
+      "name": [
+        {
+          "value": "Kwatay",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "welsh",
+      "bcp47": "cy",
+      "iso3": "cym",
+      "id": "14815",
+      "name": [
+        {
+          "value": "Cymraeg",
+          "primary": true,
+          "language": {
+            "id": "14815"
+          }
+        },
+        {
+          "value": "Welsh",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kalagen-western",
+      "bcp47": "kqe-x-Western",
+      "iso3": "kqe",
+      "id": "24360",
+      "name": [
+        {
+          "value": "Kalagen, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "armenian-western",
+      "bcp47": "hy-arevmda",
+      "iso3": "hyw",
+      "id": "20550",
+      "name": [
+        {
+          "value": "արեւմտահայերէն",
+          "primary": true,
+          "language": {
+            "id": "20550"
+          }
+        },
+        {
+          "value": "Armenian, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mixteco-monte-verde",
+      "bcp47": "xtn",
+      "iso3": "xtn",
+      "id": "23992",
+      "name": [
+        {
+          "value": "Mixteco, Monte Verde",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "korean-north",
+      "bcp47": "ko-x-North",
+      "iso3": "kor",
+      "id": "24000",
+      "name": [
+        {
+          "value": "조선어",
+          "primary": true,
+          "language": {
+            "id": "24000"
+          }
+        },
+        {
+          "value": "Korean, North",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fang-gabon",
+      "bcp47": "fan-GA",
+      "iso3": "fan",
+      "id": "24019",
+      "name": [
+        {
+          "value": "Fang, Gabon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "burmese-musselmani",
+      "bcp47": "my",
+      "iso3": "mya",
+      "id": "24293",
+      "name": [
+        {
+          "value": "မြန်မာစာ",
+          "primary": true,
+          "language": {
+            "id": "24293"
+          }
+        },
+        {
+          "value": "Burmese Musselmani",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-sudanese-spoken",
+      "bcp47": "ar-apd",
+      "iso3": "apd",
+      "id": "13562",
+      "name": [
+        {
+          "value": "Arabic, Sudanese Spoken",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "senoufo-djimini",
+      "bcp47": "dyi",
+      "iso3": "dyi",
+      "id": "16084",
+      "name": [
+        {
+          "value": "Senoufo, Djimini",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "maanyan",
+      "bcp47": "mhy",
+      "iso3": "mhy",
+      "id": "16781",
+      "name": [
+        {
+          "value": "Maanyan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malay-north-moluccan",
+      "bcp47": null,
+      "iso3": "max",
+      "id": "16900",
+      "name": [
+        {
+          "value": "Malay, North Moluccan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sabu",
+      "bcp47": "hvn",
+      "iso3": "hvn",
+      "id": "17346",
+      "name": [
+        {
+          "value": "Sabu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tomini",
+      "bcp47": null,
+      "iso3": "txm",
+      "id": "17424",
+      "name": [
+        {
+          "value": "Tomini",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bodo",
+      "bcp47": "brx",
+      "iso3": "brx",
+      "id": "19594",
+      "name": [
+        {
+          "value": "बड़ो",
+          "primary": true,
+          "language": {
+            "id": "19594"
+          }
+        },
+        {
+          "value": "Bodo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bukusu",
+      "bcp47": "bxk",
+      "iso3": "bxk",
+      "id": "19606",
+      "name": [
+        {
+          "value": "Bukusu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "buli",
+      "bcp47": "bwu",
+      "iso3": "bwu",
+      "id": "19610",
+      "name": [
+        {
+          "value": "Buli",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hiligaynon",
+      "bcp47": "hil",
+      "iso3": "hil",
+      "id": "19738",
+      "name": [
+        {
+          "value": "Hiligaynon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "halbi",
+      "bcp47": "hlb",
+      "iso3": "hlb",
+      "id": "19739",
+      "name": [
+        {
+          "value": "Halbi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hre",
+      "bcp47": "hre",
+      "iso3": "hre",
+      "id": "19747",
+      "name": [
+        {
+          "value": "Hre",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ila",
+      "bcp47": "ilb",
+      "iso3": "ilb",
+      "id": "19759",
+      "name": [
+        {
+          "value": "Ila",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "javanese-banten",
+      "bcp47": "jv-ID-BT",
+      "iso3": "jav",
+      "id": "19767",
+      "name": [
+        {
+          "value": "Javanese, Banten",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "khandesi",
+      "bcp47": "khn",
+      "iso3": "khn",
+      "id": "19800",
+      "name": [
+        {
+          "value": "Khandesi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lenje",
+      "bcp47": "leh",
+      "iso3": "leh",
+      "id": "19898",
+      "name": [
+        {
+          "value": "Lenje",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lisu",
+      "bcp47": "lis",
+      "iso3": "lis",
+      "id": "19908",
+      "name": [
+        {
+          "value": "ꓡꓲ-ꓢꓴ",
+          "primary": true,
+          "language": {
+            "id": "19908"
+          }
+        },
+        {
+          "value": "Lisu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mon",
+      "bcp47": "mnw",
+      "iso3": "mnw",
+      "id": "20010",
+      "name": [
+        {
+          "value": "ဘာသာ မန်",
+          "primary": true,
+          "language": {
+            "id": "20010"
+          }
+        },
+        {
+          "value": "Mon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "toma",
+      "bcp47": "tod",
+      "iso3": "tod",
+      "id": "20285",
+      "name": [
+        {
+          "value": "Toma",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tswa",
+      "bcp47": "tsc",
+      "iso3": "tsc",
+      "id": "20293",
+      "name": [
+        {
+          "value": "Tswa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dhopadhola",
+      "bcp47": "adh",
+      "iso3": "adh",
+      "id": "20521",
+      "name": [
+        {
+          "value": "Dhopadhola",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "twi",
+      "bcp47": "tw",
+      "iso3": "aka",
+      "id": "20525",
+      "name": [
+        {
+          "value": "Twi",
+          "primary": true,
+          "language": {
+            "id": "20525"
+          }
+        },
+        {
+          "value": "Twi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "albanian-kosovar",
+      "bcp47": "sq-aln",
+      "iso3": "aln",
+      "id": "20528",
+      "name": [
+        {
+          "value": "Albanian, Kosovar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-chadian-spoken",
+      "bcp47": "ar-shu",
+      "iso3": "shu",
+      "id": "20531",
+      "name": [
+        {
+          "value": "Arabic, Chadian Spoken",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hakka",
+      "bcp47": "hak",
+      "iso3": "hak",
+      "id": "20611",
+      "name": [
+        {
+          "value": "客家話",
+          "primary": true,
+          "language": {
+            "id": "20611"
+          }
+        },
+        {
+          "value": "Hakka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mandarin-china",
+      "bcp47": "zh",
+      "iso3": "cmn",
+      "id": "20615",
+      "name": [
+        {
+          "value": "普通話 ",
+          "primary": true,
+          "language": {
+            "id": "20615"
+          }
+        },
+        {
+          "value": "Mandarin, China",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "xiang",
+      "bcp47": "hsn",
+      "iso3": "hsn",
+      "id": "20627",
+      "name": [
+        {
+          "value": "湘语",
+          "primary": true,
+          "language": {
+            "id": "20627"
+          }
+        },
+        {
+          "value": "Xiang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dargin",
+      "bcp47": "dar",
+      "iso3": "dar",
+      "id": "20644",
+      "name": [
+        {
+          "value": "дарган мез",
+          "primary": true,
+          "language": {
+            "id": "20644"
+          }
+        },
+        {
+          "value": "Dargin",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "waata",
+      "bcp47": "ssn",
+      "iso3": "ssn",
+      "id": "143207",
+      "name": [
+        {
+          "value": "Waata",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "owa",
+      "bcp47": "stn",
+      "iso3": "stn",
+      "id": "143295",
+      "name": [
+        {
+          "value": "Owa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hdi",
+      "bcp47": "xed",
+      "iso3": "xed",
+      "id": "143340",
+      "name": [
+        {
+          "value": "Hdi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ndut",
+      "bcp47": "ndv",
+      "iso3": "ndv",
+      "id": "143453",
+      "name": [
+        {
+          "value": "Ndut",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malango-teha",
+      "bcp47": null,
+      "iso3": "mln",
+      "id": "143497",
+      "name": [
+        {
+          "value": "Malango Teha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "oyda",
+      "bcp47": null,
+      "iso3": "oyd",
+      "id": "143568",
+      "name": [
+        {
+          "value": "Oyda",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "agabag",
+      "bcp47": null,
+      "iso3": "sbr",
+      "id": "143624",
+      "name": [
+        {
+          "value": "Agabag",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sanggau",
+      "bcp47": null,
+      "iso3": "scg",
+      "id": "143690",
+      "name": [
+        {
+          "value": "Sanggau",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nahuatl-zacatlan-ahuacatlan-tepetzintla",
+      "bcp47": null,
+      "iso3": "nhi",
+      "id": "143707",
+      "name": [
+        {
+          "value": "Nahuatl, Zacatlan-Ahuacatlan-Tepetzintla",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kwaio",
+      "bcp47": "kwd",
+      "iso3": "kwd",
+      "id": "141513",
+      "name": [
+        {
+          "value": "Kwaio",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nahuatl-central-huasteca",
+      "bcp47": "nch",
+      "iso3": "nch",
+      "id": "26419",
+      "name": [
+        {
+          "value": "Māsēwallahtōlli",
+          "primary": true,
+          "language": {
+            "id": "26419"
+          }
+        },
+        {
+          "value": "Nahuatl, Central Huasteca",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kwaraae",
+      "bcp47": "kwf",
+      "iso3": "kwf",
+      "id": "141515",
+      "name": [
+        {
+          "value": "Kwara'ae",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bharia",
+      "bcp47": null,
+      "iso3": "bha",
+      "id": "5696",
+      "name": [
+        {
+          "value": "Bharia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "western-poqomchi",
+      "bcp47": "poh",
+      "iso3": "poh",
+      "id": "153551",
+      "name": [
+        {
+          "value": "Western Poqomchi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mixe-coatlan",
+      "bcp47": "mco",
+      "iso3": "mco",
+      "id": "8235",
+      "name": [
+        {
+          "value": "Mixe, Coatlan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "makaa",
+      "bcp47": "mcp",
+      "iso3": "mcp",
+      "id": "2530",
+      "name": [
+        {
+          "value": "Makaa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bhojpuri",
+      "bcp47": "bho",
+      "iso3": "bho",
+      "id": "5667",
+      "name": [
+        {
+          "value": "भोजपुरी",
+          "primary": true,
+          "language": {
+            "id": "5667"
+          }
+        },
+        {
+          "value": "Bhojpuri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mpyemo",
+      "bcp47": "mcx",
+      "iso3": "mcx",
+      "id": "3207",
+      "name": [
+        {
+          "value": "Mpyemo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mada",
+      "bcp47": "mda",
+      "iso3": "mda",
+      "id": "19951",
+      "name": [
+        {
+          "value": "Mada",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "karen-sgaw",
+      "bcp47": "ksw",
+      "iso3": "ksw",
+      "id": "8631",
+      "name": [
+        {
+          "value": "Karen, Sgaw",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "moksha",
+      "bcp47": "mdf",
+      "iso3": "mdf",
+      "id": "18487",
+      "name": [
+        {
+          "value": "мокшень кяль",
+          "primary": true,
+          "language": {
+            "id": "18487"
+          }
+        },
+        {
+          "value": "Moksha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "magindanaon",
+      "bcp47": "mdh",
+      "iso3": "mdh",
+      "id": "12635",
+      "name": [
+        {
+          "value": "Magindanaon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mangbetu",
+      "bcp47": "mdj",
+      "iso3": "mdj",
+      "id": "14749",
+      "name": [
+        {
+          "value": "Mangbetu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hamer-banna",
+      "bcp47": "amf",
+      "iso3": "amf",
+      "id": "4792",
+      "name": [
+        {
+          "value": "Hamer-Banna",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "amharic",
+      "bcp47": "am",
+      "iso3": "amh",
+      "id": "4791",
+      "name": [
+        {
+          "value": "ኣማርኛ",
+          "primary": true,
+          "language": {
+            "id": "4791"
+          }
+        },
+        {
+          "value": "Amharic",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mayogo",
+      "bcp47": "mdm",
+      "iso3": "mdm",
+      "id": "15329",
+      "name": [
+        {
+          "value": "Mayogo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lango-uganda",
+      "bcp47": "laj",
+      "iso3": "laj",
+      "id": "19884",
+      "name": [
+        {
+          "value": "Lango - Uganda",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mbala",
+      "bcp47": "mdp",
+      "iso3": "mdp",
+      "id": "19953",
+      "name": [
+        {
+          "value": "Mbala",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pao",
+      "bcp47": "blk",
+      "iso3": "blk",
+      "id": "21662",
+      "name": [
+        {
+          "value": "Pa'O",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mandar",
+      "bcp47": "mdr",
+      "iso3": "mdr",
+      "id": "17471",
+      "name": [
+        {
+          "value": "Mandar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "enwan",
+      "bcp47": null,
+      "iso3": "env",
+      "id": "140424",
+      "name": [
+        {
+          "value": "Enwan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jur-beli",
+      "bcp47": "blm",
+      "iso3": "blm",
+      "id": "114921",
+      "name": [
+        {
+          "value": "Jur Beli",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bantoanon",
+      "bcp47": "bno",
+      "iso3": "bno",
+      "id": "12801",
+      "name": [
+        {
+          "value": "Bantoanon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mbosi",
+      "bcp47": "mdw",
+      "iso3": "mdw",
+      "id": "4336",
+      "name": [
+        {
+          "value": "Mbosi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "male",
+      "bcp47": "mdy",
+      "iso3": "mdy",
+      "id": "4768",
+      "name": [
+        {
+          "value": "Male",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "plang",
+      "bcp47": "blr",
+      "iso3": "blr",
+      "id": "114936",
+      "name": [
+        {
+          "value": "Plang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "traditional-japanese",
+      "bcp47": null,
+      "iso3": "jpn",
+      "id": "185332",
+      "name": [
+        {
+          "value": "Traditional Japanese",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "medlpa",
+      "bcp47": "med",
+      "iso3": "med",
+      "id": "11668",
+      "name": [
+        {
+          "value": "Medlpa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zhuang-dejing",
+      "bcp47": null,
+      "iso3": "zyg",
+      "id": "185333",
+      "name": [
+        {
+          "value": "Zhuang, Dejing",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-najdi",
+      "bcp47": null,
+      "iso3": "ars",
+      "id": "184591",
+      "name": [
+        {
+          "value": "Arabic, Najdi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tai-dam",
+      "bcp47": "blt",
+      "iso3": "blt",
+      "id": "7516",
+      "name": [
+        {
+          "value": "Tai Dam",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mende",
+      "bcp47": "men",
+      "iso3": "men",
+      "id": "7577",
+      "name": [
+        {
+          "value": "Mende",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "merey",
+      "bcp47": "meq",
+      "iso3": "meq",
+      "id": "101729",
+      "name": [
+        {
+          "value": "Merey",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mano",
+      "bcp47": "mev",
+      "iso3": "mev",
+      "id": "5472",
+      "name": [
+        {
+          "value": "Mano",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cuyonon",
+      "bcp47": null,
+      "iso3": "cyo",
+      "id": "12773",
+      "name": [
+        {
+          "value": "Cuyonon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mixteco-eastern",
+      "bcp47": "mil",
+      "iso3": "mil",
+      "id": "8303",
+      "name": [
+        {
+          "value": "Mixteco, Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "naga-konyak",
+      "bcp47": "nbe",
+      "iso3": "nbe",
+      "id": "6144",
+      "name": [
+        {
+          "value": "Naga, Konyak",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "naga-rongmei",
+      "bcp47": "nbu",
+      "iso3": "nbu",
+      "id": "6108",
+      "name": [
+        {
+          "value": "Naga, Rongmei",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cakchiquel-central",
+      "bcp47": "cak",
+      "iso3": "cak",
+      "id": "5439",
+      "name": [
+        {
+          "value": "Cakchiquel, Central",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "berom",
+      "bcp47": "bom",
+      "iso3": "bom",
+      "id": "10185",
+      "name": [
+        {
+          "value": "Berom",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "awak",
+      "bcp47": "awo",
+      "iso3": "awo",
+      "id": "10231",
+      "name": [
+        {
+          "value": "अवधी",
+          "primary": true,
+          "language": {
+            "id": "10231"
+          }
+        },
+        {
+          "value": "Awak",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ilocano",
+      "bcp47": "ilo",
+      "iso3": "ilo",
+      "id": "12723",
+      "name": [
+        {
+          "value": "Ilokano",
+          "primary": true,
+          "language": {
+            "id": "12723"
+          }
+        },
+        {
+          "value": "Ilocano",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "palauan",
+      "bcp47": "pau",
+      "iso3": "pau",
+      "id": "10589",
+      "name": [
+        {
+          "value": "Tekoi ra Belau",
+          "primary": true,
+          "language": {
+            "id": "10589"
+          }
+        },
+        {
+          "value": "Palauan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "indonesian-yesus",
+      "bcp47": "id",
+      "iso3": "ind",
+      "id": "16639",
+      "name": [
+        {
+          "value": "bahasa Indonesia",
+          "primary": true,
+          "language": {
+            "id": "16639"
+          }
+        },
+        {
+          "value": "Indonesian (Yesus)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ingush",
+      "bcp47": "inh",
+      "iso3": "inh",
+      "id": "18555",
+      "name": [
+        {
+          "value": "ГӀалгӀай мотт",
+          "primary": true,
+          "language": {
+            "id": "18555"
+          }
+        },
+        {
+          "value": "Ingush",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "paama",
+      "bcp47": null,
+      "iso3": "pma",
+      "id": "143851",
+      "name": [
+        {
+          "value": "Paama",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sougb",
+      "bcp47": null,
+      "iso3": "mnx",
+      "id": "143861",
+      "name": [
+        {
+          "value": "Sougb",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lewo-eleng",
+      "bcp47": null,
+      "iso3": "lwe",
+      "id": "144036",
+      "name": [
+        {
+          "value": "Lewo Eleng",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lewo",
+      "bcp47": "lww",
+      "iso3": "lww",
+      "id": "144042",
+      "name": [
+        {
+          "value": "Lewo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nivacle",
+      "bcp47": null,
+      "iso3": "cag",
+      "id": "140010",
+      "name": [
+        {
+          "value": "Nivacle",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "maninka",
+      "bcp47": "emk",
+      "iso3": "emk",
+      "id": "5450",
+      "name": [
+        {
+          "value": "Maninka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bobe",
+      "bcp47": "bvb",
+      "iso3": "bvb",
+      "id": "115239",
+      "name": [
+        {
+          "value": "Bobe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chamacoco",
+      "bcp47": null,
+      "iso3": "ceg",
+      "id": "140087",
+      "name": [
+        {
+          "value": "Chamacoco",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nomane",
+      "bcp47": null,
+      "iso3": "nof",
+      "id": "144116",
+      "name": [
+        {
+          "value": "Nomane",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mualang",
+      "bcp47": null,
+      "iso3": "mtd",
+      "id": "144156",
+      "name": [
+        {
+          "value": "Mualang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "manobo-ilianen",
+      "bcp47": null,
+      "iso3": "mbi",
+      "id": "144214",
+      "name": [
+        {
+          "value": "Manobo, Ilianen",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mixtec-amoltepec",
+      "bcp47": "mbz",
+      "iso3": "mbz",
+      "id": "144228",
+      "name": [
+        {
+          "value": "Mixtec, Amoltepec",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "puinave",
+      "bcp47": null,
+      "iso3": "pui",
+      "id": "144251",
+      "name": [
+        {
+          "value": "Puinave",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "naga-sumi",
+      "bcp47": "nsm",
+      "iso3": "nsm",
+      "id": "144286",
+      "name": [
+        {
+          "value": "Naga, Sumi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "maquiritari",
+      "bcp47": null,
+      "iso3": "mch",
+      "id": "144295",
+      "name": [
+        {
+          "value": "Maquiritari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ese",
+      "bcp47": "mcq",
+      "iso3": "mcq",
+      "id": "144299",
+      "name": [
+        {
+          "value": "Ese",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "are",
+      "bcp47": null,
+      "iso3": "mwc",
+      "id": "144351",
+      "name": [
+        {
+          "value": "Are",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tepehuan-northern",
+      "bcp47": null,
+      "iso3": "ntp",
+      "id": "144370",
+      "name": [
+        {
+          "value": "Tepehuan, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quichua-tena-lowland",
+      "bcp47": null,
+      "iso3": "quw",
+      "id": "144390",
+      "name": [
+        {
+          "value": "Quichua, Tena Lowland",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quechua-panao-huanuco",
+      "bcp47": "qxh",
+      "iso3": "qxh",
+      "id": "144408",
+      "name": [
+        {
+          "value": "Qhichwa",
+          "primary": true,
+          "language": {
+            "id": "144408"
+          }
+        },
+        {
+          "value": "Quechua, Panao Huanuco",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mele-fila",
+      "bcp47": null,
+      "iso3": "mxe",
+      "id": "144425",
+      "name": [
+        {
+          "value": "Mele-Fila",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "miju-mishmi",
+      "bcp47": "mxj",
+      "iso3": "mxj",
+      "id": "144427",
+      "name": [
+        {
+          "value": "Miju-Mishmi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "meyah",
+      "bcp47": null,
+      "iso3": "mej",
+      "id": "144460",
+      "name": [
+        {
+          "value": "Meyah",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mekeo",
+      "bcp47": "mek",
+      "iso3": "mek",
+      "id": "144461",
+      "name": [
+        {
+          "value": "Mekeo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mato",
+      "bcp47": null,
+      "iso3": "met",
+      "id": "144465",
+      "name": [
+        {
+          "value": "Mato",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bangka",
+      "bcp47": null,
+      "iso3": "mfb",
+      "id": "144471",
+      "name": [
+        {
+          "value": "Bangka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mba",
+      "bcp47": null,
+      "iso3": "mfc",
+      "id": "144472",
+      "name": [
+        {
+          "value": "Mba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "brahui",
+      "bcp47": "brh",
+      "iso3": "brh",
+      "id": "351",
+      "name": [
+        {
+          "value": "Brahui",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kazakh",
+      "bcp47": "kk",
+      "iso3": "kaz",
+      "id": "371",
+      "name": [
+        {
+          "value": "قازاق ٴتىلى",
+          "primary": true,
+          "language": {
+            "id": "371"
+          }
+        },
+        {
+          "value": "Kazakh",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pashto-yusufzai",
+      "bcp47": "pbu",
+      "iso3": "pbu",
+      "id": "374",
+      "name": [
+        {
+          "value": "پښتو",
+          "primary": true,
+          "language": {
+            "id": "374"
+          }
+        },
+        {
+          "value": "Pashto, Yusufzai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sindhi",
+      "bcp47": "sd",
+      "iso3": "snd",
+      "id": "389",
+      "name": [
+        {
+          "value": "سنڌي",
+          "primary": true,
+          "language": {
+            "id": "389"
+          }
+        },
+        {
+          "value": "Sindhi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tatar",
+      "bcp47": "tt",
+      "iso3": "tat",
+      "id": "411",
+      "name": [
+        {
+          "value": "تاتارچا",
+          "primary": true,
+          "language": {
+            "id": "411"
+          }
+        },
+        {
+          "value": "Tatar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nawary",
+      "bcp47": null,
+      "iso3": "rmt",
+      "id": "427",
+      "name": [
+        {
+          "value": "Nawary",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hazaragi",
+      "bcp47": "haz",
+      "iso3": "haz",
+      "id": "450",
+      "name": [
+        {
+          "value": "هزارگی",
+          "primary": true,
+          "language": {
+            "id": "450"
+          }
+        },
+        {
+          "value": "Hazaragi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "greek",
+      "bcp47": "el",
+      "iso3": "ell",
+      "id": "483",
+      "name": [
+        {
+          "value": "Ελληνικά",
+          "primary": true,
+          "language": {
+            "id": "483"
+          }
+        },
+        {
+          "value": "Greek",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "catalan-valencian-balear",
+      "bcp47": "ca",
+      "iso3": "cat",
+      "id": "531",
+      "name": [
+        {
+          "value": "Català",
+          "primary": true,
+          "language": {
+            "id": "531"
+          }
+        },
+        {
+          "value": "Catalan - Valencian - Balear",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "vanuma",
+      "bcp47": null,
+      "iso3": "vau",
+      "id": "142380",
+      "name": [
+        {
+          "value": "Vanuma",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "vidunda",
+      "bcp47": "vid",
+      "iso3": "vid",
+      "id": "142394",
+      "name": [
+        {
+          "value": "Vidunda",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "wondama",
+      "bcp47": null,
+      "iso3": "wad",
+      "id": "142589",
+      "name": [
+        {
+          "value": "Wondama",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mandara-cameroon",
+      "bcp47": null,
+      "iso3": "mfi",
+      "id": "144476",
+      "name": [
+        {
+          "value": "Mandara, Cameroon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "meen",
+      "bcp47": "mym",
+      "iso3": "mym",
+      "id": "144517",
+      "name": [
+        {
+          "value": "Me'En",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "olunyole",
+      "bcp47": null,
+      "iso3": "nyd",
+      "id": "144539",
+      "name": [
+        {
+          "value": "Olunyole",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "wichi-lhamtes-guisnay",
+      "bcp47": null,
+      "iso3": "mzh",
+      "id": "144584",
+      "name": [
+        {
+          "value": "Wichi Lhamtes Guisnay",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "deg",
+      "bcp47": "mzw",
+      "iso3": "mzw",
+      "id": "144593",
+      "name": [
+        {
+          "value": "Deg",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "abureni",
+      "bcp47": null,
+      "iso3": "mgj",
+      "id": "144623",
+      "name": [
+        {
+          "value": "Abureni",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mailu",
+      "bcp47": "mgu",
+      "iso3": "mgu",
+      "id": "144630",
+      "name": [
+        {
+          "value": "Mailu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "okpe",
+      "bcp47": null,
+      "iso3": "oke",
+      "id": "144693",
+      "name": [
+        {
+          "value": "Okpe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "oku",
+      "bcp47": "oku",
+      "iso3": "oku",
+      "id": "144701",
+      "name": [
+        {
+          "value": "Oku",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mochi",
+      "bcp47": null,
+      "iso3": "old",
+      "id": "144705",
+      "name": [
+        {
+          "value": "Mochi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "luwu-tae",
+      "bcp47": null,
+      "iso3": "rob",
+      "id": "144740",
+      "name": [
+        {
+          "value": "Luwu, Tae'",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nahuatl-northern-puebla",
+      "bcp47": null,
+      "iso3": "ncj",
+      "id": "144765",
+      "name": [
+        {
+          "value": "Nahuatl, Northern Puebla",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nahuatl-michoacan",
+      "bcp47": null,
+      "iso3": "ncl",
+      "id": "144766",
+      "name": [
+        {
+          "value": "Nahuatl, Michoacan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ambae-east",
+      "bcp47": null,
+      "iso3": "omb",
+      "id": "144776",
+      "name": [
+        {
+          "value": "Ambae, East",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ono",
+      "bcp47": null,
+      "iso3": "ons",
+      "id": "144792",
+      "name": [
+        {
+          "value": "Ono",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "saluan",
+      "bcp47": "loe",
+      "iso3": "loe",
+      "id": "144834",
+      "name": [
+        {
+          "value": "Saluan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "miao-eastern-xiangxi",
+      "bcp47": null,
+      "iso3": "muq",
+      "id": "144844",
+      "name": [
+        {
+          "value": "Miao, Eastern Xiangxi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "miao-eastern-qiandong",
+      "bcp47": null,
+      "iso3": "hmq",
+      "id": "144869",
+      "name": [
+        {
+          "value": "Miao, Eastern Qiandong",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sylheti",
+      "bcp47": null,
+      "iso3": "syl",
+      "id": "144882",
+      "name": [
+        {
+          "value": "Sylheti",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "wa-vo",
+      "bcp47": null,
+      "iso3": "wbm",
+      "id": "144886",
+      "name": [
+        {
+          "value": "Wa, Vo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "batak-kluet",
+      "bcp47": null,
+      "iso3": "btz",
+      "id": "146379",
+      "name": [
+        {
+          "value": "Batak-Kluet",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "makoma",
+      "bcp47": "sie",
+      "iso3": "sie",
+      "id": "151261",
+      "name": [
+        {
+          "value": "Makoma",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bidayuh-jagoi",
+      "bcp47": null,
+      "iso3": "sne",
+      "id": "151767",
+      "name": [
+        {
+          "value": "Bidayuh-Jagoi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "shanjo",
+      "bcp47": "toi",
+      "iso3": "toi",
+      "id": "151817",
+      "name": [
+        {
+          "value": "Shanjo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nagamese",
+      "bcp47": "nag",
+      "iso3": "nag",
+      "id": "20842",
+      "name": [
+        {
+          "value": "Nagamese",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "comorian-shingazidja",
+      "bcp47": "zdj",
+      "iso3": "zdj",
+      "id": "15903",
+      "name": [
+        {
+          "value": "Comorian, Shingazidja",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dogri",
+      "bcp47": "dgo",
+      "iso3": "dgo",
+      "id": "20651",
+      "name": [
+        {
+          "value": "Dogri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fijian",
+      "bcp47": "fj",
+      "iso3": "fij",
+      "id": "20665",
+      "name": [
+        {
+          "value": "Vakaviti",
+          "primary": true,
+          "language": {
+            "id": "20665"
+          }
+        },
+        {
+          "value": "Fijian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hadothi",
+      "bcp47": "hoj",
+      "iso3": "hoj",
+      "id": "20696",
+      "name": [
+        {
+          "value": "Hadothi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "itawis",
+      "bcp47": "itv",
+      "iso3": "itv",
+      "id": "20717",
+      "name": [
+        {
+          "value": "Itawis",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kikamba",
+      "bcp47": "kam",
+      "iso3": "kam",
+      "id": "20730",
+      "name": [
+        {
+          "value": "Kikamba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ngakarimojong",
+      "bcp47": "kdj",
+      "iso3": "kdj",
+      "id": "20736",
+      "name": [
+        {
+          "value": "Ngakarimojong",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "karai-karai",
+      "bcp47": "kai",
+      "iso3": "kai",
+      "id": "20738",
+      "name": [
+        {
+          "value": "Karai-Karai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kru",
+      "bcp47": "klu",
+      "iso3": "klu",
+      "id": "20750",
+      "name": [
+        {
+          "value": "Kru",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "konso",
+      "bcp47": "kxc",
+      "iso3": "kxc",
+      "id": "20753",
+      "name": [
+        {
+          "value": "Konso",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kikongo",
+      "bcp47": "kng",
+      "iso3": "kng",
+      "id": "20754",
+      "name": [
+        {
+          "value": "Kikongo",
+          "primary": true,
+          "language": {
+            "id": "20754"
+          }
+        },
+        {
+          "value": "Kikongo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kurmanji-standard",
+      "bcp47": "ko-kmr",
+      "iso3": "kmr",
+      "id": "20770",
+      "name": [
+        {
+          "value": "Kurmanji Standard",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lambadi",
+      "bcp47": "lmn",
+      "iso3": "lmn",
+      "id": "20777",
+      "name": [
+        {
+          "value": "Lambadi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tshiluba",
+      "bcp47": "lua",
+      "iso3": "lua",
+      "id": "20790",
+      "name": [
+        {
+          "value": "Tshiluba",
+          "primary": true,
+          "language": {
+            "id": "20790"
+          }
+        },
+        {
+          "value": "Tshiluba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kiluba",
+      "bcp47": "lu",
+      "iso3": "lub",
+      "id": "20791",
+      "name": [
+        {
+          "value": "Kiluba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "wanga-luhya",
+      "bcp47": "lwg",
+      "iso3": "lwg",
+      "id": "20794",
+      "name": [
+        {
+          "value": "Wanga, Luhya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tsimihety",
+      "bcp47": "xmw",
+      "iso3": "xmw",
+      "id": "20805",
+      "name": [
+        {
+          "value": "Tsimihety",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mewari",
+      "bcp47": "mtr",
+      "iso3": "mtr",
+      "id": "20814",
+      "name": [
+        {
+          "value": "Mewari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kimeru",
+      "bcp47": "mer",
+      "iso3": "mer",
+      "id": "20824",
+      "name": [
+        {
+          "value": "Kimeru",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "atitlan-mixe",
+      "bcp47": "neq",
+      "iso3": "neq",
+      "id": "20830",
+      "name": [
+        {
+          "value": "Atitlan Mixe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kinandi",
+      "bcp47": "nnb",
+      "iso3": "nnb",
+      "id": "20849",
+      "name": [
+        {
+          "value": "Kinandi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sidaama",
+      "bcp47": "sid",
+      "iso3": "sid",
+      "id": "131700",
+      "name": [
+        {
+          "value": "Sidaama",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sakata",
+      "bcp47": "skt",
+      "iso3": "skt",
+      "id": "20196",
+      "name": [
+        {
+          "value": "Sakata",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bete-guiberoua",
+      "bcp47": "bet",
+      "iso3": "bet",
+      "id": "16106",
+      "name": [
+        {
+          "value": "Bete, Guiberoua",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kuranko",
+      "bcp47": "knk",
+      "iso3": "knk",
+      "id": "5485",
+      "name": [
+        {
+          "value": "Kuranko",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bena",
+      "bcp47": "bez",
+      "iso3": "bez",
+      "id": "14277",
+      "name": [
+        {
+          "value": "Bena",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "balochi-western",
+      "bcp47": "bgn",
+      "iso3": "bgn",
+      "id": "353",
+      "name": [
+        {
+          "value": "بلوچی",
+          "primary": true,
+          "language": {
+            "id": "353"
+          }
+        },
+        {
+          "value": "Balochi, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "xun",
+      "bcp47": "xuu",
+      "iso3": "xuu",
+      "id": "581",
+      "name": [
+        {
+          "value": "Xun",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lezgi",
+      "bcp47": "lez",
+      "iso3": "lez",
+      "id": "1127",
+      "name": [
+        {
+          "value": "лезги чӀал",
+          "primary": true,
+          "language": {
+            "id": "1127"
+          }
+        },
+        {
+          "value": "Lezgi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "assamese",
+      "bcp47": "as",
+      "iso3": "asm",
+      "id": "1171",
+      "name": [
+        {
+          "value": "অসমীয়া",
+          "primary": true,
+          "language": {
+            "id": "1171"
+          }
+        },
+        {
+          "value": "Assamese",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "farsi-western",
+      "bcp47": "fa",
+      "iso3": "pes",
+      "id": "6788",
+      "name": [
+        {
+          "value": "فارسي (فارسي فارسي)",
+          "primary": true,
+          "language": {
+            "id": "6788"
+          }
+        },
+        {
+          "value": "Farsi, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kurux",
+      "bcp47": "kru",
+      "iso3": "kru",
+      "id": "1194",
+      "name": [
+        {
+          "value": "Kurux",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bine",
+      "bcp47": "bon",
+      "iso3": "bon",
+      "id": "11446",
+      "name": [
+        {
+          "value": "Bine",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mundari",
+      "bcp47": "unr",
+      "iso3": "unr",
+      "id": "1250",
+      "name": [
+        {
+          "value": "Mundari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "plautdietsch",
+      "bcp47": "pdt",
+      "iso3": "pdt",
+      "id": "1278",
+      "name": [
+        {
+          "value": "Plautdietsch",
+          "primary": true,
+          "language": {
+            "id": "1278"
+          }
+        },
+        {
+          "value": "Plautdietsch",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "aja-gbe",
+      "bcp47": "ajg",
+      "iso3": "ajg",
+      "id": "1280",
+      "name": [
+        {
+          "value": "Aja-Gbe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fon-gbe",
+      "bcp47": "fon",
+      "iso3": "fon",
+      "id": "1304",
+      "name": [
+        {
+          "value": "Fon gbè",
+          "primary": true,
+          "language": {
+            "id": "1304"
+          }
+        },
+        {
+          "value": "Fon-Gbe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chatino-zenzontepec",
+      "bcp47": "czn",
+      "iso3": "czn",
+      "id": "8281",
+      "name": [
+        {
+          "value": "Chatino, Zenzontepec",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malay-bukit",
+      "bcp47": null,
+      "iso3": "bvu",
+      "id": "16883",
+      "name": [
+        {
+          "value": "Malay, Bukit",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kongo-san-salvador",
+      "bcp47": "kwy",
+      "iso3": "kwy",
+      "id": "545",
+      "name": [
+        {
+          "value": "Kongo, San Salvador",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quichua-highland-chimborazo",
+      "bcp47": "qug",
+      "iso3": "qug",
+      "id": "4481",
+      "name": [
+        {
+          "value": "Qhichwa",
+          "primary": true,
+          "language": {
+            "id": "4481"
+          }
+        },
+        {
+          "value": "Quichua, Highland, Chimborazo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "antandroy",
+      "bcp47": "mg-tdx",
+      "iso3": "tdx",
+      "id": "23192",
+      "name": [
+        {
+          "value": "Antandroy",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "telugu",
+      "bcp47": "te",
+      "iso3": "tel",
+      "id": "5848",
+      "name": [
+        {
+          "value": "తెలుగు",
+          "primary": true,
+          "language": {
+            "id": "5848"
+          }
+        },
+        {
+          "value": "Telugu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "inor",
+      "bcp47": null,
+      "iso3": "ior",
+      "id": "26184",
+      "name": [
+        {
+          "value": "Inor",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "themne",
+      "bcp47": "tem",
+      "iso3": "tem",
+      "id": "13098",
+      "name": [
+        {
+          "value": "Themne",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ipili",
+      "bcp47": "ipi",
+      "iso3": "ipi",
+      "id": "98663",
+      "name": [
+        {
+          "value": "Ipili",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yoruba",
+      "bcp47": "yo",
+      "iso3": "yor",
+      "id": "1308",
+      "name": [
+        {
+          "value": "Èdè Yorùbá",
+          "primary": true,
+          "language": {
+            "id": "1308"
+          }
+        },
+        {
+          "value": "Yoruba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ditammari",
+      "bcp47": "tbz",
+      "iso3": "tbz",
+      "id": "1318",
+      "name": [
+        {
+          "value": "Ditammari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lama",
+      "bcp47": "las",
+      "iso3": "las",
+      "id": "1333",
+      "name": [
+        {
+          "value": "Lama",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tem",
+      "bcp47": "kdh",
+      "iso3": "kdh",
+      "id": "1335",
+      "name": [
+        {
+          "value": "Tem",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gen-gbe",
+      "bcp47": "gej",
+      "iso3": "gej",
+      "id": "1342",
+      "name": [
+        {
+          "value": "Gen-Gbe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "serawai",
+      "bcp47": "ms-pse-x-Serawai",
+      "iso3": "pse",
+      "id": "17760",
+      "name": [
+        {
+          "value": "Serawai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pasemah",
+      "bcp47": "ms-pse",
+      "iso3": "pse",
+      "id": "17773",
+      "name": [
+        {
+          "value": "Pasemah",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ogan",
+      "bcp47": "ms-pse-x-Ogan",
+      "iso3": "pse",
+      "id": "17785",
+      "name": [
+        {
+          "value": "Ogan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lepcha",
+      "bcp47": "lep",
+      "iso3": "lep",
+      "id": "1352",
+      "name": [
+        {
+          "value": "Lepcha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nepali",
+      "bcp47": "npi",
+      "iso3": "npi",
+      "id": "1370",
+      "name": [
+        {
+          "value": "नेपाली",
+          "primary": true,
+          "language": {
+            "id": "1370"
+          }
+        },
+        {
+          "value": "Nepali",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tzutujil-eastern",
+      "bcp47": "tzj",
+      "iso3": "tzj",
+      "id": "5433",
+      "name": [
+        {
+          "value": "Tzutujil, Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ukrainian",
+      "bcp47": "uk",
+      "iso3": "ukr",
+      "id": "12876",
+      "name": [
+        {
+          "value": "Українська",
+          "primary": true,
+          "language": {
+            "id": "12876"
+          }
+        },
+        {
+          "value": "Ukrainian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "uzbek-southern",
+      "bcp47": "uzs",
+      "iso3": "uzs",
+      "id": "406",
+      "name": [
+        {
+          "value": "اوزبیک",
+          "primary": true,
+          "language": {
+            "id": "406"
+          }
+        },
+        {
+          "value": "Uzbek, Southern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "slavey",
+      "bcp47": "xsl",
+      "iso3": "xsl",
+      "id": "20223",
+      "name": [
+        {
+          "value": "Slavey",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kasem-burkina-faso",
+      "bcp47": "xsm",
+      "iso3": "xsm",
+      "id": "22909",
+      "name": [
+        {
+          "value": "Kasem, Burkina Faso",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "rigwe",
+      "bcp47": "iri",
+      "iso3": "iri",
+      "id": "44748",
+      "name": [
+        {
+          "value": "Rigwe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quechua-huanuco-huamalies-northern-dos-de-mayo",
+      "bcp47": null,
+      "iso3": "qvh",
+      "id": "12441",
+      "name": [
+        {
+          "value": "Quechua, Huanuco, Huamalies-Northern Dos De Mayo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quechua-margos-yarowilca-lauricocha",
+      "bcp47": "qvm",
+      "iso3": "qvm",
+      "id": "26302",
+      "name": [
+        {
+          "value": "Qhichwa",
+          "primary": true,
+          "language": {
+            "id": "26302"
+          }
+        },
+        {
+          "value": "Quechua, Margos-Yarowilca-Lauricocha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "romani-sinte",
+      "bcp47": "rmo",
+      "iso3": "rmo",
+      "id": "1113",
+      "name": [
+        {
+          "value": "रोमानो",
+          "primary": true,
+          "language": {
+            "id": "1113"
+          }
+        },
+        {
+          "value": "Romani, Sinte",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sengwer",
+      "bcp47": null,
+      "iso3": "enb",
+      "id": "185249",
+      "name": [
+        {
+          "value": "Sengwer",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "enlhet-2",
+      "bcp47": null,
+      "iso3": "enl",
+      "id": "141755",
+      "name": [
+        {
+          "value": "Enlhet",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kadiweu",
+      "bcp47": "kbc",
+      "iso3": "kbc",
+      "id": "1538",
+      "name": [
+        {
+          "value": "Kadiweu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "enxet",
+      "bcp47": null,
+      "iso3": "enx",
+      "id": "181477",
+      "name": [
+        {
+          "value": "Enxet",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dongnu",
+      "bcp47": null,
+      "iso3": "bwx",
+      "id": "3717",
+      "name": [
+        {
+          "value": "Yao, Bunu (Dongnu)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "trukese",
+      "bcp47": "chk",
+      "iso3": "chk",
+      "id": "20637",
+      "name": [
+        {
+          "value": "Trukese",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dagara",
+      "bcp47": null,
+      "iso3": "dga",
+      "id": "116416",
+      "name": [
+        {
+          "value": "Dagara",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bambam",
+      "bcp47": null,
+      "iso3": "ptu",
+      "id": "20163",
+      "name": [
+        {
+          "value": "Bambam",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bagri",
+      "bcp47": "bgq",
+      "iso3": "bgq",
+      "id": "5699",
+      "name": [
+        {
+          "value": "Bagri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dari-4",
+      "bcp47": null,
+      "iso3": "der",
+      "id": "117014",
+      "name": [
+        {
+          "value": "فارسی",
+          "primary": true,
+          "language": {
+            "id": "117014"
+          }
+        },
+        {
+          "value": "Dari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "manobo-tagabawa",
+      "bcp47": null,
+      "iso3": "bgs",
+      "id": "12839",
+      "name": [
+        {
+          "value": "Manobo, Tagabawa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kedang",
+      "bcp47": null,
+      "iso3": "ksx",
+      "id": "141620",
+      "name": [
+        {
+          "value": "Kedang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kayabi",
+      "bcp47": "kyz",
+      "iso3": "kyz",
+      "id": "1624",
+      "name": [
+        {
+          "value": "Kayabi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kayapo",
+      "bcp47": "txu",
+      "iso3": "txu",
+      "id": "1676",
+      "name": [
+        {
+          "value": "Kayapo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sanuma",
+      "bcp47": "xsu",
+      "iso3": "xsu",
+      "id": "1720",
+      "name": [
+        {
+          "value": "Sanuma",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "guyanese-creole",
+      "bcp47": "gyn",
+      "iso3": "gyn",
+      "id": "20693",
+      "name": [
+        {
+          "value": "Guyanese Creole",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "xavante",
+      "bcp47": "xav",
+      "iso3": "xav",
+      "id": "1759",
+      "name": [
+        {
+          "value": "Xavante",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "iban",
+      "bcp47": "iba",
+      "iso3": "iba",
+      "id": "1924",
+      "name": [
+        {
+          "value": "Iban",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malay",
+      "bcp47": "ms",
+      "iso3": "zlm",
+      "id": "1927",
+      "name": [
+        {
+          "value": "بهاس ملايو",
+          "primary": true,
+          "language": {
+            "id": "1927"
+          }
+        },
+        {
+          "value": "Malay",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "turkish",
+      "bcp47": "tr",
+      "iso3": "tur",
+      "id": "1942",
+      "name": [
+        {
+          "value": "Türk",
+          "primary": true,
+          "language": {
+            "id": "1942"
+          }
+        },
+        {
+          "value": "Turkish",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bulgarian",
+      "bcp47": "bg",
+      "iso3": "bul",
+      "id": "1964",
+      "name": [
+        {
+          "value": "български",
+          "primary": true,
+          "language": {
+            "id": "1964"
+          }
+        },
+        {
+          "value": "Bulgarian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sora",
+      "bcp47": "srb",
+      "iso3": "srb",
+      "id": "5879",
+      "name": [
+        {
+          "value": "Sora",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "koromfe",
+      "bcp47": null,
+      "iso3": "kfz",
+      "id": "2046",
+      "name": [
+        {
+          "value": "Koromfe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gurenne",
+      "bcp47": "gur",
+      "iso3": "gur",
+      "id": "2062",
+      "name": [
+        {
+          "value": "Gurenne",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kuy",
+      "bcp47": "kdt",
+      "iso3": "kdt",
+      "id": "2173",
+      "name": [
+        {
+          "value": "Kuy",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yamba",
+      "bcp47": "yam",
+      "iso3": "yam",
+      "id": "2249",
+      "name": [
+        {
+          "value": "Yamba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tupuri",
+      "bcp47": "tui",
+      "iso3": "tui",
+      "id": "2281",
+      "name": [
+        {
+          "value": "Tupuri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mbembe-tigon",
+      "bcp47": "nza",
+      "iso3": "nza",
+      "id": "2329",
+      "name": [
+        {
+          "value": "Mbembe, Tigon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "musgu",
+      "bcp47": "mug",
+      "iso3": "mug",
+      "id": "2449",
+      "name": [
+        {
+          "value": "Musgu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "miao-northern-qiandong",
+      "bcp47": null,
+      "iso3": "hea",
+      "id": "140948",
+      "name": [
+        {
+          "value": "Miao, Northern Qiandong",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "punjabi",
+      "bcp47": "pa",
+      "iso3": "pan",
+      "id": "46771",
+      "name": [
+        {
+          "value": "पंजाबी",
+          "primary": true,
+          "language": {
+            "id": "46771"
+          }
+        },
+        {
+          "value": "Punjabi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "paez",
+      "bcp47": "pbb",
+      "iso3": "pbb",
+      "id": "4181",
+      "name": [
+        {
+          "value": "Paez",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "panare",
+      "bcp47": "pbh",
+      "iso3": "pbh",
+      "id": "15088",
+      "name": [
+        {
+          "value": "Panare",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "manobo-western-bukidnon",
+      "bcp47": null,
+      "iso3": "mbb",
+      "id": "144210",
+      "name": [
+        {
+          "value": "Manobo, Western Bukidnon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ngiemboon",
+      "bcp47": "nnh",
+      "iso3": "nnh",
+      "id": "2348",
+      "name": [
+        {
+          "value": "Ngiemboon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "miao-southern-qiandong",
+      "bcp47": null,
+      "iso3": "hms",
+      "id": "140985",
+      "name": [
+        {
+          "value": "Miao, Southern Qiandong",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mafa",
+      "bcp47": "maf",
+      "iso3": "maf",
+      "id": "2556",
+      "name": [
+        {
+          "value": "Mafa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "peve",
+      "bcp47": "lme",
+      "iso3": "lme",
+      "id": "2561",
+      "name": [
+        {
+          "value": "Peve",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "limbum",
+      "bcp47": "lmp",
+      "iso3": "lmp",
+      "id": "2565",
+      "name": [
+        {
+          "value": "Limbum",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kuteb",
+      "bcp47": "kub",
+      "iso3": "kub",
+      "id": "2590",
+      "name": [
+        {
+          "value": "Kuteb",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kanuri-yerwa",
+      "bcp47": "knc",
+      "iso3": "knc",
+      "id": "2614",
+      "name": [
+        {
+          "value": "Kanuri",
+          "primary": true,
+          "language": {
+            "id": "2614"
+          }
+        },
+        {
+          "value": "Kanuri, Yerwa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kako",
+      "bcp47": "kkj",
+      "iso3": "kkj",
+      "id": "2639",
+      "name": [
+        {
+          "value": "Kako",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kuo",
+      "bcp47": "xuo",
+      "iso3": "xuo",
+      "id": "2641",
+      "name": [
+        {
+          "value": "Kuo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bhadrawahi",
+      "bcp47": "bhd",
+      "iso3": "bhd",
+      "id": "5671",
+      "name": [
+        {
+          "value": "Bhadrawahi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "icheve",
+      "bcp47": null,
+      "iso3": "bec",
+      "id": "145530",
+      "name": [
+        {
+          "value": "Icheve",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-north-african",
+      "bcp47": "ar-aao",
+      "iso3": "aao",
+      "id": "20538",
+      "name": [
+        {
+          "value": "Arabic, North African",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mam-northern",
+      "bcp47": "mam",
+      "iso3": "mam",
+      "id": "5427",
+      "name": [
+        {
+          "value": "Mam, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "papel",
+      "bcp47": "pbo",
+      "iso3": "pbo",
+      "id": "5446",
+      "name": [
+        {
+          "value": "Papel",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hrangkhol",
+      "bcp47": null,
+      "iso3": "hra",
+      "id": "140853",
+      "name": [
+        {
+          "value": "Hrangkhol",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "afar",
+      "bcp47": "aa",
+      "iso3": "aar",
+      "id": "4468",
+      "name": [
+        {
+          "value": "ʿAfár af",
+          "primary": true,
+          "language": {
+            "id": "4468"
+          }
+        },
+        {
+          "value": "Afar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pangwa",
+      "bcp47": null,
+      "iso3": "pbr",
+      "id": "14084",
+      "name": [
+        {
+          "value": "Pangwa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pame-central",
+      "bcp47": "pbs",
+      "iso3": "pbs",
+      "id": "8145",
+      "name": [
+        {
+          "value": "Pame, Central",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pashto-southern",
+      "bcp47": null,
+      "iso3": "pbt",
+      "id": "10519",
+      "name": [
+        {
+          "value": "Pashto, Southern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pidgin-cameroon",
+      "bcp47": "wes",
+      "iso3": "wes",
+      "id": "2261",
+      "name": [
+        {
+          "value": "Pidgin, Cameroon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "adangme",
+      "bcp47": "ada",
+      "iso3": "ada",
+      "id": "50836",
+      "name": [
+        {
+          "value": "Adangbɛ",
+          "primary": true,
+          "language": {
+            "id": "50836"
+          }
+        },
+        {
+          "value": "Adangme",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "adonara",
+      "bcp47": null,
+      "iso3": "adr",
+      "id": "96802",
+      "name": [
+        {
+          "value": "Adonara",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "betawi",
+      "bcp47": "bew",
+      "iso3": "bew",
+      "id": "16652",
+      "name": [
+        {
+          "value": "Betawi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "legbo",
+      "bcp47": "agb",
+      "iso3": "agb",
+      "id": "9291",
+      "name": [
+        {
+          "value": "Legbo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "agatu",
+      "bcp47": "agc",
+      "iso3": "agc",
+      "id": "9290",
+      "name": [
+        {
+          "value": "Agatu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "amdo-tibetan",
+      "bcp47": "adx",
+      "iso3": "adx",
+      "id": "23089",
+      "name": [
+        {
+          "value": "Amdo, Tibetan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "adzera",
+      "bcp47": "adz",
+      "iso3": "adz",
+      "id": "96809",
+      "name": [
+        {
+          "value": "Adzera",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "akeu",
+      "bcp47": "aeu",
+      "iso3": "aeu",
+      "id": "96819",
+      "name": [
+        {
+          "value": "Akeu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "iraya",
+      "bcp47": null,
+      "iso3": "iry",
+      "id": "141085",
+      "name": [
+        {
+          "value": "Iraya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pnar",
+      "bcp47": "pbv",
+      "iso3": "pbv",
+      "id": "5973",
+      "name": [
+        {
+          "value": "Pnar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kalanga",
+      "bcp47": "kck",
+      "iso3": "kck",
+      "id": "1510",
+      "name": [
+        {
+          "value": "Kalanga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kaduo",
+      "bcp47": null,
+      "iso3": "ktp",
+      "id": "99188",
+      "name": [
+        {
+          "value": "Hani, Kaduo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "moba",
+      "bcp47": "mfq",
+      "iso3": "mfq",
+      "id": "2029",
+      "name": [
+        {
+          "value": "Moba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bouyei",
+      "bcp47": "pcc",
+      "iso3": "pcc",
+      "id": "3960",
+      "name": [
+        {
+          "value": "Haasqyaix",
+          "primary": true,
+          "language": {
+            "id": "3960"
+          }
+        },
+        {
+          "value": "Bouyei",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kusaal-western",
+      "bcp47": null,
+      "iso3": "kus",
+      "id": "2045",
+      "name": [
+        {
+          "value": "Kusaal, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "phende",
+      "bcp47": "pem",
+      "iso3": "pem",
+      "id": "15213",
+      "name": [
+        {
+          "value": "Phende",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ghomala",
+      "bcp47": "bbj",
+      "iso3": "bbj",
+      "id": "2908",
+      "name": [
+        {
+          "value": "Ghomala",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kpelle-guinea",
+      "bcp47": "gkp",
+      "iso3": "gkp",
+      "id": "5456",
+      "name": [
+        {
+          "value": "Kpelle, Guinea",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fuuta-jalon",
+      "bcp47": "fuf",
+      "iso3": "fuf",
+      "id": "5459",
+      "name": [
+        {
+          "value": "Fuuta Jalon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dan",
+      "bcp47": "dnj",
+      "iso3": "dnj",
+      "id": "5462",
+      "name": [
+        {
+          "value": "Dan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yalunka",
+      "bcp47": "yal",
+      "iso3": "yal",
+      "id": "5468",
+      "name": [
+        {
+          "value": "Yalunka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "muria-eastern",
+      "bcp47": "emu",
+      "iso3": "emu",
+      "id": "98139",
+      "name": [
+        {
+          "value": "Muria, Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dinka-agar-bor",
+      "bcp47": "dib",
+      "iso3": "dib",
+      "id": "139058",
+      "name": [
+        {
+          "value": "Thuɔŋjäŋ",
+          "primary": true,
+          "language": {
+            "id": "139058"
+          }
+        },
+        {
+          "value": "Dinka, Agar-Bor",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lebanese-sign-language",
+      "bcp47": "jos",
+      "iso3": "jos",
+      "id": "139080",
+      "name": [
+        {
+          "value": "Lebanese Sign Language",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kurdi-sorani-eastern",
+      "bcp47": "ckb",
+      "iso3": "ckb",
+      "id": "139115",
+      "name": [
+        {
+          "value": "Kurdi, Sorani - Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fulfulde-bagirmi",
+      "bcp47": null,
+      "iso3": "fui",
+      "id": "3667",
+      "name": [
+        {
+          "value": "Fulfulde, Bagirmi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "khmu",
+      "bcp47": "kjg",
+      "iso3": "kjg",
+      "id": "3817",
+      "name": [
+        {
+          "value": "Khmu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zapoteco-san-juan-guelavia",
+      "bcp47": "zab",
+      "iso3": "zab",
+      "id": "8021",
+      "name": [
+        {
+          "value": "Zapoteco, San Juan Guelavia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tzeltal-bachajon",
+      "bcp47": "tzh-x-Bachajon",
+      "iso3": "tzh",
+      "id": "8072",
+      "name": [
+        {
+          "value": "Tzeltal, Bachajon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gun-gbe",
+      "bcp47": "guw",
+      "iso3": "guw",
+      "id": "1297",
+      "name": [
+        {
+          "value": "Gun-Gbe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yanomamo",
+      "bcp47": "guu",
+      "iso3": "guu",
+      "id": "1573",
+      "name": [
+        {
+          "value": "Yanomamo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "teke-central",
+      "bcp47": "TEC",
+      "iso3": "TEC",
+      "id": "4309",
+      "name": [
+        {
+          "value": "Teke, Central",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lobala",
+      "bcp47": null,
+      "iso3": "loq",
+      "id": "4343",
+      "name": [
+        {
+          "value": "Lobala",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "aari",
+      "bcp47": "aiw",
+      "iso3": "aiw",
+      "id": "4797",
+      "name": [
+        {
+          "value": "Aari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yiddish",
+      "bcp47": "ydd",
+      "iso3": "ydd",
+      "id": "5130",
+      "name": [
+        {
+          "value": "ייִדיש ייִדיש",
+          "primary": true,
+          "language": {
+            "id": "5130"
+          }
+        },
+        {
+          "value": "Yiddish",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "assyrian",
+      "bcp47": "aii",
+      "iso3": "aii",
+      "id": "20551",
+      "name": [
+        {
+          "value": "ܐܵܬ݂ܘܼܪܵܝܲܐ ܠܸܫܵܢܵܐ",
+          "primary": true,
+          "language": {
+            "id": "20551"
+          }
+        },
+        {
+          "value": "Assyrian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kwanyama",
+      "bcp47": "kj",
+      "iso3": "kua",
+      "id": "548",
+      "name": [
+        {
+          "value": "Oshikwanyama",
+          "primary": true,
+          "language": {
+            "id": "548"
+          }
+        },
+        {
+          "value": "Kwanyama",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "makonde-tanzania",
+      "bcp47": null,
+      "iso3": "kde",
+      "id": "184494",
+      "name": [
+        {
+          "value": "Makonde, Tanzania",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "panjabi-western",
+      "bcp47": "pnb",
+      "iso3": "pnb",
+      "id": "5949",
+      "name": [
+        {
+          "value": "پنجابی",
+          "primary": true,
+          "language": {
+            "id": "5949"
+          }
+        },
+        {
+          "value": "Panjabi, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kikuro",
+      "bcp47": "kui",
+      "iso3": "kui",
+      "id": "139071",
+      "name": [
+        {
+          "value": "Kikuro",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jaunsari",
+      "bcp47": "jns",
+      "iso3": "jns",
+      "id": "6428",
+      "name": [
+        {
+          "value": "Jaunsari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "margi-south",
+      "bcp47": "mfm",
+      "iso3": "mfm",
+      "id": "139128",
+      "name": [
+        {
+          "value": "Margi South",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "birifor",
+      "bcp47": "bfo",
+      "iso3": "bfo",
+      "id": "139154",
+      "name": [
+        {
+          "value": "Birifor",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ndrulo",
+      "bcp47": null,
+      "iso3": "led",
+      "id": "139155",
+      "name": [
+        {
+          "value": "Ndrulo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "thur",
+      "bcp47": null,
+      "iso3": "lth",
+      "id": "139156",
+      "name": [
+        {
+          "value": "Thur",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ehugbo",
+      "bcp47": "ig",
+      "iso3": "ibo",
+      "id": "139157",
+      "name": [
+        {
+          "value": "Ehugbo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "waorani",
+      "bcp47": null,
+      "iso3": "auc",
+      "id": "139202",
+      "name": [
+        {
+          "value": "Waorani",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ghotuo",
+      "bcp47": null,
+      "iso3": "ikh",
+      "id": "139226",
+      "name": [
+        {
+          "value": "Ghotuo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "abanyom",
+      "bcp47": null,
+      "iso3": "abm",
+      "id": "139251",
+      "name": [
+        {
+          "value": "Abanyom",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "achuar-shiwiar",
+      "bcp47": "acu",
+      "iso3": "acu",
+      "id": "139273",
+      "name": [
+        {
+          "value": "Achuár Chícham",
+          "primary": true,
+          "language": {
+            "id": "139273"
+          }
+        },
+        {
+          "value": "Achuar-Shiwiar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tobelo",
+      "bcp47": null,
+      "iso3": "tlb",
+      "id": "100859",
+      "name": [
+        {
+          "value": "Tobelo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "angaataha",
+      "bcp47": "agm",
+      "iso3": "agm",
+      "id": "139319",
+      "name": [
+        {
+          "value": "Angaataha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "aghem",
+      "bcp47": "agq",
+      "iso3": "agq",
+      "id": "139321",
+      "name": [
+        {
+          "value": "Aghem",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "awajun",
+      "bcp47": null,
+      "iso3": "agr",
+      "id": "139322",
+      "name": [
+        {
+          "value": "Awajun",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arosi",
+      "bcp47": null,
+      "iso3": "aia",
+      "id": "139342",
+      "name": [
+        {
+          "value": "Arosi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "talaud",
+      "bcp47": "tld",
+      "iso3": "tld",
+      "id": "17547",
+      "name": [
+        {
+          "value": "Talaud",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-modern-standard-egyptian",
+      "bcp47": "ar-arb-EG",
+      "iso3": "arb",
+      "id": "53441",
+      "name": [
+        {
+          "value": "اللغة المصرية الحديثة",
+          "primary": true,
+          "language": {
+            "id": "53441"
+          }
+        },
+        {
+          "value": "Arabic, Modern Standard (Egyptian)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kalo-5",
+      "bcp47": null,
+      "iso3": "khz",
+      "id": "149174",
+      "name": [
+        {
+          "value": "Kalo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lubwisi",
+      "bcp47": "tlj",
+      "iso3": "tlj",
+      "id": "22203",
+      "name": [
+        {
+          "value": "Lubwisi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "otetela",
+      "bcp47": "tll",
+      "iso3": "tll",
+      "id": "20965",
+      "name": [
+        {
+          "value": "Otetela",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dendi-malanville",
+      "bcp47": "ddn",
+      "iso3": "ddn",
+      "id": "1344",
+      "name": [
+        {
+          "value": "Dendi (Malanville)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pardhi",
+      "bcp47": "pcl",
+      "iso3": "pcl",
+      "id": "5960",
+      "name": [
+        {
+          "value": "Pardhi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "senoufo-supyire",
+      "bcp47": "spp",
+      "iso3": "spp",
+      "id": "7811",
+      "name": [
+        {
+          "value": "Senoufo, Supyire",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "angal-heneng",
+      "bcp47": null,
+      "iso3": "akh",
+      "id": "139376",
+      "name": [
+        {
+          "value": "Angal Heneng",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yanesha",
+      "bcp47": "ame",
+      "iso3": "ame",
+      "id": "139411",
+      "name": [
+        {
+          "value": "Yanesha'",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ambai",
+      "bcp47": null,
+      "iso3": "amk",
+      "id": "139414",
+      "name": [
+        {
+          "value": "Ambai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pimbwe",
+      "bcp47": null,
+      "iso3": "piw",
+      "id": "143768",
+      "name": [
+        {
+          "value": "Pimbwe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "shekkacho",
+      "bcp47": "moy",
+      "iso3": "moy",
+      "id": "143877",
+      "name": [
+        {
+          "value": "Shekkacho",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hamgyongdo",
+      "bcp47": "ko-x-Hamgyongdo",
+      "iso3": "kor",
+      "id": "7350",
+      "name": [
+        {
+          "value": "Hamgyongdo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "luchazi",
+      "bcp47": "lch",
+      "iso3": "lch",
+      "id": "555",
+      "name": [
+        {
+          "value": "Luchazi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lyele",
+      "bcp47": "lee",
+      "iso3": "lee",
+      "id": "2035",
+      "name": [
+        {
+          "value": "Lyele",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cheke-holo",
+      "bcp47": null,
+      "iso3": "mrn",
+      "id": "144083",
+      "name": [
+        {
+          "value": "Cheke Holo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "udmurt",
+      "bcp47": "udm",
+      "iso3": "udm",
+      "id": "18606",
+      "name": [
+        {
+          "value": "удмурт кыл",
+          "primary": true,
+          "language": {
+            "id": "18606"
+          }
+        },
+        {
+          "value": "Udmurt",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "romani-carpathian",
+      "bcp47": "rmc",
+      "iso3": "rmc",
+      "id": "4450",
+      "name": [
+        {
+          "value": "रोमानो",
+          "primary": true,
+          "language": {
+            "id": "4450"
+          }
+        },
+        {
+          "value": "Romani, Carpathian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dogon-tomo-kan",
+      "bcp47": null,
+      "iso3": "dtm",
+      "id": "26248",
+      "name": [
+        {
+          "value": "Dogon, Tomo Kan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "senoufo-tagbana",
+      "bcp47": "tgw",
+      "iso3": "tgw",
+      "id": "53417",
+      "name": [
+        {
+          "value": "Senoufo, Tagbana",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bishnupriya",
+      "bcp47": null,
+      "iso3": "bpy",
+      "id": "23250",
+      "name": [
+        {
+          "value": "Bishnupriya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "thai",
+      "bcp47": "th",
+      "iso3": "tha",
+      "id": "13169",
+      "name": [
+        {
+          "value": "ภาษาไทย",
+          "primary": true,
+          "language": {
+            "id": "13169"
+          }
+        },
+        {
+          "value": "Thai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chatino-nopala",
+      "bcp47": "cya",
+      "iso3": "cya",
+      "id": "8282",
+      "name": [
+        {
+          "value": "Chatino, Nopala",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hindko-southern",
+      "bcp47": null,
+      "iso3": "hnd",
+      "id": "10455",
+      "name": [
+        {
+          "value": "Hindko, Southern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "duala",
+      "bcp47": "dua",
+      "iso3": "dua",
+      "id": "2854",
+      "name": [
+        {
+          "value": "Duala",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ukrainian-sign-language",
+      "bcp47": "ukl",
+      "iso3": "ukl",
+      "id": "14783",
+      "name": [
+        {
+          "value": "Ukrainian Sign Language",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "marwari-southern",
+      "bcp47": null,
+      "iso3": "mve",
+      "id": "10528",
+      "name": [
+        {
+          "value": "Marwari, Southern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bakhtiari",
+      "bcp47": "bqi",
+      "iso3": "bqi",
+      "id": "6800",
+      "name": [
+        {
+          "value": "Bakhtiari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dongissa",
+      "bcp47": null,
+      "iso3": "ktb",
+      "id": "164768",
+      "name": [
+        {
+          "value": "Dongissa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tembarissa",
+      "bcp47": null,
+      "iso3": "ktb",
+      "id": "149770",
+      "name": [
+        {
+          "value": "Tembarissa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kok-borok",
+      "bcp47": "trp",
+      "iso3": "trp",
+      "id": "1231",
+      "name": [
+        {
+          "value": "Kok Borok",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bundel-khandi",
+      "bcp47": "bns",
+      "iso3": "bns",
+      "id": "20587",
+      "name": [
+        {
+          "value": "Bundel Khandi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jola-fogny",
+      "bcp47": "dyo",
+      "iso3": "dyo",
+      "id": "5069",
+      "name": [
+        {
+          "value": "Jola-Fogny",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fulacunda",
+      "bcp47": "fuc",
+      "iso3": "fuc",
+      "id": "5050",
+      "name": [
+        {
+          "value": "Fulacunda",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tigrinya-ethiopia",
+      "bcp47": "ti-ER",
+      "iso3": "tir",
+      "id": "4576",
+      "name": [
+        {
+          "value": "ትግርኛ",
+          "primary": true,
+          "language": {
+            "id": "4576"
+          }
+        },
+        {
+          "value": "Tigrinya, Ethiopia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "brazilian-sign-language",
+      "bcp47": "bzs",
+      "iso3": "bzs",
+      "id": "1872",
+      "name": [
+        {
+          "value": "Brazilian Sign Language",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bade",
+      "bcp47": "bde",
+      "iso3": "bde",
+      "id": "10221",
+      "name": [
+        {
+          "value": "Bade",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "saa",
+      "bcp47": "apb",
+      "iso3": "apb",
+      "id": "97071",
+      "name": [
+        {
+          "value": "Sa'a",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fanakalo",
+      "bcp47": "fng",
+      "iso3": "fng",
+      "id": "20662",
+      "name": [
+        {
+          "value": "Fanakalo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kuki",
+      "bcp47": "tcz",
+      "iso3": "tcz",
+      "id": "23569",
+      "name": [
+        {
+          "value": "Kuki",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chinese-yunnan-kunming",
+      "bcp47": "zh-CN-53-x-Kunming",
+      "iso3": "cmn",
+      "id": "23061",
+      "name": [
+        {
+          "value": "漢語",
+          "primary": true,
+          "language": {
+            "id": "23061"
+          }
+        },
+        {
+          "value": "Chinese, Yunnan (Kunming)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bhili",
+      "bcp47": "bhb",
+      "iso3": "bhb",
+      "id": "5695",
+      "name": [
+        {
+          "value": "Bhili",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kagulu",
+      "bcp47": null,
+      "iso3": "kki",
+      "id": "14157",
+      "name": [
+        {
+          "value": "Kagulu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "athpariya",
+      "bcp47": "aph",
+      "iso3": "aph",
+      "id": "97073",
+      "name": [
+        {
+          "value": "Athpariya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "paniya",
+      "bcp47": "pcg",
+      "iso3": "pcg",
+      "id": "5969",
+      "name": [
+        {
+          "value": "Paniya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pardhan",
+      "bcp47": "pch",
+      "iso3": "pch",
+      "id": "5968",
+      "name": [
+        {
+          "value": "Pardhan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "toabaita",
+      "bcp47": null,
+      "iso3": "mlu",
+      "id": "143501",
+      "name": [
+        {
+          "value": "To'Abaita",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "alaba",
+      "bcp47": "alw",
+      "iso3": "alw",
+      "id": "4793",
+      "name": [
+        {
+          "value": "Alaba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "duruwa",
+      "bcp47": "pci",
+      "iso3": "pci",
+      "id": "5967",
+      "name": [
+        {
+          "value": "Duruwa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sambal",
+      "bcp47": "xsb",
+      "iso3": "xsb",
+      "id": "20905",
+      "name": [
+        {
+          "value": "Sambal",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malagasy-antankarana",
+      "bcp47": "mg-xmv",
+      "iso3": "xmv",
+      "id": "7750",
+      "name": [
+        {
+          "value": "Fiteny Malagasy",
+          "primary": true,
+          "language": {
+            "id": "7750"
+          }
+        },
+        {
+          "value": "Malagasy, Antankarana",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "korean",
+      "bcp47": "ko",
+      "iso3": "kor",
+      "id": "3804",
+      "name": [
+        {
+          "value": "한국어",
+          "primary": true,
+          "language": {
+            "id": "3804"
+          }
+        },
+        {
+          "value": "Korean",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "latvian",
+      "bcp47": "lv",
+      "iso3": "lvs",
+      "id": "7519",
+      "name": [
+        {
+          "value": "Latviešu",
+          "primary": true,
+          "language": {
+            "id": "7519"
+          }
+        },
+        {
+          "value": "Latvian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "toraja",
+      "bcp47": "sda",
+      "iso3": "sda",
+      "id": "21247",
+      "name": [
+        {
+          "value": "Toraja",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "verre",
+      "bcp47": "ver",
+      "iso3": "ver",
+      "id": "125753",
+      "name": [
+        {
+          "value": "Verre",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nta",
+      "bcp47": null,
+      "iso3": "ndd",
+      "id": "152629",
+      "name": [
+        {
+          "value": "Nta",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "azerbaijani-iran",
+      "bcp47": "azb",
+      "iso3": "azb",
+      "id": "355",
+      "name": [
+        {
+          "value": "آذربایجانجا",
+          "primary": true,
+          "language": {
+            "id": "355"
+          }
+        },
+        {
+          "value": "Azerbaijani, Iran",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malagasy-southern-betsimisaraka",
+      "bcp47": "mg-bzc",
+      "iso3": "bzc",
+      "id": "27226",
+      "name": [
+        {
+          "value": "Fiteny Malagasy",
+          "primary": true,
+          "language": {
+            "id": "27226"
+          }
+        },
+        {
+          "value": "Malagasy, Southern Betsimisaraka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-saidi-spoken",
+      "bcp47": "ar-aec",
+      "iso3": "aec",
+      "id": "4532",
+      "name": [
+        {
+          "value": "Arabic, Saidi Spoken",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kurdi-sorani",
+      "bcp47": "ckb",
+      "iso3": "ckb",
+      "id": "139114",
+      "name": [
+        {
+          "value": "کوردی",
+          "primary": true,
+          "language": {
+            "id": "139114"
+          }
+        },
+        {
+          "value": "Kurdi, Sorani",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chuukese",
+      "bcp47": null,
+      "iso3": "chk",
+      "id": "139129",
+      "name": [
+        {
+          "value": "Chuukese",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "binukid",
+      "bcp47": null,
+      "iso3": "bkd",
+      "id": "12854",
+      "name": [
+        {
+          "value": "Binukid",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "matses",
+      "bcp47": "mcf",
+      "iso3": "mcf",
+      "id": "1604",
+      "name": [
+        {
+          "value": "Matses",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chin-asho",
+      "bcp47": "csh",
+      "iso3": "csh",
+      "id": "1181",
+      "name": [
+        {
+          "value": "Chin, Asho",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "manobo-sarangani",
+      "bcp47": "mbs",
+      "iso3": "mbs",
+      "id": "99564",
+      "name": [
+        {
+          "value": "Manobo, Sarangani",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pengo",
+      "bcp47": "peg",
+      "iso3": "peg",
+      "id": "5956",
+      "name": [
+        {
+          "value": "Pengo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "maria",
+      "bcp47": "mrr",
+      "iso3": "mrr",
+      "id": "6178",
+      "name": [
+        {
+          "value": "Maria",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "rajbangsi-india",
+      "bcp47": "rjs",
+      "iso3": "rkt",
+      "id": "23226",
+      "name": [
+        {
+          "value": "Rajbangsi, India",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kom",
+      "bcp47": "bkm",
+      "iso3": "bkm",
+      "id": "19558",
+      "name": [
+        {
+          "value": "Kom",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bekwarra",
+      "bcp47": "bkv",
+      "iso3": "bkv",
+      "id": "10208",
+      "name": [
+        {
+          "value": "Bekwarra",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "masana",
+      "bcp47": "mcn",
+      "iso3": "mcn",
+      "id": "2538",
+      "name": [
+        {
+          "value": "Masana",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "komi-permyak",
+      "bcp47": "koi",
+      "iso3": "koi",
+      "id": "18528",
+      "name": [
+        {
+          "value": "коми кыв",
+          "primary": true,
+          "language": {
+            "id": "18528"
+          }
+        },
+        {
+          "value": "Komi-Permyak",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-juba",
+      "bcp47": null,
+      "iso3": "pga",
+      "id": "38242",
+      "name": [
+        {
+          "value": "Arabic, Juba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kabyle",
+      "bcp47": "kab",
+      "iso3": "kab",
+      "id": "494",
+      "name": [
+        {
+          "value": "شئعم",
+          "primary": true,
+          "language": {
+            "id": "494"
+          }
+        },
+        {
+          "value": "Kabyle",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dhimal",
+      "bcp47": null,
+      "iso3": "dhi",
+      "id": "140205",
+      "name": [
+        {
+          "value": "Dhimal",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dutch",
+      "bcp47": "nl",
+      "iso3": "nld",
+      "id": "1269",
+      "name": [
+        {
+          "value": "Nederlands",
+          "primary": true,
+          "language": {
+            "id": "1269"
+          }
+        },
+        {
+          "value": "Dutch",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hatam",
+      "bcp47": null,
+      "iso3": "had",
+      "id": "140927",
+      "name": [
+        {
+          "value": "Hatam",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ifugao-mayoyao",
+      "bcp47": "ifu",
+      "iso3": "ifu",
+      "id": "141009",
+      "name": [
+        {
+          "value": "Ifugao, Mayoyao",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "surgujia",
+      "bcp47": "sgj",
+      "iso3": "sgj",
+      "id": "142339",
+      "name": [
+        {
+          "value": "Surgujia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "curripaco",
+      "bcp47": null,
+      "iso3": "kpc",
+      "id": "141382",
+      "name": [
+        {
+          "value": "Curripaco",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kamasau",
+      "bcp47": null,
+      "iso3": "kms",
+      "id": "141455",
+      "name": [
+        {
+          "value": "Kamasau",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "batak-simalungun",
+      "bcp47": "bts",
+      "iso3": "bts",
+      "id": "17814",
+      "name": [
+        {
+          "value": "Sahap Simalungun",
+          "primary": true,
+          "language": {
+            "id": "17814"
+          }
+        },
+        {
+          "value": "Batak Simalungun",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mambwe-lungu",
+      "bcp47": "mgr",
+      "iso3": "mgr",
+      "id": "14259",
+      "name": [
+        {
+          "value": "Mambwe-Lungu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "matengo",
+      "bcp47": null,
+      "iso3": "mgv",
+      "id": "14255",
+      "name": [
+        {
+          "value": "Matengo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "matumbi",
+      "bcp47": "mgw",
+      "iso3": "mgw",
+      "id": "14254",
+      "name": [
+        {
+          "value": "Matumbi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tampulma",
+      "bcp47": "tpm",
+      "iso3": "tpm",
+      "id": "5291",
+      "name": [
+        {
+          "value": "Tampulma",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "trique-san-juan-copala",
+      "bcp47": "trc",
+      "iso3": "trc",
+      "id": "8079",
+      "name": [
+        {
+          "value": "Trique, San Juan Copala",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kaba-naa-sara",
+      "bcp47": null,
+      "iso3": "kwv",
+      "id": "141528",
+      "name": [
+        {
+          "value": "Kaba Naa, Sara",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tehit",
+      "bcp47": "kps",
+      "iso3": "kps",
+      "id": "141560",
+      "name": [
+        {
+          "value": "Tehit",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ruwila",
+      "bcp47": null,
+      "iso3": "rwl",
+      "id": "185129",
+      "name": [
+        {
+          "value": "Ruwila",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kupsapiiny",
+      "bcp47": "kpz",
+      "iso3": "kpz",
+      "id": "141566",
+      "name": [
+        {
+          "value": "Kupsapiiny",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "doromu-koki",
+      "bcp47": "kqc",
+      "iso3": "kqc",
+      "id": "141569",
+      "name": [
+        {
+          "value": "Doromu-Koki",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "koita-ga",
+      "bcp47": null,
+      "iso3": "kqi",
+      "id": "141574",
+      "name": [
+        {
+          "value": "Koita Ga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kandas",
+      "bcp47": null,
+      "iso3": "kqw",
+      "id": "141586",
+      "name": [
+        {
+          "value": "Kandas",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bangjinge",
+      "bcp47": "bsj",
+      "iso3": "bsj",
+      "id": "28054",
+      "name": [
+        {
+          "value": "Bangjinge",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "burushaski",
+      "bcp47": null,
+      "iso3": "bsk",
+      "id": "10570",
+      "name": [
+        {
+          "value": "Burushaski",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bassa",
+      "bcp47": "bsq",
+      "iso3": "bsq",
+      "id": "19508",
+      "name": [
+        {
+          "value": "Basaá",
+          "primary": true,
+          "language": {
+            "id": "19508"
+          }
+        },
+        {
+          "value": "Bassa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pak-pak-dairi",
+      "bcp47": "btd",
+      "iso3": "btd",
+      "id": "21637",
+      "name": [
+        {
+          "value": "Pak Pak Dairi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "karon",
+      "bcp47": "krx",
+      "iso3": "krx",
+      "id": "141602",
+      "name": [
+        {
+          "value": "Karon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-egyptian-colloquial",
+      "bcp47": "ar-arz",
+      "iso3": "arz",
+      "id": "20533",
+      "name": [
+        {
+          "value": "اللغة المصرية العامية",
+          "primary": true,
+          "language": {
+            "id": "20533"
+          }
+        },
+        {
+          "value": "Arabic, Egyptian Colloquial",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mundani",
+      "bcp47": "mnf",
+      "iso3": "mnf",
+      "id": "2440",
+      "name": [
+        {
+          "value": "Mundani",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "auhelawa",
+      "bcp47": null,
+      "iso3": "kud",
+      "id": "141644",
+      "name": [
+        {
+          "value": "'Auhelawa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kusaal",
+      "bcp47": null,
+      "iso3": "kus",
+      "id": "141653",
+      "name": [
+        {
+          "value": "Kusaal",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bugis",
+      "bcp47": "bug",
+      "iso3": "bug",
+      "id": "17645",
+      "name": [
+        {
+          "value": "ᨅᨔ ᨕᨘᨁᨗ",
+          "primary": true,
+          "language": {
+            "id": "17645"
+          }
+        },
+        {
+          "value": "Bugis",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "budu-nita",
+      "bcp47": "buu-x-Nita",
+      "iso3": "buu",
+      "id": "24091",
+      "name": [
+        {
+          "value": "Budu, Nita",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "budu-koya",
+      "bcp47": "buu-x-Koya",
+      "iso3": "buu",
+      "id": "24092",
+      "name": [
+        {
+          "value": "Budu, Koya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kuni-boazi",
+      "bcp47": "kvg",
+      "iso3": "kvg",
+      "id": "141667",
+      "name": [
+        {
+          "value": "Kuni-Boazi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "digo",
+      "bcp47": "dig",
+      "iso3": "dig",
+      "id": "7176",
+      "name": [
+        {
+          "value": "Digo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "label",
+      "bcp47": null,
+      "iso3": "lbb",
+      "id": "141691",
+      "name": [
+        {
+          "value": "Label",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chakma",
+      "bcp47": "ccp",
+      "iso3": "ccp",
+      "id": "1253",
+      "name": [
+        {
+          "value": "Chakma",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "anufo",
+      "bcp47": "cko",
+      "iso3": "cko",
+      "id": "1345",
+      "name": [
+        {
+          "value": "Anufo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chilcotin",
+      "bcp47": "clc",
+      "iso3": "clc",
+      "id": "3099",
+      "name": [
+        {
+          "value": "Chilcotin",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cerma",
+      "bcp47": "cme",
+      "iso3": "cme",
+      "id": "2067",
+      "name": [
+        {
+          "value": "Cerma",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mnong-central",
+      "bcp47": "cmo",
+      "iso3": "cmo",
+      "id": "2159",
+      "name": [
+        {
+          "value": "Mnong, Central",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "koreguaje",
+      "bcp47": null,
+      "iso3": "coe",
+      "id": "4250",
+      "name": [
+        {
+          "value": "Koreguaje",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cherepon",
+      "bcp47": null,
+      "iso3": "cpn",
+      "id": "25991",
+      "name": [
+        {
+          "value": "Cherepon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "asheninca-pichis",
+      "bcp47": null,
+      "iso3": "cpu",
+      "id": "23941",
+      "name": [
+        {
+          "value": "Asheninca Pichis",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gbe-tofin",
+      "bcp47": null,
+      "iso3": "tfi",
+      "id": "142348",
+      "name": [
+        {
+          "value": "Gbe, Tofin",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bura-pabir",
+      "bcp47": "bwr",
+      "iso3": "bwr",
+      "id": "10343",
+      "name": [
+        {
+          "value": "Bura-Pabir",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "buriat-russia",
+      "bcp47": "bxr",
+      "iso3": "bxr",
+      "id": "18321",
+      "name": [
+        {
+          "value": "буряад хэлэн",
+          "primary": true,
+          "language": {
+            "id": "18321"
+          }
+        },
+        {
+          "value": "Buriat, Russia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "benyadu",
+      "bcp47": null,
+      "iso3": "byd",
+      "id": "97609",
+      "name": [
+        {
+          "value": "Benyadu'",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sapo",
+      "bcp47": null,
+      "iso3": "krn",
+      "id": "141597",
+      "name": [
+        {
+          "value": "Sapo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tanna-southwest",
+      "bcp47": "nwi",
+      "iso3": "nwi",
+      "id": "15013",
+      "name": [
+        {
+          "value": "Tanna, Southwest",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nage",
+      "bcp47": null,
+      "iso3": "nxe",
+      "id": "17269",
+      "name": [
+        {
+          "value": "Nage",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bandi",
+      "bcp47": "bza",
+      "iso3": "bza",
+      "id": "7655",
+      "name": [
+        {
+          "value": "Bandi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lamnso",
+      "bcp47": "lns",
+      "iso3": "lns",
+      "id": "2331",
+      "name": [
+        {
+          "value": "Lamnso",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "longuda",
+      "bcp47": "lnu",
+      "iso3": "lnu",
+      "id": "9506",
+      "name": [
+        {
+          "value": "Longuda",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "loloda",
+      "bcp47": null,
+      "iso3": "loa",
+      "id": "16906",
+      "name": [
+        {
+          "value": "Loloda",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tonsawang",
+      "bcp47": null,
+      "iso3": "tnw",
+      "id": "17432",
+      "name": [
+        {
+          "value": "Tonsawang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tunia",
+      "bcp47": null,
+      "iso3": "tug",
+      "id": "143322",
+      "name": [
+        {
+          "value": "Tunia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "halang",
+      "bcp47": null,
+      "iso3": "hal",
+      "id": "140932",
+      "name": [
+        {
+          "value": "Halang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tanjijili",
+      "bcp47": null,
+      "iso3": "uji",
+      "id": "142172",
+      "name": [
+        {
+          "value": "Tanjijili",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ukue",
+      "bcp47": null,
+      "iso3": "uku",
+      "id": "142179",
+      "name": [
+        {
+          "value": "Ukue",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "albanian",
+      "bcp47": "sq",
+      "iso3": "als",
+      "id": "20526",
+      "name": [
+        {
+          "value": "Shqip",
+          "primary": true,
+          "language": {
+            "id": "20526"
+          }
+        },
+        {
+          "value": "Albanian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "winye",
+      "bcp47": null,
+      "iso3": "kst",
+      "id": "141618",
+      "name": [
+        {
+          "value": "Winye",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "anuak",
+      "bcp47": "anu",
+      "iso3": "anu",
+      "id": "4790",
+      "name": [
+        {
+          "value": "Anuak",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "wasa",
+      "bcp47": null,
+      "iso3": "wss",
+      "id": "20332",
+      "name": [
+        {
+          "value": "Wasa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "czech",
+      "bcp47": "cs",
+      "iso3": "ces",
+      "id": "4432",
+      "name": [
+        {
+          "value": "Český Jazyk",
+          "primary": true,
+          "language": {
+            "id": "4432"
+          }
+        },
+        {
+          "value": "Czech",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chin-falam",
+      "bcp47": "cfm",
+      "iso3": "cfm",
+      "id": "1192",
+      "name": [
+        {
+          "value": "Chin, Falam",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chin-khumi",
+      "bcp47": "cnk",
+      "iso3": "cnk",
+      "id": "1252",
+      "name": [
+        {
+          "value": "Chin, Khumi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "crimean-tatar",
+      "bcp47": "crh",
+      "iso3": "crh",
+      "id": "22335",
+      "name": [
+        {
+          "value": "Crimean Tatar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cree-western",
+      "bcp47": "crk",
+      "iso3": "crk",
+      "id": "3087",
+      "name": [
+        {
+          "value": "ᓀᐦᐃᔭᐍᐏᐣ",
+          "primary": true,
+          "language": {
+            "id": "3087"
+          }
+        },
+        {
+          "value": "Cree, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cora",
+      "bcp47": "crn",
+      "iso3": "crn",
+      "id": "8323",
+      "name": [
+        {
+          "value": "Cora",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "seselwa-creole",
+      "bcp47": "crs",
+      "iso3": "crs",
+      "id": "13079",
+      "name": [
+        {
+          "value": "Seselwa Creole",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "batak-angkola",
+      "bcp47": "akb",
+      "iso3": "akb",
+      "id": "17689",
+      "name": [
+        {
+          "value": "Batak Angkola",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zaiwa",
+      "bcp47": "atb",
+      "iso3": "atb",
+      "id": "3710",
+      "name": [
+        {
+          "value": "Zaiwa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "avikam",
+      "bcp47": "avi",
+      "iso3": "avi",
+      "id": "16111",
+      "name": [
+        {
+          "value": "Avikam",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mardini",
+      "bcp47": "ar-ayp",
+      "iso3": "ayp",
+      "id": "23800",
+      "name": [
+        {
+          "value": "Mardini",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mai-brat",
+      "bcp47": "ayz",
+      "iso3": "ayz",
+      "id": "16176",
+      "name": [
+        {
+          "value": "Mai Brat",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "azha",
+      "bcp47": "aza",
+      "iso3": "aza",
+      "id": "97274",
+      "name": [
+        {
+          "value": "Azha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nahuatl-sierra-de-puebla",
+      "bcp47": "azz",
+      "iso3": "azz",
+      "id": "8336",
+      "name": [
+        {
+          "value": "Māsēwallahtōlli",
+          "primary": true,
+          "language": {
+            "id": "8336"
+          }
+        },
+        {
+          "value": "Nahuatl, Sierra De Puebla",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "rai-bantawa",
+      "bcp47": "bap",
+      "iso3": "bap",
+      "id": "24043",
+      "name": [
+        {
+          "value": "Rai, Bantawa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "luganda",
+      "bcp47": "lg",
+      "iso3": "lug",
+      "id": "20675",
+      "name": [
+        {
+          "value": "LùGáànda",
+          "primary": true,
+          "language": {
+            "id": "20675"
+          }
+        },
+        {
+          "value": "Luganda",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "luo",
+      "bcp47": "luo",
+      "iso3": "luo",
+      "id": "19936",
+      "name": [
+        {
+          "value": "Dholuo",
+          "primary": true,
+          "language": {
+            "id": "19936"
+          }
+        },
+        {
+          "value": "Luo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dinka-rek",
+      "bcp47": "dik",
+      "iso3": "dik",
+      "id": "24273",
+      "name": [
+        {
+          "value": "Dinka, Rek",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "luwo",
+      "bcp47": "lwo",
+      "iso3": "lwo",
+      "id": "13915",
+      "name": [
+        {
+          "value": "Luwo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "anyin",
+      "bcp47": "any",
+      "iso3": "any",
+      "id": "5333",
+      "name": [
+        {
+          "value": "Anyin",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "wumvu",
+      "bcp47": null,
+      "iso3": "wum",
+      "id": "143169",
+      "name": [
+        {
+          "value": "Wumvu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sani-3",
+      "bcp47": null,
+      "iso3": "ysn",
+      "id": "142869",
+      "name": [
+        {
+          "value": "Sani",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "naga-liangmai",
+      "bcp47": "njn",
+      "iso3": "njn",
+      "id": "143810",
+      "name": [
+        {
+          "value": "Naga, Liangmai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quechua-ambo-pasco",
+      "bcp47": "qva",
+      "iso3": "qva",
+      "id": "144393",
+      "name": [
+        {
+          "value": "Qhichwa",
+          "primary": true,
+          "language": {
+            "id": "144393"
+          }
+        },
+        {
+          "value": "Quechua, Ambo-Pasco",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "paranan",
+      "bcp47": "prf",
+      "iso3": "prf",
+      "id": "12518",
+      "name": [
+        {
+          "value": "Paranan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-algerian-spoken",
+      "bcp47": "ar-arq",
+      "iso3": "arq",
+      "id": "525",
+      "name": [
+        {
+          "value": "دزيري",
+          "primary": true,
+          "language": {
+            "id": "525"
+          }
+        },
+        {
+          "value": "Arabic, Algerian Spoken",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "aymara-central",
+      "bcp47": "ayr",
+      "iso3": "ayr",
+      "id": "616",
+      "name": [
+        {
+          "value": "Aymar Aru",
+          "primary": true,
+          "language": {
+            "id": "616"
+          }
+        },
+        {
+          "value": "Aymara, Central",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mapudungun",
+      "bcp47": "arn",
+      "iso3": "arn",
+      "id": "644",
+      "name": [
+        {
+          "value": "Mapudungun",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "azerbaijani-north",
+      "bcp47": "azj",
+      "iso3": "azj",
+      "id": "689",
+      "name": [
+        {
+          "value": "آذربایجان دیلی",
+          "primary": true,
+          "language": {
+            "id": "689"
+          }
+        },
+        {
+          "value": "Azerbaijani, North",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "belorussian",
+      "bcp47": "be",
+      "iso3": "bel",
+      "id": "1259",
+      "name": [
+        {
+          "value": "Беларуская мова",
+          "primary": true,
+          "language": {
+            "id": "1259"
+          }
+        },
+        {
+          "value": "Belorussian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "akha",
+      "bcp47": "ahk",
+      "iso3": "ahk",
+      "id": "3712",
+      "name": [
+        {
+          "value": "Akha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "abau",
+      "bcp47": "aau",
+      "iso3": "aau",
+      "id": "12296",
+      "name": [
+        {
+          "value": "Abau",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "aklanon",
+      "bcp47": "akl",
+      "iso3": "akl",
+      "id": "12853",
+      "name": [
+        {
+          "value": "Aklanon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "acholi",
+      "bcp47": "ach",
+      "iso3": "ach",
+      "id": "13555",
+      "name": [
+        {
+          "value": "Lwo",
+          "primary": true,
+          "language": {
+            "id": "13555"
+          }
+        },
+        {
+          "value": "Acholi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "alur",
+      "bcp47": "alz",
+      "iso3": "alz",
+      "id": "14694",
+      "name": [
+        {
+          "value": "Lur",
+          "primary": true,
+          "language": {
+            "id": "14694"
+          }
+        },
+        {
+          "value": "Alur",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "adioukrou",
+      "bcp47": "adj",
+      "iso3": "adj",
+      "id": "16116",
+      "name": [
+        {
+          "value": "Adioukrou",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-iraqi-baghdadi",
+      "bcp47": "ar-acm",
+      "iso3": "acm",
+      "id": "21061",
+      "name": [
+        {
+          "value": "Arabic, Iraqi Baghdadi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "altai",
+      "bcp47": "alt",
+      "iso3": "alt",
+      "id": "21554",
+      "name": [
+        {
+          "value": "алтайча",
+          "primary": true,
+          "language": {
+            "id": "21554"
+          }
+        },
+        {
+          "value": "Altai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ngas",
+      "bcp47": "anc",
+      "iso3": "anc",
+      "id": "22193",
+      "name": [
+        {
+          "value": "Ngas",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "adi",
+      "bcp47": "adi",
+      "iso3": "adi",
+      "id": "24173",
+      "name": [
+        {
+          "value": "Adi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "galo",
+      "bcp47": "adl",
+      "iso3": "adl",
+      "id": "24409",
+      "name": [
+        {
+          "value": "Galo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-gulf",
+      "bcp47": "ar-afb",
+      "iso3": "afb",
+      "id": "139181",
+      "name": [
+        {
+          "value": "Arabic Gulf",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ayta-ambala",
+      "bcp47": null,
+      "iso3": "abc",
+      "id": "139244",
+      "name": [
+        {
+          "value": "Ayta, Ambala",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lampung-nyo",
+      "bcp47": null,
+      "iso3": "abl",
+      "id": "139250",
+      "name": [
+        {
+          "value": "Lampung Nyo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ansus",
+      "bcp47": null,
+      "iso3": "and",
+      "id": "139429",
+      "name": [
+        {
+          "value": "Ansus",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "utukwang",
+      "bcp47": "afe",
+      "iso3": "afe",
+      "id": "179212",
+      "name": [
+        {
+          "value": "Utukwang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-hijazi",
+      "bcp47": null,
+      "iso3": "acw",
+      "id": "184592",
+      "name": [
+        {
+          "value": "Arabic, Hijazi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "obe-nrung-ene",
+      "bcp47": "afe",
+      "iso3": "afe",
+      "id": "184632",
+      "name": [
+        {
+          "value": "Obe Nrung Ene",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "asante-twi",
+      "bcp47": null,
+      "iso3": "aka",
+      "id": "185199",
+      "name": [
+        {
+          "value": "Asante Twi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lipovan",
+      "bcp47": null,
+      "iso3": "",
+      "id": "185230",
+      "name": [
+        {
+          "value": "Lipovan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "garifuna",
+      "bcp47": "cab",
+      "iso3": "cab",
+      "id": "1277",
+      "name": [
+        {
+          "value": "Garifuna",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bariba",
+      "bcp47": "bba",
+      "iso3": "bba",
+      "id": "1294",
+      "name": [
+        {
+          "value": "Bariba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bororo",
+      "bcp47": "bor",
+      "iso3": "bor",
+      "id": "1873",
+      "name": [
+        {
+          "value": "Bororo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "apurina",
+      "bcp47": "apu",
+      "iso3": "apu",
+      "id": "1889",
+      "name": [
+        {
+          "value": "Apurina",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bobo-madare-southern",
+      "bcp47": null,
+      "iso3": "bwq",
+      "id": "2073",
+      "name": [
+        {
+          "value": "Bobo Madare, Southern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bwamu-laa-laa",
+      "bcp47": null,
+      "iso3": "bwj",
+      "id": "2074",
+      "name": [
+        {
+          "value": "Bwamu, Laa Laa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bomu",
+      "bcp47": "bmq",
+      "iso3": "bmq",
+      "id": "2081",
+      "name": [
+        {
+          "value": "Bomu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bokyi",
+      "bcp47": "bky",
+      "iso3": "bky",
+      "id": "2788",
+      "name": [
+        {
+          "value": "Bokyi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bulu",
+      "bcp47": "bum",
+      "iso3": "bum",
+      "id": "2884",
+      "name": [
+        {
+          "value": "Bulu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "akoose",
+      "bcp47": "bss",
+      "iso3": "bss",
+      "id": "2894",
+      "name": [
+        {
+          "value": "Akoose",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "blackfoot",
+      "bcp47": "bla",
+      "iso3": "bla",
+      "id": "3105",
+      "name": [
+        {
+          "value": "ᑯᖾᖹ",
+          "primary": true,
+          "language": {
+            "id": "3105"
+          }
+        },
+        {
+          "value": "Blackfoot",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bai",
+      "bcp47": "bca",
+      "iso3": "bca",
+      "id": "3948",
+      "name": [
+        {
+          "value": "白语",
+          "primary": true,
+          "language": {
+            "id": "3948"
+          }
+        },
+        {
+          "value": "Bai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "blin",
+      "bcp47": null,
+      "iso3": "byn",
+      "id": "4593",
+      "name": [
+        {
+          "value": "Blin",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "basketto",
+      "bcp47": "bst",
+      "iso3": "bst",
+      "id": "4779",
+      "name": [
+        {
+          "value": "Basketto",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "balti",
+      "bcp47": "bft",
+      "iso3": "bft",
+      "id": "6654",
+      "name": [
+        {
+          "value": "بلتی",
+          "primary": true,
+          "language": {
+            "id": "6654"
+          }
+        },
+        {
+          "value": "Balti",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "balochi-southern",
+      "bcp47": "bcc",
+      "iso3": "bcc",
+      "id": "6679",
+      "name": [
+        {
+          "value": "بلوچی",
+          "primary": true,
+          "language": {
+            "id": "6679"
+          }
+        },
+        {
+          "value": "Balochi, Southern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bukharian",
+      "bcp47": null,
+      "iso3": "bhh",
+      "id": "6934",
+      "name": [
+        {
+          "value": "Bukharian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "obolo",
+      "bcp47": "ann",
+      "iso3": "ann",
+      "id": "10364",
+      "name": [
+        {
+          "value": "Obolo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gamai",
+      "bcp47": "ank",
+      "iso3": "ank",
+      "id": "10365",
+      "name": [
+        {
+          "value": "Gamai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bariai",
+      "bcp47": "bch",
+      "iso3": "bch",
+      "id": "10715",
+      "name": [
+        {
+          "value": "Bariai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bemba",
+      "bcp47": "bem",
+      "iso3": "bem",
+      "id": "14278",
+      "name": [
+        {
+          "value": "iciBemba",
+          "primary": true,
+          "language": {
+            "id": "14278"
+          }
+        },
+        {
+          "value": "Bemba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "baule",
+      "bcp47": "bci",
+      "iso3": "bci",
+      "id": "16107",
+      "name": [
+        {
+          "value": "Baule",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "banggai",
+      "bcp47": "bgz",
+      "iso3": "bgz",
+      "id": "17365",
+      "name": [
+        {
+          "value": "Banggai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "batak-toba",
+      "bcp47": "bbc",
+      "iso3": "bbc",
+      "id": "17818",
+      "name": [
+        {
+          "value": "Batak Toba",
+          "primary": true,
+          "language": {
+            "id": "17818"
+          }
+        },
+        {
+          "value": "Batak Toba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bahnar",
+      "bcp47": "bdq",
+      "iso3": "bdq",
+      "id": "19391",
+      "name": [
+        {
+          "value": "Bahnar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bench",
+      "bcp47": "bcq",
+      "iso3": "bcq",
+      "id": "19518",
+      "name": [
+        {
+          "value": "Bèntʂ Nòn",
+          "primary": true,
+          "language": {
+            "id": "19518"
+          }
+        },
+        {
+          "value": "Bench",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bicolano",
+      "bcp47": "bcl",
+      "iso3": "bcl",
+      "id": "22100",
+      "name": [
+        {
+          "value": "Bikol",
+          "primary": true,
+          "language": {
+            "id": "22100"
+          }
+        },
+        {
+          "value": "Bicolano",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-modern-standard",
+      "bcp47": "ar",
+      "iso3": "arb",
+      "id": "22658",
+      "name": [
+        {
+          "value": " اللغة العربية",
+          "primary": true,
+          "language": {
+            "id": "22658"
+          }
+        },
+        {
+          "value": "Arabic, Modern Standard",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bacama-bwatiye",
+      "bcp47": "bcy",
+      "iso3": "bcy",
+      "id": "53330",
+      "name": [
+        {
+          "value": "Bacama-Bwatiye",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "djola-bayote",
+      "bcp47": "bda",
+      "iso3": "bda",
+      "id": "53409",
+      "name": [
+        {
+          "value": "Djola-Bayote",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bhogoto",
+      "bcp47": "bdt",
+      "iso3": "bdt",
+      "id": "53435",
+      "name": [
+        {
+          "value": "Bhogoto",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bamu",
+      "bcp47": "bcf",
+      "iso3": "bcf",
+      "id": "97185",
+      "name": [
+        {
+          "value": "Bamu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "oroko",
+      "bcp47": "bdu",
+      "iso3": "bdu",
+      "id": "97247",
+      "name": [
+        {
+          "value": "Oroko",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "apalai",
+      "bcp47": null,
+      "iso3": "apy",
+      "id": "139476",
+      "name": [
+        {
+          "value": "Apalai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arbore",
+      "bcp47": null,
+      "iso3": "arv",
+      "id": "139498",
+      "name": [
+        {
+          "value": "Arbore",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dano",
+      "bcp47": "aso",
+      "iso3": "aso",
+      "id": "139511",
+      "name": [
+        {
+          "value": "Dano",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arhe",
+      "bcp47": null,
+      "iso3": "atg",
+      "id": "139524",
+      "name": [
+        {
+          "value": "Arhe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "burun",
+      "bcp47": "bdi",
+      "iso3": "bdi",
+      "id": "139538",
+      "name": [
+        {
+          "value": "Burun",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "burunge",
+      "bcp47": "bds",
+      "iso3": "bds",
+      "id": "139544",
+      "name": [
+        {
+          "value": "Burunge",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ayoreo",
+      "bcp47": "ayo",
+      "iso3": "ayo",
+      "id": "139601",
+      "name": [
+        {
+          "value": "Ayoreo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "awing",
+      "bcp47": null,
+      "iso3": "azo",
+      "id": "139611",
+      "name": [
+        {
+          "value": "Awing",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "babanki",
+      "bcp47": null,
+      "iso3": "bbk",
+      "id": "139635",
+      "name": [
+        {
+          "value": "Babanki",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kulung",
+      "bcp47": "bbu",
+      "iso3": "bbu",
+      "id": "139643",
+      "name": [
+        {
+          "value": "Kulung",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "awad-bing",
+      "bcp47": null,
+      "iso3": "bcu",
+      "id": "139661",
+      "name": [
+        {
+          "value": "Awad Bing",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mmen",
+      "bcp47": "bfm",
+      "iso3": "bfm",
+      "id": "139817",
+      "name": [
+        {
+          "value": "Mmen",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bali",
+      "bcp47": null,
+      "iso3": "ban",
+      "id": "145699",
+      "name": [
+        {
+          "value": "Bali",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "okpella",
+      "bcp47": "atg",
+      "iso3": "atg",
+      "id": "181696",
+      "name": [
+        {
+          "value": "Okpella",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bado-parja",
+      "bcp47": "bdv",
+      "iso3": "bdv",
+      "id": "184499",
+      "name": [
+        {
+          "value": "Bado Parja",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-bedouin",
+      "bcp47": null,
+      "iso3": "avl",
+      "id": "184531",
+      "name": [
+        {
+          "value": "Arabic, Bedouin",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-libyan",
+      "bcp47": "ar-ayl",
+      "iso3": "ayl",
+      "id": "184848",
+      "name": [
+        {
+          "value": "Arabic, Libyan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cubeo",
+      "bcp47": null,
+      "iso3": "cub",
+      "id": "1592",
+      "name": [
+        {
+          "value": "Cubeo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "daba",
+      "bcp47": "dbq",
+      "iso3": "dbq",
+      "id": "2865",
+      "name": [
+        {
+          "value": "Daba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "colombian-sign-language",
+      "bcp47": "csn",
+      "iso3": "csn",
+      "id": "4247",
+      "name": [
+        {
+          "value": "Colombian Sign Language",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kanauji",
+      "bcp47": "bjj",
+      "iso3": "bjj",
+      "id": "6631",
+      "name": [
+        {
+          "value": "Kanauji",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bhattiyali",
+      "bcp47": null,
+      "iso3": "bht",
+      "id": "6642",
+      "name": [
+        {
+          "value": "Bhattiyali",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bara",
+      "bcp47": "bhr",
+      "iso3": "bhr",
+      "id": "7735",
+      "name": [
+        {
+          "value": "Bara",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bislama",
+      "bcp47": "bi",
+      "iso3": "bis",
+      "id": "9181",
+      "name": [
+        {
+          "value": "Bislama",
+          "primary": true,
+          "language": {
+            "id": "9181"
+          }
+        },
+        {
+          "value": "Bislama",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "edo",
+      "bcp47": "bin",
+      "iso3": "bin",
+      "id": "10255",
+      "name": [
+        {
+          "value": "Edo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "balanta",
+      "bcp47": "ble",
+      "iso3": "ble",
+      "id": "13002",
+      "name": [
+        {
+          "value": "Balanta",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "budza",
+      "bcp47": null,
+      "iso3": "bja",
+      "id": "15667",
+      "name": [
+        {
+          "value": "Budza",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "biafada",
+      "bcp47": null,
+      "iso3": "bif",
+      "id": "16120",
+      "name": [
+        {
+          "value": "Biafada",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "biak",
+      "bcp47": null,
+      "iso3": "bhw",
+      "id": "16488",
+      "name": [
+        {
+          "value": "Biak",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "banjar",
+      "bcp47": "bjn",
+      "iso3": "bjn",
+      "id": "16827",
+      "name": [
+        {
+          "value": "Banjar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bada",
+      "bcp47": "bhz",
+      "iso3": "bhz",
+      "id": "19547",
+      "name": [
+        {
+          "value": "Bada",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bijago",
+      "bcp47": "bjg",
+      "iso3": "bjg",
+      "id": "21963",
+      "name": [
+        {
+          "value": "Bijago",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "balanta-naga",
+      "bcp47": "ble-x-Naga",
+      "iso3": "ble",
+      "id": "53321",
+      "name": [
+        {
+          "value": "Balanta-Naga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bhilali",
+      "bcp47": "bhi",
+      "iso3": "bhi",
+      "id": "139684",
+      "name": [
+        {
+          "value": "Bhilali",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bhele",
+      "bcp47": null,
+      "iso3": "bhy",
+      "id": "139693",
+      "name": [
+        {
+          "value": "Bhele",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fanamaket",
+      "bcp47": null,
+      "iso3": "bjp",
+      "id": "139741",
+      "name": [
+        {
+          "value": "Fanamaket",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bekwel",
+      "bcp47": null,
+      "iso3": "bkw",
+      "id": "139761",
+      "name": [
+        {
+          "value": "Bekwel",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bilua",
+      "bcp47": null,
+      "iso3": "blb",
+      "id": "139762",
+      "name": [
+        {
+          "value": "Bilua",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ayta-mag-indi",
+      "bcp47": "blx",
+      "iso3": "blx",
+      "id": "139772",
+      "name": [
+        {
+          "value": "Ayta, Mag-Indi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "somba-siawari",
+      "bcp47": "bmu",
+      "iso3": "bmu",
+      "id": "139791",
+      "name": [
+        {
+          "value": "Somba-Siawari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bum",
+      "bcp47": "bmv",
+      "iso3": "bmv",
+      "id": "139792",
+      "name": [
+        {
+          "value": "Bum",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bandial",
+      "bcp47": "bqj",
+      "iso3": "bqj",
+      "id": "139909",
+      "name": [
+        {
+          "value": "Bandial",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bulusu",
+      "bcp47": null,
+      "iso3": "bqr",
+      "id": "139916",
+      "name": [
+        {
+          "value": "Bulusu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "oniyan",
+      "bcp47": "bsc",
+      "iso3": "bsc",
+      "id": "139945",
+      "name": [
+        {
+          "value": "Oniyan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "baiso",
+      "bcp47": null,
+      "iso3": "bsw",
+      "id": "139961",
+      "name": [
+        {
+          "value": "Baiso",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bateq",
+      "bcp47": null,
+      "iso3": "btq",
+      "id": "139973",
+      "name": [
+        {
+          "value": "Bateq",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "baelelea",
+      "bcp47": null,
+      "iso3": "bvc",
+      "id": "139996",
+      "name": [
+        {
+          "value": "Baelelea",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "belanda-viri",
+      "bcp47": null,
+      "iso3": "bvi",
+      "id": "140001",
+      "name": [
+        {
+          "value": "Belanda Viri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "andio",
+      "bcp47": null,
+      "iso3": "bzb",
+      "id": "140162",
+      "name": [
+        {
+          "value": "Andio",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bozo-jenaama",
+      "bcp47": null,
+      "iso3": "bze",
+      "id": "140166",
+      "name": [
+        {
+          "value": "Bozo, Jenaama",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "barka",
+      "bcp47": null,
+      "iso3": "bib",
+      "id": "145881",
+      "name": [
+        {
+          "value": "Barka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "batak-alas",
+      "bcp47": null,
+      "iso3": "btz",
+      "id": "146378",
+      "name": [
+        {
+          "value": "Batak-Alas",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "basang",
+      "bcp47": null,
+      "iso3": "bzy",
+      "id": "146749",
+      "name": [
+        {
+          "value": "Basang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "belleh",
+      "bcp47": null,
+      "iso3": "blh",
+      "id": "158085",
+      "name": [
+        {
+          "value": "Belleh",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "brezhoneg",
+      "bcp47": "br",
+      "iso3": "bre",
+      "id": "158608",
+      "name": [
+        {
+          "value": "Ar Brezhoneg",
+          "primary": true,
+          "language": {
+            "id": "158608"
+          }
+        },
+        {
+          "value": "Brezhoneg",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bogghom",
+      "bcp47": null,
+      "iso3": "bux",
+      "id": "158871",
+      "name": [
+        {
+          "value": "Bogghom",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "central-buang",
+      "bcp47": "bzh",
+      "iso3": "bzh",
+      "id": "159546",
+      "name": [
+        {
+          "value": "Central Buang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "abanglekuo",
+      "bcp47": "bzy",
+      "iso3": "bzy",
+      "id": "184631",
+      "name": [
+        {
+          "value": "Abanglekuo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bakwe",
+      "bcp47": null,
+      "iso3": "bjw",
+      "id": "184847",
+      "name": [
+        {
+          "value": "Bakwe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "french",
+      "bcp47": "fr",
+      "iso3": "fra",
+      "id": "496",
+      "name": [
+        {
+          "value": "Français",
+          "primary": true,
+          "language": {
+            "id": "496"
+          }
+        },
+        {
+          "value": "French",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "english",
+      "bcp47": "en",
+      "iso3": "eng",
+      "id": "529",
+      "name": [
+        {
+          "value": "English",
+          "primary": true,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fulfulde-benin-togo",
+      "bcp47": "fue",
+      "iso3": "fue",
+      "id": "1299",
+      "name": [
+        {
+          "value": "Fulfulde",
+          "primary": true,
+          "language": {
+            "id": "1299"
+          }
+        },
+        {
+          "value": "Fulfulde, Benin-Togo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zarma",
+      "bcp47": "dje",
+      "iso3": "dje",
+      "id": "1343",
+      "name": [
+        {
+          "value": "Zarma",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dzongkha",
+      "bcp47": "dz",
+      "iso3": "dzo",
+      "id": "1375",
+      "name": [
+        {
+          "value": "རྫོང་ཁ",
+          "primary": true,
+          "language": {
+            "id": "1375"
+          }
+        },
+        {
+          "value": "Dzongkha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gagauz",
+      "bcp47": "gag",
+      "iso3": "gag",
+      "id": "1935",
+      "name": [
+        {
+          "value": "Gagauz",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jula",
+      "bcp47": "dyu",
+      "iso3": "dyu",
+      "id": "2104",
+      "name": [
+        {
+          "value": "Jula",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fulfulde-jelgoore",
+      "bcp47": null,
+      "iso3": "fuh",
+      "id": "2116",
+      "name": [
+        {
+          "value": "Fulfulde, Jelgoore",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ewondo",
+      "bcp47": "ewo",
+      "iso3": "ewo",
+      "id": "2713",
+      "name": [
+        {
+          "value": "Ewondo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "efik",
+      "bcp47": "efi",
+      "iso3": "efi",
+      "id": "2728",
+      "name": [
+        {
+          "value": "Efik",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "daur",
+      "bcp47": "dta",
+      "iso3": "dta",
+      "id": "3786",
+      "name": [
+        {
+          "value": "Daur",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "faroese",
+      "bcp47": "fo",
+      "iso3": "fao",
+      "id": "4455",
+      "name": [
+        {
+          "value": "Føroyskt",
+          "primary": true,
+          "language": {
+            "id": "4455"
+          }
+        },
+        {
+          "value": "Faroese",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "maria-dandami",
+      "bcp47": "daq",
+      "iso3": "daq",
+      "id": "6558",
+      "name": [
+        {
+          "value": "Maria, Dandami",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chechen",
+      "bcp47": "ce",
+      "iso3": "che",
+      "id": "7139",
+      "name": [
+        {
+          "value": "Нохчийн мотт",
+          "primary": true,
+          "language": {
+            "id": "7139"
+          }
+        },
+        {
+          "value": "Chechen",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "embu",
+      "bcp47": "ebu",
+      "iso3": "ebu",
+      "id": "7164",
+      "name": [
+        {
+          "value": "Embu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "taita",
+      "bcp47": "dav",
+      "iso3": "dav",
+      "id": "7334",
+      "name": [
+        {
+          "value": "Taita",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chonyi",
+      "bcp47": "coh",
+      "iso3": "coh",
+      "id": "7343",
+      "name": [
+        {
+          "value": "Chonyi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chinanteco-tlacoatzintepec",
+      "bcp47": "ctl",
+      "iso3": "ctl",
+      "id": "7926",
+      "name": [
+        {
+          "value": "Chinanteco, Tlacoatzintepec",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cuicateco-tepeuxila",
+      "bcp47": "cux",
+      "iso3": "cux",
+      "id": "8284",
+      "name": [
+        {
+          "value": "Cuicateco, Tepeuxila",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chopi",
+      "bcp47": "cce",
+      "iso3": "cce",
+      "id": "8420",
+      "name": [
+        {
+          "value": "Chopi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chwabo",
+      "bcp47": "chw",
+      "iso3": "chw",
+      "id": "8426",
+      "name": [
+        {
+          "value": "Chwabo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "koti",
+      "bcp47": null,
+      "iso3": "eko",
+      "id": "8434",
+      "name": [
+        {
+          "value": "Koti",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kamuku",
+      "bcp47": null,
+      "iso3": "cdr",
+      "id": "9637",
+      "name": [
+        {
+          "value": "Kamuku",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ezaa",
+      "bcp47": "eza",
+      "iso3": "eza",
+      "id": "9692",
+      "name": [
+        {
+          "value": "Ezaa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "etsako-iyekhe",
+      "bcp47": null,
+      "iso3": "ets",
+      "id": "10124",
+      "name": [
+        {
+          "value": "Etsako Iyekhe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ekpari",
+      "bcp47": "ekr",
+      "iso3": "ekr",
+      "id": "10241",
+      "name": [
+        {
+          "value": "Ekpari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dadiya",
+      "bcp47": "dbd",
+      "iso3": "dbd",
+      "id": "10292",
+      "name": [
+        {
+          "value": "Dadiya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chavacano",
+      "bcp47": "cbk",
+      "iso3": "cbk",
+      "id": "12791",
+      "name": [
+        {
+          "value": "Chavacano",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jola-kasa",
+      "bcp47": "csk",
+      "iso3": "csk",
+      "id": "13070",
+      "name": [
+        {
+          "value": "Jola-Kasa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chaldean",
+      "bcp47": "cld",
+      "iso3": "cld",
+      "id": "20592",
+      "name": [
+        {
+          "value": "Chaldean",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hui",
+      "bcp47": "czh",
+      "iso3": "cmn",
+      "id": "21211",
+      "name": [
+        {
+          "value": "Hui",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chinese-traditional",
+      "bcp47": "zh-hant",
+      "iso3": "cmn",
+      "id": "21753",
+      "name": [
+        {
+          "value": "華語",
+          "primary": true,
+          "language": {
+            "id": "21753"
+          }
+        },
+        {
+          "value": "Chinese, Traditional",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dagaari-northern",
+      "bcp47": "dgi",
+      "iso3": "dgi",
+      "id": "22197",
+      "name": [
+        {
+          "value": "Dagaari, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "deccani",
+      "bcp47": "dcc",
+      "iso3": "dcc",
+      "id": "22685",
+      "name": [
+        {
+          "value": "Deccani",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "foochow",
+      "bcp47": "cdo",
+      "iso3": "cdo",
+      "id": "23033",
+      "name": [
+        {
+          "value": "Foochow",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chinese-sichuan",
+      "bcp47": "zh-CN-51",
+      "iso3": "cmn",
+      "id": "23062",
+      "name": [
+        {
+          "value": "漢語",
+          "primary": true,
+          "language": {
+            "id": "23062"
+          }
+        },
+        {
+          "value": "Chinese, Sichuan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mandarin-taiwan",
+      "bcp47": "zh-Hant-TW",
+      "iso3": "cmn",
+      "id": "23221",
+      "name": [
+        {
+          "value": "國語",
+          "primary": true,
+          "language": {
+            "id": "23221"
+          }
+        },
+        {
+          "value": "Mandarin (Taiwan)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dhundari",
+      "bcp47": "dhd",
+      "iso3": "dhd",
+      "id": "24343",
+      "name": [
+        {
+          "value": "Dhundari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "western-carib",
+      "bcp47": "car",
+      "iso3": "car",
+      "id": "49145",
+      "name": [
+        {
+          "value": "Western Carib",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dendi-djougou",
+      "bcp47": "ddn",
+      "iso3": "ddn",
+      "id": "53326",
+      "name": [
+        {
+          "value": "Dendi (Djougou)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mro",
+      "bcp47": "cmr",
+      "iso3": "cmr",
+      "id": "53346",
+      "name": [
+        {
+          "value": "Mro",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chinese-guiliu",
+      "bcp47": "zh-x-Guiliu",
+      "iso3": "cmn",
+      "id": "53352",
+      "name": [
+        {
+          "value": "漢語",
+          "primary": true,
+          "language": {
+            "id": "53352"
+          }
+        },
+        {
+          "value": "Chinese, Guiliu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "carib-eastern",
+      "bcp47": "car-x-Eastern",
+      "iso3": "car",
+      "id": "53421",
+      "name": [
+        {
+          "value": "Carib, Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lis-ma-ron",
+      "bcp47": "cla",
+      "iso3": "cla",
+      "id": "53423",
+      "name": [
+        {
+          "value": "Lis Ma Ron",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kuna",
+      "bcp47": "cuk",
+      "iso3": "cuk",
+      "id": "53430",
+      "name": [
+        {
+          "value": "Kuna",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chinantec-usila",
+      "bcp47": "cuc",
+      "iso3": "cuc",
+      "id": "97686",
+      "name": [
+        {
+          "value": "Chinantec, Usila",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chamari",
+      "bcp47": null,
+      "iso3": "cdg",
+      "id": "97720",
+      "name": [
+        {
+          "value": "Chamari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dene",
+      "bcp47": "chp",
+      "iso3": "chp",
+      "id": "97745",
+      "name": [
+        {
+          "value": "Dene",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "alis-i-ron",
+      "bcp47": "cla",
+      "iso3": "cla",
+      "id": "134882",
+      "name": [
+        {
+          "value": "Alis I Ron",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tlicho",
+      "bcp47": "dgr",
+      "iso3": "dgr",
+      "id": "139104",
+      "name": [
+        {
+          "value": "Tlicho",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tsimane",
+      "bcp47": null,
+      "iso3": "cas",
+      "id": "140021",
+      "name": [
+        {
+          "value": "Tsimane",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ede-cabe",
+      "bcp47": "cbj",
+      "iso3": "cbj",
+      "id": "140033",
+      "name": [
+        {
+          "value": "Ede Cabe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ashaninka",
+      "bcp47": null,
+      "iso3": "cni",
+      "id": "140060",
+      "name": [
+        {
+          "value": "Ashaninka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "wamey",
+      "bcp47": "cou",
+      "iso3": "cou",
+      "id": "140083",
+      "name": [
+        {
+          "value": "Wamey",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cabecar",
+      "bcp47": "cjp",
+      "iso3": "cjp",
+      "id": "140126",
+      "name": [
+        {
+          "value": "Cabecar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "miao-chuanqiandian-cluster",
+      "bcp47": null,
+      "iso3": "cqd",
+      "id": "140246",
+      "name": [
+        {
+          "value": "Miao, Chuanqiandian Cluster",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chara",
+      "bcp47": null,
+      "iso3": "cra",
+      "id": "140248",
+      "name": [
+        {
+          "value": "Chara",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gichuka",
+      "bcp47": null,
+      "iso3": "cuh",
+      "id": "140297",
+      "name": [
+        {
+          "value": "Gichuka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dei",
+      "bcp47": null,
+      "iso3": "dee",
+      "id": "140356",
+      "name": [
+        {
+          "value": "Dei",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lower-daga",
+      "bcp47": null,
+      "iso3": "dgz",
+      "id": "146764",
+      "name": [
+        {
+          "value": "Lower Daga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "karina",
+      "bcp47": null,
+      "iso3": "car",
+      "id": "158935",
+      "name": [
+        {
+          "value": "Karina",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "juni-kuin",
+      "bcp47": "cbs",
+      "iso3": "cbs",
+      "id": "158997",
+      "name": [
+        {
+          "value": "Juni Kuin",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chakfem",
+      "bcp47": null,
+      "iso3": "cky",
+      "id": "159392",
+      "name": [
+        {
+          "value": "Chakfem",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zokam-tedim",
+      "bcp47": "ctd",
+      "iso3": "ctd",
+      "id": "159905",
+      "name": [
+        {
+          "value": "Zokam, Tedim",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bel",
+      "bcp47": "gdd",
+      "iso3": "gdd",
+      "id": "161859",
+      "name": [
+        {
+          "value": "Bel",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cofan",
+      "bcp47": "con",
+      "iso3": "con",
+      "id": "184472",
+      "name": [
+        {
+          "value": "Cofan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kakataibo",
+      "bcp47": "cbr",
+      "iso3": "cbr",
+      "id": "184585",
+      "name": [
+        {
+          "value": "Kakataibo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kandoozi",
+      "bcp47": "cbu",
+      "iso3": "cbu",
+      "id": "184586",
+      "name": [
+        {
+          "value": "Kandoozi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kalenjin-kipsigis",
+      "bcp47": "kln",
+      "iso3": "sgc",
+      "id": "7321",
+      "name": [
+        {
+          "value": "Kalenjin, Kipsigis",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arifama-miniafia",
+      "bcp47": "aai",
+      "iso3": "aai",
+      "id": "10616",
+      "name": [
+        {
+          "value": "Arifama-Miniafia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tonsea",
+      "bcp47": "txs",
+      "iso3": "txs",
+      "id": "17423",
+      "name": [
+        {
+          "value": "Tonsea",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "guarani-mbya",
+      "bcp47": "gun",
+      "iso3": "gun",
+      "id": "623",
+      "name": [
+        {
+          "value": "Avañe'ẽ",
+          "primary": true,
+          "language": {
+            "id": "623"
+          }
+        },
+        {
+          "value": "Guarani, Mbya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hajong",
+      "bcp47": "haj",
+      "iso3": "haj",
+      "id": "1193",
+      "name": [
+        {
+          "value": "Hajong",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "garo",
+      "bcp47": "grt",
+      "iso3": "grt",
+      "id": "1204",
+      "name": [
+        {
+          "value": "গারো",
+          "primary": true,
+          "language": {
+            "id": "1204"
+          }
+        },
+        {
+          "value": "Garo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gourmanchema",
+      "bcp47": "gux",
+      "iso3": "gux",
+      "id": "1296",
+      "name": [
+        {
+          "value": "Gourmanchema",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "herero",
+      "bcp47": "hz",
+      "iso3": "her",
+      "id": "1454",
+      "name": [
+        {
+          "value": "Otjiherero",
+          "primary": true,
+          "language": {
+            "id": "1454"
+          }
+        },
+        {
+          "value": "Herero",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hixkaryana",
+      "bcp47": "hix",
+      "iso3": "hix",
+      "id": "1566",
+      "name": [
+        {
+          "value": "Hixkaryana",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gaviao-do-jiparana",
+      "bcp47": "gvo",
+      "iso3": "gvo",
+      "id": "1569",
+      "name": [
+        {
+          "value": "Gaviao Do Jiparana",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "guajajara",
+      "bcp47": "gub",
+      "iso3": "gub",
+      "id": "1582",
+      "name": [
+        {
+          "value": "Guajajara",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gbaya-southwest",
+      "bcp47": "gso",
+      "iso3": "gso",
+      "id": "2518",
+      "name": [
+        {
+          "value": "Gbaya, Southwest",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gbaya-northwest",
+      "bcp47": "gya",
+      "iso3": "gya",
+      "id": "2745",
+      "name": [
+        {
+          "value": "Gbaya, Northwest",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "giziga-south",
+      "bcp47": "giz",
+      "iso3": "giz",
+      "id": "2754",
+      "name": [
+        {
+          "value": "Giziga, South",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "guambiano",
+      "bcp47": null,
+      "iso3": "gum",
+      "id": "4230",
+      "name": [
+        {
+          "value": "Guambiano",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "wayuu",
+      "bcp47": "guc",
+      "iso3": "guc",
+      "id": "4232",
+      "name": [
+        {
+          "value": "Wayuu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "haitian-creole",
+      "bcp47": "ht",
+      "iso3": "hat",
+      "id": "4473",
+      "name": [
+        {
+          "value": "Kreyòl Ayisyen",
+          "primary": true,
+          "language": {
+            "id": "4473"
+          }
+        },
+        {
+          "value": "Haitian Creole",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chhattisgarhi",
+      "bcp47": "hne",
+      "iso3": "hne",
+      "id": "6463",
+      "name": [
+        {
+          "value": "छत्तीसगढ़ी",
+          "primary": true,
+          "language": {
+            "id": "6463"
+          }
+        },
+        {
+          "value": "Chhattisgarhi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hindi",
+      "bcp47": "hi",
+      "iso3": "hin",
+      "id": "6464",
+      "name": [
+        {
+          "value": "हिंदी",
+          "primary": true,
+          "language": {
+            "id": "6464"
+          }
+        },
+        {
+          "value": "Hindi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hmar",
+      "bcp47": null,
+      "iso3": "hmr",
+      "id": "6465",
+      "name": [
+        {
+          "value": "Hmar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gondi-northern",
+      "bcp47": "gno",
+      "iso3": "gno",
+      "id": "6511",
+      "name": [
+        {
+          "value": "Gondi, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "garhwali",
+      "bcp47": "gbm",
+      "iso3": "gbm",
+      "id": "6532",
+      "name": [
+        {
+          "value": "Garhwali",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gamit",
+      "bcp47": "gbl",
+      "iso3": "gbl",
+      "id": "6533",
+      "name": [
+        {
+          "value": "Gamit",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gaddi",
+      "bcp47": null,
+      "iso3": "gbk",
+      "id": "6535",
+      "name": [
+        {
+          "value": "Gaddi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gujarati",
+      "bcp47": "gu",
+      "iso3": "guj",
+      "id": "6600",
+      "name": [
+        {
+          "value": "ગુજરાતી",
+          "primary": true,
+          "language": {
+            "id": "6600"
+          }
+        },
+        {
+          "value": "Gujarati",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gilaki",
+      "bcp47": "glk",
+      "iso3": "glk",
+      "id": "6707",
+      "name": [
+        {
+          "value": "Gilaki",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gaelic-irish",
+      "bcp47": "ga",
+      "iso3": "gle",
+      "id": "6884",
+      "name": [
+        {
+          "value": "Gaeilge",
+          "primary": true,
+          "language": {
+            "id": "6884"
+          }
+        },
+        {
+          "value": "Gaelic, Irish",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gusii",
+      "bcp47": "guz",
+      "iso3": "guz",
+      "id": "7326",
+      "name": [
+        {
+          "value": "Gusii",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gola",
+      "bcp47": "gol",
+      "iso3": "gol",
+      "id": "7617",
+      "name": [
+        {
+          "value": "Gola",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gbii",
+      "bcp47": null,
+      "iso3": "ggb",
+      "id": "7658",
+      "name": [
+        {
+          "value": "Gbii",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gbagyi",
+      "bcp47": "gbr",
+      "iso3": "gbr",
+      "id": "10085",
+      "name": [
+        {
+          "value": "Gbagyi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gokana",
+      "bcp47": "gkn",
+      "iso3": "gkn",
+      "id": "10143",
+      "name": [
+        {
+          "value": "Gokana",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fakai",
+      "bcp47": "gel",
+      "iso3": "gel",
+      "id": "10157",
+      "name": [
+        {
+          "value": "Fakai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ekajuk",
+      "bcp47": "eka",
+      "iso3": "eka",
+      "id": "10248",
+      "name": [
+        {
+          "value": "Ekajuk",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ogea",
+      "bcp47": "eri",
+      "iso3": "eri",
+      "id": "12186",
+      "name": [
+        {
+          "value": "Ogea",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "enga",
+      "bcp47": "enq",
+      "iso3": "enq",
+      "id": "12200",
+      "name": [
+        {
+          "value": "Enga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "didinga",
+      "bcp47": "did",
+      "iso3": "did",
+      "id": "13644",
+      "name": [
+        {
+          "value": "Didinga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ndendeule",
+      "bcp47": null,
+      "iso3": "dne",
+      "id": "14271",
+      "name": [
+        {
+          "value": "Ndendeule",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fordata",
+      "bcp47": "frd",
+      "iso3": "frd",
+      "id": "16956",
+      "name": [
+        {
+          "value": "Fordata",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dungan",
+      "bcp47": "dng",
+      "iso3": "dng",
+      "id": "17820",
+      "name": [
+        {
+          "value": "хуэйзў йүян",
+          "primary": true,
+          "language": {
+            "id": "17820"
+          }
+        },
+        {
+          "value": "Dungan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "aukaans",
+      "bcp47": "djk",
+      "iso3": "djk",
+      "id": "18698",
+      "name": [
+        {
+          "value": "Aukaans",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dimasa",
+      "bcp47": "dis",
+      "iso3": "dis",
+      "id": "19652",
+      "name": [
+        {
+          "value": "Dimasa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ende",
+      "bcp47": null,
+      "iso3": "end",
+      "id": "19669",
+      "name": [
+        {
+          "value": "Ende",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gadsup",
+      "bcp47": "gaj",
+      "iso3": "gaj",
+      "id": "19685",
+      "name": [
+        {
+          "value": "Gadsup",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "desia",
+      "bcp47": "dso",
+      "iso3": "dso",
+      "id": "20863",
+      "name": [
+        {
+          "value": "Desia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ejagham-western",
+      "bcp47": "etu",
+      "iso3": "etu",
+      "id": "21205",
+      "name": [
+        {
+          "value": "Ejagham, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "english-north-american-indigenous",
+      "bcp47": "en-nai",
+      "iso3": "eng",
+      "id": "23156",
+      "name": [
+        {
+          "value": "English, North American Indigenous",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "basque",
+      "bcp47": "eu",
+      "iso3": "eus",
+      "id": "23514",
+      "name": [
+        {
+          "value": "Euskara",
+          "primary": true,
+          "language": {
+            "id": "23514"
+          }
+        },
+        {
+          "value": "Euskera",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "clela",
+      "bcp47": "dri",
+      "iso3": "dri",
+      "id": "23874",
+      "name": [
+        {
+          "value": "C'Lela",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fulfulde-western-niger",
+      "bcp47": "fuh",
+      "iso3": "fuh",
+      "id": "23920",
+      "name": [
+        {
+          "value": "Fulfulde",
+          "primary": true,
+          "language": {
+            "id": "23920"
+          }
+        },
+        {
+          "value": "Fulfulde, Western Niger",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fang-equatorial-guinea",
+      "bcp47": "fan",
+      "iso3": "fan",
+      "id": "24018",
+      "name": [
+        {
+          "value": "Fang, Equatorial Guinea",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fulfulde-caka-nigeria",
+      "bcp47": "fuv",
+      "iso3": "fuv",
+      "id": "24038",
+      "name": [
+        {
+          "value": "Fulfulde",
+          "primary": true,
+          "language": {
+            "id": "24038"
+          }
+        },
+        {
+          "value": "Fulfulde, Caka Nigeria",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "garasia-adiwasi",
+      "bcp47": null,
+      "iso3": "gas",
+      "id": "24340",
+      "name": [
+        {
+          "value": "Garasia, Adiwasi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fernando-po-creole-english",
+      "bcp47": "fpe",
+      "iso3": "fpe",
+      "id": "26270",
+      "name": [
+        {
+          "value": "Fernando Po Creole English",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fa-dambu",
+      "bcp47": "fab",
+      "iso3": "fab",
+      "id": "27147",
+      "name": [
+        {
+          "value": "Fa D'Ambu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ga",
+      "bcp47": "gaa",
+      "iso3": "gaa",
+      "id": "27152",
+      "name": [
+        {
+          "value": "Gã",
+          "primary": true,
+          "language": {
+            "id": "27152"
+          }
+        },
+        {
+          "value": "Ga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kifuliiru",
+      "bcp47": "flr",
+      "iso3": "flr",
+      "id": "50087",
+      "name": [
+        {
+          "value": "Kifuliiru",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dhivehi",
+      "bcp47": "dv",
+      "iso3": "div",
+      "id": "53287",
+      "name": [
+        {
+          "value": "ދިވެހި",
+          "primary": true,
+          "language": {
+            "id": "53287"
+          }
+        },
+        {
+          "value": "Dhivehi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dadeldhureli",
+      "bcp47": "dty",
+      "iso3": "dty",
+      "id": "53355",
+      "name": [
+        {
+          "value": "Dadeldhureli",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jola-felupe",
+      "bcp47": "eja",
+      "iso3": "eja",
+      "id": "53394",
+      "name": [
+        {
+          "value": "Jola-Felupe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fur",
+      "bcp47": "fvr",
+      "iso3": "fvr",
+      "id": "53418",
+      "name": [
+        {
+          "value": "For",
+          "primary": true,
+          "language": {
+            "id": "53418"
+          }
+        },
+        {
+          "value": "Fur",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "daasanach",
+      "bcp47": "dsh",
+      "iso3": "dsh",
+      "id": "97941",
+      "name": [
+        {
+          "value": "Daasanach",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "embera-northern",
+      "bcp47": "emp",
+      "iso3": "emp",
+      "id": "98137",
+      "name": [
+        {
+          "value": "Embera, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dongo",
+      "bcp47": null,
+      "iso3": "doo",
+      "id": "140398",
+      "name": [
+        {
+          "value": "Dongo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mosiye",
+      "bcp47": null,
+      "iso3": "dox",
+      "id": "140404",
+      "name": [
+        {
+          "value": "Mosiye",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dolpo",
+      "bcp47": null,
+      "iso3": "dre",
+      "id": "140409",
+      "name": [
+        {
+          "value": "Dolpo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dogon-tommo-so",
+      "bcp47": null,
+      "iso3": "dto",
+      "id": "140443",
+      "name": [
+        {
+          "value": "Dogon, Tommo So",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "duna",
+      "bcp47": null,
+      "iso3": "duc",
+      "id": "140449",
+      "name": [
+        {
+          "value": "Duna",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "markweeta",
+      "bcp47": null,
+      "iso3": "enb",
+      "id": "140520",
+      "name": [
+        {
+          "value": "Markweeta",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dogon-jamsay",
+      "bcp47": "djm",
+      "iso3": "djm",
+      "id": "140535",
+      "name": [
+        {
+          "value": "Dogon, Jamsay",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "furu",
+      "bcp47": null,
+      "iso3": "fuu",
+      "id": "140551",
+      "name": [
+        {
+          "value": "Furu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fwe",
+      "bcp47": "fwe",
+      "iso3": "fwe",
+      "id": "140555",
+      "name": [
+        {
+          "value": "Fwe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gaddang",
+      "bcp47": null,
+      "iso3": "gad",
+      "id": "140558",
+      "name": [
+        {
+          "value": "Gaddang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "blowo",
+      "bcp47": "dnj",
+      "iso3": "dnj",
+      "id": "147081",
+      "name": [
+        {
+          "value": "Blowo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "konta",
+      "bcp47": null,
+      "iso3": "dwr",
+      "id": "147285",
+      "name": [
+        {
+          "value": "Konta",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "finallig",
+      "bcp47": null,
+      "iso3": "ebk",
+      "id": "160575",
+      "name": [
+        {
+          "value": "Finallig",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lokpa",
+      "bcp47": null,
+      "iso3": "dop",
+      "id": "176838",
+      "name": [
+        {
+          "value": "Lokpa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gaita-koitor",
+      "bcp47": "fmu",
+      "iso3": "fmu",
+      "id": "184451",
+      "name": [
+        {
+          "value": "Gaita Koitor",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lik",
+      "bcp47": "eip",
+      "iso3": "eip",
+      "id": "184626",
+      "name": [
+        {
+          "value": "Lik",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fali-south",
+      "bcp47": null,
+      "iso3": "fkk",
+      "id": "184843",
+      "name": [
+        {
+          "value": "Fali South",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-palestinian",
+      "bcp47": "ar-ajp",
+      "iso3": "apc",
+      "id": "53347",
+      "name": [
+        {
+          "value": "اللهجة العربيّة السورىّة",
+          "primary": true,
+          "language": {
+            "id": "53347"
+          }
+        },
+        {
+          "value": "Arabic, Palestinian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "american-sign-language",
+      "bcp47": "ase",
+      "iso3": "ase",
+      "id": "19171",
+      "name": [
+        {
+          "value": "American Sign Language",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "croatian",
+      "bcp47": "hr",
+      "iso3": "hrv",
+      "id": "1109",
+      "name": [
+        {
+          "value": "Hrvatski",
+          "primary": true,
+          "language": {
+            "id": "1109"
+          }
+        },
+        {
+          "value": "Croatian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tat-juhuri",
+      "bcp47": null,
+      "iso3": "jdt",
+      "id": "1126",
+      "name": [
+        {
+          "value": "Tat, Juhuri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ho",
+      "bcp47": "hoc",
+      "iso3": "hoc",
+      "id": "1189",
+      "name": [
+        {
+          "value": "Ho",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ife",
+      "bcp47": "ife",
+      "iso3": "ife",
+      "id": "1338",
+      "name": [
+        {
+          "value": "Ife",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ngomba",
+      "bcp47": "jgo",
+      "iso3": "jgo",
+      "id": "2344",
+      "name": [
+        {
+          "value": "Ngomba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "haniq-beeqhongq",
+      "bcp47": null,
+      "iso3": "how",
+      "id": "3976",
+      "name": [
+        {
+          "value": "Hani, Bukong",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "italian",
+      "bcp47": "it",
+      "iso3": "ita",
+      "id": "4415",
+      "name": [
+        {
+          "value": "Italiano",
+          "primary": true,
+          "language": {
+            "id": "4415"
+          }
+        },
+        {
+          "value": "Italian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yemsa",
+      "bcp47": null,
+      "iso3": "jnj",
+      "id": "4665",
+      "name": [
+        {
+          "value": "Yemsa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jacalteco-western",
+      "bcp47": "jac",
+      "iso3": "jac",
+      "id": "5415",
+      "name": [
+        {
+          "value": "Jacalteco, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "japanese",
+      "bcp47": "ja",
+      "iso3": "jpn",
+      "id": "7083",
+      "name": [
+        {
+          "value": "日本語",
+          "primary": true,
+          "language": {
+            "id": "7083"
+          }
+        },
+        {
+          "value": "Japanese",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jordanian-sign-language",
+      "bcp47": "jos",
+      "iso3": "jos",
+      "id": "7138",
+      "name": [
+        {
+          "value": "Jordanian Sign Language",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jibu",
+      "bcp47": "jib",
+      "iso3": "jib",
+      "id": "9669",
+      "name": [
+        {
+          "value": "Jibu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ikwo",
+      "bcp47": "iqw",
+      "iso3": "iqw",
+      "id": "9691",
+      "name": [
+        {
+          "value": "Ikwo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "izii",
+      "bcp47": "izz",
+      "iso3": "izz",
+      "id": "9694",
+      "name": [
+        {
+          "value": "Izii",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ika",
+      "bcp47": "ikk",
+      "iso3": "ikk",
+      "id": "9728",
+      "name": [
+        {
+          "value": "Ika",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nembe",
+      "bcp47": "ijs",
+      "iso3": "ijs",
+      "id": "9731",
+      "name": [
+        {
+          "value": "Nembe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kalabari",
+      "bcp47": "ijn",
+      "iso3": "ijn",
+      "id": "9733",
+      "name": [
+        {
+          "value": "Kalabari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "igbo",
+      "bcp47": "ig",
+      "iso3": "ibo",
+      "id": "9774",
+      "name": [
+        {
+          "value": "Asụsụ Igbo",
+          "primary": true,
+          "language": {
+            "id": "9774"
+          }
+        },
+        {
+          "value": "Igbo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "igala",
+      "bcp47": "igl",
+      "iso3": "igl",
+      "id": "9779",
+      "name": [
+        {
+          "value": "Igala",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "igede",
+      "bcp47": "ige",
+      "iso3": "ige",
+      "id": "9784",
+      "name": [
+        {
+          "value": "Igede",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "idoma",
+      "bcp47": "idu",
+      "iso3": "idu",
+      "id": "9793",
+      "name": [
+        {
+          "value": "Idoma",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ibibio",
+      "bcp47": "ibb",
+      "iso3": "ibb",
+      "id": "9811",
+      "name": [
+        {
+          "value": "Ibibio",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "izere",
+      "bcp47": "izr",
+      "iso3": "izr",
+      "id": "10106",
+      "name": [
+        {
+          "value": "Izere",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hindko-northern",
+      "bcp47": "hno",
+      "iso3": "hno",
+      "id": "10450",
+      "name": [
+        {
+          "value": "Hindko, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jadgali",
+      "bcp47": null,
+      "iso3": "jdg",
+      "id": "10559",
+      "name": [
+        {
+          "value": "Jadgali",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hote",
+      "bcp47": "hot",
+      "iso3": "hot",
+      "id": "12057",
+      "name": [
+        {
+          "value": "Hote",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ifugao-amganad",
+      "bcp47": "ifa",
+      "iso3": "ifa",
+      "id": "12743",
+      "name": [
+        {
+          "value": "Ifugao, Amganad",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ibaloi",
+      "bcp47": "ibl",
+      "iso3": "ibl",
+      "id": "12747",
+      "name": [
+        {
+          "value": "Ibaloi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ibanag",
+      "bcp47": "ibg",
+      "iso3": "ibg",
+      "id": "12750",
+      "name": [
+        {
+          "value": "Ibanag",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "javanese",
+      "bcp47": "jv",
+      "iso3": "jav",
+      "id": "13195",
+      "name": [
+        {
+          "value": "ꦧꦱꦗꦮ",
+          "primary": true,
+          "language": {
+            "id": "13195"
+          }
+        },
+        {
+          "value": "Javanese",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jita",
+      "bcp47": "jit",
+      "iso3": "jit",
+      "id": "14182",
+      "name": [
+        {
+          "value": "Jita",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hehe",
+      "bcp47": "heh",
+      "iso3": "heh",
+      "id": "14192",
+      "name": [
+        {
+          "value": "Hehe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "haya",
+      "bcp47": "hay",
+      "iso3": "hay",
+      "id": "14201",
+      "name": [
+        {
+          "value": "Haya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gwere",
+      "bcp47": "gwr",
+      "iso3": "gwr",
+      "id": "14692",
+      "name": [
+        {
+          "value": "Gwere",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gaelic-scots",
+      "bcp47": "gd",
+      "iso3": "gla",
+      "id": "14818",
+      "name": [
+        {
+          "value": "Gàidhlig",
+          "primary": true,
+          "language": {
+            "id": "14818"
+          }
+        },
+        {
+          "value": "Gaelic, Scots",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hunde",
+      "bcp47": null,
+      "iso3": "hke",
+      "id": "15551",
+      "name": [
+        {
+          "value": "Hunde",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hemba",
+      "bcp47": "hem",
+      "iso3": "hem",
+      "id": "15557",
+      "name": [
+        {
+          "value": "Hemba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "havu",
+      "bcp47": null,
+      "iso3": "hav",
+      "id": "15559",
+      "name": [
+        {
+          "value": "Havu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dida-yocoboue",
+      "bcp47": null,
+      "iso3": "gud",
+      "id": "16052",
+      "name": [
+        {
+          "value": "Dida, Yocoboue",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "galela",
+      "bcp47": null,
+      "iso3": "gbi",
+      "id": "16954",
+      "name": [
+        {
+          "value": "Galela",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malay-jambi",
+      "bcp47": null,
+      "iso3": "jax",
+      "id": "17753",
+      "name": [
+        {
+          "value": "Malay, Jambi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gbanu",
+      "bcp47": null,
+      "iso3": "gbv",
+      "id": "19689",
+      "name": [
+        {
+          "value": "Gbanu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "galician",
+      "bcp47": "gl",
+      "iso3": "glg",
+      "id": "19705",
+      "name": [
+        {
+          "value": "Galego",
+          "primary": true,
+          "language": {
+            "id": "19705"
+          }
+        },
+        {
+          "value": "Galician",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "guahibo",
+      "bcp47": null,
+      "iso3": "guh",
+      "id": "19720",
+      "name": [
+        {
+          "value": "Guahibo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "golin",
+      "bcp47": "gvf",
+      "iso3": "gvf",
+      "id": "19725",
+      "name": [
+        {
+          "value": "Golin",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "igiha",
+      "bcp47": null,
+      "iso3": "haq",
+      "id": "19733",
+      "name": [
+        {
+          "value": "Igiha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hiri-motu",
+      "bcp47": "ho",
+      "iso3": "hmo",
+      "id": "21120",
+      "name": [
+        {
+          "value": "Hiri Motu",
+          "primary": true,
+          "language": {
+            "id": "21120"
+          }
+        },
+        {
+          "value": "Hiri Motu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "higgi",
+      "bcp47": "hig",
+      "iso3": "hig",
+      "id": "22645",
+      "name": [
+        {
+          "value": "Higgi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gbeya",
+      "bcp47": "gbp",
+      "iso3": "gbp",
+      "id": "22651",
+      "name": [
+        {
+          "value": "Gbeya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "a-hmao",
+      "bcp47": "hmd",
+      "iso3": "hmd",
+      "id": "22812",
+      "name": [
+        {
+          "value": "A-Hmao",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "miao-huishui-northern",
+      "bcp47": null,
+      "iso3": "hmi",
+      "id": "22842",
+      "name": [
+        {
+          "value": "Miao, Huishui (Northern)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "grebo-northern",
+      "bcp47": "gbo",
+      "iso3": "gbo",
+      "id": "23926",
+      "name": [
+        {
+          "value": "Grebo, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "garasia-rajput",
+      "bcp47": "gra",
+      "iso3": "gra",
+      "id": "24341",
+      "name": [
+        {
+          "value": "Garasia, Rajput",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fiji-hindi",
+      "bcp47": "hif",
+      "iso3": "hif",
+      "id": "53300",
+      "name": [
+        {
+          "value": "फिजी बात",
+          "primary": true,
+          "language": {
+            "id": "53300"
+          }
+        },
+        {
+          "value": "Fiji-Hindi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ywom",
+      "bcp47": null,
+      "iso3": "gek",
+      "id": "53312",
+      "name": [
+        {
+          "value": "Ywom",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mgbolizhia",
+      "bcp47": "gmz",
+      "iso3": "gmz",
+      "id": "53313",
+      "name": [
+        {
+          "value": "Mgbolizhia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gaanda",
+      "bcp47": "gqa",
+      "iso3": "gqa",
+      "id": "98407",
+      "name": [
+        {
+          "value": "Ga'Anda",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gawri",
+      "bcp47": null,
+      "iso3": "gwc",
+      "id": "98458",
+      "name": [
+        {
+          "value": "Gawri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ale-gawwada",
+      "bcp47": null,
+      "iso3": "gwd",
+      "id": "98459",
+      "name": [
+        {
+          "value": "Ale, Gawwada",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gayil",
+      "bcp47": null,
+      "iso3": "gyl",
+      "id": "98476",
+      "name": [
+        {
+          "value": "Gayil",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gyaazi",
+      "bcp47": "gji",
+      "iso3": "gyz",
+      "id": "139090",
+      "name": [
+        {
+          "value": "Gyaazi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gao",
+      "bcp47": null,
+      "iso3": "gga",
+      "id": "140672",
+      "name": [
+        {
+          "value": "Gao",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "glavda",
+      "bcp47": "glw",
+      "iso3": "glw",
+      "id": "140740",
+      "name": [
+        {
+          "value": "Glavda",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gowlan",
+      "bcp47": null,
+      "iso3": "goj",
+      "id": "140770",
+      "name": [
+        {
+          "value": "Gowlan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gowli",
+      "bcp47": null,
+      "iso3": "gok",
+      "id": "140771",
+      "name": [
+        {
+          "value": "Gowli",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "oromo-eastern",
+      "bcp47": "hae",
+      "iso3": "hae",
+      "id": "140928",
+      "name": [
+        {
+          "value": "Oromo, Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "heiban",
+      "bcp47": null,
+      "iso3": "hbn",
+      "id": "140943",
+      "name": [
+        {
+          "value": "Heiban",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pontianak-hakka",
+      "bcp47": null,
+      "iso3": "hak",
+      "id": "162168",
+      "name": [
+        {
+          "value": "Pontianak, Hakka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "goan-konkani",
+      "bcp47": "gom",
+      "iso3": "gom",
+      "id": "184479",
+      "name": [
+        {
+          "value": "Goan Konkani",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hawaiian-nihau",
+      "bcp47": null,
+      "iso3": "haw",
+      "id": "184517",
+      "name": [
+        {
+          "value": "Hawaiian Ni'Hau",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "godie",
+      "bcp47": null,
+      "iso3": "god",
+      "id": "184596",
+      "name": [
+        {
+          "value": "Godie",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "north-gumuz",
+      "bcp47": "guk",
+      "iso3": "guk",
+      "id": "184659",
+      "name": [
+        {
+          "value": "North Gumuz",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gavva",
+      "bcp47": "gdf",
+      "iso3": "gdf",
+      "id": "184801",
+      "name": [
+        {
+          "value": "Gavva",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ache-2",
+      "bcp47": "guq",
+      "iso3": "guq",
+      "id": "184846",
+      "name": [
+        {
+          "value": "Ache",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "birifor-southern",
+      "bcp47": "biv",
+      "iso3": "biv",
+      "id": "5173",
+      "name": [
+        {
+          "value": "Birifor, Southern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kanembu",
+      "bcp47": null,
+      "iso3": "kbl",
+      "id": "3645",
+      "name": [
+        {
+          "value": "Kanembu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "khakas",
+      "bcp47": "kjh",
+      "iso3": "kjh",
+      "id": "3816",
+      "name": [
+        {
+          "value": "Хакас тілі",
+          "primary": true,
+          "language": {
+            "id": "3816"
+          }
+        },
+        {
+          "value": "Khakas",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jingpho",
+      "bcp47": "kac",
+      "iso3": "kac",
+      "id": "4088",
+      "name": [
+        {
+          "value": "Jingpho",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "javanese-caribbean",
+      "bcp47": "jvn",
+      "iso3": "jvn",
+      "id": "4940",
+      "name": [
+        {
+          "value": "Javanese, Caribbean",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "makonde-mozambique",
+      "bcp47": "kde",
+      "iso3": "kde",
+      "id": "8433",
+      "name": [
+        {
+          "value": "Makonde, Mozambique",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "karakalpak",
+      "bcp47": "kaa",
+      "iso3": "kaa",
+      "id": "448",
+      "name": [
+        {
+          "value": "Қарақалпақ тили",
+          "primary": true,
+          "language": {
+            "id": "448"
+          }
+        },
+        {
+          "value": "Karakalpak",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kimbundu",
+      "bcp47": "kmb",
+      "iso3": "kmb",
+      "id": "569",
+      "name": [
+        {
+          "value": "Kimbundu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kaiwa",
+      "bcp47": "kgk",
+      "iso3": "kgk",
+      "id": "622",
+      "name": [
+        {
+          "value": "Kaiwa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "khasi",
+      "bcp47": "kha",
+      "iso3": "kha",
+      "id": "1197",
+      "name": [
+        {
+          "value": "Ka Ktien Khasi",
+          "primary": true,
+          "language": {
+            "id": "1197"
+          }
+        },
+        {
+          "value": "Khasi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kekchi",
+      "bcp47": "kek",
+      "iso3": "kek",
+      "id": "1276",
+      "name": [
+        {
+          "value": "Kekchi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kabiye",
+      "bcp47": "kbp",
+      "iso3": "kbp",
+      "id": "1336",
+      "name": [
+        {
+          "value": "Kabiye",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kukele",
+      "bcp47": "kez",
+      "iso3": "kez",
+      "id": "9604",
+      "name": [
+        {
+          "value": "Kukele",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tsikimba",
+      "bcp47": "kdl",
+      "iso3": "kdl",
+      "id": "9616",
+      "name": [
+        {
+          "value": "Tsikimba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kamo",
+      "bcp47": "kcq",
+      "iso3": "kcq",
+      "id": "9618",
+      "name": [
+        {
+          "value": "Kamo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "katab",
+      "bcp47": "kcg",
+      "iso3": "kcg",
+      "id": "9626",
+      "name": [
+        {
+          "value": "Katab",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jju",
+      "bcp47": "kaj",
+      "iso3": "kaj",
+      "id": "9639",
+      "name": [
+        {
+          "value": "Jju",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "khowar",
+      "bcp47": null,
+      "iso3": "khw",
+      "id": "10558",
+      "name": [
+        {
+          "value": "Khowar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "rumu",
+      "bcp47": "klq",
+      "iso3": "klq",
+      "id": "11956",
+      "name": [
+        {
+          "value": "Rumu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kalagan-tagakaulu",
+      "bcp47": "klg",
+      "iso3": "klg",
+      "id": "12693",
+      "name": [
+        {
+          "value": "Kalagan, Tagakaulu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kakwa",
+      "bcp47": "keo",
+      "iso3": "keo",
+      "id": "13692",
+      "name": [
+        {
+          "value": "Kakwa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "karen-pwo-eastern",
+      "bcp47": "kjp",
+      "iso3": "kjp",
+      "id": "14295",
+      "name": [
+        {
+          "value": "Karen, Pwo Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kabardian",
+      "bcp47": "kbd",
+      "iso3": "kbd",
+      "id": "14632",
+      "name": [
+        {
+          "value": "Kъэбэрдеибзэ",
+          "primary": true,
+          "language": {
+            "id": "14632"
+          }
+        },
+        {
+          "value": "Kabardian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kumam",
+      "bcp47": null,
+      "iso3": "kdi",
+      "id": "14677",
+      "name": [
+        {
+          "value": "Kumam",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "konjo-highland",
+      "bcp47": null,
+      "iso3": "kjk",
+      "id": "17518",
+      "name": [
+        {
+          "value": "Konjo, Highland",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "komering",
+      "bcp47": "kge",
+      "iso3": "kge",
+      "id": "17752",
+      "name": [
+        {
+          "value": "Komering",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mongolian-halh",
+      "bcp47": "mn",
+      "iso3": "khk",
+      "id": "18259",
+      "name": [
+        {
+          "value": "ᠮᠣᠨᠭᠭᠣᠯ ᠬᠡᠯᠡ",
+          "primary": true,
+          "language": {
+            "id": "18259"
+          }
+        },
+        {
+          "value": "Mongolian, Halh",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kele",
+      "bcp47": "khy",
+      "iso3": "khy",
+      "id": "19803",
+      "name": [
+        {
+          "value": "Kele",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dera",
+      "bcp47": "kna",
+      "iso3": "kna",
+      "id": "19822",
+      "name": [
+        {
+          "value": "Dera",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kikuyu",
+      "bcp47": "ki",
+      "iso3": "kik",
+      "id": "20679",
+      "name": [
+        {
+          "value": "Gĩkũyũ",
+          "primary": true,
+          "language": {
+            "id": "20679"
+          }
+        },
+        {
+          "value": "Kikuyu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kurmanji-cis",
+      "bcp47": null,
+      "iso3": "kmr",
+      "id": "21096",
+      "name": [
+        {
+          "value": "Kurmanji - Cis",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kalaallisut-greenlandic",
+      "bcp47": "kl",
+      "iso3": "kal",
+      "id": "21199",
+      "name": [
+        {
+          "value": "Kalaallisut",
+          "primary": true,
+          "language": {
+            "id": "21199"
+          }
+        },
+        {
+          "value": "Kalaallisut (Greenlandic)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kachchhi",
+      "bcp47": "kfr",
+      "iso3": "kfr",
+      "id": "21661",
+      "name": [
+        {
+          "value": "Kachchhi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "itsekiri",
+      "bcp47": "its",
+      "iso3": "its",
+      "id": "21740",
+      "name": [
+        {
+          "value": "Itsekiri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yao-iu-mien",
+      "bcp47": "ium",
+      "iso3": "ium",
+      "id": "22098",
+      "name": [
+        {
+          "value": "Yao (Iu Mien)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jukun",
+      "bcp47": "juk",
+      "iso3": "juk",
+      "id": "22205",
+      "name": [
+        {
+          "value": "Jukun",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kafa",
+      "bcp47": "kbr",
+      "iso3": "kbr",
+      "id": "22439",
+      "name": [
+        {
+          "value": "Kafa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jorai",
+      "bcp47": "jra",
+      "iso3": "jra",
+      "id": "22499",
+      "name": [
+        {
+          "value": "Jorai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kendayan-kanayatn",
+      "bcp47": "knx",
+      "iso3": "knx",
+      "id": "22679",
+      "name": [
+        {
+          "value": "Kendayan (Kanayatn)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nosu-tianba",
+      "bcp47": null,
+      "iso3": "iii",
+      "id": "22928",
+      "name": [
+        {
+          "value": "Nosu, Tianba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "horned-miao",
+      "bcp47": null,
+      "iso3": "hrm",
+      "id": "23017",
+      "name": [
+        {
+          "value": "Horned Miao",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "khampa-eastern",
+      "bcp47": "khg",
+      "iso3": "khg",
+      "id": "23225",
+      "name": [
+        {
+          "value": "Khampa, Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kono-sierra-leone",
+      "bcp47": "kno",
+      "iso3": "kno",
+      "id": "23520",
+      "name": [
+        {
+          "value": "Kono, Sierra Leone",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kulvi",
+      "bcp47": "kfx",
+      "iso3": "kfx",
+      "id": "23692",
+      "name": [
+        {
+          "value": "Kulvi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "songai-timbuktu",
+      "bcp47": "khq",
+      "iso3": "khq",
+      "id": "24012",
+      "name": [
+        {
+          "value": "Songai, Timbuktu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mashami-chagga",
+      "bcp47": "jmc",
+      "iso3": "jmc",
+      "id": "24142",
+      "name": [
+        {
+          "value": "Mashami-Chagga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jenjo",
+      "bcp47": "jen",
+      "iso3": "jen",
+      "id": "32807",
+      "name": [
+        {
+          "value": "Jenjo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "manga",
+      "bcp47": "kby",
+      "iso3": "kby",
+      "id": "42106",
+      "name": [
+        {
+          "value": "Manga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "karnali",
+      "bcp47": "jml",
+      "iso3": "jml",
+      "id": "53298",
+      "name": [
+        {
+          "value": "Karnali",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kolokuma-izon",
+      "bcp47": "ijc",
+      "iso3": "ijc",
+      "id": "53432",
+      "name": [
+        {
+          "value": "Kolokuma (Izon)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "iranun",
+      "bcp47": null,
+      "iso3": "ilp",
+      "id": "98588",
+      "name": [
+        {
+          "value": "Iranun",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "iyaa",
+      "bcp47": null,
+      "iso3": "iyx",
+      "id": "98626",
+      "name": [
+        {
+          "value": "Iyaa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hyam",
+      "bcp47": "jab",
+      "iso3": "jab",
+      "id": "98630",
+      "name": [
+        {
+          "value": "Hyam",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hunsrik",
+      "bcp47": "hrx",
+      "iso3": "hrx",
+      "id": "98682",
+      "name": [
+        {
+          "value": "Hunsrik",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tiriki",
+      "bcp47": "ida",
+      "iso3": "ida",
+      "id": "105534",
+      "name": [
+        {
+          "value": "Tiriki",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jar",
+      "bcp47": "jgk",
+      "iso3": "jgk",
+      "id": "119071",
+      "name": [
+        {
+          "value": "Jar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hawaii-pidgin",
+      "bcp47": null,
+      "iso3": "hwc",
+      "id": "140893",
+      "name": [
+        {
+          "value": "Hawai'I Pidgin",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ikpeshi",
+      "bcp47": null,
+      "iso3": "ikp",
+      "id": "141025",
+      "name": [
+        {
+          "value": "Ikpeshi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ile-ape",
+      "bcp47": null,
+      "iso3": "ila",
+      "id": "141031",
+      "name": [
+        {
+          "value": "Ile Ape",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mouwase",
+      "bcp47": null,
+      "iso3": "jmw",
+      "id": "141066",
+      "name": [
+        {
+          "value": "Mouwase",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ivatan",
+      "bcp47": "ivv",
+      "iso3": "ivv",
+      "id": "141113",
+      "name": [
+        {
+          "value": "Ivatan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yabem",
+      "bcp47": null,
+      "iso3": "jae",
+      "id": "141124",
+      "name": [
+        {
+          "value": "Yabem",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jakun",
+      "bcp47": null,
+      "iso3": "jak",
+      "id": "141128",
+      "name": [
+        {
+          "value": "Jakun",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jeh",
+      "bcp47": null,
+      "iso3": "jeh",
+      "id": "141153",
+      "name": [
+        {
+          "value": "Jeh",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jere",
+      "bcp47": null,
+      "iso3": "jer",
+      "id": "141158",
+      "name": [
+        {
+          "value": "Jere",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "enuani",
+      "bcp47": null,
+      "iso3": "ibo",
+      "id": "148878",
+      "name": [
+        {
+          "value": "Enuani",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ichen",
+      "bcp47": "ich",
+      "iso3": "ich",
+      "id": "177626",
+      "name": [
+        {
+          "value": "Ichen",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "wampis",
+      "bcp47": "hub",
+      "iso3": "hub",
+      "id": "184483",
+      "name": [
+        {
+          "value": "Wampis",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hani-haya",
+      "bcp47": "hni",
+      "iso3": "hni",
+      "id": "184506",
+      "name": [
+        {
+          "value": "Hani, Haya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "idaasha",
+      "bcp47": "idd",
+      "iso3": "idd",
+      "id": "184549",
+      "name": [
+        {
+          "value": "Idaasha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "indonesian-isa",
+      "bcp47": "id",
+      "iso3": "ind",
+      "id": "184566",
+      "name": [
+        {
+          "value": "Indonesian (Isa)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nkim-nkum",
+      "bcp47": "isi",
+      "iso3": "isi",
+      "id": "184584",
+      "name": [
+        {
+          "value": "Nkim-Nkum",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tidung-southern",
+      "bcp47": null,
+      "iso3": "itd",
+      "id": "184691",
+      "name": [
+        {
+          "value": "Tidung, Southern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bugkalot",
+      "bcp47": null,
+      "iso3": "ilk",
+      "id": "184845",
+      "name": [
+        {
+          "value": "Bugkalot",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lahu",
+      "bcp47": "lhu",
+      "iso3": "lhu",
+      "id": "3794",
+      "name": [
+        {
+          "value": "Lahu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lingala",
+      "bcp47": "ln",
+      "iso3": "lin",
+      "id": "4344",
+      "name": [
+        {
+          "value": "Lingála",
+          "primary": true,
+          "language": {
+            "id": "4344"
+          }
+        },
+        {
+          "value": "Lingala",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "krio",
+      "bcp47": "kri",
+      "iso3": "kri",
+      "id": "4547",
+      "name": [
+        {
+          "value": "Krio",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kunama",
+      "bcp47": "kun",
+      "iso3": "kun",
+      "id": "4585",
+      "name": [
+        {
+          "value": "Kunama",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kuria",
+      "bcp47": "kuj",
+      "iso3": "kuj",
+      "id": "7186",
+      "name": [
+        {
+          "value": "Kuria",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lao",
+      "bcp47": "lo",
+      "iso3": "lao",
+      "id": "7411",
+      "name": [
+        {
+          "value": "ພາສາລາວ",
+          "primary": true,
+          "language": {
+            "id": "7411"
+          }
+        },
+        {
+          "value": "Lao",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lithuanian",
+      "bcp47": "lt",
+      "iso3": "lit",
+      "id": "7698",
+      "name": [
+        {
+          "value": "Lietuvių",
+          "primary": true,
+          "language": {
+            "id": "7698"
+          }
+        },
+        {
+          "value": "Lithuanian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lambya",
+      "bcp47": "lai",
+      "iso3": "lai",
+      "id": "7792",
+      "name": [
+        {
+          "value": "Lambya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kokola",
+      "bcp47": null,
+      "iso3": "kzn",
+      "id": "7793",
+      "name": [
+        {
+          "value": "Kokola",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "koli-wadiyara",
+      "bcp47": null,
+      "iso3": "kxp",
+      "id": "10535",
+      "name": [
+        {
+          "value": "Koli, Wadiyara",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "limba-west-central",
+      "bcp47": "lia",
+      "iso3": "lia",
+      "id": "13110",
+      "name": [
+        {
+          "value": "Limba, West-Central",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kwaya",
+      "bcp47": "kya",
+      "iso3": "kya",
+      "id": "14132",
+      "name": [
+        {
+          "value": "Kwaya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "shambala",
+      "bcp47": "ksb",
+      "iso3": "ksb",
+      "id": "14154",
+      "name": [
+        {
+          "value": "Shambala",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "khmer-northern",
+      "bcp47": "km-kxm",
+      "iso3": "kxm",
+      "id": "14384",
+      "name": [
+        {
+          "value": "ភាសាខ្មែរ",
+          "primary": true,
+          "language": {
+            "id": "14384"
+          }
+        },
+        {
+          "value": "Khmer, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kumyk",
+      "bcp47": "kum",
+      "iso3": "kum",
+      "id": "14629",
+      "name": [
+        {
+          "value": "Къумукъ Tил",
+          "primary": true,
+          "language": {
+            "id": "14629"
+          }
+        },
+        {
+          "value": "Kumyk",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lika",
+      "bcp47": "lik",
+      "iso3": "lik",
+      "id": "15395",
+      "name": [
+        {
+          "value": "Lika",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lendu",
+      "bcp47": "led",
+      "iso3": "led",
+      "id": "15615",
+      "name": [
+        {
+          "value": "Lendu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lala",
+      "bcp47": "leb",
+      "iso3": "leb",
+      "id": "15622",
+      "name": [
+        {
+          "value": "Lala (Zambia)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lamba",
+      "bcp47": "lam",
+      "iso3": "lam",
+      "id": "15631",
+      "name": [
+        {
+          "value": "Lamba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kaonde",
+      "bcp47": "kqn",
+      "iso3": "kqn",
+      "id": "15642",
+      "name": [
+        {
+          "value": "Kaonde",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kanyok",
+      "bcp47": "kny",
+      "iso3": "kny",
+      "id": "15653",
+      "name": [
+        {
+          "value": "Kanyok",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lawangan",
+      "bcp47": null,
+      "iso3": "lbx",
+      "id": "16805",
+      "name": [
+        {
+          "value": "Lawangan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ledo-ija",
+      "bcp47": "lew",
+      "iso3": "lew",
+      "id": "17492",
+      "name": [
+        {
+          "value": "Ledo, Ija",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tolaki",
+      "bcp47": "lbw",
+      "iso3": "lbw",
+      "id": "17501",
+      "name": [
+        {
+          "value": "Tolaki",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kaili-daa",
+      "bcp47": null,
+      "iso3": "kzf",
+      "id": "17509",
+      "name": [
+        {
+          "value": "Kaili, Daa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lubu",
+      "bcp47": null,
+      "iso3": "lcf",
+      "id": "17732",
+      "name": [
+        {
+          "value": "Lubu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kerinci",
+      "bcp47": null,
+      "iso3": "kvr",
+      "id": "17739",
+      "name": [
+        {
+          "value": "Kerinci",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lak",
+      "bcp47": "lbe",
+      "iso3": "lbe",
+      "id": "18509",
+      "name": [
+        {
+          "value": "Lak",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "balkar",
+      "bcp47": "krc",
+      "iso3": "krc",
+      "id": "18518",
+      "name": [
+        {
+          "value": "малкъар",
+          "primary": true,
+          "language": {
+            "id": "18518"
+          }
+        },
+        {
+          "value": "Balkar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "komi-zyrian",
+      "bcp47": "kpv",
+      "iso3": "kpv",
+      "id": "18521",
+      "name": [
+        {
+          "value": "коми кыв",
+          "primary": true,
+          "language": {
+            "id": "18521"
+          }
+        },
+        {
+          "value": "Komi-Zyrian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "koho",
+      "bcp47": null,
+      "iso3": "kpm",
+      "id": "19241",
+      "name": [
+        {
+          "value": "Koho",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kuman",
+      "bcp47": "kue",
+      "iso3": "kue",
+      "id": "19854",
+      "name": [
+        {
+          "value": "Kuman",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "karang",
+      "bcp47": "kzr",
+      "iso3": "kzr",
+      "id": "19877",
+      "name": [
+        {
+          "value": "Karang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tchien-krahn",
+      "bcp47": "kqo",
+      "iso3": "kqo",
+      "id": "22194",
+      "name": [
+        {
+          "value": "Tchien-Krahn",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kilega",
+      "bcp47": "lea",
+      "iso3": "lea",
+      "id": "22652",
+      "name": [
+        {
+          "value": "Kilega",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kayah-li-western",
+      "bcp47": "kyu",
+      "iso3": "kyu",
+      "id": "23549",
+      "name": [
+        {
+          "value": "Kayah Li, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lugbara",
+      "bcp47": "lgg",
+      "iso3": "lgg",
+      "id": "23981",
+      "name": [
+        {
+          "value": "Lugbara",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kalagan-eastern",
+      "bcp47": "kqe-x-Eastern",
+      "iso3": "kqe",
+      "id": "24359",
+      "name": [
+        {
+          "value": "Kalagan, Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kurdi-behdini",
+      "bcp47": "kmr",
+      "iso3": "kmr",
+      "id": "53333",
+      "name": [
+        {
+          "value": "کوردی",
+          "primary": true,
+          "language": {
+            "id": "53333"
+          }
+        },
+        {
+          "value": "Kurdi, Behdini",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kabuverdianu-sotaventu",
+      "bcp47": "kea",
+      "iso3": "kea",
+      "id": "53431",
+      "name": [
+        {
+          "value": "Kabuverdianu, Sotaventu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "keliko",
+      "bcp47": "kbo",
+      "iso3": "kbo",
+      "id": "98838",
+      "name": [
+        {
+          "value": "Keliko",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tyap",
+      "bcp47": "kcg",
+      "iso3": "kcg",
+      "id": "98853",
+      "name": [
+        {
+          "value": "Tyap",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "keapara",
+      "bcp47": "khz",
+      "iso3": "khz",
+      "id": "99042",
+      "name": [
+        {
+          "value": "Keapara",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lorung-northern",
+      "bcp47": "lbr",
+      "iso3": "lbr",
+      "id": "99260",
+      "name": [
+        {
+          "value": "Lorung, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "maro",
+      "bcp47": null,
+      "iso3": "liq",
+      "id": "99303",
+      "name": [
+        {
+          "value": "Maro",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kouya",
+      "bcp47": "kyf",
+      "iso3": "kyf",
+      "id": "99359",
+      "name": [
+        {
+          "value": "Kouya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kabeverdiane-barlavente",
+      "bcp47": "kea-CV-B",
+      "iso3": "kea",
+      "id": "139094",
+      "name": [
+        {
+          "value": "Kabeverdiane, Barlavente",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "akebu",
+      "bcp47": "keu",
+      "iso3": "keu",
+      "id": "141199",
+      "name": [
+        {
+          "value": "Akebu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kupia",
+      "bcp47": "key",
+      "iso3": "key",
+      "id": "141202",
+      "name": [
+        {
+          "value": "Kupia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "konda-dora",
+      "bcp47": "kfc",
+      "iso3": "kfc",
+      "id": "141204",
+      "name": [
+        {
+          "value": "Konda-Dora",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "capanahua",
+      "bcp47": null,
+      "iso3": "kaq",
+      "id": "141267",
+      "name": [
+        {
+          "value": "Capanahua",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kutu",
+      "bcp47": "kdc",
+      "iso3": "kdc",
+      "id": "141310",
+      "name": [
+        {
+          "value": "Kutu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mamusi",
+      "bcp47": null,
+      "iso3": "kdf",
+      "id": "141311",
+      "name": [
+        {
+          "value": "Mamusi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kerewe",
+      "bcp47": null,
+      "iso3": "ked",
+      "id": "141325",
+      "name": [
+        {
+          "value": "Kerewe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kim",
+      "bcp47": null,
+      "iso3": "kia",
+      "id": "141333",
+      "name": [
+        {
+          "value": "Kim",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "koalib",
+      "bcp47": null,
+      "iso3": "kib",
+      "id": "141334",
+      "name": [
+        {
+          "value": "Koalib",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "maskelynes",
+      "bcp47": null,
+      "iso3": "klv",
+      "id": "141436",
+      "name": [
+        {
+          "value": "Maskelynes",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kope",
+      "bcp47": "kiw",
+      "iso3": "kiw",
+      "id": "149217",
+      "name": [
+        {
+          "value": "Kope",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "guina-ang-kalinga",
+      "bcp47": null,
+      "iso3": "knb",
+      "id": "149408",
+      "name": [
+        {
+          "value": "Guina-Ang Kalinga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kolami",
+      "bcp47": "kfb",
+      "iso3": "kfb",
+      "id": "163136",
+      "name": [
+        {
+          "value": "Kolami",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chikunda",
+      "bcp47": "kdn",
+      "iso3": "kdn",
+      "id": "163660",
+      "name": [
+        {
+          "value": "Chikunda",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tado",
+      "bcp47": null,
+      "iso3": "klw",
+      "id": "164090",
+      "name": [
+        {
+          "value": "Tado",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "khandeshi-bhili",
+      "bcp47": "khn",
+      "iso3": "khn",
+      "id": "164337",
+      "name": [
+        {
+          "value": "Khandeshi Bhili",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "khmer-standard",
+      "bcp47": "km",
+      "iso3": "khm",
+      "id": "178043",
+      "name": [
+        {
+          "value": "Khmer, Standard",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kurdish-afrini",
+      "bcp47": "kmr",
+      "iso3": "kmr",
+      "id": "184484",
+      "name": [
+        {
+          "value": "کوردی",
+          "primary": true,
+          "language": {
+            "id": "184484"
+          }
+        },
+        {
+          "value": "Kurdish, Afrini",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nghlawa",
+      "bcp47": null,
+      "iso3": "kga",
+      "id": "184630",
+      "name": [
+        {
+          "value": "N'Ghlawa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "takwane",
+      "bcp47": "tke",
+      "iso3": "tke",
+      "id": "26862",
+      "name": [
+        {
+          "value": "Takwane",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kurumba-kannada",
+      "bcp47": "kfi",
+      "iso3": "kfi",
+      "id": "98730",
+      "name": [
+        {
+          "value": "Kurumba Kannada",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "khmer-central-m",
+      "bcp47": "km-khm",
+      "iso3": "khm",
+      "id": "24024",
+      "name": [
+        {
+          "value": "ភាសាខ្មែរ",
+          "primary": true,
+          "language": {
+            "id": "24024"
+          }
+        },
+        {
+          "value": "Khmer, Central - M",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lunda",
+      "bcp47": "lun",
+      "iso3": "lun",
+      "id": "573",
+      "name": [
+        {
+          "value": "Lunda",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lashi",
+      "bcp47": "lsi",
+      "iso3": "lsi",
+      "id": "4045",
+      "name": [
+        {
+          "value": "Lashi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "maxakali",
+      "bcp47": "mbl",
+      "iso3": "mbl",
+      "id": "1608",
+      "name": [
+        {
+          "value": "Maxakali",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lundayeh",
+      "bcp47": null,
+      "iso3": "lnd",
+      "id": "1918",
+      "name": [
+        {
+          "value": "Lundayeh",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "samia",
+      "bcp47": null,
+      "iso3": "lsm",
+      "id": "7235",
+      "name": [
+        {
+          "value": "Samia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "maasai",
+      "bcp47": "mas",
+      "iso3": "mas",
+      "id": "7309",
+      "name": [
+        {
+          "value": "ɔl Maa",
+          "primary": true,
+          "language": {
+            "id": "7309"
+          }
+        },
+        {
+          "value": "Maasai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "loma",
+      "bcp47": "lom",
+      "iso3": "lom",
+      "id": "7584",
+      "name": [
+        {
+          "value": "Loma",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "marshallese",
+      "bcp47": "mh",
+      "iso3": "mah",
+      "id": "7889",
+      "name": [
+        {
+          "value": "Kajin M̧ajeļ",
+          "primary": true,
+          "language": {
+            "id": "7889"
+          }
+        },
+        {
+          "value": "Marshallese",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mazahua",
+      "bcp47": "maz",
+      "iso3": "maz",
+      "id": "8241",
+      "name": [
+        {
+          "value": "Mazahua",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lozi",
+      "bcp47": "loz",
+      "iso3": "loz",
+      "id": "8799",
+      "name": [
+        {
+          "value": "Lozi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mbembe-cross-river",
+      "bcp47": "mfn",
+      "iso3": "mfn",
+      "id": "9473",
+      "name": [
+        {
+          "value": "Mbembe, Cross River",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "manobo-matigsalug",
+      "bcp47": null,
+      "iso3": "mbt",
+      "id": "12640",
+      "name": [
+        {
+          "value": "Manobo, Matigsalug",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "madura",
+      "bcp47": "mad",
+      "iso3": "mad",
+      "id": "13183",
+      "name": [
+        {
+          "value": "Madura",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malay-pattani",
+      "bcp47": "ms-mfa",
+      "iso3": "mfa",
+      "id": "14386",
+      "name": [
+        {
+          "value": "ภาษายาวี",
+          "primary": true,
+          "language": {
+            "id": "14386"
+          }
+        },
+        {
+          "value": "Malay, Pattani",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mongo-nkundu",
+      "bcp47": "lol",
+      "iso3": "lol",
+      "id": "15300",
+      "name": [
+        {
+          "value": "Mongo-Nkundu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "logo",
+      "bcp47": "log",
+      "iso3": "log",
+      "id": "15383",
+      "name": [
+        {
+          "value": "Logo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "rampi",
+      "bcp47": "lje",
+      "iso3": "lje",
+      "id": "19912",
+      "name": [
+        {
+          "value": "Rampi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "loko",
+      "bcp47": "lok",
+      "iso3": "lok",
+      "id": "19922",
+      "name": [
+        {
+          "value": "Loko",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malayalam",
+      "bcp47": "ml",
+      "iso3": "mal",
+      "id": "19985",
+      "name": [
+        {
+          "value": "മലയാളം",
+          "primary": true,
+          "language": {
+            "id": "19985"
+          }
+        },
+        {
+          "value": "Malayalam",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kreol-mauricean",
+      "bcp47": "mfe",
+      "iso3": "mfe",
+      "id": "21197",
+      "name": [
+        {
+          "value": "Kreol Mauricean",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "makasar",
+      "bcp47": "mak",
+      "iso3": "mak",
+      "id": "21248",
+      "name": [
+        {
+          "value": "Makasar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lipo-eastern",
+      "bcp47": "lpo",
+      "iso3": "lpo",
+      "id": "22839",
+      "name": [
+        {
+          "value": "Lipo, Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "luri-luristan-province-iran",
+      "bcp47": "lrc",
+      "iso3": "lrc",
+      "id": "23743",
+      "name": [
+        {
+          "value": "لری",
+          "primary": true,
+          "language": {
+            "id": "23743"
+          }
+        },
+        {
+          "value": "Luri (Luristan Province, Iran)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lio",
+      "bcp47": null,
+      "iso3": "ljl",
+      "id": "24211",
+      "name": [
+        {
+          "value": "Li'O",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lolo",
+      "bcp47": "llb",
+      "iso3": "llb",
+      "id": "27261",
+      "name": [
+        {
+          "value": "Lolo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "otuho-lotuko",
+      "bcp47": "lot",
+      "iso3": "lot",
+      "id": "53422",
+      "name": [
+        {
+          "value": "Otuho (Lotuko)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ngbugu",
+      "bcp47": "lnl",
+      "iso3": "lnl",
+      "id": "53433",
+      "name": [
+        {
+          "value": "Ngbugu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lukabaras",
+      "bcp47": null,
+      "iso3": "lkb",
+      "id": "99311",
+      "name": [
+        {
+          "value": "Lukabaras",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "laarim",
+      "bcp47": null,
+      "iso3": "loh",
+      "id": "99460",
+      "name": [
+        {
+          "value": "Laarim",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "olutachoni",
+      "bcp47": null,
+      "iso3": "lts",
+      "id": "99504",
+      "name": [
+        {
+          "value": "Olutachoni",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "aringa",
+      "bcp47": "luc",
+      "iso3": "luc",
+      "id": "99508",
+      "name": [
+        {
+          "value": "Aringa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lala",
+      "bcp47": "lla",
+      "iso3": "lla",
+      "id": "106963",
+      "name": [
+        {
+          "value": "Lala (Nigeria)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "goji",
+      "bcp47": "kuh",
+      "iso3": "kuh",
+      "id": "121129",
+      "name": [
+        {
+          "value": "Goji",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yamdena",
+      "bcp47": "jmd",
+      "iso3": "jmd",
+      "id": "141060",
+      "name": [
+        {
+          "value": "Yamdena",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "wala",
+      "bcp47": null,
+      "iso3": "lgl",
+      "id": "141771",
+      "name": [
+        {
+          "value": "Wala",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "col",
+      "bcp47": null,
+      "iso3": "liw",
+      "id": "141796",
+      "name": [
+        {
+          "value": "Col",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lampung-api",
+      "bcp47": null,
+      "iso3": "ljp",
+      "id": "141801",
+      "name": [
+        {
+          "value": "Lampung Api",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lamatuka",
+      "bcp47": null,
+      "iso3": "lmq",
+      "id": "143731",
+      "name": [
+        {
+          "value": "Lamatuka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lamalera",
+      "bcp47": null,
+      "iso3": "lmr",
+      "id": "143732",
+      "name": [
+        {
+          "value": "Lamalera",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lango-south-sudan",
+      "bcp47": null,
+      "iso3": "lno",
+      "id": "143747",
+      "name": [
+        {
+          "value": "Lango - South Sudan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lobi",
+      "bcp47": null,
+      "iso3": "lob",
+      "id": "143751",
+      "name": [
+        {
+          "value": "Lobi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lepki",
+      "bcp47": null,
+      "iso3": "lpe",
+      "id": "143827",
+      "name": [
+        {
+          "value": "Lepki",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "laro",
+      "bcp47": "lro",
+      "iso3": "lro",
+      "id": "143834",
+      "name": [
+        {
+          "value": "Laro",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "levuka",
+      "bcp47": null,
+      "iso3": "lvu",
+      "id": "144034",
+      "name": [
+        {
+          "value": "Levuka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kuvi-odisha",
+      "bcp47": "kxv",
+      "iso3": "kxv",
+      "id": "184467",
+      "name": [
+        {
+          "value": "Kuvi, Odisha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bai-lama",
+      "bcp47": null,
+      "iso3": "lay",
+      "id": "184480",
+      "name": [
+        {
+          "value": "Bai Lama",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "palamua",
+      "bcp47": null,
+      "iso3": "kwx",
+      "id": "184571",
+      "name": [
+        {
+          "value": "Palamua",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kaakye",
+      "bcp47": "kye",
+      "iso3": "kye",
+      "id": "184818",
+      "name": [
+        {
+          "value": "Kaakye",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mentawai",
+      "bcp47": null,
+      "iso3": "mwv",
+      "id": "17797",
+      "name": [
+        {
+          "value": "Mentawai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tajik",
+      "bcp47": "tg",
+      "iso3": "tgk",
+      "id": "24309",
+      "name": [
+        {
+          "value": "تاجيكي",
+          "primary": true,
+          "language": {
+            "id": "24309"
+          }
+        },
+        {
+          "value": "Tajik",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tagalog",
+      "bcp47": "fil",
+      "iso3": "tgl",
+      "id": "12551",
+      "name": [
+        {
+          "value": "Wikang Tagalog",
+          "primary": true,
+          "language": {
+            "id": "12551"
+          }
+        },
+        {
+          "value": "Tagalog",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mru",
+      "bcp47": "mro",
+      "iso3": "mro",
+      "id": "1251",
+      "name": [
+        {
+          "value": "Mru",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "magar-eastern",
+      "bcp47": "mgp",
+      "iso3": "mgp",
+      "id": "1371",
+      "name": [
+        {
+          "value": "मगर भाषा",
+          "primary": true,
+          "language": {
+            "id": "1371"
+          }
+        },
+        {
+          "value": "Magar, Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "moore",
+      "bcp47": "mos",
+      "iso3": "mos",
+      "id": "2028",
+      "name": [
+        {
+          "value": "Moore",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "muyang",
+      "bcp47": "muy",
+      "iso3": "muy",
+      "id": "2430",
+      "name": [
+        {
+          "value": "Muyang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mundang",
+      "bcp47": "mua",
+      "iso3": "mua",
+      "id": "2453",
+      "name": [
+        {
+          "value": "Mundang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mungaka",
+      "bcp47": "mhk",
+      "iso3": "mhk",
+      "id": "2485",
+      "name": [
+        {
+          "value": "Mungaka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "marba",
+      "bcp47": "mpg",
+      "iso3": "mpg",
+      "id": "3534",
+      "name": [
+        {
+          "value": "Marba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "munukutuba",
+      "bcp47": "mkw",
+      "iso3": "mkw",
+      "id": "4334",
+      "name": [
+        {
+          "value": "Munukutuba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "manda",
+      "bcp47": null,
+      "iso3": "mgs",
+      "id": "101919",
+      "name": [
+        {
+          "value": "Manda",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "murle",
+      "bcp47": "mur",
+      "iso3": "mur",
+      "id": "4764",
+      "name": [
+        {
+          "value": "Murle",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malo",
+      "bcp47": null,
+      "iso3": "mfx",
+      "id": "4767",
+      "name": [
+        {
+          "value": "Malo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "maltese",
+      "bcp47": "mt",
+      "iso3": "mlt",
+      "id": "7885",
+      "name": [
+        {
+          "value": "Malti",
+          "primary": true,
+          "language": {
+            "id": "7885"
+          }
+        },
+        {
+          "value": "Maltese",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mpoto",
+      "bcp47": null,
+      "iso3": "mpa",
+      "id": "7791",
+      "name": [
+        {
+          "value": "Mpoto",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mixteco-silacayoapan",
+      "bcp47": "mks",
+      "iso3": "mks",
+      "id": "8287",
+      "name": [
+        {
+          "value": "Mixteco, Silacayoapan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mixteco-southern-puebla",
+      "bcp47": "mit",
+      "iso3": "mit",
+      "id": "8293",
+      "name": [
+        {
+          "value": "Mixteco, Southern Puebla",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "magar-western",
+      "bcp47": "mrd",
+      "iso3": "mrd",
+      "id": "9030",
+      "name": [
+        {
+          "value": "मगर भाषा",
+          "primary": true,
+          "language": {
+            "id": "9030"
+          }
+        },
+        {
+          "value": "Magar, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "maori",
+      "bcp47": "mi",
+      "iso3": "mri",
+      "id": "9198",
+      "name": [
+        {
+          "value": "te Reo Māori",
+          "primary": true,
+          "language": {
+            "id": "9198"
+          }
+        },
+        {
+          "value": "Maori",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "miya",
+      "bcp47": "mkf",
+      "iso3": "mkf",
+      "id": "9461",
+      "name": [
+        {
+          "value": "Miya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "marghi-central",
+      "bcp47": "mrt",
+      "iso3": "mrt",
+      "id": "9495",
+      "name": [
+        {
+          "value": "Marghi Central",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kohistani-indus",
+      "bcp47": null,
+      "iso3": "mvy",
+      "id": "10526",
+      "name": [
+        {
+          "value": "Kohistani, Indus",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "masbatenyo",
+      "bcp47": "msb",
+      "iso3": "msb",
+      "id": "12622",
+      "name": [
+        {
+          "value": "Masbatenyo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "maranao",
+      "bcp47": "mrw",
+      "iso3": "mrw",
+      "id": "12624",
+      "name": [
+        {
+          "value": "Maranao",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "moro",
+      "bcp47": "mor",
+      "iso3": "mor",
+      "id": "13889",
+      "name": [
+        {
+          "value": "Moro",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "madi",
+      "bcp47": "mhi",
+      "iso3": "mhi",
+      "id": "13893",
+      "name": [
+        {
+          "value": "Madi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "moru",
+      "bcp47": "mgd",
+      "iso3": "mgd",
+      "id": "13901",
+      "name": [
+        {
+          "value": "Moru",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mwera",
+      "bcp47": null,
+      "iso3": "mwe",
+      "id": "14124",
+      "name": [
+        {
+          "value": "Mwera",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malila",
+      "bcp47": null,
+      "iso3": "mgq",
+      "id": "14260",
+      "name": [
+        {
+          "value": "Malila",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malay-kota-bangun-kutai",
+      "bcp47": null,
+      "iso3": "mqg",
+      "id": "16777",
+      "name": [
+        {
+          "value": "Malay, Kota Bangun Kutai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "modole",
+      "bcp47": null,
+      "iso3": "mqo",
+      "id": "17075",
+      "name": [
+        {
+          "value": "Modole",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "manggarai",
+      "bcp47": null,
+      "iso3": "mqy",
+      "id": "17282",
+      "name": [
+        {
+          "value": "Manggarai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "muna",
+      "bcp47": null,
+      "iso3": "mnb",
+      "id": "17462",
+      "name": [
+        {
+          "value": "Muna",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "duri",
+      "bcp47": "mvp",
+      "iso3": "mvp",
+      "id": "17601",
+      "name": [
+        {
+          "value": "Duri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "minangkabau",
+      "bcp47": "min",
+      "iso3": "min",
+      "id": "17695",
+      "name": [
+        {
+          "value": "Minangkabau",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "palembang",
+      "bcp47": "mui",
+      "iso3": "mui",
+      "id": "17774",
+      "name": [
+        {
+          "value": "Palembang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mari-low",
+      "bcp47": "mhr",
+      "iso3": "mhr",
+      "id": "18489",
+      "name": [
+        {
+          "value": "марий йылме",
+          "primary": true,
+          "language": {
+            "id": "18489"
+          }
+        },
+        {
+          "value": "Mari, Low",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "muong",
+      "bcp47": "mtq",
+      "iso3": "mtq",
+      "id": "19191",
+      "name": [
+        {
+          "value": "Muong",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mawchi",
+      "bcp47": "mke",
+      "iso3": "mke",
+      "id": "19988",
+      "name": [
+        {
+          "value": "Mawchi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mono",
+      "bcp47": null,
+      "iso3": "mnh",
+      "id": "20007",
+      "name": [
+        {
+          "value": "Mono",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mamuju",
+      "bcp47": null,
+      "iso3": "mqx",
+      "id": "20025",
+      "name": [
+        {
+          "value": "Mamuju",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "macedonian",
+      "bcp47": "mk",
+      "iso3": "mkd",
+      "id": "20796",
+      "name": [
+        {
+          "value": "Mакедонски",
+          "primary": true,
+          "language": {
+            "id": "20796"
+          }
+        },
+        {
+          "value": "Macedonian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "inner-mongolian",
+      "bcp47": "mvf",
+      "iso3": "mvf",
+      "id": "22293",
+      "name": [
+        {
+          "value": "Inner Mongolian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sara",
+      "bcp47": "mwm",
+      "iso3": "mwm",
+      "id": "22640",
+      "name": [
+        {
+          "value": "Sara",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lhao-vo",
+      "bcp47": "mhx",
+      "iso3": "mhx",
+      "id": "23044",
+      "name": [
+        {
+          "value": "Lhao Vo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "masikoro",
+      "bcp47": "msh",
+      "iso3": "msh",
+      "id": "23196",
+      "name": [
+        {
+          "value": "Masikoro",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "karbi",
+      "bcp47": "mjw",
+      "iso3": "mjw",
+      "id": "23563",
+      "name": [
+        {
+          "value": "Karbi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mofu-gudur",
+      "bcp47": "mif",
+      "iso3": "mif",
+      "id": "23922",
+      "name": [
+        {
+          "value": "Mofu-Gudur",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "manjaku",
+      "bcp47": "mfv",
+      "iso3": "mfv",
+      "id": "23979",
+      "name": [
+        {
+          "value": "Manjaku",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mising",
+      "bcp47": "mrg",
+      "iso3": "mrg",
+      "id": "24177",
+      "name": [
+        {
+          "value": "Mising",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mango",
+      "bcp47": "mge",
+      "iso3": "mge",
+      "id": "26152",
+      "name": [
+        {
+          "value": "Mango",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mixtec-ayutla",
+      "bcp47": "miy",
+      "iso3": "miy",
+      "id": "26162",
+      "name": [
+        {
+          "value": "Mixtec, Ayutla",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "migili",
+      "bcp47": "mgi",
+      "iso3": "mgi",
+      "id": "32122",
+      "name": [
+        {
+          "value": "Migili",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "namwanga",
+      "bcp47": "mwn",
+      "iso3": "mwn",
+      "id": "53095",
+      "name": [
+        {
+          "value": "Namwanga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "meqa",
+      "bcp47": null,
+      "iso3": "mvz",
+      "id": "101396",
+      "name": [
+        {
+          "value": "Meqa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "muria-western",
+      "bcp47": "mut",
+      "iso3": "mut",
+      "id": "101474",
+      "name": [
+        {
+          "value": "Muria, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "innu",
+      "bcp47": "moe",
+      "iso3": "moe",
+      "id": "127397",
+      "name": [
+        {
+          "value": "Innu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mundari-south-sudan",
+      "bcp47": null,
+      "iso3": "mqu",
+      "id": "127670",
+      "name": [
+        {
+          "value": "Mundari (South Sudan)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tu-huzhu",
+      "bcp47": "mjg",
+      "iso3": "mjg",
+      "id": "139089",
+      "name": [
+        {
+          "value": "Tu, Huzhu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "majhi",
+      "bcp47": null,
+      "iso3": "mjz",
+      "id": "143400",
+      "name": [
+        {
+          "value": "Majhi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "san-chi",
+      "bcp47": null,
+      "iso3": "mlc",
+      "id": "143419",
+      "name": [
+        {
+          "value": "San Chi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "manambu",
+      "bcp47": null,
+      "iso3": "mle",
+      "id": "143488",
+      "name": [
+        {
+          "value": "Manambu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kiwilwana",
+      "bcp47": null,
+      "iso3": "mlk",
+      "id": "143494",
+      "name": [
+        {
+          "value": "Kiwilwana",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "meitei",
+      "bcp47": "mni",
+      "iso3": "mni",
+      "id": "143789",
+      "name": [
+        {
+          "value": "মৈইতৈইলোন",
+          "primary": true,
+          "language": {
+            "id": "143789"
+          }
+        },
+        {
+          "value": "Meitei",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mwan",
+      "bcp47": null,
+      "iso3": "moa",
+      "id": "143863",
+      "name": [
+        {
+          "value": "Mwan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "majang",
+      "bcp47": "mpe",
+      "iso3": "mpe",
+      "id": "143881",
+      "name": [
+        {
+          "value": "Majang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "western-lipo",
+      "bcp47": null,
+      "iso3": "lpo",
+      "id": "153360",
+      "name": [
+        {
+          "value": "Western Lipo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bawean",
+      "bcp47": null,
+      "iso3": "mad",
+      "id": "153673",
+      "name": [
+        {
+          "value": "Bawean",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "matsigenka",
+      "bcp47": "mcb",
+      "iso3": "mcb",
+      "id": "173888",
+      "name": [
+        {
+          "value": "Matsigenka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kortha",
+      "bcp47": "mai",
+      "iso3": "mai",
+      "id": "183121",
+      "name": [
+        {
+          "value": "Kortha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ellomwe",
+      "bcp47": "lon",
+      "iso3": "lon",
+      "id": "184513",
+      "name": [
+        {
+          "value": "Ellomwe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "satere-mawe",
+      "bcp47": "mav",
+      "iso3": "mav",
+      "id": "184849",
+      "name": [
+        {
+          "value": "Satere-Mawe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ngombale",
+      "bcp47": "nla",
+      "iso3": "nla",
+      "id": "2357",
+      "name": [
+        {
+          "value": "Ngombale",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nyaneka",
+      "bcp47": null,
+      "iso3": "nyk",
+      "id": "588",
+      "name": [
+        {
+          "value": "Nyaneka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nago",
+      "bcp47": "nqg",
+      "iso3": "nqg",
+      "id": "1327",
+      "name": [
+        {
+          "value": "Nago",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "noone",
+      "bcp47": "nhu",
+      "iso3": "nhu",
+      "id": "2364",
+      "name": [
+        {
+          "value": "Noone",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nambikuara-southern",
+      "bcp47": "nab",
+      "iso3": "nab",
+      "id": "1816",
+      "name": [
+        {
+          "value": "Nambikuara, Southern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "munduruku",
+      "bcp47": "myu",
+      "iso3": "myu",
+      "id": "1821",
+      "name": [
+        {
+          "value": "Munduruku",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nuni-southern",
+      "bcp47": null,
+      "iso3": "nnw",
+      "id": "2021",
+      "name": [
+        {
+          "value": "Nuni, Southern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mumuye",
+      "bcp47": "mzm",
+      "iso3": "mzm",
+      "id": "2441",
+      "name": [
+        {
+          "value": "Mumuye",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mandja",
+      "bcp47": null,
+      "iso3": "mzv",
+      "id": "3171",
+      "name": [
+        {
+          "value": "Mandja",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "waumeo",
+      "bcp47": "noa",
+      "iso3": "noa",
+      "id": "4187",
+      "name": [
+        {
+          "value": "Waumeo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nawdm",
+      "bcp47": "nmz",
+      "iso3": "nmz",
+      "id": "5220",
+      "name": [
+        {
+          "value": "Nawdm",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nimadi",
+      "bcp47": null,
+      "iso3": "noe",
+      "id": "6029",
+      "name": [
+        {
+          "value": "Nimadi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mazanderani",
+      "bcp47": null,
+      "iso3": "mzn",
+      "id": "6793",
+      "name": [
+        {
+          "value": "Mazanderani",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "katang",
+      "bcp47": null,
+      "iso3": "ncq",
+      "id": "7506",
+      "name": [
+        {
+          "value": "Katang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nahuatl-orizaba",
+      "bcp47": "nlv",
+      "iso3": "nlv",
+      "id": "8164",
+      "name": [
+        {
+          "value": "Māsēwallahtōlli",
+          "primary": true,
+          "language": {
+            "id": "8164"
+          }
+        },
+        {
+          "value": "Nahuatl, Orizaba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nahuatl-southeast-puebla",
+      "bcp47": "npl",
+      "iso3": "npl",
+      "id": "8173",
+      "name": [
+        {
+          "value": "Māsēwallahtōlli",
+          "primary": true,
+          "language": {
+            "id": "8173"
+          }
+        },
+        {
+          "value": "Nahuatl, Southeast Puebla",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nahuatl-eastern-huasteca",
+      "bcp47": "nhe",
+      "iso3": "nhe",
+      "id": "8188",
+      "name": [
+        {
+          "value": "Māsēwallahtōlli",
+          "primary": true,
+          "language": {
+            "id": "8188"
+          }
+        },
+        {
+          "value": "Nahuatl, Eastern Huasteca",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ndau",
+      "bcp47": "ndc",
+      "iso3": "ndc",
+      "id": "8441",
+      "name": [
+        {
+          "value": "Ndau",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nauruan",
+      "bcp47": "na",
+      "iso3": "nau",
+      "id": "8818",
+      "name": [
+        {
+          "value": "NULLEkakairũ Naoero",
+          "primary": true,
+          "language": {
+            "id": "8818"
+          }
+        },
+        {
+          "value": "Nauruan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ngamo",
+      "bcp47": "nbh",
+      "iso3": "nbh",
+      "id": "9410",
+      "name": [
+        {
+          "value": "Ngamo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "norwegian-bokmal",
+      "bcp47": "no",
+      "iso3": "nor",
+      "id": "10393",
+      "name": [
+        {
+          "value": "Norsk",
+          "primary": true,
+          "language": {
+            "id": "10393"
+          }
+        },
+        {
+          "value": "Norwegian, Bokmal",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "numanggang",
+      "bcp47": "nop",
+      "iso3": "nop",
+      "id": "11479",
+      "name": [
+        {
+          "value": "Numanggang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ndogo",
+      "bcp47": null,
+      "iso3": "ndz",
+      "id": "13876",
+      "name": [
+        {
+          "value": "Ndogo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ngindo",
+      "bcp47": "nnq",
+      "iso3": "nnq",
+      "id": "14108",
+      "name": [
+        {
+          "value": "Ngindo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ngulu",
+      "bcp47": "ngp",
+      "iso3": "ngp",
+      "id": "14115",
+      "name": [
+        {
+          "value": "Ngulu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hema",
+      "bcp47": "nix",
+      "iso3": "nix",
+      "id": "15256",
+      "name": [
+        {
+          "value": "Hema",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nkoya",
+      "bcp47": "nka",
+      "iso3": "nka",
+      "id": "15739",
+      "name": [
+        {
+          "value": "Nkoya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nambya",
+      "bcp47": "nmq",
+      "iso3": "nmq",
+      "id": "15865",
+      "name": [
+        {
+          "value": "Nambya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nalca",
+      "bcp47": "nlc",
+      "iso3": "nlc",
+      "id": "16214",
+      "name": [
+        {
+          "value": "Nalca",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "erzya",
+      "bcp47": "myv",
+      "iso3": "myv",
+      "id": "18483",
+      "name": [
+        {
+          "value": "Эрзянь Kель",
+          "primary": true,
+          "language": {
+            "id": "18483"
+          }
+        },
+        {
+          "value": "Erzya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nogai",
+      "bcp47": null,
+      "iso3": "nog",
+      "id": "18634",
+      "name": [
+        {
+          "value": "Nogai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ndali",
+      "bcp47": null,
+      "iso3": "ndh",
+      "id": "20070",
+      "name": [
+        {
+          "value": "Ndali",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nias",
+      "bcp47": "nia",
+      "iso3": "nia",
+      "id": "20089",
+      "name": [
+        {
+          "value": "Nias",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lumasaba",
+      "bcp47": "myx",
+      "iso3": "myx",
+      "id": "20815",
+      "name": [
+        {
+          "value": "Lumasaba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ndebele-northern",
+      "bcp47": "nd",
+      "iso3": "nde",
+      "id": "20851",
+      "name": [
+        {
+          "value": "Ndebele, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ndebele-southern",
+      "bcp47": "nr",
+      "iso3": "nbl",
+      "id": "20852",
+      "name": [
+        {
+          "value": "Ndebele, Southern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "minianka",
+      "bcp47": "myk",
+      "iso3": "myk",
+      "id": "20917",
+      "name": [
+        {
+          "value": "Minianka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "thai-northern",
+      "bcp47": "th-nod",
+      "iso3": "nod",
+      "id": "21118",
+      "name": [
+        {
+          "value": "ภาษาไทย",
+          "primary": true,
+          "language": {
+            "id": "21118"
+          }
+        },
+        {
+          "value": "Thai, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "flemish",
+      "bcp47": null,
+      "iso3": "nld",
+      "id": "21578",
+      "name": [
+        {
+          "value": "Flemish",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kintandu",
+      "bcp47": "ndl",
+      "iso3": "ndl",
+      "id": "22379",
+      "name": [
+        {
+          "value": "Kintandu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mixteco-terroro-venado",
+      "bcp47": "mxv",
+      "iso3": "mxv",
+      "id": "24007",
+      "name": [
+        {
+          "value": "Mixteco, Terroro Venado",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nyiramba",
+      "bcp47": "nim",
+      "iso3": "nim",
+      "id": "24140",
+      "name": [
+        {
+          "value": "Nyiramba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zing",
+      "bcp47": "mzm-x-Zing",
+      "iso3": "mzm",
+      "id": "24216",
+      "name": [
+        {
+          "value": "Zing",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ndruna",
+      "bcp47": "niy",
+      "iso3": "niy",
+      "id": "24295",
+      "name": [
+        {
+          "value": "Ndruna",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ngbandi-ngiri",
+      "bcp47": null,
+      "iso3": "nbw",
+      "id": "26416",
+      "name": [
+        {
+          "value": "Ngbandi-Ngiri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ninzo",
+      "bcp47": "nin",
+      "iso3": "nin",
+      "id": "27269",
+      "name": [
+        {
+          "value": "Ninzo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "takuu-nakumanu",
+      "bcp47": "nho",
+      "iso3": "nho",
+      "id": "53392",
+      "name": [
+        {
+          "value": "Takuu/Nakumanu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "noiri",
+      "bcp47": null,
+      "iso3": "noi",
+      "id": "101184",
+      "name": [
+        {
+          "value": "Noiri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "naga-chang",
+      "bcp47": "nbc",
+      "iso3": "nbc",
+      "id": "101847",
+      "name": [
+        {
+          "value": "Naga, Chang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nandi",
+      "bcp47": null,
+      "iso3": "niq",
+      "id": "102324",
+      "name": [
+        {
+          "value": "Nandi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ngungwel",
+      "bcp47": null,
+      "iso3": "ngz",
+      "id": "143643",
+      "name": [
+        {
+          "value": "Ngungwel",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "naga-khezha",
+      "bcp47": "nkh",
+      "iso3": "nkh",
+      "id": "143890",
+      "name": [
+        {
+          "value": "Naga, Khezha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gela",
+      "bcp47": "nlg",
+      "iso3": "nlg",
+      "id": "143904",
+      "name": [
+        {
+          "value": "Gela",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nama",
+      "bcp47": null,
+      "iso3": "nmx",
+      "id": "144017",
+      "name": [
+        {
+          "value": "Nama",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nyangatom",
+      "bcp47": "nnj",
+      "iso3": "nnj",
+      "id": "144101",
+      "name": [
+        {
+          "value": "Nyangatom",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tambee",
+      "bcp47": null,
+      "iso3": "mzq",
+      "id": "154906",
+      "name": [
+        {
+          "value": "Tambee",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dayak-ngaju",
+      "bcp47": "nij",
+      "iso3": "nij",
+      "id": "172218",
+      "name": [
+        {
+          "value": "Dayak Ngaju",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mambilla",
+      "bcp47": "mzk",
+      "iso3": "mzk",
+      "id": "175157",
+      "name": [
+        {
+          "value": "Mambilla",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ndola",
+      "bcp47": "ndr",
+      "iso3": "ndr",
+      "id": "176097",
+      "name": [
+        {
+          "value": "Ndola",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ao",
+      "bcp47": "njo",
+      "iso3": "njo",
+      "id": "176313",
+      "name": [
+        {
+          "value": "Ao",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "phom",
+      "bcp47": null,
+      "iso3": "nph",
+      "id": "176708",
+      "name": [
+        {
+          "value": "Phom",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kwamashi",
+      "bcp47": "mho",
+      "iso3": "mho",
+      "id": "184452",
+      "name": [
+        {
+          "value": "Kwamashi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mundu",
+      "bcp47": "muh",
+      "iso3": "muh",
+      "id": "184502",
+      "name": [
+        {
+          "value": "Mundu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tehl",
+      "bcp47": null,
+      "iso3": "mtl",
+      "id": "184512",
+      "name": [
+        {
+          "value": "Tehl",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pomeranian-brazilian",
+      "bcp47": null,
+      "iso3": "nds",
+      "id": "184588",
+      "name": [
+        {
+          "value": "Pomeranian, Brazilian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malinke-kita",
+      "bcp47": "mwk",
+      "iso3": "mwk",
+      "id": "184647",
+      "name": [
+        {
+          "value": "Malinke, Kita",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "agusan-surigao-manobo",
+      "bcp47": "msm",
+      "iso3": "msm",
+      "id": "184668",
+      "name": [
+        {
+          "value": "Agusan-Surigao Manobo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "maram-naga",
+      "bcp47": "nma",
+      "iso3": "nma",
+      "id": "184815",
+      "name": [
+        {
+          "value": "Maram Naga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mixteco-potoichan",
+      "bcp47": "mim",
+      "iso3": "mim",
+      "id": "184832",
+      "name": [
+        {
+          "value": "Mixteco Potoichan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ruund",
+      "bcp47": "rnd",
+      "iso3": "rnd",
+      "id": "583",
+      "name": [
+        {
+          "value": "Ruund",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quechua-south-bolivian",
+      "bcp47": "quh",
+      "iso3": "quh",
+      "id": "633",
+      "name": [
+        {
+          "value": "Qhichwa",
+          "primary": true,
+          "language": {
+            "id": "633"
+          }
+        },
+        {
+          "value": "Quechua, South Bolivian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "wayampi-amapari",
+      "bcp47": "oym-x-Amapari",
+      "iso3": "oym",
+      "id": "1795",
+      "name": [
+        {
+          "value": "Wayampi, Amapari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "russian-sign-language",
+      "bcp47": "rsl",
+      "iso3": "rsl",
+      "id": "1944",
+      "name": [
+        {
+          "value": "Russian Sign Language",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "romani-balkan",
+      "bcp47": "rmn",
+      "iso3": "rmn",
+      "id": "1953",
+      "name": [
+        {
+          "value": "रोमानो",
+          "primary": true,
+          "language": {
+            "id": "1953"
+          }
+        },
+        {
+          "value": "Romani, Balkan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ojibwa-western",
+      "bcp47": "ojw",
+      "iso3": "ojw",
+      "id": "3001",
+      "name": [
+        {
+          "value": "ᐊᓂᔑᓈᐯᒧᐎᓐ",
+          "primary": true,
+          "language": {
+            "id": "3001"
+          }
+        },
+        {
+          "value": "Ojibwa, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sango",
+      "bcp47": "sg",
+      "iso3": "sag",
+      "id": "3156",
+      "name": [
+        {
+          "value": "Yângâ tî Sängö",
+          "primary": true,
+          "language": {
+            "id": "3156"
+          }
+        },
+        {
+          "value": "Sango",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nzakara",
+      "bcp47": "nzk",
+      "iso3": "nzk",
+      "id": "3161",
+      "name": [
+        {
+          "value": "Nzakara",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "palaung-rumai",
+      "bcp47": "rbb",
+      "iso3": "rbb",
+      "id": "3936",
+      "name": [
+        {
+          "value": "Palaung, Rumai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "palaung-pale",
+      "bcp47": "pce",
+      "iso3": "pce",
+      "id": "3957",
+      "name": [
+        {
+          "value": "Palaung, Pale",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lingao",
+      "bcp47": "onb",
+      "iso3": "onb",
+      "id": "3964",
+      "name": [
+        {
+          "value": "Lingao",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "naxi",
+      "bcp47": "nxq",
+      "iso3": "nxq",
+      "id": "3974",
+      "name": [
+        {
+          "value": "Naxi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "piaroa",
+      "bcp47": "pid",
+      "iso3": "pid",
+      "id": "4178",
+      "name": [
+        {
+          "value": "Piaroa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ipunu",
+      "bcp47": "puu",
+      "iso3": "puu",
+      "id": "4310",
+      "name": [
+        {
+          "value": "Ipunu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "polish",
+      "bcp47": "pl",
+      "iso3": "pol",
+      "id": "4451",
+      "name": [
+        {
+          "value": "polski",
+          "primary": true,
+          "language": {
+            "id": "4451"
+          }
+        },
+        {
+          "value": "Polish",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pokomo-lower",
+      "bcp47": "pkb",
+      "iso3": "pkb",
+      "id": "7248",
+      "name": [
+        {
+          "value": "Pokomo, Lower",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pokoot",
+      "bcp47": "pko",
+      "iso3": "pko",
+      "id": "7251",
+      "name": [
+        {
+          "value": "Pokoot",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "okiek",
+      "bcp47": null,
+      "iso3": "oki",
+      "id": "7266",
+      "name": [
+        {
+          "value": "Okiek",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nung",
+      "bcp47": "nut",
+      "iso3": "nut",
+      "id": "7481",
+      "name": [
+        {
+          "value": "Nung",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malagasy",
+      "bcp47": "mg",
+      "iso3": "plt",
+      "id": "7761",
+      "name": [
+        {
+          "value": "Fiteny Malagasy",
+          "primary": true,
+          "language": {
+            "id": "7761"
+          }
+        },
+        {
+          "value": "Malagasy",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "otomi-western",
+      "bcp47": "otq",
+      "iso3": "otq",
+      "id": "8154",
+      "name": [
+        {
+          "value": "Otomi, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "otomi-eastern",
+      "bcp47": "otm",
+      "iso3": "otm",
+      "id": "8156",
+      "name": [
+        {
+          "value": "Otomi, Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nsenga",
+      "bcp47": null,
+      "iso3": "nse",
+      "id": "8464",
+      "name": [
+        {
+          "value": "Nsenga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nyungwe",
+      "bcp47": "nyu",
+      "iso3": "nyu",
+      "id": "8523",
+      "name": [
+        {
+          "value": "Nyungwe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "new-zealand-sign-language",
+      "bcp47": "nzs",
+      "iso3": "nzs",
+      "id": "9194",
+      "name": [
+        {
+          "value": "New Zealand Sign Language",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "okrika",
+      "bcp47": "okr",
+      "iso3": "okr",
+      "id": "9346",
+      "name": [
+        {
+          "value": "Okrika",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nupe",
+      "bcp47": "nup",
+      "iso3": "nup",
+      "id": "9384",
+      "name": [
+        {
+          "value": "Nupe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "shina-kohistani",
+      "bcp47": null,
+      "iso3": "plk",
+      "id": "10500",
+      "name": [
+        {
+          "value": "Shina, Kohistani",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pangasinan",
+      "bcp47": "pag",
+      "iso3": "pag",
+      "id": "12606",
+      "name": [
+        {
+          "value": "Pangasinan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pijin",
+      "bcp47": "pis",
+      "iso3": "pis",
+      "id": "13316",
+      "name": [
+        {
+          "value": "Pijin",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nyamwezi",
+      "bcp47": "nym",
+      "iso3": "nym",
+      "id": "14089",
+      "name": [
+        {
+          "value": "Kinyamwezi",
+          "primary": true,
+          "language": {
+            "id": "14089"
+          }
+        },
+        {
+          "value": "Nyamwezi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nyole",
+      "bcp47": "nuj",
+      "iso3": "nuj",
+      "id": "14731",
+      "name": [
+        {
+          "value": "Nyole",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "omi",
+      "bcp47": "omi",
+      "iso3": "omi",
+      "id": "15220",
+      "name": [
+        {
+          "value": "Omi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nyanga",
+      "bcp47": null,
+      "iso3": "nyj",
+      "id": "15224",
+      "name": [
+        {
+          "value": "Nyanga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "osing",
+      "bcp47": null,
+      "iso3": "osi",
+      "id": "16640",
+      "name": [
+        {
+          "value": "Osing",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pamona",
+      "bcp47": "pmf",
+      "iso3": "pmf",
+      "id": "19521",
+      "name": [
+        {
+          "value": "Pamona",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pagoe",
+      "bcp47": null,
+      "iso3": "pgu",
+      "id": "20138",
+      "name": [
+        {
+          "value": "Pagoe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chichewa",
+      "bcp47": "ny",
+      "iso3": "nya",
+      "id": "20857",
+      "name": [
+        {
+          "value": "Chicheŵa",
+          "primary": true,
+          "language": {
+            "id": "20857"
+          }
+        },
+        {
+          "value": "Chichewa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "runyankole",
+      "bcp47": "nyn",
+      "iso3": "nyn",
+      "id": "20859",
+      "name": [
+        {
+          "value": "Runyankole",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kapampangan",
+      "bcp47": "pam",
+      "iso3": "pam",
+      "id": "20871",
+      "name": [
+        {
+          "value": "Kapampangan",
+          "primary": true,
+          "language": {
+            "id": "20871"
+          }
+        },
+        {
+          "value": "Kapampangan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kayan",
+      "bcp47": "pdu",
+      "iso3": "pdu",
+      "id": "21773",
+      "name": [
+        {
+          "value": "Kayan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nigerian-pidgin-english",
+      "bcp47": "pcm",
+      "iso3": "pcm",
+      "id": "22176",
+      "name": [
+        {
+          "value": "Nigerian Pidgin English",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "southern-nisu",
+      "bcp47": "nsd",
+      "iso3": "nsd",
+      "id": "24433",
+      "name": [
+        {
+          "value": "Southern Nisu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yom",
+      "bcp47": "pil",
+      "iso3": "pil",
+      "id": "26497",
+      "name": [
+        {
+          "value": "Yom",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pipero",
+      "bcp47": "pip",
+      "iso3": "pip",
+      "id": "51689",
+      "name": [
+        {
+          "value": "Pipero",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zul",
+      "bcp47": "plj",
+      "iso3": "plj",
+      "id": "53402",
+      "name": [
+        {
+          "value": "Zul",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "obo-manobo",
+      "bcp47": "obo",
+      "iso3": "obo",
+      "id": "53403",
+      "name": [
+        {
+          "value": "Obo Manobo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "napu",
+      "bcp47": "npy",
+      "iso3": "npy",
+      "id": "101301",
+      "name": [
+        {
+          "value": "Napu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bouyei-anshun",
+      "bcp47": "pcc",
+      "iso3": "pcc",
+      "id": "139132",
+      "name": [
+        {
+          "value": "Bouyei Anshun",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hakhun",
+      "bcp47": "nst",
+      "iso3": "nst",
+      "id": "139179",
+      "name": [
+        {
+          "value": "Hakhun",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "oriya-adivasi",
+      "bcp47": "ort",
+      "iso3": "ort",
+      "id": "143460",
+      "name": [
+        {
+          "value": "Oriya, Adivasi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ososo",
+      "bcp47": null,
+      "iso3": "oso",
+      "id": "143465",
+      "name": [
+        {
+          "value": "Ososo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ot-danum",
+      "bcp47": "otd",
+      "iso3": "otd",
+      "id": "143469",
+      "name": [
+        {
+          "value": "Ot Danum",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "otoro",
+      "bcp47": null,
+      "iso3": "otr",
+      "id": "143475",
+      "name": [
+        {
+          "value": "Otoro",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pagabete",
+      "bcp47": null,
+      "iso3": "pae",
+      "id": "143573",
+      "name": [
+        {
+          "value": "Pagabete",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "padoe",
+      "bcp47": null,
+      "iso3": "pdo",
+      "id": "143600",
+      "name": [
+        {
+          "value": "Padoe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pangwali",
+      "bcp47": null,
+      "iso3": "pgg",
+      "id": "143668",
+      "name": [
+        {
+          "value": "Pangwali",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yine",
+      "bcp47": null,
+      "iso3": "pib",
+      "id": "143753",
+      "name": [
+        {
+          "value": "Yine",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "piapoco",
+      "bcp47": null,
+      "iso3": "pio",
+      "id": "143762",
+      "name": [
+        {
+          "value": "Piapoco",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "taa",
+      "bcp47": null,
+      "iso3": "pmf",
+      "id": "153397",
+      "name": [
+        {
+          "value": "Taa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ikoma",
+      "bcp47": "ntk",
+      "iso3": "ntk",
+      "id": "154395",
+      "name": [
+        {
+          "value": "Ikoma",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "provencal",
+      "bcp47": null,
+      "iso3": "oci",
+      "id": "154958",
+      "name": [
+        {
+          "value": "Provencal",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "omwunra-toqura",
+      "bcp47": null,
+      "iso3": "omw",
+      "id": "155279",
+      "name": [
+        {
+          "value": "Omwunra-Toqura",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "uud-danum",
+      "bcp47": null,
+      "iso3": "otd",
+      "id": "171233",
+      "name": [
+        {
+          "value": "Uud Danum",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "odiya",
+      "bcp47": "ory",
+      "iso3": "ory",
+      "id": "184528",
+      "name": [
+        {
+          "value": "ଓଡ଼ିଆ",
+          "primary": true,
+          "language": {
+            "id": "184528"
+          }
+        },
+        {
+          "value": "Odiya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "od-rajput",
+      "bcp47": null,
+      "iso3": "odk",
+      "id": "184537",
+      "name": [
+        {
+          "value": "Od, Rajput",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tangsa-kimsing",
+      "bcp47": "nst",
+      "iso3": "nst",
+      "id": "184546",
+      "name": [
+        {
+          "value": "Tangsa, Kimsing",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kuvale",
+      "bcp47": null,
+      "iso3": "olu",
+      "id": "184573",
+      "name": [
+        {
+          "value": "Kuvale",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nyamboa",
+      "bcp47": null,
+      "iso3": "nwb",
+      "id": "184629",
+      "name": [
+        {
+          "value": "Nyamboa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "oadki",
+      "bcp47": null,
+      "iso3": "odk",
+      "id": "184811",
+      "name": [
+        {
+          "value": "Oadki",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "soninke",
+      "bcp47": "snk",
+      "iso3": "snk",
+      "id": "2005",
+      "name": [
+        {
+          "value": "Soninkanxaane",
+          "primary": true,
+          "language": {
+            "id": "2005"
+          }
+        },
+        {
+          "value": "Soninke",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "samo",
+      "bcp47": "sbd",
+      "iso3": "sbd",
+      "id": "2018",
+      "name": [
+        {
+          "value": "Samo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ngambay",
+      "bcp47": "sba",
+      "iso3": "sba",
+      "id": "2303",
+      "name": [
+        {
+          "value": "Ngambay",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dime",
+      "bcp47": null,
+      "iso3": "dim",
+      "id": "140225",
+      "name": [
+        {
+          "value": "Dime",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tachelhit",
+      "bcp47": "shi",
+      "iso3": "shi",
+      "id": "507",
+      "name": [
+        {
+          "value": "Tachelhit",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "samoan",
+      "bcp47": "sm",
+      "iso3": "smo",
+      "id": "530",
+      "name": [
+        {
+          "value": "Gagana Sāmoa",
+          "primary": true,
+          "language": {
+            "id": "530"
+          }
+        },
+        {
+          "value": "Samoan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dongxiang",
+      "bcp47": null,
+      "iso3": "sce",
+      "id": "3933",
+      "name": [
+        {
+          "value": "Dongxiang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "somali",
+      "bcp47": "so",
+      "iso3": "som",
+      "id": "4466",
+      "name": [
+        {
+          "value": "اللغة الصومالية",
+          "primary": true,
+          "language": {
+            "id": "4466"
+          }
+        },
+        {
+          "value": "Somali",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "rendille",
+      "bcp47": "rel",
+      "iso3": "rel",
+      "id": "7238",
+      "name": [
+        {
+          "value": "Rendille",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "popoloca-san-felipe-otlaltepec",
+      "bcp47": "pow",
+      "iso3": "pow",
+      "id": "8130",
+      "name": [
+        {
+          "value": "Popoloca, San Felipe Otlaltepec",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "popoluca-sierra",
+      "bcp47": "poi",
+      "iso3": "poi",
+      "id": "8133",
+      "name": [
+        {
+          "value": "Popoluca, Sierra",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ronga",
+      "bcp47": "rng",
+      "iso3": "rng",
+      "id": "8520",
+      "name": [
+        {
+          "value": "Ronga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "karen-pwo",
+      "bcp47": "pwo",
+      "iso3": "pwo",
+      "id": "8714",
+      "name": [
+        {
+          "value": "Karen, Pwo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "reshe",
+      "bcp47": "res",
+      "iso3": "res",
+      "id": "10048",
+      "name": [
+        {
+          "value": "Reshe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "buglere",
+      "bcp47": "sab",
+      "iso3": "sab",
+      "id": "10601",
+      "name": [
+        {
+          "value": "Buglere",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quechua-cuzco",
+      "bcp47": "quz",
+      "iso3": "quz",
+      "id": "12399",
+      "name": [
+        {
+          "value": "Qhichwa",
+          "primary": true,
+          "language": {
+            "id": "12399"
+          }
+        },
+        {
+          "value": "Quechua, Cuzco",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quechua-ayacucho",
+      "bcp47": "quy",
+      "iso3": "quy",
+      "id": "12402",
+      "name": [
+        {
+          "value": "Qhichwa",
+          "primary": true,
+          "language": {
+            "id": "12402"
+          }
+        },
+        {
+          "value": "Quechua, Ayacucho",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quechua-north-junin",
+      "bcp47": null,
+      "iso3": "qvn",
+      "id": "12428",
+      "name": [
+        {
+          "value": "Quechua, North Junin",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quechua-ancash-conchucos-southern",
+      "bcp47": null,
+      "iso3": "qxo",
+      "id": "12445",
+      "name": [
+        {
+          "value": "Quechua, Ancash, Conchucos, Southern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quechua-ancash-huaylas",
+      "bcp47": "qwh",
+      "iso3": "qwh",
+      "id": "12461",
+      "name": [
+        {
+          "value": "Qhichwa",
+          "primary": true,
+          "language": {
+            "id": "12461"
+          }
+        },
+        {
+          "value": "Quechua, Ancash, Huaylas",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "romblomanon",
+      "bcp47": "rol",
+      "iso3": "rol",
+      "id": "12602",
+      "name": [
+        {
+          "value": "Romblomanon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "molbog",
+      "bcp47": "pwm",
+      "iso3": "pwm",
+      "id": "12603",
+      "name": [
+        {
+          "value": "Molbog",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "reunion-creole-french",
+      "bcp47": "rcf",
+      "iso3": "rcf",
+      "id": "12923",
+      "name": [
+        {
+          "value": "Reunion Creole French",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "romanian-sign-language",
+      "bcp47": "rms",
+      "iso3": "rms",
+      "id": "12961",
+      "name": [
+        {
+          "value": "Romanian Sign Language",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nyaturu",
+      "bcp47": null,
+      "iso3": "rim",
+      "id": "14248",
+      "name": [
+        {
+          "value": "Nyaturu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gungu",
+      "bcp47": "rub",
+      "iso3": "rub",
+      "id": "14710",
+      "name": [
+        {
+          "value": "Gungu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "poke",
+      "bcp47": "pof",
+      "iso3": "pof",
+      "id": "15210",
+      "name": [
+        {
+          "value": "Poke",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "rejang",
+      "bcp47": "rej",
+      "iso3": "rej",
+      "id": "17769",
+      "name": [
+        {
+          "value": "Rejang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "luragoli",
+      "bcp47": "rag",
+      "iso3": "rag",
+      "id": "20785",
+      "name": [
+        {
+          "value": "Luragoli",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pohnpeian",
+      "bcp47": "pon",
+      "iso3": "pon",
+      "id": "20880",
+      "name": [
+        {
+          "value": "Pohnpeian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kirundi",
+      "bcp47": "rn",
+      "iso3": "run",
+      "id": "20896",
+      "name": [
+        {
+          "value": "ikiRǔndi",
+          "primary": true,
+          "language": {
+            "id": "20896"
+          }
+        },
+        {
+          "value": "Kirundi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "central-asian-russian",
+      "bcp47": "ru-143",
+      "iso3": "rus",
+      "id": "20899",
+      "name": [
+        {
+          "value": "Русский",
+          "primary": true,
+          "language": {
+            "id": "20899"
+          }
+        },
+        {
+          "value": "Central Asian Russian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "portuguese-portugal",
+      "bcp47": "pt-PT",
+      "iso3": "por",
+      "id": "21064",
+      "name": [
+        {
+          "value": "Português",
+          "primary": true,
+          "language": {
+            "id": "21064"
+          }
+        },
+        {
+          "value": "Portuguese, Portugal",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "romani-caldarasi",
+      "bcp47": "rmy",
+      "iso3": "rmy",
+      "id": "22334",
+      "name": [
+        {
+          "value": "रोमानो",
+          "primary": true,
+          "language": {
+            "id": "22334"
+          }
+        },
+        {
+          "value": "Romani, Caldarasi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "rajbanshi-nepal",
+      "bcp47": "rjs-NP",
+      "iso3": "rjs",
+      "id": "23548",
+      "name": [
+        {
+          "value": "Rajbanshi, Nepal",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "rohingya",
+      "bcp47": null,
+      "iso3": "rhg",
+      "id": "24263",
+      "name": [
+        {
+          "value": "Rohingya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "qiang-southern",
+      "bcp47": null,
+      "iso3": "qxs",
+      "id": "27157",
+      "name": [
+        {
+          "value": "Qiang, Southern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chamling",
+      "bcp47": "rab",
+      "iso3": "rab",
+      "id": "50165",
+      "name": [
+        {
+          "value": "Chamling",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dari",
+      "bcp47": "prs",
+      "iso3": "prs",
+      "id": "53400",
+      "name": [
+        {
+          "value": "فارسی",
+          "primary": true,
+          "language": {
+            "id": "53400"
+          }
+        },
+        {
+          "value": "Dari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tarifit",
+      "bcp47": "rif",
+      "iso3": "rif",
+      "id": "101621",
+      "name": [
+        {
+          "value": "Tarifit",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "rakhine",
+      "bcp47": "rki",
+      "iso3": "rki",
+      "id": "101630",
+      "name": [
+        {
+          "value": "Rakhine",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "marma",
+      "bcp47": null,
+      "iso3": "rmz",
+      "id": "101788",
+      "name": [
+        {
+          "value": "Marma",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chibi-setentrional",
+      "bcp47": "rmq",
+      "iso3": "rmq",
+      "id": "139134",
+      "name": [
+        {
+          "value": "Chibi, Setentrional",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pattapu",
+      "bcp47": "ptq",
+      "iso3": "ptq",
+      "id": "139166",
+      "name": [
+        {
+          "value": "Pattapu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ruruuli-runyala",
+      "bcp47": "ruc",
+      "iso3": "ruc",
+      "id": "139185",
+      "name": [
+        {
+          "value": "Ruruuli-Runyala",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "roviana",
+      "bcp47": "rug",
+      "iso3": "rug",
+      "id": "143435",
+      "name": [
+        {
+          "value": "Roviana",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "folopa",
+      "bcp47": null,
+      "iso3": "ppo",
+      "id": "144064",
+      "name": [
+        {
+          "value": "Folopa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "persian-sign-language",
+      "bcp47": null,
+      "iso3": "psc",
+      "id": "144134",
+      "name": [
+        {
+          "value": "Persian Sign Language",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "punan-tubu",
+      "bcp47": null,
+      "iso3": "puj",
+      "id": "144252",
+      "name": [
+        {
+          "value": "Punan Tubu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kroumen-pye",
+      "bcp47": null,
+      "iso3": "pye",
+      "id": "144313",
+      "name": [
+        {
+          "value": "Kroumen, Pye",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quechua-southern-pastaza",
+      "bcp47": null,
+      "iso3": "qup",
+      "id": "144330",
+      "name": [
+        {
+          "value": "Quechua, Southern Pastaza",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quichua-imbabura-highland",
+      "bcp47": null,
+      "iso3": "qvi",
+      "id": "144395",
+      "name": [
+        {
+          "value": "Quichua, Imbabura Highland",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quichua-salasaca-highland",
+      "bcp47": null,
+      "iso3": "qxl",
+      "id": "144409",
+      "name": [
+        {
+          "value": "Quichua, Salasaca Highland",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quichua-canar-highland",
+      "bcp47": "qxr",
+      "iso3": "qxr",
+      "id": "144413",
+      "name": [
+        {
+          "value": "Quichua, Canar Highland",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "rade",
+      "bcp47": null,
+      "iso3": "rad",
+      "id": "144481",
+      "name": [
+        {
+          "value": "Rade",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "rao",
+      "bcp47": "rao",
+      "iso3": "rao",
+      "id": "144489",
+      "name": [
+        {
+          "value": "Rao",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "eastern-poqomchi",
+      "bcp47": "poh",
+      "iso3": "poh",
+      "id": "153550",
+      "name": [
+        {
+          "value": "Eastern Poqomchi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "enrekang",
+      "bcp47": null,
+      "iso3": "ptt",
+      "id": "154090",
+      "name": [
+        {
+          "value": "Enrekang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kwamba",
+      "bcp47": "rwm",
+      "iso3": "rwm",
+      "id": "171395",
+      "name": [
+        {
+          "value": "Kwamba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quichua-pastaza",
+      "bcp47": "qvz",
+      "iso3": "qvz",
+      "id": "174473",
+      "name": [
+        {
+          "value": "Qhichwa",
+          "primary": true,
+          "language": {
+            "id": "174473"
+          }
+        },
+        {
+          "value": "Quichua, Pastaza",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kau-bru",
+      "bcp47": "ria",
+      "iso3": "ria",
+      "id": "175097",
+      "name": [
+        {
+          "value": "Kau Bru",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dom",
+      "bcp47": "rmt",
+      "iso3": "rmt",
+      "id": "175683",
+      "name": [
+        {
+          "value": "Dom",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arumanian",
+      "bcp47": "rup",
+      "iso3": "rup",
+      "id": "176089",
+      "name": [
+        {
+          "value": " Armâneaşti",
+          "primary": true,
+          "language": {
+            "id": "176089"
+          }
+        },
+        {
+          "value": "Arumanian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pyam",
+      "bcp47": null,
+      "iso3": "pym",
+      "id": "178026",
+      "name": [
+        {
+          "value": "Pyam",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "romani-balkan-romania",
+      "bcp47": "rmn",
+      "iso3": "rmn",
+      "id": "184455",
+      "name": [
+        {
+          "value": "रोमानो",
+          "primary": true,
+          "language": {
+            "id": "184455"
+          }
+        },
+        {
+          "value": "Romani, Balkan-Romania",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kechwa-san-martin",
+      "bcp47": "qvs",
+      "iso3": "qvs",
+      "id": "184501",
+      "name": [
+        {
+          "value": "Kechwa, San Martin",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "qashqai",
+      "bcp47": "qxq",
+      "iso3": "qxq",
+      "id": "184529",
+      "name": [
+        {
+          "value": "Qashqa'I",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "idioma-wanca",
+      "bcp47": "qvw",
+      "iso3": "qvw",
+      "id": "184547",
+      "name": [
+        {
+          "value": "Wanca",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tajpuriya",
+      "bcp47": null,
+      "iso3": "rjs",
+      "id": "185078",
+      "name": [
+        {
+          "value": "Tajpuriya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malagasy-tanosy",
+      "bcp47": "mg-txy",
+      "iso3": "txy",
+      "id": "26972",
+      "name": [
+        {
+          "value": "Fiteny Malagasy",
+          "primary": true,
+          "language": {
+            "id": "26972"
+          }
+        },
+        {
+          "value": "Malagasy, Tanosy",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "torwali",
+      "bcp47": null,
+      "iso3": "trw",
+      "id": "10474",
+      "name": [
+        {
+          "value": "Torwali",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tai-nua",
+      "bcp47": null,
+      "iso3": "tdd",
+      "id": "3910",
+      "name": [
+        {
+          "value": "Tai Nua",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tigre",
+      "bcp47": "tig",
+      "iso3": "tig",
+      "id": "4575",
+      "name": [
+        {
+          "value": "ትግረ",
+          "primary": true,
+          "language": {
+            "id": "4575"
+          }
+        },
+        {
+          "value": "Tigre",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "talysh",
+      "bcp47": "tly",
+      "iso3": "tly",
+      "id": "1124",
+      "name": [
+        {
+          "value": "Talysh",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tswana",
+      "bcp47": "tn",
+      "iso3": "tsn",
+      "id": "1479",
+      "name": [
+        {
+          "value": "Setswana",
+          "primary": true,
+          "language": {
+            "id": "1479"
+          }
+        },
+        {
+          "value": "Tswana",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ticuna",
+      "bcp47": "tca",
+      "iso3": "tca",
+      "id": "1699",
+      "name": [
+        {
+          "value": "Ticuna",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tamasheq-kidal",
+      "bcp47": "taq",
+      "iso3": "taq",
+      "id": "2000",
+      "name": [
+        {
+          "value": "Tamasheq, Kidal",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tiv",
+      "bcp47": "tiv",
+      "iso3": "tiv",
+      "id": "2285",
+      "name": [
+        {
+          "value": "Tiv",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sardinian-logudorese",
+      "bcp47": "src",
+      "iso3": "src",
+      "id": "6975",
+      "name": [
+        {
+          "value": "Sardinian, Logudorese",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sabaot",
+      "bcp47": "spy",
+      "iso3": "spy",
+      "id": "7227",
+      "name": [
+        {
+          "value": "Sabaot",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sotho-southern",
+      "bcp47": "st",
+      "iso3": "sot",
+      "id": "7546",
+      "name": [
+        {
+          "value": "seSotho",
+          "primary": true,
+          "language": {
+            "id": "7546"
+          }
+        },
+        {
+          "value": "Sotho, Southern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "shimaore",
+      "bcp47": "swb",
+      "iso3": "swb",
+      "id": "7752",
+      "name": [
+        {
+          "value": "Shimaore",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "totonaca-sierra",
+      "bcp47": "tos",
+      "iso3": "tos",
+      "id": "8089",
+      "name": [
+        {
+          "value": "Totonaca, Sierra",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tojolabal",
+      "bcp47": "toj",
+      "iso3": "toj",
+      "id": "8093",
+      "name": [
+        {
+          "value": "Tojolabal",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tarahumara-baja",
+      "bcp47": "tac",
+      "iso3": "tac",
+      "id": "8109",
+      "name": [
+        {
+          "value": "Tarahumara Baja",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tsonga",
+      "bcp47": "ts",
+      "iso3": "tso",
+      "id": "8494",
+      "name": [
+        {
+          "value": "xiTsonga",
+          "primary": true,
+          "language": {
+            "id": "8494"
+          }
+        },
+        {
+          "value": "Tsonga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "shan",
+      "bcp47": "shn",
+      "iso3": "shn",
+      "id": "8684",
+      "name": [
+        {
+          "value": "လိၵ်ႈတႆး",
+          "primary": true,
+          "language": {
+            "id": "8684"
+          }
+        },
+        {
+          "value": "Shan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "rana-tharu",
+      "bcp47": "thr",
+      "iso3": "thr",
+      "id": "8972",
+      "name": [
+        {
+          "value": "Rana Tharu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "thami",
+      "bcp47": null,
+      "iso3": "thf",
+      "id": "8982",
+      "name": [
+        {
+          "value": "Thami",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tangale",
+      "bcp47": "tan",
+      "iso3": "tan",
+      "id": "10014",
+      "name": [
+        {
+          "value": "Tangale",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mwaghavul",
+      "bcp47": "sur",
+      "iso3": "sur",
+      "id": "10021",
+      "name": [
+        {
+          "value": "Mwaghavul",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "saya",
+      "bcp47": "say",
+      "iso3": "say",
+      "id": "10040",
+      "name": [
+        {
+          "value": "Saya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sansi",
+      "bcp47": "ssi",
+      "iso3": "ssi",
+      "id": "10545",
+      "name": [
+        {
+          "value": "Sansi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "shipibo-conibo",
+      "bcp47": "shp",
+      "iso3": "shp",
+      "id": "12392",
+      "name": [
+        {
+          "value": "Shipibo-Conibo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tausug",
+      "bcp47": "tsg",
+      "iso3": "tsg",
+      "id": "12535",
+      "name": [
+        {
+          "value": "Tausug",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tiruray",
+      "bcp47": "tiy",
+      "iso3": "tiy",
+      "id": "12537",
+      "name": [
+        {
+          "value": "Tiruray",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "subanon-western",
+      "bcp47": "suc",
+      "iso3": "suc",
+      "id": "12568",
+      "name": [
+        {
+          "value": "Subanon, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "subanen-northern",
+      "bcp47": "stb",
+      "iso3": "stb",
+      "id": "12572",
+      "name": [
+        {
+          "value": "Subanen, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sangil",
+      "bcp47": "snl",
+      "iso3": "snl",
+      "id": "12585",
+      "name": [
+        {
+          "value": "Sangil",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sama-central",
+      "bcp47": "sml",
+      "iso3": "sml",
+      "id": "12588",
+      "name": [
+        {
+          "value": "Sama, Central",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bolinao",
+      "bcp47": null,
+      "iso3": "smk",
+      "id": "12589",
+      "name": [
+        {
+          "value": "Bolinao",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sama-southern",
+      "bcp47": "ssb",
+      "iso3": "ssb",
+      "id": "12595",
+      "name": [
+        {
+          "value": "Sama, Southern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ayta-mag-antsi",
+      "bcp47": null,
+      "iso3": "sgb",
+      "id": "12596",
+      "name": [
+        {
+          "value": "Ayta, Mag-Antsi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sinhala",
+      "bcp47": "si",
+      "iso3": "sin",
+      "id": "13172",
+      "name": [
+        {
+          "value": "සිංහල",
+          "primary": true,
+          "language": {
+            "id": "13172"
+          }
+        },
+        {
+          "value": "Sinhala",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sukuma",
+      "bcp47": "suk",
+      "iso3": "suk",
+      "id": "14226",
+      "name": [
+        {
+          "value": "Sukuma",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "safwa",
+      "bcp47": null,
+      "iso3": "sbk",
+      "id": "14236",
+      "name": [
+        {
+          "value": "Safwa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "songe",
+      "bcp47": "sop",
+      "iso3": "sop",
+      "id": "15480",
+      "name": [
+        {
+          "value": "Songe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "soli",
+      "bcp47": "sby",
+      "iso3": "sby",
+      "id": "15796",
+      "name": [
+        {
+          "value": "Soli",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "senoufo-cebaara",
+      "bcp47": "sef",
+      "iso3": "sef",
+      "id": "15990",
+      "name": [
+        {
+          "value": "Senoufo, Cebaara",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sunda",
+      "bcp47": "su",
+      "iso3": "sun",
+      "id": "16618",
+      "name": [
+        {
+          "value": "Basa Sunda",
+          "primary": true,
+          "language": {
+            "id": "16618"
+          }
+        },
+        {
+          "value": "Sunda",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sahu",
+      "bcp47": "saj",
+      "iso3": "saj",
+      "id": "17040",
+      "name": [
+        {
+          "value": "Sahu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sumbawa",
+      "bcp47": null,
+      "iso3": "smw",
+      "id": "17226",
+      "name": [
+        {
+          "value": "Sumbawa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lamaholot",
+      "bcp47": null,
+      "iso3": "slp",
+      "id": "17239",
+      "name": [
+        {
+          "value": "Lamaholot",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sasak",
+      "bcp47": "sas",
+      "iso3": "sas",
+      "id": "17249",
+      "name": [
+        {
+          "value": "Sasak",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "selayar",
+      "bcp47": null,
+      "iso3": "sly",
+      "id": "17556",
+      "name": [
+        {
+          "value": "Selayar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "saramaccan",
+      "bcp47": "srm",
+      "iso3": "srm",
+      "id": "18715",
+      "name": [
+        {
+          "value": "Saramaccan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sangu",
+      "bcp47": null,
+      "iso3": "sbp",
+      "id": "20199",
+      "name": [
+        {
+          "value": "Sangu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "shughni",
+      "bcp47": "sgh",
+      "iso3": "sgh",
+      "id": "20208",
+      "name": [
+        {
+          "value": "Shughni",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sadani",
+      "bcp47": "sck",
+      "iso3": "sck",
+      "id": "20902",
+      "name": [
+        {
+          "value": "Sadani",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mashi",
+      "bcp47": "shr",
+      "iso3": "shr",
+      "id": "20919",
+      "name": [
+        {
+          "value": "Mashi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "siswati",
+      "bcp47": "ss",
+      "iso3": "ssw",
+      "id": "20947",
+      "name": [
+        {
+          "value": "siSwati",
+          "primary": true,
+          "language": {
+            "id": "20947"
+          }
+        },
+        {
+          "value": "Siswati",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "thai-southern",
+      "bcp47": "th-sou",
+      "iso3": "sou",
+      "id": "20969",
+      "name": [
+        {
+          "value": "ภาษาไทย",
+          "primary": true,
+          "language": {
+            "id": "20969"
+          }
+        },
+        {
+          "value": "Thai, Southern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "spanish-latin-american",
+      "bcp47": "es",
+      "iso3": "spa",
+      "id": "21028",
+      "name": [
+        {
+          "value": "Español",
+          "primary": true,
+          "language": {
+            "id": "21028"
+          }
+        },
+        {
+          "value": "Spanish, Latin American",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sranan-tongo",
+      "bcp47": "srn",
+      "iso3": "srn",
+      "id": "21231",
+      "name": [
+        {
+          "value": "Sranan-Tongo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kisanga",
+      "bcp47": "sng",
+      "iso3": "sng",
+      "id": "22196",
+      "name": [
+        {
+          "value": "Kisanga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "swahili-tanzania",
+      "bcp47": "sw",
+      "iso3": "swh",
+      "id": "23178",
+      "name": [
+        {
+          "value": "Kiswahili",
+          "primary": true,
+          "language": {
+            "id": "23178"
+          }
+        },
+        {
+          "value": "Swahili, Tanzania",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "surjapuri",
+      "bcp47": "sjp",
+      "iso3": "sjp",
+      "id": "23316",
+      "name": [
+        {
+          "value": "Surjapuri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "swahili-congo",
+      "bcp47": "sw-swc",
+      "iso3": "swc",
+      "id": "23388",
+      "name": [
+        {
+          "value": "Kiswahili",
+          "primary": true,
+          "language": {
+            "id": "23388"
+          }
+        },
+        {
+          "value": "Swahili, Congo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sunuwar",
+      "bcp47": "suz",
+      "iso3": "suz",
+      "id": "24068",
+      "name": [
+        {
+          "value": "Sunuwar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sakalava-besalampy",
+      "bcp47": "skg",
+      "iso3": "skg",
+      "id": "24121",
+      "name": [
+        {
+          "value": "Sakalava Besalampy",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jama-mapun",
+      "bcp47": "sjm",
+      "iso3": "sjm",
+      "id": "24218",
+      "name": [
+        {
+          "value": "Jama Mapun",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sama-bangingi",
+      "bcp47": "sse",
+      "iso3": "sse",
+      "id": "24235",
+      "name": [
+        {
+          "value": "Sama, Bangingi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sirmauri",
+      "bcp47": "srx",
+      "iso3": "srx",
+      "id": "26359",
+      "name": [
+        {
+          "value": "Sirmauri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "songhay-gao",
+      "bcp47": "ses",
+      "iso3": "ses",
+      "id": "53370",
+      "name": [
+        {
+          "value": "Songhay, Gao",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yanomami-ninam",
+      "bcp47": "shb",
+      "iso3": "shb",
+      "id": "102259",
+      "name": [
+        {
+          "value": "Yanomami Ninam",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tacawit",
+      "bcp47": "shy",
+      "iso3": "shy",
+      "id": "139091",
+      "name": [
+        {
+          "value": "Tacawit",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "subanen-eastern",
+      "bcp47": null,
+      "iso3": "sfe",
+      "id": "142332",
+      "name": [
+        {
+          "value": "Subanen, Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "siar-lak",
+      "bcp47": null,
+      "iso3": "sjr",
+      "id": "142536",
+      "name": [
+        {
+          "value": "Siar-Lak",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "seko-padang",
+      "bcp47": null,
+      "iso3": "skx",
+      "id": "142642",
+      "name": [
+        {
+          "value": "Seko Padang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sissala",
+      "bcp47": null,
+      "iso3": "sld",
+      "id": "142646",
+      "name": [
+        {
+          "value": "Sissala",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sikkiligar",
+      "bcp47": null,
+      "iso3": "sle",
+      "id": "142647",
+      "name": [
+        {
+          "value": "Sikkiligar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "selaru",
+      "bcp47": "slu",
+      "iso3": "slu",
+      "id": "142753",
+      "name": [
+        {
+          "value": "Selaru",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "noon",
+      "bcp47": "snf",
+      "iso3": "snf",
+      "id": "142878",
+      "name": [
+        {
+          "value": "Noon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "temi",
+      "bcp47": null,
+      "iso3": "soz",
+      "id": "143000",
+      "name": [
+        {
+          "value": "Temi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "teke-tege",
+      "bcp47": null,
+      "iso3": "teg",
+      "id": "26378",
+      "name": [
+        {
+          "value": "Teke-Tege",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "vietnamese",
+      "bcp47": "vi",
+      "iso3": "vie",
+      "id": "3887",
+      "name": [
+        {
+          "value": "Tiếng Việt",
+          "primary": true,
+          "language": {
+            "id": "3887"
+          }
+        },
+        {
+          "value": "Vietnamese",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "uzbek-northern",
+      "bcp47": "uzn",
+      "iso3": "uzn",
+      "id": "3888",
+      "name": [
+        {
+          "value": "اوزبیک",
+          "primary": true,
+          "language": {
+            "id": "3888"
+          }
+        },
+        {
+          "value": "Uzbek, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "urdu",
+      "bcp47": "ur",
+      "iso3": "urd",
+      "id": "407",
+      "name": [
+        {
+          "value": "اردو",
+          "primary": true,
+          "language": {
+            "id": "407"
+          }
+        },
+        {
+          "value": "Urdu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tuvin",
+      "bcp47": "tyv",
+      "iso3": "tyv",
+      "id": "3892",
+      "name": [
+        {
+          "value": "Тыва дыл",
+          "primary": true,
+          "language": {
+            "id": "3892"
+          }
+        },
+        {
+          "value": "Tuvin",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "vili",
+      "bcp47": "vif",
+      "iso3": "vif",
+      "id": "4295",
+      "name": [
+        {
+          "value": "Vili",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "xamtanga",
+      "bcp47": "xan",
+      "iso3": "xan",
+      "id": "4724",
+      "name": [
+        {
+          "value": "ኃምታጛ",
+          "primary": true,
+          "language": {
+            "id": "4724"
+          }
+        },
+        {
+          "value": "Xamtanga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "turkmen",
+      "bcp47": "tk",
+      "iso3": "tuk",
+      "id": "420",
+      "name": [
+        {
+          "value": "түркmенче",
+          "primary": true,
+          "language": {
+            "id": "420"
+          }
+        },
+        {
+          "value": "Turkmen",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "umbundu",
+      "bcp47": "umb",
+      "iso3": "umb",
+      "id": "564",
+      "name": [
+        {
+          "value": "Umbundu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "waama",
+      "bcp47": "wwa",
+      "iso3": "wwa",
+      "id": "1313",
+      "name": [
+        {
+          "value": "Waama",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "urubu-kaapor",
+      "bcp47": "urb",
+      "iso3": "urb",
+      "id": "1669",
+      "name": [
+        {
+          "value": "Urubu-Kaapor",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "turkana",
+      "bcp47": "tuv",
+      "iso3": "tuv",
+      "id": "7285",
+      "name": [
+        {
+          "value": "Turkana",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tai-don",
+      "bcp47": null,
+      "iso3": "twh",
+      "id": "7428",
+      "name": [
+        {
+          "value": "Tai Don",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "vai",
+      "bcp47": "vai",
+      "iso3": "vai",
+      "id": "7564",
+      "name": [
+        {
+          "value": "Vai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tumbuka",
+      "bcp47": "tum",
+      "iso3": "tum",
+      "id": "7786",
+      "name": [
+        {
+          "value": "chiTumbuka",
+          "primary": true,
+          "language": {
+            "id": "7786"
+          }
+        },
+        {
+          "value": "Tumbuka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tamajeq-tahoua",
+      "bcp47": "ttq",
+      "iso3": "ttq",
+      "id": "7807",
+      "name": [
+        {
+          "value": "Tamajeq, Tahoua",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "wolof",
+      "bcp47": "wo",
+      "iso3": "wol",
+      "id": "7897",
+      "name": [
+        {
+          "value": "Wollof",
+          "primary": true,
+          "language": {
+            "id": "7897"
+          }
+        },
+        {
+          "value": "Wolof",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "purepecha",
+      "bcp47": "tsz",
+      "iso3": "tsz",
+      "id": "8075",
+      "name": [
+        {
+          "value": "Purepecha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mwani",
+      "bcp47": "wmw",
+      "iso3": "wmw",
+      "id": "8486",
+      "name": [
+        {
+          "value": "Mwani",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "warji",
+      "bcp47": "wji",
+      "iso3": "wji",
+      "id": "9955",
+      "name": [
+        {
+          "value": "Warji",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "waja",
+      "bcp47": "wja",
+      "iso3": "wja",
+      "id": "9959",
+      "name": [
+        {
+          "value": "Waja",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tula",
+      "bcp47": "tul",
+      "iso3": "tul",
+      "id": "9999",
+      "name": [
+        {
+          "value": "Tula",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tera",
+      "bcp47": "ttr",
+      "iso3": "ttr",
+      "id": "10007",
+      "name": [
+        {
+          "value": "Tera",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "waneci",
+      "bcp47": null,
+      "iso3": "wne",
+      "id": "10461",
+      "name": [
+        {
+          "value": "Waneci",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tboli",
+      "bcp47": "tbl",
+      "iso3": "tbl",
+      "id": "12557",
+      "name": [
+        {
+          "value": "Tboli",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "toposa",
+      "bcp47": "toq",
+      "iso3": "toq",
+      "id": "13805",
+      "name": [
+        {
+          "value": "Toposa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tira",
+      "bcp47": "tic",
+      "iso3": "tic",
+      "id": "13812",
+      "name": [
+        {
+          "value": "Tira",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "datooga",
+      "bcp47": null,
+      "iso3": "tcc",
+      "id": "14081",
+      "name": [
+        {
+          "value": "Datooga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tongan",
+      "bcp47": "to",
+      "iso3": "ton",
+      "id": "14509",
+      "name": [
+        {
+          "value": "Faka-Tonga",
+          "primary": true,
+          "language": {
+            "id": "14509"
+          }
+        },
+        {
+          "value": "Tongan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tanna-north",
+      "bcp47": "tnn",
+      "iso3": "tnn",
+      "id": "14970",
+      "name": [
+        {
+          "value": "Tanna, North",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sengele",
+      "bcp47": "szg",
+      "iso3": "szg",
+      "id": "15471",
+      "name": [
+        {
+          "value": "Sengele",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tengger",
+      "bcp47": null,
+      "iso3": "tes",
+      "id": "16628",
+      "name": [
+        {
+          "value": "Tengger",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tabaru",
+      "bcp47": "tby",
+      "iso3": "tby",
+      "id": "17028",
+      "name": [
+        {
+          "value": "Tabaru",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sula",
+      "bcp47": null,
+      "iso3": "szn",
+      "id": "17035",
+      "name": [
+        {
+          "value": "Sula",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ternate",
+      "bcp47": null,
+      "iso3": "tft",
+      "id": "17110",
+      "name": [
+        {
+          "value": "Ternate",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tombulu",
+      "bcp47": "tom",
+      "iso3": "tom",
+      "id": "17431",
+      "name": [
+        {
+          "value": "Tombulu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tabassaran",
+      "bcp47": "tab",
+      "iso3": "tab",
+      "id": "18617",
+      "name": [
+        {
+          "value": "табасаран чIал",
+          "primary": true,
+          "language": {
+            "id": "18617"
+          }
+        },
+        {
+          "value": "Tabassaran",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tondano",
+      "bcp47": null,
+      "iso3": "tdn",
+      "id": "20259",
+      "name": [
+        {
+          "value": "Tondano",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tunjung",
+      "bcp47": null,
+      "iso3": "tjg",
+      "id": "20270",
+      "name": [
+        {
+          "value": "Tunjung",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sangihe",
+      "bcp47": "sxn",
+      "iso3": "sxn",
+      "id": "20908",
+      "name": [
+        {
+          "value": "Sangihe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ateso",
+      "bcp47": "teo",
+      "iso3": "teo",
+      "id": "20963",
+      "name": [
+        {
+          "value": "Ateso",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mephaa",
+      "bcp47": "tcf",
+      "iso3": "tcf",
+      "id": "20977",
+      "name": [
+        {
+          "value": "Me'phaa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gitonga",
+      "bcp47": "toh",
+      "iso3": "toh",
+      "id": "20983",
+      "name": [
+        {
+          "value": "Gitonga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tonga-malawi",
+      "bcp47": "tog",
+      "iso3": "tog",
+      "id": "21094",
+      "name": [
+        {
+          "value": "chiTonga",
+          "primary": true,
+          "language": {
+            "id": "21094"
+          }
+        },
+        {
+          "value": "Tonga, Malawi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sharchogpa",
+      "bcp47": "tsj",
+      "iso3": "tsj",
+      "id": "23047",
+      "name": [
+        {
+          "value": "Sharchogpa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "buksa",
+      "bcp47": "tkb",
+      "iso3": "tkb",
+      "id": "23325",
+      "name": [
+        {
+          "value": "Buksa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "panchpargania",
+      "bcp47": "tdb",
+      "iso3": "tdb",
+      "id": "23403",
+      "name": [
+        {
+          "value": "Panchpargania",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tok-pisin",
+      "bcp47": "tpi",
+      "iso3": "tpi",
+      "id": "23528",
+      "name": [
+        {
+          "value": "Tok Pisin",
+          "primary": true,
+          "language": {
+            "id": "23528"
+          }
+        },
+        {
+          "value": "Tok Pisin",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "suryoyo",
+      "bcp47": "tru",
+      "iso3": "tru",
+      "id": "24145",
+      "name": [
+        {
+          "value": "Suryoyo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "shekhawati",
+      "bcp47": "swv",
+      "iso3": "swv",
+      "id": "24416",
+      "name": [
+        {
+          "value": "Shekhawati",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chitembo",
+      "bcp47": "tbt",
+      "iso3": "tbt",
+      "id": "47429",
+      "name": [
+        {
+          "value": "Chitembo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tetun-belu",
+      "bcp47": "tet",
+      "iso3": "tet",
+      "id": "53297",
+      "name": [
+        {
+          "value": "Tetun",
+          "primary": true,
+          "language": {
+            "id": "53297"
+          }
+        },
+        {
+          "value": "Tetun Belu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tal",
+      "bcp47": "tal",
+      "iso3": "tal",
+      "id": "100301",
+      "name": [
+        {
+          "value": "Tal",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tennet",
+      "bcp47": null,
+      "iso3": "tex",
+      "id": "100574",
+      "name": [
+        {
+          "value": "Tennet",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nethakani",
+      "bcp47": "te",
+      "iso3": "tel",
+      "id": "139167",
+      "name": [
+        {
+          "value": "Nethakani",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "semelai",
+      "bcp47": null,
+      "iso3": "sza",
+      "id": "141912",
+      "name": [
+        {
+          "value": "Semelai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "takia",
+      "bcp47": null,
+      "iso3": "tbc",
+      "id": "142010",
+      "name": [
+        {
+          "value": "Takia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tagbanwa-calamian",
+      "bcp47": "tbk",
+      "iso3": "tbk",
+      "id": "142016",
+      "name": [
+        {
+          "value": "Tagbanwa, Calamian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tigak",
+      "bcp47": null,
+      "iso3": "tgc",
+      "id": "142353",
+      "name": [
+        {
+          "value": "Tigak",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tangoa",
+      "bcp47": null,
+      "iso3": "tgp",
+      "id": "142360",
+      "name": [
+        {
+          "value": "Tangoa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tharu-kathariya",
+      "bcp47": null,
+      "iso3": "tkt",
+      "id": "142653",
+      "name": [
+        {
+          "value": "Tharu, Kathariya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "toba-maskoy",
+      "bcp47": null,
+      "iso3": "tmf",
+      "id": "142777",
+      "name": [
+        {
+          "value": "Toba-Maskoy",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tonga",
+      "bcp47": null,
+      "iso3": "toi",
+      "id": "142905",
+      "name": [
+        {
+          "value": "Tonga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "trinitario",
+      "bcp47": "trn",
+      "iso3": "trn",
+      "id": "143039",
+      "name": [
+        {
+          "value": "Trinitario",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tairora",
+      "bcp47": "tbg",
+      "iso3": "tbg",
+      "id": "150415",
+      "name": [
+        {
+          "value": "Tairora",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chitwan-tharu",
+      "bcp47": null,
+      "iso3": "the",
+      "id": "167552",
+      "name": [
+        {
+          "value": "Chitwan Tharu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "xinulajgsipij",
+      "bcp47": null,
+      "iso3": "tqt",
+      "id": "169603",
+      "name": [
+        {
+          "value": "Xinulajgsipij",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "eda",
+      "bcp47": "kad",
+      "iso3": "kad",
+      "id": "180999",
+      "name": [
+        {
+          "value": "Eda",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kok-borok-bangladesh",
+      "bcp47": "tpe",
+      "iso3": "tpe",
+      "id": "184464",
+      "name": [
+        {
+          "value": "Kok Borok, Bangladesh",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "aikana",
+      "bcp47": "tba",
+      "iso3": "tba",
+      "id": "184550",
+      "name": [
+        {
+          "value": "Aikana",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mephaa-de-huitzapula",
+      "bcp47": null,
+      "iso3": "tcf",
+      "id": "184831",
+      "name": [
+        {
+          "value": "Me'Phaa De Huitzapula",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yakoma",
+      "bcp47": null,
+      "iso3": "yky",
+      "id": "3144",
+      "name": [
+        {
+          "value": "Yakoma",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sherpa",
+      "bcp47": "xsr",
+      "iso3": "xsr",
+      "id": "3929",
+      "name": [
+        {
+          "value": "शेर्पा",
+          "primary": true,
+          "language": {
+            "id": "3929"
+          }
+        },
+        {
+          "value": "Sherpa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "keakalo",
+      "bcp47": "khz",
+      "iso3": "khz",
+      "id": "139193",
+      "name": [
+        {
+          "value": "Keakalo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ilchamus",
+      "bcp47": "saq",
+      "iso3": "saq",
+      "id": "184500",
+      "name": [
+        {
+          "value": "Ilchamus",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yucuna",
+      "bcp47": "ycn",
+      "iso3": "ycn",
+      "id": "4148",
+      "name": [
+        {
+          "value": "Yucuna",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mingrelian",
+      "bcp47": "xmf",
+      "iso3": "xmf",
+      "id": "5076",
+      "name": [
+        {
+          "value": "Mingrelian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ngonde",
+      "bcp47": "nyy",
+      "iso3": "nyy",
+      "id": "184510",
+      "name": [
+        {
+          "value": "Ngonde",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "konkomba",
+      "bcp47": "xon",
+      "iso3": "xon",
+      "id": "5302",
+      "name": [
+        {
+          "value": "Konkomba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kpelle-liberia",
+      "bcp47": "xpe",
+      "iso3": "xpe",
+      "id": "7609",
+      "name": [
+        {
+          "value": "Kpelle, Liberia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yao",
+      "bcp47": "yao",
+      "iso3": "yao",
+      "id": "7773",
+      "name": [
+        {
+          "value": "Yao",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zapoteco-western-pochutla",
+      "bcp47": "ztp",
+      "iso3": "ztp",
+      "id": "7946",
+      "name": [
+        {
+          "value": "Zapoteco, Western Pochutla",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zapoteco-mitla",
+      "bcp47": "zaw",
+      "iso3": "zaw",
+      "id": "8000",
+      "name": [
+        {
+          "value": "Zapoteco, Mitla",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yungur",
+      "bcp47": "yun",
+      "iso3": "yun",
+      "id": "9905",
+      "name": [
+        {
+          "value": "Yungur",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tarok",
+      "bcp47": "yer",
+      "iso3": "yer",
+      "id": "9930",
+      "name": [
+        {
+          "value": "Tarok",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yala",
+      "bcp47": "yba",
+      "iso3": "yba",
+      "id": "9940",
+      "name": [
+        {
+          "value": "Yala",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yonggom",
+      "bcp47": "yon",
+      "iso3": "yon",
+      "id": "10981",
+      "name": [
+        {
+          "value": "Yonggom",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yakan",
+      "bcp47": "yka",
+      "iso3": "yka",
+      "id": "12529",
+      "name": [
+        {
+          "value": "Yakan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "waray-waray",
+      "bcp47": "war",
+      "iso3": "war",
+      "id": "12533",
+      "name": [
+        {
+          "value": "Wáray-Wáray",
+          "primary": true,
+          "language": {
+            "id": "12533"
+          }
+        },
+        {
+          "value": "Waray-Waray",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "maay",
+      "bcp47": "ymm",
+      "iso3": "ymm",
+      "id": "13376",
+      "name": [
+        {
+          "value": "Maay",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "xhosa",
+      "bcp47": "xh",
+      "iso3": "xho",
+      "id": "13408",
+      "name": [
+        {
+          "value": "isiXhosa",
+          "primary": true,
+          "language": {
+            "id": "13408"
+          }
+        },
+        {
+          "value": "Xhosa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "venda",
+      "bcp47": "ve",
+      "iso3": "ven",
+      "id": "13414",
+      "name": [
+        {
+          "value": "tshiVenḓa",
+          "primary": true,
+          "language": {
+            "id": "13414"
+          }
+        },
+        {
+          "value": "Venda",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "katcha-kadugli-miri",
+      "bcp47": "xtc",
+      "iso3": "xtc",
+      "id": "13719",
+      "name": [
+        {
+          "value": "Katcha-Kadugli-Miri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malay-tenggarong-kutai",
+      "bcp47": null,
+      "iso3": "vkt",
+      "id": "16695",
+      "name": [
+        {
+          "value": "Malay, Tenggarong Kutai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "wolio",
+      "bcp47": null,
+      "iso3": "wlo",
+      "id": "17408",
+      "name": [
+        {
+          "value": "Wolio",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kaur",
+      "bcp47": null,
+      "iso3": "vkk",
+      "id": "17757",
+      "name": [
+        {
+          "value": "Kaur",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tiwa-northern",
+      "bcp47": "twf",
+      "iso3": "twf",
+      "id": "19002",
+      "name": [
+        {
+          "value": "Tiwa, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "vwanji",
+      "bcp47": null,
+      "iso3": "wbi",
+      "id": "20318",
+      "name": [
+        {
+          "value": "Vwanji",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "maiwa",
+      "bcp47": null,
+      "iso3": "wmm",
+      "id": "20324",
+      "name": [
+        {
+          "value": "Maiwa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "shanghainese",
+      "bcp47": "wuu",
+      "iso3": "wuu",
+      "id": "20623",
+      "name": [
+        {
+          "value": "上海闲话",
+          "primary": true,
+          "language": {
+            "id": "20623"
+          }
+        },
+        {
+          "value": "Shanghainese",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "isan",
+      "bcp47": "tts",
+      "iso3": "tts",
+      "id": "20967",
+      "name": [
+        {
+          "value": "Isan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tsishingini",
+      "bcp47": "tsw",
+      "iso3": "tsw",
+      "id": "20989",
+      "name": [
+        {
+          "value": "Tsishingini",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "wewewa",
+      "bcp47": "wew",
+      "iso3": "wew",
+      "id": "21002",
+      "name": [
+        {
+          "value": "Wewewa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "vunjo-chagga",
+      "bcp47": "vun",
+      "iso3": "vun",
+      "id": "24141",
+      "name": [
+        {
+          "value": "Vunjo-Chagga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tsuvadi",
+      "bcp47": "tvd",
+      "iso3": "tvd",
+      "id": "24161",
+      "name": [
+        {
+          "value": "Tsuvadi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "levantine-turkmen",
+      "bcp47": null,
+      "iso3": "tuk",
+      "id": "53345",
+      "name": [
+        {
+          "value": "Levantine Turkmen",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mamainde",
+      "bcp47": "wmd",
+      "iso3": "wmd",
+      "id": "99766",
+      "name": [
+        {
+          "value": "Mamainde",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "merwari",
+      "bcp47": "wry",
+      "iso3": "wry",
+      "id": "99886",
+      "name": [
+        {
+          "value": "Merwari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bungu",
+      "bcp47": null,
+      "iso3": "wun",
+      "id": "99933",
+      "name": [
+        {
+          "value": "Bungu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "awa",
+      "bcp47": null,
+      "iso3": "vwa",
+      "id": "100703",
+      "name": [
+        {
+          "value": "Awa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ushoi",
+      "bcp47": "usi",
+      "iso3": "usi",
+      "id": "125402",
+      "name": [
+        {
+          "value": "Ushoi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tugen",
+      "bcp47": null,
+      "iso3": "tuy",
+      "id": "141927",
+      "name": [
+        {
+          "value": "Tugen",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "turka",
+      "bcp47": "tuz",
+      "iso3": "tuz",
+      "id": "141928",
+      "name": [
+        {
+          "value": "Turka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ambrym-southeast",
+      "bcp47": null,
+      "iso3": "tvk",
+      "id": "141931",
+      "name": [
+        {
+          "value": "Ambrym, Southeast",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "taveta",
+      "bcp47": null,
+      "iso3": "tvs",
+      "id": "141934",
+      "name": [
+        {
+          "value": "Taveta",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "uduk",
+      "bcp47": null,
+      "iso3": "udu",
+      "id": "142121",
+      "name": [
+        {
+          "value": "Uduk",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "olukwumi",
+      "bcp47": null,
+      "iso3": "ulb",
+      "id": "142183",
+      "name": [
+        {
+          "value": "Olukwumi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "uneme-north",
+      "bcp47": null,
+      "iso3": "une",
+      "id": "142202",
+      "name": [
+        {
+          "value": "Uneme, North",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "etulo",
+      "bcp47": "utr",
+      "iso3": "utr",
+      "id": "142293",
+      "name": [
+        {
+          "value": "Etulo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "waghiri",
+      "bcp47": null,
+      "iso3": "vaa",
+      "id": "142303",
+      "name": [
+        {
+          "value": "Waghiri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "alagwa",
+      "bcp47": null,
+      "iso3": "wbj",
+      "id": "142694",
+      "name": [
+        {
+          "value": "Alagwa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "wolane",
+      "bcp47": null,
+      "iso3": "wle",
+      "id": "142947",
+      "name": [
+        {
+          "value": "Wolane",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "wambon",
+      "bcp47": null,
+      "iso3": "wms",
+      "id": "142964",
+      "name": [
+        {
+          "value": "Wambon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "waropen",
+      "bcp47": null,
+      "iso3": "wrp",
+      "id": "143147",
+      "name": [
+        {
+          "value": "Waropen",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tuyuca",
+      "bcp47": null,
+      "iso3": "tue",
+      "id": "143321",
+      "name": [
+        {
+          "value": "Tuyuca",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tiyaa",
+      "bcp47": null,
+      "iso3": "tyy",
+      "id": "179655",
+      "name": [
+        {
+          "value": "Tiyaa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "southern-gondi-adilabad",
+      "bcp47": "wsg",
+      "iso3": "wsg",
+      "id": "180517",
+      "name": [
+        {
+          "value": "Southern Gondi (Adilabad)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "amam",
+      "bcp47": "bcu",
+      "iso3": "wer",
+      "id": "184583",
+      "name": [
+        {
+          "value": "Amam",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tzeltal-tenejapa",
+      "bcp47": null,
+      "iso3": "tzh",
+      "id": "184662",
+      "name": [
+        {
+          "value": "Tzeltal, Tenejapa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "uyghur-central-asia",
+      "bcp47": null,
+      "iso3": "uig",
+      "id": "185211",
+      "name": [
+        {
+          "value": "Uyghur, Central Asia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bafut",
+      "bcp47": "bfd",
+      "iso3": "bfd",
+      "id": "2819",
+      "name": [
+        {
+          "value": "Bafut",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "medumba",
+      "bcp47": "byv",
+      "iso3": "byv",
+      "id": "2871",
+      "name": [
+        {
+          "value": "Medumba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "daza",
+      "bcp47": "dzg",
+      "iso3": "dzg",
+      "id": "3299",
+      "name": [
+        {
+          "value": "Daza",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "achang",
+      "bcp47": null,
+      "iso3": "acn",
+      "id": "3697",
+      "name": [
+        {
+          "value": "Achang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "deori",
+      "bcp47": null,
+      "iso3": "der",
+      "id": "140367",
+      "name": [
+        {
+          "value": "Deori",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mazagway-hidi",
+      "bcp47": "dkx",
+      "iso3": "dkx",
+      "id": "176144",
+      "name": [
+        {
+          "value": "Mazagway-Hidi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dong-southern",
+      "bcp47": "kmc",
+      "iso3": "kmc",
+      "id": "3803",
+      "name": [
+        {
+          "value": "Dong, Southern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kalmyk-oirat",
+      "bcp47": "xal",
+      "iso3": "xal",
+      "id": "3832",
+      "name": [
+        {
+          "value": "Kalmyk-Oirat",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "luvale",
+      "bcp47": "lue",
+      "iso3": "lue",
+      "id": "554",
+      "name": [
+        {
+          "value": "Luvale",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mbukushu",
+      "bcp47": "mhw",
+      "iso3": "mhw",
+      "id": "570",
+      "name": [
+        {
+          "value": "Mbukushu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yaka-drcongo",
+      "bcp47": "yaf",
+      "iso3": "yaf",
+      "id": "580",
+      "name": [
+        {
+          "value": "Yaka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "armenian",
+      "bcp47": "hy",
+      "iso3": "hye",
+      "id": "646",
+      "name": [
+        {
+          "value": "Հայերեն",
+          "primary": true,
+          "language": {
+            "id": "646"
+          }
+        },
+        {
+          "value": "Armenian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "russian",
+      "bcp47": "ru",
+      "iso3": "rus",
+      "id": "3934",
+      "name": [
+        {
+          "value": "русский",
+          "primary": true,
+          "language": {
+            "id": "3934"
+          }
+        },
+        {
+          "value": "Russian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "german-standard",
+      "bcp47": "de",
+      "iso3": "deu",
+      "id": "1106",
+      "name": [
+        {
+          "value": "Deutsche",
+          "primary": true,
+          "language": {
+            "id": "1106"
+          }
+        },
+        {
+          "value": "German, Standard",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hungarian",
+      "bcp47": "hu",
+      "iso3": "hun",
+      "id": "1107",
+      "name": [
+        {
+          "value": "Magyar",
+          "primary": true,
+          "language": {
+            "id": "1107"
+          }
+        },
+        {
+          "value": "Hungarian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "slovenian",
+      "bcp47": "sl",
+      "iso3": "slv",
+      "id": "1112",
+      "name": [
+        {
+          "value": "Slovenščina",
+          "primary": true,
+          "language": {
+            "id": "1112"
+          }
+        },
+        {
+          "value": "Slovenian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "burmese",
+      "bcp47": "my",
+      "iso3": "mya",
+      "id": "1254",
+      "name": [
+        {
+          "value": "မြန်မာစာ",
+          "primary": true,
+          "language": {
+            "id": "1254"
+          }
+        },
+        {
+          "value": "Burmese",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "embera-catio",
+      "bcp47": null,
+      "iso3": "cto",
+      "id": "4246",
+      "name": [
+        {
+          "value": "Embera-Catio",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "laadi",
+      "bcp47": "ldi",
+      "iso3": "ldi",
+      "id": "4350",
+      "name": [
+        {
+          "value": "Laadi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "shuar",
+      "bcp47": "jiv",
+      "iso3": "jiv",
+      "id": "4499",
+      "name": [
+        {
+          "value": "Shuar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zigula",
+      "bcp47": "ziw",
+      "iso3": "ziw",
+      "id": "14060",
+      "name": [
+        {
+          "value": "Zigula",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zanaki",
+      "bcp47": "zak",
+      "iso3": "zak",
+      "id": "14064",
+      "name": [
+        {
+          "value": "Zanaki",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kinga",
+      "bcp47": null,
+      "iso3": "zga",
+      "id": "14159",
+      "name": [
+        {
+          "value": "Kinga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zimba",
+      "bcp47": "zmb",
+      "iso3": "zmb",
+      "id": "15538",
+      "name": [
+        {
+          "value": "Zimba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zuni",
+      "bcp47": "zun",
+      "iso3": "zun",
+      "id": "18922",
+      "name": [
+        {
+          "value": "Shiwi'ma",
+          "primary": true,
+          "language": {
+            "id": "18922"
+          }
+        },
+        {
+          "value": "Zuni",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yemba",
+      "bcp47": "ybb",
+      "iso3": "ybb",
+      "id": "19504",
+      "name": [
+        {
+          "value": "Yemba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chingoni",
+      "bcp47": null,
+      "iso3": "xnj",
+      "id": "20084",
+      "name": [
+        {
+          "value": "Chingoni",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cantonese",
+      "bcp47": "yue",
+      "iso3": "yue",
+      "id": "20601",
+      "name": [
+        {
+          "value": "廣東話",
+          "primary": true,
+          "language": {
+            "id": "20601"
+          }
+        },
+        {
+          "value": "Cantonese",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lusoga",
+      "bcp47": "xog",
+      "iso3": "xog",
+      "id": "20926",
+      "name": [
+        {
+          "value": "Lusoga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kambera",
+      "bcp47": "xbr",
+      "iso3": "xbr",
+      "id": "20944",
+      "name": [
+        {
+          "value": "Kambera",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mayan",
+      "bcp47": "yua",
+      "iso3": "yua",
+      "id": "21012",
+      "name": [
+        {
+          "value": "Mayan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kiyombe",
+      "bcp47": "yom",
+      "iso3": "yom",
+      "id": "22195",
+      "name": [
+        {
+          "value": "Kiyombe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nasu-eastern",
+      "bcp47": "ywq",
+      "iso3": "ywq",
+      "id": "22847",
+      "name": [
+        {
+          "value": "Nasu, Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lokaa",
+      "bcp47": "yaz",
+      "iso3": "yaz",
+      "id": "23154",
+      "name": [
+        {
+          "value": "Lokaa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zhuang-northern-yongbei",
+      "bcp47": "zyb",
+      "iso3": "zyb",
+      "id": "23180",
+      "name": [
+        {
+          "value": "話僮",
+          "primary": true,
+          "language": {
+            "id": "23180"
+          }
+        },
+        {
+          "value": "Zhuang, Northern (Yongbei)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zhuang-northern-hongshuihe",
+      "bcp47": "zch",
+      "iso3": "zch",
+      "id": "23181",
+      "name": [
+        {
+          "value": "話僮",
+          "primary": true,
+          "language": {
+            "id": "23181"
+          }
+        },
+        {
+          "value": "Zhuang, Northern (Hongshuihe)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zande-drc",
+      "bcp47": "zne",
+      "iso3": "zne",
+      "id": "23524",
+      "name": [
+        {
+          "value": "Zande, Drc",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "iyansi",
+      "bcp47": "yns",
+      "iso3": "yns",
+      "id": "24095",
+      "name": [
+        {
+          "value": "Iyansi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "manado",
+      "bcp47": "xmm",
+      "iso3": "xmm",
+      "id": "24314",
+      "name": [
+        {
+          "value": "Manado",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zhuang-minz",
+      "bcp47": null,
+      "iso3": "zgm",
+      "id": "99581",
+      "name": [
+        {
+          "value": "Zhuang, Minz",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zhuang-youjiang",
+      "bcp47": null,
+      "iso3": "zyj",
+      "id": "99910",
+      "name": [
+        {
+          "value": "Zhuang, Youjiang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ache",
+      "bcp47": null,
+      "iso3": "yif",
+      "id": "100378",
+      "name": [
+        {
+          "value": "A Che",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zapotec-tabaa",
+      "bcp47": "zat",
+      "iso3": "zat",
+      "id": "100807",
+      "name": [
+        {
+          "value": "Zapotec, Tabaa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "likoonl",
+      "bcp47": "xon",
+      "iso3": "xon",
+      "id": "108321",
+      "name": [
+        {
+          "value": "Likoonl",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "erei",
+      "bcp47": "yay",
+      "iso3": "yay",
+      "id": "108591",
+      "name": [
+        {
+          "value": "Erei",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kenyah",
+      "bcp47": null,
+      "iso3": "xkl",
+      "id": "141870",
+      "name": [
+        {
+          "value": "Kenyah",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zhuang-yongnan",
+      "bcp47": null,
+      "iso3": "zyn",
+      "id": "141995",
+      "name": [
+        {
+          "value": "Zhuang, Yongnan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sanga",
+      "bcp47": null,
+      "iso3": "xsn",
+      "id": "142134",
+      "name": [
+        {
+          "value": "Sanga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jaminawa",
+      "bcp47": "yaa",
+      "iso3": "yaa",
+      "id": "142312",
+      "name": [
+        {
+          "value": "Jaminawa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mayangna",
+      "bcp47": null,
+      "iso3": "yan",
+      "id": "142395",
+      "name": [
+        {
+          "value": "Mayangna",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ravula",
+      "bcp47": "yea",
+      "iso3": "yea",
+      "id": "142491",
+      "name": [
+        {
+          "value": "Ravula",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nisu-northern",
+      "bcp47": null,
+      "iso3": "yiv",
+      "id": "142610",
+      "name": [
+        {
+          "value": "Nisu, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yukpa",
+      "bcp47": null,
+      "iso3": "yup",
+      "id": "142979",
+      "name": [
+        {
+          "value": "Yukpa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yuracare",
+      "bcp47": "yuz",
+      "iso3": "yuz",
+      "id": "142985",
+      "name": [
+        {
+          "value": "Yuracare",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "batui",
+      "bcp47": null,
+      "iso3": "zbt",
+      "id": "143190",
+      "name": [
+        {
+          "value": "Batui",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zhuang-nong",
+      "bcp47": null,
+      "iso3": "zhn",
+      "id": "143265",
+      "name": [
+        {
+          "value": "Zhuang, Nong",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zia",
+      "bcp47": null,
+      "iso3": "zia",
+      "id": "143268",
+      "name": [
+        {
+          "value": "Zia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malayic-dayak",
+      "bcp47": "xdy",
+      "iso3": "xdy",
+      "id": "143339",
+      "name": [
+        {
+          "value": "Malayic Dayak",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mbandja",
+      "bcp47": null,
+      "iso3": "zmz",
+      "id": "143356",
+      "name": [
+        {
+          "value": "Mbandja",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zapoteco-de-san-juan-comaltepec",
+      "bcp47": null,
+      "iso3": "zpc",
+      "id": "143368",
+      "name": [
+        {
+          "value": "Zapoteco De San Juan Comaltepec",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "karunsie",
+      "bcp47": null,
+      "iso3": "xmz",
+      "id": "150352",
+      "name": [
+        {
+          "value": "Karunsi'E",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yandang",
+      "bcp47": "ynq",
+      "iso3": "ynq",
+      "id": "168775",
+      "name": [
+        {
+          "value": "Yandang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kisan",
+      "bcp47": "xis",
+      "iso3": "xis",
+      "id": "184496",
+      "name": [
+        {
+          "value": "Kisan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pidgin-liberian",
+      "bcp47": null,
+      "iso3": "lir",
+      "id": "7586",
+      "name": [
+        {
+          "value": "Pidgin, Liberian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "banda-linda",
+      "bcp47": "liy",
+      "iso3": "liy",
+      "id": "53434",
+      "name": [
+        {
+          "value": "Banda-Linda",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kathiyawadi",
+      "bcp47": "gu-x-Kathiyawadi",
+      "iso3": "guj",
+      "id": "6596",
+      "name": [
+        {
+          "value": "Kathiyawadi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bagheli",
+      "bcp47": "bfy",
+      "iso3": "bfy",
+      "id": "6648",
+      "name": [
+        {
+          "value": "Bagheli",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "japanese-sign-language",
+      "bcp47": "jsl",
+      "iso3": "jsl",
+      "id": "7090",
+      "name": [
+        {
+          "value": "Japanese Sign Language",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "okinawan-central",
+      "bcp47": "ryu",
+      "iso3": "ryu",
+      "id": "7103",
+      "name": [
+        {
+          "value": "Okinawan, Central",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "suba",
+      "bcp47": "sxb",
+      "iso3": "sxb",
+      "id": "7222",
+      "name": [
+        {
+          "value": "Suba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "samburu",
+      "bcp47": "saq",
+      "iso3": "saq",
+      "id": "7237",
+      "name": [
+        {
+          "value": "Samburu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "korean-sign-language",
+      "bcp47": "kvk",
+      "iso3": "kvk",
+      "id": "7355",
+      "name": [
+        {
+          "value": "한국어 수화",
+          "primary": true,
+          "language": {
+            "id": "7355"
+          }
+        },
+        {
+          "value": "Korean Sign Language",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bru-eastern",
+      "bcp47": "bru",
+      "iso3": "bru",
+      "id": "7371",
+      "name": [
+        {
+          "value": "Bru, Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gurung",
+      "bcp47": "gvr",
+      "iso3": "gvr",
+      "id": "6485",
+      "name": [
+        {
+          "value": "तमु क्यी",
+          "primary": true,
+          "language": {
+            "id": "6485"
+          }
+        },
+        {
+          "value": "Gurung",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dhodia",
+      "bcp47": null,
+      "iso3": "dho",
+      "id": "6548",
+      "name": [
+        {
+          "value": "Dhodia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-hassaniya",
+      "bcp47": "ar-mey",
+      "iso3": "mey",
+      "id": "7839",
+      "name": [
+        {
+          "value": "Arabic, Hassaniya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chinanteco-tepetotutla",
+      "bcp47": "cnt",
+      "iso3": "cnt",
+      "id": "7922",
+      "name": [
+        {
+          "value": "Chinanteco, Tepetotutla",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zapoteco-yalalag",
+      "bcp47": "zpu",
+      "iso3": "zpu",
+      "id": "7960",
+      "name": [
+        {
+          "value": "Zapoteco, Yalalag",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zapoteco-sierra-de-juarez",
+      "bcp47": "zaa",
+      "iso3": "zaa",
+      "id": "8023",
+      "name": [
+        {
+          "value": "Zapoteco, Sierra De Juarez",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mixteco-central-juxtlahuaca",
+      "bcp47": "vmc",
+      "iso3": "vmc",
+      "id": "8038",
+      "name": [
+        {
+          "value": "Mixteco, Central Juxtlahuaca",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tarahumara-central",
+      "bcp47": "tar",
+      "iso3": "tar",
+      "id": "8108",
+      "name": [
+        {
+          "value": "Tarahumara, Central",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "popoloca-san-juan-atzingo",
+      "bcp47": "poe",
+      "iso3": "poe",
+      "id": "8134",
+      "name": [
+        {
+          "value": "Popoloca, San Juan Atzingo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nahuatl-western-huasteca",
+      "bcp47": "nhw",
+      "iso3": "nhw",
+      "id": "8170",
+      "name": [
+        {
+          "value": "Māsēwallahtōlli",
+          "primary": true,
+          "language": {
+            "id": "8170"
+          }
+        },
+        {
+          "value": "Nahuatl Western Huasteca",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mazateco-huautla-de-jimenez",
+      "bcp47": "mau",
+      "iso3": "mau",
+      "id": "8245",
+      "name": [
+        {
+          "value": "Mazateco, Huautla De Jimenez",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mixe-del-istmo",
+      "bcp47": null,
+      "iso3": "mir",
+      "id": "8295",
+      "name": [
+        {
+          "value": "Mixe Del Istmo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tamang-western",
+      "bcp47": "tdg",
+      "iso3": "tdg",
+      "id": "8989",
+      "name": [
+        {
+          "value": "तामाङ",
+          "primary": true,
+          "language": {
+            "id": "8989"
+          }
+        },
+        {
+          "value": "Tamang, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "papiamentu",
+      "bcp47": "pap",
+      "iso3": "pap",
+      "id": "9131",
+      "name": [
+        {
+          "value": "Papiamentu",
+          "primary": true,
+          "language": {
+            "id": "9131"
+          }
+        },
+        {
+          "value": "Papiamentu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ebira",
+      "bcp47": "igb",
+      "iso3": "igb",
+      "id": "9789",
+      "name": [
+        {
+          "value": "Ebira",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "urhobo",
+      "bcp47": "urh",
+      "iso3": "urh",
+      "id": "9976",
+      "name": [
+        {
+          "value": "Urhobo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gbari",
+      "bcp47": "gby",
+      "iso3": "gby",
+      "id": "10076",
+      "name": [
+        {
+          "value": "Gbari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "eggon",
+      "bcp47": "ego",
+      "iso3": "ego",
+      "id": "10252",
+      "name": [
+        {
+          "value": "Eggon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "marwari-northern",
+      "bcp47": "mve",
+      "iso3": "mve",
+      "id": "10527",
+      "name": [
+        {
+          "value": "Marwari, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dhatki",
+      "bcp47": "mki",
+      "iso3": "mki",
+      "id": "10529",
+      "name": [
+        {
+          "value": "Dhatki",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "guaymi",
+      "bcp47": "gym",
+      "iso3": "gym",
+      "id": "10597",
+      "name": [
+        {
+          "value": "Guaymi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "anjam",
+      "bcp47": "boj",
+      "iso3": "boj",
+      "id": "10810",
+      "name": [
+        {
+          "value": "Anjam",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bola",
+      "bcp47": "bnp",
+      "iso3": "bnp",
+      "id": "10813",
+      "name": [
+        {
+          "value": "Bola",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "watakataui",
+      "bcp47": "wtk",
+      "iso3": "wtk",
+      "id": "11033",
+      "name": [
+        {
+          "value": "Watakataui",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "vitu",
+      "bcp47": "wiv",
+      "iso3": "wiv",
+      "id": "11052",
+      "name": [
+        {
+          "value": "Vitu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lote",
+      "bcp47": "uvl",
+      "iso3": "uvl",
+      "id": "11092",
+      "name": [
+        {
+          "value": "Lote",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "urat",
+      "bcp47": null,
+      "iso3": "urt",
+      "id": "11105",
+      "name": [
+        {
+          "value": "Urat",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "urim",
+      "bcp47": "uri",
+      "iso3": "uri",
+      "id": "11108",
+      "name": [
+        {
+          "value": "Urim",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "vasui",
+      "bcp47": "tpz",
+      "iso3": "tpz",
+      "id": "11150",
+      "name": [
+        {
+          "value": "Vasui",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mandara",
+      "bcp47": "tbf",
+      "iso3": "tbf",
+      "id": "11230",
+      "name": [
+        {
+          "value": "Mandara",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "aramba",
+      "bcp47": "stk",
+      "iso3": "stk",
+      "id": "11251",
+      "name": [
+        {
+          "value": "Aramba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sinasina",
+      "bcp47": "sst",
+      "iso3": "sst",
+      "id": "11259",
+      "name": [
+        {
+          "value": "Sinasina",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sinaugoro",
+      "bcp47": "snc",
+      "iso3": "snc",
+      "id": "11303",
+      "name": [
+        {
+          "value": "Sinaugoro",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "rawa",
+      "bcp47": "rwo",
+      "iso3": "rwo",
+      "id": "11329",
+      "name": [
+        {
+          "value": "Rawa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nakanai",
+      "bcp47": "nak",
+      "iso3": "nak",
+      "id": "11536",
+      "name": [
+        {
+          "value": "Nakanai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kamano",
+      "bcp47": "kbq",
+      "iso3": "kbq",
+      "id": "12019",
+      "name": [
+        {
+          "value": "Kamano",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "inonhan",
+      "bcp47": "loc",
+      "iso3": "loc",
+      "id": "12657",
+      "name": [
+        {
+          "value": "Inonhan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kankanay-northern",
+      "bcp47": null,
+      "iso3": "xnn",
+      "id": "12696",
+      "name": [
+        {
+          "value": "Kankanay, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "isnag",
+      "bcp47": "isd",
+      "iso3": "isd",
+      "id": "12714",
+      "name": [
+        {
+          "value": "Isnag",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cebuano",
+      "bcp47": "ceb",
+      "iso3": "ceb",
+      "id": "12784",
+      "name": [
+        {
+          "value": "Sinugboanon",
+          "primary": true,
+          "language": {
+            "id": "12784"
+          }
+        },
+        {
+          "value": "Cebuano",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zinza",
+      "bcp47": "zin",
+      "iso3": "zin",
+      "id": "14183",
+      "name": [
+        {
+          "value": "Zinza",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hungana",
+      "bcp47": "hum",
+      "iso3": "hum",
+      "id": "15548",
+      "name": [
+        {
+          "value": "Hungana",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "avar",
+      "bcp47": "av",
+      "iso3": "ava",
+      "id": "15882",
+      "name": [
+        {
+          "value": "MагIарул MацI",
+          "primary": true,
+          "language": {
+            "id": "15882"
+          }
+        },
+        {
+          "value": "Avar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "guere-central",
+      "bcp47": "gxx",
+      "iso3": "gxx",
+      "id": "16048",
+      "name": [
+        {
+          "value": "Guere, Central",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dani-western",
+      "bcp47": "dnw",
+      "iso3": "dnw",
+      "id": "16447",
+      "name": [
+        {
+          "value": "Dani, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tontemboan",
+      "bcp47": "tnt",
+      "iso3": "tnt",
+      "id": "17436",
+      "name": [
+        {
+          "value": "Tontemboan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mongondow",
+      "bcp47": "mog",
+      "iso3": "mog",
+      "id": "17467",
+      "name": [
+        {
+          "value": "Mongondow",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cia-cia",
+      "bcp47": null,
+      "iso3": "cia",
+      "id": "17626",
+      "name": [
+        {
+          "value": "Cia-Cia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bajau-indonesian",
+      "bcp47": null,
+      "iso3": "bdl",
+      "id": "17655",
+      "name": [
+        {
+          "value": "Bajau, Indonesian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "batak-karo",
+      "bcp47": "btx",
+      "iso3": "btx",
+      "id": "17813",
+      "name": [
+        {
+          "value": "Cakap Karo",
+          "primary": true,
+          "language": {
+            "id": "17813"
+          }
+        },
+        {
+          "value": "Batak Karo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yakut",
+      "bcp47": "sah",
+      "iso3": "sah",
+      "id": "18379",
+      "name": [
+        {
+          "value": "Yakut",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "navaho",
+      "bcp47": "nv",
+      "iso3": "nav",
+      "id": "19097",
+      "name": [
+        {
+          "value": "Diné Bizaad",
+          "primary": true,
+          "language": {
+            "id": "19097"
+          }
+        },
+        {
+          "value": "Navaho",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "roglai-northern",
+      "bcp47": "rog",
+      "iso3": "rog",
+      "id": "19317",
+      "name": [
+        {
+          "value": "Roglai, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bakumpai",
+      "bcp47": null,
+      "iso3": "bkr",
+      "id": "19560",
+      "name": [
+        {
+          "value": "Bakumpai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gorontalo",
+      "bcp47": "gor",
+      "iso3": "gor",
+      "id": "19716",
+      "name": [
+        {
+          "value": "Gorontalo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cirebon",
+      "bcp47": "jv-x-Cirebon",
+      "iso3": "jav",
+      "id": "19766",
+      "name": [
+        {
+          "value": "Cirebon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "munda",
+      "bcp47": "unx",
+      "iso3": "unx",
+      "id": "100408",
+      "name": [
+        {
+          "value": "Munda",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "varhadi-nagpuri",
+      "bcp47": "vah",
+      "iso3": "vah",
+      "id": "100506",
+      "name": [
+        {
+          "value": "Varhadi-Nagpuri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ogoni",
+      "bcp47": "ogo",
+      "iso3": "ogo",
+      "id": "21236",
+      "name": [
+        {
+          "value": "Ogoni",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "swahili-kenya",
+      "bcp47": "sw-swh-KE",
+      "iso3": "swh",
+      "id": "23179",
+      "name": [
+        {
+          "value": "Kiswahili",
+          "primary": true,
+          "language": {
+            "id": "23179"
+          }
+        },
+        {
+          "value": "Swahili, Kenya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "rathawi",
+      "bcp47": "rtw",
+      "iso3": "rtw",
+      "id": "23313",
+      "name": [
+        {
+          "value": "Rathawi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yerukula",
+      "bcp47": "yeu",
+      "iso3": "yeu",
+      "id": "23326",
+      "name": [
+        {
+          "value": "Yerukula",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "angika",
+      "bcp47": "anp",
+      "iso3": "anp",
+      "id": "23330",
+      "name": [
+        {
+          "value": "अंगिका",
+          "primary": true,
+          "language": {
+            "id": "23330"
+          }
+        },
+        {
+          "value": "Angika",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tigrinya-eritrea",
+      "bcp47": "ti",
+      "iso3": "tir",
+      "id": "23526",
+      "name": [
+        {
+          "value": "ትግርኛ",
+          "primary": true,
+          "language": {
+            "id": "23526"
+          }
+        },
+        {
+          "value": "Tigrinya, Eritrea",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "basa",
+      "bcp47": "bzw",
+      "iso3": "bzw",
+      "id": "24010",
+      "name": [
+        {
+          "value": "Basa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fulfulde-adamawa",
+      "bcp47": "fub",
+      "iso3": "fub",
+      "id": "24014",
+      "name": [
+        {
+          "value": "Fulfulde",
+          "primary": true,
+          "language": {
+            "id": "24014"
+          }
+        },
+        {
+          "value": "Fulfulde-Adamawa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chinese-qinghai",
+      "bcp47": "cmn",
+      "iso3": "cmn",
+      "id": "24096",
+      "name": [
+        {
+          "value": "漢語",
+          "primary": true,
+          "language": {
+            "id": "24096"
+          }
+        },
+        {
+          "value": "Chinese, Qinghai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sakalava-analalava",
+      "bcp47": "skg-x-Analalava",
+      "iso3": "skg",
+      "id": "24120",
+      "name": [
+        {
+          "value": "Sakalava Analalava",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "samarkand-tajik",
+      "bcp47": "tg-x-Samarkand",
+      "iso3": "tgk",
+      "id": "24156",
+      "name": [
+        {
+          "value": "Samarkand-Tajik",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dinka-northeastern-padang",
+      "bcp47": "dip",
+      "iso3": "dip",
+      "id": "24267",
+      "name": [
+        {
+          "value": "Thuɔŋjäŋ",
+          "primary": true,
+          "language": {
+            "id": "24267"
+          }
+        },
+        {
+          "value": "Dinka, Northeastern (Padang)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "maninka-konyanka",
+      "bcp47": "mku",
+      "iso3": "mku",
+      "id": "24413",
+      "name": [
+        {
+          "value": "Maninka, Konyanka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bareli-rathwi",
+      "bcp47": "bgd",
+      "iso3": "bgd",
+      "id": "25919",
+      "name": [
+        {
+          "value": "Bareli, Rathwi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kuanua",
+      "bcp47": null,
+      "iso3": "ksd",
+      "id": "11816",
+      "name": [
+        {
+          "value": "Kuanua",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zapotec-san-pedro-quiatoni",
+      "bcp47": "zpf",
+      "iso3": "zpf",
+      "id": "26934",
+      "name": [
+        {
+          "value": "Zapotec, San Pedro Quiatoni",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dogon-toro-so",
+      "bcp47": "dts",
+      "iso3": "dts",
+      "id": "27145",
+      "name": [
+        {
+          "value": "Dogon, Toro So",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bette",
+      "bcp47": "btt",
+      "iso3": "btt",
+      "id": "28132",
+      "name": [
+        {
+          "value": "Bette",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ishinyiha",
+      "bcp47": "nih",
+      "iso3": "nih",
+      "id": "37411",
+      "name": [
+        {
+          "value": "Ishinyiha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nangjere",
+      "bcp47": "nnc",
+      "iso3": "nnc",
+      "id": "37552",
+      "name": [
+        {
+          "value": "Nangjere",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dijim-cham",
+      "bcp47": "cfa",
+      "iso3": "cfa",
+      "id": "53395",
+      "name": [
+        {
+          "value": "Dijim (Cham)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kinyakyusa-tanzania",
+      "bcp47": "nyy",
+      "iso3": "nyy",
+      "id": "53401",
+      "name": [
+        {
+          "value": "Kinyakyusa (Tanzania)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "romani-kalderash-western",
+      "bcp47": "rmy-kal",
+      "iso3": "rmy",
+      "id": "21027",
+      "name": [
+        {
+          "value": "रोमानो",
+          "primary": true,
+          "language": {
+            "id": "21027"
+          }
+        },
+        {
+          "value": "Romani, Kalderash, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "spanish-castilian",
+      "bcp47": "es-ES",
+      "iso3": "spa",
+      "id": "21046",
+      "name": [
+        {
+          "value": "Castellano",
+          "primary": true,
+          "language": {
+            "id": "21046"
+          }
+        },
+        {
+          "value": "Spanish, Castilian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "french-african",
+      "bcp47": null,
+      "iso3": "fra",
+      "id": "53424",
+      "name": [
+        {
+          "value": "French, African",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "behoa",
+      "bcp47": "bep",
+      "iso3": "bep",
+      "id": "97214",
+      "name": [
+        {
+          "value": "Behoa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "doondo",
+      "bcp47": null,
+      "iso3": "dde",
+      "id": "98033",
+      "name": [
+        {
+          "value": "Doondo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gagu",
+      "bcp47": null,
+      "iso3": "ggu",
+      "id": "98306",
+      "name": [
+        {
+          "value": "Gagu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gbaya-kresh-south-sudan",
+      "bcp47": null,
+      "iso3": "krs",
+      "id": "99152",
+      "name": [
+        {
+          "value": "Gbaya-Kresh, South Sudan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sedoa",
+      "bcp47": "tvw",
+      "iso3": "tvw",
+      "id": "100107",
+      "name": [
+        {
+          "value": "Sedoa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "naga-yimchungru",
+      "bcp47": "yim",
+      "iso3": "yim",
+      "id": "100453",
+      "name": [
+        {
+          "value": "Naga, Yimchungru",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "suba-simbiti",
+      "bcp47": "ssc",
+      "iso3": "ssc",
+      "id": "101456",
+      "name": [
+        {
+          "value": "Suba-Simbiti",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "canela",
+      "bcp47": "ram",
+      "iso3": "ram",
+      "id": "101512",
+      "name": [
+        {
+          "value": "Canela",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "moken",
+      "bcp47": "mwt",
+      "iso3": "mwt",
+      "id": "101562",
+      "name": [
+        {
+          "value": "Moken",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "naga-zeme",
+      "bcp47": "nzm",
+      "iso3": "nzm",
+      "id": "101677",
+      "name": [
+        {
+          "value": "Naga, Zeme",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hona",
+      "bcp47": "hwo",
+      "iso3": "hwo",
+      "id": "119277",
+      "name": [
+        {
+          "value": "Hona",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sambalpuri",
+      "bcp47": "spv",
+      "iso3": "spv",
+      "id": "138284",
+      "name": [
+        {
+          "value": "Sambalpuri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mangghuer-wuge",
+      "bcp47": "mjg",
+      "iso3": "mjg",
+      "id": "139111",
+      "name": [
+        {
+          "value": "Mangghuer Wuge",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malagasy-antesaka",
+      "bcp47": "mg-tkg",
+      "iso3": "tkg",
+      "id": "139117",
+      "name": [
+        {
+          "value": "Fiteny Malagasy",
+          "primary": true,
+          "language": {
+            "id": "139117"
+          }
+        },
+        {
+          "value": "Malagasy, Antesaka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kurdi-hawrami",
+      "bcp47": "hac",
+      "iso3": "hac",
+      "id": "139169",
+      "name": [
+        {
+          "value": "کوردی",
+          "primary": true,
+          "language": {
+            "id": "139169"
+          }
+        },
+        {
+          "value": "Kurdi, Hawrami",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bende-tongwe",
+      "bcp47": null,
+      "iso3": "bdp",
+      "id": "139543",
+      "name": [
+        {
+          "value": "Bende-Tongwe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bana",
+      "bcp47": "bcw",
+      "iso3": "bcw",
+      "id": "139663",
+      "name": [
+        {
+          "value": "Bana",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bora",
+      "bcp47": "boa",
+      "iso3": "boa",
+      "id": "139707",
+      "name": [
+        {
+          "value": "Bora",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bozo-tigemaxo",
+      "bcp47": null,
+      "iso3": "boz",
+      "id": "139885",
+      "name": [
+        {
+          "value": "Bozo, Tigemaxo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "baeggu",
+      "bcp47": null,
+      "iso3": "bvd",
+      "id": "139997",
+      "name": [
+        {
+          "value": "Baeggu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bisu",
+      "bcp47": null,
+      "iso3": "bzi",
+      "id": "140169",
+      "name": [
+        {
+          "value": "Bisu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ese-ejja",
+      "bcp47": "ese",
+      "iso3": "ese",
+      "id": "140434",
+      "name": [
+        {
+          "value": "Ese Ejja",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dogon-mombo",
+      "bcp47": null,
+      "iso3": "dmb",
+      "id": "140549",
+      "name": [
+        {
+          "value": "Dogon, Mombo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "huitoto-murui",
+      "bcp47": "huu",
+      "iso3": "huu",
+      "id": "140882",
+      "name": [
+        {
+          "value": "Huitoto, Murui",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "harari",
+      "bcp47": null,
+      "iso3": "har",
+      "id": "140937",
+      "name": [
+        {
+          "value": "Harari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kiviila",
+      "bcp47": null,
+      "iso3": "job",
+      "id": "141073",
+      "name": [
+        {
+          "value": "Kiviila",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "worodougou",
+      "bcp47": null,
+      "iso3": "jud",
+      "id": "141238",
+      "name": [
+        {
+          "value": "Worodougou",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kinnauri-pahari",
+      "bcp47": "kjo",
+      "iso3": "kjo",
+      "id": "141363",
+      "name": [
+        {
+          "value": "पहाड़ी",
+          "primary": true,
+          "language": {
+            "id": "141363"
+          }
+        },
+        {
+          "value": "Kinnauri, Pahari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ikota",
+      "bcp47": null,
+      "iso3": "koq",
+      "id": "141371",
+      "name": [
+        {
+          "value": "Ikota",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "karo",
+      "bcp47": null,
+      "iso3": "kxh",
+      "id": "141536",
+      "name": [
+        {
+          "value": "Karo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lihir",
+      "bcp47": null,
+      "iso3": "lih",
+      "id": "141789",
+      "name": [
+        {
+          "value": "Lihir",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tawala",
+      "bcp47": null,
+      "iso3": "tbo",
+      "id": "142078",
+      "name": [
+        {
+          "value": "Tawala",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ketengban",
+      "bcp47": "xte",
+      "iso3": "xte",
+      "id": "142141",
+      "name": [
+        {
+          "value": "Ketengban",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ndokwa-ukwuani",
+      "bcp47": null,
+      "iso3": "ukw",
+      "id": "142180",
+      "name": [
+        {
+          "value": "Ndokwa Ukwuani",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "aokha",
+      "bcp47": null,
+      "iso3": "ema",
+      "id": "142264",
+      "name": [
+        {
+          "value": "Aokha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "usarufa",
+      "bcp47": "usa",
+      "iso3": "usa",
+      "id": "142286",
+      "name": [
+        {
+          "value": "Usarufa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "makhuwa",
+      "bcp47": null,
+      "iso3": "vmw",
+      "id": "142483",
+      "name": [
+        {
+          "value": "Makhuwa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gepo",
+      "bcp47": null,
+      "iso3": "ygp",
+      "id": "142505",
+      "name": [
+        {
+          "value": "Gepo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pogoro",
+      "bcp47": "poy",
+      "iso3": "poy",
+      "id": "127283",
+      "name": [
+        {
+          "value": "Pogoro",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sika",
+      "bcp47": null,
+      "iso3": "ski",
+      "id": "142631",
+      "name": [
+        {
+          "value": "Sika",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "isangu",
+      "bcp47": null,
+      "iso3": "snq",
+      "id": "142887",
+      "name": [
+        {
+          "value": "Isangu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "totonac-coyutla",
+      "bcp47": null,
+      "iso3": "toc",
+      "id": "142900",
+      "name": [
+        {
+          "value": "Totonac, Coyutla",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "waskia",
+      "bcp47": "wsk",
+      "iso3": "wsk",
+      "id": "143157",
+      "name": [
+        {
+          "value": "Waskia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zaramo",
+      "bcp47": null,
+      "iso3": "zaj",
+      "id": "143175",
+      "name": [
+        {
+          "value": "Zaramo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mawae",
+      "bcp47": "zia",
+      "iso3": "zia",
+      "id": "152300",
+      "name": [
+        {
+          "value": "Mawae",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pattae",
+      "bcp47": null,
+      "iso3": "mqj",
+      "id": "153568",
+      "name": [
+        {
+          "value": "Pattae'",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "vajjika",
+      "bcp47": "mai",
+      "iso3": "mai",
+      "id": "153840",
+      "name": [
+        {
+          "value": "Vajjika",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "rinconada-bikol",
+      "bcp47": "bto",
+      "iso3": "bto",
+      "id": "158787",
+      "name": [
+        {
+          "value": "Rinconada Bikol",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "shawi-chayahuita",
+      "bcp47": "cbt",
+      "iso3": "cbt",
+      "id": "159000",
+      "name": [
+        {
+          "value": "Shawi (Chayahuita)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kalanguya",
+      "bcp47": null,
+      "iso3": "kak",
+      "id": "163423",
+      "name": [
+        {
+          "value": "Kalanguya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mangalorean-konkani",
+      "bcp47": null,
+      "iso3": "knn",
+      "id": "164216",
+      "name": [
+        {
+          "value": "Mangalorean Konkani",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nandeva",
+      "bcp47": null,
+      "iso3": "tpj",
+      "id": "169287",
+      "name": [
+        {
+          "value": "Nandeva",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pougouli",
+      "bcp47": null,
+      "iso3": "pug",
+      "id": "173946",
+      "name": [
+        {
+          "value": "Pougouli",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yinzebi",
+      "bcp47": null,
+      "iso3": "nzb",
+      "id": "175252",
+      "name": [
+        {
+          "value": "Yinzebi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tsamakko",
+      "bcp47": "tsb",
+      "iso3": "tsb",
+      "id": "176424",
+      "name": [
+        {
+          "value": "Tsamakko",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cook-islands-maori",
+      "bcp47": "rar",
+      "iso3": "rar",
+      "id": "176906",
+      "name": [
+        {
+          "value": "Cook Islands Maori",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kachhi-gujerati",
+      "bcp47": null,
+      "iso3": "gjk",
+      "id": "177210",
+      "name": [
+        {
+          "value": "Kachhi Gujerati",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mahasu-pahari",
+      "bcp47": "bfz",
+      "iso3": "bfz",
+      "id": "184487",
+      "name": [
+        {
+          "value": "Mahasu Pahari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "makhau-tanzania",
+      "bcp47": "vmw",
+      "iso3": "vmw",
+      "id": "184505",
+      "name": [
+        {
+          "value": "Makhau, Tanzania",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sama-mum",
+      "bcp47": "ndi",
+      "iso3": "ndi",
+      "id": "184509",
+      "name": [
+        {
+          "value": "Sama Mum",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "saho-eritrea",
+      "bcp47": "ssy",
+      "iso3": "ssy",
+      "id": "184521",
+      "name": [
+        {
+          "value": "Saho-Eritrea",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dibali",
+      "bcp47": "bcp",
+      "iso3": "bcp",
+      "id": "184541",
+      "name": [
+        {
+          "value": "Dibali",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gutob-gadaba",
+      "bcp47": null,
+      "iso3": "gbj",
+      "id": "184548",
+      "name": [
+        {
+          "value": "Gutob Gadaba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "poumai-naga",
+      "bcp47": "pmx",
+      "iso3": "pmx",
+      "id": "184557",
+      "name": [
+        {
+          "value": "Poumai Naga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malinke-kenieba",
+      "bcp47": "mlq",
+      "iso3": "mlq",
+      "id": "184646",
+      "name": [
+        {
+          "value": "Malinke, Kenieba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "thradhri-kohli",
+      "bcp47": null,
+      "iso3": "kxp",
+      "id": "184810",
+      "name": [
+        {
+          "value": "Thradhri Kohli",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dagbanli",
+      "bcp47": "dag",
+      "iso3": "dag",
+      "id": "184814",
+      "name": [
+        {
+          "value": "Dagbanli",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "penang-hokkien",
+      "bcp47": null,
+      "iso3": "nan",
+      "id": "184819",
+      "name": [
+        {
+          "value": "Penang Hokkien",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mixteco-cuquila-ocotepec",
+      "bcp47": "mie",
+      "iso3": "mie",
+      "id": "184833",
+      "name": [
+        {
+          "value": "Mixteco Cuquila Ocotepec",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ibaas-icen",
+      "bcp47": "cen",
+      "iso3": "cen",
+      "id": "184842",
+      "name": [
+        {
+          "value": "Ibaas (Icen)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mephaa-de-acatapec",
+      "bcp47": "tpx",
+      "iso3": "tpx",
+      "id": "184853",
+      "name": [
+        {
+          "value": "Me'Phaa De Acatapec",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "burmese-standard",
+      "bcp47": null,
+      "iso3": "mya",
+      "id": "184854",
+      "name": [
+        {
+          "value": "Burmese, Standard",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "burmese-common",
+      "bcp47": null,
+      "iso3": "mya",
+      "id": "184855",
+      "name": [
+        {
+          "value": "Burmese, Common",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kimpokomu",
+      "bcp47": null,
+      "iso3": "pkb",
+      "id": "184901",
+      "name": [
+        {
+          "value": "Kimpokomu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "saptari",
+      "bcp47": null,
+      "iso3": "thq",
+      "id": "184902",
+      "name": [
+        {
+          "value": "Saptari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bara-tharu",
+      "bcp47": null,
+      "iso3": "thq",
+      "id": "184903",
+      "name": [
+        {
+          "value": "Bara Tharu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bajureli",
+      "bcp47": null,
+      "iso3": "npi",
+      "id": "184907",
+      "name": [
+        {
+          "value": "Bajureli",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "javanese-banyumasan",
+      "bcp47": null,
+      "iso3": "jav",
+      "id": "184911",
+      "name": [
+        {
+          "value": "Javanese Banyumasan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "beja-bidhaawyeet",
+      "bcp47": null,
+      "iso3": "bej",
+      "id": "184917",
+      "name": [
+        {
+          "value": "Beja, Bidhaawyeet",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "awadhi-nepal",
+      "bcp47": null,
+      "iso3": "awa",
+      "id": "184922",
+      "name": [
+        {
+          "value": "Awadhi, Nepal",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "limba-tonko-sella",
+      "bcp47": null,
+      "iso3": "lia",
+      "id": "184933",
+      "name": [
+        {
+          "value": "Limba, Tonko-Sella",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "balangin-indo",
+      "bcp47": null,
+      "iso3": "knx",
+      "id": "184936",
+      "name": [
+        {
+          "value": "Balangin, Indo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ngombe-south",
+      "bcp47": null,
+      "iso3": "ngc",
+      "id": "184943",
+      "name": [
+        {
+          "value": "Ngombe, South",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ngombe-north",
+      "bcp47": null,
+      "iso3": "ngc",
+      "id": "184944",
+      "name": [
+        {
+          "value": "Ngombe, North",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kobo",
+      "bcp47": null,
+      "iso3": "okc",
+      "id": "184990",
+      "name": [
+        {
+          "value": "Kobo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kutia",
+      "bcp47": null,
+      "iso3": "ort",
+      "id": "185002",
+      "name": [
+        {
+          "value": "Kutia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "davik-kui",
+      "bcp47": null,
+      "iso3": "dwk",
+      "id": "185003",
+      "name": [
+        {
+          "value": "Davik Kui",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "english-british",
+      "bcp47": null,
+      "iso3": "eng",
+      "id": "185021",
+      "name": [
+        {
+          "value": "English, British",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bugis-soppeng",
+      "bcp47": null,
+      "iso3": "bug",
+      "id": "185058",
+      "name": [
+        {
+          "value": "Bugis, Soppeng",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "doti-doteli",
+      "bcp47": null,
+      "iso3": "dty",
+      "id": "185061",
+      "name": [
+        {
+          "value": "Doti Doteli",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dangali-tharu",
+      "bcp47": null,
+      "iso3": "thl",
+      "id": "185063",
+      "name": [
+        {
+          "value": "Dangali, Tharu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sunda-alus",
+      "bcp47": null,
+      "iso3": "sun",
+      "id": "185190",
+      "name": [
+        {
+          "value": "Sunda Alus",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sundanese-banten",
+      "bcp47": null,
+      "iso3": "sun",
+      "id": "185191",
+      "name": [
+        {
+          "value": "Sundanese, Banten",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ledo-taa",
+      "bcp47": null,
+      "iso3": "lew",
+      "id": "185194",
+      "name": [
+        {
+          "value": "Ledo, Taa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "iranun-western",
+      "bcp47": null,
+      "iso3": "ilp",
+      "id": "185197",
+      "name": [
+        {
+          "value": "Iranun, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "iranun-eastern",
+      "bcp47": null,
+      "iso3": "ilp",
+      "id": "185198",
+      "name": [
+        {
+          "value": "Iranun, Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "siddi",
+      "bcp47": null,
+      "iso3": "kan",
+      "id": "185207",
+      "name": [
+        {
+          "value": "Siddi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gilaki-rashti",
+      "bcp47": null,
+      "iso3": "glk",
+      "id": "185210",
+      "name": [
+        {
+          "value": "Gilaki, Rashti",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "assamese-muslim",
+      "bcp47": null,
+      "iso3": "asm",
+      "id": "185219",
+      "name": [
+        {
+          "value": "Assamese Muslim",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "english-african",
+      "bcp47": null,
+      "iso3": "eng",
+      "id": "185221",
+      "name": [
+        {
+          "value": "English, African",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "obamba",
+      "bcp47": null,
+      "iso3": "mdt",
+      "id": "185226",
+      "name": [
+        {
+          "value": "Obamba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "daani",
+      "bcp47": null,
+      "iso3": "bmq",
+      "id": "185232",
+      "name": [
+        {
+          "value": "Daani",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gisir",
+      "bcp47": null,
+      "iso3": "swj",
+      "id": "185234",
+      "name": [
+        {
+          "value": "Gisir",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kunimaipa",
+      "bcp47": "kup",
+      "iso3": "kup",
+      "id": "11789",
+      "name": [
+        {
+          "value": "Kunimaipa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "njebi",
+      "bcp47": "nzb",
+      "iso3": "nzb",
+      "id": "4312",
+      "name": [
+        {
+          "value": "Njebi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "masalit",
+      "bcp47": null,
+      "iso3": "mls",
+      "id": "3531",
+      "name": [
+        {
+          "value": "Masalit",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lukpa",
+      "bcp47": "dop",
+      "iso3": "dop",
+      "id": "1305",
+      "name": [
+        {
+          "value": "Lukpa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kirho",
+      "bcp47": "dud",
+      "iso3": "uth",
+      "id": "10262",
+      "name": [
+        {
+          "value": "Kirho",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tonga-zambezi",
+      "bcp47": "toi",
+      "iso3": "toi",
+      "id": "20984",
+      "name": [
+        {
+          "value": "Tonga, Zambezi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "weri-2",
+      "bcp47": null,
+      "iso3": "wer",
+      "id": "142830",
+      "name": [
+        {
+          "value": "Weri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malkangiri-koya",
+      "bcp47": "kff",
+      "iso3": "kff",
+      "id": "148910",
+      "name": [
+        {
+          "value": "Malkangiri Koya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bahasa-melayu-2",
+      "bcp47": null,
+      "iso3": "zlm",
+      "id": "170534",
+      "name": [
+        {
+          "value": "Bahasa Melayu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tali-2",
+      "bcp47": null,
+      "iso3": "kbn",
+      "id": "181020",
+      "name": [
+        {
+          "value": "Tali",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tsimanex",
+      "bcp47": "cas",
+      "iso3": "cas",
+      "id": "184827",
+      "name": [
+        {
+          "value": "Tsimanex",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dogon-togo-kan",
+      "bcp47": null,
+      "iso3": "dtk",
+      "id": "185246",
+      "name": [
+        {
+          "value": "Dogon, Togo Kan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ikhin",
+      "bcp47": null,
+      "iso3": "ikh",
+      "id": "185251",
+      "name": [
+        {
+          "value": "Ikhin",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "uneme-south",
+      "bcp47": null,
+      "iso3": "une",
+      "id": "185254",
+      "name": [
+        {
+          "value": "Uneme, South",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ut-hun",
+      "bcp47": null,
+      "iso3": "uth",
+      "id": "160430",
+      "name": [
+        {
+          "value": "Ut-Hun",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chin-mun",
+      "bcp47": "mwq",
+      "iso3": "mwq",
+      "id": "8746",
+      "name": [
+        {
+          "value": "Chin, Mun",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mwimbi-igoji-muthambi",
+      "bcp47": null,
+      "iso3": "mws",
+      "id": "7300",
+      "name": [
+        {
+          "value": "Mwimbi-Igoji-Muthambi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hmong-daw",
+      "bcp47": "mww",
+      "iso3": "mww",
+      "id": "4012",
+      "name": [
+        {
+          "value": "lol Hmongb",
+          "primary": true,
+          "language": {
+            "id": "4012"
+          }
+        },
+        {
+          "value": "Hmong Daw",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mixteco-northwest-oaxaca",
+      "bcp47": "mxa",
+      "iso3": "mxa",
+      "id": "8202",
+      "name": [
+        {
+          "value": "Mixteco, Northwest Oaxaca",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nafaanra",
+      "bcp47": "nfr",
+      "iso3": "nfr",
+      "id": "5228",
+      "name": [
+        {
+          "value": "Nafaanra",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tzotzil-chamula",
+      "bcp47": "tzo",
+      "iso3": "tzo",
+      "id": "8069",
+      "name": [
+        {
+          "value": "Tzotzil, Chamula",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tzeltal-tenango",
+      "bcp47": "tzh-x-Tenango",
+      "iso3": "tzh",
+      "id": "23135",
+      "name": [
+        {
+          "value": "Tzeltal, Tenango",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tamazight-central-atlas",
+      "bcp47": "tzm",
+      "iso3": "tzm",
+      "id": "512",
+      "name": [
+        {
+          "value": "ⵜⴰⵎⴰⵣⵉⵖⵜ",
+          "primary": true,
+          "language": {
+            "id": "512"
+          }
+        },
+        {
+          "value": "Tamazight, Central Atlas",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kiche-cunen",
+      "bcp47": "quc",
+      "iso3": "quc",
+      "id": "139116",
+      "name": [
+        {
+          "value": "Kiche, Cunen",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "antesaka",
+      "bcp47": "tkg",
+      "iso3": "tkg",
+      "id": "139153",
+      "name": [
+        {
+          "value": "Antesaka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kohli-parkari",
+      "bcp47": null,
+      "iso3": "kvx",
+      "id": "10536",
+      "name": [
+        {
+          "value": "Kohli, Parkari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "madi-okollo",
+      "bcp47": null,
+      "iso3": "snm",
+      "id": "139183",
+      "name": [
+        {
+          "value": "Ma'Di Okollo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "powari",
+      "bcp47": null,
+      "iso3": "pwr",
+      "id": "101328",
+      "name": [
+        {
+          "value": "Powari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "karen-pwo-omkoi",
+      "bcp47": "pww",
+      "iso3": "pww",
+      "id": "14358",
+      "name": [
+        {
+          "value": "Karen, Pwo Omkoi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "xaasongaxango",
+      "bcp47": "kao",
+      "iso3": "kao",
+      "id": "141265",
+      "name": [
+        {
+          "value": "Xaasongaxango",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lungga",
+      "bcp47": null,
+      "iso3": "lga",
+      "id": "141767",
+      "name": [
+        {
+          "value": "Lungga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "qanjobal",
+      "bcp47": null,
+      "iso3": "kjb",
+      "id": "141355",
+      "name": [
+        {
+          "value": "Q'Anjob'Al",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kinyarwanda",
+      "bcp47": "rw",
+      "iso3": "kin",
+      "id": "20900",
+      "name": [
+        {
+          "value": "Ikinyarwanda",
+          "primary": true,
+          "language": {
+            "id": "20900"
+          }
+        },
+        {
+          "value": "Kinyarwanda",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mbugwe",
+      "bcp47": null,
+      "iso3": "mgz",
+      "id": "144632",
+      "name": [
+        {
+          "value": "Mbugwe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "digaro-mishmi",
+      "bcp47": "mhu",
+      "iso3": "mhu",
+      "id": "144716",
+      "name": [
+        {
+          "value": "Digaro-Mishmi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "khiamniungan",
+      "bcp47": null,
+      "iso3": "kix",
+      "id": "163806",
+      "name": [
+        {
+          "value": "Khiamniungan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pinyin",
+      "bcp47": "pny",
+      "iso3": "pny",
+      "id": "143962",
+      "name": [
+        {
+          "value": "Pinyin",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "rufumbira",
+      "bcp47": "rw",
+      "iso3": "kin",
+      "id": "106188",
+      "name": [
+        {
+          "value": "Rufumbira",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kyrgyz",
+      "bcp47": "ky",
+      "iso3": "kir",
+      "id": "53299",
+      "name": [
+        {
+          "value": "قىرعىز",
+          "primary": true,
+          "language": {
+            "id": "53299"
+          }
+        },
+        {
+          "value": "Kyrgyz",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dersim-zazaki",
+      "bcp47": "kiu",
+      "iso3": "kiu",
+      "id": "22684",
+      "name": [
+        {
+          "value": "Dersim Zazaki",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kisi",
+      "bcp47": null,
+      "iso3": "kiz",
+      "id": "98914",
+      "name": [
+        {
+          "value": "Kisi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kwangali",
+      "bcp47": "kwn",
+      "iso3": "kwn",
+      "id": "547",
+      "name": [
+        {
+          "value": "Kwangali",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kamayo",
+      "bcp47": null,
+      "iso3": "kyk",
+      "id": "99364",
+      "name": [
+        {
+          "value": "Kamayo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bangla-2",
+      "bcp47": "bn",
+      "iso3": "ben",
+      "id": "176243",
+      "name": [
+        {
+          "value": "Bangla",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zabana",
+      "bcp47": null,
+      "iso3": "kji",
+      "id": "141359",
+      "name": [
+        {
+          "value": "Zabana",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "apinaye",
+      "bcp47": "apn",
+      "iso3": "apn",
+      "id": "1890",
+      "name": [
+        {
+          "value": "Apinaye",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "saafi-saafi",
+      "bcp47": null,
+      "iso3": "sav",
+      "id": "143610",
+      "name": [
+        {
+          "value": "Saafi-Saafi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "suau",
+      "bcp47": null,
+      "iso3": "swp",
+      "id": "143387",
+      "name": [
+        {
+          "value": "Suau",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bimin",
+      "bcp47": "bhl",
+      "iso3": "bhl",
+      "id": "12286",
+      "name": [
+        {
+          "value": "Bimin",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "enggano",
+      "bcp47": null,
+      "iso3": "eno",
+      "id": "140421",
+      "name": [
+        {
+          "value": "Enggano",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "toura",
+      "bcp47": null,
+      "iso3": "neb",
+      "id": "102103",
+      "name": [
+        {
+          "value": "Toura",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "acchami",
+      "bcp47": null,
+      "iso3": "npi",
+      "id": "111586",
+      "name": [
+        {
+          "value": "Acchami",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "baitadeli",
+      "bcp47": null,
+      "iso3": "npi",
+      "id": "111587",
+      "name": [
+        {
+          "value": "Baitadeli",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tat-azeri",
+      "bcp47": null,
+      "iso3": "ttt",
+      "id": "143311",
+      "name": [
+        {
+          "value": "Tat, Azeri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bajhangi",
+      "bcp47": null,
+      "iso3": "npi",
+      "id": "111589",
+      "name": [
+        {
+          "value": "Bajhangi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "uripiv-wala-rano-atchin",
+      "bcp47": "upv",
+      "iso3": "upv",
+      "id": "142266",
+      "name": [
+        {
+          "value": "Uripiv-Wala-Rano-Atchin",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lughuru",
+      "bcp47": "ruf",
+      "iso3": "ruf",
+      "id": "132358",
+      "name": [
+        {
+          "value": "Lughuru",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "orokaiva",
+      "bcp47": "okv",
+      "iso3": "okv",
+      "id": "144702",
+      "name": [
+        {
+          "value": "Orokaiva",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ngbaka",
+      "bcp47": "nga",
+      "iso3": "nga",
+      "id": "4327",
+      "name": [
+        {
+          "value": "Ngbaka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mixtec-magdalena-penasco",
+      "bcp47": null,
+      "iso3": "xtm",
+      "id": "142146",
+      "name": [
+        {
+          "value": "Mixtec, Magdalena Penasco",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ngbandi",
+      "bcp47": "ngb",
+      "iso3": "ngb",
+      "id": "15269",
+      "name": [
+        {
+          "value": "Ngbandi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ngombe",
+      "bcp47": "ngc",
+      "iso3": "ngc",
+      "id": "20077",
+      "name": [
+        {
+          "value": "Ngombe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-sanaani",
+      "bcp47": null,
+      "iso3": "ayn",
+      "id": "15161",
+      "name": [
+        {
+          "value": "Arabic, Sanaani",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "uare",
+      "bcp47": "ksj",
+      "iso3": "ksj",
+      "id": "141610",
+      "name": [
+        {
+          "value": "Uare",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ngada",
+      "bcp47": null,
+      "iso3": "nxg",
+      "id": "144528",
+      "name": [
+        {
+          "value": "Ngad'A",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "aralle",
+      "bcp47": null,
+      "iso3": "atq",
+      "id": "145459",
+      "name": [
+        {
+          "value": "Aralle",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cishingini",
+      "bcp47": "asg",
+      "iso3": "asg",
+      "id": "9316",
+      "name": [
+        {
+          "value": "Cishingini",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ngizim",
+      "bcp47": "ngi",
+      "iso3": "ngi",
+      "id": "9396",
+      "name": [
+        {
+          "value": "Ngizim",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "isoko",
+      "bcp47": "iso",
+      "iso3": "iso",
+      "id": "9699",
+      "name": [
+        {
+          "value": "Isoko",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tchumbuli",
+      "bcp47": null,
+      "iso3": "bqa",
+      "id": "139904",
+      "name": [
+        {
+          "value": "Tchumbuli",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chinese-hokkien-amoy",
+      "bcp47": "nan",
+      "iso3": "nan",
+      "id": "184515",
+      "name": [
+        {
+          "value": "臺灣話",
+          "primary": true,
+          "language": {
+            "id": "184515"
+          }
+        },
+        {
+          "value": "Chinese, Hokkien Amoy",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "guarani-western-bolivian",
+      "bcp47": "gnw",
+      "iso3": "gnw",
+      "id": "184828",
+      "name": [
+        {
+          "value": "Guarani, Western Bolivian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fali-north",
+      "bcp47": null,
+      "iso3": "fli",
+      "id": "184844",
+      "name": [
+        {
+          "value": "Fali North",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lomwe",
+      "bcp47": "ngl",
+      "iso3": "ngl",
+      "id": "7790",
+      "name": [
+        {
+          "value": "Lomwe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bareli-pawri",
+      "bcp47": "bfb",
+      "iso3": "bfb",
+      "id": "184486",
+      "name": [
+        {
+          "value": "Bareli Pawri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yao-tanzania",
+      "bcp47": null,
+      "iso3": "yao",
+      "id": "184489",
+      "name": [
+        {
+          "value": "Yao, Tanzania",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dogose",
+      "bcp47": "dos",
+      "iso3": "dos",
+      "id": "139072",
+      "name": [
+        {
+          "value": "Dogose",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gondi-aheri",
+      "bcp47": "esg",
+      "iso3": "esg",
+      "id": "147829",
+      "name": [
+        {
+          "value": "Gondi, Aheri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "beembe",
+      "bcp47": "beq",
+      "iso3": "beq",
+      "id": "4276",
+      "name": [
+        {
+          "value": "Beembe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chatgaya-chittagonian-muslim",
+      "bcp47": "ctg",
+      "iso3": "ctg",
+      "id": "21674",
+      "name": [
+        {
+          "value": "Chatgaya Chittagonian Muslim",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dangi",
+      "bcp47": "dhn",
+      "iso3": "dhn",
+      "id": "22682",
+      "name": [
+        {
+          "value": "Dangi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jur-modo",
+      "bcp47": "bex",
+      "iso3": "bex",
+      "id": "13745",
+      "name": [
+        {
+          "value": "Jur Modo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "abidji",
+      "bcp47": "abi",
+      "iso3": "abi",
+      "id": "15909",
+      "name": [
+        {
+          "value": "Abidji",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "abkhaz",
+      "bcp47": null,
+      "iso3": "abk",
+      "id": "5074",
+      "name": [
+        {
+          "value": "Abkhaz",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lebanese-syrian-arabic",
+      "bcp47": null,
+      "iso3": "apc",
+      "id": "156811",
+      "name": [
+        {
+          "value": "Lebanese-Syrian Arabic",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "ayta-abellen",
+      "bcp47": "abp",
+      "iso3": "abp",
+      "id": "96911",
+      "name": [
+        {
+          "value": "Ayta, Abellen",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "abure",
+      "bcp47": null,
+      "iso3": "abu",
+      "id": "16117",
+      "name": [
+        {
+          "value": "Abure",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "aceh",
+      "bcp47": "ace",
+      "iso3": "ace",
+      "id": "17688",
+      "name": [
+        {
+          "value": "Aceh",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "vale",
+      "bcp47": null,
+      "iso3": "vae",
+      "id": "142372",
+      "name": [
+        {
+          "value": "Vale",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hmong-shuad",
+      "bcp47": "hmz",
+      "iso3": "hmz",
+      "id": "22826",
+      "name": [
+        {
+          "value": "lol Hmongb",
+          "primary": true,
+          "language": {
+            "id": "22826"
+          }
+        },
+        {
+          "value": "Hmong Shuad",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "vaiphei",
+      "bcp47": "vap",
+      "iso3": "vap",
+      "id": "142378",
+      "name": [
+        {
+          "value": "Vaiphei",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "vietnamese-northern",
+      "bcp47": "vi-x-Northern",
+      "iso3": "vie",
+      "id": "22500",
+      "name": [
+        {
+          "value": "Tiếng Việt",
+          "primary": true,
+          "language": {
+            "id": "22500"
+          }
+        },
+        {
+          "value": "Vietnamese, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-tunisian",
+      "bcp47": "ar-aeb",
+      "iso3": "aeb",
+      "id": "20547",
+      "name": [
+        {
+          "value": "Arabic, Tunisian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quechua-eastern-apurimac",
+      "bcp47": "qve",
+      "iso3": "qve",
+      "id": "27039",
+      "name": [
+        {
+          "value": "Qhichwa",
+          "primary": true,
+          "language": {
+            "id": "27039"
+          }
+        },
+        {
+          "value": "Quechua, Eastern Apurimac",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nguna",
+      "bcp47": "llp",
+      "iso3": "llp",
+      "id": "149957",
+      "name": [
+        {
+          "value": "Nguna",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bari",
+      "bcp47": "bfa",
+      "iso3": "bfa",
+      "id": "13586",
+      "name": [
+        {
+          "value": "Bari",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "afrikaans",
+      "bcp47": "af",
+      "iso3": "afr",
+      "id": "1444",
+      "name": [
+        {
+          "value": "Afrikaans",
+          "primary": true,
+          "language": {
+            "id": "1444"
+          }
+        },
+        {
+          "value": "Afrikaans",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "vasavi-kolche",
+      "bcp47": "vas",
+      "iso3": "vas",
+      "id": "181949",
+      "name": [
+        {
+          "value": "Vasavi (Kolche)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "suodi",
+      "bcp47": "ii",
+      "iso3": "iii",
+      "id": "22863",
+      "name": [
+        {
+          "value": "Suodi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bhojpuri-nepal",
+      "bcp47": null,
+      "iso3": "bho",
+      "id": "145845",
+      "name": [
+        {
+          "value": "Bhojpuri, Nepal",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kashubian",
+      "bcp47": "csb",
+      "iso3": "csb",
+      "id": "12869",
+      "name": [
+        {
+          "value": "Kaszëbsczi Jãzëk",
+          "primary": true,
+          "language": {
+            "id": "12869"
+          }
+        },
+        {
+          "value": "Kashubian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nyishi",
+      "bcp47": "njz",
+      "iso3": "njz",
+      "id": "22564",
+      "name": [
+        {
+          "value": "Nyishi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sarlahi-tharu",
+      "bcp47": null,
+      "iso3": "thq",
+      "id": "151150",
+      "name": [
+        {
+          "value": "Sarlahi Tharu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "agarabi",
+      "bcp47": "agd",
+      "iso3": "agd",
+      "id": "96835",
+      "name": [
+        {
+          "value": "Agarabi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tzutujil-western",
+      "bcp47": "tzj",
+      "iso3": "tzj",
+      "id": "150571",
+      "name": [
+        {
+          "value": "Tzutujil, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dusun",
+      "bcp47": "dtp",
+      "iso3": "dtp",
+      "id": "20654",
+      "name": [
+        {
+          "value": "Dusun",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dubli",
+      "bcp47": null,
+      "iso3": "dub",
+      "id": "23342",
+      "name": [
+        {
+          "value": "Dubli",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "duruma",
+      "bcp47": "dug",
+      "iso3": "dug",
+      "id": "7166",
+      "name": [
+        {
+          "value": "Duruma",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dungra-bhil",
+      "bcp47": "duh",
+      "iso3": "duh",
+      "id": "23258",
+      "name": [
+        {
+          "value": "Dungra Bhil",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "anaang",
+      "bcp47": "anw",
+      "iso3": "anw",
+      "id": "9317",
+      "name": [
+        {
+          "value": "Anaang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hadza",
+      "bcp47": null,
+      "iso3": "hts",
+      "id": "140867",
+      "name": [
+        {
+          "value": "Hadza",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chasu-pare",
+      "bcp47": "asa",
+      "iso3": "asa",
+      "id": "24223",
+      "name": [
+        {
+          "value": "Chasu-Pare",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tarifit-latin-based-script",
+      "bcp47": "rif",
+      "iso3": "rif",
+      "id": "184498",
+      "name": [
+        {
+          "value": "Tarifit yura s lḥuruf n latiniya",
+          "primary": true,
+          "language": {
+            "id": "184498"
+          }
+        },
+        {
+          "value": "Tarifit (Lbs)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gangam",
+      "bcp47": "gng",
+      "iso3": "gng",
+      "id": "117883",
+      "name": [
+        {
+          "value": "Gangam",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-moroccan-spoken",
+      "bcp47": "ar-ary",
+      "iso3": "ary",
+      "id": "8418",
+      "name": [
+        {
+          "value": "الدارجة",
+          "primary": true,
+          "language": {
+            "id": "8418"
+          }
+        },
+        {
+          "value": "Arabic, Moroccan Spoken",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bankagooma",
+      "bcp47": null,
+      "iso3": "bxw",
+      "id": "139862",
+      "name": [
+        {
+          "value": "Bankagooma",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gayo",
+      "bcp47": null,
+      "iso3": "gay",
+      "id": "17807",
+      "name": [
+        {
+          "value": "Gayo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gibaio",
+      "bcp47": "kiw",
+      "iso3": "kiw",
+      "id": "149219",
+      "name": [
+        {
+          "value": "Gibaio",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "eshira-2",
+      "bcp47": null,
+      "iso3": "swj",
+      "id": "143382",
+      "name": [
+        {
+          "value": "Eshira",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yawa",
+      "bcp47": null,
+      "iso3": "yva",
+      "id": "142986",
+      "name": [
+        {
+          "value": "Yawa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "darchuleli",
+      "bcp47": null,
+      "iso3": "npi",
+      "id": "111588",
+      "name": [
+        {
+          "value": "Darchuleli",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "huasteco-san-luis-potosi",
+      "bcp47": "hus-MX-SLP",
+      "iso3": "hus",
+      "id": "8265",
+      "name": [
+        {
+          "value": "Huasteco, San Luis Potosi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zayse",
+      "bcp47": "zay",
+      "iso3": "zay",
+      "id": "152162",
+      "name": [
+        {
+          "value": "Zayse",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "awgni",
+      "bcp47": "awn",
+      "iso3": "awn",
+      "id": "53389",
+      "name": [
+        {
+          "value": "አውጚ",
+          "primary": true,
+          "language": {
+            "id": "53389"
+          }
+        },
+        {
+          "value": "Awgni",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bashkir",
+      "bcp47": "ba",
+      "iso3": "bak",
+      "id": "18450",
+      "name": [
+        {
+          "value": "башҡорт теле",
+          "primary": true,
+          "language": {
+            "id": "18450"
+          }
+        },
+        {
+          "value": "Bashkir",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bambara",
+      "bcp47": "bm",
+      "iso3": "bam",
+      "id": "2075",
+      "name": [
+        {
+          "value": "Bamanankan",
+          "primary": true,
+          "language": {
+            "id": "2075"
+          }
+        },
+        {
+          "value": "Bambara",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "parakana",
+      "bcp47": "pak",
+      "iso3": "pak",
+      "id": "184475",
+      "name": [
+        {
+          "value": "Parakana",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kwangwa",
+      "bcp47": "lyn",
+      "iso3": "lyn",
+      "id": "184511",
+      "name": [
+        {
+          "value": "Kwangwa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bali-madya",
+      "bcp47": "ban",
+      "iso3": "ban",
+      "id": "19617",
+      "name": [
+        {
+          "value": "Basa Bali",
+          "primary": true,
+          "language": {
+            "id": "19617"
+          }
+        },
+        {
+          "value": "Bali, Madya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "guro",
+      "bcp47": "goa",
+      "iso3": "goa",
+      "id": "16064",
+      "name": [
+        {
+          "value": "Guro",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gogo",
+      "bcp47": "gog",
+      "iso3": "gog",
+      "id": "14206",
+      "name": [
+        {
+          "value": "Gogo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "basaa",
+      "bcp47": "bas",
+      "iso3": "bas",
+      "id": "2923",
+      "name": [
+        {
+          "value": "ɓasaá",
+          "primary": true,
+          "language": {
+            "id": "2923"
+          }
+        },
+        {
+          "value": "Basaa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bhatri",
+      "bcp47": "bgw",
+      "iso3": "bgw",
+      "id": "5697",
+      "name": [
+        {
+          "value": "Bhatri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mexican-sign-language",
+      "bcp47": "mfs",
+      "iso3": "mfs",
+      "id": "8230",
+      "name": [
+        {
+          "value": "Mexican Sign Language",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "badaga",
+      "bcp47": "bfq",
+      "iso3": "bfq",
+      "id": "5613",
+      "name": [
+        {
+          "value": "படகா",
+          "primary": true,
+          "language": {
+            "id": "5613"
+          }
+        },
+        {
+          "value": "Badaga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "balanta-ganja",
+      "bcp47": null,
+      "iso3": "bjt",
+      "id": "23511",
+      "name": [
+        {
+          "value": "Balanta-Ganja",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lutos",
+      "bcp47": null,
+      "iso3": "ndy",
+      "id": "143542",
+      "name": [
+        {
+          "value": "Lutos",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nahuatl-isthmus-pajapan",
+      "bcp47": null,
+      "iso3": "nhp",
+      "id": "143712",
+      "name": [
+        {
+          "value": "Nahuatl, Isthmus-Pajapan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mbuko",
+      "bcp47": "mqb",
+      "iso3": "mqb",
+      "id": "100947",
+      "name": [
+        {
+          "value": "Mbuko",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "wakatobi",
+      "bcp47": null,
+      "iso3": "bhq",
+      "id": "157752",
+      "name": [
+        {
+          "value": "Wakatobi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hausa",
+      "bcp47": "ha",
+      "iso3": "hau",
+      "id": "1341",
+      "name": [
+        {
+          "value": " حَوْسَ",
+          "primary": true,
+          "language": {
+            "id": "1341"
+          }
+        },
+        {
+          "value": "Hausa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "avokaya",
+      "bcp47": "avu",
+      "iso3": "avu",
+      "id": "13567",
+      "name": [
+        {
+          "value": "Avokaya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tontemboan-makelai",
+      "bcp47": null,
+      "iso3": "tnt",
+      "id": "185195",
+      "name": [
+        {
+          "value": "Tontemboan, Makelai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-modern-standard-sharif",
+      "bcp47": "ar-arb",
+      "iso3": "arb",
+      "id": "184495",
+      "name": [
+        {
+          "value": "اللغة العربية الفصحى",
+          "primary": true,
+          "language": {
+            "id": "184495"
+          }
+        },
+        {
+          "value": "Arabic, Modern Standard (Sharif)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sherbro",
+      "bcp47": "bun",
+      "iso3": "bun",
+      "id": "13084",
+      "name": [
+        {
+          "value": "Sherbro",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "portuguese-brazil",
+      "bcp47": "pt",
+      "iso3": "por",
+      "id": "584",
+      "name": [
+        {
+          "value": "Português",
+          "primary": true,
+          "language": {
+            "id": "584"
+          }
+        },
+        {
+          "value": "Portuguese, Brazil",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yaka",
+      "bcp47": "axk",
+      "iso3": "axk",
+      "id": "19495",
+      "name": [
+        {
+          "value": "Yaka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "huave-san-mateo-del-mar",
+      "bcp47": "huv",
+      "iso3": "huv",
+      "id": "8266",
+      "name": [
+        {
+          "value": "Huave, San Mateo Del Mar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "huba",
+      "bcp47": "hbb",
+      "iso3": "hbb",
+      "id": "9597",
+      "name": [
+        {
+          "value": "Huba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mamasa",
+      "bcp47": "mqj",
+      "iso3": "mqj",
+      "id": "17616",
+      "name": [
+        {
+          "value": "Mamasa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bolewa",
+      "bcp47": null,
+      "iso3": "bol",
+      "id": "19581",
+      "name": [
+        {
+          "value": "Bolewa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bosnian",
+      "bcp47": "bs",
+      "iso3": "bos",
+      "id": "20581",
+      "name": [
+        {
+          "value": "Босански",
+          "primary": true,
+          "language": {
+            "id": "20581"
+          }
+        },
+        {
+          "value": "Bosnian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bongo",
+      "bcp47": "bot",
+      "iso3": "bot",
+      "id": "97457",
+      "name": [
+        {
+          "value": "Bongo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mixteco-metlatonoc",
+      "bcp47": "mxv-x-Metlatonoc",
+      "iso3": "mxv",
+      "id": "8193",
+      "name": [
+        {
+          "value": "Mixteco, Metlatonoc",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "huichol",
+      "bcp47": "hch",
+      "iso3": "hch",
+      "id": "8277",
+      "name": [
+        {
+          "value": "Huichol",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hainanese",
+      "bcp47": "nan-CN-46",
+      "iso3": "nan",
+      "id": "13192",
+      "name": [
+        {
+          "value": "海南話",
+          "primary": true,
+          "language": {
+            "id": "13192"
+          }
+        },
+        {
+          "value": "Hainanese",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "teochew",
+      "bcp47": "nan-x-Teochew",
+      "iso3": "nan",
+      "id": "23075",
+      "name": [
+        {
+          "value": "潮州話",
+          "primary": true,
+          "language": {
+            "id": "23075"
+          }
+        },
+        {
+          "value": "Teochew",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chamba-daka",
+      "bcp47": null,
+      "iso3": "ccg",
+      "id": "159038",
+      "name": [
+        {
+          "value": "Chamba Daka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "inuktitut-eastern-canadian",
+      "bcp47": "ike",
+      "iso3": "ike",
+      "id": "3076",
+      "name": [
+        {
+          "value": "ᐃᓄᒃᑎᑐᑦ",
+          "primary": true,
+          "language": {
+            "id": "3076"
+          }
+        },
+        {
+          "value": "Inuktitut, Eastern Canadian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hebrew",
+      "bcp47": "he",
+      "iso3": "heb",
+      "id": "6930",
+      "name": [
+        {
+          "value": "עברית",
+          "primary": true,
+          "language": {
+            "id": "6930"
+          }
+        },
+        {
+          "value": "Hebrew",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mizo-lushai",
+      "bcp47": "lus",
+      "iso3": "lus",
+      "id": "23578",
+      "name": [
+        {
+          "value": "Mizo, Lushai",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mixteco-santa-maria-apasco",
+      "bcp47": "mip",
+      "iso3": "mip",
+      "id": "8296",
+      "name": [
+        {
+          "value": "Mixteco, Santa Maria Apasco",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kokoda-k-ainake",
+      "bcp47": "hkk",
+      "iso3": "hkk",
+      "id": "184462",
+      "name": [
+        {
+          "value": "Kokoda K Ainake",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "south-gumuz",
+      "bcp47": "guk",
+      "iso3": "guk",
+      "id": "184660",
+      "name": [
+        {
+          "value": "South Gumuz",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "batak-mandailing",
+      "bcp47": null,
+      "iso3": "btm",
+      "id": "17815",
+      "name": [
+        {
+          "value": "Batak Mandailing",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chokwe-congo",
+      "bcp47": "cjk-CD",
+      "iso3": "cjk",
+      "id": "23491",
+      "name": [
+        {
+          "value": "Chokwe, Congo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chokwe-angola",
+      "bcp47": "cjk",
+      "iso3": "cjk",
+      "id": "23492",
+      "name": [
+        {
+          "value": "Chokwe, Angola",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "santali-india",
+      "bcp47": "sat",
+      "iso3": "sat",
+      "id": "24249",
+      "name": [
+        {
+          "value": "संथाली",
+          "primary": true,
+          "language": {
+            "id": "24249"
+          }
+        },
+        {
+          "value": "Santali, India",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lesser-antillean-creole-french",
+      "bcp47": "gcf",
+      "iso3": "gcf",
+      "id": "4472",
+      "name": [
+        {
+          "value": "Lesser Antillean Creole French",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cham-western",
+      "bcp47": "cja",
+      "iso3": "cja",
+      "id": "2145",
+      "name": [
+        {
+          "value": "Cham, Western",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quechua-ancash-conchucos-northern",
+      "bcp47": "qxn",
+      "iso3": "qxn",
+      "id": "12449",
+      "name": [
+        {
+          "value": "Qhichwa",
+          "primary": true,
+          "language": {
+            "id": "12449"
+          }
+        },
+        {
+          "value": "Quechua, Ancash, Conchucos, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "khoekhoegowab",
+      "bcp47": "naq",
+      "iso3": "naq",
+      "id": "53327",
+      "name": [
+        {
+          "value": "Khoekhoegowab",
+          "primary": true,
+          "language": {
+            "id": "53327"
+          }
+        },
+        {
+          "value": "Khoekhoegowab",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "naasioi",
+      "bcp47": "nas",
+      "iso3": "nas",
+      "id": "20061",
+      "name": [
+        {
+          "value": "Naasioi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cham-eastern",
+      "bcp47": "cjm",
+      "iso3": "cjm",
+      "id": "19372",
+      "name": [
+        {
+          "value": "Cham, Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "uyghur",
+      "bcp47": "ug",
+      "iso3": "uig",
+      "id": "410",
+      "name": [
+        {
+          "value": "ئۇيغۇر تىلى",
+          "primary": true,
+          "language": {
+            "id": "410"
+          }
+        },
+        {
+          "value": "Uyghur",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malay-ambonese",
+      "bcp47": "ms-abs",
+      "iso3": "abs",
+      "id": "16891",
+      "name": [
+        {
+          "value": "Malay, Ambonese",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sotho-northern",
+      "bcp47": "nso",
+      "iso3": "nso",
+      "id": "13465",
+      "name": [
+        {
+          "value": "Sesotho sa Leboa",
+          "primary": true,
+          "language": {
+            "id": "13465"
+          }
+        },
+        {
+          "value": "Sotho, Northern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tlapaneco-de-tlacoapa",
+      "bcp47": "tpl",
+      "iso3": "tpl",
+      "id": "169301",
+      "name": [
+        {
+          "value": "Tlapaneco De Tlacoapa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bangla-muslim",
+      "bcp47": "bn-BD",
+      "iso3": "ben",
+      "id": "139082",
+      "name": [
+        {
+          "value": "বাংলা",
+          "primary": true,
+          "language": {
+            "id": "139082"
+          }
+        },
+        {
+          "value": "Bangla Muslim",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zhuang-qiubei",
+      "bcp47": null,
+      "iso3": "zqe",
+      "id": "99804",
+      "name": [
+        {
+          "value": "Zhuang, Qiubei",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "dulangan-manobo",
+      "bcp47": "mta",
+      "iso3": "mta",
+      "id": "173673",
+      "name": [
+        {
+          "value": "Dulangan Manobo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "runyoro",
+      "bcp47": "nyo",
+      "iso3": "nyo",
+      "id": "20861",
+      "name": [
+        {
+          "value": "Runyoro",
+          "primary": true,
+          "language": {
+            "id": "20861"
+          }
+        },
+        {
+          "value": "Runyoro",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "waura",
+      "bcp47": "wau",
+      "iso3": "wau",
+      "id": "100773",
+      "name": [
+        {
+          "value": "Waura",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zapoteco-southern-rincon",
+      "bcp47": "zsr",
+      "iso3": "zsr",
+      "id": "7954",
+      "name": [
+        {
+          "value": "Zapoteco, Southern Rincon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "amanab",
+      "bcp47": "amn",
+      "iso3": "amn",
+      "id": "10685",
+      "name": [
+        {
+          "value": "Amanab",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "santhali-nepal",
+      "bcp47": null,
+      "iso3": "sat",
+      "id": "184924",
+      "name": [
+        {
+          "value": "Santhali, Nepal",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kermanshahi",
+      "bcp47": "sdh",
+      "iso3": "sdh",
+      "id": "111677",
+      "name": [
+        {
+          "value": "Kermanshahi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "amuzgo-guerrero",
+      "bcp47": "amu",
+      "iso3": "amu",
+      "id": "8351",
+      "name": [
+        {
+          "value": "Amuzgo, Guerrero",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zulu",
+      "bcp47": "zu",
+      "iso3": "zul",
+      "id": "7547",
+      "name": [
+        {
+          "value": "isiZulu",
+          "primary": true,
+          "language": {
+            "id": "7547"
+          }
+        },
+        {
+          "value": "Zulu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sadri-oraon",
+      "bcp47": null,
+      "iso3": "sdr",
+      "id": "23797",
+      "name": [
+        {
+          "value": "Sadri, Oraon",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "wayampi-oiapoque",
+      "bcp47": "oym-x-Oiapoque",
+      "iso3": "oym",
+      "id": "1796",
+      "name": [
+        {
+          "value": "Wayampi, Oiapoque",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sylhetti",
+      "bcp47": "syl",
+      "iso3": "syl",
+      "id": "1236",
+      "name": [
+        {
+          "value": "Sylhetti",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "cogui",
+      "bcp47": null,
+      "iso3": "kog",
+      "id": "23924",
+      "name": [
+        {
+          "value": "Cogui",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gojri",
+      "bcp47": null,
+      "iso3": "gju",
+      "id": "43229",
+      "name": [
+        {
+          "value": "Gojri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "banda-mid-southern",
+      "bcp47": null,
+      "iso3": "bjo",
+      "id": "3122",
+      "name": [
+        {
+          "value": "Banda, Mid-Southern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kulango-bouna",
+      "bcp47": null,
+      "iso3": "nku",
+      "id": "5224",
+      "name": [
+        {
+          "value": "Kulango, Bouna",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bilaspuri",
+      "bcp47": null,
+      "iso3": "kfs",
+      "id": "6363",
+      "name": [
+        {
+          "value": "Bilaspuri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kulango-bondoukou",
+      "bcp47": null,
+      "iso3": "kzc",
+      "id": "5257",
+      "name": [
+        {
+          "value": "Kulango, Bondoukou",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "parecis",
+      "bcp47": "pab",
+      "iso3": "pab",
+      "id": "1794",
+      "name": [
+        {
+          "value": "Parecis",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "borna-shinasha",
+      "bcp47": null,
+      "iso3": "bwo",
+      "id": "97524",
+      "name": [
+        {
+          "value": "Borna, Shinasha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bazigar",
+      "bcp47": "bfr",
+      "iso3": "bfr",
+      "id": "5612",
+      "name": [
+        {
+          "value": "Bazigar",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bai-southern",
+      "bcp47": "bfs",
+      "iso3": "bfs",
+      "id": "25916",
+      "name": [
+        {
+          "value": "Bai, Southern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "shui",
+      "bcp47": "swi",
+      "iso3": "swi",
+      "id": "22094",
+      "name": [
+        {
+          "value": "Shui",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sena-malawi",
+      "bcp47": "swk",
+      "iso3": "swk",
+      "id": "7788",
+      "name": [
+        {
+          "value": "Sena, Malawi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bamun",
+      "bcp47": "bax",
+      "iso3": "bax",
+      "id": "2912",
+      "name": [
+        {
+          "value": "Bamun",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gbe-saxwe",
+      "bcp47": "sxw",
+      "iso3": "sxw",
+      "id": "100227",
+      "name": [
+        {
+          "value": "Gbe, Saxwe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zande-south-sudan",
+      "bcp47": "zne-Sd",
+      "iso3": "zne",
+      "id": "23525",
+      "name": [
+        {
+          "value": "Zande, South Sudan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "siang",
+      "bcp47": null,
+      "iso3": "sya",
+      "id": "20248",
+      "name": [
+        {
+          "value": "Siang",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kinyamulenge",
+      "bcp47": null,
+      "iso3": "kin",
+      "id": "185227",
+      "name": [
+        {
+          "value": "Kinyamulenge",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kenyah-badeng",
+      "bcp47": null,
+      "iso3": "xkl",
+      "id": "185228",
+      "name": [
+        {
+          "value": "Kenyah, Badeng",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "syriac",
+      "bcp47": "syc",
+      "iso3": "syc",
+      "id": "53438",
+      "name": [
+        {
+          "value": "ܠܫܵܢܵܐ ܣܘܪܝܝܐ",
+          "primary": true,
+          "language": {
+            "id": "53438"
+          }
+        },
+        {
+          "value": "Syriac",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "arabic-taizzi-yemeni",
+      "bcp47": "ar-acq",
+      "iso3": "acq",
+      "id": "184627",
+      "name": [
+        {
+          "value": "Arabic, Ta'Izzi Yemeni",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jamaican-patwa",
+      "bcp47": "jam",
+      "iso3": "jam",
+      "id": "184701",
+      "name": [
+        {
+          "value": "Jamaican Patwa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "pashto-eastern-afghan",
+      "bcp47": null,
+      "iso3": "pbu",
+      "id": "184820",
+      "name": [
+        {
+          "value": "Pashto, Eastern Afghan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "maithili-nepal",
+      "bcp47": null,
+      "iso3": "mai",
+      "id": "184939",
+      "name": [
+        {
+          "value": "Maithili, Nepal",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sukur",
+      "bcp47": null,
+      "iso3": "syk",
+      "id": "10022",
+      "name": [
+        {
+          "value": "Sukur",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "zo",
+      "bcp47": null,
+      "iso3": "zom",
+      "id": "99703",
+      "name": [
+        {
+          "value": "Zo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tzeltal-oxchuc",
+      "bcp47": "tzh",
+      "iso3": "tzh",
+      "id": "23936",
+      "name": [
+        {
+          "value": "Tzeltal, Oxchuc",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "baka",
+      "bcp47": "bdh",
+      "iso3": "bdh",
+      "id": "97237",
+      "name": [
+        {
+          "value": "Baka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yaka-d-r-c",
+      "bcp47": null,
+      "iso3": "yaf",
+      "id": "139126",
+      "name": [
+        {
+          "value": "Yaka, D R C",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chatgaya-chittagonian-hindu",
+      "bcp47": null,
+      "iso3": "ctg",
+      "id": "139131",
+      "name": [
+        {
+          "value": "Chatgaya Chittagonian Hindu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "portuguese-mozambique",
+      "bcp47": "pt-MZ",
+      "iso3": "por",
+      "id": "139136",
+      "name": [
+        {
+          "value": "Português",
+          "primary": true,
+          "language": {
+            "id": "139136"
+          }
+        },
+        {
+          "value": "Portuguese, Mozambique",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bengali-indian",
+      "bcp47": "bn",
+      "iso3": "ben",
+      "id": "139081",
+      "name": [
+        {
+          "value": "বাংলা",
+          "primary": true,
+          "language": {
+            "id": "139081"
+          }
+        },
+        {
+          "value": "Bengali (Indian)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bedamuni",
+      "bcp47": "beo",
+      "iso3": "beo",
+      "id": "21577",
+      "name": [
+        {
+          "value": "Bedamuni",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "haryanvi",
+      "bcp47": "bgc",
+      "iso3": "bgc",
+      "id": "5709",
+      "name": [
+        {
+          "value": "Haryanvi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": null,
+      "bcp47": null,
+      "iso3": "vvl",
+      "id": "185345",
+      "name": []
+    },
+    {
+      "slug": "bauria",
+      "bcp47": "bge",
+      "iso3": "bge",
+      "id": "5703",
+      "name": [
+        {
+          "value": "Bauria",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yakpa",
+      "bcp47": null,
+      "iso3": "bjo",
+      "id": "109459",
+      "name": [
+        {
+          "value": "Yakpa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lumun",
+      "bcp47": "lmd",
+      "iso3": "lmd",
+      "id": "141728",
+      "name": [
+        {
+          "value": "Lumun",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hano",
+      "bcp47": null,
+      "iso3": "lml",
+      "id": "141734",
+      "name": [
+        {
+          "value": "Hano",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "lhasa-tibetan",
+      "bcp47": "bo",
+      "iso3": "bod",
+      "id": "21795",
+      "name": [
+        {
+          "value": "Lhasa, Tibetan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "buurak",
+      "bcp47": "bys",
+      "iso3": "bys",
+      "id": "49141",
+      "name": [
+        {
+          "value": "Buurak",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "alangan",
+      "bcp47": null,
+      "iso3": "alj",
+      "id": "139397",
+      "name": [
+        {
+          "value": "Alangan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "andaandi",
+      "bcp47": null,
+      "iso3": "dgl",
+      "id": "140196",
+      "name": [
+        {
+          "value": "Andaandi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tawbuid-eastern",
+      "bcp47": null,
+      "iso3": "bnj",
+      "id": "139803",
+      "name": [
+        {
+          "value": "Tawbuid, Oriental",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hanunoo",
+      "bcp47": null,
+      "iso3": "hnn",
+      "id": "140994",
+      "name": [
+        {
+          "value": "Hanunoo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "awa-cuaiquer",
+      "bcp47": null,
+      "iso3": "kwi",
+      "id": "141518",
+      "name": [
+        {
+          "value": "Awa-Cuaiquer",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "miao-small-flowery",
+      "bcp47": null,
+      "iso3": "sfm",
+      "id": "142333",
+      "name": [
+        {
+          "value": "Miao, Small Flowery",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "iraqw",
+      "bcp47": "irk",
+      "iso3": "irk",
+      "id": "14187",
+      "name": [
+        {
+          "value": "Iraqw",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tai-lue",
+      "bcp47": "khb",
+      "iso3": "khb",
+      "id": "20789",
+      "name": [
+        {
+          "value": "ᦑᦺᦟᦹᧉ",
+          "primary": true,
+          "language": {
+            "id": "20789"
+          }
+        },
+        {
+          "value": "Tai Lue",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kaba",
+      "bcp47": "ksp",
+      "iso3": "ksp",
+      "id": "3191",
+      "name": [
+        {
+          "value": "Kaba",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kisi-southern",
+      "bcp47": "kss",
+      "iso3": "kss",
+      "id": "7587",
+      "name": [
+        {
+          "value": "Kisi, Southern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kroumen-plapo",
+      "bcp47": "ktj",
+      "iso3": "ktj",
+      "id": "99184",
+      "name": [
+        {
+          "value": "Kroumen, Plapo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "katu-eastern",
+      "bcp47": null,
+      "iso3": "ktv",
+      "id": "141637",
+      "name": [
+        {
+          "value": "Katu, Eastern",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "heiyi-zhuang-minz",
+      "bcp47": null,
+      "iso3": "zgm",
+      "id": "185329",
+      "name": [
+        {
+          "value": "Heiyi Zhuang Minz",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bangi",
+      "bcp47": null,
+      "iso3": "bni",
+      "id": "4360",
+      "name": [
+        {
+          "value": "Bangi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "urdu-indian",
+      "bcp47": null,
+      "iso3": "urd",
+      "id": "22563",
+      "name": [
+        {
+          "value": "Urdu (Indian)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "marakwet",
+      "bcp47": null,
+      "iso3": "enb",
+      "id": "24410",
+      "name": [
+        {
+          "value": "Marakwet",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "bikol-buhinon",
+      "bcp47": "ubl",
+      "iso3": "ubl",
+      "id": "100255",
+      "name": [
+        {
+          "value": "Bikol, Buhi'Non",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kroumen-tepo",
+      "bcp47": "ted",
+      "iso3": "ted",
+      "id": "100677",
+      "name": [
+        {
+          "value": "Kroumen, Tepo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "malay-papuan",
+      "bcp47": "ms-pmy",
+      "iso3": "pmy",
+      "id": "100882",
+      "name": [
+        {
+          "value": "Malay, Papuan",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kasem-ghana",
+      "bcp47": "xsm-GH",
+      "iso3": "xsm",
+      "id": "22910",
+      "name": [
+        {
+          "value": "Kasem, Ghana",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "yakha",
+      "bcp47": "ybh",
+      "iso3": "ybh",
+      "id": "100282",
+      "name": [
+        {
+          "value": "Yakha",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mbelime",
+      "bcp47": "mql",
+      "iso3": "mql",
+      "id": "100953",
+      "name": [
+        {
+          "value": "Mbelime",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nyala",
+      "bcp47": null,
+      "iso3": "nle",
+      "id": "100971",
+      "name": [
+        {
+          "value": "Nyala",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "popoloca-san-luis-temalacayuca",
+      "bcp47": "pps",
+      "iso3": "pps",
+      "id": "101096",
+      "name": [
+        {
+          "value": "Popoloca, San Luis Temalacayuca",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "naga-chokri",
+      "bcp47": "nri",
+      "iso3": "nri",
+      "id": "101310",
+      "name": [
+        {
+          "value": "Naga, Chokri",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "naga-sangtam",
+      "bcp47": "nsa",
+      "iso3": "nsa",
+      "id": "101316",
+      "name": [
+        {
+          "value": "Naga, Sangtam",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "moma",
+      "bcp47": null,
+      "iso3": "myl",
+      "id": "101665",
+      "name": [
+        {
+          "value": "Moma",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "melpa",
+      "bcp47": null,
+      "iso3": "med",
+      "id": "101718",
+      "name": [
+        {
+          "value": "Melpa",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "matal",
+      "bcp47": "mfh",
+      "iso3": "mfh",
+      "id": "101827",
+      "name": [
+        {
+          "value": "Matal",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mbe",
+      "bcp47": "mfo",
+      "iso3": "mfo",
+      "id": "101833",
+      "name": [
+        {
+          "value": "Mbe",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tasahlit",
+      "bcp47": "kab",
+      "iso3": "kab",
+      "id": "139137",
+      "name": [
+        {
+          "value": "Tasahlit",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "costa-rican-sign-language",
+      "bcp47": "csr",
+      "iso3": "csr",
+      "id": "4394",
+      "name": [
+        {
+          "value": "Costa Rican Sign Language",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "silte",
+      "bcp47": null,
+      "iso3": "stv",
+      "id": "143300",
+      "name": [
+        {
+          "value": "Silt'E",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "suena",
+      "bcp47": null,
+      "iso3": "sue",
+      "id": "143302",
+      "name": [
+        {
+          "value": "Suena",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "jaruara",
+      "bcp47": "jaa",
+      "iso3": "jaa",
+      "id": "1552",
+      "name": [
+        {
+          "value": "Jaruara",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "nzanyi",
+      "bcp47": "nja",
+      "iso3": "nja",
+      "id": "2363",
+      "name": [
+        {
+          "value": "Nzanyi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kumauni",
+      "bcp47": "kfy",
+      "iso3": "kfy",
+      "id": "6353",
+      "name": [
+        {
+          "value": "Kumauni",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "halia",
+      "bcp47": "hla",
+      "iso3": "hla",
+      "id": "12065",
+      "name": [
+        {
+          "value": "Halia",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "mixteco-diuxi-tilantongo",
+      "bcp47": "xtd",
+      "iso3": "xtd",
+      "id": "8294",
+      "name": [
+        {
+          "value": "Mixteco, Diuxi-Tilantongo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chinese-simplified",
+      "bcp47": "zh-hans",
+      "iso3": "cmn",
+      "id": "21754",
+      "name": [
+        {
+          "value": "中文",
+          "primary": true,
+          "language": {
+            "id": "21754"
+          }
+        },
+        {
+          "value": "Chinese, Simplified",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "rangpuria-bangla",
+      "bcp47": null,
+      "iso3": "rkt",
+      "id": "101632",
+      "name": [
+        {
+          "value": "Rangpuria Bangla",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "senoufo-nyarafolo",
+      "bcp47": null,
+      "iso3": "sev",
+      "id": "102234",
+      "name": [
+        {
+          "value": "Senoufo, Nyarafolo",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tarifit-arabic-based-script",
+      "bcp47": "rif",
+      "iso3": "rif",
+      "id": "184497",
+      "name": [
+        {
+          "value": "(تاريفيت )يُوْرَا س لحروف ن ثعْرابث۔",
+          "primary": true,
+          "language": {
+            "id": "184497"
+          }
+        },
+        {
+          "value": "Tarifit (Abs)",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "duya",
+      "bcp47": "ldb",
+      "iso3": "ldb",
+      "id": "141739",
+      "name": [
+        {
+          "value": "Duya",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kurumba-jennu",
+      "bcp47": "xuj",
+      "iso3": "xuj",
+      "id": "142214",
+      "name": [
+        {
+          "value": "Kurumba, Jennu",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "sheko",
+      "bcp47": null,
+      "iso3": "she",
+      "id": "142418",
+      "name": [
+        {
+          "value": "Sheko",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gata",
+      "bcp47": null,
+      "iso3": "gaq",
+      "id": "140566",
+      "name": [
+        {
+          "value": "Gata'",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gadaba-mudhili",
+      "bcp47": "gau",
+      "iso3": "gau",
+      "id": "140569",
+      "name": [
+        {
+          "value": "Gadaba, Mudhili",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "fataleka",
+      "bcp47": null,
+      "iso3": "far",
+      "id": "140614",
+      "name": [
+        {
+          "value": "Fataleka",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "totonac-papantla",
+      "bcp47": "top",
+      "iso3": "top",
+      "id": "142907",
+      "name": [
+        {
+          "value": "Totonac, Papantla",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "iten",
+      "bcp47": "etx",
+      "iso3": "etx",
+      "id": "184485",
+      "name": [
+        {
+          "value": "Iten",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "kilaangi",
+      "bcp47": "lag",
+      "iso3": "lag",
+      "id": "164996",
+      "name": [
+        {
+          "value": "Kilaangi",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "hlai-has",
+      "bcp47": "lic",
+      "iso3": "lic",
+      "id": "184504",
+      "name": [
+        {
+          "value": "Hlai, Has",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chamorro",
+      "bcp47": "ch",
+      "iso3": "cha",
+      "id": "5379",
+      "name": [
+        {
+          "value": "Chamoru",
+          "primary": true,
+          "language": {
+            "id": "5379"
+          }
+        },
+        {
+          "value": "Chamorro",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "chinanteco-quiotepec",
+      "bcp47": "chq",
+      "iso3": "chq",
+      "id": "8343",
+      "name": [
+        {
+          "value": "Chinanteco, Quiotepec",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quechua-north-bolivian",
+      "bcp47": "qul",
+      "iso3": "qul",
+      "id": "1428",
+      "name": [
+        {
+          "value": "Qhichwa",
+          "primary": true,
+          "language": {
+            "id": "1428"
+          }
+        },
+        {
+          "value": "Quechua, North Bolivian",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quiche-joyabaj",
+      "bcp47": "quc",
+      "iso3": "quc",
+      "id": "5398",
+      "name": [
+        {
+          "value": "Quiche, Joyabaj",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quiche-central",
+      "bcp47": "quc",
+      "iso3": "quc",
+      "id": "5399",
+      "name": [
+        {
+          "value": "Qhichwa",
+          "primary": true,
+          "language": {
+            "id": "5399"
+          }
+        },
+        {
+          "value": "Quiche, Central",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quechua-lambayeque",
+      "bcp47": null,
+      "iso3": "quf",
+      "id": "12421",
+      "name": [
+        {
+          "value": "Quechua, Lambayeque",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "quechua-huanuco-huallaga",
+      "bcp47": "qub",
+      "iso3": "qub",
+      "id": "12422",
+      "name": [
+        {
+          "value": "Quechua, Huanuco, Huallaga",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "gikyode",
+      "bcp47": "acd",
+      "iso3": "acd",
+      "id": "5166",
+      "name": [
+        {
+          "value": "Gikyode",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "tharu-dangaura",
+      "bcp47": "thl",
+      "iso3": "thl",
+      "id": "23714",
+      "name": [
+        {
+          "value": "Tharu, Dangaura",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "letuama-tanimuca",
+      "bcp47": "tnc",
+      "iso3": "tnc",
+      "id": "41117",
+      "name": [
+        {
+          "value": "Letuama-Tanimuca",
+          "primary": false,
+          "language": {
+            "id": "529"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/apps/watch/src/libs/localeMapping/localeMapping.ts
+++ b/apps/watch/src/libs/localeMapping/localeMapping.ts
@@ -24,7 +24,7 @@ export const LANGUAGE_MAPPINGS: Record<string, LocaleMapping> = {
     locale: 'en',
     localName: 'English',
     nativeName: 'English',
-    languageSlugs: ['english.html'],
+    languageSlugs: ['english'],
     geoLocations: [
       'US', // United States
       'GB', // United Kingdom
@@ -41,7 +41,7 @@ export const LANGUAGE_MAPPINGS: Record<string, LocaleMapping> = {
     locale: 'es',
     localName: 'Español',
     nativeName: 'Spanish',
-    languageSlugs: ['spanish-latin-american.html', 'spanish-castilian.html'],
+    languageSlugs: ['spanish-latin-american', 'spanish-castilian'],
     geoLocations: [
       'ES', // Spain
       'MX', // Mexico
@@ -71,7 +71,7 @@ export const LANGUAGE_MAPPINGS: Record<string, LocaleMapping> = {
     locale: 'fr',
     localName: 'Français',
     nativeName: 'French',
-    languageSlugs: ['french.html', 'french-african.html'],
+    languageSlugs: ['french', 'french-african'],
     geoLocations: [
       'FR', // France
       'BE', // Belgium
@@ -98,7 +98,7 @@ export const LANGUAGE_MAPPINGS: Record<string, LocaleMapping> = {
     locale: 'id',
     localName: 'Bahasa Indonesia',
     nativeName: 'Indonesian',
-    languageSlugs: ['indonesian-yesus.html', 'indonesian-isa.html'],
+    languageSlugs: ['indonesian-yesus', 'indonesian-isa'],
     geoLocations: [
       'ID', // Indonesia
       'TL' // Timor-Leste (East Timor)
@@ -109,7 +109,7 @@ export const LANGUAGE_MAPPINGS: Record<string, LocaleMapping> = {
     locale: 'th',
     localName: 'ไทย',
     nativeName: 'Thai',
-    languageSlugs: ['thai.html', 'thai-southern.html', 'thai-northern.html'],
+    languageSlugs: ['thai', 'thai-southern', 'thai-northern'],
     geoLocations: [
       'TH' // Thailand
     ],
@@ -119,7 +119,7 @@ export const LANGUAGE_MAPPINGS: Record<string, LocaleMapping> = {
     locale: 'ja',
     localName: '日本語',
     nativeName: 'Japanese',
-    languageSlugs: ['japanese.html', 'japanese-sign-language.html'],
+    languageSlugs: ['japanese', 'japanese-sign-language'],
     geoLocations: [
       'JP' // Japan
     ],
@@ -130,9 +130,9 @@ export const LANGUAGE_MAPPINGS: Record<string, LocaleMapping> = {
     localName: '한국어',
     nativeName: 'Korean',
     languageSlugs: [
-      'korean.html',
-      'korean-sign-language.html',
-      'korean-north.html'
+      'korean',
+      'korean-sign-language',
+      'korean-north'
     ],
     geoLocations: [
       'KR', // South Korea
@@ -145,9 +145,9 @@ export const LANGUAGE_MAPPINGS: Record<string, LocaleMapping> = {
     localName: 'Русский',
     nativeName: 'Russian',
     languageSlugs: [
-      'russian.html',
-      'central-asian-russian.html',
-      'russian-sign-language.html'
+      'russian',
+      'central-asian-russian',
+      'russian-sign-language'
     ],
     geoLocations: [
       'RU', // Russia
@@ -166,7 +166,7 @@ export const LANGUAGE_MAPPINGS: Record<string, LocaleMapping> = {
     locale: 'tr',
     localName: 'Türkçe',
     nativeName: 'Turkish',
-    languageSlugs: ['turkish.html'],
+    languageSlugs: ['turkish'],
     geoLocations: [
       'TR', // Turkey
       'CY' // Cyprus
@@ -178,9 +178,9 @@ export const LANGUAGE_MAPPINGS: Record<string, LocaleMapping> = {
     localName: '繁體中文',
     nativeName: 'Traditional Chinese',
     languageSlugs: [
-      'chinese-mandarin.html',
-      'chinese-traditional.html',
-      'chinese-hokkien-amoy.html'
+      'chinese-mandarin',
+      'chinese-traditional',
+      'chinese-hokkien-amoy'
     ],
     geoLocations: [
       'TW', // Taiwan
@@ -193,7 +193,7 @@ export const LANGUAGE_MAPPINGS: Record<string, LocaleMapping> = {
     locale: 'zh-Hans-CN',
     localName: '中文',
     nativeName: 'Simplified Chinese',
-    languageSlugs: ['chinese-simplified.html'],
+    languageSlugs: ['chinese-simplified'],
     geoLocations: [
       'CN', // China
       'SG', // Singapore

--- a/apps/watch/src/libs/localeMapping/localeMapping.ts
+++ b/apps/watch/src/libs/localeMapping/localeMapping.ts
@@ -129,11 +129,7 @@ export const LANGUAGE_MAPPINGS: Record<string, LocaleMapping> = {
     locale: 'ko',
     localName: '한국어',
     nativeName: 'Korean',
-    languageSlugs: [
-      'korean',
-      'korean-sign-language',
-      'korean-north'
-    ],
+    languageSlugs: ['korean', 'korean-sign-language', 'korean-north'],
     geoLocations: [
       'KR', // South Korea
       'KP' // North Korea

--- a/apps/watch/src/libs/watchContext/useLanguageActions/useLanguageActions.spec.tsx
+++ b/apps/watch/src/libs/watchContext/useLanguageActions/useLanguageActions.spec.tsx
@@ -90,10 +90,9 @@ describe('useLanguageActions', () => {
         result.current.actions.updateSiteLanguage('es')
       })
 
-      expect(mockSetCookie).toHaveBeenCalledWith('NEXT_LOCALE', 'es')
       expect(mockSetCookie).toHaveBeenCalledWith('AUDIO_LANGUAGE', '530')
       expect(mockSetCookie).toHaveBeenCalledWith('SUBTITLE_LANGUAGE', '530')
-      expect(mockSetCookie).toHaveBeenCalledTimes(3)
+      expect(mockSetCookie).toHaveBeenCalledTimes(2)
     })
 
     it('should fallback to current language IDs when selected language not found', async () => {
@@ -126,7 +125,6 @@ describe('useLanguageActions', () => {
         result.current.actions.updateSiteLanguage('de')
       })
 
-      expect(mockSetCookie).toHaveBeenCalledWith('NEXT_LOCALE', 'de')
       expect(mockSetCookie).toHaveBeenCalledWith('AUDIO_LANGUAGE', '529') // fallback to current
       expect(mockSetCookie).toHaveBeenCalledWith('SUBTITLE_LANGUAGE', '529') // fallback to current
     })
@@ -207,7 +205,6 @@ describe('useLanguageActions', () => {
         result.current.actions.updateSiteLanguage('es')
       })
 
-      expect(mockSetCookie).toHaveBeenCalledWith('NEXT_LOCALE', 'es')
       expect(mockSetCookie).toHaveBeenCalledWith('AUDIO_LANGUAGE', '529')
       expect(mockSetCookie).toHaveBeenCalledWith('SUBTITLE_LANGUAGE', '529')
     })

--- a/apps/watch/src/libs/watchContext/useLanguageActions/useLanguageActions.spec.tsx
+++ b/apps/watch/src/libs/watchContext/useLanguageActions/useLanguageActions.spec.tsx
@@ -16,7 +16,7 @@ const mockSetCookie = setCookie as jest.MockedFunction<typeof setCookie>
 
 describe('useLanguageActions', () => {
   const mockReload = jest.fn()
-  const mockRouter = { 
+  const mockRouter = {
     reload: mockReload,
     asPath: '/watch/english.html',
     push: jest.fn()

--- a/apps/watch/src/libs/watchContext/useLanguageActions/useLanguageActions.spec.tsx
+++ b/apps/watch/src/libs/watchContext/useLanguageActions/useLanguageActions.spec.tsx
@@ -16,7 +16,11 @@ const mockSetCookie = setCookie as jest.MockedFunction<typeof setCookie>
 
 describe('useLanguageActions', () => {
   const mockReload = jest.fn()
-  const mockRouter = { reload: mockReload } as unknown as NextRouter
+  const mockRouter = { 
+    reload: mockReload,
+    asPath: '/watch/english.html',
+    push: jest.fn()
+  } as unknown as NextRouter
 
   const defaultInitialState: WatchInitialState = {
     siteLanguage: 'en',

--- a/apps/watch/src/libs/watchContext/useLanguageActions/useLanguageActions.ts
+++ b/apps/watch/src/libs/watchContext/useLanguageActions/useLanguageActions.ts
@@ -38,8 +38,7 @@ export function useLanguageActions() {
       const newAudioLanguage = selectedLangObj?.id ?? state.audioLanguage
       const newSubtitleLanguage = selectedLangObj?.id ?? state.subtitleLanguage
 
-      // Set all affected cookies
-      setCookie('NEXT_LOCALE', language)
+      // Set affected cookies (exclude site language cookie; language defined by URL)
       setCookie('AUDIO_LANGUAGE', newAudioLanguage)
       setCookie('SUBTITLE_LANGUAGE', newSubtitleLanguage)
 

--- a/apps/watch/src/libs/watchContext/useLanguageActions/useLanguageActions.ts
+++ b/apps/watch/src/libs/watchContext/useLanguageActions/useLanguageActions.ts
@@ -48,17 +48,17 @@ export function useLanguageActions() {
       // Change the URL to include the language slug while preserving current page context
       if (state.router && languageSlug && state.router.asPath) {
         const currentPath = state.router.asPath
-        
+
         // Check if we're on a main page or inner page
         if (currentPath.includes('/watch/') && currentPath.includes('.html/')) {
           // Inner page: preserve the page structure but update language
           // Example: /watch/jesus-calms-the-storm.html/english.html -> /watch/jesus-calms-the-storm.html/spanish.html
           const pathParts = currentPath.split('/')
-          
+
           // Replace the language part with the new language slug
           const newLastPart = `${languageSlug}.html`
           pathParts[pathParts.length - 1] = newLastPart
-          
+
           const newUrl = pathParts.join('/')
           void state.router.push(newUrl)
         } else {

--- a/apps/watch/src/libs/watchContext/useLanguageActions/useLanguageActions.ts
+++ b/apps/watch/src/libs/watchContext/useLanguageActions/useLanguageActions.ts
@@ -42,8 +42,32 @@ export function useLanguageActions() {
       setCookie('AUDIO_LANGUAGE', newAudioLanguage)
       setCookie('SUBTITLE_LANGUAGE', newSubtitleLanguage)
 
-      // Trigger page reload
-      if (state.router) {
+      // Find the language slug for the selected language
+      const languageSlug = selectedLangObj?.slug
+
+      // Change the URL to include the language slug while preserving current page context
+      if (state.router && languageSlug && state.router.asPath) {
+        const currentPath = state.router.asPath
+        
+        // Check if we're on a main page or inner page
+        if (currentPath.includes('/watch/') && currentPath.includes('.html/')) {
+          // Inner page: preserve the page structure but update language
+          // Example: /watch/jesus-calms-the-storm.html/english.html -> /watch/jesus-calms-the-storm.html/spanish.html
+          const pathParts = currentPath.split('/')
+          
+          // Replace the language part with the new language slug
+          const newLastPart = `${languageSlug}.html`
+          pathParts[pathParts.length - 1] = newLastPart
+          
+          const newUrl = pathParts.join('/')
+          void state.router.push(newUrl)
+        } else {
+          // Main page: go to language-specific main page
+          const newUrl = `/watch/${languageSlug}`
+          void state.router.push(newUrl)
+        }
+      } else {
+        // Fallback to reload if no slug found
         setTimeout(() => state.router?.reload(), 0)
       }
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Locale is now determined solely from the URL path; logo and Videos tab link adapt to path-based locale slugs.
  - Navigation preserves query parameters and injects language filters when appropriate.
- Bug Fixes
  - Ignores browser language, cookies, and geolocation for locale selection to prevent unintended switches.
- Refactor
  - Removed the site-language cookie; audio and subtitle preference cookies still persist.
- Chore
  - Disabled automatic locale detection in i18n config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->