### PR TITLE
chore: disable e2e on stage push

### DIFF
--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -198,7 +198,7 @@ jobs:
   build-e2e-matrix:
     name: Build E2E Matrix
     needs: [affected, deploy-preview]
-    if: ${{ github.event_name != 'merge_group' && needs.deploy-preview.result == 'success' }}
+    if: ${{ github.event_name != 'merge_group' && needs.deploy-preview.result == 'success' && !(github.event_name == 'push' && github.ref == 'refs/heads/stage') }}
     permissions:
       actions: read
       contents: read
@@ -247,7 +247,7 @@ jobs:
     name: Playwright E2E (${{ matrix.app }})
     needs: [build-e2e-matrix]
     # Only run if ALL deploy-preview matrix entries succeeded and we have URLs
-    if: ${{ github.event_name != 'merge_group' && needs.build-e2e-matrix.result == 'success' && needs.build-e2e-matrix.outputs.apps != '[]' && needs.build-e2e-matrix.outputs.apps != '' }}
+    if: ${{ github.event_name != 'merge_group' && needs.build-e2e-matrix.result == 'success' && needs.build-e2e-matrix.outputs.apps != '[]' && needs.build-e2e-matrix.outputs.apps != '' && !(github.event_name == 'push' && github.ref == 'refs/heads/stage') }}
     permissions:
       contents: read
     runs-on: blacksmith-4vcpu-ubuntu-2204


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized deployment workflow to skip end-to-end test runs for stage branch pushes, improving CI efficiency and shortening pipeline durations.
  * No changes to application behavior or user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->