### PR TITLE
chore: update E2E workflow conditions to exclude draft pull requests

### DIFF
--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -198,7 +198,7 @@ jobs:
   build-e2e-matrix:
     name: Build E2E Matrix
     needs: [affected, deploy-preview]
-    if: ${{ github.event_name != 'merge_group' && needs.deploy-preview.result == 'success' && !(github.event_name == 'push' && github.ref == 'refs/heads/stage') }}
+    if: ${{ github.event_name != 'merge_group' && needs.deploy-preview.result == 'success' && !(github.event_name == 'push' && github.ref == 'refs/heads/stage') && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     permissions:
       actions: read
       contents: read
@@ -247,7 +247,7 @@ jobs:
     name: Playwright E2E (${{ matrix.app }})
     needs: [build-e2e-matrix]
     # Only run if ALL deploy-preview matrix entries succeeded and we have URLs
-    if: ${{ github.event_name != 'merge_group' && needs.build-e2e-matrix.result == 'success' && needs.build-e2e-matrix.outputs.apps != '[]' && needs.build-e2e-matrix.outputs.apps != '' && !(github.event_name == 'push' && github.ref == 'refs/heads/stage') }}
+    if: ${{ github.event_name != 'merge_group' && needs.build-e2e-matrix.result == 'success' && needs.build-e2e-matrix.outputs.apps != '[]' && needs.build-e2e-matrix.outputs.apps != '' && !(github.event_name == 'push' && github.ref == 'refs/heads/stage') && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     permissions:
       contents: read
     runs-on: blacksmith-4vcpu-ubuntu-2204


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Optimized CI by skipping E2E matrix and Playwright E2E runs on draft pull requests to avoid unnecessary executions.
  - Existing safeguards remain (no runs on stage pushes or merge groups); behavior unchanged for non-draft PRs and other events.
  - Outcome: faster CI cycles for drafts, reduced resource usage, and clearer signals when changes are ready for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->