### PR TITLE
chore: use variants instead of variant on arclight queries

### DIFF
--- a/apis/api-media/schema.graphql
+++ b/apis/api-media/schema.graphql
@@ -841,7 +841,7 @@ type Video
   """The number of published child videos associated with this video"""
   childrenCount: Int!
   variantLanguagesWithSlug(input: VideoVariantFilter): [LanguageWithSlug!]!
-  variants(input: VideoVariantFilter): [VideoVariant!]!
+  variants(input: VideoVariantFilter, languageId: ID): [VideoVariant!]!
   subtitles(languageId: ID, primary: Boolean, edition: String): [VideoSubtitle!]!
   variant(languageId: ID, input: VideoVariantFilter): VideoVariant
   images(aspectRatio: ImageAspectRatio): [CloudflareImage!]!

--- a/apis/api-media/src/schema/video/video.spec.ts
+++ b/apis/api-media/src/schema/video/video.spec.ts
@@ -1005,6 +1005,89 @@ describe('video', () => {
       })
       expect(data).toHaveProperty('data.videos', result)
     })
+
+    it('should query variants with languageId parameter', async () => {
+      const VARIANTS_WITH_LANGUAGE_ID_QUERY = graphql(`
+        query VideosWithVariantsLanguageId($languageId: ID) {
+          videos {
+            id
+            variants(languageId: $languageId) {
+              id
+              language {
+                id
+              }
+            }
+          }
+        }
+      `)
+
+      const filteredVariants = [
+        {
+          id: 'variantId2',
+          hls: 'hlsUrl',
+          languageId: 'languageId2',
+          slug: 'slug2',
+          videoId: 'videoId',
+          edition: 'edition',
+          dash: null,
+          downloadable: true,
+          duration: null,
+          lengthInMilliseconds: null,
+          share: null,
+          published: true,
+          muxVideoId: 'muxVideoId',
+          masterUrl: 'masterUrl',
+          masterWidth: 320,
+          masterHeight: 180,
+          assetId: null,
+          brightcoveId: null,
+          version: 1
+        }
+      ]
+
+      const videoWithFilteredVariants = {
+        ...videos[0]
+      }
+      videoWithFilteredVariants.variants = filteredVariants
+      prismaMock.video.findMany.mockResolvedValueOnce([
+        videoWithFilteredVariants
+      ])
+
+      const data = await client({
+        document: VARIANTS_WITH_LANGUAGE_ID_QUERY,
+        variables: {
+          languageId: 'languageId2'
+        }
+      })
+
+      expect(prismaMock.video.findMany).toHaveBeenCalledWith({
+        skip: 0,
+        take: 100,
+        where: { published: true },
+        include: expect.objectContaining({
+          variants: {
+            where: {
+              published: true,
+              languageId: 'languageId2'
+            }
+          }
+        })
+      })
+
+      expect(data).toHaveProperty('data.videos', [
+        {
+          id: 'videoId',
+          variants: [
+            {
+              id: 'variantId2',
+              language: {
+                id: 'languageId2'
+              }
+            }
+          ]
+        }
+      ])
+    })
   })
 
   describe('video', () => {

--- a/apis/api-media/src/schema/video/video.ts
+++ b/apis/api-media/src/schema/video/video.ts
@@ -266,12 +266,14 @@ const Video = builder.prismaObject('Video', {
       type: [VideoVariant],
       nullable: false,
       args: {
-        input: t.arg({ type: VideoVariantFilter, required: false })
+        input: t.arg({ type: VideoVariantFilter, required: false }),
+        languageId: t.arg.id({ required: false })
       },
-      select: ({ input }) => ({
+      select: ({ input, languageId }) => ({
         variants: {
           where: {
-            published: input?.onlyPublished === false ? undefined : true
+            published: input?.onlyPublished === false ? undefined : true,
+            languageId: languageId ?? undefined
           }
         }
       }),

--- a/apps/arclight/src/app/v2/[...route]/_media-component-links/[mediaComponentId]/index.ts
+++ b/apps/arclight/src/app/v2/[...route]/_media-component-links/[mediaComponentId]/index.ts
@@ -55,7 +55,7 @@ const GET_VIDEO_CHILDREN = graphql(`
         }
         childrenCount
         availableLanguages
-        variants {
+        variants(languageId: "529") {
           hls
           lengthInMilliseconds
           language {
@@ -115,7 +115,7 @@ const GET_VIDEO_CHILDREN = graphql(`
         }
         childrenCount
         availableLanguages
-        variants {
+        variants(languageId: "529") {
           hls
           lengthInMilliseconds
           language {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Media items now derive display data from a primary variant: accurate duration, streaming/subtitle/share URLs, download availability and explicit small/large download sizes.
  * Variant-level language IDs added for more accurate language-specific results and optional language filtering.
  * Content typing, titles, descriptions, and study questions consistently surfaced.

* **Tests**
  * Added a test validating variant filtering by language ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->