### PR TITLE
feat: add notification and role icons always

### DIFF
--- a/apps/journeys-admin/src/components/AccessDialog/AccessDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/AccessDialog/AccessDialog.spec.tsx
@@ -278,6 +278,320 @@ describe('AccessDialog', () => {
     expect(getAllByText('Jotaro Kujo')).toHaveLength(1)
   })
 
+  it('should display header with icons when no team members exist', async () => {
+    const mocksNoTeamMembers = [
+      {
+        request: {
+          query: GET_JOURNEY_WITH_PERMISSIONS,
+          variables: {
+            id: 'journeyId'
+          }
+        },
+        result: {
+          data: {
+            journey: {
+              id: 'journeyId',
+              team: {
+                __typename: 'Team',
+                id: 'teamId',
+                userTeams: [] // Empty array - no team members
+              },
+              userJourneys: [
+                {
+                  __typename: 'UserJourney',
+                  id: 'userJourneyId1',
+                  role: 'owner',
+                  user: {
+                    ...user1,
+                    firstName: 'Amin',
+                    lastName: 'One',
+                    imageUrl: 'https://bit.ly/3Gth4Yf'
+                  },
+                  journeyNotification: {
+                    id: 'journeyNotificationId',
+                    visitorInteractionEmail: true
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        request: {
+          query: GET_USER_INVITES,
+          variables: {
+            journeyId: 'journeyId'
+          }
+        },
+        result: {
+          data: {
+            userInvites: []
+          }
+        }
+      }
+    ]
+
+    const handleClose = jest.fn()
+    const { getByText, queryByText } = render(
+      <SnackbarProvider>
+        <MockedProvider addTypename mocks={mocksNoTeamMembers}>
+          <AccessDialog journeyId="journeyId" open onClose={handleClose} />
+        </MockedProvider>
+      </SnackbarProvider>
+    )
+
+    await waitFor(() => {
+      // Header should always be visible
+      expect(getByText('Team Members')).toBeInTheDocument()
+    })
+
+    // UserTeamList should NOT be rendered when no team members exist
+    // We can verify this by checking that no team member names appear
+    expect(queryByText('Jotaro Kujo')).not.toBeInTheDocument()
+    expect(queryByText('Koichi Hirose')).not.toBeInTheDocument()
+    expect(queryByText('Josuke Higashikata')).not.toBeInTheDocument()
+  })
+  
+  it('should display header for journey owners with no team members', async () => {
+    // Create mock for journey owner scenario with empty team
+    const mocksJourneyOwner = [
+      {
+        request: {
+          query: GET_JOURNEY_WITH_PERMISSIONS,
+          variables: {
+            id: 'journeyId'
+          }
+        },
+        result: {
+          data: {
+            journey: {
+              id: 'journeyId',
+              team: {
+                __typename: 'Team',
+                id: 'teamId',
+                userTeams: [] // Empty team members array
+              },
+              userJourneys: [
+                {
+                  __typename: 'UserJourney',
+                  id: 'userJourneyId1',
+                  role: 'owner', // Current user is journey owner
+                  user: {
+                    ...user1, // Using the same user that's mocked as current user
+                    firstName: 'Owner',
+                    lastName: 'User',
+                    imageUrl: 'https://bit.ly/3Gth4Yf'
+                  },
+                  journeyNotification: {
+                    id: 'journeyNotificationId',
+                    visitorInteractionEmail: true
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        request: {
+          query: GET_USER_INVITES,
+          variables: {
+            journeyId: 'journeyId'
+          }
+        },
+        result: {
+          data: {
+            userInvites: []
+          }
+        }
+      }
+    ]
+
+    const handleClose = jest.fn()
+    const { getByText, queryByText } = render(
+      <SnackbarProvider>
+        <MockedProvider addTypename mocks={mocksJourneyOwner}>
+          <AccessDialog journeyId="journeyId" open onClose={handleClose} />
+        </MockedProvider>
+      </SnackbarProvider>
+    )
+
+    await waitFor(() => {
+      // Header should be visible for journey owners
+      expect(getByText('Team Members')).toBeInTheDocument()
+    })
+
+    // Verify that the header icons are present by checking for their test IDs
+    expect(document.querySelector('[data-testid="EmailIcon"]')).toBeInTheDocument()
+    expect(document.querySelector('[data-testid="ShieldCheckIcon"]')).toBeInTheDocument()
+
+    // No team members should be displayed
+    expect(queryByText('Jotaro Kujo')).not.toBeInTheDocument()
+    expect(queryByText('Koichi Hirose')).not.toBeInTheDocument()
+    expect(queryByText('Josuke Higashikata')).not.toBeInTheDocument()
+  })
+  
+  it('should display header for guests with no team access', async () => {
+    // Create mock for guest user scenario with empty team
+    const mocksGuestUser = [
+      {
+        request: {
+          query: GET_JOURNEY_WITH_PERMISSIONS,
+          variables: {
+            id: 'journeyId'
+          }
+        },
+        result: {
+          data: {
+            journey: {
+              id: 'journeyId',
+              team: {
+                __typename: 'Team',
+                id: 'teamId',
+                userTeams: [] // Empty team members array
+              },
+              userJourneys: [
+                {
+                  __typename: 'UserJourney',
+                  id: 'userJourneyId1',
+                  role: 'editor', // Guest user with editor role
+                  user: {
+                    ...user1, // Using the same user that's mocked as current user
+                    firstName: 'Guest',
+                    lastName: 'User',
+                    imageUrl: 'https://bit.ly/3Gth4Yf'
+                  },
+                  journeyNotification: {
+                    id: 'journeyNotificationId',
+                    visitorInteractionEmail: true
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        request: {
+          query: GET_USER_INVITES,
+          variables: {
+            journeyId: 'journeyId'
+          }
+        },
+        result: {
+          data: {
+            userInvites: []
+          }
+        }
+      }
+    ]
+
+    const handleClose = jest.fn()
+    const { getByText, queryByText } = render(
+      <SnackbarProvider>
+        <MockedProvider addTypename mocks={mocksGuestUser}>
+          <AccessDialog journeyId="journeyId" open onClose={handleClose} />
+        </MockedProvider>
+      </SnackbarProvider>
+    )
+
+    await waitFor(() => {
+      // Header should be visible for guests
+      expect(getByText('Team Members')).toBeInTheDocument()
+    })
+
+    // Verify that the header icons are present by checking for their test IDs
+    expect(document.querySelector('[data-testid="EmailIcon"]')).toBeInTheDocument()
+    expect(document.querySelector('[data-testid="ShieldCheckIcon"]')).toBeInTheDocument()
+
+    // No team members should be displayed
+    expect(queryByText('Jotaro Kujo')).not.toBeInTheDocument()
+    expect(queryByText('Koichi Hirose')).not.toBeInTheDocument()
+    expect(queryByText('Josuke Higashikata')).not.toBeInTheDocument()
+  })
+  
+  it('should verify tooltip functionality works regardless of team member presence', async () => {
+    // Create mock with empty team members
+    const mocksEmptyTeam = [
+      {
+        request: {
+          query: GET_JOURNEY_WITH_PERMISSIONS,
+          variables: {
+            id: 'journeyId'
+          }
+        },
+        result: {
+          data: {
+            journey: {
+              id: 'journeyId',
+              team: {
+                __typename: 'Team',
+                id: 'teamId',
+                userTeams: [] // Empty team members array
+              },
+              userJourneys: [
+                {
+                  __typename: 'UserJourney',
+                  id: 'userJourneyId1',
+                  role: 'editor',
+                  user: {
+                    ...user1,
+                    firstName: 'Test',
+                    lastName: 'User',
+                    imageUrl: 'https://bit.ly/3Gth4Yf'
+                  },
+                  journeyNotification: {
+                    id: 'journeyNotificationId',
+                    visitorInteractionEmail: true
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        request: {
+          query: GET_USER_INVITES,
+          variables: {
+            journeyId: 'journeyId'
+          }
+        },
+        result: {
+          data: {
+            userInvites: []
+          }
+        }
+      }
+    ]
+
+    const handleClose = jest.fn()
+    const { getByText, getAllByRole } = render(
+      <SnackbarProvider>
+        <MockedProvider addTypename mocks={mocksEmptyTeam}>
+          <AccessDialog journeyId="journeyId" open onClose={handleClose} />
+        </MockedProvider>
+      </SnackbarProvider>
+    )
+
+    await waitFor(() => {
+      expect(getByText('Team Members')).toBeInTheDocument()
+    })
+
+    // Find the tooltip elements by their aria-label attributes
+    const emailIcon = document.querySelector('[data-testid="EmailIcon"]')
+    const shieldIcon = document.querySelector('[data-testid="ShieldCheckIcon"]')
+    
+    expect(emailIcon).toBeInTheDocument()
+    expect(shieldIcon).toBeInTheDocument()
+    
+    // Verify that tooltips are properly associated with their icons
+    // The tooltips are implemented using MUI Tooltip which adds aria-describedby attributes
+    expect(emailIcon?.closest('[aria-label="Email Notifications"]')).toBeInTheDocument()
+    expect(shieldIcon?.closest('[aria-label="User Role"]')).toBeInTheDocument()
+  })
+
   it('calls on close', () => {
     const handleClose = jest.fn()
     const { getByTestId } = render(

--- a/apps/journeys-admin/src/components/AccessDialog/AccessDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/AccessDialog/AccessDialog.spec.tsx
@@ -352,7 +352,7 @@ describe('AccessDialog', () => {
     expect(queryByText('Koichi Hirose')).not.toBeInTheDocument()
     expect(queryByText('Josuke Higashikata')).not.toBeInTheDocument()
   })
-  
+
   it('should display header for journey owners with no team members', async () => {
     // Create mock for journey owner scenario with empty team
     const mocksJourneyOwner = [
@@ -423,15 +423,19 @@ describe('AccessDialog', () => {
     })
 
     // Verify that the header icons are present by checking for their test IDs
-    expect(document.querySelector('[data-testid="EmailIcon"]')).toBeInTheDocument()
-    expect(document.querySelector('[data-testid="ShieldCheckIcon"]')).toBeInTheDocument()
+    expect(
+      document.querySelector('[data-testid="EmailIcon"]')
+    ).toBeInTheDocument()
+    expect(
+      document.querySelector('[data-testid="ShieldCheckIcon"]')
+    ).toBeInTheDocument()
 
     // No team members should be displayed
     expect(queryByText('Jotaro Kujo')).not.toBeInTheDocument()
     expect(queryByText('Koichi Hirose')).not.toBeInTheDocument()
     expect(queryByText('Josuke Higashikata')).not.toBeInTheDocument()
   })
-  
+
   it('should display header for guests with no team access', async () => {
     // Create mock for guest user scenario with empty team
     const mocksGuestUser = [
@@ -502,15 +506,19 @@ describe('AccessDialog', () => {
     })
 
     // Verify that the header icons are present by checking for their test IDs
-    expect(document.querySelector('[data-testid="EmailIcon"]')).toBeInTheDocument()
-    expect(document.querySelector('[data-testid="ShieldCheckIcon"]')).toBeInTheDocument()
+    expect(
+      document.querySelector('[data-testid="EmailIcon"]')
+    ).toBeInTheDocument()
+    expect(
+      document.querySelector('[data-testid="ShieldCheckIcon"]')
+    ).toBeInTheDocument()
 
     // No team members should be displayed
     expect(queryByText('Jotaro Kujo')).not.toBeInTheDocument()
     expect(queryByText('Koichi Hirose')).not.toBeInTheDocument()
     expect(queryByText('Josuke Higashikata')).not.toBeInTheDocument()
   })
-  
+
   it('should verify tooltip functionality works regardless of team member presence', async () => {
     // Create mock with empty team members
     const mocksEmptyTeam = [
@@ -582,13 +590,15 @@ describe('AccessDialog', () => {
     // Find the tooltip elements by their aria-label attributes
     const emailIcon = document.querySelector('[data-testid="EmailIcon"]')
     const shieldIcon = document.querySelector('[data-testid="ShieldCheckIcon"]')
-    
+
     expect(emailIcon).toBeInTheDocument()
     expect(shieldIcon).toBeInTheDocument()
-    
+
     // Verify that tooltips are properly associated with their icons
     // The tooltips are implemented using MUI Tooltip which adds aria-describedby attributes
-    expect(emailIcon?.closest('[aria-label="Email Notifications"]')).toBeInTheDocument()
+    expect(
+      emailIcon?.closest('[aria-label="Email Notifications"]')
+    ).toBeInTheDocument()
     expect(shieldIcon?.closest('[aria-label="User Role"]')).toBeInTheDocument()
   })
 

--- a/apps/journeys-admin/src/components/AccessDialog/AccessDialog.stories.tsx
+++ b/apps/journeys-admin/src/components/AccessDialog/AccessDialog.stories.tsx
@@ -203,4 +203,84 @@ export const Loading: StoryObj<typeof AccessDialog> = {
   render: () => <LoadingAccessDialog />
 }
 
+const NoTeamMembersAccessDialog = (): ReactNode => {
+  const [open, setOpen] = useState(true)
+  return (
+    <MockedProvider
+      mocks={[
+        {
+          request: {
+            query: GET_JOURNEY_WITH_PERMISSIONS,
+            variables: {
+              id: 'journeyId'
+            }
+          },
+          result: {
+            data: {
+              journey: {
+                id: 'journeyId',
+                team: {
+                  __typename: 'Team',
+                  id: 'teamId',
+                  userTeams: [] // Empty team members array
+                },
+                userJourneys: [
+                  {
+                    __typename: 'UserJourney',
+                    id: 'userJourneyId1',
+                    role: 'editor',
+                    user: {
+                      id: 'userId10',
+                      firstName: 'Guest',
+                      lastName: 'User',
+                      imageUrl: 'https://bit.ly/3Gth4Yf',
+                      email: 'guest@email.com'
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          request: {
+            query: GET_USER_INVITES,
+            variables: {
+              journeyId: 'journeyId'
+            }
+          },
+          result: {
+            data: {
+              userInvites: []
+            }
+          }
+        },
+        {
+          request: {
+            query: GET_CURRENT_USER
+          },
+          result: {
+            data: {
+              me: {
+                id: 'userId10',
+                email: 'guest@email.com'
+              }
+            }
+          }
+        }
+      ]}
+    >
+      <AccessDialog
+        journeyId="journeyId"
+        open={open}
+        onClose={() => setOpen(false)}
+      />
+    </MockedProvider>
+  )
+}
+
+export const NoTeamMembers: StoryObj<typeof AccessDialog> = {
+  render: () => <NoTeamMembersAccessDialog />
+}
+
 export default Demo

--- a/apps/journeys-admin/src/components/AccessDialog/AccessDialog.tsx
+++ b/apps/journeys-admin/src/components/AccessDialog/AccessDialog.tsx
@@ -159,47 +159,45 @@ export function AccessDialog({
       testId="AccessDialog"
     >
       <Stack spacing={4}>
+        <Grid container spacing={1} alignItems="center" sx={{ pb: 4 }}>
+          <Grid xs={2} sm={1}>
+            <Stack sx={{ ml: 2 }}>
+              <UsersProfiles2 sx={{ color: 'secondary.light' }} />
+            </Stack>
+          </Grid>
+          <Grid xs={5} sm={7}>
+            <Typography
+              variant="subtitle3"
+              color="secondary.light"
+              sx={{ opacity: 0.8, ml: 1 }}
+            >
+              {t('Team Members')}
+            </Typography>
+          </Grid>
+          <Grid xs={2} sm={2}>
+            <Stack sx={{ ml: 4 }}>
+              <Tooltip title={t('Email Notifications')}>
+                <EmailIcon sx={{ color: 'secondary.light' }} />
+              </Tooltip>
+            </Stack>
+          </Grid>
+          <Grid xs={3} sm={2}>
+            <Stack sx={{ ml: 7 }}>
+              <Tooltip title={t('User Role')}>
+                <ShieldCheck sx={{ color: 'secondary.light' }} />
+              </Tooltip>
+            </Stack>
+          </Grid>
+        </Grid>
         {data?.journey?.team?.userTeams != null &&
           data?.journey?.team?.userTeams.length > 0 && (
-            <>
-              <Grid container spacing={1} alignItems="center" sx={{ pb: 4 }}>
-                <Grid xs={2} sm={1}>
-                  <Stack sx={{ ml: 2 }}>
-                    <UsersProfiles2 sx={{ color: 'secondary.light' }} />
-                  </Stack>
-                </Grid>
-                <Grid xs={5} sm={7}>
-                  <Typography
-                    variant="subtitle3"
-                    color="secondary.light"
-                    sx={{ opacity: 0.8, ml: 1 }}
-                  >
-                    {t('Team Members')}
-                  </Typography>
-                </Grid>
-                <Grid xs={2} sm={2}>
-                  <Stack sx={{ ml: 4 }}>
-                    <Tooltip title={t('Email Notifications')}>
-                      <EmailIcon sx={{ color: 'secondary.light' }} />
-                    </Tooltip>
-                  </Stack>
-                </Grid>
-                <Grid xs={3} sm={2}>
-                  <Stack sx={{ ml: 7 }}>
-                    <Tooltip title={t('User Role')}>
-                      <ShieldCheck sx={{ color: 'secondary.light' }} />
-                    </Tooltip>
-                  </Stack>
-                </Grid>
-              </Grid>
-              <UserTeamList
-                data={data?.journey?.team ?? undefined}
-                currentUserTeam={currentUserTeam}
-                loading={loading}
-                variant="readonly"
-                journeyId={journeyId}
-              />
-            </>
+            <UserTeamList
+              data={data?.journey?.team ?? undefined}
+              currentUserTeam={currentUserTeam}
+              loading={loading}
+              variant="readonly"
+              journeyId={journeyId}
+            />
           )}
         <UserList
           title={t('Requested Access')}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Access dialog now always shows the header (Team Members, Email Notifications, User Role) even when there are no team members, with consistent icons and tooltips.
- Documentation
  - Added a Storybook scenario to preview the “no team members” state of the Access dialog.
- Tests
  - Expanded test coverage for “no team members” scenarios across roles, verifying header visibility, absence of member rows, icon presence, and tooltip behavior for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->