### PR TITLE
fix: broken watch lint

### DIFF
--- a/apps/watch/src/components/LanguageSwitchDialog/AudioTrackSelect/AudioTrackSelect.spec.tsx
+++ b/apps/watch/src/components/LanguageSwitchDialog/AudioTrackSelect/AudioTrackSelect.spec.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
   within
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 
@@ -14,7 +15,6 @@ import { GET_LANGUAGES_SLUG } from '../../../libs/useLanguagesSlugQuery'
 import { WatchProvider } from '../../../libs/watchContext'
 
 import { AudioTrackSelect } from './AudioTrackSelect'
-import userEvent from '@testing-library/user-event'
 
 // Mock only external libraries
 jest.mock('next/router', () => ({
@@ -1216,13 +1216,13 @@ describe('AudioTrackSelect', () => {
         expect(screen.getByText('Language')).toBeInTheDocument()
       })
 
-      userEvent.click(screen.getByRole('combobox'))
+      await userEvent.click(screen.getByRole('combobox'))
       await waitFor(() => {
         expect(
           screen.getByRole('option', { name: 'Spanish' })
         ).toBeInTheDocument()
       })
-      userEvent.click(screen.getByRole('option', { name: 'Spanish' }))
+      await userEvent.click(screen.getByRole('option', { name: 'Spanish' }))
 
       await waitFor(() => {
         expect(mockUpdateAudioLanguage).toHaveBeenCalledWith(
@@ -1334,13 +1334,13 @@ describe('AudioTrackSelect', () => {
         expect(screen.getByText('Language')).toBeInTheDocument()
       })
 
-      userEvent.click(screen.getByRole('combobox'))
+      await userEvent.click(screen.getByRole('combobox'))
       await waitFor(() => {
         expect(
           screen.getByRole('option', { name: 'French' })
         ).toBeInTheDocument()
       })
-      userEvent.click(screen.getByRole('option', { name: 'French' }))
+      await userEvent.click(screen.getByRole('option', { name: 'French' }))
 
       await waitFor(() => {
         expect(mockUpdateAudioLanguage).toHaveBeenCalledWith(
@@ -1425,13 +1425,13 @@ describe('AudioTrackSelect', () => {
         expect(screen.getByText('Language')).toBeInTheDocument()
       })
 
-      userEvent.click(screen.getByRole('combobox'))
+      await userEvent.click(screen.getByRole('combobox'))
       await waitFor(() => {
         expect(
           screen.getByRole('option', { name: 'Spanish' })
         ).toBeInTheDocument()
       })
-      userEvent.click(screen.getByRole('option', { name: 'Spanish' }))
+      await userEvent.click(screen.getByRole('option', { name: 'Spanish' }))
 
       await waitFor(() => {
         expect(mockUpdateAudioLanguage).toHaveBeenCalledWith(
@@ -1532,13 +1532,13 @@ describe('AudioTrackSelect', () => {
         expect(screen.getByText('Language')).toBeInTheDocument()
       })
 
-      userEvent.click(screen.getByRole('combobox'))
+      await userEvent.click(screen.getByRole('combobox'))
       await waitFor(() => {
         expect(
           screen.getByRole('option', { name: 'English' })
         ).toBeInTheDocument()
       })
-      userEvent.click(screen.getByRole('option', { name: 'English' }))
+      await userEvent.click(screen.getByRole('option', { name: 'English' }))
 
       await waitFor(() => {
         expect(mockUpdateAudioLanguage).toHaveBeenCalledWith(
@@ -1591,13 +1591,13 @@ describe('AudioTrackSelect', () => {
         expect(screen.getByText('Language')).toBeInTheDocument()
       })
 
-      userEvent.click(screen.getByRole('combobox'))
+      await userEvent.click(screen.getByRole('combobox'))
       await waitFor(() => {
         expect(
           screen.getByRole('option', { name: 'English' })
         ).toBeInTheDocument()
       })
-      userEvent.click(screen.getByRole('option', { name: 'English' }))
+      await userEvent.click(screen.getByRole('option', { name: 'English' }))
 
       await waitFor(() => {
         expect(mockUpdateAudioLanguage).toHaveBeenCalledWith(
@@ -1650,13 +1650,13 @@ describe('AudioTrackSelect', () => {
         expect(screen.getByText('Language')).toBeInTheDocument()
       })
 
-      userEvent.click(screen.getByRole('combobox'))
+      await userEvent.click(screen.getByRole('combobox'))
       await waitFor(() => {
         expect(
           screen.getByRole('option', { name: 'English' })
         ).toBeInTheDocument()
       })
-      userEvent.click(screen.getByRole('option', { name: 'English' }))
+      await userEvent.click(screen.getByRole('option', { name: 'English' }))
 
       await waitFor(() => {
         expect(mockUpdateAudioLanguage).toHaveBeenCalledWith(


### PR DESCRIPTION
linting watch is currently broken in main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved reliability of interaction tests for the audio track selection dialog by using asynchronous event handling.
  - Enhances test stability around opening the selector and choosing options, reducing flakiness.
  - No changes to user-facing behavior or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->