### PR TITLE
fix: subtitle selection and share dialog URL generation

### DIFF
--- a/apps/watch/src/components/ShareDialog/ShareDialog.spec.tsx
+++ b/apps/watch/src/components/ShareDialog/ShareDialog.spec.tsx
@@ -6,18 +6,10 @@ import { VideoProvider } from '../../libs/videoContext'
 import { videos } from '../Videos/__generated__/testData'
 
 import { ShareDialog } from './ShareDialog'
+import mockRouter from 'next-router-mock'
 
 const onClose = jest.fn()
 const originalEnv = process.env
-
-jest.mock('next/router', () => ({
-  __esModule: true,
-  useRouter() {
-    return {
-      query: { part1: 'the-story-of-jesus-for-children' }
-    }
-  }
-}))
 
 const video: VideoContentFields = {
   ...videos[0],
@@ -75,6 +67,9 @@ describe('ShareDialog', () => {
   })
 
   it('only shows share link on playlist video', () => {
+    mockRouter.push(
+      '/watch/the-story-of-jesus-for-children.html/english.html?r=0'
+    )
     const { getByRole, queryAllByRole } = render(
       <SnackbarProvider>
         <VideoProvider
@@ -90,8 +85,8 @@ describe('ShareDialog', () => {
       </SnackbarProvider>
     )
     const link = `${
-      process.env.NEXT_PUBLIC_WATCH_URL as string
-    }/the-story-of-jesus-for-children`
+      process.env.NEXT_PUBLIC_WATCH_URL
+    }/the-story-of-jesus-for-children.html/english.html`
     expect(getByRole('textbox')).toHaveValue(link)
     expect(getByRole('button', { name: 'Copy Link' })).toBeInTheDocument()
     expect(queryAllByRole('tab')).toHaveLength(0)
@@ -112,9 +107,12 @@ describe('ShareDialog', () => {
     })
 
     it('should share video to facebook', () => {
+      mockRouter.push(
+        '/watch/the-story-of-jesus-for-children.html/english.html?r=0'
+      )
       const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${
-        process.env.NEXT_PUBLIC_WATCH_URL as string
-      }/the-story-of-jesus-for-children`
+        process.env.NEXT_PUBLIC_WATCH_URL
+      }/the-story-of-jesus-for-children.html/english.html`
 
       const { getByRole } = render(
         <SnackbarProvider>
@@ -135,9 +133,12 @@ describe('ShareDialog', () => {
     })
 
     it('should share video to twitter', () => {
+      mockRouter.push(
+        '/watch/the-story-of-jesus-for-children.html/english.html?r=0'
+      )
       const facebookUrl = `https://twitter.com/intent/tweet?url=${
-        process.env.NEXT_PUBLIC_WATCH_URL as string
-      }/the-story-of-jesus-for-children`
+        process.env.NEXT_PUBLIC_WATCH_URL
+      }/the-story-of-jesus-for-children.html/english.html`
 
       const { getByRole } = render(
         <SnackbarProvider>
@@ -173,7 +174,10 @@ describe('ShareDialog', () => {
     })
 
     it('should share video to facebook', () => {
-      const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=https://watch-jesusfilm.vercel.app/the-story-of-jesus-for-children`
+      mockRouter.push(
+        '/watch/the-story-of-jesus-for-children.html/english.html?r=0'
+      )
+      const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=https://watch-jesusfilm.vercel.app/watch/the-story-of-jesus-for-children.html/english.html`
 
       const { getByRole } = render(
         <SnackbarProvider>
@@ -194,7 +198,10 @@ describe('ShareDialog', () => {
     })
 
     it('should share video to twitter', () => {
-      const facebookUrl = `https://twitter.com/intent/tweet?url=https://watch-jesusfilm.vercel.app/the-story-of-jesus-for-children`
+      mockRouter.push(
+        '/watch/the-story-of-jesus-for-children.html/english.html?r=0'
+      )
+      const facebookUrl = `https://twitter.com/intent/tweet?url=https://watch-jesusfilm.vercel.app/watch/the-story-of-jesus-for-children.html/english.html`
 
       const { getByRole } = render(
         <SnackbarProvider>
@@ -232,14 +239,12 @@ describe('ShareDialog', () => {
     })
 
     it('should copy share link', async () => {
-      jest.resetModules()
-      process.env = {
-        ...originalEnv,
-        NEXT_PUBLIC_WATCH_URL: undefined
-      }
-
-      const link =
-        'https://watch-jesusfilm.vercel.app/the-story-of-jesus-for-children'
+      mockRouter.push(
+        '/watch/the-story-of-jesus-for-children.html/english.html?r=0'
+      )
+      const link = `${
+        process.env.NEXT_PUBLIC_WATCH_URL
+      }/the-story-of-jesus-for-children.html/english.html`
       const { getByRole, getByText } = render(
         <SnackbarProvider>
           <VideoProvider value={{ content: video }}>

--- a/apps/watch/src/components/ShareDialog/ShareDialog.spec.tsx
+++ b/apps/watch/src/components/ShareDialog/ShareDialog.spec.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, waitFor } from '@testing-library/react'
+import mockRouter from 'next-router-mock'
 import { SnackbarProvider } from 'notistack'
 
 import { VideoContentFields } from '../../../__generated__/VideoContentFields'
@@ -6,7 +7,6 @@ import { VideoProvider } from '../../libs/videoContext'
 import { videos } from '../Videos/__generated__/testData'
 
 import { ShareDialog } from './ShareDialog'
-import mockRouter from 'next-router-mock'
 
 const onClose = jest.fn()
 const originalEnv = process.env

--- a/apps/watch/src/components/ShareDialog/ShareDialog.spec.tsx
+++ b/apps/watch/src/components/ShareDialog/ShareDialog.spec.tsx
@@ -66,8 +66,8 @@ describe('ShareDialog', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
-  it('only shows share link on playlist video', () => {
-    mockRouter.push(
+  it('only shows share link on playlist video', async () => {
+    await mockRouter.push(
       '/watch/the-story-of-jesus-for-children.html/english.html?r=0'
     )
     const { getByRole, queryAllByRole } = render(
@@ -106,8 +106,8 @@ describe('ShareDialog', () => {
       process.env = originalEnv
     })
 
-    it('should share video to facebook', () => {
-      mockRouter.push(
+    it('should share video to facebook', async () => {
+      await mockRouter.push(
         '/watch/the-story-of-jesus-for-children.html/english.html?r=0'
       )
       const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${
@@ -132,11 +132,11 @@ describe('ShareDialog', () => {
       )
     })
 
-    it('should share video to twitter', () => {
-      mockRouter.push(
+    it('should share video to twitter', async () => {
+      await mockRouter.push(
         '/watch/the-story-of-jesus-for-children.html/english.html?r=0'
       )
-      const facebookUrl = `https://twitter.com/intent/tweet?url=${
+      const twitterUrl = `https://twitter.com/intent/tweet?url=${
         process.env.NEXT_PUBLIC_WATCH_URL
       }/the-story-of-jesus-for-children.html/english.html`
 
@@ -150,7 +150,7 @@ describe('ShareDialog', () => {
 
       expect(getByRole('link', { name: 'Share to Twitter' })).toHaveAttribute(
         'href',
-        facebookUrl
+        twitterUrl
       )
       expect(getByRole('link', { name: 'Share to Twitter' })).toHaveAttribute(
         'target',
@@ -173,8 +173,8 @@ describe('ShareDialog', () => {
       process.env = originalEnv
     })
 
-    it('should share video to facebook', () => {
-      mockRouter.push(
+    it('should share video to facebook', async () => {
+      await mockRouter.push(
         '/watch/the-story-of-jesus-for-children.html/english.html?r=0'
       )
       const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=https://watch-jesusfilm.vercel.app/watch/the-story-of-jesus-for-children.html/english.html`
@@ -197,11 +197,11 @@ describe('ShareDialog', () => {
       )
     })
 
-    it('should share video to twitter', () => {
-      mockRouter.push(
+    it('should share video to twitter', async () => {
+      await mockRouter.push(
         '/watch/the-story-of-jesus-for-children.html/english.html?r=0'
       )
-      const facebookUrl = `https://twitter.com/intent/tweet?url=https://watch-jesusfilm.vercel.app/watch/the-story-of-jesus-for-children.html/english.html`
+      const twitterUrl = `https://twitter.com/intent/tweet?url=https://watch-jesusfilm.vercel.app/watch/the-story-of-jesus-for-children.html/english.html`
 
       const { getByRole } = render(
         <SnackbarProvider>
@@ -213,7 +213,7 @@ describe('ShareDialog', () => {
 
       expect(getByRole('link', { name: 'Share to Twitter' })).toHaveAttribute(
         'href',
-        facebookUrl
+        twitterUrl
       )
       expect(getByRole('link', { name: 'Share to Twitter' })).toHaveAttribute(
         'target',
@@ -239,7 +239,7 @@ describe('ShareDialog', () => {
     })
 
     it('should copy share link', async () => {
-      mockRouter.push(
+      await mockRouter.push(
         '/watch/the-story-of-jesus-for-children.html/english.html?r=0'
       )
       const link = `${

--- a/apps/watch/src/components/ShareDialog/ShareDialog.tsx
+++ b/apps/watch/src/components/ShareDialog/ShareDialog.tsx
@@ -47,13 +47,11 @@ export function ShareDialog({
         ? last(snippet)?.value
         : ''
 
-  const shareLink =
-    router?.query != null
-      ? `${
-          process.env.NEXT_PUBLIC_WATCH_URL ??
-          'https://watch-jesusfilm.vercel.app'
-        }/${Object.values(router?.query).join('/')}`.trim()
-      : ''
+  const sharePath = router?.asPath.split('?')[0].replace('/watch', '')
+  const shareLink = `${
+    process.env.NEXT_PUBLIC_WATCH_URL ??
+    'https://watch-jesusfilm.vercel.app/watch'
+  }${sharePath}`
 
   const handleShareLinkClick = async (): Promise<void> => {
     await navigator.clipboard.writeText(shareLink)

--- a/apps/watch/src/components/VideoContainerPage/VideoContainerPage.spec.tsx
+++ b/apps/watch/src/components/VideoContainerPage/VideoContainerPage.spec.tsx
@@ -10,15 +10,6 @@ import { videos } from '../Videos/__generated__/testData'
 
 import { VideoContainerPage } from '.'
 
-jest.mock('next/router', () => ({
-  __esModule: true,
-  useRouter: () => {
-    return {
-      query: {}
-    }
-  }
-}))
-
 jest.mock('react-instantsearch')
 jest.mock('@core/journeys/ui/algolia/useAlgoliaVideos')
 


### PR DESCRIPTION
## Bug Fixes

This PR contains two small bugfixes for the WAT (Watch) project:

### 1. Subtitle Selection Fix - Show Only Available Subtitles for Variant
- **Issue**: Subtitle selection was not correctly filtering to show only the subtitles available for the current video variant
- **Fix**: Updated the `GET_VIDEO_LANGUAGES` query to properly fetch subtitle languages through the `variant` field with `languageId` parameter, ensuring only subtitles available for that specific variant are displayed
- **Files**: 
  - `apps/watch/pages/watch/[part1]/[part2].tsx`
  - `apps/watch/pages/watch/[part1]/[part2]/[part3].tsx`

### 2. Share Dialog URL Generation Fix
- **Issue**: Share links were not generating the correct URL structure for video pages
- **Fix**: Updated share link generation to use `router.asPath` and properly construct the URL path
- **Files**:
  - `apps/watch/src/components/ShareDialog/ShareDialog.tsx`
  - `apps/watch/src/components/ShareDialog/ShareDialog.spec.tsx`

## Changes Made

### Subtitle Selection Changes:
- Added `$languageId: ID` parameter to `GET_VIDEO_LANGUAGES` query
- Changed subtitle language access from `subtitles { id: languageId }` to `variant(languageId: $languageId) { subtitleLanguages: subtitle { languageId } }`
- Updated query variables to include `languageId` parameter
- Fixed subtitle ID mapping to use `languageId` field
- This ensures subtitle selection only shows subtitles that are actually available for the current video variant

### Share Dialog Changes:
- Replaced manual query parameter joining with `router.asPath` usage
- Fixed URL path construction to properly handle the `/watch` prefix
- Updated test cases to reflect the new URL structure
- Removed unnecessary router mocking in favor of `next-router-mock`

These fixes ensure that:
1. Subtitle selection correctly shows only available subtitles for the current variant
2. Share links generate correct URLs for video content

## Related Linear Issue
- [WAT-154](https://linear.app/jesus-film-project/issue/WAT-154/fix-subtitle-selection-and-share-dialog-url-generation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subtitle options on watch pages now reflect locale-derived language selection via variant-aware queries.

* **Bug Fixes**
  * Share links now mirror the visible URL path (including language segment) for more accurate sharing and consistency across environments.

* **Tests**
  * Routing tests migrated to next-router-mock; expectations updated to the richer .html/english.html URL shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->