### PR TITLE
feat: update journeys-admin config and add react-transition-group dependency

### DIFF
--- a/apps/journeys-admin/next.config.js
+++ b/apps/journeys-admin/next.config.js
@@ -106,7 +106,6 @@ const nextConfig = {
     ]
   },
   experimental: {
-    fallbackNodePolyfills: false,
     reactCompiler: true
   }
 }

--- a/package.json
+++ b/package.json
@@ -209,6 +209,7 @@
     "react-loading-hook": "^1.1.2",
     "react-simple-timefield": "^3.3.1",
     "react-swipeable": "^7.0.1",
+    "react-transition-group": "^4.4.5",
     "react-use-downloader": "^1.2.10",
     "react-window": "1.8.10",
     "reactflow": "^11.11.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -530,6 +530,9 @@ importers:
       react-swipeable:
         specifier: ^7.0.1
         version: 7.0.2(react@19.0.0)
+      react-transition-group:
+        specifier: ^4.4.5
+        version: 4.4.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-use-downloader:
         specifier: ^1.2.10
         version: 1.2.10(react@19.0.0)


### PR DESCRIPTION
## Summary

This PR updates the Next.js configuration and adds a new dependency for React transitions.

## Changes

### Next.js Configuration Update
- Removed `fallbackNodePolyfills: false` from experimental config in `apps/journeys-admin/next.config.js`
- This simplifies the Next.js configuration by removing an experimental feature

### Dependency Addition
- Added `react-transition-group: ^4.4.5` to package.json
- This dependency provides transition components for React applications

## Files Modified
- `apps/journeys-admin/next.config.js`
- `package.json`
- `pnpm-lock.yaml` (auto-generated)

## React 19 Compatibility Analysis
✅ **Already Compatible**: After thorough analysis, all CSSTransition components in the codebase already have proper `nodeRef` implementation:
- `Content.tsx`: Uses `const nodeRef = useRef(null)` and `nodeRef={nodeRef}` ✅
- `Canvas.tsx`: Uses `const nodeRef = useRef(null)` and `nodeRef={nodeRef}` ✅
- Other Transition components are MUI components (not react-transition-group) ✅

## Linear Ticket
Closes [NES-763](https://linear.app/jesus-film-project/issue/NES-763/update-nextjs-config-and-add-react-transition-group-dependency)