### PR TITLE
feat: add tagalog mapping

### DIFF
--- a/apps/watch/src/libs/localeMapping/localeMapping.ts
+++ b/apps/watch/src/libs/localeMapping/localeMapping.ts
@@ -173,6 +173,14 @@ export const LANGUAGE_MAPPINGS: Record<string, LocaleMapping> = {
     ],
     languageId: '1942'
   },
+  tl: {
+    locale: 'tl',
+    nativeName: 'Wikang Tagalog',
+    englishName: 'Tagalog',
+    languageSlugs: ['tagalog.html'],
+    geoLocations: ['PH'],
+    languageId: '12551'
+  },
   zh: {
     locale: 'zh',
     nativeName: '繁體中文',
@@ -200,14 +208,6 @@ export const LANGUAGE_MAPPINGS: Record<string, LocaleMapping> = {
       'MY' // Malaysia
     ],
     languageId: '21754'
-  },
-  'tl': {
-    locale: 'tl',
-    localName: 'Tagalog',
-    nativeName: 'Filipino',
-    languageSlugs: ['tagalog.html'],
-    geoLocations: ['PH'],
-    languageId: '12551'
   }
 }
 

--- a/apps/watch/src/libs/localeMapping/localeMapping.ts
+++ b/apps/watch/src/libs/localeMapping/localeMapping.ts
@@ -200,6 +200,14 @@ export const LANGUAGE_MAPPINGS: Record<string, LocaleMapping> = {
       'MY' // Malaysia
     ],
     languageId: '21754'
+  },
+  'tl': {
+    locale: 'tl',
+    localName: 'Tagalog',
+    nativeName: 'Filipino',
+    languageSlugs: ['tagalog.html'],
+    geoLocations: ['PH'],
+    languageId: '12551'
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Tagalog (Filipino) language support — users can select Tagalog from the language menu and view the app in Tagalog.
  * Improved localization coverage for users in the Philippines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->