### PR TITLE
fix: first card on journey displaying 'default' style

### DIFF
--- a/apps/journeys-admin/src/libs/useJourneyCreateMutation/useJourneyCreateMutation.ts
+++ b/apps/journeys-admin/src/libs/useJourneyCreateMutation/useJourneyCreateMutation.ts
@@ -62,7 +62,12 @@ export const CREATE_JOURNEY = gql`
       id
     }
     cardBlockCreate(
-      input: { id: $cardId, parentBlockId: $stepId, journeyId: $journeyId }
+      input: {
+        id: $cardId
+        parentBlockId: $stepId
+        journeyId: $journeyId
+        themeMode: dark
+      }
     ) {
       id
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newly created cards in Journeys now default to a dark theme, providing a consistent appearance when building dark-themed experiences.
* **Style**
  * Improved visual consistency: cards added to steps inherit a dark look by default, reducing the need for manual theme adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->