### PR TITLE
feat: add Apollo Rover installation to devcontainer setup

### DIFF
--- a/.devcontainer/post-create-command.sh
+++ b/.devcontainer/post-create-command.sh
@@ -29,6 +29,9 @@ corepack enable && corepack prepare pnpm --activate
 echo "Installing global CLIs..."
 npm i -g nx @nestjs/cli@^8.1.5 foreman apollo graphql
 
+echo "Installing rover..."
+curl -sSL https://rover.apollo.dev/nix/v0.23.0 | sh
+
 # install all dependencies
 echo "Installing project dependencies..."
 pnpm install

--- a/apis/api-journeys/project.json
+++ b/apis/api-journeys/project.json
@@ -90,7 +90,7 @@
     "generate-graphql": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm dlx @apollo/rover@0.23.0 subgraph introspect http://localhost:4001/graphql > apis/api-journeys/schema.graphql"
+        "command": "rover subgraph introspect http://localhost:4001/graphql > apis/api-journeys/schema.graphql"
       }
     },
     "subgraph-check": {


### PR DESCRIPTION
## Summary
Add Apollo Rover CLI installation to the devcontainer post-create script to improve GraphQL development workflow.

## Changes Made
- Added Apollo Rover installation step in `.devcontainer/post-create-command.sh`
- Updated `apis/api-journeys/project.json` to use the installed rover command instead of `pnpm dlx`

## Details
The devcontainer setup now includes:
1. Installation of Apollo Rover CLI (v0.23.0) via curl
2. Updated GraphQL schema generation command to use the globally installed rover

This improves the development experience by having rover available globally rather than downloading it each time via pnpm dlx.

## Files Modified
- `.devcontainer/post-create-command.sh`
- `apis/api-journeys/project.json`

Closes ENG-3167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Improved development environment setup by automatically installing the Rover CLI during container initialization.
  * Added a reliable database bootstrap step with clear error handling to prevent partial setups and ensure consistent local environments.
  * Standardized GraphQL schema introspection to use the installed Rover CLI directly, simplifying the workflow and removing dependency on ad-hoc runners.
  * Enhanced setup messaging to clearly indicate failures and successful completion, aiding quicker onboarding and troubleshooting for contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->