### PR TITLE
feat: pnpm stickydisk

### DIFF
--- a/.github/workflows/api-deploy-prod.yml
+++ b/.github/workflows/api-deploy-prod.yml
@@ -28,11 +28,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Mount pnpm store (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-pnpm-store-${{ runner.os }}
           path: $HOME/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Configure pnpm store-dir
         run: pnpm config set store-dir $HOME/.pnpm-store
       - name: Install dependencies

--- a/.github/workflows/api-deploy-stage.yml
+++ b/.github/workflows/api-deploy-stage.yml
@@ -28,11 +28,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Mount pnpm store (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-pnpm-store-${{ runner.os }}
           path: $HOME/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Configure pnpm store-dir
         run: pnpm config set store-dir $HOME/.pnpm-store
       - name: Install dependencies

--- a/.github/workflows/api-deploy-worker.yml
+++ b/.github/workflows/api-deploy-worker.yml
@@ -62,11 +62,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Mount pnpm store (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-pnpm-store-${{ runner.os }}
           path: $HOME/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Configure pnpm store-dir
         run: pnpm config set store-dir $HOME/.pnpm-store
       - name: Install dependencies

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -30,11 +30,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Mount pnpm store (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-pnpm-store-${{ runner.os }}
           path: $HOME/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Configure pnpm store-dir
         run: pnpm config set store-dir $HOME/.pnpm-store
@@ -105,11 +107,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Mount pnpm store (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-pnpm-store-${{ runner.os }}
           path: $HOME/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Configure pnpm store-dir
         run: pnpm config set store-dir $HOME/.pnpm-store
       - name: Install dependencies
@@ -271,11 +275,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Mount pnpm store (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-pnpm-store-${{ runner.os }}
           path: $HOME/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Configure pnpm store-dir
         run: pnpm config set store-dir $HOME/.pnpm-store
 
@@ -360,11 +366,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Mount pnpm store (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-pnpm-store-${{ runner.os }}
           path: $HOME/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Configure pnpm store-dir
         run: pnpm config set store-dir $HOME/.pnpm-store

--- a/.github/workflows/autofix.ci.yml
+++ b/.github/workflows/autofix.ci.yml
@@ -30,11 +30,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Mount pnpm store (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-pnpm-store-${{ runner.os }}
           path: $HOME/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Configure pnpm store-dir
         run: pnpm config set store-dir $HOME/.pnpm-store
       - name: Install dependencies

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -38,11 +38,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Mount pnpm store (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-pnpm-store-${{ runner.os }}
           path: $HOME/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Configure pnpm store-dir
         run: pnpm config set store-dir $HOME/.pnpm-store
       - name: Install dependencies

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -77,11 +77,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - name: Mount pnpm store (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-pnpm-store-${{ runner.os }}
           path: $HOME/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Configure pnpm store-dir
         run: pnpm config set store-dir $HOME/.pnpm-store
       - name: Install dependencies
@@ -179,11 +181,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Mount pnpm store (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-pnpm-store-${{ runner.os }}
           path: $HOME/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Configure pnpm store-dir
         run: pnpm config set store-dir $HOME/.pnpm-store
 

--- a/.github/workflows/ecs-frontend-deploy-prod-worker.yml
+++ b/.github/workflows/ecs-frontend-deploy-prod-worker.yml
@@ -78,11 +78,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Mount pnpm store (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-pnpm-store-${{ runner.os }}
           path: $HOME/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Configure pnpm store-dir
         run: pnpm config set store-dir $HOME/.pnpm-store
       - name: Install dependencies

--- a/.github/workflows/ecs-frontend-deploy-stage-worker.yml
+++ b/.github/workflows/ecs-frontend-deploy-stage-worker.yml
@@ -78,11 +78,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Mount pnpm store (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-pnpm-store-${{ runner.os }}
           path: $HOME/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Configure pnpm store-dir
         run: pnpm config set store-dir $HOME/.pnpm-store
       - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,11 +32,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Mount pnpm store (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-pnpm-store-${{ runner.os }}
           path: $HOME/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Configure pnpm store-dir
         run: pnpm config set store-dir $HOME/.pnpm-store
       - name: Install dependencies
@@ -98,11 +100,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Mount pnpm store (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-pnpm-store-${{ runner.os }}
           path: $HOME/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Configure pnpm store-dir
         run: pnpm config set store-dir $HOME/.pnpm-store
       - name: Install dependencies

--- a/.github/workflows/task-deploy-worker.yml
+++ b/.github/workflows/task-deploy-worker.yml
@@ -47,11 +47,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Mount pnpm store (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-pnpm-store-${{ runner.os }}
           path: $HOME/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Configure pnpm store-dir
         run: pnpm config set store-dir $HOME/.pnpm-store
       - name: Install dependencies

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -30,11 +30,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Mount pnpm store (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-pnpm-store-${{ runner.os }}
           path: $HOME/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Configure pnpm store-dir
         run: pnpm config set store-dir $HOME/.pnpm-store
       - name: Install dependencies

--- a/.github/workflows/worker-deploy.yml
+++ b/.github/workflows/worker-deploy.yml
@@ -29,11 +29,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Mount pnpm store (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-pnpm-store-${{ runner.os }}
           path: $HOME/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Configure pnpm store-dir
         run: pnpm config set store-dir $HOME/.pnpm-store
       - name: Install dependencies
@@ -73,11 +75,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Mount pnpm store (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-pnpm-store-${{ runner.os }}
           path: $HOME/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Configure pnpm store-dir
         run: pnpm config set store-dir $HOME/.pnpm-store
       - name: Install dependencies
@@ -116,11 +120,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Mount pnpm store (stickydisk)
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-pnpm-store-${{ runner.os }}
           path: $HOME/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Configure pnpm store-dir
         run: pnpm config set store-dir $HOME/.pnpm-store
       - name: Install dependencies


### PR DESCRIPTION
The current pnpm cache is creating per-pr stores. This changes it to use 1 faster store

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Standardized PNPM store across CI: added PNPM_STORE_PATH, switched to a cached PNPM store with explicit store-dir configuration, removed previous mount-based approach, and unified Node setup action usage.
- Tests
  - E2E workflows now include Node 22 and use the centralized PNPM store cache for more reliable, faster runs.
- Note
  - No changes to app features or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->