### PR TITLE
feat: add hideLabel field to TextResponseBlock and its input types

### DIFF
--- a/apis/api-journeys-modern/src/schema/block/textResponse/inputs/textResponseBlockUpdateInput.ts
+++ b/apis/api-journeys-modern/src/schema/block/textResponse/inputs/textResponseBlockUpdateInput.ts
@@ -10,6 +10,7 @@ export const TextResponseBlockUpdateInput = builder.inputType(
       placeholder: t.string({ required: false }),
       required: t.boolean({ required: false }),
       hint: t.string({ required: false }),
+      hideLabel: t.boolean({ required: false }),
       minRows: t.int({ required: false }),
       routeId: t.string({ required: false }),
       type: t.field({ type: TextResponseType, required: false }),

--- a/apis/api-journeys-modern/src/schema/block/textResponse/textResponse.ts
+++ b/apis/api-journeys-modern/src/schema/block/textResponse/textResponse.ts
@@ -22,6 +22,9 @@ export const TextResponseBlock = builder.prismaObject('Block', {
     hint: t.exposeString('hint', {
       nullable: true
     }),
+    hideLabel: t.exposeBoolean('hideLabel', {
+      nullable: true
+    }),
     minRows: t.exposeInt('minRows', {
       nullable: true
     }),

--- a/apis/api-journeys/src/app/modules/block/textResponse/textResponse.graphql
+++ b/apis/api-journeys/src/app/modules/block/textResponse/textResponse.graphql
@@ -7,6 +7,7 @@ type TextResponseBlock implements Block @shareable {
   placeholder: String @shareable
   required: Boolean @shareable
   hint: String @shareable
+  hideLabel: Boolean @shareable
   minRows: Int @shareable
   type: TextResponseType @shareable
   routeId: String @shareable
@@ -33,6 +34,7 @@ input TextResponseBlockUpdateInput {
   placeholder: String
   required: Boolean
   hint: String
+  hideLabel: Boolean
   minRows: Int
   routeId: String
   type: TextResponseType

--- a/libs/prisma/journeys/db/schema.prisma
+++ b/libs/prisma/journeys/db/schema.prisma
@@ -522,6 +522,7 @@ model Block {
   nextBlockId                String?
   locked                     Boolean?
   hint                       String?
+  hideLabel                  Boolean?             @default(false)
   minRows                    Int?
   content                    String?
   align                      String?


### PR DESCRIPTION
- Introduced hideLabel field in the TextResponseBlock GraphQL type.
- Updated TextResponseBlockUpdateInput to include hideLabel.
- Modified the Prisma schema to support hideLabel with a default value of false.