### PR TITLE
fix: retain parent step id on journey duplicate

### DIFF
--- a/apis/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
+++ b/apis/api-journeys/src/app/modules/journey/journey.resolver.spec.ts
@@ -1784,6 +1784,91 @@ describe('JourneyResolver', () => {
       })
     })
 
+    it('should duplicate customizable actions on journey duplicate', async () => {
+      const customizableDuplicatedButton = {
+        ...duplicatedButton,
+        action: {
+          ...duplicatedButton.action,
+          customizable: true
+        }
+      }
+
+      blockService.getDuplicateChildren.mockResolvedValue([
+        duplicatedStep,
+        customizableDuplicatedButton,
+        duplicatedNextStep
+      ])
+
+      mockUuidv4.mockReturnValueOnce(duplicatedStep.id)
+      mockUuidv4.mockReturnValueOnce(duplicatedNextStep.id)
+      mockUuidv4.mockReturnValueOnce(duplicatedButton.id)
+      const duplicateStepIds = new Map([
+        [step.id, duplicatedStep.id],
+        [nextStep.id, duplicatedNextStep.id]
+      ])
+      prismaService.block.findMany
+        .mockReset()
+        .mockResolvedValueOnce([step, nextStep])
+      await resolver.journeyDuplicate(ability, 'journeyId', 'userId', 'teamId')
+      expect(blockService.getDuplicateChildren).toHaveBeenCalledWith(
+        [step, nextStep],
+        'journeyId',
+        null,
+        true,
+        duplicateStepIds,
+        undefined,
+        'duplicateJourneyId',
+        duplicateStepIds
+      )
+      expect(prismaService.action.create).toHaveBeenCalledWith({
+        data: {
+          ...customizableDuplicatedButton.action,
+          customizable: true,
+          parentStepId: null,
+          blockId: duplicatedNextStep.id,
+          parentBlockId: duplicatedButton.id
+        }
+      })
+    })
+
+    it('should handle parentStepId mapping for actions', async () => {
+      const buttonWithParentStep: Block & { action: Action } = {
+        ...button,
+        action: {
+          ...button.action,
+          parentStepId: step.id
+        }
+      }
+      const duplicatedButtonWithParentStep = {
+        ...buttonWithParentStep,
+        id: 'duplicateButtonId',
+        journeyId: 'duplicateJourneyId'
+      }
+
+      blockService.getDuplicateChildren.mockResolvedValue([
+        duplicatedStep,
+        duplicatedButtonWithParentStep,
+        duplicatedNextStep
+      ])
+
+      mockUuidv4.mockReturnValueOnce(duplicatedStep.id)
+      mockUuidv4.mockReturnValueOnce(duplicatedNextStep.id)
+      mockUuidv4.mockReturnValueOnce(duplicatedButton.id)
+
+      prismaService.block.findMany
+        .mockReset()
+        .mockResolvedValueOnce([step, nextStep])
+      await resolver.journeyDuplicate(ability, 'journeyId', 'userId', 'teamId')
+      expect(prismaService.action.create).toHaveBeenCalledWith({
+        data: {
+          ...duplicatedButtonWithParentStep.action,
+          customizable: false,
+          parentStepId: duplicatedStep.id,
+          parentBlockId: duplicatedButton.id
+        }
+      })
+    })
+
     it('should duplicate customization fields', async () => {
       mockUuidv4.mockReturnValueOnce(duplicatedStep.id)
       mockUuidv4.mockReturnValueOnce('duplicateFieldId')

--- a/apis/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apis/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -697,8 +697,11 @@ export class JourneyResolver {
             await this.prismaService.action.create({
               data: {
                 ...block.action,
-                customizable: false,
-                parentStepId: null,
+                customizable: block?.action?.customizable ?? false,
+                parentStepId:
+                  block.action.parentStepId != null
+                    ? (duplicateStepIds.get(block.action.parentStepId) ?? null)
+                    : null,
                 parentBlockId: block.id
               }
             })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicating a journey now preserves action customization settings on duplicated buttons and blocks, preventing loss of “customizable” configurations.
  * Actions that reference steps are correctly re-linked to their corresponding duplicated steps, avoiding broken interactions in duplicated journeys.
  * Overall reliability of journey duplication with complex actions is improved, ensuring duplicated flows behave consistently with the original.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->