### PR TITLE
feat(watch): enable click-to-unmute on hero video

### DIFF
--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoControls/VideoControls.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoControls/VideoControls.tsx
@@ -542,7 +542,8 @@ export function VideoControls({
                 dispatch: dispatchPlayer,
                 mute,
                 volume,
-                play
+                play,
+                onMuteToggle
               })
             }}
           />
@@ -592,7 +593,8 @@ export function VideoControls({
                   dispatch: dispatchPlayer,
                   mute,
                   volume,
-                  play
+                  play,
+                  onMuteToggle
                 })
               }}
             />

--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoControls/utils/handleVideoTitleClick/handleVideoTitleClick.spec.ts
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoControls/utils/handleVideoTitleClick/handleVideoTitleClick.spec.ts
@@ -11,6 +11,7 @@ describe('handleVideoTitleClick', () => {
     volume: jest.fn(),
     play: jest.fn()
   } as unknown as Player
+  const onMuteToggle = jest.fn()
 
   afterEach(() => {
     jest.clearAllMocks()
@@ -36,13 +37,15 @@ describe('handleVideoTitleClick', () => {
       dispatch,
       mute: true,
       volume: 0,
-      play: false
+      play: false,
+      onMuteToggle
     })
     expect(player.muted).toHaveBeenCalledWith(false)
     expect(dispatch).toHaveBeenCalledWith({ type: 'SetMute', mute: false })
     expect(dispatch).toHaveBeenCalledWith({ type: 'SetVolume', volume: 100 })
     expect(player.volume).toHaveBeenCalledWith(1)
     expect(player.play).toHaveBeenCalled()
+    expect(onMuteToggle).toHaveBeenCalledWith(false)
   })
 
   it('should increase volume and play if volume is 0 and not playing', () => {

--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoControls/utils/handleVideoTitleClick/handleVideoTitleClick.ts
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoControls/utils/handleVideoTitleClick/handleVideoTitleClick.ts
@@ -8,6 +8,7 @@ interface HandleVideoTitleClickProps {
   mute: boolean
   volume: number
   play: boolean
+  onMuteToggle?: (isMuted: boolean) => void
 }
 
 export function handleVideoTitleClick({
@@ -15,7 +16,8 @@ export function handleVideoTitleClick({
   dispatch,
   mute,
   volume,
-  play
+  play,
+  onMuteToggle
 }: HandleVideoTitleClickProps): void {
   if (player == null) return
   if (mute) {
@@ -35,4 +37,5 @@ export function handleVideoTitleClick({
   if (!play) {
     void player.play()
   }
+  onMuteToggle?.(false)
 }


### PR DESCRIPTION
## Summary
- allow hero video to unmute when clicking video surface
- centralize unmute logic so video clicks and button share behavior
- cover unmute callback with a unit test

## Testing
- `pnpm nx test watch`


------
https://chatgpt.com/codex/tasks/task_e_68c81a5fd2c883289455d5dea14dc30e