### PR TITLE
feat(watch): animate new carousel items

### DIFF
--- a/apps/watch/public/watch/global.css
+++ b/apps/watch/public/watch/global.css
@@ -136,6 +136,33 @@
     opacity: 0;
   }
 
+  @keyframes video-card-enter {
+    0% {
+      transform: translate3d(120%, 0, 0);
+      opacity: 0;
+    }
+
+    100% {
+      transform: translate3d(0, 0, 0);
+      opacity: 1;
+    }
+  }
+
+  .animate-video-card-enter {
+    /* Keep duration in sync with VIDEO_CARD_ENTER_DURATION_MS in VideoCarousel.tsx */
+    animation: video-card-enter var(--video-card-enter-duration, 0.45s)
+      var(--video-card-enter-easing, cubic-bezier(0.16, 1, 0.3, 1)) forwards;
+    will-change: transform, opacity;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .animate-video-card-enter {
+      animation: none !important;
+      transform: none !important;
+      opacity: 1 !important;
+    }
+  }
+
   .animation-delay-100 {
     animation-delay: 0.1s;
   }

--- a/apps/watch/src/components/NewVideoContentPage/VideoCarousel/VideoCard/VideoCard.tsx
+++ b/apps/watch/src/components/NewVideoContentPage/VideoCarousel/VideoCard/VideoCard.tsx
@@ -6,18 +6,17 @@ import { ReactElement, useState } from 'react'
 
 import Play3 from '@core/shared/ui/icons/Play3'
 
-import { LazyImage } from './LazyImage'
-
 import { VideoChildFields } from '../../../../../__generated__/VideoChildFields'
+import { usePlayer } from '../../../../libs/playerContext'
 import { getLabelDetails } from '../../../../libs/utils/getLabelDetails/getLabelDetails'
 import { getWatchUrl } from '../../../../libs/utils/getWatchUrl'
-import { usePlayer } from '../../../../libs/playerContext'
 
 interface VideoCardProps {
   video: VideoChildFields
   containerSlug?: string
   active: boolean
   transparent?: boolean
+  isNew?: boolean
   onVideoSelect?: (videoId: string) => void
 }
 
@@ -148,6 +147,7 @@ export function VideoCard({
   containerSlug,
   active,
   transparent = false,
+  isNew = false,
   onVideoSelect
 }: VideoCardProps): ReactElement {
   const { t } = useTranslation('apps-watch')
@@ -177,7 +177,9 @@ export function VideoCard({
   )
 
   const commonProps = {
-    className: `block beveled no-underline text-inherit ${transparent ? 'opacity-70' : ''}`,
+    className: `block beveled no-underline text-inherit ${transparent ? 'opacity-70' : ''} ${
+      isNew ? 'animate-video-card-enter' : ''
+    }`,
     'aria-label': last(video.title)?.value ?? `Video ${video.slug}`,
     'data-testid': `VideoCard-${video.id}`
   }


### PR DESCRIPTION
## Summary
- track newly added videos inside the carousel and clear animation flags once the slide-in finishes
- allow VideoCard to receive the transient animation flag and play a slide-in transition
- add a reusable Tailwind utility for the video-card enter animation with prefers-reduced-motion support

## Testing
- pnpm nx run watch:lint -- --lintFilePatterns=apps/watch/src/components/NewVideoContentPage/VideoCarousel/VideoCarousel.tsx --lintFilePatterns=apps/watch/src/components/NewVideoContentPage/VideoCarousel/VideoCard/VideoCard.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c86633b364832881fcac5fea4a262e