### PR TITLE
feat(watch): add video blacklist handling

### DIFF
--- a/apps/watch/config/video-playlist.json
+++ b/apps/watch/config/video-playlist.json
@@ -1,6 +1,7 @@
 {
   "version": "1.0.0",
   "_comment": "All IDs in playlistSequence are archlight database IDs, not slugs",
+  "blacklistedVideoIds": [],
   "playlistSequence": [
     ["1_jf-0-0"],
     ["JFP-Featured"],

--- a/apps/watch/src/components/VideoHero/libs/useCarouselVideos/useCarouselVideos.ts
+++ b/apps/watch/src/components/VideoHero/libs/useCarouselVideos/useCarouselVideos.ts
@@ -18,7 +18,8 @@ import {
   getPoolKey,
   saveCurrentVideoSession,
   loadCurrentVideoSession,
-  clearCurrentVideoSession
+  clearCurrentVideoSession,
+  filterOutBlacklistedVideos
 } from './utils'
 
 export interface CarouselVideo {
@@ -79,6 +80,10 @@ export function useCarouselVideos(locale?: string): UseCarouselVideosReturn {
   const [error, setError] = useState<Error | null>(null)
 
   const config = getPlaylistConfig()
+  const blacklistedVideoIds = useMemo(
+    () => new Set(config.blacklistedVideoIds),
+    [config.blacklistedVideoIds]
+  )
   const languageId = getLanguageIdFromLocale(locale)
 
   // Reset pool exhaustion every 50 videos to ensure infinite cycling
@@ -236,7 +241,10 @@ export function useCarouselVideos(locale?: string): UseCarouselVideosReturn {
         })
 
         const children = data?.video?.children || []
-        const videoChildren = children.filter((c: any) => c.variant)
+        const videoChildren = filterOutBlacklistedVideos(
+          children.filter((c: any) => c.variant),
+          blacklistedVideoIds
+        )
         if (videoChildren.length > 0) {
           const offset = getDeterministicOffset(
             collectionId,
@@ -272,7 +280,8 @@ export function useCarouselVideos(locale?: string): UseCarouselVideosReturn {
       languageId,
       poolIndex,
       videos.length,
-      getRandomFromMultipleCollections
+      getRandomFromMultipleCollections,
+      blacklistedVideoIds
     ]
   )
 
@@ -286,7 +295,10 @@ export function useCarouselVideos(locale?: string): UseCarouselVideosReturn {
 
       if (pool[0] === 'shortFilms') {
         // Handle short films
-        const shortFilms = shortFilmsData?.videos || []
+        const shortFilms = filterOutBlacklistedVideos(
+          shortFilmsData?.videos || [],
+          blacklistedVideoIds
+        )
         if (shortFilms.length > 0) {
           const offset = getDeterministicOffset(
             'shortFilms',
@@ -337,7 +349,8 @@ export function useCarouselVideos(locale?: string): UseCarouselVideosReturn {
       countsData,
       findVideoInCollection,
       getRandomFromMultipleCollections,
-      languageId
+      languageId,
+      blacklistedVideoIds
     ]
   )
 

--- a/apps/watch/src/components/VideoHero/libs/useCarouselVideos/utils.spec.ts
+++ b/apps/watch/src/components/VideoHero/libs/useCarouselVideos/utils.spec.ts
@@ -1,0 +1,42 @@
+import { filterOutBlacklistedVideos, normalizeBlacklistedVideoIds } from './utils'
+
+describe('normalizeBlacklistedVideoIds', () => {
+  it('returns an empty array when value is undefined', () => {
+    expect(normalizeBlacklistedVideoIds(undefined)).toEqual([])
+  })
+
+  it('filters out non-string entries and trims whitespace', () => {
+    const input = [' video-1 ', 123, null, '']
+
+    expect(normalizeBlacklistedVideoIds(input)).toEqual(['video-1'])
+  })
+})
+
+describe('filterOutBlacklistedVideos', () => {
+  it('returns videos unchanged when blacklist is empty', () => {
+    const videos = [{ id: 'video-1' }, { id: 'video-2' }]
+
+    expect(filterOutBlacklistedVideos(videos, new Set())).toEqual(videos)
+  })
+
+  it('filters videos whose IDs are in the blacklist', () => {
+    const videos = [
+      { id: 'video-1' },
+      { id: 'video-2' },
+      { id: 'video-3' }
+    ]
+
+    const result = filterOutBlacklistedVideos(videos, new Set(['video-2']))
+
+    expect(result).toEqual([
+      { id: 'video-1' },
+      { id: 'video-3' }
+    ])
+  })
+
+  it('ignores entries without an ID', () => {
+    const videos = [{ id: 'video-1' }, { id: undefined } as any]
+
+    expect(filterOutBlacklistedVideos(videos, new Set(['video-1']))).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- extend the video playlist configuration with a blacklistedVideoIds array and sanitize it when loading settings
- update the carousel logic to build a blacklist set and filter collection and short film videos accordingly
- add focused unit tests for blacklist normalization and filtering alongside refreshed carousel test mocks

## Testing
- `pnpm exec jest --selectProjects watch --runTestsByPath apps/watch/src/components/VideoHero/libs/useCarouselVideos/utils.spec.ts --runInBand`
- `pnpm exec jest --selectProjects watch --runTestsByPath apps/watch/src/components/VideoHero/libs/useCarouselVideos/useCarouselVideos.spec.tsx --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68c86898c2c48328a4a21e28dc3bc56b