### PR TITLE
feat(watch): add apologist chat api route

### DIFF
--- a/apps/watch/README.md
+++ b/apps/watch/README.md
@@ -1,0 +1,70 @@
+# Watch application
+
+## Streaming chat API
+
+The Watch app exposes a streaming chat endpoint at `/api/chat`. The handler
+mirrors the Journeys application API and streams Apologist responses formatted
+for the Vercel AI SDK UI helpers. Requests should include the following JSON
+shape:
+
+```json
+{
+  "messages": [
+    {
+      "parts": [
+        { "type": "text", "text": "Hello" }
+      ]
+    }
+  ],
+  "contextText": "Optional additional context rendered in the system prompt",
+  "sessionId": "Identifier used for Langfuse traces",
+  "journeyId": "Optional metadata identifier",
+  "userId": "User identifier passed through to Langfuse"
+}
+```
+
+The response is streamed using `text/event-stream` semantics so the Watch
+front-end receives incremental updates while `streamText` is running.
+
+## Required environment variables
+
+Add the following variables to the Watch runtime (e.g., Doppler, Vercel, or a
+local `.env` file) before invoking `/api/chat`:
+
+| Variable | Description |
+| --- | --- |
+| `APOLOGIST_API_KEY` | API key for the Apologist OpenAI-compatible endpoint. |
+| `APOLOGIST_API_URL` | Base URL for the Apologist service. |
+| `LANGFUSE_SECRET_KEY` | Secret key used by `@langfuse/client`. |
+| `LANGFUSE_PUBLIC_KEY` | Public key used by Langfuse tracing dashboards. |
+| `LANGFUSE_HOST` | Langfuse host (e.g., `https://cloud.langfuse.com`). |
+
+The instrumentation bootstrap automatically populates
+`LANGFUSE_TRACING_ENVIRONMENT` based on the deployment environment, matching the
+Journeys application behaviour. Ensure these variables are available in any
+hosting environment before deploying the chat route.
+
+## Local development
+
+1. Ensure the environment variables above are defined.
+2. Start the Watch dev server:
+
+   ```bash
+   pnpm dlx nx run watch:serve
+   ```
+
+3. Send a test request to `/api/chat` with a valid payload to verify streaming
+   behaviour. A simple example using `curl` (replace tokens as needed):
+
+   ```bash
+   curl -N -X POST http://localhost:4300/api/chat \
+     -H "Content-Type: application/json" \
+     -d '{
+       "messages": [{"parts": [{"type": "text", "text": "Hello"}]}],
+       "sessionId": "local-dev",
+       "userId": "tester"
+     }'
+   ```
+
+The command streams the Apologist completion in the terminal and confirms that
+Langfuse spans are flushed when the request completes.

--- a/apps/watch/instrumentation.ts
+++ b/apps/watch/instrumentation.ts
@@ -1,0 +1,20 @@
+import { LangfuseSpanProcessor, ShouldExportSpan } from '@langfuse/otel'
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
+
+import { langfuseEnvironment } from './src/libs/ai/langfuse/server'
+
+process.env.LANGFUSE_TRACING_ENVIRONMENT = langfuseEnvironment
+
+const shouldExportSpan: ShouldExportSpan = ({ otelSpan }) => {
+  return otelSpan.instrumentationScope.name !== 'next.js'
+}
+
+export const langfuseSpanProcessor = new LangfuseSpanProcessor({
+  shouldExportSpan
+})
+
+const tracerProvider = new NodeTracerProvider({
+  spanProcessors: [langfuseSpanProcessor]
+})
+
+tracerProvider.register()

--- a/apps/watch/pages/api/__tests__/chat.spec.ts
+++ b/apps/watch/pages/api/__tests__/chat.spec.ts
@@ -1,0 +1,188 @@
+import { EventEmitter } from 'events'
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+
+jest.mock(
+  '@langfuse/tracing',
+  () => ({
+    observe: jest.fn((handler) => handler),
+    updateActiveObservation: jest.fn(),
+    updateActiveTrace: jest.fn()
+  }),
+  { virtual: true }
+)
+
+const mockEnd = jest.fn()
+jest.mock('@opentelemetry/api', () => ({
+  trace: {
+    getActiveSpan: jest.fn(() => ({
+      end: mockEnd
+    }))
+  }
+}))
+
+jest.mock(
+  '../../../instrumentation',
+  () => ({
+    langfuseSpanProcessor: {
+      forceFlush: jest.fn().mockResolvedValue(undefined)
+    }
+  }),
+  { virtual: true }
+)
+
+jest.mock(
+  '../../../src/libs/ai/langfuse/promptHelper',
+  () => ({
+    getPrompt: jest.fn(() => Promise.resolve('mocked-system-prompt'))
+  }),
+  { virtual: true }
+)
+
+const mockModel = { id: 'openai/gpt/4o' }
+jest.mock(
+  '@ai-sdk/openai-compatible',
+  () => ({
+    createOpenAICompatible: jest.fn(() => jest.fn(() => mockModel))
+  }),
+  { virtual: true }
+)
+
+const mockPipeDataStreamToResponse = jest.fn()
+let capturedOnFinish: (({ text }: { text: string }) => void) | undefined
+jest.mock('ai', () => ({
+  convertToModelMessages: jest.fn(() => 'converted-messages'),
+  streamText: jest.fn((options) => {
+    capturedOnFinish = options.onFinish
+    return {
+      pipeDataStreamToResponse: mockPipeDataStreamToResponse
+    }
+  })
+}))
+
+const { updateActiveObservation, updateActiveTrace } = jest.requireMock(
+  '@langfuse/tracing'
+) as {
+  updateActiveObservation: jest.Mock
+  updateActiveTrace: jest.Mock
+}
+
+const { trace } = jest.requireMock('@opentelemetry/api') as {
+  trace: { getActiveSpan: jest.Mock }
+}
+
+const { langfuseSpanProcessor } = jest.requireMock('../../../instrumentation') as {
+  langfuseSpanProcessor: { forceFlush: jest.Mock }
+}
+
+const { getPrompt } = jest.requireMock(
+  '../../../src/libs/ai/langfuse/promptHelper'
+) as {
+  getPrompt: jest.Mock
+}
+
+const { convertToModelMessages, streamText } = jest.requireMock('ai') as {
+  convertToModelMessages: jest.Mock
+  streamText: jest.Mock
+}
+
+const { chatHandler } = require('../chat') as {
+  chatHandler: (req: NextApiRequest, res: NextApiResponse) => Promise<void>
+}
+
+describe('chatHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    capturedOnFinish = undefined
+  })
+
+  it('should return 405 for non-POST methods', async () => {
+    const req = { method: 'GET' } as unknown as NextApiRequest
+    const res = {
+      setHeader: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    } as unknown as NextApiResponse
+
+    await chatHandler(req, res)
+
+    expect(res.setHeader).toHaveBeenCalledWith('Allow', 'POST')
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Method not allowed' })
+  })
+
+  it('should stream chat responses and flush spans', async () => {
+    const body = {
+      messages: [
+        {
+          parts: [
+            {
+              type: 'text',
+              text: 'Hello'
+            }
+          ]
+        }
+      ],
+      contextText: 'context',
+      sessionId: 'session-123',
+      journeyId: 'journey-456',
+      userId: 'user-789'
+    }
+
+    const req = {
+      method: 'POST',
+      body
+    } as unknown as NextApiRequest
+
+    const res = Object.assign(new EventEmitter(), {
+      setHeader: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    }) as unknown as NextApiResponse & EventEmitter
+
+    await chatHandler(req, res)
+
+    expect(updateActiveObservation).toHaveBeenCalledWith({ input: 'Hello' })
+    expect(updateActiveTrace).toHaveBeenCalledWith({
+      name: 'ai-assistant-chat',
+      sessionId: 'session-123',
+      userId: 'user-789',
+      input: 'Hello',
+      metadata: { journeyId: 'journey-456' }
+    })
+
+    expect(getPrompt).toHaveBeenCalledWith('Chat-Prompt', { contextText: 'context' })
+    expect(convertToModelMessages).toHaveBeenCalledWith(body.messages)
+    expect(streamText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: mockModel,
+        system: 'mocked-system-prompt',
+        messages: 'converted-messages',
+        experimental_telemetry: { isEnabled: true }
+      })
+    )
+
+    expect(mockPipeDataStreamToResponse).toHaveBeenCalledWith(
+      res,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'text/event-stream; charset=utf-8',
+          'Cache-Control': 'no-cache, no-transform',
+          Connection: 'keep-alive'
+        })
+      })
+    )
+
+    capturedOnFinish?.({ text: 'final text' })
+
+    expect(updateActiveObservation).toHaveBeenLastCalledWith({ output: 'final text' })
+    expect(updateActiveTrace).toHaveBeenLastCalledWith({ output: 'final text' })
+    expect(trace.getActiveSpan).toHaveBeenCalled()
+    expect(mockEnd).toHaveBeenCalled()
+
+    res.emit('finish')
+    await Promise.resolve()
+
+    expect(langfuseSpanProcessor.forceFlush).toHaveBeenCalled()
+  })
+})

--- a/apps/watch/pages/api/chat.ts
+++ b/apps/watch/pages/api/chat.ts
@@ -1,0 +1,101 @@
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
+import {
+  observe,
+  updateActiveObservation,
+  updateActiveTrace
+} from '@langfuse/tracing'
+import { trace } from '@opentelemetry/api'
+import { convertToModelMessages, streamText } from 'ai'
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+import { langfuseSpanProcessor } from '../../instrumentation'
+import { getPrompt } from '../../src/libs/ai/langfuse/promptHelper'
+
+type ChatRequestBody = {
+  messages: Array<{
+    parts: Array<{ type: string; text?: string }>
+  }>
+  contextText?: string
+  sessionId?: string
+  journeyId?: string
+  userId?: string
+}
+
+export const chatHandler = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    res.status(405).json({ error: 'Method not allowed' })
+    return
+  }
+
+  const { messages, contextText, sessionId, journeyId, userId } =
+    (req.body as ChatRequestBody) ?? {}
+
+  const inputText = messages?.[messages.length - 1]?.parts.find(
+    (part) => part.type === 'text'
+  )?.text
+
+  updateActiveObservation({
+    input: inputText
+  })
+
+  updateActiveTrace({
+    name: 'ai-assistant-chat',
+    sessionId,
+    userId,
+    input: inputText,
+    metadata: {
+      journeyId
+    }
+  })
+
+  const apologist = createOpenAICompatible({
+    name: 'apologist',
+    apiKey: process.env.APOLOGIST_API_KEY,
+    baseURL: process.env.APOLOGIST_API_URL ?? ''
+  })
+
+  const systemPrompt = await getPrompt('Chat-Prompt', { contextText })
+
+  const result = streamText({
+    model: apologist('openai/gpt/4o'),
+    messages: convertToModelMessages(messages ?? []),
+    system: systemPrompt,
+    experimental_telemetry: {
+      isEnabled: true
+    },
+    onFinish: ({ text }) => {
+      updateActiveObservation({
+        output: text
+      })
+      updateActiveTrace({
+        output: text
+      })
+
+      trace.getActiveSpan()?.end()
+    }
+  })
+
+  const flushSpans = async () => {
+    await langfuseSpanProcessor.forceFlush()
+  }
+
+  res.once('finish', flushSpans)
+  res.once('close', flushSpans)
+
+  result.pipeDataStreamToResponse(res, {
+    headers: {
+      'Content-Type': 'text/event-stream; charset=utf-8',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive'
+    }
+  })
+}
+
+export default observe(chatHandler, {
+  name: 'chat-message',
+  endOnExit: false
+})

--- a/apps/watch/src/libs/ai/langfuse/promptHelper.ts
+++ b/apps/watch/src/libs/ai/langfuse/promptHelper.ts
@@ -1,0 +1,36 @@
+import { langfuseClient, langfuseEnvironment } from './server'
+
+/**
+ * Retrieves and compiles a Langfuse prompt with optional variables.
+ *
+ * This helper function encapsulates the process of fetching a prompt from Langfuse
+ * using the configured environment and compiling it with provided variables.
+ *
+ * @param promptName - The name of the prompt to retrieve from Langfuse
+ * @param promptVariables - Optional object containing variables to compile into the prompt.
+ *                         Keys should match template variables in the Langfuse prompt.
+ * @returns Promise that resolves to the compiled prompt string, or empty string if promptName is falsy
+ * @throws Error if prompt retrieval or compilation fails
+ */
+export async function getPrompt(
+  promptName: string,
+  promptVariables: Record<string, any> = {}
+): Promise<string> {
+  if (!promptName) {
+    return ''
+  }
+
+  try {
+    const prompt = await langfuseClient.prompt.get(promptName, {
+      label: langfuseEnvironment,
+      cacheTtlSeconds: ['development', 'preview'].includes(langfuseEnvironment)
+        ? 0
+        : 60
+    })
+
+    return prompt.compile(promptVariables)
+  } catch (error) {
+    console.error(`Failed to get or compile prompt "${promptName}":`, error)
+    throw error
+  }
+}

--- a/apps/watch/src/libs/ai/langfuse/server.ts
+++ b/apps/watch/src/libs/ai/langfuse/server.ts
@@ -1,0 +1,9 @@
+import { LangfuseClient } from '@langfuse/client'
+
+export const langfuseEnvironment =
+  process.env.VERCEL_ENV ??
+  process.env.DD_ENV ??
+  process.env.NODE_ENV ??
+  'development'
+
+export const langfuseClient = new LangfuseClient()


### PR DESCRIPTION
## Summary
- add Langfuse client utilities for the Watch app
- configure Langfuse tracing instrumentation
- implement the Apologist-backed streaming chat API with coverage and docs

## Testing
- pnpm dlx nx test watch --testFile=apps/watch/pages/api/__tests__/chat.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68c9398cdc8883289179f23e106a0def