### PR TITLE
fix: placement of ai chat button

### DIFF
--- a/apps/journeys-admin/__generated__/GetAdminJourney.ts
+++ b/apps/journeys-admin/__generated__/GetAdminJourney.ts
@@ -725,6 +725,7 @@ export interface GetAdminJourney_journey {
   showShareButton: boolean | null;
   showLikeButton: boolean | null;
   showDislikeButton: boolean | null;
+  showAssistant: boolean | null;
   /**
    * public title for viewers
    */

--- a/apps/journeys-admin/__generated__/GetAdminJourneyWithPlausibleToken.ts
+++ b/apps/journeys-admin/__generated__/GetAdminJourneyWithPlausibleToken.ts
@@ -725,6 +725,7 @@ export interface GetAdminJourneyWithPlausibleToken_journey {
   showShareButton: boolean | null;
   showLikeButton: boolean | null;
   showDislikeButton: boolean | null;
+  showAssistant: boolean | null;
   /**
    * public title for viewers
    */

--- a/apps/journeys-admin/__generated__/GetJourney.ts
+++ b/apps/journeys-admin/__generated__/GetJourney.ts
@@ -725,6 +725,7 @@ export interface GetJourney_journey {
   showShareButton: boolean | null;
   showLikeButton: boolean | null;
   showDislikeButton: boolean | null;
+  showAssistant: boolean | null;
   /**
    * public title for viewers
    */

--- a/apps/journeys-admin/__generated__/GetPublisherTemplate.ts
+++ b/apps/journeys-admin/__generated__/GetPublisherTemplate.ts
@@ -725,6 +725,7 @@ export interface GetPublisherTemplate_publisherTemplate {
   showShareButton: boolean | null;
   showLikeButton: boolean | null;
   showDislikeButton: boolean | null;
+  showAssistant: boolean | null;
   /**
    * public title for viewers
    */

--- a/apps/journeys-admin/__generated__/JourneyFields.ts
+++ b/apps/journeys-admin/__generated__/JourneyFields.ts
@@ -725,6 +725,7 @@ export interface JourneyFields {
   showShareButton: boolean | null;
   showLikeButton: boolean | null;
   showDislikeButton: boolean | null;
+  showAssistant: boolean | null;
   /**
    * public title for viewers
    */

--- a/apps/journeys-admin/src/components/Editor/Editor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.spec.tsx
@@ -103,7 +103,8 @@ describe('Editor', () => {
     journeyCustomizationFields: [],
     fromTemplateId: null,
     socialNodeX: null,
-    socialNodeY: null
+    socialNodeY: null,
+    showAssistant: null
   }
 
   beforeEach(() => {

--- a/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
@@ -89,7 +89,8 @@ const journey: Journey = {
   journeyCustomizationFields: [],
   fromTemplateId: null,
   socialNodeX: null,
-  socialNodeY: null
+  socialNodeY: null,
+  showAssistant: null
 }
 
 const mockGetStepBlocksWithPosition: MockedResponse<GetStepBlocksWithPosition> =

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Goals/Goals.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Goals/Goals.spec.tsx
@@ -172,7 +172,8 @@ describe('Goals', () => {
     fromTemplateId: null,
     socialNodeX: null,
     socialNodeY: null,
-    journeyTheme: null
+    journeyTheme: null,
+    showAssistant: null
   }
 
   it('should render placeholder', () => {

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/SocialPreviewNode/SocialPreviewNode.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/SocialPreviewNode/SocialPreviewNode.spec.tsx
@@ -98,7 +98,8 @@ describe('SocialPreviewNode', () => {
     journeyCustomizationFields: [],
     fromTemplateId: null,
     socialNodeX: null,
-    socialNodeY: null
+    socialNodeY: null,
+    showAssistant: null
   }
 
   const blankSeoJourney: Journey = {

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/SocialPreviewNode/SocialPreviewNode.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/SocialPreviewNode/SocialPreviewNode.stories.tsx
@@ -149,7 +149,8 @@ const defaultJourney: Journey = {
   journeyCustomizationFields: [],
   fromTemplateId: null,
   socialNodeX: null,
-  socialNodeY: null
+  socialNodeY: null,
+  showAssistant: null
 }
 
 const blankSeoJourney: Journey = {

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundColor/BackgroundColor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundColor/BackgroundColor.spec.tsx
@@ -89,7 +89,8 @@ const journey: Journey = {
   journeyCustomizationFields: [],
   fromTemplateId: null,
   socialNodeX: null,
-  socialNodeY: null
+  socialNodeY: null,
+  showAssistant: null
 }
 
 describe('BackgroundColor', () => {

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/BackgroundMedia.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/BackgroundMedia.stories.tsx
@@ -91,7 +91,8 @@ const journey: Journey = {
   journeyCustomizationFields: [],
   fromTemplateId: null,
   socialNodeX: null,
-  socialNodeY: null
+  socialNodeY: null,
+  showAssistant: null
 }
 
 const card: TreeBlock<CardBlock> = {

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
@@ -113,7 +113,8 @@ const journey: Journey = {
   journeyCustomizationFields: [],
   fromTemplateId: null,
   socialNodeX: null,
-  socialNodeY: null
+  socialNodeY: null,
+  showAssistant: null
 }
 
 const card: TreeBlock<CardBlock> = {

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/CardLayout/CardLayout.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/CardLayout/CardLayout.spec.tsx
@@ -78,7 +78,8 @@ const journey: Journey = {
   journeyCustomizationFields: [],
   fromTemplateId: null,
   socialNodeX: null,
-  socialNodeY: null
+  socialNodeY: null,
+  showAssistant: null
 }
 
 describe('CardLayout', () => {

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/CardLayout/CardLayout.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/CardLayout/CardLayout.stories.tsx
@@ -80,7 +80,8 @@ const journey: Journey = {
   journeyCustomizationFields: [],
   fromTemplateId: null,
   socialNodeX: null,
-  socialNodeY: null
+  socialNodeY: null,
+  showAssistant: null
 }
 
 const block: TreeBlock<CardBlock> = {

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/CardStyling/CardStyling.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/CardStyling/CardStyling.spec.tsx
@@ -91,7 +91,8 @@ const journey: Journey = {
   journeyCustomizationFields: [],
   fromTemplateId: null,
   socialNodeX: null,
-  socialNodeY: null
+  socialNodeY: null,
+  showAssistant: null
 }
 
 describe('CardStyling', () => {

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/CardStyling/CardStyling.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/CardStyling/CardStyling.stories.tsx
@@ -80,7 +80,8 @@ const journey: Journey = {
   journeyCustomizationFields: [],
   fromTemplateId: null,
   socialNodeX: null,
-  socialNodeY: null
+  socialNodeY: null,
+  showAssistant: null
 }
 
 const block: TreeBlock<CardBlock> = {

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/RadioOption/RadioOptionImage/RadioOptionImage.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/RadioOption/RadioOptionImage/RadioOptionImage.spec.tsx
@@ -113,7 +113,8 @@ const journey: Journey = {
   journeyCustomizationFields: [],
   fromTemplateId: null,
   socialNodeX: null,
-  socialNodeY: null
+  socialNodeY: null,
+  showAssistant: null
 }
 
 const radioOption: TreeBlock<RadioOptionBlock> = {

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Typography/ThemeBuilderDialog/ThemeBuilderDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Typography/ThemeBuilderDialog/ThemeBuilderDialog.spec.tsx
@@ -79,7 +79,8 @@ describe('ThemeBuilderDialog', () => {
     },
     journeyCustomizationDescription: null,
     journeyCustomizationFields: [],
-    fromTemplateId: null
+    fromTemplateId: null,
+    showAssistant: null
   }
 
   const mockJourneyWithoutTheme: JourneyFields = {

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/controls/Action/Action.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/controls/Action/Action.stories.tsx
@@ -76,7 +76,8 @@ const journey: Journey = {
   journeyCustomizationFields: [],
   fromTemplateId: null,
   socialNodeX: null,
-  socialNodeY: null
+  socialNodeY: null,
+  showAssistant: null
 }
 
 const Template: StoryObj<typeof Action> = {

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/Settings/Poster/Library/VideoBlockEditorSettingsPosterLibrary.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/Settings/Poster/Library/VideoBlockEditorSettingsPosterLibrary.spec.tsx
@@ -113,7 +113,8 @@ const journey: Journey = {
   journeyCustomizationFields: [],
   fromTemplateId: null,
   socialNodeX: null,
-  socialNodeY: null
+  socialNodeY: null,
+  showAssistant: null
 }
 
 const video: TreeBlock<VideoBlock> = {

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/SocialDetails.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/SocialDetails.stories.tsx
@@ -81,7 +81,8 @@ const journey: Journey = {
   journeyCustomizationFields: [],
   fromTemplateId: null,
   socialNodeX: null,
-  socialNodeY: null
+  socialNodeY: null,
+  showAssistant: null
 }
 
 const image: ImageBlock = {

--- a/apps/journeys-admin/src/libs/blockDeleteUpdate/blockDeleteUpdate.spec.ts
+++ b/apps/journeys-admin/src/libs/blockDeleteUpdate/blockDeleteUpdate.spec.ts
@@ -130,7 +130,8 @@ const journey: Journey = {
   journeyCustomizationFields: [],
   fromTemplateId: null,
   socialNodeX: null,
-  socialNodeY: null
+  socialNodeY: null,
+  showAssistant: null
 }
 
 const response = [{ ...image, parentOrder: 0 }]

--- a/apps/journeys/__generated__/GetJourney.ts
+++ b/apps/journeys/__generated__/GetJourney.ts
@@ -725,6 +725,7 @@ export interface GetJourney_journey {
   showShareButton: boolean | null;
   showLikeButton: boolean | null;
   showDislikeButton: boolean | null;
+  showAssistant: boolean | null;
   /**
    * public title for viewers
    */

--- a/apps/journeys/__generated__/JourneyFields.ts
+++ b/apps/journeys/__generated__/JourneyFields.ts
@@ -725,6 +725,7 @@ export interface JourneyFields {
   showShareButton: boolean | null;
   showLikeButton: boolean | null;
   showDislikeButton: boolean | null;
+  showAssistant: boolean | null;
   /**
    * public title for viewers
    */

--- a/apps/journeys/src/components/Conductor/Conductor.spec.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.spec.tsx
@@ -159,7 +159,8 @@ describe('Conductor', () => {
     journeyTheme: null,
     journeyCustomizationDescription: null,
     journeyCustomizationFields: [],
-    fromTemplateId: null
+    fromTemplateId: null,
+    showAssistant: null
   }
 
   it('should create a journeyViewEvent', async () => {

--- a/apps/journeys/src/components/Conductor/Conductor.stories.tsx
+++ b/apps/journeys/src/components/Conductor/Conductor.stories.tsx
@@ -102,7 +102,8 @@ const defaultJourney: Journey = {
   journeyTheme: null,
   journeyCustomizationDescription: null,
   journeyCustomizationFields: [],
-  fromTemplateId: null
+  fromTemplateId: null,
+  showAssistant: null
 }
 
 type Story = StoryObj<ComponentProps<typeof Conductor> & { journey?: Journey }>

--- a/apps/journeys/src/components/EmbeddedPreview/EmbeddedPreview.spec.tsx
+++ b/apps/journeys/src/components/EmbeddedPreview/EmbeddedPreview.spec.tsx
@@ -99,7 +99,8 @@ const journey: Journey = {
   journeyTheme: null,
   journeyCustomizationDescription: null,
   journeyCustomizationFields: [],
-  fromTemplateId: null
+  fromTemplateId: null,
+  showAssistant: null
 }
 
 const mockUuidv4 = uuidv4 as jest.MockedFunction<typeof uuidv4>

--- a/apps/journeys/src/components/EmbeddedPreview/EmbeddedPreview.stories.tsx
+++ b/apps/journeys/src/components/EmbeddedPreview/EmbeddedPreview.stories.tsx
@@ -102,7 +102,8 @@ const journey: Journey = {
   journeyTheme: null,
   journeyCustomizationDescription: null,
   journeyCustomizationFields: [],
-  fromTemplateId: null
+  fromTemplateId: null,
+  showAssistant: null
 }
 
 const Template: StoryObj<typeof EmbeddedPreview> = {

--- a/apps/watch/__generated__/GetJourney.ts
+++ b/apps/watch/__generated__/GetJourney.ts
@@ -725,6 +725,7 @@ export interface GetJourney_journey {
   showShareButton: boolean | null;
   showLikeButton: boolean | null;
   showDislikeButton: boolean | null;
+  showAssistant: boolean | null;
   /**
    * public title for viewers
    */

--- a/apps/watch/__generated__/JourneyFields.ts
+++ b/apps/watch/__generated__/JourneyFields.ts
@@ -725,6 +725,7 @@ export interface JourneyFields {
   showShareButton: boolean | null;
   showLikeButton: boolean | null;
   showDislikeButton: boolean | null;
+  showAssistant: boolean | null;
   /**
    * public title for viewers
    */

--- a/libs/journeys/ui/src/components/AiChat/AiChat.tsx
+++ b/libs/journeys/ui/src/components/AiChat/AiChat.tsx
@@ -26,7 +26,7 @@ import {
   PromptInputSubmit,
   PromptInputTextarea
 } from '../PromptInput'
-import type { PromptInputMessage } from '../PromptInput/PromptInput'
+import type { PromptInputMessage } from '../PromptInput'
 import { Response } from '../Response'
 import { Suggestion, Suggestions } from '../Suggestion'
 

--- a/libs/journeys/ui/src/components/AiChatButton/AiChatButton.tsx
+++ b/libs/journeys/ui/src/components/AiChatButton/AiChatButton.tsx
@@ -58,7 +58,7 @@ export function AiChatButton(): ReactElement {
           aria-label={open ? 'Close AI chat' : 'Open AI chat'}
           tabIndex={0}
           data-testid="AiChatButton"
-          className="fixed z-1 bg-background text-foreground rounded-full size-11 hover:bg-background/80"
+          className="bg-background text-foreground rounded-full size-11 hover:bg-background/80"
         >
           <AutoAwesomeIcon />
         </Button>

--- a/libs/journeys/ui/src/components/Card/utils/getFooterElements/getFooterElements.ts
+++ b/libs/journeys/ui/src/components/Card/utils/getFooterElements/getFooterElements.ts
@@ -43,6 +43,13 @@ export function hasChatWidget({
   )
 }
 
+export function hasAiChatButton({
+  journey,
+  variant = 'default'
+}: JourneyInfoProps): boolean {
+  return variant !== 'admin' && journey?.showAssistant === true
+}
+
 export function getTitle({ journey }: JourneyInfoProps): string | null {
   if (journey?.displayTitle == null) {
     return journey?.seoTitle ?? null
@@ -82,7 +89,8 @@ export function getFooterMobileSpacing({
       hasHost ||
       hasChatWidget({ journey, variant }) ||
       title != null ||
-      reactions
+      reactions ||
+      hasAiChatButton({ journey, variant })
 
     if (hasTopRow && hasBottomRow) {
       return FULL_HEIGHT
@@ -106,7 +114,8 @@ export function getFooterMobileHeight({
       hasHostAvatar({ journey, variant }) ||
       hasHostDetails({ journey }) ||
       hasChatWidget({ journey, variant }) ||
-      getTitle({ journey }) != null
+      getTitle({ journey }) != null ||
+      hasAiChatButton({ journey, variant })
 
     if (hasBottomRow) {
       return HALF_HEIGHT

--- a/libs/journeys/ui/src/components/Card/utils/getFooterElements/index.ts
+++ b/libs/journeys/ui/src/components/Card/utils/getFooterElements/index.ts
@@ -6,5 +6,6 @@ export {
   getTitle,
   hasCombinedFooter,
   getFooterMobileSpacing,
-  getFooterMobileHeight
+  getFooterMobileHeight,
+  hasAiChatButton
 } from './getFooterElements'

--- a/libs/journeys/ui/src/components/Step/Step.spec.tsx
+++ b/libs/journeys/ui/src/components/Step/Step.spec.tsx
@@ -112,7 +112,8 @@ const journey: Journey = {
   journeyTheme: null,
   journeyCustomizationDescription: null,
   journeyCustomizationFields: [],
-  fromTemplateId: null
+  fromTemplateId: null,
+  showAssistant: null
 }
 
 const block: TreeBlock<StepFields> = {

--- a/libs/journeys/ui/src/components/StepFooter/ChatButtons/ChatButtons.spec.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/ChatButtons/ChatButtons.spec.tsx
@@ -155,21 +155,20 @@ describe('ChatButtons', () => {
     Object.defineProperty(window, 'location', originalLocation)
   })
 
-  // bring this back after PR 7704
-  // it('renders chat buttons', () => {
-  //   const { getAllByRole, getByTestId } = render(
-  //     <MockedProvider>
-  //       <JourneyProvider value={{ journey: { ...journey, chatButtons } }}>
-  //         <ChatButtons />
-  //       </JourneyProvider>
-  //     </MockedProvider>
-  //   )
+  it('renders chat buttons', () => {
+    const { getAllByRole, getByTestId } = render(
+      <MockedProvider>
+        <JourneyProvider value={{ journey: { ...journey, chatButtons } }}>
+          <ChatButtons />
+        </JourneyProvider>
+      </MockedProvider>
+    )
 
-  //   const buttons = getAllByRole('button')
-  //   expect(buttons).toHaveLength(chatButtons.length)
-  //   expect(getByTestId('FacebookIcon')).toBeInTheDocument()
-  //   expect(getByTestId('TelegramIcon')).toBeInTheDocument()
-  // })
+    const buttons = getAllByRole('button')
+    expect(buttons).toHaveLength(chatButtons.length)
+    expect(getByTestId('FacebookIcon')).toBeInTheDocument()
+    expect(getByTestId('TelegramIcon')).toBeInTheDocument()
+  })
 
   it('handles button click and sends a mutation', async () => {
     window.open = jest.fn()

--- a/libs/journeys/ui/src/components/StepFooter/ChatButtons/ChatButtons.spec.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/ChatButtons/ChatButtons.spec.tsx
@@ -107,7 +107,8 @@ describe('ChatButtons', () => {
     journeyTheme: null,
     journeyCustomizationDescription: null,
     journeyCustomizationFields: [],
-    fromTemplateId: null
+    fromTemplateId: null,
+    showAssistant: null
   }
 
   const result = jest.fn(() => ({

--- a/libs/journeys/ui/src/components/StepFooter/ChatButtons/ChatButtons.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/ChatButtons/ChatButtons.tsx
@@ -17,7 +17,6 @@ import { JourneyFields_chatButtons as ChatButton } from '../../../libs/JourneyPr
 import { MessageChatIcon } from '../../../libs/MessageChatIcon'
 import { JourneyPlausibleEvents, keyify } from '../../../libs/plausibleHelpers'
 import { getJourneyRTL } from '../../../libs/rtl'
-import { AiChatButton } from '../../AiChatButton/AiChatButton'
 
 import {
   ChatButtonEventCreate,
@@ -156,7 +155,6 @@ export function ChatButtons(): ReactElement {
           <Plus2 sx={{ color: (theme) => theme.palette.grey[700] }} />
         </IconButton>
       )}
-      {variant !== 'embed' && <AiChatButton />}
     </Stack>
   )
 }

--- a/libs/journeys/ui/src/components/StepFooter/HostAvatars/HostAvatars.spec.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/HostAvatars/HostAvatars.spec.tsx
@@ -71,7 +71,8 @@ describe('HostAvatars', () => {
     journeyTheme: null,
     journeyCustomizationDescription: null,
     journeyCustomizationFields: [],
-    fromTemplateId: null
+    fromTemplateId: null,
+    showAssistant: null
   }
 
   it('renders both avatars if both images are set', () => {

--- a/libs/journeys/ui/src/components/StepFooter/HostAvatars/HostAvatars.stories.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/HostAvatars/HostAvatars.stories.tsx
@@ -79,7 +79,8 @@ const journey: Journey = {
   journeyTheme: null,
   journeyCustomizationDescription: null,
   journeyCustomizationFields: [],
-  fromTemplateId: null
+  fromTemplateId: null,
+  showAssistant: null
 }
 
 const Template: StoryObj<ComponentProps<typeof HostAvatars>> = {

--- a/libs/journeys/ui/src/components/StepFooter/HostTitleLocation/HostTitleLocation.spec.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/HostTitleLocation/HostTitleLocation.spec.tsx
@@ -70,7 +70,8 @@ describe('HostTitleLocation', () => {
     journeyTheme: null,
     journeyCustomizationDescription: null,
     journeyCustomizationFields: [],
-    fromTemplateId: null
+    fromTemplateId: null,
+    showAssistant: null
   }
 
   const rtlLanguage = {

--- a/libs/journeys/ui/src/components/StepFooter/StepFooter.spec.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/StepFooter.spec.tsx
@@ -205,14 +205,14 @@ describe('StepFooter', () => {
       expect(screen.getAllByTestId('StepFooterButtonList')).toHaveLength(2)
     })
 
-    it('should show ai chat button', () => {
+    it('should show ai chat button on journey', () => {
       render(
         <MockedProvider>
           <SnackbarProvider>
             <JourneyProvider
               value={{
                 journey: { ...journey, showAssistant: true },
-                variant: 'admin'
+                variant: 'default'
               }}
             >
               <StepFooter />
@@ -223,7 +223,7 @@ describe('StepFooter', () => {
       expect(screen.getByTestId('AiChatButton')).toBeInTheDocument()
     })
 
-    it('should not show ai chat button', () => {
+    it('should not show ai chat button on journey if chat buttons exist', () => {
       render(
         <MockedProvider>
           <SnackbarProvider>
@@ -241,7 +241,7 @@ describe('StepFooter', () => {
                     }
                   ]
                 },
-                variant: 'admin'
+                variant: 'default'
               }}
             >
               <StepFooter />

--- a/libs/journeys/ui/src/components/StepFooter/StepFooter.spec.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/StepFooter.spec.tsx
@@ -78,7 +78,8 @@ describe('StepFooter', () => {
     journeyTheme: null,
     journeyCustomizationDescription: null,
     journeyCustomizationFields: [],
-    fromTemplateId: null
+    fromTemplateId: null,
+    showAssistant: null
   }
 
   it('should render custom styles', () => {

--- a/libs/journeys/ui/src/components/StepFooter/StepFooter.spec.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/StepFooter.spec.tsx
@@ -4,6 +4,7 @@ import { SnackbarProvider } from 'notistack'
 
 import {
   JourneyStatus,
+  MessagePlatform,
   ThemeMode,
   ThemeName
 } from '../../../__generated__/globalTypes'
@@ -202,6 +203,54 @@ describe('StepFooter', () => {
       )
 
       expect(screen.getAllByTestId('StepFooterButtonList')).toHaveLength(2)
+    })
+
+    it('should show ai chat button', () => {
+      render(
+        <MockedProvider>
+          <SnackbarProvider>
+            <JourneyProvider
+              value={{
+                journey: { ...journey, showAssistant: true },
+                variant: 'admin'
+              }}
+            >
+              <StepFooter />
+            </JourneyProvider>
+          </SnackbarProvider>
+        </MockedProvider>
+      )
+      expect(screen.getByTestId('AiChatButton')).toBeInTheDocument()
+    })
+
+    it('should not show ai chat button', () => {
+      render(
+        <MockedProvider>
+          <SnackbarProvider>
+            <JourneyProvider
+              value={{
+                journey: {
+                  ...journey,
+                  showAssistant: true,
+                  chatButtons: [
+                    {
+                      __typename: 'ChatButton',
+                      id: 'chatButtonId',
+                      link: 'https://www.google.com',
+                      platform: MessagePlatform.whatsApp
+                    }
+                  ]
+                },
+                variant: 'admin'
+              }}
+            >
+              <StepFooter />
+            </JourneyProvider>
+          </SnackbarProvider>
+        </MockedProvider>
+      )
+
+      expect(screen.queryByTestId('AiChatButton')).not.toBeInTheDocument()
     })
   })
 

--- a/libs/journeys/ui/src/components/StepFooter/StepFooter.stories.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/StepFooter.stories.tsx
@@ -83,7 +83,8 @@ const journey: Journey = {
   journeyTheme: null,
   journeyCustomizationDescription: null,
   journeyCustomizationFields: [],
-  fromTemplateId: null
+  fromTemplateId: null,
+  showAssistant: null
 }
 
 const rtlLanguage = {

--- a/libs/journeys/ui/src/components/StepFooter/StepFooter.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/StepFooter.tsx
@@ -6,14 +6,15 @@ import { ReactElement } from 'react'
 
 import { useJourney } from '../../libs/JourneyProvider'
 import { getJourneyRTL } from '../../libs/rtl'
+import { AiChatButton } from '../AiChatButton'
 import {
   getFooterMobileHeight,
   getTitle,
+  hasAiChatButton,
   hasChatWidget,
   hasCombinedFooter,
   hasHostAvatar,
-  hasHostDetails,
-  hasAiChatButton
+  hasHostDetails
 } from '../Card/utils/getFooterElements'
 import { InformationButton } from '../StepHeader/InformationButton'
 
@@ -21,7 +22,6 @@ import { ChatButtons } from './ChatButtons'
 import { FooterButtonList } from './FooterButtonList'
 import { HostAvatars } from './HostAvatars'
 import { HostTitleLocation } from './HostTitleLocation'
-import { AiChatButton } from '../AiChatButton'
 
 interface StepFooterProps {
   onFooterClick?: () => void

--- a/libs/journeys/ui/src/components/StepFooter/StepFooter.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/StepFooter.tsx
@@ -12,7 +12,8 @@ import {
   hasChatWidget,
   hasCombinedFooter,
   hasHostAvatar,
-  hasHostDetails
+  hasHostDetails,
+  hasAiChatButton
 } from '../Card/utils/getFooterElements'
 import { InformationButton } from '../StepHeader/InformationButton'
 
@@ -20,6 +21,7 @@ import { ChatButtons } from './ChatButtons'
 import { FooterButtonList } from './FooterButtonList'
 import { HostAvatars } from './HostAvatars'
 import { HostTitleLocation } from './HostTitleLocation'
+import { AiChatButton } from '../AiChatButton'
 
 interface StepFooterProps {
   onFooterClick?: () => void
@@ -37,6 +39,7 @@ export function StepFooter({
   const hostDetails = hasHostDetails({ journey })
   const chat = hasChatWidget({ journey, variant })
   const title = getTitle({ journey })
+  const aiChat = hasAiChatButton({ journey, variant })
 
   const footerMobileHeight = getFooterMobileHeight({ journey, variant })
   const combinedFooter = hasCombinedFooter({ journey, variant })
@@ -139,7 +142,7 @@ export function StepFooter({
               </Box>
             </Stack>
           )}
-          <Box>{chat && <ChatButtons />}</Box>
+          <Box>{chat ? <ChatButtons /> : aiChat ? <AiChatButton /> : null}</Box>
         </Stack>
       </Stack>
     </Box>

--- a/libs/journeys/ui/src/components/StepHeader/InformationButton/InformationButton.spec.tsx
+++ b/libs/journeys/ui/src/components/StepHeader/InformationButton/InformationButton.spec.tsx
@@ -89,7 +89,8 @@ describe('InformationButton', () => {
     journeyTheme: null,
     journeyCustomizationDescription: null,
     journeyCustomizationFields: [],
-    fromTemplateId: null
+    fromTemplateId: null,
+    showAssistant: null
   }
 
   it('should have report contact button', () => {

--- a/libs/journeys/ui/src/components/StepHeader/InformationButton/InformationButton.stories.tsx
+++ b/libs/journeys/ui/src/components/StepHeader/InformationButton/InformationButton.stories.tsx
@@ -71,7 +71,8 @@ const journey: Journey = {
   journeyTheme: null,
   journeyCustomizationDescription: null,
   journeyCustomizationFields: [],
-  fromTemplateId: null
+  fromTemplateId: null,
+  showAssistant: null
 }
 
 type Story = StoryObj<ComponentPropsWithoutRef<typeof InformationButton>>

--- a/libs/journeys/ui/src/components/StepHeader/StepHeader.stories.tsx
+++ b/libs/journeys/ui/src/components/StepHeader/StepHeader.stories.tsx
@@ -80,7 +80,8 @@ const defaultJourney: Journey = {
   journeyTheme: null,
   journeyCustomizationDescription: null,
   journeyCustomizationFields: [],
-  fromTemplateId: null
+  fromTemplateId: null,
+  showAssistant: null
 }
 
 const step1: TreeBlock<StepBlock> = {

--- a/libs/journeys/ui/src/components/TemplateView/CreateJourneyButton/CreateJourneyButton.spec.tsx
+++ b/libs/journeys/ui/src/components/TemplateView/CreateJourneyButton/CreateJourneyButton.spec.tsx
@@ -91,7 +91,8 @@ const journey: Journey = {
   journeyTheme: null,
   journeyCustomizationDescription: null,
   journeyCustomizationFields: [],
-  fromTemplateId: null
+  fromTemplateId: null,
+  showAssistant: null
 }
 
 const teamResult = jest.fn(() => ({

--- a/libs/journeys/ui/src/components/TemplateView/TemplateFooter/data.ts
+++ b/libs/journeys/ui/src/components/TemplateView/TemplateFooter/data.ts
@@ -171,5 +171,6 @@ export const journey: Journey = {
   journeyTheme: null,
   journeyCustomizationDescription: null,
   journeyCustomizationFields: [],
-  fromTemplateId: null
+  fromTemplateId: null,
+  showAssistant: null
 }

--- a/libs/journeys/ui/src/components/TemplateView/data.ts
+++ b/libs/journeys/ui/src/components/TemplateView/data.ts
@@ -115,7 +115,8 @@ export const defaultJourney: Journey = {
   journeyTheme: null,
   journeyCustomizationDescription: null,
   journeyCustomizationFields: [],
-  fromTemplateId: null
+  fromTemplateId: null,
+  showAssistant: null
 }
 
 export const publishedJourney: Journey = {

--- a/libs/journeys/ui/src/libs/JourneyProvider/JourneyProvider.mock.ts
+++ b/libs/journeys/ui/src/libs/JourneyProvider/JourneyProvider.mock.ts
@@ -67,5 +67,6 @@ export const journey: Journey = {
   journeyCustomizationFields: [],
   fromTemplateId: null,
   socialNodeX: null,
-  socialNodeY: null
+  socialNodeY: null,
+  showAssistant: null
 }

--- a/libs/journeys/ui/src/libs/JourneyProvider/JourneyProvider.tsx
+++ b/libs/journeys/ui/src/libs/JourneyProvider/JourneyProvider.tsx
@@ -1,4 +1,5 @@
 import { ReactElement, ReactNode, createContext, useContext } from 'react'
+
 import { JourneyFields as Journey } from './__generated__/JourneyFields'
 
 interface Context {

--- a/libs/journeys/ui/src/libs/JourneyProvider/__generated__/JourneyFields.ts
+++ b/libs/journeys/ui/src/libs/JourneyProvider/__generated__/JourneyFields.ts
@@ -725,6 +725,7 @@ export interface JourneyFields {
   showShareButton: boolean | null;
   showLikeButton: boolean | null;
   showDislikeButton: boolean | null;
+  showAssistant: boolean | null;
   /**
    * public title for viewers
    */

--- a/libs/journeys/ui/src/libs/JourneyProvider/journeyFields.tsx
+++ b/libs/journeys/ui/src/libs/JourneyProvider/journeyFields.tsx
@@ -92,6 +92,7 @@ export const JOURNEY_FIELDS = gql`
     showShareButton
     showLikeButton
     showDislikeButton
+    showAssistant
     displayTitle
     logoImageBlock {
       ...ImageFields

--- a/libs/journeys/ui/src/libs/rtl/rtl.spec.tsx
+++ b/libs/journeys/ui/src/libs/rtl/rtl.spec.tsx
@@ -64,7 +64,8 @@ const journey: Journey = {
   journeyTheme: null,
   journeyCustomizationDescription: null,
   journeyCustomizationFields: [],
-  fromTemplateId: null
+  fromTemplateId: null,
+  showAssistant: null
 }
 
 describe('getJourneyRTL', () => {

--- a/libs/journeys/ui/src/libs/useJourneyQuery/__generated__/GetJourney.ts
+++ b/libs/journeys/ui/src/libs/useJourneyQuery/__generated__/GetJourney.ts
@@ -725,6 +725,7 @@ export interface GetJourney_journey {
   showShareButton: boolean | null;
   showLikeButton: boolean | null;
   showDislikeButton: boolean | null;
+  showAssistant: boolean | null;
   /**
    * public title for viewers
    */

--- a/libs/journeys/ui/src/libs/useJourneyQuery/useJourneyQuery.spec.tsx
+++ b/libs/journeys/ui/src/libs/useJourneyQuery/useJourneyQuery.spec.tsx
@@ -84,7 +84,8 @@ describe('useJourneyQuery', () => {
       journeyTheme: null,
       journeyCustomizationDescription: null,
       journeyCustomizationFields: [],
-      fromTemplateId: null
+      fromTemplateId: null,
+      showAssistant: null
     }
 
     const result = jest.fn(() => ({ data: { journey } }))


### PR DESCRIPTION
This PR removes the ai chat button from the list of other chat buttons. 

As it is undecided as of yet where this button should live, this ai chat button will only appear if there are no chat widgets.