### PR TITLE
chore: update GitHub Actions workflows to use actions/setup-node@v5 a…

### DIFF
--- a/.github/workflows/api-deploy-prod.yml
+++ b/.github/workflows/api-deploy-prod.yml
@@ -24,7 +24,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'

--- a/.github/workflows/api-deploy-stage.yml
+++ b/.github/workflows/api-deploy-stage.yml
@@ -24,7 +24,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'

--- a/.github/workflows/api-deploy-worker.yml
+++ b/.github/workflows/api-deploy-worker.yml
@@ -58,7 +58,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
@@ -95,7 +95,7 @@ jobs:
 
       - name: Build and push Docker image to Amazon ECR
         id: build-image-ecs
-        uses: useblacksmith/build-push-action@v1
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: apis/${{ inputs.name }}/Dockerfile

--- a/.github/workflows/api-gateway-prod-worker.yml
+++ b/.github/workflows/api-gateway-prod-worker.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Build and push Docker image to Amazon ECR
         id: build-image-ecs
-        uses: useblacksmith/build-push-action@v1
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: apis/api-gateway/Dockerfile

--- a/.github/workflows/api-gateway-stage-worker.yml
+++ b/.github/workflows/api-gateway-stage-worker.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Build and push Docker image to Amazon ECR
         id: build-image-ecs
-        uses: useblacksmith/build-push-action@v1
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: apis/api-gateway/Dockerfile

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -25,7 +25,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
@@ -92,7 +92,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
@@ -251,18 +251,20 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --silent
-      - name: Mount playwright cache
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-playwright-cache
           path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-playwright-
       - name: Run Playwright tests
         run: pnpm exec nx run ${{ matrix.app }}-e2e:e2e
         env:
@@ -332,7 +334,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'

--- a/.github/workflows/autofix.ci.yml
+++ b/.github/workflows/autofix.ci.yml
@@ -27,17 +27,19 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --silent
-      - name: Mount lint cache
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache lint artifacts
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-lint
           path: ./.cache
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-lint-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-lint-
       - name: generate prisma imports
         uses: mansagroup/nrwl-nx-action@v3
         with:

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -33,7 +33,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -72,17 +72,19 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --silent
-      - name: Mount playwright cache
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-playwright-cache
           path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-node-22-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-22-playwright-
       - uses: nrwl/nx-set-shas@v4
       - name: vercel deployment
         env:
@@ -165,18 +167,20 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --silent
-      - name: Mount playwright cache
-        uses: useblacksmith/stickydisk@v1
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-playwright-cache-${{ matrix.test-suite }}
           path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-playwright-
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
       - name: Set deployment URL for single test run

--- a/.github/workflows/ecs-frontend-deploy-prod-worker.yml
+++ b/.github/workflows/ecs-frontend-deploy-prod-worker.yml
@@ -74,7 +74,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
@@ -151,7 +151,7 @@ jobs:
       - name: Build and push Docker image to Amazon ECR
         if: contains(steps.affected-apps.outputs.apps, inputs.name)
         id: build-image-ecs
-        uses: useblacksmith/build-push-action@v1
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: apps/${{ inputs.name }}/Dockerfile

--- a/.github/workflows/ecs-frontend-deploy-stage-worker.yml
+++ b/.github/workflows/ecs-frontend-deploy-stage-worker.yml
@@ -74,7 +74,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
@@ -151,7 +151,7 @@ jobs:
       - name: Build and push Docker image to Amazon ECR
         if: contains(steps.affected-apps.outputs.apps, inputs.name)
         id: build-image-ecs
-        uses: useblacksmith/build-push-action@v1
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: apps/${{ inputs.name }}/Dockerfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
@@ -87,7 +87,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'

--- a/.github/workflows/task-deploy-worker.yml
+++ b/.github/workflows/task-deploy-worker.yml
@@ -43,7 +43,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
@@ -94,7 +94,7 @@ jobs:
       - name: Build and push Docker image to Amazon ECR
         if: contains(steps.affected-apps.outputs.apps, inputs.name)
         id: build-image-ecs
-        uses: useblacksmith/build-push-action@v1
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: apis/${{ inputs.name }}/Dockerfile

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -25,7 +25,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'

--- a/.github/workflows/worker-deploy.yml
+++ b/.github/workflows/worker-deploy.yml
@@ -24,7 +24,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
@@ -60,7 +60,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
@@ -95,7 +95,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'


### PR DESCRIPTION
…nd docker/build-push-action@v6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Migrated CI workflows to official GitHub Actions for Node setup and Docker build/push.
  - Replaced custom cache steps with actions/cache, adding dynamic keys and restore-keys for Playwright and lint caches to speed up runs.
  - Standardized configurations across deploy, staging, E2E, visual tests, and maintenance workflows.
  - No application behavior changes; improvements are limited to CI/CD reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->