### PR TITLE
refactor: TeamProvider refactor to fix account switching bug

### DIFF
--- a/apps/journeys-admin/pages/_app.tsx
+++ b/apps/journeys-admin/pages/_app.tsx
@@ -44,6 +44,8 @@ function JourneysAdminApp({
       ? JSON.parse(pageProps.userSerialized)
       : null
 
+  console.log('user in app', user)
+
   const apolloClient = useApollo({
     initialState: pageProps.initialApolloState,
     token: user?._token

--- a/apps/journeys-admin/pages/index.tsx
+++ b/apps/journeys-admin/pages/index.tsx
@@ -25,14 +25,21 @@ function IndexPage(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   const user = useUser()
   const router = useRouter()
-  const { query, activeTeam, refetch } = useTeam()
+  const { activeTeam, getLastActiveTeamIdAndTeams } = useTeam()
 
   // MA - ensure team is refetched if user is not loaded before provider
   useEffect(() => {
-    if (activeTeam == null) {
-      void refetch()
+    console.log('user.id', user.id)
+    console.log('activeTeam', activeTeam)
+    console.log(
+      'activeTeam == null && user.id != null',
+      activeTeam == null && user.id != null
+    )
+
+    if (activeTeam == null && user.id != null) {
+      void getLastActiveTeamIdAndTeams()
     }
-  }, [user.id, query, activeTeam, refetch])
+  }, [user.id, activeTeam, getLastActiveTeamIdAndTeams])
 
   return (
     <>

--- a/apps/journeys-admin/pages/publisher/index.tsx
+++ b/apps/journeys-admin/pages/publisher/index.tsx
@@ -28,16 +28,16 @@ function PublisherIndexPage(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   const user = useUser()
   const router = useRouter()
-  const { query, activeTeam, refetch } = useTeam()
+  const { activeTeam, getLastActiveTeamIdAndTeams } = useTeam()
 
   const { data } = useUserRoleQuery()
 
   // Ensure team is refetched if user is not loaded before provider
   useEffect(() => {
     if (activeTeam == null) {
-      void refetch()
+      void getLastActiveTeamIdAndTeams()
     }
-  }, [user.id, query, activeTeam, refetch])
+  }, [user.id, activeTeam, getLastActiveTeamIdAndTeams])
 
   useEffect(() => {
     if (

--- a/apps/journeys-admin/pages/templates/index.tsx
+++ b/apps/journeys-admin/pages/templates/index.tsx
@@ -33,14 +33,15 @@ function TemplateIndexPage(): ReactElement {
   const user = useUser()
   const router = useRouter()
   const { data } = useQuery<GetMe>(GET_ME)
-  const { query } = useTeam()
+  const { getLastActiveTeamIdAndTeams } = useTeam()
   if (data?.me?.id != null && !data?.me?.emailVerified) {
     void router.push('/users/verify?redirect=/templates')
   }
 
-  useEffect(() => {
-    void query.refetch()
-  }, [user.id, query])
+  // useEffect(() => {
+  //   console.log('templates index page useEffect')
+  //   void getLastActiveTeamIdAndTeams()
+  // }, [user.id, getLastActiveTeamIdAndTeams])
 
   const userSignedIn = user?.id != null
 

--- a/apps/journeys-admin/src/components/OnboardingPanel/CreateJourneyButton/CreateJourneyButton.tsx
+++ b/apps/journeys-admin/src/components/OnboardingPanel/CreateJourneyButton/CreateJourneyButton.tsx
@@ -11,10 +11,7 @@ import { SidePanelContainer } from '../../PageWrapper/SidePanelContainer'
 
 export function CreateJourneyButton(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
-  const {
-    query: { loading: loadingTeams },
-    activeTeam
-  } = useTeam()
+  const { teamsLoading, activeTeam } = useTeam()
   const router = useRouter()
   const { createJourney, loading: loadingJourneyCreateMutation } =
     useJourneyCreateMutation()
@@ -26,13 +23,13 @@ export function CreateJourneyButton(): ReactElement {
       })
     }
   }
-  return activeTeam != null || loadingTeams ? (
+  return activeTeam != null || teamsLoading ? (
     <SidePanelContainer>
       <ContainedIconButton
         label={t('Create Custom Journey')}
         thumbnailIcon={<FilePlus1Icon />}
         onClick={handleCreateJourneyClick}
-        loading={loadingJourneyCreateMutation || loadingTeams}
+        loading={loadingJourneyCreateMutation || teamsLoading}
       />
     </SidePanelContainer>
   ) : (

--- a/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/UserNavigation/UserMenu/UserMenu.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/UserNavigation/UserMenu/UserMenu.tsx
@@ -102,8 +102,8 @@ export function UserMenu({
           icon={<Logout2Icon fontSize="small" />}
           onClick={async () => {
             handleProfileClose()
-            await client.clearStore()
             await user.signOut()
+            await client.clearStore()
             await enqueueSnackbar(t('Logout successful'), {
               variant: 'success',
               preventDuplicate: true

--- a/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.tsx
+++ b/apps/journeys-admin/src/components/Team/TeamSelect/TeamSelect.tsx
@@ -22,7 +22,7 @@ interface TeamSelectProps {
 }
 
 export function TeamSelect({ onboarding }: TeamSelectProps): ReactElement {
-  const { query, activeTeam, setActiveTeam } = useTeam()
+  const { teams, activeTeam, setActiveTeam, teamsLoading } = useTeam()
   const { t } = useTranslation('apps-journeys-admin')
   const anchorRef = useRef(null)
   const currentRef = anchorRef.current
@@ -32,9 +32,7 @@ export function TeamSelect({ onboarding }: TeamSelectProps): ReactElement {
     useMutation<UpdateLastActiveTeamId>(UPDATE_LAST_ACTIVE_TEAM_ID)
 
   function handleChange(event: SelectChangeEvent): void {
-    const team = query?.data?.teams.find(
-      (team) => team.id === event.target.value
-    )
+    const team = teams.find((team) => team.id === event.target.value)
     setActiveTeam(team ?? null)
     void updateLastActiveTeamId({
       variables: {
@@ -62,7 +60,7 @@ export function TeamSelect({ onboarding }: TeamSelectProps): ReactElement {
         <FormControl variant="standard" sx={{ minWidth: 100 }}>
           <Select
             defaultValue={activeTeam?.id}
-            disabled={query.loading}
+            disabled={teamsLoading}
             displayEmpty
             value={activeTeam?.id ?? ''}
             disableUnderline
@@ -97,10 +95,7 @@ export function TeamSelect({ onboarding }: TeamSelectProps): ReactElement {
             }}
             IconComponent={ChevronDownIcon}
           >
-            {(query?.data?.teams != null
-              ? sortBy(query.data?.teams, 'title')
-              : []
-            ).map((team) => (
+            {(teams != null ? sortBy(teams, 'title') : []).map((team) => (
               <MenuItem
                 key={team.id}
                 value={team.id}


### PR DESCRIPTION
An attempt to refactor the team provider, in order to fix bug where: 
1. User 1 logs out
2. On sign in page, log in to user 2
3. When navigated back to the journey list page, the teams for user 1 would be displayed in the TeamSelect component, and the team avatars in the TeamMenu would display the users for user 1's active team. 

Though this refactor fixed the issue, it still contained a bug where the old user's team would "flash" on the screen before rendering user 2's data. Likely a caching issue. More details inside linear ticket. 

This should not be merged. But wanted to create PR for future reference