### PR TITLE
fix: disable dragging of window when analytics overlay is on

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Fab/Fab.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Fab/Fab.spec.tsx
@@ -73,6 +73,36 @@ describe('Fab', () => {
       expect(screen.getByRole('button', { name: 'Add Block' })).toBeDisabled()
     })
 
+    it('should be disabled when Analytics Overlay is on', () => {
+      const analyticsOverlayState = {
+        ...state,
+        showAnalytics: true
+      }
+
+      render(
+        <EditorProvider initialState={analyticsOverlayState}>
+          <Fab variant="canvas" />
+        </EditorProvider>
+      )
+
+      expect(screen.getByRole('button', { name: 'Add Block' })).toBeDisabled()
+    })
+
+    it('should be enabled when Analytics Overlay is off', () => {
+      const analyticsOverlayState = {
+        ...state,
+        showAnalytics: false
+      }
+
+      render(
+        <EditorProvider initialState={analyticsOverlayState}>
+          <Fab variant="canvas" />
+        </EditorProvider>
+      )
+
+      expect(screen.getByRole('button', { name: 'Add Block' })).not.toBeDisabled()
+    })
+
     it('should handle add', () => {
       render(
         <EditorProvider initialState={state}>

--- a/apps/journeys-admin/src/components/Editor/Fab/Fab.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Fab/Fab.spec.tsx
@@ -100,7 +100,9 @@ describe('Fab', () => {
         </EditorProvider>
       )
 
-      expect(screen.getByRole('button', { name: 'Add Block' })).not.toBeDisabled()
+      expect(
+        screen.getByRole('button', { name: 'Add Block' })
+      ).not.toBeDisabled()
     })
 
     it('should handle add', () => {

--- a/apps/journeys-admin/src/components/Editor/Fab/Fab.tsx
+++ b/apps/journeys-admin/src/components/Editor/Fab/Fab.tsx
@@ -27,7 +27,8 @@ export function Fab({ variant }: FabProps): ReactElement {
       selectedStep,
       steps,
       activeSlide,
-      activeContent
+      activeContent,
+      showAnalytics
     },
     dispatch
   } = useEditor()
@@ -68,7 +69,7 @@ export function Fab({ variant }: FabProps): ReactElement {
       block.__typename === 'VideoBlock' && cardBlock.coverBlockId !== block.id
   )
 
-  const disabled = steps == null || videoBlock != null
+  const disabled = steps == null || videoBlock != null || showAnalytics === true
 
   const fabIn =
     variant === 'mobile'

--- a/apps/journeys-admin/src/components/Editor/Slider/Slider.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Slider.tsx
@@ -154,6 +154,7 @@ export function Slider(): ReactElement {
       style={{
         height: `calc(100svh - ${EDIT_TOOLBAR_HEIGHT}px)`
       }}
+      className={showAnalytics === true ? 'swiper-no-swiping' : ''}
     >
       {/* back (mobile top) button */}
       <Box


### PR DESCRIPTION
Disable the ability to drag the window when analytics overlay is on