### PR TITLE
refactor watch hero carousel into reusable hook

### DIFF
--- a/apps/watch/src/components/WatchHomePage/AboutProjectSection.tsx
+++ b/apps/watch/src/components/WatchHomePage/AboutProjectSection.tsx
@@ -1,0 +1,63 @@
+import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { useTranslation } from 'next-i18next'
+import { type ReactElement } from 'react'
+
+export function AboutProjectSection(): ReactElement {
+  const { t } = useTranslation('apps-watch')
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        width: '100%',
+        alignItems: 'center',
+        position: 'relative',
+        py: { xs: 10, lg: 20 }
+      }}
+    >
+      <Stack spacing={10}>
+        <Typography variant="h3" component="h2" color="text.primary">
+          {t('About Our Project')}
+        </Typography>
+        <Stack direction="row" spacing={4}>
+          <Box
+            sx={{
+              backgroundColor: 'primary.main',
+              height: 'inherit',
+              width: { xs: 38, lg: 14 }
+            }}
+          />
+          <Typography
+            variant="subtitle2"
+            component="h3"
+            sx={{ opacity: 0.85 }}
+            color="text.primary"
+          >
+            {t(
+              'With 70% of the world not being able to speak English, there ' +
+                'is a huge opportunity for the gospel to spread to unreached ' +
+                'places. We have a vision to make it easier to watch, ' +
+                'download and share Christian videos with people in their ' +
+                'native heart language.'
+            )}
+          </Typography>
+        </Stack>
+        <Typography
+          variant="subtitle1"
+          component="h3"
+          sx={{ opacity: 0.8 }}
+          color="text.primary"
+        >
+          {t(
+            'Jesus Film Project is a Christian ministry with a vision to ' +
+              'reach the world with the gospel of Jesus Christ through ' +
+              'evangelistic videos. Watch from over 2000 languages on any ' +
+              'device and share it with others.'
+          )}
+        </Typography>
+      </Stack>
+    </Box>
+  )
+}

--- a/apps/watch/src/components/WatchHomePage/CollectionsRail.tsx
+++ b/apps/watch/src/components/WatchHomePage/CollectionsRail.tsx
@@ -1,0 +1,59 @@
+import dynamic from 'next/dynamic'
+import { type ReactElement } from 'react'
+
+import { collectionShowcaseSources } from '../CollectionsPage/collectionShowcaseConfig'
+
+const SectionVideoCarousel = dynamic(
+  () =>
+    import('../SectionVideoCarousel').then((mod) => ({
+      default: mod.SectionVideoCarousel
+    })),
+  { ssr: false }
+)
+
+const SectionVideoGrid = dynamic(
+  () =>
+    import('../SectionVideoGrid').then((mod) => ({
+      default: mod.SectionVideoGrid
+    })),
+  { ssr: false }
+)
+
+interface CollectionsRailProps {
+  languageId?: string
+}
+
+export function CollectionsRail({ languageId }: CollectionsRailProps): ReactElement {
+  return (
+    <>
+      <SectionVideoCarousel
+        id="home-collection-showcase"
+        sources={collectionShowcaseSources}
+        primaryCollectionId="LUMOCollection"
+        subtitleOverride="Video Bible Collection"
+        titleOverride="Discover the full story"
+        descriptionOverride="Explore our collection of videos and resources that bring the Bible to life through engaging stories and teachings."
+        languageId={languageId}
+      />
+      <SectionVideoGrid
+        id="home-collection-showcase-grid"
+        sources={collectionShowcaseSources}
+        primaryCollectionId="LUMOCollection"
+        subtitleOverride="Video Bible Collection"
+        titleOverride="Discover the full story (Grid View)"
+        descriptionOverride="Explore our collection of videos and resources that bring the Bible to life through engaging stories and teachings."
+        languageId={languageId}
+      />
+      <SectionVideoGrid
+        id="home-collection-showcase-grid-vertical"
+        sources={collectionShowcaseSources}
+        primaryCollectionId="LUMOCollection"
+        subtitleOverride="Video Bible Collection"
+        titleOverride="Discover the full story (Vertical Cards)"
+        descriptionOverride="Explore our collection of videos and resources that bring the Bible to life through engaging stories and teachings."
+        orientation="vertical"
+        languageId={languageId}
+      />
+    </>
+  )
+}

--- a/apps/watch/src/components/WatchHomePage/WatchHero.tsx
+++ b/apps/watch/src/components/WatchHomePage/WatchHero.tsx
@@ -1,0 +1,58 @@
+import { type ReactElement, type ReactNode } from 'react'
+
+import { VideoContentFields } from '../../../__generated__/VideoContentFields'
+import { VideoProvider } from '../../libs/videoContext'
+import {
+  type CarouselMuxSlide,
+  type VideoCarouselSlide
+} from '../../types/inserts'
+import { ContentPageBlurFilter } from '../NewVideoContentPage/ContentPageBlurFilter'
+import { VideoCarousel } from '../NewVideoContentPage/VideoCarousel/VideoCarousel'
+import { VideoContentHero } from '../NewVideoContentPage/VideoContentHero/VideoContentHero'
+
+interface WatchHeroProps {
+  slides: VideoCarouselSlide[]
+  activeVideoId?: string
+  activeVideo: VideoContentFields | null
+  currentMuxInsert: CarouselMuxSlide | null
+  loading: boolean
+  onSelectSlide: (slideId: string) => void
+  onMuxInsertComplete: () => void
+  children?: ReactNode
+}
+
+export function WatchHero({
+  slides,
+  activeVideoId,
+  activeVideo,
+  currentMuxInsert,
+  loading,
+  onSelectSlide,
+  onMuxInsertComplete,
+  children
+}: WatchHeroProps): ReactElement {
+  return (
+    <>
+      {activeVideo != null && (
+        <VideoProvider value={{ content: activeVideo }}>
+          <VideoContentHero
+            isPreview
+            currentMuxInsert={currentMuxInsert}
+            onMuxInsertComplete={onMuxInsertComplete}
+          />
+        </VideoProvider>
+      )}
+      <ContentPageBlurFilter>
+        <div className="pt-4">
+          <VideoCarousel
+            slides={slides}
+            activeVideoId={activeVideoId}
+            loading={loading}
+            onVideoSelect={onSelectSlide}
+          />
+        </div>
+        {children}
+      </ContentPageBlurFilter>
+    </>
+  )
+}

--- a/apps/watch/src/components/WatchHomePage/WatchHomePage.tsx
+++ b/apps/watch/src/components/WatchHomePage/WatchHomePage.tsx
@@ -1,55 +1,20 @@
-import Box from '@mui/material/Box'
-import Stack from '@mui/material/Stack'
-import Typography from '@mui/material/Typography'
-import dynamic from 'next/dynamic'
-import Image from 'next/image'
-import NextLink from 'next/link'
-import { useTranslation } from 'next-i18next'
-import {
-  type ReactElement,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState
-} from 'react'
+import { type ReactElement } from 'react'
 import { Index } from 'react-instantsearch'
 
 import { ThemeProvider } from '@core/shared/ui/ThemeProvider'
 import { ThemeMode, ThemeName } from '@core/shared/ui/themes'
 
-import { VideoLabel } from '../../../__generated__/globalTypes'
-import { VideoContentFields } from '../../../__generated__/VideoContentFields'
 import { useAlgoliaRouter } from '../../libs/algolia/useAlgoliaRouter'
-import type { VideoCarouselSlide, CarouselMuxSlide } from '../../types/inserts'
-import { isMuxSlide, isVideoSlide } from '../../types/inserts'
-
-
-import { PlayerProvider , usePlayer } from '../../libs/playerContext'
-import { VideoProvider } from '../../libs/videoContext'
+import { PlayerProvider } from '../../libs/playerContext'
 import { WatchProvider } from '../../libs/watchContext'
-import { collectionShowcaseSources } from '../CollectionsPage/collectionShowcaseConfig'
-import { ContentPageBlurFilter } from '../NewVideoContentPage/ContentPageBlurFilter'
-import { useCarouselVideos } from '../VideoHero/libs/useCarouselVideos'
-import { VideoCarousel } from '../NewVideoContentPage/VideoCarousel/VideoCarousel'
-import { VideoContentHero } from '../NewVideoContentPage/VideoContentHero/VideoContentHero'
-import { PageWrapper } from '../PageWrapper'
-import { AlgoliaVideoGrid } from '../VideoGrid/AlgoliaVideoGrid'
-
 import { Header } from '../Header'
 import { SearchComponent } from '../SearchComponent'
-import { HomeHero } from './HomeHero'
-import { SeeAllVideos } from './SeeAllVideos'
 
-// Dynamically import SectionVideoCarousel to make it client-side only
-const SectionVideoCarousel = dynamic(
-  () => import('../SectionVideoCarousel').then(mod => ({ default: mod.SectionVideoCarousel })),
-  { ssr: false }
-)
-const SectionVideoGrid = dynamic(
-  () => import('../SectionVideoGrid').then(mod => ({ default: mod.SectionVideoGrid })),
-  { ssr: false }
-)
+import { AboutProjectSection } from './AboutProjectSection'
+import { CollectionsRail } from './CollectionsRail'
+import { SeeAllVideos } from './SeeAllVideos'
+import { WatchHero } from './WatchHero'
+import { useWatchHeroCarousel } from './useWatchHeroCarousel'
 
 interface WatchHomePageProps {
   languageId?: string | undefined
@@ -65,388 +30,19 @@ function WatchHomePageContent({ languageId }: WatchHomePageProps): ReactElement 
   )
 }
 
-// Inner component that uses player context
-function WatchHomePageBody({
-  languageId
-}: WatchHomePageProps): ReactElement {
-  const { t } = useTranslation('apps-watch')
+function WatchHomePageBody({ languageId }: WatchHomePageProps): ReactElement {
   useAlgoliaRouter()
-  
+
   const indexName = process.env.NEXT_PUBLIC_ALGOLIA_INDEX ?? ''
-
-  const [activeVideoId, setActiveVideoId] = useState<string | undefined>()
   const {
-    videos,
-    slides: rawSlides,
-    currentIndex,
+    slides,
     loading,
-    moveToNext,
-    jumpToVideo,
-    currentPoolIndex
-  } = useCarouselVideos('529') // Use language ID 529 for now
-  const [displaySlides, setDisplaySlides] = useState<VideoCarouselSlide[]>(rawSlides)
-  const [autoProgressEnabled, setAutoProgressEnabled] = useState(true)
-  const [currentSlideId, setCurrentSlideId] = useState<string | null>(null)
-  useEffect(() => {
-    setDisplaySlides((prevSlides) => {
-      if (prevSlides === rawSlides) return prevSlides
-
-      const previousByKey = new Map(
-        prevSlides.map((slide) => [`${slide.source}:${slide.id}`, slide])
-      )
-
-      const nextSlides = rawSlides.map((slide) => {
-        const key = `${slide.source}:${slide.id}`
-        const previousSlide = previousByKey.get(key)
-
-        if (
-          previousSlide != null &&
-          isMuxSlide(slide) &&
-          isMuxSlide(previousSlide) &&
-          previousSlide.playbackId === slide.playbackId &&
-          previousSlide.playbackIndex === slide.playbackIndex
-        ) {
-          return previousSlide
-        }
-
-        if (
-          previousSlide != null &&
-          isVideoSlide(slide) &&
-          isVideoSlide(previousSlide) &&
-          previousSlide.video === slide.video
-        ) {
-          return previousSlide
-        }
-
-        return slide
-      })
-
-      const isSameLength = nextSlides.length === prevSlides.length
-      if (
-        isSameLength &&
-        nextSlides.every((slide, idx) => slide === prevSlides[idx])
-      ) {
-        return prevSlides
-      }
-
-      return nextSlides
-    })
-  }, [rawSlides])
-
-  // Map videos to ensure data structure matches what VideoCard expects
-  const carouselVideos = videos.map((video) => ({
-    __typename: 'Video' as const,
-    id: video.id,
-    slug: video.slug,
-    childrenCount: video.childrenCount,
-    title: (video.title || [{ value: video.slug }]).map((t) => ({
-      __typename: 'VideoTitle' as const,
-      value: t.value
-    })),
-    images: (video.images || []).map((img) => ({
-      __typename: 'CloudflareImage' as const,
-      mobileCinematicHigh: img.mobileCinematicHigh
-    })),
-    imageAlt: (
-      video.imageAlt || [{ value: video.title?.[0]?.value || video.slug }]
-    ).map((alt) => ({
-      __typename: 'VideoImageAlt' as const,
-      value: alt.value
-    })),
-    snippet: [{ __typename: 'VideoSnippet' as const, value: '' }],
-    label:
-      video.label &&
-      Object.values(VideoLabel).includes(video.label as VideoLabel)
-        ? (video.label as VideoLabel)
-        : VideoLabel.shortFilm,
-    variant: video.variant
-      ? {
-          __typename: 'VideoVariant' as const,
-          id: video.variant.id,
-          duration: video.variant.duration,
-          hls: video.variant.hls,
-          slug: video.variant.slug
-        }
-      : null
-  }))
-
-  // Get current video from videos array using currentIndex
-  const currentVideo = videos[currentIndex] || null
-
-  // Get the current slide (could be video or mux insert)
-  const currentSlide: VideoCarouselSlide | null = useMemo(() => {
-    if (currentSlideId) {
-      // If a specific slide is selected, find it
-      return (
-        displaySlides.find((slide) => slide.id === currentSlideId) || null
-      )
-    }
-
-    // Default to the first slide (mux insert or first video)
-    if (displaySlides.length > 0) {
-      return displaySlides[0]
-    }
-
-    return null
-  }, [currentSlideId, displaySlides])
-
-  const currentSlideIndex = useMemo(() => {
-    if (!currentSlide) return -1
-    return displaySlides.findIndex((slide) => slide.id === currentSlide.id)
-  }, [currentSlide, displaySlides])
-
-  const currentMuxInsert: CarouselMuxSlide | null = useMemo(() => {
-    if (currentSlide != null && isMuxSlide(currentSlide)) {
-      return currentSlide
-    }
-    return null
-  }, [currentSlide])
-
-  const { state: playerState } = usePlayer()
-  const [lastProgress, setLastProgress] = useState(0)
-  const [isProgressing, setIsProgressing] = useState(false)
-  const resetRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  // Set the current slide as active (includes both videos and mux inserts)
-  useEffect(() => {
-    if (currentSlide && currentSlide.id !== activeVideoId) {
-      setActiveVideoId(currentSlide.id)
-    }
-  }, [currentSlide, activeVideoId])
-
-  // Reset progress tracking when video changes
-  useEffect(() => {
-    setLastProgress(0)
-    if (resetRef.current != null) clearTimeout(resetRef.current)
-    resetRef.current = setTimeout(() => {
-      setIsProgressing(false)
-    }, 500)
-  }, [activeVideoId])
-
-  // Auto-progress to next video function
-  const progressToNextVideo = useCallback(() => {
-    if (!autoProgressEnabled || isProgressing || !displaySlides.length) return
-
-    setIsProgressing(true)
-
-    // Use moveToNext from useCarouselVideos hook
-    moveToNext()
-
-    // Update currentSlideId to sync the main video with the carousel
-    const nextIndex = currentIndex + 1
-    if (nextIndex < displaySlides.length) {
-      setCurrentSlideId(displaySlides[nextIndex].id)
-    }
-
-    setLastProgress(0) // Reset progress tracking for new video
-
-    // Allow progression again after a short delay
-    if (resetRef.current != null) clearTimeout(resetRef.current)
-    resetRef.current = setTimeout(() => {
-      setIsProgressing(false)
-    }, 2000)
-  }, [
-    moveToNext,
-    autoProgressEnabled,
-    isProgressing,
-    displaySlides,
-    currentIndex
-  ])
-
-  // Effect to detect video end and progress immediately
-  useEffect(() => {
-    // Check if video has ended (progress >= 95%)
-    if (playerState.progress >= 95 && lastProgress < 95 && !isProgressing) {
-      progressToNextVideo()
-    }
-    setLastProgress(playerState.progress)
-  }, [playerState.progress, lastProgress, progressToNextVideo, isProgressing])
-
-  // Get the active video for playback (current slide from carousel)
-  // Transform CarouselVideo or MuxSlide to VideoContentFields for VideoProvider
-  const activeVideo: VideoContentFields | null = useMemo(() => {
-    if (!currentSlide) {
-      return null
-    }
-
-    // Handle mux inserts
-    if (isMuxSlide(currentSlide)) {
-      const muxSlide = currentSlide
-      return {
-        __typename: 'Video' as const,
-        id: muxSlide.id,
-        slug: muxSlide.id,
-        title: [
-          {
-            __typename: 'VideoTitle' as const,
-            value: muxSlide.overlay.title
-          }
-        ],
-        images: [
-          {
-            __typename: 'CloudflareImage' as const,
-            mobileCinematicHigh: muxSlide.urls.poster
-          }
-        ],
-        imageAlt: [
-          {
-            __typename: 'VideoImageAlt' as const,
-            value: muxSlide.overlay.title
-          }
-        ],
-        snippet: [],
-        description: [
-          {
-            __typename: 'VideoDescription' as const,
-            value: muxSlide.overlay.description
-          }
-        ],
-        studyQuestions: [],
-        bibleCitations: [],
-        label: muxSlide.overlay.label as any,
-        variant: {
-          __typename: 'VideoVariant' as const,
-          id: `${muxSlide.id}-variant`,
-          duration: 0, // We don't have duration for mux videos
-          hls: muxSlide.urls.hls,
-          downloadable: false,
-          downloads: [],
-          language: {
-            __typename: 'Language' as const,
-            id: '529',
-            name: [
-              {
-                __typename: 'LanguageName' as const,
-                value: 'English',
-                primary: true
-              }
-            ],
-            bcp47: 'en'
-          },
-          slug: `${muxSlide.id}/variant`,
-          subtitleCount: 0
-        },
-        variantLanguagesCount: 1,
-        childrenCount: 0
-      }
-    }
-
-    // Handle regular videos
-    const video = currentSlide.video as any
-    if (!video) {
-      return null
-    }
-
-    const title = (video.title ?? []).map((t) => ({
-      __typename: 'VideoTitle' as const,
-      value: t.value
-    }))
-
-    const images = (video.images ?? []).map((img) => ({
-      __typename: 'CloudflareImage' as const,
-      mobileCinematicHigh: img.mobileCinematicHigh
-    }))
-
-    const imageAlt = (video.imageAlt ?? []).map((alt) => ({
-      __typename: 'VideoImageAlt' as const,
-      value: alt.value
-    }))
-
-    const snippet = []
-    const description = (video.description ?? []).map((desc) => ({
-      __typename: 'VideoDescription' as const,
-      value: desc.value
-    }))
-    const studyQuestions = []
-    const bibleCitations = []
-
-    const variant =
-      video.variant &&
-      video.variant.id &&
-      video.variant.duration !== undefined &&
-      video.variant.hls &&
-      video.variant.slug
-        ? {
-            __typename: 'VideoVariant' as const,
-            id: video.variant.id,
-            duration: video.variant.duration,
-            hls: video.variant.hls,
-            downloadable: false,
-            downloads: [],
-            language: {
-              __typename: 'Language' as const,
-              id: '529',
-              name: [
-                {
-                  __typename: 'LanguageName' as const,
-                  value: 'English',
-                  primary: true
-                }
-              ],
-              bcp47: 'en'
-            },
-            slug: video.variant.slug,
-            subtitleCount: 0
-          }
-        : null
-
-    return {
-      __typename: 'Video' as const,
-      id: video.id,
-      slug: video.slug,
-      label:
-        video.label &&
-        Object.values(VideoLabel).includes(video.label as VideoLabel)
-          ? (video.label as VideoLabel)
-          : VideoLabel.shortFilm,
-      title,
-      images,
-      imageAlt,
-      snippet,
-      description,
-      studyQuestions,
-      bibleCitations,
-      variant,
-      variantLanguagesCount: 1,
-      childrenCount: video.childrenCount ?? 0
-    }
-  }, [currentSlide])
-
-  const handleMuxInsertComplete = useCallback(() => {
-    if (!autoProgressEnabled || isProgressing || currentSlideIndex === -1) {
-      return
-    }
-
-    const nextIndex = currentSlideIndex + 1
-    const nextSlide = displaySlides[nextIndex]
-
-    if (!nextSlide) {
-      return
-    }
-
-    setIsProgressing(true)
-    setCurrentSlideId(nextSlide.id)
-
-    if (!isMuxSlide(nextSlide)) {
-      const jumped = jumpToVideo(nextSlide.id)
-      if (!jumped) {
-        moveToNext()
-      }
-    }
-
-    if (resetRef.current != null) clearTimeout(resetRef.current)
-    resetRef.current = setTimeout(() => {
-      setIsProgressing(false)
-    }, 500)
-  }, [
-    autoProgressEnabled,
-    currentSlideIndex,
-    isProgressing,
-    jumpToVideo,
-    moveToNext,
-    displaySlides
-  ])
-
+    activeVideoId,
+    activeVideo,
+    currentMuxInsert,
+    handleVideoSelect,
+    handleMuxInsertComplete
+  } = useWatchHeroCarousel({ locale: '529' })
 
   return (
     <div>
@@ -458,49 +54,17 @@ function WatchHomePageBody({
         showLanguageSwitcher
       />
       <Index indexName={indexName}>
-        <SearchComponent languageId={languageId} floating={true} />
+        <SearchComponent languageId={languageId} floating />
       </Index>
-      <VideoProvider value={{ content: activeVideo }}>
-        <VideoContentHero
-          isPreview={true}
-          currentMuxInsert={currentMuxInsert}
-          onMuxInsertComplete={handleMuxInsertComplete}
-        />
-      </VideoProvider>
-
-      <ContentPageBlurFilter>
-        <div className="pt-4">
-          <VideoCarousel
-            slides={displaySlides}
-            activeVideoId={activeVideoId}
-            loading={loading}
-            onVideoSelect={(videoId: string) => {
-              // Check if this is a mux insert
-              const selectedSlide = displaySlides.find(
-                (slide) => slide.id === videoId
-              )
-              if (selectedSlide && isMuxSlide(selectedSlide)) {
-                // For mux inserts, set the current slide ID
-                setCurrentSlideId(videoId)
-                setIsProgressing(false)
-              } else {
-                // For regular videos, set the current slide ID and use jump logic
-                setCurrentSlideId(videoId)
-                const success = jumpToVideo(videoId)
-                if (success) {
-                  setIsProgressing(false)
-                  // Note: activeVideoId will be automatically updated by the currentVideo sync effect
-                } else {
-                  // If jump failed, still keep the slide selected for UI consistency
-                }
-              }
-            }}
-            onSlideChange={(activeIndex: number) => {
-              // Note: Slide changes in the carousel don't directly affect video playback
-              // Video playback is controlled by the useCarouselVideos hook
-            }}
-          />
-        </div>
+      <WatchHero
+        slides={slides}
+        activeVideoId={activeVideoId}
+        activeVideo={activeVideo}
+        currentMuxInsert={currentMuxInsert}
+        loading={loading}
+        onSelectSlide={handleVideoSelect}
+        onMuxInsertComplete={handleMuxInsertComplete}
+      >
         <div
           data-testid="WatchHomePage"
           className="flex flex-col py-20 z-10 responsive-container"
@@ -511,96 +75,16 @@ function WatchHomePageBody({
             nested
           >
             <SeeAllVideos />
-            <Box
-              sx={{
-                display: 'flex',
-                width: '100%',
-                alignItems: 'center',
-                position: 'relative',
-                py: { xs: 10, lg: 20 }
-              }}
-            >
-              <Stack spacing={10}>
-                <Typography variant="h3" component="h2" color="text.primary">
-                  {t('About Our Project')}
-                </Typography>
-                <Stack direction="row" spacing={4}>
-                  <Box
-                    sx={{
-                      backgroundColor: 'primary.main',
-                      height: 'inherit',
-                      width: { xs: 38, lg: 14 }
-                    }}
-                  />
-                  <Typography
-                    variant="subtitle2"
-                    component="h3"
-                    sx={{ opacity: 0.85 }}
-                    color="text.primary"
-                  >
-                    {t(
-                      'With 70% of the world not being able to speak English, there ' +
-                        'is a huge opportunity for the gospel to spread to unreached ' +
-                        'places. We have a vision to make it easier to watch, ' +
-                        'download and share Christian videos with people in their ' +
-                        'native heart language.'
-                    )}
-                  </Typography>
-                </Stack>
-                <Typography
-                  variant="subtitle1"
-                  component="h3"
-                  sx={{ opacity: 0.8 }}
-                  color="text.primary"
-                >
-                  {t(
-                    'Jesus Film Project is a Christian ministry with a vision to ' +
-                      'reach the world with the gospel of Jesus Christ through ' +
-                      'evangelistic videos. Watch from over 2000 languages on any ' +
-                      'device and share it with others.'
-                  )}
-                </Typography>
-              </Stack>
-            </Box>
+            <AboutProjectSection />
           </ThemeProvider>
         </div>
-            <SectionVideoCarousel
-              id="home-collection-showcase"
-              sources={collectionShowcaseSources}
-              primaryCollectionId="LUMOCollection"
-              subtitleOverride="Video Bible Collection"
-              titleOverride="Discover the full story"
-              descriptionOverride="Explore our collection of videos and resources that bring the Bible to life through engaging stories and teachings."
-              languageId={languageId}
-            />
-            <SectionVideoGrid
-              id="home-collection-showcase-grid"
-              sources={collectionShowcaseSources}
-              primaryCollectionId="LUMOCollection"
-              subtitleOverride="Video Bible Collection"
-              titleOverride="Discover the full story (Grid View)"
-              descriptionOverride="Explore our collection of videos and resources that bring the Bible to life through engaging stories and teachings."
-              languageId={languageId}
-            />
-            <SectionVideoGrid
-              id="home-collection-showcase-grid-vertical"
-              sources={collectionShowcaseSources}
-              primaryCollectionId="LUMOCollection"
-              subtitleOverride="Video Bible Collection"
-              titleOverride="Discover the full story (Vertical Cards)"
-              descriptionOverride="Explore our collection of videos and resources that bring the Bible to life through engaging stories and teachings."
-              orientation="vertical"
-              languageId={languageId}
-            />
-      </ContentPageBlurFilter>
+        <CollectionsRail languageId={languageId} />
+      </WatchHero>
     </div>
   )
 }
 
-// Main component with providers
-export function WatchHomePage({
-  languageId
-}: WatchHomePageProps): ReactElement {
+export function WatchHomePage({ languageId }: WatchHomePageProps): ReactElement {
   return (
     <PlayerProvider>
       <WatchProvider>

--- a/apps/watch/src/components/WatchHomePage/useWatchHeroCarousel.spec.tsx
+++ b/apps/watch/src/components/WatchHomePage/useWatchHeroCarousel.spec.tsx
@@ -1,0 +1,219 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { VideoLabel } from '../../../__generated__/globalTypes'
+import type { PlayerState } from '../../libs/playerContext'
+import type {
+  CarouselMuxSlide,
+  VideoCarouselSlide
+} from '../../types/inserts'
+import {
+  type CarouselVideo,
+  useCarouselVideos
+} from '../VideoHero/libs/useCarouselVideos'
+
+import { useWatchHeroCarousel } from './useWatchHeroCarousel'
+import { usePlayer } from '../../libs/playerContext'
+
+jest.mock('../VideoHero/libs/useCarouselVideos', () => ({
+  useCarouselVideos: jest.fn()
+}))
+
+jest.mock('../../libs/playerContext', () => ({
+  usePlayer: jest.fn()
+}))
+
+describe('useWatchHeroCarousel', () => {
+  const useCarouselVideosMock = jest.mocked(useCarouselVideos)
+  const usePlayerMock = jest.mocked(usePlayer)
+
+  const createVideo = (overrides: Partial<CarouselVideo> = {}): CarouselVideo => ({
+    id: 'video-1',
+    slug: 'video-1/english',
+    title: [{ value: 'Video 1' }],
+    images: [{ mobileCinematicHigh: 'poster-1.jpg' }],
+    imageAlt: [{ value: 'Poster 1' }],
+    label: VideoLabel.shortFilm,
+    variant: {
+      id: 'variant-1',
+      duration: 120,
+      hls: 'video-1.m3u8',
+      slug: 'video-1/english'
+    },
+    childrenCount: 0,
+    ...overrides
+  })
+
+  const createMuxSlide = (id: string): CarouselMuxSlide => ({
+    source: 'mux',
+    id,
+    overlay: {
+      label: 'Staff Pick',
+      title: `Mux ${id}`,
+      collection: 'Highlights',
+      description: 'Mux insert description'
+    },
+    playbackId: `playback-${id}`,
+    playbackIndex: 0,
+    urls: {
+      hls: `https://example.com/${id}.m3u8`,
+      poster: `https://example.com/${id}.jpg`
+    },
+    duration: 4
+  })
+
+  const muxSlideOne = createMuxSlide('welcome-start')
+  const muxSlideTwo = createMuxSlide('second-insert')
+  const videoOne: CarouselVideo = createVideo()
+  const videoTwo: CarouselVideo = createVideo({
+    id: 'video-2',
+    slug: 'video-2/english',
+    title: [{ value: 'Video 2' }],
+    images: [{ mobileCinematicHigh: 'poster-2.jpg' }],
+    imageAlt: [{ value: 'Poster 2' }],
+    variant: {
+      id: 'variant-2',
+      duration: 140,
+      hls: 'video-2.m3u8',
+      slug: 'video-2/english'
+    }
+  })
+
+  const muxSlides: CarouselMuxSlide[] = [muxSlideOne, muxSlideTwo]
+  const videoSlides: VideoCarouselSlide[] = [
+    { source: 'video', id: videoOne.id, video: videoOne },
+    { source: 'video', id: videoTwo.id, video: videoTwo }
+  ]
+
+  let moveToNextMock: jest.Mock
+  let jumpToVideoMock: jest.Mock
+  let playerState: PlayerState
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+
+    moveToNextMock = jest.fn()
+    jumpToVideoMock = jest.fn().mockReturnValue(true)
+
+    playerState = {
+      play: false,
+      active: true,
+      currentTime: '0:00',
+      progress: 0,
+      progressPercentNotYetEmitted: [10, 25, 50, 75, 90],
+      volume: 0,
+      mute: true,
+      fullscreen: false,
+      openSubtitleDialog: false,
+      loadSubtitleDialog: false,
+      loading: false,
+      durationSeconds: 0,
+      duration: '0:00'
+    }
+
+    usePlayerMock.mockReturnValue({ state: playerState })
+    useCarouselVideosMock.mockReturnValue({
+      slides: [...muxSlides, ...videoSlides],
+      videos: [videoOne, videoTwo],
+      loading: false,
+      currentIndex: 0,
+      error: null,
+      moveToNext: moveToNextMock,
+      moveToPrevious: jest.fn(),
+      jumpToVideo: jumpToVideoMock,
+      currentPoolIndex: 0
+    })
+  })
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+    jest.useRealTimers()
+    jest.clearAllMocks()
+  })
+
+  it('initializes with the first slide active', () => {
+    const { result } = renderHook(() => useWatchHeroCarousel())
+
+    expect(result.current.activeVideoId).toBe(muxSlideOne.id)
+    expect(result.current.currentMuxInsert).toBe(muxSlideOne)
+    expect(result.current.activeVideo?.id).toBe(muxSlideOne.id)
+  })
+
+  it('advances through mux slides and into videos when inserts complete', () => {
+    const { result } = renderHook(() => useWatchHeroCarousel())
+
+    act(() => {
+      result.current.handleMuxInsertComplete()
+    })
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(result.current.activeVideoId).toBe(muxSlideTwo.id)
+    expect(jumpToVideoMock).not.toHaveBeenCalled()
+
+    act(() => {
+      result.current.handleMuxInsertComplete()
+    })
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(result.current.activeVideoId).toBe(videoOne.id)
+    expect(result.current.currentMuxInsert).toBeNull()
+    expect(jumpToVideoMock).toHaveBeenCalledWith(videoOne.id)
+  })
+
+  it('jumps to a requested video when a carousel item is selected', () => {
+    const { result } = renderHook(() => useWatchHeroCarousel())
+
+    act(() => {
+      result.current.handleMuxInsertComplete()
+    })
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+    act(() => {
+      result.current.handleMuxInsertComplete()
+    })
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+    jumpToVideoMock.mockClear()
+
+    act(() => {
+      result.current.handleVideoSelect(videoTwo.id)
+    })
+
+    expect(result.current.activeVideoId).toBe(videoTwo.id)
+    expect(jumpToVideoMock).toHaveBeenCalledWith(videoTwo.id)
+  })
+
+  it('automatically advances when playback nears completion', () => {
+    const { result, rerender } = renderHook(() => useWatchHeroCarousel())
+
+    act(() => {
+      result.current.handleMuxInsertComplete()
+    })
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+    act(() => {
+      result.current.handleMuxInsertComplete()
+    })
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+    jumpToVideoMock.mockClear()
+
+    act(() => {
+      playerState = { ...playerState, progress: 96 }
+      usePlayerMock.mockReturnValue({ state: playerState })
+      rerender()
+    })
+
+    expect(result.current.activeVideoId).toBe(videoTwo.id)
+    expect(jumpToVideoMock).toHaveBeenCalledWith(videoTwo.id)
+  })
+})

--- a/apps/watch/src/components/WatchHomePage/useWatchHeroCarousel.ts
+++ b/apps/watch/src/components/WatchHomePage/useWatchHeroCarousel.ts
@@ -1,0 +1,498 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { VideoLabel } from '../../../__generated__/globalTypes'
+import {
+  type VideoContentFields,
+  type VideoContentFields_description,
+  type VideoContentFields_imageAlt,
+  type VideoContentFields_images,
+  type VideoContentFields_snippet,
+  type VideoContentFields_title,
+  type VideoContentFields_variant,
+  type VideoContentFields_variant_language
+} from '../../../__generated__/VideoContentFields'
+import { usePlayer } from '../../libs/playerContext'
+import {
+  type CarouselMuxSlide,
+  type CarouselVideoLike,
+  type CarouselVideoSlide,
+  type VideoCarouselSlide,
+  isMuxSlide,
+  isVideoSlide
+} from '../../types/inserts'
+import {
+  type CarouselVideo,
+  useCarouselVideos
+} from '../VideoHero/libs/useCarouselVideos'
+
+interface UseWatchHeroCarouselOptions {
+  locale?: string
+}
+
+interface UseWatchHeroCarouselResult {
+  loading: boolean
+  slides: VideoCarouselSlide[]
+  activeVideoId?: string
+  activeVideo: VideoContentFields | null
+  currentMuxInsert: CarouselMuxSlide | null
+  handleVideoSelect: (slideId: string) => void
+  handleMuxInsertComplete: () => void
+}
+
+const DEFAULT_LANGUAGE: VideoContentFields_variant_language = {
+  __typename: 'Language',
+  id: '529',
+  name: [
+    {
+      __typename: 'LanguageName',
+      value: 'English',
+      primary: true
+    }
+  ],
+  bcp47: 'en'
+}
+
+function toVideoTitles(
+  video: CarouselVideoLike
+): VideoContentFields_title[] {
+  const fallback = (video as CarouselVideo).slug ?? video.id
+  const titles = (video as any).title
+
+  if (Array.isArray(titles) && titles.length > 0) {
+    return titles.map((title: any) => ({
+      __typename: 'VideoTitle',
+      value: title?.value ?? fallback
+    }))
+  }
+
+  return [
+    {
+      __typename: 'VideoTitle',
+      value: fallback
+    }
+  ]
+}
+
+function toImages(video: CarouselVideoLike): VideoContentFields_images[] {
+  const images = (video as any).images
+
+  if (!Array.isArray(images)) return []
+
+  return images.map((image: any) => ({
+    __typename: 'CloudflareImage',
+    mobileCinematicHigh: image?.mobileCinematicHigh ?? null
+  }))
+}
+
+function toImageAlts(
+  video: CarouselVideoLike,
+  fallbackTitle: string
+): VideoContentFields_imageAlt[] {
+  const imageAlt = (video as any).imageAlt
+
+  if (!Array.isArray(imageAlt) || imageAlt.length === 0) {
+    return [
+      {
+        __typename: 'VideoImageAlt',
+        value: fallbackTitle
+      }
+    ]
+  }
+
+  return imageAlt.map((alt: any) => ({
+    __typename: 'VideoImageAlt',
+    value: alt?.value ?? fallbackTitle
+  }))
+}
+
+function toSnippets(video: CarouselVideoLike): VideoContentFields_snippet[] {
+  const snippets = (video as any).snippet
+
+  if (!Array.isArray(snippets)) return []
+
+  return snippets.map((snippet: any) => ({
+    __typename: 'VideoSnippet',
+    value: snippet?.value ?? ''
+  }))
+}
+
+function toDescriptions(
+  video: CarouselVideoLike
+): VideoContentFields_description[] {
+  const descriptions = (video as any).description
+
+  if (!Array.isArray(descriptions)) return []
+
+  return descriptions.map((description: any) => ({
+    __typename: 'VideoDescription',
+    value: description?.value ?? ''
+  }))
+}
+
+function mapVideoLabel(label: string | undefined): VideoLabel {
+  if (!label) return VideoLabel.shortFilm
+  const values = Object.values(VideoLabel)
+  return (values.includes(label as VideoLabel)
+    ? (label as VideoLabel)
+    : VideoLabel.shortFilm)
+}
+
+function toVariant(video: CarouselVideoLike): VideoContentFields_variant | null {
+  const variant = (video as any).variant
+
+  if (!variant) return null
+
+  const { id, duration, hls, slug } = variant
+
+  if (!id || typeof duration !== 'number' || !slug) return null
+
+  const language = variant.language ?? DEFAULT_LANGUAGE
+
+  return {
+    __typename: 'VideoVariant',
+    id,
+    duration,
+    hls: hls ?? null,
+    downloadable: Boolean(variant.downloadable),
+    downloads: Array.isArray(variant.downloads)
+      ? variant.downloads.map((download: any) => ({
+          __typename: 'VideoVariantDownload',
+          quality: download?.quality,
+          size: download?.size ?? 0,
+          url: download?.url ?? ''
+        }))
+      : [],
+    language: {
+      __typename: 'Language',
+      id: language?.id ?? DEFAULT_LANGUAGE.id,
+      name: Array.isArray(language?.name) && language.name.length > 0
+        ? language.name.map((name: any) => ({
+            __typename: 'LanguageName',
+            value: name?.value ?? DEFAULT_LANGUAGE.name[0].value,
+            primary: name?.primary ?? true
+          }))
+        : DEFAULT_LANGUAGE.name,
+      bcp47: language?.bcp47 ?? DEFAULT_LANGUAGE.bcp47
+    },
+    slug,
+    subtitleCount: variant.subtitleCount ?? 0
+  }
+}
+
+function createVideoContentFromVideo(
+  slide: CarouselVideoSlide
+): VideoContentFields {
+  const video = slide.video
+  const title = toVideoTitles(video)
+  const primaryTitle = title[0]?.value ?? video.id
+
+  return {
+    __typename: 'Video',
+    id: video.id,
+    slug: (video as any).slug ?? video.id,
+    label: mapVideoLabel((video as any).label),
+    title,
+    images: toImages(video),
+    imageAlt: toImageAlts(video, primaryTitle),
+    snippet: toSnippets(video),
+    description: toDescriptions(video),
+    studyQuestions: [],
+    bibleCitations: [],
+    variant: toVariant(video),
+    variantLanguagesCount: (video as any).variantLanguagesCount ?? 1,
+    childrenCount: (video as any).childrenCount ?? 0
+  }
+}
+
+function createVideoContentFromMux(
+  slide: CarouselMuxSlide
+): VideoContentFields {
+  const title = slide.overlay.title
+  const poster = slide.posterOverride ?? slide.urls.poster
+
+  return {
+    __typename: 'Video',
+    id: slide.id,
+    slug: slide.id,
+    title: [
+      {
+        __typename: 'VideoTitle',
+        value: title
+      }
+    ],
+    images: [
+      {
+        __typename: 'CloudflareImage',
+        mobileCinematicHigh: poster
+      }
+    ],
+    imageAlt: [
+      {
+        __typename: 'VideoImageAlt',
+        value: title
+      }
+    ],
+    snippet: [],
+    description: [
+      {
+        __typename: 'VideoDescription',
+        value: slide.overlay.description
+      }
+    ],
+    studyQuestions: [],
+    bibleCitations: [],
+    label: mapVideoLabel(slide.overlay.label),
+    variant: {
+      __typename: 'VideoVariant',
+      id: `${slide.id}-variant`,
+      duration: slide.duration ?? 0,
+      hls: slide.urls.hls,
+      downloadable: false,
+      downloads: [],
+      language: DEFAULT_LANGUAGE,
+      slug: `${slide.id}/variant`,
+      subtitleCount: 0
+    },
+    variantLanguagesCount: 1,
+    childrenCount: 0
+  }
+}
+
+export function useWatchHeroCarousel({
+  locale
+}: UseWatchHeroCarouselOptions = {}): UseWatchHeroCarouselResult {
+  const {
+    slides: rawSlides,
+    loading,
+    moveToNext,
+    jumpToVideo
+  } = useCarouselVideos(locale)
+  const { state: playerState } = usePlayer()
+
+  const [slides, setSlides] = useState<VideoCarouselSlide[]>(rawSlides)
+  const [activeSlideId, setActiveSlideId] = useState<string | null>(null)
+  const [lastProgress, setLastProgress] = useState(0)
+  const [isProgressing, setIsProgressing] = useState(false)
+  const autoProgressEnabled = true
+  const resetRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    setSlides((previousSlides) => {
+      if (previousSlides === rawSlides) return previousSlides
+
+      const previousByKey = new Map(
+        previousSlides.map((slide) => [`${slide.source}:${slide.id}`, slide])
+      )
+
+      const nextSlides = rawSlides.map((slide) => {
+        const key = `${slide.source}:${slide.id}`
+        const previousSlide = previousByKey.get(key)
+
+        if (
+          previousSlide != null &&
+          isMuxSlide(slide) &&
+          isMuxSlide(previousSlide) &&
+          previousSlide.playbackId === slide.playbackId &&
+          previousSlide.playbackIndex === slide.playbackIndex
+        ) {
+          return previousSlide
+        }
+
+        if (
+          previousSlide != null &&
+          isVideoSlide(slide) &&
+          isVideoSlide(previousSlide) &&
+          previousSlide.video === slide.video
+        ) {
+          return previousSlide
+        }
+
+        return slide
+      })
+
+      const isSameLength = nextSlides.length === previousSlides.length
+
+      if (
+        isSameLength &&
+        nextSlides.every((slide, index) => slide === previousSlides[index])
+      ) {
+        return previousSlides
+      }
+
+      return nextSlides
+    })
+  }, [rawSlides])
+
+  useEffect(() => {
+    return () => {
+      if (resetRef.current != null) clearTimeout(resetRef.current)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (slides.length === 0) {
+      setActiveSlideId(null)
+      return
+    }
+
+    if (activeSlideId == null) {
+      setActiveSlideId(slides[0]?.id ?? null)
+      return
+    }
+
+    if (!slides.some((slide) => slide.id === activeSlideId)) {
+      setActiveSlideId(slides[0]?.id ?? null)
+    }
+  }, [slides, activeSlideId])
+
+  const activeSlide = useMemo(() => {
+    if (activeSlideId == null) return slides[0] ?? null
+    return slides.find((slide) => slide.id === activeSlideId) ?? null
+  }, [activeSlideId, slides])
+
+  const activeVideoId = activeSlide?.id
+
+  const activeSlideIndex = useMemo(() => {
+    if (!activeSlide) return -1
+    return slides.findIndex((slide) => slide.id === activeSlide.id)
+  }, [slides, activeSlide])
+
+  const scheduleReset = useCallback((delay: number) => {
+    if (resetRef.current != null) clearTimeout(resetRef.current)
+    resetRef.current = setTimeout(() => {
+      setIsProgressing(false)
+    }, delay)
+  }, [])
+
+  useEffect(() => {
+    setLastProgress(0)
+    if (activeVideoId != null) {
+      scheduleReset(500)
+    }
+  }, [activeVideoId, scheduleReset])
+
+  const handleVideoSelect = useCallback(
+    (slideId: string) => {
+      const nextSlide = slides.find((slide) => slide.id === slideId)
+      if (!nextSlide) return
+
+      setActiveSlideId(slideId)
+      setIsProgressing(false)
+
+      if (isVideoSlide(nextSlide)) {
+        const jumped = jumpToVideo(slideId)
+        if (!jumped) {
+          moveToNext()
+        }
+      }
+    },
+    [slides, jumpToVideo, moveToNext]
+  )
+
+  const moveToSlide = useCallback(
+    (index: number, resetDelay: number) => {
+      const nextSlide = slides[index]
+      if (!nextSlide) return
+
+      setIsProgressing(true)
+      setActiveSlideId(nextSlide.id)
+
+      if (isVideoSlide(nextSlide)) {
+        const jumped = jumpToVideo(nextSlide.id)
+        if (!jumped) {
+          moveToNext()
+        }
+      } else {
+        moveToNext()
+      }
+
+      scheduleReset(resetDelay)
+    },
+    [slides, jumpToVideo, moveToNext, scheduleReset]
+  )
+
+  const handleMuxInsertComplete = useCallback(() => {
+    if (!autoProgressEnabled || isProgressing || activeSlideIndex === -1) {
+      return
+    }
+
+    const nextIndex = activeSlideIndex + 1
+    const nextSlide = slides[nextIndex]
+    if (!nextSlide) return
+
+    setIsProgressing(true)
+    setActiveSlideId(nextSlide.id)
+
+    if (isVideoSlide(nextSlide)) {
+      const jumped = jumpToVideo(nextSlide.id)
+      if (!jumped) {
+        moveToNext()
+      }
+    }
+
+    scheduleReset(500)
+  }, [
+    activeSlideIndex,
+    autoProgressEnabled,
+    isProgressing,
+    slides,
+    jumpToVideo,
+    moveToNext,
+    scheduleReset
+  ])
+
+  const advanceOnProgress = useCallback(() => {
+    if (!autoProgressEnabled || isProgressing || activeSlideIndex === -1) {
+      return
+    }
+
+    moveToSlide(activeSlideIndex + 1, 2000)
+    setLastProgress(0)
+  }, [
+    activeSlideIndex,
+    autoProgressEnabled,
+    isProgressing,
+    moveToSlide
+  ])
+
+  useEffect(() => {
+    if (playerState.progress >= 95 && lastProgress < 95 && !isProgressing) {
+      advanceOnProgress()
+    }
+
+    setLastProgress(playerState.progress)
+  }, [
+    playerState.progress,
+    lastProgress,
+    advanceOnProgress,
+    isProgressing
+  ])
+
+  const currentMuxInsert = useMemo(() => {
+    if (activeSlide && isMuxSlide(activeSlide)) {
+      return activeSlide
+    }
+    return null
+  }, [activeSlide])
+
+  const activeVideo: VideoContentFields | null = useMemo(() => {
+    if (!activeSlide) return null
+    if (isMuxSlide(activeSlide)) {
+      return createVideoContentFromMux(activeSlide)
+    }
+    if (isVideoSlide(activeSlide)) {
+      return createVideoContentFromVideo(activeSlide)
+    }
+    return null
+  }, [activeSlide])
+
+  return {
+    loading,
+    slides,
+    activeVideoId,
+    activeVideo,
+    currentMuxInsert,
+    handleVideoSelect,
+    handleMuxInsertComplete
+  }
+}


### PR DESCRIPTION
## Summary
- extract carousel playback synchronization into a dedicated `useWatchHeroCarousel` hook that wraps `useCarouselVideos`
- compose the watch homepage from new `WatchHero`, `CollectionsRail`, and `AboutProjectSection` components for clarity
- add focused unit tests to cover hero carousel progression and selection behaviour

## Testing
- pnpm nx test watch --testFile=watch/src/components/WatchHomePage/useWatchHeroCarousel.spec.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d3c7577f4c8328928ecee7617e1e9b