### PR TITLE
Fix SectionVideoCarousel slug parsing

### DIFF
--- a/apps/watch/src/components/SectionVideoCarousel/SectionVideoCarousel.spec.tsx
+++ b/apps/watch/src/components/SectionVideoCarousel/SectionVideoCarousel.spec.tsx
@@ -267,6 +267,27 @@ describe('SectionVideoCarousel', () => {
     expect(
       screen.getByTestId('SectionVideoCarouselSlide-video-1')
     ).toBeInTheDocument()
+
+    const featureFilmCard = screen.getByTestId(
+      'VideoCard-child-1'
+    ) as HTMLAnchorElement
+    expect(featureFilmCard.getAttribute('href')).toBe(
+      '/watch/collection-slug.html/child-one/en.html'
+    )
+
+    const episodeCard = screen.getByTestId(
+      'VideoCard-grandchild-1'
+    ) as HTMLAnchorElement
+    expect(episodeCard.getAttribute('href')).toBe(
+      '/watch/child-collection-slug.html/grandchild-one/en.html'
+    )
+
+    const singleVideoCard = screen.getByTestId(
+      'VideoCard-video-1'
+    ) as HTMLAnchorElement
+    expect(singleVideoCard.getAttribute('href')).toBe(
+      '/watch/single-video.html/en.html'
+    )
     expect(screen.getByTestId('SectionVideoCarouselCTA')).toHaveTextContent(
       'Watch'
     )


### PR DESCRIPTION
## Summary
- parse SectionVideoCarousel slide hrefs to recover container and variant slugs for VideoCard
- ensure VideoCard receives the resolved container slug and variant slugs include id/language pairs
- add carousel spec expectations that rendered cards link to the correct watch URLs

## Testing
- pnpm test watch -- SectionVideoCarousel.spec.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d33c2c6c748328a6080126b74a2bc9