### PR TITLE
fix: derive video grid watch links

### DIFF
--- a/apps/watch/src/components/SectionVideoGrid/SectionVideoGrid.spec.tsx
+++ b/apps/watch/src/components/SectionVideoGrid/SectionVideoGrid.spec.tsx
@@ -262,11 +262,29 @@ describe('SectionVideoGrid', () => {
       ).toBeInTheDocument()
     )
     expect(
+      screen.getByTestId('VideoCard-child-1')
+    ).toHaveAttribute(
+      'href',
+      '/watch/collection-slug.html/child-one/en.html'
+    )
+    expect(
       screen.getByTestId('VideoCard-grandchild-1')
     ).toBeInTheDocument()
     expect(
+      screen.getByTestId('VideoCard-grandchild-1')
+    ).toHaveAttribute(
+      'href',
+      '/watch/child-collection-slug.html/grandchild-one/en.html'
+    )
+    expect(
       screen.getByTestId('VideoCard-video-1')
     ).toBeInTheDocument()
+    expect(
+      screen.getByTestId('VideoCard-video-1')
+    ).toHaveAttribute(
+      'href',
+      '/watch/single-video.html/en.html'
+    )
     expect(screen.getByTestId('SectionVideoGridCTA')).toHaveTextContent(
       'Watch'
     )

--- a/apps/watch/src/components/VideoGrid/VideoGrid.tsx
+++ b/apps/watch/src/components/VideoGrid/VideoGrid.tsx
@@ -9,6 +9,7 @@ export interface VideoGridProps {
   videos?: VideoChildFields[]
   showLoadMore?: boolean
   containerSlug?: string
+  containerSlugByVideoId?: Record<string, string | undefined>
   orientation?: 'horizontal' | 'vertical'
   loading?: boolean
   showMore?: () => void
@@ -22,6 +23,7 @@ export function VideoGrid({
   videos = [],
   showLoadMore = false,
   containerSlug,
+  containerSlugByVideoId,
   orientation = 'horizontal',
   loading = false,
   showMore,
@@ -43,7 +45,11 @@ export function VideoGrid({
             <VideoCard
               video={video}
               orientation={orientation}
-              containerSlug={containerSlug}
+              containerSlug={
+                (video?.id != null
+                  ? containerSlugByVideoId?.[video.id]
+                  : undefined) ?? containerSlug
+              }
               onClick={onCardClick}
               analyticsTag={analyticsTag}
             />


### PR DESCRIPTION
## Summary
- parse SectionVideoGrid slide hrefs to derive video and variant slugs for the grid
- allow VideoGrid to supply per-video container slugs when rendering cards
- cover SectionVideoGrid card href generation in unit tests

## Testing
- pnpm test watch -- SectionVideoGrid.spec.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d33c148df88328a3f38bee0e5a06ed