### PR TITLE
fix: enforce break-word wrapping style for text blocks

### DIFF
--- a/libs/journeys/ui/src/components/Typography/Typography.tsx
+++ b/libs/journeys/ui/src/components/Typography/Typography.tsx
@@ -47,6 +47,7 @@ export function Typography({
           gutterBottom
           whiteSpace="pre-line"
           data-testid="JourneysTypography"
+          sx={{ wordBreak: 'break-word' }}
         >
           {displayContent}
         </MuiTypography>
@@ -58,6 +59,7 @@ export function Typography({
           gutterBottom
           whiteSpace="pre-line"
           data-testid="JourneysTypography"
+          sx={{ wordBreak: 'break-word' }}
         >
           {displayContent}
         </MuiTypography>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved text overflow in typography elements by enabling automatic word wrapping. Long strings (e.g., URLs, IDs) now wrap correctly, improving readability on small screens and in localized content.
* **Style**
  * Updated typography rendering to gracefully break long words in overline and caption variants and related text, ensuring a more consistent and stable layout across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->