### PR TITLE
fix: check all services are running before attempting to start gateway

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -5,5 +5,5 @@ journeys-modern: nx serve api-journeys-modern
 languages: nx serve api-languages
 media: nx serve api-media
 users: nx serve api-users
-gateway: nx serve api-gateway
+gateway: tools/scripts/wait-for-services.sh && nx serve api-gateway
 gateway-watcher: nx generate-graphql api-gateway --watch

--- a/tools/scripts/wait-for-services.sh
+++ b/tools/scripts/wait-for-services.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+#
+# Wait for Services Script
+# This script waits for all required services to be healthy before starting the gateway
+# This gets run from "nf start".
+#
+# Checks health check endpoints for each service
+# Waits up to MAX_ATTEMPTS attempts, x SLEEP_INTERVAL seconds, per service
+# Requires `curl` to be installed.
+############################################################################################
+
+set -e
+
+SLEEP_INTERVAL=2
+MAX_ATTEMPTS=60
+# This is a total of 2 minutes of wait time (for each service checked).
+# Why 2 minutes? Becuase it can take upto 2 minutes for everything to start.
+
+# Service URLs - sourced from environment variables with fallback to localhost
+ANALYTICS_URL="${ANALYTICS_URL:-http://localhost:4008}"
+JOURNEYS_URL="${JOURNEYS_URL:-http://localhost:4001}"
+LANGUAGES_URL="${LANGUAGES_URL:-http://localhost:4003}"
+MEDIA_URL="${MEDIA_URL:-http://localhost:4005}"
+USERS_URL="${USERS_URL:-http://localhost:4002}"
+JOURNEYS_MODERN_URL="${JOURNEYS_MODERN_URL:-http://localhost:4004}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Function to check if a service is healthy
+check_service_health() {
+    local service_name=$1
+    local url=$2
+    local max_attempts=${3:-$MAX_ATTEMPTS}
+    local attempt=1
+    
+    print_status "Waiting for $service_name to be ready at $url..."
+    
+    while [ $attempt -le $max_attempts ]; do
+        if curl -f -s "$url" > /dev/null 2>&1; then
+            print_success "$service_name is ready on ${url}!"
+            return 0
+        fi
+        
+        print_status "Attempt $attempt/$max_attempts - gateway startup is waiting for $service_name..."
+        
+        sleep $SLEEP_INTERVAL
+        attempt=$((attempt + 1))
+    done
+    
+    print_error "$service_name failed to become ready after $max_attempts attempts on ${url}"
+    return 1
+}
+
+# Main function
+main() {
+    print_status "Starting service dependency checks..."
+    
+    # Check if required tools are available
+    if ! command -v curl > /dev/null 2>&1; then
+        print_error "curl is required but not installed. Please install curl and try again."
+        exit 1
+    fi
+    
+    # Wait for all services to be ready
+    local services_ready=true
+    
+    # Define services to check (name:url pairs)
+    local services=(
+        "Analytics|${ANALYTICS_URL}"
+        "Journeys|${JOURNEYS_URL}"
+        "Languages|${LANGUAGES_URL}"
+        "Media|${MEDIA_URL}"
+        "Users|${USERS_URL}"
+        "Journeys Modern|${JOURNEYS_MODERN_URL}"
+    )
+
+    # Check each service
+    for service in "${services[@]}"; do
+        local service_name="${service%%|*}"
+        local service_url="${service##*|}"
+
+        if ! check_service_health "$service_name" "${service_url}/.well-known/apollo/server-health" $MAX_ATTEMPTS; then
+            services_ready=false
+            break
+        fi
+    done
+
+    if [ "$services_ready" = true ]; then
+        print_success "All services are ready! Starting gateway..."
+        return 0
+    else
+        print_error "Not all services are ready. Gateway will not start."
+        return 1
+    fi
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
Checks that all services are running before attempting to start gateway.

The problem that this is intended to fix is documented in Linear in [the ticket](https://linear.app/jesus-film-project/issue/NES-839/add-health-check-before-booting-gateway); in short, the problem was:

```
5:22:58 AM gateway.1          |  {"level":"error","time":1758518578420,"pid":72966,"hostname":"2804e3465a60","service":"api-gateway","err":{"type":"GraphQLError","message":"connect ECONNREFUSED 127.0.0.1:4008","stack":"Error: connect ECONNREFUSED 127.0.0.1:4008\n    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)","path":["siteCreate"],"extensions":{"request":{"method":"POST","body":"{\n  "query": "mutation SiteCreate($input:SiteCreateInput!){__typename siteCreate(input:$input){__typename ...on Error{message…
```

This happened because gateway attempted to start up before analytics is ready.

However, since hitting that problem, I learnt that, whenever changing branch or doing a git pull, these commands should be run:

```
nx run-many --target=prisma-generate
nx run-many --target=prisma-migrate
nx run-many --target=prisma-seed

```
(Wish I had known this from the start!)

Now that I know that and have been doing that, this problem has gone away. Therefore, this code may no longer be needed, and less is better. However, the code was already, done, so if it has any value, here it is. This is where I need a decision from the reviewer please.

Another factor consider is: this code is run from within "nf start"; as best I understand, "nf start" is only used in a development environment, because services are started by other means in AWS ECS, i.e. in production and staging environments; if not, this code will need checking because it currently uses environment variables, such as JOURNEYS_URL, to get the URL and port for that service, and that may not be correct.

### Next Step
Review the code; decide whether to keep or drop.