### PR TITLE
feat(watch): add creative showcase section

### DIFF
--- a/apps/watch/src/components/WatchHomePage/SectionCreativeShowcase.spec.tsx
+++ b/apps/watch/src/components/WatchHomePage/SectionCreativeShowcase.spec.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { SectionCreativeShowcase } from './SectionCreativeShowcase'
+
+beforeAll(() => {
+  window.HTMLElement.prototype.scrollIntoView = jest.fn()
+})
+
+describe('SectionCreativeShowcase', () => {
+  it('renders the default English animated preview', () => {
+    render(<SectionCreativeShowcase />)
+
+    const styleVideo = screen.getByTestId('style-video') as HTMLVideoElement
+
+    expect(styleVideo).toHaveAttribute(
+      'src',
+      'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerFun.mp4'
+    )
+  })
+
+  it('updates the preview when a new style is selected', () => {
+    render(<SectionCreativeShowcase />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cinematic' }))
+
+    const styleVideo = screen.getByTestId('style-video') as HTMLVideoElement
+
+    expect(styleVideo).toHaveAttribute(
+      'src',
+      'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4'
+    )
+  })
+
+  it('switches to the selected language cut', async () => {
+    render(<SectionCreativeShowcase />)
+
+    const trigger = screen.getByRole('combobox', {
+      name: 'Choose a language'
+    })
+
+    fireEvent.click(trigger)
+    const spanishOption = await screen.findByText('Spanish')
+    fireEvent.click(spanishOption)
+
+    const styleVideo = screen.getByTestId('style-video') as HTMLVideoElement
+
+    expect(styleVideo).toHaveAttribute(
+      'src',
+      'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4'
+    )
+  })
+})

--- a/apps/watch/src/components/WatchHomePage/SectionCreativeShowcase.tsx
+++ b/apps/watch/src/components/WatchHomePage/SectionCreativeShowcase.tsx
@@ -1,0 +1,203 @@
+import { type ReactElement, useMemo, useState } from 'react'
+
+import { Button } from '../Button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '../Select'
+
+const HEART_RECORD_IT_VIDEO_URL =
+  'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4'
+
+const styleOptions = [
+  { value: 'animated', label: 'Animated' },
+  { value: 'cinematic', label: 'Cinematic' },
+  { value: '3d', label: '3-D Movie' }
+] as const
+
+type VideoStyle = (typeof styleOptions)[number]['value']
+
+type LanguageOption = {
+  value: string
+  label: string
+  description: string
+  videos: Record<VideoStyle, string>
+}
+
+const languageOptions: LanguageOption[] = [
+  {
+    value: 'english',
+    label: 'English',
+    description:
+      'Discover production-ready assets narrated in English for quick previews and pitches.',
+    videos: {
+      animated:
+        'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerFun.mp4',
+      cinematic:
+        'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4',
+      '3d':
+        'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/Sintel.mp4'
+    }
+  },
+  {
+    value: 'spanish',
+    label: 'Spanish',
+    description:
+      'Preview localized storytelling moments voiced in Spanish to align creative direction.',
+    videos: {
+      animated:
+        'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4',
+      cinematic:
+        'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/TearsOfSteel.mp4',
+      '3d':
+        'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerMeltdowns.mp4'
+    }
+  },
+  {
+    value: 'portuguese',
+    label: 'Portuguese',
+    description:
+      'Review the expressive Portuguese mixes to validate tone, timing, and ADR pacing.',
+    videos: {
+      animated:
+        'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4',
+      cinematic:
+        'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
+      '3d':
+        'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4'
+    }
+  }
+]
+
+const defaultLanguage = languageOptions[0]
+const defaultStyle: VideoStyle = styleOptions[0].value
+
+export function SectionCreativeShowcase(): ReactElement {
+  const [selectedStyle, setSelectedStyle] = useState<VideoStyle>(defaultStyle)
+  const [selectedLanguage, setSelectedLanguage] = useState<string>(
+    defaultLanguage.value
+  )
+
+  const activeLanguage = useMemo(
+    () =>
+      languageOptions.find((language) => language.value === selectedLanguage) ??
+      defaultLanguage,
+    [selectedLanguage]
+  )
+
+  const activeVideoSource = activeLanguage.videos[selectedStyle]
+
+  return (
+    <section
+      aria-labelledby="creative-showcase-heading"
+      className="mt-16 rounded-3xl border border-white/5 bg-white/5 p-8 text-white shadow-xl backdrop-blur"
+    >
+      <div className="mb-8 flex flex-col gap-2 text-center lg:text-left">
+        <p className="text-sm uppercase tracking-[0.3em] text-white/70">
+          Watch home experience
+        </p>
+        <h2
+          id="creative-showcase-heading"
+          className="text-3xl font-semibold tracking-tight sm:text-4xl"
+        >
+          Shape the experience in real-time
+        </h2>
+        <p className="text-base text-white/70">
+          Experiment with curated cuts, creative styles, and localization choices
+          without leaving the homepage.
+        </p>
+      </div>
+      <div className="grid gap-8 lg:grid-cols-3">
+        <div className="flex flex-col gap-4">
+          <div>
+            <h3 className="text-xl font-semibold">Heart “Record It”</h3>
+            <p className="mt-1 text-sm text-white/70">
+              Review the original inspiration cut. Use it as a reference while
+              tailoring the experience on the right.
+            </p>
+          </div>
+          <div className="aspect-video overflow-hidden rounded-2xl border border-white/10 bg-black/80">
+            <video
+              className="h-full w-full object-cover"
+              controls
+              src={HEART_RECORD_IT_VIDEO_URL}
+              title="Heart Record It reference"
+            >
+              Your browser does not support the video tag.
+            </video>
+          </div>
+        </div>
+        <div className="flex flex-col gap-4">
+          <div>
+            <h3 className="text-xl font-semibold">Style playground</h3>
+            <p className="mt-1 text-sm text-white/70">
+              Toggle a creative direction to instantly preview how the showcase
+              adapts.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2" role="group" aria-label="Video style selector">
+            {styleOptions.map(({ value, label }) => (
+              <Button
+                key={value}
+                type="button"
+                variant={selectedStyle === value ? 'default' : 'outline'}
+                onClick={() => setSelectedStyle(value)}
+              >
+                {label}
+              </Button>
+            ))}
+          </div>
+          <div className="aspect-video overflow-hidden rounded-2xl border border-white/10 bg-black/80">
+            <video
+              key={`${selectedLanguage}-${selectedStyle}`}
+              className="h-full w-full object-cover"
+              controls
+              data-testid="style-video"
+              src={activeVideoSource}
+              title={`${activeLanguage.label} ${selectedStyle} preview`}
+            >
+              Your browser does not support the video tag.
+            </video>
+          </div>
+        </div>
+        <div className="flex flex-col gap-4">
+          <div>
+            <h3 className="text-xl font-semibold">Language spotlight</h3>
+            <p className="mt-1 text-sm text-white/70">
+              Swap localized narrations to confirm the right cut plays in the
+              preview player.
+            </p>
+          </div>
+          <Select
+            value={selectedLanguage}
+            onValueChange={setSelectedLanguage}
+          >
+            <SelectTrigger aria-label="Choose a language" className="w-full">
+              <SelectValue placeholder="Select a language" />
+            </SelectTrigger>
+            <SelectContent>
+              {languageOptions.map(({ value, label }) => (
+                <SelectItem key={value} value={value}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <div className="rounded-2xl border border-white/10 bg-black/50 p-5 text-sm leading-relaxed text-white/70">
+            <p className="font-semibold text-white">
+              {activeLanguage.label} · {styleOptions.find(({ value }) => value === selectedStyle)?.label}
+            </p>
+            <p className="mt-2">{activeLanguage.description}</p>
+            <p className="mt-2">
+              The selected language automatically updates the showcase video to
+              keep your preview in sync with localization needs.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/watch/src/components/WatchHomePage/WatchHomePage.tsx
+++ b/apps/watch/src/components/WatchHomePage/WatchHomePage.tsx
@@ -13,6 +13,7 @@ import { SearchComponent } from '../SearchComponent'
 import { AboutProjectSection } from './AboutProjectSection'
 import { CollectionsRail } from './CollectionsRail'
 import { SeeAllVideos } from './SeeAllVideos'
+import { SectionCreativeShowcase } from './SectionCreativeShowcase'
 import { WatchHero } from './WatchHero'
 import { useWatchHeroCarousel } from './useWatchHeroCarousel'
 
@@ -75,6 +76,7 @@ function WatchHomePageBody({ languageId }: WatchHomePageProps): ReactElement {
             nested
           >
             <SeeAllVideos />
+            <SectionCreativeShowcase />
             <AboutProjectSection />
           </ThemeProvider>
         </div>

--- a/prds/watch/work.md
+++ b/prds/watch/work.md
@@ -56,3 +56,31 @@
 - Consider moving category metadata to CMS-driven config if design requires frequent updates.
 - Evaluate migrating remaining MUI layout primitives to Tailwind equivalents in a future iteration.
 
+# Watch Home Creative Showcase Section
+
+## Goals
+- [x] Add a three-column creative showcase section that meets the embedded reference, style toggle, and language selector requirements.
+- [x] Cover the interactive video switching logic with focused component tests.
+
+## Implementation Strategy
+- [x] Model reusable video style and language configuration objects with sensible defaults.
+- [x] Build `SectionCreativeShowcase` with responsive layout, accessible controls, and deterministic data-testid hooks.
+- [x] Wire the section into `WatchHomePage` and author Jest specs for style and language changes.
+
+## Obstacles
+- External sample video hosts commonly used for demos responded with 403 errors through the development proxy.
+
+## Resolutions
+- Switched to Google’s `gtv-videos-bucket` sample assets which provide stable CORS-compatible MP4 files.
+
+## Test Coverage
+- `pnpm dlx jest --config apps/watch/jest.config.ts --runTestsByPath apps/watch/src/components/WatchHomePage/SectionCreativeShowcase.spec.tsx`
+
+## User Flows
+- Load the Watch homepage → scroll to the creative showcase section → tap **Cinematic** → preview swaps to the cinematic cut.
+- Open the language selector → choose **Spanish** → preview updates to the Spanish animated variant.
+
+## Follow-up Ideas
+- Replace hard-coded sample assets with curated ministry-approved clips sourced from the CMS.
+- Connect the section to existing localization metadata so the dropdown reflects available dubbing tracks dynamically.
+


### PR DESCRIPTION
## Summary
- add a three-column creative showcase section to the Watch homepage with static reference, style toggles, and language selector
- wire the new section into the homepage theme container and capture expected behaviour with component tests
- document the implementation details and validation steps in the `work.md` PRD log

## Testing
- `pnpm dlx jest --config apps/watch/jest.config.ts --runTestsByPath apps/watch/src/components/WatchHomePage/SectionCreativeShowcase.spec.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68d40526227c832884aec0e51118b42e