### PR TITLE
fix: respect detection toggles during scene adaptation

### DIFF
--- a/apps/cropper/src/lib/scene-detection.ts
+++ b/apps/cropper/src/lib/scene-detection.ts
@@ -1,10 +1,4 @@
-import type {
-  SceneChangeResult,
-  SceneChangeConfig,
-  SceneChangeWorkerMessage,
-  SceneChangeCallbacks,
-  SceneChangeOptions
-} from '../types/detection'
+import type { SceneChangeResult, SceneChangeConfig, SceneChangeWorkerMessage } from '../types/detection'
 
 export interface SceneChangeCallbacks {
   onChunk?: (result: SceneChangeResult) => void
@@ -22,9 +16,9 @@ export class SceneDetectionWorkerController {
   private videoElement?: HTMLVideoElement
   private canvas?: OffscreenCanvas
   private ctx?: OffscreenCanvasRenderingContext2D
-  private isExtractionPaused: boolean = false
+  private isExtractionPaused = false
   private extractionTimeoutId?: number
-  private lastProcessedTime: number = 0
+  private lastProcessedTime = 0
 
   start(duration: number, callbacks: SceneChangeCallbacks, options: SceneChangeOptions = {}, videoElement?: HTMLVideoElement) {
     if (typeof window === 'undefined') {
@@ -77,7 +71,7 @@ export class SceneDetectionWorkerController {
     }
 
     // Start detection with video processing
-    this.startVideoProcessing(duration, options, callbacks)
+    this.startVideoProcessing(duration, options)
 
     // Start frame extraction if we have a video element
     if (videoElement) {
@@ -189,16 +183,8 @@ export class SceneDetectionWorkerController {
     extractFrame()
   }
 
-  private async startVideoProcessing(duration: number, options: SceneChangeOptions, callbacks: SceneChangeCallbacks) {
+  private async startVideoProcessing(duration: number, options: SceneChangeOptions) {
     if (!this.worker) {
-      // Fallback to mock processing if no worker available
-      this.worker?.postMessage({
-        type: 'startSceneDetection',
-        payload: {
-          duration,
-          config: options.config
-        }
-      })
       return
     }
 
@@ -222,7 +208,12 @@ export class SceneDetectionWorkerController {
   }
 
   resumeExtraction() {
+    const wasPaused = this.isExtractionPaused
     this.isExtractionPaused = false
+
+    if ((wasPaused || !this.extractionTimeoutId) && this.videoElement && this.worker) {
+      this.startFrameExtraction()
+    }
   }
 
   stop() {

--- a/prds/watch/pr-review-wat162.md
+++ b/prds/watch/pr-review-wat162.md
@@ -1,0 +1,12 @@
+# PR Review Tasks for WAT-162
+
+## Context
+Tasks derived from review recommendations regarding scene detection and crop adaptation logic.
+
+## Task List
+- [x] Rework the `'transition'` branch in `adaptCropPathToSceneChange` to add transition keyframes without deleting earlier frames that remain valid for interpolation, potentially using `previousSceneChange` to scope the cleanup.
+  - Preserve keyframes outside a tight transition window (and always keep the last pre-transition frame) before appending the new transition keyframe.
+- [x] Thread the `autoTrackingEnabled` and `sceneChangeDetectionEnabled` flags through the detection callbacks so disabling either feature immediately halts automatic keyframe merges or adjustments.
+  - Track the latest toggle values via refs and guard both the reducer merge and worker callbacks.
+- [x] Update `SceneDetectionWorkerController.resumeExtraction` so it restarts the frame extraction loop after clearing the pause state (for example by rescheduling `startFrameExtraction` or triggering the throttled callback).
+  - When resuming, restart the extraction loop if no timer is active and we have the necessary handles.


### PR DESCRIPTION
## Summary
- preserve existing crop keyframes when adapting to scene transitions instead of dropping the full history
- gate automatic detection merges and scene-adjustments on refs that reflect the latest toggle state
- restart scene detection extraction on resume and record the completed follow-up tasks in the review log

## Testing
- pnpm exec eslint apps/cropper/src/lib/crop-engine.ts
- pnpm exec eslint apps/cropper/src/hooks/use-cropper.ts
- pnpm exec eslint apps/cropper/src/lib/scene-detection.ts

------
https://chatgpt.com/codex/tasks/task_e_68d3fd0069e883289b761bb1d10b9b4c