### PR TITLE
fix: disable copy button for non original templates

### DIFF
--- a/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/MultiStepForm.tsx
+++ b/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/MultiStepForm.tsx
@@ -139,20 +139,6 @@ export function MultiStepForm(): ReactElement {
         >
           {renderScreen(activeScreen, handleNext, handleScreenNavigation)}
         </Box>
-
-        {/* TODO: delete back button. This is only here for the dev's to use */}
-        {/* <Button
-          variant="contained"
-          color="primary"
-          onClick={() => {
-            if (activeScreen > 0) {
-              setActiveScreen(activeScreen - 1)
-            }
-          }}
-          sx={{ width: '300px', alignSelf: 'center' }}
-        >
-          {`back (this will be deleted)`}
-        </Button> */}
       </Stack>
     </Container>
   )

--- a/libs/journeys/ui/src/components/CopyToTeamDialog/CopyToTeamDialog.spec.tsx
+++ b/libs/journeys/ui/src/components/CopyToTeamDialog/CopyToTeamDialog.spec.tsx
@@ -650,7 +650,7 @@ describe('CopyToTeamDialog', () => {
     expect(handleCloseMenuMock).toHaveBeenCalled()
   })
 
-  it('should not allow translation of non-original templates to prevent degradation', async () => {
+  it('should not allow copy or translation of non-original templates in publisher', async () => {
     // Mock router to return templates admin path
     mockUseRouter.mockReturnValue({
       pathname: '/publisher'
@@ -694,6 +694,7 @@ describe('CopyToTeamDialog', () => {
                 title="Copy To Journey"
                 onClose={handleCloseMenuMock}
                 submitAction={handleSubmitActionMock}
+                submitLabel="Copy"
               />
             </TeamProvider>
           </JourneyProvider>
@@ -709,5 +710,6 @@ describe('CopyToTeamDialog', () => {
 
     const translationSwitch = getByRole('checkbox', { name: 'Translation' })
     expect(translationSwitch).toBeDisabled()
+    expect(getByRole('button', { name: 'Copy' })).toBeDisabled()
   })
 })

--- a/libs/journeys/ui/src/components/CopyToTeamDialog/CopyToTeamDialog.tsx
+++ b/libs/journeys/ui/src/components/CopyToTeamDialog/CopyToTeamDialog.tsx
@@ -97,6 +97,10 @@ export function CopyToTeamDialog({
   const isOriginalTemplate =
     journey?.template && journey?.fromTemplateId == null
 
+  // this is to prevent publishers from copying and translating non-original templates - which will break Languages screen of journey customization flow
+  const disablePublisherCopyAndTranslate =
+    !isOriginalTemplate && isTemplatesAdmin
+
   const { data: languagesData, loading: languagesLoading } = useLanguagesQuery({
     languageId: '529',
     where: {
@@ -212,6 +216,7 @@ export function CopyToTeamDialog({
             onTranslate={handleFormSubmit}
             title={title}
             loading={loading || isSubmitting}
+            disabled={disablePublisherCopyAndTranslate}
             isTranslation={values.showTranslation || isTranslating}
             submitLabel={submitLabel}
             divider={false}
@@ -270,7 +275,7 @@ export function CopyToTeamDialog({
                 <FormControlLabel
                   control={
                     <Switch
-                      disabled={!isOriginalTemplate && isTemplatesAdmin}
+                      disabled={disablePublisherCopyAndTranslate}
                       checked={values.showTranslation}
                       onChange={(e) =>
                         setFieldValue('showTranslation', e.target.checked)
@@ -284,10 +289,10 @@ export function CopyToTeamDialog({
                   }
                 />
               </Stack>
-              {!isOriginalTemplate && isTemplatesAdmin && (
+              {disablePublisherCopyAndTranslate && (
                 <Typography variant="caption" color="red">
                   {t(
-                    'This is not the original journey template, it is a translation or copy of the original template. If you want to translate this journey - please use the original template.'
+                    'This is not the original journey template, it is a translation or copy of the original template. If you want to translate or copy this journey - please use the original template.'
                   )}
                 </Typography>
               )}

--- a/libs/journeys/ui/src/components/TranslationDialogWrapper/TranslationDialogWrapper.tsx
+++ b/libs/journeys/ui/src/components/TranslationDialogWrapper/TranslationDialogWrapper.tsx
@@ -16,6 +16,7 @@ interface TranslationDialogWrapperProps {
   title: string
   loadingText?: string
   loading: boolean
+  disabled?: boolean
   testId?: string
   children: ReactNode
   submitLabel?: string
@@ -44,6 +45,7 @@ interface TranslationDialogWrapperProps {
  * @param {string} props.title - The title to display in the dialog header
  * @param {string} [props.loadingText] - Optional custom text to display during loading state
  * @param {boolean} props.loading - Flag indicating whether the dialog is in a loading state
+ * @param {boolean} props.disabled - Flag indicating whether the dialog is disabled
  * @param {string} [props.testId] - Optional test ID for testing purposes
  * @param {ReactNode} props.children - The content to render within the dialog
  * @param {string} [props.submitLabel] - Optional custom label for the submit button (defaults to "Create")
@@ -59,6 +61,7 @@ export function TranslationDialogWrapper({
   title,
   loadingText,
   loading,
+  disabled = false,
   testId,
   children,
   submitLabel,
@@ -98,6 +101,7 @@ export function TranslationDialogWrapper({
                 variant="contained"
                 onClick={onTranslate}
                 loading={loading}
+                disabled={disabled}
                 sx={{
                   backgroundColor: 'secondary.dark'
                 }}

--- a/libs/locales/en/libs-journeys-ui.json
+++ b/libs/locales/en/libs-journeys-ui.json
@@ -10,7 +10,7 @@
   "Journey will be copied to selected team.": "Journey will be copied to selected team.",
   "Select Team": "Select Team",
   "Translation": "Translation",
-  "This is not the original journey template, it is a translation or copy of the original template. If you want to translate this journey - please use the original template.": "This is not the original journey template, it is a translation or copy of the original template. If you want to translate this journey - please use the original template.",
+  "This is not the original journey template, it is a translation or copy of the original template. If you want to translate or copy this journey - please use the original template.": "This is not the original journey template, it is a translation or copy of the original template. If you want to translate or copy this journey - please use the original template.",
   "Sorry, no results": "Sorry, no results",
   "Try removing or changing something from your request": "Try removing or changing something from your request",
   "Required": "Required",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Publishers are now blocked from copying or translating non‑original templates. Related controls and submit actions are disabled, with clear guidance to use the original template instead.
  - The copy dialog’s submit button now shows “Copy” for clarity and consistency.
  - Translation workflow honors a disabled state to prevent submission when copying/translating is not allowed.
  - Updated user-facing text to reference “translate or copy” for clearer messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->