### PR TITLE
feat: show country details after repeated language map cluster clicks

### DIFF
--- a/prds/watch/home-language-map-section.md
+++ b/prds/watch/home-language-map-section.md
@@ -20,6 +20,7 @@ Render a language coverage map on the Watch homepage that visualizes the global 
 - [x] Add a client-only map component that renders clustered language markers using MapLibre GL with accessibility-friendly controls and popovers.
 - [x] Integrate the new section into `WatchHomePage` beneath the existing hero content and ensure fallbacks render while data loads.
 - [x] Update English translations for the new section headings and descriptions.
+- [x] Limit cluster zoom interactions to two consecutive clicks and present a country-specific language list on the third interaction.
 - [ ] Validate the implementation with linting, type-checking, and any relevant component tests.
 
 ## Technical Analysis


### PR DESCRIPTION
## Summary
- track the most recent cluster interaction so only two zoom clicks are allowed before showing a country-specific popup
- gather the country’s languages from cached map points, fit the viewport to its bounds, and render the list in the popup
- document the new interaction flow in the home language map section PRD

## Testing
- pnpm dlx nx run watch:serve *(fails: /watch responds 500 in this environment because Algolia env vars resolve to empty URLs)*

------
https://chatgpt.com/codex/tasks/task_e_68daea34fa448328ba712fe6f917228b