### PR TITLE
feat(watch): add numbered mode to video grid

### DIFF
--- a/apps/watch/src/components/VideoCard/VideoCard.tsx
+++ b/apps/watch/src/components/VideoCard/VideoCard.tsx
@@ -21,6 +21,7 @@ interface VideoCardProps {
   imageClassName?: string
   onClick?: (videoId?: string) => (event: MouseEvent) => void
   analyticsTag?: string
+  showSequenceNumber?: boolean
 }
 
 export function getSlug(
@@ -48,7 +49,8 @@ export function VideoCard({
   active,
   imageClassName,
   onClick: handleClick,
-  analyticsTag
+  analyticsTag,
+  showSequenceNumber = false
 }: VideoCardProps): ReactElement {
   const { t } = useTranslation('apps-watch')
 
@@ -62,6 +64,7 @@ export function VideoCard({
   // Compute safe image src and alt with proper guards
   const imageSrc = last(video?.images)?.mobileCinematicHigh
   const imageAlt = last(video?.imageAlt)?.value ?? ''
+  const sequenceLabel = showSequenceNumber && index != null ? index + 1 : null
 
   return (
     <a
@@ -77,6 +80,15 @@ export function VideoCard({
           disabled={video == null}
           className={`relative overflow-hidden rounded-lg ${orientation === 'vertical' ? 'aspect-[2/3]' : 'aspect-video'} hover:scale-102 focus-visible:scale-102 transition-transform duration-300 beveled ${imageClassName || ''}`}
         >
+          {sequenceLabel != null && (
+            <span
+              className="absolute top-3 left-3 text-5xl font-black text-white drop-shadow-[0_4px_10px_rgba(0,0,0,0.7)]"
+              aria-hidden="true"
+              data-testid="VideoCardSequenceNumber"
+            >
+              {sequenceLabel}
+            </span>
+          )}
           <div className="absolute inset-0 rounded-lg overflow-hidden bg-black/50 transition-transform duration-300">
             {imageSrc ? (
               <Image

--- a/apps/watch/src/components/VideoGrid/VideoGrid.spec.tsx
+++ b/apps/watch/src/components/VideoGrid/VideoGrid.spec.tsx
@@ -123,4 +123,22 @@ describe('VideoGrid', () => {
 
     expect(screen.getByText('Sorry, no results')).toBeInTheDocument()
   })
+
+  it('should render sequence numbers when enabled', () => {
+    mockedUseAlgoliaVideos.mockReturnValue({
+      loading: false,
+      noResults: false,
+      items: [],
+      showMore: jest.fn(),
+      isLastPage: false,
+      sendEvent: jest.fn()
+    })
+
+    render(<VideoGrid videos={videos.slice(0, 2)} showSequenceNumbers />)
+
+    const sequenceBadges = screen.getAllByTestId('VideoCardSequenceNumber')
+    expect(sequenceBadges).toHaveLength(2)
+    expect(sequenceBadges[0]).toHaveTextContent('1')
+    expect(sequenceBadges[1]).toHaveTextContent('2')
+  })
 })

--- a/apps/watch/src/components/VideoGrid/VideoGrid.tsx
+++ b/apps/watch/src/components/VideoGrid/VideoGrid.tsx
@@ -16,6 +16,7 @@ export interface VideoGridProps {
   hasNoResults?: boolean
   onCardClick?: (videoId?: string) => (event: MouseEvent) => void
   analyticsTag?: string
+  showSequenceNumbers?: boolean
 }
 
 export function VideoGrid({
@@ -28,7 +29,8 @@ export function VideoGrid({
   hasNextPage = true,
   hasNoResults = false,
   onCardClick,
-  analyticsTag
+  analyticsTag,
+  showSequenceNumbers = false
 }: VideoGridProps): ReactElement {
   const { t } = useTranslation('apps-watch')
 
@@ -44,8 +46,10 @@ export function VideoGrid({
               video={video}
               orientation={orientation}
               containerSlug={containerSlug}
+              index={index}
               onClick={onCardClick}
               analyticsTag={analyticsTag}
+              showSequenceNumber={showSequenceNumbers}
             />
           </div>
         ))}

--- a/prds/watch/work.md
+++ b/prds/watch/work.md
@@ -31,6 +31,34 @@
 - Share a typed helper for reusing the slide-to-video snapshot logic in other sections.
 - Consider centralizing Jest icon mocks to reduce repetition.
 
+# Video Grid Sequence Overlay
+
+## Goals
+
+- [x] Add a numbered overlay mode to `VideoGrid` for curated collection layouts.
+- [x] Render bold sequence markers on each `VideoCard` thumbnail.
+- [x] Cover the new mode with unit tests.
+
+## Obstacles
+
+- Existing `VideoCard` markup had no obvious hook for overlays without disturbing current layout.
+
+## Resolutions
+
+- Reused the `index` prop and injected an absolutely positioned badge for the sequence label.
+
+## Test Coverage
+
+- `pnpm test watch -- VideoGrid`
+
+## User Flows
+
+- Enable numbered mode on a grid -> cards render 1..n badges over thumbnails.
+
+## Follow-up Ideas
+
+- Consider exposing badge styling tokens so editorial can tweak typography per layout.
+
 # Search Component Overlay Refactor
 
 ## Goals


### PR DESCRIPTION
## Summary
- add a `showSequenceNumbers` mode to `VideoGrid` and plumb the index into each card
- render a bold sequence badge on `VideoCard` thumbnails when the mode is enabled
- document the work in the watch PRD log and add unit coverage for the new mode

## Testing
- pnpm test watch -- VideoGrid

------
https://chatgpt.com/codex/tasks/task_e_68da8fbb2c8883288ca83f2ccfe589e6