### PR TITLE
feat(watch): add collection backgrounds to video sections

### DIFF
--- a/apps/watch/src/components/SectionVideoCarousel/SectionVideoCarousel.spec.tsx
+++ b/apps/watch/src/components/SectionVideoCarousel/SectionVideoCarousel.spec.tsx
@@ -376,6 +376,11 @@ describe('SectionVideoCarousel', () => {
     expect(
       screen.getByTestId('SectionVideoCarouselDescription')
     ).toHaveTextContent('Our mission is to reach everyone. Secondary sentence.')
+
+    const background = screen.getByTestId('SectionVideoCarouselBackground')
+    expect(background).toHaveStyle({
+      backgroundImage: 'url(https://example.com/collection-poster.jpg)'
+    })
   })
 
   it('respects override props for copy and CTA', async () => {

--- a/apps/watch/src/components/SectionVideoCarousel/SectionVideoCarousel.tsx
+++ b/apps/watch/src/components/SectionVideoCarousel/SectionVideoCarousel.tsx
@@ -47,7 +47,16 @@ export function SectionVideoCarousel({
 }: SectionVideoCarouselProps): ReactElement | null {
   const { t } = useTranslation('apps-watch')
 
-  const { loading, slides, subtitle, title, description, ctaHref, ctaLabel } =
+  const {
+    loading,
+    slides,
+    subtitle,
+    title,
+    description,
+    ctaHref,
+    ctaLabel,
+    backgroundImageUrl
+  } =
     useSectionVideoCollectionCarouselContent({
       sources,
       primaryCollectionId,
@@ -65,13 +74,19 @@ export function SectionVideoCarousel({
   return (
     <section
       id={id}
-      className={cn(
-        'relative bg-linear-to-tr from-blue-950/10 via-purple-950/10 to-[#91214A]/90 py-16 scroll-snap-start-always',
-        backgroundClassName
-      )}
+      className={cn('relative overflow-hidden py-16 scroll-snap-start-always', backgroundClassName)}
       data-testid="SectionVideoCarousel"
     >
-      <div className="absolute inset-0 bg-[url(/watch/assets/overlay.svg)] bg-repeat mix-blend-multiply" />
+      {backgroundImageUrl != null ? (
+        <div
+          aria-hidden
+          className="absolute inset-0 -z-30 bg-cover bg-center"
+          style={{ backgroundImage: `url(${backgroundImageUrl})` }}
+          data-testid="SectionVideoCarouselBackground"
+        />
+      ) : null}
+      <div className="absolute inset-0 -z-20 bg-linear-to-tr from-blue-950/40 via-purple-950/30 to-[#91214A]/80" />
+      <div className="absolute inset-0 -z-10 bg-[url(/watch/assets/overlay.svg)] bg-repeat mix-blend-multiply" />
       <div className="padded relative z-2 pb-6">
         <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex flex-col gap-1">

--- a/apps/watch/src/components/SectionVideoCarousel/useSectionVideoCollectionCarouselContent.ts
+++ b/apps/watch/src/components/SectionVideoCarousel/useSectionVideoCollectionCarouselContent.ts
@@ -42,6 +42,7 @@ export interface SectionVideoCollectionCarouselContentResult {
   ctaLabel: string
   ctaHref: string
   primaryCollection?: ShowcaseVideoNode
+  backgroundImageUrl?: string
 }
 
 interface FlattenOptions {
@@ -121,6 +122,19 @@ function selectImageUrl(node: MaybeCollection | VideoNode): string | undefined {
   if (banner?.mobileCinematicHigh != null) return banner.mobileCinematicHigh
 
   return undefined
+}
+
+function selectCollectionBackgroundImageUrl(
+  collection?: MaybeCollection
+): string | undefined {
+  if (collection == null) return undefined
+
+  const banner = collection.bannerImages?.find(
+    (image) => image?.mobileCinematicHigh != null
+  )
+  if (banner?.mobileCinematicHigh != null) return banner.mobileCinematicHigh
+
+  return selectImageUrl(collection)
 }
 
 function selectAltText(node: MaybeCollection | VideoNode): string | undefined {
@@ -439,6 +453,7 @@ export function useSectionVideoCollectionCarouselContent({
     description,
     ctaLabel,
     ctaHref,
-    primaryCollection
+    primaryCollection,
+    backgroundImageUrl: selectCollectionBackgroundImageUrl(primaryCollection)
   }
 }

--- a/apps/watch/src/components/SectionVideoGrid/SectionVideoGrid.spec.tsx
+++ b/apps/watch/src/components/SectionVideoGrid/SectionVideoGrid.spec.tsx
@@ -375,6 +375,11 @@ describe('SectionVideoGrid', () => {
     expect(screen.getByTestId('SectionVideoGridDescription')).toHaveTextContent(
       'Our mission is to reach everyone. Secondary sentence.'
     )
+
+    const background = screen.getByTestId('SectionVideoGridBackground')
+    expect(background).toHaveStyle({
+      backgroundImage: 'url(https://example.com/collection-poster.jpg)'
+    })
   })
 
   it('respects override props for copy and CTA', async () => {

--- a/apps/watch/src/components/SectionVideoGrid/SectionVideoGrid.tsx
+++ b/apps/watch/src/components/SectionVideoGrid/SectionVideoGrid.tsx
@@ -46,7 +46,16 @@ export function SectionVideoGrid({
 }: SectionVideoGridProps): ReactElement | null {
   const { t } = useTranslation('apps-watch')
 
-  const { loading, slides, subtitle, title, description, ctaHref, ctaLabel } =
+  const {
+    loading,
+    slides,
+    subtitle,
+    title,
+    description,
+    ctaHref,
+    ctaLabel,
+    backgroundImageUrl
+  } =
     useSectionVideoCollectionCarouselContent({
       sources,
       primaryCollectionId,
@@ -66,13 +75,19 @@ export function SectionVideoGrid({
   return (
     <section
       id={id}
-      className={cn(
-        'relative bg-linear-to-tr from-blue-950/10 via-purple-950/10 to-[#91214A]/90 py-16 scroll-snap-start-always',
-        backgroundClassName
-      )}
+      className={cn('relative overflow-hidden py-16 scroll-snap-start-always', backgroundClassName)}
       data-testid="SectionVideoGrid"
     >
-      <div className="absolute inset-0 bg-[url(/watch/assets/overlay.svg)] bg-repeat mix-blend-multiply" />
+      {backgroundImageUrl != null ? (
+        <div
+          aria-hidden
+          className="absolute inset-0 -z-30 bg-cover bg-center"
+          style={{ backgroundImage: `url(${backgroundImageUrl})` }}
+          data-testid="SectionVideoGridBackground"
+        />
+      ) : null}
+      <div className="absolute inset-0 -z-20 bg-linear-to-tr from-blue-950/40 via-purple-950/30 to-[#91214A]/80" />
+      <div className="absolute inset-0 -z-10 bg-[url(/watch/assets/overlay.svg)] bg-repeat mix-blend-multiply" />
       <div className="padded relative z-2 pb-6">
         <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex flex-col gap-1">

--- a/prds/watch/work.md
+++ b/prds/watch/work.md
@@ -65,3 +65,38 @@
 
 - Consider moving category metadata to CMS-driven config if design requires frequent updates.
 - Evaluate migrating remaining MUI layout primitives to Tailwind equivalents in a future iteration.
+
+# Collection Section Background Enhancements
+
+## Goals
+
+- [x] Surface collection cover imagery within section backgrounds for carousel/grid sections.
+
+## Obstacles
+
+- Needed to preserve the existing gradient/pattern overlay layering while introducing cover imagery.
+
+## Resolutions
+
+- Layered the background image beneath recreated gradient and pattern overlays to maintain readability.
+
+## Implementation Strategy
+
+- [x] Audit `useSectionVideoCollectionCarouselContent` to identify available collection imagery.
+- [x] Expose a `backgroundImageUrl` from the hook that prefers banner art with poster fallback.
+- [x] Render the background image beneath gradient + texture overlays in SectionVideoGrid and SectionVideoCarousel.
+- [x] Extend unit tests to assert that background URLs render when data is available.
+
+## Test Coverage
+
+- `pnpm exec jest apps/watch/src/components/SectionVideoGrid/SectionVideoGrid.spec.tsx --config=apps/watch/jest.config.ts`
+- `pnpm exec jest apps/watch/src/components/SectionVideoCarousel/SectionVideoCarousel.spec.tsx --config=apps/watch/jest.config.ts`
+
+## User Flows
+
+- Load a SectionVideoGrid fed by a collection – the collection's cover art appears behind the grid with existing overlays intact.
+- Load a SectionVideoCarousel fed by the same data – the carousel inherits the same background treatment.
+
+## Follow-up Ideas
+
+- Consider supporting responsive art direction (mobile vs desktop) if API exposes additional image sizes.


### PR DESCRIPTION
## Summary
- expose a `backgroundImageUrl` from `useSectionVideoCollectionCarouselContent` that prefers collection banner art and falls back to poster imagery
- render the returned background on SectionVideoGrid and SectionVideoCarousel beneath the existing gradient/texture overlays
- document the change in the watch work log and extend unit tests to assert the new backgrounds

## Testing
- pnpm exec jest apps/watch/src/components/SectionVideoGrid/SectionVideoGrid.spec.tsx --config=apps/watch/jest.config.ts
- pnpm exec jest apps/watch/src/components/SectionVideoCarousel/SectionVideoCarousel.spec.tsx --config=apps/watch/jest.config.ts


------
https://chatgpt.com/codex/tasks/task_e_68da8f5a315483289fc281b9e3d35fa8