### PR TITLE
Pause hero video when search overlay opens

### DIFF
--- a/apps/watch/src/components/SearchComponent/hooks/useFloatingSearchOverlay.spec.ts
+++ b/apps/watch/src/components/SearchComponent/hooks/useFloatingSearchOverlay.spec.ts
@@ -35,7 +35,7 @@ describe('useFloatingSearchOverlay', () => {
       trendingSearches: [],
       isLoading: false,
       error: null,
-      fetchTrendingSearches: jest.fn()
+      fetchTrendingSearches: jest.fn().mockResolvedValue(undefined)
     })
   })
 
@@ -81,7 +81,7 @@ describe('useFloatingSearchOverlay', () => {
   })
 
   it('requests trending searches when the overlay opens', async () => {
-    const fetchTrendingSearches = jest.fn()
+    const fetchTrendingSearches = jest.fn().mockResolvedValue(undefined)
     mockUseTrendingSearches.mockReturnValue({
       trendingSearches: [],
       isLoading: false,
@@ -98,6 +98,25 @@ describe('useFloatingSearchOverlay', () => {
     await waitFor(() => {
       expect(fetchTrendingSearches).toHaveBeenCalled()
     })
+  })
+
+  it('pauses active videos when the overlay opens', async () => {
+    const video = document.createElement('video')
+    const pauseSpy = jest.spyOn(video, 'pause').mockImplementation(() => {})
+    document.body.appendChild(video)
+
+    const { result } = renderHook(() => useFloatingSearchOverlay())
+
+    act(() => {
+      result.current.handleSearchFocus()
+    })
+
+    await waitFor(() => {
+      expect(pauseSpy).toHaveBeenCalled()
+    })
+
+    pauseSpy.mockRestore()
+    document.body.removeChild(video)
   })
 
   it('uses translated fallback searches when trending fails', () => {

--- a/apps/watch/src/components/SearchComponent/hooks/useFloatingSearchOverlay.ts
+++ b/apps/watch/src/components/SearchComponent/hooks/useFloatingSearchOverlay.ts
@@ -46,6 +46,20 @@ export function useFloatingSearchOverlay(): UseFloatingSearchOverlayResult {
   const searchInputRef = useRef<HTMLInputElement | null>(null)
   const loadingTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
+  const pauseActiveVideos = useCallback((): void => {
+    if (typeof document === 'undefined') return
+
+    document
+      .querySelectorAll('video')
+      .forEach((videoElement) => {
+        try {
+          videoElement.pause()
+        } catch (error) {
+          console.warn('Failed to pause video when opening search overlay', error)
+        }
+      })
+  }, [])
+
   const {
     trendingSearches,
     isLoading: isTrendingLoading,
@@ -100,6 +114,12 @@ export function useFloatingSearchOverlay(): UseFloatingSearchOverlayResult {
     trendingError,
     fetchTrendingSearches
   ])
+
+  useEffect(() => {
+    if (!isSearchActive) return
+
+    pauseActiveVideos()
+  }, [isSearchActive, pauseActiveVideos])
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary
- pause any playing videos whenever the floating search overlay is activated so the search dialog doesn't compete with audio
- cover the new behavior with a hook unit test and ensure trending search mocks resolve promises cleanly

## Testing
- pnpm dlx nx test watch --testFile=apps/watch/src/components/SearchComponent/hooks/useFloatingSearchOverlay.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68da8e9c3d788328932968423d1236fa