### PR TITLE
feat(watch): add skip control to hero preview

### DIFF
--- a/apps/watch/src/components/NewVideoContentPage/VideoContentHero/HeroVideo/HeroVideo.tsx
+++ b/apps/watch/src/components/NewVideoContentPage/VideoContentHero/HeroVideo/HeroVideo.tsx
@@ -25,6 +25,7 @@ interface HeroVideoProps {
   onMuteToggle?: (isMuted: boolean) => void
   currentMuxInsert?: CarouselMuxSlide | null
   onMuxInsertComplete?: () => void
+  onSkip?: () => void
 }
 
 export function HeroVideo({
@@ -32,7 +33,8 @@ export function HeroVideo({
   collapsed = true,
   onMuteToggle,
   currentMuxInsert,
-  onMuxInsertComplete
+  onMuxInsertComplete,
+  onSkip
 }: HeroVideoProps): ReactElement {
   const { variant, ...video } = useVideo()
   const {
@@ -244,6 +246,7 @@ export function HeroVideo({
               action={currentMuxInsert?.overlay.action}
               isMuxInsert={currentMuxInsert != null}
               muxOverlay={currentMuxInsert?.overlay}
+              onSkip={onSkip}
             />
           </>
         )}

--- a/apps/watch/src/components/NewVideoContentPage/VideoContentHero/VideoContentHero.tsx
+++ b/apps/watch/src/components/NewVideoContentPage/VideoContentHero/VideoContentHero.tsx
@@ -11,11 +11,13 @@ import { HeroVideo } from './HeroVideo'
 export function VideoContentHero({
   isPreview = false,
   currentMuxInsert,
-  onMuxInsertComplete
+  onMuxInsertComplete,
+  onSkipActiveVideo
 }: {
   isPreview?: boolean
   currentMuxInsert?: CarouselMuxSlide | null
   onMuxInsertComplete?: () => void
+  onSkipActiveVideo?: () => void
 }): ReactElement {
   const { variant } = useVideo()
   const {
@@ -50,6 +52,7 @@ export function VideoContentHero({
         onMuteToggle={handleMuteToggle}
         currentMuxInsert={currentMuxInsert}
         onMuxInsertComplete={onMuxInsertComplete}
+        onSkip={onSkipActiveVideo}
         key={currentMuxInsert ? currentMuxInsert.id : variant?.hls}
       />
       <div

--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoControls/VideoControls.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoControls/VideoControls.tsx
@@ -62,6 +62,7 @@ interface VideoControlProps {
   action?: InsertAction
   isMuxInsert?: boolean
   muxOverlay?: InsertOverlay
+  onSkip?: () => void
 }
 
 function evtToDataLayer(
@@ -94,7 +95,8 @@ export function VideoControls({
   customDuration,
   action,
   isMuxInsert = false,
-  muxOverlay
+  muxOverlay,
+  onSkip
 }: VideoControlProps): ReactElement {
   const [initialLoadComplete, setInitialLoadComplete] = useState(false)
   const {
@@ -612,6 +614,7 @@ export function VideoControls({
             collectionTitle={collectionTitle}
             action={action}
             isMuxInsert={isMuxInsert}
+            onSkip={onSkip}
             onMuteToggle={() => {
               handleMute()
             }}
@@ -664,6 +667,7 @@ export function VideoControls({
               collectionTitle={collectionTitle}
               action={action}
               isMuxInsert={isMuxInsert}
+              onSkip={onSkip}
               onMuteToggle={() => {
                 handleMute()
               }}

--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoTitle/VideoTitle.spec.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoTitle/VideoTitle.spec.tsx
@@ -117,4 +117,19 @@ describe('VideoTitle', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Play with sound' }))
     expect(onClick).toHaveBeenCalled()
   })
+
+  it('renders skip button when preview with handler', () => {
+    const onSkip = jest.fn()
+    renderWithProviders(
+      <VideoTitle
+        videoTitle="Test Video"
+        showButton
+        isPreview
+        onSkip={onSkip}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Skip video' }))
+    expect(onSkip).toHaveBeenCalled()
+  })
 })

--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoTitle/VideoTitle.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoTitle/VideoTitle.tsx
@@ -1,4 +1,5 @@
 import PlayArrowRounded from '@mui/icons-material/PlayArrowRounded'
+import SkipNextRounded from '@mui/icons-material/SkipNextRounded'
 import VolumeOff from '@mui/icons-material/VolumeOff'
 import VolumeUpOutlined from '@mui/icons-material/VolumeUpOutlined'
 import NextLink from 'next/link'
@@ -24,6 +25,7 @@ interface VideoTitleProps {
   collectionTitle?: string
   action?: InsertAction
   isMuxInsert?: boolean
+  onSkip?: () => void
 }
 
 export function VideoTitle({
@@ -38,7 +40,8 @@ export function VideoTitle({
   onMuteToggle,
   collectionTitle,
   action,
-  isMuxInsert = false
+  isMuxInsert = false,
+  onSkip
 }: VideoTitleProps): ReactElement {
   const { t } = useTranslation('apps-watch')
   const { label, variant: videoVariant } = useVideo()
@@ -151,17 +154,33 @@ export function VideoTitle({
           Watch Now
         </NextLink>
       )}
-      {isPreview && onMuteToggle && (
-        <button
-          onClick={(e) => {
-            e.stopPropagation()
-            onMuteToggle()
-          }}
-          className="absolute z-0 cursor-pointer bottom-7 right-0 scale-125 text-stone-50 p-2 rounded-full hover:bg-white/20 transition-colors duration-200 mute-preview-toggle"
-          aria-label={mute || volume === 0 ? t('Unmute') : t('Mute')}
-        >
-          {mute || volume === 0 ? <VolumeOff /> : <VolumeUpOutlined />}
-        </button>
+      {isPreview && (onMuteToggle != null || onSkip != null) && (
+        <div className="absolute z-0 bottom-7 right-0 flex items-center gap-2 scale-125">
+          {onSkip != null && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onSkip()
+              }}
+              className="cursor-pointer text-stone-50 p-2 rounded-full hover:bg-white/20 transition-colors duration-200"
+              aria-label={t('Skip video')}
+            >
+              <SkipNextRounded fontSize="medium" />
+            </button>
+          )}
+          {onMuteToggle != null && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onMuteToggle()
+              }}
+              className="cursor-pointer text-stone-50 p-2 rounded-full hover:bg-white/20 transition-colors duration-200 mute-preview-toggle"
+              aria-label={mute || volume === 0 ? t('Unmute') : t('Mute')}
+            >
+              {mute || volume === 0 ? <VolumeOff /> : <VolumeUpOutlined />}
+            </button>
+          )}
+        </div>
       )}
     </div>
   )

--- a/apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoTitle/VideoTitle.tsx
+++ b/apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoTitle/VideoTitle.tsx
@@ -155,14 +155,14 @@ export function VideoTitle({
         </NextLink>
       )}
       {isPreview && (onMuteToggle != null || onSkip != null) && (
-        <div className="absolute z-0 bottom-7 right-0 flex items-center gap-2 scale-125">
+        <div className="absolute z-0 bottom-7 right-0 flex items-center gap-2 scale-150">
           {onSkip != null && (
             <button
               onClick={(e) => {
                 e.stopPropagation()
                 onSkip()
               }}
-              className="cursor-pointer text-stone-50 p-2 rounded-full hover:bg-white/20 transition-colors duration-200"
+              className="z-50 cursor-pointer text-stone-50/50 p-2 rounded-full hover:text-stone-50 transition-colors duration-200"
               aria-label={t('Skip video')}
             >
               <SkipNextRounded fontSize="medium" />
@@ -174,7 +174,7 @@ export function VideoTitle({
                 e.stopPropagation()
                 onMuteToggle()
               }}
-              className="cursor-pointer text-stone-50 p-2 rounded-full hover:bg-white/20 transition-colors duration-200 mute-preview-toggle"
+              className="cursor-pointer text-stone-50/50 p-2 rounded-full hover:text-stone-50 transition-colors duration-200 mute-preview-toggle"
               aria-label={mute || volume === 0 ? t('Unmute') : t('Mute')}
             >
               {mute || volume === 0 ? <VolumeOff /> : <VolumeUpOutlined />}

--- a/apps/watch/src/components/WatchHomePage/WatchHero.tsx
+++ b/apps/watch/src/components/WatchHomePage/WatchHero.tsx
@@ -18,6 +18,7 @@ interface WatchHeroProps {
   loading: boolean
   onSelectSlide: (slideId: string) => void
   onMuxInsertComplete: () => void
+  onSkipActiveVideo?: () => void
   children?: ReactNode
 }
 
@@ -29,6 +30,7 @@ export function WatchHero({
   loading,
   onSelectSlide,
   onMuxInsertComplete,
+  onSkipActiveVideo,
   children
 }: WatchHeroProps): ReactElement {
   return (
@@ -39,6 +41,7 @@ export function WatchHero({
             isPreview
             currentMuxInsert={currentMuxInsert}
             onMuxInsertComplete={onMuxInsertComplete}
+            onSkipActiveVideo={onSkipActiveVideo}
           />
         </VideoProvider>
       )}

--- a/apps/watch/src/components/WatchHomePage/WatchHomePage.tsx
+++ b/apps/watch/src/components/WatchHomePage/WatchHomePage.tsx
@@ -46,7 +46,8 @@ function WatchHomePageBody({ languageId }: WatchHomePageProps): ReactElement {
     activeVideo,
     currentMuxInsert,
     handleVideoSelect,
-    handleMuxInsertComplete
+    handleMuxInsertComplete,
+    handleSkipActiveVideo
   } = useWatchHeroCarousel({ locale: '529' })
 
   return (
@@ -69,6 +70,7 @@ function WatchHomePageBody({ languageId }: WatchHomePageProps): ReactElement {
         loading={loading}
         onSelectSlide={handleVideoSelect}
         onMuxInsertComplete={handleMuxInsertComplete}
+        onSkipActiveVideo={handleSkipActiveVideo}
       >
         <div
           data-testid="WatchHomePage"

--- a/apps/watch/src/components/WatchHomePage/useWatchHeroCarousel.spec.tsx
+++ b/apps/watch/src/components/WatchHomePage/useWatchHeroCarousel.spec.tsx
@@ -190,6 +190,44 @@ describe('useWatchHeroCarousel', () => {
     expect(jumpToVideoMock).toHaveBeenCalledWith(videoTwo.id)
   })
 
+  it('skips to the next slide when skip handler is invoked', () => {
+    const { result } = renderHook(() => useWatchHeroCarousel())
+
+    act(() => {
+      result.current.handleSkipActiveVideo()
+    })
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(result.current.activeVideoId).toBe(muxSlideTwo.id)
+
+    act(() => {
+      result.current.handleSkipActiveVideo()
+    })
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(result.current.activeVideoId).toBe(videoOne.id)
+  })
+
+  it('requests additional videos when skipping beyond available slides', () => {
+    const { result } = renderHook(() => useWatchHeroCarousel())
+
+    act(() => {
+      result.current.handleVideoSelect(videoTwo.id)
+    })
+
+    moveToNextMock.mockClear()
+
+    act(() => {
+      result.current.handleSkipActiveVideo()
+    })
+
+    expect(moveToNextMock).toHaveBeenCalled()
+  })
+
   it('automatically advances when playback nears completion', () => {
     const { result, rerender } = renderHook(() => useWatchHeroCarousel())
 

--- a/apps/watch/src/components/WatchHomePage/useWatchHeroCarousel.ts
+++ b/apps/watch/src/components/WatchHomePage/useWatchHeroCarousel.ts
@@ -37,6 +37,7 @@ interface UseWatchHeroCarouselResult {
   currentMuxInsert: CarouselMuxSlide | null
   handleVideoSelect: (slideId: string) => void
   handleMuxInsertComplete: () => void
+  handleSkipActiveVideo: () => void
 }
 
 const DEFAULT_LANGUAGE: VideoContentFields_variant_language = {
@@ -477,6 +478,21 @@ export function useWatchHeroCarousel({
     setLastProgress(0)
   }, [activeSlideIndex, autoProgressEnabled, isProgressing, moveToSlide])
 
+  const handleSkipActiveVideo = useCallback(() => {
+    if (activeSlideIndex === -1) return
+
+    const nextIndex = activeSlideIndex + 1
+
+    if (nextIndex < slides.length) {
+      moveToSlide(nextIndex, 500)
+      setLastProgress(0)
+      return
+    }
+
+    moveToNext()
+    setLastProgress(0)
+  }, [activeSlideIndex, slides.length, moveToSlide, moveToNext])
+
   useEffect(() => {
     if (playerState.progress >= 95 && lastProgress < 95 && !isProgressing) {
       advanceOnProgress()
@@ -510,6 +526,7 @@ export function useWatchHeroCarousel({
     activeVideo,
     currentMuxInsert,
     handleVideoSelect,
-    handleMuxInsertComplete
+    handleMuxInsertComplete,
+    handleSkipActiveVideo
   }
 }

--- a/libs/locales/am-ET/apps-watch.json
+++ b/libs/locales/am-ET/apps-watch.json
@@ -48,6 +48,7 @@
   "Play Video": "Play Video",
   "{{ duration }} min": "{{ duration }} min",
   "Play with sound": "Play with sound",
+  "Skip video": "Skip video",
   "Languages": "Languages",
   "Subtitles": "Subtitles",
   "Title": "Title",

--- a/libs/locales/ar-SA/apps-watch.json
+++ b/libs/locales/ar-SA/apps-watch.json
@@ -69,6 +69,7 @@
   "Play Video": "تشغيل الفيديو",
   "{{ duration }} min": "{{ duration }} دقيقة",
   "Play with sound": "اللعب بالصوت",
+  "Skip video": "Skip video",
   "Sorry, no results": "عذراً، لا توجد نتائج",
   "Try removing or changing something from your request": "حاول إزالة أو تغيير شيء ما من طلبك",
   "Languages": "اللغات",

--- a/libs/locales/bn-BD/apps-watch.json
+++ b/libs/locales/bn-BD/apps-watch.json
@@ -48,6 +48,7 @@
   "Play Video": "Play Video",
   "{{ duration }} min": "{{ duration }} min",
   "Play with sound": "Play with sound",
+  "Skip video": "Skip video",
   "Languages": "Languages",
   "Subtitles": "Subtitles",
   "Title": "Title",

--- a/libs/locales/de-DE/apps-watch.json
+++ b/libs/locales/de-DE/apps-watch.json
@@ -69,6 +69,7 @@
   "Play Video": "Video abspielen",
   "{{ duration }} min": "{{ duration }} min",
   "Play with sound": "Mit Sound spielen",
+  "Skip video": "Skip video",
   "Sorry, no results": "Sorry, keine Ergebnisse",
   "Try removing or changing something from your request": "Versuche, etwas aus deiner Anfrage zu entfernen oder zu ändern",
   "Languages": "Sprachen",

--- a/libs/locales/en/apps-watch.json
+++ b/libs/locales/en/apps-watch.json
@@ -71,6 +71,7 @@
   "Play Video": "Play Video",
   "{{ duration }} min": "{{ duration }} min",
   "Play with sound": "Play with sound",
+  "Skip video": "Skip video",
   "Sorry, no results": "Sorry, no results",
   "Try removing or changing something from your request": "Try removing or changing something from your request",
   "Languages": "Languages",

--- a/libs/locales/es-ES/apps-watch.json
+++ b/libs/locales/es-ES/apps-watch.json
@@ -69,6 +69,7 @@
   "Play Video": "Reproducir vídeo",
   "{{ duration }} min": "{{ duration }} min",
   "Play with sound": "Juega con el sonido",
+  "Skip video": "Skip video",
   "Sorry, no results": "Lo sentimos, no hay resultados",
   "Try removing or changing something from your request": "Intenta eliminar o cambiar algo de tu solicitud",
   "Languages": "Idiomas",

--- a/libs/locales/fr-FR/apps-watch.json
+++ b/libs/locales/fr-FR/apps-watch.json
@@ -69,6 +69,7 @@
   "Play Video": "Jouer la vidéo",
   "{{ duration }} min": "{{ duration }} min",
   "Play with sound": "Joue avec le son",
+  "Skip video": "Skip video",
   "Sorry, no results": "Désolé, pas de résultats",
   "Try removing or changing something from your request": "Essaie de supprimer ou de changer quelque chose dans ta demande",
   "Languages": "Les langues",

--- a/libs/locales/hi-IN/apps-watch.json
+++ b/libs/locales/hi-IN/apps-watch.json
@@ -48,6 +48,7 @@
   "Play Video": "Play Video",
   "{{ duration }} min": "{{ duration }} min",
   "Play with sound": "Play with sound",
+  "Skip video": "Skip video",
   "Languages": "Languages",
   "Subtitles": "Subtitles",
   "Title": "Title",

--- a/libs/locales/id-ID/apps-watch.json
+++ b/libs/locales/id-ID/apps-watch.json
@@ -69,6 +69,7 @@
   "Play Video": "Putar Video",
   "{{ duration }} min": "{{ duration }} min",
   "Play with sound": "Bermain dengan suara",
+  "Skip video": "Skip video",
   "Sorry, no results": "Maaf, tidak ada hasil",
   "Try removing or changing something from your request": "Coba hapus atau ubah sesuatu dari permintaan Anda",
   "Languages": "Bahasa",

--- a/libs/locales/ja-JP/apps-watch.json
+++ b/libs/locales/ja-JP/apps-watch.json
@@ -69,6 +69,7 @@
   "Play Video": "ビデオ再生",
   "{{ duration }} min": "{{ duration }} 分",
   "Play with sound": "音で遊ぶ",
+  "Skip video": "Skip video",
   "Sorry, no results": "申し訳ありませんが、結果はありません。",
   "Try removing or changing something from your request": "リクエストから何かを削除または変更してみる",
   "Languages": "言語",

--- a/libs/locales/ko-KR/apps-watch.json
+++ b/libs/locales/ko-KR/apps-watch.json
@@ -69,6 +69,7 @@
   "Play Video": "비디오 재생",
   "{{ duration }} min": "{{ duration }} 분",
   "Play with sound": "사운드와 함께 플레이",
+  "Skip video": "Skip video",
   "Sorry, no results": "죄송합니다, 결과가 없습니다.",
   "Try removing or changing something from your request": "요청에서 무언가를 제거하거나 변경해 보세요.",
   "Languages": "언어",

--- a/libs/locales/my-MM/apps-watch.json
+++ b/libs/locales/my-MM/apps-watch.json
@@ -48,6 +48,7 @@
   "Play Video": "Play Video",
   "{{ duration }} min": "{{ duration }} min",
   "Play with sound": "Play with sound",
+  "Skip video": "Skip video",
   "Languages": "Languages",
   "Subtitles": "Subtitles",
   "Title": "Title",

--- a/libs/locales/ne-NP/apps-watch.json
+++ b/libs/locales/ne-NP/apps-watch.json
@@ -48,6 +48,7 @@
   "Play Video": "भिडियो प्ले गर्नुहोस्",
   "{{ duration }} min": "{{ duration }} min",
   "Play with sound": "ध्वनिसँग खेल्नुहोस्",
+  "Skip video": "Skip video",
   "Languages": "भाषाहरू",
   "Subtitles": "उपशीर्षकहरू",
   "Title": "शीर्षक",

--- a/libs/locales/pt-BR/apps-watch.json
+++ b/libs/locales/pt-BR/apps-watch.json
@@ -69,6 +69,7 @@
   "Play Video": "Reproduzir vídeo",
   "{{ duration }} min": "{{ duration }} min",
   "Play with sound": "Reproduzir com som",
+  "Skip video": "Skip video",
   "Sorry, no results": "Desculpe, nenhum resultado",
   "Try removing or changing something from your request": "Tente remover ou alterar algo da sua solicitação",
   "Languages": "Idiomas",

--- a/libs/locales/ru-RU/apps-watch.json
+++ b/libs/locales/ru-RU/apps-watch.json
@@ -69,6 +69,7 @@
   "Play Video": "Смотреть",
   "{{ duration }} min": "{{ duration }} мин",
   "Play with sound": "Играй со звуком",
+  "Skip video": "Skip video",
   "Sorry, no results": "Извини, результатов нет",
   "Try removing or changing something from your request": "Попробуй убрать или изменить что-то из своего запроса",
   "Languages": "Языки",

--- a/libs/locales/th-TH/apps-watch.json
+++ b/libs/locales/th-TH/apps-watch.json
@@ -69,6 +69,7 @@
   "Play Video": "เล่นวิดีโอ",
   "{{ duration }} min": "{{ duration }} นาที",
   "Play with sound": "เล่นกับเสียง",
+  "Skip video": "Skip video",
   "Sorry, no results": "ขอโทษ ไม่พบผลลัพธ์",
   "Try removing or changing something from your request": "ลองลบหรือเปลี่ยนบางอย่างจากคำขอของคุณ",
   "Languages": "ภาษา",

--- a/libs/locales/tl-PH/apps-watch.json
+++ b/libs/locales/tl-PH/apps-watch.json
@@ -69,6 +69,7 @@
   "Play Video": "I-play ang Video",
   "{{ duration }} min": "{{ duration }} min",
   "Play with sound": "I-play na may tunog",
+  "Skip video": "Skip video",
   "Sorry, no results": "Paumanhin, walang mga resulta",
   "Try removing or changing something from your request": "Subukan na alisin o baguhin ang isang bagay sa iyong kahilingan",
   "Languages": "Mga Wika",

--- a/libs/locales/tr-TR/apps-watch.json
+++ b/libs/locales/tr-TR/apps-watch.json
@@ -69,6 +69,7 @@
   "Play Video": "Video Oynat",
   "{{ duration }} min": "{{ duration }} min",
   "Play with sound": "Ses ile oynayın",
+  "Skip video": "Skip video",
   "Sorry, no results": "Üzgünüm, sonuç yok",
   "Try removing or changing something from your request": "Talebinizden bir şeyi kaldırmayı veya değiştirmeyi deneyin",
   "Languages": "Diller",

--- a/libs/locales/ur-PK/apps-watch.json
+++ b/libs/locales/ur-PK/apps-watch.json
@@ -48,6 +48,7 @@
   "Play Video": "Play Video",
   "{{ duration }} min": "{{ duration }} min",
   "Play with sound": "Play with sound",
+  "Skip video": "Skip video",
   "Languages": "Languages",
   "Subtitles": "Subtitles",
   "Title": "Title",

--- a/libs/locales/vi-VN/apps-watch.json
+++ b/libs/locales/vi-VN/apps-watch.json
@@ -69,6 +69,7 @@
   "Play Video": "Play Video",
   "{{ duration }} min": "{{ duration }} min",
   "Play with sound": "Chơi với âm thanh",
+  "Skip video": "Skip video",
   "Sorry, no results": "Sorry, no results",
   "Try removing or changing something from your request": "Try removing or changing something from your request",
   "Languages": "Languages",

--- a/libs/locales/zh-Hans-CN/apps-watch.json
+++ b/libs/locales/zh-Hans-CN/apps-watch.json
@@ -69,6 +69,7 @@
   "Play Video": "播放视频",
   "{{ duration }} min": "{{ duration }} 分钟",
   "Play with sound": "播放声音",
+  "Skip video": "Skip video",
   "Sorry, no results": "抱歉，没有结果",
   "Try removing or changing something from your request": "尝试删除或更改请求中的某些内容",
   "Languages": "语言",

--- a/libs/locales/zh-Hant-TW/apps-watch.json
+++ b/libs/locales/zh-Hant-TW/apps-watch.json
@@ -69,6 +69,7 @@
   "Play Video": "播放視訊",
   "{{ duration }} min": "{{ duration }} min",
   "Play with sound": "播放聲音",
+  "Skip video": "Skip video",
   "Sorry, no results": "抱歉，沒有結果",
   "Try removing or changing something from your request": "嘗試從您的要求中移除或變更某些內容",
   "Languages": "語言",

--- a/prds/watch/work.md
+++ b/prds/watch/work.md
@@ -65,3 +65,40 @@
 
 - Consider moving category metadata to CMS-driven config if design requires frequent updates.
 - Evaluate migrating remaining MUI layout primitives to Tailwind equivalents in a future iteration.
+
+# Featured Hero Skip Control
+
+## Goals
+
+- [x] Add a skip control beside the preview mute toggle so users can quickly advance featured videos.
+- [x] Wire the skip control into the carousel state so the next slide loads consistently.
+
+## Implementation Strategy
+
+- [x] Expose a `handleSkipActiveVideo` helper from `useWatchHeroCarousel` that reuses existing slide advancement logic.
+- [x] Thread the handler through `WatchHero` → `VideoContentHero` → `HeroVideo` → `VideoControls` → `VideoTitle`.
+- [x] Render a Skip button in the preview control cluster with translated aria label and icon-only styling.
+- [x] Localize the new "Skip video" copy across existing locale bundles and extend unit coverage for the new handler.
+
+## Obstacles
+
+- Ensuring the skip handler cooperated with the debounced progress reset logic without regressing autoplay sequencing.
+
+## Resolutions
+
+- Reused the existing `moveToSlide` utility so skip events share the same scheduling + pooling behaviour as autoplay.
+
+## Test Coverage
+
+- `pnpm dlx nx test watch --testFile=apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoTitle/VideoTitle.spec.tsx`
+- `pnpm dlx nx test watch --testFile=apps/watch/src/components/WatchHomePage/useWatchHeroCarousel.spec.tsx`
+
+## User Flows
+
+- Watch homepage loads → hero renders preview → user taps Skip → carousel advances immediately to the next slide.
+- User taps Skip on final slide → carousel queues additional content via `moveToNext` fallback.
+
+## Follow-up Ideas
+
+- Consider showing a brief tooltip on first visit explaining the Skip control for accessibility.
+- Evaluate whether skip interactions should emit analytics distinct from autoplay completions.


### PR DESCRIPTION
## Summary
- add a skip handler to the featured carousel and wire it through the watch hero preview components
- render an icon-only skip control beside the preview mute toggle and add translations
- extend unit tests and update the work log to cover the new control

## Testing
- pnpm dlx nx test watch --testFile=apps/watch/src/components/VideoContentPage/VideoHero/VideoPlayer/VideoTitle/VideoTitle.spec.tsx
- pnpm dlx nx test watch --testFile=apps/watch/src/components/WatchHomePage/useWatchHeroCarousel.spec.tsx

------
https://chatgpt.com/codex/tasks/task_e_68daad1cff788328a03ff92414cbaa70