### PR TITLE
refactor: remove ButtonClickEventCreateInput and related resolver fro…

### DIFF
--- a/apis/api-gateway/schema.graphql
+++ b/apis/api-gateway/schema.graphql
@@ -261,7 +261,6 @@ type Mutation @join__type(graph: API_ANALYTICS)  @join__type(graph: API_JOURNEYS
   customDomainUpdate(id: ID!, input: CustomDomainUpdateInput!) : CustomDomain! @join__field(graph: API_JOURNEYS) 
   customDomainDelete(id: ID!) : CustomDomain! @join__field(graph: API_JOURNEYS) 
   customDomainCheck(id: ID!) : CustomDomainCheck! @join__field(graph: API_JOURNEYS) 
-  buttonClickEventCreate(input: ButtonClickEventCreateInput!) : ButtonClickEvent! @join__field(graph: API_JOURNEYS_MODERN, override: "api-journeys") 
   chatOpenEventCreate(input: ChatOpenEventCreateInput!) : ChatOpenEvent! @join__field(graph: API_JOURNEYS) 
   """
   Creates a JourneyViewEvent, returns null if attempting to create another
@@ -400,6 +399,7 @@ type Mutation @join__type(graph: API_ANALYTICS)  @join__type(graph: API_JOURNEYS
   blockUpdateLinkAction(id: ID!, input: LinkActionInput!, journeyId: ID) : LinkAction! @join__field(graph: API_JOURNEYS_MODERN, override: "api-journeys") 
   blockUpdateNavigateToBlockAction(id: ID!, input: NavigateToBlockActionInput!, journeyId: ID) : NavigateToBlockAction! @join__field(graph: API_JOURNEYS_MODERN, override: "api-journeys") 
   blockUpdatePhoneAction(id: ID!, input: PhoneActionInput!, journeyId: ID) : PhoneAction! @join__field(graph: API_JOURNEYS_MODERN, override: "api-journeys") 
+  buttonClickEventCreate(input: ButtonClickEventCreateInput!) : ButtonClickEvent! @join__field(graph: API_JOURNEYS_MODERN, override: "api-journeys") 
   multiselectSubmissionEventCreate(input: MultiselectSubmissionEventCreateInput!) : MultiselectSubmissionEvent! @join__field(graph: API_JOURNEYS_MODERN, override: "api-journeys") 
   journeySimpleUpdate(id: ID!, journey: Json!) : Json @join__field(graph: API_JOURNEYS_MODERN) 
   journeyAiTranslateCreate(input: JourneyAiTranslateInput!) : Journey! @join__field(graph: API_JOURNEYS_MODERN) 
@@ -3813,36 +3813,6 @@ input CustomDomainUpdateInput @join__type(graph: API_JOURNEYS)  @join__type(grap
   routeAllTeamJourneys: Boolean
 }
 
-input ButtonClickEventCreateInput @join__type(graph: API_JOURNEYS)  @join__type(graph: API_JOURNEYS_MODERN)  {
-  """
-  ID should be unique Event UUID (Provided for optimistic mutation result matching)
-  """
-  id: ID
-  blockId: ID!
-  """
-  id of the parent stepBlock
-  """
-  stepId: ID
-  """
-  stepName of the parent stepBlock
-  """
-  label: String
-  """
-  label of the button
-  """
-  value: String
-  """
-  Action type of the button when it was clicked
-  """
-  action: ButtonAction
-  """
-  The label for each corresponding action, mapping below:
-  NavigateToBlockAction - StepName (generated in client) of the StepBlock
-  LinkAction - url of the link
-  """
-  actionValue: String
-}
-
 input ChatOpenEventCreateInput @join__type(graph: API_JOURNEYS)  @join__type(graph: API_JOURNEYS_MODERN)  {
   """
   ID should be unique Event UUID (Provided for optimistic mutation result matching)
@@ -4538,6 +4508,36 @@ input BlockUpdateActionInput @join__type(graph: API_JOURNEYS_MODERN)  {
   countryCode: String
   target: String
   blockId: String
+}
+
+input ButtonClickEventCreateInput @join__type(graph: API_JOURNEYS_MODERN)  {
+  """
+  ID should be unique Event UUID (Provided for optimistic mutation result matching)
+  """
+  id: ID
+  blockId: ID!
+  """
+  id of the parent stepBlock
+  """
+  stepId: ID
+  """
+  stepName of the parent stepBlock
+  """
+  label: String
+  """
+  label of the button
+  """
+  value: String
+  """
+  Action type of the button when it was clicked
+  """
+  action: ButtonAction
+  """
+  The label for each corresponding action, mapping below: 
+            NavigateToBlockAction - StepName (generated in client) of the StepBlock 
+            LinkAction - url of the link
+  """
+  actionValue: String
 }
 
 input EmailActionInput @join__type(graph: API_JOURNEYS_MODERN)  {

--- a/apis/api-gateway/schema.graphql
+++ b/apis/api-gateway/schema.graphql
@@ -4534,8 +4534,8 @@ input ButtonClickEventCreateInput @join__type(graph: API_JOURNEYS_MODERN)  {
   action: ButtonAction
   """
   The label for each corresponding action, mapping below: 
-            NavigateToBlockAction - StepName (generated in client) of the StepBlock 
-            LinkAction - url of the link
+  NavigateToBlockAction - StepName (generated in client) of the StepBlock 
+  LinkAction - url of the link
   """
   actionValue: String
 }

--- a/apis/api-journeys-modern/schema.graphql
+++ b/apis/api-journeys-modern/schema.graphql
@@ -145,8 +145,8 @@ input ButtonClickEventCreateInput {
 
   """
   The label for each corresponding action, mapping below: 
-            NavigateToBlockAction - StepName (generated in client) of the StepBlock 
-            LinkAction - url of the link
+  NavigateToBlockAction - StepName (generated in client) of the StepBlock 
+  LinkAction - url of the link
   """
   actionValue: String
 }

--- a/apis/api-journeys-modern/schema.graphql
+++ b/apis/api-journeys-modern/schema.graphql
@@ -125,12 +125,29 @@ type ButtonClickEvent implements Event
 }
 
 input ButtonClickEventCreateInput {
+  """
+  ID should be unique Event UUID (Provided for optimistic mutation result matching)
+  """
   id: ID
   blockId: ID!
+
+  """id of the parent stepBlock"""
   stepId: ID
+
+  """stepName of the parent stepBlock"""
   label: String
+
+  """label of the button"""
   value: String
+
+  """Action type of the button when it was clicked"""
   action: ButtonAction
+
+  """
+  The label for each corresponding action, mapping below: 
+            NavigateToBlockAction - StepName (generated in client) of the StepBlock 
+            LinkAction - url of the link
+  """
   actionValue: String
 }
 

--- a/apis/api-journeys-modern/src/schema/event/button/inputs/buttonClickEventCreateInput.ts
+++ b/apis/api-journeys-modern/src/schema/event/button/inputs/buttonClickEventCreateInput.ts
@@ -28,8 +28,8 @@ export const ButtonClickEventCreateInput = builder.inputType(
       actionValue: t.string({
         required: false,
         description: `The label for each corresponding action, mapping below: 
-          NavigateToBlockAction - StepName (generated in client) of the StepBlock 
-          LinkAction - url of the link`
+NavigateToBlockAction - StepName (generated in client) of the StepBlock 
+LinkAction - url of the link`
       })
     })
   }

--- a/apis/api-journeys-modern/src/schema/event/button/inputs/buttonClickEventCreateInput.ts
+++ b/apis/api-journeys-modern/src/schema/event/button/inputs/buttonClickEventCreateInput.ts
@@ -5,13 +5,32 @@ export const ButtonClickEventCreateInput = builder.inputType(
   'ButtonClickEventCreateInput',
   {
     fields: (t) => ({
-      id: t.id({ required: false }),
+      id: t.id({
+        required: false,
+        description:
+          'ID should be unique Event UUID (Provided for optimistic mutation result matching)'
+      }),
       blockId: t.id({ required: true }),
-      stepId: t.id({ required: false }),
-      label: t.string({ required: false }),
-      value: t.string({ required: false }),
-      action: t.field({ type: ButtonActionEnum, required: false }),
-      actionValue: t.string({ required: false })
+      stepId: t.id({
+        required: false,
+        description: 'id of the parent stepBlock'
+      }),
+      label: t.string({
+        required: false,
+        description: 'stepName of the parent stepBlock'
+      }),
+      value: t.string({ required: false, description: 'label of the button' }),
+      action: t.field({
+        type: ButtonActionEnum,
+        required: false,
+        description: 'Action type of the button when it was clicked'
+      }),
+      actionValue: t.string({
+        required: false,
+        description: `The label for each corresponding action, mapping below: 
+          NavigateToBlockAction - StepName (generated in client) of the StepBlock 
+          LinkAction - url of the link`
+      })
     })
   }
 )

--- a/apis/api-journeys/schema.graphql
+++ b/apis/api-journeys/schema.graphql
@@ -434,7 +434,6 @@ type Mutation {
   customDomainUpdate(id: ID!, input: CustomDomainUpdateInput!): CustomDomain!
   customDomainDelete(id: ID!): CustomDomain!
   customDomainCheck(id: ID!): CustomDomainCheck!
-  buttonClickEventCreate(input: ButtonClickEventCreateInput!): ButtonClickEvent!
   chatOpenEventCreate(input: ChatOpenEventCreateInput!): ChatOpenEvent!
 
   """
@@ -1409,33 +1408,6 @@ enum ButtonAction {
   LinkAction
   EmailAction
   PhoneAction
-}
-
-input ButtonClickEventCreateInput {
-  """
-  ID should be unique Event UUID (Provided for optimistic mutation result matching)
-  """
-  id: ID
-  blockId: ID!
-
-  """id of the parent stepBlock"""
-  stepId: ID
-
-  """stepName of the parent stepBlock"""
-  label: String
-
-  """label of the button"""
-  value: String
-
-  """Action type of the button when it was clicked"""
-  action: ButtonAction
-
-  """
-  The label for each corresponding action, mapping below:
-  NavigateToBlockAction - StepName (generated in client) of the StepBlock
-  LinkAction - url of the link
-  """
-  actionValue: String
 }
 
 type ButtonClickEvent implements Event

--- a/apis/api-journeys/src/__generated__/graphql.ts
+++ b/apis/api-journeys/src/__generated__/graphql.ts
@@ -216,12 +216,22 @@ export type ButtonClickEvent = Event & {
 };
 
 export type ButtonClickEventCreateInput = {
+  /** Action type of the button when it was clicked */
   action?: InputMaybe<ButtonAction>;
+  /**
+   * The label for each corresponding action, mapping below:
+   * NavigateToBlockAction - StepName (generated in client) of the StepBlock
+   * LinkAction - url of the link
+   */
   actionValue?: InputMaybe<Scalars['String']['input']>;
   blockId: Scalars['ID']['input'];
+  /** ID should be unique Event UUID (Provided for optimistic mutation result matching) */
   id?: InputMaybe<Scalars['ID']['input']>;
+  /** stepName of the parent stepBlock */
   label?: InputMaybe<Scalars['String']['input']>;
+  /** id of the parent stepBlock */
   stepId?: InputMaybe<Scalars['ID']['input']>;
+  /** label of the button */
   value?: InputMaybe<Scalars['String']['input']>;
 };
 

--- a/apis/api-journeys/src/__generated__/graphql.ts
+++ b/apis/api-journeys/src/__generated__/graphql.ts
@@ -216,22 +216,12 @@ export type ButtonClickEvent = Event & {
 };
 
 export type ButtonClickEventCreateInput = {
-  /** Action type of the button when it was clicked */
   action?: InputMaybe<ButtonAction>;
-  /**
-   * The label for each corresponding action, mapping below:
-   * NavigateToBlockAction - StepName (generated in client) of the StepBlock
-   * LinkAction - url of the link
-   */
   actionValue?: InputMaybe<Scalars['String']['input']>;
   blockId: Scalars['ID']['input'];
-  /** ID should be unique Event UUID (Provided for optimistic mutation result matching) */
   id?: InputMaybe<Scalars['ID']['input']>;
-  /** stepName of the parent stepBlock */
   label?: InputMaybe<Scalars['String']['input']>;
-  /** id of the parent stepBlock */
   stepId?: InputMaybe<Scalars['ID']['input']>;
-  /** label of the button */
   value?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -1629,6 +1619,7 @@ export type Mutation = {
   playlistCreate?: Maybe<MutationPlaylistCreateResult>;
   playlistDelete?: Maybe<MutationPlaylistDeleteResult>;
   playlistItemAdd?: Maybe<MutationPlaylistItemAddResult>;
+  playlistItemAddWithVideoAndLanguageIds?: Maybe<MutationPlaylistItemAddWithVideoAndLanguageIdsResult>;
   playlistItemRemove?: Maybe<MutationPlaylistItemRemoveResult>;
   playlistItemsReorder?: Maybe<MutationPlaylistItemsReorderResult>;
   playlistUpdate?: Maybe<MutationPlaylistUpdateResult>;
@@ -2243,9 +2234,14 @@ export type MutationPlaylistDeleteArgs = {
 
 
 export type MutationPlaylistItemAddArgs = {
-  id?: InputMaybe<Scalars['ID']['input']>;
   playlistId: Scalars['ID']['input'];
-  videoVariantId: Scalars['ID']['input'];
+  videoVariantIds: Array<Scalars['ID']['input']>;
+};
+
+
+export type MutationPlaylistItemAddWithVideoAndLanguageIdsArgs = {
+  playlistId: Scalars['ID']['input'];
+  videos: Array<PlaylistItemVideoInput>;
 };
 
 
@@ -2822,7 +2818,14 @@ export type MutationPlaylistItemAddResult = MutationPlaylistItemAddSuccess | Not
 
 export type MutationPlaylistItemAddSuccess = {
   __typename?: 'MutationPlaylistItemAddSuccess';
-  data: PlaylistItem;
+  data: Array<PlaylistItem>;
+};
+
+export type MutationPlaylistItemAddWithVideoAndLanguageIdsResult = MutationPlaylistItemAddWithVideoAndLanguageIdsSuccess | NotFoundError;
+
+export type MutationPlaylistItemAddWithVideoAndLanguageIdsSuccess = {
+  __typename?: 'MutationPlaylistItemAddWithVideoAndLanguageIdsSuccess';
+  data: Array<PlaylistItem>;
 };
 
 export type MutationPlaylistItemRemoveResult = MutationPlaylistItemRemoveSuccess | NotFoundError;
@@ -3259,6 +3262,14 @@ export type PlaylistItem = {
   playlist: Playlist;
   updatedAt: Scalars['DateTime']['output'];
   videoVariant: VideoVariant;
+};
+
+/** The video variant to add to the playlist. This is used instead of the videoVariantId as clients typically know the video id and language id of the video variant but not the videoVariantId. */
+export type PlaylistItemVideoInput = {
+  /** The language id of the video variant */
+  languageId: Scalars['String']['input'];
+  /** The video id of the video variant */
+  videoId: Scalars['String']['input'];
 };
 
 export type PlaylistUpdateInput = {

--- a/apis/api-journeys/src/app/__generated__/graphql.ts
+++ b/apis/api-journeys/src/app/__generated__/graphql.ts
@@ -512,16 +512,6 @@ export class CustomDomainUpdateInput {
     routeAllTeamJourneys?: Nullable<boolean>;
 }
 
-export class ButtonClickEventCreateInput {
-    id?: Nullable<string>;
-    blockId: string;
-    stepId?: Nullable<string>;
-    label?: Nullable<string>;
-    value?: Nullable<string>;
-    action?: Nullable<ButtonAction>;
-    actionValue?: Nullable<string>;
-}
-
 export class ChatOpenEventCreateInput {
     id?: Nullable<string>;
     blockId: string;
@@ -1144,8 +1134,6 @@ export abstract class IMutation {
     abstract customDomainDelete(id: string): CustomDomain | Promise<CustomDomain>;
 
     abstract customDomainCheck(id: string): CustomDomainCheck | Promise<CustomDomainCheck>;
-
-    abstract buttonClickEventCreate(input: ButtonClickEventCreateInput): ButtonClickEvent | Promise<ButtonClickEvent>;
 
     abstract chatOpenEventCreate(input: ChatOpenEventCreateInput): ChatOpenEvent | Promise<ChatOpenEvent>;
 

--- a/apis/api-journeys/src/app/modules/event/button/button.graphql
+++ b/apis/api-journeys/src/app/modules/event/button/button.graphql
@@ -5,36 +5,6 @@ enum ButtonAction {
   PhoneAction
 }
 
-input ButtonClickEventCreateInput {
-  """
-  ID should be unique Event UUID (Provided for optimistic mutation result matching)
-  """
-  id: ID
-  blockId: ID!
-  """
-  id of the parent stepBlock
-  """
-  stepId: ID
-  """
-  stepName of the parent stepBlock
-  """
-  label: String
-  """
-  label of the button
-  """
-  value: String
-  """
-  Action type of the button when it was clicked
-  """
-  action: ButtonAction
-  """
-  The label for each corresponding action, mapping below:
-  NavigateToBlockAction - StepName (generated in client) of the StepBlock
-  LinkAction - url of the link
-  """
-  actionValue: String
-}
-
 type ButtonClickEvent implements Event @shareable {
   id: ID!
   """
@@ -143,6 +113,5 @@ type ChatOpenEvent implements Event @shareable {
 }
 
 extend type Mutation {
-  buttonClickEventCreate(input: ButtonClickEventCreateInput!): ButtonClickEvent!
   chatOpenEventCreate(input: ChatOpenEventCreateInput!): ChatOpenEvent!
 }

--- a/apis/api-journeys/src/app/modules/event/button/button.resolver.spec.ts
+++ b/apis/api-journeys/src/app/modules/event/button/button.resolver.spec.ts
@@ -1,93 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing'
 
 import {
-  ButtonAction,
-  ButtonClickEventCreateInput,
   ChatOpenEventCreateInput,
   MessagePlatform
 } from '../../../__generated__/graphql'
 import { PrismaService } from '../../../lib/prisma.service'
 import { EventService } from '../event.service'
 
-import {
-  ButtonClickEventResolver,
-  ChatOpenEventResolver
-} from './button.resolver'
-
-describe('ButtonClickEventResolver', () => {
-  let resolver: ButtonClickEventResolver, prismaService: PrismaService
-
-  const response = {
-    visitor: { id: 'visitor.id' },
-    journeyVisitor: {
-      journeyId: 'journey.id',
-      visitorId: 'visitor.id',
-      activityCount: 0
-    },
-    journeyId: 'journey.id'
-  }
-
-  const eventService = {
-    provide: EventService,
-    useFactory: () => ({
-      save: jest.fn((event) => event),
-      validateBlockEvent: jest.fn(() => response)
-    })
-  }
-
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [ButtonClickEventResolver, eventService, PrismaService]
-    }).compile()
-    resolver = module.get<ButtonClickEventResolver>(ButtonClickEventResolver)
-    prismaService = module.get<PrismaService>(PrismaService)
-    prismaService.visitor.update = jest.fn().mockResolvedValueOnce(null)
-    prismaService.journeyVisitor.update = jest.fn().mockResolvedValueOnce(null)
-  })
-
-  describe('buttonClickEventCreate', () => {
-    it('returns ButtonClickEvent', async () => {
-      const input: ButtonClickEventCreateInput = {
-        id: '1',
-        blockId: 'block.id',
-        stepId: 'step.id',
-        label: 'Step name',
-        value: 'Button label',
-        action: ButtonAction.NavigateToBlockAction,
-        actionValue: 'Step 1'
-      }
-
-      expect(await resolver.buttonClickEventCreate('userId', input)).toEqual({
-        ...input,
-        typename: 'ButtonClickEvent',
-        visitor: {
-          connect: { id: 'visitor.id' }
-        },
-        journey: { connect: { id: 'journey.id' } }
-      })
-    })
-
-    it('should update visitor last link action', async () => {
-      const input: ButtonClickEventCreateInput = {
-        id: '1',
-        blockId: 'block.id',
-        stepId: 'step.id',
-        label: 'Step name',
-        value: 'Button label',
-        action: ButtonAction.LinkAction,
-        actionValue: 'https://test.com/some-link'
-      }
-      await resolver.buttonClickEventCreate('userId', input)
-
-      expect(prismaService.visitor.update).toHaveBeenCalledWith({
-        where: { id: 'visitor.id' },
-        data: {
-          lastLinkAction: 'https://test.com/some-link'
-        }
-      })
-    })
-  })
-})
+import { ChatOpenEventResolver } from './button.resolver'
 
 describe('ChatOpenEventResolver', () => {
   let resolver: ChatOpenEventResolver, prismaService: PrismaService

--- a/apis/api-journeys/src/app/modules/event/button/button.resolver.ts
+++ b/apis/api-journeys/src/app/modules/event/button/button.resolver.ts
@@ -7,80 +7,12 @@ import { CurrentUserId } from '@core/nest/decorators/CurrentUserId'
 import { GqlAuthGuard } from '@core/nest/gqlAuthGuard/GqlAuthGuard'
 
 import {
-  ButtonAction,
-  ButtonClickEvent,
-  ButtonClickEventCreateInput,
   ChatOpenEvent,
   ChatOpenEventCreateInput,
   MessagePlatform
 } from '../../../__generated__/graphql'
 import { PrismaService } from '../../../lib/prisma.service'
 import { EventService } from '../event.service'
-
-@Resolver('ButtonClickEvent')
-export class ButtonClickEventResolver {
-  constructor(
-    private readonly eventService: EventService,
-    private readonly prismaService: PrismaService
-  ) {}
-
-  @Mutation()
-  @UseGuards(GqlAuthGuard)
-  async buttonClickEventCreate(
-    @CurrentUserId() userId: string,
-    @Args('input') input: ButtonClickEventCreateInput
-  ): Promise<ButtonClickEvent> {
-    const { visitor, journeyVisitor, journeyId } =
-      await this.eventService.validateBlockEvent(
-        userId,
-        input.blockId,
-        input.stepId
-      )
-
-    const promises = [
-      this.eventService.save({
-        ...input,
-        id: input.id ?? undefined,
-        typename: 'ButtonClickEvent',
-        visitor: { connect: { id: visitor.id } },
-        stepId: input.stepId ?? undefined,
-        journey: { connect: { id: journeyId } }
-      })
-    ]
-
-    if (input.action === ButtonAction.LinkAction) {
-      promises.push(
-        this.prismaService.visitor.update({
-          where: { id: visitor.id },
-          data: {
-            lastLinkAction: input.actionValue ?? undefined
-          }
-        }),
-        this.prismaService.journeyVisitor.update({
-          where: { journeyId_visitorId: { journeyId, visitorId: visitor.id } },
-          data: {
-            lastLinkAction: input.actionValue ?? undefined,
-            activityCount: journeyVisitor.activityCount + 1
-          }
-        })
-      )
-    }
-
-    if (input.action === ButtonAction.EmailAction) {
-      promises.push(
-        this.prismaService.journeyVisitor.update({
-          where: { journeyId_visitorId: { journeyId, visitorId: visitor.id } },
-          data: {
-            activityCount: journeyVisitor.activityCount + 1
-          }
-        })
-      )
-    }
-
-    const [buttonClickEvent] = await Promise.all(promises)
-    return buttonClickEvent as ButtonClickEvent
-  }
-}
 
 @Resolver('ChatOpenEvent')
 export class ChatOpenEventResolver {

--- a/apis/api-journeys/src/app/modules/event/event.module.ts
+++ b/apis/api-journeys/src/app/modules/event/event.module.ts
@@ -10,10 +10,7 @@ import { BlockService } from '../block/block.service'
 import { IntegrationGrowthSpacesService } from '../integration/growthSpaces/growthSpaces.service'
 import { VisitorService } from '../visitor/visitor.service'
 
-import {
-  ButtonClickEventResolver,
-  ChatOpenEventResolver
-} from './button/button.resolver'
+import { ChatOpenEventResolver } from './button/button.resolver'
 import { EventResolver } from './event.resolver'
 import { EventService } from './event.service'
 import { JourneyViewEventResolver } from './journey/journey.resolver'
@@ -43,7 +40,6 @@ import {
   ],
   providers: [
     BlockService,
-    ButtonClickEventResolver,
     ChatOpenEventResolver,
     EventService,
     EventResolver,

--- a/apps/journeys-admin/__generated__/GetJourneyVisitors.ts
+++ b/apps/journeys-admin/__generated__/GetJourneyVisitors.ts
@@ -36,7 +36,7 @@ export interface GetJourneyVisitors_visitors_edges_node_visitor {
 }
 
 export interface GetJourneyVisitors_visitors_edges_node_events_JourneyEvent {
-  __typename: "JourneyEvent" | "ButtonClickEvent" | "ChatOpenEvent" | "JourneyViewEvent" | "RadioQuestionSubmissionEvent" | "SignUpSubmissionEvent" | "StepViewEvent" | "StepNextEvent" | "StepPreviousEvent" | "VideoStartEvent" | "VideoPlayEvent" | "VideoPauseEvent" | "VideoCompleteEvent" | "VideoExpandEvent" | "VideoCollapseEvent" | "VideoProgressEvent" | "MultiselectSubmissionEvent";
+  __typename: "JourneyEvent" | "ChatOpenEvent" | "JourneyViewEvent" | "RadioQuestionSubmissionEvent" | "SignUpSubmissionEvent" | "StepViewEvent" | "StepNextEvent" | "StepPreviousEvent" | "VideoStartEvent" | "VideoPlayEvent" | "VideoPauseEvent" | "VideoCompleteEvent" | "VideoExpandEvent" | "VideoCollapseEvent" | "VideoProgressEvent" | "ButtonClickEvent" | "MultiselectSubmissionEvent";
   id: string;
   createdAt: any;
   label: string | null;


### PR DESCRIPTION
…m API schemas

- Removed ButtonClickEventCreateInput from both api-gateway and api-journeys schemas.
- Deleted ButtonClickEventResolver and its associated tests.
- Updated related GraphQL mutations and inputs to reflect the removal of button click event handling.
- Adjusted imports and references across the codebase to ensure consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Removed the buttonClickEventCreate mutation and its resolver from the Journeys API.
- API Changes
  - Gateway now routes button-click creation to the modern Journeys API and uses a standardized ButtonClickEventCreate input; the modern API input includes stepName.
- Documentation
  - Added detailed field descriptions to the ButtonClickEventCreate input for clearer client usage (id, stepId, label, value, action, actionValue).
- Tests
  - Replaced button-click tests with ChatOpenEvent-focused tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->