### PR TITLE
feat(watch): prefix first mux insert title with date

### DIFF
--- a/apps/watch/src/components/VideoHero/libs/useCarouselVideos/insertMux.spec.ts
+++ b/apps/watch/src/components/VideoHero/libs/useCarouselVideos/insertMux.spec.ts
@@ -10,7 +10,12 @@ describe('mergeMuxInserts', () => {
     jest.resetModules()
   })
 
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
   it('adds sequence-start inserts before the first video', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-10-15T12:00:00Z'))
     jest.doMock('../../../../../config/video-inserts.mux.json', () => ({
       __esModule: true,
       default: {
@@ -37,6 +42,7 @@ describe('mergeMuxInserts', () => {
 
     expect(slides[0].source).toBe('mux')
     expect(slides[1].source).toBe('video')
+    expect((slides[0] as any).overlay.title).toBe('Oct 15: Morning Nature Background')
   })
 
   it('inserts after the configured count', async () => {


### PR DESCRIPTION
## Summary
- prefix the first sequence-start mux insert overlay title with the current date label
- avoid duplicating the prefix when the title is already formatted
- extend the mux insert unit test suite to assert the new title format and keep timers clean

## Testing
- pnpm dlx nx test watch --testFile apps/watch/src/components/VideoHero/libs/useCarouselVideos/insertMux.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68df03ee669c83288ed81915ac98181d