### PR TITLE
fix: preserve min/max values when equal to child count in multiselect…

### DIFF
--- a/apis/api-journeys-modern/src/schema/block/multiselect/multiselectBlockUpdate.mutation.spec.ts
+++ b/apis/api-journeys-modern/src/schema/block/multiselect/multiselectBlockUpdate.mutation.spec.ts
@@ -253,7 +253,7 @@ describe('multiselectBlockUpdate', () => {
     })
   })
 
-  it('nullifies min/max when equal to child count on update', async () => {
+  it('preserves min/max when equal to child count on update', async () => {
     const {
       fetchBlockWithJourneyAcl
     } = require('../../../lib/auth/fetchBlockWithJourneyAcl')
@@ -271,8 +271,8 @@ describe('multiselectBlockUpdate', () => {
           typename: 'MultiselectBlock',
           journeyId: 'journeyId',
           parentBlockId: 'parentId',
-          min: null,
-          max: null
+          min: 4,
+          max: 4
         })
       },
       journey: { update: jest.fn().mockResolvedValue({ id: 'journeyId' }) }
@@ -294,14 +294,14 @@ describe('multiselectBlockUpdate', () => {
     )
     expect(tx.block.update).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ min: null, max: null })
+        data: expect.objectContaining({ min: 4, max: 4 })
       })
     )
     expect(result).toEqual({
       data: {
         multiselectBlockUpdate: expect.objectContaining({
-          min: null,
-          max: null
+          min: 4,
+          max: 4
         })
       }
     })

--- a/apis/api-journeys-modern/src/schema/block/multiselect/multiselectBlockUpdate.mutation.ts
+++ b/apis/api-journeys-modern/src/schema/block/multiselect/multiselectBlockUpdate.mutation.ts
@@ -79,9 +79,10 @@ builder.mutationField('multiselectBlockUpdate', (t) =>
           )
         }
         // Normalize values relative to optionCount
+        // Keep explicit constraints when equal to option count
         if (optionCount > 0) {
-          if (min != null && (min === optionCount || min < 1)) input.min = null
-          if (max != null && max >= optionCount) input.max = null
+          if (min != null && min < 1) input.min = null
+          if (max != null && max > optionCount) input.max = null
         }
       }
 


### PR DESCRIPTION
… block update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Multiselect blocks now preserve explicit min/max selections when they equal the number of options, preventing unintended clearing of constraints.
  * Improved validation ensures min is only cleared when below 1 and max only when exceeding the option count.

* **Tests**
  * Updated test scenarios to reflect preserved min/max behavior when equal to the option count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->