### PR TITLE
feat(studio): add faith-focused quotes panel

### DIFF
--- a/apps/studio/src/components/FaithQuotesSection.tsx
+++ b/apps/studio/src/components/FaithQuotesSection.tsx
@@ -1,0 +1,235 @@
+/* eslint-disable import/order, sort-imports */
+import React, { useMemo, useState } from 'react';
+import { Button, Tab, Tabs } from '@blueprintjs/core';
+import { observer } from 'mobx-react-lite';
+import { SectionTab, type Section } from 'polotno/side-panel';
+import type { StoreType } from 'polotno/model/store';
+import {
+  faithVoiceQuotes,
+  feltNeedCategories,
+  type FaithVoiceQuote,
+  type FeltNeedCategory,
+  type FeltNeedQuote
+} from '../data/quotes';
+
+interface QuotePanelProps {
+  store: StoreType;
+}
+
+type QuoteTab = 'bible' | 'voices';
+
+const containerStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+};
+
+const scrollAreaStyle: React.CSSProperties = {
+  flex: 1,
+  overflowY: 'auto',
+  padding: '12px',
+  gap: '12px',
+  display: 'flex',
+  flexDirection: 'column',
+};
+
+const quoteCardStyle: React.CSSProperties = {
+  borderRadius: '8px',
+  border: '1px solid #d9e2ec',
+  padding: '12px',
+  backgroundColor: '#ffffff',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
+};
+
+const quoteTextStyle: React.CSSProperties = {
+  fontSize: '14px',
+  lineHeight: 1.5,
+  margin: 0,
+  whiteSpace: 'pre-wrap',
+};
+
+const quoteAttributionStyle: React.CSSProperties = {
+  fontSize: '12px',
+  fontWeight: 600,
+  margin: 0,
+  color: '#475569',
+};
+
+const categoryButtonRowStyle: React.CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '8px',
+};
+
+const sectionTitleStyle: React.CSSProperties = {
+  fontSize: '15px',
+  fontWeight: 600,
+  margin: '12px 0 4px',
+};
+
+const sectionSummaryStyle: React.CSSProperties = {
+  fontSize: '12px',
+  color: '#475569',
+  marginBottom: '8px',
+};
+
+const FaithQuotesPanel = observer(({ store }: QuotePanelProps) => {
+  const [activeTab, setActiveTab] = useState<QuoteTab>('bible');
+  const [activeCategoryId, setActiveCategoryId] = useState<string>(
+    feltNeedCategories[0]?.id ?? ''
+  );
+
+  const activeCategory: FeltNeedCategory | undefined = useMemo(
+    () => feltNeedCategories.find((category) => category.id === activeCategoryId),
+    [activeCategoryId]
+  );
+
+  const addQuoteToCanvas = (text: string, attribution?: string) => {
+    const page = store.activePage || store.pages[0];
+
+    if (!page) {
+      return;
+    }
+
+    const width = Math.min(store.width * 0.75, 720);
+    const x = (store.width - width) / 2;
+    const y = store.height * 0.25;
+    const fullText = attribution ? `${text}\n${attribution}` : text;
+
+    void store.history.transaction(() => {
+      const element = page.addElement({
+        type: 'text',
+        text: fullText,
+        name: 'Quote',
+        fontFamily: 'Roboto',
+        fontSize: 38,
+        align: 'center',
+        width,
+        x,
+        y,
+        lineHeight: 1.3,
+        fill: '#1f2937',
+      });
+
+      if (element) {
+        store.selectElements([element.id]);
+      }
+    });
+  };
+
+  const renderBibleQuotes = () => {
+    if (!activeCategory) {
+      return null;
+    }
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+        <div style={categoryButtonRowStyle}>
+          {feltNeedCategories.map((category) => (
+            <Button
+              key={category.id}
+              small
+              minimal
+              intent={category.id === activeCategoryId ? 'primary' : 'none'}
+              onClick={() => setActiveCategoryId(category.id)}
+              style={{
+                border:
+                  category.id === activeCategoryId
+                    ? '1px solid rgba(45, 112, 253, 0.6)'
+                    : '1px solid #d9e2ec',
+                backgroundColor:
+                  category.id === activeCategoryId ? 'rgba(45, 112, 253, 0.08)' : '#f8fafc',
+                color: '#1f2937',
+              }}
+            >
+              {category.title}
+            </Button>
+          ))}
+        </div>
+
+        <div>
+          <div style={sectionTitleStyle}>{activeCategory.title}</div>
+          <div style={sectionSummaryStyle}>{activeCategory.summary}</div>
+        </div>
+
+        {activeCategory.quotes.map((quote: FeltNeedQuote, index: number) => (
+          <div key={`${activeCategory.id}-${index}`} style={quoteCardStyle}>
+            <p style={quoteTextStyle}>{quote.text}</p>
+            <p style={quoteAttributionStyle}>— {quote.reference}</p>
+            <div>
+              <Button
+                small
+                intent="primary"
+                onClick={() => addQuoteToCanvas(quote.text, `— ${quote.reference}`)}
+              >
+                Add to canvas
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  const renderFaithVoices = () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+      {faithVoiceQuotes.map((quote: FaithVoiceQuote, index: number) => {
+        const attribution = quote.source
+          ? `${quote.author}, ${quote.source}`
+          : quote.author;
+
+        return (
+          <div key={`faith-voice-${index}`} style={quoteCardStyle}>
+            <p style={quoteTextStyle}>{quote.text}</p>
+            <p style={quoteAttributionStyle}>— {attribution}</p>
+            <div>
+              <Button
+                small
+                intent="primary"
+                onClick={() => addQuoteToCanvas(quote.text, `— ${attribution}`)}
+              >
+                Add to canvas
+              </Button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  return (
+    <div style={containerStyle}>
+      <Tabs
+        id="faith-quotes-tabs"
+        large
+        onChange={(newTabId) => setActiveTab(newTabId as QuoteTab)}
+        selectedTabId={activeTab}
+      >
+        <Tab id="bible" title="Bible Verses by Felt Need" />
+        <Tab id="voices" title="Faith Voices" />
+      </Tabs>
+
+      <div style={scrollAreaStyle}>
+        {activeTab === 'bible' ? renderBibleQuotes() : renderFaithVoices()}
+      </div>
+    </div>
+  );
+});
+
+const FaithQuotesTab = observer(
+  ({ active, onClick }: { active: boolean; onClick: () => void }) => (
+    <SectionTab
+      active={active}
+      name="Faith Quotes"
+      onClick={onClick}
+    />
+  )
+);
+
+export const FaithQuotesSection: Section = {
+  name: 'faith-quotes',
+  Tab: FaithQuotesTab,
+  Panel: FaithQuotesPanel,
+};

--- a/apps/studio/src/components/editor.tsx
+++ b/apps/studio/src/components/editor.tsx
@@ -1,11 +1,15 @@
+import Image from 'next/image';
 import { PolotnoContainer, SidePanelWrap, WorkspaceWrap } from 'polotno';
 import { Workspace } from 'polotno/canvas/workspace';
 import { unstable_setAnimationsEnabled } from 'polotno/config';
 import { createStore } from 'polotno/model/store';
 import { PagesTimeline } from 'polotno/pages-timeline';
+import { DEFAULT_SECTIONS, SidePanel } from 'polotno/side-panel';
 import { Toolbar } from 'polotno/toolbar/toolbar';
 import { ZoomButtons } from 'polotno/toolbar/zoom-buttons';
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
+
+import { FaithQuotesSection } from './FaithQuotesSection';
 
 // Enable animations
 unstable_setAnimationsEnabled(true);
@@ -21,6 +25,11 @@ const store = createStore({
 // Don't preload initial state - let useEffect handle loading
 
 export const Editor = () => {
+  const sections = useMemo(
+    () => [FaithQuotesSection, ...DEFAULT_SECTIONS],
+    []
+  );
+
   useEffect(() => {
     const loadDesign = async () => {
       const getDefaultDesign = () => JSON.parse(initialState);
@@ -56,16 +65,38 @@ export const Editor = () => {
 
   return (
     <>
-    <div className="bp5-navbar" 
-        style={{  position: 'fixed', top: 0, left: 0, right: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px' }}
-        >
-          <img
-            src="/jesusfilm-sign.svg"
-            alt="Jesus Film Project"
-            style={{ width: 'auto', height: 'auto', maxHeight: '24px' }}
-          />
-          <h1 style={{ fontSize: '21px', fontWeight: 'bold', color: '#333', margin: 0 }}>Studio</h1>
-        </div>
+    <div
+      className="bp5-navbar"
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '12px',
+      }}
+    >
+      <Image
+        src="/jesusfilm-sign.svg"
+        alt="Jesus Film Project"
+        width={160}
+        height={24}
+        style={{ width: 'auto', height: 'auto', maxHeight: '24px' }}
+        priority
+      />
+      <h1
+        style={{
+          fontSize: '21px',
+          fontWeight: 'bold',
+          color: '#333',
+          margin: 0,
+        }}
+      >
+        Studio
+      </h1>
+    </div>
     <PolotnoContainer style={{ width: '100vw', height: '100vh', paddingTop: '51px' }}>
       <link
         rel="stylesheet"
@@ -86,7 +117,11 @@ export const Editor = () => {
         `
       }} />
       <SidePanelWrap>
-        {/* <SidePanel store={store} /> */}
+        <SidePanel
+          store={store}
+          sections={sections}
+          defaultSection="faith-quotes"
+        />
       </SidePanelWrap>
       <WorkspaceWrap>
         <Toolbar store={store} downloadButtonEnabled />

--- a/apps/studio/src/data/quotes/famousVoices.ts
+++ b/apps/studio/src/data/quotes/famousVoices.ts
@@ -1,0 +1,42 @@
+export interface FaithVoiceQuote {
+  text: string;
+  author: string;
+  source?: string;
+}
+
+export const faithVoiceQuotes: FaithVoiceQuote[] = [
+  {
+    text:
+      'Being a Christian is more than just an instantaneous conversion; it is a daily process whereby you grow to be more and more like Christ.',
+    author: 'Billy Graham',
+    source: 'Hope for the Troubled Heart (1991)'
+  },
+  {
+    text:
+      'Faith sees the invisible, believes the unbelievable, and receives the impossible.',
+    author: 'Corrie ten Boom',
+    source: 'Tramp for the Lord (1974)'
+  },
+  {
+    text:
+      'I believe in Christianity as I believe that the Sun has risen: not only because I see it, but because by it I see everything else.',
+    author: 'C. S. Lewis',
+    source: 'Is Theology Poetry? (1944 address)'
+  },
+  {
+    text:
+      'A little faith will bring your soul to heaven; a great faith will bring heaven to your soul.',
+    author: 'Charles Spurgeon'
+  },
+  {
+    text:
+      'Faith is taking the first step even when you don’t see the whole staircase.',
+    author: 'Martin Luther King Jr.'
+  },
+  {
+    text:
+      'Faith does not eliminate questions. But faith knows where to take them.',
+    author: 'Elisabeth Elliot',
+    source: 'A Path Through Suffering (1990)'
+  }
+];

--- a/apps/studio/src/data/quotes/feltNeeds.ts
+++ b/apps/studio/src/data/quotes/feltNeeds.ts
@@ -1,0 +1,99 @@
+export interface FeltNeedQuote {
+  text: string;
+  reference: string;
+}
+
+export interface FeltNeedCategory {
+  id: string;
+  title: string;
+  summary: string;
+  quotes: FeltNeedQuote[];
+}
+
+export const feltNeedCategories: FeltNeedCategory[] = [
+  {
+    id: 'peace-anxiety',
+    title: 'Peace for Anxious Hearts',
+    summary: 'Verses that calm worry and invite the peace Jesus promised.',
+    quotes: [
+      {
+        text:
+          "Do not be anxious about anything, but in everything by prayer and supplication with thanksgiving let your requests be made known to God. And the peace of God, which surpasses all understanding, will guard your hearts and your minds in Christ Jesus.",
+        reference: 'Philippians 4:6-7 (ESV)'
+      },
+      {
+        text:
+          "Peace I leave with you; my peace I give to you. Not as the world gives do I give to you. Let not your hearts be troubled, neither let them be afraid.",
+        reference: 'John 14:27 (ESV)'
+      }
+    ]
+  },
+  {
+    id: 'strength-weakness',
+    title: 'Strength in Weakness',
+    summary: 'Promises of God’s strength when you feel worn thin.',
+    quotes: [
+      {
+        text:
+          "But he said to me, ‘My grace is sufficient for you, for my power is made perfect in weakness.’ Therefore I will boast all the more gladly of my weaknesses, so that the power of Christ may rest upon me.",
+        reference: '2 Corinthians 12:9 (ESV)'
+      },
+      {
+        text:
+          "He gives power to the faint, and to him who has no might he increases strength. Even youths shall faint and be weary, and young men shall fall exhausted; but they who wait for the LORD shall renew their strength; they shall mount up with wings like eagles; they shall run and not be weary; they shall walk and not faint.",
+        reference: 'Isaiah 40:29-31 (ESV)'
+      }
+    ]
+  },
+  {
+    id: 'guidance-purpose',
+    title: 'Guidance and Purpose',
+    summary: 'Direction for those seeking God’s will for their steps.',
+    quotes: [
+      {
+        text:
+          "Trust in the LORD with all your heart, and do not lean on your own understanding. In all your ways acknowledge him, and he will make straight your paths.",
+        reference: 'Proverbs 3:5-6 (ESV)'
+      },
+      {
+        text:
+          "For I know the plans I have for you, declares the LORD, plans for welfare and not for evil, to give you a future and a hope.",
+        reference: 'Jeremiah 29:11 (ESV)'
+      }
+    ]
+  },
+  {
+    id: 'freedom-fear',
+    title: 'Freedom from Fear',
+    summary: 'Assurance of God’s presence when fear and uncertainty rise.',
+    quotes: [
+      {
+        text:
+          "Fear not, for I am with you; be not dismayed, for I am your God; I will strengthen you, I will help you, I will uphold you with my righteous right hand.",
+        reference: 'Isaiah 41:10 (ESV)'
+      },
+      {
+        text:
+          "The LORD is my light and my salvation; whom shall I fear? The LORD is the stronghold of my life; of whom shall I be afraid?",
+        reference: 'Psalm 27:1 (ESV)'
+      }
+    ]
+  },
+  {
+    id: 'grace-salvation',
+    title: 'Grace and Salvation',
+    summary: 'Celebrations of the gift of salvation in Christ.',
+    quotes: [
+      {
+        text:
+          "For by grace you have been saved through faith. And this is not your own doing; it is the gift of God, not a result of works, so that no one may boast.",
+        reference: 'Ephesians 2:8-9 (ESV)'
+      },
+      {
+        text:
+          "Because, if you confess with your mouth that Jesus is Lord and believe in your heart that God raised him from the dead, you will be saved. For with the heart one believes and is justified, and with the mouth one confesses and is saved.",
+        reference: 'Romans 10:9-10 (ESV)'
+      }
+    ]
+  }
+];

--- a/apps/studio/src/data/quotes/index.ts
+++ b/apps/studio/src/data/quotes/index.ts
@@ -1,0 +1,2 @@
+export * from './feltNeeds';
+export * from './famousVoices';


### PR DESCRIPTION
## Summary
- add a custom Faith Quotes side panel that lets Polotno users drop Bible verses by felt need or faith quotes from Christian leaders onto the canvas
- store curated scripture and leader quotations in a dedicated apps/studio/src/data/quotes folder for reuse
- wire the new panel into the Studio editor and switch the header logo to use Next.js Image for optimization

## Testing
- pnpm nx lint studio *(fails: existing lint violations in apps/studio/pages/new.tsx unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68eef158fdc88328be41d88bda82044a