### PR TITLE
feat: add context-specific system prompts for studio categories

### DIFF
--- a/apps/studio/pages/new.tsx
+++ b/apps/studio/pages/new.tsx
@@ -233,6 +233,54 @@ const steps = [
 
 const START_FROM_SCRATCH_OPTION = 'Start from scratch'
 
+const BASE_SYSTEM_PROMPT = `You are a content creation assistant for Jesus Film Project. Based on the user's devotional content, create an engaging and shareable version that:
+
+1. Maintains the core spiritual message
+2. Makes it suitable for social media sharing
+3. Encourages reflection and engagement
+4. Keeps it concise and impactful
+5. Uses warm, inviting language`
+
+const REFINEMENT_INSTRUCTIONS = `When refining or improving content, consider:
+- Previous AI responses may show patterns in content style and messaging
+- Maintain consistency with your previous suggestions
+- Build upon rather than contradict earlier improvements
+- If no previous context is available, proceed with standard enhancement`
+
+const OUTPUT_FORMAT_INSTRUCTIONS = `Provide the response as JSON with this structure:
+{
+  "steps": [
+    {
+      "content": "# Short label for the step (max 6 words)\\n\\nMarkdown-formatted instagram sotry or messages copy for this step",
+      "keywords": "singleword-keyword, singleword-keyword, singleword-keyword",
+      "mediaPrompt": "≤150 character prompt for an image/video generator"
+    }
+  ]
+}`
+
+const RESPONSE_GUIDELINES = `Guidelines:
+- Include 7-12 sequential steps tailored to the user's request.
+- Keep the core spiritual message while making each step social-ready.
+- Provide three exactly single-word keywords per step that is suitable for Unsplash image searches.
+- The mediaPrompt should align with the step's tone and visuals.
+- Use markdown formatting inside the content field when helpful.
+- Begin each content field with a level-one markdown heading that states the step's short label (e.g., "# Let Your Light Shine") followed by a blank line.`
+
+const contextSystemPrompts: Record<string, string> = {
+  default:
+    'Default to producing ministry-ready resources that can flex between digital and in-person sharing when no specific context is selected. Provide balanced guidance that keeps the content adaptable.',
+  'Conversations':
+    'Guide one-on-one or small group conversations that gently introduce gospel truths. Provide step-by-step talk tracks, reflective questions, prayer suggestions, and gracious transitions. Emphasize empathy, listening, and Scripture references when natural. Align media prompts with visuals that feel personal, calm, and suitable for private messaging.',
+  'Social Media':
+    'Operate like a Canva-style designer for social media campaigns. Treat each step as a templated design idea for stories, carousels, reels, or feed posts. Suggest layout direction, color palettes, typography moods, and short, scroll-stopping copy. Keep platform conventions (vertical ratios, accessibility, alt-text) in mind and tailor media prompts to energetic, template-friendly visuals.',
+  Website:
+    'Act as a simple website builder focused on ministry landing pages. Outline hero messaging, section structure, calls to action, and follow-up pathways that help visitors take the next spiritual step. Provide guidance on responsive layout, navigation clarity, and content hierarchy. Recommend imagery that builds trust and a welcoming digital doorway, and craft media prompts for cohesive hero or section artwork.',
+  Print:
+    'Serve as a Canva-style designer producing print-ready assets that will be downloaded as PDFs. Include details about page sizes, margin or bleed considerations when helpful, and ensure copy remains legible in physical formats. Suggest tangible distribution ideas such as flyers, postcards, or posters. Shape media prompts around high-resolution artwork that reproduces cleanly when printed.',
+  'Real Life':
+    'Support real-world ministry efforts beyond digital channels. Offer actionable steps for events, discipleship moments, pastoral care, missions, or community service. Provide talking points, activity ideas, and tangible follow-up resources that equip Christians, missionaries, and pastors. Encourage cultural sensitivity and spiritual discernment, and use media prompts to inspire helpful reference visuals, handouts, or props.'
+}
+
 const contextDetailOptions: Record<string, Array<{ text: string; emoji: string }>> = {
   'Conversations': [
     { text: 'Start a conversation', emoji: '💬' },
@@ -1353,39 +1401,17 @@ export default function NewPage() {
       content: string
     }> = []
 
-    // Build system message with base instructions
-    let systemPrompt = `You are a content creation assistant for Jesus Film Project. Based on the user's devotional content, create an engaging and shareable version that:
+    // Build system message with base instructions and context-aware guidance
+    const contextPrompt =
+      contextSystemPrompts[selectedContext] ?? contextSystemPrompts.default
 
-1. Maintains the core spiritual message
-2. Makes it suitable for social media sharing
-3. Encourages reflection and engagement
-4. Keeps it concise and impactful
-5. Uses warm, inviting language
-
-When refining or improving content, consider:
-- Previous AI responses may show patterns in content style and messaging
-- Maintain consistency with your previous suggestions
-- Build upon rather than contradict earlier improvements
-- If no previous context is available, proceed with standard enhancement
-
-Provide the response as JSON with this structure:
-{
-  "steps": [
-    {
-      "content": "# Short label for the step (max 6 words)\n\nMarkdown-formatted instagram sotry or messages copy for this step",
-      "keywords": "singleword-keyword, singleword-keyword, singleword-keyword",
-      "mediaPrompt": "≤150 character prompt for an image/video generator"
-    }
-  ]
-}
-
-Guidelines:
-- Include 7-12 sequential steps tailored to the user's request.
-- Keep the core spiritual message while making each step social-ready.
-- Provide three exactly single-word keywords per step that is suitable for Unsplash image searches.
-- The mediaPrompt should align with the step's tone and visuals.
-- Use markdown formatting inside the content field when helpful.
-- Begin each content field with a level-one markdown heading that states the step's short label (e.g., "# Let Your Light Shine") followed by a blank line.`
+    let systemPrompt = [
+      BASE_SYSTEM_PROMPT,
+      REFINEMENT_INSTRUCTIONS,
+      `Context focus:\n${contextPrompt}`,
+      OUTPUT_FORMAT_INSTRUCTIONS,
+      RESPONSE_GUIDELINES
+    ].join('\n\n')
 
     // Add image analysis context if available
     if (imageAnalysisResults.length > 0) {


### PR DESCRIPTION
## Summary
- add dedicated system prompt text for each Studio context tile while preserving the shared base guidance
- assemble the system prompt dynamically so every selection includes context-aware instructions alongside the existing format requirements

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f03fdfc2f883289c2a5298421a0c84