### PR TITLE
Fix studio lint and type errors

### DIFF
--- a/apps/studio/pages/studio.tsx
+++ b/apps/studio/pages/studio.tsx
@@ -2,6 +2,7 @@ import { ArrowRight, Camera, MessageCircle, Sparkles, Video, Waves } from 'lucid
 import Head from 'next/head'
 import Image from 'next/image'
 import Link from 'next/link'
+import type { ReactElement } from 'react'
 
 import { Button } from '../src/components/ui/button'
 import { cn } from '../src/libs/cn/cn'
@@ -49,7 +50,7 @@ const processSteps = [
 
 const inputTypes = ['Text', 'Image', 'Video', 'Quote', 'Link', 'Audio Note']
 
-export default function StudioLandingPage(): JSX.Element {
+export default function StudioLandingPage(): ReactElement {
   return (
     <>
       <Head>

--- a/apps/studio/src/components/ui/checkbox.tsx
+++ b/apps/studio/src/components/ui/checkbox.tsx
@@ -1,31 +1,29 @@
-"use client"
+import React from 'react'
 
-// eslint-disable-next-line import/no-namespace
-import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
-import { CheckIcon } from "lucide-react"
-import React from "react"
+import { cn } from '../../libs/cn/cn'
 
-import { cn } from "../../libs/cn/cn"
+type CheckboxProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> & {
+  onCheckedChange?: (checked: boolean) => void
+}
 
-const Checkbox = React.forwardRef<
-  React.ElementRef<typeof CheckboxPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <CheckboxPrimitive.Root
-    ref={ref}
-    className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
-      className
-    )}
-    {...props}
-  >
-    <CheckboxPrimitive.Indicator
-      className={cn("flex items-center justify-center text-current")}
-    >
-      <CheckIcon className="h-4 w-4" />
-    </CheckboxPrimitive.Indicator>
-  </CheckboxPrimitive.Root>
-))
-Checkbox.displayName = CheckboxPrimitive.Root.displayName
+const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ className, onChange, onCheckedChange, ...props }, ref) => (
+    <input
+      ref={ref}
+      type="checkbox"
+      className={cn(
+        'peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 checked:bg-primary checked:text-primary-foreground',
+        className
+      )}
+      onChange={(event) => {
+        onChange?.(event)
+        onCheckedChange?.(event.currentTarget.checked)
+      }}
+      {...props}
+    />
+  )
+)
+
+Checkbox.displayName = 'Checkbox'
 
 export { Checkbox }

--- a/apps/studio/src/components/ui/tabs.tsx
+++ b/apps/studio/src/components/ui/tabs.tsx
@@ -1,56 +1,166 @@
 "use client"
 
-// eslint-disable-next-line import/no-namespace
-import * as TabsPrimitive from "@radix-ui/react-tabs"
-import React from "react"
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from 'react'
 
-import { cn } from "../../libs/cn/cn"
+import { cn } from '../../libs/cn/cn'
 
-const Tabs = TabsPrimitive.Root
+type TabsContextValue = {
+  value: string
+  setValue: (value: string) => void
+}
 
-const TabsList = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.List
-    ref={ref}
-    className={cn(
-      "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
-      className
-    )}
-    {...props}
-  />
-))
-TabsList.displayName = TabsPrimitive.List.displayName
+const TabsContext = createContext<TabsContextValue | null>(null)
 
-const TabsTrigger = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
-      className
-    )}
-    {...props}
-  />
-))
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+const useTabsContext = (component: string) => {
+  const context = useContext(TabsContext)
+  if (!context) {
+    throw new Error(`${component} must be used within <Tabs>`) // helps debugging
+  }
+  return context
+}
 
-const TabsContent = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Content
-    ref={ref}
-    className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-      className
-    )}
-    {...props}
-  />
-))
-TabsContent.displayName = TabsPrimitive.Content.displayName
+type TabsProps = React.HTMLAttributes<HTMLDivElement> & {
+  value?: string
+  defaultValue?: string
+  onValueChange?: (value: string) => void
+}
+
+const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
+  ({ value: controlledValue, defaultValue, onValueChange, className, children, ...props }, ref) => {
+    const [uncontrolledValue, setUncontrolledValue] = useState(defaultValue ?? '')
+    const isControlled = controlledValue !== undefined
+    const currentValue = isControlled ? controlledValue : uncontrolledValue
+
+    useEffect(() => {
+      if (!isControlled && defaultValue !== undefined) {
+        setUncontrolledValue(defaultValue)
+      }
+    }, [defaultValue, isControlled])
+
+    useEffect(() => {
+      if (isControlled && controlledValue !== undefined) {
+        setUncontrolledValue(controlledValue)
+      }
+    }, [controlledValue, isControlled])
+
+    const setValue = useCallback(
+      (nextValue: string) => {
+        if (!isControlled) {
+          setUncontrolledValue(nextValue)
+        }
+        onValueChange?.(nextValue)
+      },
+      [isControlled, onValueChange]
+    )
+
+    const contextValue = useMemo(
+      () => ({
+        value: currentValue,
+        setValue
+      }),
+      [currentValue, setValue]
+    )
+
+    return (
+      <TabsContext.Provider value={contextValue}>
+        <div ref={ref} className={cn(className)} {...props}>
+          {children}
+        </div>
+      </TabsContext.Provider>
+    )
+  }
+)
+Tabs.displayName = 'Tabs'
+
+type TabsListProps = React.HTMLAttributes<HTMLDivElement>
+
+const TabsList = React.forwardRef<HTMLDivElement, TabsListProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      role="tablist"
+      className={cn(
+        'inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground',
+        className
+      )}
+      {...props}
+    />
+  )
+)
+TabsList.displayName = 'TabsList'
+
+type TabsTriggerProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  value: string
+}
+
+const TabsTrigger = React.forwardRef<HTMLButtonElement, TabsTriggerProps>(
+  ({ className, value, disabled, onClick, ...props }, ref) => {
+    const { value: activeValue, setValue } = useTabsContext('TabsTrigger')
+    const isActive = activeValue === value
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        role="tab"
+        aria-selected={isActive}
+        aria-disabled={disabled}
+        tabIndex={isActive ? 0 : -1}
+        data-state={isActive ? 'active' : 'inactive'}
+        data-disabled={disabled ? '' : undefined}
+        className={cn(
+          'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow',
+          className
+        )}
+        onClick={(event) => {
+          if (disabled) {
+            event.preventDefault()
+            return
+          }
+          setValue(value)
+          onClick?.(event)
+        }}
+        {...props}
+      />
+    )
+  }
+)
+TabsTrigger.displayName = 'TabsTrigger'
+
+type TabsContentProps = React.HTMLAttributes<HTMLDivElement> & {
+  value: string
+}
+
+const TabsContent = React.forwardRef<HTMLDivElement, TabsContentProps>(
+  ({ className, value, children, ...props }, ref) => {
+    const { value: activeValue } = useTabsContext('TabsContent')
+    const isActive = activeValue === value
+
+    return (
+      <div
+        ref={ref}
+        role="tabpanel"
+        tabIndex={0}
+        hidden={!isActive}
+        data-state={isActive ? 'active' : 'inactive'}
+        className={cn(
+          'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+          className
+        )}
+        {...props}
+      >
+        {isActive ? children : null}
+      </div>
+    )
+  }
+)
+TabsContent.displayName = 'TabsContent'
 
 export { Tabs, TabsList, TabsTrigger, TabsContent }


### PR DESCRIPTION
## Summary
- tighten the OpenAI respond API normalization and build the payload with typed optional fields
- refactor the studio editor to remove unused imports, use next/image, and surface token usage while loading sessions
- replace Radix-based checkbox/tabs with internal components and tidy the Studio “new” flow to satisfy linting

## Testing
- pnpm dlx nx run studio:lint
- pnpm dlx nx run studio:type-check

------
https://chatgpt.com/codex/tasks/task_e_68f192cdd5a08328a638b9ae9d8f7826