### PR TITLE
feat(studio): surface watch video metadata

### DIFF
--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -2,6 +2,7 @@ import type { AppProps } from 'next/app'
 import Head from 'next/head'
 import { DefaultSeo } from 'next-seo'
 
+import { InstantSearchProvider } from '@core/journeys/ui/algolia/InstantSearchProvider'
 import { ThemeProvider } from '@core/shared/ui/ThemeProvider'
 import { ThemeMode, ThemeName } from '@core/shared/ui/themes'
 
@@ -19,7 +20,9 @@ function StudioApp({ Component, pageProps }: AppProps) {
         <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
       </Head>
       <ThemeProvider themeName={ThemeName.website} themeMode={ThemeMode.light}>
-        <Component {...pageProps} />
+        <InstantSearchProvider>
+          <Component {...pageProps} />
+        </InstantSearchProvider>
       </ThemeProvider>
     </>
   )

--- a/apps/studio/src/libs/storage.ts
+++ b/apps/studio/src/libs/storage.ts
@@ -13,6 +13,17 @@ export interface GeneratedStepContent {
   keywords: string[]
   mediaPrompt: string
   selectedImageUrl?: string
+  selectedVideo?: StepSelectedVideo
+}
+
+export interface StepSelectedVideo {
+  id: string
+  title?: string
+  description?: string
+  image?: string
+  duration?: number
+  slug?: string
+  source?: string
 }
 
 export interface UserInputData {
@@ -194,7 +205,48 @@ class UserInputStorage {
                       .filter((keyword): keyword is string => Boolean(keyword))
                       .slice(0, 5)
                   : [],
-                mediaPrompt: step?.mediaPrompt || ''
+                mediaPrompt: step?.mediaPrompt || '',
+                selectedImageUrl:
+                  typeof step?.selectedImageUrl === 'string'
+                    ? step.selectedImageUrl
+                    : undefined,
+                selectedVideo:
+                  step?.selectedVideo != null && typeof step.selectedVideo === 'object'
+                    ? {
+                        id: String((step.selectedVideo as { id?: string | number }).id ?? ''),
+                        title:
+                          typeof (step.selectedVideo as { title?: string }).title === 'string'
+                            ? (step.selectedVideo as { title: string }).title
+                            : undefined,
+                        description:
+                          typeof (step.selectedVideo as { description?: string }).description === 'string'
+                            ? (step.selectedVideo as { description: string }).description
+                            : undefined,
+                        image:
+                          typeof (step.selectedVideo as { image?: string }).image === 'string'
+                            ? (step.selectedVideo as { image: string }).image
+                            : undefined,
+                        duration: (() => {
+                          const duration = (step.selectedVideo as { duration?: number | string }).duration
+                          if (typeof duration === 'number') return duration
+                          if (typeof duration === 'string') {
+                            const parsed = Number(duration)
+                            return Number.isFinite(parsed) ? parsed : undefined
+                          }
+                          return undefined
+                        })(),
+                        slug: (() => {
+                          const rawSlug = (step.selectedVideo as { slug?: unknown }).slug
+                          if (typeof rawSlug !== 'string') return undefined
+                          const trimmed = rawSlug.trim()
+                          return trimmed === '' ? undefined : trimmed
+                        })(),
+                        source:
+                          typeof (step.selectedVideo as { source?: string }).source === 'string'
+                            ? (step.selectedVideo as { source: string }).source
+                            : undefined
+                      }
+                    : undefined
               }))
             : [],
           imageAnalysisResults: Array.isArray(data.imageAnalysisResults)

--- a/libs/journeys/ui/src/libs/algolia/useAlgoliaVideos/useAlgoliaVideos.ts
+++ b/libs/journeys/ui/src/libs/algolia/useAlgoliaVideos/useAlgoliaVideos.ts
@@ -10,6 +10,7 @@ interface Video {
   description?: string
   image?: string
   duration?: number
+  slug?: string
   source: VideoBlockSource
 }
 
@@ -39,6 +40,7 @@ export function transformItemsDefault(items: AlgoliaVideo[]): Video[] {
     description: videoVariant.description[0],
     image: videoVariant.image,
     duration: videoVariant.duration,
+    slug: videoVariant.slug,
     source: VideoBlockSource.internal
   }))
 }


### PR DESCRIPTION
## Summary
- capture and persist Algolia slug metadata when selecting Watch videos in Studio
- share a duration formatter and show duration/source chips on reviewed steps
- expose the slug field from the shared useAlgoliaVideos helper so Studio can store it

## Testing
- pnpm nx lint studio

------
https://chatgpt.com/codex/tasks/task_e_68f190ad1f58832891a5f69fb1a6044f