### PR TITLE
Add Mux video upload support to Studio step review

### DIFF
--- a/apps/studio/pages/api/mux/create-upload.ts
+++ b/apps/studio/pages/api/mux/create-upload.ts
@@ -1,0 +1,67 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+import { callStudioGraphQL } from '../../../src/server/graphqlClient'
+
+const CREATE_MUX_VIDEO_UPLOAD_BY_FILE = `
+  mutation CreateMuxVideoUploadByFile($name: String!) {
+    createMuxVideoUploadByFile(name: $name) {
+      id
+      uploadUrl
+    }
+  }
+`
+
+interface CreateUploadResponse {
+  createMuxVideoUploadByFile: {
+    id: string
+    uploadUrl: string
+  } | null
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    res.status(405).json({ error: 'Method not allowed' })
+    return
+  }
+
+  const name = typeof req.body?.name === 'string' ? req.body.name.trim() : ''
+
+  if (!name) {
+    res.status(400).json({ error: 'Missing video name' })
+    return
+  }
+
+  try {
+    const data = await callStudioGraphQL<CreateUploadResponse>(
+      CREATE_MUX_VIDEO_UPLOAD_BY_FILE,
+      {
+        variables: { name },
+        token: req.headers.authorization
+      }
+    )
+
+    const payload = data.createMuxVideoUploadByFile
+
+    if (!payload?.id || !payload?.uploadUrl) {
+      throw new Error('Invalid response from GraphQL when creating Mux upload')
+    }
+
+    res.setHeader('Cache-Control', 'no-store')
+    res.status(200).json({ uploadId: payload.id, uploadUrl: payload.uploadUrl })
+  } catch (error) {
+    console.error('Failed to create Mux upload for Studio step:', error)
+    res
+      .status(500)
+      .json({
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to create Mux upload'
+      })
+  }
+}
+

--- a/apps/studio/pages/api/mux/status.ts
+++ b/apps/studio/pages/api/mux/status.ts
@@ -1,0 +1,74 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+import { callStudioGraphQL } from '../../../src/server/graphqlClient'
+
+const GET_MY_MUX_VIDEO = `
+  query GetMyMuxVideo($id: ID!) {
+    getMyMuxVideo(id: $id) {
+      id
+      assetId
+      playbackId
+      readyToStream
+      duration
+    }
+  }
+`
+
+interface GetMuxVideoResponse {
+  getMyMuxVideo: {
+    id: string
+    assetId: string | null
+    playbackId: string | null
+    readyToStream: boolean
+    duration: number | null
+  } | null
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET')
+    res.status(405).json({ error: 'Method not allowed' })
+    return
+  }
+
+  const uploadIdParam = req.query.id
+  const uploadId = Array.isArray(uploadIdParam)
+    ? uploadIdParam[0]
+    : uploadIdParam
+
+  if (!uploadId) {
+    res.status(400).json({ error: 'Missing upload id' })
+    return
+  }
+
+  try {
+    const data = await callStudioGraphQL<GetMuxVideoResponse>(GET_MY_MUX_VIDEO, {
+      variables: { id: uploadId },
+      token: req.headers.authorization
+    })
+
+    const video = data.getMyMuxVideo
+
+    if (!video) {
+      res.status(404).json({ error: 'Mux upload not found' })
+      return
+    }
+
+    res.setHeader('Cache-Control', 'no-store')
+    res.status(200).json({ video })
+  } catch (error) {
+    console.error('Failed to load Mux upload status for Studio step:', error)
+    res
+      .status(500)
+      .json({
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to load Mux upload status'
+      })
+  }
+}
+

--- a/apps/studio/src/libs/storage.ts
+++ b/apps/studio/src/libs/storage.ts
@@ -8,11 +8,20 @@ export interface ImageAnalysisResult {
   isAnalyzing?: boolean
 }
 
+export interface StepVideoAttachment {
+  muxUploadId: string
+  muxAssetId: string
+  muxPlaybackId: string
+  duration?: number | null
+  filename?: string
+}
+
 export interface GeneratedStepContent {
   content: string
   keywords: string[]
   mediaPrompt: string
   selectedImageUrl?: string
+  video?: StepVideoAttachment
 }
 
 export interface UserInputData {
@@ -194,7 +203,18 @@ class UserInputStorage {
                       .filter((keyword): keyword is string => Boolean(keyword))
                       .slice(0, 5)
                   : [],
-                mediaPrompt: step?.mediaPrompt || ''
+                mediaPrompt: step?.mediaPrompt || '',
+                selectedImageUrl: step?.selectedImageUrl || undefined,
+                video:
+                  step?.video != null
+                    ? {
+                        muxUploadId: step.video.muxUploadId,
+                        muxAssetId: step.video.muxAssetId,
+                        muxPlaybackId: step.video.muxPlaybackId,
+                        duration: step.video.duration ?? null,
+                        filename: step.video.filename || undefined
+                      }
+                    : undefined
               }))
             : [],
           imageAnalysisResults: Array.isArray(data.imageAnalysisResults)

--- a/apps/studio/src/server/graphqlClient.ts
+++ b/apps/studio/src/server/graphqlClient.ts
@@ -1,0 +1,74 @@
+interface GraphQLRequestOptions {
+  variables?: Record<string, any>
+  token?: string
+}
+
+interface GraphQLError {
+  message?: string
+}
+
+interface GraphQLResponse<TData> {
+  data?: TData
+  errors?: GraphQLError[]
+}
+
+const DEFAULT_CLIENT_NAME = 'studio'
+
+const resolveAuthHeader = (token?: string): string | undefined => {
+  const rawToken =
+    token ??
+    process.env.STUDIO_GRAPHQL_JWT ??
+    process.env.JWT_TOKEN ??
+    process.env.STUDIO_MUX_GRAPHQL_JWT
+
+  if (!rawToken) return undefined
+
+  if (rawToken.startsWith('Bearer ') || rawToken.startsWith('JWT ')) {
+    return rawToken
+  }
+
+  return `JWT ${rawToken}`
+}
+
+export async function callStudioGraphQL<TData>(
+  query: string,
+  { variables, token }: GraphQLRequestOptions = {}
+): Promise<TData> {
+  const endpoint = process.env.NEXT_PUBLIC_GATEWAY_URL
+
+  if (!endpoint) {
+    throw new Error('NEXT_PUBLIC_GATEWAY_URL is not configured. Unable to contact GraphQL API.')
+  }
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'x-graphql-client-name': DEFAULT_CLIENT_NAME,
+    'x-graphql-client-version':
+      process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ?? 'local-dev'
+  }
+
+  const authHeader = resolveAuthHeader(token)
+  if (authHeader) {
+    headers.Authorization = authHeader
+  }
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ query, variables })
+  })
+
+  const payload = (await response.json()) as GraphQLResponse<TData>
+
+  if (!response.ok || payload.errors?.length) {
+    const firstError = payload.errors?.[0]?.message ?? response.statusText
+    throw new Error(firstError || 'GraphQL request failed')
+  }
+
+  if (!payload.data) {
+    throw new Error('GraphQL response did not include data')
+  }
+
+  return payload.data
+}
+


### PR DESCRIPTION
## Summary
- add per-step video upload controls in the Studio review step using Mux direct uploads and UpChunk so reviewers can attach clips alongside generated content
- persist uploaded video metadata on step content and expose API routes that proxy to the existing GraphQL Mux mutations
- share a small server-side GraphQL helper so Studio can call the gateway without duplicating client setup

## Testing
- pnpm dlx nx run studio:type-check *(fails: existing Studio type errors in respond API handler and legacy components)*
- pnpm dlx nx run studio:lint *(fails: existing Studio lint violations in editor files and legacy UI imports)*

------
https://chatgpt.com/codex/tasks/task_e_68f18fed65f8832898b18e92bdf04bb6