### PR TITLE
feat(studio): support custom step image uploads

### DIFF
--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -26,6 +26,10 @@ const nextConfig = {
       {
         protocol: 'https',
         hostname: 'source.unsplash.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'imagedelivery.net',
       }
     ]
   }


### PR DESCRIPTION
## Summary
- add a Cloudflare-powered upload option as the first slot in the step inspiration carousel
- track custom image selections, upload state, and errors alongside existing Unsplash results
- allow Cloudflare Image Delivery hosts in the Studio Next.js image configuration

## Testing
- NX_OUTPUT_STYLE=stream pnpm dlx nx lint studio *(fails: pre-existing lint violations in apps/studio/src/components/editor.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68f18c5ca7f08328a63c4bab24831da7