### PR TITLE
docs(watch): expand homepage refactor roadmap

### DIFF
--- a/prds/watch/work.md
+++ b/prds/watch/work.md
@@ -65,3 +65,49 @@
 
 - Consider moving category metadata to CMS-driven config if design requires frequent updates.
 - Evaluate migrating remaining MUI layout primitives to Tailwind equivalents in a future iteration.
+
+# Watch Homepage Review Notes (work branch vs. main)
+
+## Simplification Opportunities
+
+- **Hero carousel module boundaries**
+  - Extract the slide-to-video transformers into a typed utility module so `useWatchHeroCarousel` only orchestrates state. The first ~200 lines house conversion helpers with heavy `any` usage that would be easier to unit-test when decoupled from the hook lifecycle.【F:apps/watch/src/components/WatchHomePage/useWatchHeroCarousel.ts†L1-L205】
+  - Break the autoplay/progress plumbing (callbacks around `moveToSlide`, `advanceOnProgress`, and `handleMuxInsertComplete`) into a dedicated hook that receives the navigation API. This isolates the progress timers from the data loading logic and lets tests mock timing without fixture-heavy slide objects.【F:apps/watch/src/components/WatchHomePage/useWatchHeroCarousel.ts†L419-L486】
+  - Gate or remove the verbose debug logging for click tracking and mux inserts. If we still need analytics, reroute it through a composable reporter so the core hook remains noise-free.【F:apps/watch/src/components/WatchHomePage/useWatchHeroCarousel.ts†L380-L404】
+- **Newsletter form composition**
+  - Split `SectionNewsletterSignup` into container + subcomponents (intro copy, contact fields, checkbox groups) driven by config arrays to avoid duplicating label/description markup and `setSubmitted(false)` handlers for every field.【F:apps/watch/src/components/WatchHomePage/SectionNewsletterSignup.tsx†L20-L200】
+  - Extract a `useNewsletterSignupForm` hook that centralizes the toggling helpers and submission state. That will shrink the JSX file while making validation logic testable outside React rendering.【F:apps/watch/src/components/WatchHomePage/SectionNewsletterSignup.tsx†L120-L142】
+- **Language map lifecycle**
+  - Wrap the MapLibre bootstrapping into a `useMapLibre` utility that returns the map instance and shared popups. The current effect handles feature collection updates, control wiring, and teardown with abundant console logs, which muddies the core rendering intent.【F:apps/watch/src/components/WatchHomePage/SectionLanguageMap/LanguageMap.tsx†L210-L492】
+  - Move static helpers (`createFeatureCollection`, popup renderers, cluster bounds) into a separate module so the component focuses on wiring props to the hook. This also helps prune the `renderCountryPopupContent` DOM building from the main file.【F:apps/watch/src/components/WatchHomePage/SectionLanguageMap/LanguageMap.tsx†L37-L183】
+  - Consider letting `useLanguageMap` accept a dependency-injected fetcher or API URL override so we can reuse it during tests or server rendering without hitting the hardcoded `/api/language-map` endpoint.【F:apps/watch/src/libs/useLanguageMap/useLanguageMap.ts†L1-L24】
+- **Collections rail config**
+  - Replace the trio of explicit section renders with an array of variants and a single map, allowing us to co-locate the id/title/description overrides and orientation differences. That keeps the component declarative and simplifies future additions.【F:apps/watch/src/components/WatchHomePage/CollectionsRail.tsx†L1-L59】
+- **Homepage provider scope**
+  - Reduce `PlayerProvider`/`WatchProvider` scope to only wrap the hero + search context instead of the entire page, and collapse the nested `<Index>` components to a single Algolia context provider. This will cut unnecessary re-renders for static sections and clarify which parts rely on search/player state.【F:apps/watch/src/components/WatchHomePage/WatchHomePage.tsx†L26-L105】
+- **Promo content data source**
+  - Hoist the promo `points` and `highlights` arrays into a shared config (or JSON locale) so the component focuses on layout. That prepares the ground for CMS-driven content and reduces translation duplication.【F:apps/watch/src/components/WatchHomePage/SectionPromo.tsx†L11-L140】
+
+## Stepwise Simplification Roadmap
+
+1. **Type-safe carousel transformers** – Extract the slide mappers into `apps/watch/src/components/WatchHomePage/libs/carouselTransformers.ts` (or similar), add unit tests around mux/video conversions, and update the hook to consume the helpers. This pares down the hook size before we tackle behavioural splits.【F:apps/watch/src/components/WatchHomePage/useWatchHeroCarousel.ts†L1-L205】
+2. **Carousel progression & telemetry hook** – Introduce `useCarouselAutoAdvance` that receives `activeSlideId`, navigation callbacks, and player progress so that analytics logging and timeout resets are isolated from data updates. Wire the hook within `useWatchHeroCarousel` and cover it with timer-based tests.【F:apps/watch/src/components/WatchHomePage/useWatchHeroCarousel.ts†L380-L486】
+3. **Watch homepage provider tightening** – Refactor `WatchHomePage` to render providers around `WatchHero` (or even inside it) while leaving newsletter/map/promo sections outside. Consolidate the duplicated `Index` wrappers into one context at the top level.【F:apps/watch/src/components/WatchHomePage/WatchHomePage.tsx†L26-L105】
+4. **Collections rail config pass** – Replace the hard-coded trio of section invocations with a `const railVariants = [...]` map and update stories/tests accordingly. This PR should also document how to add new variants via config only.【F:apps/watch/src/components/WatchHomePage/CollectionsRail.tsx†L1-L59】
+5. **Newsletter form modularization** – Extract child components (`NewsletterIntro`, `ContactFields`, `InterestCheckboxGroup`, etc.) and a `useNewsletterSignupForm` hook, moving copy into locale-driven config where possible. Write interaction tests around the hook to keep form coverage green.【F:apps/watch/src/components/WatchHomePage/SectionNewsletterSignup.tsx†L20-L200】
+6. **Language map infrastructure layer** – Land a `useMapLibre` wrapper that owns map creation, control wiring, and cleanup, plus move helper functions into `LanguageMap.utils.ts`. Replace console logging with a debug flag or instrumentation callback so production builds stay quiet.【F:apps/watch/src/components/WatchHomePage/SectionLanguageMap/LanguageMap.tsx†L210-L492】
+7. **Language map UI polish** – After the infrastructure split, focus on the UI shell: loading/unsupported states, popup content, and translation strings sourced from locales rather than inline templates. This keeps UX tweaks reviewable without map bootstrapping noise.【F:apps/watch/src/components/WatchHomePage/SectionLanguageMap/LanguageMap.tsx†L37-L433】
+8. **Promo content config & analytics** – Migrate promo highlights to a config export (or CMS hook), ensure translations flow through locale files, and introduce a centralized CTA analytics helper so the promo grid remains a presentational component.【F:apps/watch/src/components/WatchHomePage/SectionPromo.tsx†L11-L140】
+
+## Suggested PR Breakdown
+
+1. **Design System & Tailwind Foundations** – Introduce the new `libs/ui` shadcn components, Tailwind globals, and updated `tailwind.config.ts` so subsequent feature PRs can focus on page functionality without mixing foundational styling changes.【F:apps/watch/styles/globals.css†L1-L298】【F:apps/watch/tailwind.config.ts†L1-L77】【F:libs/ui/src/components/button.tsx†L1-L56】
+2. **Hero Carousel Transformers** – Land the extracted transformer utilities, updated tests, and the slimmer `useWatchHeroCarousel` that now consumes them. Keep autoplay logic untouched here to constrain the diff scope.【F:apps/watch/src/components/WatchHomePage/useWatchHeroCarousel.ts†L1-L205】【F:apps/watch/src/components/WatchHomePage/WatchHero.tsx†L1-L58】
+3. **Hero Carousel Progression Logic** – Follow up with the new `useCarouselAutoAdvance` (or equivalent) plus analytics reporter wiring, updating `WatchHero` integration as needed. This isolates behavioural review from data-shaping changes.【F:apps/watch/src/components/WatchHomePage/useWatchHeroCarousel.ts†L380-L514】
+4. **Homepage Provider & Search Context** – Adjust provider boundaries and remove the nested Algolia `Index` wrappers so static sections render outside of heavy contexts. Ensure regression tests cover hero playback with the tightened scope.【F:apps/watch/src/components/WatchHomePage/WatchHomePage.tsx†L26-L105】
+5. **Collections Showcase Rail** – Add the config-driven rail component and related stories/tests, keeping Algolia collection wiring isolated from other homepage work.【F:apps/watch/src/components/WatchHomePage/CollectionsRail.tsx†L1-L59】
+6. **Newsletter Experience** – Ship the modularized newsletter section (container + subcomponents + hook) with accompanying tests and locale updates so reviewers can focus on UX/accessibility details in one place.【F:apps/watch/src/components/WatchHomePage/SectionNewsletterSignup.tsx†L20-L200】【F:apps/watch/src/components/WatchHomePage/SectionNewsletterSignup.spec.tsx†L1-L191】【F:libs/locales/en/apps-watch.json†L1-L83】
+7. **Language Map Infrastructure** – Introduce the `useMapLibre` helper, extracted utilities, and quieter logging, landing the feature flag + hook updates independently of UI polish.【F:apps/watch/src/components/WatchHomePage/SectionLanguageMap/LanguageMap.tsx†L210-L492】【F:apps/watch/src/libs/useLanguageMap/useLanguageMap.ts†L1-L24】
+8. **Language Map UI & Copy** – Layer in the refined `LanguageMap` UI, translations, and unsupported/loading states once the infrastructure work is merged, ensuring reviewers only evaluate presentation changes here.【F:apps/watch/src/components/WatchHomePage/SectionLanguageMap/LanguageMap.tsx†L37-L433】【F:apps/watch/src/components/WatchHomePage/SectionLanguageMap/SectionLanguageMap.tsx†L1-L75】
+9. **Promo & Marketing Blocks** – Finalise the promo cards/points section with config-driven content and analytics hooks, keeping marketing copy adjustments separate from technical refactors.【F:apps/watch/src/components/WatchHomePage/SectionPromo.tsx†L11-L140】
+


### PR DESCRIPTION
## Summary
- expand the Watch homepage simplification guidance with detailed component-level action items
- add a stepwise refactor roadmap and refreshed multi-PR breakdown for the work branch

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68da950c65a88328b45e32929ce5306c