### PR TITLE
refactor(studio): use shadcn carousel for prayer carousel

### DIFF
--- a/apps/studio/src/components/PrayerCarousel.tsx
+++ b/apps/studio/src/components/PrayerCarousel.tsx
@@ -7,6 +7,9 @@ import {
   useState
 } from 'react'
 
+import { Carousel, CarouselContent, CarouselItem } from '@/components/ui/carousel'
+import type { CarouselApi } from '@/components/ui/carousel'
+
 function usePrefersReducedMotion() {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
 
@@ -102,6 +105,7 @@ export function PrayerCarousel({
     []
   )
 
+  const [carouselApi, setCarouselApi] = useState<CarouselApi | null>(null)
   const [currentSlide, setCurrentSlide] = useState(0)
   const [isVisible, setIsVisible] = useState(false)
   const collapseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -119,13 +123,25 @@ export function PrayerCarousel({
 
   const handlePrevious = useCallback(() => {
     clearAutoAdvance()
+    if (carouselApi != null) {
+      carouselApi.scrollPrev()
+      return
+    }
     setCurrentSlide((prev) => (prev - 1 + slides.length) % slides.length)
-  }, [clearAutoAdvance, slides.length])
+  }, [carouselApi, clearAutoAdvance, slides.length])
 
   const handleNext = useCallback(() => {
     clearAutoAdvance()
+    if (carouselApi != null) {
+      if (carouselApi.canScrollNext()) {
+        carouselApi.scrollNext()
+      } else {
+        carouselApi.scrollTo(0)
+      }
+      return
+    }
     setCurrentSlide((prev) => (prev + 1) % slides.length)
-  }, [clearAutoAdvance, slides.length])
+  }, [carouselApi, clearAutoAdvance, slides.length])
 
   useEffect(() => {
     if (isActive) {
@@ -134,6 +150,9 @@ export function PrayerCarousel({
         collapseTimeoutRef.current = null
       }
       setCurrentSlide(0)
+      if (carouselApi != null) {
+        carouselApi.scrollTo(0)
+      }
       const frame = requestAnimationFrame(() => setIsVisible(true))
       return () => cancelAnimationFrame(frame)
     }
@@ -150,7 +169,7 @@ export function PrayerCarousel({
         collapseTimeoutRef.current = null
       }
     }
-  }, [isActive, onCollapseComplete])
+  }, [carouselApi, isActive, onCollapseComplete])
 
   useEffect(() => {
     if (!isActive || !isVisible) {
@@ -183,7 +202,15 @@ export function PrayerCarousel({
     clearAutoAdvance()
     autoAdvanceTimeoutRef.current = setTimeout(() => {
       autoAdvanceTimeoutRef.current = null
-      setCurrentSlide((prev) => (prev + 1) % slides.length)
+      if (carouselApi != null) {
+        if (carouselApi.canScrollNext()) {
+          carouselApi.scrollNext()
+        } else {
+          carouselApi.scrollTo(0)
+        }
+      } else {
+        setCurrentSlide((prev) => (prev + 1) % slides.length)
+      }
     }, SLIDE_DURATION)
 
     return () => {
@@ -194,6 +221,7 @@ export function PrayerCarousel({
       clearAutoAdvance()
     }
   }, [
+    carouselApi,
     currentSlide,
     isActive,
     isVisible,
@@ -226,6 +254,25 @@ export function PrayerCarousel({
     }
   }, [handleNext, handlePrevious, isActive, isVisible])
 
+  useEffect(() => {
+    if (carouselApi == null) {
+      return
+    }
+
+    const handleSelect = () => {
+      setCurrentSlide(carouselApi.selectedScrollSnap())
+    }
+
+    handleSelect()
+    carouselApi.on('select', handleSelect)
+    carouselApi.on('reInit', handleSelect)
+
+    return () => {
+      carouselApi.off('select', handleSelect)
+      carouselApi.off('reInit', handleSelect)
+    }
+  }, [carouselApi])
+
   return (
     <div
       className="mt-6 overflow-hidden rounded-3xl border border-amber-200/70 bg-gradient-to-br from-amber-50 via-white to-rose-50 transition-all duration-700 ease-out"
@@ -237,52 +284,63 @@ export function PrayerCarousel({
       }}
     >
       <div className="px-6 md:px-10">
-        <div
-          className="relative min-h-[180px]"
-          id={slidesRegionId}
-          role="group"
-          aria-live="polite"
-          aria-atomic="true"
+        <Carousel
+          className="relative"
+          opts={{ loop: true }}
+          setApi={(api) => {
+            setCarouselApi(api)
+          }}
+          aria-label="Prayer focus carousel"
         >
-          {slides.map((slide, index) => {
-            const isCurrent = index === currentSlide
-            return (
-              <div
-                key={slide.title}
-                className="absolute inset-0 flex flex-col justify-center gap-4"
-                style={{
-                  opacity: isCurrent && isVisible ? 1 : 0,
-                  transform: isCurrent && isVisible ? 'translateY(0px)' : 'translateY(16px)',
-                  transition: 'opacity 600ms ease, transform 600ms ease'
-                }}
-              >
-                <span className="text-xs font-semibold uppercase tracking-[0.3em] text-amber-500/90">
-                  During this moment
-                </span>
-                <h3 className="text-xl font-semibold text-amber-900 md:text-2xl">
-                  {slide.title}
-                </h3>
-                {slide.body != null && (
-                  <p className="text-sm leading-relaxed text-amber-900/80 md:text-base">
-                    {slide.body}
-                  </p>
-                )}
-                {Array.isArray(slide.bullets) && slide.bullets.length > 0 && (
-                  <ul className="list-disc space-y-2 pl-5 text-sm leading-relaxed text-amber-900/80 marker:text-amber-500 md:text-base">
-                    {slide.bullets.map((item) => (
-                      <li key={item}>{item}</li>
-                    ))}
-                  </ul>
-                )}
-                {slide.reference != null && (
-                  <p className="text-xs font-medium uppercase tracking-[0.2em] text-amber-500/70">
-                    {slide.reference}
-                  </p>
-                )}
-              </div>
-            )
-          })}
-        </div>
+          <CarouselContent
+            id={slidesRegionId}
+            role="group"
+            aria-live="polite"
+            aria-atomic="true"
+            className="min-h-[180px]"
+          >
+            {slides.map((slide, index) => {
+              const isCurrent = index === currentSlide
+              return (
+                <CarouselItem key={slide.title} className="!pl-0">
+                  <div
+                    className="flex h-full flex-col justify-center gap-4"
+                    style={{
+                      opacity: isCurrent && isVisible ? 1 : 0,
+                      transform: isCurrent && isVisible ? 'translateY(0px)' : 'translateY(16px)',
+                      transition: 'opacity 600ms ease, transform 600ms ease'
+                    }}
+                    aria-hidden={!isCurrent || !isVisible}
+                  >
+                    <span className="text-xs font-semibold uppercase tracking-[0.3em] text-amber-500/90">
+                      During this moment
+                    </span>
+                    <h3 className="text-xl font-semibold text-amber-900 md:text-2xl">
+                      {slide.title}
+                    </h3>
+                    {slide.body != null && (
+                      <p className="text-sm leading-relaxed text-amber-900/80 md:text-base">
+                        {slide.body}
+                      </p>
+                    )}
+                    {Array.isArray(slide.bullets) && slide.bullets.length > 0 && (
+                      <ul className="list-disc space-y-2 pl-5 text-sm leading-relaxed text-amber-900/80 marker:text-amber-500 md:text-base">
+                        {slide.bullets.map((item) => (
+                          <li key={item}>{item}</li>
+                        ))}
+                      </ul>
+                    )}
+                    {slide.reference != null && (
+                      <p className="text-xs font-medium uppercase tracking-[0.2em] text-amber-500/70">
+                        {slide.reference}
+                      </p>
+                    )}
+                  </div>
+                </CarouselItem>
+              )
+            })}
+          </CarouselContent>
+        </Carousel>
         <div
           className="mt-8 flex items-center justify-center gap-4"
           id={indicatorRegionId}


### PR DESCRIPTION
## Summary
- replace the custom PrayerCarousel implementation with the shared shadcn carousel primitives
- wire Embla carousel events to preserve auto-advance, keyboard, and progress behaviours
- keep the existing prayer slide content and indicator styling within the new carousel layout

## Testing
- pnpm dlx nx lint studio *(fails: existing lint errors in apps/studio/pages/old.tsx and apps/studio/src/components/editor.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68f6651a806083288d8c47469434ad71