### PR TITLE
Handle language map network errors with retry

### DIFF
--- a/apps/watch/src/components/WatchHomePage/SectionLanguageMap/SectionLanguageMap.tsx
+++ b/apps/watch/src/components/WatchHomePage/SectionLanguageMap/SectionLanguageMap.tsx
@@ -11,7 +11,7 @@ import { LanguageMap } from './LanguageMap'
 
 export function SectionLanguageMap(): ReactElement {
   const { t } = useTranslation('apps-watch')
-  const { points, isLoading, error } = useLanguageMap()
+  const { points, isLoading, error, retry } = useLanguageMap()
 
   const hasData = points.length > 0
   const uniqueLanguagesCount = useMemo(() => {
@@ -63,9 +63,23 @@ export function SectionLanguageMap(): ReactElement {
             />
           ) : (
             <div className="flex h-full w-full items-center justify-center px-6 text-center text-sm text-white/70">
-              {error != null && !isLoading
-                ? t('We had trouble loading the language map. Please try again later.')
-                : t('Loading language coverage…')}
+              {error != null && !isLoading ? (
+                <div className="flex flex-col items-center gap-4">
+                  <p className="max-w-sm text-balance">
+                    {t('We had trouble loading the language map. Please try again later.')}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={retry}
+                    disabled={isLoading}
+                    className="rounded-full border border-white/30 px-5 py-2 text-sm font-medium text-white transition hover:border-white/60 hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {t('Try again')}
+                  </button>
+                </div>
+              ) : (
+                t('Loading language coverage…')
+              )}
             </div>
           )}
         </div>

--- a/apps/watch/src/libs/useLanguageMap/useLanguageMap.ts
+++ b/apps/watch/src/libs/useLanguageMap/useLanguageMap.ts
@@ -1,12 +1,28 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import useSWR from 'swr'
 
 import type { LanguageMapPoint } from './types'
 
+class LanguageMapNetworkError extends Error {
+  constructor(message = 'NetworkError when attempting to fetch resource.') {
+    super(message)
+    this.name = 'LanguageMapNetworkError'
+  }
+}
+
 const fetcher = async (url: string): Promise<LanguageMapPoint[]> => {
-  const response = await fetch(url)
-  if (!response.ok) throw new Error('Failed to load language map')
-  return await response.json()
+  try {
+    const response = await fetch(url)
+    if (!response.ok) throw new Error('Failed to load language map')
+    return await response.json()
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw new LanguageMapNetworkError()
+    }
+    throw error instanceof Error
+      ? error
+      : new Error('Failed to load language map')
+  }
 }
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000
@@ -15,8 +31,9 @@ export function useLanguageMap(): {
   points: LanguageMapPoint[]
   isLoading: boolean
   error?: Error
+  retry: () => void
 } {
-  const { data, error, isLoading } = useSWR<LanguageMapPoint[]>(
+  const { data, error, isLoading, mutate } = useSWR<LanguageMapPoint[]>(
     '/api/language-map',
     fetcher,
     {
@@ -26,6 +43,9 @@ export function useLanguageMap(): {
   )
 
   const points = useMemo(() => data ?? [], [data])
+  const retry = useCallback(() => {
+    void mutate()
+  }, [mutate])
 
-  return { points, isLoading, error: error ?? undefined }
+  return { points, isLoading, error: error ?? undefined, retry }
 }

--- a/libs/locales/en/apps-watch.json
+++ b/libs/locales/en/apps-watch.json
@@ -90,6 +90,7 @@
   "Discover where the JESUS Film is available and see how the gospel is being shared across every continent.": "Discover where the JESUS Film is available and see how the gospel is being shared across every continent.",
   "Loading language coverage…": "Loading language coverage…",
   "We had trouble loading the language map. Please try again later.": "We had trouble loading the language map. Please try again later.",
+  "Try again": "Try again",
   "Interactive map is not supported on this device.": "Interactive map is not supported on this device.",
   "PromoEyebrow": "Future-ready for global missions",
   "PromoHeading": "The media landscape is changing—so is Jesus Film Project.",


### PR DESCRIPTION
## Summary
- wrap the language map SWR fetcher so network errors surface as recoverable failures instead of crashing
- expose a retry helper from `useLanguageMap` and surface a retry button in the section fallback UI
- add translation for the new retry action copy

## Testing
- pnpm dlx nx lint watch --skip-nx-cache *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f68ee4c1e88328bffe916f5a59489a