### PR TITLE
Fix studio carousel import path

### DIFF
--- a/apps/studio/src/components/PrayerCarousel.tsx
+++ b/apps/studio/src/components/PrayerCarousel.tsx
@@ -7,8 +7,8 @@ import {
   useState
 } from 'react'
 
-import { Carousel, CarouselContent, CarouselItem } from '@/components/ui/carousel'
-import type { CarouselApi } from '@/components/ui/carousel'
+import { Carousel, CarouselContent, CarouselItem } from './ui/carousel'
+import type { CarouselApi } from './ui/carousel'
 
 function usePrefersReducedMotion() {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)


### PR DESCRIPTION
## Summary
- update PrayerCarousel to import the local carousel component via a relative path so the module resolves during the build

## Testing
- pnpm dlx nx lint studio *(fails: existing lint error in apps/studio/pages/old.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68f6b866d1f48328b0fca797423e97bf