### PR TITLE
fix: launch darkly crashing

### DIFF
--- a/libs/shared/ui/src/libs/getLaunchDarklyClient/getLaunchDarklyClient.ts
+++ b/libs/shared/ui/src/libs/getLaunchDarklyClient/getLaunchDarklyClient.ts
@@ -8,7 +8,10 @@ let launchDarklyClient: LDClient
  */
 export async function getLaunchDarklyClient(user?: LDUser): Promise<LDClient> {
   if (launchDarklyClient == null) {
-    launchDarklyClient = init(process.env.LAUNCH_DARKLY_SDK_KEY ?? '')
+    launchDarklyClient = init(process.env.LAUNCH_DARKLY_SDK_KEY ?? '', {
+      stream: false,
+      pollInterval: 60000 // 1 minute
+    })
   }
 
   await launchDarklyClient.waitForInitialization()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated LaunchDarkly feature flag service configuration to use polling instead of real-time streaming, with a 60-second update interval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->