### PR TITLE
Show progress cursor while AI prompt is running

### DIFF
--- a/apps/studio/src/components/newPage/MainPromptBlock.tsx
+++ b/apps/studio/src/components/newPage/MainPromptBlock.tsx
@@ -1,6 +1,6 @@
+import { Camera, Info, Users, X } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import Image from 'next/image'
-import { Camera, Info, Users, X } from 'lucide-react'
 import type {
   ChangeEvent,
   ClipboardEvent,
@@ -11,8 +11,8 @@ import type {
   SetStateAction
 } from 'react'
 
-import { AutoResizeTextarea, Textarea } from '@/components/ui/textarea'
-
+import { cn } from '../../libs/cn/cn'
+import type { ImageAnalysisResult } from '../../libs/storage'
 import { Button } from '../ui/button'
 import {
   Dialog,
@@ -23,7 +23,7 @@ import {
   DialogTrigger
 } from '../ui/dialog'
 import { Input } from '../ui/input'
-import type { ImageAnalysisResult } from '../../libs/storage'
+import { AutoResizeTextarea, Textarea } from '@/components/ui/textarea'
 
 const AnimatedLoadingText = dynamic(
   async () => {
@@ -193,7 +193,10 @@ export function MainPromptBlock({
               onClick={() => {
                 void handleSubmit()
               }}
-              className="px-4 py-2 text-sm font-medium text-white rounded-full bg-primary hover:bg-primary/90 transition-colors group disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-primary/90"
+              className={cn(
+                'px-4 py-2 text-sm font-medium text-white rounded-full bg-primary hover:bg-primary/90 transition-colors group disabled:opacity-50 disabled:hover:bg-primary/90',
+                isProcessing ? 'cursor-progress' : 'disabled:cursor-not-allowed'
+              )}
               type="button"
               disabled={isProcessing || hasPendingImageAnalysis}
               title={


### PR DESCRIPTION
## Summary
- add the cn utility to the prompt action button so the cursor switches to a progress indicator while the AI request is running
- preserve the previous disabled cursor when the prompt is blocked by pending image analysis

## Testing
- pnpm dlx nx lint studio *(fails: existing lint ordering and unused import violations throughout apps/studio including pages/new.tsx, ConversationMapView.tsx, MainPromptBlock.tsx, StepContentRenderer.tsx, and StepsList.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68f95d1cf61083289bdc6c8ab91b151f