### PR TITLE
Remove conversation map response presets

### DIFF
--- a/apps/studio/src/libs/storage.ts
+++ b/apps/studio/src/libs/storage.ts
@@ -16,14 +16,6 @@ export interface GeneratedStepContent {
   selectedVideoUrl?: string
 }
 
-export interface ConversationMapResponseOption {
-  id: string
-  label: string
-  icon: string | null
-  responderMessage: string
-  guideFollowUps: string[]
-}
-
 export interface ConversationMapFlow {
   sequence: string[]
   rationale: string | null
@@ -46,7 +38,6 @@ export interface ConversationMapStep {
   purpose: string | null
   guideMessage: string
   scriptureOptions: ConversationMapScriptureOption[]
-  responseOptions: ConversationMapResponseOption[]
 }
 
 export interface ConversationMap {


### PR DESCRIPTION
## Summary
- remove the "Common responses" UI and state from the conversation map view so only scripture guidance remains
- update the conversation generation prompts and normalization logic to exclude response options and follow-up replies
- simplify the stored conversation map type now that responder options are no longer produced

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fb9fd60758832886d55478391ecdd9