### PR TITLE
fix: sanitize AI retry conversation history

### DIFF
--- a/apps/studio/src/hooks/useAiContent.ts
+++ b/apps/studio/src/hooks/useAiContent.ts
@@ -87,9 +87,25 @@ export const useAiContent = ({
       setAiResponse('')
 
       try {
-        const messages = buildConversationHistory()
         const currentUserMessage = currentValue.trim()
-        messages.push({
+        const conversationHistory = buildConversationHistory()
+
+        const sanitizedHistory = conversationHistory
+          .filter((message) => message.role !== 'assistant')
+          .filter((message) => {
+            if (message.role !== 'user') {
+              return true
+            }
+
+            const trimmedContent = message.content.trim()
+            if (!trimmedContent) {
+              return false
+            }
+
+            return trimmedContent !== currentUserMessage
+          })
+
+        sanitizedHistory.push({
           role: 'user',
           content: currentUserMessage
         })
@@ -101,7 +117,7 @@ export const useAiContent = ({
           },
           body: JSON.stringify({
             // model: 'gpt-5-nano',
-            messages
+            messages: sanitizedHistory
           })
         })
 


### PR DESCRIPTION
## Summary
- filter assistant entries out of the stored conversation history before retrying Studio AI requests
- avoid sending duplicate user prompts when rebuilding the message list so retries mirror the initial request shape

## Testing
- CI=1 pnpm dlx nx lint studio *(fails: existing import-order violations in apps/studio pages/components)*

------
https://chatgpt.com/codex/tasks/task_e_68fc1b4b586483289493c15cfc332da2