### PR TITLE
fix: prevent guidance message clipping

### DIFF
--- a/apps/watch-modern/src/components/PrayerCarousel.tsx
+++ b/apps/watch-modern/src/components/PrayerCarousel.tsx
@@ -7,8 +7,7 @@ import {
   useState
 } from 'react'
 
-import { Carousel, CarouselContent, CarouselItem } from './ui/carousel'
-import type { CarouselApi } from './ui/carousel'
+import { Bot } from 'lucide-react'
 
 function usePrefersReducedMotion() {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
@@ -41,7 +40,7 @@ function usePrefersReducedMotion() {
   return prefersReducedMotion
 }
 
-type PrayerSlide = {
+type PrayerMessage = {
   title: string
   body?: string
   verse?: string
@@ -58,12 +57,11 @@ export function PrayerCarousel({
   isActive,
   onCollapseComplete
 }: PrayerCarouselProps) {
-  const SLIDE_DURATION = 8000
+  const MESSAGE_DELAY = 2500
   const prefersReducedMotion = usePrefersReducedMotion()
   const carouselId = useId()
-  const slidesRegionId = `${carouselId}-slides`
-  const indicatorRegionId = `${carouselId}-indicators`
-  const slides = useMemo<PrayerSlide[]>(
+  const messagesRegionId = `${carouselId}-messages`
+  const messages = useMemo<PrayerMessage[]>(
     () => [
       {
         title: 'What’s Happening Now',
@@ -96,43 +94,19 @@ export function PrayerCarousel({
     []
   )
 
-  const [carouselApi, setCarouselApi] = useState<CarouselApi | null>(null)
-  const [currentSlide, setCurrentSlide] = useState(0)
+  const [visibleMessageCount, setVisibleMessageCount] = useState(0)
   const [isVisible, setIsVisible] = useState(false)
   const collapseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const [progress, setProgress] = useState(0)
-  const [isProgressAnimating, setIsProgressAnimating] = useState(false)
-  const progressFrameRef = useRef<number | null>(null)
-  const autoAdvanceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const revealTimeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([])
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [contentHeight, setContentHeight] = useState<number | null>(null)
 
-  const clearAutoAdvance = useCallback(() => {
-    if (autoAdvanceTimeoutRef.current) {
-      clearTimeout(autoAdvanceTimeoutRef.current)
-      autoAdvanceTimeoutRef.current = null
+  const clearRevealTimeouts = useCallback(() => {
+    for (const timeoutId of revealTimeoutsRef.current) {
+      clearTimeout(timeoutId)
     }
+    revealTimeoutsRef.current = []
   }, [])
-
-  const handlePrevious = useCallback(() => {
-    clearAutoAdvance()
-    if (carouselApi != null) {
-      carouselApi.scrollPrev()
-      return
-    }
-    setCurrentSlide((prev) => (prev - 1 + slides.length) % slides.length)
-  }, [carouselApi, clearAutoAdvance, slides.length])
-
-  const handleNext = useCallback(() => {
-    clearAutoAdvance()
-    if (carouselApi != null) {
-      if (carouselApi.canScrollNext()) {
-        carouselApi.scrollNext()
-      } else {
-        carouselApi.scrollTo(0)
-      }
-      return
-    }
-    setCurrentSlide((prev) => (prev + 1) % slides.length)
-  }, [carouselApi, clearAutoAdvance, slides.length])
 
   useEffect(() => {
     if (isActive) {
@@ -140,15 +114,13 @@ export function PrayerCarousel({
         clearTimeout(collapseTimeoutRef.current)
         collapseTimeoutRef.current = null
       }
-      setCurrentSlide(0)
-      if (carouselApi != null) {
-        carouselApi.scrollTo(0)
-      }
       const frame = requestAnimationFrame(() => setIsVisible(true))
       return () => cancelAnimationFrame(frame)
     }
 
     setIsVisible(false)
+    setVisibleMessageCount(0)
+    clearRevealTimeouts()
 
     collapseTimeoutRef.current = setTimeout(() => {
       onCollapseComplete?.()
@@ -159,116 +131,91 @@ export function PrayerCarousel({
         clearTimeout(collapseTimeoutRef.current)
         collapseTimeoutRef.current = null
       }
+      clearRevealTimeouts()
     }
-  }, [carouselApi, isActive, onCollapseComplete])
+  }, [clearRevealTimeouts, isActive, onCollapseComplete])
 
   useEffect(() => {
     if (!isActive || !isVisible) {
-      if (progressFrameRef.current != null) {
-        cancelAnimationFrame(progressFrameRef.current)
-        progressFrameRef.current = null
-      }
-      clearAutoAdvance()
-      setIsProgressAnimating(false)
-      setProgress(0)
       return
     }
 
-    if (progressFrameRef.current != null) {
-      cancelAnimationFrame(progressFrameRef.current)
-      progressFrameRef.current = null
+    clearRevealTimeouts()
+
+    if (prefersReducedMotion) {
+      setVisibleMessageCount(messages.length)
+      return
     }
 
-    setIsProgressAnimating(false)
-    setProgress(prefersReducedMotion ? 100 : 0)
+    setVisibleMessageCount(messages.length > 0 ? 1 : 0)
+    messages.slice(1).forEach((_, index) => {
+      const timeoutId = setTimeout(() => {
+        setVisibleMessageCount((prev) => {
+          const nextCount = Math.max(prev, index + 2)
+          return nextCount > messages.length ? messages.length : nextCount
+        })
+      }, MESSAGE_DELAY * (index + 1))
 
-    if (!prefersReducedMotion) {
-      progressFrameRef.current = requestAnimationFrame(() => {
-        setIsProgressAnimating(true)
-        setProgress(100)
-        progressFrameRef.current = null
+      revealTimeoutsRef.current.push(timeoutId)
+    })
+
+    return () => {
+      clearRevealTimeouts()
+    }
+  }, [clearRevealTimeouts, isActive, isVisible, messages, prefersReducedMotion])
+
+  useEffect(() => {
+    return () => {
+      clearRevealTimeouts()
+    }
+  }, [clearRevealTimeouts])
+
+  useEffect(() => {
+    if (!isVisible) {
+      setContentHeight(null)
+      return
+    }
+
+    const container = containerRef.current
+    if (!container) {
+      return
+    }
+
+    const measure = () => {
+      setContentHeight(container.scrollHeight)
+    }
+
+    measure()
+
+    if (typeof window !== 'undefined' && 'ResizeObserver' in window) {
+      const observer = new window.ResizeObserver(() => {
+        measure()
       })
+
+      observer.observe(container)
+
+      return () => {
+        observer.disconnect()
+      }
     }
 
-    clearAutoAdvance()
-    autoAdvanceTimeoutRef.current = setTimeout(() => {
-      autoAdvanceTimeoutRef.current = null
-      if (carouselApi != null) {
-        if (carouselApi.canScrollNext()) {
-          carouselApi.scrollNext()
-        } else {
-          carouselApi.scrollTo(0)
-        }
-      } else {
-        setCurrentSlide((prev) => (prev + 1) % slides.length)
-      }
-    }, SLIDE_DURATION)
+    const frame = requestAnimationFrame(measure)
 
     return () => {
-      if (progressFrameRef.current != null) {
-        cancelAnimationFrame(progressFrameRef.current)
-        progressFrameRef.current = null
-      }
-      clearAutoAdvance()
+      cancelAnimationFrame(frame)
     }
-  }, [
-    carouselApi,
-    currentSlide,
-    isActive,
-    isVisible,
-    prefersReducedMotion,
-    slides.length,
-    SLIDE_DURATION,
-    clearAutoAdvance
-  ])
-
-  useEffect(() => {
-    if (!isActive || !isVisible) {
-      return
-    }
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'ArrowLeft') {
-        event.preventDefault()
-        handlePrevious()
-      }
-
-      if (event.key === 'ArrowRight') {
-        event.preventDefault()
-        handleNext()
-      }
-    }
-
-    window.addEventListener('keydown', handleKeyDown)
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [handleNext, handlePrevious, isActive, isVisible])
-
-  useEffect(() => {
-    if (carouselApi == null) {
-      return
-    }
-
-    const handleSelect = () => {
-      setCurrentSlide(carouselApi.selectedScrollSnap())
-    }
-
-    handleSelect()
-    carouselApi.on('select', handleSelect)
-    carouselApi.on('reInit', handleSelect)
-
-    return () => {
-      carouselApi.off('select', handleSelect)
-      carouselApi.off('reInit', handleSelect)
-    }
-  }, [carouselApi])
+  }, [isVisible, visibleMessageCount])
 
   return (
     <div
+      ref={containerRef}
       className="mt-6 overflow-hidden rounded-3xl transition-all duration-700 ease-out"
       style={{
-        maxHeight: isVisible ? 360 : 0,
+        maxHeight: isVisible
+          ? contentHeight != null
+            ? `${contentHeight}px`
+            : 'none'
+          : 0,
         opacity: isVisible ? 1 : 0,
         paddingTop: isVisible ? '24px' : '0px',
         paddingBottom: isVisible ? '24px' : '0px'
@@ -276,125 +223,58 @@ export function PrayerCarousel({
     >
       <div className="relative px-6 md:px-10">
         <div
-          className="absolute right-6 top-6 z-10 flex flex-row items-center justify-end gap-4 min-w-[380px]"
-          id={indicatorRegionId}
-          role="group"
-          aria-label="Prayer focus slides"
+          id={messagesRegionId}
+          role="log"
+          aria-live="polite"
+          aria-relevant="additions"
+          className="flex flex-col gap-6"
         >
-          {slides.length > 1 && (
-            <button
-              type="button"
-              onClick={handlePrevious}
-              className="flex h-8 w-8 items-center justify-center rounded-full border border-amber-200/80 bg-white/80 text-amber-600 transition hover:bg-amber-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60 cursor-pointer"
-              aria-label="Previous slide"
-              aria-controls={slidesRegionId}
-            >
-              ‹
-            </button>
-          )}
-          <div className="flex items-center gap-4" aria-hidden>
-            {slides.map((_, index) => {
-              const isCurrent = index === currentSlide && isVisible
-
-              if (isCurrent) {
-                return (
-                  <div
-                    key={index}
-                    className="relative h-1.5 w-12 overflow-hidden rounded-full bg-amber-500/20"
-                  >
-                    <span
-                      className="absolute inset-y-0 left-0 rounded-full bg-amber-500"
-                      style={{
-                        width: `${progress}%`,
-                        transition:
-                          isProgressAnimating && !prefersReducedMotion
-                          ? `width ${SLIDE_DURATION}ms linear`
-                          : 'none'
-                      }}
-                      aria-hidden
-                    />
-                  </div>
-                )
-              }
-
-              return (
+          {messages.slice(0, visibleMessageCount).map((message) => (
+            <div key={message.title} className="flex items-start gap-3">
+              <span className="mt-1 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-amber-500/15 text-amber-700">
+                <Bot aria-hidden className="h-4 w-4" />
+              </span>
+              <div className="relative max-w-[min(100%,_38rem)] flex-1 rounded-3xl bg-white/95 p-5 shadow-md ring-1 ring-amber-200/70 backdrop-blur">
                 <span
-                  key={index}
-                  className="h-2 w-2 rounded-full bg-amber-400/40 transition-colors"
                   aria-hidden
+                  className="absolute -left-2 top-10 block h-3 w-3 origin-bottom-left rotate-45 rounded-sm bg-white/95 ring-1 ring-amber-200/70"
                 />
-              )
-            })}
-          </div>
-          {slides.length > 1 && (
-            <button
-              type="button"
-              onClick={handleNext}
-              className="flex h-8 w-8 items-center justify-center rounded-full border border-amber-200/80 bg-white/80 text-amber-600 transition hover:bg-amber-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60 cursor-pointer"
-              aria-label="Next slide"
-              aria-controls={slidesRegionId}
-            >
-              ›
-            </button>
-          )}
-        </div>
-        <Carousel
-          className="relative"
-          opts={{ loop: true }}
-          setApi={(api) => {
-            setCarouselApi(api)
-          }}
-          aria-label="Prayer focus carousel"
-        >
-          <CarouselContent
-            id={slidesRegionId}
-            role="group"
-            aria-live="polite"
-            aria-atomic="true"
-            className="min-h-[180px]"
-          >
-            {slides.map((slide, index) => {
-              const isCurrent = index === currentSlide
-              return (
-                <CarouselItem key={slide.title}>
-                  <div
-                    className="flex h-full flex-col justify-top gap-4"
-                    aria-hidden={!isCurrent}
-                  >
+                <div className="space-y-3 text-amber-900">
+                  <div className="space-y-2">
                     <span className="text-xs font-semibold uppercase tracking-[0.3em] text-amber-500/90">
                       During this moment
                     </span>
-                    <h3 className="text-xl font-semibold text-amber-900 md:text-2xl">
-                      {slide.title}
+                    <h3 className="text-lg font-semibold md:text-xl">
+                      {message.title}
                     </h3>
-                    {slide.body != null && (
-                      <p className="text-sm leading-relaxed text-amber-900/80 whitespace-pre-line md:text-base">
-                        {slide.body}
-                      </p>
-                    )}
-                    {slide.verse != null && (
-                      <p className="text-sm italic leading-relaxed text-amber-900/80 whitespace-pre-line md:text-base">
-                        {slide.verse}
-                      </p>
-                    )}
-                    {Array.isArray(slide.bullets) && slide.bullets.length > 0 && (
-                      <ul className="list-disc space-y-2 pl-5 text-sm leading-relaxed text-amber-900/80 marker:text-amber-500 md:text-base">
-                        {slide.bullets.map((item) => (
-                          <li key={item}>{item}</li>
-                        ))}
-                      </ul>
-                    )}
-                    {slide.reference != null && (
-                      <p className="text-xs font-medium uppercase tracking-[0.2em] text-amber-500/70">
-                        {slide.reference}
-                      </p>
-                    )}
                   </div>
-                </CarouselItem>
-              )
-            })}
-          </CarouselContent>
-        </Carousel>
+                  {message.body != null && (
+                    <p className="whitespace-pre-line text-sm leading-relaxed text-amber-900/85 md:text-base">
+                      {message.body}
+                    </p>
+                  )}
+                  {message.verse != null && (
+                    <p className="whitespace-pre-line text-sm italic leading-relaxed text-amber-900/80 md:text-base">
+                      {message.verse}
+                    </p>
+                  )}
+                  {Array.isArray(message.bullets) && message.bullets.length > 0 && (
+                    <ul className="list-disc space-y-2 pl-5 text-sm leading-relaxed text-amber-900/80 marker:text-amber-500 md:text-base">
+                      {message.bullets.map((item) => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  )}
+                  {message.reference != null && (
+                    <p className="text-xs font-medium uppercase tracking-[0.2em] text-amber-500/70">
+                      {message.reference}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- measure the prayer guidance container so the expanding chat bubbles set their max height dynamically
- keep the collapse animation while allowing the full "Purpose of This Tool" message to remain visible

## Testing
- CI=1 pnpm dlx nx lint watch-modern *(fails: existing literal string and import-order violations in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68ffc54516048328a91eff381ed3ae0c