### PR TITLE
Improve Studio AI error callout contrast

### DIFF
--- a/apps/watch-modern/pages/new.tsx
+++ b/apps/watch-modern/pages/new.tsx
@@ -2610,7 +2610,7 @@ export default function NewPage() {
                     />
                     {aiError && (
                       <div
-                        className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-400/40 dark:bg-amber-500/10 dark:text-amber-100"
+                        className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-amber-300 bg-amber-100 px-4 py-3 text-sm font-medium text-amber-950 shadow-sm dark:border-amber-400/60 dark:bg-amber-500/20 dark:text-amber-50"
                         role="status"
                         aria-live="polite"
                       >
@@ -2619,6 +2619,7 @@ export default function NewPage() {
                           <Button
                             variant="outline"
                             size="sm"
+                            className="border-amber-400 text-amber-900 hover:bg-amber-200 dark:border-amber-300 dark:text-amber-50 dark:hover:bg-amber-500/30"
                             onClick={() => {
                               setAiError(null)
                               void handleSubmit()

--- a/prds/watch/work.md
+++ b/prds/watch/work.md
@@ -130,3 +130,27 @@
 
 - Consider showing a brief tooltip on first visit explaining the Skip control for accessibility.
 - Evaluate whether skip interactions should emit analytics distinct from autoplay completions.
+
+# Studio AI Error Callout Contrast
+
+## Goals
+
+- [x] Improve the readability of the Studio AI error callout in the creation workflow.
+- [x] Ensure the retry action remains visible against the updated background treatment.
+
+## Obstacles
+
+- Existing tailwind utility mix produced low contrast between the background and message text, especially in dark mode.
+
+## Resolutions
+
+- Replaced the amber color tokens with higher-contrast values and added font-weight/shadow adjustments for readability.
+- Tuned the retry button styles to maintain prominence on the new surface.
+
+## Test Coverage
+
+- Visual verification via Tailwind utility adjustments (no automated tests required).
+
+## Follow-up Ideas
+
+- Consider extracting a shared alert component for consistent warning styling across Studio experiences.


### PR DESCRIPTION
## Summary
- adjust the Studio AI error callout styling to improve legibility in both light and dark themes
- ensure the retry action retains sufficient contrast against the new surface treatment
- document the contrast fix in the watch work log for future reference

## Testing
- pnpm dlx nx lint watch-modern --output-style=static *(fails: existing i18next/no-literal-string violations across watch-modern unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68fff10016f883289118fad0d68dfb86