### PR TITLE
feat: extend watch-modern auth ux

### DIFF
--- a/apps/watch-modern/pages/_app.tsx
+++ b/apps/watch-modern/pages/_app.tsx
@@ -3,6 +3,10 @@ import Head from 'next/head'
 import { DefaultSeo } from 'next-seo'
 import '../styles/globals.css'
 
+import { initAuth } from '../src/libs/auth/initAuth'
+
+initAuth()
+
 function StudioApp({ Component, pageProps }: AppProps) {
   return (
     <>

--- a/apps/watch-modern/pages/api/ai/respond.spec.ts
+++ b/apps/watch-modern/pages/api/ai/respond.spec.ts
@@ -1,0 +1,136 @@
+import { createHash, createHmac } from 'node:crypto'
+
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+import handler from './respond'
+
+jest.mock(
+  '@ai-sdk/openai',
+  () => ({
+    createOpenAI: jest.fn(() => ({
+      responses: jest.fn(() => 'mock-model')
+    }))
+  }),
+  { virtual: true }
+)
+
+jest.mock(
+  'ai',
+  () => ({
+    convertToCoreMessages: jest.fn((messages: unknown) => messages),
+    generateText: jest.fn().mockResolvedValue({
+      text: 'ok',
+      response: { id: 'response', timestamp: new Date() },
+      finishReason: 'stop',
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 }
+    })
+  }),
+  { virtual: true }
+)
+
+jest.mock('next-firebase-auth', () => ({
+  verifyIdToken: jest.fn()
+}))
+
+jest.mock('../../../src/libs/auth/initAuth', () => ({
+  initAuth: jest.fn(),
+  authCookieHeaderName: 'watch-modern.AuthUser'
+}))
+
+type MockResponse = NextApiResponse & {
+  statusCode: number
+  headers: Record<string, string | string[]>
+  body?: unknown
+}
+
+const createMockRes = (): MockResponse => {
+  const res: Partial<MockResponse> = {
+    statusCode: 200,
+    headers: {},
+    setHeader: jest.fn((key: string, value: string | string[]) => {
+      res.headers![key] = value
+      return res as MockResponse
+    }),
+    status: jest.fn((code: number) => {
+      res.statusCode = code
+      return res as MockResponse
+    }),
+    json: jest.fn((payload: unknown) => {
+      res.body = payload
+      return res as MockResponse
+    })
+  }
+
+  return res as MockResponse
+}
+
+const createMockReq = (overrides: Partial<NextApiRequest> = {}): NextApiRequest => ({
+  method: 'POST',
+  headers: { 'user-agent': 'jest', ...overrides.headers } as NextApiRequest['headers'],
+  body: {
+    messages: [
+      {
+        role: 'user',
+        content: 'Hello there'
+      }
+    ],
+    ...overrides.body
+  },
+  cookies: {},
+  query: {},
+  ...overrides
+}) as NextApiRequest
+
+describe('POST /studio/api/ai/respond guest usage enforcement', () => {
+  const originalAuthSecret = process.env.AUTH_SECRET
+  const originalOpenRouterKey = process.env.OPENROUTER_API_KEY
+
+  beforeEach(() => {
+    process.env.AUTH_SECRET = 'test-secret'
+    process.env.OPENROUTER_API_KEY = 'test-openrouter-key'
+  })
+
+  afterEach(() => {
+    process.env.AUTH_SECRET = originalAuthSecret
+    process.env.OPENROUTER_API_KEY = originalOpenRouterKey
+    jest.clearAllMocks()
+  })
+
+  it('returns 429 when guest usage exceeds the daily limit', async () => {
+    const req = createMockReq()
+    const res = createMockRes()
+
+    const fingerprint = createHash('sha256')
+      .update(String(req.headers['user-agent']))
+      .digest('hex')
+    const payload = JSON.stringify({
+      id: 'guest-id',
+      count: 5,
+      resetAt: Date.now() + 1000,
+      fingerprint
+    })
+    const signature = createHmac('sha256', process.env.AUTH_SECRET!)
+      .update(payload)
+      .digest('hex')
+    const encoded = Buffer.from(`${payload}.${signature}`).toString('base64url')
+
+    req.cookies = {
+      'watch-modern.guest-usage': encoded
+    }
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(429)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.stringContaining('Daily guest limit reached'),
+        requiresAuth: true,
+        limit: 5
+      })
+    )
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Set-Cookie',
+      expect.stringContaining('watch-modern.guest-usage=')
+    )
+  })
+})

--- a/apps/watch-modern/pages/api/login.spec.ts
+++ b/apps/watch-modern/pages/api/login.spec.ts
@@ -1,0 +1,72 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+import handler from './login'
+
+const mockSetAuthCookies = jest.fn()
+
+jest.mock('next-firebase-auth', () => ({
+  setAuthCookies: (...args: unknown[]) => mockSetAuthCookies(...args)
+}))
+
+jest.mock('../../src/libs/auth/initAuth', () => ({
+  initAuth: jest.fn()
+}))
+
+type MockResponse = NextApiResponse & {
+  statusCode: number
+  json: jest.Mock
+  headers: Record<string, string | string[]>
+}
+
+const createResponse = (): MockResponse => {
+  const res: Partial<MockResponse> = {
+    statusCode: 200,
+    headers: {},
+    setHeader: jest.fn((key: string, value: string | string[]) => {
+      res.headers![key] = value
+      return res as MockResponse
+    }),
+    status: jest.fn((code: number) => {
+      res.statusCode = code
+      return res as MockResponse
+    }),
+    json: jest.fn((payload: unknown) => {
+      res.body = payload
+      return res as MockResponse
+    })
+  }
+
+  return res as MockResponse
+}
+
+const createRequest = (method: string): NextApiRequest =>
+  ({ method, body: {}, cookies: {}, query: {}, headers: {} } as NextApiRequest)
+
+describe('/studio/api/login', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('rejects non-POST requests', async () => {
+    const req = createRequest('GET')
+    const res = createResponse()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Method Not Allowed' })
+    expect(res.headers['Allow']).toBe('POST')
+    expect(mockSetAuthCookies).not.toHaveBeenCalled()
+  })
+
+  it('sets auth cookies on POST requests', async () => {
+    const req = createRequest('POST')
+    const res = createResponse()
+
+    await handler(req, res)
+
+    expect(mockSetAuthCookies).toHaveBeenCalledWith(req, res, {})
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith({ success: true })
+  })
+})

--- a/apps/watch-modern/pages/api/login.ts
+++ b/apps/watch-modern/pages/api/login.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { setAuthCookies } from 'next-firebase-auth'
+
+import { initAuth } from '../../src/libs/auth/initAuth'
+
+initAuth()
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    res.status(405).json({ error: 'Method Not Allowed' })
+    return
+  }
+  try {
+    await setAuthCookies(req, res, {})
+    res.status(200).json({ success: true })
+  } catch (error) {
+    console.error('Failed to set auth cookies during login.', error)
+    res.status(500).json({ error: 'Unexpected authentication error.' })
+  }
+}

--- a/apps/watch-modern/pages/api/logout.ts
+++ b/apps/watch-modern/pages/api/logout.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { unsetAuthCookies } from 'next-firebase-auth'
+
+import { initAuth } from '../../src/libs/auth/initAuth'
+
+initAuth()
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  try {
+    await unsetAuthCookies(req, res)
+    res.status(200).json({ success: true })
+  } catch (error) {
+    console.error('Failed to clear auth cookies during logout.', error)
+    res.status(500).json({ error: 'Unexpected logout error.' })
+  }
+}

--- a/apps/watch-modern/pages/api/refresh-token.ts
+++ b/apps/watch-modern/pages/api/refresh-token.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { setAuthCookies } from 'next-firebase-auth'
+
+import { initAuth } from '../../src/libs/auth/initAuth'
+
+initAuth()
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  try {
+    await setAuthCookies(req, res, {})
+    res.status(200).json({ success: true })
+  } catch (error) {
+    console.error('Failed to refresh auth cookies.', error)
+    res.status(500).json({ error: 'Unable to refresh authentication token.' })
+  }
+}

--- a/apps/watch-modern/pages/users/sign-in.tsx
+++ b/apps/watch-modern/pages/users/sign-in.tsx
@@ -1,0 +1,81 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
+
+import { SignInButton } from '../../src/components/auth/SignInButton'
+import { useAuthUser } from '../../src/hooks/useAuthUser'
+import { useRedirectAfterLogin } from '../../src/hooks/useRedirectAfterLogin'
+
+export default function SignInPage() {
+  const router = useRouter()
+  const { isAuthenticated } = useAuthUser()
+  const redirectAfterLogin = useRedirectAfterLogin()
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      void redirectAfterLogin()
+    }
+  }, [isAuthenticated, redirectAfterLogin])
+
+  return (
+    <>
+      <Head>
+        <title>Sign in | WatchModern Studio</title>
+      </Head>
+      <main className="flex min-h-screen items-center justify-center bg-stone-100 px-4 py-16">
+        <div className="w-full max-w-md rounded-3xl bg-white p-10 shadow-2xl">
+          <div className="space-y-4 text-center">
+            <h1 className="text-2xl font-semibold text-foreground">
+              Sign in to WatchModern Studio
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Use your Google account to unlock media uploads, AI image analysis, and higher daily prompt limits.
+            </p>
+          </div>
+          <div className="mt-8 space-y-4">
+            <SignInButton
+              className="w-full"
+              afterSignIn={() => redirectAfterLogin()}
+            >
+              Continue with Google
+            </SignInButton>
+            <p className="text-sm text-muted-foreground">
+              Prefer to explore without signing in?{' '}
+              <button
+                className="text-primary underline-offset-4 hover:underline"
+                type="button"
+                onClick={() => {
+                  void router.push('/studio/new')
+                }}
+              >
+                Return to the studio
+              </button>
+            </p>
+            <p className="text-xs text-muted-foreground">
+              By continuing, you agree to our{' '}
+              <Link
+                href="https://www.jesusfilm.org/terms-of-use"
+                className="text-primary underline-offset-4 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Terms of Use
+              </Link>{' '}
+              and{' '}
+              <Link
+                href="https://www.jesusfilm.org/privacy"
+                className="text-primary underline-offset-4 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Privacy Policy
+              </Link>
+              .
+            </p>
+          </div>
+        </div>
+      </main>
+    </>
+  )
+}

--- a/apps/watch-modern/src/components/auth/AuthRequiredDialog.tsx
+++ b/apps/watch-modern/src/components/auth/AuthRequiredDialog.tsx
@@ -1,0 +1,111 @@
+import { useMemo } from 'react'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '../ui/dialog'
+
+import { SignInButton } from './SignInButton'
+
+export type AuthRequirementReason =
+  | 'attachment'
+  | 'limit'
+  | 'media'
+  | 'unsplash'
+
+type AuthRequiredDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  reason: AuthRequirementReason
+  message?: string
+  remaining?: number
+  onSignInSuccess: () => Promise<void> | void
+}
+
+// Auth UX V4 enhancement
+const getDialogCopy = (
+  reason: AuthRequirementReason,
+  message?: string,
+  remaining?: number
+) => {
+  if (message) {
+    return {
+      title:
+        reason === 'attachment'
+          ? 'Sign in to add images'
+          : reason === 'media' || reason === 'unsplash'
+            ? 'Unlock media tools'
+            : 'Sign in for higher daily limits',
+      description: message
+    }
+  }
+
+  switch (reason) {
+    case 'attachment':
+      return {
+        title: 'Sign in to add images',
+        description:
+          'Image uploads, camera capture, and AI analysis are only available after signing in with Google.'
+      }
+    case 'media':
+    case 'unsplash':
+      return {
+        title: 'Unlock media tools',
+        description:
+          'Sign in with Google to explore Unsplash results and save media preferences for your projects.'
+      }
+    case 'limit':
+    default: {
+      const hasRemaining = remaining != null && Number.isFinite(remaining) && remaining > 0
+      const remainingLabel = remaining === 1 ? 'prompt' : 'prompts'
+      return {
+        title: 'Sign in for higher daily limits',
+        description: hasRemaining
+          ? `Only ${remaining} ${remainingLabel} remain before Google sign-in is required.`
+          : 'Guests can run up to five prompts per day. Sign in with Google to keep creating without interruption.'
+      }
+    }
+  }
+}
+
+// Auth UX V4 enhancement
+export function AuthRequiredDialog({
+  open,
+  onOpenChange,
+  reason,
+  message,
+  remaining,
+  onSignInSuccess
+}: AuthRequiredDialogProps) {
+  const { title, description } = useMemo(
+    () => getDialogCopy(reason, message, remaining),
+    [message, reason, remaining]
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[420px]">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <SignInButton
+            className="w-full"
+            variant="secondary"
+            afterSignIn={() => onSignInSuccess()}
+            onError={() => {
+              console.warn('Google sign-in was cancelled or failed.')
+            }}
+          >
+            Continue with Google
+          </SignInButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/watch-modern/src/components/auth/SignInButton.tsx
+++ b/apps/watch-modern/src/components/auth/SignInButton.tsx
@@ -1,0 +1,68 @@
+import { Loader2 } from 'lucide-react'
+import { getAuth, GoogleAuthProvider, signInWithPopup } from 'firebase/auth'
+import { useRouter } from 'next/router'
+import { useCallback, useState, type ReactNode } from 'react'
+
+import { Button } from '../ui/button'
+
+type SignInButtonProps = {
+  className?: string
+  children?: ReactNode
+  size?: 'default' | 'sm' | 'lg' | 'icon'
+  variant?: 'default' | 'secondary' | 'ghost' | 'outline'
+  afterSignIn?: () => Promise<void> | void
+  onError?: (error: unknown) => void
+}
+
+export function SignInButton({
+  className,
+  children,
+  size = 'default',
+  variant = 'default',
+  afterSignIn,
+  onError
+}: SignInButtonProps) {
+  const router = useRouter()
+  const [isSigningIn, setIsSigningIn] = useState(false)
+
+  const handleSignIn = useCallback(async () => {
+    if (isSigningIn) return
+
+    setIsSigningIn(true)
+    try {
+      const auth = getAuth()
+      const provider = new GoogleAuthProvider()
+      provider.setCustomParameters({ prompt: 'select_account' })
+      await signInWithPopup(auth, provider)
+      await afterSignIn?.()
+    } catch (error) {
+      console.error('Failed to sign in with Google.', error)
+      onError?.(error)
+      if (router.isFallback) {
+        console.warn('Router is in fallback mode during sign-in; state may not update immediately.')
+      }
+    } finally {
+      setIsSigningIn(false)
+    }
+  }, [afterSignIn, isSigningIn, onError, router.isFallback])
+
+  return (
+    <Button
+      type="button"
+      variant={variant}
+      size={size}
+      className={className}
+      onClick={() => void handleSignIn()}
+      disabled={isSigningIn}
+    >
+      {isSigningIn ? (
+        <span className="flex items-center gap-2">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span>Signing in…</span>
+        </span>
+      ) : (
+        children ?? 'Continue with Google'
+      )}
+    </Button>
+  )
+}

--- a/apps/watch-modern/src/components/newPage/MainPromptBlock.tsx
+++ b/apps/watch-modern/src/components/newPage/MainPromptBlock.tsx
@@ -63,6 +63,9 @@ type MainPromptBlockProps = {
     field: keyof PersonaSettings
   ) => (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void
   handlePersonaSubmit: FormEventHandler<HTMLFormElement>
+  canAttachImages: boolean
+  onRequestSignIn?: () => void
+  signInCta?: ReactElement
 }
 
 export function MainPromptBlock({
@@ -84,7 +87,10 @@ export function MainPromptBlock({
   aiResponse,
   personaSettings,
   handlePersonaFieldChange,
-  handlePersonaSubmit
+  handlePersonaSubmit,
+  canAttachImages,
+  onRequestSignIn,
+  signInCta
 }: MainPromptBlockProps): ReactElement {
   return (
     <div
@@ -166,16 +172,33 @@ export function MainPromptBlock({
         />
 
         {/* Camera button - bottom left */}
-        <div className="absolute bottom-3 left-3">
+        <div className="absolute bottom-3 left-3 flex flex-wrap items-center gap-2">
           <button
-            onClick={handleOpenCamera}
-            className="flex items-center gap-2 px-3 py-2 text-sm font-medium rounded-full bg-transparent text-foreground hover:bg-muted/30 transition-colors cursor-pointer"
-            title="Add image"
+            onClick={() => {
+              if (!canAttachImages) {
+                onRequestSignIn?.()
+                return
+              }
+              handleOpenCamera()
+            }}
+            className={`flex items-center gap-2 px-3 py-2 text-sm font-medium rounded-full bg-transparent transition-colors ${
+              canAttachImages
+                ? 'text-foreground hover:bg-muted/30 cursor-pointer'
+                : 'text-muted-foreground cursor-not-allowed'
+            }`}
+            title={
+              canAttachImages
+                ? 'Add image'
+                : 'Sign in to add images and analyze media attachments'
+            }
             type="button"
+            disabled={!canAttachImages}
+            aria-disabled={!canAttachImages}
           >
             <Camera className="w-4 h-4" />
             <span className="hidden md:inline">Add Image</span>
           </button>
+          {!canAttachImages && signInCta}
         </div>
 
         {/* Action buttons - bottom right */}

--- a/apps/watch-modern/src/env.ts
+++ b/apps/watch-modern/src/env.ts
@@ -7,6 +7,7 @@ export const env = createEnv({
    * isn't built with invalid env vars.
    */
   server: {
+    AUTH_SECRET: z.string().default('watch-modern-dev-secret'),
     ANALYZE: z
       .string()
       .optional()
@@ -36,7 +37,12 @@ export const env = createEnv({
     VERCEL_GIT_COMMIT_AUTHOR_LOGIN: z.string().optional(),
     VERCEL_GIT_COMMIT_AUTHOR_NAME: z.string().optional(),
     VERCEL_GIT_PREVIOUS_SHA: z.string().optional(),
-    VERCEL_GIT_PULL_REQUEST_ID: z.string().optional()
+    VERCEL_GIT_PULL_REQUEST_ID: z.string().optional(),
+    FIREBASE_CLIENT_EMAIL: z.string().optional(),
+    FIREBASE_PRIVATE_KEY: z.string().optional(),
+    PRIVATE_FIREBASE_CLIENT_EMAIL: z.string().optional(),
+    PRIVATE_FIREBASE_PRIVATE_KEY: z.string().optional(),
+    AUTH_SECRET_PREVIOUS: z.string().optional()
   },
 
   /**
@@ -60,7 +66,11 @@ export const env = createEnv({
         'ap2.datadoghq.com'
       ])
       .default('datadoghq.com'),
-    NEXT_PUBLIC_DATADOG_VERSION: z.string().optional()
+    NEXT_PUBLIC_DATADOG_VERSION: z.string().optional(),
+    NEXT_PUBLIC_FIREBASE_API_KEY: z.string().optional(),
+    NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: z.string().optional(),
+    NEXT_PUBLIC_FIREBASE_PROJECT_ID: z.string().optional(),
+    NEXT_PUBLIC_FIREBASE_APP_ID: z.string().optional()
   },
 
   /**
@@ -79,6 +89,10 @@ export const env = createEnv({
     NEXT_PUBLIC_DATADOG_ENV: process.env['VERCEL_ENV'],
     NEXT_PUBLIC_DATADOG_SITE: process.env['NEXT_PUBLIC_DATADOG_SITE'],
     NEXT_PUBLIC_DATADOG_VERSION: process.env['VERCEL_GIT_COMMIT_SHA'],
+    NEXT_PUBLIC_FIREBASE_API_KEY: process.env['NEXT_PUBLIC_FIREBASE_API_KEY'],
+    NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: process.env['NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN'],
+    NEXT_PUBLIC_FIREBASE_PROJECT_ID: process.env['NEXT_PUBLIC_FIREBASE_PROJECT_ID'],
+    NEXT_PUBLIC_FIREBASE_APP_ID: process.env['NEXT_PUBLIC_FIREBASE_APP_ID'],
     VERCEL: process.env['VERCEL'],
     VERCEL_ENV: process.env['VERCEL_ENV'],
     VERCEL_URL: process.env['VERCEL_URL'],
@@ -101,7 +115,12 @@ export const env = createEnv({
       process.env['VERCEL_GIT_COMMIT_AUTHOR_LOGIN'],
     VERCEL_GIT_COMMIT_AUTHOR_NAME: process.env['VERCEL_GIT_COMMIT_AUTHOR_NAME'],
     VERCEL_GIT_PREVIOUS_SHA: process.env['VERCEL_GIT_PREVIOUS_SHA'],
-    VERCEL_GIT_PULL_REQUEST_ID: process.env['VERCEL_GIT_PULL_REQUEST_ID']
+    VERCEL_GIT_PULL_REQUEST_ID: process.env['VERCEL_GIT_PULL_REQUEST_ID'],
+    FIREBASE_CLIENT_EMAIL: process.env['FIREBASE_CLIENT_EMAIL'],
+    FIREBASE_PRIVATE_KEY: process.env['FIREBASE_PRIVATE_KEY'],
+    PRIVATE_FIREBASE_CLIENT_EMAIL: process.env['PRIVATE_FIREBASE_CLIENT_EMAIL'],
+    PRIVATE_FIREBASE_PRIVATE_KEY: process.env['PRIVATE_FIREBASE_PRIVATE_KEY'],
+    AUTH_SECRET_PREVIOUS: process.env['AUTH_SECRET_PREVIOUS']
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/apps/watch-modern/src/hooks/useAuthRequiredDialog.spec.ts
+++ b/apps/watch-modern/src/hooks/useAuthRequiredDialog.spec.ts
@@ -1,0 +1,74 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { useAuthRequiredDialog } from './useAuthRequiredDialog'
+
+describe('useAuthRequiredDialog', () => {
+  it('opens for limit prompts and closes after sign-in', async () => {
+    const resumeAction = jest.fn()
+    const onSignedIn = jest.fn().mockResolvedValue(undefined)
+
+    const { result } = renderHook(() =>
+      useAuthRequiredDialog({
+        onSignedIn
+      })
+    )
+
+    act(() => {
+      result.current.requestAuth({
+        reason: 'limit',
+        message: 'Daily limit reached',
+        remaining: 0,
+        resumeAction
+      })
+    })
+
+    expect(result.current.isOpen).toBe(true)
+    expect(result.current.dialogState).toEqual({
+      reason: 'limit',
+      message: 'Daily limit reached',
+      remaining: 0
+    })
+
+    await act(async () => {
+      await result.current.onSignInSuccess()
+    })
+
+    expect(onSignedIn).toHaveBeenCalledTimes(1)
+    expect(result.current.isOpen).toBe(false)
+    expect(result.current.resumeRequested).toBe(true)
+
+    await act(async () => {
+      await result.current.runPendingAction()
+    })
+
+    expect(resumeAction).toHaveBeenCalledTimes(1)
+    expect(result.current.resumeRequested).toBe(false)
+  })
+
+  it('clears pending action when dialog closes without signing in', () => {
+    const resumeAction = jest.fn()
+    const { result } = renderHook(() => useAuthRequiredDialog())
+
+    act(() => {
+      result.current.requestAuth({
+        reason: 'attachment',
+        message: 'Sign in to add images',
+        resumeAction
+      })
+    })
+
+    expect(result.current.isOpen).toBe(true)
+
+    act(() => {
+      result.current.onOpenChange(false)
+    })
+
+    expect(result.current.isOpen).toBe(false)
+
+    act(() => {
+      void result.current.runPendingAction()
+    })
+
+    expect(resumeAction).not.toHaveBeenCalled()
+  })
+})

--- a/apps/watch-modern/src/hooks/useAuthRequiredDialog.ts
+++ b/apps/watch-modern/src/hooks/useAuthRequiredDialog.ts
@@ -1,0 +1,80 @@
+import { useCallback, useRef, useState } from 'react'
+
+import type { AuthRequirementReason } from '../components/auth/AuthRequiredDialog'
+
+type AuthDialogState = {
+  reason: AuthRequirementReason
+  message?: string
+  remaining?: number
+}
+
+type RequestAuthOptions = AuthDialogState & {
+  resumeAction?: () => Promise<void> | void
+}
+
+type UseAuthRequiredDialogOptions = {
+  onSignedIn?: () => Promise<void> | void
+}
+
+type UseAuthRequiredDialogReturn = {
+  dialogState: AuthDialogState | null
+  isOpen: boolean
+  requestAuth: (options: RequestAuthOptions) => void
+  onOpenChange: (open: boolean) => void
+  onSignInSuccess: () => Promise<void>
+  resumeRequested: boolean
+  runPendingAction: () => Promise<void>
+}
+
+// Auth UX V4 enhancement
+export function useAuthRequiredDialog({
+  onSignedIn
+}: UseAuthRequiredDialogOptions = {}): UseAuthRequiredDialogReturn {
+  const [dialogState, setDialogState] = useState<AuthDialogState | null>(null)
+  const pendingActionRef = useRef<(() => Promise<void> | void) | null>(null)
+  const [resumeRequested, setResumeRequested] = useState(false)
+
+  const requestAuth = useCallback((options: RequestAuthOptions) => {
+    pendingActionRef.current = options.resumeAction ?? null
+    setDialogState({
+      reason: options.reason,
+      message: options.message,
+      remaining: options.remaining
+    })
+  }, [])
+
+  const onOpenChange = useCallback((open: boolean) => {
+    if (!open) {
+      setDialogState(null)
+      pendingActionRef.current = null
+      setResumeRequested(false)
+    }
+  }, [])
+
+  const onSignInSuccess = useCallback(async () => {
+    setDialogState(null)
+    setResumeRequested(true)
+    if (onSignedIn) {
+      await onSignedIn()
+    }
+  }, [onSignedIn])
+
+  const runPendingAction = useCallback(async () => {
+    const action = pendingActionRef.current
+    pendingActionRef.current = null
+    setResumeRequested(false)
+    if (action) {
+      await action()
+    }
+  }, [])
+
+  return {
+    dialogState,
+    isOpen: dialogState != null,
+    requestAuth,
+    onOpenChange,
+    onSignInSuccess,
+    resumeRequested,
+    runPendingAction
+  }
+}

--- a/apps/watch-modern/src/hooks/useAuthUser.ts
+++ b/apps/watch-modern/src/hooks/useAuthUser.ts
@@ -1,0 +1,14 @@
+import { useUser } from 'next-firebase-auth'
+import { useMemo } from 'react'
+
+export function useAuthUser() {
+  const user = useUser()
+
+  return useMemo(
+    () => ({
+      user,
+      isAuthenticated: user?.id != null && user.id.length > 0
+    }),
+    [user]
+  )
+}

--- a/apps/watch-modern/src/hooks/useGuestPromptLimit.spec.tsx
+++ b/apps/watch-modern/src/hooks/useGuestPromptLimit.spec.tsx
@@ -1,0 +1,74 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import React, { useState } from 'react'
+
+import { GUEST_PROMPT_LIMIT, useGuestPromptLimit } from './useGuestPromptLimit'
+
+function GuestPromptHarness({ initialAuth = false }: { initialAuth?: boolean }) {
+  const [isAuthenticated, setIsAuthenticated] = useState(initialAuth)
+  const { remaining, isAtLimit, registerPrompt } = useGuestPromptLimit(isAuthenticated)
+
+  return (
+    <div>
+      <div data-testid="remaining">
+        {Number.isFinite(remaining) ? remaining : 'infinite'}
+      </div>
+      <div data-testid="isAtLimit">{isAtLimit ? 'true' : 'false'}</div>
+      <button type="button" onClick={() => registerPrompt()}>
+        register
+      </button>
+      <button type="button" onClick={() => setIsAuthenticated((prev) => !prev)}>
+        toggle
+      </button>
+    </div>
+  )
+}
+
+describe('useGuestPromptLimit', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('tracks guest prompt usage and persists to localStorage', () => {
+    const { unmount } = render(<GuestPromptHarness />)
+
+    expect(screen.getByTestId('remaining')).toHaveTextContent(
+      String(GUEST_PROMPT_LIMIT)
+    )
+    expect(screen.getByTestId('isAtLimit')).toHaveTextContent('false')
+
+    for (let index = 0; index < GUEST_PROMPT_LIMIT; index += 1) {
+      fireEvent.click(screen.getByText('register'))
+    }
+
+    expect(screen.getByTestId('remaining')).toHaveTextContent('0')
+    expect(screen.getByTestId('isAtLimit')).toHaveTextContent('true')
+
+    // re-render to verify state is restored from localStorage
+    unmount()
+    render(<GuestPromptHarness />)
+
+    expect(screen.getByTestId('remaining')).toHaveTextContent('0')
+    expect(screen.getByTestId('isAtLimit')).toHaveTextContent('true')
+  })
+
+  it('resets usage when the user signs in', () => {
+    render(<GuestPromptHarness />)
+
+    fireEvent.click(screen.getByText('register'))
+
+    expect(screen.getByTestId('remaining')).toHaveTextContent(
+      String(GUEST_PROMPT_LIMIT - 1)
+    )
+
+    fireEvent.click(screen.getByText('toggle'))
+
+    expect(screen.getByTestId('remaining')).toHaveTextContent('infinite')
+    expect(screen.getByTestId('isAtLimit')).toHaveTextContent('false')
+    expect(window.localStorage.getItem('watchModern.guestPromptUsage')).toBeNull()
+  })
+})

--- a/apps/watch-modern/src/hooks/useGuestPromptLimit.ts
+++ b/apps/watch-modern/src/hooks/useGuestPromptLimit.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+type GuestUsage = {
+  count: number
+  resetAt: number
+}
+
+const STORAGE_KEY = 'watchModern.guestPromptUsage'
+export const GUEST_PROMPT_LIMIT = 5
+
+const getDefaultUsage = (): GuestUsage => ({
+  count: 0,
+  resetAt: Date.now() + 24 * 60 * 60 * 1000
+})
+
+const readFromStorage = (): GuestUsage => {
+  if (typeof window === 'undefined') return getDefaultUsage()
+
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  if (raw == null) return getDefaultUsage()
+
+  try {
+    const parsed = JSON.parse(raw) as GuestUsage
+    if (typeof parsed.resetAt !== 'number' || typeof parsed.count !== 'number') {
+      throw new Error('Invalid shape')
+    }
+
+    if (Date.now() > parsed.resetAt) {
+      return getDefaultUsage()
+    }
+
+    return parsed
+  } catch (error) {
+    console.warn('Failed to parse guest prompt usage from storage. Resetting.', error)
+    return getDefaultUsage()
+  }
+}
+
+export const useGuestPromptLimit = (isAuthenticated: boolean) => {
+  const [usage, setUsage] = useState<GuestUsage>(getDefaultUsage)
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      setUsage(getDefaultUsage())
+      if (typeof window !== 'undefined') {
+        window.localStorage.removeItem(STORAGE_KEY)
+      }
+      return
+    }
+
+    setUsage(readFromStorage())
+  }, [isAuthenticated])
+
+  useEffect(() => {
+    if (isAuthenticated || typeof window === 'undefined') return
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(usage))
+  }, [isAuthenticated, usage])
+
+  const isAtLimit = useMemo(() => usage.count >= GUEST_PROMPT_LIMIT, [usage.count])
+
+  const remaining = useMemo(
+    () => (isAuthenticated ? Infinity : Math.max(GUEST_PROMPT_LIMIT - usage.count, 0)),
+    [isAuthenticated, usage.count]
+  )
+
+  const registerPrompt = useCallback(() => {
+    setUsage((prev) => {
+      const now = Date.now()
+      if (now > prev.resetAt) {
+        return {
+          count: 1,
+          resetAt: now + 24 * 60 * 60 * 1000
+        }
+      }
+
+      return {
+        ...prev,
+        count: Math.min(prev.count + 1, GUEST_PROMPT_LIMIT)
+      }
+    })
+  }, [])
+
+  return {
+    usage,
+    isAtLimit,
+    remaining,
+    registerPrompt
+  }
+}

--- a/apps/watch-modern/src/hooks/useImageAnalysis.ts
+++ b/apps/watch-modern/src/hooks/useImageAnalysis.ts
@@ -8,16 +8,24 @@ interface UseImageAnalysisOptions {
   extractTextFromResponse: (data: any) => string
   accumulateUsage: (usage: any) => void
   prompt: string
+  isEnabled?: boolean
+  onBlocked?: (resume: () => Promise<void> | void) => void
 }
 
 export const useImageAnalysis = ({
   setImageAnalysisResults,
   extractTextFromResponse,
   accumulateUsage,
-  prompt
+  prompt,
+  isEnabled = true,
+  onBlocked
 }: UseImageAnalysisOptions) => {
   const analyzeImageWithAI = useCallback(
     async (imageSrc: string, imageIndex: number) => {
+      if (!isEnabled) {
+        onBlocked?.(() => analyzeImageWithAI(imageSrc, imageIndex))
+        return
+      }
       setImageAnalysisResults((prev) => {
         const updated = [...prev]
         if (!updated[imageIndex]) {
@@ -133,7 +141,14 @@ export const useImageAnalysis = ({
         })
       }
     },
-    [accumulateUsage, extractTextFromResponse, prompt, setImageAnalysisResults]
+    [
+      accumulateUsage,
+      extractTextFromResponse,
+      isEnabled,
+      onBlocked,
+      prompt,
+      setImageAnalysisResults
+    ]
   )
 
   return { analyzeImageWithAI }

--- a/apps/watch-modern/src/hooks/useRedirectAfterLogin.spec.ts
+++ b/apps/watch-modern/src/hooks/useRedirectAfterLogin.spec.ts
@@ -1,0 +1,64 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { useRedirectAfterLogin } from './useRedirectAfterLogin'
+
+const mockReplace = jest.fn().mockResolvedValue(true)
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(() => ({
+    query: {},
+    replace: mockReplace
+  }))
+}))
+
+describe('useRedirectAfterLogin', () => {
+  beforeEach(() => {
+    mockReplace.mockClear()
+  })
+
+  it('defaults to /studio/new when no redirect query is present', async () => {
+    const { result } = renderHook(() => useRedirectAfterLogin())
+
+    await act(async () => {
+      await result.current()
+    })
+
+    expect(mockReplace).toHaveBeenCalledWith('/studio/new')
+  })
+
+  it('uses a safe redirect when provided', async () => {
+    const useRouter = jest.requireMock('next/router').useRouter as jest.Mock
+    useRouter.mockReturnValueOnce({
+      query: {
+        redirect: encodeURIComponent('http://localhost/studio/custom')
+      },
+      replace: mockReplace
+    })
+
+    const { result } = renderHook(() => useRedirectAfterLogin())
+
+    await act(async () => {
+      await result.current()
+    })
+
+    expect(mockReplace).toHaveBeenCalledWith('http://localhost/studio/custom')
+  })
+
+  it('falls back to the fallback URL for unsafe redirects', async () => {
+    const useRouter = jest.requireMock('next/router').useRouter as jest.Mock
+    useRouter.mockReturnValueOnce({
+      query: {
+        redirect: encodeURIComponent('https://malicious.example.com')
+      },
+      replace: mockReplace
+    })
+
+    const { result } = renderHook(() => useRedirectAfterLogin())
+
+    await act(async () => {
+      await result.current('/studio/new')
+    })
+
+    expect(mockReplace).toHaveBeenCalledWith('/studio/new')
+  })
+})

--- a/apps/watch-modern/src/hooks/useRedirectAfterLogin.ts
+++ b/apps/watch-modern/src/hooks/useRedirectAfterLogin.ts
@@ -1,0 +1,46 @@
+import { useRouter } from 'next/router'
+import { useCallback } from 'react'
+
+const isSafeRedirect = (target: string, origin: string): boolean => {
+  try {
+    const url = new URL(target)
+    return url.origin === origin
+  } catch {
+    try {
+      const fallback = new URL(target, origin)
+      return fallback.origin === origin
+    } catch {
+      return false
+    }
+  }
+}
+
+export function useRedirectAfterLogin(): (fallbackUrl?: string) => Promise<void> {
+  const router = useRouter()
+  const redirectParam = router.query['redirect']
+
+  return useCallback(
+    async (fallbackUrl: string = '/studio/new') => {
+      const origin = typeof window !== 'undefined' ? window.location.origin : ''
+      const encodedRedirect =
+        typeof redirectParam === 'string' ? redirectParam : undefined
+      let redirectCandidate: string | undefined
+
+      if (encodedRedirect != null) {
+        try {
+          redirectCandidate = decodeURIComponent(encodedRedirect)
+        } catch (error) {
+          console.warn('Failed to decode redirect parameter. Falling back to default.', error)
+        }
+      }
+
+      const destination =
+        redirectCandidate && origin && isSafeRedirect(redirectCandidate, origin)
+          ? redirectCandidate
+          : fallbackUrl
+
+      await router.replace(destination)
+    },
+    [redirectParam, router]
+  )
+}

--- a/apps/watch-modern/src/libs/auth/config.ts
+++ b/apps/watch-modern/src/libs/auth/config.ts
@@ -1,0 +1,47 @@
+const normalizePrivateKey = (key: string | undefined): string =>
+  key?.replace(/\\n/g, '\n') ?? ''
+
+const getCookieKeys = (): string[] => {
+  const current = process.env.AUTH_SECRET ?? 'watch-modern-dev-secret'
+  const previous = process.env.AUTH_SECRET_PREVIOUS
+
+  return previous != null && previous.length > 0 ? [current, previous] : [current]
+}
+
+export const authCookieName = 'watch-modern'
+
+export const firebaseAdminConfig = {
+  credential: {
+    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID ?? '',
+    clientEmail:
+      process.env.FIREBASE_CLIENT_EMAIL ??
+      process.env.PRIVATE_FIREBASE_CLIENT_EMAIL ??
+      '',
+    privateKey: normalizePrivateKey(
+      process.env.FIREBASE_PRIVATE_KEY ?? process.env.PRIVATE_FIREBASE_PRIVATE_KEY
+    )
+  }
+}
+
+export const firebaseClientConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY ?? '',
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN ?? '',
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID ?? '',
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID ?? ''
+}
+
+export const authCookiesConfig = {
+  name: authCookieName,
+  keys: getCookieKeys(),
+  httpOnly: true,
+  maxAge: 5 * 24 * 60 * 60 * 1000,
+  overwrite: true,
+  path: '/',
+  sameSite: 'lax' as const,
+  secure:
+    process.env.NODE_ENV === 'production' ||
+    process.env.NEXT_PUBLIC_VERCEL_ENV === 'prod' ||
+    process.env.NEXT_PUBLIC_VERCEL_ENV === 'stage' ||
+    process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview',
+  signed: true
+}

--- a/apps/watch-modern/src/libs/auth/initAuth.ts
+++ b/apps/watch-modern/src/libs/auth/initAuth.ts
@@ -1,0 +1,91 @@
+import absoluteUrl from 'next-absolute-url'
+import { init } from 'next-firebase-auth'
+
+import {
+  authCookieName,
+  authCookiesConfig,
+  firebaseAdminConfig,
+  firebaseClientConfig
+} from './config'
+
+let initialized = false
+
+const buildRedirectUrl = (input: string, origin: string): string => {
+  try {
+    const url = new URL(input, origin)
+    return url.toString()
+  } catch (error) {
+    console.warn('Failed to construct redirect URL. Falling back to studio home.', error)
+    return `${origin}/studio/new`
+  }
+}
+
+const isAllowedRedirect = (target: string, originHost: string): boolean => {
+  try {
+    const url = new URL(target)
+    return url.host === originHost
+  } catch {
+    return false
+  }
+}
+
+export const initAuth = (): void => {
+  if (initialized) return
+
+  init({
+    debug: process.env.NODE_ENV === 'development',
+    loginAPIEndpoint: '/studio/api/login',
+    logoutAPIEndpoint: '/studio/api/logout',
+    onLoginRequestError: (error) => {
+      console.error('Failed to log in via next-firebase-auth.', error)
+    },
+    firebaseAdminInitConfig: {
+      credential: firebaseAdminConfig.credential,
+      databaseURL: ''
+    },
+    firebaseClientInitConfig: firebaseClientConfig,
+    cookies: authCookiesConfig,
+    authPageURL: ({ ctx }) => {
+      const isServerSide = typeof window === 'undefined'
+      const origin = isServerSide ? absoluteUrl(ctx?.req).origin : window.location.origin
+      const redirectPath = isServerSide ? ctx?.resolvedUrl ?? '/' : window.location.href
+      const redirectUrl = buildRedirectUrl(redirectPath, origin)
+
+      return `/studio/users/sign-in?redirect=${encodeURIComponent(redirectUrl)}`
+    },
+    appPageURL: ({ ctx }) => {
+      const isServerSide = typeof window === 'undefined'
+      const origin = isServerSide ? absoluteUrl(ctx?.req).origin : window.location.origin
+      const originHost = new URL(origin).host
+      const params = isServerSide
+        ? new URL(ctx?.req.url ?? '/', origin).searchParams
+        : new URLSearchParams(window.location.search)
+      const encodedRedirect = params.get('redirect')
+
+      if (encodedRedirect != null) {
+        const redirect = decodeURIComponent(encodedRedirect)
+        if (isAllowedRedirect(redirect, originHost)) {
+          return redirect
+        }
+        console.warn('Blocked unsafe redirect attempt after authentication.', redirect)
+      }
+
+      return '/studio/new'
+    },
+    cookiesRedirectAllowedDomains: [
+      'localhost:3000',
+      'localhost:4200',
+      process.env.VERCEL_URL,
+      process.env.NEXT_PUBLIC_VERCEL_ENV === 'prod'
+        ? process.env.VERCEL_PROJECT_PRODUCTION_URL
+        : undefined
+    ].filter(Boolean) as string[]
+  })
+
+  initialized = true
+  if (process.env.NODE_ENV === 'development') {
+    console.info('WatchModern authentication initialized.')
+  }
+}
+
+export const authCookieHeaderName = `${authCookieName}.AuthUser`

--- a/prds/studio/watchmodern-auth-roadmap.md
+++ b/prds/studio/watchmodern-auth-roadmap.md
@@ -1,0 +1,53 @@
+# WatchModern Authentication Roadmap
+
+## Goal
+- Allow anyone to experiment with text-only prompts in the WatchModern studio while keeping premium actions (image attachments and higher request volume) gated behind Google sign-in.
+- Reuse the Firebase-based single sign-on pattern that already works in Videos Admin and Journeys Admin, adapting it to WatchModern's Next.js pages router and AI workflow on `/new`.
+
+## Reference Implementations
+
+### Videos Admin (Video Management app)
+- Uses Firebase client auth helpers that force in-memory persistence so the browser never stores long-lived credentials, then launches a Google popup for the user and exchanges the resulting ID token with the backend via `/api/login`.【F:apps/videos-admin/src/libs/auth/firebase.ts†L1-L52】【F:apps/videos-admin/src/app/users/sign-in/page.tsx†L20-L88】【F:apps/videos-admin/src/app/api/index.ts†L3-L37】
+- A middleware powered by `next-firebase-auth-edge` protects all non-public routes, wiring the Firebase service account, cookie serialization, and downstream GraphQL authorization check before allowing navigation.【F:apps/videos-admin/src/middleware.ts†L1-L86】【F:apps/videos-admin/src/libs/auth/config.ts†L1-L18】
+
+### Journeys Admin (Pages router application)
+- Initializes `next-firebase-auth` once in `_app` so both server and client can share Firebase configuration, cookie policy, and redirect helpers for sign-in/out routes.【F:apps/journeys-admin/pages/_app.tsx†L1-L136】【F:apps/journeys-admin/src/libs/firebaseClient/initAuth.ts†L6-L82】
+- The `/api/login` handler simply calls `setAuthCookies`, letting the package mint signed cookies after a Google popup completes on the client side.【F:apps/journeys-admin/pages/api/login.tsx†L1-L18】【F:apps/journeys-admin/src/components/SignIn/SignInServiceButton/SignInServiceButton.tsx†L1-L50】
+
+**Key takeaways for WatchModern**
+1. Both apps rely on Firebase ID tokens exchanged for HTTP-only cookies, ensuring SSR requests have access to authenticated identity.
+2. Videos Admin shows how to centralize route protection in middleware; Journeys Admin shows a lighter-weight approach that suits a pages-router codebase like WatchModern.
+3. Client sign-in buttons simply trigger `signInWithPopup` with a Google provider configured to prompt account selection.
+
+## Recommended Approach for WatchModern
+- Start with the Journeys Admin pattern (`next-firebase-auth`) because WatchModern already uses the pages router (`pages/_app.tsx`) and needs granular gating rather than a hard redirect on every page load.【F:apps/watch-modern/pages/_app.tsx†L1-L21】
+- Keep the Videos Admin middleware in mind for future migration to the app router or for protecting API routes that must always be authenticated.
+
+## Phased Roadmap
+
+### Phase 1 – Firebase & Session Infrastructure
+1. **Add shared Firebase config:** create `apps/watch-modern/src/libs/auth/config.ts` that mirrors the environment-driven settings from Videos Admin (`apiKey`, `authDomain`, `projectId`, `appId`, plus server-side service account keys).【F:apps/videos-admin/src/libs/auth/config.ts†L1-L18】
+2. **Initialize `next-firebase-auth`:** add `src/libs/auth/initAuth.ts` and call it from `pages/_app.tsx`, following Journeys Admin's pattern so SSR and client code can read session cookies.【F:apps/journeys-admin/src/libs/firebaseClient/initAuth.ts†L6-L82】【F:apps/journeys-admin/pages/_app.tsx†L20-L24】
+3. **Implement API handlers:** add `pages/api/login.ts`, `pages/api/logout.ts`, and (optionally) `pages/api/refresh-token.ts` using the helper exports from `next-firebase-auth-edge` or `next-firebase-auth` to exchange ID tokens for cookies, mirroring the fetches already used in Videos Admin's client helper.【F:apps/videos-admin/src/app/api/index.ts†L3-L37】
+4. **Expose auth context hook:** create `useAuthUser` (thin wrapper around `useUser` from `next-firebase-auth`) so feature gating in React components is ergonomic.
+
+### Phase 2 – Client Sign-In & UX
+1. **Build Google sign-in button:** reuse the pattern from Journeys Admin's `SignInServiceButton` (Google provider, popup flow, `select_account` prompt) to create a `SignInButton` component under `src/components/auth`.【F:apps/journeys-admin/src/components/SignIn/SignInServiceButton/SignInServiceButton.tsx†L18-L50】
+2. **Add authentication drawer/modal:** surface the button inside WatchModern's `/new` experience so users can sign in without leaving context. `MainPromptBlock` already renders the image picker and submit actions, making it a natural insertion point for gated prompts.【F:apps/watch-modern/src/components/newPage/MainPromptBlock.tsx†L68-L200】
+3. **Handle post-login redirect:** mimic Videos Admin’s `useRedirectAfterLogin` strategy so the app returns users to the prompt they were editing after successful sign-in.【F:apps/videos-admin/src/app/users/sign-in/page.tsx†L20-L88】
+
+### Phase 3 – Feature Gating & Usage Limits
+1. **Gate image attachments:** before calling `handleOpenCamera` or accepting pasted images in `MainPromptBlock`, check `authUser`. If unauthenticated, show a call-to-action modal leading to the sign-in component and block the action.【F:apps/watch-modern/src/components/newPage/MainPromptBlock.tsx†L148-L199】
+2. **Track daily prompt count:** instrument the submit handler defined in `pages/new.tsx` to count completed prompt runs. Persist guest usage in a signed, short-lived cookie or local storage token, and enforce a server-side cap (e.g., via a `pages/api/prompts` handler that rejects when anonymous requests exceed five per 24 hours).【F:apps/watch-modern/pages/new.tsx†L1-L200】
+3. **Enforce limits server-side:** when requests hit backend AI services, inspect the Firebase user ID from cookies; for anonymous sessions, derive a hashed device fingerprint from the guest cookie so limits cannot be bypassed with simple reloads.
+4. **Upgrade attachment flows:** ensure media analysis hooks (`useImageAnalysis`, `useUnsplashMedia`) short-circuit if the user is not authenticated, guiding them to sign in before continuing.【F:apps/watch-modern/pages/new.tsx†L52-L98】
+
+### Phase 4 – Observability & QA
+1. **Add logging/analytics:** emit telemetry when users hit the limit or attempt gated actions without signing in to size demand for higher quotas.
+2. **Automated tests:** add unit tests for the auth helpers and integration tests that simulate the guest prompt limit, similar to how Videos Admin verifies role checks inside middleware.【F:apps/videos-admin/src/middleware.ts†L33-L86】
+3. **Document support playbook:** update PRD/README with troubleshooting steps for Firebase configuration, token refresh, and guest-limit resets.
+
+## Open Questions & Follow-Ups
+- Decide whether to share Firebase project credentials with existing apps or provision a dedicated WatchModern project to isolate quotas.
+- Determine persistence for guest usage counters (signed cookies vs. backend storage keyed by anonymous token) to balance ease of implementation with abuse prevention.
+- Evaluate whether certain API routes (e.g., exports, saved drafts) require the stricter `next-firebase-auth-edge` middleware later, borrowing Videos Admin’s pattern once the pages router migrates to the app router.


### PR DESCRIPTION
## Summary
- replace the legacy sign-in prompt with an AuthRequiredDialog that resumes gated actions after Google login
- guard /studio/api/login behind POST, decode redirect hints, and add focused Jest coverage for the new auth flows
- document the Auth UX V4 rollout in the watch PRD log

## Testing
- pnpm dlx nx test watch-modern --testFile=apps/watch-modern/pages/api/login.spec.ts
- pnpm dlx nx test watch-modern --testFile=apps/watch-modern/src/hooks/useAuthRequiredDialog.spec.ts
- pnpm dlx nx test watch-modern --testFile=apps/watch-modern/src/hooks/useRedirectAfterLogin.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_6900da6ae938832889af360710c3c121