### PR TITLE
chore: add ripgrep to dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,7 +32,7 @@ RUN echo 'Acquire::http::Pipeline-Depth 0;' > /etc/apt/apt.conf.d/99fixbadproxy 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends gnupg2 libpixman-1-dev libcairo2-dev \
     libpango1.0-dev postgresql-client-13 chromium apt-transport-https ca-certificates curl \
-    gnupg doppler ffmpeg
+    gnupg doppler ffmpeg ripgrep
 
 # [Optional] Uncomment if you want to install an additional version of node using nvm
 # ARG EXTRA_NODE_VERSION=20


### PR DESCRIPTION
AI always wants ripgrep over grep, so add it to the dockerfile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration with additional system tools to support development workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->