### PR TITLE
feat(watch-modern): add API basic auth middleware

### DIFF
--- a/apps/watch-modern/middleware.spec.ts
+++ b/apps/watch-modern/middleware.spec.ts
@@ -2,8 +2,28 @@ import { NextRequest } from 'next/server'
 
 import { config, middleware } from './middleware'
 
+const globalWithOptionalAtob = globalThis as typeof globalThis & {
+  atob?: (value: string) => string
+}
+
 describe('middleware', () => {
   const originalEnv = process.env
+  const originalAtob = globalWithOptionalAtob.atob
+
+  beforeAll(() => {
+    if (!globalWithOptionalAtob.atob) {
+      globalWithOptionalAtob.atob = (value: string) =>
+        Buffer.from(value, 'base64').toString('utf-8')
+    }
+  })
+
+  afterAll(() => {
+    if (originalAtob) {
+      globalWithOptionalAtob.atob = originalAtob
+    } else {
+      Reflect.deleteProperty(globalWithOptionalAtob, 'atob')
+    }
+  })
 
   beforeEach(() => {
     process.env = { ...originalEnv }

--- a/apps/watch-modern/middleware.ts
+++ b/apps/watch-modern/middleware.ts
@@ -6,12 +6,12 @@ const UNAUTHORIZED_RESPONSE = {
 } as const
 
 const decodeCredentials = (encoded: string): string | undefined => {
-  try {
-    if (typeof globalThis.atob === 'function') {
-      return globalThis.atob(encoded)
-    }
+  if (typeof globalThis.atob !== 'function') {
+    return undefined
+  }
 
-    return Buffer.from(encoded, 'base64').toString('utf-8')
+  try {
+    return globalThis.atob(encoded)
   } catch {
     return undefined
   }


### PR DESCRIPTION
## Summary
- add a Next.js middleware to enforce BASIC auth on watch-modern API routes
- cover the middleware behavior and matcher configuration with unit tests

## Testing
- pnpm dlx nx test watch-modern *(fails: EditorHeader site selector > opens and closes the site selector menu)*

------
https://chatgpt.com/codex/tasks/task_e_69016e9badc08328bffe237855f1006e