### PR TITLE
feat(watch): reuse search language dropdown in header

### DIFF
--- a/apps/watch/src/components/Header/BottomAppBar/BottomAppBar.tsx
+++ b/apps/watch/src/components/Header/BottomAppBar/BottomAppBar.tsx
@@ -1,0 +1,88 @@
+import Box from '@mui/material/Box'
+import Container from '@mui/material/Container'
+import Fade from '@mui/material/Fade'
+import Stack from '@mui/material/Stack'
+import Toolbar from '@mui/material/Toolbar'
+import { ReactElement } from 'react'
+
+import { HeaderTabButtons } from '../HeaderTabButtons'
+
+interface BottomAppBarProps {
+  lightTheme?: boolean
+  bottomBarTrigger?: boolean
+  shouldFade?: boolean
+}
+
+export function BottomAppBar({
+  lightTheme = true,
+  bottomBarTrigger = false,
+  shouldFade = false
+}: BottomAppBarProps): ReactElement {
+  const lightStyles = {
+    backgroundImage:
+      'linear-gradient(rgb(255 255 255 / 60%), rgb(255 255 255 / 26%))',
+    backdropFilter: 'blur(20px) brightness(1.1)',
+    WebkitBackdropFilter: 'blur(20px) brightness(1.1)'
+  }
+
+  const darkStyles = {
+    backgroundImage: 'linear-gradient(rgb(0 0 0 / 60%), rgb(0 0 0 / 26%))',
+    backdropFilter: 'blur(20px) brightness(0.9)',
+    WebkitBackdropFilter: 'blur(20px) brightness(0.9)'
+  }
+  const appBarStyles = lightTheme ? lightStyles : darkStyles
+
+  return (
+    <Fade
+      appear={false}
+      in={shouldFade}
+      style={{
+        transitionDelay: shouldFade ? undefined : '2s',
+        transitionDuration: '225ms'
+      }}
+      timeout={{ exit: 2225 }}
+    >
+      <Stack
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          height: 80,
+          position: bottomBarTrigger ? 'fixed' : 'absolute',
+          top: 0,
+          width: '100%',
+          zIndex: 3,
+          background: 'transparent',
+          '&::before': {
+            content: "' '",
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            bottom: 0,
+            right: 0,
+            opacity: bottomBarTrigger ? 1 : 0,
+            ...appBarStyles,
+            transition: 'opacity 0.3s ease'
+          }
+        }}
+      >
+        <Container
+          data-testid="BottomAppBar"
+          maxWidth="xl"
+          disableGutters
+          sx={{
+            px: 4,
+            color: 'text.primary',
+            background: 'transparent',
+            boxShadow: 'none'
+          }}
+        >
+          <Toolbar disableGutters>
+            <Box sx={{ width: '100%' }}>
+              <HeaderTabButtons />
+            </Box>
+          </Toolbar>
+        </Container>
+      </Stack>
+    </Fade>
+  )
+}

--- a/apps/watch/src/components/Header/BottomAppBar/index.ts
+++ b/apps/watch/src/components/Header/BottomAppBar/index.ts
@@ -1,0 +1,1 @@
+export { BottomAppBar } from './BottomAppBar'

--- a/apps/watch/src/components/Header/Header.spec.tsx
+++ b/apps/watch/src/components/Header/Header.spec.tsx
@@ -9,6 +9,10 @@ jest.mock('@mui/material/useScrollTrigger', () => ({
   default: jest.fn()
 }))
 
+jest.mock('../SearchComponent/LanguageSelector', () => ({
+  LanguageSelector: () => <div data-testid="LanguageSelector" />
+}))
+
 const useScrollTriggerMock = useScrollTrigger as jest.Mock
 
 describe('Header', () => {
@@ -71,5 +75,14 @@ describe('Header', () => {
       </MockedProvider>
     )
     expect(screen.queryByTestId('TopAppBar')).not.toBeInTheDocument()
+  })
+
+  it('should render language selector when enabled', () => {
+    render(
+      <MockedProvider>
+        <Header showLanguageSwitcher />
+      </MockedProvider>
+    )
+    expect(screen.getByTestId('LanguageSelector')).toBeInTheDocument()
   })
 })

--- a/apps/watch/src/components/Header/Header.tsx
+++ b/apps/watch/src/components/Header/Header.tsx
@@ -1,39 +1,73 @@
 import Box from '@mui/material/Box'
 import Container from '@mui/material/Container'
+import { useTheme } from '@mui/material/styles'
 import SwipeableDrawer from '@mui/material/SwipeableDrawer'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import useScrollTrigger from '@mui/material/useScrollTrigger'
 import { ReactElement, useState } from 'react'
 
+import { useFlags } from '@core/shared/ui/FlagsProvider'
 import { ThemeProvider } from '@core/shared/ui/ThemeProvider'
 import { ThemeMode, ThemeName } from '@core/shared/ui/themes'
 
+import { BottomAppBar } from './BottomAppBar'
 import { HeaderMenuPanel } from './HeaderMenuPanel'
+import { LocalAppBar } from './LocalAppBar'
 
-/**
- * Props for the Header component.
- * @interface HeaderProps
- */
 interface HeaderProps {
-  /** Theme mode to apply to the header. */
+  hideTopAppBar?: boolean
+  hideBottomAppBar?: boolean
+  hideSpacer?: boolean
   themeMode?: ThemeMode
+  showLanguageSwitcher?: boolean
 }
 
-/**
- * Header component for the application.
- *
- * Renders a swipeable drawer for navigation menu.
- *
- * @param {HeaderProps} props - Component props.
- * @returns {ReactElement} Rendered Header component.
- */
 export function Header({
-  themeMode = ThemeMode.light
+  hideTopAppBar,
+  hideBottomAppBar,
+  hideSpacer,
+  themeMode = ThemeMode.light,
+  showLanguageSwitcher = false
 }: HeaderProps): ReactElement {
-  /** State to control the drawer open/closed state. */
   const [drawerOpen, setDrawerOpen] = useState(false)
+  const theme = useTheme()
+  const isXS = useMediaQuery(theme.breakpoints.only('xs'))
+  const lightTheme = themeMode === ThemeMode.light
+  const { strategies, journeys } = useFlags()
+
+  const bottomBarTrigger = useScrollTrigger({
+    disableHysteresis: true,
+    threshold: isXS ? 100 : 159
+  })
+
+  const shouldShowBottomAppBar = strategies || journeys
+  const shouldFade = hideBottomAppBar !== true || bottomBarTrigger
 
   return (
     <>
       <ThemeProvider themeName={ThemeName.website} themeMode={themeMode} nested>
+        {!hideTopAppBar && (
+          <Box sx={{ background: 'background.default' }}>
+            <LocalAppBar
+              hideSpacer={hideSpacer}
+              onMenuClick={() => setDrawerOpen((prev) => !prev)}
+              menuOpen={drawerOpen}
+              showLanguageSwitcher={showLanguageSwitcher}
+            />
+          </Box>
+        )}
+        {shouldShowBottomAppBar && (
+          <Box sx={{ position: 'relative' }}>
+            {!hideSpacer && (
+              <Box data-testid="HeaderSpacer" sx={{ height: 80 }} />
+            )}
+            <BottomAppBar
+              lightTheme={lightTheme}
+              bottomBarTrigger={bottomBarTrigger}
+              shouldFade={shouldFade}
+            />
+          </Box>
+        )}
       </ThemeProvider>
       <ThemeProvider
         themeName={ThemeName.website}

--- a/apps/watch/src/components/Header/LocalAppBar/LocalAppBar.tsx
+++ b/apps/watch/src/components/Header/LocalAppBar/LocalAppBar.tsx
@@ -1,0 +1,169 @@
+import AppBar, { AppBarProps } from '@mui/material/AppBar'
+import Box from '@mui/material/Box'
+import Container from '@mui/material/Container'
+import IconButton from '@mui/material/IconButton'
+import Stack from '@mui/material/Stack'
+import Image from 'next/image'
+import NextLink from 'next/link'
+import { MouseEventHandler, ReactElement } from 'react'
+
+import { LanguageSelector } from '../../SearchComponent/LanguageSelector'
+import logo from '../assets/logo.svg'
+
+interface LocalAppBarProps extends AppBarProps {
+  onMenuClick: MouseEventHandler<HTMLButtonElement>
+  hideSpacer?: boolean
+  menuOpen?: boolean
+  showLanguageSwitcher?: boolean
+}
+
+export function LocalAppBar({
+  onMenuClick,
+  hideSpacer = false,
+  menuOpen = false,
+  showLanguageSwitcher = false,
+  ...props
+}: LocalAppBarProps): ReactElement {
+  return (
+    <AppBar
+      data-testid="TopAppBar"
+      position="static"
+      {...props}
+      sx={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        background: 'transparent',
+        color: hideSpacer ? 'background.default' : 'inherit',
+        boxShadow: 'none',
+        py: 10,
+        pt: { lg: '69px' },
+        pb: { lg: 14 },
+        height: { xs: 100, lg: 159 },
+        width: '100%',
+        ...props.sx
+      }}
+    >
+      <Container maxWidth="xxl" disableGutters sx={{ px: 8 }}>
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+          flexGrow={1}
+        >
+          <Box
+            component={NextLink}
+            href="https://www.jesusfilm.org/"
+            data-testid="WatchLogo"
+            sx={{
+              width: { xs: 126, lg: 186 },
+              mt: { xs: 1.2, lg: 3.5 },
+              mb: { xs: -1.2, lg: -3.5 },
+              zIndex: (theme) => ({ xs: theme.zIndex.drawer + 1, lg: 0 })
+            }}
+            locale={false}
+          >
+            <Image
+              src={logo}
+              alt="Watch Logo"
+              style={{
+                cursor: 'pointer',
+                maxWidth: '100%',
+                height: 'auto',
+                width: 'auto'
+              }}
+            />
+          </Box>
+          <Box
+            data-testid="MenuBox"
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: { xs: 2, md: 3 }
+            }}
+          >
+            {showLanguageSwitcher && (
+              <Box
+                data-testid="LanguageSelector"
+                sx={{
+                  minWidth: { xs: 140, sm: 200, lg: 240 },
+                  maxWidth: 280,
+                  mr: { xs: 0, md: 2 },
+                  position: 'relative'
+                }}
+              >
+                <LanguageSelector
+                  containerClassName="w-full"
+                  triggerClassName="h-11 px-4 text-sm"
+                />
+              </Box>
+            )}
+
+            <IconButton
+              data-testid="MenuIcon"
+              color="inherit"
+              aria-label="open header menu"
+              edge="start"
+              onClick={onMenuClick}
+              disableRipple
+              className={menuOpen ? 'expanded' : ''}
+              aria-expanded={menuOpen}
+              sx={{
+                width: 39,
+                height: 30,
+                p: 0,
+                position: 'relative',
+                zIndex: (theme) => theme.zIndex.drawer + 1,
+                '& span': {
+                  display: 'block',
+                  position: 'absolute',
+                  width: '100%',
+                  height: 6,
+                  borderRadius: 6,
+                  backgroundColor: 'text.secondary',
+                  opacity: 1,
+                  left: 0,
+                  transform: 'rotate(0deg)',
+                  transition: '0.15s ease-in-out',
+                  '&:nth-of-type(1)': {
+                    top: 0
+                  },
+                  '&:nth-of-type(2)': {
+                    top: 12
+                  },
+                  '&:nth-of-type(3)': {
+                    top: 12
+                  },
+                  '&:nth-of-type(4)': {
+                    top: 24
+                  }
+                },
+                '&.expanded': {
+                  '& span': {
+                    '&:nth-of-type(1), &:nth-of-type(4)': {
+                      top: 15,
+                      width: '0%',
+                      left: '50%',
+                      opacity: 0
+                    },
+                    '&:nth-of-type(2)': {
+                      transform: 'rotate(45deg)'
+                    },
+                    '&:nth-of-type(3)': {
+                      transform: 'rotate(-45deg)'
+                    }
+                  }
+                }
+              }}
+            >
+              <span />
+              <span />
+              <span />
+              <span />
+            </IconButton>
+          </Box>
+        </Stack>
+      </Container>
+    </AppBar>
+  )
+}

--- a/apps/watch/src/components/Header/LocalAppBar/index.ts
+++ b/apps/watch/src/components/Header/LocalAppBar/index.ts
@@ -1,0 +1,1 @@
+export { LocalAppBar } from './LocalAppBar'

--- a/apps/watch/src/components/SearchComponent/LanguageSelector.tsx
+++ b/apps/watch/src/components/SearchComponent/LanguageSelector.tsx
@@ -24,8 +24,26 @@ interface LanguageOption {
   count?: number
 }
 
+interface LanguageSelectorProps {
+  /**
+   * Optional class name applied to the outer container. Useful for constraining width
+   * or adjusting layout when reusing the selector in different contexts (e.g. header).
+   */
+  containerClassName?: string
+  /**
+   * Optional class name applied to the trigger button. Allows downstream components
+   * to tweak spacing, font sizing, or height without duplicating component logic.
+   */
+  triggerClassName?: string
+}
+
+const defaultTriggerClassName = 'w-full justify-between cursor-pointer h-12'
+
 // Single-select language filter component
-export function LanguageSelector(): JSX.Element {
+export function LanguageSelector({
+  containerClassName,
+  triggerClassName
+}: LanguageSelectorProps = {}): JSX.Element {
   const { t } = useTranslation('apps-watch')
   const { items, refine } = useRefinementList(languageRefinementProps)
   const { languages, isLoading: languagesLoading } = useLanguages()
@@ -129,13 +147,17 @@ export function LanguageSelector(): JSX.Element {
 
   if (languagesLoading) {
     return (
-      <div className="relative">
-      <Button
-        variant="outline"
-        role="combobox"
-        disabled
-        className="w-full justify-between opacity-50 h-12 px-4"
-      >
+      <div className={cn('relative', containerClassName)}>
+        <Button
+          variant="outline"
+          role="combobox"
+          disabled
+          className={cn(
+            defaultTriggerClassName,
+            'opacity-50 px-4',
+            triggerClassName
+          )}
+        >
           <div className="flex items-center">
             <Globe className="mr-2 h-4 w-4 text-muted-foreground" />
             <span>{t('Loading languages...')}</span>
@@ -147,13 +169,16 @@ export function LanguageSelector(): JSX.Element {
   }
 
   return (
-    <div className="relative" ref={containerRef}>
+    <div
+      className={cn('relative', containerClassName)}
+      ref={containerRef}
+    >
       <Button
         variant="outline"
         role="combobox"
         aria-expanded={open}
         onClick={() => setOpen(!open)}
-        className="w-full justify-between cursor-pointer h-12"
+        className={cn(defaultTriggerClassName, triggerClassName)}
       >
         <div className="flex items-center">
           <Globe className="mr-2 h-5 w-5 text-muted-foreground" />


### PR DESCRIPTION
## Summary
- restore the local header app bar and bottom app bar so the navigation drawer and spacer logic continue to work
- reuse the search modal language selector inside the header by adapting LocalAppBar and exposing sizing hooks in the selector component
- expand header test coverage to ensure the language selector renders when enabled

## Testing
- pnpm dlx jest --config apps/watch/jest.config.ts --findRelatedTests apps/watch/src/components/Header/Header.tsx *(fails: suite pulls in unrelated specs with existing issues such as missing `variant` mocks)*

------
https://chatgpt.com/codex/tasks/task_e_690568ad3c908328a0d47b95fc61476a