### PR TITLE
feat(watch): reuse search language selector in header

### DIFF
--- a/apps/watch/src/components/Header/BottomAppBar/BottomAppBar.spec.tsx
+++ b/apps/watch/src/components/Header/BottomAppBar/BottomAppBar.spec.tsx
@@ -1,0 +1,24 @@
+import Fade from '@mui/material/Fade'
+import { render, screen } from '@testing-library/react'
+
+import { BottomAppBar } from './BottomAppBar'
+
+describe('BottomAppBar', () => {
+  it('should render the header tab buttons', () => {
+    render(<BottomAppBar />)
+
+    expect(screen.getByTestId('HeaderBottomAppBar')).toBeInTheDocument()
+  })
+
+  it('should render fade component with correct props', () => {
+    const { container } = render(
+      <BottomAppBar bottomBarTrigger shouldFade lightTheme={false} />
+    )
+
+    const fadeComponent = container.querySelectorAll(
+      `[data-testid="HeaderBottomAppBar"]`
+    )
+    expect(fadeComponent.length).toBeGreaterThan(0)
+    expect(Fade).toBeDefined()
+  })
+})

--- a/apps/watch/src/components/Header/BottomAppBar/BottomAppBar.tsx
+++ b/apps/watch/src/components/Header/BottomAppBar/BottomAppBar.tsx
@@ -1,0 +1,88 @@
+import Box from '@mui/material/Box'
+import Container from '@mui/material/Container'
+import Fade from '@mui/material/Fade'
+import Stack from '@mui/material/Stack'
+import Toolbar from '@mui/material/Toolbar'
+import { ReactElement } from 'react'
+
+import { HeaderTabButtons } from '../HeaderTabButtons'
+
+interface BottomAppBarProps {
+  lightTheme?: boolean
+  bottomBarTrigger?: boolean
+  shouldFade?: boolean
+}
+
+export function BottomAppBar({
+  lightTheme = true,
+  bottomBarTrigger = false,
+  shouldFade = false
+}: BottomAppBarProps): ReactElement {
+  const lightStyles = {
+    backgroundImage:
+      'linear-gradient(rgb(255 255 255 / 60%), rgb(255 255 255 / 26%))',
+    backdropFilter: 'blur(20px) brightness(1.1)',
+    WebkitBackdropFilter: 'blur(20px) brightness(1.1)'
+  }
+
+  const darkStyles = {
+    backgroundImage: 'linear-gradient(rgb(0 0 0 / 60%), rgb(0 0 0 / 26%))',
+    backdropFilter: 'blur(20px) brightness(0.9)',
+    WebkitBackdropFilter: 'blur(20px) brightness(0.9)'
+  }
+  const appBarStyles = lightTheme ? lightStyles : darkStyles
+
+  return (
+    <Fade
+      appear={false}
+      in={shouldFade}
+      style={{
+        transitionDelay: shouldFade ? undefined : '2s',
+        transitionDuration: '225ms'
+      }}
+      timeout={{ exit: 2225 }}
+    >
+      <Stack
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          height: 80,
+          position: bottomBarTrigger ? 'fixed' : 'absolute',
+          top: 0,
+          width: '100%',
+          zIndex: 3,
+          background: 'transparent',
+          '&::before': {
+            content: "' '",
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            bottom: 0,
+            right: 0,
+            opacity: bottomBarTrigger ? 1 : 0,
+            ...appBarStyles,
+            transition: 'opacity 0.3s ease'
+          }
+        }}
+      >
+        <Container
+          data-testid="HeaderBottomAppBar"
+          maxWidth="xl"
+          disableGutters
+          sx={{
+            px: 4,
+            color: 'text.primary',
+            background: 'transparent',
+            boxShadow: 'none'
+          }}
+        >
+          <Toolbar disableGutters>
+            <Box sx={{ width: '100%' }}>
+              <HeaderTabButtons />
+            </Box>
+          </Toolbar>
+        </Container>
+      </Stack>
+    </Fade>
+  )
+}

--- a/apps/watch/src/components/Header/BottomAppBar/index.ts
+++ b/apps/watch/src/components/Header/BottomAppBar/index.ts
@@ -1,0 +1,1 @@
+export { BottomAppBar } from './BottomAppBar'

--- a/apps/watch/src/components/Header/Header.tsx
+++ b/apps/watch/src/components/Header/Header.tsx
@@ -1,39 +1,73 @@
 import Box from '@mui/material/Box'
 import Container from '@mui/material/Container'
+import { useTheme } from '@mui/material/styles'
 import SwipeableDrawer from '@mui/material/SwipeableDrawer'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import useScrollTrigger from '@mui/material/useScrollTrigger'
 import { ReactElement, useState } from 'react'
 
+import { useFlags } from '@core/shared/ui/FlagsProvider'
 import { ThemeProvider } from '@core/shared/ui/ThemeProvider'
 import { ThemeMode, ThemeName } from '@core/shared/ui/themes'
 
+import { BottomAppBar } from './BottomAppBar'
 import { HeaderMenuPanel } from './HeaderMenuPanel'
+import { LocalAppBar } from './LocalAppBar'
 
-/**
- * Props for the Header component.
- * @interface HeaderProps
- */
 interface HeaderProps {
-  /** Theme mode to apply to the header. */
+  hideTopAppBar?: boolean
+  hideBottomAppBar?: boolean
+  hideSpacer?: boolean
   themeMode?: ThemeMode
+  showLanguageSwitcher?: boolean
 }
 
-/**
- * Header component for the application.
- *
- * Renders a swipeable drawer for navigation menu.
- *
- * @param {HeaderProps} props - Component props.
- * @returns {ReactElement} Rendered Header component.
- */
 export function Header({
-  themeMode = ThemeMode.light
+  hideTopAppBar,
+  hideBottomAppBar,
+  hideSpacer,
+  themeMode = ThemeMode.light,
+  showLanguageSwitcher = false
 }: HeaderProps): ReactElement {
-  /** State to control the drawer open/closed state. */
   const [drawerOpen, setDrawerOpen] = useState(false)
+  const theme = useTheme()
+  const isXS = useMediaQuery(theme.breakpoints.only('xs'))
+  const lightTheme = themeMode === ThemeMode.light
+  const { strategies, journeys } = useFlags()
+
+  const bottomBarTrigger = useScrollTrigger({
+    disableHysteresis: true,
+    threshold: isXS ? 100 : 159
+  })
+
+  const shouldShowBottomAppBar = strategies || journeys
+  const shouldFade = hideBottomAppBar !== true || bottomBarTrigger
 
   return (
     <>
       <ThemeProvider themeName={ThemeName.website} themeMode={themeMode} nested>
+        {!hideTopAppBar && (
+          <Box sx={{ background: 'background.default' }}>
+            <LocalAppBar
+              hideSpacer={hideSpacer}
+              onMenuClick={() => setDrawerOpen((prev) => !prev)}
+              menuOpen={drawerOpen}
+              showLanguageSwitcher={showLanguageSwitcher}
+            />
+          </Box>
+        )}
+        {shouldShowBottomAppBar && (
+          <Box sx={{ position: 'relative' }}>
+            {!hideSpacer && (
+              <Box data-testid="HeaderSpacer" sx={{ height: 80 }} />
+            )}
+            <BottomAppBar
+              lightTheme={lightTheme}
+              bottomBarTrigger={bottomBarTrigger}
+              shouldFade={shouldFade}
+            />
+          </Box>
+        )}
       </ThemeProvider>
       <ThemeProvider
         themeName={ThemeName.website}

--- a/apps/watch/src/components/Header/LocalAppBar/LocalAppBar.spec.tsx
+++ b/apps/watch/src/components/Header/LocalAppBar/LocalAppBar.spec.tsx
@@ -1,0 +1,101 @@
+import { MockedProvider } from '@apollo/client/testing'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { LocalAppBar } from './LocalAppBar'
+
+jest.mock('../../SearchComponent/LanguageSelector', () => ({
+  LanguageSelector: () => <div data-testid="LanguageSelector" />
+}))
+
+describe('LocalAppBar', () => {
+  const mockOnMenuClick = jest.fn()
+
+  beforeEach(() => {
+    mockOnMenuClick.mockReset()
+  })
+
+  it('should render correctly', () => {
+    render(
+      <MockedProvider>
+        <LocalAppBar onMenuClick={mockOnMenuClick} />
+      </MockedProvider>
+    )
+
+    expect(screen.getByTestId('Header')).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: 'Watch Logo' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'open header menu' })
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('MenuBox')).toBeInTheDocument()
+  })
+
+  it('should call onMenuClick when menu button is clicked', () => {
+    render(
+      <MockedProvider>
+        <LocalAppBar onMenuClick={mockOnMenuClick} />
+      </MockedProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'open header menu' }))
+    expect(mockOnMenuClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('should have a link to the watch page', () => {
+    render(
+      <MockedProvider>
+        <LocalAppBar onMenuClick={mockOnMenuClick} />
+      </MockedProvider>
+    )
+
+    expect(screen.getByTestId('WatchLogo')).toHaveAttribute(
+      'href',
+      'https://www.jesusfilm.org/'
+    )
+  })
+
+  it('should add expanded class to menu button when menuOpen is true', () => {
+    render(
+      <MockedProvider>
+        <LocalAppBar onMenuClick={mockOnMenuClick} menuOpen />
+      </MockedProvider>
+    )
+
+    const menuButton = screen.getByRole('button', { name: 'open header menu' })
+    expect(menuButton).toHaveClass('expanded')
+    expect(menuButton).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('should not add expanded class to menu button when menuOpen is false', () => {
+    render(
+      <MockedProvider>
+        <LocalAppBar onMenuClick={mockOnMenuClick} menuOpen={false} />
+      </MockedProvider>
+    )
+
+    const menuButton = screen.getByRole('button', { name: 'open header menu' })
+    expect(menuButton).not.toHaveClass('expanded')
+    expect(menuButton).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('should hide language selector by default', () => {
+    render(
+      <MockedProvider>
+        <LocalAppBar onMenuClick={jest.fn()} />
+      </MockedProvider>
+    )
+
+    expect(
+      screen.queryByTestId('HeaderLanguageSelector')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should render language selector when showLanguageSwitcher is true', () => {
+    render(
+      <MockedProvider>
+        <LocalAppBar onMenuClick={mockOnMenuClick} showLanguageSwitcher />
+      </MockedProvider>
+    )
+
+    expect(screen.getByTestId('LanguageSelector')).toBeInTheDocument()
+  })
+})

--- a/apps/watch/src/components/Header/LocalAppBar/LocalAppBar.tsx
+++ b/apps/watch/src/components/Header/LocalAppBar/LocalAppBar.tsx
@@ -1,0 +1,161 @@
+import AppBar, { AppBarProps } from '@mui/material/AppBar'
+import Box from '@mui/material/Box'
+import Container from '@mui/material/Container'
+import IconButton from '@mui/material/IconButton'
+import Stack from '@mui/material/Stack'
+import Image from 'next/image'
+import NextLink from 'next/link'
+import { MouseEventHandler, ReactElement } from 'react'
+
+import logo from '../assets/logo.svg'
+
+import { LanguageSelector } from '../../SearchComponent/LanguageSelector'
+
+interface LocalAppBarProps extends AppBarProps {
+  onMenuClick: MouseEventHandler<HTMLButtonElement>
+  hideSpacer?: boolean
+  menuOpen?: boolean
+  showLanguageSwitcher?: boolean
+}
+
+export function LocalAppBar({
+  onMenuClick,
+  hideSpacer = false,
+  menuOpen = false,
+  showLanguageSwitcher = false,
+  ...props
+}: LocalAppBarProps): ReactElement {
+  return (
+    <AppBar
+      data-testid="Header"
+      position="static"
+      {...props}
+      sx={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        background: 'transparent',
+        color: hideSpacer ? 'background.default' : 'inherit',
+        boxShadow: 'none',
+        py: 10,
+        pt: { lg: '69px' },
+        pb: { lg: 14 },
+        height: { xs: 100, lg: 159 },
+        width: '100%',
+        ...props.sx
+      }}
+    >
+      <Container maxWidth="xxl" disableGutters sx={{ px: 8 }}>
+        <Stack
+          data-testid="TopAppBar"
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+          flexGrow={1}
+        >
+          <Box
+            component={NextLink}
+            href="https://www.jesusfilm.org/"
+            data-testid="WatchLogo"
+            sx={{
+              width: { xs: 126, lg: 186 },
+              mt: { xs: 1.2, lg: 3.5 },
+              mb: { xs: -1.2, lg: -3.5 },
+              zIndex: (theme) => ({ xs: theme.zIndex.drawer + 1, lg: 0 })
+            }}
+            locale={false}
+          >
+            <Image
+              src={logo}
+              alt="Watch Logo"
+              style={{
+                cursor: 'pointer',
+                maxWidth: '100%',
+                height: 'auto'
+              }}
+            />
+          </Box>
+          <Stack
+            direction="row"
+            alignItems="center"
+            spacing={4}
+            data-testid="MenuBox"
+          >
+            {showLanguageSwitcher && (
+              <Box
+                data-testid="HeaderLanguageSelector"
+                sx={{
+                  width: { xs: 200, sm: 240 },
+                  display: { xs: 'none', md: 'block' }
+                }}
+              >
+                <LanguageSelector />
+              </Box>
+            )}
+            <IconButton
+              data-testid="MenuIcon"
+              color="inherit"
+              aria-label="open header menu"
+              edge="start"
+              onClick={onMenuClick}
+              disableRipple
+              className={menuOpen ? 'expanded' : ''}
+              aria-expanded={menuOpen}
+              sx={{
+                width: 39,
+                height: 30,
+                p: 0,
+                position: 'relative',
+                zIndex: (theme) => theme.zIndex.drawer + 1,
+                '& span': {
+                  display: 'block',
+                  position: 'absolute',
+                  width: '100%',
+                  height: 6,
+                  borderRadius: 6,
+                  backgroundColor: 'text.secondary',
+                  opacity: 1,
+                  left: 0,
+                  transform: 'rotate(0deg)',
+                  transition: '0.15s ease-in-out',
+                  '&:nth-of-type(1)': {
+                    top: 0
+                  },
+                  '&:nth-of-type(2)': {
+                    top: 12
+                  },
+                  '&:nth-of-type(3)': {
+                    top: 12
+                  },
+                  '&:nth-of-type(4)': {
+                    top: 24
+                  }
+                },
+                '&.expanded': {
+                  '& span': {
+                    '&:nth-of-type(1), &:nth-of-type(4)': {
+                      top: 15,
+                      width: '0%',
+                      left: '50%'
+                    },
+                    '&:nth-of-type(2)': {
+                      transform: 'rotate(45deg)'
+                    },
+                    '&:nth-of-type(3)': {
+                      transform: 'rotate(-45deg)'
+                    }
+                  }
+                }
+              }}
+            >
+              <span />
+              <span />
+              <span />
+              <span />
+            </IconButton>
+          </Stack>
+        </Stack>
+      </Container>
+    </AppBar>
+  )
+}

--- a/apps/watch/src/components/Header/LocalAppBar/index.ts
+++ b/apps/watch/src/components/Header/LocalAppBar/index.ts
@@ -1,0 +1,1 @@
+export { LocalAppBar } from './LocalAppBar'

--- a/apps/watch/src/components/PageWrapper/PageWrapper.tsx
+++ b/apps/watch/src/components/PageWrapper/PageWrapper.tsx
@@ -19,6 +19,8 @@ interface PageWrapperProps {
   headerThemeMode?: ThemeMode
   hideFooter?: boolean
   isFullscreen?: boolean
+  hideHeaderSpacer?: boolean
+  showLanguageSwitcher?: boolean
 }
 
 export function PageWrapper({
@@ -28,13 +30,17 @@ export function PageWrapper({
   testId,
   headerThemeMode,
   hideFooter = false,
-  isFullscreen = false
+  isFullscreen = false,
+  hideHeaderSpacer = false,
+  showLanguageSwitcher = false
 }: PageWrapperProps): ReactElement {
   return (
     <Div100vh>
       {hideHeader !== true && (
         <Header
           themeMode={headerThemeMode}
+          hideSpacer={hideHeaderSpacer}
+          showLanguageSwitcher={showLanguageSwitcher}
         />
       )}
       <Stack


### PR DESCRIPTION
## Summary
- reintroduce header app bar structure and embed the search modal language selector in the top-right of the header
- add shared bottom app bar and local app bar components with updated unit tests
- allow page wrapper to forward hide spacer and language switcher options to the header

## Testing
- CI=1 pnpm dlx nx test watch --testFile=apps/watch/src/components/Header/LocalAppBar/LocalAppBar.spec.tsx
- CI=1 pnpm dlx nx test watch --testFile=apps/watch/src/components/Header/Header.spec.tsx


------
https://chatgpt.com/codex/tasks/task_e_690568ad3c908328a0d47b95fc61476a