### PR TITLE
feat(watch): show hovered country details on language map

### DIFF
--- a/apps/watch/pages/api/language-map.ts
+++ b/apps/watch/pages/api/language-map.ts
@@ -27,6 +27,7 @@ const GET_LANGUAGE_MAP = graphql(`
           name(primary: true) {
             value
           }
+          population
         }
       }
     }
@@ -62,7 +63,8 @@ function buildLanguagePoint({
   latitude,
   longitude,
   isPrimaryCountryLanguage,
-  speakers
+  speakers,
+  population
 }: {
   languageId: string
   slug: string | null
@@ -74,6 +76,7 @@ function buildLanguagePoint({
   longitude?: number | null
   isPrimaryCountryLanguage: boolean
   speakers: number
+  population?: number | null
 }): LanguageMapPoint | null {
   if (latitude == null || longitude == null) return null
 
@@ -93,7 +96,8 @@ function buildLanguagePoint({
     latitude,
     longitude,
     isPrimaryCountryLanguage,
-    speakers
+    speakers,
+    countryPopulation: population ?? undefined
   }
 }
 
@@ -144,7 +148,8 @@ export default async function handler(
               latitude: country.latitude,
               longitude: country.longitude,
               isPrimaryCountryLanguage: primary,
-              speakers
+              speakers,
+              population: country.population
             })
           )
           .filter((point): point is LanguageMapPoint => point != null)

--- a/apps/watch/src/libs/useLanguageMap/types.ts
+++ b/apps/watch/src/libs/useLanguageMap/types.ts
@@ -7,6 +7,7 @@ export interface LanguageMapPoint {
   nativeName?: string
   countryId: string
   countryName?: string
+  countryPopulation?: number
   latitude: number
   longitude: number
   isPrimaryCountryLanguage: boolean


### PR DESCRIPTION
## Summary
- include country population data in the language map API payload and types so hover interactions have access to demographics
- surface hovered country details from the aggregated map data and render an on-map tooltip with the country name and population
- preserve hover state when the dataset refreshes and clear tooltip state when leaving the map layers for consistent UX

## Testing
- `pnpm dlx nx run watch:test --skip-nx-cache` *(fails: existing Watch test suite issues unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_69056900aa3083288951ecaca6240c24