### PR TITLE
feat(watch): add animated page transitions

### DIFF
--- a/apps/watch/pages/_app.tsx
+++ b/apps/watch/pages/_app.tsx
@@ -8,6 +8,7 @@ import localFont from 'next/font/local'
 import Head from 'next/head'
 import Script from 'next/script'
 import { appWithTranslation } from 'next-i18next'
+import { useRouter } from 'next/router'
 import { DefaultSeo } from 'next-seo'
 import { type ReactElement, useEffect } from 'react'
 
@@ -19,6 +20,7 @@ import { ThemeMode, ThemeName } from '@core/shared/ui/themes'
 
 import i18nConfig from '../next-i18next.config'
 import { useApolloClient } from '../src/libs/apolloClient'
+import { PageTransition } from '../src/components/PageTransition/PageTransition'
 
 import 'swiper/css'
 import 'swiper/css/a11y'
@@ -55,6 +57,7 @@ function WatchApp({
   pageProps,
   emotionCache = createEmotionCache({})
 }: WatchAppProps): ReactElement {
+  const router = useRouter()
   useEffect(() => {
     // Remove the server-side injected CSS.
     const jssStyles = document.querySelector('#jss-server-side')
@@ -145,7 +148,9 @@ function WatchApp({
                 <GoogleTagManager
                   gtmId={process.env.NEXT_PUBLIC_GTM_ID ?? ''}
                 />
-                <Component {...pageProps} />
+                <PageTransition routeKey={router.asPath}>
+                  <Component {...pageProps} />
+                </PageTransition>
               </InstantSearchProvider>
             </ThemeProvider>
           </AppCacheProvider>

--- a/apps/watch/src/components/PageTransition/PageTransition.spec.tsx
+++ b/apps/watch/src/components/PageTransition/PageTransition.spec.tsx
@@ -1,0 +1,77 @@
+import { act, render, screen } from '@testing-library/react'
+
+import { PageTransition } from './PageTransition'
+
+describe('PageTransition', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+    jest.useRealTimers()
+  })
+
+  it('animates between route changes', () => {
+    const { rerender } = render(
+      <PageTransition routeKey="/initial">
+        <div>Initial Page</div>
+      </PageTransition>
+    )
+
+    expect(screen.getByText('Initial Page')).toBeInTheDocument()
+    expect(screen.getByTestId('page-transition')).toHaveClass(
+      'watch-page-transition--enter'
+    )
+
+    act(() => {
+      jest.advanceTimersByTime(400)
+    })
+
+    expect(screen.getByTestId('page-transition')).not.toHaveClass(
+      'watch-page-transition--enter'
+    )
+
+    rerender(
+      <PageTransition routeKey="/next">
+        <div>Next Page</div>
+      </PageTransition>
+    )
+
+    expect(screen.getByTestId('page-transition')).toHaveClass(
+      'watch-page-transition--exit'
+    )
+    expect(screen.getByText('Initial Page')).toBeInTheDocument()
+
+    act(() => {
+      jest.advanceTimersByTime(400)
+    })
+
+    expect(screen.getByText('Next Page')).toBeInTheDocument()
+    expect(screen.getByTestId('page-transition')).toHaveClass(
+      'watch-page-transition--enter'
+    )
+  })
+
+  it('keeps rendered page synced when route key stays the same', () => {
+    const { rerender } = render(
+      <PageTransition routeKey="/stable">
+        <div>First Render</div>
+      </PageTransition>
+    )
+
+    rerender(
+      <PageTransition routeKey="/stable">
+        <div>Updated Render</div>
+      </PageTransition>
+    )
+
+    act(() => {
+      jest.advanceTimersByTime(400)
+    })
+
+    expect(screen.getByText('Updated Render')).toBeInTheDocument()
+  })
+})

--- a/apps/watch/src/components/PageTransition/PageTransition.tsx
+++ b/apps/watch/src/components/PageTransition/PageTransition.tsx
@@ -1,0 +1,96 @@
+import clsx from 'clsx'
+import {
+  type CSSProperties,
+  type PropsWithChildren,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
+
+const TRANSITION_DURATION = 360
+
+type TransitionPhase = 'idle' | 'enter' | 'exit'
+
+export interface PageTransitionProps {
+  routeKey: string
+  duration?: number
+  className?: string
+}
+
+export function PageTransition({
+  routeKey,
+  duration = TRANSITION_DURATION,
+  className,
+  children
+}: PropsWithChildren<PageTransitionProps>): JSX.Element {
+  const [rendered, setRendered] = useState({ key: routeKey, node: children })
+  const [phase, setPhase] = useState<TransitionPhase>('enter')
+  const exitTimeoutRef = useRef<NodeJS.Timeout>()
+  const settleTimeoutRef = useRef<NodeJS.Timeout>()
+
+  const style = useMemo(
+    () =>
+      ({
+        '--watch-page-transition-duration': `${duration}ms`
+      }) as CSSProperties,
+    [duration]
+  )
+
+  useEffect(() => {
+    return () => {
+      if (exitTimeoutRef.current != null) clearTimeout(exitTimeoutRef.current)
+      if (settleTimeoutRef.current != null) clearTimeout(settleTimeoutRef.current)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (routeKey === rendered.key) {
+      setRendered({ key: routeKey, node: children })
+      return
+    }
+
+    if (exitTimeoutRef.current != null) clearTimeout(exitTimeoutRef.current)
+    if (settleTimeoutRef.current != null) clearTimeout(settleTimeoutRef.current)
+
+    setPhase('exit')
+
+    const next = { key: routeKey, node: children }
+    exitTimeoutRef.current = setTimeout(() => {
+      setRendered(next)
+      setPhase('enter')
+    }, duration)
+
+    return () => {
+      if (exitTimeoutRef.current != null) clearTimeout(exitTimeoutRef.current)
+    }
+  }, [children, duration, rendered.key, routeKey])
+
+  useEffect(() => {
+    if (phase !== 'enter') return
+
+    if (settleTimeoutRef.current != null) clearTimeout(settleTimeoutRef.current)
+    settleTimeoutRef.current = setTimeout(() => {
+      setPhase('idle')
+    }, duration)
+
+    return () => {
+      if (settleTimeoutRef.current != null) clearTimeout(settleTimeoutRef.current)
+    }
+  }, [duration, phase])
+
+  return (
+    <div
+      data-testid="page-transition"
+      className={clsx(
+        'watch-page-transition',
+        className,
+        phase === 'enter' && 'watch-page-transition--enter',
+        phase === 'exit' && 'watch-page-transition--exit'
+      )}
+      style={style}
+    >
+      {rendered.node}
+    </div>
+  )
+}

--- a/apps/watch/styles/globals.css
+++ b/apps/watch/styles/globals.css
@@ -143,6 +143,87 @@
     backdrop-filter: blur(10px);
     background: none;
   }
+
+  .watch-page-transition {
+    position: relative;
+    width: 100%;
+    min-height: 100%;
+    isolation: isolate;
+    overflow: hidden;
+    --watch-page-transition-duration: 360ms;
+    perspective: 1200px;
+    will-change: opacity, transform, filter;
+  }
+
+  .watch-page-transition::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(
+      circle at 20% 20%,
+      hsl(0 0% 100% / 0.08),
+      transparent 55%
+    );
+    mix-blend-mode: screen;
+    opacity: 0;
+    transition: opacity var(--watch-page-transition-duration) ease;
+  }
+
+  .watch-page-transition--enter::before {
+    opacity: 0.45;
+  }
+
+  .watch-page-transition--enter {
+    animation: watch-page-transition-enter
+      var(--watch-page-transition-duration)
+      cubic-bezier(0.22, 0.61, 0.36, 1)
+      both;
+  }
+
+  .watch-page-transition--exit {
+    animation: watch-page-transition-exit
+      var(--watch-page-transition-duration)
+      cubic-bezier(0.4, 0, 0.2, 1)
+      both;
+  }
+
+  @keyframes watch-page-transition-enter {
+    0% {
+      opacity: 0;
+      transform: translate3d(0, 28px, 0) scale3d(0.98, 0.98, 1)
+        rotateX(8deg);
+      filter: blur(12px);
+    }
+
+    55% {
+      opacity: 1;
+      transform: translate3d(0, -6px, 0) scale3d(1.01, 1.01, 1)
+        rotateX(0deg);
+      filter: blur(0px);
+    }
+
+    100% {
+      opacity: 1;
+      transform: translate3d(0, 0, 0) scale3d(1, 1, 1);
+      filter: blur(0px);
+    }
+  }
+
+  @keyframes watch-page-transition-exit {
+    0% {
+      opacity: 1;
+      transform: translate3d(0, 0, 0) scale3d(1, 1, 1);
+      filter: blur(0px);
+    }
+
+    100% {
+      opacity: 0;
+      transform: translate3d(0, 28px, 0) scale3d(0.96, 0.96, 1)
+        rotateX(6deg);
+      filter: blur(14px);
+    }
+  }
 }
 
 /* 3. Utilities layer - highest specificity */

--- a/prds/watch/work.md
+++ b/prds/watch/work.md
@@ -94,6 +94,42 @@
 - Consider moving category metadata to CMS-driven config if design requires frequent updates.
 - Evaluate migrating remaining MUI layout primitives to Tailwind equivalents in a future iteration.
 
+# Page Transition Experience
+
+## Goals
+
+- [x] Introduce a reusable transition shell that wraps all Watch pages.
+- [x] Deliver a smooth, modern blend of depth, blur, and motion between route changes.
+- [x] Exercise the transition timing logic with automated coverage.
+
+## Implementation Strategy
+
+- [x] Scaffold a `PageTransition` component that tracks the currently rendered route and transition phase.
+- [x] Layer bespoke Tailwind utilities and keyframes into `globals.css` for enter/exit animations and light burst accents.
+- [x] Wrap `_app` page rendering with the transition shell keyed by `router.asPath`.
+- [x] Author Jest specs to ensure route updates trigger exit/enter phases in the expected order.
+
+## Obstacles
+
+- Balancing animation flair with performance required carefully tuning blur/transform values to avoid jank on slower GPUs.
+
+## Resolutions
+
+- Limited the effect to a single container with hardware-accelerated transforms and bounded blur while isolating it via `will-change`.
+
+## Test Coverage
+
+- `pnpm dlx nx test watch --testFile=apps/watch/src/components/PageTransition/PageTransition.spec.tsx`
+
+## User Flows
+
+- Navigate between Watch routes → existing page glides downward with soft blur → new page lifts into place with subtle highlight.
+
+## Follow-up Ideas
+
+- Expose transition timing tokens through theme variables so editorial teams can dial animations seasonally.
+- Explore complementing the motion with route-level skeletons for data-heavy transitions.
+
 # Featured Hero Skip Control
 
 ## Goals


### PR DESCRIPTION
## Summary
- wrap the Watch app with a reusable PageTransition shell to animate route changes
- add tailored Tailwind keyframes and lighting accents for enter/exit transitions
- cover transition timing with focused Jest tests and document the plan in the watch work log

## Testing
- pnpm dlx nx test watch --testFile=apps/watch/src/components/PageTransition/PageTransition.spec.tsx --output-style=stream

------
https://chatgpt.com/codex/tasks/task_e_690569276f948328b1e5675ff69b8db6