### PR TITLE
feat(watch): add creative page transitions

### DIFF
--- a/apps/watch/pages/_app.tsx
+++ b/apps/watch/pages/_app.tsx
@@ -18,12 +18,14 @@ import { ThemeProvider } from '@core/shared/ui/ThemeProvider'
 import { ThemeMode, ThemeName } from '@core/shared/ui/themes'
 
 import i18nConfig from '../next-i18next.config'
+import { PageTransition } from '../src/components/PageTransition/PageTransition'
 import { useApolloClient } from '../src/libs/apolloClient'
 
 import 'swiper/css'
 import 'swiper/css/a11y'
 import 'swiper/css/navigation'
 import '../styles/globals.css'
+import '../styles/page-transition.css'
 import './fonts/fonts.css'
 
 // Polyfills
@@ -145,7 +147,9 @@ function WatchApp({
                 <GoogleTagManager
                   gtmId={process.env.NEXT_PUBLIC_GTM_ID ?? ''}
                 />
-                <Component {...pageProps} />
+                <PageTransition>
+                  <Component {...pageProps} />
+                </PageTransition>
               </InstantSearchProvider>
             </ThemeProvider>
           </AppCacheProvider>

--- a/apps/watch/src/components/PageTransition/PageTransition.tsx
+++ b/apps/watch/src/components/PageTransition/PageTransition.tsx
@@ -1,0 +1,131 @@
+import { useRouter } from 'next/router'
+import {
+  type ReactElement,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState
+} from 'react'
+
+import { cn } from '../../libs/cn/cn'
+
+const EXIT_DURATION = 360
+const ENTER_DURATION = 420
+
+interface PageTransitionProps {
+  children: ReactNode
+}
+
+function usePrefersReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || window.matchMedia == null) return
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
+    setPrefersReducedMotion(mediaQuery.matches)
+
+    const listener = (event: MediaQueryListEvent): void => {
+      setPrefersReducedMotion(event.matches)
+    }
+
+    mediaQuery.addEventListener('change', listener)
+
+    return () => {
+      mediaQuery.removeEventListener('change', listener)
+    }
+  }, [])
+
+  return prefersReducedMotion
+}
+
+export function PageTransition({ children }: PageTransitionProps): ReactElement {
+  const router = useRouter()
+  const reduceMotion = usePrefersReducedMotion()
+  const [displayedContent, setDisplayedContent] = useState<ReactNode>(children)
+  const displayedRef = useRef<ReactNode>(children)
+  const displayedKeyRef = useRef<string>(router.asPath)
+  const [incomingContent, setIncomingContent] = useState<ReactNode | null>(null)
+  const [outgoingContent, setOutgoingContent] = useState<ReactNode | null>(null)
+  const [isTransitioning, setIsTransitioning] = useState(false)
+  const firstRenderRef = useRef(true)
+  const exitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const enterTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (exitTimeoutRef.current != null) clearTimeout(exitTimeoutRef.current)
+      if (enterTimeoutRef.current != null) clearTimeout(enterTimeoutRef.current)
+    }
+  }, [])
+
+  useEffect(() => {
+    displayedRef.current = displayedContent
+  }, [displayedContent])
+
+  useEffect(() => {
+    if (firstRenderRef.current) {
+      firstRenderRef.current = false
+      setDisplayedContent(children)
+      displayedKeyRef.current = router.asPath
+      return
+    }
+
+    if (reduceMotion) {
+      setDisplayedContent(children)
+      displayedKeyRef.current = router.asPath
+      setOutgoingContent(null)
+      setIncomingContent(null)
+      setIsTransitioning(false)
+      return
+    }
+
+    setOutgoingContent(displayedRef.current)
+    setIncomingContent(children)
+    setIsTransitioning(true)
+
+    if (exitTimeoutRef.current != null) clearTimeout(exitTimeoutRef.current)
+    if (enterTimeoutRef.current != null) clearTimeout(enterTimeoutRef.current)
+
+    exitTimeoutRef.current = setTimeout(() => {
+      setDisplayedContent(children)
+      displayedKeyRef.current = router.asPath
+      setOutgoingContent(null)
+    }, EXIT_DURATION)
+
+    enterTimeoutRef.current = setTimeout(() => {
+      setIncomingContent(null)
+      setIsTransitioning(false)
+    }, EXIT_DURATION + ENTER_DURATION)
+  }, [children, reduceMotion, router.asPath])
+
+  const activeContent = incomingContent ?? displayedContent
+  const currentKey = reduceMotion ? router.asPath : displayedKeyRef.current
+
+  return (
+    <div
+      className={cn(
+        'page-transition',
+        isTransitioning ? 'page-transition--animating' : undefined
+      )}
+    >
+      {isTransitioning && outgoingContent != null && (
+        <div className="page-transition__layer page-transition__layer--exit">
+          {outgoingContent}
+        </div>
+      )}
+      <div
+        key={currentKey}
+        className={cn(
+          'page-transition__layer',
+          isTransitioning && incomingContent != null
+            ? 'page-transition__layer--enter'
+            : 'page-transition__layer--rest'
+        )}
+      >
+        {activeContent}
+      </div>
+      <div className="page-transition__sheen" aria-hidden />
+    </div>
+  )
+}

--- a/apps/watch/styles/page-transition.css
+++ b/apps/watch/styles/page-transition.css
@@ -1,0 +1,108 @@
+.page-transition {
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+  background: radial-gradient(circle at top, rgba(77, 104, 255, 0.12), transparent 55%),
+    radial-gradient(circle at bottom, rgba(245, 183, 43, 0.08), transparent 60%);
+}
+
+.page-transition__layer {
+  position: relative;
+  min-height: 100%;
+  will-change: transform, opacity, filter;
+  transform-origin: 50% 50%;
+}
+
+.page-transition__layer--rest {
+  opacity: 1;
+}
+
+.page-transition__layer--enter {
+  animation: page-transition-enter var(--page-transition-enter-duration, 420ms)
+      cubic-bezier(0.22, 1, 0.36, 1)
+      forwards;
+}
+
+.page-transition__layer--exit {
+  position: absolute;
+  inset: 0;
+  animation: page-transition-exit var(--page-transition-exit-duration, 360ms)
+      cubic-bezier(0.55, 0.085, 0.68, 0.53)
+      forwards;
+  pointer-events: none;
+}
+
+.page-transition__sheen {
+  position: absolute;
+  inset: -10%;
+  z-index: -1;
+  pointer-events: none;
+  background: conic-gradient(
+    from 140deg,
+    rgba(255, 255, 255, 0) 0deg,
+    rgba(255, 255, 255, 0.28) 95deg,
+    rgba(255, 255, 255, 0) 200deg
+  );
+  opacity: 0;
+  transform: scale(1.05) rotate(0.5deg);
+  transition: opacity 320ms ease, transform 450ms ease;
+}
+
+.page-transition--animating .page-transition__sheen {
+  opacity: 0.25;
+  transform: scale(1.08) rotate(2deg);
+}
+
+@keyframes page-transition-enter {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 48px, 0) scale(0.98);
+    filter: blur(16px);
+  }
+
+  60% {
+    opacity: 1;
+    filter: blur(6px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+    filter: blur(0);
+  }
+}
+
+@keyframes page-transition-exit {
+  from {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+    filter: blur(0);
+  }
+
+  to {
+    opacity: 0;
+    transform: translate3d(0, -36px, 0) scale(0.96);
+    filter: blur(14px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page-transition {
+    overflow: visible;
+    background: none;
+  }
+
+  .page-transition__layer--enter,
+  .page-transition__layer--exit {
+    animation: none !important;
+    transform: none !important;
+    filter: none !important;
+    opacity: 1 !important;
+  }
+
+  .page-transition__sheen {
+    transition: none;
+    opacity: 0 !important;
+    transform: none !important;
+  }
+}

--- a/prds/watch/work.md
+++ b/prds/watch/work.md
@@ -130,3 +130,35 @@
 
 - Consider showing a brief tooltip on first visit explaining the Skip control for accessibility.
 - Evaluate whether skip interactions should emit analytics distinct from autoplay completions.
+
+# Watch Page Creative Transitions
+
+## Goals
+
+- [x] Introduce a cohesive transition system that animates between `/watch` pages.
+- [x] Ensure transitions feel modern without overwhelming users who prefer reduced motion.
+- [x] Keep the solution framework-agnostic so other screens can reuse it later.
+
+## Obstacles
+
+- Needed to orchestrate exit/enter states manually because no animation helper library exists in the project.
+- Had to respect `prefers-reduced-motion` while still providing layered effects for everyone else.
+
+## Resolutions
+
+- Added a `PageTransition` wrapper that stages outgoing and incoming routes with timed swapping logic.
+- Authored dedicated CSS (blurred slides + sheen overlay) to create a cinematic yet performant effect.
+- Included a custom reduced-motion hook to gracefully fall back to instant page swaps.
+
+## Test Coverage
+
+- `pnpm dlx nx lint watch` *(fails: existing lint debt across unrelated components)*
+
+## User Flows
+
+- Navigate between `/watch`, `/watch/videos`, and a video detail page -> outgoing view glides upward while the next fades in with a soft blur.
+
+## Follow-up Ideas
+
+- Consider exposing transition duration tokens so editorial teams can fine-tune pacing per campaign.
+- Explore hooking analytics into the transition wrapper to measure navigation sentiment.


### PR DESCRIPTION
## Summary
- wrap watch routes in a new PageTransition component to stage outgoing and incoming pages
- design bespoke CSS-driven motion and sheen overlay that delivers a modern transition while respecting reduced-motion preferences
- log the implementation details and verification notes in the watch PRD

## Testing
- pnpm dlx nx lint watch *(fails: existing lint debt across unrelated watch files)*

------
https://chatgpt.com/codex/tasks/task_e_690569276f948328b1e5675ff69b8db6