### PR TITLE
feat(watch): add animated page transitions

### DIFF
--- a/apps/watch/pages/_app.tsx
+++ b/apps/watch/pages/_app.tsx
@@ -18,6 +18,7 @@ import { ThemeProvider } from '@core/shared/ui/ThemeProvider'
 import { ThemeMode, ThemeName } from '@core/shared/ui/themes'
 
 import i18nConfig from '../next-i18next.config'
+import { PageTransition } from '../src/components/PageTransition'
 import { useApolloClient } from '../src/libs/apolloClient'
 
 import 'swiper/css'
@@ -145,7 +146,9 @@ function WatchApp({
                 <GoogleTagManager
                   gtmId={process.env.NEXT_PUBLIC_GTM_ID ?? ''}
                 />
-                <Component {...pageProps} />
+                <PageTransition>
+                  <Component {...pageProps} />
+                </PageTransition>
               </InstantSearchProvider>
             </ThemeProvider>
           </AppCacheProvider>

--- a/apps/watch/src/components/PageTransition/PageTransition.tsx
+++ b/apps/watch/src/components/PageTransition/PageTransition.tsx
@@ -1,0 +1,27 @@
+import { useRouter } from 'next/router'
+import { type ReactNode, useRef } from 'react'
+import { CSSTransition, SwitchTransition } from 'react-transition-group'
+
+export interface PageTransitionProps {
+  children: ReactNode
+}
+
+export function PageTransition({ children }: PageTransitionProps) {
+  const router = useRouter()
+  const nodeRef = useRef<HTMLDivElement | null>(null)
+
+  return (
+    <SwitchTransition mode="out-in">
+      <CSSTransition
+        key={router.asPath}
+        classNames="watch-page"
+        timeout={{ enter: 600, exit: 360 }}
+        nodeRef={nodeRef}
+      >
+        <div ref={nodeRef} className="watch-page-transition">
+          {children}
+        </div>
+      </CSSTransition>
+    </SwitchTransition>
+  )
+}

--- a/apps/watch/src/components/PageTransition/index.ts
+++ b/apps/watch/src/components/PageTransition/index.ts
@@ -1,0 +1,2 @@
+export { PageTransition } from './PageTransition'
+export type { PageTransitionProps } from './PageTransition'

--- a/apps/watch/styles/globals.css
+++ b/apps/watch/styles/globals.css
@@ -65,6 +65,10 @@
   --radius-lg: 1rem;
   --radius: var(--radius-md);
 
+  --watch-transition-duration: 600ms;
+  --watch-transition-exit-duration: 360ms;
+  --watch-transition-timing: cubic-bezier(0.22, 1, 0.36, 1);
+
   @keyframes mesh-gradient {
     0% {
       background-position: 0% 50%;
@@ -142,6 +146,102 @@
   .blured-bg {
     backdrop-filter: blur(10px);
     background: none;
+  }
+
+  .watch-page-transition {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+    isolation: isolate;
+    z-index: 0;
+  }
+
+  .watch-page-transition::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background:
+      radial-gradient(
+        circle at top right,
+        rgba(203, 51, 59, 0.18),
+        transparent 55%
+      ),
+      radial-gradient(
+        circle at bottom left,
+        rgba(114, 131, 190, 0.16),
+        transparent 60%
+      );
+    opacity: 0;
+    transform: scale(1.05);
+    transition:
+      opacity var(--watch-transition-duration)
+        var(--watch-transition-timing),
+      transform calc(var(--watch-transition-duration) + 120ms)
+        var(--watch-transition-timing);
+    z-index: 0;
+    filter: saturate(120%);
+  }
+
+  .watch-page-transition > * {
+    position: relative;
+    z-index: 1;
+  }
+
+  .watch-page-enter {
+    opacity: 0;
+    transform: translate3d(0, 24px, 0) scale(0.985);
+  }
+
+  .watch-page-enter::before {
+    opacity: 0.35;
+    transform: scale(1.12);
+  }
+
+  .watch-page-enter-active {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+    transition:
+      opacity var(--watch-transition-duration)
+        var(--watch-transition-timing),
+      transform calc(var(--watch-transition-duration) - 120ms)
+        var(--watch-transition-timing);
+  }
+
+  .watch-page-enter-active::before {
+    opacity: 0;
+    transform: scale(1);
+  }
+
+  .watch-page-exit {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+
+  .watch-page-exit::before {
+    opacity: 0;
+    transform: scale(1);
+  }
+
+  .watch-page-exit-active {
+    opacity: 0;
+    transform: translate3d(0, -20px, 0) scale(0.99);
+    transition:
+      opacity var(--watch-transition-exit-duration)
+        var(--watch-transition-timing),
+      transform var(--watch-transition-exit-duration)
+        var(--watch-transition-timing);
+  }
+
+  .watch-page-exit-active::before {
+    opacity: 0.25;
+    transform: scale(1.08);
+    transition:
+      opacity var(--watch-transition-exit-duration)
+        var(--watch-transition-timing),
+      transform var(--watch-transition-exit-duration)
+        var(--watch-transition-timing);
   }
 }
 

--- a/prds/watch/work.md
+++ b/prds/watch/work.md
@@ -130,3 +130,35 @@
 
 - Consider showing a brief tooltip on first visit explaining the Skip control for accessibility.
 - Evaluate whether skip interactions should emit analytics distinct from autoplay completions.
+
+# Watch Page Transitions
+
+## Goals
+
+- [x] Introduce a global transition shell so navigating between Watch pages feels deliberate and modern.
+- [x] Blend in a branded gradient wash during the transition without blocking interactions.
+- [x] Keep the integration confined to `_app.tsx` so individual pages stay unaware of the animation layer.
+
+## Obstacles
+
+- The watch lint task currently fails with dozens of pre-existing violations, masking new regressions.
+- CSS-only transitions can easily steal pointer events when layered globally.
+
+## Resolutions
+
+- Verified the new component in isolation with `pnpm dlx eslint apps/watch/src/components/PageTransition/PageTransition.tsx` while documenting the broader lint backlog.
+- Wrapped page content in a `SwitchTransition` + `CSSTransition` duo and used `pointer-events: none` overlays so the gradient never interferes with clicks.
+
+## Test Coverage
+
+- `pnpm dlx eslint apps/watch/src/components/PageTransition/PageTransition.tsx`
+- `NX_DAEMON=false pnpm dlx nx lint watch --skip-nx-cache --output-style=stream` *(fails from legacy lint violations; see terminal log for the existing errors.)*
+
+## User Flows
+
+- Navigate between Watch routes → current page lifts and fades → soft gradient wash trails the route change → destination content settles smoothly into place.
+
+## Follow-up Ideas
+
+- Consider layering a page-level progress indicator tied to router events so longer navigations still feel responsive.
+- Audit the outstanding lint failures and capture dedicated cleanup tickets so future UI work gains faster feedback loops.


### PR DESCRIPTION
## Summary
- add a shared PageTransition wrapper so Watch routes fade and lift between navigations
- style the transitions with branded gradient washes and timing tokens in the global stylesheet
- log the work in the Watch PRD work log for this branch

## Testing
- pnpm dlx eslint apps/watch/src/components/PageTransition/PageTransition.tsx
- NX_DAEMON=false pnpm dlx nx lint watch --skip-nx-cache --output-style=stream *(fails: existing lint violations in unrelated legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_690569276f948328b1e5675ff69b8db6