### PR TITLE
Improve mobile layout for Watch homepage

### DIFF
--- a/apps/watch/src/components/NewVideoContentPage/VideoCarousel/VideoCarousel.tsx
+++ b/apps/watch/src/components/NewVideoContentPage/VideoCarousel/VideoCarousel.tsx
@@ -92,9 +92,9 @@ export function VideoCarousel({
         <SwiperSlide
           key={`skeleton-${i}`}
           virtualIndex={i}
-          className="max-w-[200px]"
+          className="max-w-[200px] w-[min(80vw,200px)]"
         >
-          <Skeleton width={200} height={240} />
+          <Skeleton width="100%" height={240} />
         </SwiperSlide>
       )),
     []
@@ -211,7 +211,7 @@ export function VideoCarousel({
                       : `video-${slide.id}`
                   }
                   virtualIndex={index}
-                  className={`max-w-[200px] ${index === 0 ? 'padded-l' : ''}`}
+                  className={`max-w-[200px] w-[min(80vw,200px)] ${index === 0 ? 'padded-l' : ''}`}
                   data-testid={`CarouselSlide-${slide.id}`}
                 >
                   <VideoCard

--- a/apps/watch/src/components/SearchComponent/SearchComponent.tsx
+++ b/apps/watch/src/components/SearchComponent/SearchComponent.tsx
@@ -35,8 +35,8 @@ export function SearchComponent({
 
   return (
     <SearchBarProvider>
-      <div className="fixed top-[26px] lg:top-[76px] left-1/2 -translate-x-1/2 w-[calc(100%-60px)] min-w-[300px] max-w-[800px] z-[100] px-2 md:px-0">
-        <div className="w-full max-w-[70%] min-w-[60%] mx-auto">
+      <div className="fixed left-0 right-0 top-6 sm:top-8 lg:top-[76px] z-[100] px-4 sm:px-6 md:px-8">
+        <div className="mx-auto w-full max-w-[800px]">
           <SimpleSearchBar
             loading={loading && hasQuery}
             value={searchValue}

--- a/apps/watch/src/components/SearchComponent/SimpleSearchBar.tsx
+++ b/apps/watch/src/components/SearchComponent/SimpleSearchBar.tsx
@@ -65,7 +65,7 @@ export function SimpleSearchBar({
                 placeholder={t('Search videos by keyword...')}
                 autoComplete="off"
                 className={`
-                  w-full pl-12 pr-12 py-6 text-lg rounded-[35px] border-none outline-1 outline-white/20 shadow-xl shadow-stone-800/10 
+                  w-full pl-12 pr-12 py-4 sm:py-5 md:py-6 text-base sm:text-lg rounded-[35px] border-none outline-1 outline-white/20 shadow-xl shadow-stone-800/10
                   bg-white/10 backdrop-blur-[10px] transition-all duration-200
                   text-white placeholder:text-white/70 cursor-text hover:cursor-text focus:cursor-text
                   focus:bg-white/80 focus:text-black focus:placeholder:text-black/60

--- a/apps/watch/src/components/SectionVideoCarousel/SectionVideoCarousel.tsx
+++ b/apps/watch/src/components/SectionVideoCarousel/SectionVideoCarousel.tsx
@@ -176,15 +176,15 @@ export function SectionVideoCarousel({
             ? Array.from({ length: 4 }).map((_, index) => (
                 <SwiperSlide
                   key={`skeleton-${index}`}
-                  className={`max-w-[200px] ${index === 0 ? 'padded-l' : ''}`}
+                  className={`max-w-[200px] w-[min(80vw,200px)] ${index === 0 ? 'padded-l' : ''}`}
                 >
-                  <div className="h-[330px] w-[220px] rounded-lg bg-white/10 animate-pulse" />
+                  <div className="h-[330px] w-full rounded-lg bg-white/10 animate-pulse" />
                 </SwiperSlide>
               ))
             : slides.map((slide, index) => (
                 <SwiperSlide
                   key={slide.id}
-                  className={`max-w-[200px] py-1 ${index === 0 ? 'padded-l' : ''}`}
+                  className={`max-w-[200px] w-[min(80vw,200px)] py-1 ${index === 0 ? 'padded-l' : ''}`}
                   data-testid={`SectionVideoCarouselSlide-${slide.id}`}
                 >
                   <VideoCard

--- a/apps/watch/src/components/Skeleton/Skeleton.tsx
+++ b/apps/watch/src/components/Skeleton/Skeleton.tsx
@@ -1,8 +1,8 @@
 import { ReactElement } from 'react'
 
 interface SkeletonProps {
-  height?: number
-  width?: number
+  height?: number | string
+  width?: number | string
   className?: string
 }
 
@@ -14,7 +14,10 @@ export function Skeleton({
   return (
     <div
       className={`rounded-lg animate-pulse bg-text-secondary ${className}`}
-      style={{ width: `${width}px`, height: `${height}px` }}
+      style={{
+        width: typeof width === 'number' ? `${width}px` : width,
+        height: typeof height === 'number' ? `${height}px` : height
+      }}
     />
   )
 }

--- a/prds/watch/cursor-work.md
+++ b/prds/watch/cursor-work.md
@@ -1,0 +1,32 @@
+# Watch Homepage Mobile Layout
+
+## Goals
+
+- [x] Relax rigid widths in the floating search bar so it can fill narrow mobile viewports.
+- [x] Resize carousel slides and skeleton placeholders to respect small screens without clipping.
+- [x] Smooth out input spacing so the search affordance feels balanced on phones.
+
+## Obstacles
+
+- Tailwind utility strings were baked into JSX template literals, so widening support for arbitrary width utilities required careful updates in multiple components.
+- The shared `Skeleton` helper only supported numeric dimensions, which made responsive placeholders impossible until the prop types were expanded.
+
+## Resolutions
+
+- Replaced the absolute-centered search wrapper with a full-width fixed bar that collapses padding below the tablet breakpoint.
+- Added `min()`-based width utilities to carousel slides and swapped skeleton widths to `100%`, keeping cards within the viewport on compact devices.
+- Extended the `Skeleton` component to accept string dimensions so responsive values can flow through without breaking existing consumers.
+
+## Test Coverage
+
+- `pnpm dlx nx lint watch` *(fails: pre-existing lint violations across the watch app)*
+
+## User Flows
+
+- Mobile visitor lands on `/watch` → floating search spans the viewport with comfortable padding → typing maintains the streamlined layout.
+- Carousel renders on mobile → slides shrink to fit within the screen → skeletons mirror the card sizing while data loads.
+
+## Follow-up Ideas
+
+- Consider promoting the `min()` width helper into a shared Tailwind plugin so other carousels can reuse the pattern.
+- Audit other sections for legacy pixel-based skeleton dimensions now that the helper supports responsive values.


### PR DESCRIPTION
## Summary
- adjust the floating Watch search bar so it spans the viewport on small screens
- scale carousel slides and skeleton placeholders with responsive min() widths and flexible Skeleton props
- document the mobile layout work in the Watch PRD log

## Testing
- pnpm dlx nx lint watch *(fails: pre-existing lint violations across the watch app)*

------
https://chatgpt.com/codex/tasks/task_e_6905693ac4608328b9f1659c436fa986