### PR TITLE
Fix Watch mobile viewport handling

### DIFF
--- a/apps/watch/src/components/CollectionsPage/CollectionsPageContent/CollectionsPageContent.tsx
+++ b/apps/watch/src/components/CollectionsPage/CollectionsPageContent/CollectionsPageContent.tsx
@@ -13,14 +13,14 @@ export function CollectionsPageContent({
       data-testid="CollectionPage"
     >
       <div
-        className="max-w-[1920px] mx-auto sticky h-[100vh] top-0"
+        className="max-w-[1920px] mx-auto sticky top-0 h-[100svh]"
         data-testid="CollectionPageBlurFilter"
         style={{
           backgroundColor: 'rgba(0, 0, 0, 0.1)',
           backdropFilter: 'brightness(.6) blur(40px)'
         }}
       ></div>
-      <div className="w-full mt-[-100vh]" data-testid="CollectionPageContainer">
+      <div className="w-full mt-[-100svh]" data-testid="CollectionPageContainer">
         <div
           className="max-w-[1920px] mx-auto pb-40"
           data-testid="CollectionPageContent"

--- a/apps/watch/src/components/CollectionsPage/ContainerHero/CollectionsHeader/LanguageModal/LanguageModal.tsx
+++ b/apps/watch/src/components/CollectionsPage/ContainerHero/CollectionsHeader/LanguageModal/LanguageModal.tsx
@@ -52,7 +52,7 @@ export function LanguageModal({
         }
       }}
     >
-      <div className="w-full h-[100vh] flex justify-center items-center px-1 sm:px-2 overflow-hidden bg-black/80 backdrop-blur-lg">
+      <div className="w-full h-[100svh] flex justify-center items-center px-1 sm:px-2 overflow-hidden bg-black/80 backdrop-blur-lg">
         <div className="w-full max-w-md rounded-lg p-6">
           <div className="grid grid-cols-1 gap-4 font-sans">
             {languages.map((language) => (

--- a/apps/watch/src/components/Header/HeaderMenuPanel/HeaderMenuPanel.tsx
+++ b/apps/watch/src/components/Header/HeaderMenuPanel/HeaderMenuPanel.tsx
@@ -29,7 +29,7 @@ export function HeaderMenuPanel({
       elevation={0}
       data-testid="HeaderMenuPanel"
       sx={{
-        minHeight: '100vh',
+        minHeight: '100svh',
         display: 'flex',
         flexDirection: 'column',
         width: '100%',

--- a/apps/watch/src/components/NewVideoContentPage/ContentPageBlurFilter/ContentPageBlurFilter.spec.tsx
+++ b/apps/watch/src/components/NewVideoContentPage/ContentPageBlurFilter/ContentPageBlurFilter.spec.tsx
@@ -47,6 +47,6 @@ describe('ContentPageBlurFilter', () => {
 
     const contentContainer = screen.getByTestId('ContentPageContainer')
     expect(contentContainer).toHaveClass('relative', 'z-10')
-    expect(contentContainer).toHaveStyle('margin-top: -100vh')
+    expect(contentContainer).toHaveStyle('margin-top: -100svh')
   })
 })

--- a/apps/watch/src/components/NewVideoContentPage/ContentPageBlurFilter/ContentPageBlurFilter.tsx
+++ b/apps/watch/src/components/NewVideoContentPage/ContentPageBlurFilter/ContentPageBlurFilter.tsx
@@ -14,14 +14,17 @@ export function ContentPageBlurFilter({
       style={{ minHeight: '100svh' }}
     >
       <div
-        className="max-w-[1920px] z-[1] mx-auto sticky h-screen top-0 bg-black/10"
+        className="max-w-[1920px] z-[1] mx-auto sticky top-0 bg-black/10"
         data-testid="ContentPageBlurFilter"
-        style={{ backdropFilter: 'brightness(.6) blur(40px)' }}
+        style={{
+          backdropFilter: 'brightness(.6) blur(40px)',
+          height: '100svh'
+        }}
       />
       <div
         className="max-w-[1920px] mx-auto overflow-hidden relative z-10"
         data-testid="ContentPageContainer"
-        style={{ marginTop: '-100vh' }}
+        style={{ marginTop: '-100svh' }}
       >
         {children}
       </div>

--- a/libs/journeys/ui/src/libs/algolia/InstantSearchProvider/InstantSearchProvider.tsx
+++ b/libs/journeys/ui/src/libs/algolia/InstantSearchProvider/InstantSearchProvider.tsx
@@ -1,11 +1,28 @@
 import { SearchClient, algoliasearch } from 'algoliasearch'
 import { ReactElement, ReactNode, createContext, useContext } from 'react'
 
-const searchClient = algoliasearch(
-  process.env.NEXT_PUBLIC_ALGOLIA_APP_ID ?? '',
+const fallbackAppId = 'watch-local-app'
+const fallbackApiKey = 'watch-local-key'
+
+const resolvedAppId =
+  process.env.NEXT_PUBLIC_ALGOLIA_APP_ID ??
+  (process.env.NODE_ENV === 'production' ? '' : fallbackAppId)
+
+const resolvedApiKey =
   process.env.ALGOLIA_SERVER_API_KEY ??
-    process.env.NEXT_PUBLIC_ALGOLIA_API_KEY ??
-    ''
+  process.env.NEXT_PUBLIC_ALGOLIA_API_KEY ??
+  (process.env.NODE_ENV === 'production' ? '' : fallbackApiKey)
+
+if (
+  process.env.NODE_ENV === 'production' &&
+  (resolvedAppId === '' || resolvedApiKey === '')
+) {
+  throw new Error('Missing Algolia credentials for InstantSearch')
+}
+
+const searchClient = algoliasearch(
+  resolvedAppId === '' ? fallbackAppId : resolvedAppId,
+  resolvedApiKey === '' ? fallbackApiKey : resolvedApiKey
 )
 
 const InstantSearchContext = createContext<SearchClient>(searchClient)

--- a/prds/watch/work.md
+++ b/prds/watch/work.md
@@ -94,6 +94,32 @@
 - Consider moving category metadata to CMS-driven config if design requires frequent updates.
 - Evaluate migrating remaining MUI layout primitives to Tailwind equivalents in a future iteration.
 
+# Watch Home Mobile Viewport Fixes
+
+## Goals
+
+- [x] Replace `100vh` viewport locks with `svh` units so the Watch hero and drawers size correctly on mobile browsers.
+- [x] Allow local development to boot `/watch` without Algolia credentials to unblock responsive testing.
+
+## Obstacles
+
+- The dev container cannot download Google fonts, producing repeated warnings while hitting the page.
+- `InstantSearch` throws when Algolia credentials are missing, preventing `/watch` from rendering at all.
+
+## Resolutions
+
+- Converted sticky wrappers in `ContentPageBlurFilter`, the collections shell, language modal, and menu drawer to use `100svh` heights and offsets.
+- Added guarded fallbacks inside `InstantSearchProvider` so non-production environments use stub Algolia keys instead of crashing.
+
+## Test Coverage
+
+- `pnpm dlx nx test watch --testFile=apps/watch/src/components/NewVideoContentPage/ContentPageBlurFilter/ContentPageBlurFilter.spec.tsx`
+
+## Follow-up Ideas
+
+- Consider stubbing Algolia results in dev builds so `getServerState` does not fail when credentials are unavailable.
+- Replace Google Fonts usage during development to avoid noisy build logs in offline environments.
+
 # Featured Hero Skip Control
 
 ## Goals


### PR DESCRIPTION
## Summary
- switch Watch hero wrappers, collections shell, and language modal to `svh`-based viewport sizing so mobile browsers render correctly
- provide a development-only Algolia fallback so `/watch` can boot without credentials
- log the mobile viewport adjustments in `prds/watch/work.md`

## Testing
- pnpm dlx nx test watch --testFile=apps/watch/src/components/NewVideoContentPage/ContentPageBlurFilter/ContentPageBlurFilter.spec.tsx

------
https://chatgpt.com/codex/tasks/task_e_6905693ac4608328b9f1659c436fa986