### PR TITLE
Adjust watch mobile layout

### DIFF
--- a/apps/watch/src/components/NewVideoContentPage/VideoCarousel/VideoCarousel.tsx
+++ b/apps/watch/src/components/NewVideoContentPage/VideoCarousel/VideoCarousel.tsx
@@ -52,6 +52,11 @@ export function VideoCarousel({
       })) ?? []
     )
   }, [slides, videos])
+  const effectiveActiveVideoId =
+    activeVideoId ??
+    (mode === 'inlinePlayback' && computedSlides.length > 0
+      ? computedSlides[computedSlides.length - 1].id
+      : undefined)
   const nextRef = useRef<HTMLDivElement>(null)
   const prevRef = useRef<HTMLDivElement>(null)
   const swiperRef = useRef<SwiperType | null>(null)
@@ -59,28 +64,40 @@ export function VideoCarousel({
   const swiperBreakpoints: SwiperOptions['breakpoints'] = useMemo(
     () => ({
       [breakpoints.values.xs]: {
-        slidesPerGroup: 2,
-        slidesPerView: 2.4
+        slidesPerGroup: 1,
+        slidesPerView: 1.2,
+        spaceBetween: 12,
+        slidesOffsetAfter: 24
       },
       [breakpoints.values.sm]: {
-        slidesPerGroup: 3,
-        slidesPerView: 3.4
+        slidesPerGroup: 2,
+        slidesPerView: 2.4,
+        spaceBetween: 16,
+        slidesOffsetAfter: 32
       },
       [breakpoints.values.md]: {
-        slidesPerGroup: 4,
-        slidesPerView: 4.4
+        slidesPerGroup: 3,
+        slidesPerView: 3.4,
+        spaceBetween: 18,
+        slidesOffsetAfter: 36
       },
       [breakpoints.values.lg]: {
-        slidesPerGroup: 5,
-        slidesPerView: 5.4
+        slidesPerGroup: 4,
+        slidesPerView: 4.4,
+        spaceBetween: 20,
+        slidesOffsetAfter: 40
       },
       [breakpoints.values.xl]: {
-        slidesPerGroup: 6,
-        slidesPerView: 6.4
+        slidesPerGroup: 5,
+        slidesPerView: 5.4,
+        spaceBetween: 20,
+        slidesOffsetAfter: 44
       },
       [breakpoints.values.xxl]: {
-        slidesPerGroup: 7,
-        slidesPerView: 7.4
+        slidesPerGroup: 6,
+        slidesPerView: 6.4,
+        spaceBetween: 24,
+        slidesOffsetAfter: 48
       }
     }),
     [breakpoints.values]
@@ -92,9 +109,11 @@ export function VideoCarousel({
         <SwiperSlide
           key={`skeleton-${i}`}
           virtualIndex={i}
-          className="max-w-[200px]"
+          className={`w-[80vw] max-w-[320px] sm:w-[200px] ${i === 0 ? 'padded-l' : ''}`}
         >
-          <Skeleton width={200} height={240} />
+          <div className="aspect-[2/3] w-full">
+            <Skeleton width="100%" height="100%" />
+          </div>
         </SwiperSlide>
       )),
     []
@@ -127,11 +146,15 @@ export function VideoCarousel({
       if (swiperRef.current && computedSlides.length > 0) {
         // Find the current video index
         const currentVideoIndex = computedSlides.findIndex((s) =>
-          isVideoSlide(s) ? s.video.id === activeVideoId : false
+          isVideoSlide(s) ? s.video.id === effectiveActiveVideoId : false
         )
 
         // Only scroll to end if current playing card is not one of the first 5 cards
-        if (currentVideoIndex >= 5) {
+        const minimumIndexForAutoScroll = Math.min(
+          5,
+          computedSlides.length - 1
+        )
+        if (currentVideoIndex >= minimumIndexForAutoScroll) {
           const lastSlideIndex = computedSlides.length - 1
           swiperRef.current.slideTo(lastSlideIndex, 1800)
         }
@@ -182,8 +205,8 @@ export function VideoCarousel({
         mousewheel={{ forceToAxis: true }}
         grabCursor
         slidesPerView="auto"
-        spaceBetween={20}
-        slidesOffsetAfter={40}
+        spaceBetween={16}
+        slidesOffsetAfter={32}
         navigation={{
           nextEl: nextRef.current,
           prevEl: prevRef.current
@@ -211,13 +234,13 @@ export function VideoCarousel({
                       : `video-${slide.id}`
                   }
                   virtualIndex={index}
-                  className={`max-w-[200px] ${index === 0 ? 'padded-l' : ''}`}
+                  className={`w-[80vw] max-w-[320px] sm:w-[200px] ${index === 0 ? 'padded-l' : ''}`}
                   data-testid={`CarouselSlide-${slide.id}`}
                 >
                   <VideoCard
                     containerSlug={containerSlug}
                     data={isMuxSlide(slide) ? transformMuxSlide(slide) : transformVideoChild(slide.video as VideoChildFields)}
-                    active={activeVideoId === slide.id}
+                    active={effectiveActiveVideoId === slide.id}
                     transparent={isAfterCurrentVideo}
                     onVideoSelect={handleVideoSelect}
                   />

--- a/apps/watch/src/components/SearchComponent/SearchComponent.tsx
+++ b/apps/watch/src/components/SearchComponent/SearchComponent.tsx
@@ -35,8 +35,10 @@ export function SearchComponent({
 
   return (
     <SearchBarProvider>
-      <div className="fixed top-[26px] lg:top-[76px] left-1/2 -translate-x-1/2 w-[calc(100%-60px)] min-w-[300px] max-w-[800px] z-[100] px-2 md:px-0">
-        <div className="w-full max-w-[70%] min-w-[60%] mx-auto">
+      <div
+        className="fixed top-6 left-0 right-0 z-[100] px-4 lg:top-[76px] lg:left-1/2 lg:right-auto lg:w-[calc(100%-60px)] lg:max-w-[800px] lg:min-w-[300px] lg:-translate-x-1/2 lg:px-0"
+      >
+        <div className="w-full lg:max-w-[70%] lg:min-w-[60%] mx-auto">
           <SimpleSearchBar
             loading={loading && hasQuery}
             value={searchValue}

--- a/apps/watch/src/components/SectionVideoCarousel/SectionVideoCarousel.tsx
+++ b/apps/watch/src/components/SectionVideoCarousel/SectionVideoCarousel.tsx
@@ -166,8 +166,8 @@ export function SectionVideoCarousel({
           mousewheel={{ forceToAxis: true }}
           observeParents
           slidesPerView="auto"
-          spaceBetween={20}
-          slidesOffsetAfter={40}
+          spaceBetween={16}
+          slidesOffsetAfter={32}
           pagination={{ clickable: true }}
           className="w-full"
           data-testid="SectionVideoCarouselSwiper"
@@ -176,15 +176,15 @@ export function SectionVideoCarousel({
             ? Array.from({ length: 4 }).map((_, index) => (
                 <SwiperSlide
                   key={`skeleton-${index}`}
-                  className={`max-w-[200px] ${index === 0 ? 'padded-l' : ''}`}
+                  className={`w-[80vw] max-w-[320px] sm:w-[200px] ${index === 0 ? 'padded-l' : ''}`}
                 >
-                  <div className="h-[330px] w-[220px] rounded-lg bg-white/10 animate-pulse" />
+                  <div className="aspect-[2/3] w-full rounded-lg bg-white/10 animate-pulse" />
                 </SwiperSlide>
               ))
             : slides.map((slide, index) => (
                 <SwiperSlide
                   key={slide.id}
-                  className={`max-w-[200px] py-1 ${index === 0 ? 'padded-l' : ''}`}
+                  className={`w-[80vw] max-w-[320px] py-1 sm:w-[200px] ${index === 0 ? 'padded-l' : ''}`}
                   data-testid={`SectionVideoCarouselSlide-${slide.id}`}
                 >
                   <VideoCard

--- a/apps/watch/src/components/Skeleton/Skeleton.tsx
+++ b/apps/watch/src/components/Skeleton/Skeleton.tsx
@@ -1,8 +1,10 @@
 import { ReactElement } from 'react'
 
+type SkeletonDimension = number | string
+
 interface SkeletonProps {
-  height?: number
-  width?: number
+  height?: SkeletonDimension
+  width?: SkeletonDimension
   className?: string
 }
 
@@ -14,7 +16,10 @@ export function Skeleton({
   return (
     <div
       className={`rounded-lg animate-pulse bg-text-secondary ${className}`}
-      style={{ width: `${width}px`, height: `${height}px` }}
+      style={{
+        width: typeof width === 'number' ? `${width}px` : width,
+        height: typeof height === 'number' ? `${height}px` : height
+      }}
     />
   )
 }

--- a/prds/watch/work.md
+++ b/prds/watch/work.md
@@ -130,3 +130,37 @@
 
 - Consider showing a brief tooltip on first visit explaining the Skip control for accessibility.
 - Evaluate whether skip interactions should emit analytics distinct from autoplay completions.
+
+# Watch Home Mobile Polish
+
+## Goals
+
+- [x] Expand the Watch search bar to span the mobile viewport while preserving the centered layout on large screens.
+- [x] Widen hero and collection carousel cards on small devices so a single featured card reads clearly.
+- [x] Smooth out carousel spacing to remove cramped gutters on touch devices.
+
+## Obstacles
+
+- Local `/watch` builds rely on Algolia credentials, so the page crashes before rendering without valid environment data.
+
+## Resolutions
+
+- Audited the SearchComponent container and added breakpoint-specific classes so the wrapper takes the full viewport width on mobile while retaining the centered fixed positioning for desktop.
+- Updated the shared Swiper configurations to use smaller mobile slide groups, responsive spacing, and viewport-based slide widths.
+- Reused the responsive sizing in SectionVideoCarousel so collection cards inherit the same touch-friendly layout as the hero.
+
+## Test Coverage
+
+- `pnpm dlx nx test watch --testFile=apps/watch/src/components/NewVideoContentPage/VideoCarousel/VideoCarousel.spec.tsx`
+- `pnpm dlx nx test watch --testFile=apps/watch/src/components/SectionVideoCarousel/SectionVideoCarousel.spec.tsx`
+
+## User Flows
+
+- Open `/watch` on a phone-sized viewport → search bar stretches edge-to-edge with comfortable padding.
+- Swipe the hero carousel → a single large card is centered with gentle margins, advancing one slide at a time.
+- Scroll to the “Discover the full story” carousel → cards match the hero sizing and spacing, eliminating edge clipping on touch screens.
+
+## Follow-up Ideas
+
+- Consider adding breakpoint-aware `slidesOffsetBefore` values so the leading card aligns perfectly with other content paddings.
+- Explore lazy-loading smaller poster variants to trim mobile payload sizes now that cards occupy more screen real estate.


### PR DESCRIPTION
## Summary
- expand the Watch search bar to use the full viewport on phones while keeping the centered desktop layout
- tune the hero carousel for mobile by widening slides, adjusting breakpoints, and ensuring inline playback still auto-advances
- mirror the responsive carousel updates for the collection rail, allow flexible skeleton sizing, and document the work in the Watch PRD log

## Testing
- pnpm dlx nx test watch --testFile=apps/watch/src/components/NewVideoContentPage/VideoCarousel/VideoCarousel.spec.tsx
- pnpm dlx nx test watch --testFile=apps/watch/src/components/SectionVideoCarousel/SectionVideoCarousel.spec.tsx

------
https://chatgpt.com/codex/tasks/task_e_6905693ac4608328b9f1659c436fa986