### PR TITLE
feat(watch): add support for tagalog

### DIFF
--- a/apps/watch/next-i18next.config.js
+++ b/apps/watch/next-i18next.config.js
@@ -16,7 +16,6 @@ if (isBrowser) {
  * @type {Record<string, string>}
  */
 const fallbackLng = {
-  default: [], // left blank so english isn't sent to the client
   es: 'es-ES',
   fr: 'fr-FR',
   id: 'id-ID',
@@ -52,7 +51,7 @@ const i18nConfig = {
   },
   ns: ['apps-watch'],
   fallbackLng: {
-    default: []
+    default: [] // left blank so english isn't sent to the client
   },
   localePath: (lng, ns) =>
     `${localePath}/${fallbackLng[lng] ?? lng}/${ns}.json`,


### PR DESCRIPTION
Adds Tagalog language support to the Watch app.

Related to: WAT-191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internationalization configuration for the watch app to improve locale handling and fallback resolution.
  * Registered the app's translation namespace and simplified fallback mappings to avoid sending the default English bundle to the client and ensure more consistent translation loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->