### PR TITLE
fix: show cc menu in full screen

### DIFF
--- a/libs/journeys/ui/src/components/Video/VideoControls/DesktopControls/DesktopControls.tsx
+++ b/libs/journeys/ui/src/components/Video/VideoControls/DesktopControls/DesktopControls.tsx
@@ -186,6 +186,7 @@ export function DesktopControls({
         source={source}
         visible={visible}
         setActive={setActive}
+        fullscreen={fullscreen}
       />
       <VideoSettings player={player} onToggleStats={handleToggleStats} />
       {showFullscreenButton && (

--- a/libs/journeys/ui/src/components/Video/VideoControls/MobileControls/MobileControls.tsx
+++ b/libs/journeys/ui/src/components/Video/VideoControls/MobileControls/MobileControls.tsx
@@ -83,6 +83,7 @@ export function MobileControls({
             source={source}
             visible={visible}
             setActive={setActive}
+            fullscreen={fullscreen}
           />
           <VideoSettings player={player} onToggleStats={handleToggleStats} />
           {showFullscreenButton && (

--- a/libs/journeys/ui/src/components/Video/VideoControls/SubtitleButton/SubtitleButton.tsx
+++ b/libs/journeys/ui/src/components/Video/VideoControls/SubtitleButton/SubtitleButton.tsx
@@ -23,13 +23,15 @@ interface SubtitleButtonProps {
   source: VideoBlockSource
   visible: boolean
   setActive: Dispatch<SetStateAction<boolean>>
+  fullscreen?: boolean
 }
 
 export function SubtitleButton({
   player,
   source,
   visible,
-  setActive
+  setActive,
+  fullscreen = false
 }: SubtitleButtonProps): ReactElement {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
 
@@ -133,6 +135,7 @@ export function SubtitleButton({
         tracks={tracks}
         activeTrack={activeTrack}
         onChange={handleSubtitleChange}
+        fullscreen={fullscreen}
       />
     </>
   )

--- a/libs/journeys/ui/src/components/Video/VideoControls/SubtitleButton/SubtitleMenu/SubtitleMenu.tsx
+++ b/libs/journeys/ui/src/components/Video/VideoControls/SubtitleButton/SubtitleMenu/SubtitleMenu.tsx
@@ -11,6 +11,7 @@ interface SubtitleMenuProps {
   tracks: TextTrack[]
   activeTrack: TextTrack | undefined
   onChange: (trackId: string | null) => void
+  fullscreen?: boolean
 }
 
 export function SubtitleMenu({
@@ -19,7 +20,8 @@ export function SubtitleMenu({
   onClose,
   tracks,
   activeTrack,
-  onChange
+  onChange,
+  fullscreen = false
 }: SubtitleMenuProps): ReactElement {
   const { t } = useTranslation('libs-journeys-ui')
 
@@ -35,6 +37,7 @@ export function SubtitleMenu({
       anchorEl={anchorEl}
       open={open}
       onClose={onClose}
+      disablePortal={fullscreen}
       anchorOrigin={{
         vertical: 'top',
         horizontal: 'right'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced subtitle menu behavior and positioning when video is displayed in fullscreen mode.

* **Tests**
  * Added comprehensive test coverage to verify subtitle menu functionality works correctly in both fullscreen and standard viewing modes, including portal rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->