### PR TITLE
fix: reduce launchdarkly initialisation timeout

### DIFF
--- a/libs/shared/ui/src/libs/getLaunchDarklyClient/getLaunchDarklyClient.ts
+++ b/libs/shared/ui/src/libs/getLaunchDarklyClient/getLaunchDarklyClient.ts
@@ -23,7 +23,7 @@ export async function getLaunchDarklyClient(user?: LDUser): Promise<LDClient> {
 
   try {
     await Promise.race([
-      launchDarklyClient.waitForInitialization({ timeout: 60 }),
+      launchDarklyClient.waitForInitialization({ timeout: 1 }),
       new Promise((_, reject) =>
         setTimeout(
           () => reject(new Error('LaunchDarkly initialization timeout')),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted feature-flag client initialization timing so the system falls back faster when startup takes longer than expected, causing a quicker switch to the stub client to improve responsiveness and reduce blocking during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->