### PR TITLE
feat(watch): restyle language dialog overlay

### DIFF
--- a/apps/watch/src/components/DialogLangSwitch/AudioTrackSelect/AudioTrackSelect.tsx
+++ b/apps/watch/src/components/DialogLangSwitch/AudioTrackSelect/AudioTrackSelect.tsx
@@ -1,16 +1,12 @@
-import SpatialAudioOffOutlinedIcon from '@mui/icons-material/SpatialAudioOffOutlined'
-import Autocomplete from '@mui/material/Autocomplete'
-import Box from '@mui/material/Box'
-import TextField from '@mui/material/TextField'
-import Typography from '@mui/material/Typography'
+import { Languages } from 'lucide-react'
 import { useTranslation } from 'next-i18next'
-import { ReactElement, useMemo } from 'react'
+import { ReactElement, useId, useMemo } from 'react'
 import { useInstantSearch } from 'react-instantsearch'
 
 import { LANGUAGE_MAPPINGS } from '../../../libs/localeMapping'
 import { type Language, useLanguages } from '../../../libs/useLanguages'
 import { useLanguageActions } from '../../../libs/watchContext'
-import { filterOptions } from '../utils/filterOptions'
+import { LanguageCommandSelect } from '../LanguageCommandSelect'
 
 function useSafeInstantSearch() {
   try {
@@ -29,10 +25,12 @@ export function AudioTrackSelect({
   videoAudioLanguageIds,
   audioLanguageId
 }: AudioTrackSelectProps): ReactElement {
-  const { t, i18n } = useTranslation()
+  const { t, i18n } = useTranslation('apps-watch')
   const { updateAudioLanguage } = useLanguageActions()
   const { languages, isLoading } = useLanguages()
   const instantSearch = useSafeInstantSearch()
+  const comboboxId = useId()
+  const helperTextId = `${comboboxId}-helper`
 
   const selectedOption = useMemo(
     () => languages.find((language) => language.id === audioLanguageId) ?? null,
@@ -40,11 +38,9 @@ export function AudioTrackSelect({
   )
   const options = useMemo(() => {
     if (videoAudioLanguageIds == null) return languages
-    return [
-      ...languages.filter((language) =>
-        videoAudioLanguageIds.includes(language.id)
-      )
-    ]
+    return languages.filter((language) =>
+      videoAudioLanguageIds.includes(language.id)
+    )
   }, [languages, videoAudioLanguageIds])
   const helperText = useMemo(() => {
     if (isLoading) return t('Loading...')
@@ -72,9 +68,7 @@ export function AudioTrackSelect({
     }
   }, [isLoading, t, videoAudioLanguageIds, selectedOption])
 
-  function handleChange(_, language: Language | null): void {
-    if (language == null) return
-
+  function handleSelect(language: Language): void {
     let reload = instantSearch == null
     if (reload) {
       const found = videoAudioLanguageIds?.find((id) => id === language.id)
@@ -103,8 +97,8 @@ export function AudioTrackSelect({
     <div className="mx-6 font-sans">
       <div className="flex items-center justify-between">
         <label
-          htmlFor="audio-select"
-          className="ml-7 block text-xl font-medium text-gray-700"
+          htmlFor={comboboxId}
+          className="ml-7 block text-xl font-medium text-gray-200"
         >
           {t('Language')}
         </label>
@@ -118,55 +112,20 @@ export function AudioTrackSelect({
             </span>
           )}
       </div>
-      <div className="relative mt-1 flex items-start gap-2">
-        <div className="pt-4">
-          <SpatialAudioOffOutlinedIcon fontSize="small" />
-        </div>
-        <div className="relative w-full">
-          <Autocomplete
-            disableClearable
-            // this is a workaround to keep the autocomplete controlled
-            value={selectedOption as unknown as Language | undefined}
-            options={options}
-            filterOptions={filterOptions}
-            onChange={handleChange}
-            loading={isLoading}
-            getOptionKey={(option) => option.id}
-            getOptionLabel={(option) => option.displayName}
-            renderOption={({ key, ...optionProps }, option) => {
-              return (
-                <Box
-                  key={key}
-                  component="li"
-                  {...optionProps}
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 1,
-                    justifyContent: 'space-between !important'
-                  }}
-                >
-                  <Typography variant="body1">{option.displayName}</Typography>
-                  {option.nativeName &&
-                    option.nativeName.value !== option.displayName && (
-                      <Typography variant="body2" color="text.secondary">
-                        {option.nativeName.value}
-                      </Typography>
-                    )}
-                </Box>
-              )
-            }}
-            renderInput={(params) => (
-              <TextField
-                {...params}
-                id="audio-select"
-                hiddenLabel
-                variant="filled"
-                helperText={helperText}
-              />
-            )}
-          />
-        </div>
+      <div className="relative mt-2">
+        <LanguageCommandSelect
+          options={options}
+          selectedOption={selectedOption}
+          placeholder={t('Search languages...')}
+          emptyMessage={t('No languages found.')}
+          loadingMessage={t('Loading languages...')}
+          helperText={helperText}
+          onSelect={handleSelect}
+          icon={<Languages className="h-5 w-5 text-stone-400" />}
+          disabled={isLoading}
+          id={comboboxId}
+          ariaDescribedBy={helperText != null ? helperTextId : undefined}
+        />
       </div>
     </div>
   )

--- a/apps/watch/src/components/DialogLangSwitch/DialogLangSwitch.spec.tsx
+++ b/apps/watch/src/components/DialogLangSwitch/DialogLangSwitch.spec.tsx
@@ -14,6 +14,27 @@ const useLanguagesMock = useLanguages as jest.MockedFunction<
   typeof useLanguages
 >
 
+beforeAll(() => {
+  class ResizeObserverMock {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+
+  // @ts-expect-error ResizeObserver is not defined in jsdom
+  global.ResizeObserver = ResizeObserverMock
+
+  if (
+    window.HTMLElement != null &&
+    window.HTMLElement.prototype.scrollIntoView == null
+  ) {
+    Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: jest.fn()
+    })
+  }
+})
+
 describe('DialogLangSwitch', () => {
   const french = {
     id: '496',
@@ -120,9 +141,9 @@ describe('DialogLangSwitch', () => {
     await waitFor(() => {
       expect(screen.getAllByRole('combobox')[0]).toBeInTheDocument()
     })
-    expect(screen.getAllByRole('combobox')[0]).toHaveValue('English')
 
     const audioTrackSelect = screen.getAllByRole('combobox')[0]
+    expect(audioTrackSelect).toHaveTextContent('English')
     await userEvent.click(audioTrackSelect)
     // available languages
     expect(screen.getByRole('option', { name: 'English' })).toBeInTheDocument()
@@ -151,9 +172,9 @@ describe('DialogLangSwitch', () => {
     await waitFor(() => {
       expect(screen.getAllByRole('combobox')[1]).toBeInTheDocument()
     })
-    expect(screen.getAllByRole('combobox')[1]).toHaveValue('English')
 
     const subtitlesSelect = screen.getAllByRole('combobox')[1]
+    expect(subtitlesSelect).toHaveTextContent('English')
     await userEvent.click(subtitlesSelect)
     // available languages
     expect(screen.getByRole('option', { name: 'English' })).toBeInTheDocument()

--- a/apps/watch/src/components/DialogLangSwitch/DialogLangSwitch.tsx
+++ b/apps/watch/src/components/DialogLangSwitch/DialogLangSwitch.tsx
@@ -1,15 +1,14 @@
-import CloseIcon from '@mui/icons-material/Close'
-import Box from '@mui/material/Box'
-import Dialog from '@mui/material/Dialog'
-import DialogContent from '@mui/material/DialogContent'
-import IconButton from '@mui/material/IconButton'
-import Stack from '@mui/material/Stack'
-import { ThemeProvider } from '@mui/material/styles'
 import { ReactElement } from 'react'
 
-import { websiteLight } from '@core/shared/ui/themes/website/theme'
-
 import { useWatch } from '../../libs/watchContext'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle
+} from '../Dialog'
 
 import { AudioTrackSelect } from './AudioTrackSelect'
 import { SubtitlesSelect } from './SubtitlesSelect'
@@ -32,40 +31,45 @@ export function DialogLangSwitch({
       subtitleOn
     }
   } = useWatch()
-  return (
-    <ThemeProvider theme={websiteLight}>
-      <Dialog
-        open={open || false}
-        onClose={handleClose}
-        maxWidth="sm"
-        fullWidth
-        aria-label="Language Settings"
-      >
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-          <IconButton
-            onClick={handleClose}
-            size="small"
-            aria-label="Close dialog"
-            sx={{ m: 2 }}
-          >
-            <CloseIcon />
-          </IconButton>
-        </Box>
+  const handleOpenChange = (isOpen: boolean): void => {
+    if (!isOpen && handleClose != null) handleClose()
+  }
 
-        <DialogContent sx={{ pt: 0, pb: 6, px: 0 }}>
-          <Stack gap={8}>
-            <AudioTrackSelect
-              videoAudioLanguageIds={videoAudioLanguageIds}
-              audioLanguageId={audioLanguageId}
-            />
-            <SubtitlesSelect
-              videoSubtitleLanguageIds={videoSubtitleLanguageIds}
-              subtitleLanguageId={subtitleLanguageId}
-              subtitleOn={subtitleOn}
-            />
-          </Stack>
+  return (
+    <Dialog open={open ?? false} onOpenChange={handleOpenChange}>
+      <DialogPortal>
+        <DialogOverlay className="blured-bg bg-stone-900/5" />
+        <DialogContent
+          aria-label="Language Settings"
+          className="
+            fixed inset-0 z-[201] max-w-none translate-x-0 translate-y-0 border-0
+            bg-transparent p-0 shadow-none outline-none
+            overflow-y-auto overscroll-contain
+            [&>button]:right-10 [&>button]:top-10 [&>button]:cursor-pointer
+            [&>button]:text-white [&>button]:scale-150
+          "
+        >
+          <DialogTitle className="sr-only">Language Settings</DialogTitle>
+          <DialogDescription className="sr-only">
+            Select audio language and subtitle options for the current video.
+          </DialogDescription>
+          <div className="flex min-h-full w-full items-center justify-center px-4 py-12 md:px-10">
+            <div className="w-full max-w-2xl rounded-[32px] border border-white/10 bg-black/40 px-6 py-10 backdrop-blur-sm">
+              <div className="flex flex-col gap-12">
+                <AudioTrackSelect
+                  videoAudioLanguageIds={videoAudioLanguageIds}
+                  audioLanguageId={audioLanguageId}
+                />
+                <SubtitlesSelect
+                  videoSubtitleLanguageIds={videoSubtitleLanguageIds}
+                  subtitleLanguageId={subtitleLanguageId}
+                  subtitleOn={subtitleOn}
+                />
+              </div>
+            </div>
+          </div>
         </DialogContent>
-      </Dialog>
-    </ThemeProvider>
+      </DialogPortal>
+    </Dialog>
   )
 }

--- a/apps/watch/src/components/DialogLangSwitch/LanguageCommandSelect.tsx
+++ b/apps/watch/src/components/DialogLangSwitch/LanguageCommandSelect.tsx
@@ -1,0 +1,159 @@
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList
+} from '@core/shared/uimodern/components/command'
+import { cn } from '@core/shared/uimodern/utils'
+import { Check, ChevronsUpDown } from 'lucide-react'
+import { ReactNode, useEffect, useMemo, useRef, useState } from 'react'
+
+import { Language } from '../../libs/useLanguages'
+
+type LanguageCommandSelectProps = {
+  options: Language[]
+  selectedOption: Language | null
+  placeholder: string
+  emptyMessage: string
+  loadingMessage: string
+  helperText?: string
+  onSelect: (language: Language) => void
+  icon?: ReactNode
+  disabled?: boolean
+  id?: string
+  ariaDescribedBy?: string
+}
+
+export function LanguageCommandSelect({
+  options,
+  selectedOption,
+  placeholder,
+  emptyMessage,
+  loadingMessage,
+  helperText,
+  onSelect,
+  icon,
+  disabled = false,
+  id,
+  ariaDescribedBy
+}: LanguageCommandSelectProps): JSX.Element {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  const displayValue = useMemo(() => {
+    if (disabled) return loadingMessage
+    if (selectedOption == null) return placeholder
+    return selectedOption.displayName
+  }, [disabled, placeholder, loadingMessage, selectedOption])
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        containerRef.current != null &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setOpen(false)
+      }
+    }
+
+    if (open) {
+      document.addEventListener('mousedown', handleClickOutside)
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (open && searchInputRef.current != null) {
+      searchInputRef.current.focus()
+    }
+  }, [open])
+
+  const handleSelect = (language: Language) => {
+    onSelect(language)
+    setOpen(false)
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        id={id}
+        type="button"
+        role="combobox"
+        aria-expanded={open}
+        aria-describedby={ariaDescribedBy}
+        onClick={() => {
+          if (!disabled) setOpen((previous) => !previous)
+        }}
+        className="w-full flex items-center justify-between cursor-pointer h-12 px-4 bg-stone-800/50 border border-stone-700/50 hover:bg-stone-800/70 text-white rounded-md"
+        disabled={disabled}
+      >
+        <div className="flex items-center flex-1 min-w-0 gap-2">
+          {icon}
+          <span className="truncate text-base font-medium text-white">
+            {displayValue}
+          </span>
+        </div>
+        <ChevronsUpDown className="ml-2 h-5 w-5 shrink-0 opacity-50 text-stone-400" />
+      </button>
+
+      {open && !disabled && (
+        <div className="absolute top-full left-0 right-0 z-[200] mt-1 px-3 bg-popover border border-border rounded-md shadow-md">
+          <Command>
+            <CommandInput
+              ref={searchInputRef}
+              placeholder={placeholder}
+              className="focus:outline-none focus-visible:outline-none"
+            />
+            <CommandList className="max-h-[60svh] [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+              <CommandEmpty>{emptyMessage}</CommandEmpty>
+              <CommandGroup>
+                {options.map((option) => (
+                  <CommandItem
+                    key={option.id}
+                    value={`${option.displayName} ${option.nativeName?.value ?? ''} ${option.englishName?.value ?? ''}`}
+                    onSelect={() => handleSelect(option)}
+                    className="flex items-center justify-between cursor-pointer px-4 py-2 hover:bg-white/5"
+                  >
+                    <div className="flex flex-col items-start flex-1">
+                      <span className="font-medium text-base">
+                        {option.displayName}
+                      </span>
+                      {option.nativeName != null &&
+                        option.nativeName.value !== option.displayName && (
+                          <span className="text-sm text-muted-foreground">
+                            {option.nativeName.value}
+                          </span>
+                        )}
+                    </div>
+                    <Check
+                      className={cn(
+                        'ml-2 h-5 w-5',
+                        selectedOption?.id === option.id
+                          ? 'opacity-100'
+                          : 'opacity-0'
+                      )}
+                    />
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </div>
+      )}
+      {helperText != null && (
+        <p
+          id={ariaDescribedBy}
+          className="mt-2 text-sm text-muted-foreground"
+        >
+          {helperText}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/apps/watch/src/components/DialogLangSwitch/SubtitlesSelect/SubtitlesSelect.tsx
+++ b/apps/watch/src/components/DialogLangSwitch/SubtitlesSelect/SubtitlesSelect.tsx
@@ -1,15 +1,11 @@
-import ClosedCaptionOffOutlinedIcon from '@mui/icons-material/ClosedCaptionOffOutlined'
-import Autocomplete from '@mui/material/Autocomplete'
-import Box from '@mui/material/Box'
-import TextField from '@mui/material/TextField'
-import Typography from '@mui/material/Typography'
+import { Captions } from 'lucide-react'
 import { useTranslation } from 'next-i18next'
-import { ChangeEvent, ReactElement, useMemo } from 'react'
+import { ChangeEvent, ReactElement, useId, useMemo } from 'react'
 
 import { SUBTITLE_LANGUAGE_IDS } from '../../../libs/localeMapping'
 import { Language, useLanguages } from '../../../libs/useLanguages'
 import { useLanguageActions } from '../../../libs/watchContext'
-import { filterOptions } from '../utils/filterOptions'
+import { LanguageCommandSelect } from '../LanguageCommandSelect'
 
 interface SubtitlesSelectProps {
   videoSubtitleLanguageIds?: string[]
@@ -22,9 +18,11 @@ export function SubtitlesSelect({
   subtitleLanguageId,
   subtitleOn
 }: SubtitlesSelectProps): ReactElement {
-  const { t } = useTranslation()
+  const { t } = useTranslation('apps-watch')
   const { updateSubtitleLanguage, updateSubtitlesOn } = useLanguageActions()
   const { languages: allLanguages, isLoading } = useLanguages()
+  const comboboxId = useId()
+  const helperTextId = `${comboboxId}-helper`
   const languages = useMemo(() => {
     return allLanguages.filter((language) =>
       SUBTITLE_LANGUAGE_IDS.includes(language.id)
@@ -38,11 +36,9 @@ export function SubtitlesSelect({
   )
   const options = useMemo(() => {
     if (videoSubtitleLanguageIds == null) return languages
-    return [
-      ...languages.filter((language) =>
-        videoSubtitleLanguageIds.includes(language.id)
-      )
-    ]
+    return languages.filter((language) =>
+      videoSubtitleLanguageIds.includes(language.id)
+    )
   }, [languages, videoSubtitleLanguageIds])
   const helperText = useMemo(() => {
     if (isLoading) return t('Loading...')
@@ -70,9 +66,7 @@ export function SubtitlesSelect({
     }
   }, [isLoading, t, videoSubtitleLanguageIds, selectedOption])
 
-  function handleSubtitleLanguageChange(_, language: Language | null): void {
-    if (language == null) return
-
+  function handleSubtitleLanguageChange(language: Language): void {
     updateSubtitleLanguage(language)
   }
   function handleSubtitlesOnChange(event: ChangeEvent<HTMLInputElement>): void {
@@ -83,8 +77,8 @@ export function SubtitlesSelect({
     <div className="mx-6 font-sans">
       <div className="flex items-center justify-between">
         <label
-          htmlFor="subtitles-select"
-          className="ml-7 block text-xl font-medium text-gray-700"
+          htmlFor={comboboxId}
+          className="ml-7 block text-xl font-medium text-gray-200"
         >
           {t('Subtitles')}
         </label>
@@ -98,55 +92,20 @@ export function SubtitlesSelect({
             </span>
           )}
       </div>
-      <div className="relative mt-1 flex items-start gap-2">
-        <div className="pt-4">
-          <ClosedCaptionOffOutlinedIcon fontSize="small" />
-        </div>
-        <div className="relative w-full">
-          <Autocomplete
-            disableClearable
-            // this is a workaround to keep the autocomplete controlled
-            value={selectedOption as unknown as Language | undefined}
-            options={options}
-            filterOptions={filterOptions}
-            onChange={handleSubtitleLanguageChange}
-            loading={isLoading}
-            getOptionKey={(option) => option.id}
-            getOptionLabel={(option) => option.displayName}
-            renderOption={({ key, ...optionProps }, option) => {
-              return (
-                <Box
-                  key={key}
-                  component="li"
-                  {...optionProps}
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 1,
-                    justifyContent: 'space-between !important'
-                  }}
-                >
-                  <Typography variant="body1">{option.displayName}</Typography>
-                  {option.nativeName &&
-                    option.nativeName.value !== option.displayName && (
-                      <Typography variant="body2" color="text.secondary">
-                        {option.nativeName.value}
-                      </Typography>
-                    )}
-                </Box>
-              )
-            }}
-            renderInput={(params) => (
-              <TextField
-                {...params}
-                hiddenLabel
-                id="subtitles-select"
-                variant="filled"
-                helperText={helperText}
-              />
-            )}
-          />
-        </div>
+      <div className="relative mt-2">
+        <LanguageCommandSelect
+          options={options}
+          selectedOption={selectedOption}
+          placeholder={t('Search languages...')}
+          emptyMessage={t('No languages found.')}
+          loadingMessage={t('Loading languages...')}
+          helperText={helperText}
+          onSelect={handleSubtitleLanguageChange}
+          icon={<Captions className="h-5 w-5 text-stone-400" />}
+          disabled={isLoading}
+          id={comboboxId}
+          ariaDescribedBy={helperText != null ? helperTextId : undefined}
+        />
       </div>
       <div className="my-4 ml-8 flex items-center gap-2">
         <input

--- a/prds/watch/work.md
+++ b/prds/watch/work.md
@@ -1,0 +1,23 @@
+# Language dialog overlay refresh
+
+## Goals
+- Match the watch language selection dialog visuals to the search overlay (dark, blurred, fullscreen, with a clear close icon).
+
+## Implementation Strategy
+- [x] Replace the existing MUI `Dialog` shell with the shared shadcn-based dialog from `apps/watch/src/components/Dialog` so we can style the overlay/background identically to the search overlay.
+- [x] Apply the same `blured-bg` / `bg-stone-900/5` overlay treatment and extend the content to full-screen width, positioning the close icon in the top-right corner.
+- [x] Keep the existing `AudioTrackSelect` and `SubtitlesSelect` stacks intact but wrap them in a centered container that mirrors the search modal padding.
+- [x] Ensure accessibility labels remain (`aria-label="Language Settings"`) so automated tests keep passing.
+- [x] Update the Jest spec if necessary and re-run the component tests.
+
+## Obstacles & Resolutions
+- **Portal styling**: The shared dialog component auto-renders its own overlay, so to customize it like the search modal we follow the same pattern—render an explicit `DialogPortal`/`DialogOverlay` before `DialogContent` and pass the desired Tailwind classes.
+
+## Test Coverage
+- `pnpm dlx nx test watch --testFile apps/watch/src/components/DialogLangSwitch/DialogLangSwitch.spec.tsx`
+
+## User Flow
+- Open video player → tap the language icon → fullscreen overlay appears with blurred dark background and close icon → pick language/subtitle → close.
+
+## Follow-up Ideas
+- Consider extracting a shared "fullscreen overlay" wrapper used by both Search and Language dialogs to avoid duplicated Tailwind strings.


### PR DESCRIPTION
## Summary
- replace the legacy MUI shell in `DialogLangSwitch` with the shared shadcn dialog so the overlay is fullscreen, blurred, and matches the search modal treatment
- wrap the audio and subtitle selectors in a centered glassmorphic panel, add hidden dialog title/description for accessibility, and keep the close affordance in the top-right corner
- log the implementation details for this work under `prds/watch/work.md`

## Testing
- pnpm dlx nx test watch --testFile apps/watch/src/components/DialogLangSwitch/DialogLangSwitch.spec.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691496d79dc0832882f790130d310d88)