### PR TITLE
fix: exclude global templates from "Shared with me" journeys

### DIFF
--- a/apis/api-journeys/src/app/modules/journey/journey.resolver.ts
+++ b/apis/api-journeys/src/app/modules/journey/journey.resolver.ts
@@ -148,7 +148,15 @@ export class JourneyResolver {
         throw new GraphQLError('journey profile not found', {
           extensions: { code: 'NOT_FOUND' }
         })
-      filter.teamId = profile.lastActiveTeamId ?? undefined
+      if (profile.lastActiveTeamId !== null) {
+        filter.teamId = profile.lastActiveTeamId
+      } else {
+        // Fetch "Shared with me" journeys and filter out global templates
+        filter.NOT = {
+          template: true,
+          teamId: 'jfp-team'
+        }
+      }
     }
     if (teamId != null) {
       filter.teamId = teamId


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved journey filtering logic to correctly exclude global templates from shared journey results in certain scenarios.

* **Tests**
  * Added test coverage to verify that global templates are properly excluded from shared journey queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->