### PR TITLE
fix: privacy policy added to nexus page

### DIFF
--- a/apps/videos-admin/src/components/CenterPage/CenterPage.tsx
+++ b/apps/videos-admin/src/components/CenterPage/CenterPage.tsx
@@ -51,10 +51,7 @@ export function CenterPage({ children }: CenterPageProps): ReactElement {
       justifyContent="space-evenly"
       data-testid="CenterPageContainer"
     >
-      <Stack
-        alignItems="center"
-        gap={5}
-      >
+      <Stack alignItems="center" gap={5}>
         <Card variant="outlined" data-testid="CenterPageCard">
           {children}
         </Card>

--- a/apps/videos-admin/src/components/CenterPage/Centerpage.spec.tsx
+++ b/apps/videos-admin/src/components/CenterPage/Centerpage.spec.tsx
@@ -57,10 +57,8 @@ describe('CenterPage Component', () => {
 
     expect(screen.getByRole('button', { name: 'Privacy Policy' }))
 
-    expect(screen.getByRole('link', { name: 'Privacy Policy'})
-          ).toHaveAttribute(
-            'href', 
-            'https://www.cru.org/us/en/about/privacy.html'
-          )
+    expect(
+      screen.getByRole('link', { name: 'Privacy Policy' })
+    ).toHaveAttribute('href', 'https://www.cru.org/us/en/about/privacy.html')
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a localized Privacy Policy button on the center page that opens the external privacy page.

* **Style**
  * Centered and reflowed content layout for improved spacing and responsive alignment; moved card and privacy link into a centered stack and adjusted visual emphasis.

* **Tests**
  * Added a test to verify the Privacy Policy button is rendered and links to the external privacy page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->