### PR TITLE
feat: add standard margin on menu divider

### DIFF
--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DefaultMenu/DefaultMenu.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DefaultMenu/DefaultMenu.tsx
@@ -216,7 +216,7 @@ export function DefaultMenu({
         journey={journeyFromLazyQuery?.journey}
         handleCloseMenu={handleCloseMenu}
         handleKeepMounted={handleKeepMounted}
-      />      
+      />
       <Divider sx={{ my: 1 }} />
       {template !== true && activeTeam != null && (
         <>


### PR DESCRIPTION
## What?
Looking at this area, all `<Dividers/>` look the same, yet one does not have the same margin as the others.
Note, the standard margin is (4px 0px), where as this one is (0px 0px)

## Why?
When the Divider's preceding sibling is a Box (not a MenuItem), it prevents MUI from automatically 
applying margins that it would apply when following a direct MenuItem.

e.g. `ShareItem` (precedes the divider) wraps its `MenuItem` in a `Box`, so this Divider's preceding sibling is a `Box` (not a `MenuItem`)

## Note
- This fixes the margin issue for both issues listed in the ticket