### PR TITLE
fix: increase the polling timeout for mux videos

### DIFF
--- a/apps/journeys-admin/src/components/MuxVideoUploadProvider/utils/constants.ts
+++ b/apps/journeys-admin/src/components/MuxVideoUploadProvider/utils/constants.ts
@@ -1,3 +1,3 @@
-export const POLL_INTERVAL = 1000 // 3 seconds
-export const MAX_POLL_TIME = 60000 // 60 seconds
+export const POLL_INTERVAL = 5000 // 5 seconds (reduced API calls)
+export const MAX_POLL_TIME = 15 * 60 * 1000 // 15 minutes - Mux processing can take time
 export const TASK_CLEANUP_DELAY = 1000 // Delay before removing completed/errored tasks from pollingTasks


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted video upload processing parameters: reduced status check frequency to every 5 seconds and extended the maximum processing timeout to 15 minutes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->