### PR TITLE
fix: phone subtitles

### DIFF
--- a/libs/journeys/ui/src/components/Video/InitAndPlay/InitAndPlay.spec.tsx
+++ b/libs/journeys/ui/src/components/Video/InitAndPlay/InitAndPlay.spec.tsx
@@ -9,8 +9,6 @@ import { TreeBlock, blockHistoryVar } from '../../../libs/block'
 import { BlockFields_StepBlock as StepBlock } from '../../../libs/block/__generated__/BlockFields'
 import { JourneyProvider } from '../../../libs/JourneyProvider'
 import { JourneyFields as Journey } from '../../../libs/JourneyProvider/__generated__/JourneyFields'
-import { extractYouTubeCaptionsAndAddTextTracks } from '../utils/extractYouTubeCaptionsAndAddTextTracks'
-import { getCaptionsAndSubtitleTracks } from '../utils/getCaptionsAndSubtitleTracks'
 import { getMuxMetadata } from '../utils/getMuxMetadata'
 import VideoJsPlayer from '../utils/videoJsTypes'
 
@@ -308,7 +306,7 @@ describe('InitAndPlay', () => {
 
       expect(mockGetCaptionsAndSubtitleTracks).toHaveBeenCalledWith(player)
       expect(mockSubtitleTrack.mode).toBe('showing')
-      expect(mockCaptionTrack.mode).toBe('hidden')
+      expect(mockCaptionTrack.mode).toBe('showing')
     })
 
     it('should hide Mux subtitles when showGeneratedSubtitles is false', () => {
@@ -379,7 +377,7 @@ describe('InitAndPlay', () => {
       expect(subtitleTrack.mode).toBe('hidden')
     })
 
-    it('should only affect subtitle tracks, not caption tracks', () => {
+    it('should affect subtitle tracks and caption tracks', () => {
       const subtitleTrack = {
         ...mockSubtitleTrack,
         mode: 'hidden' as TextTrackMode
@@ -403,7 +401,7 @@ describe('InitAndPlay', () => {
       render(<InitAndPlay {...props} />)
 
       expect(subtitleTrack.mode).toBe('showing')
-      expect(captionTrack.mode).toBe('hidden')
+      expect(captionTrack.mode).toBe('showing')
     })
 
     it('should not process subtitles when player readyState is not 4', () => {

--- a/libs/journeys/ui/src/components/Video/InitAndPlay/InitAndPlay.tsx
+++ b/libs/journeys/ui/src/components/Video/InitAndPlay/InitAndPlay.tsx
@@ -280,7 +280,8 @@ export function InitAndPlay({
       const tracks = getCaptionsAndSubtitleTracks(player)
       tracks.forEach((track) => {
         if (
-          track.kind === 'subtitles'
+          track.kind === 'subtitles' ||
+          track.kind === 'captions'
           // add this check in once subtitleLanguage gets mutated
           //  &&
           // track.language === subtitleLanguage?.bcp47
@@ -290,7 +291,13 @@ export function InitAndPlay({
       })
     }
     // player ready state is needed in deps array to ensure useEffect is fired at correct time
-  }, [player, source, subtitleLanguage, player?.readyState()])
+  }, [
+    player,
+    source,
+    subtitleLanguage,
+    player?.readyState(),
+    showGeneratedSubtitles
+  ])
 
   return <></>
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video subtitle handling: Caption tracks are now displayed alongside subtitle tracks when enabling generated subtitles for Mux video sources, providing better accessibility and consistency in subtitle/caption display options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->