### PR TITLE
fix: template family aggregate query

### DIFF
--- a/apis/api-journeys-modern/src/schema/plausible/templateFamilyStatsAggregate/templateFamilyStatsAggregate.query.spec.ts
+++ b/apis/api-journeys-modern/src/schema/plausible/templateFamilyStatsAggregate/templateFamilyStatsAggregate.query.spec.ts
@@ -203,7 +203,12 @@ describe('templateFamilyStatsAggregate', () => {
     }
 
     prismaMock.journey.findUnique.mockResolvedValue(templateJourney as any)
-    prismaMock.journey.findMany.mockResolvedValue([])
+    prismaMock.journey.findMany.mockResolvedValue([
+      {
+        id: 'journey-1',
+        slug: 'journey-1-slug'
+      }
+    ] as any)
     prismaMock.journeyVisitor.groupBy.mockResolvedValue([])
 
     mockAxios.get.mockResolvedValue({
@@ -387,7 +392,12 @@ describe('templateFamilyStatsAggregate', () => {
     }
 
     prismaMock.journey.findUnique.mockResolvedValue(templateJourney as any)
-    prismaMock.journey.findMany.mockResolvedValue([])
+    prismaMock.journey.findMany.mockResolvedValue([
+      {
+        id: 'journey-1',
+        slug: 'journey-1-slug'
+      }
+    ] as any)
     prismaMock.journeyVisitor.groupBy.mockResolvedValue([])
 
     mockAxios.get.mockResolvedValue({

--- a/apis/api-journeys-modern/src/schema/plausible/templateFamilyStatsAggregate/templateFamilyStatsAggregate.query.ts
+++ b/apis/api-journeys-modern/src/schema/plausible/templateFamilyStatsAggregate/templateFamilyStatsAggregate.query.ts
@@ -69,12 +69,10 @@ builder.queryField('templateFamilyStatsAggregate', (t) =>
         templateSiteId
       )
 
-      const { childJourneysCount, totalJourneysViews } =
-        transformBreakdownResults(breakdownResults)
+      const { totalJourneysViews } = transformBreakdownResults(breakdownResults)
 
-      const totalJourneysResponses = await getTotalJourneysResponses(
-        templateJourney.id
-      )
+      const { totalJourneysResponses, childJourneysCount } =
+        await getTotalJourneysResponses(templateJourney.id)
 
       return {
         childJourneysCount,
@@ -87,7 +85,7 @@ builder.queryField('templateFamilyStatsAggregate', (t) =>
 
 function transformBreakdownResults(
   breakdownResults: PlausibleStatsResponse[]
-): { childJourneysCount: number; totalJourneysViews: number } {
+): { totalJourneysViews: number } {
   const slugMaxVisitors = new Map<string, number>()
 
   for (const result of breakdownResults) {
@@ -114,12 +112,14 @@ function transformBreakdownResults(
   )
 
   return {
-    childJourneysCount: slugMaxVisitors.size,
     totalJourneysViews
   }
 }
 
-async function getTotalJourneysResponses(templateId: string): Promise<number> {
+async function getTotalJourneysResponses(templateId: string): Promise<{
+  totalJourneysResponses: number
+  childJourneysCount: number
+}> {
   const childJourneys = await prisma.journey.findMany({
     where: {
       fromTemplateId: templateId
@@ -130,10 +130,14 @@ async function getTotalJourneysResponses(templateId: string): Promise<number> {
   })
 
   if (childJourneys.length === 0) {
-    return 0
+    return {
+      totalJourneysResponses: 0,
+      childJourneysCount: 0
+    }
   }
 
   const journeyIds = childJourneys.map((journey) => journey.id)
+  const childJourneysCount = journeyIds.length
 
   const results = await prisma.journeyVisitor.groupBy({
     by: ['journeyId'],
@@ -145,10 +149,13 @@ async function getTotalJourneysResponses(templateId: string): Promise<number> {
       journeyId: true
     }
   })
-  const childJourneysCount = results.reduce(
+  const totalJourneysResponses = results.reduce(
     (total, result) => total + (result._count.journeyId ?? 0),
     0
   )
 
-  return childJourneysCount
+  return {
+    totalJourneysResponses,
+    childJourneysCount
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved statistics aggregation to compute total journey views from per-journey maximums for more accurate visitor metrics.
  * Surfaced child-journey counts alongside total responses (instead of embedded in breakdown output) so callers receive both values.
  * Updated tests to reflect non-empty child-journey sets and revised aggregation behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->