### PR TITLE
feat: add timezone support for Google Sheets sync

### DIFF
--- a/apis/api-journeys-modern/src/schema/journeyVisitor/journeyVisitorExportToGoogleSheet.mutation.spec.ts
+++ b/apis/api-journeys-modern/src/schema/journeyVisitor/journeyVisitorExportToGoogleSheet.mutation.spec.ts
@@ -251,6 +251,7 @@ describe('journeyVisitorExportToGoogleSheet', () => {
         sheetName: '2024-01-01 test-journey',
         folderId: 'folder-id',
         email: 'test@example.com',
+        timezone: 'UTC',
         deletedAt: null
       }
     })

--- a/apis/api-journeys-modern/src/schema/journeyVisitor/journeyVisitorExportToGoogleSheet.mutation.ts
+++ b/apis/api-journeys-modern/src/schema/journeyVisitor/journeyVisitorExportToGoogleSheet.mutation.ts
@@ -597,6 +597,7 @@ builder.mutationField('journeyVisitorExportToGoogleSheet', (t) =>
         folderId:
           destination.mode === 'create' ? (destination.folderId ?? null) : null,
         email: integrationEmail,
+        timezone: userTimezone, // Store user's timezone for consistent date formatting in live sync
         deletedAt: null
       }
 

--- a/libs/prisma/journeys/db/migrations/20260107193142_20260107193140/migration.sql
+++ b/libs/prisma/journeys/db/migrations/20260107193142_20260107193140/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "GoogleSheetsSync" ADD COLUMN     "timezone" TEXT;

--- a/libs/prisma/journeys/db/schema.prisma
+++ b/libs/prisma/journeys/db/schema.prisma
@@ -288,6 +288,7 @@ model GoogleSheetsSync {
   sheetName     String
   folderId      String?
   email         String?
+  timezone      String? // IANA timezone identifier captured when sync was created (e.g., "Pacific/Auckland")
   deletedAt     DateTime?
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt


### PR DESCRIPTION
- Introduced timezone field in GoogleSheetsSync model to store IANA timezone identifier.
- Updated appendEventToGoogleSheets function to use stored timezone for date formatting.
- Modified journeyVisitorExportToGoogleSheet mutation to capture user's timezone for consistent date handling.
- Added timezone parameter in relevant tests for validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Google Sheets exports now use your configured timezone for date formatting instead of always defaulting to UTC
  * Dates in exported spreadsheets are now displayed in your timezone preference rather than UTC
  * Your timezone setting is automatically saved with your spreadsheet sync configuration to ensure consistent formatting in all future exports

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->