### PR TITLE
feat: add validation for Google account integration to prevent duplic…

### DIFF
--- a/apis/api-journeys-modern/src/schema/integration/google/googleCreate.mutation.spec.ts
+++ b/apis/api-journeys-modern/src/schema/integration/google/googleCreate.mutation.spec.ts
@@ -93,7 +93,7 @@ describe('integrationGoogleCreate', () => {
       tag: 'tag'
     })
     // No existing integration for this user with the same Google account
-    prismaMock.integration.findFirst.mockResolvedValue(null)
+    prismaMock.integration.findUnique.mockResolvedValue(null)
     prismaMock.integration.create.mockResolvedValue(mockIntegration as any)
 
     const result = await authClient({
@@ -314,7 +314,7 @@ describe('integrationGoogleCreate', () => {
     mockAxios.get.mockResolvedValueOnce(mockUserInfoResponse as any)
 
     // Simulate existing integration with the same Google account for this user
-    prismaMock.integration.findFirst.mockResolvedValue({
+    prismaMock.integration.findUnique.mockResolvedValue({
       id: 'existing-integration-id',
       type: 'google',
       teamId: 'other-team-id',
@@ -346,11 +346,14 @@ describe('integrationGoogleCreate', () => {
       ]
     })
 
-    expect(prismaMock.integration.findFirst).toHaveBeenCalledWith({
+    expect(prismaMock.integration.findUnique).toHaveBeenCalledWith({
       where: {
-        userId: 'userId',
-        type: 'google',
-        accountEmail: 'existing@example.com'
+        userId_teamId_type_accountEmail: {
+          userId: 'userId',
+          teamId: 'team-id',
+          type: 'google',
+          accountEmail: 'existing@example.com'
+        }
       }
     })
 
@@ -392,7 +395,7 @@ describe('integrationGoogleCreate', () => {
     })
 
     // No existing integration for this user (another user may have same email)
-    prismaMock.integration.findFirst.mockResolvedValue(null)
+    prismaMock.integration.findUnique.mockResolvedValue(null)
     prismaMock.integration.create.mockResolvedValue(mockIntegration as any)
 
     const result = await authClient({

--- a/apis/api-journeys-modern/src/schema/integration/google/googleCreate.mutation.ts
+++ b/apis/api-journeys-modern/src/schema/integration/google/googleCreate.mutation.ts
@@ -126,12 +126,15 @@ builder.mutationField('integrationGoogleCreate', (t) =>
         }
         const accountEmail = userInfo.data.email
 
-        // Check if user already has a Google integration with this account email
-        const existingIntegration = await prisma.integration.findFirst({
+        // Check if user in team  already has a Google integration with this account email
+        const existingIntegration = await prisma.integration.findUnique({
           where: {
-            userId,
-            type: 'google',
-            accountEmail
+            userId_teamId_type_accountEmail: {
+              userId,
+              teamId,
+              type: 'google',
+              accountEmail
+            }
           }
         })
 

--- a/libs/prisma/journeys/db/migrations/20260108205634_20260108205606/migration.sql
+++ b/libs/prisma/journeys/db/migrations/20260108205634_20260108205606/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[userId,teamId,type,accountEmail]` on the table `Integration` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Integration_userId_teamId_type_accountEmail_key" ON "Integration"("userId", "teamId", "type", "accountEmail");

--- a/libs/prisma/journeys/db/schema.prisma
+++ b/libs/prisma/journeys/db/schema.prisma
@@ -275,6 +275,7 @@ model Integration {
   googleSheetsSyncs      GoogleSheetsSync[]
   team                   Team               @relation(fields: [teamId], references: [id], onDelete: Cascade)
 
+  @@unique([userId, teamId, type, accountEmail])
   @@index([teamId])
   @@index(userId)
 }


### PR DESCRIPTION
…ates

- Implemented a check to ensure users cannot link the same Google account multiple times.
- Added tests to verify behavior when a user attempts to create a Google integration with an already linked account.
- Enhanced error handling to provide user-friendly messages for existing integrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents linking the same Google account to a user twice; attempts now return a user-facing error.

* **Database**
  * Adds a uniqueness constraint to enforce one integration per user/team/type/account combination.

* **Tests**
  * New tests cover duplicate-account detection and verify different users can link the same Google account.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->