### PR TITLE
feat: enhance Google Sheets event handling to include new block colum…

### DIFF
--- a/apis/api-journeys-modern/src/schema/event/utils.spec.ts
+++ b/apis/api-journeys-modern/src/schema/event/utils.spec.ts
@@ -735,8 +735,8 @@ describe('event utils', () => {
 
       // Header should be updated to include the new poll column
       expect(mockUpdateRangeValues).toHaveBeenCalled()
-      const updateCall = mockUpdateRangeValues.mock.calls.find(
-        (call) => call[0].range?.includes('A1')
+      const updateCall = mockUpdateRangeValues.mock.calls.find((call) =>
+        call[0].range?.includes('A1')
       )
       expect(updateCall).toBeDefined()
       // The header row should now include 3 columns: Visitor ID, Date, and Poll


### PR DESCRIPTION
…ns in headers

This update ensures that when a new block is added to a journey, its corresponding column is included in the header during the first event submission. The logic has been adjusted to rebuild the header dynamically, preventing data loss for new blocks. Additionally, tests have been added to verify this functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Google Sheets export now dynamically expands headers when new questions/blocks are introduced mid-journey, keeps rows correctly aligned across multiple synced sheets, and correctly maps responses even with overlapping block IDs or varying label whitespace.

* **Tests**
  * Added tests validating header expansion, accurate row placement, handling of overlapping IDs, whitespace-normalized labels, and multi-sheet sync scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->