### PR TITLE
Change CMS admin flags default values to false

### DIFF
--- a/apps/cms/config/admin.ts
+++ b/apps/cms/config/admin.ts
@@ -14,8 +14,8 @@ const adminConfig = ({ env }) => ({
     encryptionKey: env('ENCRYPTION_KEY')
   },
   flags: {
-    nps: env.bool('FLAG_NPS', true),
-    promoteEE: env.bool('FLAG_PROMOTE_EE', true)
+    nps: env.bool('FLAG_NPS', false),
+    promoteEE: env.bool('FLAG_PROMOTE_EE', false)
   }
 })
 


### PR DESCRIPTION
Update default values for `FLAG_NPS` and `FLAG_PROMOTE_EE` flags in CMS admin config from `true` to `false`.

**Changes:**
- `FLAG_NPS` default: `true` → `false`
- `FLAG_PROMOTE_EE` default: `true` → `false`

**File:** `apps/cms/config/admin.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated default configuration settings to disable two administrative features by default, reducing initial system prompts and promotional elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->