### PR TITLE
fix: normalize the database editions when finding for importer executable

### DIFF
--- a/apps/video-importer/src/utils/videoEditionValidator.ts
+++ b/apps/video-importer/src/utils/videoEditionValidator.ts
@@ -50,7 +50,9 @@ export async function validateVideoAndEdition(
     )
 
     const editions = response.video.videoEditions || []
-    const edition = editions.find((e) => e.name === editionName)
+    const edition = editions.find(
+      (e) => e.name.toLowerCase() === editionName.toLowerCase()
+    )
 
     if (!edition) {
       console.log(`   Edition not found: ${editionName}`)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Video edition matching is now case-insensitive, improving reliability when searching for editions during imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->