### PR TITLE
Up/nes 1194 youtube videos fail to play on android when opened via

### DIFF
--- a/apis/api-users/src/schema/user/findOrFetchUser.ts
+++ b/apis/api-users/src/schema/user/findOrFetchUser.ts
@@ -19,7 +19,7 @@ export async function findOrFetchUser(
   if (existingUser != null && existingUser.emailVerified == null) {
     const user = await prisma.user.update({
       where: {
-        id: userId
+        userId
       },
       data: {
         emailVerified: false
@@ -86,7 +86,7 @@ export async function findOrFetchUser(
     do {
       user = await prisma.user.update({
         where: {
-          id: userId
+          userId
         },
         data
       })

--- a/libs/journeys/ui/src/components/Card/ContainedCover/BackgroundVideo/BackgroundVideo.tsx
+++ b/libs/journeys/ui/src/components/Card/ContainedCover/BackgroundVideo/BackgroundVideo.tsx
@@ -4,8 +4,8 @@ import { CSSProperties, ReactElement, useEffect, useRef, useState } from 'react'
 import videojs from 'video.js'
 import Player from 'video.js/dist/types/player'
 
-import { isInstagramAndroidWebView } from '@core/shared/ui/deviceUtils'
 import { defaultBackgroundVideoJsOptions } from '@core/shared/ui/defaultVideoJsOptions'
+import { isInstagramAndroidWebView } from '@core/shared/ui/deviceUtils'
 
 import {
   VideoBlockObjectFit,
@@ -155,7 +155,12 @@ export function BackgroundVideo({
         <iframe
           src={`https://www.youtube.com/embed/${videoId}?start=${startAt ?? 0}&end=${endAt ?? 0}&autoplay=1&mute=1&loop=1&playsinline=1&controls=0`}
           allow="accelerometer; autoplay; encrypted-media"
-          style={{ width: '100%', height: '100%', border: 'none', pointerEvents: 'none' }}
+          style={{
+            width: '100%',
+            height: '100%',
+            border: 'none',
+            pointerEvents: 'none'
+          }}
           title="Background video"
         />
       </Box>

--- a/libs/journeys/ui/src/components/Card/ContainedCover/BackgroundVideo/BackgroundVideo.tsx
+++ b/libs/journeys/ui/src/components/Card/ContainedCover/BackgroundVideo/BackgroundVideo.tsx
@@ -1,9 +1,10 @@
 import Box from '@mui/material/Box'
 import { styled } from '@mui/material/styles'
-import { CSSProperties, ReactElement, useEffect, useRef } from 'react'
+import { CSSProperties, ReactElement, useEffect, useRef, useState } from 'react'
 import videojs from 'video.js'
 import Player from 'video.js/dist/types/player'
 
+import { isInstagramAndroidWebView } from '@core/shared/ui/deviceUtils'
 import { defaultBackgroundVideoJsOptions } from '@core/shared/ui/defaultVideoJsOptions'
 
 import {
@@ -36,6 +37,11 @@ export function BackgroundVideo({
   const videoRef = useRef<HTMLVideoElement>(null)
   const playerRef = useRef<Player | null>(null)
   const isYouTube = source === VideoBlockSource.youTube
+  const [inAppBrowser, setInAppBrowser] = useState(false)
+
+  useEffect(() => {
+    setInAppBrowser(isInstagramAndroidWebView())
+  }, [])
 
   // Initiate Video
   useEffect(() => {
@@ -134,6 +140,26 @@ export function BackgroundVideo({
         videoFit = 'cover'
         break
     }
+  }
+
+  if (inAppBrowser && isYouTube && videoId != null) {
+    return (
+      <Box
+        height="100%"
+        width="100%"
+        minHeight="-webkit-fill-available"
+        overflow="hidden"
+        position="absolute"
+        data-testid="CardContainedBackgroundVideo"
+      >
+        <iframe
+          src={`https://www.youtube.com/embed/${videoId}?start=${startAt ?? 0}&end=${endAt ?? 0}&autoplay=1&mute=1&loop=1&playsinline=1&controls=0`}
+          allow="accelerometer; autoplay; encrypted-media"
+          style={{ width: '100%', height: '100%', border: 'none', pointerEvents: 'none' }}
+          title="Background video"
+        />
+      </Box>
+    )
   }
 
   return (

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -226,7 +226,9 @@ export function Video({
           />
         )}
 
-      {videoId != null && inAppBrowser && source === VideoBlockSource.youTube ? (
+      {videoId != null &&
+      inAppBrowser &&
+      source === VideoBlockSource.youTube ? (
         <Box
           data-testid="in-app-browser-youtube-fallback"
           sx={{

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react'
 import { use100vh } from 'react-div-100vh'
 
+import { isInstagramAndroidWebView } from '@core/shared/ui/deviceUtils'
 import { NextImage } from '@core/shared/ui/NextImage'
 
 import {
@@ -74,6 +75,11 @@ export function Video({
   const [player, setPlayer] = useState<VideoJsPlayer>()
   const [showPoster, setShowPoster] = useState(true)
   const [activeStep, setActiveStep] = useState(false)
+  const [inAppBrowser, setInAppBrowser] = useState(false)
+
+  useEffect(() => {
+    setInAppBrowser(isInstagramAndroidWebView())
+  }, [])
 
   const { blockHistory } = useBlocks()
   const { variant, journey } = useJourney()
@@ -220,7 +226,24 @@ export function Video({
           />
         )}
 
-      {videoId != null ? (
+      {videoId != null && inAppBrowser && source === VideoBlockSource.youTube ? (
+        <Box
+          data-testid="in-app-browser-youtube-fallback"
+          sx={{
+            width: '100%',
+            height: '100%',
+            position: 'relative'
+          }}
+        >
+          <iframe
+            src={`https://www.youtube.com/embed/${videoId}?start=${effectiveStartAt}&end=${effectiveEndAt}&autoplay=0&playsinline=1`}
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"
+            allowFullScreen
+            style={{ width: '100%', height: '100%', border: 'none' }}
+            title={title ?? 'YouTube video'}
+          />
+        </Box>
+      ) : videoId != null ? (
         <>
           <Box
             height={{

--- a/libs/shared/ui/src/libs/deviceUtils/deviceUtils.ts
+++ b/libs/shared/ui/src/libs/deviceUtils/deviceUtils.ts
@@ -60,6 +60,17 @@ export function isIOSTouchScreen(): boolean {
   )
 }
 
+export function isInstagramAndroidWebView(): boolean {
+  if (
+    typeof navigator === 'undefined' ||
+    typeof navigator.userAgent === 'undefined'
+  )
+    return false
+
+  const ua = navigator.userAgent
+  return /Android/i.test(ua) && /Instagram/i.test(ua)
+}
+
 // TODO: should only resort to user agent sniffing as a last resport
 export function isMobile(): boolean {
   if (

--- a/libs/shared/ui/src/libs/deviceUtils/index.ts
+++ b/libs/shared/ui/src/libs/deviceUtils/index.ts
@@ -1,5 +1,6 @@
 export {
   hasTouchScreen,
+  isInstagramAndroidWebView,
   isIPhone,
   isMobile,
   isIOS,


### PR DESCRIPTION
This fix follows @Ur-imazing’s suggestion.
It resolves the issue with Instagram WebView on Android without affecting other scenarios.
My previous push needs to be merged to prevent conflicts. https://github.com/JesusFilm/core/pull/8749

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YouTube playback for users opening content in Instagram's Android in-app browser: videos now use an embedded YouTube player fallback for better compatibility and reliability.
* **New Features**
  * Added in-app browser detection to ensure the correct video rendering path is used in affected mobile environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->