### PR TITLE
feat: add automated stage branch reset script and Cursor skill

### DIFF
--- a/.cursor/skills/reset-stage/SKILL.md
+++ b/.cursor/skills/reset-stage/SKILL.md
@@ -101,8 +101,8 @@ deterministic — same PR set + same order = same result.
 
 ### If stage is broken after a reset
 
-Run the reset again. The script deletes the remote stage branch and
-recreates it from `main`, so every reset starts completely fresh.
+Run the reset again. The script resets stage to `main` and force-pushes,
+so every reset starts completely fresh.
 
 ### If an engineer's PR is causing problems on stage
 

--- a/apps/docs/docs/04-engineering-practices/02-deployment/index.md
+++ b/apps/docs/docs/04-engineering-practices/02-deployment/index.md
@@ -35,10 +35,10 @@ Use the `reset-stage` Cursor skill — it automates the entire process and handl
 
 **What it does:**
 
-1. Deletes and recreates the `stage` branch from `main`
+1. Resets the local `stage` branch to `main`
 2. Fetches all open PRs with the `on stage` label
 3. Merges each one in turn — conflicts are auto-resolved by accepting the incoming PR's changes (`-X theirs`)
-4. Pushes `stage` to origin, triggering the stage deploy workflows
+4. Force-pushes `stage` to origin, triggering the stage deploy workflows
 5. Posts a summary to Slack with a breakdown of merged and auto-resolved PRs
 
 **Why `-X theirs` is safe:** Stage is ephemeral — it exists only for integration testing and gets fully replaced on every reset. PR branches are the source of truth and are never modified. The worst outcome is a broken stage build, which is fixed by running the reset again.

--- a/tools/scripts/reset-stage.sh
+++ b/tools/scripts/reset-stage.sh
@@ -267,7 +267,7 @@ else
 fi
 echo ""
 
-# ── Slack notification (failures only) ───────────────────────────────
+# ── Slack notification ────────────────────────────────────────────────
 
 if ! $NO_SLACK; then
 


### PR DESCRIPTION
## Summary

- Adds `tools/scripts/reset-stage.sh` — a bash script that automates the stage branch reset process (fetching "on stage" PRs, rebuilding stage from main, reporting merged/failed PRs)
- Adds `.cursor/skills/reset-stage/SKILL.md` — a Cursor skill that wraps the script with trigger phrases like "reset stage" and "dry run stage"
- Slack integration posts a summary + threaded details using bot token from Doppler (`STAGE_RESET_SLACK_BOT_TOKEN`, `SLACK_ENGINEERING_CHANNEL_ID`)
- Default mode is a safe dry-run; `--apply` flag performs the actual reset with a confirmation prompt

Closes ENG-3587

## Test plan

- [x] Dry-run mode tested against 33 "on stage" PRs (20 merged, 13 failed)
- [x] Real `--apply` mode tested (stage reset and pushed successfully)
- [x] Slack threading verified (summary + 2 threaded replies)
- [x] Doppler fallback verified (graceful warning when secrets not found)
- [ ] Add `STAGE_RESET_SLACK_BOT_TOKEN` and `SLACK_ENGINEERING_CHANNEL_ID` to Doppler `core/dev`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reset-stage automation to rebuild the stage branch from main, re-merge open stage PRs, and report outcomes.
  * Dry-run by default with an explicit apply flag and confirmation for destructive actions.
  * Per-PR merge loop with auto-resolve fallback, detailed outcome classification, and optional Slack notifications.

* **Documentation**
  * Added user guide covering usage, trigger phrases, modes, recovery steps, and operational prerequisites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->