### PR TITLE
fix: filter deleted blocks from adminJourney query

### DIFF
--- a/apis/api-journeys-modern/src/schema/journey/journey.ts
+++ b/apis/api-journeys-modern/src/schema/journey/journey.ts
@@ -55,7 +55,8 @@ export const JourneyRef = builder.prismaObject('Journey', {
       resolve: (journey) => ({ id: journey.languageId ?? '529' })
     }),
     blocks: t.relation('blocks', {
-      nullable: true
+      nullable: true,
+      query: () => ({ where: { deletedAt: null } })
     }),
     chatButtons: t.relation('chatButtons', {
       nullable: false


### PR DESCRIPTION
## Summary
- The `blocks` relation on the Journey type in `api-journeys-modern` was returning all blocks including soft-deleted ones (`deletedAt != null`)
- The legacy `api-journeys` resolver correctly filtered these with `deletedAt: null` — this was missed during the port
- Adds `query: () => ({ where: { deletedAt: null } })` to the `blocks` relation, consistent with all other block queries in the codebase

## Test plan
- [ ] Verify `adminJourney` query no longer returns blocks with non-null `deletedAt`
- [ ] Verify block delete/restore undo functionality still works (uses separate mutation, not this relation)
- [ ] Verify journey editor loads blocks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where deleted blocks were appearing in journey data. Deleted blocks are now properly excluded from results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->