### PR TITLE
fix: scope visitor lookup by teamId to prevent cross-team mismatches

### DIFF
--- a/apis/api-journeys-modern/src/schema/event/utils.spec.ts
+++ b/apis/api-journeys-modern/src/schema/event/utils.spec.ts
@@ -91,6 +91,9 @@ describe('event utils', () => {
 
       const result = await validateBlockEvent('user-id', 'block-id', 'step-id')
 
+      expect(prismaMock.visitor.findFirst).toHaveBeenCalledWith({
+        where: { userId: 'user-id', teamId: 'team-id' }
+      })
       expect(result).toEqual({
         visitor: mockVisitor,
         journeyVisitor: mockJourneyVisitor,
@@ -261,6 +264,7 @@ describe('event utils', () => {
 
   describe('getByUserIdAndJourneyId', () => {
     it('should return visitor and journeyVisitor when both exist', async () => {
+      const mockJourney = { teamId: 'team-id' }
       const mockVisitor = {
         id: 'visitor-id'
       }
@@ -270,6 +274,7 @@ describe('event utils', () => {
         visitorId: 'visitor-id'
       }
 
+      prismaMock.journey.findUnique.mockResolvedValue(mockJourney as any)
       prismaMock.visitor.findFirst.mockResolvedValue(mockVisitor as any)
       prismaMock.journeyVisitor.findUnique.mockResolvedValue(
         mockJourneyVisitor as any
@@ -277,13 +282,27 @@ describe('event utils', () => {
 
       const result = await getByUserIdAndJourneyId('user-id', 'journey-id')
 
+      expect(prismaMock.visitor.findFirst).toHaveBeenCalledWith({
+        where: { userId: 'user-id', teamId: 'team-id' }
+      })
       expect(result).toEqual({
         visitor: mockVisitor,
         journeyVisitor: mockJourneyVisitor
       })
     })
 
+    it('should return null when journey does not exist', async () => {
+      prismaMock.journey.findUnique.mockResolvedValue(null)
+
+      const result = await getByUserIdAndJourneyId('user-id', 'journey-id')
+
+      expect(result).toBeNull()
+    })
+
     it('should return null when visitor does not exist', async () => {
+      prismaMock.journey.findUnique.mockResolvedValue({
+        teamId: 'team-id'
+      } as any)
       prismaMock.visitor.findFirst.mockResolvedValue(null)
 
       const result = await getByUserIdAndJourneyId('user-id', 'journey-id')
@@ -292,6 +311,9 @@ describe('event utils', () => {
     })
 
     it('should return null when journeyVisitor does not exist', async () => {
+      prismaMock.journey.findUnique.mockResolvedValue({
+        teamId: 'team-id'
+      } as any)
       prismaMock.visitor.findFirst.mockResolvedValue({
         id: 'visitor-id'
       } as any)

--- a/apis/api-journeys-modern/src/schema/event/utils.ts
+++ b/apis/api-journeys-modern/src/schema/event/utils.ts
@@ -84,9 +84,10 @@ export async function validateBlockEvent(
     })
   }
 
-  // Get visitor by userId and check if they have access to this journey
+  // Get visitor by userId scoped to the journey's team to avoid
+  // returning a visitor from a different team (e.g. jfp-team)
   const visitor = await prisma.visitor.findFirst({
-    where: { userId }
+    where: { userId, teamId: journey.teamId }
   })
 
   if (visitor == null) {
@@ -152,8 +153,17 @@ export async function getByUserIdAndJourneyId(
   visitor: Visitor
   journeyVisitor: JourneyVisitor
 } | null> {
+  const journey = await prisma.journey.findUnique({
+    where: { id: journeyId },
+    select: { teamId: true }
+  })
+
+  if (journey == null) {
+    return null
+  }
+
   const visitor = await prisma.visitor.findFirst({
-    where: { userId }
+    where: { userId, teamId: journey.teamId }
   })
 
   if (visitor == null) {


### PR DESCRIPTION
## Summary
- `validateBlockEvent` and `getByUserIdAndJourneyId` in `api-journeys-modern` were querying visitors by `userId` alone (`findFirst({ where: { userId } })`), without filtering by `teamId`
- When a user had visitor records across multiple teams, this could return a visitor from the wrong team (e.g. `jfp-team` instead of the journey's actual team)
- This caused duplicate `JourneyVisitor` records linking the wrong visitor to a journey, and incorrect event attribution
- Fix: add `teamId: journey.teamId` to both `findFirst` queries so visitors are always scoped to the correct team

## Context
Riah reported duplicate visitor records appearing mid-session. Investigation showed the same journey (`e3cffd88-...`) had two JourneyVisitor records pointing to visitors on different teams — one on the correct team (`d0a8d4bb-...`) and one on `jfp-team`. The root cause was the unscoped `findFirst` returning whichever visitor Postgres found first, regardless of team.

## Test plan
- [x] Updated `validateBlockEvent` tests to assert `teamId` is included in visitor query
- [x] Updated `getByUserIdAndJourneyId` tests to mock journey lookup and assert team-scoped query
- [x] Added test for `getByUserIdAndJourneyId` returning null when journey doesn't exist
- [ ] Verify on stage: visiting a journey creates visitor on the correct team only
- [ ] Verify on stage: mid-session actions don't create duplicate visitors across teams

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced visitor data access control to ensure lookups are properly scoped to the appropriate team, preventing unintended cross-team data visibility and improving overall system security.

* **Tests**
  * Expanded test coverage for visitor lookup and journey validation to include additional edge cases and ensure consistent query behavior across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->