### PR TITLE
fix: pass journeyId to mobile AnalyticsItem in Menu.tsx

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Toolbar/Menu/Menu.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Menu/Menu.spec.tsx
@@ -643,6 +643,9 @@ describe('Toolbar Menu', () => {
         screen.getByRole('menuitem', { name: 'Analytics 0 visitors' })
       ).toBeInTheDocument()
       expect(
+        screen.getByRole('menuitem', { name: 'Analytics 0 visitors' })
+      ).toHaveAttribute('href', '/journeys/journeyId/reports')
+      expect(
         screen.getByRole('menuitem', { name: 'Strategy' })
       ).toBeInTheDocument()
       expect(

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Menu/Menu.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Menu/Menu.tsx
@@ -97,7 +97,9 @@ export function Menu({ user }: MenuProps): ReactElement {
         {!isLocalTemplate && (
           <AccessItem variant="menu-item" onClose={handleCloseMenu} />
         )}
-        {!mdUp && !isTemplate && <AnalyticsItem variant="menu-item" />}
+        {!mdUp && !isTemplate && (
+          <AnalyticsItem variant="menu-item" journeyId={journey?.id} />
+        )}
         {!sharedWithMeTeam && !isTemplate && (
           <>
             <CreateTemplateItem variant="menu-item" globalPublish={false} />


### PR DESCRIPTION
## Summary
- **Bug:** On mobile, tapping "Analytics" from the Journey Builder three-dot menu navigated to `/journeys/undefined/reports` instead of the correct analytics page
- **Root cause:** `AnalyticsItem` in `Menu.tsx` was rendered without the `journeyId` prop (the desktop version in `Items.tsx` already passed it correctly)
- **Fix:** Added `journeyId={journey?.id}` to match the desktop pattern

## Test plan
- [x] Added `href` assertion to existing mobile menu test to verify correct URL
- [x] All 561 test suites pass (3040 tests)
- [ ] QA: Open Journey Builder on mobile → tap three-dot menu → tap Analytics → verify it opens `/journeys/{id}/reports`
- [ ] Verify desktop Analytics button still works correctly

Resolves NES-1485

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics menu item in the editor toolbar now correctly links to the journey's reports page, enabling proper access to journey-specific analytics data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->