### PR TITLE
fix: mobile drawer missing scroll prevents CreateJourneyButton visibility (NES-1115)

### DIFF
--- a/apps/journeys-admin/src/components/JourneyList/AddJourneyFab/AddJourneyFab.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/AddJourneyFab/AddJourneyFab.tsx
@@ -9,8 +9,7 @@ import {
   MOBILE_FAB_BOTTOM_OFFSET,
   MOBILE_FAB_RIGHT_OFFSET,
   MOBILE_HELPSCOUT_FAB_MARGIN_X,
-  MOBILE_HELPSCOUT_FAB_WIDTH,
-  MOBILE_HELPSCOUT_FAB_Z_INDEX
+  MOBILE_HELPSCOUT_FAB_WIDTH
 } from '../../HelpScoutBeacon/constants'
 
 export function AddJourneyFab(): ReactElement {
@@ -38,7 +37,7 @@ export function AddJourneyFab(): ReactElement {
           MOBILE_FAB_RIGHT_OFFSET +
           MOBILE_HELPSCOUT_FAB_WIDTH +
           MOBILE_HELPSCOUT_FAB_MARGIN_X,
-        zIndex: MOBILE_HELPSCOUT_FAB_Z_INDEX,
+        zIndex: (theme) => theme.zIndex.fab,
         display: { xs: 'flex', md: 'none' }
       }}
       data-testid="AddJourneyFab"

--- a/apps/journeys-admin/src/components/JourneyList/AddJourneyFab/AddJourneyFab.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/AddJourneyFab/AddJourneyFab.tsx
@@ -9,7 +9,8 @@ import {
   MOBILE_FAB_BOTTOM_OFFSET,
   MOBILE_FAB_RIGHT_OFFSET,
   MOBILE_HELPSCOUT_FAB_MARGIN_X,
-  MOBILE_HELPSCOUT_FAB_WIDTH
+  MOBILE_HELPSCOUT_FAB_WIDTH,
+  MOBILE_HELPSCOUT_FAB_Z_INDEX
 } from '../../HelpScoutBeacon/constants'
 
 export function AddJourneyFab(): ReactElement {
@@ -37,7 +38,7 @@ export function AddJourneyFab(): ReactElement {
           MOBILE_FAB_RIGHT_OFFSET +
           MOBILE_HELPSCOUT_FAB_WIDTH +
           MOBILE_HELPSCOUT_FAB_MARGIN_X,
-        zIndex: (theme) => theme.zIndex.fab,
+        zIndex: MOBILE_HELPSCOUT_FAB_Z_INDEX,
         display: { xs: 'flex', md: 'none' }
       }}
       data-testid="AddJourneyFab"

--- a/apps/journeys-admin/src/components/PageWrapper/SidePanel/SidePanel.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/SidePanel/SidePanel.tsx
@@ -71,9 +71,10 @@ function DrawerContent({
       <Stack
         data-testid="side-body"
         border="hidden"
+        flexGrow={1}
         sx={{
-          overflow: 'none',
-          overflowY: { sm: 'auto' }
+          overflow: 'hidden',
+          overflowY: 'auto'
         }}
       >
         {children}


### PR DESCRIPTION
## Summary
- On certain Android devices (Redmi Note 13 Pro+, OnePlus Nord2), tapping the "Add" FAB opens the mobile bottom drawer but the "Create Custom Journey" button inside is not visible
- Root cause: the `DrawerContent` side-body Stack had `overflow: 'none'` (invalid CSS, ignored by browsers) and `overflowY` only enabled scroll at `sm+` breakpoint — not on `xs` (mobile portrait < 568px)
- Without scroll on `xs`, content overflowed and was clipped by the Drawer paper, hiding the button off-screen
- Fix: corrected to `overflow: 'hidden'`, `overflowY: 'auto'` for all breakpoints, and added `flexGrow={1}` so the Stack fills available drawer height

## Test plan
- [ ] On Chrome DevTools mobile emulation (< 568px width, e.g. Pixel 5), open the journeys list page
- [ ] Tap the "Add" FAB at bottom-right to open the mobile drawer
- [ ] Verify the "Create Custom Journey" button is visible at the top of the drawer content
- [ ] Scroll down in the drawer to verify "Use Template" section and template list are accessible
- [ ] Verify the desktop side panel (>= 600px width) still scrolls correctly with long content
- [ ] Verify the drawer close button (X) works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved side panel scrolling behavior to ensure vertical scrolling is consistently available and horizontal scrolling is disabled across all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->