### PR TITLE
fix: social media step spacing, preview size, and UI cleanup (NES-1530)

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/DescriptionEdit/DescriptionEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/DescriptionEdit/DescriptionEdit.tsx
@@ -113,7 +113,9 @@ export function DescriptionEdit({
           label={t('Secondary Text')}
           fullWidth
           disabled
-          helperText={hideHelperText ? undefined : t('Recommended length: up to 18 words')}
+          helperText={
+            hideHelperText ? undefined : t('Recommended length: up to 18 words')
+          }
           data-testid="DescriptionEdit"
         />
       )}

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/DescriptionEdit/DescriptionEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/DescriptionEdit/DescriptionEdit.tsx
@@ -19,7 +19,13 @@ export const JOURNEY_SEO_DESCRIPTION_UPDATE = gql`
   }
 `
 
-export function DescriptionEdit(): ReactElement {
+interface DescriptionEditProps {
+  hideHelperText?: boolean
+}
+
+export function DescriptionEdit({
+  hideHelperText = false
+}: DescriptionEditProps): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   const [journeyUpdate] = useMutation<JourneySeoDescriptionUpdate>(
     JOURNEY_SEO_DESCRIPTION_UPDATE
@@ -82,9 +88,11 @@ export function DescriptionEdit(): ReactElement {
                   Boolean(errors.seoDescription)
                 }
                 helperText={
-                  errors.seoDescription != null
-                    ? (errors.seoDescription as string)
-                    : t('Recommended length: up to 18 words')
+                  hideHelperText
+                    ? undefined
+                    : errors.seoDescription != null
+                      ? (errors.seoDescription as string)
+                      : t('Recommended length: up to 18 words')
                 }
                 onChange={handleChange}
                 onBlur={(e) => {
@@ -105,7 +113,7 @@ export function DescriptionEdit(): ReactElement {
           label={t('Secondary Text')}
           fullWidth
           disabled
-          helperText={t('Recommended length: up to 18 words')}
+          helperText={hideHelperText ? undefined : t('Recommended length: up to 18 words')}
           data-testid="DescriptionEdit"
         />
       )}

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/TitleEdit/TitleEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/TitleEdit/TitleEdit.tsx
@@ -110,7 +110,9 @@ export function TitleEdit({
           label={t('Headline')}
           fullWidth
           disabled
-          helperText={hideHelperText ? undefined : t('Recommended length: 5 words')}
+          helperText={
+            hideHelperText ? undefined : t('Recommended length: 5 words')
+          }
           data-testid="TitleEdit"
         />
       )}

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/TitleEdit/TitleEdit.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/TitleEdit/TitleEdit.tsx
@@ -19,7 +19,13 @@ export const JOURNEY_SEO_TITLE_UPDATE = gql`
   }
 `
 
-export function TitleEdit(): ReactElement {
+interface TitleEditProps {
+  hideHelperText?: boolean
+}
+
+export function TitleEdit({
+  hideHelperText = false
+}: TitleEditProps): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   const [journeyUpdate] = useMutation<JourneySeoTitleUpdate>(
     JOURNEY_SEO_TITLE_UPDATE
@@ -79,9 +85,11 @@ export function TitleEdit(): ReactElement {
                 value={values.seoTitle}
                 error={touched.seoTitle === true && Boolean(errors.seoTitle)}
                 helperText={
-                  errors.seoTitle != null
-                    ? (errors.seoTitle as string)
-                    : t('Recommended length: 5 words')
+                  hideHelperText
+                    ? undefined
+                    : errors.seoTitle != null
+                      ? (errors.seoTitle as string)
+                      : t('Recommended length: 5 words')
                 }
                 onChange={handleChange}
                 onBlur={(e) => {
@@ -102,7 +110,7 @@ export function TitleEdit(): ReactElement {
           label={t('Headline')}
           fullWidth
           disabled
-          helperText={t('Recommended length: 5 words')}
+          helperText={hideHelperText ? undefined : t('Recommended length: 5 words')}
           data-testid="TitleEdit"
         />
       )}

--- a/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/CustomizeFlowNextButton/CustomizeFlowNextButton.tsx
+++ b/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/CustomizeFlowNextButton/CustomizeFlowNextButton.tsx
@@ -47,7 +47,7 @@ export const CustomizeFlowNextButton = ({
         width: { xs: '100%', sm: BUTTON_NEXT_STEP_WIDTH },
         height: BUTTON_NEXT_STEP_HEIGHT,
         alignSelf: 'center',
-        mt: { xs: 6, sm: 4 },
+        mt: 5,
         borderRadius: 2,
         ...sx
       }}

--- a/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/SocialScreen/SocialScreen.tsx
+++ b/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/SocialScreen/SocialScreen.tsx
@@ -1,4 +1,3 @@
-import Box from '@mui/material/Box'
 import Stack from '@mui/material/Stack'
 import { useTranslation } from 'next-i18next'
 import { ReactElement, useState } from 'react'
@@ -9,12 +8,6 @@ import { CustomizeFlowNextButton } from '../../CustomizeFlowNextButton'
 import { ScreenWrapper } from '../ScreenWrapper'
 
 import { SocialScreenSocialImage } from './SocialScreenSocialImage'
-
-const helperTextHiddenSx = {
-  '& .MuiFormHelperText-root': {
-    display: 'none'
-  }
-}
 
 interface SocialScreenProps {
   handleNext: (overrideJourneyId?: string) => void
@@ -47,19 +40,15 @@ export function SocialScreen({ handleNext }: SocialScreenProps): ReactElement {
     >
       <Stack
         alignItems="center"
-        gap={2.5}
+        gap={4}
         data-testid="SocialShareAppearance"
         sx={{
           width: '100%'
         }}
       >
-        <SocialScreenSocialImage />
-        <Box sx={{ width: '100%', ...helperTextHiddenSx }}>
-          <TitleEdit />
-        </Box>
-        <Box sx={{ width: '100%', ...helperTextHiddenSx }}>
-          <DescriptionEdit />
-        </Box>
+        <SocialScreenSocialImage hideAdornments />
+        <TitleEdit hideHelperText />
+        <DescriptionEdit hideHelperText />
       </Stack>
     </ScreenWrapper>
   )

--- a/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/SocialScreen/SocialScreen.tsx
+++ b/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/SocialScreen/SocialScreen.tsx
@@ -1,3 +1,4 @@
+import Box from '@mui/material/Box'
 import Stack from '@mui/material/Stack'
 import { useTranslation } from 'next-i18next'
 import { ReactElement, useState } from 'react'
@@ -8,6 +9,12 @@ import { CustomizeFlowNextButton } from '../../CustomizeFlowNextButton'
 import { ScreenWrapper } from '../ScreenWrapper'
 
 import { SocialScreenSocialImage } from './SocialScreenSocialImage'
+
+const helperTextHiddenSx = {
+  '& .MuiFormHelperText-root': {
+    display: 'none'
+  }
+}
 
 interface SocialScreenProps {
   handleNext: (overrideJourneyId?: string) => void
@@ -40,16 +47,19 @@ export function SocialScreen({ handleNext }: SocialScreenProps): ReactElement {
     >
       <Stack
         alignItems="center"
-        gap={6}
+        gap={2.5}
         data-testid="SocialShareAppearance"
         sx={{
-          width: '100%',
-          py: 5
+          width: '100%'
         }}
       >
         <SocialScreenSocialImage />
-        <TitleEdit />
-        <DescriptionEdit />
+        <Box sx={{ width: '100%', ...helperTextHiddenSx }}>
+          <TitleEdit />
+        </Box>
+        <Box sx={{ width: '100%', ...helperTextHiddenSx }}>
+          <DescriptionEdit />
+        </Box>
       </Stack>
     </ScreenWrapper>
   )

--- a/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/SocialScreen/SocialScreen.tsx
+++ b/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/SocialScreen/SocialScreen.tsx
@@ -40,7 +40,7 @@ export function SocialScreen({ handleNext }: SocialScreenProps): ReactElement {
     >
       <Stack
         alignItems="center"
-        gap={4}
+        gap={5}
         data-testid="SocialShareAppearance"
         sx={{
           width: '100%'

--- a/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/SocialScreen/SocialScreenSocialImage/SocialScreenSocialImage.tsx
+++ b/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/SocialScreen/SocialScreenSocialImage/SocialScreenSocialImage.tsx
@@ -1,5 +1,11 @@
+import AccountCircleRoundedIcon from '@mui/icons-material/AccountCircleRounded'
+import ChatBubbleRoundedIcon from '@mui/icons-material/ChatBubbleRounded'
+import ShareRoundedIcon from '@mui/icons-material/ShareRounded'
+import ThumbUpOffAltRoundedIcon from '@mui/icons-material/ThumbUpOffAltRounded'
 import Card from '@mui/material/Card'
+import CardActions from '@mui/material/CardActions'
 import CardContent from '@mui/material/CardContent'
+import CardHeader from '@mui/material/CardHeader'
 import CardMedia from '@mui/material/CardMedia'
 import CircularProgress from '@mui/material/CircularProgress'
 import IconButton from '@mui/material/IconButton'
@@ -23,7 +29,7 @@ import { useJourneyImageBlockCreateMutation } from '../../../../../../libs/useJo
 import { useJourneyImageBlockUpdateMutation } from '../../../../../../libs/useJourneyImageBlockUpdateMutation'
 
 interface SocialScreenSocialImage {
-  hasCreatorDescription?: boolean
+  hideAdornments?: boolean
 }
 
 const MEDIA_MOBILE_WIDTH = 215
@@ -45,7 +51,7 @@ const StyledInput = styled('input')({
 })
 
 export function SocialScreenSocialImage({
-  hasCreatorDescription = false
+  hideAdornments = false
 }: SocialScreenSocialImage): ReactElement {
   const { journey } = useJourney()
   const { t } = useTranslation('apps-journeys-admin')
@@ -134,6 +140,33 @@ export function SocialScreenSocialImage({
         }
       }}
     >
+      {!hideAdornments && (
+        <CardHeader
+          avatar={<AccountCircleRoundedIcon sx={{ color: 'divider' }} />}
+          title={
+            <Skeleton variant="text" width={85} height={20} animation={false} />
+          }
+          action={
+            <IconButton disabled>
+              <Skeleton
+                variant="circular"
+                width={12}
+                height={12}
+                animation={false}
+              />
+            </IconButton>
+          }
+          sx={{
+            px: 0,
+            pt: 0,
+            pb: 3,
+            '& .MuiCardHeader-action': {
+              alignSelf: 'center'
+            }
+          }}
+        />
+      )}
+
       <CardMedia
         sx={{
           display: 'flex',
@@ -143,15 +176,7 @@ export function SocialScreenSocialImage({
           backgroundColor:
             journey != null ? 'background.default' : 'transparent',
           overflow: 'hidden',
-          borderRadius: 3,
-          borderBottomRightRadius: {
-            xs: 12,
-            sm: hasCreatorDescription ? 0 : 12
-          },
-          borderBottomLeftRadius: {
-            xs: 12,
-            sm: hasCreatorDescription ? 0 : 12
-          },
+          borderRadius: 2,
           width: {
             xs: `${MEDIA_MOBILE_WIDTH}px`,
             sm: `${MEDIA_DESKTOP_WIDTH}px`
@@ -232,7 +257,14 @@ export function SocialScreenSocialImage({
         )}
       </CardMedia>
 
-      <CardContent sx={{ px: 0, pb: 1, pt: `${CARD_SPACING}px` }}>
+      <CardContent
+        sx={{
+          px: 0,
+          pb: 0,
+          pt: `${CARD_SPACING}px`,
+          '&:last-child': { pb: 0 }
+        }}
+      >
         <Typography
           variant="body2"
           color="secondary"
@@ -266,6 +298,23 @@ export function SocialScreenSocialImage({
           {t('your.nextstep.is')}
         </Typography>
       </CardContent>
+
+      {!hideAdornments && (
+        <CardActions sx={{ justifyContent: 'space-around', p: 0 }}>
+          <IconButton disabled>
+            <ThumbUpOffAltRoundedIcon
+              fontSize="small"
+              sx={{ color: 'divider' }}
+            />
+          </IconButton>
+          <IconButton disabled>
+            <ChatBubbleRoundedIcon fontSize="small" sx={{ color: 'divider' }} />
+          </IconButton>
+          <IconButton disabled>
+            <ShareRoundedIcon fontSize="small" sx={{ color: 'divider' }} />
+          </IconButton>
+        </CardActions>
+      )}
     </Card>
   )
 }

--- a/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/SocialScreen/SocialScreenSocialImage/SocialScreenSocialImage.tsx
+++ b/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/SocialScreen/SocialScreenSocialImage/SocialScreenSocialImage.tsx
@@ -266,7 +266,6 @@ export function SocialScreenSocialImage({
           {t('your.nextstep.is')}
         </Typography>
       </CardContent>
-
     </Card>
   )
 }

--- a/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/SocialScreen/SocialScreenSocialImage/SocialScreenSocialImage.tsx
+++ b/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/SocialScreen/SocialScreenSocialImage/SocialScreenSocialImage.tsx
@@ -1,11 +1,5 @@
-import AccountCircleRoundedIcon from '@mui/icons-material/AccountCircleRounded'
-import ChatBubbleRoundedIcon from '@mui/icons-material/ChatBubbleRounded'
-import ShareRoundedIcon from '@mui/icons-material/ShareRounded'
-import ThumbUpOffAltRoundedIcon from '@mui/icons-material/ThumbUpOffAltRounded'
 import Card from '@mui/material/Card'
-import CardActions from '@mui/material/CardActions'
 import CardContent from '@mui/material/CardContent'
-import CardHeader from '@mui/material/CardHeader'
 import CardMedia from '@mui/material/CardMedia'
 import CircularProgress from '@mui/material/CircularProgress'
 import IconButton from '@mui/material/IconButton'
@@ -32,10 +26,10 @@ interface SocialScreenSocialImage {
   hasCreatorDescription?: boolean
 }
 
-const MEDIA_MOBILE_WIDTH = 223
-const MEDIA_MOBILE_HEIGHT = 139
-const MEDIA_DESKTOP_WIDTH = 284
-const MEDIA_DESKTOP_HEIGHT = 194
+const MEDIA_MOBILE_WIDTH = 215
+const MEDIA_MOBILE_HEIGHT = 147
+const MEDIA_DESKTOP_WIDTH = 215
+const MEDIA_DESKTOP_HEIGHT = 147
 const CARD_SPACING = 12
 
 const StyledInput = styled('input')({
@@ -128,8 +122,11 @@ export function SocialScreenSocialImage({
 
   return (
     <Card
+      variant="outlined"
+      elevation={0}
       sx={{
         borderRadius: 3,
+        borderColor: 'divider',
         p: `${CARD_SPACING}px`,
         width: {
           xs: `calc(${MEDIA_MOBILE_WIDTH}px + calc(${CARD_SPACING}px*2))`,
@@ -137,31 +134,6 @@ export function SocialScreenSocialImage({
         }
       }}
     >
-      <CardHeader
-        avatar={<AccountCircleRoundedIcon sx={{ color: 'divider' }} />}
-        title={
-          <Skeleton variant="text" width={85} height={20} animation={false} />
-        }
-        action={
-          <IconButton disabled>
-            <Skeleton
-              variant="circular"
-              width={12}
-              height={12}
-              animation={false}
-            />
-          </IconButton>
-        }
-        sx={{
-          px: 0,
-          pt: 0,
-          pb: 3,
-          '& .MuiCardHeader-action': {
-            alignSelf: 'center'
-          }
-        }}
-      />
-
       <CardMedia
         sx={{
           display: 'flex',
@@ -295,20 +267,6 @@ export function SocialScreenSocialImage({
         </Typography>
       </CardContent>
 
-      <CardActions sx={{ justifyContent: 'space-around', p: 0 }}>
-        <IconButton disabled>
-          <ThumbUpOffAltRoundedIcon
-            fontSize="small"
-            sx={{ color: 'divider' }}
-          />
-        </IconButton>
-        <IconButton disabled>
-          <ChatBubbleRoundedIcon fontSize="small" sx={{ color: 'divider' }} />
-        </IconButton>
-        <IconButton disabled>
-          <ShareRoundedIcon fontSize="small" sx={{ color: 'divider' }} />
-        </IconButton>
-      </CardActions>
     </Card>
   )
 }


### PR DESCRIPTION
## Summary
- Reduced spacing between elements from 48px to 20px and removed vertical padding
- Removed Facebook-like UI elements (likes/comments/share icons, avatar header) from social preview card
- Replaced card shadow with outlined border using divider color
- Reduced social preview card media size to 215x147px per Figma spec
- Hidden assisting/helper text on Headline and Secondary Text fields

Fixes NES-1530

## Test plan
- [x] SocialScreen tests pass (7/7)
- [x] SocialScreenSocialImage tests pass (7/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined spacing and padding on social customization screens for a cleaner, more compact layout.
  * Updated social preview card visuals with consistent corner radii, adjusted media sizing, and clarified borders.
  * Standardized button spacing for more consistent vertical rhythm.

* **Refactor**
  * Components can now optionally suppress helper text and decorative adornments for slimmer editor and preview displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->