### PR TITLE
fix: use simplified header for guest users in customize flow (NES-1526)

### DIFF
--- a/apps/journeys-admin/pages/templates/[journeyId]/customize.tsx
+++ b/apps/journeys-admin/pages/templates/[journeyId]/customize.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../../__generated__/GetJourney'
 import { IdType } from '../../../__generated__/globalTypes'
 import { PageWrapper } from '../../../src/components/PageWrapper'
+import { GuestCustomizeHeader } from '../../../src/components/TemplateCustomization/GuestCustomizeHeader'
 import { MultiStepForm } from '../../../src/components/TemplateCustomization/MultiStepForm'
 import { JOURNEY_NOT_FOUND_ERROR } from '../../../src/components/TemplateCustomization/utils/customizationRoutes/customizationRoutes'
 import { useAuth } from '../../../src/libs/auth'
@@ -86,6 +87,7 @@ function CustomizePage() {
   const router = useRouter()
   const { t } = useTranslation('apps-journeys-admin')
   const { user } = useAuth()
+  const isGuest = user == null || user.email == null
   const { data, loading, error } = useJourneyQuery({
     id: router.query.journeyId as string,
     idType: IdType.databaseId,
@@ -116,9 +118,12 @@ function CustomizePage() {
       <PageWrapper
         user={user}
         showMainHeader={false}
+        showAppHeader={!isGuest}
+        showNavBar={!isGuest}
         mainBodyPadding={false}
         background="linear-gradient(to bottom, #1f2c430f, #2568994d)"
       >
+        {isGuest && <GuestCustomizeHeader />}
         <JourneyProvider
           value={{
             journey: data?.journey,

--- a/apps/journeys-admin/src/components/PageWrapper/PageWrapper.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/PageWrapper.tsx
@@ -86,13 +86,13 @@ export function PageWrapper({
         data-testid="JourneysAdminPageWrapper"
       >
         <Stack direction={{ md: 'row' }} sx={{ height: 'inherit' }}>
-          <Box
-            sx={{
-              minWidth: navbar.width,
-              backgroundColor: backgroundColor ?? 'background.default'
-            }}
-          >
-            {showNavBar && (
+          {showNavBar && (
+            <Box
+              sx={{
+                minWidth: navbar.width,
+                backgroundColor: backgroundColor ?? 'background.default'
+              }}
+            >
               <Fade in appear={fadeInNavBar} timeout={500}>
                 <Box>
                   <NavigationDrawer
@@ -103,8 +103,8 @@ export function PageWrapper({
                   />
                 </Box>
               </Fade>
-            )}
-          </Box>
+            </Box>
+          )}
 
           <Stack
             flexGrow={1}
@@ -113,7 +113,7 @@ export function PageWrapper({
               backgroundColor: backgroundColor ?? 'background.default',
               ...(background != null && { background }),
               width: '100%',
-              pt: { xs: toolbar.height, md: 0 },
+              pt: { xs: showAppHeader ? toolbar.height : 0, md: 0 },
               pb: {
                 xs: bottomPanelChildren != null ? bottomPanel.height : 0,
                 md: 0
@@ -143,7 +143,9 @@ export function PageWrapper({
               sx={{
                 width: {
                   xs: 'inherit',
-                  md: `calc(100vw - ${navbar.width})`
+                  md: showNavBar
+                    ? `calc(100vw - ${navbar.width})`
+                    : '100vw'
                 },
                 height: '100%'
               }}
@@ -163,8 +165,12 @@ export function PageWrapper({
                     xs: 'inherit',
                     md:
                       sidePanelChildren != null || customSidePanel != null
-                        ? `calc(100vw - ${navbar.width} - ${sidePanel.width})`
-                        : `calc(100vw - ${navbar.width})`
+                        ? showNavBar
+                          ? `calc(100vw - ${navbar.width} - ${sidePanel.width})`
+                          : `calc(100vw - ${sidePanel.width})`
+                        : showNavBar
+                          ? `calc(100vw - ${navbar.width})`
+                          : '100vw'
                   },
                   height: showMainHeader
                     ? `calc(100% - ${toolbar.height})`

--- a/apps/journeys-admin/src/components/PageWrapper/PageWrapper.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/PageWrapper.tsx
@@ -143,9 +143,7 @@ export function PageWrapper({
               sx={{
                 width: {
                   xs: 'inherit',
-                  md: showNavBar
-                    ? `calc(100vw - ${navbar.width})`
-                    : '100vw'
+                  md: showNavBar ? `calc(100vw - ${navbar.width})` : '100vw'
                 },
                 height: '100%'
               }}

--- a/apps/journeys-admin/src/components/TemplateCustomization/GuestCustomizeHeader/GuestCustomizeHeader.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateCustomization/GuestCustomizeHeader/GuestCustomizeHeader.spec.tsx
@@ -34,25 +34,25 @@ describe('GuestCustomizeHeader', () => {
     jest.clearAllMocks()
   })
 
-  it('should render the home button', () => {
-    const { getByRole } = render(<GuestCustomizeHeader />)
-    expect(getByRole('button', { name: 'home' })).toBeInTheDocument()
+  it('should render the logo in the header', () => {
+    const { getByAltText } = render(<GuestCustomizeHeader />)
+    expect(getByAltText('Next Steps')).toBeInTheDocument()
   })
 
-  it('should navigate to home on home button click', () => {
+  it('should navigate to home on logo click', () => {
     const { getByRole } = render(<GuestCustomizeHeader />)
     fireEvent.click(getByRole('button', { name: 'home' }))
     expect(mockPush).toHaveBeenCalledWith('/')
   })
 
-  it('should render the logo', () => {
-    const { getByAltText } = render(<GuestCustomizeHeader />)
-    expect(getByAltText('Next Steps')).toBeInTheDocument()
-  })
-
-  it('should render the language button', () => {
+  it('should render the language button with globe icon', () => {
     const { getByRole } = render(<GuestCustomizeHeader />)
     expect(getByRole('button', { name: 'language' })).toBeInTheDocument()
+  })
+
+  it('should not display locale text in language button', () => {
+    const { queryByText } = render(<GuestCustomizeHeader />)
+    expect(queryByText('en')).not.toBeInTheDocument()
   })
 
   it('should open language switcher on language button click', () => {
@@ -61,12 +61,7 @@ describe('GuestCustomizeHeader', () => {
     expect(getByText('Change Language')).toBeInTheDocument()
   })
 
-  it('should display the current language code', () => {
-    const { getByText } = render(<GuestCustomizeHeader />)
-    expect(getByText('en')).toBeInTheDocument()
-  })
-
-  it('should have white background', () => {
+  it('should render the header', () => {
     const { getByTestId } = render(<GuestCustomizeHeader />)
     expect(getByTestId('GuestCustomizeHeader')).toBeInTheDocument()
   })

--- a/apps/journeys-admin/src/components/TemplateCustomization/GuestCustomizeHeader/GuestCustomizeHeader.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateCustomization/GuestCustomizeHeader/GuestCustomizeHeader.spec.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render } from '@testing-library/react'
+
+import { GuestCustomizeHeader } from './GuestCustomizeHeader'
+
+const mockPush = jest.fn()
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    asPath: '/templates/123/customize',
+    query: {}
+  })
+}))
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({
+    t: (str: string) => str,
+    i18n: {
+      language: 'en'
+    }
+  })
+}))
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: { alt: string; src: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={props.alt} src={props.src} />
+  )
+}))
+
+describe('GuestCustomizeHeader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render the home button', () => {
+    const { getByRole } = render(<GuestCustomizeHeader />)
+    expect(getByRole('button', { name: 'home' })).toBeInTheDocument()
+  })
+
+  it('should navigate to home on home button click', () => {
+    const { getByRole } = render(<GuestCustomizeHeader />)
+    fireEvent.click(getByRole('button', { name: 'home' }))
+    expect(mockPush).toHaveBeenCalledWith('/')
+  })
+
+  it('should render the logo', () => {
+    const { getByAltText } = render(<GuestCustomizeHeader />)
+    expect(getByAltText('Next Steps')).toBeInTheDocument()
+  })
+
+  it('should render the language button', () => {
+    const { getByRole } = render(<GuestCustomizeHeader />)
+    expect(getByRole('button', { name: 'language' })).toBeInTheDocument()
+  })
+
+  it('should open language switcher on language button click', () => {
+    const { getByRole, getByText } = render(<GuestCustomizeHeader />)
+    fireEvent.click(getByRole('button', { name: 'language' }))
+    expect(getByText('Change Language')).toBeInTheDocument()
+  })
+
+  it('should display the current language code', () => {
+    const { getByText } = render(<GuestCustomizeHeader />)
+    expect(getByText('en')).toBeInTheDocument()
+  })
+
+  it('should have white background', () => {
+    const { getByTestId } = render(<GuestCustomizeHeader />)
+    expect(getByTestId('GuestCustomizeHeader')).toBeInTheDocument()
+  })
+})

--- a/apps/journeys-admin/src/components/TemplateCustomization/GuestCustomizeHeader/GuestCustomizeHeader.tsx
+++ b/apps/journeys-admin/src/components/TemplateCustomization/GuestCustomizeHeader/GuestCustomizeHeader.tsx
@@ -1,27 +1,16 @@
 import LanguageIcon from '@mui/icons-material/Language'
-import AppBar from '@mui/material/AppBar'
-import Box from '@mui/material/Box'
 import IconButton from '@mui/material/IconButton'
 import Stack from '@mui/material/Stack'
-import Toolbar from '@mui/material/Toolbar'
-import Typography from '@mui/material/Typography'
 import Image from 'next/image'
 import { useRouter } from 'next/router'
-import { useTranslation } from 'next-i18next'
 import { ReactElement, useState } from 'react'
-
-import Home4Icon from '@core/shared/ui/icons/Home4'
 
 import taskbarIcon from '../../../../public/taskbar-icon.svg'
 import { LanguageSwitcher } from '../../LanguageSwitcher'
-import { usePageWrapperStyles } from '../../PageWrapper/utils/usePageWrapperStyles'
 
 export function GuestCustomizeHeader(): ReactElement {
   const router = useRouter()
-  const { toolbar } = usePageWrapperStyles()
   const [open, setOpen] = useState(false)
-  const { i18n } = useTranslation('apps-journeys-admin')
-  const currentLanguageCode = (i18n?.language ?? '').slice(0, 2)
 
   function handleHomeClick(): void {
     void router.push('/')
@@ -36,67 +25,42 @@ export function GuestCustomizeHeader(): ReactElement {
   }
 
   return (
-    <Box sx={{ display: { md: 'none' } }} data-testid="GuestCustomizeHeader">
-      <AppBar
-        role="banner"
-        position="fixed"
-        sx={{
-          display: { xs: 'flex', md: 'none' },
-          backgroundColor: 'background.paper'
-        }}
-        elevation={0}
+    <Stack
+      direction="row"
+      alignItems="center"
+      justifyContent="space-between"
+      sx={{
+        position: 'fixed',
+        top: 0,
+        left: { xs: 0, sm: 0 },
+        right: 0,
+        zIndex: 1,
+        px: '24px',
+        pt: '10px',
+        pb: '20px',
+        pointerEvents: 'none',
+        '& > *': { pointerEvents: 'auto' }
+      }}
+      data-testid="GuestCustomizeHeader"
+    >
+      <IconButton
+        onClick={handleHomeClick}
+        aria-label="home"
+        disableRipple
+        sx={{ p: 0 }}
       >
-        <Toolbar variant={toolbar.variant}>
-          <Stack direction="row" alignItems="center" width="100%">
-            <Stack direction="row" flexGrow={1} justifyContent="left">
-              <IconButton
-                size="large"
-                edge="start"
-                onClick={handleHomeClick}
-                aria-label="home"
-              >
-                <Home4Icon sx={{ color: 'secondary.dark' }} />
-              </IconButton>
-            </Stack>
-            <Stack direction="row" flexGrow={1} justifyContent="center">
-              <Image
-                src={taskbarIcon}
-                width={32}
-                height={32}
-                alt="Next Steps"
-              />
-            </Stack>
-            <Stack direction="row" flexGrow={1} justifyContent="right">
-              <IconButton
-                size="large"
-                edge="start"
-                onClick={handleLanguageOpen}
-                aria-label="language"
-                sx={{
-                  border: '1.75px solid',
-                  borderColor: 'secondary.dark',
-                  borderRadius: 2.25,
-                  height: 25,
-                  width: 52
-                }}
-              >
-                <LanguageIcon
-                  sx={{ fontSize: 13, color: 'secondary.dark', mr: 1 }}
-                />
-                <Typography
-                  variant="overline2"
-                  sx={{ fontSize: 12, color: 'secondary.dark' }}
-                >
-                  {currentLanguageCode}
-                </Typography>
-              </IconButton>
-            </Stack>
-          </Stack>
-          {open && (
-            <LanguageSwitcher open={open} handleClose={handleLanguageClose} />
-          )}
-        </Toolbar>
-      </AppBar>
-    </Box>
+        <Image src={taskbarIcon} width={32} height={32} alt="Next Steps" />
+      </IconButton>
+      <IconButton
+        onClick={handleLanguageOpen}
+        aria-label="language"
+        sx={{ p: 0 }}
+      >
+        <LanguageIcon sx={{ fontSize: 24, color: 'action.active' }} />
+      </IconButton>
+      {open && (
+        <LanguageSwitcher open={open} handleClose={handleLanguageClose} />
+      )}
+    </Stack>
   )
 }

--- a/apps/journeys-admin/src/components/TemplateCustomization/GuestCustomizeHeader/GuestCustomizeHeader.tsx
+++ b/apps/journeys-admin/src/components/TemplateCustomization/GuestCustomizeHeader/GuestCustomizeHeader.tsx
@@ -1,0 +1,105 @@
+import LanguageIcon from '@mui/icons-material/Language'
+import AppBar from '@mui/material/AppBar'
+import Box from '@mui/material/Box'
+import IconButton from '@mui/material/IconButton'
+import Stack from '@mui/material/Stack'
+import Toolbar from '@mui/material/Toolbar'
+import Typography from '@mui/material/Typography'
+import Image from 'next/image'
+import { useRouter } from 'next/router'
+import { useTranslation } from 'next-i18next'
+import { ReactElement, useState } from 'react'
+
+import Home4Icon from '@core/shared/ui/icons/Home4'
+
+import taskbarIcon from '../../../../public/taskbar-icon.svg'
+import { LanguageSwitcher } from '../../LanguageSwitcher'
+import { usePageWrapperStyles } from '../../PageWrapper/utils/usePageWrapperStyles'
+
+export function GuestCustomizeHeader(): ReactElement {
+  const router = useRouter()
+  const { toolbar } = usePageWrapperStyles()
+  const [open, setOpen] = useState(false)
+  const { i18n } = useTranslation('apps-journeys-admin')
+  const currentLanguageCode = (i18n?.language ?? '').slice(0, 2)
+
+  function handleHomeClick(): void {
+    void router.push('/')
+  }
+
+  function handleLanguageOpen(): void {
+    setOpen(true)
+  }
+
+  function handleLanguageClose(): void {
+    setOpen(false)
+  }
+
+  return (
+    <Box
+      sx={{ display: { md: 'none' } }}
+      data-testid="GuestCustomizeHeader"
+    >
+      <AppBar
+        role="banner"
+        position="fixed"
+        sx={{
+          display: { xs: 'flex', md: 'none' },
+          backgroundColor: 'background.paper'
+        }}
+        elevation={0}
+      >
+        <Toolbar variant={toolbar.variant}>
+          <Stack direction="row" alignItems="center" width="100%">
+            <Stack direction="row" flexGrow={1} justifyContent="left">
+              <IconButton
+                size="large"
+                edge="start"
+                onClick={handleHomeClick}
+                aria-label="home"
+              >
+                <Home4Icon sx={{ color: 'secondary.dark' }} />
+              </IconButton>
+            </Stack>
+            <Stack direction="row" flexGrow={1} justifyContent="center">
+              <Image
+                src={taskbarIcon}
+                width={32}
+                height={32}
+                alt="Next Steps"
+              />
+            </Stack>
+            <Stack direction="row" flexGrow={1} justifyContent="right">
+              <IconButton
+                size="large"
+                edge="start"
+                onClick={handleLanguageOpen}
+                aria-label="language"
+                sx={{
+                  border: '1.75px solid',
+                  borderColor: 'secondary.dark',
+                  borderRadius: 2.25,
+                  height: 25,
+                  width: 52
+                }}
+              >
+                <LanguageIcon
+                  sx={{ fontSize: 13, color: 'secondary.dark', mr: 1 }}
+                />
+                <Typography
+                  variant="overline2"
+                  sx={{ fontSize: 12, color: 'secondary.dark' }}
+                >
+                  {currentLanguageCode}
+                </Typography>
+              </IconButton>
+            </Stack>
+          </Stack>
+          {open && (
+            <LanguageSwitcher open={open} handleClose={handleLanguageClose} />
+          )}
+        </Toolbar>
+      </AppBar>
+    </Box>
+  )
+}

--- a/apps/journeys-admin/src/components/TemplateCustomization/GuestCustomizeHeader/GuestCustomizeHeader.tsx
+++ b/apps/journeys-admin/src/components/TemplateCustomization/GuestCustomizeHeader/GuestCustomizeHeader.tsx
@@ -36,10 +36,7 @@ export function GuestCustomizeHeader(): ReactElement {
   }
 
   return (
-    <Box
-      sx={{ display: { md: 'none' } }}
-      data-testid="GuestCustomizeHeader"
-    >
+    <Box sx={{ display: { md: 'none' } }} data-testid="GuestCustomizeHeader">
       <AppBar
         role="banner"
         position="fixed"

--- a/apps/journeys-admin/src/components/TemplateCustomization/GuestCustomizeHeader/index.ts
+++ b/apps/journeys-admin/src/components/TemplateCustomization/GuestCustomizeHeader/index.ts
@@ -1,0 +1,1 @@
+export { GuestCustomizeHeader } from './GuestCustomizeHeader'

--- a/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/MultiStepForm.tsx
+++ b/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/MultiStepForm.tsx
@@ -153,7 +153,7 @@ export function MultiStepForm(): ReactElement {
             (hasEditableText ||
               hasCustomizableLinks ||
               hasCustomizableMedia) && (
-              <Box sx={{ mt: { xs: 3, sm: 6 } }}>
+              <Box sx={{ mt: 5 }}>
                 <ProgressStepper
                   activeStepNumber={activeStepForStepper}
                   totalSteps={totalSteps}

--- a/docs/plans/2026-04-08-001-fix-guest-customize-header-issues-plan.md
+++ b/docs/plans/2026-04-08-001-fix-guest-customize-header-issues-plan.md
@@ -1,5 +1,5 @@
 ---
-title: "fix: guest customize header layout, visibility, and locale issues (NES-1526)"
+title: 'fix: guest customize header layout, visibility, and locale issues (NES-1526)'
 type: fix
 status: active
 date: 2026-04-08
@@ -135,6 +135,7 @@ Remove the `currentLanguageCode` variable since it's no longer needed.
 ### Task 5 — Investigate locale switching
 
 **Files to check:**
+
 - `apps/journeys-admin/src/components/LanguageSwitcher/LanguageSwitcher.tsx`
 - `apps/journeys-admin/pages/templates/[journeyId]/customize.tsx` (getServerSideProps)
 - `apps/journeys-admin/src/libs/initAndAuthApp/initAndAuthApp.ts`
@@ -162,6 +163,7 @@ Remove the `currentLanguageCode` variable since it's no longer needed.
 **File:** `GuestCustomizeHeader.spec.tsx`
 
 Update existing tests to reflect the new layout:
+
 - Remove test for home button (replaced by logo click)
 - Add test for logo click navigating to `/`
 - Update test for language button (no locale text displayed)
@@ -179,11 +181,11 @@ Update existing tests to reflect the new layout:
 
 ## Files to Modify
 
-| File | Change |
-|------|--------|
-| `apps/journeys-admin/src/components/PageWrapper/PageWrapper.tsx` | Conditional navbar width |
-| `apps/journeys-admin/src/components/TemplateCustomization/GuestCustomizeHeader/GuestCustomizeHeader.tsx` | Desktop visibility, logo layout, globe-only button |
-| `apps/journeys-admin/src/components/TemplateCustomization/GuestCustomizeHeader/GuestCustomizeHeader.spec.tsx` | Update tests |
+| File                                                                                                          | Change                                             |
+| ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `apps/journeys-admin/src/components/PageWrapper/PageWrapper.tsx`                                              | Conditional navbar width                           |
+| `apps/journeys-admin/src/components/TemplateCustomization/GuestCustomizeHeader/GuestCustomizeHeader.tsx`      | Desktop visibility, logo layout, globe-only button |
+| `apps/journeys-admin/src/components/TemplateCustomization/GuestCustomizeHeader/GuestCustomizeHeader.spec.tsx` | Update tests                                       |
 
 ## Sources
 

--- a/docs/plans/2026-04-08-001-fix-guest-customize-header-issues-plan.md
+++ b/docs/plans/2026-04-08-001-fix-guest-customize-header-issues-plan.md
@@ -1,0 +1,192 @@
+---
+title: "fix: guest customize header layout, visibility, and locale issues (NES-1526)"
+type: fix
+status: active
+date: 2026-04-08
+---
+
+# fix: Guest Customize Header — Layout, Visibility, and Locale Issues (NES-1526)
+
+## Overview
+
+The guest customize header (introduced in `9c951c86e0`) has several issues that need fixing:
+a leftover sidebar space on desktop, mobile-only visibility, wrong icon layout, and a
+potential locale-switching bug. This plan addresses all four UI fixes plus the locale investigation.
+
+## Problem Statement
+
+1. **White sidebar ghost space**: `PageWrapper` always renders a 72px-wide `Box` for the navbar
+   even when `showNavBar={false}`, leaving a white bar on the left of the customize page for guests.
+2. **Header hidden on desktop**: `GuestCustomizeHeader` uses `display: { md: 'none' }` so it
+   only shows on mobile.
+3. **Wrong left icon**: A Home4 icon is shown on the left instead of the logo; the logo sits
+   centered. Per Figma, the logo should be top-left and link to `/`.
+4. **Language button shows locale text**: The button displays a globe + 2-letter code (e.g. "EN").
+   Per Figma, it should be a globe icon only.
+5. **Locale switching may not work**: Changing language in the LanguageSwitcher might not
+   actually switch the page content — possible that translations aren't loaded or the router
+   push isn't triggering correctly for guests.
+
+## Implementation Plan
+
+### Task 1 — Fix sidebar ghost space in PageWrapper
+
+**File:** `apps/journeys-admin/src/components/PageWrapper/PageWrapper.tsx`
+**Lines 89-107**
+
+The outer `Box` wrapping `NavigationDrawer` always has `minWidth: navbar.width` (72px).
+When `showNavBar` is false, this box should collapse to 0 width.
+
+```tsx
+// Before (line 89-93):
+<Box
+  sx={{
+    minWidth: navbar.width,
+    backgroundColor: backgroundColor ?? 'background.default'
+  }}
+>
+
+// After:
+<Box
+  sx={{
+    minWidth: showNavBar ? navbar.width : 0,
+    backgroundColor: backgroundColor ?? 'background.default'
+  }}
+>
+```
+
+Also fix the main content width calculation on **line 147** which always subtracts
+`navbar.width`. When `showNavBar` is false, it should use `100vw`:
+
+```tsx
+// Before:
+width: { xs: 'inherit', md: `calc(100vw - ${navbar.width})` }
+
+// After:
+width: { xs: 'inherit', md: showNavBar ? `calc(100vw - ${navbar.width})` : '100vw' }
+```
+
+Same for **line 164-167** (sidePanel width calc).
+
+### Task 2 — Show GuestCustomizeHeader on desktop
+
+**File:** `apps/journeys-admin/src/components/TemplateCustomization/GuestCustomizeHeader/GuestCustomizeHeader.tsx`
+
+Remove the `md: 'none'` breakpoint restrictions:
+
+- **Line 39**: Remove `sx={{ display: { md: 'none' } }}` from outer `Box` (or remove the Box entirely)
+- **Line 44**: Remove `display: { xs: 'flex', md: 'none' }` from `AppBar`
+
+The header should display on all screen sizes. Consider using `position: 'sticky'` on desktop
+instead of `fixed` to avoid overlapping content, since `PageWrapper` only adds top padding
+(`pt: toolbar.height`) on `xs` breakpoint.
+
+### Task 3 — Replace home icon with logo in top-left
+
+**File:** `GuestCustomizeHeader.tsx`
+
+- Remove the `Home4Icon` import and the home `IconButton` (lines 52-59)
+- Move the logo `Image` from the center column to the left column
+- Make the logo clickable (wrap in a link or button that navigates to `/`)
+- Remove the center column entirely (it becomes empty)
+- Use a two-column layout: logo left, globe right
+
+```tsx
+// Left: Logo linking to /
+<Stack direction="row" flexGrow={1} justifyContent="left">
+  <IconButton onClick={handleHomeClick} aria-label="home" disableRipple>
+    <Image src={taskbarIcon} width={32} height={32} alt="Next Steps" />
+  </IconButton>
+</Stack>
+
+// Right: Globe button
+<Stack direction="row" flexGrow={0} justifyContent="right">
+  {/* globe button */}
+</Stack>
+```
+
+### Task 4 — Globe icon only (no locale text)
+
+**File:** `GuestCustomizeHeader.tsx`
+
+Remove the `Typography` element showing `currentLanguageCode` (lines 86-91).
+Adjust the button dimensions to be square/circular for a globe-only icon:
+
+```tsx
+<IconButton
+  size="large"
+  edge="start"
+  onClick={handleLanguageOpen}
+  aria-label="language"
+  sx={{
+    border: '1.75px solid',
+    borderColor: 'secondary.dark',
+    borderRadius: '50%',
+    height: 32,
+    width: 32
+  }}
+>
+  <LanguageIcon sx={{ fontSize: 18, color: 'secondary.dark' }} />
+</IconButton>
+```
+
+Remove the `currentLanguageCode` variable since it's no longer needed.
+
+### Task 5 — Investigate locale switching
+
+**Files to check:**
+- `apps/journeys-admin/src/components/LanguageSwitcher/LanguageSwitcher.tsx`
+- `apps/journeys-admin/pages/templates/[journeyId]/customize.tsx` (getServerSideProps)
+- `apps/journeys-admin/src/libs/initAndAuthApp/initAndAuthApp.ts`
+- `apps/journeys-admin/next-i18next.config.js`
+
+**Investigation points:**
+
+1. **Cookie format**: `NEXT_LOCALE=00004---${languageCode}` uses a custom fingerprint format.
+   Verify Next.js reads this correctly — by default, Next.js expects `NEXT_LOCALE=en` without
+   a fingerprint prefix. Check if there's middleware that strips the fingerprint.
+
+2. **Server-side translation loading**: `initAndAuthApp` loads translations via
+   `serverSideTranslations(locale ?? 'en', [...])`. If `ctx.locale` isn't being set correctly
+   from the cookie, it will always load `'en'`.
+
+3. **Router locale prop**: `router.push(path, path, { locale: languageCode })` should trigger
+   a full page navigation with the new locale. Verify this is happening (not a shallow push).
+
+4. **Guest anonymous user flow**: When `makeAccountOnAnonymous: true`, an anonymous Firebase
+   account is created. Check if the auth flow is interfering with the locale cookie or causing
+   a redirect that loses the locale parameter.
+
+### Task 6 — Update tests
+
+**File:** `GuestCustomizeHeader.spec.tsx`
+
+Update existing tests to reflect the new layout:
+- Remove test for home button (replaced by logo click)
+- Add test for logo click navigating to `/`
+- Update test for language button (no locale text displayed)
+- Add test that component renders on all breakpoints (no `md: 'none'`)
+
+## Acceptance Criteria
+
+- [ ] No white space on the left of the customize page for guest users on desktop
+- [ ] `GuestCustomizeHeader` visible on both mobile and desktop
+- [ ] Logo (taskbar icon) in top-left position, navigates to `/` on click
+- [ ] Language button shows globe icon only, no locale text
+- [ ] Language switching works correctly for guest users
+- [ ] All existing tests updated and passing
+- [ ] No regressions for authenticated user customize flow
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `apps/journeys-admin/src/components/PageWrapper/PageWrapper.tsx` | Conditional navbar width |
+| `apps/journeys-admin/src/components/TemplateCustomization/GuestCustomizeHeader/GuestCustomizeHeader.tsx` | Desktop visibility, logo layout, globe-only button |
+| `apps/journeys-admin/src/components/TemplateCustomization/GuestCustomizeHeader/GuestCustomizeHeader.spec.tsx` | Update tests |
+
+## Sources
+
+- Linear issue: [NES-1526](https://linear.app/jesus-film-project/issue/NES-1526/wrong-header-for-guests)
+- PR: [#8965](https://github.com/JesusFilm/core/pull/8965)
+- Prior commits: `9c951c86e0`, `28373b90bc`


### PR DESCRIPTION
## Summary
- Created new `GuestCustomizeHeader` component with home button, logo, and language switcher on a white background
- Guest users (no email / anonymous) now see a clean header without the navigation drawer menu
- Non-guest users continue to see the standard `AppHeader` with hamburger menu and dark background

Fixes NES-1526

## Test plan
- [x] GuestCustomizeHeader unit tests pass (7/7)
- [x] Customize page conditionally renders correct header based on user type

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated guest header with logo navigation and language switcher; app header and navigation are hidden for guest users.

* **Bug Fixes**
  * Resolved layout spacing so no empty sidebar appears when navigation is hidden; responsive content width adjusted.

* **Style**
  * Tweaked progress stepper spacing for consistent layout.

* **Tests**
  * Added tests covering the guest header behavior and interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->