### PR TITLE
refactor: split slow journeys-admin e2e specs for parallel execution

### DIFF
--- a/apps/journeys-admin-e2e/README.md
+++ b/apps/journeys-admin-e2e/README.md
@@ -1,0 +1,183 @@
+# journeys-admin-e2e
+
+Playwright end-to-end test suite for the `journeys-admin` application.
+
+## Running Tests
+
+```bash
+# Full test suite
+pnpm exec nx run journeys-admin-e2e:e2e-full
+
+# Smoke tests only
+pnpm exec nx run journeys-admin-e2e:e2e
+
+# Single spec file
+pnpm exec nx run journeys-admin-e2e:e2e-full -- src/e2e/discover/custom-journey.spec.ts
+
+# Single test by name
+pnpm exec nx run journeys-admin-e2e:e2e-full -- --grep "should show error for invalid YouTube URL"
+
+# Headed mode (see the browser)
+pnpm exec nx run journeys-admin-e2e:e2e-full -- --headed
+
+# Update visual snapshots
+pnpm exec nx run journeys-admin-e2e:update-snapshots
+```
+
+## Environment Variables
+
+Copy `.env.example` to `.env` (or set these in CI secrets):
+
+| Variable | Description |
+|---|---|
+| `JOURNEYS_ADMIN_DAILY_E2E` | URL of the staging deployment to test against |
+| `DEPLOYMENT_URL` | Fallback URL (e.g. a Vercel preview URL) |
+| `PLAYWRIGHT_EMAIL` | Email of the pre-existing admin test account |
+| `PLAYWRIGHT_PASSWORD` | Password for the admin test account |
+| `PLAYWRIGHT_USER` | Display name for the admin test account |
+| `PLAYWRIGHT_TEAM_NAME` | Team name used by the admin test account |
+| `EXAMPLE_EMAIL_TOKEN` | Static OTP token used during new user registration |
+
+If none of the URL variables are set, tests fall back to `http://localhost:4200`.
+
+## Project Structure
+
+```
+src/
+├── e2e/
+│   ├── customization/      # Template customization flow (YouTube, media upload)
+│   ├── discover/           # Discover page — journeys, teams, members, sorting
+│   ├── lighthouse/         # Performance audits
+│   ├── profile/            # User profile & email preferences
+│   ├── publisher-and-templates/
+│   ├── un-auth/            # Unauthenticated user flows
+│   └── users/              # Sign-in / sign-up flows
+├── fixtures/
+│   ├── authenticated.ts    # authedPage fixture — pre-logged-in page as admin
+│   └── workerAuth.ts       # workerEmail fixture — one registration per worker (see below)
+├── pages/                  # Page Object Model classes
+├── framework/              # Shared helpers (getEmail, getOTP, etc.)
+├── smoke/                  # Subset of tests run on every deployment
+└── global-setup.ts         # Waits for the target URL to be healthy before tests start
+```
+
+## Authentication Architecture
+
+### Admin fixture (`fixtures/authenticated.ts`)
+
+Used by `customization/youtube-video.spec.ts` and other tests that need a stable
+pre-existing admin account. A single sign-in state is reused for all tests in the file.
+
+```typescript
+import { test, expect } from '../../fixtures/authenticated'
+
+test('my test', async ({ authedPage }) => { /* ... */ })
+```
+
+### Worker-level registration (`fixtures/workerAuth.ts`)
+
+All `discover/` and `profile/` spec files use a **worker-scoped** fixture that registers
+one fresh user per Playwright worker process, then reuses those credentials for every
+spec file that runs on that worker.
+
+```typescript
+import { test } from '../../fixtures/workerAuth'
+
+test.beforeAll('Register new account', async ({ browser, workerEmail }) => {
+  sharedContext = await browser.newContext()
+  const page = await sharedContext.newPage()
+  await new LandingPage(page).goToAdminUrl()
+  await new LoginPage(page).logInWithCreatedNewUser(workerEmail)
+})
+```
+
+#### How it works
+
+Playwright's `{ scope: 'worker' }` fixture option runs the setup code **once per worker
+process** and caches the result. All subsequent requests for `workerEmail` within the
+same worker return the cached value instantly — no re-registration.
+
+```
+Worker 1 starts
+  ├─ spec A beforeAll → fixture runs: registers user → email cached
+  ├─ spec B beforeAll → fixture cached: returns email immediately (login only)
+  └─ spec C beforeAll → fixture cached: returns email immediately (login only)
+
+Worker 2 starts
+  ├─ spec D beforeAll → fixture runs: registers user → email cached
+  └─ spec E beforeAll → fixture cached: returns email immediately (login only)
+```
+
+#### Why this matters
+
+| | Before | After |
+|---|---|---|
+| Registrations per CI run | ~13 (one per spec file) | 4 (one per worker) |
+| Backend load at startup | High — 13 concurrent OTP + onboarding flows | Low — 4 staggered flows |
+| Test isolation | Full (each spec gets its own `BrowserContext`) | Full (unchanged) |
+
+Each spec file still creates its own `BrowserContext`, so sessionStorage, cookies, and
+navigation state are completely isolated between spec files. The only thing shared
+across spec files on a worker is the server-side user account.
+
+#### Why data accumulation is safe
+
+- All `toHaveCount` assertions target UI element counts (dropdowns, buttons), not total
+  journey or team counts.
+- Journey and team names use unique random suffixes, so lookups never collide.
+- `selectTeamToCopyTheJourney()` uses `.last()` to pick the most-recently-created team,
+  so pre-existing teams from earlier spec files on the same worker don't interfere.
+
+## Writing New Tests
+
+### For `discover/` or `profile/` tests
+
+Import `test` from `workerAuth` instead of `@playwright/test`:
+
+```typescript
+import type { BrowserContext, Page } from 'playwright-core'
+
+import { test } from '../../fixtures/workerAuth'
+import { JourneyPage } from '../../pages/journey-page'
+import { LandingPage } from '../../pages/landing-page'
+import { LoginPage } from '../../pages/login-page'
+
+let sharedPage: Page | undefined
+let sharedContext: BrowserContext | undefined
+
+test.describe('My feature', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  test.beforeAll('Login', async ({ browser, workerEmail }) => {
+    sharedContext = await browser.newContext()
+    sharedPage = await sharedContext.newPage()
+    await new LandingPage(sharedPage).goToAdminUrl()
+    await new LoginPage(sharedPage).logInWithCreatedNewUser(workerEmail)
+  })
+
+  test.afterAll(async () => {
+    await sharedPage?.close()
+    await sharedContext?.close()
+    sharedPage = undefined
+    sharedContext = undefined
+  })
+
+  test('does something', async () => { /* ... */ })
+})
+```
+
+### For `customization/` tests
+
+Use the `authedPage` fixture from `authenticated.ts` (logs in as the shared admin account):
+
+```typescript
+import { test, expect } from '../../fixtures/authenticated'
+
+test('my customization test', async ({ authedPage }) => { /* ... */ })
+```
+
+### Do not register in `beforeAll`
+
+Avoid calling `register.registerNewAccount()` inside a `beforeAll` hook — this causes
+concurrent backend load when multiple workers start simultaneously. Use the
+`workerEmail` fixture instead, which staggers registrations automatically.

--- a/apps/journeys-admin-e2e/README.md
+++ b/apps/journeys-admin-e2e/README.md
@@ -28,15 +28,15 @@ pnpm exec nx run journeys-admin-e2e:update-snapshots
 
 Copy `.env.example` to `.env` (or set these in CI secrets):
 
-| Variable | Description |
-|---|---|
-| `JOURNEYS_ADMIN_DAILY_E2E` | URL of the staging deployment to test against |
-| `DEPLOYMENT_URL` | Fallback URL (e.g. a Vercel preview URL) |
-| `PLAYWRIGHT_EMAIL` | Email of the pre-existing admin test account |
-| `PLAYWRIGHT_PASSWORD` | Password for the admin test account |
-| `PLAYWRIGHT_USER` | Display name for the admin test account |
-| `PLAYWRIGHT_TEAM_NAME` | Team name used by the admin test account |
-| `EXAMPLE_EMAIL_TOKEN` | Static OTP token used during new user registration |
+| Variable                   | Description                                        |
+| -------------------------- | -------------------------------------------------- |
+| `JOURNEYS_ADMIN_DAILY_E2E` | URL of the staging deployment to test against      |
+| `DEPLOYMENT_URL`           | Fallback URL (e.g. a Vercel preview URL)           |
+| `PLAYWRIGHT_EMAIL`         | Email of the pre-existing admin test account       |
+| `PLAYWRIGHT_PASSWORD`      | Password for the admin test account                |
+| `PLAYWRIGHT_USER`          | Display name for the admin test account            |
+| `PLAYWRIGHT_TEAM_NAME`     | Team name used by the admin test account           |
+| `EXAMPLE_EMAIL_TOKEN`      | Static OTP token used during new user registration |
 
 If none of the URL variables are set, tests fall back to `http://localhost:4200`.
 
@@ -71,7 +71,9 @@ pre-existing admin account. A single sign-in state is reused for all tests in th
 ```typescript
 import { test, expect } from '../../fixtures/authenticated'
 
-test('my test', async ({ authedPage }) => { /* ... */ })
+test('my test', async ({ authedPage }) => {
+  /* ... */
+})
 ```
 
 ### Worker-level registration (`fixtures/workerAuth.ts`)
@@ -110,11 +112,11 @@ Worker 2 starts
 
 #### Why this matters
 
-| | Before | After |
-|---|---|---|
-| Registrations per CI run | ~13 (one per spec file) | 4 (one per worker) |
-| Backend load at startup | High — 13 concurrent OTP + onboarding flows | Low — 4 staggered flows |
-| Test isolation | Full (each spec gets its own `BrowserContext`) | Full (unchanged) |
+|                          | Before                                         | After                   |
+| ------------------------ | ---------------------------------------------- | ----------------------- |
+| Registrations per CI run | ~13 (one per spec file)                        | 4 (one per worker)      |
+| Backend load at startup  | High — 13 concurrent OTP + onboarding flows    | Low — 4 staggered flows |
+| Test isolation           | Full (each spec gets its own `BrowserContext`) | Full (unchanged)        |
 
 Each spec file still creates its own `BrowserContext`, so sessionStorage, cookies, and
 navigation state are completely isolated between spec files. The only thing shared
@@ -162,7 +164,9 @@ test.describe('My feature', () => {
     sharedContext = undefined
   })
 
-  test('does something', async () => { /* ... */ })
+  test('does something', async () => {
+    /* ... */
+  })
 })
 ```
 
@@ -173,7 +177,9 @@ Use the `authedPage` fixture from `authenticated.ts` (logs in as the shared admi
 ```typescript
 import { test, expect } from '../../fixtures/authenticated'
 
-test('my customization test', async ({ authedPage }) => { /* ... */ })
+test('my customization test', async ({ authedPage }) => {
+  /* ... */
+})
 ```
 
 ### Do not register in `beforeAll`

--- a/apps/journeys-admin-e2e/playwright.config.ts
+++ b/apps/journeys-admin-e2e/playwright.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 3 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 10 : 1,
+  workers: process.env.CI ? 4 : 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/apps/journeys-admin-e2e/src/e2e/discover/active-archived-trash.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/active-archived-trash.spec.ts
@@ -13,7 +13,8 @@ let sharedPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
 const getSharedPage = (): Page => {
-  if (sharedPage == null) throw new Error('Shared authenticated page was not initialized')
+  if (sharedPage == null)
+    throw new Error('Shared authenticated page was not initialized')
   return sharedPage
 }
 
@@ -54,9 +55,7 @@ test.describe('Verify user able to Active, Archived, Trash the journeys', () => 
   // tabs) is not found – locator('button[id*="archived-status-panel-tab"]') times out. Likely environment- or
   // routing-related (e.g. discover list not visible in this deployment). Re-enable when the discover journey
   // list is available.
-  test.skip('Verify the user able to move the single journeys from Active, archived, Trash page', async ({
-    
-  }) => {
+  test.skip('Verify the user able to move the single journeys from Active, archived, Trash page', async ({}) => {
     const page = getSharedPage()
     const journeyPage = new JourneyPage(page)
     // Verify the user able to move the single journeys from Active to archived page
@@ -81,9 +80,7 @@ test.describe('Verify user able to Active, Archived, Trash the journeys', () => 
   // ISSUE: After archiving (or when the test runs), the Discover journey list (Active/Archived/Trash tabs) is
   // not found – button[id*="archived-status-panel-tab"] times out. Likely environment- or routing-related.
   // Re-enable when the discover journey list is available.
-  test.skip('Verify the user able to move the all journeys from Active, archived, Trash page', async ({
-    
-  }) => {
+  test.skip('Verify the user able to move the all journeys from Active, archived, Trash page', async ({}) => {
     const page = getSharedPage()
     const journeyPage = new JourneyPage(page)
     await journeyPage.clickCreateCustomJourney() // clicking on the create custom journey button

--- a/apps/journeys-admin-e2e/src/e2e/discover/active-archived-trash.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/active-archived-trash.spec.ts
@@ -1,39 +1,53 @@
 /* eslint-disable playwright/no-skipped-test */
 /* eslint-disable playwright/expect-expect */
 import { test } from '@playwright/test'
+import type { BrowserContext, Page } from 'playwright-core'
 
 import { JourneyPage } from '../../pages/journey-page'
 import { LandingPage } from '../../pages/landing-page'
-import { LoginPage } from '../../pages/login-page'
 import { Register } from '../../pages/register-Page'
 import { TeamsPage } from '../../pages/teams-page'
 
 let userEmail = ''
+let sharedPage: Page | undefined
+let sharedContext: BrowserContext | undefined
+
+const getSharedPage = (): Page => {
+  if (sharedPage == null) throw new Error('Shared authenticated page was not initialized')
+  return sharedPage
+}
 
 test.describe('Verify user able to Active, Archived, Trash the journeys', () => {
+  test.describe.configure({ mode: 'serial' })
+
   // Issue 1 : In Terms and Conditions page,The 'Next' button is not working properly
   // Issue 2 : The error toast message is displaying after registration new account
   test.beforeAll('Register new account', async ({ browser }) => {
-    const page = await browser.newPage()
-    const landingPage = new LandingPage(page)
-    const teamsPage = new TeamsPage(page)
-    const register = new Register(page)
+    sharedContext = await browser.newContext()
+    sharedPage = await sharedContext.newPage()
+    const landingPage = new LandingPage(sharedPage)
+    const teamsPage = new TeamsPage(sharedPage)
+    const register = new Register(sharedPage)
     await landingPage.goToAdminUrl()
     await register.registerNewAccount() // registering new user account
     userEmail = await register.getUserEmailId() // storing the registered user email id
     await teamsPage.createNewTeamAndVerifyCreatedTeam() // create new team and verify the created team
     console.log(`userName : ${userEmail}`)
-    await page.close()
   })
 
-  test.beforeEach(async ({ page }) => {
-    const landingPage = new LandingPage(page)
-    const loginPage = new LoginPage(page)
+  test.beforeEach(async () => {
+    const page = getSharedPage()
     const journeyPage = new JourneyPage(page)
-    await landingPage.goToAdminUrl()
-    await loginPage.logInWithCreatedNewUser(userEmail) // login as registered user
+    await page.goto('/')
     await journeyPage.clickCreateCustomJourney() // clicking on the create custom journey button
     await journeyPage.createAndVerifyCustomJourney() // creating the custom journey and verifing the created journey is updated in the active tab list
+  })
+
+  test.afterAll(async () => {
+    if (sharedPage != null) await sharedPage.close()
+    if (sharedContext != null) await sharedContext.close()
+    sharedPage = undefined
+    sharedContext = undefined
   })
 
   // ISSUE: After archiving a journey (or when the test runs), the Discover journey list (Active/Archived/Trash
@@ -41,8 +55,9 @@ test.describe('Verify user able to Active, Archived, Trash the journeys', () => 
   // routing-related (e.g. discover list not visible in this deployment). Re-enable when the discover journey
   // list is available.
   test.skip('Verify the user able to move the single journeys from Active, archived, Trash page', async ({
-    page
+    
   }) => {
+    const page = getSharedPage()
     const journeyPage = new JourneyPage(page)
     // Verify the user able to move the single journeys from Active to archived page
     await journeyPage.verifyExistingJourneyMovedActiveToArchivedTab()
@@ -67,8 +82,9 @@ test.describe('Verify user able to Active, Archived, Trash the journeys', () => 
   // not found – button[id*="archived-status-panel-tab"] times out. Likely environment- or routing-related.
   // Re-enable when the discover journey list is available.
   test.skip('Verify the user able to move the all journeys from Active, archived, Trash page', async ({
-    page
+    
   }) => {
+    const page = getSharedPage()
     const journeyPage = new JourneyPage(page)
     await journeyPage.clickCreateCustomJourney() // clicking on the create custom journey button
     await journeyPage.createAndVerifyCustomJourney() // creating the custom journey and verifing the created journey is updated in the active tab list

--- a/apps/journeys-admin-e2e/src/e2e/discover/active-archived-trash.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/active-archived-trash.spec.ts
@@ -1,14 +1,13 @@
 /* eslint-disable playwright/no-skipped-test */
 /* eslint-disable playwright/expect-expect */
-import { test } from '@playwright/test'
 import type { BrowserContext, Page } from 'playwright-core'
 
+import { test } from '../../fixtures/workerAuth'
 import { JourneyPage } from '../../pages/journey-page'
 import { LandingPage } from '../../pages/landing-page'
-import { Register } from '../../pages/register-Page'
+import { LoginPage } from '../../pages/login-page'
 import { TeamsPage } from '../../pages/teams-page'
 
-let userEmail = ''
 let sharedPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
@@ -23,17 +22,15 @@ test.describe('Verify user able to Active, Archived, Trash the journeys', () => 
 
   // Issue 1 : In Terms and Conditions page,The 'Next' button is not working properly
   // Issue 2 : The error toast message is displaying after registration new account
-  test.beforeAll('Register new account', async ({ browser }) => {
+  test.beforeAll('Register new account', async ({ browser, workerEmail }) => {
     sharedContext = await browser.newContext()
     sharedPage = await sharedContext.newPage()
     const landingPage = new LandingPage(sharedPage)
+    const loginPage = new LoginPage(sharedPage)
     const teamsPage = new TeamsPage(sharedPage)
-    const register = new Register(sharedPage)
     await landingPage.goToAdminUrl()
-    await register.registerNewAccount() // registering new user account
-    userEmail = await register.getUserEmailId() // storing the registered user email id
+    await loginPage.logInWithCreatedNewUser(workerEmail)
     await teamsPage.createNewTeamAndVerifyCreatedTeam() // create new team and verify the created team
-    console.log(`userName : ${userEmail}`)
   })
 
   test.beforeEach(async () => {

--- a/apps/journeys-admin-e2e/src/e2e/discover/analytics.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/analytics.spec.ts
@@ -11,7 +11,8 @@ let sharedPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
 const getSharedPage = (): Page => {
-  if (sharedPage == null) throw new Error('Shared authenticated page was not initialized')
+  if (sharedPage == null)
+    throw new Error('Shared authenticated page was not initialized')
   return sharedPage
 }
 

--- a/apps/journeys-admin-e2e/src/e2e/discover/analytics.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/analytics.spec.ts
@@ -1,34 +1,56 @@
 /* eslint-disable playwright/expect-expect */
 import { test } from '@playwright/test'
+import type { BrowserContext, Page } from 'playwright-core'
 
 import { JourneyPage } from '../../pages/journey-page'
 import { LandingPage } from '../../pages/landing-page'
-import { LoginPage } from '../../pages/login-page'
 import { Register } from '../../pages/register-Page'
 
 let userEmail = ''
+let sharedPage: Page | undefined
+let sharedContext: BrowserContext | undefined
+
+const getSharedPage = (): Page => {
+  if (sharedPage == null) throw new Error('Shared authenticated page was not initialized')
+  return sharedPage
+}
+
+const getSharedContext = (): BrowserContext => {
+  if (sharedContext == null) {
+    throw new Error('Shared authenticated context was not initialized')
+  }
+  return sharedContext
+}
 
 test.describe('Verify analytics page functionality', () => {
+  test.describe.configure({ mode: 'serial' })
+
   test.beforeAll('Register new account', async ({ browser }) => {
-    const page = await browser.newPage()
-    const landingPage = new LandingPage(page)
-    const register = new Register(page)
+    sharedContext = await browser.newContext()
+    sharedPage = await sharedContext.newPage()
+    const landingPage = new LandingPage(sharedPage)
+    const register = new Register(sharedPage)
     await landingPage.goToAdminUrl()
     await register.registerNewAccount() // registering new user account
     userEmail = await register.getUserEmailId() // storing the registered user email id
     console.log(`userName : ${userEmail}`)
-    await page.close()
   })
 
-  test.beforeEach(async ({ page }) => {
-    const landingPage = new LandingPage(page)
-    const loginPage = new LoginPage(page)
-    await landingPage.goToAdminUrl()
-    await loginPage.logInWithCreatedNewUser(userEmail) // login as registered user
+  test.beforeEach(async () => {
+    await getSharedPage().goto('/')
+  })
+
+  test.afterAll(async () => {
+    if (sharedPage != null) await sharedPage.close()
+    if (sharedContext != null) await sharedContext.close()
+    sharedPage = undefined
+    sharedContext = undefined
   })
 
   // Verify the user able to navigate to Journey analytics page through analytics icon
-  test('navigate to Journey analytics', async ({ page, context }) => {
+  test('navigate to Journey analytics', async () => {
+    const page = getSharedPage()
+    const context = getSharedContext()
     const journeyPage = new JourneyPage(page)
     await journeyPage.setBrowserContext(context)
     await journeyPage.clickCreateCustomJourney() // click create custom journey button

--- a/apps/journeys-admin-e2e/src/e2e/discover/analytics.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/analytics.spec.ts
@@ -1,12 +1,11 @@
 /* eslint-disable playwright/expect-expect */
-import { test } from '@playwright/test'
 import type { BrowserContext, Page } from 'playwright-core'
 
+import { test } from '../../fixtures/workerAuth'
 import { JourneyPage } from '../../pages/journey-page'
 import { LandingPage } from '../../pages/landing-page'
-import { Register } from '../../pages/register-Page'
+import { LoginPage } from '../../pages/login-page'
 
-let userEmail = ''
 let sharedPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
@@ -26,15 +25,13 @@ const getSharedContext = (): BrowserContext => {
 test.describe('Verify analytics page functionality', () => {
   test.describe.configure({ mode: 'serial' })
 
-  test.beforeAll('Register new account', async ({ browser }) => {
+  test.beforeAll('Register new account', async ({ browser, workerEmail }) => {
     sharedContext = await browser.newContext()
     sharedPage = await sharedContext.newPage()
     const landingPage = new LandingPage(sharedPage)
-    const register = new Register(sharedPage)
+    const loginPage = new LoginPage(sharedPage)
     await landingPage.goToAdminUrl()
-    await register.registerNewAccount() // registering new user account
-    userEmail = await register.getUserEmailId() // storing the registered user email id
-    console.log(`userName : ${userEmail}`)
+    await loginPage.logInWithCreatedNewUser(workerEmail)
   })
 
   test.beforeEach(async () => {

--- a/apps/journeys-admin-e2e/src/e2e/discover/card-level-actions-footer.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/card-level-actions-footer.spec.ts
@@ -11,7 +11,8 @@ let sharedPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
 const getSharedPage = (): Page => {
-  if (sharedPage == null) throw new Error('Shared authenticated page was not initialized')
+  if (sharedPage == null)
+    throw new Error('Shared authenticated page was not initialized')
   return sharedPage
 }
 

--- a/apps/journeys-admin-e2e/src/e2e/discover/card-level-actions-footer.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/card-level-actions-footer.spec.ts
@@ -1,11 +1,11 @@
 /* eslint-disable playwright/expect-expect */
-import { test } from '@playwright/test'
 import type { BrowserContext, Page } from 'playwright-core'
 
+import { test } from '../../fixtures/workerAuth'
 import { CardLevelActionPage } from '../../pages/card-level-actions'
 import { JourneyPage } from '../../pages/journey-page'
 import { LandingPage } from '../../pages/landing-page'
-import { Register } from '../../pages/register-Page'
+import { LoginPage } from '../../pages/login-page'
 
 let sharedPage: Page | undefined
 let sharedContext: BrowserContext | undefined
@@ -19,13 +19,13 @@ const getSharedPage = (): Page => {
 test.describe('verify card level actions - footer', () => {
   test.describe.configure({ mode: 'serial' })
 
-  test.beforeAll('Register new account', async ({ browser }) => {
+  test.beforeAll('Register new account', async ({ browser, workerEmail }) => {
     sharedContext = await browser.newContext()
     sharedPage = await sharedContext.newPage()
     const landingPage = new LandingPage(sharedPage)
-    const register = new Register(sharedPage)
+    const loginPage = new LoginPage(sharedPage)
     await landingPage.goToAdminUrl()
-    await register.registerNewAccount()
+    await loginPage.logInWithCreatedNewUser(workerEmail)
   })
 
   test.beforeEach(async () => {

--- a/apps/journeys-admin-e2e/src/e2e/discover/card-level-actions-footer.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/card-level-actions-footer.spec.ts
@@ -1,0 +1,105 @@
+/* eslint-disable playwright/expect-expect */
+import { test } from '@playwright/test'
+import type { BrowserContext, Page } from 'playwright-core'
+
+import { CardLevelActionPage } from '../../pages/card-level-actions'
+import { JourneyPage } from '../../pages/journey-page'
+import { LandingPage } from '../../pages/landing-page'
+import { Register } from '../../pages/register-Page'
+
+let sharedPage: Page | undefined
+let sharedContext: BrowserContext | undefined
+
+const getSharedPage = (): Page => {
+  if (sharedPage == null) throw new Error('Shared authenticated page was not initialized')
+  return sharedPage
+}
+
+test.describe('verify card level actions - footer', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  test.beforeAll('Register new account', async ({ browser }) => {
+    sharedContext = await browser.newContext()
+    sharedPage = await sharedContext.newPage()
+    const landingPage = new LandingPage(sharedPage)
+    const register = new Register(sharedPage)
+    await landingPage.goToAdminUrl()
+    await register.registerNewAccount()
+  })
+
+  test.beforeEach(async () => {
+    const page = getSharedPage()
+    const cardLevelActionPage = new CardLevelActionPage(page)
+    const journeyPage = new JourneyPage(page)
+    await page.goto('/')
+    await journeyPage.clickCreateCustomJourney()
+    await cardLevelActionPage.waitUntilJourneyCardLoaded()
+    await cardLevelActionPage.clickOnJourneyCard()
+    await journeyPage.clickThreeDotBtnOfCustomJourney()
+    await journeyPage.clickEditDetailsInThreeDotOptions()
+    await journeyPage.enterTitle()
+    await journeyPage.clickSaveBtn()
+  })
+
+  test.afterAll(async () => {
+    if (sharedPage != null) await sharedPage.close()
+    if (sharedContext != null) await sharedContext.close()
+    sharedPage = undefined
+    sharedContext = undefined
+  })
+
+  test('Footer properties (Journey) - create, update & delete', async () => {
+    const page = getSharedPage()
+    const footerTitle = 'Footer Playwright'
+    const cardLevelActionPage = new CardLevelActionPage(page)
+    await cardLevelActionPage.selectWholeFooterSectionInCard()
+    await cardLevelActionPage.expandJourneyAppearance('Reactions')
+    await cardLevelActionPage.selectAllTheReactionOptions()
+    await cardLevelActionPage.expandJourneyAppearance('Display Title')
+    await cardLevelActionPage.enterDisplayTitleForFooter(footerTitle)
+    await cardLevelActionPage.expandJourneyAppearance('Hosted By')
+    await cardLevelActionPage.clicSelectHostBtn()
+    await cardLevelActionPage.clickCreateNewBtn()
+    await cardLevelActionPage.enterHostName()
+    await cardLevelActionPage.enterLocation()
+    await cardLevelActionPage.clickOnJourneyCard()
+    await cardLevelActionPage.verifyHostNameAddedInCard()
+    await cardLevelActionPage.selectWholeFooterSectionInCard()
+    await cardLevelActionPage.expandJourneyAppearance('Chat Widget')
+    await cardLevelActionPage.clickMessangerDropDown('WhatsApp')
+    await cardLevelActionPage.enterWhatsAppLink()
+    await cardLevelActionPage.verifyChatWidgetAddedToCard()
+    await cardLevelActionPage.validateFooterTitleAndReactionButtonsInCard(
+      footerTitle
+    )
+  })
+
+  test('Footer properties (WebSite) - create, update & delete', async () => {
+    const page = getSharedPage()
+    const footerTitle = 'Footer Playwright'
+    const cardLevelActionPage = new CardLevelActionPage(page)
+    await cardLevelActionPage.selectWholeFooterSectionInCard()
+    await cardLevelActionPage.clickJourneyOrWebSiteOptionForFooter('Website')
+    await cardLevelActionPage.expandJourneyAppearance('Logo')
+    await cardLevelActionPage.clickSelectImageBtn()
+    await cardLevelActionPage.selectFirstImageFromGalleryForFooter()
+    await cardLevelActionPage.valdiateSelectedImageWithDeleteIcon()
+    await cardLevelActionPage.closeToolDrawerForFooterImage()
+    await cardLevelActionPage.validateSelectedImageWithEditIcon()
+    await cardLevelActionPage.expandJourneyAppearance('Display Title')
+    await cardLevelActionPage.enterDisplayTitleForFooter(footerTitle)
+    await cardLevelActionPage.expandJourneyAppearance('Menu')
+    await cardLevelActionPage.clickSelectIconDropdownForFooterMenu()
+    await cardLevelActionPage.selectChevronDownIconForFooter()
+    await cardLevelActionPage.selectWholeFooterSectionInCard()
+    await cardLevelActionPage.expandJourneyAppearance('Chat Widget')
+    await cardLevelActionPage.clickMessangerDropDown('WhatsApp')
+    await cardLevelActionPage.enterWhatsAppLink()
+    await cardLevelActionPage.verifyChatWidgetAddedToCard()
+    await cardLevelActionPage.validateWebsiteFooterSectionInCard(footerTitle)
+    await cardLevelActionPage.expandJourneyAppearance('Menu')
+    await cardLevelActionPage.clickCreateMenuCardButtonInMenuFooter()
+    await cardLevelActionPage.clickleftSideArrowIcon()
+    await cardLevelActionPage.validateMenuCardInReactFlow()
+  })
+})

--- a/apps/journeys-admin-e2e/src/e2e/discover/card-level-actions.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/card-level-actions.spec.ts
@@ -1,14 +1,13 @@
 /* eslint-disable playwright/no-skipped-test */
 /* eslint-disable playwright/expect-expect */
-import { test } from '@playwright/test'
 import type { BrowserContext, Page } from 'playwright-core'
 
+import { test } from '../../fixtures/workerAuth'
 import { CardLevelActionPage } from '../../pages/card-level-actions'
 import { JourneyPage } from '../../pages/journey-page'
 import { LandingPage } from '../../pages/landing-page'
-import { Register } from '../../pages/register-Page'
+import { LoginPage } from '../../pages/login-page'
 
-let userEmail = ''
 let sharedPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
@@ -21,15 +20,13 @@ const getSharedPage = (): Page => {
 test.describe('verify card level actions', () => {
   test.describe.configure({ mode: 'serial' })
 
-  test.beforeAll('Register new account', async ({ browser }) => {
+  test.beforeAll('Register new account', async ({ browser, workerEmail }) => {
     sharedContext = await browser.newContext()
     sharedPage = await sharedContext.newPage()
     const landingPage = new LandingPage(sharedPage)
-    const register = new Register(sharedPage)
+    const loginPage = new LoginPage(sharedPage)
     await landingPage.goToAdminUrl()
-    await register.registerNewAccount()
-    userEmail = await register.getUserEmailId() // storing the registered user email id
-    console.log(`userEamil : ${userEmail}`)
+    await loginPage.logInWithCreatedNewUser(workerEmail)
   })
 
   test.beforeEach(async () => {

--- a/apps/journeys-admin-e2e/src/e2e/discover/card-level-actions.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/card-level-actions.spec.ts
@@ -1,34 +1,41 @@
 /* eslint-disable playwright/no-skipped-test */
 /* eslint-disable playwright/expect-expect */
 import { test } from '@playwright/test'
+import type { BrowserContext, Page } from 'playwright-core'
 
 import { CardLevelActionPage } from '../../pages/card-level-actions'
 import { JourneyPage } from '../../pages/journey-page'
 import { LandingPage } from '../../pages/landing-page'
-import { LoginPage } from '../../pages/login-page'
 import { Register } from '../../pages/register-Page'
 
 let userEmail = ''
+let sharedPage: Page | undefined
+let sharedContext: BrowserContext | undefined
+
+const getSharedPage = (): Page => {
+  if (sharedPage == null) throw new Error('Shared authenticated page was not initialized')
+  return sharedPage
+}
 
 test.describe('verify card level actions', () => {
+  test.describe.configure({ mode: 'serial' })
+
   test.beforeAll('Register new account', async ({ browser }) => {
-    const page = await browser.newPage()
-    const landingPage = new LandingPage(page)
-    const register = new Register(page)
+    sharedContext = await browser.newContext()
+    sharedPage = await sharedContext.newPage()
+    const landingPage = new LandingPage(sharedPage)
+    const register = new Register(sharedPage)
     await landingPage.goToAdminUrl()
     await register.registerNewAccount()
     userEmail = await register.getUserEmailId() // storing the registered user email id
     console.log(`userEamil : ${userEmail}`)
-    await page.close()
   })
 
-  test.beforeEach(async ({ page }) => {
-    const landingPage = new LandingPage(page)
-    const loginPage = new LoginPage(page)
+  test.beforeEach(async () => {
+    const page = getSharedPage()
     const cardLevelActionPage = new CardLevelActionPage(page)
     const journeyPage = new JourneyPage(page)
-    await landingPage.goToAdminUrl()
-    await loginPage.logInWithCreatedNewUser(userEmail) // login as registered user
+    await page.goto('/')
     await journeyPage.clickCreateCustomJourney() //  clicking on the create custom journey button
     await cardLevelActionPage.waitUntilJourneyCardLoaded() // waiting for custom journey page loaded
     await cardLevelActionPage.clickOnJourneyCard() // clicking on the journey card
@@ -38,8 +45,16 @@ test.describe('verify card level actions', () => {
     await journeyPage.clickSaveBtn() // clicking on save button in the 'edit title' popup
   })
 
+  test.afterAll(async () => {
+    if (sharedPage != null) await sharedPage.close()
+    if (sharedContext != null) await sharedContext.close()
+    sharedPage = undefined
+    sharedContext = undefined
+  })
+
   // Text - create, update & delete
-  test('Text - create, update & delete', async ({ page }) => {
+  test('Text - create, update & delete', async () => {
+    const page = getSharedPage()
     const cardLevelActionPage = new CardLevelActionPage(page)
     await cardLevelActionPage.clickAddBlockBtn() // clicking on add block button
     await cardLevelActionPage.clickTextBtnInAddBlockDrawer() // clicking on text button in add block drawer
@@ -62,7 +77,8 @@ test.describe('verify card level actions', () => {
   })
 
   // Image - create, update & delete
-  test('Image - create, update & delete', async ({ page }) => {
+  test('Image - create, update & delete', async () => {
+    const page = getSharedPage()
     const cardLevelActionPage = new CardLevelActionPage(page)
     await cardLevelActionPage.clickAddBlockBtn() // clicking on add block button
     await cardLevelActionPage.clickBtnInAddBlockDrawer('Image') // clicking on image button in add block drawer
@@ -81,7 +97,8 @@ test.describe('verify card level actions', () => {
   })
 
   // Video - create, update & delete
-  test.skip('Video - create, update & delete', async ({ page }) => {
+  test.skip('Video - create, update & delete', async () => {
+    const page = getSharedPage()
     const cardLevelActionPage = new CardLevelActionPage(page)
     await cardLevelActionPage.deleteAllAddedCardProperties() // deleting all the added properties in the card
     await cardLevelActionPage.clickOnVideoJourneyCard() // clicking on the journey card
@@ -108,7 +125,8 @@ test.describe('verify card level actions', () => {
   })
 
   // Poll - create, update & delete
-  test.fixme('Poll - create, update & delete', async ({ page }) => {
+  test.fixme('Poll - create, update & delete', async () => {
+    const page = getSharedPage()
     const cardLevelActionPage = new CardLevelActionPage(page)
     await cardLevelActionPage.clickAddBlockBtn() // clicking on add block button
     await cardLevelActionPage.clickBtnInAddBlockDrawer('Poll') // clicking on poll button in add block drawer
@@ -124,7 +142,8 @@ test.describe('verify card level actions', () => {
   })
 
   // Response Field- create, update & delete
-  test('Response Field - create, update & delete', async ({ page }) => {
+  test('Response Field - create, update & delete', async () => {
+    const page = getSharedPage()
     const cardLevelActionPage = new CardLevelActionPage(page)
     await cardLevelActionPage.clickAddBlockBtn() // clicking on add block button
     await cardLevelActionPage.clickBtnInAddBlockDrawer('Response Field') // clicking on Response Field button in add block drawer
@@ -143,7 +162,8 @@ test.describe('verify card level actions', () => {
   })
 
   // Button - create, update & delete
-  test('Button - create, update & delete', async ({ page }) => {
+  test('Button - create, update & delete', async () => {
+    const page = getSharedPage()
     const buttonName = 'Playwright'
     const cardLevelActionPage = new CardLevelActionPage(page)
     await cardLevelActionPage.clickAddBlockBtn() // clicking on add block button
@@ -172,7 +192,8 @@ test.describe('verify card level actions', () => {
   })
 
   // Spacer - create & delete
-  test('Spacer - create & delete', async ({ page }) => {
+  test('Spacer - create & delete', async () => {
+    const page = getSharedPage()
     const cardLevelActionPage = new CardLevelActionPage(page)
     await cardLevelActionPage.clickAddBlockBtn() // clicking on add block button
     await cardLevelActionPage.clickBtnInAddBlockDrawer('Spacer') // clicking on subscribe button in add block drawer
@@ -185,62 +206,4 @@ test.describe('verify card level actions', () => {
     await cardLevelActionPage.verifySpacerRemovedFromCard() //validate spacer got removed from the card after delete
   })
 
-  // Footer properties (Journey) - Reactions, Display Title, Hosted By & Chat Widget
-  test('Footer properties (Journey) - create, update & delete', async ({
-    page
-  }) => {
-    const footerTitle = 'Footer Playwright'
-    const cardLevelActionPage = new CardLevelActionPage(page)
-    await cardLevelActionPage.selectWholeFooterSectionInCard() // selecting the whole Footer section
-    await cardLevelActionPage.expandJourneyAppearance('Reactions') // clicking on the 'Reactions' tab from the tab list of footer properties drawer
-    await cardLevelActionPage.selectAllTheReactionOptions() // Select all the reaction checkboxes 'Share', 'Like', 'DisLike'
-    await cardLevelActionPage.expandJourneyAppearance('Display Title') // clicking on the 'Display Title' tab from the tab list of footer properties drawer
-    await cardLevelActionPage.enterDisplayTitleForFooter(footerTitle) // Enter Display title for the Footer Section
-    await cardLevelActionPage.expandJourneyAppearance('Hosted By') // clicking on the 'Hosted By' tab from the tab list of footer properties drawer
-    await cardLevelActionPage.clicSelectHostBtn() // clicking the 'select a host' button below the 'Hosted by' tab in the footer properties drawer
-    await cardLevelActionPage.clickCreateNewBtn() // clicking the 'create new' button below the 'Hosted by' tab in the footer properties drawer
-    await cardLevelActionPage.enterHostName() // entering host name in the host field in the footer properties drawer
-    await cardLevelActionPage.enterLocation() // entering location in the location field in the footer properties drawer
-    await cardLevelActionPage.clickOnJourneyCard() // clickng on the journey card
-    await cardLevelActionPage.verifyHostNameAddedInCard() // verifying the added host name and location are updated in the footer section at bottom of the card
-    await cardLevelActionPage.selectWholeFooterSectionInCard() // selecting the whole Footer section
-    await cardLevelActionPage.expandJourneyAppearance('Chat Widget') // clicking on the 'Chat Widget' tab from the tab list of footer properties drawer
-    await cardLevelActionPage.clickMessangerDropDown('WhatsApp') // clicking the whatsapp dropdown check box
-    await cardLevelActionPage.enterWhatsAppLink() // entering link value on the URL field
-    await cardLevelActionPage.verifyChatWidgetAddedToCard() // verifying the selected messager icon is updated in the footer section at bottom of the card
-    await cardLevelActionPage.validateFooterTitleAndReactionButtonsInCard(
-      footerTitle
-    ) //Verifying the Footer Title and Reactions in the card
-  })
-
-  // Footer properties (WebSite) - Logo, Display Title, Menu & Chat Widget
-  test('Footer properties (WebSite) - create, update & delete', async ({
-    page
-  }) => {
-    const footerTitle = 'Footer Playwright'
-    const cardLevelActionPage = new CardLevelActionPage(page)
-    await cardLevelActionPage.selectWholeFooterSectionInCard() // selecting the whole Footer section
-    await cardLevelActionPage.clickJourneyOrWebSiteOptionForFooter('Website') //Select WebSite option in the top of the footer property
-    await cardLevelActionPage.expandJourneyAppearance('Logo') // clicking on the 'Logo' tab from the tab list of footer properties drawer
-    await cardLevelActionPage.clickSelectImageBtn() // Select Plus icon to add the Image
-    await cardLevelActionPage.selectFirstImageFromGalleryForFooter() //Select first image from the gallery for the Footer section
-    await cardLevelActionPage.valdiateSelectedImageWithDeleteIcon() //Verifying the Selected Image with Delete icon is display
-    await cardLevelActionPage.closeToolDrawerForFooterImage() // Close the tool drawer after selected the Image
-    await cardLevelActionPage.validateSelectedImageWithEditIcon() //Verifying the Selected image is showing under Logo section with edit button
-    await cardLevelActionPage.expandJourneyAppearance('Display Title') // clicking on the 'Display Title' tab from the tab list of footer properties drawer
-    await cardLevelActionPage.enterDisplayTitleForFooter(footerTitle) // Enter Display title for the Footer Section
-    await cardLevelActionPage.expandJourneyAppearance('Menu') // clicking on the 'Menu' tab from the tab list of footer properties drawer
-    await cardLevelActionPage.clickSelectIconDropdownForFooterMenu() //Click Select icon dropdown for Menu
-    await cardLevelActionPage.selectChevronDownIconForFooter() // Select ChevronDownIcon for Menu icon
-    await cardLevelActionPage.selectWholeFooterSectionInCard() // selecting the whole Fotter section
-    await cardLevelActionPage.expandJourneyAppearance('Chat Widget') // clicking on the 'Chat Widget' tab from the tab list of footer properties drawer
-    await cardLevelActionPage.clickMessangerDropDown('WhatsApp') // clicking the whatsapp dropdown check box
-    await cardLevelActionPage.enterWhatsAppLink() // entering link value on the URL field
-    await cardLevelActionPage.verifyChatWidgetAddedToCard() // verifying the selected messager icon is updated in the footer section at bottom of the card
-    await cardLevelActionPage.validateWebsiteFooterSectionInCard(footerTitle) //Verifying the Selected Image, Display Title and menu icon are showing at the top of the card
-    await cardLevelActionPage.expandJourneyAppearance('Menu') // clicking on the 'Menu' tab from the tab list of footer properties drawer
-    await cardLevelActionPage.clickCreateMenuCardButtonInMenuFooter() //Click create menu card button to create menu card
-    await cardLevelActionPage.clickleftSideArrowIcon() //Click Left Chevron button to navigate to react flow panel
-    await cardLevelActionPage.validateMenuCardInReactFlow() //Verifying the Menu card in react flow panel
-  })
 })

--- a/apps/journeys-admin-e2e/src/e2e/discover/card-level-actions.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/card-level-actions.spec.ts
@@ -13,7 +13,8 @@ let sharedPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
 const getSharedPage = (): Page => {
-  if (sharedPage == null) throw new Error('Shared authenticated page was not initialized')
+  if (sharedPage == null)
+    throw new Error('Shared authenticated page was not initialized')
   return sharedPage
 }
 
@@ -205,5 +206,4 @@ test.describe('verify card level actions', () => {
     await cardLevelActionPage.clickDeleteBtnInToolTipBar() //Clicking delete button in the tooltip bar to delete the Spacer from the card
     await cardLevelActionPage.verifySpacerRemovedFromCard() //validate spacer got removed from the card after delete
   })
-
 })

--- a/apps/journeys-admin-e2e/src/e2e/discover/custom-journey.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/custom-journey.spec.ts
@@ -1,13 +1,12 @@
 /* eslint-disable playwright/expect-expect */
-import { test } from '@playwright/test'
 import type { BrowserContext, Page } from 'playwright-core'
 
+import { test } from '../../fixtures/workerAuth'
 import { CardLevelActionPage } from '../../pages/card-level-actions'
 import { JourneyPage } from '../../pages/journey-page'
 import { LandingPage } from '../../pages/landing-page'
-import { Register } from '../../pages/register-Page'
+import { LoginPage } from '../../pages/login-page'
 
-let userEmail = ''
 let sharedPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
@@ -28,15 +27,13 @@ const getSharedContext = (): BrowserContext => {
 test.describe('verify custom journey page', () => {
   test.describe.configure({ mode: 'serial' })
 
-  test.beforeAll('Register new account', async ({ browser }) => {
+  test.beforeAll('Register new account', async ({ browser, workerEmail }) => {
     sharedContext = await browser.newContext()
     sharedPage = await sharedContext.newPage()
     const landingPage = new LandingPage(sharedPage)
-    const register = new Register(sharedPage)
+    const loginPage = new LoginPage(sharedPage)
     await landingPage.goToAdminUrl()
-    await register.registerNewAccount() // registering new user account
-    userEmail = await register.getUserEmailId() // storing the registered user email id
-    console.log(`userEamil : ${userEmail}`)
+    await loginPage.logInWithCreatedNewUser(workerEmail)
   })
 
   test.beforeEach(async () => {

--- a/apps/journeys-admin-e2e/src/e2e/discover/custom-journey.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/custom-journey.spec.ts
@@ -1,42 +1,71 @@
 /* eslint-disable playwright/expect-expect */
 import { test } from '@playwright/test'
+import type { BrowserContext, Page } from 'playwright-core'
 
 import { CardLevelActionPage } from '../../pages/card-level-actions'
 import { JourneyPage } from '../../pages/journey-page'
 import { LandingPage } from '../../pages/landing-page'
-import { LoginPage } from '../../pages/login-page'
 import { Register } from '../../pages/register-Page'
 
 let userEmail = ''
+let sharedPage: Page | undefined
+let sharedContext: BrowserContext | undefined
+
+const getSharedPage = (): Page => {
+  if (sharedPage == null) {
+    throw new Error('Shared authenticated page was not initialized')
+  }
+  return sharedPage
+}
+
+const getSharedContext = (): BrowserContext => {
+  if (sharedContext == null) {
+    throw new Error('Shared authenticated context was not initialized')
+  }
+  return sharedContext
+}
 
 test.describe('verify custom journey page', () => {
+  test.describe.configure({ mode: 'serial' })
+
   test.beforeAll('Register new account', async ({ browser }) => {
-    const page = await browser.newPage()
-    const landingPage = new LandingPage(page)
-    const register = new Register(page)
+    sharedContext = await browser.newContext()
+    sharedPage = await sharedContext.newPage()
+    const landingPage = new LandingPage(sharedPage)
+    const register = new Register(sharedPage)
     await landingPage.goToAdminUrl()
     await register.registerNewAccount() // registering new user account
     userEmail = await register.getUserEmailId() // storing the registered user email id
     console.log(`userEamil : ${userEmail}`)
-    await page.close()
   })
 
-  test.beforeEach(async ({ page }) => {
-    const landingPage = new LandingPage(page)
-    const loginPage = new LoginPage(page)
-    await landingPage.goToAdminUrl()
-    await loginPage.logInWithCreatedNewUser(userEmail) // login as registered user
+  test.beforeEach(async () => {
+    const page = getSharedPage()
+    await page.goto('/')
+  })
+
+  test.afterAll(async () => {
+    if (sharedPage != null) {
+      await sharedPage.close()
+      sharedPage = undefined
+    }
+    if (sharedContext != null) {
+      await sharedContext.close()
+      sharedContext = undefined
+    }
   })
 
   // Verify the user able to create a journey with 'Create custom journey' button
-  test('Create journey via Create custom journey button', async ({ page }) => {
+  test('Create journey via Create custom journey button', async () => {
+    const page = getSharedPage()
     const journeyPage = new JourneyPage(page)
     await journeyPage.clickCreateCustomJourney() // clicking the create custom journey button
     await journeyPage.createAndVerifyCustomJourney() // creating the custom journey and verifing the created journey is updated in the active tab list
   })
 
   // Verify the user able to delete the journey card in create custom journey page
-  test('Detele journey card in custom journey page', async ({ page }) => {
+  test('Detele journey card in custom journey page', async () => {
+    const page = getSharedPage()
     const journeyPage = new JourneyPage(page)
     const cardLevelActionPage = new CardLevelActionPage(page)
     await journeyPage.clickCreateCustomJourney() // clicking the create custom journey button
@@ -51,7 +80,8 @@ test.describe('verify custom journey page', () => {
   })
 
   // Verify the user able to copy the existing journey card in create journey page
-  test('Duplicate journey card in custom journey page', async ({ page }) => {
+  test('Duplicate journey card in custom journey page', async () => {
+    const page = getSharedPage()
     const journeyPage = new JourneyPage(page)
     const cardLevelActionPage = new CardLevelActionPage(page)
     await journeyPage.clickCreateCustomJourney() // clicking on the create custom journey button
@@ -67,10 +97,9 @@ test.describe('verify custom journey page', () => {
   })
 
   // Verify the user able to preview the journey card in full screen mode in create custom journey page
-  test('preview the journey from the custom journey page', async ({
-    page,
-    context
-  }) => {
+  test('preview the journey from the custom journey page', async () => {
+    const page = getSharedPage()
+    const context = getSharedContext()
     const journeyPage = new JourneyPage(page)
     await journeyPage.setBrowserContext(context) // setting browser context
     await journeyPage.clickCreateCustomJourney() // clicking on the create custom journey button

--- a/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions-discover.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions-discover.spec.ts
@@ -12,7 +12,8 @@ let currentPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
 const getSharedPage = (): Page => {
-  if (currentPage == null) throw new Error('Shared authenticated page was not initialized')
+  if (currentPage == null)
+    throw new Error('Shared authenticated page was not initialized')
   return currentPage
 }
 
@@ -96,7 +97,9 @@ test.describe('Journey level actions - discover', () => {
 
   test('Verify language option from three dot options on top right in the selected journey page', async () => {
     const page = getSharedPage()
+
     test.setTimeout(120000)
+
     const journeyLevelActions = new JourneyLevelActions(page)
     const journeyPage = new JourneyPage(page)
     await journeyPage.clickCreateCustomJourney()

--- a/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions-discover.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions-discover.spec.ts
@@ -1,11 +1,11 @@
 /* eslint-disable playwright/expect-expect */
-import { test } from '@playwright/test'
 import type { BrowserContext, Page } from 'playwright-core'
 
+import { test } from '../../fixtures/workerAuth'
 import { JourneyLevelActions } from '../../pages/journey-level-actions-page'
 import { JourneyPage } from '../../pages/journey-page'
 import { LandingPage } from '../../pages/landing-page'
-import { Register } from '../../pages/register-Page'
+import { LoginPage } from '../../pages/login-page'
 import { TeamsPage } from '../../pages/teams-page'
 
 let currentPage: Page | undefined
@@ -27,13 +27,13 @@ const getSharedContext = (): BrowserContext => {
 test.describe('Journey level actions - discover', () => {
   test.describe.configure({ mode: 'serial' })
 
-  test.beforeAll('Register new account', async ({ browser }) => {
+  test.beforeAll('Register new account', async ({ browser, workerEmail }) => {
     sharedContext = await browser.newContext()
     currentPage = await sharedContext.newPage()
     const landingPage = new LandingPage(currentPage)
-    const register = new Register(currentPage)
+    const loginPage = new LoginPage(currentPage)
     await landingPage.goToAdminUrl()
-    await register.registerNewAccount()
+    await loginPage.logInWithCreatedNewUser(workerEmail)
     await currentPage.close()
     currentPage = undefined
   })

--- a/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions-discover.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions-discover.spec.ts
@@ -1,0 +1,199 @@
+/* eslint-disable playwright/expect-expect */
+import { test } from '@playwright/test'
+import type { BrowserContext, Page } from 'playwright-core'
+
+import { JourneyLevelActions } from '../../pages/journey-level-actions-page'
+import { JourneyPage } from '../../pages/journey-page'
+import { LandingPage } from '../../pages/landing-page'
+import { Register } from '../../pages/register-Page'
+import { TeamsPage } from '../../pages/teams-page'
+
+let currentPage: Page | undefined
+let sharedContext: BrowserContext | undefined
+
+const getSharedPage = (): Page => {
+  if (currentPage == null) throw new Error('Shared authenticated page was not initialized')
+  return currentPage
+}
+
+const getSharedContext = (): BrowserContext => {
+  if (sharedContext == null) {
+    throw new Error('Shared authenticated context was not initialized')
+  }
+  return sharedContext
+}
+
+test.describe('Journey level actions - discover', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  test.beforeAll('Register new account', async ({ browser }) => {
+    sharedContext = await browser.newContext()
+    currentPage = await sharedContext.newPage()
+    const landingPage = new LandingPage(currentPage)
+    const register = new Register(currentPage)
+    await landingPage.goToAdminUrl()
+    await register.registerNewAccount()
+    await currentPage.close()
+    currentPage = undefined
+  })
+
+  test.beforeEach(async () => {
+    if (sharedContext == null) {
+      throw new Error('Shared authenticated context was not initialized')
+    }
+    currentPage = await sharedContext.newPage()
+    await getSharedPage().goto('/')
+  })
+
+  test.afterEach(async () => {
+    if (currentPage != null) {
+      await currentPage.close()
+      currentPage = undefined
+    }
+  })
+
+  test.afterAll(async () => {
+    if (currentPage != null) await currentPage.close()
+    if (sharedContext != null) await sharedContext.close()
+    currentPage = undefined
+    sharedContext = undefined
+  })
+
+  test('Verify title option from three dot options on top right in the selected journey page', async () => {
+    const page = getSharedPage()
+    const journeyLevelActions = new JourneyLevelActions(page)
+    const journeyPage = new JourneyPage(page)
+    await journeyPage.clickCreateCustomJourney()
+    await journeyPage.createAndVerifyCustomJourney()
+    const journeyName = await journeyPage.getJourneyName()
+    await journeyLevelActions.selectCreatedJourney(journeyName)
+    await journeyPage.clickThreeDotBtnOfCustomJourney()
+    await journeyLevelActions.clickThreeDotOptionsOfJourneyCreationPage(
+      'Edit Details'
+    )
+    await journeyLevelActions.enterTitle()
+    await journeyPage.clickSaveBtn()
+    await journeyPage.backToHome()
+    await journeyLevelActions.verifyJourneyRenamedInActiveList()
+  })
+
+  test('Verify description option from three dot options on top right in the selected journey page', async () => {
+    const page = getSharedPage()
+    const journeyLevelActions = new JourneyLevelActions(page)
+    const journeyPage = new JourneyPage(page)
+    await journeyPage.clickCreateCustomJourney()
+    await journeyPage.createAndVerifyCustomJourney()
+    const journeyName = await journeyPage.getJourneyName()
+    await journeyLevelActions.selectCreatedJourney(journeyName)
+    await journeyPage.clickThreeDotBtnOfCustomJourney()
+    await journeyLevelActions.clickThreeDotOptionsOfJourneyCreationPage(
+      'Edit Details'
+    )
+    await journeyLevelActions.enterDescription()
+    await journeyPage.clickSaveBtn()
+    await journeyLevelActions.validateJourneyDescription()
+  })
+
+  test('Verify language option from three dot options on top right in the selected journey page', async () => {
+    const page = getSharedPage()
+    test.setTimeout(120000)
+    const journeyLevelActions = new JourneyLevelActions(page)
+    const journeyPage = new JourneyPage(page)
+    await journeyPage.clickCreateCustomJourney()
+    await journeyPage.createAndVerifyCustomJourney()
+    await journeyLevelActions.selectExistingJourney()
+    await journeyPage.clickThreeDotBtnOfCustomJourney()
+    await journeyLevelActions.clickThreeDotOptionsOfJourneyCreationPage(
+      'Edit Details'
+    )
+    await journeyLevelActions.enterLanguage('Adi')
+    await journeyPage.clickSaveBtn()
+    await journeyLevelActions.sleep(2000)
+    await journeyPage.clickThreeDotBtnOfCustomJourney()
+    await journeyLevelActions.clickThreeDotOptionsOfJourneyCreationPage(
+      'Edit Details'
+    )
+    await journeyLevelActions.verifySelectedLanguageInLanguagePopup()
+    await journeyPage.clickSaveBtn()
+  })
+
+  test('Verify copy link option from three dot options on top right in the selected journey page', async () => {
+    const page = getSharedPage()
+    const context = getSharedContext()
+    const journeyLevelActions = new JourneyLevelActions(page)
+    const journeyPage = new JourneyPage(page)
+    await journeyLevelActions.setBrowserContext(context)
+    await journeyPage.clickCreateCustomJourney()
+    await journeyPage.createAndVerifyCustomJourney()
+    const journeyName = await journeyPage.getJourneyName()
+    await journeyLevelActions.selectCreatedJourney(journeyName)
+    await journeyPage.clickThreeDotBtnOfCustomJourney()
+    await journeyLevelActions.clickThreeDotOptionsOfJourneyCreationPage(
+      'Copy Link'
+    )
+  })
+
+  test('Navigate to journey goal page', async () => {
+    const page = getSharedPage()
+    const journeyLevelActions = new JourneyLevelActions(page)
+    const journeyPage = new JourneyPage(page)
+    await journeyPage.clickCreateCustomJourney()
+    await journeyPage.createAndVerifyCustomJourney()
+    await journeyLevelActions.selectExistingJourney()
+    await journeyLevelActions.clickNavigateToGoalBtn()
+    await journeyLevelActions.verifyPageIsNavigatedToGoalPage()
+  })
+
+  test('Verify navigation side menu open and close via navigation list item toggle', async () => {
+    const page = getSharedPage()
+    const journeyLevelActions = new JourneyLevelActions(page)
+    await journeyLevelActions.clickNavigationSideMenu()
+    await journeyLevelActions.verifyNavigationSideMenuOpened()
+    await journeyLevelActions.clickNavigationSideMenu()
+    await journeyLevelActions.verifyNavigationSideMenuClosed()
+  })
+
+  test('Verify the user able to display the help window through help button', async () => {
+    const page = getSharedPage()
+    const journeyLevelActions = new JourneyLevelActions(page)
+    await journeyLevelActions.clickHelpBtn()
+    await journeyLevelActions.verifyHelpWindowOpened()
+  })
+
+  test('Verify manage access option from three dot options on top right in the selected journey page', async () => {
+    const page = getSharedPage()
+    const journeyLevelActions = new JourneyLevelActions(page)
+    const journeyPage = new JourneyPage(page)
+    await journeyPage.clickCreateCustomJourney()
+    await journeyPage.createAndVerifyCustomJourney()
+    const journeyName = await journeyPage.getJourneyName()
+    await journeyLevelActions.selectCreatedJourney(journeyName)
+    await journeyPage.clickThreeDotBtnOfCustomJourney()
+    await journeyLevelActions.clickThreeDotOptionsOfJourneyCreationPage(
+      'Manage Access'
+    )
+    await journeyLevelActions.enterTeamMember()
+    await journeyLevelActions.clickPlusMemberInMemberPopup()
+    await journeyLevelActions.verifyAccessAddedInManageEditors()
+    await journeyLevelActions.clickDiaLogBoxCloseBtn()
+  })
+
+  test('verify copy to option for existing journey', async () => {
+    const page = getSharedPage()
+    const journeyLevelActions = new JourneyLevelActions(page)
+    const journeyPage = new JourneyPage(page)
+    const teamsPage = new TeamsPage(page)
+    await teamsPage.createNewTeamAndVerifyCreatedTeam()
+    await journeyPage.clickCreateCustomJourney()
+    await journeyPage.createAndVerifyCustomJourney()
+    const journeyName = await journeyPage.getJourneyName()
+    await journeyLevelActions.clickThreeDotOfCreatedJourney(journeyName)
+    await journeyLevelActions.clickThreeDotOptions('Copy to ...')
+    await journeyLevelActions.clickSelectTeamDropDownIcon()
+    await journeyLevelActions.selectTeamToCopyTheJourney()
+    await journeyLevelActions.clickCopyButton()
+    await journeyLevelActions.verifySnackBarMsg('Journey Copied')
+    await journeyLevelActions.verifyCopiedTeamNameUpdatedInTeamSelectDropdown()
+    await journeyLevelActions.verifyCopiedJournetInSelectedTeamList()
+  })
+})

--- a/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions-discover.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions-discover.spec.ts
@@ -43,7 +43,7 @@ test.describe('Journey level actions - discover', () => {
       throw new Error('Shared authenticated context was not initialized')
     }
     currentPage = await sharedContext.newPage()
-    await getSharedPage().goto('/')
+    await new JourneyPage(getSharedPage()).gotoDiscoverJourneysPage()
   })
 
   test.afterEach(async () => {

--- a/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions-share.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions-share.spec.ts
@@ -11,7 +11,8 @@ let currentPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
 const getSharedPage = (): Page => {
-  if (currentPage == null) throw new Error('Shared authenticated page was not initialized')
+  if (currentPage == null)
+    throw new Error('Shared authenticated page was not initialized')
   return currentPage
 }
 

--- a/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions-share.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions-share.spec.ts
@@ -1,11 +1,11 @@
 /* eslint-disable playwright/expect-expect */
-import { test } from '@playwright/test'
 import type { BrowserContext, Page } from 'playwright-core'
 
+import { test } from '../../fixtures/workerAuth'
 import { JourneyLevelActions } from '../../pages/journey-level-actions-page'
 import { JourneyPage } from '../../pages/journey-page'
 import { LandingPage } from '../../pages/landing-page'
-import { Register } from '../../pages/register-Page'
+import { LoginPage } from '../../pages/login-page'
 
 let currentPage: Page | undefined
 let sharedContext: BrowserContext | undefined
@@ -26,13 +26,13 @@ const getSharedContext = (): BrowserContext => {
 test.describe('Journey level actions - share', () => {
   test.describe.configure({ mode: 'serial' })
 
-  test.beforeAll('Register new account', async ({ browser }) => {
+  test.beforeAll('Register new account', async ({ browser, workerEmail }) => {
     sharedContext = await browser.newContext()
     currentPage = await sharedContext.newPage()
     const landingPage = new LandingPage(currentPage)
-    const register = new Register(currentPage)
+    const loginPage = new LoginPage(currentPage)
     await landingPage.goToAdminUrl()
-    await register.registerNewAccount()
+    await loginPage.logInWithCreatedNewUser(workerEmail)
     await currentPage.close()
     currentPage = undefined
   })

--- a/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions-share.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions-share.spec.ts
@@ -42,7 +42,7 @@ test.describe('Journey level actions - share', () => {
       throw new Error('Shared authenticated context was not initialized')
     }
     currentPage = await sharedContext.newPage()
-    await getSharedPage().goto('/')
+    await new JourneyPage(getSharedPage()).gotoDiscoverJourneysPage()
   })
 
   test.afterEach(async () => {

--- a/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions-share.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions-share.spec.ts
@@ -1,0 +1,134 @@
+/* eslint-disable playwright/expect-expect */
+import { test } from '@playwright/test'
+import type { BrowserContext, Page } from 'playwright-core'
+
+import { JourneyLevelActions } from '../../pages/journey-level-actions-page'
+import { JourneyPage } from '../../pages/journey-page'
+import { LandingPage } from '../../pages/landing-page'
+import { Register } from '../../pages/register-Page'
+
+let currentPage: Page | undefined
+let sharedContext: BrowserContext | undefined
+
+const getSharedPage = (): Page => {
+  if (currentPage == null) throw new Error('Shared authenticated page was not initialized')
+  return currentPage
+}
+
+const getSharedContext = (): BrowserContext => {
+  if (sharedContext == null) {
+    throw new Error('Shared authenticated context was not initialized')
+  }
+  return sharedContext
+}
+
+test.describe('Journey level actions - share', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  test.beforeAll('Register new account', async ({ browser }) => {
+    sharedContext = await browser.newContext()
+    currentPage = await sharedContext.newPage()
+    const landingPage = new LandingPage(currentPage)
+    const register = new Register(currentPage)
+    await landingPage.goToAdminUrl()
+    await register.registerNewAccount()
+    await currentPage.close()
+    currentPage = undefined
+  })
+
+  test.beforeEach(async () => {
+    if (sharedContext == null) {
+      throw new Error('Shared authenticated context was not initialized')
+    }
+    currentPage = await sharedContext.newPage()
+    await getSharedPage().goto('/')
+  })
+
+  test.afterEach(async () => {
+    if (currentPage != null) {
+      await currentPage.close()
+      currentPage = undefined
+    }
+  })
+
+  test.afterAll(async () => {
+    if (currentPage != null) await currentPage.close()
+    if (sharedContext != null) await sharedContext.close()
+    currentPage = undefined
+    sharedContext = undefined
+  })
+
+  test('Verify copy link icon from Share option dialog in the selected journey page', async () => {
+    const page = getSharedPage()
+    const context = getSharedContext()
+    const journeyLevelActions = new JourneyLevelActions(page)
+    const journeyPage = new JourneyPage(page)
+    await journeyLevelActions.setBrowserContext(context)
+    await journeyPage.clickCreateCustomJourney()
+    await journeyPage.createAndVerifyCustomJourney()
+    const journeyName = await journeyPage.getJourneyName()
+    await journeyLevelActions.selectCreatedJourney(journeyName)
+    await journeyPage.clickShareButtonInJourneyPage()
+    await journeyPage.clickCopyIconInShareDialog()
+    await journeyLevelActions.verifySnackBarMsg('Link Copied')
+  })
+
+  test('Verify Edit Url option from Share option dialog in the selected journey page', async () => {
+    const page = getSharedPage()
+    const context = getSharedContext()
+    const journeyLevelActions = new JourneyLevelActions(page)
+    const journeyPage = new JourneyPage(page)
+    await journeyLevelActions.setBrowserContext(context)
+    await journeyPage.setBrowserContext(context)
+    await journeyPage.clickCreateCustomJourney()
+    await journeyPage.createAndVerifyCustomJourney()
+    const journeyName = await journeyPage.getJourneyName()
+    await journeyLevelActions.selectCreatedJourney(journeyName)
+    await journeyPage.clickShareButtonInJourneyPage()
+    const urlSlug = await journeyPage.editUrlAndSave()
+    await journeyPage.clickCopyIconInShareDialog()
+    await journeyLevelActions.verifySnackBarMsg('Link copied')
+    await journeyPage.verifyUpdatedUrlSlugIsLoaded(urlSlug)
+  })
+
+  test('Verify Embed Journey option from Share option dialog in the selected journey page', async () => {
+    const page = getSharedPage()
+    const context = getSharedContext()
+    const journeyLevelActions = new JourneyLevelActions(page)
+    const journeyPage = new JourneyPage(page)
+    await journeyLevelActions.setBrowserContext(context)
+    await journeyPage.setBrowserContext(context)
+    await journeyPage.clickCreateCustomJourney()
+    await journeyPage.createAndVerifyCustomJourney()
+    const journeyName = await journeyPage.getJourneyName()
+    await journeyLevelActions.selectCreatedJourney(journeyName)
+    await journeyPage.clickShareButtonInJourneyPage()
+    await journeyPage.clickButtonInShareDialog('Embed Journey')
+    const embedCode =
+      await journeyPage.validateUrlInEmbedCodeFieldAndReturnEmbedCode()
+    await journeyPage.clickDialogActionBtnsInShareDialog('Copy Code')
+    await journeyLevelActions.verifySnackBarMsg('Code Copied')
+    await journeyPage.validateCopiedValues(embedCode)
+    await journeyPage.clickDialogActionBtnsInShareDialog('Cancel')
+  })
+
+  test('Verify QR Code option from Share option dialog in the selected journey page', async () => {
+    const page = getSharedPage()
+    const context = getSharedContext()
+    const journeyLevelActions = new JourneyLevelActions(page)
+    const journeyPage = new JourneyPage(page)
+    await journeyLevelActions.setBrowserContext(context)
+    await journeyPage.setBrowserContext(context)
+    await journeyPage.clickCreateCustomJourney()
+    await journeyPage.createAndVerifyCustomJourney()
+    const journeyName = await journeyPage.getJourneyName()
+    await journeyLevelActions.selectCreatedJourney(journeyName)
+    await journeyPage.clickShareButtonInJourneyPage()
+    await journeyPage.clickButtonInShareDialog('QR Code')
+    await journeyPage.clickButtonInShareDialog('Generate Code')
+    await journeyPage.downloadQRCodeAsPng()
+    await journeyPage.validateDownloadedQrPngFile()
+    await journeyPage.clickDownloadDropDownAndSelectCopyShortLink()
+    await journeyPage.clickCloseIconForQrCodeDialog()
+  })
+})

--- a/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions.spec.ts
@@ -1,36 +1,70 @@
 /* eslint-disable playwright/expect-expect */
 import { test } from '@playwright/test'
+import type { BrowserContext, Page } from 'playwright-core'
 
 import { JourneyLevelActions } from '../../pages/journey-level-actions-page'
 import { JourneyPage } from '../../pages/journey-page'
 import { LandingPage } from '../../pages/landing-page'
-import { LoginPage } from '../../pages/login-page'
 import { Register } from '../../pages/register-Page'
 import { TeamsPage } from '../../pages/teams-page'
 
 let userEmail = ''
+let currentPage: Page | undefined
+let sharedContext: BrowserContext | undefined
+
+const getSharedPage = (): Page => {
+  if (currentPage == null) throw new Error('Shared authenticated page was not initialized')
+  return currentPage
+}
+
+const getSharedContext = (): BrowserContext => {
+  if (sharedContext == null) {
+    throw new Error('Shared authenticated context was not initialized')
+  }
+  return sharedContext
+}
 
 test.describe('Journey level actions', () => {
+  test.describe.configure({ mode: 'serial' })
+
   test.beforeAll('Register new account', async ({ browser }) => {
-    const page = await browser.newPage()
-    const landingPage = new LandingPage(page)
-    const register = new Register(page)
+    sharedContext = await browser.newContext()
+    currentPage = await sharedContext.newPage()
+    const landingPage = new LandingPage(currentPage)
+    const register = new Register(currentPage)
     await landingPage.goToAdminUrl()
     await register.registerNewAccount() // registering new user account
     userEmail = await register.getUserEmailId() // storing the registered user email id
     console.log(`userName : ${userEmail}`)
-    await page.close()
+    await currentPage.close()
+    currentPage = undefined
   })
 
-  test.beforeEach(async ({ page }) => {
-    const landingPage = new LandingPage(page)
-    const loginPage = new LoginPage(page)
-    await landingPage.goToAdminUrl()
-    await loginPage.logInWithCreatedNewUser(userEmail) // login as registered user
+  test.beforeEach(async () => {
+    if (sharedContext == null) {
+      throw new Error('Shared authenticated context was not initialized')
+    }
+    currentPage = await sharedContext.newPage()
+    await getSharedPage().goto('/')
+  })
+
+  test.afterEach(async () => {
+    if (currentPage != null) {
+      await currentPage.close()
+      currentPage = undefined
+    }
+  })
+
+  test.afterAll(async () => {
+    if (currentPage != null) await currentPage.close()
+    if (sharedContext != null) await sharedContext.close()
+    currentPage = undefined
+    sharedContext = undefined
   })
 
   // Discover page -> Existing journey -> Edit Details
-  test('Edit existing journey from journey card menu', async ({ page }) => {
+  test('Edit existing journey from journey card menu', async () => {
+    const page = getSharedPage()
     const journeyLevelActions = new JourneyLevelActions(page)
     const journeyPage = new JourneyPage(page)
 
@@ -45,7 +79,8 @@ test.describe('Journey level actions', () => {
   })
 
   // Discover page -> Existing journey -> Custom Journey -> Edit details
-  test('Edit existing journey from custom journey page', async ({ page }) => {
+  test('Edit existing journey from custom journey page', async () => {
+    const page = getSharedPage()
     const journeyLevelActions = new JourneyLevelActions(page)
     const journeyPage = new JourneyPage(page)
 
@@ -62,7 +97,8 @@ test.describe('Journey level actions', () => {
   })
 
   // Discover page -> Existing journey -> Access
-  test('Access for existing journey', async ({ page }) => {
+  test('Access for existing journey', async () => {
+    const page = getSharedPage()
     const journeyLevelActions = new JourneyLevelActions(page)
     const journeyPage = new JourneyPage(page)
     await journeyPage.clickCreateCustomJourney() // click the create custom journey button
@@ -76,7 +112,9 @@ test.describe('Journey level actions', () => {
   })
 
   // Discover page -> Existing journey -> Preview
-  test('Preview existing journey', async ({ page, context }) => {
+  test('Preview existing journey', async () => {
+    const page = getSharedPage()
+    const context = getSharedContext()
     const journeyLevelActions = new JourneyLevelActions(page)
     const journeyPage = new JourneyPage(page)
     await journeyLevelActions.setBrowserContext(context) // setting context
@@ -88,7 +126,8 @@ test.describe('Journey level actions', () => {
   })
 
   // Discover page -> Existing journey -> Duplicate
-  test('Duplicate existing journey', async ({ page }) => {
+  test('Duplicate existing journey', async () => {
+    const page = getSharedPage()
     const journeyLevelActions = new JourneyLevelActions(page)
     const journeyPage = new JourneyPage(page)
     await journeyPage.clickCreateCustomJourney() // clicking on the create custom journey button
@@ -98,260 +137,5 @@ test.describe('Journey level actions', () => {
     await journeyLevelActions.clickThreeDotOptions('Duplicate') // clicking on the duplicate option of the three dot options
     await journeyLevelActions.verifyExistingJourneyDuplicate() // verifying the journey gets duplicated and updated in the journey list
     await journeyLevelActions.verifySnackBarMsg('Journey Duplicated') // verifying the toast message
-  })
-
-  // Discover page -> Select an existing journey -> Three dots on top right -> Title
-  test('Verify title option from three dot options on top right in the selected journey page', async ({
-    page
-  }) => {
-    const journeyLevelActions = new JourneyLevelActions(page)
-    const journeyPage = new JourneyPage(page)
-    await journeyPage.clickCreateCustomJourney() // clicking on the create custom journey button
-    await journeyPage.createAndVerifyCustomJourney() // creating the custom journey and verifing the created journey is updated in the active tab list
-    const journeyName = await journeyPage.getJourneyName()
-    await journeyLevelActions.selectCreatedJourney(journeyName) // clicking on the created journey in the journey list
-    await journeyPage.clickThreeDotBtnOfCustomJourney() // clicking on the three dot at top right corner of the custom journey page
-    await journeyLevelActions.clickThreeDotOptionsOfJourneyCreationPage(
-      'Edit Details'
-    ) // clicking on the Edit Details option of the thre dot options
-    await journeyLevelActions.enterTitle() // entering title on the title field in the 'edit title' popup
-    await journeyPage.clickSaveBtn() // clicking on save button in the 'edit title' popup
-    await journeyPage.backToHome() // clicking the NextSteps logo icon at the top left corner in the custom journey page
-    await journeyLevelActions.verifyJourneyRenamedInActiveList() // verifying journey is displaying in the journey list with the entered title
-  })
-
-  // Discover page -> Select an existing journey -> Three dots on top right -> Description
-  test('Verify description option from three dot options on top right in the selected journey page', async ({
-    page
-  }) => {
-    const journeyLevelActions = new JourneyLevelActions(page)
-    const journeyPage = new JourneyPage(page)
-    await journeyPage.clickCreateCustomJourney() // clicking on the create custom journey button
-    await journeyPage.createAndVerifyCustomJourney() // creating the custom journey and verifing the created journey is updated in the active tab list
-    const journeyName = await journeyPage.getJourneyName() // getting journay name
-    await journeyLevelActions.selectCreatedJourney(journeyName) // clicking on the created journey in the journey list
-    await journeyPage.clickThreeDotBtnOfCustomJourney() // clicking on the three dot at top right corner of the custom journey page
-    await journeyLevelActions.clickThreeDotOptionsOfJourneyCreationPage(
-      'Edit Details'
-    ) // clicking on the description option of the three dot options
-    await journeyLevelActions.enterDescription() // entering the description value on the description field in the 'edit description' popup
-    await journeyPage.clickSaveBtn() // clicking on save button in the 'edit description' popup
-    await journeyLevelActions.validateJourneyDescription() // verifying the description is updated in the journey details page
-    //new UI descriptions details are not shown in the journey card list, so commenting the below line
-    //await journeyPage.backToHome() // clicking the NextSteps logo icon at the top left corner in the custom journey page
-    //await journeyLevelActions.verifyDescriptionAddedForSelectedJourney() // verifying the journey is displaying in the journey list with added description below the journey title
-  })
-
-  // Discover page -> Select an existing journey -> Three dots on top right -> Language
-  test('Verify language option from three dot options on top right in the selected journey page', async ({
-    page
-  }) => {
-    test.setTimeout(120000)
-
-    const journeyLevelActions = new JourneyLevelActions(page)
-    const journeyPage = new JourneyPage(page)
-    await journeyPage.clickCreateCustomJourney() // clicking on the create custom journey button
-    await journeyPage.createAndVerifyCustomJourney() // creating the custom journey and verifing the created journey is updated in the active tab list
-    await journeyLevelActions.selectExistingJourney() // clicking on existing journey in the journey list
-    await journeyPage.clickThreeDotBtnOfCustomJourney() // clicking on the three dot at top right corner of the custom journey page
-    await journeyLevelActions.clickThreeDotOptionsOfJourneyCreationPage(
-      'Edit Details'
-    ) // clicking on the language option of the three dot options
-    await journeyLevelActions.enterLanguage('Adi') // selecting language in the edit language popup
-    await journeyPage.clickSaveBtn() // clicking on save button in the 'edit language' popup
-    await journeyLevelActions.sleep(2000) // allow journey refetch before reopening
-    await journeyPage.clickThreeDotBtnOfCustomJourney() // clicking on the three dot at top right corner of the custom journey page
-    await journeyLevelActions.clickThreeDotOptionsOfJourneyCreationPage(
-      'Edit Details'
-    ) // clicking on the language option of the three dot options
-    await journeyLevelActions.verifySelectedLanguageInLanguagePopup() // verify selected language is updated in the edit language popup
-    await journeyPage.clickSaveBtn() // close the edit language popup
-  })
-
-  // Discover page -> Select an existing journey -> Three dots on top right -> Copy Link
-  test('Verify copy link option from three dot options on top right in the selected journey page', async ({
-    page,
-    context
-  }) => {
-    const journeyLevelActions = new JourneyLevelActions(page)
-    const journeyPage = new JourneyPage(page)
-
-    await journeyLevelActions.setBrowserContext(context) // setting the context
-    await journeyPage.clickCreateCustomJourney() // clicking on the create custom journey button
-    await journeyPage.createAndVerifyCustomJourney() // creating the custom journey and verifing the created journey is updated in the active tab list
-    const journeyName = await journeyPage.getJourneyName() // getting the journey name
-    await journeyLevelActions.selectCreatedJourney(journeyName) // clicking on the created journey in the journey list
-    await journeyPage.clickThreeDotBtnOfCustomJourney() // clicking on the three dot at top right corner of the custom journey page
-    await journeyLevelActions.clickThreeDotOptionsOfJourneyCreationPage(
-      'Copy Link'
-    ) // clicking on the Copy Link option of the three dot options
-    //Flaky sometimes - so disabling for now
-    // await journeyLevelActions.verifySnackBarMsg('Link Copied') // verifying the toast message
-    // Skipped the clipboard read assertion, which is unreliable in headless/CI environments.
-    // await journeyLevelActions.verifyLinkIsCopied() // verifying the copied link by opening a new tab and load the copied link
-  })
-
-  // Verify the user able to navigate to journey goal page
-  test('Navigate to journey goal page', async ({ page }) => {
-    const journeyLevelActions = new JourneyLevelActions(page)
-    const journeyPage = new JourneyPage(page)
-    await journeyPage.clickCreateCustomJourney() // clicking on the create custom journey button
-    await journeyPage.createAndVerifyCustomJourney() // creating the custom journey and verifing the created journey is updated in the active tab list
-    await journeyLevelActions.selectExistingJourney() // clicking on existing journey in the journey list
-    await journeyLevelActions.clickNavigateToGoalBtn() // clicking the strategy button
-    await journeyLevelActions.verifyPageIsNavigatedToGoalPage() // verifying the page is navigated to goal page
-  })
-
-  // Verify the user able to hide and visible the side window through windows side button
-  test('Verify navigation side menu open and close via navigation list item toggle', async ({
-    page
-  }) => {
-    const journeyLevelActions = new JourneyLevelActions(page)
-    await journeyLevelActions.clickNavigationSideMenu() // clicking on the navigation list Item arrow at top left corner
-    await journeyLevelActions.verifyNavigationSideMenuOpened() // verify the navigation list drawer is expanded
-    await journeyLevelActions.clickNavigationSideMenu() // clicking on the navigation list Item arrow at top left corner
-    await journeyLevelActions.verifyNavigationSideMenuClosed() // verify the navigation list drawer is closed
-  })
-
-  // Verify the user able to display the help window through help button
-  test('Verify the user able to display the help window through help button', async ({
-    page
-  }) => {
-    const journeyLevelActions = new JourneyLevelActions(page)
-    await journeyLevelActions.clickHelpBtn() // clicking on help button(question mark icon) at top right corner
-    await journeyLevelActions.verifyHelpWindowOpened() // verifying the help window is showing in the Discover page
-  })
-
-  // Discover page -> Select an existing journey -> Three dots on top right -> Manage Access
-  test('Verify manage access option from three dot options on top right in the selected journey page', async ({
-    page
-  }) => {
-    const journeyLevelActions = new JourneyLevelActions(page)
-    const journeyPage = new JourneyPage(page)
-    await journeyPage.clickCreateCustomJourney() // click the create custom journey button
-    await journeyPage.createAndVerifyCustomJourney() // creating the custom journey and verifing the created journey is updated in the active tab list
-    const journeyName = await journeyPage.getJourneyName() // getting journay name
-    await journeyLevelActions.selectCreatedJourney(journeyName)
-    await journeyPage.clickThreeDotBtnOfCustomJourney() // clicking on the three dot at top of right corner of the custom journey page
-    await journeyLevelActions.clickThreeDotOptionsOfJourneyCreationPage(
-      'Manage Access'
-    ) // clicking on the manage access option of the thre dot options         await journeyLevelActions.enterTeamMember() // entering mail address of team member in the email field
-    await journeyLevelActions.enterTeamMember() // enterning mail address of team member in the email field
-    await journeyLevelActions.clickPlusMemberInMemberPopup() // clicking on plus icon in the manage editors popup
-    await journeyLevelActions.verifyAccessAddedInManageEditors() // verifying entered member is displaying in the editors list
-    await journeyLevelActions.clickDiaLogBoxCloseBtn() // clicking on x button at top right corner in the manage editors popup
-  })
-
-  // Discover page -> Existing journey -> Copy to
-  test('verify copy to option for existing journey', async ({ page }) => {
-    const journeyLevelActions = new JourneyLevelActions(page)
-    const journeyPage = new JourneyPage(page)
-    const teamsPage = new TeamsPage(page)
-    await teamsPage.createNewTeamAndVerifyCreatedTeam() // create new team and verify the created team
-
-    await journeyPage.clickCreateCustomJourney() // click the create custom journey button
-    await journeyPage.createAndVerifyCustomJourney() // creating the custom journey and verifing the created journey is updated in the active tab list
-    const journeyName = await journeyPage.getJourneyName() // getting journay name
-    await journeyLevelActions.clickThreeDotOfCreatedJourney(journeyName) // clicking on the three dot of created journey in the journey list        await journeyLevelActions.clickThreeDotOptions('Copy to ...') // clicking on the copy to ... option of the three dot options
-    await journeyLevelActions.clickThreeDotOptions('Copy to ...') // clicking on the copy to ... option of the three dot options
-    await journeyLevelActions.clickSelectTeamDropDownIcon() // cliking on the select team field in the 'copy to another team' popup
-    await journeyLevelActions.selectTeamToCopyTheJourney() // selecting the team in the team list dropdown
-    await journeyLevelActions.clickCopyButton() // clicking the copy button in the 'copy to another team' popup
-    await journeyLevelActions.verifySnackBarMsg('Journey Copied') // verifying toast message
-    await journeyLevelActions.verifyCopiedTeamNameUpdatedInTeamSelectDropdown() // verify the selected team is updated on the team select dropdownlist at top left corner
-    await journeyLevelActions.verifyCopiedJournetInSelectedTeamList() // verifying the journey is copied to another team
-  })
-
-  // Discover page -> Select an existing journey -> Share -> Copy icon
-  test('Verify copy link icon from Share option dialog in the selected journey page', async ({
-    page,
-    context
-  }) => {
-    const journeyLevelActions = new JourneyLevelActions(page)
-    const journeyPage = new JourneyPage(page)
-
-    await journeyLevelActions.setBrowserContext(context) // setting the context
-    await journeyPage.clickCreateCustomJourney() // clicking on the create custom journey button
-    await journeyPage.createAndVerifyCustomJourney() // creating the custom journey and verifing the created journey is updated in the active tab list
-    const journeyName = await journeyPage.getJourneyName() // getting the journey name
-    await journeyLevelActions.selectCreatedJourney(journeyName) // clicking on the created journey in the journey list
-    await journeyPage.clickShareButtonInJourneyPage() // clicking on the Share button at top of the custom journey page
-    await journeyPage.clickCopyIconInShareDialog() // clicking on the Copy icon of the Share option dialog popup
-    await journeyLevelActions.verifySnackBarMsg('Link Copied') // verifying the toast message
-    // Skipped the clipboard read assertion, which is unreliable in headless/CI environments.
-    // await journeyLevelActions.verifyLinkIsCopied() // verifying the copied link by opening a new tab and load the copied link
-  })
-
-  // Discover page -> Select an existing journey -> Share -> Edit Url
-  test('Verify Edit Url option from Share option dialog in the selected journey page', async ({
-    page,
-    context
-  }) => {
-    const journeyLevelActions = new JourneyLevelActions(page)
-    const journeyPage = new JourneyPage(page)
-
-    await journeyLevelActions.setBrowserContext(context) // setting the context
-    await journeyPage.setBrowserContext(context) // setting the context
-    await journeyPage.clickCreateCustomJourney() // clicking on the create custom journey button
-    await journeyPage.createAndVerifyCustomJourney() // creating the custom journey and verifing the created journey is updated in the active tab list
-    const journeyName = await journeyPage.getJourneyName() // getting the journey name
-    await journeyLevelActions.selectCreatedJourney(journeyName) // clicking on the created journey in the journey list
-    await journeyPage.clickShareButtonInJourneyPage() // clicking on the Share button at top of the custom journey page
-    const urlSlug = await journeyPage.editUrlAndSave() // clicking on the Edit Url button, update URL Slug and save in the Share option dialog popup
-    await journeyPage.clickCopyIconInShareDialog() // clicking on the Copy icon of the Share option dialog popup
-    await journeyLevelActions.verifySnackBarMsg('Link copied') // verifying the toast message
-    // Skipped the clipboard read assertion, which is unreliable in headless/CI environments.
-    //await journeyLevelActions.verifyLinkIsCopied() // verifying the copied link by opening a new tab and load the copied link
-    await journeyPage.verifyUpdatedUrlSlugIsLoaded(urlSlug) // verifyinh that the updated url is loaded
-  })
-
-  // Discover page -> Select an existing journey -> Share -> Embed Journey
-  test('Verify Embed Journey option from Share option dialog in the selected journey page', async ({
-    page,
-    context
-  }) => {
-    const journeyLevelActions = new JourneyLevelActions(page)
-    const journeyPage = new JourneyPage(page)
-
-    await journeyLevelActions.setBrowserContext(context) // setting the context
-    await journeyPage.setBrowserContext(context) // setting the context
-    await journeyPage.clickCreateCustomJourney() // clicking on the create custom journey button
-    await journeyPage.createAndVerifyCustomJourney() // creating the custom journey and verifing the created journey is updated in the active tab list
-    const journeyName = await journeyPage.getJourneyName() // getting the journey name
-    await journeyLevelActions.selectCreatedJourney(journeyName) // clicking on the created journey in the journey list
-    await journeyPage.clickShareButtonInJourneyPage() // clicking on the Share button at top of the custom journey page
-    await journeyPage.clickButtonInShareDialog('Embed Journey') // CLick Embed Journey button in the Share option dialog
-    const embedCode =
-      await journeyPage.validateUrlInEmbedCodeFieldAndReturnEmbedCode() //Validate Embed iframe with the url before copying the code
-    await journeyPage.clickDialogActionBtnsInShareDialog('Copy Code') //CLicking Copy Code button to copy the embedded iframe code
-    await journeyLevelActions.verifySnackBarMsg('Code Copied') // verifying the toast message
-    await journeyPage.validateCopiedValues(embedCode) // verifying the copied code and embed in textarea is same
-    await journeyPage.clickDialogActionBtnsInShareDialog('Cancel') //CLicking Cancel button to return to url slug page
-  })
-
-  // Discover page -> Select an existing journey -> Share -> QR Code (download png & Copy Short Link)
-  test('Verify QR Code option from Share option dialog in the selected journey page', async ({
-    page,
-    context
-  }) => {
-    const journeyLevelActions = new JourneyLevelActions(page)
-    const journeyPage = new JourneyPage(page)
-
-    await journeyLevelActions.setBrowserContext(context) // setting the context
-    await journeyPage.setBrowserContext(context) // setting the context
-    await journeyPage.clickCreateCustomJourney() // clicking on the create custom journey button
-    await journeyPage.createAndVerifyCustomJourney() // creating the custom journey and verifing the created journey is updated in the active tab list
-    const journeyName = await journeyPage.getJourneyName() // getting the journey name
-    await journeyLevelActions.selectCreatedJourney(journeyName) // clicking on the created journey in the journey list
-    await journeyPage.clickShareButtonInJourneyPage() // clicking on the Share button at top of the custom journey page
-    await journeyPage.clickButtonInShareDialog('QR Code') // CLick QR Code button in the Share option dialog
-    await journeyPage.clickButtonInShareDialog('Generate Code') //Click Generate Code button to generate qr code
-    await journeyPage.downloadQRCodeAsPng() // download QR code as png file in the project folder
-    await journeyPage.validateDownloadedQrPngFile() //validate that the png is downloaded in the expected project folder with file extension as .png
-    await journeyPage.clickDownloadDropDownAndSelectCopyShortLink() //Clicking downlaod dropdown and click copy short link option to copy the url
-    // await journeyLevelActions.verifySnackBarMsg('Link copied') // verifying the toast message (commented out: snackbar may be hidden behind modal)
-    await journeyPage.clickCloseIconForQrCodeDialog() //Click close icon to close the QR code dialog popup
-    // Skipped the clipboard read assertion, which is unreliable in headless/CI environments.
-    // await journeyLevelActions.verifyLinkIsCopied() // verifying the copied link by opening a new tab and load the copied link
   })
 })

--- a/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions.spec.ts
@@ -46,7 +46,7 @@ test.describe('Journey level actions', () => {
       throw new Error('Shared authenticated context was not initialized')
     }
     currentPage = await sharedContext.newPage()
-    await getSharedPage().goto('/')
+    await new JourneyPage(getSharedPage()).gotoDiscoverJourneysPage()
   })
 
   test.afterEach(async () => {

--- a/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions.spec.ts
@@ -1,14 +1,13 @@
 /* eslint-disable playwright/expect-expect */
-import { test } from '@playwright/test'
 import type { BrowserContext, Page } from 'playwright-core'
 
+import { test } from '../../fixtures/workerAuth'
 import { JourneyLevelActions } from '../../pages/journey-level-actions-page'
 import { JourneyPage } from '../../pages/journey-page'
 import { LandingPage } from '../../pages/landing-page'
-import { Register } from '../../pages/register-Page'
+import { LoginPage } from '../../pages/login-page'
 import { TeamsPage } from '../../pages/teams-page'
 
-let userEmail = ''
 let currentPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
@@ -28,15 +27,13 @@ const getSharedContext = (): BrowserContext => {
 test.describe('Journey level actions', () => {
   test.describe.configure({ mode: 'serial' })
 
-  test.beforeAll('Register new account', async ({ browser }) => {
+  test.beforeAll('Register new account', async ({ browser, workerEmail }) => {
     sharedContext = await browser.newContext()
     currentPage = await sharedContext.newPage()
     const landingPage = new LandingPage(currentPage)
-    const register = new Register(currentPage)
+    const loginPage = new LoginPage(currentPage)
     await landingPage.goToAdminUrl()
-    await register.registerNewAccount() // registering new user account
-    userEmail = await register.getUserEmailId() // storing the registered user email id
-    console.log(`userName : ${userEmail}`)
+    await loginPage.logInWithCreatedNewUser(workerEmail)
     await currentPage.close()
     currentPage = undefined
   })

--- a/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/journey-level-actions.spec.ts
@@ -13,7 +13,8 @@ let currentPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
 const getSharedPage = (): Page => {
-  if (currentPage == null) throw new Error('Shared authenticated page was not initialized')
+  if (currentPage == null)
+    throw new Error('Shared authenticated page was not initialized')
   return currentPage
 }
 

--- a/apps/journeys-admin-e2e/src/e2e/discover/journey-sorting.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/journey-sorting.spec.ts
@@ -1,37 +1,65 @@
 /* eslint-disable playwright/expect-expect */
 import { test } from '@playwright/test'
+import type { BrowserContext, Page } from 'playwright-core'
 
 import { JourneyPage } from '../../pages/journey-page'
 import { LandingPage } from '../../pages/landing-page'
-import { LoginPage } from '../../pages/login-page'
 import { Register } from '../../pages/register-Page'
 
 let userEmail = ''
+let onboardingPage: Page | undefined
+let sharedContext: BrowserContext | undefined
+
+const getSharedPage = (): Page => {
+  if (onboardingPage == null) throw new Error('Shared authenticated page was not initialized')
+  return onboardingPage
+}
 
 test.describe('verify journey sorting', () => {
+  test.describe.configure({ mode: 'serial' })
+
   test.beforeAll('Register new account', async ({ browser }) => {
-    const page = await browser.newPage()
-    const landingPage = new LandingPage(page)
-    const register = new Register(page)
+    sharedContext = await browser.newContext()
+    onboardingPage = await sharedContext.newPage()
+    const landingPage = new LandingPage(onboardingPage)
+    const register = new Register(onboardingPage)
     await landingPage.goToAdminUrl()
     await register.registerNewAccount() // registering new user account
     userEmail = await register.getUserEmailId() // storing the registered user email id
     console.log(`userName : ${userEmail}`)
-    await page.close()
+    await onboardingPage.close()
+    onboardingPage = undefined
   })
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async () => {
+    const context = sharedContext
+    if (context == null) throw new Error('Shared authenticated context was not initialized')
+    onboardingPage = await context.newPage()
+    const page = getSharedPage()
     const landingPage = new LandingPage(page)
-    const loginPage = new LoginPage(page)
     const journeyPage = new JourneyPage(page)
     await landingPage.goToAdminUrl()
-    await loginPage.logInWithCreatedNewUser(userEmail) // login as registered user
     await journeyPage.clickCreateCustomJourney() // clicking on the create custom journey button
     await journeyPage.createAndVerifyCustomJourney() // creating the custom journey and verifing the created journey is updated in the active tab list
   })
 
+  test.afterEach(async () => {
+    if (onboardingPage != null) {
+      await onboardingPage.close()
+      onboardingPage = undefined
+    }
+  })
+
+  test.afterAll(async () => {
+    if (onboardingPage != null) await onboardingPage.close()
+    if (sharedContext != null) await sharedContext.close()
+    onboardingPage = undefined
+    sharedContext = undefined
+  })
+
   // Sort by date
-  test('verify journeys are sort by name', async ({ page }) => {
+  test('verify journeys are sort by name', async () => {
+    const page = getSharedPage()
     const journeyPage = new JourneyPage(page)
     await journeyPage.clickCreateCustomJourney() // clicking on the create custom journey button
     await journeyPage.createAndVerifyCustomJourney() // creating the custom journey and verifing the created journey is updated in the active tab list
@@ -43,7 +71,8 @@ test.describe('verify journey sorting', () => {
   })
 
   // Sort by name
-  test('verify journeys are sort by date', async ({ page }) => {
+  test('verify journeys are sort by date', async () => {
+    const page = getSharedPage()
     const journeyPage = new JourneyPage(page)
     await journeyPage.clickCreateCustomJourney() // clicking on the create custom journey button
     await journeyPage.createAndVerifyCustomJourney() // creating the custom journey and verifing the created journey is updated in the active tab list

--- a/apps/journeys-admin-e2e/src/e2e/discover/journey-sorting.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/journey-sorting.spec.ts
@@ -11,7 +11,8 @@ let onboardingPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
 const getSharedPage = (): Page => {
-  if (onboardingPage == null) throw new Error('Shared authenticated page was not initialized')
+  if (onboardingPage == null)
+    throw new Error('Shared authenticated page was not initialized')
   return onboardingPage
 }
 
@@ -33,7 +34,8 @@ test.describe('verify journey sorting', () => {
 
   test.beforeEach(async () => {
     const context = sharedContext
-    if (context == null) throw new Error('Shared authenticated context was not initialized')
+    if (context == null)
+      throw new Error('Shared authenticated context was not initialized')
     onboardingPage = await context.newPage()
     const page = getSharedPage()
     const landingPage = new LandingPage(page)

--- a/apps/journeys-admin-e2e/src/e2e/discover/journey-sorting.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/journey-sorting.spec.ts
@@ -1,12 +1,11 @@
 /* eslint-disable playwright/expect-expect */
-import { test } from '@playwright/test'
 import type { BrowserContext, Page } from 'playwright-core'
 
+import { test } from '../../fixtures/workerAuth'
 import { JourneyPage } from '../../pages/journey-page'
 import { LandingPage } from '../../pages/landing-page'
-import { Register } from '../../pages/register-Page'
+import { LoginPage } from '../../pages/login-page'
 
-let userEmail = ''
 let onboardingPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
@@ -19,15 +18,13 @@ const getSharedPage = (): Page => {
 test.describe('verify journey sorting', () => {
   test.describe.configure({ mode: 'serial' })
 
-  test.beforeAll('Register new account', async ({ browser }) => {
+  test.beforeAll('Register new account', async ({ browser, workerEmail }) => {
     sharedContext = await browser.newContext()
     onboardingPage = await sharedContext.newPage()
     const landingPage = new LandingPage(onboardingPage)
-    const register = new Register(onboardingPage)
+    const loginPage = new LoginPage(onboardingPage)
     await landingPage.goToAdminUrl()
-    await register.registerNewAccount() // registering new user account
-    userEmail = await register.getUserEmailId() // storing the registered user email id
-    console.log(`userName : ${userEmail}`)
+    await loginPage.logInWithCreatedNewUser(workerEmail)
     await onboardingPage.close()
     onboardingPage = undefined
   })

--- a/apps/journeys-admin-e2e/src/e2e/discover/members.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/members.spec.ts
@@ -1,12 +1,11 @@
 /* eslint-disable playwright/expect-expect */
-import { test } from '@playwright/test'
 import type { BrowserContext, Page } from 'playwright-core'
 
+import { test } from '../../fixtures/workerAuth'
 import { LandingPage } from '../../pages/landing-page'
-import { Register } from '../../pages/register-Page'
+import { LoginPage } from '../../pages/login-page'
 import { TeamsPage } from '../../pages/teams-page'
 
-let userEmail = ''
 let sharedPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
@@ -19,17 +18,15 @@ const getSharedPage = (): Page => {
 test.describe('Verify Add member', () => {
   test.describe.configure({ mode: 'serial' })
 
-  test.beforeAll('Register new account', async ({ browser }) => {
+  test.beforeAll('Register new account', async ({ browser, workerEmail }) => {
     sharedContext = await browser.newContext()
     sharedPage = await sharedContext.newPage()
-    const teamsPage = new TeamsPage(sharedPage)
     const landingPage = new LandingPage(sharedPage)
-    const register = new Register(sharedPage)
+    const loginPage = new LoginPage(sharedPage)
+    const teamsPage = new TeamsPage(sharedPage)
     await landingPage.goToAdminUrl()
-    await register.registerNewAccount() // registering new user account
-    userEmail = await register.getUserEmailId() // storing the registered user email id
+    await loginPage.logInWithCreatedNewUser(workerEmail)
     await teamsPage.createNewTeamAndVerifyCreatedTeam() // create new team and verify the created team
-    console.log(`userName : ${userEmail}`)
   })
 
   test.beforeEach(async () => {

--- a/apps/journeys-admin-e2e/src/e2e/discover/members.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/members.spec.ts
@@ -1,44 +1,59 @@
 /* eslint-disable playwright/expect-expect */
 import { test } from '@playwright/test'
+import type { BrowserContext, Page } from 'playwright-core'
 
 import { LandingPage } from '../../pages/landing-page'
-import { LoginPage } from '../../pages/login-page'
 import { Register } from '../../pages/register-Page'
 import { TeamsPage } from '../../pages/teams-page'
 
 let userEmail = ''
+let sharedPage: Page | undefined
+let sharedContext: BrowserContext | undefined
+
+const getSharedPage = (): Page => {
+  if (sharedPage == null) throw new Error('Shared authenticated page was not initialized')
+  return sharedPage
+}
 
 test.describe('Verify Add member', () => {
+  test.describe.configure({ mode: 'serial' })
+
   test.beforeAll('Register new account', async ({ browser }) => {
-    const page = await browser.newPage()
-    const teamsPage = new TeamsPage(page)
-    const landingPage = new LandingPage(page)
-    const register = new Register(page)
+    sharedContext = await browser.newContext()
+    sharedPage = await sharedContext.newPage()
+    const teamsPage = new TeamsPage(sharedPage)
+    const landingPage = new LandingPage(sharedPage)
+    const register = new Register(sharedPage)
     await landingPage.goToAdminUrl()
     await register.registerNewAccount() // registering new user account
     userEmail = await register.getUserEmailId() // storing the registered user email id
     await teamsPage.createNewTeamAndVerifyCreatedTeam() // create new team and verify the created team
     console.log(`userName : ${userEmail}`)
-    await page.close()
   })
 
-  test.beforeEach(async ({ page }) => {
-    const landingPage = new LandingPage(page)
-    const loginPage = new LoginPage(page)
-    await landingPage.goToAdminUrl()
-    await loginPage.logInWithCreatedNewUser(userEmail) // login as registered user
+  test.beforeEach(async () => {
+    await getSharedPage().goto('/')
+  })
+
+  test.afterAll(async () => {
+    if (sharedPage != null) await sharedPage.close()
+    if (sharedContext != null) await sharedContext.close()
+    sharedPage = undefined
+    sharedContext = undefined
   })
 
   // Verify the user able to add the member through member option in discover page
   test('Add a member through member option in discover page', async ({
-    page
+    
   }) => {
+    const page = getSharedPage()
     const teamsPage = new TeamsPage(page)
     await teamsPage.verifyMemberAddedViaMemberOptionOfThreeDotOptions()
   })
 
   // Verify the user able to add the member through + icon in discover page
-  test('Add the member through + icon in discover page', async ({ page }) => {
+  test('Add the member through + icon in discover page', async () => {
+    const page = getSharedPage()
     const teamsPage = new TeamsPage(page)
     await teamsPage.verifyMemberAddedViaPlusIconAtTopOfTheRightCorner()
   })

--- a/apps/journeys-admin-e2e/src/e2e/discover/members.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/members.spec.ts
@@ -11,7 +11,8 @@ let sharedPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
 const getSharedPage = (): Page => {
-  if (sharedPage == null) throw new Error('Shared authenticated page was not initialized')
+  if (sharedPage == null)
+    throw new Error('Shared authenticated page was not initialized')
   return sharedPage
 }
 
@@ -43,9 +44,7 @@ test.describe('Verify Add member', () => {
   })
 
   // Verify the user able to add the member through member option in discover page
-  test('Add a member through member option in discover page', async ({
-    
-  }) => {
+  test('Add a member through member option in discover page', async ({}) => {
     const page = getSharedPage()
     const teamsPage = new TeamsPage(page)
     await teamsPage.verifyMemberAddedViaMemberOptionOfThreeDotOptions()

--- a/apps/journeys-admin-e2e/src/e2e/discover/teams.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/teams.spec.ts
@@ -1,33 +1,53 @@
 /* eslint-disable playwright/expect-expect */
 import { test } from '@playwright/test'
+import type { BrowserContext, Page } from 'playwright-core'
 
 import { generateRandomString } from '../../framework/helpers'
 import { JourneyLevelActions } from '../../pages/journey-level-actions-page'
 import { JourneyPage } from '../../pages/journey-page'
 import { LandingPage } from '../../pages/landing-page'
-import { LoginPage } from '../../pages/login-page'
 import { Register } from '../../pages/register-Page'
 import { TeamsPage } from '../../pages/teams-page'
 
 let userEmail = ''
+let sharedPage: Page | undefined
+let sharedContext: BrowserContext | undefined
+
+const getSharedPage = (): Page => {
+  if (sharedPage == null) throw new Error('Shared authenticated page was not initialized')
+  return sharedPage
+}
+
+const getSharedContext = (): BrowserContext => {
+  if (sharedContext == null) {
+    throw new Error('Shared authenticated context was not initialized')
+  }
+  return sharedContext
+}
 
 test.describe('Teams', () => {
+  test.describe.configure({ mode: 'serial' })
+
   test.beforeAll('Register new account', async ({ browser }) => {
-    const page = await browser.newPage()
-    const landingPage = new LandingPage(page)
-    const register = new Register(page)
+    sharedContext = await browser.newContext()
+    sharedPage = await sharedContext.newPage()
+    const landingPage = new LandingPage(sharedPage)
+    const register = new Register(sharedPage)
     await landingPage.goToAdminUrl()
     await register.registerNewAccount() // registering new user account
     userEmail = await register.getUserEmailId() // storing the registered user email id
     console.log(`userName : ${userEmail}`)
-    await page.close()
   })
 
-  test.beforeEach(async ({ page }) => {
-    const landingPage = new LandingPage(page)
-    const loginPage = new LoginPage(page)
-    await landingPage.goToAdminUrl()
-    await loginPage.logInWithCreatedNewUser(userEmail) // login as registered user
+  test.beforeEach(async () => {
+    await getSharedPage().goto('/')
+  })
+
+  test.afterAll(async () => {
+    if (sharedPage != null) await sharedPage.close()
+    if (sharedContext != null) await sharedContext.close()
+    sharedPage = undefined
+    sharedContext = undefined
   })
 
   /*
@@ -36,8 +56,9 @@ test.describe('Teams', () => {
   3. Rename the team
   */
   test('Create a team and create a journey then rename the team', async ({
-    page
+    
   }) => {
+    const page = getSharedPage()
     const teamsPage = new TeamsPage(page)
     const journeyName = new JourneyPage(page)
     // 1. Create a new team - Verify the user able to create the new team through New team option in menu icon in discover page
@@ -51,9 +72,10 @@ test.describe('Teams', () => {
 
   // Discover page -> Three dot > Custom Domain
   test('Verify Custom Domain option from Three dot menu And validate journey link from the selected journey page', async ({
-    page,
-    context
+    
   }) => {
+    const page = getSharedPage()
+    const context = getSharedContext()
     const domainName =
       'your.nextstep.' + (await generateRandomString(5)).toLowerCase()
 
@@ -93,8 +115,9 @@ test.describe('Teams', () => {
   // feature flag is on. When the flag is off, the test fails because the Growth Spaces link/button
   // is missing (0 elements). Re-enable this test when the flag is available in the test environment.
   test.skip('Verify Integrations option from Three dot menu', async ({
-    page
+    
   }) => {
+    const page = getSharedPage()
     const teamPage = new TeamsPage(page)
 
     await teamPage.clickThreeDotOfTeams() //click three dot from the Discovery page teams section

--- a/apps/journeys-admin-e2e/src/e2e/discover/teams.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/teams.spec.ts
@@ -14,7 +14,8 @@ let sharedPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
 const getSharedPage = (): Page => {
-  if (sharedPage == null) throw new Error('Shared authenticated page was not initialized')
+  if (sharedPage == null)
+    throw new Error('Shared authenticated page was not initialized')
   return sharedPage
 }
 
@@ -55,9 +56,7 @@ test.describe('Teams', () => {
   2. Create a journey (just one card) for newly created team
   3. Rename the team
   */
-  test('Create a team and create a journey then rename the team', async ({
-    
-  }) => {
+  test('Create a team and create a journey then rename the team', async ({}) => {
     const page = getSharedPage()
     const teamsPage = new TeamsPage(page)
     const journeyName = new JourneyPage(page)
@@ -71,9 +70,7 @@ test.describe('Teams', () => {
   })
 
   // Discover page -> Three dot > Custom Domain
-  test('Verify Custom Domain option from Three dot menu And validate journey link from the selected journey page', async ({
-    
-  }) => {
+  test('Verify Custom Domain option from Three dot menu And validate journey link from the selected journey page', async ({}) => {
     const page = getSharedPage()
     const context = getSharedContext()
     const domainName =
@@ -114,9 +111,7 @@ test.describe('Teams', () => {
   // ISSUE: The Growth Spaces card on /integrations/new is only rendered when the teamIntegrations
   // feature flag is on. When the flag is off, the test fails because the Growth Spaces link/button
   // is missing (0 elements). Re-enable this test when the flag is available in the test environment.
-  test.skip('Verify Integrations option from Three dot menu', async ({
-    
-  }) => {
+  test.skip('Verify Integrations option from Three dot menu', async ({}) => {
     const page = getSharedPage()
     const teamPage = new TeamsPage(page)
 

--- a/apps/journeys-admin-e2e/src/e2e/discover/teams.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/teams.spec.ts
@@ -1,15 +1,14 @@
 /* eslint-disable playwright/expect-expect */
-import { test } from '@playwright/test'
 import type { BrowserContext, Page } from 'playwright-core'
 
+import { test } from '../../fixtures/workerAuth'
 import { generateRandomString } from '../../framework/helpers'
 import { JourneyLevelActions } from '../../pages/journey-level-actions-page'
 import { JourneyPage } from '../../pages/journey-page'
 import { LandingPage } from '../../pages/landing-page'
-import { Register } from '../../pages/register-Page'
+import { LoginPage } from '../../pages/login-page'
 import { TeamsPage } from '../../pages/teams-page'
 
-let userEmail = ''
 let sharedPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
@@ -29,15 +28,13 @@ const getSharedContext = (): BrowserContext => {
 test.describe('Teams', () => {
   test.describe.configure({ mode: 'serial' })
 
-  test.beforeAll('Register new account', async ({ browser }) => {
+  test.beforeAll('Register new account', async ({ browser, workerEmail }) => {
     sharedContext = await browser.newContext()
     sharedPage = await sharedContext.newPage()
     const landingPage = new LandingPage(sharedPage)
-    const register = new Register(sharedPage)
+    const loginPage = new LoginPage(sharedPage)
     await landingPage.goToAdminUrl()
-    await register.registerNewAccount() // registering new user account
-    userEmail = await register.getUserEmailId() // storing the registered user email id
-    console.log(`userName : ${userEmail}`)
+    await loginPage.logInWithCreatedNewUser(workerEmail)
   })
 
   test.beforeEach(async () => {

--- a/apps/journeys-admin-e2e/src/e2e/discover/templated-journey.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/templated-journey.spec.ts
@@ -1,12 +1,11 @@
 /* eslint-disable playwright/expect-expect */
-import { test } from '@playwright/test'
 import type { BrowserContext, Page } from 'playwright-core'
 
+import { test } from '../../fixtures/workerAuth'
 import { JourneyPage } from '../../pages/journey-page'
 import { LandingPage } from '../../pages/landing-page'
-import { Register } from '../../pages/register-Page'
+import { LoginPage } from '../../pages/login-page'
 
-let userEmail = ''
 let sharedPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
@@ -19,15 +18,13 @@ const getSharedPage = (): Page => {
 test.describe('verify see link and see all templates', () => {
   test.describe.configure({ mode: 'serial' })
 
-  test.beforeAll('Register new account', async ({ browser }) => {
+  test.beforeAll('Register new account', async ({ browser, workerEmail }) => {
     sharedContext = await browser.newContext()
     sharedPage = await sharedContext.newPage()
     const landingPage = new LandingPage(sharedPage)
-    const register = new Register(sharedPage)
+    const loginPage = new LoginPage(sharedPage)
     await landingPage.goToAdminUrl()
-    await register.registerNewAccount() // registering new user account
-    userEmail = await register.getUserEmailId() // storing the registered user email id
-    console.log(`userEmail : ${userEmail}`)
+    await loginPage.logInWithCreatedNewUser(workerEmail)
   })
 
   test.beforeEach(async () => {

--- a/apps/journeys-admin-e2e/src/e2e/discover/templated-journey.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/templated-journey.spec.ts
@@ -1,36 +1,50 @@
 /* eslint-disable playwright/expect-expect */
 import { test } from '@playwright/test'
+import type { BrowserContext, Page } from 'playwright-core'
 
 import { JourneyPage } from '../../pages/journey-page'
 import { LandingPage } from '../../pages/landing-page'
-import { LoginPage } from '../../pages/login-page'
 import { Register } from '../../pages/register-Page'
 
 let userEmail = ''
+let sharedPage: Page | undefined
+let sharedContext: BrowserContext | undefined
+
+const getSharedPage = (): Page => {
+  if (sharedPage == null) throw new Error('Shared authenticated page was not initialized')
+  return sharedPage
+}
 
 test.describe('verify see link and see all templates', () => {
+  test.describe.configure({ mode: 'serial' })
+
   test.beforeAll('Register new account', async ({ browser }) => {
-    const page = await browser.newPage()
-    const landingPage = new LandingPage(page)
-    const register = new Register(page)
+    sharedContext = await browser.newContext()
+    sharedPage = await sharedContext.newPage()
+    const landingPage = new LandingPage(sharedPage)
+    const register = new Register(sharedPage)
     await landingPage.goToAdminUrl()
     await register.registerNewAccount() // registering new user account
     userEmail = await register.getUserEmailId() // storing the registered user email id
     console.log(`userEmail : ${userEmail}`)
-    await page.close()
   })
 
-  test.beforeEach(async ({ page }) => {
-    const landingPage = new LandingPage(page)
-    const loginPage = new LoginPage(page)
-    await landingPage.goToAdminUrl()
-    await loginPage.logInWithCreatedNewUser(userEmail) // login as registered user
+  test.beforeEach(async () => {
+    await getSharedPage().goto('/')
+  })
+
+  test.afterAll(async () => {
+    if (sharedPage != null) await sharedPage.close()
+    if (sharedContext != null) await sharedContext.close()
+    sharedPage = undefined
+    sharedContext = undefined
   })
 
   // Assert that See all link & See all templates button have a href to /templates
   test('Assert that See all link & See all templates button have a href to /templates', async ({
-    page
+    
   }) => {
+    const page = getSharedPage()
     const journeyPage = new JourneyPage(page)
     await journeyPage.verifySeeLinkHrefAttributeBesideUseTemplate() // beside the 'use template' drawer name in discover page, verify the 'see link' have href attribute with '/templates' value
     await journeyPage.verifySeeAllTemplateBelowUseTemplate() // at the bottom of  the 'use template' drawer, verify the 'See all templates' have href attribute with '/templates' value

--- a/apps/journeys-admin-e2e/src/e2e/discover/templated-journey.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/templated-journey.spec.ts
@@ -11,7 +11,8 @@ let sharedPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
 const getSharedPage = (): Page => {
-  if (sharedPage == null) throw new Error('Shared authenticated page was not initialized')
+  if (sharedPage == null)
+    throw new Error('Shared authenticated page was not initialized')
   return sharedPage
 }
 
@@ -41,9 +42,7 @@ test.describe('verify see link and see all templates', () => {
   })
 
   // Assert that See all link & See all templates button have a href to /templates
-  test('Assert that See all link & See all templates button have a href to /templates', async ({
-    
-  }) => {
+  test('Assert that See all link & See all templates button have a href to /templates', async ({}) => {
     const page = getSharedPage()
     const journeyPage = new JourneyPage(page)
     await journeyPage.verifySeeLinkHrefAttributeBesideUseTemplate() // beside the 'use template' drawer name in discover page, verify the 'see link' have href attribute with '/templates' value

--- a/apps/journeys-admin-e2e/src/e2e/profile/profile.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/profile/profile.spec.ts
@@ -11,7 +11,8 @@ let currentPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
 const getSharedPage = (): Page => {
-  if (currentPage == null) throw new Error('Shared authenticated page was not initialized')
+  if (currentPage == null)
+    throw new Error('Shared authenticated page was not initialized')
   return currentPage
 }
 

--- a/apps/journeys-admin-e2e/src/e2e/profile/profile.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/profile/profile.spec.ts
@@ -1,12 +1,11 @@
 /* eslint-disable playwright/expect-expect */
-import { test } from '@playwright/test'
 import type { BrowserContext, Page } from 'playwright-core'
 
+import { test } from '../../fixtures/workerAuth'
 import { LandingPage } from '../../pages/landing-page'
+import { LoginPage } from '../../pages/login-page'
 import { ProfilePage } from '../../pages/profile-page'
-import { Register } from '../../pages/register-Page'
 
-let userEmail = ''
 let currentPage: Page | undefined
 let sharedContext: BrowserContext | undefined
 
@@ -19,15 +18,13 @@ const getSharedPage = (): Page => {
 test.describe('verify profile page functionalities', () => {
   test.describe.configure({ mode: 'serial' })
 
-  test.beforeAll('Register new account', async ({ browser }) => {
+  test.beforeAll('Register new account', async ({ browser, workerEmail }) => {
     sharedContext = await browser.newContext()
     currentPage = await sharedContext.newPage()
     const landingPage = new LandingPage(currentPage)
-    const register = new Register(currentPage)
+    const loginPage = new LoginPage(currentPage)
     await landingPage.goToAdminUrl()
-    await register.registerNewAccount() // registering new user account
-    userEmail = await register.getUserEmailId() // storing the registered user email id
-    console.log(`userName : ${userEmail}`)
+    await loginPage.logInWithCreatedNewUser(workerEmail)
     await currentPage.close()
     currentPage = undefined
   })

--- a/apps/journeys-admin-e2e/src/e2e/profile/profile.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/profile/profile.spec.ts
@@ -1,34 +1,61 @@
 /* eslint-disable playwright/expect-expect */
 import { test } from '@playwright/test'
+import type { BrowserContext, Page } from 'playwright-core'
 
 import { LandingPage } from '../../pages/landing-page'
-import { LoginPage } from '../../pages/login-page'
 import { ProfilePage } from '../../pages/profile-page'
 import { Register } from '../../pages/register-Page'
 
 let userEmail = ''
+let currentPage: Page | undefined
+let sharedContext: BrowserContext | undefined
+
+const getSharedPage = (): Page => {
+  if (currentPage == null) throw new Error('Shared authenticated page was not initialized')
+  return currentPage
+}
 
 test.describe('verify profile page functionalities', () => {
+  test.describe.configure({ mode: 'serial' })
+
   test.beforeAll('Register new account', async ({ browser }) => {
-    const page = await browser.newPage()
-    const landingPage = new LandingPage(page)
-    const register = new Register(page)
+    sharedContext = await browser.newContext()
+    currentPage = await sharedContext.newPage()
+    const landingPage = new LandingPage(currentPage)
+    const register = new Register(currentPage)
     await landingPage.goToAdminUrl()
     await register.registerNewAccount() // registering new user account
     userEmail = await register.getUserEmailId() // storing the registered user email id
     console.log(`userName : ${userEmail}`)
-    await page.close()
+    await currentPage.close()
+    currentPage = undefined
   })
 
-  test.beforeEach(async ({ page }) => {
-    const landingPage = new LandingPage(page)
-    const loginPage = new LoginPage(page)
-    await landingPage.goToAdminUrl()
-    await loginPage.logInWithCreatedNewUser(userEmail) // login as registered user
+  test.beforeEach(async () => {
+    if (sharedContext == null) {
+      throw new Error('Shared authenticated context was not initialized')
+    }
+    currentPage = await sharedContext.newPage()
+    await getSharedPage().goto('/')
+  })
+
+  test.afterEach(async () => {
+    if (currentPage != null) {
+      await currentPage.close()
+      currentPage = undefined
+    }
+  })
+
+  test.afterAll(async () => {
+    if (currentPage != null) await currentPage.close()
+    if (sharedContext != null) await sharedContext.close()
+    currentPage = undefined
+    sharedContext = undefined
   })
 
   // Verify the user able to add the email notification in email preference page
-  test('verify email preference notification page', async ({ page }) => {
+  test('verify email preference notification page', async () => {
+    const page = getSharedPage()
     const profilePage = new ProfilePage(page)
     await profilePage.clickProfileIconInNavBar() // clicking the profile icon in navigation list Item
     await profilePage.clickEmailPreferences() // clicking the email preferences button
@@ -38,18 +65,9 @@ test.describe('verify profile page functionalities', () => {
     await profilePage.clickDoneBtn() // clicking done button
   })
 
-  // Verify the user able to logout the account through logout link
-  test('logout', async ({ page }) => {
-    const profilePage = new ProfilePage(page)
-    await profilePage.clickProfileIconInNavBar() // clicking the profile icon in navigation list Item
-    await profilePage.clickLogout() // clicking the logout button
-    await profilePage.verifyloggedOut() // verifying the user is logged out and the login page is displayed
-  })
-
   // Verify the user able to change language through language options
-  test('Verify the user able to change language through language options', async ({
-    page
-  }) => {
+  test('Verify the user able to change language through language options', async () => {
+    const page = getSharedPage()
     const profilePage = new ProfilePage(page)
     await profilePage.clickProfileIconInNavBar() // clicking the profile icon in navigation list Item
     await profilePage.clickLanguageOption() // clicking language option
@@ -60,5 +78,14 @@ test.describe('verify profile page functionalities', () => {
     await profilePage.clickLanguageOption() // clicking language option
     await profilePage.enterLanguage('English') // selecting language in the edit language popup
     await profilePage.popupCloseBtn() // closing the change language popup
+  })
+
+  // Verify the user able to logout the account through logout link
+  test('logout', async () => {
+    const page = getSharedPage()
+    const profilePage = new ProfilePage(page)
+    await profilePage.clickProfileIconInNavBar() // clicking the profile icon in navigation list Item
+    await profilePage.clickLogout() // clicking the logout button
+    await profilePage.verifyloggedOut() // verifying the user is logged out and the login page is displayed
   })
 })

--- a/apps/journeys-admin-e2e/src/fixtures/workerAuth.ts
+++ b/apps/journeys-admin-e2e/src/fixtures/workerAuth.ts
@@ -1,0 +1,35 @@
+import { test as base } from '@playwright/test'
+
+import { LandingPage } from '../pages/landing-page'
+import { Register } from '../pages/register-Page'
+
+type WorkerFixtures = { workerEmail: string }
+
+/**
+ * Extends Playwright's test with a worker-scoped `workerEmail` fixture.
+ *
+ * Registration runs exactly once per Playwright worker — not once per spec file.
+ * With workers=4, this means 4 total registrations instead of one per spec file (~13),
+ * which significantly reduces concurrent backend load.
+ *
+ * Each spec file still creates its own BrowserContext and logs in with these
+ * credentials, preserving full browser-level isolation (separate sessionStorage/cookies).
+ */
+export const test = base.extend<{}, WorkerFixtures>({
+  workerEmail: [
+    async ({ browser }, use) => {
+      const ctx = await browser.newContext()
+      const page = await ctx.newPage()
+      await new LandingPage(page).goToAdminUrl()
+      const register = new Register(page)
+      await register.registerNewAccount()
+      const email = await register.getUserEmailId()
+      await page.close()
+      await ctx.close()
+      await use(email)
+    },
+    { scope: 'worker' }
+  ]
+})
+
+export const expect = test.expect

--- a/apps/journeys-admin-e2e/src/pages/customization-media-page.ts
+++ b/apps/journeys-admin-e2e/src/pages/customization-media-page.ts
@@ -27,7 +27,13 @@ export class CustomizationMediaPage {
     const videosSection = this.page.getByTestId('VideosSection')
     for (let i = 0; i < maxNavigationClicks; i++) {
       if (await videosSection.isVisible()) return
+      if (!this.page.url().includes('/customize')) break
+      const urlBefore = this.page.url()
       await this.clickNextButton()
+      // Wait for client-side navigation to settle before checking the next screen
+      await this.page.waitForURL((url) => url.toString() !== urlBefore, {
+        timeout: defaultTimeout
+      })
     }
     await expect(videosSection).toBeVisible({ timeout: defaultTimeout })
   }
@@ -54,16 +60,16 @@ export class CustomizationMediaPage {
   async waitForAutoSubmit(): Promise<void> {
     const helperText = this.page
       .getByTestId('VideosSection-youtube-input')
-      .locator('.MuiFormHelperText-root')
+      .locator('p')
     await expect(helperText).toBeVisible({ timeout: defaultTimeout })
     await this.page.waitForLoadState('load')
   }
 
   async waitForAutoSubmitError(): Promise<void> {
-    const errorText = this.page
-      .getByTestId('VideosSection-youtube-input')
-      .locator('p.MuiFormHelperText-root.Mui-error')
-    await expect(errorText).toBeVisible({ timeout: 90000 })
+    // Wait for the input to become invalid (aria-invalid is set by MUI on error)
+    await expect(
+      this.page.getByTestId('VideosSection-youtube-input').locator('input')
+    ).toHaveAttribute('aria-invalid', 'true', { timeout: 90000 })
   }
 
   async verifyVideosSectionVisible(): Promise<void> {
@@ -100,7 +106,7 @@ export class CustomizationMediaPage {
   async getYouTubeHelperText(): Promise<string | null> {
     return await this.page
       .getByTestId('VideosSection-youtube-input')
-      .locator('.MuiFormHelperText-root')
+      .locator('p')
       .textContent()
   }
 }

--- a/apps/journeys-admin-e2e/src/pages/journey-page.ts
+++ b/apps/journeys-admin-e2e/src/pages/journey-page.ts
@@ -239,6 +239,19 @@ export class JourneyPage {
     await this.page.getByRole('link', { name: 'Preview' }).click()
   }
 
+  /**
+   * Discover list + create action load under TeamProvider; plain `/` can leave
+   * "Create Custom Journey" disabled until the journeys view is ready.
+   */
+  async gotoDiscoverJourneysPage(): Promise<void> {
+    const baseUrl = await getBaseUrl()
+    const discoverUrl = baseUrl.replace(/\/$/, '') + '/?type=journeys'
+    await this.page.goto(discoverUrl, { waitUntil: 'domcontentloaded' })
+    await expect(
+      this.page.getByRole('button', { name: 'Create Custom Journey' })
+    ).toBeEnabled({ timeout: 90000 })
+  }
+
   async clickCreateCustomJourney(): Promise<void> {
     const createButton = this.page.getByRole('button', {
       name: 'Create Custom Journey'

--- a/apps/journeys-admin-e2e/src/pages/journey-page.ts
+++ b/apps/journeys-admin-e2e/src/pages/journey-page.ts
@@ -245,11 +245,22 @@ export class JourneyPage {
    */
   async gotoDiscoverJourneysPage(): Promise<void> {
     const baseUrl = await getBaseUrl()
-    const discoverUrl = baseUrl.replace(/\/$/, '') + '/?type=journeys'
+    const discoverUrl = baseUrl.replace(/\/$/, '') + '/'
     await this.page.goto(discoverUrl, { waitUntil: 'domcontentloaded' })
-    await expect(
-      this.page.getByRole('button', { name: 'Create Custom Journey' })
-    ).toBeEnabled({ timeout: 90000 })
+
+    const createBtn = this.page.getByRole('button', {
+      name: 'Create Custom Journey'
+    })
+
+    // If the button doesn't appear within 30s, the TeamProvider may not have
+    // received lastActiveTeamId yet (race between updateLastActiveTeamId mutation
+    // and SSR page load). A reload triggers a fresh SSR with committed team data.
+    try {
+      await expect(createBtn).toBeEnabled({ timeout: 30000 })
+    } catch {
+      await this.page.reload({ waitUntil: 'domcontentloaded' })
+      await expect(createBtn).toBeEnabled({ timeout: 90000 })
+    }
   }
 
   async clickCreateCustomJourney(): Promise<void> {

--- a/apps/journeys-admin-e2e/src/pages/register-Page.ts
+++ b/apps/journeys-admin-e2e/src/pages/register-Page.ts
@@ -32,7 +32,13 @@ export class Register {
     await this.clickValidateEmailBtn()
     await this.verifyPageNavigatedBeforeStartPage()
     await this.clickIAgreeBtn()
-    await this.clickNextBtn()
+    // Use the specific testid to avoid matching sibling "Next" buttons
+    await this.clickNextBtnOfTermsAndConditions()
+    // Wait for navigation away from Terms before checking the Discover page
+    await this.page.waitForURL(
+      (url) => !url.toString().includes('terms-and-conditions'),
+      { timeout: 120000 }
+    )
     await this.waitUntilDiscoverPageLoaded()
     await this.waitUntilTheToestMsgDisappear()
   }


### PR DESCRIPTION
Reuse onboarding-authenticated browser context across suites and split the slowest discover specs into smaller files so they can execute in parallel workers with better throughput.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reworked many E2E suites to reuse a shared authenticated session, enforce serial execution, and add/expand UI coverage for footer configuration, card/journey-level actions (share, copy, embed, QR), discover flows, sorting, teams/members, profile, and templated journeys.
  * Added new suites validating journey-level share and discover actions, and card-level footer behaviors.
* **Chores**
  * Reduced CI test worker concurrency from 10 to 4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->