### PR TITLE
fix(journeys-admin): allow 2-line display and 100-char limit for adapter notes

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/VideoBlockEditor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/VideoBlockEditor.spec.tsx
@@ -682,5 +682,117 @@ describe('VideoBlockEditor', () => {
         expect(onChange).toHaveBeenCalledWith({ notes: 'trailer' })
       )
     })
+
+    it('enforces a 100-character maximum on the notes input', () => {
+      const videoWithCustomizable = {
+        ...videoInternal,
+        customizable: true,
+        notes: null
+      } as TreeBlock<VideoBlock>
+
+      render(
+        <ThemeProvider>
+          <MockedProvider mocks={mocks}>
+            <SnackbarProvider>
+              <FlagsProvider flags={{ customizableMedia: true }}>
+                <JourneyProvider
+                  value={{
+                    journey: { template: true } as unknown as JourneyFields,
+                    variant: 'admin'
+                  }}
+                >
+                  <CommandProvider>
+                    <EditorProvider>
+                      <VideoBlockEditor
+                        selectedBlock={videoWithCustomizable}
+                        onChange={jest.fn()}
+                      />
+                    </EditorProvider>
+                  </CommandProvider>
+                </JourneyProvider>
+              </FlagsProvider>
+            </SnackbarProvider>
+          </MockedProvider>
+        </ThemeProvider>
+      )
+
+      const input = screen.getByLabelText('Template Adapter Notes')
+      expect(input).toHaveAttribute('maxLength', '100')
+    })
+
+    it('shows helper text when notes reach 100-character limit', () => {
+      const longNote = 'a'.repeat(100)
+      const videoWithCustomizable = {
+        ...videoInternal,
+        customizable: true,
+        notes: longNote
+      } as TreeBlock<VideoBlock>
+
+      render(
+        <ThemeProvider>
+          <MockedProvider mocks={mocks}>
+            <SnackbarProvider>
+              <FlagsProvider flags={{ customizableMedia: true }}>
+                <JourneyProvider
+                  value={{
+                    journey: { template: true } as unknown as JourneyFields,
+                    variant: 'admin'
+                  }}
+                >
+                  <CommandProvider>
+                    <EditorProvider>
+                      <VideoBlockEditor
+                        selectedBlock={videoWithCustomizable}
+                        onChange={jest.fn()}
+                      />
+                    </EditorProvider>
+                  </CommandProvider>
+                </JourneyProvider>
+              </FlagsProvider>
+            </SnackbarProvider>
+          </MockedProvider>
+        </ThemeProvider>
+      )
+
+      expect(screen.getByText('Maximum 100 characters')).toBeInTheDocument()
+    })
+
+    it('does not show helper text when notes are under 100 characters', () => {
+      const videoWithCustomizable = {
+        ...videoInternal,
+        customizable: true,
+        notes: 'short note'
+      } as TreeBlock<VideoBlock>
+
+      render(
+        <ThemeProvider>
+          <MockedProvider mocks={mocks}>
+            <SnackbarProvider>
+              <FlagsProvider flags={{ customizableMedia: true }}>
+                <JourneyProvider
+                  value={{
+                    journey: { template: true } as unknown as JourneyFields,
+                    variant: 'admin'
+                  }}
+                >
+                  <CommandProvider>
+                    <EditorProvider>
+                      <VideoBlockEditor
+                        selectedBlock={videoWithCustomizable}
+                        onChange={jest.fn()}
+                      />
+                    </EditorProvider>
+                  </CommandProvider>
+                </JourneyProvider>
+              </FlagsProvider>
+            </SnackbarProvider>
+          </MockedProvider>
+        </ThemeProvider>
+      )
+
+      expect(
+        screen.queryByText('Maximum 100 characters')
+      ).not.toBeInTheDocument()
+    })
   })
 })

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/VideoBlockEditor.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/VideoBlockEditor.tsx
@@ -85,7 +85,15 @@ export function VideoBlockEditor({
                 value={notesInputValue}
                 onChange={(e) => setNotesInputValue(e.target.value)}
                 onBlur={handleNotesBlur}
-                inputProps={{ 'aria-label': t('Template Adapter Notes') }}
+                inputProps={{
+                  'aria-label': t('Template Adapter Notes'),
+                  maxLength: 100
+                }}
+                helperText={
+                  notesInputValue.length >= 100
+                    ? t('Maximum 100 characters')
+                    : undefined
+                }
               />
             </Collapse>
           </>

--- a/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/MediaScreen/Sections/VideosSection/VideosSection.tsx
+++ b/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/MediaScreen/Sections/VideosSection/VideosSection.tsx
@@ -82,7 +82,9 @@ function VideoAdapterNote({ note }: VideoAdapterNoteProps): ReactElement {
       sx={{
         overflow: 'hidden',
         textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap'
+        display: '-webkit-box',
+        WebkitLineClamp: 2,
+        WebkitBoxOrient: 'vertical'
       }}
     >
       {note}

--- a/libs/locales/en/apps-journeys-admin.json
+++ b/libs/locales/en/apps-journeys-admin.json
@@ -497,6 +497,7 @@
   "Template Adapter Notes (opt.)": "Template Adapter Notes (opt.)",
   "e.g. trailer, intro": "e.g. trailer, intro",
   "Template Adapter Notes": "Template Adapter Notes",
+  "Maximum 100 characters": "Maximum 100 characters",
   "Less": "Less",
   "More": "More",
   "Video Details": "Video Details",


### PR DESCRIPTION
## Summary

Fixes [NES-1445](https://linear.app/jesus-film-project/issue/NES-1445): Long template adapter notes were being cropped to a single line in the Media screen customisation flow.

- **Display fix**: Replace `whiteSpace: 'nowrap'` with CSS line-clamp (2 lines) in `VideoAdapterNote` so long notes wrap instead of being truncated
- **Input limit**: Add `maxLength=100` to the Template Adapter Notes TextField in the editor, with conditional "Maximum 100 characters" helper text shown only when the limit is reached
- **Frontend-only**: No backend/GraphQL schema changes

## Test plan

- [x] Existing VideosSection tests pass (27/27)
- [x] Existing VideoBlockEditor tests pass (19/19)
- [x] New test: TextField enforces maxLength=100
- [x] New test: Helper text appears at 100-character limit
- [x] New test: Helper text hidden under 100 characters

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — purely presentational CSS change and client-side input constraint with no backend impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enforced a 100-character client-side limit on video notes and show a "Maximum 100 characters" helper when reached.
  * Adapter notes now display up to two lines instead of single-line truncation for better readability.

* **Tests**
  * Added tests covering the notes character limit and helper text behavior at, below, and at-limit conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->