### PR TITLE
fix(api-journeys-modern): disable shared response cache for getJourneyProfile

### DIFF
--- a/apis/api-journeys-modern/src/yoga.ts
+++ b/apis/api-journeys-modern/src/yoga.ts
@@ -86,7 +86,11 @@ export const yoga = createYoga<
             'Journey.blockTypenames': 0,
             'Query.adminJourney': 0,
             'Query.adminJourneys': 0,
-            'Query.getJourneyProfile': 1000,
+            // Private per-user data — must not be served from a global shared
+            // cache (session: () => null). TTL 0 disables caching entirely for
+            // this field, preventing cross-user profile contamination that caused
+            // the terms-and-conditions redirect to be skipped for new users.
+            'Query.getJourneyProfile': 0,
             'Query.getUserRole': 0,
             'Query.googleSheetsSyncs': 0,
             'Query.journeysPlausibleStatsAggregate': 5000,


### PR DESCRIPTION
## Problem

`api-journeys-modern` caches the `getJourneyProfile` query result in a **single shared in-memory bucket for all users**. The `useResponseCache` plugin in `apis/api-journeys-modern/src/yoga.ts` is configured with `session: () => null`, meaning the cache key is derived only from the query shape — the calling user's identity is ignored entirely.

The cache TTL for `Query.getJourneyProfile` was set to **1000ms**. Any response cached for one user is served to every other user within that 1-second window.

## Why this is a problem

`getJourneyProfile` returns `{ acceptedTermsAt }`, the sole field used by `checkConditionalRedirect` to decide whether a new user must see the Terms and Conditions page:

\`\`\`typescript
// apps/journeys-admin/src/libs/checkConditionalRedirect/checkConditionalRedirect.ts
if (data.getJourneyProfile?.acceptedTermsAt == null) {
  return { destination: '/users/terms-and-conditions', ... }
}
// terms already accepted + no teams → redirect to /teams/new
if (data.teams.length === 0) {
  return { destination: '/teams/new', ... }
}
\`\`\`

If the cache serves another user's profile (with `acceptedTermsAt` set), a brand-new user is silently skipped past Terms and their `journeyProfileCreate` mutation is never called. The DB has no `acceptedTermsAt` record, so every subsequent page load bounces the user between Terms and `/teams/new` in a redirect loop.

## Impact on CI / E2E Playwright tests
E2E tests are becoming flaky due to this issue, e.g: https://github.com/JesusFilm/core/actions/runs/24218710172/job/70705138907

CI runs 6 Playwright workers in parallel. Each registers a brand-new account, and all hit the terms page SSR within the same second:

\`\`\`
Worker A  journeyProfileCreate → profile { acceptedTermsAt: now } cached globally
Worker B  email verified → terms page SSR → getJourneyProfile
          → cache HIT: gets Worker A's profile
          → checkConditionalRedirect redirects to /teams/new instead of terms
          → registerNewAccount() times out waiting 90s for the terms URL → FAILS
\`\`\`

Observed CI error:
\`\`\`
Error: registerNewAccount failed
  (url: .../teams/new?redirect=%2F, heading: Create Your Workspace)
  expect(page).toHaveURL(/terms-and-conditions/) — Timeout: 90000ms
  88 × unexpected value ".../teams/new?redirect=%2F"
\`\`\`

With 6 concurrent workers, the collision probability is near 100%, making the tests permanently flaky in CI.

## Impact on production users

`getJourneyProfile` is called on every page load for every authenticated user via `initAndAuthApp → checkConditionalRedirect`. The shared cache entry is refreshed continuously by active users.

Any new user landing on the terms page within 1 second of any other authenticated user loading any page receives the wrong profile data. This is also a **data privacy concern** — one user's `userId`, `acceptedTermsAt`, and `lastActiveTeamId` are being served to other users.

When hit in production, the new user is redirected to `/teams/new`, creates a workspace, but their profile still has no `acceptedTermsAt` in the DB. The next page load redirects them back to terms — creating a redirect loop that can only be resolved by luck of the cache timing out.

## Fix

Set `Query.getJourneyProfile` TTL to `0` (disable caching), consistent with `Query.adminJourney`, `Query.adminJourneys`, and `Query.getUserRole` — all already at `0` for the same reason (private per-user data).

\`\`\`typescript
// Before
'Query.getJourneyProfile': 1000,

// After
'Query.getJourneyProfile': 0,
\`\`\`

The DB resolver is always called and always returns the correct profile for the requesting user.

**Future improvement:** Upgrade `@graphql-yoga/plugin-response-cache` to a version after Dec 2024 that supports `session: ({ context }) => ...`, then switch to:
\`\`\`typescript
session: ({ context }) => get(context as object, 'jwt.payload.sub', null),
\`\`\`
This restores the caching performance benefit while isolating each user's data in their own bucket. `jwt.payload` is already injected into context by `useForwardedJWT` (already in the plugins array).

## Scope

- 1 file changed: `apis/api-journeys-modern/src/yoga.ts`
- No schema changes, no gateway changes, no E2E test changes
- Zero new TypeScript errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Journey profile data is now always fetched fresh, ensuring users see the most current information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->