### PR TITLE
fix(journeys-admin): prevent stale text response filter on visitors page

### DIFF
--- a/apps/journeys-admin/pages/journeys/[journeyId]/reports/visitors.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/reports/visitors.tsx
@@ -215,18 +215,6 @@ function JourneyVisitorsPage({
     if (visitorEdges != null && hasNextPage) {
       const response = await fetchMore({
         variables: {
-          filter: {
-            journeyId,
-            hasChatStarted: chatStarted,
-            hasPollAnswers: withPollAnswers,
-            hasMultiselectSubmission: withMultiselectAnswers,
-            hasTextResponse:
-              withSubmittedText &&
-              availableBlockTypes.includes('TextResponseBlock'),
-            hasIcon: withIcon,
-            hideInactive: hideInteractive
-          },
-          first: 100,
           after: endCursor
         }
       })

--- a/apps/journeys-admin/pages/journeys/[journeyId]/reports/visitors.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/reports/visitors.tsx
@@ -177,11 +177,13 @@ function JourneyVisitorsPage({
     }
   }, [blockTypesLoaded, availableBlockTypes, withSubmittedText])
 
+  const waitingForBlockTypes = withSubmittedText && !blockTypesLoaded
+
   const { data: userRoleData } = useUserRoleQuery()
-  const { fetchMore, loading } = useQuery<GetJourneyVisitors>(
+  const { fetchMore, loading: queryLoading } = useQuery<GetJourneyVisitors>(
     GET_JOURNEY_VISITORS,
     {
-      skip: withSubmittedText && !blockTypesLoaded,
+      skip: waitingForBlockTypes,
       variables: {
         filter: {
           journeyId,
@@ -202,6 +204,8 @@ function JourneyVisitorsPage({
       }
     }
   )
+  const loading = queryLoading || waitingForBlockTypes
+
   const { data: userTeamsData } = useUserTeamsAndInvitesQuery(
     journey?.team != null
       ? {

--- a/apps/journeys-admin/pages/journeys/[journeyId]/reports/visitors.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/reports/visitors.tsx
@@ -28,7 +28,10 @@ import { useIntegrationGoogleCreate } from '../../../../src/components/Google/Go
 import { HelpScoutBeacon } from '../../../../src/components/HelpScoutBeacon'
 import { JourneyVisitorsList } from '../../../../src/components/JourneyVisitorsList'
 import { ExportEventsButton } from '../../../../src/components/JourneyVisitorsList/ExportEventsButton'
-import { FilterDrawer } from '../../../../src/components/JourneyVisitorsList/FilterDrawer/FilterDrawer'
+import {
+  FilterDrawer,
+  GET_JOURNEY_BLOCK_TYPENAMES
+} from '../../../../src/components/JourneyVisitorsList/FilterDrawer/FilterDrawer'
 import { GoogleSheetsSyncDialog } from '../../../../src/components/JourneyVisitorsList/FilterDrawer/GoogleSheetsSyncDialog'
 import { GoogleSheetsSyncButton } from '../../../../src/components/JourneyVisitorsList/GoogleSheetsSyncButton'
 import { VisitorToolbar } from '../../../../src/components/JourneyVisitorsList/VisitorToolbar/VisitorToolbar'
@@ -155,6 +158,24 @@ function JourneyVisitorsPage({
   const [hideInteractive, setHideInterActive] = useState(false)
   const [sortSetting, setSortSetting] = useState<'date' | 'duration'>('date')
 
+  const { data: blockTypesData } = useQuery(GET_JOURNEY_BLOCK_TYPENAMES, {
+    skip: journeyId == null,
+    variables: { id: journeyId! }
+  })
+  const availableBlockTypes: string[] =
+    blockTypesData?.journey?.blockTypenames ?? []
+
+  useEffect(() => {
+    const blockTypenames = blockTypesData?.journey?.blockTypenames
+    if (
+      blockTypenames != null &&
+      withSubmittedText &&
+      !blockTypenames.includes('TextResponseBlock')
+    ) {
+      setWithSubmittedText(false)
+    }
+  }, [blockTypesData?.journey?.blockTypenames, withSubmittedText])
+
   const { data: userRoleData } = useUserRoleQuery()
   const { fetchMore, loading } = useQuery<GetJourneyVisitors>(
     GET_JOURNEY_VISITORS,
@@ -165,7 +186,9 @@ function JourneyVisitorsPage({
           hasChatStarted: chatStarted,
           hasPollAnswers: withPollAnswers,
           hasMultiselectSubmission: withMultiselectAnswers,
-          hasTextResponse: withSubmittedText,
+          hasTextResponse:
+            withSubmittedText &&
+            availableBlockTypes.includes('TextResponseBlock'),
           hasIcon: withIcon,
           hideInactive: hideInteractive
         },
@@ -192,7 +215,17 @@ function JourneyVisitorsPage({
     if (visitorEdges != null && hasNextPage) {
       const response = await fetchMore({
         variables: {
-          filter: { journeyId },
+          filter: {
+            journeyId,
+            hasChatStarted: chatStarted,
+            hasPollAnswers: withPollAnswers,
+            hasMultiselectSubmission: withMultiselectAnswers,
+            hasTextResponse:
+              withSubmittedText &&
+              availableBlockTypes.includes('TextResponseBlock'),
+            hasIcon: withIcon,
+            hideInactive: hideInteractive
+          },
           first: 100,
           after: endCursor
         }

--- a/apps/journeys-admin/pages/journeys/[journeyId]/reports/visitors.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/reports/visitors.tsx
@@ -165,6 +165,7 @@ function JourneyVisitorsPage({
   const availableBlockTypes: string[] =
     blockTypesData?.journey?.blockTypenames ?? []
 
+  // Reset URL-driven withSubmittedText filter when journey has no TextResponseBlock (NES-1486)
   useEffect(() => {
     const blockTypenames = blockTypesData?.journey?.blockTypenames
     if (

--- a/apps/journeys-admin/pages/journeys/[journeyId]/reports/visitors.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/reports/visitors.tsx
@@ -160,7 +160,7 @@ function JourneyVisitorsPage({
 
   const { data: blockTypesData } = useQuery(GET_JOURNEY_BLOCK_TYPENAMES, {
     skip: journeyId == null,
-    variables: { id: journeyId! }
+    variables: { id: journeyId }
   })
   const availableBlockTypes: string[] =
     blockTypesData?.journey?.blockTypenames ?? []

--- a/apps/journeys-admin/pages/journeys/[journeyId]/reports/visitors.tsx
+++ b/apps/journeys-admin/pages/journeys/[journeyId]/reports/visitors.tsx
@@ -162,34 +162,33 @@ function JourneyVisitorsPage({
     skip: journeyId == null,
     variables: { id: journeyId }
   })
+  const blockTypesLoaded = blockTypesData?.journey?.blockTypenames != null
   const availableBlockTypes: string[] =
     blockTypesData?.journey?.blockTypenames ?? []
 
   // Reset URL-driven withSubmittedText filter when journey has no TextResponseBlock (NES-1486)
   useEffect(() => {
-    const blockTypenames = blockTypesData?.journey?.blockTypenames
     if (
-      blockTypenames != null &&
+      blockTypesLoaded &&
       withSubmittedText &&
-      !blockTypenames.includes('TextResponseBlock')
+      !availableBlockTypes.includes('TextResponseBlock')
     ) {
       setWithSubmittedText(false)
     }
-  }, [blockTypesData?.journey?.blockTypenames, withSubmittedText])
+  }, [blockTypesLoaded, availableBlockTypes, withSubmittedText])
 
   const { data: userRoleData } = useUserRoleQuery()
   const { fetchMore, loading } = useQuery<GetJourneyVisitors>(
     GET_JOURNEY_VISITORS,
     {
+      skip: withSubmittedText && !blockTypesLoaded,
       variables: {
         filter: {
           journeyId,
           hasChatStarted: chatStarted,
           hasPollAnswers: withPollAnswers,
           hasMultiselectSubmission: withMultiselectAnswers,
-          hasTextResponse:
-            withSubmittedText &&
-            availableBlockTypes.includes('TextResponseBlock'),
+          hasTextResponse: withSubmittedText,
           hasIcon: withIcon,
           hideInactive: hideInteractive
         },


### PR DESCRIPTION
## Summary

Fixes the Analytics "Visitors" page showing "No Visitors" on load for journeys without a TextResponseBlock.

- **Root cause**: `ResponsesItem` links to the visitors page with `?withSubmittedText=true`, which sets `hasTextResponse: true` in the GraphQL filter. For journeys without a `TextResponseBlock`, no visitors have text responses → empty result. The "Submitted Text" checkbox is hidden for such journeys, so the active filter is invisible to the user.
- Guard `hasTextResponse` filter against the journey's available block types — only apply when `TextResponseBlock` actually exists
- Add `useEffect` to reset `withSubmittedText` state when block types load and `TextResponseBlock` is absent
- Simplify `handleFetchNext` to inherit `filter`/`first`/`sort` from the original `useQuery` variables instead of overriding with only `journeyId`

Closes NES-1486

## Test plan

- [ ] Open a journey **without** a TextResponseBlock that has poll response visitor data
- [ ] Navigate to Analytics > Visitors via the Responses toolbar item
- [ ] Verify visitor data loads immediately (no "No Visitors" empty state)
- [ ] Open a journey **with** a TextResponseBlock
- [ ] Navigate via Responses toolbar item — verify "Submitted Text" filter is correctly applied
- [ ] Verify "Clear All" still resets all filters
- [ ] Verify pagination loads correctly with active filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Submitted-text filter now automatically clears when it's not applicable to a journey, preventing the filter from remaining selected incorrectly.
  * Validation of filter states improved to avoid invalid configurations.

* **Performance**
  * Reduced unnecessary queries and refined loading behavior in the visitors report.
  * Improved pagination to fetch more efficiently and avoid extra data requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->