### PR TITLE
fix: node docker image

### DIFF
--- a/apis/api-analytics/Dockerfile
+++ b/apis/api-analytics/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine3.20
+FROM node:24-alpine3.23
 
 EXPOSE 4008
 

--- a/apis/api-journeys-modern/Dockerfile
+++ b/apis/api-journeys-modern/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine3.20
+FROM node:24-alpine3.23
 
 EXPOSE 4004
 

--- a/apis/api-journeys/Dockerfile
+++ b/apis/api-journeys/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine3.20
+FROM node:24-alpine3.23
 
 EXPOSE 4001
 

--- a/apis/api-languages/Dockerfile
+++ b/apis/api-languages/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine3.20
+FROM node:24-alpine3.23
 
 EXPOSE 4003
 

--- a/apis/api-media/Dockerfile
+++ b/apis/api-media/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine3.20
+FROM node:24-alpine3.23
 
 EXPOSE 4005
 

--- a/apis/api-users/Dockerfile
+++ b/apis/api-users/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine3.20
+FROM node:24-alpine3.23
 
 EXPOSE 4002
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container runtime environments across API services: Node.js upgraded from version 22 to version 24 and Alpine Linux updated from version 3.20 to version 3.23. All service functionality and configurations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->