### PR TITLE
feat: session-level Gemini fallback with concurrent call optimization

### DIFF
--- a/apis/api-journeys-modern/src/schema/journeyAiTranslate/journeyAiTranslate.ts
+++ b/apis/api-journeys-modern/src/schema/journeyAiTranslate/journeyAiTranslate.ts
@@ -3,7 +3,7 @@ import { GraphQLError } from 'graphql'
 import { z } from 'zod'
 
 import { prisma } from '@core/prisma/journeys/client'
-import { withGeminiFallback } from '@core/shared/ai/geminiModel'
+import { createGeminiFallbackSession } from '@core/shared/ai/geminiModel'
 import { hardenPrompt, preSystemPrompt } from '@core/shared/ai/prompts'
 
 import { Action, ability, subject } from '../../lib/auth/ability'
@@ -199,6 +199,8 @@ builder.subscriptionField('journeyAiTranslateCreateSubscription', (t) =>
           journey: null
         }
 
+        const session = createGeminiFallbackSession()
+
         // Step 1: Analyze and translate journey title, description, and SEO fields
         const combinedPrompt = `
 Analyze this journey content and provide the key intent, themes, and target audience.
@@ -233,7 +235,7 @@ Return in this format:
 }
 `
 
-        const { output: analysisResult } = await withGeminiFallback((model) =>
+        const { output: analysisResult } = await session.execute((model) =>
           generateText({
             model,
             maxRetries: 0,
@@ -432,7 +434,7 @@ If there is no Bible translation was available, use the the most popular English
             )
 
             try {
-              await withGeminiFallback(async (model) => {
+              await session.execute(async (model) => {
                 // Stream the translations
                 const { elementStream } = streamText({
                   model,
@@ -454,13 +456,7 @@ If there is no Bible translation was available, use the the most popular English
                   ],
                   output: Output.array({
                     element: BlockTranslationSchema
-                  }),
-                  onError: ({ error }) => {
-                    console.warn(
-                      `Error in translation stream for card ${cardBlock.id}:`,
-                      error
-                    )
-                  }
+                  })
                 })
 
                 for await (const item of elementStream) {
@@ -685,7 +681,9 @@ Return in this format:
 `
 
       try {
-        const { output: analysisAndTranslation } = await withGeminiFallback(
+        const session = createGeminiFallbackSession()
+
+        const { output: analysisAndTranslation } = await session.execute(
           (model) =>
             generateText({
               model,
@@ -861,7 +859,7 @@ You must never make changes to content from the Bible yourself.
 If there is no Bible translation was available, use the the most popular English Bible translation available. 
 `
               try {
-                await withGeminiFallback(async (model) => {
+                await session.execute(async (model) => {
                   // Stream the translations
                   const { elementStream } = streamText({
                     model,
@@ -883,13 +881,7 @@ If there is no Bible translation was available, use the the most popular English
                     ],
                     output: Output.array({
                       element: BlockTranslationSchema
-                    }),
-                    onError: ({ error }) => {
-                      console.warn(
-                        `Error in translation stream for card ${cardBlock.id}:`,
-                        error
-                      )
-                    }
+                    })
                   })
 
                   for await (const item of elementStream) {

--- a/libs/shared/ai/src/geminiModel/geminiModel.spec.ts
+++ b/libs/shared/ai/src/geminiModel/geminiModel.spec.ts
@@ -1,6 +1,7 @@
 import { google } from '@ai-sdk/google'
 
 import {
+  createGeminiFallbackSession,
   getGeminiFallbackModel,
   getGeminiMaxRetries,
   getGeminiModel,
@@ -271,6 +272,313 @@ describe('geminiModel', () => {
         'rate limited'
       )
       expect(operation).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('createGeminiFallbackSession', () => {
+    beforeEach(() => {
+      jest.useFakeTimers()
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    it('should use primary model when no 429 occurs', async () => {
+      const session = createGeminiFallbackSession()
+      const operation = jest.fn().mockResolvedValue('ok')
+      const result = await session.execute(operation)
+
+      expect(result).toBe('ok')
+      expect(operation).toHaveBeenCalledTimes(1)
+      expect(operation).toHaveBeenCalledWith(
+        expect.objectContaining({ modelId: 'gemini-2.5-flash' })
+      )
+    })
+
+    it('should keep using primary across multiple successful calls', async () => {
+      const session = createGeminiFallbackSession()
+
+      const op1 = jest.fn().mockResolvedValue('first')
+      const op2 = jest.fn().mockResolvedValue('second')
+
+      expect(await session.execute(op1)).toBe('first')
+      expect(await session.execute(op2)).toBe('second')
+
+      expect(op1.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ modelId: 'gemini-2.5-flash' })
+      )
+      expect(op2.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ modelId: 'gemini-2.5-flash' })
+      )
+    })
+
+    it('should retry primary with exponential backoff on 429', async () => {
+      process.env.GEMINI_MAX_RETRIES = '2'
+      const rateLimitError = Object.assign(new Error('rate limited'), {
+        statusCode: 429
+      })
+      const operation = jest
+        .fn()
+        .mockRejectedValueOnce(rateLimitError)
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce('ok')
+
+      const session = createGeminiFallbackSession()
+      const promise = session.execute(operation)
+      await jest.advanceTimersByTimeAsync(1000)
+      await jest.advanceTimersByTimeAsync(2000)
+      const result = await promise
+
+      expect(result).toBe('ok')
+      expect(operation).toHaveBeenCalledTimes(3)
+      for (const call of operation.mock.calls) {
+        expect(call[0]).toEqual(
+          expect.objectContaining({ modelId: 'gemini-2.5-flash' })
+        )
+      }
+    })
+
+    it('should switch to fallback after primary retries are exhausted', async () => {
+      process.env.GEMINI_MAX_RETRIES = '1'
+      const rateLimitError = Object.assign(new Error('rate limited'), {
+        statusCode: 429
+      })
+      const operation = jest
+        .fn()
+        .mockRejectedValueOnce(rateLimitError)
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce('fallback-ok')
+
+      const session = createGeminiFallbackSession()
+      const promise = session.execute(operation)
+      await jest.advanceTimersByTimeAsync(1000)
+      const result = await promise
+
+      expect(result).toBe('fallback-ok')
+      expect(operation).toHaveBeenCalledTimes(3)
+      expect(operation.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ modelId: 'gemini-2.5-flash' })
+      )
+      expect(operation.mock.calls[1][0]).toEqual(
+        expect.objectContaining({ modelId: 'gemini-2.5-flash' })
+      )
+      expect(operation.mock.calls[2][0]).toEqual(
+        expect.objectContaining({ modelId: 'gemini-2.0-flash' })
+      )
+    })
+
+    it('should skip primary and use fallback directly on all subsequent calls after primary exhaustion', async () => {
+      process.env.GEMINI_MAX_RETRIES = '0'
+      const rateLimitError = Object.assign(new Error('rate limited'), {
+        statusCode: 429
+      })
+      const session = createGeminiFallbackSession()
+
+      // First call: primary 429 → useFallback flips → fallback succeeds
+      const op1 = jest
+        .fn()
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce('first-fallback')
+      const result1 = await session.execute(op1)
+
+      expect(result1).toBe('first-fallback')
+      expect(op1.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ modelId: 'gemini-2.5-flash' })
+      )
+      expect(op1.mock.calls[1][0]).toEqual(
+        expect.objectContaining({ modelId: 'gemini-2.0-flash' })
+      )
+
+      // Second call: goes straight to fallback, primary never called
+      const op2 = jest.fn().mockResolvedValue('second-fallback')
+      const result2 = await session.execute(op2)
+
+      expect(result2).toBe('second-fallback')
+      expect(op2).toHaveBeenCalledTimes(1)
+      expect(op2.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ modelId: 'gemini-2.0-flash' })
+      )
+
+      // Third call: still fallback
+      const op3 = jest.fn().mockResolvedValue('third-fallback')
+      await session.execute(op3)
+      expect(op3.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ modelId: 'gemini-2.0-flash' })
+      )
+    })
+
+    it('should apply exponential backoff to fallback when useFallback is true', async () => {
+      process.env.GEMINI_MAX_RETRIES = '1'
+      const rateLimitError = Object.assign(new Error('rate limited'), {
+        statusCode: 429
+      })
+      const session = createGeminiFallbackSession()
+
+      // First call: exhaust primary (2 attempts) → useFallback flips → fallback succeeds
+      const op1 = jest
+        .fn()
+        .mockRejectedValueOnce(rateLimitError)
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce('fallback-first')
+
+      const p1 = session.execute(op1)
+      await jest.advanceTimersByTimeAsync(1000)
+      await p1
+
+      // Second call: fallback with its own backoff (429 then success)
+      const op2 = jest
+        .fn()
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce('fallback-retry-ok')
+
+      const p2 = session.execute(op2)
+      await jest.advanceTimersByTimeAsync(1000)
+      const result2 = await p2
+
+      expect(result2).toBe('fallback-retry-ok')
+      expect(op2).toHaveBeenCalledTimes(2)
+      expect(op2.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ modelId: 'gemini-2.0-flash' })
+      )
+      expect(op2.mock.calls[1][0]).toEqual(
+        expect.objectContaining({ modelId: 'gemini-2.0-flash' })
+      )
+    })
+
+    it('should throw immediately on non-429 error', async () => {
+      const session = createGeminiFallbackSession()
+      const error = new Error('bad request')
+      const operation = jest.fn().mockRejectedValue(error)
+
+      await expect(session.execute(operation)).rejects.toThrow('bad request')
+      expect(operation).toHaveBeenCalledTimes(1)
+    })
+
+    it('should throw if both primary retries and fallback fail', async () => {
+      process.env.GEMINI_MAX_RETRIES = '0'
+      const rateLimitError = Object.assign(new Error('rate limited'), {
+        statusCode: 429
+      })
+      const session = createGeminiFallbackSession()
+      const operation = jest.fn().mockRejectedValue(rateLimitError)
+
+      await expect(session.execute(operation)).rejects.toThrow('rate limited')
+      expect(operation).toHaveBeenCalledTimes(2)
+    })
+
+    it('should throw when fallback exhausts its own retries after useFallback is set', async () => {
+      process.env.GEMINI_MAX_RETRIES = '1'
+      const rateLimitError = Object.assign(new Error('rate limited'), {
+        statusCode: 429
+      })
+      const session = createGeminiFallbackSession()
+
+      // First call: exhaust primary (2 attempts) → useFallback flips → fallback succeeds
+      const op1 = jest
+        .fn()
+        .mockRejectedValueOnce(rateLimitError) // primary 0
+        .mockRejectedValueOnce(rateLimitError) // primary 1
+        .mockResolvedValueOnce('ok') // fallback 0
+
+      const p1 = session.execute(op1)
+      await jest.advanceTimersByTimeAsync(1000)
+      await p1
+
+      // Second call: useFallback=true, fallback 429s on both attempts → throws.
+      // Attach the rejection handler BEFORE advancing timers to avoid an unhandled
+      // rejection between timer advancement and the assertion.
+      const op2 = jest
+        .fn()
+        .mockRejectedValueOnce(rateLimitError) // fallback 0
+        .mockRejectedValueOnce(rateLimitError) // fallback 1
+
+      const rejectExpectation = expect(session.execute(op2)).rejects.toThrow(
+        'rate limited'
+      )
+      await jest.advanceTimersByTimeAsync(1000) // fallback retry delay
+      await rejectExpectation
+
+      expect(op2).toHaveBeenCalledTimes(2)
+      for (const call of op2.mock.calls) {
+        expect(call[0]).toEqual(
+          expect.objectContaining({ modelId: 'gemini-2.0-flash' })
+        )
+      }
+    })
+
+    it('should throw immediately on non-429 error from fallback when useFallback is true', async () => {
+      process.env.GEMINI_MAX_RETRIES = '0'
+      const rateLimitError = Object.assign(new Error('rate limited'), {
+        statusCode: 429
+      })
+      const session = createGeminiFallbackSession()
+
+      // First call: exhaust primary (0 retries) → fallback succeeds → useFallback=true
+      const op1 = jest
+        .fn()
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce('ok')
+      await session.execute(op1)
+
+      // Second call: useFallback=true, fallback throws a non-429 error immediately
+      const nonRateLimitError = new Error('bad request')
+      const op2 = jest.fn().mockRejectedValue(nonRateLimitError)
+
+      await expect(session.execute(op2)).rejects.toThrow('bad request')
+      expect(op2).toHaveBeenCalledTimes(1)
+      expect(op2.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ modelId: 'gemini-2.0-flash' })
+      )
+    })
+
+    it('should bail out of primary retries when a concurrent call already flipped useFallback', async () => {
+      process.env.GEMINI_MAX_RETRIES = '1'
+      const rateLimitError = Object.assign(new Error('rate limited'), {
+        statusCode: 429
+      })
+      const session = createGeminiFallbackSession()
+
+      // opA exhausts primary on both retries then succeeds on fallback.
+      // A registers its 1s retry timer first, so its timer fires first.
+      const opA = jest
+        .fn()
+        .mockRejectedValueOnce(rateLimitError) // primary 0
+        .mockRejectedValueOnce(rateLimitError) // primary 1 (A exhausts, sets useFallback=true)
+        .mockResolvedValueOnce('A-fallback') // fallback 0
+
+      // opB fails on primary 0 and then should bail — it must NOT make a primary 1 attempt
+      // because A will have set useFallback=true by the time B wakes from its 1s sleep.
+      const opB = jest
+        .fn()
+        .mockRejectedValueOnce(rateLimitError) // primary 0
+        .mockResolvedValueOnce('B-fallback') // fallback 0 (after bail-out)
+
+      // Start both concurrently. A registers its sleep timer before B does.
+      const promiseA = session.execute(opA)
+      const promiseB = session.execute(opB)
+
+      // Advancing 1s fires A's timer first (earlier registration). A wakes, exhausts
+      // primary, sets useFallback=true, calls fallback and resolves — all before B's
+      // timer fires. B then wakes, sees shouldAbort()=true, bails without a second
+      // primary attempt, and goes straight to fallback.
+      await jest.advanceTimersByTimeAsync(1000)
+
+      const [resultA, resultB] = await Promise.all([promiseA, promiseB])
+
+      expect(resultA).toBe('A-fallback')
+      expect(resultB).toBe('B-fallback')
+
+      // A: primary 0, primary 1, fallback 0 = 3 calls
+      expect(opA).toHaveBeenCalledTimes(3)
+      // B: primary 0, fallback 0 = 2 calls — primary 1 was skipped due to bail-out
+      expect(opB).toHaveBeenCalledTimes(2)
+      expect(opB.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ modelId: 'gemini-2.5-flash' })
+      )
+      expect(opB.mock.calls[1][0]).toEqual(
+        expect.objectContaining({ modelId: 'gemini-2.0-flash' })
+      )
     })
   })
 })

--- a/libs/shared/ai/src/geminiModel/geminiModel.ts
+++ b/libs/shared/ai/src/geminiModel/geminiModel.ts
@@ -96,7 +96,12 @@ export function createGeminiFallbackSession(): GeminiFallbackSession {
       }
 
       try {
-        return await retryWithBackoff(primaryModel, operation, maxRetries, () => useFallback)
+        return await retryWithBackoff(
+          primaryModel,
+          operation,
+          maxRetries,
+          () => useFallback
+        )
       } catch (error) {
         if (!isRateLimitError(error)) throw error
         // Primary exhausted all retries (or aborted early due to a concurrent

--- a/libs/shared/ai/src/geminiModel/geminiModel.ts
+++ b/libs/shared/ai/src/geminiModel/geminiModel.ts
@@ -31,24 +31,89 @@ export function isRateLimitError(error: unknown): boolean {
   return lastError?.statusCode === 429
 }
 
-export async function withGeminiFallback<T>(
-  operation: (model: ReturnType<typeof google>) => Promise<T>
+/**
+ * Retries `operation` with exponential backoff on 429s.
+ *
+ * @param shouldAbort - Optional callback checked after each retry delay. If it
+ *   returns true the current iteration is skipped and the last 429 is thrown so
+ *   the caller can route to a fallback immediately. This lets a concurrent
+ *   session call that already switched to fallback short-circuit in-progress
+ *   primary retries.
+ */
+async function retryWithBackoff<T>(
+  model: ReturnType<typeof google>,
+  operation: (model: ReturnType<typeof google>) => Promise<T>,
+  maxRetries: number,
+  shouldAbort?: () => boolean
 ): Promise<T> {
-  const maxRetries = getGeminiMaxRetries()
-  const primaryModel = getGeminiModel()
-
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+  const clampedMaxRetries = Math.max(0, maxRetries)
+  let lastError: unknown
+  for (let attempt = 0; attempt <= clampedMaxRetries; attempt++) {
     if (attempt > 0) {
       const delayMs = BACKOFF_BASE_MS * Math.pow(2, attempt - 1)
       await new Promise((resolve) => setTimeout(resolve, delayMs))
+      // After sleeping, check whether a concurrent call already switched to
+      // fallback. If so, bail early so this call also routes to fallback.
+      if (shouldAbort?.()) break
     }
     try {
-      return await operation(primaryModel)
+      return await operation(model)
     } catch (error) {
       if (!isRateLimitError(error)) throw error
+      lastError = error
     }
   }
+  throw lastError
+}
 
-  // Primary model exhausted all retries; try fallback model once
-  return operation(getGeminiFallbackModel())
+export interface GeminiFallbackSession {
+  execute<T>(
+    operation: (model: ReturnType<typeof google>) => Promise<T>
+  ): Promise<T>
+}
+
+/**
+ * Creates a session-aware fallback that shares state across calls.
+ * Once the primary model exhausts its retries on a 429, ALL subsequent
+ * calls in the same session skip the primary and go straight to the fallback.
+ *
+ * Concurrent calls: if a concurrent `execute()` call flips `useFallback` while
+ * another call is sleeping between primary retries, the sleeping call aborts
+ * its remaining primary retries and routes to the fallback model immediately.
+ */
+export function createGeminiFallbackSession(): GeminiFallbackSession {
+  const maxRetries = getGeminiMaxRetries()
+  const primaryModel = getGeminiModel()
+  const fallbackModel = getGeminiFallbackModel()
+  let useFallback = false
+
+  return {
+    async execute<T>(
+      operation: (model: ReturnType<typeof google>) => Promise<T>
+    ): Promise<T> {
+      if (useFallback) {
+        return retryWithBackoff(fallbackModel, operation, maxRetries)
+      }
+
+      try {
+        return await retryWithBackoff(primaryModel, operation, maxRetries, () => useFallback)
+      } catch (error) {
+        if (!isRateLimitError(error)) throw error
+        // Primary exhausted all retries (or aborted early due to a concurrent
+        // call); switch to fallback permanently for this session.
+        useFallback = true
+        return retryWithBackoff(fallbackModel, operation, maxRetries)
+      }
+    }
+  }
+}
+
+/**
+ * Stateless fallback helper — thin wrapper around a single-use session.
+ * Kept for backward compatibility with callers that don't need cross-call state.
+ */
+export async function withGeminiFallback<T>(
+  operation: (model: ReturnType<typeof google>) => Promise<T>
+): Promise<T> {
+  return createGeminiFallbackSession().execute(operation)
 }

--- a/libs/shared/ai/src/geminiModel/index.ts
+++ b/libs/shared/ai/src/geminiModel/index.ts
@@ -3,5 +3,8 @@ export {
   getGeminiFallbackModel,
   getGeminiMaxRetries,
   isRateLimitError,
+  createGeminiFallbackSession,
   withGeminiFallback
 } from './geminiModel'
+
+export type { GeminiFallbackSession } from './geminiModel'


### PR DESCRIPTION
## Summary

- **Session-level model switching:** `createGeminiFallbackSession()` replaces the stateless `withGeminiFallback`. The session shares a `useFallback` flag across all calls — once the primary model (gemini-2.5-flash) exhausts its exponential-backoff retries on a 429, every subsequent call in that session skips primary entirely and goes straight to the fallback (gemini-2.0-flash). The old `withGeminiFallback` is kept as a thin wrapper for backward compatibility (`getImageDescription`, `journeyLanguageAiDetect`).

- **Concurrent card translations bail out early:** `retryWithBackoff` now accepts a `shouldAbort` callback that is checked after each retry sleep. In `Promise.allSettled` batches (card translation), once any one card exhausts primary retries and flips `useFallback`, all other cards that are sleeping between primary retries detect the flag on wake-up and jump straight to fallback — avoiding redundant primary retry cycles across the whole batch.

- **Root cause fix — `onError` was silently swallowing 429 errors:** Both `streamText` calls in `journeyAiTranslate.ts` (subscription and mutation) had an `onError` handler that `console.warn`-ed and returned, preventing the error from propagating to `withGeminiFallback`. The fallback never triggered for card-block translation. Removing `onError` lets 429s surface so the session can retry and fall back correctly.

- **Transition call gets full retry on fallback:** Previously the first call to exhaust primary retries only got a single fallback attempt (no backoff). Now it also goes through `retryWithBackoff` on the fallback model, consistent with all subsequent calls.

- One session is created per translation flow (shared across the title/description `generateText` call and all card-block `streamText` calls), so a 429 on the title step causes all card steps to go straight to fallback without re-exhausting primary.

Fixes [QA-349](https://linear.app/jesusfilm/issue/QA-349)

## Test plan

- [ ] All 36 unit tests in `geminiModel.spec.ts` pass (`npx jest --config libs/shared/ai/jest.config.ts --no-coverage 'libs/shared/ai/src/geminiModel/geminiModel.spec.ts'`)
- [ ] New session tests cover: session-level skip, concurrent bail-out, fallback exhaustion, non-429 from fallback
- [ ] Existing `withGeminiFallback` tests still pass unchanged (backward compat)
- [ ] Manually verify journey translation completes successfully under normal conditions
- [ ] Manually verify journey translation falls back to gemini-2.0-flash when primary is rate-limited

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved AI translation resilience: per-translation session fallback (single session governs fallback routing), exponential backoff on rate limits, and stronger concurrency handling; removed noisy console warnings during streaming errors.
* **Tests**
  * Added comprehensive tests covering retry/backoff behavior, fallback switching and exhaustion, concurrency interactions, and timing of retry logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->