### PR TITLE
feat: folders demo prototype for template section organization

### DIFF
--- a/apps/journeys-admin/src/components/CollectionsDemo/CollectionCard.tsx
+++ b/apps/journeys-admin/src/components/CollectionsDemo/CollectionCard.tsx
@@ -1,0 +1,199 @@
+import { useDroppable } from '@dnd-kit/core'
+import Box from '@mui/material/Box'
+import Card from '@mui/material/Card'
+import CardActionArea from '@mui/material/CardActionArea'
+import Chip from '@mui/material/Chip'
+import Stack from '@mui/material/Stack'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { ReactElement } from 'react'
+
+import type { Collection, MockTemplate } from './mockData'
+import {
+  COLLECTION_CARD_INFO_HEIGHT,
+  COLLECTION_CARD_MOSAIC_RATIO,
+  MOCK_TEMPLATES
+} from './mockData'
+
+function getTemplateById(id: string): MockTemplate | undefined {
+  return MOCK_TEMPLATES.find((t) => t.id === id)
+}
+
+interface CollectionCardProps {
+  collection: Collection
+  onOpen: (collectionId: string) => void
+  onTogglePublish: (collectionId: string) => void
+}
+
+export function CollectionCard({
+  collection,
+  onOpen,
+  onTogglePublish
+}: CollectionCardProps): ReactElement {
+  const { isOver, setNodeRef } = useDroppable({ id: collection.id })
+  const count = collection.templateIds.length
+  const showCountTile = count > 3
+  const visibleImages = showCountTile
+    ? collection.templateIds.slice(0, 3)
+    : collection.templateIds.slice(0, 4)
+  const remainingCount = count - 3
+
+  return (
+    <Tooltip
+      title={
+        isOver && collection.isPublished
+          ? 'Published \u2014 templates locked'
+          : ''
+      }
+      open={isOver && collection.isPublished}
+      arrow
+      placement="top"
+    >
+    <Card
+      ref={setNodeRef}
+      variant="outlined"
+      sx={{
+        backgroundColor: collection.backgroundColor,
+        borderColor: isOver
+          ? collection.isPublished
+            ? 'text.disabled'
+            : 'primary.main'
+          : 'rgba(0,0,0,0.08)',
+        borderWidth: isOver ? 2 : 1,
+        borderStyle: isOver ? 'dashed' : 'solid',
+        transition: 'border-color 0.2s ease',
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column'
+      }}
+    >
+      <CardActionArea
+        onClick={() => onOpen(collection.id)}
+        aria-label={`open ${collection.title}`}
+      >
+        {/* Image mosaic */}
+        <Box sx={{ position: 'relative' }}>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+            gridTemplateRows: '1fr 1fr',
+            gap: '2px',
+            aspectRatio: `${COLLECTION_CARD_MOSAIC_RATIO}`,
+            overflow: 'hidden',
+            borderRadius: '8px 8px 0 0',
+            backgroundColor: 'rgba(0,0,0,0.06)'
+          }}
+        >
+          {[0, 1, 2, 3].map((i) => {
+            // 4th slot becomes a count tile when there are 4+ templates
+            if (i === 3 && showCountTile) {
+              return (
+                <Box
+                  key="count"
+                  sx={{
+                    width: '100%',
+                    height: '100%',
+                    bgcolor: 'rgba(0,0,0,0.06)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center'
+                  }}
+                >
+                  <Typography
+                    variant="subtitle2"
+                    color="text.secondary"
+                    sx={{ fontWeight: 700 }}
+                  >
+                    +{remainingCount}
+                  </Typography>
+                </Box>
+              )
+            }
+
+            const tmpl =
+              visibleImages[i] != null
+                ? getTemplateById(visibleImages[i])
+                : null
+            return tmpl != null ? (
+              <Box
+                key={tmpl.id}
+                component="img"
+                src={tmpl.imageUrl}
+                alt={tmpl.title}
+                sx={{ width: '100%', height: '100%', objectFit: 'cover' }}
+              />
+            ) : (
+              <Box
+                key={i}
+                sx={{
+                  width: '100%',
+                  height: '100%',
+                  bgcolor: 'rgba(0,0,0,0.04)'
+                }}
+              />
+            )
+          })}
+        </Box>
+        {/* Drop overlay */}
+        {isOver && !collection.isPublished && (
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              backgroundColor: 'rgba(0,0,0,0.45)',
+              borderRadius: '8px 8px 0 0',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              pointerEvents: 'none'
+            }}
+          >
+            <Typography
+              variant="subtitle2"
+              sx={{ color: 'white', fontWeight: 600 }}
+            >
+              Drop here
+            </Typography>
+          </Box>
+        )}
+        </Box>
+        {/* Info */}
+        <Box sx={{ p: 1.5, height: COLLECTION_CARD_INFO_HEIGHT }}>
+          <Typography variant="subtitle2" noWrap>
+            {collection.title}
+          </Typography>
+          <Stack
+            direction="row"
+            alignItems="center"
+            spacing={0.5}
+            sx={{ mt: 0.5 }}
+          >
+            <Chip
+              size="small"
+              label={collection.isPublished ? 'Published' : 'Draft'}
+              onClick={(e) => {
+                e.stopPropagation()
+                onTogglePublish(collection.id)
+              }}
+              aria-label={`toggle publish for ${collection.title}`}
+              sx={{
+                fontSize: 11,
+                height: 22,
+                cursor: 'pointer',
+                backgroundColor: collection.isPublished
+                  ? 'success.light'
+                  : 'action.selected',
+                color: collection.isPublished
+                  ? 'success.dark'
+                  : 'text.secondary',
+                '& .MuiChip-label': { px: 1 }
+              }}
+            />
+          </Stack>
+        </Box>
+      </CardActionArea>
+    </Card>
+    </Tooltip>
+  )
+}

--- a/apps/journeys-admin/src/components/CollectionsDemo/CollectionDetailDialog.tsx
+++ b/apps/journeys-admin/src/components/CollectionsDemo/CollectionDetailDialog.tsx
@@ -1,0 +1,185 @@
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
+import Box from '@mui/material/Box'
+import Card from '@mui/material/Card'
+import Chip from '@mui/material/Chip'
+import IconButton from '@mui/material/IconButton'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { ReactElement } from 'react'
+
+import X2Icon from '@core/shared/ui/icons/X2'
+
+import type { Collection, MockTemplate } from './mockData'
+import { MOCK_TEMPLATES } from './mockData'
+
+function getTemplateById(id: string): MockTemplate | undefined {
+  return MOCK_TEMPLATES.find((t) => t.id === id)
+}
+
+interface CollectionDetailOverlayProps {
+  collection: Collection
+  onClose: () => void
+  onRemoveTemplate: (collectionId: string, templateId: string) => void
+}
+
+export function CollectionDetailOverlay({
+  collection,
+  onClose,
+  onRemoveTemplate
+}: CollectionDetailOverlayProps): ReactElement {
+  return (
+    <Box
+      sx={{
+        position: 'absolute',
+        inset: 0,
+        backgroundColor: 'background.paper',
+        zIndex: 5,
+        display: 'flex',
+        flexDirection: 'column',
+        borderRadius: 3,
+        border: '1px solid',
+        borderColor: 'divider',
+        overflow: 'hidden'
+      }}
+    >
+      {/* Header */}
+      <Stack
+        direction="row"
+        alignItems="center"
+        spacing={1}
+        sx={{
+          px: 2.5,
+          py: 2,
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          flexShrink: 0
+        }}
+      >
+        <Box
+          sx={{
+            width: 12,
+            height: 12,
+            borderRadius: '50%',
+            backgroundColor: collection.backgroundColor,
+            border: '2px solid rgba(0,0,0,0.15)',
+            flexShrink: 0
+          }}
+        />
+        <Typography variant="subtitle1" sx={{ flex: 1, fontWeight: 600 }}>
+          {collection.title}
+        </Typography>
+        <Chip
+          size="small"
+          label={collection.isPublished ? 'Published' : 'Draft'}
+          sx={{
+            fontSize: 11,
+            height: 24,
+            backgroundColor: collection.isPublished
+              ? 'success.light'
+              : 'action.selected',
+            color: collection.isPublished ? 'success.dark' : 'text.secondary'
+          }}
+        />
+        <Typography variant="caption" color="text.secondary">
+          {collection.templateIds.length}{' '}
+          {collection.templateIds.length === 1 ? 'template' : 'templates'}
+        </Typography>
+        <IconButton
+          onClick={onClose}
+          aria-label="close collection detail"
+          edge="end"
+          size="small"
+        >
+          <X2Icon />
+        </IconButton>
+      </Stack>
+
+      {/* Scrollable template list */}
+      <Box sx={{ flex: 1, overflowY: 'auto', p: 2 }}>
+        {collection.templateIds.length === 0 ? (
+          <Box
+            sx={{
+              py: 6,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center'
+            }}
+          >
+            <Typography variant="body2" color="text.secondary">
+              No templates in this collection yet.
+            </Typography>
+          </Box>
+        ) : (
+          <Stack spacing={1}>
+            {collection.templateIds.map((id) => {
+              const tmpl = getTemplateById(id)
+              if (tmpl == null) return null
+              return (
+                <Card
+                  key={id}
+                  variant="outlined"
+                  sx={{
+                    p: 1.5,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 2,
+                    '&:hover .remove-btn': { opacity: 1 }
+                  }}
+                >
+                  <Box
+                    component="img"
+                    src={tmpl.imageUrl}
+                    alt={tmpl.title}
+                    sx={{
+                      width: 72,
+                      height: 50,
+                      borderRadius: 1,
+                      objectFit: 'cover',
+                      flexShrink: 0
+                    }}
+                  />
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Typography variant="subtitle2" noWrap>
+                      {tmpl.title}
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        display: 'block'
+                      }}
+                    >
+                      {tmpl.description}
+                    </Typography>
+                    <Chip
+                      size="small"
+                      label={tmpl.languageCode}
+                      sx={{ mt: 0.5, fontSize: 10, height: 20 }}
+                    />
+                  </Box>
+                  <IconButton
+                    className="remove-btn"
+                    size="small"
+                    onClick={() => onRemoveTemplate(collection.id, id)}
+                    aria-label={`remove ${tmpl.title} from collection`}
+                    sx={{
+                      opacity: 0,
+                      transition: 'opacity 0.15s ease',
+                      color: 'error.main',
+                      flexShrink: 0
+                    }}
+                  >
+                    <DeleteOutlineIcon />
+                  </IconButton>
+                </Card>
+              )
+            })}
+          </Stack>
+        )}
+      </Box>
+    </Box>
+  )
+}

--- a/apps/journeys-admin/src/components/CollectionsDemo/CollectionPreview.tsx
+++ b/apps/journeys-admin/src/components/CollectionsDemo/CollectionPreview.tsx
@@ -1,0 +1,250 @@
+import PlayArrowIcon from '@mui/icons-material/PlayArrow'
+import Avatar from '@mui/material/Avatar'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Card from '@mui/material/Card'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { ReactElement } from 'react'
+
+import type { Collection, MockTemplate } from './mockData'
+import { MOCK_TEMPLATES } from './mockData'
+
+function getTemplateById(id: string): MockTemplate | undefined {
+  return MOCK_TEMPLATES.find((t) => t.id === id)
+}
+
+interface CollectionPreviewProps {
+  collection: Collection
+}
+
+export function CollectionPreview({
+  collection
+}: CollectionPreviewProps): ReactElement {
+  return (
+    <Box
+      sx={{
+        backgroundColor: 'background.paper',
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        overflow: 'hidden'
+      }}
+    >
+      <Box sx={{ flex: 1, overflowY: 'auto' }}>
+        {/* Header */}
+        <Box sx={{ px: 4, pt: 4, pb: 1 }}>
+          <Typography
+            variant="h4"
+            sx={{ fontWeight: 700, mb: 1.5, lineHeight: 1.2 }}
+          >
+            {collection.title || 'Untitled Collection'}
+          </Typography>
+
+          {collection.description !== '' && (
+            <Typography
+              variant="body1"
+              color="text.secondary"
+              sx={{ mb: 1, lineHeight: 1.6 }}
+            >
+              {collection.description}
+            </Typography>
+          )}
+
+          {collection.pageDescription !== '' && (
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ mb: 1.5, lineHeight: 1.6 }}
+            >
+              {collection.pageDescription}
+            </Typography>
+          )}
+
+          {collection.creatorName !== '' && (
+            <Stack
+              direction="row"
+              alignItems="center"
+              spacing={1}
+            >
+              <Avatar
+                src={collection.creatorImageUrl || undefined}
+                sx={{ width: 32, height: 32 }}
+              />
+              <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                {collection.creatorName}
+              </Typography>
+            </Stack>
+          )}
+        </Box>
+
+        {/* Template cards — horizontal scroll */}
+        {collection.templateIds.length > 0 && (
+          <Box
+            sx={{
+              px: 4,
+              my: 4,
+              overflowX: 'auto',
+              '&::-webkit-scrollbar': { height: 6 },
+              '&::-webkit-scrollbar-thumb': {
+                borderRadius: 3,
+                backgroundColor: 'rgba(0,0,0,0.15)'
+              }
+            }}
+          >
+            <Stack direction="row" spacing={2} sx={{ width: 'max-content' }}>
+              {collection.templateIds.map((id) => {
+                const tmpl = getTemplateById(id)
+                if (tmpl == null) return null
+                return (
+                  <Card
+                    key={id}
+                    variant="outlined"
+                    sx={{
+                      width: 220,
+                      flexShrink: 0,
+                      borderRadius: 2,
+                      overflow: 'hidden',
+                      display: 'flex',
+                      flexDirection: 'column'
+                    }}
+                  >
+                    {/* Image */}
+                    <Box
+                      sx={{
+                        position: 'relative',
+                        height: 260,
+                        overflow: 'hidden'
+                      }}
+                    >
+                      <Box
+                        component="img"
+                        src={tmpl.imageUrl}
+                        alt={tmpl.title}
+                        sx={{
+                          width: '100%',
+                          height: '100%',
+                          objectFit: 'cover'
+                        }}
+                      />
+                    </Box>
+
+                    {/* Info */}
+                    <Box sx={{ p: 1.5, flex: 1 }}>
+                      <Typography
+                        variant="overline"
+                        color="text.secondary"
+                        sx={{ fontSize: 10, lineHeight: 1.2 }}
+                      >
+                        {tmpl.languageCode}
+                      </Typography>
+                      <Typography
+                        variant="subtitle2"
+                        sx={{ fontWeight: 700, mt: 0.25, mb: 0.5 }}
+                      >
+                        {tmpl.title}
+                      </Typography>
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{
+                          display: '-webkit-box',
+                          WebkitLineClamp: 3,
+                          WebkitBoxOrient: 'vertical',
+                          overflow: 'hidden',
+                          lineHeight: 1.4
+                        }}
+                      >
+                        {tmpl.description}
+                      </Typography>
+                    </Box>
+
+                    {/* Actions */}
+                    <Stack
+                      direction="row"
+                      spacing={1}
+                      sx={{ px: 1.5, pb: 1.5 }}
+                    >
+                      <Button
+                        variant="outlined"
+                        size="small"
+                        sx={{
+                          flex: 1,
+                          textTransform: 'none',
+                          borderRadius: 5,
+                          fontWeight: 600
+                        }}
+                      >
+                        Use
+                      </Button>
+                      <Button
+                        variant="contained"
+                        size="small"
+                        sx={{
+                          minWidth: 36,
+                          px: 0,
+                          borderRadius: 5,
+                          backgroundColor: 'text.primary',
+                          '&:hover': {
+                            backgroundColor: 'text.secondary'
+                          }
+                        }}
+                      >
+                        <PlayArrowIcon sx={{ fontSize: 18 }} />
+                      </Button>
+                    </Stack>
+                  </Card>
+                )
+              })}
+            </Stack>
+          </Box>
+        )}
+
+        {collection.templateIds.length === 0 && (
+          <Box sx={{ px: 4, my: 4 }}>
+            <Box
+              sx={{
+                py: 4,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                border: '1px dashed',
+                borderColor: 'divider',
+                borderRadius: 2
+              }}
+            >
+              <Typography variant="body2" color="text.secondary">
+                No templates in this collection yet.
+              </Typography>
+            </Box>
+          </Box>
+        )}
+
+        {/* PDF/Video embed placeholder */}
+        {collection.pdfVideoUrl !== '' && (
+          <Box sx={{ px: 4, pb: 4 }}>
+            <Box
+              sx={{
+                backgroundColor: 'grey.100',
+                borderRadius: 2,
+                p: 3,
+                height: 340,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center'
+              }}
+            >
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ wordBreak: 'break-all', textAlign: 'center' }}
+              >
+                {collection.pdfVideoUrl}
+              </Typography>
+            </Box>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  )
+}

--- a/apps/journeys-admin/src/components/CollectionsDemo/CollectionSidePanel.tsx
+++ b/apps/journeys-admin/src/components/CollectionsDemo/CollectionSidePanel.tsx
@@ -1,0 +1,334 @@
+import CheckIcon from '@mui/icons-material/Check'
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
+import VisibilityIcon from '@mui/icons-material/Visibility'
+import Avatar from '@mui/material/Avatar'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import IconButton from '@mui/material/IconButton'
+import Stack from '@mui/material/Stack'
+import Switch from '@mui/material/Switch'
+import TextField from '@mui/material/TextField'
+import Typography from '@mui/material/Typography'
+import { ReactElement, useState } from 'react'
+
+import Edit2Icon from '@core/shared/ui/icons/Edit2'
+import X2Icon from '@core/shared/ui/icons/X2'
+
+import type { Collection } from './mockData'
+
+const COLOR_OPTIONS = [
+  { label: 'Mint', value: '#E8F5E9' },
+  { label: 'Sky', value: '#E3F2FD' },
+  { label: 'Peach', value: '#FFF3E0' },
+  { label: 'Lavender', value: '#F3E5F5' },
+  { label: 'Lemon', value: '#FFF9C4' },
+  { label: 'Blush', value: '#FCE4EC' },
+  { label: 'Cyan', value: '#E0F7FA' },
+  { label: 'Lime', value: '#F1F8E9' },
+  { label: 'Violet', value: '#EDE7F6' },
+  { label: 'Coral', value: '#FBE9E7' },
+  { label: 'White', value: '#FFFFFF' },
+  { label: 'Light Grey', value: '#F5F5F5' }
+]
+
+interface CollectionSidePanelProps {
+  collection: Collection
+  onClose: () => void
+  onUpdateCollection: (id: string, updates: Partial<Collection>) => void
+  onDeleteCollection: (id: string) => void
+  onPreview: () => void
+  isPreviewOpen: boolean
+}
+
+export function CollectionSidePanel({
+  collection,
+  onClose,
+  onUpdateCollection,
+  onDeleteCollection,
+  onPreview,
+  isPreviewOpen
+}: CollectionSidePanelProps): ReactElement {
+  const [unpublishDialogOpen, setUnpublishDialogOpen] = useState(false)
+
+  const handlePublishToggle = (): void => {
+    if (collection.isPublished) {
+      setUnpublishDialogOpen(true)
+    } else {
+      onUpdateCollection(collection.id, { isPublished: true })
+    }
+  }
+
+  const handleConfirmUnpublish = (): void => {
+    onUpdateCollection(collection.id, { isPublished: false })
+    setUnpublishDialogOpen(false)
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {/* Header */}
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        sx={{
+          px: 2.5,
+          py: 2,
+          borderBottom: '1px solid',
+          borderColor: 'divider'
+        }}
+      >
+        <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+          Edit Collection
+        </Typography>
+        <IconButton
+          onClick={onClose}
+          aria-label="close collection panel"
+          edge="end"
+          size="small"
+        >
+          <X2Icon />
+        </IconButton>
+      </Stack>
+
+      {/* Scrollable content */}
+      <Box sx={{ flex: 1, overflowY: 'auto', px: 2.5, py: 2 }}>
+        <Stack spacing={3}>
+          {/* Preview button */}
+          <Button
+            variant="blockContained"
+            startIcon={<VisibilityIcon />}
+            onClick={onPreview}
+            fullWidth
+          >
+            {isPreviewOpen ? 'Close Preview' : 'Preview Page'}
+          </Button>
+
+          {/* Publish toggle */}
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+          >
+            <Typography variant="body2" sx={{ fontWeight: 600 }}>
+              Publish Status
+            </Typography>
+            <Stack direction="row" alignItems="center" spacing={1}>
+              <Typography
+                variant="caption"
+                color={
+                  collection.isPublished ? 'success.main' : 'text.secondary'
+                }
+              >
+                {collection.isPublished ? 'Published' : 'Draft'}
+              </Typography>
+              <Switch
+                size="small"
+                checked={collection.isPublished}
+                onChange={handlePublishToggle}
+                aria-label="toggle publish status"
+              />
+            </Stack>
+          </Stack>
+
+          {/* Title */}
+          <TextField
+            label="Title"
+            value={collection.title}
+            onChange={(e) =>
+              onUpdateCollection(collection.id, { title: e.target.value })
+            }
+            fullWidth
+            size="small"
+          />
+
+          {/* Description */}
+          <TextField
+            label="Description"
+            value={collection.description}
+            onChange={(e) =>
+              onUpdateCollection(collection.id, { description: e.target.value })
+            }
+            fullWidth
+            size="small"
+            multiline
+            rows={3}
+          />
+
+          {/* Background Color */}
+          <Box>
+            <Typography variant="body2" sx={{ mb: 1, fontWeight: 600 }}>
+              Background Color
+            </Typography>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+              {COLOR_OPTIONS.map((color) => (
+                <IconButton
+                  key={color.value}
+                  onClick={() =>
+                    onUpdateCollection(collection.id, {
+                      backgroundColor: color.value
+                    })
+                  }
+                  aria-label={`set background to ${color.label}`}
+                  sx={{
+                    width: 28,
+                    height: 28,
+                    backgroundColor: color.value,
+                    border: '2px solid',
+                    borderColor:
+                      collection.backgroundColor === color.value
+                        ? 'primary.main'
+                        : 'rgba(0,0,0,0.12)',
+                    borderRadius: '50%',
+                    p: 0,
+                    '&:hover': {
+                      backgroundColor: color.value,
+                      borderColor: 'primary.main'
+                    }
+                  }}
+                >
+                  {collection.backgroundColor === color.value && (
+                    <CheckIcon sx={{ fontSize: 14, color: 'primary.main' }} />
+                  )}
+                </IconButton>
+              ))}
+            </Box>
+          </Box>
+
+          {/* Page description / instructions */}
+          <Box>
+            <Typography variant="body2" sx={{ mb: 1, fontWeight: 600 }}>
+              Page description / instructions
+            </Typography>
+            <TextField
+              value={collection.pageDescription}
+              onChange={(e) =>
+                onUpdateCollection(collection.id, {
+                  pageDescription: e.target.value
+                })
+              }
+              fullWidth
+              size="small"
+              multiline
+              rows={3}
+              placeholder="Enter page description or instructions..."
+            />
+          </Box>
+
+          {/* Creator details */}
+          <Box>
+            <Typography variant="body2" sx={{ mb: 1, fontWeight: 600 }}>
+              Creator Details
+            </Typography>
+            <Stack direction="row" spacing={2} alignItems="center">
+              <Box sx={{ position: 'relative', flexShrink: 0 }}>
+                <Avatar
+                  src={collection.creatorImageUrl || undefined}
+                  sx={{ width: 48, height: 48 }}
+                />
+                <IconButton
+                  size="small"
+                  aria-label="edit creator image"
+                  sx={{
+                    position: 'absolute',
+                    bottom: -4,
+                    right: -4,
+                    backgroundColor: 'background.paper',
+                    border: '1px solid',
+                    borderColor: 'divider',
+                    width: 22,
+                    height: 22,
+                    '&:hover': { backgroundColor: 'action.hover' }
+                  }}
+                >
+                  <Edit2Icon sx={{ fontSize: 12 }} />
+                </IconButton>
+              </Box>
+              <TextField
+                value={collection.creatorName}
+                onChange={(e) =>
+                  onUpdateCollection(collection.id, {
+                    creatorName: e.target.value
+                  })
+                }
+                placeholder="Creator's info"
+                fullWidth
+                size="small"
+              />
+            </Stack>
+          </Box>
+
+          {/* PDF / Video URL */}
+          <Box>
+            <Typography variant="body2" sx={{ mb: 1, fontWeight: 600 }}>
+              Add PDF / Video with instructions
+            </Typography>
+            <TextField
+              value={collection.pdfVideoUrl}
+              onChange={(e) =>
+                onUpdateCollection(collection.id, {
+                  pdfVideoUrl: e.target.value
+                })
+              }
+              placeholder="Paste URL"
+              fullWidth
+              size="small"
+            />
+          </Box>
+        </Stack>
+      </Box>
+
+      {/* Delete — pinned to bottom */}
+      <Box
+        sx={{
+          px: 2.5,
+          py: 2,
+          borderTop: '1px solid',
+          borderColor: 'divider',
+          flexShrink: 0
+        }}
+      >
+        <Button
+          variant="outlined"
+          color="error"
+          size="small"
+          startIcon={<DeleteOutlineIcon />}
+          onClick={() => onDeleteCollection(collection.id)}
+          fullWidth
+          aria-label={`delete collection ${collection.title}`}
+        >
+          Delete Collection
+        </Button>
+      </Box>
+
+      {/* Unpublish confirmation dialog */}
+      <Dialog
+        open={unpublishDialogOpen}
+        onClose={() => setUnpublishDialogOpen(false)}
+        aria-label="confirm unpublish"
+      >
+        <DialogTitle>Unpublish Collection?</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2">
+            Unpublishing &quot;{collection.title}&quot; will remove it from the
+            public library. You will be able to edit templates in this
+            collection again.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setUnpublishDialogOpen(false)}>Cancel</Button>
+          <Button
+            onClick={handleConfirmUnpublish}
+            color="error"
+            variant="contained"
+          >
+            Unpublish
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  )
+}

--- a/apps/journeys-admin/src/components/CollectionsDemo/CollectionsDemo.tsx
+++ b/apps/journeys-admin/src/components/CollectionsDemo/CollectionsDemo.tsx
@@ -1,0 +1,850 @@
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
+  MouseSensor,
+  TouchSensor,
+  useDroppable,
+  useSensor,
+  useSensors
+} from '@dnd-kit/core'
+import AddIcon from '@mui/icons-material/Add'
+import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import SearchIcon from '@mui/icons-material/Search'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Card from '@mui/material/Card'
+import Dialog from '@mui/material/Dialog'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import Divider from '@mui/material/Divider'
+import Fade from '@mui/material/Fade'
+import Grid from '@mui/material/Grid'
+import InputAdornment from '@mui/material/InputAdornment'
+import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { ReactElement, useCallback, useRef, useState } from 'react'
+
+import { useBreakpoints } from '@core/shared/ui/useBreakpoints'
+
+import { MockTemplateCard } from '../FoldersDemo/MockTemplateCard'
+
+import type { JourneyStatus } from '../JourneyList/JourneyListView/JourneyListView'
+import { JourneySort, SortOrder } from '../JourneyList/JourneySort'
+import { JourneyStatusFilter } from '../JourneyList/JourneyStatusFilter'
+
+import { CollectionCard } from './CollectionCard'
+import { CollectionPreview } from './CollectionPreview'
+import { CollectionSidePanel } from './CollectionSidePanel'
+import { MobileCollectionsDemo } from './MobileCollectionsDemo'
+import { TemplateInfoPanel } from './TemplateInfoPanel'
+import {
+  COLLECTION_CARD_HEIGHT,
+  COLLECTION_CARD_INFO_HEIGHT,
+  COLLECTION_CARD_MOSAIC_RATIO,
+  COLLECTION_CARD_WIDTHS,
+  Collection,
+  MOCK_TEMPLATES,
+  MockTemplate,
+  SECTION_HEADER_HEIGHT,
+  SECTION_PADDING,
+  TEMPLATE_CARD_HEIGHT,
+  getNextPastelColor
+} from './mockData'
+
+const PANEL_WIDTH = 375
+// 1 card + header + padding
+const MIN_COLLECTIONS_HEIGHT =
+  COLLECTION_CARD_HEIGHT + SECTION_HEADER_HEIGHT + SECTION_PADDING
+// 1 card + header + filter row + padding
+const MIN_TEMPLATES_HEIGHT =
+  TEMPLATE_CARD_HEIGHT + SECTION_HEADER_HEIGHT * 2 + SECTION_PADDING
+
+function getTemplateById(id: string): MockTemplate | undefined {
+  return MOCK_TEMPLATES.find((t) => t.id === id)
+}
+
+function DroppableZone({
+  id,
+  children
+}: {
+  id: string
+  children: ReactElement
+}): ReactElement {
+  const { isOver, setNodeRef } = useDroppable({ id })
+  return (
+    <Box
+      ref={setNodeRef}
+      sx={{
+        flex: 1,
+        minHeight: 0,
+        borderRadius: 2,
+        border: isOver ? '2px dashed' : '2px dashed transparent',
+        borderColor: isOver ? 'primary.main' : 'transparent',
+        backgroundColor: isOver ? 'action.hover' : 'transparent',
+        transition: 'all 0.2s ease',
+        p: isOver ? 1 : 0,
+        display: 'flex',
+        flexDirection: 'column'
+      }}
+    >
+      {children}
+    </Box>
+  )
+}
+
+const CREATE_COLLECTION_DROP_ID = 'create-new-collection'
+
+function CreateCollectionDropTarget({
+  onClick
+}: {
+  onClick: () => void
+}): ReactElement {
+  const { isOver, setNodeRef } = useDroppable({ id: CREATE_COLLECTION_DROP_ID })
+  return (
+    <Box ref={setNodeRef} sx={{ width: COLLECTION_CARD_WIDTHS }}>
+      <Card
+        variant="outlined"
+        onClick={onClick}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') onClick()
+        }}
+        tabIndex={0}
+        role="button"
+        aria-label="create new collection"
+        sx={{
+          border: '2px dashed',
+          borderColor: isOver ? 'primary.main' : 'divider',
+          cursor: 'pointer',
+          backgroundColor: isOver ? 'action.hover' : 'transparent',
+          transition: 'all 0.2s ease',
+          overflow: 'hidden',
+          '&:hover': {
+            borderColor: 'primary.main',
+            backgroundColor: 'action.hover'
+          }
+        }}
+      >
+        <Box
+          sx={{
+            aspectRatio: `${COLLECTION_CARD_MOSAIC_RATIO}`,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexDirection: 'column'
+          }}
+        >
+          <AddIcon
+            color={isOver ? 'primary' : 'action'}
+            sx={{ fontSize: 32, mb: 1 }}
+          />
+          <Typography
+            variant="body2"
+            color={isOver ? 'primary' : 'text.secondary'}
+          >
+            {isOver ? 'Drop to create' : 'Create collection'}
+          </Typography>
+        </Box>
+        <Box sx={{ height: COLLECTION_CARD_INFO_HEIGHT }} />
+      </Card>
+    </Box>
+  )
+}
+
+function CollectionsDropZone({
+  collectionId,
+  isPublished,
+  sx,
+  children
+}: {
+  collectionId: string | null
+  isPublished: boolean
+  sx: Record<string, unknown>
+  children: ReactElement | ReactElement[]
+}): ReactElement {
+  const { isOver, setNodeRef } = useDroppable({
+    id: collectionId ?? 'collections-disabled',
+    disabled: collectionId == null
+  })
+
+  const dropActive = collectionId != null && isOver
+
+  return (
+    <Tooltip
+      title={dropActive && isPublished ? 'Published — templates locked' : ''}
+      open={dropActive && isPublished}
+      arrow
+      placement="top"
+    >
+      <Box
+        ref={collectionId != null ? setNodeRef : undefined}
+        sx={{
+          ...sx,
+          ...(dropActive
+            ? isPublished
+              ? {
+                  borderColor: 'text.disabled',
+                  borderStyle: 'dashed',
+                  borderWidth: 2
+                }
+              : {
+                  borderColor: 'primary.main',
+                  borderStyle: 'dashed',
+                  borderWidth: 2,
+                  backgroundColor: 'action.hover'
+                }
+            : {})
+        }}
+      >
+        {children}
+      </Box>
+    </Tooltip>
+  )
+}
+
+function DesktopCollectionsDemo(): ReactElement {
+  const [collections, setCollections] = useState<Collection[]>([])
+  const [unsectionedIds, setUnsectionedIds] = useState<string[]>(
+    MOCK_TEMPLATES.map((t) => t.id)
+  )
+  const [openCollectionId, setOpenCollectionId] = useState<string | null>(null)
+  const [activeTemplateId, setActiveTemplateId] = useState<string | null>(null)
+  const [previewOpen, setPreviewOpen] = useState(false)
+
+  // Resize
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [topRatio, setTopRatio] = useState(0.4)
+  const [isResizing, setIsResizing] = useState(false)
+
+  // Filters
+  const [searchQuery, setSearchQuery] = useState('')
+  const [filterStatus, setFilterStatus] = useState<JourneyStatus>('active')
+  const [sortOrder, setSortOrder] = useState<SortOrder | undefined>()
+
+  const mouseSensor = useSensor(MouseSensor, {
+    activationConstraint: { distance: 8 }
+  })
+  const touchSensor = useSensor(TouchSensor, {
+    activationConstraint: { delay: 200, tolerance: 5 }
+  })
+  const sensors = useSensors(mouseSensor, touchSensor)
+
+  const openCollection =
+    collections.find((c) => c.id === openCollectionId) ?? null
+
+  // --- Handlers ---
+
+  const handleDragStart = (event: DragStartEvent): void => {
+    setActiveTemplateId(event.active.id as string)
+  }
+
+  const handleDragEnd = (event: DragEndEvent): void => {
+    setActiveTemplateId(null)
+    const { active, over } = event
+    if (over == null) return
+
+    const templateId = active.id as string
+    const targetZone = over.id as string
+
+    const isInUnsectioned = unsectionedIds.includes(templateId)
+    const sourceCollection = collections.find((c) =>
+      c.templateIds.includes(templateId)
+    )
+    const targetCollection = collections.find((c) => c.id === targetZone)
+
+    // Block drag into/out of published collections
+    if (targetCollection?.isPublished === true) return
+    if (sourceCollection?.isPublished === true) return
+
+    // Validate target is a known zone
+    const isValidTarget =
+      targetZone === 'unsectioned' ||
+      targetZone === CREATE_COLLECTION_DROP_ID ||
+      targetCollection != null
+    if (!isValidTarget) return
+
+    // No-op if dropping on the same zone
+    if (isInUnsectioned && targetZone === 'unsectioned') return
+    if (sourceCollection != null && sourceCollection.id === targetZone) return
+
+    // Remove from source
+    if (isInUnsectioned) {
+      setUnsectionedIds((prev) => prev.filter((id) => id !== templateId))
+    } else if (sourceCollection != null) {
+      setCollections((prev) =>
+        prev.map((c) =>
+          c.id === sourceCollection.id
+            ? {
+                ...c,
+                templateIds: c.templateIds.filter((id) => id !== templateId)
+              }
+            : c
+        )
+      )
+    }
+
+    // Add to target
+    if (targetZone === 'unsectioned') {
+      setUnsectionedIds((prev) => [...prev, templateId])
+    } else if (targetZone === CREATE_COLLECTION_DROP_ID) {
+      const existingTitles = new Set(collections.map((c) => c.title))
+      let title = 'New Collection'
+      if (existingTitles.has(title)) {
+        let counter = 2
+        while (existingTitles.has(`New Collection ${counter}`)) counter++
+        title = `New Collection ${counter}`
+      }
+      const id = `collection-${Date.now()}`
+      setCollections((prev) => [
+        ...prev,
+        {
+          id,
+          title,
+          description: '',
+          pageDescription: '',
+          creatorName: '',
+          creatorImageUrl: '',
+          pdfVideoUrl: '',
+          templateIds: [templateId],
+          backgroundColor: getNextPastelColor(
+            new Set(collections.map((c) => c.backgroundColor))
+          ),
+          isPublished: false
+        }
+      ])
+    } else {
+      setCollections((prev) =>
+        prev.map((c) =>
+          c.id === targetZone
+            ? { ...c, templateIds: [...c.templateIds, templateId] }
+            : c
+        )
+      )
+    }
+  }
+
+  const handleAddCollection = (): void => {
+    const existingTitles = new Set(collections.map((c) => c.title))
+    let title = 'New Collection'
+    if (existingTitles.has(title)) {
+      let counter = 2
+      while (existingTitles.has(`New Collection ${counter}`)) counter++
+      title = `New Collection ${counter}`
+    }
+
+    const id = `collection-${Date.now()}`
+    setCollections((prev) => [
+      ...prev,
+      {
+        id,
+        title,
+        description: '',
+        pageDescription: '',
+        creatorName: '',
+        creatorImageUrl: '',
+        pdfVideoUrl: '',
+        templateIds: [],
+        backgroundColor: getNextPastelColor(
+          new Set(prev.map((c) => c.backgroundColor))
+        ),
+        isPublished: false
+      }
+    ])
+    setOpenCollectionId(id)
+  }
+
+  const handleDeleteCollection = (collectionId: string): void => {
+    const collection = collections.find((c) => c.id === collectionId)
+    if (collection == null) return
+    setUnsectionedIds((prev) => [...prev, ...collection.templateIds])
+    setCollections((prev) => prev.filter((c) => c.id !== collectionId))
+    if (openCollectionId === collectionId) setOpenCollectionId(null)
+  }
+
+  const handleUpdateCollection = useCallback(
+    (id: string, updates: Partial<Collection>): void => {
+      setCollections((prev) =>
+        prev.map((c) => (c.id === id ? { ...c, ...updates } : c))
+      )
+    },
+    []
+  )
+
+  const handleTogglePublish = (collectionId: string): void => {
+    setCollections((prev) =>
+      prev.map((c) =>
+        c.id === collectionId ? { ...c, isPublished: !c.isPublished } : c
+      )
+    )
+  }
+
+  const handleRemoveTemplate = (
+    collectionId: string,
+    templateId: string
+  ): void => {
+    const collection = collections.find((c) => c.id === collectionId)
+    if (collection?.isPublished === true) return
+
+    setCollections((prev) =>
+      prev.map((c) =>
+        c.id === collectionId
+          ? {
+              ...c,
+              templateIds: c.templateIds.filter((id) => id !== templateId)
+            }
+          : c
+      )
+    )
+    setUnsectionedIds((prev) => [...prev, templateId])
+  }
+
+  const handleOpenCollection = (collectionId: string): void => {
+    setOpenCollectionId(collectionId)
+  }
+
+  const handleCloseCollection = (): void => {
+    setOpenCollectionId(null)
+  }
+
+  // Resize handle between sections
+  const handleResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    setIsResizing(true)
+    const startY = e.clientY
+    const container = containerRef.current
+    if (container == null) return
+    const containerHeight = container.getBoundingClientRect().height
+    const handleHeight = 8
+    const usableHeight = containerHeight - handleHeight
+
+    const handleMouseMove = (moveEvent: MouseEvent): void => {
+      const offsetY =
+        moveEvent.clientY - container.getBoundingClientRect().top
+      const minRatio = MIN_COLLECTIONS_HEIGHT / usableHeight
+      const maxRatio = 1 - MIN_TEMPLATES_HEIGHT / usableHeight
+      const newRatio = Math.max(
+        minRatio,
+        Math.min(offsetY / usableHeight, maxRatio)
+      )
+      setTopRatio(newRatio)
+    }
+    const handleMouseUp = (): void => {
+      setIsResizing(false)
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mouseup', handleMouseUp)
+    }
+    document.addEventListener('mousemove', handleMouseMove)
+    document.addEventListener('mouseup', handleMouseUp)
+  }, [])
+
+  // Filtered templates
+  const filteredUnsectionedIds =
+    searchQuery.trim() === ''
+      ? unsectionedIds
+      : unsectionedIds.filter((id) => {
+          const t = getTemplateById(id)
+          return (
+            t != null &&
+            t.title.toLowerCase().includes(searchQuery.toLowerCase())
+          )
+        })
+
+  const activeTemplate =
+    activeTemplateId != null ? getTemplateById(activeTemplateId) : null
+
+  return (
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <Stack
+        direction="row"
+        spacing={3}
+        sx={{
+          mt: { xs: 3, sm: 2 },
+          height: 'calc(100vh - 140px)',
+          alignItems: 'stretch'
+        }}
+      >
+        {/* Main content */}
+        <Box
+          ref={containerRef}
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: 0,
+            userSelect: isResizing ? 'none' : 'auto'
+          }}
+        >
+          {/* Collections section */}
+          <CollectionsDropZone
+            collectionId={openCollection?.id ?? null}
+            isPublished={openCollection?.isPublished === true}
+            sx={{
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: 3,
+              p: 3,
+              flex: `${topRatio} 0 0`,
+              display: 'flex',
+              flexDirection: 'column',
+              minHeight: MIN_COLLECTIONS_HEIGHT,
+              overflow: 'hidden',
+              backgroundColor:
+                openCollection?.backgroundColor ?? 'transparent',
+              transition: 'background-color 0.3s ease'
+            }}
+          >
+            {/* Breadcrumb header */}
+            <Stack
+              direction="row"
+              alignItems="center"
+              spacing={0.5}
+              sx={{ mb: 1, flexShrink: 0 }}
+            >
+              <Typography
+                variant="h6"
+                onClick={
+                  openCollection != null ? handleCloseCollection : undefined
+                }
+                sx={{
+                  fontWeight: 600,
+                  cursor: openCollection != null ? 'pointer' : 'default',
+                  '&:hover':
+                    openCollection != null ? { color: 'primary.main' } : {}
+                }}
+              >
+                Collections
+              </Typography>
+              <Fade in={openCollection != null} timeout={300} unmountOnExit>
+                <Stack direction="row" alignItems="center" spacing={0.5}>
+                  <ChevronRightIcon
+                    sx={{ fontSize: 20, color: 'text.secondary' }}
+                  />
+                  <Box
+                    sx={{
+                      width: 10,
+                      height: 10,
+                      borderRadius: '50%',
+                      backgroundColor:
+                        openCollection?.backgroundColor ?? 'transparent',
+                      border: '1.5px solid rgba(0,0,0,0.15)',
+                      flexShrink: 0
+                    }}
+                  />
+                  <Typography variant="h6" sx={{ fontWeight: 600 }}>
+                    {openCollection?.title}
+                  </Typography>
+                </Stack>
+              </Fade>
+            </Stack>
+
+            {/* Content */}
+            <Fade
+              key={openCollection != null ? 'open' : 'grid'}
+              in
+              timeout={250}
+            >
+            <Box sx={{ flex: 1, overflowY: 'auto', minHeight: 0 }}>
+              {openCollection != null ? (
+                // Opened collection — same card style as All Templates
+                openCollection.templateIds.length === 0 ? (
+                  <Box
+                    sx={{
+                      py: 4,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center'
+                    }}
+                  >
+                    <Typography variant="body2" color="text.secondary">
+                      Drag templates here from All Templates below.
+                    </Typography>
+                  </Box>
+                ) : (
+                  <Grid container spacing={2} rowSpacing={2}>
+                    {openCollection.templateIds.map((tmplId) => {
+                      const template = getTemplateById(tmplId)
+                      if (template == null) return null
+                      return (
+                        <Grid
+                          key={tmplId}
+                          size={{ xs: 12, sm: 6, lg: 4, xl: 3 }}
+                        >
+                          <MockTemplateCard
+                            template={template}
+                            dragDisabled={openCollection.isPublished}
+                          />
+                        </Grid>
+                      )
+                    })}
+                  </Grid>
+                )
+              ) : (
+                <Box
+                  sx={{ display: 'flex', flexWrap: 'wrap', gap: 1.5 }}
+                >
+                  {/* Always-first create card */}
+                  <CreateCollectionDropTarget
+                    onClick={handleAddCollection}
+                  />
+                  {collections.map((collection) => (
+                    <Box
+                      key={collection.id}
+                      sx={{ width: COLLECTION_CARD_WIDTHS }}
+                    >
+                      <CollectionCard
+                        collection={collection}
+                        onOpen={handleOpenCollection}
+                        onTogglePublish={handleTogglePublish}
+                      />
+                    </Box>
+                  ))}
+                </Box>
+              )}
+            </Box>
+            </Fade>
+          </CollectionsDropZone>
+
+          {/* Resize handle */}
+          <Box
+            onMouseDown={handleResizeStart}
+            sx={{
+              height: 8,
+              flexShrink: 0,
+              cursor: 'row-resize',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              '&:hover': { '& > div': { backgroundColor: 'error.dark' } }
+            }}
+          >
+            <Box
+              sx={{
+                width: 40,
+                height: 3,
+                borderRadius: 1.5,
+                backgroundColor: 'error.main',
+                transition: 'background-color 0.2s ease'
+              }}
+            />
+          </Box>
+
+          {/* All Templates section */}
+          <Box
+            sx={{
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: 3,
+              p: 3,
+              flex: `${1 - topRatio} 0 0`,
+              display: 'flex',
+              flexDirection: 'column',
+              minHeight: MIN_TEMPLATES_HEIGHT,
+              overflow: 'hidden'
+            }}
+          >
+            <Stack
+              direction="row"
+              alignItems="center"
+              spacing={2}
+              sx={{ mb: 2, flexShrink: 0 }}
+            >
+              <Typography variant="h6" sx={{ fontWeight: 600 }}>
+                All Templates
+                <Typography
+                  component="span"
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ ml: 1 }}
+                >
+                  ({filteredUnsectionedIds.length})
+                </Typography>
+              </Typography>
+              <Box sx={{ flexGrow: 1 }} />
+              <TextField
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                size="small"
+                placeholder="Search..."
+                aria-label="search templates"
+                sx={{ width: 200 }}
+                slotProps={{
+                  input: {
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <SearchIcon sx={{ fontSize: 18 }} />
+                      </InputAdornment>
+                    )
+                  }
+                }}
+              />
+              <JourneyStatusFilter
+                status={filterStatus}
+                onChange={setFilterStatus}
+              />
+              <JourneySort sortOrder={sortOrder} onChange={setSortOrder} />
+            </Stack>
+
+            <DroppableZone id="unsectioned">
+              <Box sx={{ flex: 1, overflowY: 'auto', minHeight: 0 }}>
+                <Grid container spacing={2} rowSpacing={2}>
+                  {filteredUnsectionedIds.map((tmplId) => {
+                    const template = getTemplateById(tmplId)
+                    if (template == null) return null
+                    return (
+                      <Grid
+                        key={tmplId}
+                        size={{ xs: 12, sm: 6, lg: 4, xl: 3 }}
+                      >
+                        <MockTemplateCard template={template} />
+                      </Grid>
+                    )
+                  })}
+                </Grid>
+                {filteredUnsectionedIds.length === 0 && (
+                  <Box
+                    sx={{
+                      py: 4,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center'
+                    }}
+                  >
+                    <Typography variant="body2" color="text.secondary">
+                      {searchQuery.trim() !== ''
+                        ? 'No templates match your search.'
+                        : 'All templates are in collections.'}
+                    </Typography>
+                  </Box>
+                )}
+              </Box>
+            </DroppableZone>
+          </Box>
+        </Box>
+
+        {/* Right: Side panel */}
+        <Box
+          sx={{
+            width: PANEL_WIDTH,
+            flexShrink: 0,
+            display: { xs: 'none', md: 'flex' },
+            flexDirection: 'column',
+            backgroundColor: 'background.paper',
+            borderRadius: '12px',
+            border: '1px solid',
+            borderColor: 'divider',
+            overflow: 'hidden',
+            zIndex: (theme) => theme.zIndex.modal,
+            position: 'relative'
+          }}
+        >
+          <Fade
+            key={openCollection != null ? 'editor' : 'info'}
+            in
+            timeout={300}
+          >
+            <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+              {openCollection != null ? (
+                <CollectionSidePanel
+                  collection={openCollection}
+                  onClose={handleCloseCollection}
+                  onUpdateCollection={handleUpdateCollection}
+                  onDeleteCollection={handleDeleteCollection}
+                  onPreview={() => setPreviewOpen((prev) => !prev)}
+                  isPreviewOpen={previewOpen}
+                />
+              ) : (
+                <TemplateInfoPanel />
+              )}
+            </Box>
+          </Fade>
+        </Box>
+      </Stack>
+
+      {/* Shared backdrop — behind both preview modal and side panel */}
+      {openCollection != null && previewOpen && (
+        <Box
+          onClick={() => setPreviewOpen(false)}
+          sx={{
+            position: 'fixed',
+            inset: 0,
+            backgroundColor: 'rgba(0,0,0,0.5)',
+            zIndex: (theme) => theme.zIndex.modal - 1
+          }}
+        />
+      )}
+
+      {/* Preview modal — centered */}
+      {openCollection != null && previewOpen && (
+          <Dialog
+            open
+            onClose={() => setPreviewOpen(false)}
+            maxWidth="sm"
+            fullWidth
+            hideBackdrop
+            disableEnforceFocus
+            disableAutoFocus
+            disableRestoreFocus
+            sx={{
+              pointerEvents: 'none',
+              '& .MuiDialog-paper': {
+                pointerEvents: 'auto',
+                height: '80vh',
+                maxHeight: 720,
+                aspectRatio: '16 / 10'
+              }
+            }}
+          >
+            <DialogTitle sx={{ pb: 1 }}>
+              <Stack
+                direction="row"
+                alignItems="center"
+                justifyContent="space-between"
+              >
+                <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                  Page Preview
+                </Typography>
+                <Button
+                  size="small"
+                  onClick={() => setPreviewOpen(false)}
+                  sx={{ textTransform: 'none' }}
+                >
+                  Close
+                </Button>
+              </Stack>
+            </DialogTitle>
+            <Divider />
+            <DialogContent sx={{ p: 0 }}>
+              <CollectionPreview collection={openCollection} />
+            </DialogContent>
+          </Dialog>
+        )}
+
+      {/* Drag Overlay */}
+      <DragOverlay>
+        {activeTemplate != null ? (
+          <Box sx={{ width: 240 }}>
+            <MockTemplateCard template={activeTemplate} isDragOverlay />
+          </Box>
+        ) : null}
+      </DragOverlay>
+    </DndContext>
+  )
+}
+
+export function CollectionsDemo(): ReactElement {
+  const breakpoints = useBreakpoints()
+
+  if (!breakpoints.sm) {
+    return <MobileCollectionsDemo />
+  }
+
+  return <DesktopCollectionsDemo />
+}

--- a/apps/journeys-admin/src/components/CollectionsDemo/FloatingActionBar.tsx
+++ b/apps/journeys-admin/src/components/CollectionsDemo/FloatingActionBar.tsx
@@ -1,0 +1,102 @@
+import AddIcon from '@mui/icons-material/Add'
+import MenuBookIcon from '@mui/icons-material/MenuBook'
+import SearchIcon from '@mui/icons-material/Search'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import InputAdornment from '@mui/material/InputAdornment'
+import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+import { ReactElement } from 'react'
+
+import type { JourneyStatus } from '../JourneyList/JourneyListView/JourneyListView'
+import { JourneySort, SortOrder } from '../JourneyList/JourneySort'
+import { JourneyStatusFilter } from '../JourneyList/JourneyStatusFilter'
+
+interface FloatingActionBarProps {
+  onAddCollection: () => void
+  onToggleHelp: () => void
+  searchQuery: string
+  onSearchChange: (query: string) => void
+  filterStatus: JourneyStatus
+  onFilterStatusChange: (status: JourneyStatus) => void
+  sortOrder: SortOrder | undefined
+  onSortOrderChange: (order: SortOrder) => void
+}
+
+export function FloatingActionBar({
+  onAddCollection,
+  onToggleHelp,
+  searchQuery,
+  onSearchChange,
+  filterStatus,
+  onFilterStatusChange,
+  sortOrder,
+  onSortOrderChange
+}: FloatingActionBarProps): ReactElement {
+  return (
+    <Box
+      sx={{
+        position: 'absolute',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        backgroundColor: 'background.paper',
+        borderTop: '1px solid',
+        borderColor: 'divider',
+        boxShadow: '0 -4px 20px rgba(0,0,0,0.08)',
+        zIndex: 10,
+        borderRadius: '12px 12px 0 0'
+      }}
+    >
+      <Stack
+        direction="row"
+        alignItems="center"
+        spacing={1.5}
+        sx={{ px: 2, py: 1 }}
+      >
+        <TextField
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+          size="small"
+          placeholder="Search templates..."
+          aria-label="search templates"
+          sx={{ width: 200 }}
+          slotProps={{
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon sx={{ fontSize: 18 }} />
+                </InputAdornment>
+              )
+            }
+          }}
+        />
+        <Button
+          size="small"
+          variant="text"
+          startIcon={<MenuBookIcon sx={{ fontSize: 16 }} />}
+          onClick={onToggleHelp}
+          sx={{ textTransform: 'none', color: 'text.secondary', flexShrink: 0 }}
+        >
+          Guide
+        </Button>
+        <Button
+          size="small"
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={onAddCollection}
+          aria-label="create new collection"
+          sx={{ flexShrink: 0 }}
+        >
+          Collection
+        </Button>
+        <Box sx={{ flexGrow: 1 }} />
+        <JourneyStatusFilter
+          status={filterStatus}
+          onChange={onFilterStatusChange}
+        />
+        <JourneySort sortOrder={sortOrder} onChange={onSortOrderChange} />
+      </Stack>
+    </Box>
+  )
+}

--- a/apps/journeys-admin/src/components/CollectionsDemo/HelpBanner.tsx
+++ b/apps/journeys-admin/src/components/CollectionsDemo/HelpBanner.tsx
@@ -1,0 +1,69 @@
+import MenuBookIcon from '@mui/icons-material/MenuBook'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Card from '@mui/material/Card'
+import IconButton from '@mui/material/IconButton'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { ReactElement } from 'react'
+
+import X2Icon from '@core/shared/ui/icons/X2'
+
+interface HelpBannerProps {
+  dismissed: boolean
+  onDismiss: () => void
+  onReopen: () => void
+}
+
+export function HelpBanner({
+  dismissed,
+  onDismiss,
+  onReopen
+}: HelpBannerProps): ReactElement {
+  if (dismissed) {
+    return (
+      <Button
+        size="small"
+        variant="text"
+        startIcon={<MenuBookIcon sx={{ fontSize: 16 }} />}
+        onClick={onReopen}
+        aria-label="show help guide"
+        sx={{ mb: 1.5, textTransform: 'none', color: 'text.secondary' }}
+      >
+        Guide
+      </Button>
+    )
+  }
+
+  return (
+    <Card
+      variant="outlined"
+      sx={{
+        mb: 2,
+        p: 2,
+        backgroundColor: '#E3F2FD',
+        borderColor: 'rgba(0,0,0,0.08)'
+      }}
+    >
+      <Stack direction="row" alignItems="flex-start" spacing={1}>
+        <Box sx={{ flex: 1 }}>
+          <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+            Getting Started with Collections
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ lineHeight: 1.5 }}>
+            Create collections to organize and publish groups of templates.
+            Drag templates from the right panel into collections on the left.
+            Each collection can be published independently as its own page.
+          </Typography>
+        </Box>
+        <IconButton
+          size="small"
+          onClick={onDismiss}
+          aria-label="dismiss help banner"
+        >
+          <X2Icon sx={{ fontSize: 18 }} />
+        </IconButton>
+      </Stack>
+    </Card>
+  )
+}

--- a/apps/journeys-admin/src/components/CollectionsDemo/MobileCollectionsDemo.tsx
+++ b/apps/journeys-admin/src/components/CollectionsDemo/MobileCollectionsDemo.tsx
@@ -1,0 +1,862 @@
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
+  MouseSensor,
+  TouchSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors
+} from '@dnd-kit/core'
+import AddIcon from '@mui/icons-material/Add'
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
+import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
+import SearchIcon from '@mui/icons-material/Search'
+import Avatar from '@mui/material/Avatar'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Card from '@mui/material/Card'
+import Chip from '@mui/material/Chip'
+import Dialog from '@mui/material/Dialog'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import Divider from '@mui/material/Divider'
+import IconButton from '@mui/material/IconButton'
+import InputAdornment from '@mui/material/InputAdornment'
+import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+import Typography from '@mui/material/Typography'
+import { ReactElement, useCallback, useRef, useState } from 'react'
+import { A11y } from 'swiper/modules'
+import { Swiper, SwiperSlide } from 'swiper/react'
+import type { SwiperClass } from 'swiper/react'
+
+import ChevronDownIcon from '@core/shared/ui/icons/ChevronDown'
+import X2Icon from '@core/shared/ui/icons/X2'
+
+
+import type { JourneyStatus } from '../JourneyList/JourneyListView/JourneyListView'
+import { JourneySort, SortOrder } from '../JourneyList/JourneySort'
+import { JourneyStatusFilter } from '../JourneyList/JourneyStatusFilter'
+
+import { CollectionPreview } from './CollectionPreview'
+import { CollectionSidePanel } from './CollectionSidePanel'
+import {
+  Collection,
+  MOCK_TEMPLATES,
+  MockTemplate,
+  getNextPastelColor
+} from './mockData'
+
+import 'swiper/css'
+
+function getTemplateById(id: string): MockTemplate | undefined {
+  return MOCK_TEMPLATES.find((t) => t.id === id)
+}
+
+// Droppable chip for a collection in the horizontal scroll
+function CollectionChip({
+  collection,
+  isActive,
+  onClick
+}: {
+  collection: Collection
+  isActive: boolean
+  onClick: () => void
+}): ReactElement {
+  const { isOver, setNodeRef } = useDroppable({ id: collection.id })
+
+  return (
+    <Chip
+      ref={setNodeRef}
+      label={
+        <Stack direction="row" spacing={0.5} alignItems="center">
+          <Typography variant="caption" sx={{ fontWeight: 600 }}>
+            {collection.title}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            ({collection.templateIds.length})
+          </Typography>
+        </Stack>
+      }
+      onClick={onClick}
+      sx={{
+        height: 36,
+        borderRadius: 2,
+        backgroundColor: collection.backgroundColor,
+        border: '2px solid',
+        borderColor: isOver
+          ? 'primary.main'
+          : isActive
+            ? 'primary.main'
+            : 'rgba(0,0,0,0.08)',
+        borderStyle: isOver ? 'dashed' : 'solid',
+        cursor: 'pointer',
+        flexShrink: 0,
+        '& .MuiChip-label': { px: 1.5 }
+      }}
+    />
+  )
+}
+
+function OpenCollectionDropZone({
+  collectionId,
+  isPublished,
+  backgroundColor,
+  children
+}: {
+  collectionId: string
+  isPublished: boolean
+  backgroundColor: string
+  children: ReactElement | ReactElement[]
+}): ReactElement {
+  const { isOver, setNodeRef } = useDroppable({ id: collectionId })
+
+  return (
+    <Box
+      ref={setNodeRef}
+      sx={{
+        // ~52px per line item (36px height + 8px padding + 8px gap) * 6 + 16px container padding
+        maxHeight: 328,
+        overflowY: 'auto',
+        backgroundColor,
+        borderRadius: 2,
+        p: 2,
+        flexShrink: 0,
+        border: isOver
+          ? isPublished
+            ? '2px dashed'
+            : '2px dashed'
+          : '2px solid transparent',
+        borderColor: isOver
+          ? isPublished
+            ? 'text.disabled'
+            : 'primary.main'
+          : 'transparent',
+        transition: 'all 0.2s ease'
+      }}
+    >
+      {children}
+    </Box>
+  )
+}
+
+function DroppableAllTemplates({
+  children
+}: {
+  children: ReactElement
+}): ReactElement {
+  const { isOver, setNodeRef } = useDroppable({ id: 'unsectioned' })
+  return (
+    <Box
+      ref={setNodeRef}
+      sx={{
+        flex: 1,
+        minHeight: 0,
+        borderRadius: 2,
+        border: isOver ? '2px dashed' : '2px dashed transparent',
+        borderColor: isOver ? 'primary.main' : 'transparent',
+        backgroundColor: isOver ? 'action.hover' : 'transparent',
+        transition: 'all 0.2s ease',
+        display: 'flex',
+        flexDirection: 'column'
+      }}
+    >
+      {children}
+    </Box>
+  )
+}
+
+// Template line item for mobile
+function TemplateLineItem({
+  template,
+  dragDisabled = false,
+  draggable = false
+}: {
+  template: MockTemplate
+  dragDisabled?: boolean
+  draggable?: boolean
+}): ReactElement {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: draggable ? template.id : `static-${template.id}`,
+    disabled: !draggable || dragDisabled
+  })
+
+  return (
+    <Card
+      ref={draggable ? setNodeRef : undefined}
+      variant="outlined"
+      {...(draggable && !dragDisabled ? { ...attributes, ...listeners } : {})}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1.5,
+        p: 1,
+        opacity: isDragging ? 0.3 : 1,
+        cursor: draggable && !dragDisabled ? 'grab' : 'default',
+        touchAction: 'none'
+      }}
+    >
+      <Box
+        component="img"
+        src={template.imageUrl}
+        alt={template.title}
+        sx={{
+          width: 48,
+          height: 36,
+          borderRadius: 1,
+          objectFit: 'cover',
+          flexShrink: 0
+        }}
+      />
+      <Box sx={{ flex: 1, minWidth: 0, overflow: 'hidden', pr: 1 }}>
+        <Typography
+          variant="caption"
+          sx={{ fontWeight: 600, display: 'block' }}
+          noWrap
+        >
+          {template.title}
+        </Typography>
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ display: 'block' }}
+          noWrap
+        >
+          {template.description}
+        </Typography>
+      </Box>
+      <Chip
+        size="small"
+        label={template.languageCode}
+        sx={{ fontSize: 10, height: 18, flexShrink: 0 }}
+      />
+    </Card>
+  )
+}
+
+export function MobileCollectionsDemo(): ReactElement {
+  const [collections, setCollections] = useState<Collection[]>([])
+  const [unsectionedIds, setUnsectionedIds] = useState<string[]>(
+    MOCK_TEMPLATES.map((t) => t.id)
+  )
+  const [openCollectionId, setOpenCollectionId] = useState<string | null>(null)
+  const [activeTemplateId, setActiveTemplateId] = useState<string | null>(null)
+  const [editModalOpen, setEditModalOpen] = useState(false)
+  const [helpModalOpen, setHelpModalOpen] = useState(false)
+  const swiperRef = useRef<SwiperClass | null>(null)
+  const [activeSlide, setActiveSlide] = useState(0)
+
+  const [searchQuery, setSearchQuery] = useState('')
+  const [filterStatus, setFilterStatus] = useState<JourneyStatus>('active')
+  const [sortOrder, setSortOrder] = useState<SortOrder | undefined>()
+
+  const mouseSensor = useSensor(MouseSensor, {
+    activationConstraint: { distance: 8 }
+  })
+  const touchSensor = useSensor(TouchSensor, {
+    activationConstraint: { delay: 200, tolerance: 5 }
+  })
+  const sensors = useSensors(mouseSensor, touchSensor)
+
+  const openCollection =
+    collections.find((c) => c.id === openCollectionId) ?? null
+
+  // --- Handlers ---
+
+  const handleDragStart = (event: DragStartEvent): void => {
+    setActiveTemplateId(event.active.id as string)
+  }
+
+  const handleDragEnd = (event: DragEndEvent): void => {
+    setActiveTemplateId(null)
+    const { active, over } = event
+    if (over == null) return
+
+    const templateId = active.id as string
+    const targetZone = over.id as string
+
+    const isInUnsectioned = unsectionedIds.includes(templateId)
+    const sourceCollection = collections.find((c) =>
+      c.templateIds.includes(templateId)
+    )
+    const targetCollection = collections.find((c) => c.id === targetZone)
+
+    if (targetCollection?.isPublished === true) return
+    if (sourceCollection?.isPublished === true) return
+
+    const isValidTarget =
+      targetZone === 'unsectioned' || targetCollection != null
+    if (!isValidTarget) return
+    if (isInUnsectioned && targetZone === 'unsectioned') return
+    if (sourceCollection != null && sourceCollection.id === targetZone) return
+
+    if (isInUnsectioned) {
+      setUnsectionedIds((prev) => prev.filter((id) => id !== templateId))
+    } else if (sourceCollection != null) {
+      setCollections((prev) =>
+        prev.map((c) =>
+          c.id === sourceCollection.id
+            ? {
+                ...c,
+                templateIds: c.templateIds.filter((id) => id !== templateId)
+              }
+            : c
+        )
+      )
+    }
+
+    if (targetZone === 'unsectioned') {
+      setUnsectionedIds((prev) => [...prev, templateId])
+    } else {
+      setCollections((prev) =>
+        prev.map((c) =>
+          c.id === targetZone
+            ? { ...c, templateIds: [...c.templateIds, templateId] }
+            : c
+        )
+      )
+    }
+  }
+
+  const handleAddCollection = (): void => {
+    const existingTitles = new Set(collections.map((c) => c.title))
+    let title = 'New Collection'
+    if (existingTitles.has(title)) {
+      let counter = 2
+      while (existingTitles.has(`New Collection ${counter}`)) counter++
+      title = `New Collection ${counter}`
+    }
+    setCollections((prev) => [
+      ...prev,
+      {
+        id: `collection-${Date.now()}`,
+        title,
+        description: '',
+        pageDescription: '',
+        creatorName: '',
+        creatorImageUrl: '',
+        pdfVideoUrl: '',
+        templateIds: [],
+        backgroundColor: getNextPastelColor(
+          new Set(prev.map((c) => c.backgroundColor))
+        ),
+        isPublished: false
+      }
+    ])
+  }
+
+  const handleDeleteCollection = (collectionId: string): void => {
+    const collection = collections.find((c) => c.id === collectionId)
+    if (collection == null) return
+    setUnsectionedIds((prev) => [...prev, ...collection.templateIds])
+    setCollections((prev) => prev.filter((c) => c.id !== collectionId))
+    if (openCollectionId === collectionId) {
+      setOpenCollectionId(null)
+      setEditModalOpen(false)
+    }
+  }
+
+  const handleUpdateCollection = useCallback(
+    (id: string, updates: Partial<Collection>): void => {
+      setCollections((prev) =>
+        prev.map((c) => (c.id === id ? { ...c, ...updates } : c))
+      )
+    },
+    []
+  )
+
+  const handleRemoveTemplate = (
+    collectionId: string,
+    templateId: string
+  ): void => {
+    const collection = collections.find((c) => c.id === collectionId)
+    if (collection?.isPublished === true) return
+    setCollections((prev) =>
+      prev.map((c) =>
+        c.id === collectionId
+          ? {
+              ...c,
+              templateIds: c.templateIds.filter((id) => id !== templateId)
+            }
+          : c
+      )
+    )
+    setUnsectionedIds((prev) => [...prev, templateId])
+  }
+
+  const filteredUnsectionedIds =
+    searchQuery.trim() === ''
+      ? unsectionedIds
+      : unsectionedIds.filter((id) => {
+          const t = getTemplateById(id)
+          return (
+            t != null &&
+            t.title.toLowerCase().includes(searchQuery.toLowerCase())
+          )
+        })
+
+  const activeTemplate =
+    activeTemplateId != null ? getTemplateById(activeTemplateId) : null
+
+  return (
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <Box
+        sx={{
+          mt: 2,
+          display: 'flex',
+          flexDirection: 'column',
+          height: 'calc(100vh - 120px)'
+        }}
+      >
+        {/* Collections horizontal bar */}
+        <Box sx={{ mb: 2, flexShrink: 0 }}>
+          <Stack
+            direction="row"
+            alignItems="center"
+            spacing={1}
+            sx={{ mb: 1 }}
+          >
+            <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+              {openCollection != null ? (
+                <Stack direction="row" alignItems="center" spacing={0.5}>
+                  <Box
+                    component="span"
+                    onClick={() => setOpenCollectionId(null)}
+                    sx={{ cursor: 'pointer', '&:hover': { color: 'primary.main' } }}
+                  >
+                    Collections
+                  </Box>
+                  <ChevronRightIcon
+                    sx={{ fontSize: 18, color: 'text.secondary' }}
+                  />
+                  <Box
+                    component="span"
+                    sx={{
+                      width: 8,
+                      height: 8,
+                      borderRadius: '50%',
+                      backgroundColor: openCollection.backgroundColor,
+                      display: 'inline-block',
+                      border: '1px solid rgba(0,0,0,0.15)'
+                    }}
+                  />
+                  <span>{openCollection.title}</span>
+                </Stack>
+              ) : (
+                'Collections'
+              )}
+            </Typography>
+            <Box sx={{ flexGrow: 1 }} />
+            {openCollection != null && (
+              <Button
+                size="small"
+                variant="outlined"
+                onClick={() => setEditModalOpen(true)}
+                sx={{ textTransform: 'none', fontSize: 12 }}
+              >
+                Edit
+              </Button>
+            )}
+            {openCollection == null && (
+              <IconButton
+                size="small"
+                onClick={handleAddCollection}
+                aria-label="create new collection"
+              >
+                <AddIcon fontSize="small" />
+              </IconButton>
+            )}
+            <IconButton
+              size="small"
+              onClick={() => setHelpModalOpen(true)}
+              aria-label="open help"
+            >
+              <HelpOutlineIcon fontSize="small" />
+            </IconButton>
+          </Stack>
+
+          {/* Horizontal scroll of collection chips */}
+          {openCollection == null && (
+            <Stack
+              direction="row"
+              spacing={1}
+              sx={{
+                overflowX: 'auto',
+                pb: 1,
+                '&::-webkit-scrollbar': { height: 4 },
+                '&::-webkit-scrollbar-thumb': {
+                  borderRadius: 2,
+                  backgroundColor: 'rgba(0,0,0,0.1)'
+                }
+              }}
+            >
+              {collections.map((c) => (
+                <CollectionChip
+                  key={c.id}
+                  collection={c}
+                  isActive={false}
+                  onClick={() => setOpenCollectionId(c.id)}
+                />
+              ))}
+              {collections.length === 0 && (
+                <Typography variant="caption" color="text.secondary">
+                  No collections yet. Tap + to create one.
+                </Typography>
+              )}
+            </Stack>
+          )}
+        </Box>
+
+        {/* Opened collection — droppable, with draggable templates */}
+        {openCollection != null && (
+          <OpenCollectionDropZone
+            collectionId={openCollection.id}
+            isPublished={openCollection.isPublished}
+            backgroundColor={openCollection.backgroundColor}
+          >
+            {openCollection.templateIds.length === 0 ? (
+              <Box
+                sx={{
+                  py: 3,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center'
+                }}
+              >
+                <Typography variant="body2" color="text.secondary">
+                  Drag templates here from below.
+                </Typography>
+              </Box>
+            ) : (
+              <Stack spacing={1} sx={{ overflowY: 'auto' }}>
+                {openCollection.templateIds.map((id) => {
+                  const tmpl = getTemplateById(id)
+                  if (tmpl == null) return null
+                  return (
+                    <TemplateLineItem
+                      key={id}
+                      template={tmpl}
+                      draggable
+                      dragDisabled={openCollection.isPublished}
+                    />
+                  )
+                })}
+              </Stack>
+            )}
+          </OpenCollectionDropZone>
+        )}
+
+        {/* All Templates */}
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: 0,
+            mt: openCollection != null ? 2 : 0
+          }}
+        >
+          <Stack
+            direction="row"
+            alignItems="center"
+            spacing={1}
+            sx={{ mb: 1, flexShrink: 0 }}
+          >
+            <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+              All Templates ({filteredUnsectionedIds.length})
+            </Typography>
+            <Box sx={{ flexGrow: 1 }} />
+            <TextField
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              size="small"
+              placeholder="Search..."
+              aria-label="search templates"
+              sx={{ width: 140 }}
+              slotProps={{
+                input: {
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <SearchIcon sx={{ fontSize: 16 }} />
+                    </InputAdornment>
+                  )
+                }
+              }}
+            />
+            <JourneyStatusFilter
+              status={filterStatus}
+              onChange={setFilterStatus}
+            />
+            <JourneySort sortOrder={sortOrder} onChange={setSortOrder} />
+          </Stack>
+
+          <DroppableAllTemplates>
+            <Box sx={{ flex: 1, overflowY: 'auto', minHeight: 0 }}>
+              <Stack spacing={1}>
+                {filteredUnsectionedIds.map((id) => {
+                  const template = getTemplateById(id)
+                  if (template == null) return null
+                  return (
+                    <TemplateLineItem
+                      key={id}
+                      template={template}
+                      draggable
+                    />
+                  )
+                })}
+              </Stack>
+              {filteredUnsectionedIds.length === 0 && (
+                <Box
+                  sx={{
+                    py: 3,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center'
+                  }}
+                >
+                  <Typography variant="body2" color="text.secondary">
+                    {searchQuery.trim() !== ''
+                      ? 'No templates match your search.'
+                      : 'All templates are in collections.'}
+                  </Typography>
+                </Box>
+              )}
+            </Box>
+          </DroppableAllTemplates>
+        </Box>
+      </Box>
+
+      {/* Drag Overlay */}
+      <DragOverlay>
+        {activeTemplate != null ? (
+          <Box sx={{ width: 200 }}>
+            <TemplateLineItem template={activeTemplate} />
+          </Box>
+        ) : null}
+      </DragOverlay>
+
+      {/* Edit + Preview — Swiper wraps two modal-style panels */}
+      {openCollection != null && editModalOpen && (
+        <Box
+          sx={{
+            position: 'fixed',
+            inset: 0,
+            zIndex: (theme) => theme.zIndex.modal,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center'
+          }}
+        >
+          {/* Backdrop */}
+          <Box
+            onClick={() => setEditModalOpen(false)}
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              backgroundColor: 'rgba(0,0,0,0.5)'
+            }}
+          />
+
+          {/* Swiper — each slide is a modal panel */}
+          <Box
+            sx={{
+              position: 'relative',
+              width: 'calc(100% - 32px)',
+              maxWidth: 500,
+              height: '85vh',
+              maxHeight: 700,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center'
+            }}
+          >
+            <Swiper
+              modules={[A11y]}
+              spaceBetween={16}
+              slidesPerView={1}
+              onSwiper={(swiper) => { swiperRef.current = swiper }}
+              onSlideChange={(swiper) => setActiveSlide(swiper.activeIndex)}
+              style={{ width: '100%', flex: 1, minHeight: 0 }}
+            >
+              {/* Slide 1: Edit collection */}
+              <SwiperSlide>
+                <Box
+                  sx={{
+                    height: '100%',
+                    backgroundColor: 'background.paper',
+                    borderRadius: 3,
+                    overflow: 'hidden',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    boxShadow: 24
+                  }}
+                >
+                  <CollectionSidePanel
+                    collection={openCollection}
+                    onClose={() => setEditModalOpen(false)}
+                    onUpdateCollection={handleUpdateCollection}
+                    onDeleteCollection={handleDeleteCollection}
+                    onPreview={() => swiperRef.current?.slideNext()}
+                    isPreviewOpen={false}
+                  />
+                </Box>
+              </SwiperSlide>
+
+              {/* Slide 2: Page preview */}
+              <SwiperSlide>
+                <Box
+                  sx={{
+                    height: '100%',
+                    backgroundColor: 'background.paper',
+                    borderRadius: 3,
+                    overflow: 'hidden',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    boxShadow: 24
+                  }}
+                >
+                  <Stack
+                    direction="row"
+                    alignItems="center"
+                    sx={{ px: 2, py: 1.5, flexShrink: 0 }}
+                  >
+                    <IconButton
+                      size="small"
+                      onClick={() => swiperRef.current?.slidePrev()}
+                      aria-label="back to edit"
+                    >
+                      <ChevronLeftIcon />
+                    </IconButton>
+                    <Typography
+                      variant="subtitle2"
+                      sx={{ flex: 1, fontWeight: 600 }}
+                    >
+                      Page Preview
+                    </Typography>
+                  </Stack>
+                  <Divider />
+                  <Box sx={{ flex: 1, overflowY: 'auto' }}>
+                    <CollectionPreview collection={openCollection} />
+                  </Box>
+                </Box>
+              </SwiperSlide>
+            </Swiper>
+
+            {/* Pagination dots */}
+            <Stack
+              direction="row"
+              spacing={1}
+              justifyContent="center"
+              sx={{ pt: 1.5, flexShrink: 0 }}
+            >
+              {[0, 1].map((i) => (
+                <Box
+                  key={i}
+                  onClick={() => swiperRef.current?.slideTo(i)}
+                  sx={{
+                    width: 8,
+                    height: 8,
+                    borderRadius: '50%',
+                    backgroundColor:
+                      activeSlide === i ? 'primary.main' : 'rgba(0,0,0,0.2)',
+                    cursor: 'pointer',
+                    transition: 'background-color 0.2s ease'
+                  }}
+                />
+              ))}
+            </Stack>
+          </Box>
+        </Box>
+      )}
+
+      {/* Help Modal */}
+      {helpModalOpen && (
+        <Dialog
+          open
+          onClose={() => setHelpModalOpen(false)}
+          fullScreen
+        >
+          <Stack
+            direction="row"
+            alignItems="center"
+            sx={{ px: 2, py: 1.5 }}
+          >
+            <Typography variant="subtitle1" sx={{ flex: 1, fontWeight: 600 }}>
+              Help
+            </Typography>
+            <IconButton
+              size="small"
+              onClick={() => setHelpModalOpen(false)}
+              aria-label="close help"
+            >
+              <X2Icon />
+            </IconButton>
+          </Stack>
+          <Divider />
+          <DialogContent>
+            <Typography variant="h6" sx={{ fontWeight: 700, mb: 1 }}>
+              What templates are about:
+            </Typography>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ mb: 3, lineHeight: 1.6 }}
+            >
+              You can share projects created on our platform with others. This
+              allows you to track the performance of every project generated
+              from your template.
+            </Typography>
+
+            {[
+              {
+                title: 'Template Types',
+                content:
+                  'Templates can be journeys, websites, or quick-start projects. Each type has different configuration options and sharing capabilities.'
+              },
+              {
+                title: 'How to create',
+                content:
+                  'Create a new template from scratch or duplicate an existing journey. Customize the content, add images, and configure settings before publishing.'
+              },
+              {
+                title: 'Tracking and Analytics',
+                content:
+                  'Monitor how your templates perform with detailed analytics. Track views, completions, and engagement across all projects created from your templates.'
+              },
+              {
+                title: 'Sharing and Publishing',
+                content:
+                  'Publish templates to the library for others to discover. Share directly via link or make them available to specific teams.'
+              }
+            ].map((item) => (
+              <Box key={item.title} sx={{ mb: 1 }}>
+                <Divider />
+                <Typography
+                  variant="subtitle2"
+                  sx={{ fontWeight: 600, py: 1.5 }}
+                >
+                  {item.title}
+                </Typography>
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ pb: 1.5 }}
+                >
+                  {item.content}
+                </Typography>
+              </Box>
+            ))}
+          </DialogContent>
+        </Dialog>
+      )}
+    </DndContext>
+  )
+}

--- a/apps/journeys-admin/src/components/CollectionsDemo/TemplateInfoPanel.tsx
+++ b/apps/journeys-admin/src/components/CollectionsDemo/TemplateInfoPanel.tsx
@@ -1,0 +1,152 @@
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import Accordion from '@mui/material/Accordion'
+import AccordionDetails from '@mui/material/AccordionDetails'
+import AccordionSummary from '@mui/material/AccordionSummary'
+import Box from '@mui/material/Box'
+import Divider from '@mui/material/Divider'
+import IconButton from '@mui/material/IconButton'
+import Typography from '@mui/material/Typography'
+import { ReactElement } from 'react'
+
+import ChevronDownIcon from '@core/shared/ui/icons/ChevronDown'
+
+export function TemplateInfoPanel(): ReactElement {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {/* Header */}
+      <Box sx={{ px: 2.5, pt: 3, pb: 2 }}>
+        <Typography
+          variant="h6"
+          sx={{ fontWeight: 700, mb: 1, color: 'text.primary' }}
+        >
+          What templates are about:
+        </Typography>
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ lineHeight: 1.6 }}
+        >
+          You can share projects created on our platform with others. This
+          allows you to track the performance of every project generated from
+          your template.
+        </Typography>
+      </Box>
+
+      <Divider />
+
+      {/* Accordion sections */}
+      <Box sx={{ flex: 1, overflowY: 'auto' }}>
+        <Accordion
+          disableGutters
+          elevation={0}
+          sx={{ '&:before': { display: 'none' } }}
+        >
+          <AccordionSummary
+            expandIcon={<ChevronDownIcon />}
+            sx={{ px: 2.5, minHeight: 56 }}
+            aria-label="toggle template types"
+          >
+            <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+              Template Types
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails sx={{ px: 2.5, pt: 0, pb: 2 }}>
+            <Typography variant="body2" color="text.secondary">
+              Templates can be journeys, websites, or quick-start projects.
+              Each type has different configuration options and sharing
+              capabilities.
+            </Typography>
+          </AccordionDetails>
+        </Accordion>
+        <Divider />
+
+        <Accordion
+          disableGutters
+          elevation={0}
+          sx={{ '&:before': { display: 'none' } }}
+        >
+          <AccordionSummary
+            expandIcon={<ChevronDownIcon />}
+            sx={{ px: 2.5, minHeight: 56 }}
+            aria-label="toggle how to create"
+          >
+            <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+              How to create
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails sx={{ px: 2.5, pt: 0, pb: 2 }}>
+            <Typography variant="body2" color="text.secondary">
+              Create a new template from scratch or duplicate an existing
+              journey. Customize the content, add images, and configure settings
+              before publishing.
+            </Typography>
+          </AccordionDetails>
+        </Accordion>
+        <Divider />
+
+        <Accordion
+          disableGutters
+          elevation={0}
+          sx={{ '&:before': { display: 'none' } }}
+        >
+          <AccordionSummary
+            expandIcon={<ChevronDownIcon />}
+            sx={{ px: 2.5, minHeight: 56 }}
+            aria-label="toggle tracking and analytics"
+          >
+            <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+              Tracking and Analytics
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails sx={{ px: 2.5, pt: 0, pb: 2 }}>
+            <Typography variant="body2" color="text.secondary">
+              Monitor how your templates perform with detailed analytics. Track
+              views, completions, and engagement across all projects created
+              from your templates.
+            </Typography>
+          </AccordionDetails>
+        </Accordion>
+        <Divider />
+
+        <Accordion
+          disableGutters
+          elevation={0}
+          sx={{ '&:before': { display: 'none' } }}
+        >
+          <AccordionSummary
+            expandIcon={<ChevronDownIcon />}
+            sx={{ px: 2.5, minHeight: 56 }}
+            aria-label="toggle sharing and publishing"
+          >
+            <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+              Sharing and Publishing
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails sx={{ px: 2.5, pt: 0, pb: 2 }}>
+            <Typography variant="body2" color="text.secondary">
+              Publish templates to the library for others to discover. Share
+              directly via link or make them available to specific teams.
+            </Typography>
+          </AccordionDetails>
+        </Accordion>
+        <Divider />
+      </Box>
+
+      {/* Footer */}
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          px: 2,
+          py: 1,
+          borderTop: '1px solid',
+          borderColor: 'divider'
+        }}
+      >
+        <IconButton size="small" aria-label="open help in new window">
+          <OpenInNewIcon sx={{ fontSize: 18 }} />
+        </IconButton>
+      </Box>
+    </Box>
+  )
+}

--- a/apps/journeys-admin/src/components/CollectionsDemo/index.ts
+++ b/apps/journeys-admin/src/components/CollectionsDemo/index.ts
@@ -1,0 +1,1 @@
+export { CollectionsDemo } from './CollectionsDemo'

--- a/apps/journeys-admin/src/components/CollectionsDemo/mockData.ts
+++ b/apps/journeys-admin/src/components/CollectionsDemo/mockData.ts
@@ -1,0 +1,56 @@
+export { MOCK_TEMPLATES } from '../FoldersDemo/mockData'
+
+// Shared layout constants
+export const TEMPLATE_CARD_CONTENT_HEIGHT = 80
+export const TEMPLATE_CARD_IMAGE_HEIGHT = 140 // approx at typical grid width
+export const TEMPLATE_CARD_HEIGHT =
+  TEMPLATE_CARD_IMAGE_HEIGHT + TEMPLATE_CARD_CONTENT_HEIGHT + 14
+export const SECTION_HEADER_HEIGHT = 48
+export const SECTION_PADDING = 48 // p: 3 = 24px * 2
+
+export const COLLECTION_CARD_MOSAIC_RATIO = 1.4
+export const COLLECTION_CARD_INFO_HEIGHT = 76
+export const COLLECTION_CARD_HEIGHT = 180 + COLLECTION_CARD_INFO_HEIGHT // mosaic approx + info
+
+export const COLLECTION_CARD_WIDTHS = {
+  xs: '100%',
+  sm: 'calc(50% - 6px)',
+  md: 'calc(33.333% - 8px)',
+  lg: 'calc(25% - 9px)',
+  xl: 'calc(20% - 10px)'
+}
+export type { MockTemplate } from '../FoldersDemo/mockData'
+
+export interface Collection {
+  id: string
+  title: string
+  description: string
+  pageDescription: string
+  creatorName: string
+  creatorImageUrl: string
+  pdfVideoUrl: string
+  templateIds: string[]
+  backgroundColor: string
+  isPublished: boolean
+}
+
+export const PASTEL_PALETTE = [
+  '#E8F5E9', // mint green
+  '#E3F2FD', // light blue
+  '#FFF3E0', // peach
+  '#F3E5F5', // lavender
+  '#FFF9C4', // lemon
+  '#FCE4EC', // blush pink
+  '#E0F7FA', // pale cyan
+  '#F1F8E9', // lime cream
+  '#EDE7F6', // soft violet
+  '#FBE9E7' // warm coral
+]
+
+export function getNextPastelColor(usedColors: Set<string>): string {
+  const unused = PASTEL_PALETTE.filter((c) => !usedColors.has(c))
+  if (unused.length > 0) {
+    return unused[Math.floor(Math.random() * unused.length)]
+  }
+  return PASTEL_PALETTE[Math.floor(Math.random() * PASTEL_PALETTE.length)]
+}

--- a/apps/journeys-admin/src/components/FoldersDemo/FoldersDemo.tsx
+++ b/apps/journeys-admin/src/components/FoldersDemo/FoldersDemo.tsx
@@ -1,0 +1,520 @@
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
+  MouseSensor,
+  TouchSensor,
+  useDroppable,
+  useSensor,
+  useSensors
+} from '@dnd-kit/core'
+import AddIcon from '@mui/icons-material/Add'
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
+import Box from '@mui/material/Box'
+import Card from '@mui/material/Card'
+import Grid from '@mui/material/Grid'
+import IconButton from '@mui/material/IconButton'
+import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+import Typography from '@mui/material/Typography'
+import { ReactElement, useState } from 'react'
+
+import Edit2Icon from '@core/shared/ui/icons/Edit2'
+
+import type { JourneyStatus } from '../JourneyList/JourneyListView/JourneyListView'
+import { JourneySort, SortOrder } from '../JourneyList/JourneySort'
+import { JourneyStatusFilter } from '../JourneyList/JourneyStatusFilter'
+
+import { MockTemplateCard } from './MockTemplateCard'
+import { MOCK_TEMPLATES, MockTemplate } from './mockData'
+import { SectionSidePanel } from './SectionSidePanel'
+import { TemplateInfoPanel } from './TemplateInfoPanel'
+
+export interface Section {
+  id: string
+  title: string
+  description: string
+  pageDescription: string
+  creatorName: string
+  creatorImageUrl: string
+  pdfVideoUrl: string
+  templateIds: string[]
+  backgroundColor: string
+}
+
+const PANEL_WIDTH = 375
+
+const PASTEL_PALETTE = [
+  '#E8F5E9', // mint green
+  '#E3F2FD', // light blue
+  '#FFF3E0', // peach
+  '#F3E5F5', // lavender
+  '#FFF9C4', // lemon
+  '#FCE4EC', // blush pink
+  '#E0F7FA', // pale cyan
+  '#F1F8E9', // lime cream
+  '#EDE7F6', // soft violet
+  '#FBE9E7' // warm coral
+]
+
+let pastelIndex = 0
+function getNextPastelColor(usedColors: Set<string>): string {
+  const unused = PASTEL_PALETTE.find((c) => !usedColors.has(c))
+  if (unused != null) return unused
+  // All colors used — fall back to round-robin
+  const color = PASTEL_PALETTE[pastelIndex % PASTEL_PALETTE.length]
+  pastelIndex++
+  return color
+}
+
+interface DroppableSectionProps {
+  id: string
+  children: ReactElement | ReactElement[]
+}
+
+function DroppableZone({ id, children }: DroppableSectionProps): ReactElement {
+  const { isOver, setNodeRef } = useDroppable({ id })
+
+  return (
+    <Box
+      ref={setNodeRef}
+      sx={{
+        minHeight: 80,
+        borderRadius: 2,
+        border: isOver ? '2px dashed' : '2px dashed transparent',
+        borderColor: isOver ? 'primary.main' : 'transparent',
+        backgroundColor: isOver ? 'action.hover' : 'transparent',
+        transition: 'all 0.2s ease',
+        p: isOver ? 1 : 0
+      }}
+    >
+      {children}
+    </Box>
+  )
+}
+
+function getTemplateById(id: string): MockTemplate | undefined {
+  return MOCK_TEMPLATES.find((t) => t.id === id)
+}
+
+export function FoldersDemo(): ReactElement {
+  const [sections, setSections] = useState<Section[]>([])
+  const [unsectionedIds, setUnsectionedIds] = useState<string[]>(
+    MOCK_TEMPLATES.map((t) => t.id)
+  )
+  const [selectedSectionId, setSelectedSectionId] = useState<string | null>(
+    null
+  )
+  const [activeTemplateId, setActiveTemplateId] = useState<string | null>(null)
+  const [editingTitleId, setEditingTitleId] = useState<string | null>(null)
+  const [editingTitleValue, setEditingTitleValue] = useState('')
+  const [filterStatus, setFilterStatus] = useState<JourneyStatus>('active')
+  const [filterSortOrder, setFilterSortOrder] = useState<SortOrder | undefined>()
+
+  const mouseSensor = useSensor(MouseSensor, {
+    activationConstraint: { distance: 8 }
+  })
+  const touchSensor = useSensor(TouchSensor, {
+    activationConstraint: { delay: 200, tolerance: 5 }
+  })
+  const sensors = useSensors(mouseSensor, touchSensor)
+
+  const selectedSection =
+    sections.find((s) => s.id === selectedSectionId) ?? null
+
+  const handleDragStart = (event: DragStartEvent): void => {
+    setActiveTemplateId(event.active.id as string)
+  }
+
+  const handleDragEnd = (event: DragEndEvent): void => {
+    setActiveTemplateId(null)
+    const { active, over } = event
+    if (over == null) return
+
+    const templateId = active.id as string
+    const targetZone = over.id as string
+
+    const isInUnsectioned = unsectionedIds.includes(templateId)
+    const sourceSection = sections.find((s) =>
+      s.templateIds.includes(templateId)
+    )
+
+    if (isInUnsectioned) {
+      setUnsectionedIds((prev) => prev.filter((id) => id !== templateId))
+    } else if (sourceSection != null) {
+      if (sourceSection.id === targetZone) return
+      setSections((prev) =>
+        prev.map((s) =>
+          s.id === sourceSection.id
+            ? {
+                ...s,
+                templateIds: s.templateIds.filter((id) => id !== templateId)
+              }
+            : s
+        )
+      )
+    }
+
+    if (targetZone === 'unsectioned') {
+      if (!isInUnsectioned) {
+        setUnsectionedIds((prev) => [...prev, templateId])
+      }
+    } else {
+      setSections((prev) =>
+        prev.map((s) =>
+          s.id === targetZone
+            ? { ...s, templateIds: [...s.templateIds, templateId] }
+            : s
+        )
+      )
+    }
+  }
+
+  const getNextSectionName = (): string => {
+    const existingTitles = new Set(sections.map((s) => s.title))
+    if (!existingTitles.has('New Section')) return 'New Section'
+    let counter = 2
+    while (existingTitles.has(`New Section ${counter}`)) {
+      counter++
+    }
+    return `New Section ${counter}`
+  }
+
+  const handleAddSection = (): void => {
+    const title = getNextSectionName()
+    const id = `section-${Date.now()}`
+    const newSection: Section = {
+      id,
+      title,
+      description: '',
+      pageDescription: '',
+      creatorName: '',
+      creatorImageUrl: '',
+      pdfVideoUrl: '',
+      templateIds: [],
+      backgroundColor: getNextPastelColor(
+        new Set(sections.map((s) => s.backgroundColor))
+      )
+    }
+    setSections((prev) => [...prev, newSection])
+    setSelectedSectionId(id)
+    setEditingTitleId(id)
+    setEditingTitleValue(title)
+  }
+
+  const handleDeleteSection = (sectionId: string): void => {
+    const section = sections.find((s) => s.id === sectionId)
+    if (section == null) return
+
+    setUnsectionedIds((prev) => [...prev, ...section.templateIds])
+    setSections((prev) => prev.filter((s) => s.id !== sectionId))
+
+    if (selectedSectionId === sectionId) {
+      setSelectedSectionId(null)
+    }
+  }
+
+  const handleUpdateSection = (
+    id: string,
+    updates: Partial<Section>
+  ): void => {
+    setSections((prev) =>
+      prev.map((s) => (s.id === id ? { ...s, ...updates } : s))
+    )
+  }
+
+  const handleTitleDoubleClick = (section: Section): void => {
+    setEditingTitleId(section.id)
+    setEditingTitleValue(section.title)
+  }
+
+  const handleTitleSubmit = (): void => {
+    if (editingTitleId == null) return
+    const trimmed = editingTitleValue.trim()
+    if (trimmed !== '') {
+      handleUpdateSection(editingTitleId, { title: trimmed })
+    }
+    setEditingTitleId(null)
+    setEditingTitleValue('')
+  }
+
+  const handleTitleKeyDown = (
+    e: React.KeyboardEvent<HTMLInputElement>
+  ): void => {
+    if (e.key === 'Enter') {
+      handleTitleSubmit()
+    } else if (e.key === 'Escape') {
+      setEditingTitleId(null)
+      setEditingTitleValue('')
+    }
+  }
+
+  const activeTemplate =
+    activeTemplateId != null ? getTemplateById(activeTemplateId) : null
+
+  return (
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <Stack
+        direction="row"
+        spacing={3}
+        sx={{ mt: { xs: 3, sm: 2 }, alignItems: 'flex-start' }}
+      >
+        {/* Main content area */}
+        <Box sx={{ flex: 1, minWidth: 0, px: { xs: 5, sm: 0 } }}>
+          {/* Add Section Card + Filters row */}
+          <Stack
+            direction="row"
+            alignItems="center"
+            sx={{ mb: 4 }}
+          >
+            <Card
+              variant="outlined"
+              onClick={handleAddSection}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  handleAddSection()
+                }
+              }}
+              tabIndex={0}
+              role="button"
+              aria-label="add a new section"
+              sx={{
+                border: '2px dashed',
+                borderColor: 'divider',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                p: 3,
+                cursor: 'pointer',
+                maxWidth: 400,
+                '&:hover': {
+                  borderColor: 'primary.main',
+                  backgroundColor: 'action.hover'
+                }
+              }}
+            >
+              <Stack direction="row" spacing={1} alignItems="center">
+                <AddIcon color="action" />
+                <Typography variant="subtitle2" color="text.secondary">
+                  Add Section
+                </Typography>
+              </Stack>
+            </Card>
+            <Box sx={{ flexGrow: 1 }} />
+            <Stack direction="row" alignItems="center" spacing={1}>
+              <JourneyStatusFilter
+                status={filterStatus}
+                onChange={setFilterStatus}
+              />
+              <JourneySort
+                sortOrder={filterSortOrder}
+                onChange={setFilterSortOrder}
+              />
+            </Stack>
+          </Stack>
+
+          {/* Sections */}
+          {sections.map((section) => (
+            <Box
+              key={section.id}
+              sx={{
+                mb: 4,
+                backgroundColor: section.backgroundColor,
+                borderRadius: 3,
+                p: 3,
+                border: '1px solid',
+                borderColor:
+                  selectedSectionId === section.id
+                    ? 'primary.main'
+                    : 'rgba(0,0,0,0.08)',
+                transition: 'border-color 0.2s ease'
+              }}
+            >
+              <Stack
+                direction="row"
+                alignItems="center"
+                spacing={1}
+                sx={{ mb: 2 }}
+              >
+                <Box
+                  sx={{
+                    width: 12,
+                    height: 12,
+                    borderRadius: '50%',
+                    backgroundColor: section.backgroundColor,
+                    border: '2px solid rgba(0,0,0,0.2)',
+                    flexShrink: 0
+                  }}
+                />
+                {editingTitleId === section.id ? (
+                  <TextField
+                    value={editingTitleValue}
+                    onChange={(e) => setEditingTitleValue(e.target.value)}
+                    onKeyDown={handleTitleKeyDown}
+                    onBlur={handleTitleSubmit}
+                    size="small"
+                    variant="standard"
+                    autoFocus
+                    inputRef={(input) => {
+                      if (input != null) {
+                        input.select()
+                      }
+                    }}
+                    inputProps={{
+                      'aria-label': 'edit section title',
+                      style: { fontSize: '1.25rem', fontWeight: 500 }
+                    }}
+                    sx={{ minWidth: 150 }}
+                  />
+                ) : (
+                  <Typography
+                    variant="h6"
+                    onDoubleClick={() => handleTitleDoubleClick(section)}
+                    sx={{ cursor: 'default', userSelect: 'none' }}
+                  >
+                    {section.title}
+                  </Typography>
+                )}
+                <IconButton
+                  size="small"
+                  onClick={() => setSelectedSectionId(section.id)}
+                  aria-label={`edit section ${section.title}`}
+                >
+                  <Edit2Icon fontSize="small" />
+                </IconButton>
+                {section.description !== '' && (
+                  <Typography variant="body2" color="text.secondary">
+                    — {section.description}
+                  </Typography>
+                )}
+                <Box sx={{ flexGrow: 1 }} />
+                <IconButton
+                  size="small"
+                  onClick={() => handleDeleteSection(section.id)}
+                  aria-label={`delete section ${section.title}`}
+                  sx={{ color: 'error.main' }}
+                >
+                  <DeleteOutlineIcon fontSize="small" />
+                </IconButton>
+              </Stack>
+              <DroppableZone id={section.id}>
+                {section.templateIds.length > 0 ? (
+                  <Grid container spacing={4} rowSpacing={{ xs: 2.5, sm: 4 }}>
+                    {section.templateIds.map((tmplId) => {
+                      const template = getTemplateById(tmplId)
+                      if (template == null) return null
+                      return (
+                        <Grid
+                          key={tmplId}
+                          size={{ xs: 12, sm: 6, md: 6, lg: 4, xl: 3 }}
+                        >
+                          <MockTemplateCard template={template} />
+                        </Grid>
+                      )
+                    })}
+                  </Grid>
+                ) : (
+                  <Box
+                    sx={{
+                      py: 4,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      border: '1px dashed',
+                      borderColor: 'rgba(0,0,0,0.15)',
+                      borderRadius: 2
+                    }}
+                  >
+                    <Typography variant="body2" color="text.secondary">
+                      Drag templates here
+                    </Typography>
+                  </Box>
+                )}
+              </DroppableZone>
+            </Box>
+          ))}
+
+          {/* All Templates (unsectioned) */}
+          <Box sx={{ mb: 4 }}>
+            <Typography variant="h6" sx={{ mb: 2 }}>
+              All Templates
+            </Typography>
+            <DroppableZone id="unsectioned">
+              <Grid container spacing={4} rowSpacing={{ xs: 2.5, sm: 4 }}>
+                {unsectionedIds.map((tmplId) => {
+                  const template = getTemplateById(tmplId)
+                  if (template == null) return null
+                  return (
+                    <Grid
+                      key={tmplId}
+                      size={{ xs: 12, sm: 6, md: 6, lg: 4, xl: 3 }}
+                    >
+                      <MockTemplateCard template={template} />
+                    </Grid>
+                  )
+                })}
+              </Grid>
+            </DroppableZone>
+            {unsectionedIds.length === 0 && (
+              <Box
+                sx={{
+                  py: 4,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center'
+                }}
+              >
+                <Typography variant="body2" color="text.secondary">
+                  All templates have been organized into sections.
+                </Typography>
+              </Box>
+            )}
+          </Box>
+        </Box>
+
+        {/* Right panel — always visible, sticky */}
+        <Box
+          sx={{
+            width: PANEL_WIDTH,
+            flexShrink: 0,
+            position: 'sticky',
+            top: 80,
+            alignSelf: 'flex-start',
+            height: `calc(100vh - 100px)`,
+            display: { xs: 'none', md: 'flex' },
+            flexDirection: 'column',
+            backgroundColor: 'background.paper',
+            borderRadius: '12px',
+            border: '1px solid',
+            borderColor: 'divider',
+            overflow: 'hidden'
+          }}
+        >
+          {selectedSection != null ? (
+            <SectionSidePanel
+              section={selectedSection}
+              onClose={() => setSelectedSectionId(null)}
+              onUpdateSection={handleUpdateSection}
+            />
+          ) : (
+            <TemplateInfoPanel />
+          )}
+        </Box>
+      </Stack>
+
+      {/* Drag Overlay */}
+      <DragOverlay>
+        {activeTemplate != null ? (
+          <Box sx={{ width: 280 }}>
+            <MockTemplateCard template={activeTemplate} isDragOverlay />
+          </Box>
+        ) : null}
+      </DragOverlay>
+    </DndContext>
+  )
+}

--- a/apps/journeys-admin/src/components/FoldersDemo/MockTemplateCard.tsx
+++ b/apps/journeys-admin/src/components/FoldersDemo/MockTemplateCard.tsx
@@ -3,6 +3,7 @@ import Box from '@mui/material/Box'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
 import Chip from '@mui/material/Chip'
+import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import { ReactElement } from 'react'
 
@@ -11,6 +12,7 @@ import type { MockTemplate } from './mockData'
 interface MockTemplateCardProps {
   template: MockTemplate
   isDragOverlay?: boolean
+  dragDisabled?: boolean
 }
 
 function CardVisual({ template }: { template: MockTemplate }): ReactElement {
@@ -53,14 +55,14 @@ function CardVisual({ template }: { template: MockTemplate }): ReactElement {
           }}
         />
       </Box>
-      <CardContent sx={{ pl: 2.5, pr: 2, pt: 1, pb: 2 }}>
+      <CardContent sx={{ pl: 2.5, pr: 2, pt: 1, pb: 2, height: 80 }}>
         <Typography
           variant="subtitle2"
           sx={{
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             display: '-webkit-box',
-            WebkitLineClamp: 2,
+            WebkitLineClamp: 1,
             WebkitBoxOrient: 'vertical'
           }}
         >
@@ -87,10 +89,12 @@ function CardVisual({ template }: { template: MockTemplate }): ReactElement {
 
 export function MockTemplateCard({
   template,
-  isDragOverlay = false
+  isDragOverlay = false,
+  dragDisabled = false
 }: MockTemplateCardProps): ReactElement {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
-    id: template.id
+    id: template.id,
+    disabled: dragDisabled
   })
 
   if (isDragOverlay) {
@@ -110,19 +114,18 @@ export function MockTemplateCard({
     )
   }
 
-  return (
+  const card = (
     <Card
       ref={setNodeRef}
       variant="outlined"
-      {...attributes}
-      {...listeners}
+      {...(dragDisabled ? {} : { ...attributes, ...listeners })}
       sx={{
         borderColor: 'divider',
-        cursor: 'grab',
+        cursor: dragDisabled ? 'default' : 'grab',
         opacity: isDragging ? 0.3 : 1,
         touchAction: 'none',
         '&:hover': {
-          boxShadow: 2
+          boxShadow: dragDisabled ? 0 : 2
         }
       }}
       aria-label={`template card ${template.title}`}
@@ -130,6 +133,16 @@ export function MockTemplateCard({
       <CardVisual template={template} />
     </Card>
   )
+
+  if (dragDisabled) {
+    return (
+      <Tooltip title="Published — templates locked" arrow>
+        {card}
+      </Tooltip>
+    )
+  }
+
+  return card
 }
 
 export { CardVisual }

--- a/apps/journeys-admin/src/components/FoldersDemo/MockTemplateCard.tsx
+++ b/apps/journeys-admin/src/components/FoldersDemo/MockTemplateCard.tsx
@@ -1,0 +1,135 @@
+import { useDraggable } from '@dnd-kit/core'
+import Box from '@mui/material/Box'
+import Card from '@mui/material/Card'
+import CardContent from '@mui/material/CardContent'
+import Chip from '@mui/material/Chip'
+import Typography from '@mui/material/Typography'
+import { ReactElement } from 'react'
+
+import type { MockTemplate } from './mockData'
+
+interface MockTemplateCardProps {
+  template: MockTemplate
+  isDragOverlay?: boolean
+}
+
+function CardVisual({ template }: { template: MockTemplate }): ReactElement {
+  return (
+    <>
+      <Box
+        sx={{
+          position: 'relative',
+          width: 'auto',
+          aspectRatio: '1.43',
+          mx: 1.75,
+          mt: 1.75,
+          borderRadius: '8px',
+          overflow: 'hidden',
+          bgcolor: 'rgba(0, 0, 0, 0.06)'
+        }}
+      >
+        <Box
+          component="img"
+          src={template.imageUrl}
+          alt={template.title}
+          sx={{
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            display: 'block'
+          }}
+        />
+        <Chip
+          label={template.languageCode}
+          size="small"
+          sx={{
+            position: 'absolute',
+            top: 8,
+            right: 8,
+            backgroundColor: 'rgba(0,0,0,0.7)',
+            color: 'white',
+            fontSize: 10,
+            height: 22
+          }}
+        />
+      </Box>
+      <CardContent sx={{ pl: 2.5, pr: 2, pt: 1, pb: 2 }}>
+        <Typography
+          variant="subtitle2"
+          sx={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical'
+          }}
+        >
+          {template.title}
+        </Typography>
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            mt: 0.5
+          }}
+        >
+          {template.description}
+        </Typography>
+      </CardContent>
+    </>
+  )
+}
+
+export function MockTemplateCard({
+  template,
+  isDragOverlay = false
+}: MockTemplateCardProps): ReactElement {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: template.id
+  })
+
+  if (isDragOverlay) {
+    return (
+      <Card
+        variant="outlined"
+        sx={{
+          borderColor: 'divider',
+          cursor: 'grabbing',
+          boxShadow: 8,
+          transform: 'rotate(2deg)',
+          maxWidth: 280
+        }}
+      >
+        <CardVisual template={template} />
+      </Card>
+    )
+  }
+
+  return (
+    <Card
+      ref={setNodeRef}
+      variant="outlined"
+      {...attributes}
+      {...listeners}
+      sx={{
+        borderColor: 'divider',
+        cursor: 'grab',
+        opacity: isDragging ? 0.3 : 1,
+        touchAction: 'none',
+        '&:hover': {
+          boxShadow: 2
+        }
+      }}
+      aria-label={`template card ${template.title}`}
+    >
+      <CardVisual template={template} />
+    </Card>
+  )
+}
+
+export { CardVisual }

--- a/apps/journeys-admin/src/components/FoldersDemo/SectionSidePanel.tsx
+++ b/apps/journeys-admin/src/components/FoldersDemo/SectionSidePanel.tsx
@@ -1,0 +1,251 @@
+import CheckIcon from '@mui/icons-material/Check'
+import Accordion from '@mui/material/Accordion'
+import AccordionDetails from '@mui/material/AccordionDetails'
+import AccordionSummary from '@mui/material/AccordionSummary'
+import Avatar from '@mui/material/Avatar'
+import Box from '@mui/material/Box'
+import IconButton from '@mui/material/IconButton'
+import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+import Typography from '@mui/material/Typography'
+import { ReactElement } from 'react'
+
+import ChevronDownIcon from '@core/shared/ui/icons/ChevronDown'
+import Edit2Icon from '@core/shared/ui/icons/Edit2'
+import X2Icon from '@core/shared/ui/icons/X2'
+
+import type { Section } from './FoldersDemo'
+
+const COLOR_OPTIONS = [
+  { label: 'Mint', value: '#E8F5E9' },
+  { label: 'Sky', value: '#E3F2FD' },
+  { label: 'Peach', value: '#FFF3E0' },
+  { label: 'Lavender', value: '#F3E5F5' },
+  { label: 'Lemon', value: '#FFF9C4' },
+  { label: 'Blush', value: '#FCE4EC' },
+  { label: 'Cyan', value: '#E0F7FA' },
+  { label: 'Lime', value: '#F1F8E9' },
+  { label: 'Violet', value: '#EDE7F6' },
+  { label: 'Coral', value: '#FBE9E7' },
+  { label: 'White', value: '#FFFFFF' },
+  { label: 'Light Grey', value: '#F5F5F5' }
+]
+
+interface SectionSidePanelProps {
+  section: Section
+  onClose: () => void
+  onUpdateSection: (id: string, updates: Partial<Section>) => void
+}
+
+export function SectionSidePanel({
+  section,
+  onClose,
+  onUpdateSection
+}: SectionSidePanelProps): ReactElement {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        sx={{ px: 2.5, py: 2, borderBottom: '1px solid', borderColor: 'divider' }}
+      >
+        <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+          Section Details
+        </Typography>
+        <IconButton
+          onClick={onClose}
+          aria-label="close section panel"
+          edge="end"
+          size="small"
+        >
+          <X2Icon />
+        </IconButton>
+      </Stack>
+
+      <Box sx={{ overflowY: 'auto', flex: 1 }}>
+        <Accordion
+          defaultExpanded
+          disableGutters
+          elevation={0}
+          sx={{ '&:before': { display: 'none' } }}
+        >
+          <AccordionSummary
+            expandIcon={<ChevronDownIcon />}
+            sx={{ px: 2.5 }}
+            aria-label="toggle title and description"
+          >
+            <Typography variant="subtitle2">Title & Description</Typography>
+          </AccordionSummary>
+          <AccordionDetails sx={{ px: 2.5, pt: 0 }}>
+            <Stack spacing={2}>
+              <TextField
+                label="Title"
+                value={section.title}
+                onChange={(e) =>
+                  onUpdateSection(section.id, { title: e.target.value })
+                }
+                fullWidth
+                size="small"
+              />
+              <TextField
+                label="Description"
+                value={section.description}
+                onChange={(e) =>
+                  onUpdateSection(section.id, {
+                    description: e.target.value
+                  })
+                }
+                fullWidth
+                size="small"
+                multiline
+                rows={2}
+              />
+              <Box>
+                <Typography variant="body2" sx={{ mb: 1, fontWeight: 600 }}>
+                  Background Color
+                </Typography>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: 1
+                  }}
+                >
+                  {COLOR_OPTIONS.map((color) => (
+                    <IconButton
+                      key={color.value}
+                      onClick={() =>
+                        onUpdateSection(section.id, {
+                          backgroundColor: color.value
+                        })
+                      }
+                      aria-label={`set background to ${color.label}`}
+                      sx={{
+                        width: 32,
+                        height: 32,
+                        backgroundColor: color.value,
+                        border: '2px solid',
+                        borderColor:
+                          section.backgroundColor === color.value
+                            ? 'primary.main'
+                            : 'rgba(0,0,0,0.12)',
+                        borderRadius: '50%',
+                        p: 0,
+                        '&:hover': {
+                          backgroundColor: color.value,
+                          borderColor: 'primary.main'
+                        }
+                      }}
+                    >
+                      {section.backgroundColor === color.value && (
+                        <CheckIcon sx={{ fontSize: 16, color: 'primary.main' }} />
+                      )}
+                    </IconButton>
+                  ))}
+                </Box>
+              </Box>
+            </Stack>
+          </AccordionDetails>
+        </Accordion>
+
+        <Accordion
+          disableGutters
+          elevation={0}
+          sx={{ '&:before': { display: 'none' } }}
+        >
+          <AccordionSummary
+            expandIcon={<ChevronDownIcon />}
+            sx={{ px: 2.5 }}
+            aria-label="toggle more details"
+          >
+            <Typography variant="subtitle2">More Details</Typography>
+          </AccordionSummary>
+          <AccordionDetails sx={{ px: 2.5, pt: 0 }}>
+            <Stack spacing={3}>
+              <Box>
+                <Typography variant="body2" sx={{ mb: 1, fontWeight: 600 }}>
+                  Page description/instructions
+                </Typography>
+                <TextField
+                  value={section.pageDescription}
+                  onChange={(e) =>
+                    onUpdateSection(section.id, {
+                      pageDescription: e.target.value
+                    })
+                  }
+                  fullWidth
+                  size="small"
+                  multiline
+                  rows={3}
+                  placeholder="Enter page description or instructions..."
+                />
+              </Box>
+
+              <Box>
+                <Typography variant="body2" sx={{ mb: 1, fontWeight: 600 }}>
+                  Creator Details
+                </Typography>
+                <Stack direction="row" spacing={2} alignItems="center">
+                  <Box sx={{ position: 'relative', flexShrink: 0 }}>
+                    <Avatar
+                      src={section.creatorImageUrl || undefined}
+                      sx={{ width: 48, height: 48 }}
+                    />
+                    <IconButton
+                      size="small"
+                      aria-label="edit creator image"
+                      sx={{
+                        position: 'absolute',
+                        bottom: -4,
+                        right: -4,
+                        backgroundColor: 'background.paper',
+                        border: '1px solid',
+                        borderColor: 'divider',
+                        width: 22,
+                        height: 22,
+                        '&:hover': {
+                          backgroundColor: 'action.hover'
+                        }
+                      }}
+                    >
+                      <Edit2Icon sx={{ fontSize: 12 }} />
+                    </IconButton>
+                  </Box>
+                  <TextField
+                    value={section.creatorName}
+                    onChange={(e) =>
+                      onUpdateSection(section.id, {
+                        creatorName: e.target.value
+                      })
+                    }
+                    placeholder="Creator's info"
+                    fullWidth
+                    size="small"
+                  />
+                </Stack>
+              </Box>
+
+              <Box>
+                <Typography variant="body2" sx={{ mb: 1, fontWeight: 600 }}>
+                  Add PDF / Video with instructions
+                </Typography>
+                <TextField
+                  value={section.pdfVideoUrl}
+                  onChange={(e) =>
+                    onUpdateSection(section.id, {
+                      pdfVideoUrl: e.target.value
+                    })
+                  }
+                  placeholder="Paste URL"
+                  fullWidth
+                  size="small"
+                />
+              </Box>
+            </Stack>
+          </AccordionDetails>
+        </Accordion>
+      </Box>
+    </Box>
+  )
+}

--- a/apps/journeys-admin/src/components/FoldersDemo/TemplateInfoPanel.tsx
+++ b/apps/journeys-admin/src/components/FoldersDemo/TemplateInfoPanel.tsx
@@ -1,0 +1,152 @@
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import Accordion from '@mui/material/Accordion'
+import AccordionDetails from '@mui/material/AccordionDetails'
+import AccordionSummary from '@mui/material/AccordionSummary'
+import Box from '@mui/material/Box'
+import Divider from '@mui/material/Divider'
+import IconButton from '@mui/material/IconButton'
+import Typography from '@mui/material/Typography'
+import { ReactElement } from 'react'
+
+import ChevronDownIcon from '@core/shared/ui/icons/ChevronDown'
+
+export function TemplateInfoPanel(): ReactElement {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {/* Header */}
+      <Box sx={{ px: 2.5, pt: 3, pb: 2 }}>
+        <Typography
+          variant="h6"
+          sx={{ fontWeight: 700, mb: 1, color: 'text.primary' }}
+        >
+          What templates are about:
+        </Typography>
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ lineHeight: 1.6 }}
+        >
+          You can share projects created on our platform with others. This
+          allows you to track the performance of every project generated from
+          your template.
+        </Typography>
+      </Box>
+
+      <Divider />
+
+      {/* Accordion sections */}
+      <Box sx={{ flex: 1, overflowY: 'auto' }}>
+        <Accordion
+          disableGutters
+          elevation={0}
+          sx={{ '&:before': { display: 'none' } }}
+        >
+          <AccordionSummary
+            expandIcon={<ChevronDownIcon />}
+            sx={{ px: 2.5, minHeight: 56 }}
+            aria-label="toggle template types"
+          >
+            <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+              Template Types
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails sx={{ px: 2.5, pt: 0, pb: 2 }}>
+            <Typography variant="body2" color="text.secondary">
+              Templates can be journeys, websites, or quick-start projects.
+              Each type has different configuration options and sharing
+              capabilities.
+            </Typography>
+          </AccordionDetails>
+        </Accordion>
+        <Divider />
+
+        <Accordion
+          disableGutters
+          elevation={0}
+          sx={{ '&:before': { display: 'none' } }}
+        >
+          <AccordionSummary
+            expandIcon={<ChevronDownIcon />}
+            sx={{ px: 2.5, minHeight: 56 }}
+            aria-label="toggle how to create"
+          >
+            <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+              How to create
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails sx={{ px: 2.5, pt: 0, pb: 2 }}>
+            <Typography variant="body2" color="text.secondary">
+              Create a new template from scratch or duplicate an existing
+              journey. Customize the content, add images, and configure
+              settings before publishing.
+            </Typography>
+          </AccordionDetails>
+        </Accordion>
+        <Divider />
+
+        <Accordion
+          disableGutters
+          elevation={0}
+          sx={{ '&:before': { display: 'none' } }}
+        >
+          <AccordionSummary
+            expandIcon={<ChevronDownIcon />}
+            sx={{ px: 2.5, minHeight: 56 }}
+            aria-label="toggle tracking and analytics"
+          >
+            <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+              Tracking and Analytics
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails sx={{ px: 2.5, pt: 0, pb: 2 }}>
+            <Typography variant="body2" color="text.secondary">
+              Monitor how your templates perform with detailed analytics. Track
+              views, completions, and engagement across all projects created
+              from your templates.
+            </Typography>
+          </AccordionDetails>
+        </Accordion>
+        <Divider />
+
+        <Accordion
+          disableGutters
+          elevation={0}
+          sx={{ '&:before': { display: 'none' } }}
+        >
+          <AccordionSummary
+            expandIcon={<ChevronDownIcon />}
+            sx={{ px: 2.5, minHeight: 56 }}
+            aria-label="toggle sharing and publishing"
+          >
+            <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+              Sharing and Publishing
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails sx={{ px: 2.5, pt: 0, pb: 2 }}>
+            <Typography variant="body2" color="text.secondary">
+              Publish templates to the library for others to discover. Share
+              directly via link or make them available to specific teams.
+            </Typography>
+          </AccordionDetails>
+        </Accordion>
+        <Divider />
+      </Box>
+
+      {/* Footer */}
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          px: 2,
+          py: 1,
+          borderTop: '1px solid',
+          borderColor: 'divider'
+        }}
+      >
+        <IconButton size="small" aria-label="open help in new window">
+          <OpenInNewIcon sx={{ fontSize: 18 }} />
+        </IconButton>
+      </Box>
+    </Box>
+  )
+}

--- a/apps/journeys-admin/src/components/FoldersDemo/index.ts
+++ b/apps/journeys-admin/src/components/FoldersDemo/index.ts
@@ -1,0 +1,2 @@
+export { FoldersDemo } from './FoldersDemo'
+export type { Section } from './FoldersDemo'

--- a/apps/journeys-admin/src/components/FoldersDemo/mockData.ts
+++ b/apps/journeys-admin/src/components/FoldersDemo/mockData.ts
@@ -1,0 +1,205 @@
+export interface MockTemplate {
+  id: string
+  title: string
+  description: string
+  language: string
+  languageCode: string
+  imageUrl: string
+}
+
+export const MOCK_TEMPLATES: MockTemplate[] = [
+  // English (7)
+  {
+    id: 'tmpl-1',
+    title: 'Finding Hope in Difficult Times',
+    description:
+      'A journey exploring hope and resilience through life\u2019s challenges.',
+    language: 'English',
+    languageCode: 'EN',
+    imageUrl:
+      'https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=400&h=300&fit=crop'
+  },
+  {
+    id: 'tmpl-2',
+    title: 'The Easter Story',
+    description: 'Experience the powerful story of Easter and its meaning.',
+    language: 'English',
+    languageCode: 'EN',
+    imageUrl:
+      'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=400&h=300&fit=crop'
+  },
+  {
+    id: 'tmpl-3',
+    title: 'Who Is Jesus?',
+    description: 'Discover the life and teachings of Jesus Christ.',
+    language: 'English',
+    languageCode: 'EN',
+    imageUrl:
+      'https://images.unsplash.com/photo-1470252649378-9c29740c9fa8?w=400&h=300&fit=crop'
+  },
+  {
+    id: 'tmpl-4',
+    title: 'Life Questions',
+    description: 'Explore the big questions about purpose and meaning.',
+    language: 'English',
+    languageCode: 'EN',
+    imageUrl:
+      'https://images.unsplash.com/photo-1557672172-298e090bd0f1?w=400&h=300&fit=crop'
+  },
+  {
+    id: 'tmpl-5',
+    title: 'Dealing With Anxiety',
+    description: 'Practical guidance for finding peace in anxious times.',
+    language: 'English',
+    languageCode: 'EN',
+    imageUrl:
+      'https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=400&h=300&fit=crop'
+  },
+  {
+    id: 'tmpl-6',
+    title: 'Prayer Guide',
+    description: 'Learn how to develop a meaningful prayer life.',
+    language: 'English',
+    languageCode: 'EN',
+    imageUrl:
+      'https://images.unsplash.com/photo-1505118380757-91f5f5632de0?w=400&h=300&fit=crop'
+  },
+  {
+    id: 'tmpl-7',
+    title: 'Marriage Foundations',
+    description: 'Build a strong foundation for a lasting relationship.',
+    language: 'English',
+    languageCode: 'EN',
+    imageUrl:
+      'https://images.unsplash.com/photo-1477959858617-67f85cf4f1df?w=400&h=300&fit=crop'
+  },
+  // Russian (7)
+  {
+    id: 'tmpl-8',
+    title: '\u041D\u0430\u0434\u0435\u0436\u0434\u0430 \u0432 \u0442\u0440\u0443\u0434\u043D\u044B\u0435 \u0432\u0440\u0435\u043C\u0435\u043D\u0430',
+    description:
+      '\u041F\u0443\u0442\u0435\u0448\u0435\u0441\u0442\u0432\u0438\u0435, \u0438\u0441\u0441\u043B\u0435\u0434\u0443\u044E\u0449\u0435\u0435 \u043D\u0430\u0434\u0435\u0436\u0434\u0443 \u0438 \u0443\u0441\u0442\u043E\u0439\u0447\u0438\u0432\u043E\u0441\u0442\u044C \u0432 \u0436\u0438\u0437\u043D\u0438.',
+    language: 'Russian',
+    languageCode: 'RU',
+    imageUrl:
+      'https://images.unsplash.com/photo-1534088568595-a066f410bcda?w=400&h=300&fit=crop'
+  },
+  {
+    id: 'tmpl-9',
+    title: '\u0418\u0441\u0442\u043E\u0440\u0438\u044F \u041F\u0430\u0441\u0445\u0438',
+    description:
+      '\u041F\u043E\u0437\u043D\u0430\u0439\u0442\u0435 \u0441\u0438\u043B\u0443 \u043F\u0430\u0441\u0445\u0430\u043B\u044C\u043D\u043E\u0439 \u0438\u0441\u0442\u043E\u0440\u0438\u0438.',
+    language: 'Russian',
+    languageCode: 'RU',
+    imageUrl:
+      'https://images.unsplash.com/photo-1501854140801-50d01698950b?w=400&h=300&fit=crop'
+  },
+  {
+    id: 'tmpl-10',
+    title: '\u041A\u0442\u043E \u0442\u0430\u043A\u043E\u0439 \u0418\u0438\u0441\u0443\u0441?',
+    description:
+      '\u041E\u0442\u043A\u0440\u043E\u0439\u0442\u0435 \u0434\u043B\u044F \u0441\u0435\u0431\u044F \u0436\u0438\u0437\u043D\u044C \u0438 \u0443\u0447\u0435\u043D\u0438\u0435 \u0418\u0438\u0441\u0443\u0441\u0430 \u0425\u0440\u0438\u0441\u0442\u0430.',
+    language: 'Russian',
+    languageCode: 'RU',
+    imageUrl:
+      'https://images.unsplash.com/photo-1486325212027-8081e485255e?w=400&h=300&fit=crop'
+  },
+  {
+    id: 'tmpl-11',
+    title: '\u0412\u043E\u043F\u0440\u043E\u0441\u044B \u0436\u0438\u0437\u043D\u0438',
+    description:
+      '\u0418\u0441\u0441\u043B\u0435\u0434\u0443\u0439\u0442\u0435 \u0433\u043B\u0430\u0432\u043D\u044B\u0435 \u0432\u043E\u043F\u0440\u043E\u0441\u044B \u043E \u0441\u043C\u044B\u0441\u043B\u0435 \u0436\u0438\u0437\u043D\u0438.',
+    language: 'Russian',
+    languageCode: 'RU',
+    imageUrl:
+      'https://images.unsplash.com/photo-1439853949127-fa647821eba0?w=400&h=300&fit=crop'
+  },
+  {
+    id: 'tmpl-12',
+    title: '\u041F\u0440\u0435\u043E\u0434\u043E\u043B\u0435\u043D\u0438\u0435 \u0441\u0442\u0440\u0430\u0445\u0430',
+    description:
+      '\u041F\u0440\u0430\u043A\u0442\u0438\u0447\u0435\u0441\u043A\u043E\u0435 \u0440\u0443\u043A\u043E\u0432\u043E\u0434\u0441\u0442\u0432\u043E \u043F\u043E \u043F\u0440\u0435\u043E\u0434\u043E\u043B\u0435\u043D\u0438\u044E \u0441\u0442\u0440\u0430\u0445\u0430.',
+    language: 'Russian',
+    languageCode: 'RU',
+    imageUrl:
+      'https://images.unsplash.com/photo-1509316785289-025f5b846b35?w=400&h=300&fit=crop'
+  },
+  {
+    id: 'tmpl-13',
+    title: '\u0420\u0443\u043A\u043E\u0432\u043E\u0434\u0441\u0442\u0432\u043E \u043F\u043E \u043C\u043E\u043B\u0438\u0442\u0432\u0435',
+    description:
+      '\u0423\u0437\u043D\u0430\u0439\u0442\u0435, \u043A\u0430\u043A \u0440\u0430\u0437\u0432\u0438\u0442\u044C \u043C\u043E\u043B\u0438\u0442\u0432\u0435\u043D\u043D\u0443\u044E \u0436\u0438\u0437\u043D\u044C.',
+    language: 'Russian',
+    languageCode: 'RU',
+    imageUrl:
+      'https://images.unsplash.com/photo-1490750967868-88aa4f44baee?w=400&h=300&fit=crop'
+  },
+  {
+    id: 'tmpl-14',
+    title: '\u041E\u0441\u043D\u043E\u0432\u044B \u0441\u0435\u043C\u044C\u0438',
+    description:
+      '\u041F\u043E\u0441\u0442\u0440\u043E\u0439\u0442\u0435 \u043A\u0440\u0435\u043F\u043A\u0438\u0439 \u0444\u0443\u043D\u0434\u0430\u043C\u0435\u043D\u0442 \u0434\u043B\u044F \u0441\u0435\u043C\u0435\u0439\u043D\u044B\u0445 \u043E\u0442\u043D\u043E\u0448\u0435\u043D\u0438\u0439.',
+    language: 'Russian',
+    languageCode: 'RU',
+    imageUrl:
+      'https://images.unsplash.com/photo-1502082553048-f009c37129b9?w=400&h=300&fit=crop'
+  },
+  // Spanish (6)
+  {
+    id: 'tmpl-15',
+    title: 'Encontrando Esperanza',
+    description: 'Un viaje explorando la esperanza y la resiliencia.',
+    language: 'Spanish',
+    languageCode: 'ES',
+    imageUrl:
+      'https://images.unsplash.com/photo-1507525428034-b723cf961d3e?w=400&h=300&fit=crop'
+  },
+  {
+    id: 'tmpl-16',
+    title: 'La Historia de Pascua',
+    description: 'Experimenta la poderosa historia de la Pascua.',
+    language: 'Spanish',
+    languageCode: 'ES',
+    imageUrl:
+      'https://images.unsplash.com/photo-1416879595882-3373a0480b5b?w=400&h=300&fit=crop'
+  },
+  {
+    id: 'tmpl-17',
+    title: '\u00BFQui\u00E9n es Jes\u00FAs?',
+    description:
+      'Descubre la vida y las ense\u00F1anzas de Jesucristo.',
+    language: 'Spanish',
+    languageCode: 'ES',
+    imageUrl:
+      'https://images.unsplash.com/photo-1472214103451-9374bd1c798e?w=400&h=300&fit=crop'
+  },
+  {
+    id: 'tmpl-18',
+    title: 'Preguntas de la Vida',
+    description: 'Explora las grandes preguntas sobre el prop\u00F3sito.',
+    language: 'Spanish',
+    languageCode: 'ES',
+    imageUrl:
+      'https://images.unsplash.com/photo-1433086966358-54859d0ed716?w=400&h=300&fit=crop'
+  },
+  {
+    id: 'tmpl-19',
+    title: 'Manejo de la Ansiedad',
+    description:
+      'Gu\u00EDa pr\u00E1ctica para encontrar paz en tiempos dif\u00EDciles.',
+    language: 'Spanish',
+    languageCode: 'ES',
+    imageUrl:
+      'https://images.unsplash.com/photo-1504567961542-e24d9439a724?w=400&h=300&fit=crop'
+  },
+  {
+    id: 'tmpl-20',
+    title: 'Gu\u00EDa de Oraci\u00F3n',
+    description:
+      'Aprende a desarrollar una vida de oraci\u00F3n significativa.',
+    language: 'Spanish',
+    languageCode: 'ES',
+    imageUrl:
+      'https://images.unsplash.com/photo-1499002238440-d264edd596ec?w=400&h=300&fit=crop'
+  }
+]

--- a/apps/journeys-admin/src/components/JourneyList/JourneyList.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyList.tsx
@@ -7,6 +7,7 @@ import { User } from '../../libs/auth/authContext'
 import { useAdminJourneysQuery } from '../../libs/useAdminJourneysQuery'
 import { usePageWrapperStyles } from '../PageWrapper/utils/usePageWrapperStyles'
 
+import { CollectionsDemo } from '../CollectionsDemo'
 import { FoldersDemo } from '../FoldersDemo'
 
 import { AddJourneyFab } from './AddJourneyFab'
@@ -100,6 +101,9 @@ export function JourneyList({
   ): ReactElement => {
     if (contentType === 'foldersDemo') {
       return <FoldersDemo />
+    }
+    if (contentType === 'collectionsDemo') {
+      return <CollectionsDemo />
     }
 
     // Only pass event to the currently active content type to prevent duplicate actions

--- a/apps/journeys-admin/src/components/JourneyList/JourneyList.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyList.tsx
@@ -7,6 +7,8 @@ import { User } from '../../libs/auth/authContext'
 import { useAdminJourneysQuery } from '../../libs/useAdminJourneysQuery'
 import { usePageWrapperStyles } from '../PageWrapper/utils/usePageWrapperStyles'
 
+import { FoldersDemo } from '../FoldersDemo'
+
 import { AddJourneyFab } from './AddJourneyFab'
 import { JourneyListContent } from './JourneyListContent'
 import { JourneyListView } from './JourneyListView'
@@ -96,6 +98,10 @@ export function JourneyList({
     contentType: ContentType,
     status: JourneyStatusFilter
   ): ReactElement => {
+    if (contentType === 'foldersDemo') {
+      return <FoldersDemo />
+    }
+
     // Only pass event to the currently active content type to prevent duplicate actions
     const eventForThisContentType =
       contentType === currentContentType ? event : undefined

--- a/apps/journeys-admin/src/components/JourneyList/JourneyListView/DisplayModes/TeamMode/TeamMode.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyListView/DisplayModes/TeamMode/TeamMode.tsx
@@ -37,55 +37,75 @@ export const TeamMode = ({
   setActiveEvent,
   router,
   renderList
-}: TeamModeProps): ReactElement => (
-  <>
-    <Tabs
-      value={activeContentTypeTab}
-      onChange={handleContentTypeChange}
-      aria-label="journey content type tabs"
-      data-testid="journey-list-view"
-      sx={{
-        // Allow overflow to prevent hover circle on JourneyListMenu from being clipped
-        // MUI Tabs uses an internal scroller with overflow: hidden by default
-        overflow: 'visible',
-        pr: 2,
-        display: 'flex',
-        alignItems: 'center',
-        '& .MuiTabs-scroller': {
-          overflow: 'visible !important'
-        },
-        '& .MuiTab-root': {
-          typography: 'subtitle2'
-        }
-      }}
-    >
-      <Tab
-        label={contentTypeOptions[0].displayValue}
-        {...tabA11yProps(
-          'journeys-content-panel',
-          contentTypeOptions[0].tabIndex
-        )}
-      />
-      <Tab
-        label={contentTypeOptions[1].displayValue}
-        {...tabA11yProps(
-          'templates-content-panel',
-          contentTypeOptions[1].tabIndex
-        )}
-      />
-      <StatusFilterControl
-        selectedStatus={selectedStatus}
-        handleStatusChange={handleStatusChange}
-      />
-      <SortControl sortOrder={sortOrder} setSortOrder={setSortOrder} />
-      <MenuControl
-        setActiveEvent={setActiveEvent}
-        menuMarginRight={{
-          xs: 1,
-          sm: router?.query?.type === 'templates' ? -12 : -8
+}: TeamModeProps): ReactElement => {
+  const isFoldersDemo =
+    contentTypeOptions[2] != null &&
+    activeContentTypeTab === contentTypeOptions[2].tabIndex
+
+  return (
+    <>
+      <Tabs
+        value={activeContentTypeTab}
+        onChange={handleContentTypeChange}
+        aria-label="journey content type tabs"
+        data-testid="journey-list-view"
+        sx={{
+          // Allow overflow to prevent hover circle on JourneyListMenu from being clipped
+          // MUI Tabs uses an internal scroller with overflow: hidden by default
+          overflow: 'visible',
+          pr: 2,
+          display: 'flex',
+          alignItems: 'center',
+          '& .MuiTabs-scroller': {
+            overflow: 'visible !important'
+          },
+          '& .MuiTab-root': {
+            typography: 'subtitle2'
+          }
         }}
-      />
-    </Tabs>
+      >
+        <Tab
+          label={contentTypeOptions[0].displayValue}
+          {...tabA11yProps(
+            'journeys-content-panel',
+            contentTypeOptions[0].tabIndex
+          )}
+        />
+        <Tab
+          label={contentTypeOptions[1].displayValue}
+          {...tabA11yProps(
+            'templates-content-panel',
+            contentTypeOptions[1].tabIndex
+          )}
+        />
+        {contentTypeOptions[2] != null && (
+          <Tab
+            label={contentTypeOptions[2].displayValue}
+            {...tabA11yProps(
+              'folders-demo-content-panel',
+              contentTypeOptions[2].tabIndex
+            )}
+          />
+        )}
+        {!isFoldersDemo && (
+          <StatusFilterControl
+            selectedStatus={selectedStatus}
+            handleStatusChange={handleStatusChange}
+          />
+        )}
+        {!isFoldersDemo && (
+          <SortControl sortOrder={sortOrder} setSortOrder={setSortOrder} />
+        )}
+        {!isFoldersDemo && (
+          <MenuControl
+            setActiveEvent={setActiveEvent}
+            menuMarginRight={{
+              xs: 1,
+              sm: router?.query?.type === 'templates' ? -12 : -8
+            }}
+          />
+        )}
+      </Tabs>
     {/* Journeys tab panel */}
     <TabPanel
       name="journeys-content-panel"
@@ -108,5 +128,20 @@ export const TeamMode = ({
     >
       {renderList('templates', selectedStatus)}
     </TabPanel>
+    {/* Folders Demo tab panel */}
+    {contentTypeOptions[2] != null && (
+      <TabPanel
+        name="folders-demo-content-panel"
+        value={activeContentTypeTab}
+        index={contentTypeOptions[2].tabIndex}
+        unmountUntilVisible={
+          router?.query?.type !== undefined &&
+          router?.query?.type !== 'foldersDemo'
+        }
+      >
+        {renderList('foldersDemo', selectedStatus)}
+      </TabPanel>
+    )}
   </>
-)
+  )
+}

--- a/apps/journeys-admin/src/components/JourneyList/JourneyListView/DisplayModes/TeamMode/TeamMode.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyListView/DisplayModes/TeamMode/TeamMode.tsx
@@ -38,9 +38,11 @@ export const TeamMode = ({
   router,
   renderList
 }: TeamModeProps): ReactElement => {
-  const isFoldersDemo =
-    contentTypeOptions[2] != null &&
-    activeContentTypeTab === contentTypeOptions[2].tabIndex
+  const isDemoMode =
+    (contentTypeOptions[2] != null &&
+      activeContentTypeTab === contentTypeOptions[2].tabIndex) ||
+    (contentTypeOptions[3] != null &&
+      activeContentTypeTab === contentTypeOptions[3].tabIndex)
 
   return (
     <>
@@ -87,16 +89,25 @@ export const TeamMode = ({
             )}
           />
         )}
-        {!isFoldersDemo && (
+        {contentTypeOptions[3] != null && (
+          <Tab
+            label={contentTypeOptions[3].displayValue}
+            {...tabA11yProps(
+              'collections-demo-content-panel',
+              contentTypeOptions[3].tabIndex
+            )}
+          />
+        )}
+        {!isDemoMode && (
           <StatusFilterControl
             selectedStatus={selectedStatus}
             handleStatusChange={handleStatusChange}
           />
         )}
-        {!isFoldersDemo && (
+        {!isDemoMode && (
           <SortControl sortOrder={sortOrder} setSortOrder={setSortOrder} />
         )}
-        {!isFoldersDemo && (
+        {!isDemoMode && (
           <MenuControl
             setActiveEvent={setActiveEvent}
             menuMarginRight={{
@@ -140,6 +151,20 @@ export const TeamMode = ({
         }
       >
         {renderList('foldersDemo', selectedStatus)}
+      </TabPanel>
+    )}
+    {/* Collections Demo tab panel */}
+    {contentTypeOptions[3] != null && (
+      <TabPanel
+        name="collections-demo-content-panel"
+        value={activeContentTypeTab}
+        index={contentTypeOptions[3].tabIndex}
+        unmountUntilVisible={
+          router?.query?.type !== undefined &&
+          router?.query?.type !== 'collectionsDemo'
+        }
+      >
+        {renderList('collectionsDemo', selectedStatus)}
       </TabPanel>
     )}
   </>

--- a/apps/journeys-admin/src/components/JourneyList/JourneyListView/JourneyListView.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyListView/JourneyListView.tsx
@@ -18,7 +18,7 @@ import { SortOrder } from '../JourneySort'
 import { SharedWithMeMode } from './DisplayModes/SharedWithMeMode/SharedWithMeMode'
 import { ContentTypeOption, TeamMode } from './DisplayModes/TeamMode/TeamMode'
 
-export type ContentType = 'journeys' | 'templates'
+export type ContentType = 'journeys' | 'templates' | 'foldersDemo'
 export type JourneyStatus = 'active' | 'archived' | 'trashed'
 
 export interface JourneyListViewProps {
@@ -69,6 +69,11 @@ export function JourneyListView({
       queryParam: 'templates',
       displayValue: breakpoints.sm ? t('Team Templates') : t('Templates'),
       tabIndex: 1
+    },
+    {
+      queryParam: 'foldersDemo',
+      displayValue: t('Folders Demo'),
+      tabIndex: 2
     }
   ]
 

--- a/apps/journeys-admin/src/components/JourneyList/JourneyListView/JourneyListView.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyListView/JourneyListView.tsx
@@ -18,7 +18,7 @@ import { SortOrder } from '../JourneySort'
 import { SharedWithMeMode } from './DisplayModes/SharedWithMeMode/SharedWithMeMode'
 import { ContentTypeOption, TeamMode } from './DisplayModes/TeamMode/TeamMode'
 
-export type ContentType = 'journeys' | 'templates' | 'foldersDemo'
+export type ContentType = 'journeys' | 'templates' | 'foldersDemo' | 'collectionsDemo'
 export type JourneyStatus = 'active' | 'archived' | 'trashed'
 
 export interface JourneyListViewProps {
@@ -74,6 +74,11 @@ export function JourneyListView({
       queryParam: 'foldersDemo',
       displayValue: t('Folders Demo'),
       tabIndex: 2
+    },
+    {
+      queryParam: 'collectionsDemo',
+      displayValue: t('Collections Demo'),
+      tabIndex: 3
     }
   ]
 


### PR DESCRIPTION
## Summary
- Adds a **Folders Demo** tab alongside Projects and Templates in the journeys admin list view
- 20 mock template cards (English, Russian, Spanish) with Unsplash images in a grid layout
- Drag-and-drop templates into named sections using `@dnd-kit/core`
- Sections have pastel background colors (auto-assigned, unique), inline title editing (double-click or on creation), and delete functionality
- Persistent right-side panel matching Figma design ("What templates are about:") with collapsible accordion sections
- Section detail panel replaces info panel in the same slot when editing — includes title, description, background color picker, page instructions, creator details, and PDF/video URL fields
- Status filter and sort controls remain in the content area alongside the add-section button
- All state is local (lost on refresh) — this is a prototype for exploring folder-based template organization

## Test plan
- [ ] Navigate to the Folders Demo tab and verify 20 template cards render in a grid
- [ ] Click "Add Section" and verify a section is created with auto-name and inline title edit
- [ ] Double-click a section title to rename it, press Enter to confirm
- [ ] Drag template cards into sections and between sections
- [ ] Delete a section and verify cards return to "All Templates"
- [ ] Click the edit icon on a section and verify the detail panel opens in place of the info panel
- [ ] Verify the panel never overlaps template cards
- [ ] Verify existing Projects and Templates tabs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)