### PR TITLE
chore: blockDuplicate modern

### DIFF
--- a/apis/api-gateway/schema.graphql
+++ b/apis/api-gateway/schema.graphql
@@ -155,7 +155,7 @@ type Mutation @join__type(graph: API_ANALYTICS)  @join__type(graph: API_JOURNEYS
     the editor.
     """
     y: Int
-  ): [Block!]! @join__field(graph: API_JOURNEYS) 
+  ): [Block!]! @join__field(graph: API_JOURNEYS_MODERN, override: "api-journeys") 
   blockOrderUpdate(
     id: ID!
     parentOrder: Int!

--- a/apis/api-journeys-modern/schema.graphql
+++ b/apis/api-journeys-modern/schema.graphql
@@ -1350,6 +1350,16 @@ input MultiselectSubmissionEventCreateInput {
 }
 
 type Mutation {
+  blockDuplicate(
+    id: ID!
+    parentOrder: Int
+    idMap: [BlockDuplicateIdMap!]
+
+    """drop this parameter after merging teams"""
+    journeyId: ID
+    x: Int
+    y: Int
+  ): [Block!]! @override(from: "api-journeys")
   blockOrderUpdate(
     id: ID!
     parentOrder: Int!

--- a/apis/api-journeys-modern/src/schema/block/blockDuplicate.mutation.spec.ts
+++ b/apis/api-journeys-modern/src/schema/block/blockDuplicate.mutation.spec.ts
@@ -1,0 +1,206 @@
+import { getClient } from '../../../test/client'
+import { prismaMock } from '../../../test/prismaMock'
+import { Action, ability } from '../../lib/auth/ability'
+import { graphql } from '../../lib/graphql/subgraphGraphql'
+
+jest.mock('../../lib/auth/ability', () => ({
+  Action: { Update: 'update' },
+  ability: jest.fn(),
+  subject: jest.fn((type, object) => ({ subject: type, object }))
+}))
+
+jest.mock('../../lib/auth/fetchBlockWithJourneyAcl', () => ({
+  fetchBlockWithJourneyAcl: jest.fn()
+}))
+
+jest.mock(
+  '../../lib/recalculateJourneyCustomizable/recalculateJourneyCustomizable',
+  () => ({
+    recalculateJourneyCustomizable: jest.fn()
+  })
+)
+
+describe('blockDuplicate', () => {
+  const mockUser = { id: 'userId' }
+  const authClient = getClient({
+    headers: { authorization: 'token' },
+    context: { currentUser: mockUser }
+  })
+
+  const BLOCK_DUPLICATE = graphql(`
+    mutation BlockDuplicate(
+      $id: ID!
+      $parentOrder: Int
+      $idMap: [BlockDuplicateIdMap!]
+      $x: Int
+      $y: Int
+    ) {
+      blockDuplicate(
+        id: $id
+        parentOrder: $parentOrder
+        idMap: $idMap
+        x: $x
+        y: $y
+      ) {
+        id
+        journeyId
+        parentBlockId
+        parentOrder
+      }
+    }
+  `)
+
+  const {
+    fetchBlockWithJourneyAcl
+  } = require('../../lib/auth/fetchBlockWithJourneyAcl')
+  const {
+    recalculateJourneyCustomizable
+  } = require('../../lib/recalculateJourneyCustomizable/recalculateJourneyCustomizable')
+  const mockAbility = ability as jest.MockedFunction<typeof ability>
+
+  const id = 'blockId'
+  const journey = { id: 'journeyId' }
+  const block = {
+    id,
+    typename: 'ImageBlock',
+    journeyId: 'journeyId',
+    parentBlockId: 'parentId',
+    parentOrder: 0,
+    action: null,
+    journey
+  }
+
+  const duplicatedBlock = {
+    id: 'duplicatedBlockId',
+    typename: 'ImageBlock',
+    journeyId: 'journeyId',
+    parentBlockId: 'parentId',
+    parentOrder: 1,
+    action: null
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('duplicates the block when authorized', async () => {
+    fetchBlockWithJourneyAcl.mockResolvedValue(block)
+    mockAbility.mockReturnValue(true)
+
+    prismaMock.block.findUnique.mockResolvedValue(block as any)
+    prismaMock.block.findMany.mockResolvedValueOnce([])
+    prismaMock.block.create.mockResolvedValue(duplicatedBlock as any)
+    prismaMock.block.findMany.mockResolvedValue([
+      block as any,
+      duplicatedBlock as any
+    ])
+    prismaMock.block.update
+      .mockResolvedValueOnce({ ...block, parentOrder: 0 } as any)
+      .mockResolvedValueOnce({ ...duplicatedBlock, parentOrder: 1 } as any)
+
+    const tx = {
+      journey: { update: jest.fn().mockResolvedValue(journey) }
+    }
+    prismaMock.$transaction.mockImplementation(async (cb: any) => await cb(tx))
+
+    await authClient({
+      document: BLOCK_DUPLICATE,
+      variables: { id, parentOrder: 1 }
+    })
+
+    expect(fetchBlockWithJourneyAcl).toHaveBeenCalledWith(id)
+    expect(mockAbility).toHaveBeenCalledWith(
+      Action.Update,
+      { subject: 'Journey', object: journey },
+      expect.any(Object)
+    )
+    expect(tx.journey.update).toHaveBeenCalledWith({
+      where: { id: 'journeyId' },
+      data: { updatedAt: expect.any(String) }
+    })
+    expect(recalculateJourneyCustomizable).toHaveBeenCalledWith('journeyId')
+  })
+
+  it('duplicates with custom idMap', async () => {
+    fetchBlockWithJourneyAcl.mockResolvedValue(block)
+    mockAbility.mockReturnValue(true)
+
+    const customBlock = {
+      ...block,
+      settings: {},
+      action: null
+    }
+
+    prismaMock.block.findUnique.mockResolvedValue(customBlock as any)
+    prismaMock.block.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([customBlock as any, { ...duplicatedBlock, id: 'customNewId' } as any])
+    prismaMock.block.create.mockResolvedValue({
+      ...duplicatedBlock,
+      id: 'customNewId'
+    } as any)
+    prismaMock.block.update.mockImplementation((async (args: any) => ({
+      ...duplicatedBlock,
+      id: args.where.id,
+      parentOrder: args.data.parentOrder ?? 0
+    })) as any)
+
+    const tx = {
+      journey: { update: jest.fn().mockResolvedValue(journey) }
+    }
+    prismaMock.$transaction.mockImplementation(async (cb: any) => await cb(tx))
+
+    const idMap = [{ oldId: 'blockId', newId: 'customNewId' }]
+
+    await authClient({
+      document: BLOCK_DUPLICATE,
+      variables: { id, parentOrder: 1, idMap }
+    })
+
+    expect(recalculateJourneyCustomizable).toHaveBeenCalledWith('journeyId')
+  })
+
+  it('returns FORBIDDEN when unauthorized', async () => {
+    fetchBlockWithJourneyAcl.mockResolvedValue(block)
+    mockAbility.mockReturnValue(false)
+
+    const result = await authClient({
+      document: BLOCK_DUPLICATE,
+      variables: { id }
+    })
+
+    expect(result).toEqual({
+      data: null,
+      errors: [
+        expect.objectContaining({
+          message: 'user is not allowed to update block'
+        })
+      ]
+    })
+    expect(prismaMock.$transaction).not.toHaveBeenCalled()
+    expect(recalculateJourneyCustomizable).not.toHaveBeenCalled()
+  })
+
+  it('returns NOT_FOUND when block does not exist', async () => {
+    const { GraphQLError } = require('graphql')
+    fetchBlockWithJourneyAcl.mockRejectedValue(
+      new GraphQLError('block not found', {
+        extensions: { code: 'NOT_FOUND' }
+      })
+    )
+
+    const result = await authClient({
+      document: BLOCK_DUPLICATE,
+      variables: { id }
+    })
+
+    expect(result).toEqual({
+      data: null,
+      errors: [
+        expect.objectContaining({
+          message: 'block not found'
+        })
+      ]
+    })
+  })
+})

--- a/apis/api-journeys-modern/src/schema/block/blockDuplicate.mutation.spec.ts
+++ b/apis/api-journeys-modern/src/schema/block/blockDuplicate.mutation.spec.ts
@@ -67,43 +67,72 @@ describe('blockDuplicate', () => {
     parentBlockId: 'parentId',
     parentOrder: 0,
     action: null,
+    settings: {},
     journey
-  }
-
-  const duplicatedBlock = {
-    id: 'duplicatedBlockId',
-    typename: 'ImageBlock',
-    journeyId: 'journeyId',
-    parentBlockId: 'parentId',
-    parentOrder: 1,
-    action: null
   }
 
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
-  it('duplicates the block when authorized', async () => {
+  it('duplicates the block when authorized and returns response fields', async () => {
     fetchBlockWithJourneyAcl.mockResolvedValue(block)
     mockAbility.mockReturnValue(true)
 
     prismaMock.block.findUnique.mockResolvedValue(block as any)
-    prismaMock.block.findMany.mockResolvedValueOnce([])
-    prismaMock.block.create.mockResolvedValue(duplicatedBlock as any)
-    prismaMock.block.findMany.mockResolvedValue([
-      block as any,
-      duplicatedBlock as any
-    ])
+    prismaMock.block.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([
+        { ...block, parentOrder: 0 } as any,
+        {
+          id: 'duplicatedBlockId',
+          typename: 'ImageBlock',
+          journeyId: 'journeyId',
+          parentBlockId: 'parentId',
+          parentOrder: 1,
+          action: null
+        } as any
+      ])
+    prismaMock.block.create.mockResolvedValue({
+      id: 'duplicatedBlockId',
+      typename: 'ImageBlock',
+      journeyId: 'journeyId',
+      parentBlockId: 'parentId',
+      parentOrder: null,
+      action: null
+    } as any)
     prismaMock.block.update
-      .mockResolvedValueOnce({ ...block, parentOrder: 0 } as any)
-      .mockResolvedValueOnce({ ...duplicatedBlock, parentOrder: 1 } as any)
+      .mockResolvedValueOnce({
+        id: 'duplicatedBlockId',
+        typename: 'ImageBlock',
+        journeyId: 'journeyId',
+        parentBlockId: 'parentId',
+        parentOrder: null,
+        action: null
+      } as any)
+      .mockResolvedValueOnce({
+        id,
+        typename: 'ImageBlock',
+        journeyId: 'journeyId',
+        parentBlockId: 'parentId',
+        parentOrder: 0,
+        action: null
+      } as any)
+      .mockResolvedValueOnce({
+        id: 'duplicatedBlockId',
+        typename: 'ImageBlock',
+        journeyId: 'journeyId',
+        parentBlockId: 'parentId',
+        parentOrder: 1,
+        action: null
+      } as any)
 
     const tx = {
       journey: { update: jest.fn().mockResolvedValue(journey) }
     }
     prismaMock.$transaction.mockImplementation(async (cb: any) => await cb(tx))
 
-    await authClient({
+    const result = await authClient({
       document: BLOCK_DUPLICATE,
       variables: { id, parentOrder: 1 }
     })
@@ -119,34 +148,72 @@ describe('blockDuplicate', () => {
       data: { updatedAt: expect.any(String) }
     })
     expect(recalculateJourneyCustomizable).toHaveBeenCalledWith('journeyId')
+    expect(result).toEqual({
+      data: {
+        blockDuplicate: [
+          { id, journeyId: 'journeyId', parentBlockId: 'parentId', parentOrder: 0 },
+          {
+            id: 'duplicatedBlockId',
+            journeyId: 'journeyId',
+            parentBlockId: 'parentId',
+            parentOrder: 1
+          }
+        ]
+      }
+    })
   })
 
-  it('duplicates with custom idMap', async () => {
+  it('duplicates with custom idMap and returns the mapped id', async () => {
     fetchBlockWithJourneyAcl.mockResolvedValue(block)
     mockAbility.mockReturnValue(true)
 
-    const customBlock = {
-      ...block,
-      settings: {},
-      action: null
-    }
-
-    prismaMock.block.findUnique.mockResolvedValue(customBlock as any)
+    prismaMock.block.findUnique.mockResolvedValue(block as any)
     prismaMock.block.findMany
       .mockResolvedValueOnce([])
       .mockResolvedValue([
-        customBlock as any,
-        { ...duplicatedBlock, id: 'customNewId' } as any
+        { ...block, parentOrder: 0 } as any,
+        {
+          id: 'customNewId',
+          typename: 'ImageBlock',
+          journeyId: 'journeyId',
+          parentBlockId: 'parentId',
+          parentOrder: 1,
+          action: null
+        } as any
       ])
     prismaMock.block.create.mockResolvedValue({
-      ...duplicatedBlock,
-      id: 'customNewId'
+      id: 'customNewId',
+      typename: 'ImageBlock',
+      journeyId: 'journeyId',
+      parentBlockId: 'parentId',
+      parentOrder: null,
+      action: null
     } as any)
-    prismaMock.block.update.mockImplementation((async (args: any) => ({
-      ...duplicatedBlock,
-      id: args.where.id,
-      parentOrder: args.data.parentOrder ?? 0
-    })) as any)
+    prismaMock.block.update
+      .mockResolvedValueOnce({
+        id: 'customNewId',
+        typename: 'ImageBlock',
+        journeyId: 'journeyId',
+        parentBlockId: 'parentId',
+        parentOrder: null,
+        action: null
+      } as any)
+      .mockResolvedValueOnce({
+        id,
+        typename: 'ImageBlock',
+        journeyId: 'journeyId',
+        parentBlockId: 'parentId',
+        parentOrder: 0,
+        action: null
+      } as any)
+      .mockResolvedValueOnce({
+        id: 'customNewId',
+        typename: 'ImageBlock',
+        journeyId: 'journeyId',
+        parentBlockId: 'parentId',
+        parentOrder: 1,
+        action: null
+      } as any)
 
     const tx = {
       journey: { update: jest.fn().mockResolvedValue(journey) }
@@ -155,12 +222,136 @@ describe('blockDuplicate', () => {
 
     const idMap = [{ oldId: 'blockId', newId: 'customNewId' }]
 
-    await authClient({
+    const result = await authClient({
       document: BLOCK_DUPLICATE,
       variables: { id, parentOrder: 1, idMap }
     })
 
     expect(recalculateJourneyCustomizable).toHaveBeenCalledWith('journeyId')
+    expect(result).toEqual({
+      data: {
+        blockDuplicate: [
+          { id, journeyId: 'journeyId', parentBlockId: 'parentId', parentOrder: 0 },
+          {
+            id: 'customNewId',
+            journeyId: 'journeyId',
+            parentBlockId: 'parentId',
+            parentOrder: 1
+          }
+        ]
+      }
+    })
+  })
+
+  it('duplicates a StepBlock with x and y coordinates', async () => {
+    const stepBlock = {
+      ...block,
+      id: 'stepBlockId',
+      typename: 'StepBlock',
+      parentBlockId: null,
+      parentOrder: 0,
+      x: 100,
+      y: 200
+    }
+
+    fetchBlockWithJourneyAcl.mockResolvedValue(stepBlock)
+    mockAbility.mockReturnValue(true)
+
+    prismaMock.block.findUnique.mockResolvedValue(stepBlock as any)
+    prismaMock.block.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([
+        { ...stepBlock, parentOrder: 0 } as any,
+        {
+          id: 'duplicatedStepId',
+          typename: 'StepBlock',
+          journeyId: 'journeyId',
+          parentBlockId: null,
+          parentOrder: 1,
+          x: 300,
+          y: 400,
+          action: null
+        } as any
+      ])
+    prismaMock.block.create.mockResolvedValue({
+      id: 'duplicatedStepId',
+      typename: 'StepBlock',
+      journeyId: 'journeyId',
+      parentBlockId: null,
+      parentOrder: null,
+      x: 100,
+      y: 200,
+      action: null
+    } as any)
+    prismaMock.block.update
+      .mockResolvedValueOnce({
+        id: 'duplicatedStepId',
+        typename: 'StepBlock',
+        journeyId: 'journeyId',
+        parentBlockId: null,
+        parentOrder: null,
+        x: 300,
+        y: 400,
+        action: null
+      } as any)
+      .mockResolvedValueOnce({
+        id: 'stepBlockId',
+        typename: 'StepBlock',
+        journeyId: 'journeyId',
+        parentBlockId: null,
+        parentOrder: 0,
+        x: 100,
+        y: 200,
+        action: null
+      } as any)
+      .mockResolvedValueOnce({
+        id: 'duplicatedStepId',
+        typename: 'StepBlock',
+        journeyId: 'journeyId',
+        parentBlockId: null,
+        parentOrder: 1,
+        x: 300,
+        y: 400,
+        action: null
+      } as any)
+
+    const tx = {
+      journey: { update: jest.fn().mockResolvedValue(journey) }
+    }
+    prismaMock.$transaction.mockImplementation(async (cb: any) => await cb(tx))
+
+    const idMap = [{ oldId: 'stepBlockId', newId: 'duplicatedStepId' }]
+
+    const result = await authClient({
+      document: BLOCK_DUPLICATE,
+      variables: { id: 'stepBlockId', parentOrder: 1, x: 300, y: 400, idMap }
+    })
+
+    expect(prismaMock.block.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'duplicatedStepId' },
+        data: expect.objectContaining({ x: 300, y: 400 })
+      })
+    )
+    expect(recalculateJourneyCustomizable).toHaveBeenCalledWith('journeyId')
+    expect(result).toEqual({
+      data: {
+        blockDuplicate: [
+          {
+            id: 'stepBlockId',
+            journeyId: 'journeyId',
+            parentBlockId: null,
+            parentOrder: 0
+          },
+          {
+            id: 'duplicatedStepId',
+            journeyId: 'journeyId',
+            parentBlockId: null,
+            parentOrder: 1
+          }
+        ]
+      }
+    })
   })
 
   it('returns FORBIDDEN when unauthorized', async () => {

--- a/apis/api-journeys-modern/src/schema/block/blockDuplicate.mutation.spec.ts
+++ b/apis/api-journeys-modern/src/schema/block/blockDuplicate.mutation.spec.ts
@@ -134,7 +134,10 @@ describe('blockDuplicate', () => {
     prismaMock.block.findUnique.mockResolvedValue(customBlock as any)
     prismaMock.block.findMany
       .mockResolvedValueOnce([])
-      .mockResolvedValue([customBlock as any, { ...duplicatedBlock, id: 'customNewId' } as any])
+      .mockResolvedValue([
+        customBlock as any,
+        { ...duplicatedBlock, id: 'customNewId' } as any
+      ])
     prismaMock.block.create.mockResolvedValue({
       ...duplicatedBlock,
       id: 'customNewId'

--- a/apis/api-journeys-modern/src/schema/block/blockDuplicate.mutation.spec.ts
+++ b/apis/api-journeys-modern/src/schema/block/blockDuplicate.mutation.spec.ts
@@ -80,19 +80,17 @@ describe('blockDuplicate', () => {
     mockAbility.mockReturnValue(true)
 
     prismaMock.block.findUnique.mockResolvedValue(block as any)
-    prismaMock.block.findMany
-      .mockResolvedValueOnce([])
-      .mockResolvedValue([
-        { ...block, parentOrder: 0 } as any,
-        {
-          id: 'duplicatedBlockId',
-          typename: 'ImageBlock',
-          journeyId: 'journeyId',
-          parentBlockId: 'parentId',
-          parentOrder: 1,
-          action: null
-        } as any
-      ])
+    prismaMock.block.findMany.mockResolvedValueOnce([]).mockResolvedValue([
+      { ...block, parentOrder: 0 } as any,
+      {
+        id: 'duplicatedBlockId',
+        typename: 'ImageBlock',
+        journeyId: 'journeyId',
+        parentBlockId: 'parentId',
+        parentOrder: 1,
+        action: null
+      } as any
+    ])
     prismaMock.block.create.mockResolvedValue({
       id: 'duplicatedBlockId',
       typename: 'ImageBlock',
@@ -151,7 +149,12 @@ describe('blockDuplicate', () => {
     expect(result).toEqual({
       data: {
         blockDuplicate: [
-          { id, journeyId: 'journeyId', parentBlockId: 'parentId', parentOrder: 0 },
+          {
+            id,
+            journeyId: 'journeyId',
+            parentBlockId: 'parentId',
+            parentOrder: 0
+          },
           {
             id: 'duplicatedBlockId',
             journeyId: 'journeyId',
@@ -168,19 +171,17 @@ describe('blockDuplicate', () => {
     mockAbility.mockReturnValue(true)
 
     prismaMock.block.findUnique.mockResolvedValue(block as any)
-    prismaMock.block.findMany
-      .mockResolvedValueOnce([])
-      .mockResolvedValue([
-        { ...block, parentOrder: 0 } as any,
-        {
-          id: 'customNewId',
-          typename: 'ImageBlock',
-          journeyId: 'journeyId',
-          parentBlockId: 'parentId',
-          parentOrder: 1,
-          action: null
-        } as any
-      ])
+    prismaMock.block.findMany.mockResolvedValueOnce([]).mockResolvedValue([
+      { ...block, parentOrder: 0 } as any,
+      {
+        id: 'customNewId',
+        typename: 'ImageBlock',
+        journeyId: 'journeyId',
+        parentBlockId: 'parentId',
+        parentOrder: 1,
+        action: null
+      } as any
+    ])
     prismaMock.block.create.mockResolvedValue({
       id: 'customNewId',
       typename: 'ImageBlock',
@@ -231,7 +232,12 @@ describe('blockDuplicate', () => {
     expect(result).toEqual({
       data: {
         blockDuplicate: [
-          { id, journeyId: 'journeyId', parentBlockId: 'parentId', parentOrder: 0 },
+          {
+            id,
+            journeyId: 'journeyId',
+            parentBlockId: 'parentId',
+            parentOrder: 0
+          },
           {
             id: 'customNewId',
             journeyId: 'journeyId',
@@ -258,21 +264,19 @@ describe('blockDuplicate', () => {
     mockAbility.mockReturnValue(true)
 
     prismaMock.block.findUnique.mockResolvedValue(stepBlock as any)
-    prismaMock.block.findMany
-      .mockResolvedValueOnce([])
-      .mockResolvedValue([
-        { ...stepBlock, parentOrder: 0 } as any,
-        {
-          id: 'duplicatedStepId',
-          typename: 'StepBlock',
-          journeyId: 'journeyId',
-          parentBlockId: null,
-          parentOrder: 1,
-          x: 300,
-          y: 400,
-          action: null
-        } as any
-      ])
+    prismaMock.block.findMany.mockResolvedValueOnce([]).mockResolvedValue([
+      { ...stepBlock, parentOrder: 0 } as any,
+      {
+        id: 'duplicatedStepId',
+        typename: 'StepBlock',
+        journeyId: 'journeyId',
+        parentBlockId: null,
+        parentOrder: 1,
+        x: 300,
+        y: 400,
+        action: null
+      } as any
+    ])
     prismaMock.block.create.mockResolvedValue({
       id: 'duplicatedStepId',
       typename: 'StepBlock',

--- a/apis/api-journeys-modern/src/schema/block/blockDuplicate.mutation.ts
+++ b/apis/api-journeys-modern/src/schema/block/blockDuplicate.mutation.ts
@@ -1,0 +1,72 @@
+import { GraphQLError } from 'graphql'
+
+import { prisma } from '@core/prisma/journeys/client'
+
+import {
+  Action,
+  ability,
+  subject as abilitySubject
+} from '../../lib/auth/ability'
+import { fetchBlockWithJourneyAcl } from '../../lib/auth/fetchBlockWithJourneyAcl'
+import { recalculateJourneyCustomizable } from '../../lib/recalculateJourneyCustomizable/recalculateJourneyCustomizable'
+import { builder } from '../builder'
+
+import { Block } from './block'
+import { BlockDuplicateIdMapInput } from './inputs'
+import { duplicateBlock } from './service'
+
+builder.mutationField('blockDuplicate', (t) =>
+  t.withAuth({ $any: { isAuthenticated: true, isAnonymous: true } }).field({
+    type: [Block],
+    nullable: false,
+    override: { from: 'api-journeys' },
+    args: {
+      id: t.arg({ type: 'ID', required: true }),
+      parentOrder: t.arg({ type: 'Int', required: false }),
+      idMap: t.arg({ type: [BlockDuplicateIdMapInput], required: false }),
+      journeyId: t.arg({
+        type: 'ID',
+        required: false,
+        description: 'drop this parameter after merging teams'
+      }),
+      x: t.arg({ type: 'Int', required: false }),
+      y: t.arg({ type: 'Int', required: false })
+    },
+    resolve: async (_parent, args, context) => {
+      const { id, parentOrder, idMap, x, y } = args
+
+      const block = await fetchBlockWithJourneyAcl(id)
+      if (
+        !ability(
+          Action.Update,
+          abilitySubject('Journey', block.journey),
+          context.user
+        )
+      ) {
+        throw new GraphQLError('user is not allowed to update block', {
+          extensions: { code: 'FORBIDDEN' }
+        })
+      }
+
+      const isStepBlock = block.typename === 'StepBlock'
+
+      const result = await prisma.$transaction(async (tx) => {
+        const duplicatedBlocks = await duplicateBlock(
+          block,
+          isStepBlock,
+          parentOrder,
+          idMap ?? undefined,
+          x,
+          y
+        )
+        await tx.journey.update({
+          where: { id: block.journeyId },
+          data: { updatedAt: new Date().toISOString() }
+        })
+        return duplicatedBlocks
+      })
+      await recalculateJourneyCustomizable(block.journeyId)
+      return result
+    }
+  })
+)

--- a/apis/api-journeys-modern/src/schema/block/index.ts
+++ b/apis/api-journeys-modern/src/schema/block/index.ts
@@ -1,4 +1,5 @@
 // Export all block schemas from a central location
+import './blockDuplicate.mutation'
 import './blockOrderUpdate.mutation'
 import './button'
 import './card'

--- a/apis/api-journeys-modern/src/schema/block/service.ts
+++ b/apis/api-journeys-modern/src/schema/block/service.ts
@@ -240,14 +240,20 @@ async function getDuplicateBlockAndChildren(
     if (key === 'nextBlockId') {
       updatedBlockProps[key] = null
     } else if (key.includes('BlockId') || key.includes('IconId')) {
-      const blockId: string | null | undefined = (block as Record<string, unknown>)[key] as string | null | undefined
+      const blockId: string | null | undefined = (
+        block as Record<string, unknown>
+      )[key] as string | null | undefined
       updatedBlockProps[key] = blockId != null ? childIds.get(blockId) : null
     }
     if (key === 'action') {
       const action = omit(block.action, 'parentBlockId') as unknown as Action
       updatedBlockProps[key] = action
     }
-    if (key === 'submitEnabled' && (block as Record<string, unknown>)[key] === true && !isStepBlock) {
+    if (
+      key === 'submitEnabled' &&
+      (block as Record<string, unknown>)[key] === true &&
+      !isStepBlock
+    ) {
       updatedBlockProps[key] = false
     }
   })
@@ -351,8 +357,7 @@ export async function duplicateBlock(
           posterBlockId: newBlock.posterBlockId ?? undefined,
           coverBlockId: newBlock.coverBlockId ?? undefined,
           nextBlockId: newBlock.nextBlockId ?? undefined,
-          pollOptionImageBlockId:
-            newBlock.pollOptionImageBlockId ?? undefined,
+          pollOptionImageBlockId: newBlock.pollOptionImageBlockId ?? undefined,
           action:
             !isActionEmpty && newBlock.action != null
               ? {
@@ -395,8 +400,7 @@ export async function duplicateBlock(
   const defaultDuplicateBlockIndex = siblings.findIndex(
     (s) => s.id === duplicatedBlock.id
   )
-  const insertIndex =
-    parentOrder != null ? parentOrder : siblings.length + 1
+  const insertIndex = parentOrder != null ? parentOrder : siblings.length + 1
   siblings.splice(defaultDuplicateBlockIndex, 1)
   siblings.splice(insertIndex, 0, duplicatedBlock)
   const reorderedBlocks = await reorderSiblings(siblings)

--- a/apis/api-journeys-modern/src/schema/block/service.ts
+++ b/apis/api-journeys-modern/src/schema/block/service.ts
@@ -1,5 +1,6 @@
 import { GraphQLError } from 'graphql'
 import omit from 'lodash/omit'
+import { v4 as uuidv4 } from 'uuid'
 
 import { Action, Block, Prisma, prisma } from '@core/prisma/journeys/client'
 import { User } from '@core/yoga/firebaseClient'
@@ -196,4 +197,209 @@ export async function update<T>(
   })
   await recalculateJourneyCustomizable(result.journeyId)
   return result as unknown as T
+}
+
+export interface BlockDuplicateIdMap {
+  oldId: string
+  newId: string
+}
+
+async function getDuplicateBlockAndChildren(
+  id: string,
+  journeyId: string,
+  parentBlockId: string | null,
+  isStepBlock: boolean,
+  duplicateId?: string,
+  idMap?: BlockDuplicateIdMap[]
+): Promise<BlockWithAction[]> {
+  const block = await prisma.block.findUnique({
+    where: { id, deletedAt: null },
+    include: { action: true }
+  })
+  if (block == null) {
+    throw new Error("Block doesn't exist")
+  }
+
+  const duplicateBlockId = duplicateId ?? uuidv4()
+
+  const children = await prisma.block.findMany({
+    where: { parentBlockId: block.id, journeyId, deletedAt: null },
+    include: { action: true },
+    orderBy: { parentOrder: 'asc' }
+  })
+  const childIds = new Map<string, string>()
+  children.forEach((child) => {
+    const duplicatedChildId = idMap?.find(
+      (map) => map.oldId === child.id
+    )?.newId
+    childIds.set(child.id, duplicatedChildId ?? uuidv4())
+  })
+
+  const updatedBlockProps: Record<string, unknown> = {}
+  Object.keys(block).forEach((key) => {
+    if (key === 'nextBlockId') {
+      updatedBlockProps[key] = null
+    } else if (key.includes('BlockId') || key.includes('IconId')) {
+      const blockId: string | null | undefined = (block as Record<string, unknown>)[key] as string | null | undefined
+      updatedBlockProps[key] = blockId != null ? childIds.get(blockId) : null
+    }
+    if (key === 'action') {
+      const action = omit(block.action, 'parentBlockId') as unknown as Action
+      updatedBlockProps[key] = action
+    }
+    if (key === 'submitEnabled' && (block as Record<string, unknown>)[key] === true && !isStepBlock) {
+      updatedBlockProps[key] = false
+    }
+  })
+
+  const duplicateBlock = {
+    ...block,
+    ...updatedBlockProps,
+    id: duplicateBlockId,
+    journeyId: block.journeyId,
+    parentBlockId
+  }
+
+  const duplicateChildren = await getDuplicateChildren(
+    children,
+    journeyId,
+    duplicateBlockId,
+    isStepBlock,
+    childIds,
+    idMap
+  )
+
+  return [duplicateBlock as BlockWithAction, ...duplicateChildren]
+}
+
+async function getDuplicateChildren(
+  children: BlockWithAction[],
+  journeyId: string,
+  parentBlockId: string | null,
+  isStepBlock: boolean,
+  duplicateIds: Map<string, string>,
+  idMap?: BlockDuplicateIdMap[]
+): Promise<BlockWithAction[]> {
+  const duplicateChildren = await Promise.all(
+    children.map(async (child) => {
+      return await getDuplicateBlockAndChildren(
+        child.id,
+        journeyId,
+        parentBlockId,
+        isStepBlock,
+        duplicateIds.get(child.id),
+        idMap
+      )
+    })
+  )
+  return duplicateChildren.reduce((acc, val) => acc.concat(val), [])
+}
+
+export async function duplicateBlock(
+  block: BlockWithAction,
+  isStepBlock: boolean,
+  parentOrder?: number | null,
+  idMap?: BlockDuplicateIdMap[],
+  x?: number | null,
+  y?: number | null
+): Promise<BlockWithAction[]> {
+  const duplicateBlockId = idMap?.find((map) => block.id === map.oldId)?.newId
+  const blockAndChildrenData = await getDuplicateBlockAndChildren(
+    block.id,
+    block.journeyId,
+    block.parentBlockId ?? null,
+    isStepBlock,
+    duplicateBlockId,
+    idMap
+  )
+
+  await Promise.all(
+    blockAndChildrenData.map(async (b) =>
+      prisma.block.create({
+        data: {
+          ...omit(b, [
+            ...OMITTED_BLOCK_FIELDS,
+            'parentBlockId',
+            'posterBlockId',
+            'coverBlockId',
+            'nextBlockId',
+            'action',
+            'slug',
+            'pollOptionImageBlockId'
+          ]),
+          customizable: false,
+          settings: b.settings ?? {},
+          journey: { connect: { id: b.journeyId } }
+        } as unknown as Prisma.BlockCreateInput
+      })
+    )
+  )
+
+  const duplicateBlockAndChildren = await Promise.all(
+    blockAndChildrenData.map(async (newBlock) => {
+      if (
+        newBlock.parentBlockId != null ||
+        newBlock.posterBlockId != null ||
+        newBlock.coverBlockId != null ||
+        newBlock.nextBlockId != null ||
+        newBlock.pollOptionImageBlockId != null ||
+        newBlock.action != null
+      ) {
+        const isActionEmpty = Object.keys(newBlock.action ?? {}).length === 0
+        const updateBlockData = {
+          parentBlockId: newBlock.parentBlockId ?? undefined,
+          posterBlockId: newBlock.posterBlockId ?? undefined,
+          coverBlockId: newBlock.coverBlockId ?? undefined,
+          nextBlockId: newBlock.nextBlockId ?? undefined,
+          pollOptionImageBlockId:
+            newBlock.pollOptionImageBlockId ?? undefined,
+          action:
+            !isActionEmpty && newBlock.action != null
+              ? {
+                  create: {
+                    ...newBlock.action,
+                    customizable: false,
+                    parentStepId: null
+                  }
+                }
+              : undefined
+        }
+        if (newBlock.typename === 'StepBlock') {
+          return await prisma.block.update({
+            where: { id: newBlock.id },
+            include: { action: true },
+            data: {
+              ...updateBlockData,
+              x: x ?? newBlock.x,
+              y: y ?? newBlock.y
+            }
+          })
+        }
+        return await prisma.block.update({
+          where: { id: newBlock.id },
+          include: { action: true },
+          data: updateBlockData
+        })
+      }
+      return newBlock
+    })
+  )
+
+  const duplicatedBlock = duplicateBlockAndChildren[0]
+  const duplicatedChildren = duplicateBlockAndChildren.slice(1)
+
+  const siblings = await getSiblingsInternal(
+    block.journeyId,
+    block.parentBlockId
+  )
+  const defaultDuplicateBlockIndex = siblings.findIndex(
+    (s) => s.id === duplicatedBlock.id
+  )
+  const insertIndex =
+    parentOrder != null ? parentOrder : siblings.length + 1
+  siblings.splice(defaultDuplicateBlockIndex, 1)
+  siblings.splice(insertIndex, 0, duplicatedBlock)
+  const reorderedBlocks = await reorderSiblings(siblings)
+
+  return reorderedBlocks.concat(duplicatedChildren)
 }


### PR DESCRIPTION
…rn journeys

- Introduced a new `blockDuplicate` mutation in the `schema.graphql` for duplicating blocks with associated children.
- Updated the `blockOrderUpdate` mutation to use a modern graph reference.
- Added import for the new mutation in the block index file.
- Enhanced the service layer to handle block duplication logic, including ID mapping and child duplication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duplicate a block along with all nested children within a journey.
  * Place duplicated blocks at custom coordinates and specific sibling positions.
  * Optionally provide deterministic ID mappings for predictable duplication results.
* **Behavior & Safety**
  * Duplication preserves content relationships, updates journey timestamps, and triggers recalculation.
  * Operations enforce edit permissions; unauthorized attempts return an error.
* **Tests**
  * End-to-end tests cover success, ID-mapping, authorization failure, and not-found cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->