### PR TITLE
chore(api-media,api-journeys): split Hindu/Buddist tag migration (NES-1591)

### DIFF
--- a/apis/api-journeys/project.json
+++ b/apis/api-journeys/project.json
@@ -117,6 +117,12 @@
       "options": {
         "commands": ["pnpm exec tsx apis/api-journeys/db/seed.ts"]
       }
+    },
+    "backfill-buddhist-journey-tag": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec tsx apis/api-journeys/src/workers/migrations/backfill-buddhist-journey-tag/backfill-buddhist-journey-tag.ts"
+      }
     }
   }
 }

--- a/apis/api-journeys/src/workers/migrations/backfill-buddhist-journey-tag/backfill-buddhist-journey-tag.ts
+++ b/apis/api-journeys/src/workers/migrations/backfill-buddhist-journey-tag/backfill-buddhist-journey-tag.ts
@@ -20,8 +20,10 @@
  *   npx nx backfill-buddhist-journey-tag api-journeys
  */
 
-import { prisma as journeysPrisma } from '@core/prisma/journeys/client'
-import { prisma as mediaPrisma } from '@core/prisma/media/client'
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { prisma as journeysPrisma } from '../../../../../../libs/prisma/journeys/src/client'
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { prisma as mediaPrisma } from '../../../../../../libs/prisma/media/src/client'
 
 const HINDU_TAG_NAME = 'Hindu'
 const BUDDHIST_TAG_NAME = 'Buddhist'

--- a/apis/api-journeys/src/workers/migrations/backfill-buddhist-journey-tag/backfill-buddhist-journey-tag.ts
+++ b/apis/api-journeys/src/workers/migrations/backfill-buddhist-journey-tag/backfill-buddhist-journey-tag.ts
@@ -1,0 +1,118 @@
+/**
+ * One-time migration (NES-1591) that backfills the new "Buddhist" JourneyTag
+ * onto every journey that is currently tagged with the renamed "Hindu" tag
+ * (previously "Hindu/Buddist"). Because the split is not retroactively
+ * classifiable, every affected journey receives both tags so template
+ * discoverability under the Audience filter is preserved for both religions.
+ *
+ * Depends on the api-media migration ("split-hindu-buddhist-tag") having run
+ * first against the same environment. That migration renames the old tag to
+ * "Hindu" and creates "Buddhist". This script looks both up by name in the
+ * media database, so no UUIDs need to be threaded between environments.
+ *
+ * The script is idempotent: the JourneyTag table has a unique constraint on
+ * (journeyId, tagId), and `createMany({ skipDuplicates: true })` guarantees
+ * existing rows are not duplicated on re-run.
+ *
+ * Usage (local / stage / prod):
+ *   PG_DATABASE_URL_MEDIA=<media-url> \
+ *   PG_DATABASE_URL_JOURNEYS=<journeys-url> \
+ *   npx nx backfill-buddhist-journey-tag api-journeys
+ */
+
+import { prisma as journeysPrisma } from '@core/prisma/journeys/client'
+import { prisma as mediaPrisma } from '@core/prisma/media/client'
+
+const HINDU_TAG_NAME = 'Hindu'
+const BUDDHIST_TAG_NAME = 'Buddhist'
+const BATCH_SIZE = 500
+
+interface BackfillStats {
+  sourceRows: number
+  created: number
+  skippedDuplicates: number
+}
+
+async function backfillBuddhistJourneyTag(): Promise<BackfillStats> {
+  const hinduTag = await mediaPrisma.tag.findUnique({
+    where: { name: HINDU_TAG_NAME }
+  })
+  const buddhistTag = await mediaPrisma.tag.findUnique({
+    where: { name: BUDDHIST_TAG_NAME }
+  })
+
+  if (hinduTag == null || buddhistTag == null) {
+    throw new Error(
+      `Expected Tags named "${HINDU_TAG_NAME}" and "${BUDDHIST_TAG_NAME}" in the media database. ` +
+        `Run the api-media migration "split-hindu-buddhist-tag" first against this environment.`
+    )
+  }
+
+  console.log(
+    `Media tag IDs: hindu=${hinduTag.id} buddhist=${buddhistTag.id}`
+  )
+
+  const stats: BackfillStats = {
+    sourceRows: 0,
+    created: 0,
+    skippedDuplicates: 0
+  }
+
+  let cursor: string | undefined
+
+  while (true) {
+    const batch = await journeysPrisma.journeyTag.findMany({
+      where: { tagId: hinduTag.id },
+      select: { id: true, journeyId: true },
+      take: BATCH_SIZE,
+      ...(cursor != null ? { skip: 1, cursor: { id: cursor } } : {}),
+      orderBy: { id: 'asc' }
+    })
+
+    if (batch.length === 0) break
+
+    stats.sourceRows += batch.length
+
+    const result = await journeysPrisma.journeyTag.createMany({
+      data: batch.map((row) => ({
+        journeyId: row.journeyId,
+        tagId: buddhistTag.id
+      })),
+      skipDuplicates: true
+    })
+
+    stats.created += result.count
+    stats.skippedDuplicates += batch.length - result.count
+
+    console.log(
+      `  Batch processed: source=${batch.length} created=${result.count} skipped=${batch.length - result.count}`
+    )
+
+    cursor = batch[batch.length - 1].id
+  }
+
+  return stats
+}
+
+async function main(): Promise<void> {
+  try {
+    console.log('Starting backfill of Buddhist JourneyTag rows...')
+    console.log('---')
+    const stats = await backfillBuddhistJourneyTag()
+    console.log('---')
+    console.log('Backfill complete:')
+    console.log(`  Source JourneyTag rows (Hindu):  ${stats.sourceRows}`)
+    console.log(`  New JourneyTag rows (Buddhist):  ${stats.created}`)
+    console.log(`  Skipped existing Buddhist rows:  ${stats.skippedDuplicates}`)
+  } catch (error) {
+    console.error('Migration failed:', error)
+    process.exitCode = 1
+  } finally {
+    await Promise.all([
+      mediaPrisma.$disconnect(),
+      journeysPrisma.$disconnect()
+    ])
+  }
+}
+
+void main()

--- a/apis/api-journeys/src/workers/migrations/backfill-buddhist-journey-tag/backfill-buddhist-journey-tag.ts
+++ b/apis/api-journeys/src/workers/migrations/backfill-buddhist-journey-tag/backfill-buddhist-journey-tag.ts
@@ -48,9 +48,7 @@ async function backfillBuddhistJourneyTag(): Promise<BackfillStats> {
     )
   }
 
-  console.log(
-    `Media tag IDs: hindu=${hinduTag.id} buddhist=${buddhistTag.id}`
-  )
+  console.log(`Media tag IDs: hindu=${hinduTag.id} buddhist=${buddhistTag.id}`)
 
   const stats: BackfillStats = {
     sourceRows: 0,
@@ -108,10 +106,7 @@ async function main(): Promise<void> {
     console.error('Migration failed:', error)
     process.exitCode = 1
   } finally {
-    await Promise.all([
-      mediaPrisma.$disconnect(),
-      journeysPrisma.$disconnect()
-    ])
+    await Promise.all([mediaPrisma.$disconnect(), journeysPrisma.$disconnect()])
   }
 }
 

--- a/apis/api-media/project.json
+++ b/apis/api-media/project.json
@@ -172,6 +172,12 @@
       "options": {
         "commands": ["pnpm exec tsx apis/api-media/db/seed.ts"]
       }
+    },
+    "split-hindu-buddhist-tag": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec tsx apis/api-media/src/workers/migrations/split-hindu-buddhist-tag/split-hindu-buddhist-tag.ts"
+      }
     }
   }
 }

--- a/apis/api-media/src/workers/migrations/split-hindu-buddhist-tag/split-hindu-buddhist-tag.ts
+++ b/apis/api-media/src/workers/migrations/split-hindu-buddhist-tag/split-hindu-buddhist-tag.ts
@@ -1,0 +1,142 @@
+/**
+ * One-time migration (NES-1591) to split the combined "Hindu/Buddist" Audience
+ * tag into two separate tags: "Hindu" and "Buddhist".
+ *
+ * Steps (all inside a single transaction):
+ *   1. Rename the existing Tag row from "Hindu/Buddist" to "Hindu".
+ *      The UUID is preserved so every existing JourneyTag / Tagging reference
+ *      continues to resolve.
+ *   2. Rename the primary English TagName row (languageId=529) value from
+ *      "Hindu/Buddist" to "Hindu" so the label users see in the UI updates.
+ *   3. Create a new Tag "Buddhist" under the same Audience parent, plus a
+ *      matching primary English TagName row.
+ *
+ * Non-English TagName rows for the old tag are NOT touched. They are logged
+ * so the operator can coordinate any translation follow-up separately.
+ *
+ * The script is idempotent:
+ *   - If "Hindu/Buddist" is absent it assumes the migration already ran and
+ *     exits cleanly.
+ *   - It aborts with a clear error if any tag named "Hindu" or "Buddhist"
+ *     already exists (indicating a prior partial run or manual data).
+ *
+ * Usage (local / stage / prod):
+ *   PG_DATABASE_URL_MEDIA=<target-url> npx nx split-hindu-buddhist-tag api-media
+ */
+
+import { prisma } from '@core/prisma/media/client'
+
+const OLD_TAG_NAME = 'Hindu/Buddist'
+const RENAMED_TAG_NAME = 'Hindu'
+const NEW_TAG_NAME = 'Buddhist'
+const ENGLISH_LANGUAGE_ID = '529'
+
+async function splitHinduBuddhistTag(): Promise<void> {
+  const oldTag = await prisma.tag.findUnique({
+    where: { name: OLD_TAG_NAME },
+    include: { tagName: true }
+  })
+
+  if (oldTag == null) {
+    console.log(
+      `No tag named "${OLD_TAG_NAME}" found. Migration already applied or never needed. Exiting.`
+    )
+    return
+  }
+
+  const existingHindu = await prisma.tag.findUnique({
+    where: { name: RENAMED_TAG_NAME }
+  })
+  if (existingHindu != null && existingHindu.id !== oldTag.id) {
+    throw new Error(
+      `A separate Tag named "${RENAMED_TAG_NAME}" already exists (id=${existingHindu.id}). ` +
+        `Refusing to continue — this likely indicates a prior partial run or manual data. ` +
+        `Reconcile manually before re-running.`
+    )
+  }
+
+  const existingBuddhist = await prisma.tag.findUnique({
+    where: { name: NEW_TAG_NAME }
+  })
+  if (existingBuddhist != null) {
+    throw new Error(
+      `A Tag named "${NEW_TAG_NAME}" already exists (id=${existingBuddhist.id}). ` +
+        `Refusing to continue — this likely indicates a prior partial run. ` +
+        `Reconcile manually before re-running.`
+    )
+  }
+
+  console.log(`Found old tag: id=${oldTag.id} parentId=${oldTag.parentId}`)
+  console.log(`TagName rows for old tag (${oldTag.tagName.length} total):`)
+  for (const row of oldTag.tagName) {
+    console.log(
+      `  - languageId=${row.languageId} primary=${row.primary} value="${row.value}"`
+    )
+  }
+  const nonEnglishRows = oldTag.tagName.filter(
+    (row) => row.languageId !== ENGLISH_LANGUAGE_ID
+  )
+  if (nonEnglishRows.length > 0) {
+    console.log(
+      `NOTE: ${nonEnglishRows.length} non-English TagName row(s) will NOT be modified by this migration. ` +
+        `Coordinate any translation updates separately.`
+    )
+  }
+
+  const newTag = await prisma.$transaction(async (tx) => {
+    await tx.tag.update({
+      where: { id: oldTag.id },
+      data: { name: RENAMED_TAG_NAME }
+    })
+
+    await tx.tagName.updateMany({
+      where: {
+        tagId: oldTag.id,
+        languageId: ENGLISH_LANGUAGE_ID
+      },
+      data: { value: RENAMED_TAG_NAME }
+    })
+
+    const created = await tx.tag.create({
+      data: {
+        name: NEW_TAG_NAME,
+        parentId: oldTag.parentId,
+        service: oldTag.service,
+        tagName: {
+          create: {
+            value: NEW_TAG_NAME,
+            languageId: ENGLISH_LANGUAGE_ID,
+            primary: true
+          }
+        }
+      }
+    })
+
+    return created
+  })
+
+  console.log('---')
+  console.log('Migration complete:')
+  console.log(
+    `  Renamed tag: id=${oldTag.id} "${OLD_TAG_NAME}" -> "${RENAMED_TAG_NAME}"`
+  )
+  console.log(`  Created tag: id=${newTag.id} name="${NEW_TAG_NAME}"`)
+  console.log(
+    `  Next: run "npx nx backfill-buddhist-journey-tag api-journeys" against the same environment ` +
+      `(with both PG_DATABASE_URL_MEDIA and PG_DATABASE_URL_JOURNEYS set) ` +
+      `to tag existing journeys with the new Buddhist tag.`
+  )
+}
+
+async function main(): Promise<void> {
+  try {
+    await splitHinduBuddhistTag()
+  } catch (error) {
+    console.error('Migration failed:', error)
+    process.exitCode = 1
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+void main()

--- a/apis/api-media/src/workers/migrations/split-hindu-buddhist-tag/split-hindu-buddhist-tag.ts
+++ b/apis/api-media/src/workers/migrations/split-hindu-buddhist-tag/split-hindu-buddhist-tag.ts
@@ -24,7 +24,8 @@
  *   PG_DATABASE_URL_MEDIA=<target-url> npx nx split-hindu-buddhist-tag api-media
  */
 
-import { prisma } from '@core/prisma/media/client'
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { prisma } from '../../../../../../libs/prisma/media/src/client'
 
 const OLD_TAG_NAME = 'Hindu/Buddist'
 const RENAMED_TAG_NAME = 'Hindu'


### PR DESCRIPTION
## Summary
- Adds two one-off migration scripts (api-media + api-journeys) to split the combined `Hindu/Buddist` Audience tag into `Hindu` and `Buddhist`, fix the spelling, and backfill existing journeys so templates already tagged `Hindu/Buddist` also receive the new `Buddhist` tag.
- Intended to run against stage, then prod, then this PR is **closed unmerged** so the one-off code does not stay on `main`. The lasting fix to `seedTags()` lives in a separate PR.

## Why this shape
- Renaming the existing `Tag` (instead of delete + create) preserves its UUID, so every existing `JourneyTag` and `Tagging` reference keeps working.
- The journeys-side script imports both the media and journeys Prisma clients and looks up the tag IDs by name, so no UUIDs need to be copied between environments.
- Both scripts are idempotent: re-runs no-op cleanly (media migration exits early if `Hindu/Buddist` is absent and aborts if `Hindu`/`Buddhist` already exist separately; journeys migration relies on `JourneyTag @@unique([journeyId, tagId])` + `createMany({ skipDuplicates: true })`).

## Execution per environment
1. Run the media migration:
   ```
   PG_DATABASE_URL_MEDIA=<url> npx nx split-hindu-buddhist-tag api-media
   ```
   Confirm the logs show the renamed tag id and the new `Buddhist` tag id. Note any non-English `TagName` rows surfaced in the log — they are intentionally left alone for separate translation follow-up.
2. Run the journeys backfill:
   ```
   PG_DATABASE_URL_MEDIA=<url> PG_DATABASE_URL_JOURNEYS=<url> npx nx backfill-buddhist-journey-tag api-journeys
   ```
   Confirm the `source` / `created` / `skipped` counts line up.
3. Visually verify in the admin Template Settings → Categories panel that the Audience checkboxes read `Hindu` and `Buddhist` separately and that previously-`Hindu/Buddist`-tagged templates have both selected.

## Test plan
- [ ] Run the media migration on stage; confirm `Tag.name` rename + English `TagName.value` rename + new `Buddhist` tag with primary English TagName.
- [ ] Re-run the media migration on stage; confirm it exits cleanly as a no-op.
- [ ] Run the journeys backfill on stage; confirm every source `JourneyTag(tagId=Hindu)` has a sibling `JourneyTag(tagId=Buddhist)`.
- [ ] Re-run the journeys backfill on stage; confirm `created=0` and `skipped=<sourceRows>`.
- [ ] Verify admin Template Settings → Categories panel shows `Hindu` and `Buddhist` separately on stage.
- [ ] Repeat the three execution steps on prod.
- [ ] Close this PR without merging.

Refs: NES-1591

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added migration infrastructure to update tag management systems, improving the organization and separation of Hindu and Buddhist tag classifications across journeys and content throughout the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->