### PR TITLE
fix(api-media): split Hindu/Buddist Audience seed tag, fix spelling (NES-1591)

### DIFF
--- a/apis/api-media/src/workers/seed/service/tag/tag.ts
+++ b/apis/api-media/src/workers/seed/service/tag/tag.ts
@@ -76,7 +76,8 @@ export async function seedTags(): Promise<void> {
   await upsertTag('Audience', [
     'Catholic/Orthodox',
     'Muslim',
-    'Hindu/Buddist',
+    'Hindu',
+    'Buddhist',
     'Atheist/Agnostic',
     'Seeker',
     'New Believer',


### PR DESCRIPTION
## Summary
- Replace the combined `Hindu/Buddist` Audience seed tag with two separate, correctly-spelt entries: `Hindu` and `Buddhist`.

## Why
- The combined tag is offensive to users of both religions and `Buddist` is misspelt (reported by Melissa — training audience noticed it).
- `seedTags()` only runs when `NODE_ENV !== 'production'` (see `apis/api-media/src/workers/server.ts`), so this change affects **new dev databases only**. The prod / stage data update — renaming the existing tag in place, creating the `Buddhist` tag, and backfilling `JourneyTag` — ships in companion PR #9050, which is executed against each environment and then closed unmerged.

## Test plan
- [ ] On a fresh local media DB, run the seed and confirm the `Audience` parent tag has `Hindu` and `Buddhist` as separate children with no `Hindu/Buddist` child.
- [ ] Verify the admin Template Settings → Categories panel's Audience dropdown shows `Hindu` and `Buddhist` as two separate options.

Refs: NES-1591

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated tag categorization data to provide more granular classification options under the Audience category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->