### PR TITLE
fix: update Dashboard button to text variant with primary color (NES-1566)

### DIFF
--- a/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/DoneScreen/DoneScreen.tsx
+++ b/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/DoneScreen/DoneScreen.tsx
@@ -117,8 +117,8 @@ export function DoneScreen(): ReactElement {
       footer={
         <Button
           data-testid="ProjectsDashboardButton"
-          variant="blockContained"
-          color="solid"
+          variant="text"
+          color="primary"
           onClick={handleGoToProjectsDashboard}
           loading={navigating}
           endIcon={<ChevronRightIcon />}


### PR DESCRIPTION
## Summary
- Changes the "Go To Projects Dashboard" button on the DoneScreen to use `variant="text"` and `color="primary"`
- Chevron icon unchanged

Fixes NES-1566

Note: Re-raising this fix — the previous PR #9042 was merged as an empty commit and the change never landed on main.

## Test plan
- [ ] Complete the template customisation flow and reach the Done screen
- [ ] Verify the "Go To Projects Dashboard" button uses text variant with primary color
- [ ] Verify the chevron icon is still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual appearance of the "Go to Projects Dashboard" button on the completion screen for improved design consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->