### PR TITLE
feat: add compound reminder hook on git push

### DIFF
--- a/.claude/hooks/compound-reminder.sh
+++ b/.claude/hooks/compound-reminder.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Compound reminder hook — checks if docs were created on this branch
+# Runs before git push to remind about /ce-compound
+
+BRANCH=$(git branch --show-current)
+
+# Skip for main, stage, and sync branches
+if [[ "$BRANCH" == "main" || "$BRANCH" == "stage" || "$BRANCH" == *"chore-ce-sync"* ]]; then
+  exit 0
+fi
+
+# Check if this branch has any changes to docs/plans/ or docs/solutions/
+DOCS_CHANGED=$(git diff main --name-only 2>/dev/null | grep -E "^docs/(plans|solutions)/" | head -1)
+
+if [ -z "$DOCS_CHANGED" ]; then
+  # Count non-trivial changed files (exclude generated, config, lock files)
+  CHANGED_COUNT=$(git diff main --name-only 2>/dev/null | grep -vE "(\.generated\.|__generated__|pnpm-lock|\.json$|\.graphql$)" | wc -l)
+
+  if [ "$CHANGED_COUNT" -gt 3 ]; then
+    echo ""
+    echo "📝 No plan or solution docs found on this branch."
+    echo "   If this work involved non-obvious decisions or gotchas,"
+    echo "   consider running /ce-compound before merging."
+    echo ""
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/compound-reminder.sh
+++ b/.claude/hooks/compound-reminder.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Compound reminder hook — checks if docs were created on this branch
 # Runs before git push to remind about /ce-compound
+# Version: 1.0.0
 
 BRANCH=$(git branch --show-current)
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,5 +6,20 @@
       "Bash(docker run*-v /*)",
       "Bash(docker run*--privileged*)"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/compound-reminder.sh",
+            "if": "Bash(git push*)",
+            "statusMessage": "Checking for compound docs..."
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,20 +6,5 @@
       "Bash(docker run*-v /*)",
       "Bash(docker run*--privileged*)"
     ]
-  },
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": ".claude/hooks/compound-reminder.sh",
-            "if": "Bash(git push*)",
-            "statusMessage": "Checking for compound docs..."
-          }
-        ]
-      }
-    ]
   }
 }


### PR DESCRIPTION
## Summary
- Adds a Claude Code `PreToolUse` hook that triggers before `git push` commands
- Checks if the current branch has any `docs/plans/` or `docs/solutions/` files
- If not, and the branch has >3 non-trivial changed files, shows a reminder to run `/ce-compound`
- Skips for `main`, `stage`, and CE sync branches

## How it works
- Hook script: `.claude/hooks/compound-reminder.sh`
- Registered in `.claude/settings.json` under `hooks.PreToolUse` with `if: "Bash(git push*)"`
- Only runs inside Claude Code sessions — has no effect on direct terminal pushes

## Test plan
- [ ] Push a branch with code changes but no docs — verify reminder appears
- [ ] Push a branch with `docs/plans/` or `docs/solutions/` changes — verify no reminder
- [ ] Push from `main` — verify no reminder
- [ ] Push a trivial change (1-2 files) — verify no reminder

🤖 Generated with [Claude Code](https://claude.com/claude-code)