### PR TITLE
feat: update GraphQL schema for blocks query in api-journeys-modern

### DIFF
--- a/apis/api-gateway/schema.graphql
+++ b/apis/api-gateway/schema.graphql
@@ -714,7 +714,7 @@ type Journey @join__type(graph: API_JOURNEYS, key: "id")  @join__type(graph: API
 }
 
 type Query @join__type(graph: API_ANALYTICS)  @join__type(graph: API_JOURNEYS)  @join__type(graph: API_JOURNEYS_MODERN)  @join__type(graph: API_LANGUAGES)  @join__type(graph: API_MEDIA)  @join__type(graph: API_USERS)  {
-  blocks(where: BlocksFilter) : [Block!]! @join__field(graph: API_JOURNEYS) 
+  blocks(where: BlocksFilter) : [Block!]! @join__field(graph: API_JOURNEYS_MODERN, override: "api-journeys") 
   block(id: ID!) : Block! @join__field(graph: API_JOURNEYS_MODERN, override: "api-journeys") 
   customDomain(id: ID!) : CustomDomain! @join__field(graph: API_JOURNEYS) 
   customDomains(teamId: ID!) : [CustomDomain!]! @join__field(graph: API_JOURNEYS) 

--- a/apis/api-journeys-modern/schema.graphql
+++ b/apis/api-journeys-modern/schema.graphql
@@ -1867,6 +1867,7 @@ input QrCodesFilter {
 
 type Query {
   block(id: ID!): Block! @override(from: "api-journeys")
+  blocks(where: BlocksFilter): [Block!]! @override(from: "api-journeys")
   node(id: ID!): Node
   nodes(ids: [ID!]!): [Node]!
   journeySimpleGet(id: ID!): Json

--- a/apis/api-journeys-modern/src/schema/block/blocks.query.spec.ts
+++ b/apis/api-journeys-modern/src/schema/block/blocks.query.spec.ts
@@ -1,0 +1,143 @@
+import { getClient } from '../../../test/client'
+import { prismaMock } from '../../../test/prismaMock'
+import { graphql } from '../../lib/graphql/subgraphGraphql'
+
+describe('blocks', () => {
+  const mockUser = { id: 'userId' }
+  const authClient = getClient({
+    headers: { authorization: 'token' },
+    context: { currentUser: mockUser }
+  })
+
+  const BLOCKS_QUERY = graphql(`
+    query Blocks($where: BlocksFilter) {
+      blocks(where: $where) {
+        id
+        journeyId
+        parentBlockId
+        parentOrder
+      }
+    }
+  `)
+
+  const block = {
+    id: 'blockId',
+    typename: 'StepBlock',
+    journeyId: 'journeyId',
+    parentBlockId: null,
+    parentOrder: 0,
+    action: null
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns blocks when authorized', async () => {
+    prismaMock.block.findMany.mockResolvedValue([block as any])
+
+    const result = await authClient({
+      document: BLOCKS_QUERY,
+      variables: { where: null }
+    })
+
+    expect(result).toEqual({
+      data: {
+        blocks: [
+          {
+            id: 'blockId',
+            journeyId: 'journeyId',
+            parentBlockId: null,
+            parentOrder: 0
+          }
+        ]
+      }
+    })
+
+    expect(prismaMock.block.findMany).toHaveBeenCalledWith({
+      where: {
+        AND: [
+          {
+            journey: {
+              is: expect.objectContaining({
+                OR: expect.arrayContaining([
+                  expect.objectContaining({
+                    team: expect.any(Object)
+                  })
+                ])
+              })
+            }
+          },
+          { deletedAt: null }
+        ]
+      },
+      include: {
+        action: true
+      }
+    })
+  })
+
+  it('returns filtered blocks by journeyIds and typenames', async () => {
+    prismaMock.block.findMany.mockResolvedValue([block as any])
+
+    const result = await authClient({
+      document: BLOCKS_QUERY,
+      variables: {
+        where: {
+          journeyIds: ['journeyId'],
+          typenames: ['StepBlock']
+        }
+      }
+    })
+
+    expect(result).toEqual({
+      data: {
+        blocks: [
+          {
+            id: 'blockId',
+            journeyId: 'journeyId',
+            parentBlockId: null,
+            parentOrder: 0
+          }
+        ]
+      }
+    })
+
+    expect(prismaMock.block.findMany).toHaveBeenCalledWith({
+      where: {
+        AND: [
+          {
+            journey: {
+              is: expect.objectContaining({
+                OR: expect.any(Array)
+              })
+            }
+          },
+          {
+            journeyId: { in: ['journeyId'] },
+            typename: { in: ['StepBlock'] },
+            deletedAt: null
+          }
+        ]
+      },
+      include: {
+        action: true
+      }
+    })
+  })
+
+  it('returns empty array when no blocks found', async () => {
+    prismaMock.block.findMany.mockResolvedValue([])
+
+    const result = await authClient({
+      document: BLOCKS_QUERY,
+      variables: { where: null }
+    })
+
+    expect(result).toEqual({
+      data: {
+        blocks: []
+      }
+    })
+  })
+})

--- a/apis/api-journeys-modern/src/schema/block/blocks.query.ts
+++ b/apis/api-journeys-modern/src/schema/block/blocks.query.ts
@@ -1,0 +1,44 @@
+import { Prisma, prisma } from '@core/prisma/journeys/client'
+
+import { builder } from '../builder'
+import { journeyReadAccessWhere } from '../journey/journey.acl'
+
+import { Block } from './block'
+import { BlocksFilterInput } from './inputs'
+
+builder.queryField('blocks', (t) =>
+  t.withAuth({ $any: { isAuthenticated: true, isAnonymous: true } }).field({
+    type: [Block],
+    nullable: false,
+    override: { from: 'api-journeys' },
+    args: {
+      where: t.arg({ type: BlocksFilterInput, required: false })
+    },
+    resolve: async (_parent, args, context) => {
+      const userId = context.user.id
+      const currentUser = context.user as typeof context.user & {
+        roles?: string[]
+      }
+
+      const filter: Prisma.BlockWhereInput = {
+        deletedAt: null
+      }
+
+      if (args.where?.typenames != null)
+        filter.typename = { in: args.where.typenames }
+      if (args.where?.journeyIds != null)
+        filter.journeyId = { in: args.where.journeyIds as string[] }
+
+      const accessibleJourneys = journeyReadAccessWhere(userId, currentUser)
+
+      return await prisma.block.findMany({
+        where: {
+          AND: [{ journey: { is: accessibleJourneys } }, filter]
+        },
+        include: {
+          action: true
+        }
+      })
+    }
+  })
+)

--- a/apis/api-journeys-modern/src/schema/block/index.ts
+++ b/apis/api-journeys-modern/src/schema/block/index.ts
@@ -1,5 +1,6 @@
 // Export all block schemas from a central location
 import './block.query'
+import './blocks.query'
 import './blockDelete.mutation'
 import './blockDuplicate.mutation'
 import './blockOrderUpdate.mutation'


### PR DESCRIPTION
- Added 'blocks' query to api-journeys-modern schema with override from 'api-journeys'.
- Updated 'blocks' field in api-gateway schema to use 'api-journeys-modern' with an override.
- Imported 'blocks.query' in block index file for centralized schema management.