### PR TITLE
revert: remove Instagram Android WebView YouTube iframe fallback (NES-1194, #8759)

### DIFF
--- a/libs/journeys/ui/src/components/Card/ContainedCover/BackgroundVideo/BackgroundVideo.tsx
+++ b/libs/journeys/ui/src/components/Card/ContainedCover/BackgroundVideo/BackgroundVideo.tsx
@@ -1,11 +1,10 @@
 import Box from '@mui/material/Box'
 import { styled } from '@mui/material/styles'
-import { CSSProperties, ReactElement, useEffect, useRef, useState } from 'react'
+import { CSSProperties, ReactElement, useEffect, useRef } from 'react'
 import videojs from 'video.js'
 import Player from 'video.js/dist/types/player'
 
 import { defaultBackgroundVideoJsOptions } from '@core/shared/ui/defaultVideoJsOptions'
-import { isInstagramAndroidWebView } from '@core/shared/ui/deviceUtils'
 
 import {
   VideoBlockObjectFit,
@@ -37,11 +36,6 @@ export function BackgroundVideo({
   const videoRef = useRef<HTMLVideoElement>(null)
   const playerRef = useRef<Player | null>(null)
   const isYouTube = source === VideoBlockSource.youTube
-  const [inAppBrowser, setInAppBrowser] = useState(false)
-
-  useEffect(() => {
-    setInAppBrowser(isInstagramAndroidWebView())
-  }, [])
 
   // Initiate Video
   useEffect(() => {
@@ -140,31 +134,6 @@ export function BackgroundVideo({
         videoFit = 'cover'
         break
     }
-  }
-
-  if (inAppBrowser && isYouTube && videoId != null) {
-    return (
-      <Box
-        height="100%"
-        width="100%"
-        minHeight="-webkit-fill-available"
-        overflow="hidden"
-        position="absolute"
-        data-testid="CardContainedBackgroundVideo"
-      >
-        <iframe
-          src={`https://www.youtube.com/embed/${videoId}?start=${startAt ?? 0}&end=${endAt ?? 0}&autoplay=1&mute=1&loop=1&playsinline=1&controls=0`}
-          allow="accelerometer; autoplay; encrypted-media"
-          style={{
-            width: '100%',
-            height: '100%',
-            border: 'none',
-            pointerEvents: 'none'
-          }}
-          title="Background video"
-        />
-      </Box>
-    )
   }
 
   return (

--- a/libs/journeys/ui/src/components/Video/Video.tsx
+++ b/libs/journeys/ui/src/components/Video/Video.tsx
@@ -13,7 +13,6 @@ import {
 } from 'react'
 import { use100vh } from 'react-div-100vh'
 
-import { isInstagramAndroidWebView } from '@core/shared/ui/deviceUtils'
 import { NextImage } from '@core/shared/ui/NextImage'
 
 import {
@@ -75,11 +74,6 @@ export function Video({
   const [player, setPlayer] = useState<VideoJsPlayer>()
   const [showPoster, setShowPoster] = useState(true)
   const [activeStep, setActiveStep] = useState(false)
-  const [inAppBrowser, setInAppBrowser] = useState(false)
-
-  useEffect(() => {
-    setInAppBrowser(isInstagramAndroidWebView())
-  }, [])
 
   const { blockHistory } = useBlocks()
   const { variant, journey } = useJourney()
@@ -227,26 +221,7 @@ export function Video({
           />
         )}
 
-      {videoId != null &&
-      inAppBrowser &&
-      source === VideoBlockSource.youTube ? (
-        <Box
-          data-testid="in-app-browser-youtube-fallback"
-          sx={{
-            width: '100%',
-            height: '100%',
-            position: 'relative'
-          }}
-        >
-          <iframe
-            src={`https://www.youtube.com/embed/${videoId}?start=${effectiveStartAt}&end=${effectiveEndAt}&autoplay=0&playsinline=1`}
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"
-            allowFullScreen
-            style={{ width: '100%', height: '100%', border: 'none' }}
-            title={title ?? 'YouTube video'}
-          />
-        </Box>
-      ) : videoId != null ? (
+      {videoId != null ? (
         <>
           <Box
             height={{

--- a/libs/shared/ui/src/libs/deviceUtils/deviceUtils.ts
+++ b/libs/shared/ui/src/libs/deviceUtils/deviceUtils.ts
@@ -60,17 +60,6 @@ export function isIOSTouchScreen(): boolean {
   )
 }
 
-export function isInstagramAndroidWebView(): boolean {
-  if (
-    typeof navigator === 'undefined' ||
-    typeof navigator.userAgent === 'undefined'
-  )
-    return false
-
-  const ua = navigator.userAgent
-  return /Android/i.test(ua) && /Instagram/i.test(ua)
-}
-
 // TODO: should only resort to user agent sniffing as a last resport
 export function isMobile(): boolean {
   if (

--- a/libs/shared/ui/src/libs/deviceUtils/index.ts
+++ b/libs/shared/ui/src/libs/deviceUtils/index.ts
@@ -1,6 +1,5 @@
 export {
   hasTouchScreen,
-  isInstagramAndroidWebView,
   isIPhone,
   isMobile,
   isIOS,


### PR DESCRIPTION
## Summary

Reverts the **frontend** changes introduced in #8759 (NES-1194 — "YouTube videos fail to play on Android when opened via Instagram in-app browser").

## Why revert

The PR was merged with multiple outstanding issues:

- **Unaddressed `CHANGES_REQUESTED` review** from @csiyang (Mar 24) — naming (`inAppBrowser` → `useIframePlayer`), DRY issue in `Video.tsx`, styling inconsistency between iframe and video-js paths.
- **Missing unit tests** — @Ur-imazing explicitly requested tests for both `Video.tsx` and `BackgroundVideo.tsx`; none were added.
- **Real bugs flagged by CodeRabbit**:
  - Iframe URL uses `loop=1` without the required `&playlist=${videoId}` parameter → video won't actually loop.
  - Iframe URL uses `end=${endAt ?? 0}` → when `endAt` is null, `end=0` stops playback immediately.
  - Race condition: `inAppBrowser` is set via `useEffect` after first render, so the video.js player initializes on a DOM node that unmounts, leaving an orphaned player with `setLoading` never resolving.

## Scope

Four files reverted: `Video.tsx`, `BackgroundVideo.tsx`, `deviceUtils.ts`, `deviceUtils/index.ts`.

**Not reverted:** `apis/api-users/src/schema/user/findOrFetchUser.ts`. That Prisma `id: userId` → `userId` change was piggybacked into #8759 but was also merged independently and legitimately via #8749 on Feb 24 (byte-identical change, plus a spec update). Leaving that file untouched preserves #8749's fix.

## Follow-up

The Instagram Android WebView fix should be re-raised as a new PR with the review comments addressed, unit tests added, and without the duplicated Prisma change.

## Test plan

- [ ] Verify CI is green
- [ ] Smoke test YouTube video playback on a normal desktop/mobile browser (regression check)
- [ ] Confirm `findOrFetchUser.ts` on main still matches #8749 (i.e., `userId` keys are preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)