### PR TITLE
feat: update chatButtonCreate mutation for modern journeys

### DIFF
--- a/apis/api-gateway/schema.graphql
+++ b/apis/api-gateway/schema.graphql
@@ -118,7 +118,7 @@ type Mutation @join__type(graph: API_ANALYTICS)  @join__type(graph: API_JOURNEYS
   blockRestore is used for redo/undo
   """
   blockRestore(id: ID!) : [Block!]! @join__field(graph: API_JOURNEYS) 
-  chatButtonCreate(journeyId: ID!, input: ChatButtonCreateInput) : ChatButton! @join__field(graph: API_JOURNEYS) 
+  chatButtonCreate(journeyId: ID!, input: ChatButtonCreateInput) : ChatButton! @join__field(graph: API_JOURNEYS_MODERN, override: "api-journeys") 
   chatButtonUpdate(id: ID!, journeyId: ID!, input: ChatButtonUpdateInput!) : ChatButton! @join__field(graph: API_JOURNEYS) 
   chatButtonRemove(id: ID!) : ChatButton! @join__field(graph: API_JOURNEYS) 
   customDomainCreate(input: CustomDomainCreateInput!) : CustomDomain! @join__field(graph: API_JOURNEYS) 

--- a/apis/api-journeys-modern/schema.graphql
+++ b/apis/api-journeys-modern/schema.graphql
@@ -1518,6 +1518,7 @@ type Mutation {
   blockUpdateNavigateToBlockAction(id: ID!, input: NavigateToBlockActionInput!, journeyId: ID): NavigateToBlockAction!
   blockUpdatePhoneAction(id: ID!, input: PhoneActionInput!, journeyId: ID): PhoneAction!
   blockUpdateChatAction(id: ID!, input: ChatActionInput!, journeyId: ID): ChatAction!
+  chatButtonCreate(journeyId: ID!, input: ChatButtonCreateInput): ChatButton! @override(from: "api-journeys")
   buttonClickEventCreate(input: ButtonClickEventCreateInput!): ButtonClickEvent!
   chatOpenEventCreate(input: ChatOpenEventCreateInput!): ChatOpenEvent!
   radioQuestionSubmissionEventCreate(input: RadioQuestionSubmissionEventCreateInput!): RadioQuestionSubmissionEvent!

--- a/apis/api-journeys-modern/src/schema/chatButton/chatButtonCreate.mutation.spec.ts
+++ b/apis/api-journeys-modern/src/schema/chatButton/chatButtonCreate.mutation.spec.ts
@@ -1,0 +1,164 @@
+import { getUserFromPayload } from '@core/yoga/firebaseClient'
+
+import { getClient } from '../../../test/client'
+import { prismaMock } from '../../../test/prismaMock'
+import { graphql } from '../../lib/graphql/subgraphGraphql'
+
+jest.mock('@core/yoga/firebaseClient', () => ({
+  getUserFromPayload: jest.fn()
+}))
+
+const mockGetUserFromPayload = getUserFromPayload as jest.MockedFunction<
+  typeof getUserFromPayload
+>
+
+describe('chatButtonCreate', () => {
+  const mockUser = {
+    id: 'userId',
+    firstName: 'Test',
+    emailVerified: true
+  }
+  const authClient = getClient({
+    headers: { authorization: 'token' },
+    context: { currentUser: mockUser }
+  })
+
+  const CHAT_BUTTON_CREATE = graphql(`
+    mutation ChatButtonCreate($journeyId: ID!, $input: ChatButtonCreateInput) {
+      chatButtonCreate(journeyId: $journeyId, input: $input) {
+        id
+        link
+        platform
+      }
+    }
+  `)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetUserFromPayload.mockReturnValue(mockUser)
+    prismaMock.userRole.findUnique.mockResolvedValue({
+      id: 'userRoleId',
+      userId: mockUser.id,
+      roles: []
+    })
+  })
+
+  it('creates a chat button when authorized', async () => {
+    prismaMock.chatButton.findMany.mockResolvedValue([])
+    prismaMock.chatButton.create.mockResolvedValue({
+      id: 'chatButtonId',
+      journeyId: 'journeyId',
+      link: 'https://m.me/user',
+      platform: 'facebook',
+      customizable: null
+    } as any)
+
+    const result = await authClient({
+      document: CHAT_BUTTON_CREATE,
+      variables: {
+        journeyId: 'journeyId',
+        input: { link: 'https://m.me/user', platform: 'facebook' as any }
+      }
+    })
+
+    expect(result).toEqual({
+      data: {
+        chatButtonCreate: {
+          id: 'chatButtonId',
+          link: 'https://m.me/user',
+          platform: 'facebook'
+        }
+      }
+    })
+
+    expect(prismaMock.chatButton.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          journeyId: 'journeyId',
+          link: 'https://m.me/user',
+          platform: 'facebook'
+        }
+      })
+    )
+  })
+
+  it('creates a chat button with null input', async () => {
+    prismaMock.chatButton.findMany.mockResolvedValue([])
+    prismaMock.chatButton.create.mockResolvedValue({
+      id: 'chatButtonId',
+      journeyId: 'journeyId',
+      link: null,
+      platform: null,
+      customizable: null
+    } as any)
+
+    const result = await authClient({
+      document: CHAT_BUTTON_CREATE,
+      variables: {
+        journeyId: 'journeyId'
+      }
+    })
+
+    expect(result).toEqual({
+      data: {
+        chatButtonCreate: {
+          id: 'chatButtonId',
+          link: null,
+          platform: null
+        }
+      }
+    })
+  })
+
+  it('throws error when journey already has 2 chat buttons', async () => {
+    prismaMock.chatButton.findMany.mockResolvedValue([
+      { id: '1' },
+      { id: '2' }
+    ] as any)
+
+    const result = await authClient({
+      document: CHAT_BUTTON_CREATE,
+      variables: {
+        journeyId: 'journeyId',
+        input: { link: 'https://m.me/user', platform: 'facebook' as any }
+      }
+    })
+
+    expect(result).toEqual({
+      data: null,
+      errors: [
+        expect.objectContaining({
+          message:
+            'There are already 2 chat buttons associated with the given journey'
+        })
+      ]
+    })
+
+    expect(prismaMock.chatButton.create).not.toHaveBeenCalled()
+  })
+
+  it('throws error when user is not authenticated', async () => {
+    mockGetUserFromPayload.mockReturnValue(null)
+    const unauthClient = getClient({
+      headers: { authorization: 'token' },
+      context: { currentUser: null }
+    })
+
+    const result = await unauthClient({
+      document: CHAT_BUTTON_CREATE,
+      variables: {
+        journeyId: 'journeyId',
+        input: { link: 'https://m.me/user', platform: 'facebook' as any }
+      }
+    })
+
+    expect(result).toEqual({
+      data: null,
+      errors: [
+        expect.objectContaining({
+          message: expect.stringContaining('Not authorized')
+        })
+      ]
+    })
+  })
+})

--- a/apis/api-journeys-modern/src/schema/chatButton/chatButtonCreate.mutation.ts
+++ b/apis/api-journeys-modern/src/schema/chatButton/chatButtonCreate.mutation.ts
@@ -1,0 +1,44 @@
+import { GraphQLError } from 'graphql'
+
+import { prisma } from '@core/prisma/journeys/client'
+
+import { builder } from '../builder'
+
+import { ChatButtonRef } from './chatButton'
+import { ChatButtonCreateInput } from './inputs'
+
+builder.mutationField('chatButtonCreate', (t) =>
+  t
+    .withAuth({ $any: { isAuthenticated: true, isAnonymous: true } })
+    .prismaField({
+      type: ChatButtonRef,
+      nullable: false,
+      override: { from: 'api-journeys' },
+      args: {
+        journeyId: t.arg({ type: 'ID', required: true }),
+        input: t.arg({ type: ChatButtonCreateInput, required: false })
+      },
+      resolve: async (query, _parent, args, _context) => {
+        const { journeyId, input } = args
+
+        const chatButtons = await prisma.chatButton.findMany({
+          where: { journeyId }
+        })
+
+        if (chatButtons.length >= 2) {
+          throw new GraphQLError(
+            'There are already 2 chat buttons associated with the given journey',
+            { extensions: { code: 'BAD_USER_INPUT' } }
+          )
+        }
+
+        return await prisma.chatButton.create({
+          ...query,
+          data: {
+            journeyId,
+            ...input
+          }
+        })
+      }
+    })
+)

--- a/apis/api-journeys-modern/src/schema/chatButton/index.ts
+++ b/apis/api-journeys-modern/src/schema/chatButton/index.ts
@@ -1,2 +1,3 @@
 import './chatButton'
+import './chatButtonCreate.mutation'
 import './inputs'

--- a/apps/journeys-admin/__generated__/BlockDelete.ts
+++ b/apps/journeys-admin/__generated__/BlockDelete.ts
@@ -27,9 +27,6 @@ export interface BlockDelete_blockDelete_StepBlock {
 export type BlockDelete_blockDelete = BlockDelete_blockDelete_ImageBlock | BlockDelete_blockDelete_StepBlock;
 
 export interface BlockDelete {
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   blockDelete: BlockDelete_blockDelete[];
 }
 

--- a/apps/journeys-admin/__generated__/BlockDeleteForCoverImage.ts
+++ b/apps/journeys-admin/__generated__/BlockDeleteForCoverImage.ts
@@ -14,9 +14,6 @@ export interface BlockDeleteForCoverImage_blockDelete {
 }
 
 export interface BlockDeleteForCoverImage {
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   blockDelete: BlockDeleteForCoverImage_blockDelete[];
 }
 

--- a/apps/journeys-admin/__generated__/BlockDuplicate.ts
+++ b/apps/journeys-admin/__generated__/BlockDuplicate.ts
@@ -621,9 +621,6 @@ export interface BlockDuplicate_blockDuplicate_VideoTriggerBlock {
 export type BlockDuplicate_blockDuplicate = BlockDuplicate_blockDuplicate_GridContainerBlock | BlockDuplicate_blockDuplicate_ButtonBlock | BlockDuplicate_blockDuplicate_CardBlock | BlockDuplicate_blockDuplicate_IconBlock | BlockDuplicate_blockDuplicate_ImageBlock | BlockDuplicate_blockDuplicate_MultiselectOptionBlock | BlockDuplicate_blockDuplicate_MultiselectBlock | BlockDuplicate_blockDuplicate_RadioOptionBlock | BlockDuplicate_blockDuplicate_RadioQuestionBlock | BlockDuplicate_blockDuplicate_SignUpBlock | BlockDuplicate_blockDuplicate_SpacerBlock | BlockDuplicate_blockDuplicate_StepBlock | BlockDuplicate_blockDuplicate_TextResponseBlock | BlockDuplicate_blockDuplicate_TypographyBlock | BlockDuplicate_blockDuplicate_VideoBlock | BlockDuplicate_blockDuplicate_VideoTriggerBlock;
 
 export interface BlockDuplicate {
-  /**
-   * blockDuplicate returns the updated block, it's children and sibling blocks on successful duplicate
-   */
   blockDuplicate: BlockDuplicate_blockDuplicate[];
 }
 

--- a/apps/journeys-admin/__generated__/CardCtaDelete.ts
+++ b/apps/journeys-admin/__generated__/CardCtaDelete.ts
@@ -121,53 +121,17 @@ export interface CardCtaDelete_imageDelete {
 
 export interface CardCtaDelete {
   cardBlockUpdate: CardCtaDelete_cardBlockUpdate;
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   endIcon3Delete: CardCtaDelete_endIcon3Delete[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   startIcon3Delete: CardCtaDelete_startIcon3Delete[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   button3Delete: CardCtaDelete_button3Delete[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   endIcon2Delete: CardCtaDelete_endIcon2Delete[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   startIcon2Delete: CardCtaDelete_startIcon2Delete[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   button2Delete: CardCtaDelete_button2Delete[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   endIcon1Delete: CardCtaDelete_endIcon1Delete[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   startIcon1Delete: CardCtaDelete_startIcon1Delete[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   button1Delete: CardCtaDelete_button1Delete[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   titleDelete: CardCtaDelete_titleDelete[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   subtitleDelete: CardCtaDelete_subtitleDelete[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   imageDelete: CardCtaDelete_imageDelete[];
 }
 

--- a/apps/journeys-admin/__generated__/CardFormDelete.ts
+++ b/apps/journeys-admin/__generated__/CardFormDelete.ts
@@ -96,37 +96,13 @@ export interface CardFormDelete_cardBlockUpdate {
 }
 
 export interface CardFormDelete {
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   body: CardFormDelete_body[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   endIcon: CardFormDelete_endIcon[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   startIcon: CardFormDelete_startIcon[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   button: CardFormDelete_button[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   textResponse: CardFormDelete_textResponse[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   title: CardFormDelete_title[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   subtitle: CardFormDelete_subtitle[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   image: CardFormDelete_image[];
   cardBlockUpdate: CardFormDelete_cardBlockUpdate;
 }

--- a/apps/journeys-admin/__generated__/CardIntroDelete.ts
+++ b/apps/journeys-admin/__generated__/CardIntroDelete.ts
@@ -50,33 +50,12 @@ export interface CardIntroDelete_subtitle {
 }
 
 export interface CardIntroDelete {
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   video: CardIntroDelete_video[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   endIcon: CardIntroDelete_endIcon[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   startIcon: CardIntroDelete_startIcon[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   button: CardIntroDelete_button[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   body: CardIntroDelete_body[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   title: CardIntroDelete_title[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   subtitle: CardIntroDelete_subtitle[];
 }
 

--- a/apps/journeys-admin/__generated__/CardPollDelete.ts
+++ b/apps/journeys-admin/__generated__/CardPollDelete.ts
@@ -62,41 +62,14 @@ export interface CardPollDelete_imageDelete {
 }
 
 export interface CardPollDelete {
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   bodyDelete: CardPollDelete_bodyDelete[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   radioOption4Delete: CardPollDelete_radioOption4Delete[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   radioOption3Delete: CardPollDelete_radioOption3Delete[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   radioOption2Delete: CardPollDelete_radioOption2Delete[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   radioOption1Delete: CardPollDelete_radioOption1Delete[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   radioQuestionDelete: CardPollDelete_radioQuestionDelete[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   titleDelete: CardPollDelete_titleDelete[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   subtitleDelete: CardPollDelete_subtitleDelete[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   imageDelete: CardPollDelete_imageDelete[];
 }
 

--- a/apps/journeys-admin/__generated__/CardQuoteDelete.ts
+++ b/apps/journeys-admin/__generated__/CardQuoteDelete.ts
@@ -73,21 +73,9 @@ export interface CardQuoteDelete_image {
 
 export interface CardQuoteDelete {
   cardBlockUpdate: CardQuoteDelete_cardBlockUpdate;
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   body: CardQuoteDelete_body[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   title: CardQuoteDelete_title[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   subtitle: CardQuoteDelete_subtitle[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   image: CardQuoteDelete_image[];
 }
 

--- a/apps/journeys-admin/__generated__/CardVideoDelete.ts
+++ b/apps/journeys-admin/__generated__/CardVideoDelete.ts
@@ -204,9 +204,6 @@ export interface CardVideoDelete_video_VideoBlock {
 export type CardVideoDelete_video = CardVideoDelete_video_ImageBlock | CardVideoDelete_video_VideoBlock;
 
 export interface CardVideoDelete {
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   video: CardVideoDelete_video[];
 }
 

--- a/apps/journeys-admin/__generated__/CoverBlockDelete.ts
+++ b/apps/journeys-admin/__generated__/CoverBlockDelete.ts
@@ -25,9 +25,6 @@ export interface CoverBlockDelete_cardBlockUpdate {
 }
 
 export interface CoverBlockDelete {
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   blockDelete: CoverBlockDelete_blockDelete[];
   cardBlockUpdate: CoverBlockDelete_cardBlockUpdate;
 }

--- a/apps/journeys-admin/__generated__/JourneyImageBlockDelete.ts
+++ b/apps/journeys-admin/__generated__/JourneyImageBlockDelete.ts
@@ -14,9 +14,6 @@ export interface JourneyImageBlockDelete_blockDelete {
 }
 
 export interface JourneyImageBlockDelete {
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   blockDelete: JourneyImageBlockDelete_blockDelete[];
 }
 

--- a/apps/journeys-admin/__generated__/MenuBlockDelete.ts
+++ b/apps/journeys-admin/__generated__/MenuBlockDelete.ts
@@ -47,9 +47,6 @@ export interface MenuBlockDelete_journeyUpdate {
 }
 
 export interface MenuBlockDelete {
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   stepDelete: MenuBlockDelete_stepDelete[];
   journeyUpdate: MenuBlockDelete_journeyUpdate;
 }

--- a/apps/journeys-admin/__generated__/MultiselectWithButtonDelete.ts
+++ b/apps/journeys-admin/__generated__/MultiselectWithButtonDelete.ts
@@ -44,29 +44,11 @@ export interface MultiselectWithButtonDelete_multiselect {
 }
 
 export interface MultiselectWithButtonDelete {
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   endIcon: MultiselectWithButtonDelete_endIcon[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   startIcon: MultiselectWithButtonDelete_startIcon[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   button: MultiselectWithButtonDelete_button[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   option2: MultiselectWithButtonDelete_option2[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   option1: MultiselectWithButtonDelete_option1[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   multiselect: MultiselectWithButtonDelete_multiselect[];
 }
 

--- a/apps/journeys-admin/__generated__/PosterImageBlockDelete.ts
+++ b/apps/journeys-admin/__generated__/PosterImageBlockDelete.ts
@@ -25,9 +25,6 @@ export interface PosterImageBlockDelete_videoBlockUpdate {
 }
 
 export interface PosterImageBlockDelete {
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   blockDelete: PosterImageBlockDelete_blockDelete[];
   videoBlockUpdate: PosterImageBlockDelete_videoBlockUpdate;
 }

--- a/apps/journeys-admin/__generated__/RadioOptionImageDelete.ts
+++ b/apps/journeys-admin/__generated__/RadioOptionImageDelete.ts
@@ -25,9 +25,6 @@ export interface RadioOptionImageDelete_radioOptionBlockUpdate {
 }
 
 export interface RadioOptionImageDelete {
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   blockDelete: RadioOptionImageDelete_blockDelete[];
   radioOptionBlockUpdate: RadioOptionImageDelete_radioOptionBlockUpdate;
 }

--- a/apps/journeys-admin/__generated__/StepBlockDeleteFromAction.ts
+++ b/apps/journeys-admin/__generated__/StepBlockDeleteFromAction.ts
@@ -41,9 +41,6 @@ export interface StepBlockDeleteFromAction_blockUpdateAction {
 }
 
 export interface StepBlockDeleteFromAction {
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   blockDelete: StepBlockDeleteFromAction_blockDelete[];
   blockUpdateAction: StepBlockDeleteFromAction_blockUpdateAction;
 }

--- a/apps/journeys-admin/__generated__/StepBlockDeleteFromActionWithoutAction.ts
+++ b/apps/journeys-admin/__generated__/StepBlockDeleteFromActionWithoutAction.ts
@@ -81,9 +81,6 @@ export interface StepBlockDeleteFromActionWithoutAction_blockDeleteAction_VideoB
 export type StepBlockDeleteFromActionWithoutAction_blockDeleteAction = StepBlockDeleteFromActionWithoutAction_blockDeleteAction_ImageBlock | StepBlockDeleteFromActionWithoutAction_blockDeleteAction_RadioOptionBlock | StepBlockDeleteFromActionWithoutAction_blockDeleteAction_ButtonBlock | StepBlockDeleteFromActionWithoutAction_blockDeleteAction_SignUpBlock | StepBlockDeleteFromActionWithoutAction_blockDeleteAction_VideoBlock;
 
 export interface StepBlockDeleteFromActionWithoutAction {
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   blockDelete: StepBlockDeleteFromActionWithoutAction_blockDelete[];
   blockDeleteAction: StepBlockDeleteFromActionWithoutAction_blockDeleteAction;
 }

--- a/apps/journeys-admin/__generated__/StepBlockDeleteFromSocialPreview.ts
+++ b/apps/journeys-admin/__generated__/StepBlockDeleteFromSocialPreview.ts
@@ -33,9 +33,6 @@ export interface StepBlockDeleteFromSocialPreview_blockOrderUpdate {
 }
 
 export interface StepBlockDeleteFromSocialPreview {
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   blockDelete: StepBlockDeleteFromSocialPreview_blockDelete[];
   blockOrderUpdate: StepBlockDeleteFromSocialPreview_blockOrderUpdate[];
 }

--- a/apps/journeys-admin/__generated__/StepBlockDeleteFromStep.ts
+++ b/apps/journeys-admin/__generated__/StepBlockDeleteFromStep.ts
@@ -39,9 +39,6 @@ export interface StepBlockDeleteFromStep_stepBlockUpdate {
 }
 
 export interface StepBlockDeleteFromStep {
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   blockDelete: StepBlockDeleteFromStep_blockDelete[];
   stepBlockUpdate: StepBlockDeleteFromStep_stepBlockUpdate;
 }

--- a/apps/journeys-admin/__generated__/StepDuplicate.ts
+++ b/apps/journeys-admin/__generated__/StepDuplicate.ts
@@ -631,9 +631,6 @@ export interface StepDuplicate_blockDuplicate_VideoTriggerBlock {
 export type StepDuplicate_blockDuplicate = StepDuplicate_blockDuplicate_GridContainerBlock | StepDuplicate_blockDuplicate_ButtonBlock | StepDuplicate_blockDuplicate_CardBlock | StepDuplicate_blockDuplicate_IconBlock | StepDuplicate_blockDuplicate_ImageBlock | StepDuplicate_blockDuplicate_MultiselectOptionBlock | StepDuplicate_blockDuplicate_MultiselectBlock | StepDuplicate_blockDuplicate_RadioOptionBlock | StepDuplicate_blockDuplicate_RadioQuestionBlock | StepDuplicate_blockDuplicate_SignUpBlock | StepDuplicate_blockDuplicate_SpacerBlock | StepDuplicate_blockDuplicate_StepBlock | StepDuplicate_blockDuplicate_TextResponseBlock | StepDuplicate_blockDuplicate_TypographyBlock | StepDuplicate_blockDuplicate_VideoBlock | StepDuplicate_blockDuplicate_VideoTriggerBlock;
 
 export interface StepDuplicate {
-  /**
-   * blockDuplicate returns the updated block, it's children and sibling blocks on successful duplicate
-   */
   blockDuplicate: StepDuplicate_blockDuplicate[];
 }
 

--- a/apps/journeys-admin/__generated__/TextResponseWithButtonDelete.ts
+++ b/apps/journeys-admin/__generated__/TextResponseWithButtonDelete.ts
@@ -32,21 +32,9 @@ export interface TextResponseWithButtonDelete_textResponse {
 }
 
 export interface TextResponseWithButtonDelete {
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   endIcon: TextResponseWithButtonDelete_endIcon[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   startIcon: TextResponseWithButtonDelete_startIcon[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   button: TextResponseWithButtonDelete_button[];
-  /**
-   * blockDelete returns the updated sibling blocks on successful delete
-   */
   textResponse: TextResponseWithButtonDelete_textResponse[];
 }
 


### PR DESCRIPTION
- Changed the chatButtonCreate mutation in the api-gateway schema to use the modern journeys graph with an override.
- Added the chatButtonCreate mutation to the api-journeys-modern schema with an override from api-journeys.
- Updated imports in the chatButton index file to include the new chatButtonCreate mutation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chat button creation capability now available, with support for configurable link and platform settings.
  * Maximum of 2 chat buttons per journey enforced with authentication requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->