### PR TITLE
fix: pin system time in utils.spec.ts to eliminate minute-boundary flakiness

### DIFF
--- a/apis/api-journeys-modern/src/schema/event/utils.spec.ts
+++ b/apis/api-journeys-modern/src/schema/event/utils.spec.ts
@@ -476,6 +476,13 @@ describe('event utils', () => {
       __setGoogleSheetsSyncQueueForTests(mockGoogleSheetsSyncQueue)
       delete process.env.NODE_ENV
       mockLogger.warn.mockClear()
+      // Pin clock to a known mid-minute time so delay calculations are deterministic
+      jest.useFakeTimers()
+      jest.setSystemTime(new Date('2024-01-01T00:00:30.000Z'))
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
     })
 
     it('should return early when no sync config exists', async () => {
@@ -539,11 +546,10 @@ describe('event utils', () => {
         })
       )
 
-      // Verify delay is between 1-60 seconds (1000-60000ms)
+      // Clock is pinned to :30s, so next minute boundary is exactly 30 seconds away
       const callArgs = mockGoogleSheetsSyncQueue.add.mock.calls[0]
       const delay = callArgs[2]?.delay
-      expect(delay).toBeGreaterThanOrEqual(1000)
-      expect(delay).toBeLessThanOrEqual(60000)
+      expect(delay).toBe(30000)
     })
 
     it('should skip syncs without integrationId', async () => {


### PR DESCRIPTION
## Summary
- `appendEventToGoogleSheets` test was timing-dependent — if it ran in the last ~999ms of a minute, the delay calculation was < 1000ms and the assertion failed
- Fixed by adding `jest.useFakeTimers()` + `jest.setSystemTime()` to pin the clock to mid-minute (same pattern used elsewhere in the suite)
- Replaced flaky range assertion with deterministic `toBe(30000)`

## Test plan
- [ ] `api-journeys-modern:test` shard 3/3 should pass consistently now
- [ ] No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by implementing deterministic timing behavior in event processing tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->