### PR TITLE
chore: ignore personal claude rules at any depth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,7 +91,7 @@ terraform.tfstate.backup
 .claude/commands/*.dev.md
 .claude/rules/preferences.md
 .claude/rules/workflows.md
-.claude/rules/*.dev.md
+.claude/rules/**/*.dev.md
 .claude/worktrees
 
 # ignore exports


### PR DESCRIPTION
## Summary

Updates the personal Claude rules ignore pattern from `*.dev.md` (single-level) to `**/*.dev.md` (recursive), so personal rules organised into subfolders (e.g. `.claude/rules/workflow/`) stay ignored.

The `**` glob still matches files at the root, so existing `.claude/rules/*.dev.md` files continue to be ignored too — no behaviour change for the current layout.

## Test plan

- [x] \`git check-ignore -v .claude/rules/lfg-workflow.dev.md\` reports the new pattern
- [x] \`git check-ignore -v .claude/rules/workflow/lfg-workflow.dev.md\` (when moved) reports the new pattern
- [x] No tracked rule files are affected (codebase rules in \`backend/\`, \`frontend/\`, \`infra/\` use no \`.dev\` suffix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git configuration to improve handling of development files in nested directory structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->