### PR TITLE
ci: skip autofix.ci on /sync-ce-generated PRs

### DIFF
--- a/.github/workflows/autofix.ci.yml
+++ b/.github/workflows/autofix.ci.yml
@@ -9,6 +9,7 @@ on:
     branches: [main]
 jobs:
   lint:
+    if: ${{ !contains(github.head_ref, 'chore-ce-sync') }}
     runs-on: blacksmith-2vcpu-ubuntu-2204
     strategy:
       matrix:

--- a/.github/workflows/autofix.ci.yml
+++ b/.github/workflows/autofix.ci.yml
@@ -9,7 +9,7 @@ on:
     branches: [main]
 jobs:
   lint:
-    if: ${{ !contains(github.head_ref, 'chore-ce-sync') }}
+    if: ${{ !contains(github.head_ref, '-chore-ce-sync-') }}
     runs-on: blacksmith-2vcpu-ubuntu-2204
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

The `/sync-ce` skill creates PRs that only touch `.claude/skills/`, `.claude/agents/`, `.ce-version`, and `.ce-manifest` — none of which are in any nx project. autofix.ci therefore has nothing to fix on these PRs but still spends ~5 minutes on install + Prisma/GraphQL codegen before running prettier/eslint/type-check against zero matched files.

This adds a job-level `if:` guard that skips the lint job when the branch name contains `chore-ce-sync` (the segment present in every `/sync-ce` branch: `00-00-XX-chore-ce-sync-vX-Y-Z`).

## Why this is safe on non-PR events

`github.head_ref` is only populated for `pull_request` / `pull_request_target` events. On `push` (to main), `merge_group`, and `workflow_call` it is empty, so `contains('', 'chore-ce-sync')` is `false` and `!contains(...)` is `true` — the job runs exactly as it does today. No fail-open risk on main pushes or the merge queue.

## Test plan

- [ ] Confirm autofix.ci still runs on this PR (branch is `00-00-JC-ci-skip-autofix-on-ce-sync` — no `chore-ce-sync` substring, so should run)
- [ ] On the next `/sync-ce` PR, confirm the autofix.ci check is skipped (shows as "Skipped" in the PR checks)
- [ ] Confirm autofix.ci still runs on push to main after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to optimize build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->