### PR TITLE
feat: NES-1610 restrict team template editing (frontend)

### DIFF
--- a/apps/journeys-admin/__generated__/GetAdminJourney.ts
+++ b/apps/journeys-admin/__generated__/GetAdminJourney.ts
@@ -860,6 +860,12 @@ export interface GetAdminJourney_journey {
    * used to display quick start label on customizable templates
    */
   customizable: boolean | null;
+  /**
+   * When true on a template, only the journey owner (creator) and team
+   * managers may mutate the journey. Plain team members and journey editors
+   * retain read access. Has no effect on non-templates and on global templates.
+   */
+  restrictEditing: boolean | null;
   showAssistant: boolean | null;
 }
 

--- a/apps/journeys-admin/__generated__/GetAdminJourneyWithPlausibleToken.ts
+++ b/apps/journeys-admin/__generated__/GetAdminJourneyWithPlausibleToken.ts
@@ -860,6 +860,12 @@ export interface GetAdminJourneyWithPlausibleToken_journey {
    * used to display quick start label on customizable templates
    */
   customizable: boolean | null;
+  /**
+   * When true on a template, only the journey owner (creator) and team
+   * managers may mutate the journey. Plain team members and journey editors
+   * retain read access. Has no effect on non-templates and on global templates.
+   */
+  restrictEditing: boolean | null;
   showAssistant: boolean | null;
   /**
    * used in a plausible share link to embed report

--- a/apps/journeys-admin/__generated__/GetAdminJourneys.ts
+++ b/apps/journeys-admin/__generated__/GetAdminJourneys.ts
@@ -111,6 +111,12 @@ export interface GetAdminJourneys_journeys {
    * used to display quick start label on customizable templates
    */
   customizable: boolean | null;
+  /**
+   * When true on a template, only the journey owner (creator) and team
+   * managers may mutate the journey. Plain team members and journey editors
+   * retain read access. Has no effect on non-templates and on global templates.
+   */
+  restrictEditing: boolean | null;
 }
 
 export interface GetAdminJourneys {

--- a/apps/journeys-admin/__generated__/GetJourney.ts
+++ b/apps/journeys-admin/__generated__/GetJourney.ts
@@ -860,6 +860,12 @@ export interface GetJourney_journey {
    * used to display quick start label on customizable templates
    */
   customizable: boolean | null;
+  /**
+   * When true on a template, only the journey owner (creator) and team
+   * managers may mutate the journey. Plain team members and journey editors
+   * retain read access. Has no effect on non-templates and on global templates.
+   */
+  restrictEditing: boolean | null;
   showAssistant: boolean | null;
 }
 

--- a/apps/journeys-admin/__generated__/GetPublisherTemplate.ts
+++ b/apps/journeys-admin/__generated__/GetPublisherTemplate.ts
@@ -860,6 +860,12 @@ export interface GetPublisherTemplate_publisherTemplate {
    * used to display quick start label on customizable templates
    */
   customizable: boolean | null;
+  /**
+   * When true on a template, only the journey owner (creator) and team
+   * managers may mutate the journey. Plain team members and journey editors
+   * retain read access. Has no effect on non-templates and on global templates.
+   */
+  restrictEditing: boolean | null;
   showAssistant: boolean | null;
 }
 

--- a/apps/journeys-admin/__generated__/JourneyFields.ts
+++ b/apps/journeys-admin/__generated__/JourneyFields.ts
@@ -860,5 +860,11 @@ export interface JourneyFields {
    * used to display quick start label on customizable templates
    */
   customizable: boolean | null;
+  /**
+   * When true on a template, only the journey owner (creator) and team
+   * managers may mutate the journey. Plain team members and journey editors
+   * retain read access. Has no effect on non-templates and on global templates.
+   */
+  restrictEditing: boolean | null;
   showAssistant: boolean | null;
 }

--- a/apps/journeys-admin/__generated__/JourneySettingsUpdate.ts
+++ b/apps/journeys-admin/__generated__/JourneySettingsUpdate.ts
@@ -76,6 +76,12 @@ export interface JourneySettingsUpdate_journeyUpdate {
   menuStepBlock: JourneySettingsUpdate_journeyUpdate_menuStepBlock | null;
   socialNodeX: number | null;
   socialNodeY: number | null;
+  /**
+   * When true on a template, only the journey owner (creator) and team
+   * managers may mutate the journey. Plain team members and journey editors
+   * retain read access. Has no effect on non-templates and on global templates.
+   */
+  restrictEditing: boolean | null;
 }
 
 export interface JourneySettingsUpdate {

--- a/apps/journeys-admin/__generated__/globalTypes.ts
+++ b/apps/journeys-admin/__generated__/globalTypes.ts
@@ -696,6 +696,7 @@ export interface JourneyUpdateInput {
   logoImageBlockId?: string | null;
   socialNodeX?: number | null;
   socialNodeY?: number | null;
+  restrictEditing?: boolean | null;
 }
 
 export interface JourneyVisitorFilter {

--- a/apps/journeys-admin/src/components/Editor/Editor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.spec.tsx
@@ -105,6 +105,7 @@ describe('Editor', () => {
     socialNodeX: null,
     socialNodeY: null,
     customizable: null,
+    restrictEditing: null,
     showAssistant: null
   }
 

--- a/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Editor.stories.tsx
@@ -91,6 +91,7 @@ const journey: Journey = {
   socialNodeX: null,
   socialNodeY: null,
   customizable: null,
+  restrictEditing: null,
   showAssistant: null
 }
 

--- a/apps/journeys-admin/src/components/Editor/Slider/Content/Goals/Goals.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Content/Goals/Goals.spec.tsx
@@ -178,6 +178,7 @@ describe('Goals', () => {
     socialNodeY: null,
     journeyTheme: null,
     customizable: null,
+    restrictEditing: null,
     showAssistant: null
   }
 

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/SocialPreviewNode/SocialPreviewNode.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/SocialPreviewNode/SocialPreviewNode.spec.tsx
@@ -101,6 +101,7 @@ describe('SocialPreviewNode', () => {
     socialNodeX: null,
     socialNodeY: null,
     customizable: null,
+    restrictEditing: null,
     showAssistant: null
   }
 

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/SocialPreviewNode/SocialPreviewNode.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/nodes/SocialPreviewNode/SocialPreviewNode.stories.tsx
@@ -153,6 +153,7 @@ const defaultJourney: Journey = {
   socialNodeX: null,
   socialNodeY: null,
   customizable: null,
+  restrictEditing: null,
   showAssistant: null
 }
 

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundColor/BackgroundColor.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundColor/BackgroundColor.spec.tsx
@@ -91,6 +91,7 @@ const journey: Journey = {
   socialNodeX: null,
   socialNodeY: null,
   customizable: null,
+  restrictEditing: null,
   showAssistant: null
 }
 

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/BackgroundMedia.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/BackgroundMedia.stories.tsx
@@ -93,6 +93,7 @@ const journey: Journey = {
   socialNodeX: null,
   socialNodeY: null,
   customizable: null,
+  restrictEditing: null,
   showAssistant: null
 }
 

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/Image/BackgroundMediaImage.spec.tsx
@@ -116,6 +116,7 @@ const journey: Journey = {
   socialNodeX: null,
   socialNodeY: null,
   customizable: null,
+  restrictEditing: null,
   showAssistant: null
 }
 

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/CardLayout/CardLayout.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/CardLayout/CardLayout.spec.tsx
@@ -80,6 +80,7 @@ const journey: Journey = {
   socialNodeX: null,
   socialNodeY: null,
   customizable: null,
+  restrictEditing: null,
   showAssistant: null
 }
 

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/CardLayout/CardLayout.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/CardLayout/CardLayout.stories.tsx
@@ -82,6 +82,7 @@ const journey: Journey = {
   socialNodeX: null,
   socialNodeY: null,
   customizable: null,
+  restrictEditing: null,
   showAssistant: null
 }
 

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/CardStyling/CardStyling.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/CardStyling/CardStyling.spec.tsx
@@ -94,6 +94,7 @@ const journey: Journey = {
   socialNodeX: null,
   socialNodeY: null,
   customizable: null,
+  restrictEditing: null,
   showAssistant: null
 }
 

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/CardStyling/CardStyling.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/CardStyling/CardStyling.stories.tsx
@@ -82,6 +82,7 @@ const journey: Journey = {
   socialNodeX: null,
   socialNodeY: null,
   customizable: null,
+  restrictEditing: null,
   showAssistant: null
 }
 

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/RadioOption/RadioOptionImage/RadioOptionImage.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/RadioOption/RadioOptionImage/RadioOptionImage.spec.tsx
@@ -115,6 +115,7 @@ const journey: Journey = {
   socialNodeX: null,
   socialNodeY: null,
   customizable: null,
+  restrictEditing: null,
   showAssistant: null
 }
 

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Typography/ThemeBuilderDialog/ThemeBuilderDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Typography/ThemeBuilderDialog/ThemeBuilderDialog.spec.tsx
@@ -87,6 +87,7 @@ describe('ThemeBuilderDialog', () => {
     journeyCustomizationFields: [],
     fromTemplateId: null,
     customizable: null,
+    restrictEditing: null,
     showAssistant: null
   }
 

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/controls/Action/Action.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/controls/Action/Action.stories.tsx
@@ -78,6 +78,7 @@ const journey: Journey = {
   socialNodeX: null,
   socialNodeY: null,
   customizable: null,
+  restrictEditing: null,
   showAssistant: null
 }
 

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/Settings/Poster/Library/VideoBlockEditorSettingsPosterLibrary.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoBlockEditor/Settings/Poster/Library/VideoBlockEditorSettingsPosterLibrary.spec.tsx
@@ -115,6 +115,7 @@ const journey: Journey = {
   socialNodeX: null,
   socialNodeY: null,
   customizable: null,
+  restrictEditing: null,
   showAssistant: null
 }
 

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromMux/AddByFile/AddByFile.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromMux/AddByFile/AddByFile.spec.tsx
@@ -85,6 +85,7 @@ const mockJourney: Journey = {
   journeyCustomizationFields: [],
   fromTemplateId: null,
   customizable: null,
+  restrictEditing: null,
   showAssistant: null
 }
 

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromMux/VideoFromMux.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromMux/VideoFromMux.spec.tsx
@@ -131,6 +131,7 @@ const mockJourneyWithValidLanguage: Journey = {
   journeyCustomizationFields: [],
   fromTemplateId: null,
   customizable: null,
+  restrictEditing: null,
   showAssistant: null
 }
 

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/SocialDetails.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/SocialDetails/SocialDetails.stories.tsx
@@ -83,6 +83,7 @@ const journey: Journey = {
   socialNodeX: null,
   socialNodeY: null,
   customizable: null,
+  restrictEditing: null,
   showAssistant: null
 }
 

--- a/apps/journeys-admin/src/components/JourneyList/ActiveJourneyList/ActivePriorityList/ActiveJourneyListData.ts
+++ b/apps/journeys-admin/src/components/JourneyList/ActiveJourneyList/ActivePriorityList/ActiveJourneyListData.ts
@@ -88,7 +88,8 @@ export const defaultJourney: Journey = {
   template: false,
   primaryImageBlock: null,
   fromTemplateId: null,
-  customizable: null
+  customizable: null,
+  restrictEditing: null
 }
 
 export const journey: Journey = {

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DefaultMenu/DefaultMenu.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/DefaultMenu/DefaultMenu.tsx
@@ -37,6 +37,7 @@ import { ShareItem } from '../../../../Editor/Toolbar/Items/ShareItem/ShareItem'
 import { MenuItem } from '../../../../MenuItem'
 import { CopyToTeamMenuItem } from '../../../../Team/CopyToTeamMenuItem/CopyToTeamMenuItem'
 import { DuplicateJourneyMenuItem } from '../DuplicateJourneyMenuItem'
+import { RestrictEditingToggle } from '../RestrictEditingToggle'
 
 import { ArchiveJourney } from './ArchiveJourney'
 
@@ -288,6 +289,13 @@ export function DefaultMenu({
             journey={journey}
             refetchTemplateStats={refetchTemplateStats}
           />
+          {isLocalTemplate && (
+            <RestrictEditingToggle
+              journey={journey}
+              teamRole={teamRole}
+              handleCloseMenu={handleCloseMenu}
+            />
+          )}
           <Divider />
         </>
       )}

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/RestrictEditingToggle/RestrictEditingToggle.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/RestrictEditingToggle/RestrictEditingToggle.spec.tsx
@@ -1,0 +1,132 @@
+import { MockedProvider } from '@apollo/client/testing'
+import { render, screen } from '@testing-library/react'
+import { SnackbarProvider } from 'notistack'
+
+import { GetAdminJourneys_journeys as Journey } from '../../../../../../__generated__/GetAdminJourneys'
+import { UserTeamRole } from '../../../../../../__generated__/globalTypes'
+
+import { RestrictEditingToggle } from './RestrictEditingToggle'
+
+const localTemplate = {
+  __typename: 'Journey',
+  id: 'journey-1',
+  title: 'Local template',
+  description: null,
+  template: true,
+  team: { __typename: 'Team', id: 'team-1' },
+  language: {
+    __typename: 'Language',
+    id: '529',
+    name: [{ __typename: 'LanguageName', value: 'English', primary: true }]
+  },
+  website: null,
+  customizable: null,
+  restrictEditing: false
+} as unknown as Journey
+
+const globalTemplate = {
+  ...localTemplate,
+  team: { __typename: 'Team', id: 'jfp-team' }
+} as unknown as Journey
+
+const handleCloseMenu = jest.fn()
+
+describe('RestrictEditingToggle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders nothing for non-template journeys', () => {
+    const journey = { ...localTemplate, template: false } as Journey
+    const { container } = render(
+      <MockedProvider>
+        <SnackbarProvider>
+          <RestrictEditingToggle
+            journey={journey}
+            teamRole={UserTeamRole.manager}
+            handleCloseMenu={handleCloseMenu}
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing for global templates', () => {
+    const { container } = render(
+      <MockedProvider>
+        <SnackbarProvider>
+          <RestrictEditingToggle
+            journey={globalTemplate}
+            teamRole={UserTeamRole.manager}
+            handleCloseMenu={handleCloseMenu}
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows enabled toggle for managers', () => {
+    render(
+      <MockedProvider>
+        <SnackbarProvider>
+          <RestrictEditingToggle
+            journey={localTemplate}
+            teamRole={UserTeamRole.manager}
+            handleCloseMenu={handleCloseMenu}
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    )
+    const toggle = screen.getByTestId('RestrictEditingToggle')
+    expect(toggle).not.toHaveAttribute('aria-disabled', 'true')
+    const checkbox = screen.getByRole('checkbox', {
+      name: 'Restrict editing to managers'
+    })
+    expect(checkbox).not.toBeDisabled()
+    expect(checkbox).not.toBeChecked()
+  })
+
+  it('shows disabled toggle for non-managers with helper text', () => {
+    render(
+      <MockedProvider>
+        <SnackbarProvider>
+          <RestrictEditingToggle
+            journey={localTemplate}
+            teamRole={UserTeamRole.member}
+            handleCloseMenu={handleCloseMenu}
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    )
+    expect(
+      screen.getByText('Only team managers can change this')
+    ).toBeInTheDocument()
+    const checkbox = screen.getByRole('checkbox', {
+      name: 'Restrict editing to managers'
+    })
+    expect(checkbox).toBeDisabled()
+  })
+
+  it('reflects the current restrictEditing state', () => {
+    const restricted = { ...localTemplate, restrictEditing: true } as Journey
+    render(
+      <MockedProvider>
+        <SnackbarProvider>
+          <RestrictEditingToggle
+            journey={restricted}
+            teamRole={UserTeamRole.manager}
+            handleCloseMenu={handleCloseMenu}
+          />
+        </SnackbarProvider>
+      </MockedProvider>
+    )
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'Restrict editing to managers'
+      })
+    ).toBeChecked()
+  })
+
+})

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/RestrictEditingToggle/RestrictEditingToggle.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/RestrictEditingToggle/RestrictEditingToggle.tsx
@@ -39,7 +39,7 @@ export function RestrictEditingToggle({
 }: RestrictEditingToggleProps): ReactElement | null {
   const { t } = useTranslation('apps-journeys-admin')
   const { enqueueSnackbar } = useSnackbar()
-  const [journeyUpdate] = useJourneyUpdateMutation()
+  const [journeyUpdate, { loading }] = useJourneyUpdateMutation()
 
   if (journey == null) return null
 
@@ -51,34 +51,13 @@ export function RestrictEditingToggle({
   const checked = journey.restrictEditing === true
 
   const handleToggle = async (): Promise<void> => {
-    if (!isManager) return
+    if (!isManager || loading) return
     const next = !checked
     try {
       await journeyUpdate({
         variables: {
           id: journey.id,
           input: { restrictEditing: next }
-        },
-        optimisticResponse: {
-          journeyUpdate: {
-            __typename: 'Journey',
-            id: journey.id,
-            title: journey.title,
-            description: journey.description,
-            strategySlug: null,
-            language: journey.language,
-            tags: [],
-            website: journey.website,
-            showShareButton: null,
-            showLikeButton: null,
-            showDislikeButton: null,
-            displayTitle: null,
-            menuButtonIcon: null,
-            menuStepBlock: null,
-            socialNodeX: null,
-            socialNodeY: null,
-            restrictEditing: next
-          }
         }
       })
       enqueueSnackbar(
@@ -87,20 +66,19 @@ export function RestrictEditingToggle({
           : t('Editing unlocked for the team'),
         { variant: 'success', preventDuplicate: true }
       )
+      handleCloseMenu()
     } catch {
       enqueueSnackbar(t('Could not change template edit restriction'), {
         variant: 'error',
         preventDuplicate: true
       })
-    } finally {
-      handleCloseMenu()
     }
   }
 
   return (
     <MenuItem
       onClick={handleToggle}
-      disabled={!isManager}
+      disabled={!isManager || loading}
       data-testid="RestrictEditingToggle"
     >
       <ListItemIcon>
@@ -119,9 +97,12 @@ export function RestrictEditingToggle({
       <Switch
         edge="end"
         checked={checked}
-        disabled={!isManager}
+        disabled={!isManager || loading}
         inputProps={{
-          'aria-label': t('Restrict editing to managers')
+          'aria-label': t('Restrict editing to managers'),
+          // Prevent double-activation: MenuItem onClick already triggers
+          // the toggle, so the Switch should not be a separate tab stop.
+          tabIndex: -1
         }}
       />
     </MenuItem>

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/RestrictEditingToggle/RestrictEditingToggle.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/RestrictEditingToggle/RestrictEditingToggle.tsx
@@ -1,0 +1,129 @@
+import ListItemIcon from '@mui/material/ListItemIcon'
+import ListItemText from '@mui/material/ListItemText'
+import MenuItem from '@mui/material/MenuItem'
+import Switch from '@mui/material/Switch'
+import { useTranslation } from 'next-i18next'
+import { useSnackbar } from 'notistack'
+import { ReactElement } from 'react'
+
+import Lock1Icon from '@core/shared/ui/icons/Lock1'
+import LockOpen1Icon from '@core/shared/ui/icons/LockOpen1'
+
+import { GetAdminJourneys_journeys as Journey } from '../../../../../../__generated__/GetAdminJourneys'
+import { UserTeamRole } from '../../../../../../__generated__/globalTypes'
+import { useJourneyUpdateMutation } from '../../../../../libs/useJourneyUpdateMutation'
+
+interface RestrictEditingToggleProps {
+  journey?: Journey
+  /**
+   * Current user's role on the team that owns this journey. When undefined or
+   * not `manager`, the toggle is disabled with a helper that explains why.
+   */
+  teamRole?: UserTeamRole
+  handleCloseMenu: () => void
+}
+
+/**
+ * Manager-only switch that flips `Journey.restrictEditing`. When ON, the
+ * backend ACL restricts edit access on the team-local template to the
+ * journey owner (creator) and team managers. Plain team members and
+ * journey editors retain read access only.
+ *
+ * The component renders nothing for non-team-local templates (global
+ * templates are governed by the publisher rule instead).
+ */
+export function RestrictEditingToggle({
+  journey,
+  teamRole,
+  handleCloseMenu
+}: RestrictEditingToggleProps): ReactElement | null {
+  const { t } = useTranslation('apps-journeys-admin')
+  const { enqueueSnackbar } = useSnackbar()
+  const [journeyUpdate] = useJourneyUpdateMutation()
+
+  if (journey == null) return null
+
+  const isLocalTemplate =
+    journey.template === true && journey.team?.id !== 'jfp-team'
+  if (!isLocalTemplate) return null
+
+  const isManager = teamRole === UserTeamRole.manager
+  const checked = journey.restrictEditing === true
+
+  const handleToggle = async (): Promise<void> => {
+    if (!isManager) return
+    const next = !checked
+    try {
+      await journeyUpdate({
+        variables: {
+          id: journey.id,
+          input: { restrictEditing: next }
+        },
+        optimisticResponse: {
+          journeyUpdate: {
+            __typename: 'Journey',
+            id: journey.id,
+            title: journey.title,
+            description: journey.description,
+            strategySlug: null,
+            language: journey.language,
+            tags: [],
+            website: journey.website,
+            showShareButton: null,
+            showLikeButton: null,
+            showDislikeButton: null,
+            displayTitle: null,
+            menuButtonIcon: null,
+            menuStepBlock: null,
+            socialNodeX: null,
+            socialNodeY: null,
+            restrictEditing: next
+          }
+        }
+      })
+      enqueueSnackbar(
+        next
+          ? t('Editing restricted to managers and creator')
+          : t('Editing unlocked for the team'),
+        { variant: 'success', preventDuplicate: true }
+      )
+    } catch {
+      enqueueSnackbar(t('Could not change template edit restriction'), {
+        variant: 'error',
+        preventDuplicate: true
+      })
+    } finally {
+      handleCloseMenu()
+    }
+  }
+
+  return (
+    <MenuItem
+      onClick={handleToggle}
+      disabled={!isManager}
+      data-testid="RestrictEditingToggle"
+    >
+      <ListItemIcon>
+        {checked ? (
+          <Lock1Icon color="secondary" />
+        ) : (
+          <LockOpen1Icon color="secondary" />
+        )}
+      </ListItemIcon>
+      <ListItemText
+        primary={t('Restrict editing to managers')}
+        secondary={
+          isManager ? undefined : t('Only team managers can change this')
+        }
+      />
+      <Switch
+        edge="end"
+        checked={checked}
+        disabled={!isManager}
+        inputProps={{
+          'aria-label': t('Restrict editing to managers')
+        }}
+      />
+    </MenuItem>
+  )
+}

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/RestrictEditingToggle/index.ts
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCardMenu/RestrictEditingToggle/index.ts
@@ -1,0 +1,1 @@
+export { RestrictEditingToggle } from './RestrictEditingToggle'

--- a/apps/journeys-admin/src/components/JourneyList/journeyListData.ts
+++ b/apps/journeys-admin/src/components/JourneyList/journeyListData.ts
@@ -92,7 +92,8 @@ export const defaultJourney: Journey = {
   template: false,
   primaryImageBlock: null,
   fromTemplateId: null,
-  customizable: null
+  customizable: null,
+  restrictEditing: null
 }
 
 export const journeyWithImage: Journey = {
@@ -169,6 +170,7 @@ export const templateJourneyFromTemplate: Journey = {
 export const customizableTemplateJourney: Journey = {
   ...templateJourney,
   customizable: true,
+  restrictEditing: null,
   journeyCustomizationDescription: 'a customizable template journey',
   journeyCustomizationFields: [
     {
@@ -198,6 +200,7 @@ export const customizableWebsiteTemplateJourney: Journey = {
   website: true,
   template: true,
   customizable: true,
+  restrictEditing: null,
   journeyCustomizationDescription: 'a customizable website template journey',
   journeyCustomizationFields: [
     {

--- a/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/MediaScreen/Sections/VideosSection/VideosSection.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/MediaScreen/Sections/VideosSection/VideosSection.spec.tsx
@@ -117,6 +117,7 @@ const journeyWithMatchingVideoBlock: Journey = {
   socialNodeX: null,
   socialNodeY: null,
   customizable: null,
+  restrictEditing: null,
   showAssistant: null
 }
 

--- a/apps/journeys-admin/src/components/TemplateList/data.ts
+++ b/apps/journeys-admin/src/components/TemplateList/data.ts
@@ -63,7 +63,8 @@ export const defaultTemplate: Journey = {
   primaryImageBlock: null,
   trashedAt: null,
   fromTemplateId: null,
-  customizable: null
+  customizable: null,
+  restrictEditing: null
 }
 
 export const oldTemplate: Journey = {

--- a/apps/journeys-admin/src/libs/blockDeleteUpdate/blockDeleteUpdate.spec.ts
+++ b/apps/journeys-admin/src/libs/blockDeleteUpdate/blockDeleteUpdate.spec.ts
@@ -139,6 +139,7 @@ const journey: Journey = {
   socialNodeX: null,
   socialNodeY: null,
   customizable: null,
+  restrictEditing: null,
   showAssistant: null
 }
 

--- a/apps/journeys-admin/src/libs/useAdminJourneysQuery/useAdminJourneysQuery.ts
+++ b/apps/journeys-admin/src/libs/useAdminJourneysQuery/useAdminJourneysQuery.ts
@@ -76,6 +76,7 @@ export const GET_ADMIN_JOURNEYS = gql`
       }
       website
       customizable
+      restrictEditing
     }
   }
 `

--- a/apps/journeys-admin/src/libs/useJourneyUpdateMutation/useJourneyUpdateMutation.ts
+++ b/apps/journeys-admin/src/libs/useJourneyUpdateMutation/useJourneyUpdateMutation.ts
@@ -43,6 +43,7 @@ export const JOURNEY_SETTINGS_UPDATE = gql`
       }
       socialNodeX
       socialNodeY
+      restrictEditing
     }
   }
 `

--- a/libs/journeys/ui/src/components/TemplateView/TemplateFooter/data.ts
+++ b/libs/journeys/ui/src/components/TemplateView/TemplateFooter/data.ts
@@ -178,5 +178,6 @@ export const journey: Journey = {
   socialNodeX: null,
   socialNodeY: null,
   customizable: null,
+  restrictEditing: null,
   showAssistant: null
 }

--- a/libs/journeys/ui/src/components/TemplateView/data.ts
+++ b/libs/journeys/ui/src/components/TemplateView/data.ts
@@ -122,6 +122,7 @@ export const defaultJourney: Journey = {
   socialNodeX: null,
   socialNodeY: null,
   customizable: null,
+  restrictEditing: null,
   showAssistant: null
 }
 

--- a/libs/journeys/ui/src/libs/JourneyProvider/JourneyProvider.mock.ts
+++ b/libs/journeys/ui/src/libs/JourneyProvider/JourneyProvider.mock.ts
@@ -69,5 +69,6 @@ export const journey: Journey = {
   socialNodeX: null,
   socialNodeY: null,
   customizable: null,
+  restrictEditing: null,
   showAssistant: null
 }

--- a/libs/journeys/ui/src/libs/JourneyProvider/__generated__/JourneyFields.ts
+++ b/libs/journeys/ui/src/libs/JourneyProvider/__generated__/JourneyFields.ts
@@ -860,5 +860,11 @@ export interface JourneyFields {
    * used to display quick start label on customizable templates
    */
   customizable: boolean | null;
+  /**
+   * When true on a template, only the journey owner (creator) and team
+   * managers may mutate the journey. Plain team members and journey editors
+   * retain read access. Has no effect on non-templates and on global templates.
+   */
+  restrictEditing: boolean | null;
   showAssistant: boolean | null;
 }

--- a/libs/journeys/ui/src/libs/JourneyProvider/journeyFields.tsx
+++ b/libs/journeys/ui/src/libs/JourneyProvider/journeyFields.tsx
@@ -121,6 +121,7 @@ export const JOURNEY_FIELDS = gql`
     }
     fromTemplateId
     customizable
+    restrictEditing
     showAssistant
   }
 `

--- a/libs/journeys/ui/src/libs/useJourneyQuery/__generated__/GetJourney.ts
+++ b/libs/journeys/ui/src/libs/useJourneyQuery/__generated__/GetJourney.ts
@@ -860,6 +860,12 @@ export interface GetJourney_journey {
    * used to display quick start label on customizable templates
    */
   customizable: boolean | null;
+  /**
+   * When true on a template, only the journey owner (creator) and team
+   * managers may mutate the journey. Plain team members and journey editors
+   * retain read access. Has no effect on non-templates and on global templates.
+   */
+  restrictEditing: boolean | null;
   showAssistant: boolean | null;
 }
 


### PR DESCRIPTION
## Summary

Frontend complement to the backend `restrictEditing` ACL in [PR #9099](https://github.com/JesusFilm/core/pull/9099). This PR is **based on the backend branch** — merge backend first, then rebase this onto `main`.

Adds a manager-only switch on the team template card menu that flips `Journey.restrictEditing`. When ON, only the journey creator (owner) and team managers can edit the template; plain team members and journey editors retain read access only.

Linear: [NES-1610](https://linear.app/jesus-film-project/issue/NES-1610/restrict-team-template-edit-access-to-managers-only)

## What this PR does

- **GraphQL field threading.** Add `restrictEditing` to:
  - `apps/journeys-admin/src/libs/useAdminJourneysQuery/useAdminJourneysQuery.ts` — so the team template card menu can read the current state.
  - `apps/journeys-admin/src/libs/useJourneyUpdateMutation/useJourneyUpdateMutation.ts` — so the toggle can persist + Apollo cache picks up the new value.
  - `libs/journeys/ui/src/libs/JourneyProvider/journeyFields.tsx` (`JOURNEY_FIELDS` fragment) — used by the editor / publisher / journey pages.
- **New `RestrictEditingToggle` component** — a `MenuItem` with a `Switch` that appears in `JourneyCardMenu` → `DefaultMenu` for team-local templates only (hidden on global templates and on non-templates).
  - Manager: switch is enabled. Click flips the flag, fires `journeyUpdate`, shows success/failure snackbar.
  - Non-manager: switch is disabled with helper text "Only team managers can change this".
  - Icon flips between locked/unlocked to reflect state.

The backend ACL is the source of truth — even if a non-manager calls `journeyUpdate { restrictEditing: true }` directly via devtools, the field-level Manage rule in `journey.acl.ts` rejects it. The frontend toggle is UX polish, not a security control.

## Testing

- 5 new toggle tests (rendering paths × role gating).
- 25/25 `DefaultMenu` tests still pass.
- Lint clean.
- Codegen regenerated for `journeys-admin` and `journeys-ui`.

## Manual testing

- [ ] As a **team manager** on a team templates tab, open a local template's card menu → the "Restrict editing to managers" switch appears, enabled.
- [ ] Toggling ON shows a success snackbar and the icon switches to locked.
- [ ] Toggling OFF shows a different success snackbar and the icon switches to unlocked.
- [ ] As a **team member**, the switch appears but is disabled with helper text.
- [ ] On a **global template** card menu, the switch does not appear.
- [ ] On a **non-template** journey card menu, the switch does not appear.
- [ ] After toggling ON, a non-manager team member trying to edit the template via the editor's mutations gets a Forbidden error from the backend (sanity-check the backend lock).

## Post-Deploy Monitoring & Validation

- **Dashboards/logs:**
  - `apps/journeys-admin` Sentry / browser console for any GraphQL errors on `JourneySettingsUpdate` mutations carrying `restrictEditing`.
  - Snackbar "Could not change template edit restriction" surfaces on the user's screen — also logs to console as an Apollo error.
- **Validation queries:**
  - `SELECT COUNT(*) FROM "Journey" WHERE "restrictEditing" IS TRUE;` — should slowly grow as managers opt-in. Initial value 0.
- **Failure signal / rollback trigger:**
  - Toggle does not visibly update after click → likely Apollo cache miss because the mutation selection set is missing the field. Check `useJourneyUpdateMutation` selection includes `restrictEditing`.
  - Manager sees "Only team managers can change this" — likely a `useTeam`/role-resolution bug. Inspect `activeTeam.userTeams`.
  - Toggle appears on global templates — code regression in `isLocalTemplate` check.
- **Validation window & owner**
  - Window: 24h post-deploy after backend (PR #9099) is merged.
  - Owner: @jianwei1 (this PR), with @csiyang or @edmonday as reviewer.

## Out of scope (deferred follow-ups)

- `AccessDenied` "Restricted template" variant — current behaviour is the default `AccessDenied` page if the editor is opened by a non-eligible user. Acceptable for v1; a custom variant ("This template is locked. Duplicate to edit your own copy") is a follow-up.
- "Manager-only edit" chip on `JourneyCard` — would make the lock state visible before opening the menu.
- Bulk-toggle multiple templates at once.

## Dependency

This PR's branch is based on `jianweichong/nes-1610-restrict-template-edit-backend` (backend PR #9099). Once the backend lands on `main`, rebase this branch.

## References

- Plan: [`docs/plans/2026-04-28-001-feat-restrict-team-template-edit-access-plan.md`](./docs/plans/2026-04-28-001-feat-restrict-team-template-edit-access-plan.md) (lives on backend branch)
- Backend PR: #9099
- Linear: [NES-1610](https://linear.app/jesus-film-project/issue/NES-1610/restrict-team-template-edit-access-to-managers-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)