### PR TITLE
fix(ci): checkout repo in crowdin-auto-merge so gh CLI can detect repo context (ENG-3672)

### DIFF
--- a/.github/workflows/crowdin-auto-merge.yml
+++ b/.github/workflows/crowdin-auto-merge.yml
@@ -58,6 +58,11 @@ jobs:
           app-id: ${{ secrets.CI_BOT_APP_ID }}
           private-key: ${{ secrets.CI_BOT_PRIVATE_KEY }}
 
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          token: ${{ steps.app-token.outputs.token }}
+
       - name: Resolve CI Bot identity
         id: bot-login
         env:


### PR DESCRIPTION
## Summary

The Crowdin auto-merge workflow (`#9072`) had no checkout step, so when `gh pr list` ran on the runner it failed with `fatal: not a git repository` and the workflow aborted at the very first step.

`gh` CLI determines which repo to operate on by reading the local git remote (`git remote -v`). Without a `.git` directory present on the runner, that detection fails. Surfaced by the first dry run after `#9072` merged.

## Change

Add `actions/checkout@v4` (shallow, `fetch-depth: 2`) right after token generation, using the CI Bot App token. Mirrors the pattern already established in `.github/workflows/ai-build-spike.yml` for "App-token + gh CLI" workflows.

```yaml
- uses: actions/checkout@v4
  with:
    fetch-depth: 2
    token: ${{ steps.app-token.outputs.token }}
```

With this, `gh` detects the repo via the local git remote and all subsequent `gh` subcommands work normally (`gh pr list`, `gh pr edit`, `gh pr review`, `gh pr checks`, `gh run rerun`, `gh pr merge`).

## Test plan

- [ ] Trigger workflow_dispatch with `dry_run: true` from `main`
- [ ] Confirm "Find open Crowdin PR" step succeeds and identifies the open Crowdin PR
- [ ] Confirm assign / approve / rerun steps execute against the live PR
- [ ] Confirm "Enable auto-merge" step logs the dry-run "Would execute…" line and skips the actual merge

Related: ENG-3672, #9072

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the automated merge workflow with enhanced repository initialization and authentication handling to ensure more reliable automated merge operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->