### PR TITLE
fix(ci): exempt Crowdin translation PRs from Danger assignee check (ENG-3672)

### DIFF
--- a/.github/workflows/crowdin-auto-merge.yml
+++ b/.github/workflows/crowdin-auto-merge.yml
@@ -182,19 +182,6 @@ jobs:
           echo "All $FILE_COUNT changed files are under libs/locales/. Safe to proceed."
           echo "| Files changed | $FILE_COUNT (all under \`libs/locales/\`) |" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Assign PR to CI Bot
-        if: steps.find-pr.outputs.found == 'true'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ steps.find-pr.outputs.number }}
-          BOT_LOGIN: ${{ steps.bot-login.outputs.login }}
-        run: |
-          set -euo pipefail
-          echo "Assigning PR #$PR_NUMBER to $BOT_LOGIN"
-          gh pr edit "$PR_NUMBER" --add-assignee "$BOT_LOGIN"
-          echo "Assigned successfully."
-          echo "| Assignee | \`$BOT_LOGIN\` |" >> "$GITHUB_STEP_SUMMARY"
-
       - name: Approve PR
         if: steps.find-pr.outputs.found == 'true'
         env:

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -47,8 +47,16 @@ export default async () => {
     markdown(`> (pr title - ${danger.github.pr.title}): \n${errors}`)
   }
 
+  // Crowdin translation PRs are auto-merged by the crowdin-auto-merge workflow,
+  // which approves via the CI Bot App. GitHub Apps cannot be assignees, so skip
+  // the assignee check for these PRs. Identified by repo + branch + title triple.
+  const isCrowdinTranslationPR =
+    danger.github.pr.head.repo.full_name === 'JesusFilm/core' &&
+    danger.github.pr.head.ref === '00-00-CI-chore-i10n-updates' &&
+    danger.github.pr.title === 'chore: new crowdin translations'
+
   // check PR has assignee
-  if (danger.github.pr.assignee === null) {
+  if (!isCrowdinTranslationPR && danger.github.pr.assignee === null) {
     fail('Please assign someone to merge this PR.')
   }
 


### PR DESCRIPTION
## Summary

The crowdin-auto-merge workflow's first dry run failed at the `Assign PR to CI Bot` step:

```
'jesusfilm-ci-bot[bot]' not found
```

Verified empirically against `GET /repos/JesusFilm/core/assignees/<login>`:

| Login | Result |
|---|---|
| `jesusfilm-ci-bot[bot]` | 404 (not assignable) |
| `jesusfilm-ci-bot` (bare slug) | 404 (not assignable) |
| `tataihono` | 204 (assignable) ✓ |

GitHub Apps cannot be assignees via the REST API — it's a platform-level restriction, not a permission scope thing. Per discussion with @tataihono, the agreed fix is to **exempt Crowdin translation PRs from the assignee check** rather than assign a real human to every weekly translation PR.

## Changes

**`dangerfile.ts`** — add an `isCrowdinTranslationPR` guard scoped by repo + branch + title triple. The `head.repo.full_name === 'JesusFilm/core'` check ensures fork PRs can't impersonate to bypass the gate.

```typescript
const isCrowdinTranslationPR =
  danger.github.pr.head.repo.full_name === 'JesusFilm/core' &&
  danger.github.pr.head.ref === '00-00-CI-chore-i10n-updates' &&
  danger.github.pr.title === 'chore: new crowdin translations'

if (!isCrowdinTranslationPR && danger.github.pr.assignee === null) {
  fail('Please assign someone to merge this PR.')
}
```

**`.github/workflows/crowdin-auto-merge.yml`** — drop the `Assign PR to CI Bot` step entirely. Once Danger no longer requires an assignee on Crowdin PRs, the step is dead weight (and was the actual blocker on the first dry run).

## What's deliberately not in this PR

The dangerfile reviewer check is **untouched**. My theoretical analysis says it'll also block the merge queue (the bot's approval doesn't re-trigger Danger; `pull_request_review.submitted` isn't a `pull_request` event sub-type), but the empirical answer is best confirmed by an actual non-dry-run after this PR merges. If the merge queue does stall on the reviewer check, a small follow-up PR adds the same `!isCrowdinTranslationPR &&` guard to it.

## Test plan

- [ ] After merge, trigger workflow_dispatch on `crowdin-auto-merge.yml` from `main` with `dry_run: true`
- [ ] Confirm the workflow runs end-to-end (no assign step → no 404)
- [ ] Confirm the run page's step summary shows assignee row absent (deliberately) and approval row present
- [ ] Trigger a non-dry-run (`dry_run: false`) and observe the Crowdin PR
- [ ] If the PR merges cleanly: done.
- [ ] If the PR sits with auto-merge enabled but Danger reviewer check red: open PR follow-up adding the reviewer-check exemption

## Security note

The `head.repo.full_name === 'JesusFilm/core'` check closes the obvious fork-impersonation vector. Fork PRs cannot match the `isCrowdinTranslationPR` predicate, so the regular Danger assignee check still applies to them. Branch protection's required-approvals rule remains the gating mechanism for any PR touching this repo regardless of Danger's behaviour.

Refs ENG-3672, follow-up to #9072

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PR automation to remove assignee assignment from translation pull requests.
  * Added exception to bypass the assignee requirement specifically for translation pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->