### PR TITLE
feat(ci): enable weekly schedule on crowdin-auto-merge workflow (ENG-3672)

### DIFF
--- a/.github/workflows/crowdin-auto-merge.yml
+++ b/.github/workflows/crowdin-auto-merge.yml
@@ -6,8 +6,8 @@ on:
         description: 'Skip the merge-queue enqueue step (default: true for safety)'
         type: boolean
         default: true
-  # schedule:
-  #   - cron: '0 1 * * 5'  # Friday 01:00 UTC = Friday 1pm NZST / 2pm NZDT
+  schedule:
+    - cron: '0 1 * * 5' # Friday 01:00 UTC = Friday 1pm NZST / 2pm NZDT
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

Final piece of ENG-3672. Uncomments the `schedule:` trigger on `crowdin-auto-merge.yml` so the workflow runs weekly without manual intervention.

## Validation already done

Across previous PRs (#9072, #9101, #9105) and several `workflow_dispatch` runs, the workflow has been validated end-to-end on PR #9048:

- ✅ App token + checkout + bot identity resolution
- ✅ Find Crowdin PR (with `isCrossRepository: false` + `headRepositoryOwner.login == "JesusFilm"` guards)
- ✅ Locale-file path validation (verified safety guard rejects non-locale changes)
- ✅ Bot approval submission (with idempotency check for already-approved state)
- ✅ Failed-required-check rerun via `gh run rerun` (confirms CI Bot App has `Actions: write`)
- ✅ Dry-run gate skips merge-queue enqueue
- ✅ Non-dry run successfully enabled auto-merge and the PR entered the merge queue

## What this PR does

```diff
-  # schedule:
-  #   - cron: '0 1 * * 5'  # Friday 01:00 UTC = Friday 1pm NZST / 2pm NZDT
+  schedule:
+    - cron: '0 1 * * 5' # Friday 01:00 UTC = Friday 1pm NZST / 2pm NZDT
```

After this merges, the next scheduled run will fire **Friday 01:00 UTC** (≈ 1pm NZST / 2pm NZDT) and operate on whatever Crowdin PR is open at that time.

## What this PR doesn't do

- No log trimming. Considered it but reverted — the workflow runs once a week, total log volume is tiny, and the diagnostic value of the verbose logs outweighs the cleanup benefit.
- No reviewer-check exemption in `dangerfile.ts`. My theoretical prediction is the steady-state weekly cycle will hit the reviewer-check failure (`reviews.length === 0` at the time Danger runs on `synchronize`), but waiting to confirm empirically before adding a second exemption. If the first scheduled run on Friday stalls in the merge queue with Danger red, follow-up PR will add the same `!isCrowdinTranslationPR &&` guard to the reviewer check.

## Test plan

- [ ] After merge, watch the next Friday 01:00 UTC scheduled run
- [ ] If the Crowdin PR auto-merges cleanly: feature is fully functional, ENG-3672 done
- [ ] If the PR enters the merge queue but stalls on Danger reviewer check: open the small follow-up PR adding the reviewer-check exemption

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Re-enabled automated weekly maintenance tasks to support regular system updates and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->