### PR TITLE
fix(ci): move crowdin-auto-merge cron off the top of the hour (ENG-3672)

### DIFF
--- a/.github/workflows/crowdin-auto-merge.yml
+++ b/.github/workflows/crowdin-auto-merge.yml
@@ -7,7 +7,7 @@ on:
         type: boolean
         default: true
   schedule:
-    - cron: '0 1 * * 5' # Friday 01:00 UTC = Friday 1pm NZST / 2pm NZDT
+    - cron: '17 1 * * 5' # Friday 01:17 UTC = Friday 1:17pm NZST / 2:17pm NZDT — off-peak minute to avoid GitHub Actions schedule drops at the top of the hour
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

The previous cron (`0 1 * * 5` — Friday 01:00 UTC) silently failed to fire on its first scheduled run after #9111 enabled the schedule. No run was created and no error surfaced.

GitHub's docs explicitly call out this failure mode:
> *"The schedule event can be delayed during periods of high loads of GitHub Actions workflow runs. **High load times include the start of every hour.** If the load is sufficiently high enough, **some queued jobs may be dropped**."*

The top-of-the-hour Friday slot is one of the most-contested cron windows globally.

## Change

```diff
-    - cron: '0 1 * * 5'  # Friday 01:00 UTC = Friday 1pm NZST / 2pm NZDT
+    - cron: '17 1 * * 5' # Friday 01:17 UTC = Friday 1:17pm NZST / 2:17pm NZDT — off-peak minute to avoid GitHub Actions schedule drops at the top of the hour
```

Same Friday afternoon NZ window, just a less-contended minute. PR #9048 (this week's Crowdin PR) was merged manually after the missed scheduled run; future runs should fire reliably with this change.

## Test plan

- [ ] Workflow YAML still parses (no other changes besides the cron value)
- [ ] Next Friday 01:17 UTC, watch the run page for a `schedule`-triggered run

Refs ENG-3672

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated scheduled automation workflow timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->