### PR TITLE
chore: add .claude/skills/ and .claude/agents/ to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -15,6 +15,13 @@ schema.graphql
 playwright-report/
 .github/chatmodes/
 .cursor/
+
+# Agent-tooling content vendored from upstream (synced via /sync-ce). We don't
+# author these files and any reformatting here gets overwritten on the next
+# sync — same treatment as .cursor/ above.
+.claude/skills/
+.claude/agents/
+
 !apis/api-languages/src/__generated__/languageSlugs.ts
 pnpm-lock.yaml
 


### PR DESCRIPTION
## Summary

The CE plugin's skill and agent files in `.claude/skills/` and `.claude/agents/` are vendored verbatim from `EveryInc/compound-engineering-plugin` (synced via `/sync-ce`) and aren't prettier-formatted upstream. Without ignoring them, `autofix.ci` runs prettier on the 165+ files on every non-/sync-ce PR, the autofix-ci action pushes a `fix: lint issues` commit back to whoever's PR it is, and the next `/sync-ce` overwrites that work on the next upstream pull.

We already treat `.cursor/` (the equivalent vendored content for the Cursor IDE) the same way — this PR adds the parallel pattern for `.claude/`.

## Why now

PR #9150 (sync-ce v3.5.0) merged a few hours ago, landing 165+ unformatted CE files on main for the first time. The very next non-/sync-ce PR (#9156, an unrelated docs change) immediately picked up two `fix: lint issues` commits totalling **165 files, +3298/-2130 lines** of pure prettier reformatting. Every PR opened against main right now is going to inherit the same reformat-everything blob until this lands.

## Why not fix it on the sync side

We could format the CE files when copying them in via `/sync-ce`, but:
- It violates the "CE files are read-only / treated as upstream content" principle the sync-ce skill already documents.
- It would create merge-conflict noise on every upstream sync.
- Other vendored content in this repo (`.cursor/`, `pnpm-lock.yaml`, `.terraform/`, `.next/`) follows the same "ignore, don't reformat" treatment — this PR keeps the convention consistent.

## Verification

```bash
# Before this PR — prettier would flag and reformat:
$ npx prettier --check .claude/skills/ce-code-review/SKILL.md
# (would report formatting issues)

# After this PR:
$ npx prettier --check .claude/skills/ce-code-review/SKILL.md
Checking formatting...
All matched files use Prettier code style!
```

Confirmed locally that `prettier --check` on the full `.claude/skills/**/*.md` and `.claude/agents/*.md` glob now passes cleanly with the new ignore rules.

## Follow-up

Once this lands, I'll force-push #9156 back to its clean single-commit state so its diff is just the docs change reviewers care about, then re-add it to the merge queue.

## Test plan

- [ ] CI on this PR passes — `autofix.ci` should NOT now re-format the CE files (which means no surprise `fix: lint issues` commit on this PR).
- [ ] After merge, opening any new PR against main does not pick up an autofix-ci reformat commit on the CE files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code formatting configuration to exclude additional directories from formatting checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->