### PR TITLE
feat: add journey list view toggle

### DIFF
--- a/apps/journeys-admin/src/components/JourneyList/JourneyList.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyList.tsx
@@ -106,6 +106,7 @@ export function JourneyList({
         user={contentType === 'journeys' ? user : undefined}
         sortOrder={sortOrder}
         event={eventForThisContentType}
+        display={router?.query?.view === 'list' ? 'list' : 'grid'}
       />
     )
   }

--- a/apps/journeys-admin/src/components/JourneyList/JourneyListContent/JourneyListContent.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyListContent/JourneyListContent.tsx
@@ -13,7 +13,10 @@ import { ReactElement, ReactNode, useEffect, useMemo, useState } from 'react'
 
 import { useTeam } from '@core/journeys/ui/TeamProvider'
 
-import { JourneyStatus } from '../../../../__generated__/globalTypes'
+import {
+  JourneyStatus,
+  UserJourneyRole
+} from '../../../../__generated__/globalTypes'
 import { User } from '../../../libs/auth/authContext'
 import { useAdminJourneysQuery } from '../../../libs/useAdminJourneysQuery'
 import {
@@ -23,8 +26,14 @@ import {
 import { ActivePriorityList } from '../ActiveJourneyList/ActivePriorityList'
 import { AddJourneyButton } from '../ActiveJourneyList/AddJourneyButton'
 import { JourneyCard } from '../JourneyCard'
+import { JourneyCardVariant } from '../JourneyCard/journeyCardVariant'
 import type { JourneyListEvent } from '../JourneyList'
-import type { ContentType, JourneyStatusFilter } from '../JourneyListView'
+import type {
+  ContentType,
+  JourneyListDisplay,
+  JourneyStatusFilter
+} from '../JourneyListView'
+import { JourneyListRows, type JourneyListRowItem } from '../JourneyListRow'
 import { SortOrder } from '../JourneySort'
 import { sortJourneys } from '../JourneySort/utils/sortJourneys'
 import { LoadingJourneyList } from '../LoadingJourneyList'
@@ -105,6 +114,7 @@ export interface JourneyListContentProps {
   user?: User | null
   sortOrder?: SortOrder
   event?: JourneyListEvent
+  display?: JourneyListDisplay
 }
 
 export function JourneyListContent({
@@ -112,7 +122,8 @@ export function JourneyListContent({
   status,
   user,
   sortOrder,
-  event
+  event,
+  display = 'grid'
 }: JourneyListContentProps): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   const { enqueueSnackbar } = useSnackbar()
@@ -417,6 +428,45 @@ export function JourneyListContent({
   const usePriorityList =
     status === 'active' && contentType === 'journeys' && user != null
 
+  const listRows = useMemo(() => {
+    if (sortedJourneys == null) return undefined
+
+    if (!usePriorityList) {
+      return sortedJourneys.map((journey) => ({ journey }))
+    }
+
+    const newJourneys: JourneyListRowItem[] = []
+    const actionRequiredJourneys: JourneyListRowItem[] = []
+    const activeJourneys: JourneyListRowItem[] = []
+
+    sortedJourneys.forEach((journey) => {
+      const currentUserJourney = journey.userJourneys?.find(
+        (userJourney) => userJourney.user?.id === user?.id
+      )
+
+      if (
+        currentUserJourney?.role === UserJourneyRole.owner &&
+        journey.userJourneys?.find(
+          (userJourney) => userJourney.role === UserJourneyRole.inviteRequested
+        ) != null
+      ) {
+        actionRequiredJourneys.push({
+          journey,
+          variant: JourneyCardVariant.actionRequired
+        })
+      } else if (
+        currentUserJourney != null &&
+        currentUserJourney.openedAt == null
+      ) {
+        newJourneys.push({ journey, variant: JourneyCardVariant.new })
+      } else {
+        activeJourneys.push({ journey })
+      }
+    })
+
+    return [...actionRequiredJourneys, ...newJourneys, ...activeJourneys]
+  }, [sortedJourneys, usePriorityList, user?.id])
+
   // Get dialog labels based on contentType and status
   const getDialogLabels = (): {
     primary: { title: string; submitLabel: string; message: string }
@@ -570,7 +620,9 @@ export function JourneyListContent({
             }
           }}
         >
-          {usePriorityList ? (
+          {display === 'list' && listRows != null ? (
+            <JourneyListRows rows={listRows} refetch={refetch} />
+          ) : usePriorityList ? (
             <>
               <ActivePriorityList
                 journeys={data?.journeys ?? []}

--- a/apps/journeys-admin/src/components/JourneyList/JourneyListRow/JourneyListRow.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyListRow/JourneyListRow.tsx
@@ -1,0 +1,398 @@
+import { ApolloQueryResult } from '@apollo/client'
+import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import IconButton from '@mui/material/IconButton'
+import Paper from '@mui/material/Paper'
+import Skeleton from '@mui/material/Skeleton'
+import Stack from '@mui/material/Stack'
+import Table from '@mui/material/Table'
+import TableBody from '@mui/material/TableBody'
+import TableCell from '@mui/material/TableCell'
+import TableContainer from '@mui/material/TableContainer'
+import TableHead from '@mui/material/TableHead'
+import TableRow from '@mui/material/TableRow'
+import Typography from '@mui/material/Typography'
+import dynamic from 'next/dynamic'
+import Image from 'next/image'
+import NextLink from 'next/link'
+import { useTranslation } from 'next-i18next/pages'
+import { ReactElement, useState } from 'react'
+
+import { useNavigationState } from '@core/journeys/ui/useNavigationState'
+import BarGroup3Icon from '@core/shared/ui/icons/BarGroup3'
+import Globe from '@core/shared/ui/icons/Globe'
+import Lightning2 from '@core/shared/ui/icons/Lightning2'
+
+import {
+  GetAdminJourneys,
+  GetAdminJourneys_journeys as Journey
+} from '../../../../__generated__/GetAdminJourneys'
+import { UserJourneyRole } from '../../../../__generated__/globalTypes'
+import logoGray from '../../../../public/logo-grayscale.svg'
+import { Avatar } from '../../Avatar'
+import { AnalyticsItem } from '../../Editor/Toolbar/Items/AnalyticsItem'
+import { ResponsesItem } from '../../Editor/Toolbar/Items/ResponsesItem'
+import { JourneyCardMenu } from '../JourneyCard/JourneyCardMenu'
+import { LastModifiedDate } from '../JourneyCard/JourneyCardText/LastModifiedDate'
+import { JourneyCardVariant } from '../JourneyCard/journeyCardVariant'
+import { TemplateAggregateAnalytics } from '../JourneyCard/TemplateAggregateAnalytics'
+
+const TemplateBreakdownAnalyticsDialog = dynamic(
+  async () =>
+    await import(
+      /* webpackChunkName: "TemplateBreakdownAnalyticsDialog" */
+      '../../TemplateBreakdownAnalyticsDialog/TemplateBreakdownAnalyticsDialog'
+    ).then((mod) => mod.TemplateBreakdownAnalyticsDialog),
+  { ssr: false }
+)
+
+export interface JourneyListRowItem {
+  journey: Journey
+  variant?: JourneyCardVariant
+}
+
+interface JourneyListRowsProps {
+  rows: JourneyListRowItem[]
+  refetch?: () => Promise<ApolloQueryResult<GetAdminJourneys>>
+}
+
+interface JourneyListRowProps extends JourneyListRowItem {
+  refetch?: () => Promise<ApolloQueryResult<GetAdminJourneys>>
+}
+
+export function JourneyListRows({
+  rows,
+  refetch
+}: JourneyListRowsProps): ReactElement {
+  const { t } = useTranslation('apps-journeys-admin')
+
+  return (
+    <TableContainer
+      component={Paper}
+      variant="outlined"
+      sx={{
+        borderRadius: 2,
+        bgcolor: 'background.paper'
+      }}
+    >
+      <Table size="small">
+        <TableHead>
+          <TableRow sx={{ bgcolor: '#FAFAFB' }}>
+            <TableCell sx={{ width: 78 }} />
+            <TableCell>{t('Name')}</TableCell>
+            <TableCell align="right">{t('Activity')}</TableCell>
+            <TableCell>{t('Language')}</TableCell>
+            <TableCell>{t('Owner')}</TableCell>
+            <TableCell>{t('Last modified')}</TableCell>
+            <TableCell sx={{ width: 48 }} />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map(({ journey, variant }) => (
+            <JourneyListRow
+              key={journey.id}
+              journey={journey}
+              variant={variant}
+              refetch={refetch}
+            />
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  )
+}
+
+function JourneyListRow({
+  journey,
+  variant = JourneyCardVariant.default,
+  refetch
+}: JourneyListRowProps): ReactElement {
+  const { t } = useTranslation('apps-journeys-admin')
+  const isNavigating = useNavigationState()
+  const [isImageLoading, setIsImageLoading] = useState(true)
+  const [breakdownDialogOpen, setBreakdownDialogOpen] = useState(false)
+  const [, setHasOpenDialog] = useState(false)
+  const languageName = journey.language.name.find(
+    ({ primary }) =>
+      primary || journey.language.name.some(({ primary }) => !primary)
+  )?.value
+  const isTemplateCard =
+    journey.template === true && journey.team?.id !== 'jfp-team'
+
+  return (
+    <>
+      <TableRow
+        hover
+        data-testid={`JourneyListRow-${journey.id}`}
+        sx={{
+          cursor: 'pointer',
+          '& .MuiTableCell-root': {
+            py: 1.25
+          }
+        }}
+      >
+        <TableCell>
+          <Thumbnail
+            journey={journey}
+            isNavigating={isNavigating}
+            isImageLoading={isImageLoading}
+            setIsImageLoading={setIsImageLoading}
+          />
+        </TableCell>
+        <TableCell>
+          <Typography
+            component={NextLink}
+            prefetch={false}
+            href={`/journeys/${journey.id}`}
+            sx={{
+              display: 'block',
+              fontWeight: 500,
+              color: 'text.primary',
+              textDecoration: 'none',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              opacity: isNavigating ? 0.5 : 1,
+              pointerEvents: isNavigating ? 'none' : 'auto'
+            }}
+          >
+            {journey.title}
+          </Typography>
+          <Stack direction="row" spacing={0.5} sx={{ mt: 0.5 }}>
+            {variant !== JourneyCardVariant.default && (
+              <TagChip
+                label={
+                  variant === JourneyCardVariant.new
+                    ? t('New')
+                    : t('Action Required')
+                }
+              />
+            )}
+            {journey.customizable === true && (
+              <TagChip
+                label={t('Quick Start')}
+                icon={<Lightning2 sx={{ fontSize: 12 }} />}
+              />
+            )}
+            {journey.website === true && (
+              <TagChip
+                label={t('Website')}
+                icon={<Globe sx={{ fontSize: 12 }} />}
+              />
+            )}
+          </Stack>
+        </TableCell>
+        <TableCell align="right">
+          <ActivityCell
+            journey={journey}
+            isTemplateCard={isTemplateCard}
+            onOpenBreakdown={() => setBreakdownDialogOpen(true)}
+          />
+        </TableCell>
+        <TableCell sx={{ color: 'text.secondary' }}>{languageName}</TableCell>
+        <TableCell>
+          <OwnerCell journey={journey} />
+        </TableCell>
+        <TableCell sx={{ color: 'text.secondary' }} suppressHydrationWarning>
+          <LastModifiedDate modifiedDate={journey.updatedAt} />
+        </TableCell>
+        <TableCell>
+          <JourneyCardMenu
+            id={journey.id}
+            status={journey.status}
+            slug={journey.slug}
+            published={journey.publishedAt != null}
+            refetch={refetch}
+            journey={journey}
+            hovered
+            onMenuClose={() => {
+              setHasOpenDialog(false)
+            }}
+            template={journey.template ?? false}
+            setHasOpenDialog={setHasOpenDialog}
+          />
+        </TableCell>
+      </TableRow>
+      <TemplateBreakdownAnalyticsDialog
+        journeyId={journey.id}
+        open={breakdownDialogOpen}
+        handleClose={() => setBreakdownDialogOpen(false)}
+      />
+    </>
+  )
+}
+
+function Thumbnail({
+  journey,
+  isNavigating,
+  isImageLoading,
+  setIsImageLoading
+}: {
+  journey: Journey
+  isNavigating: boolean
+  isImageLoading: boolean
+  setIsImageLoading: (loading: boolean) => void
+}): ReactElement {
+  return (
+    <Box
+      component={NextLink}
+      prefetch={false}
+      href={`/journeys/${journey.id}`}
+      aria-label={journey.title}
+      sx={{
+        position: 'relative',
+        display: 'block',
+        width: 56,
+        height: 36,
+        borderRadius: 1,
+        bgcolor: 'divider',
+        overflow: 'hidden',
+        opacity: isNavigating ? 0.5 : 1,
+        pointerEvents: isNavigating ? 'none' : 'auto'
+      }}
+    >
+      {journey.primaryImageBlock?.src != null ? (
+        <>
+          {isImageLoading && (
+            <Skeleton
+              variant="rectangular"
+              width="100%"
+              height="100%"
+              sx={{ position: 'absolute', inset: 0 }}
+            />
+          )}
+          <Image
+            data-testid="JourneyListRowImage"
+            src={journey.primaryImageBlock.src}
+            alt={journey.primaryImageBlock.alt ?? ''}
+            fill
+            style={{ objectFit: 'cover' }}
+            sizes="56px"
+            onLoadingComplete={() => setIsImageLoading(false)}
+          />
+        </>
+      ) : (
+        <Image
+          data-testid="JourneyListRowNoImage"
+          src={logoGray}
+          alt=""
+          width={26}
+          height={26}
+          style={{
+            objectFit: 'contain',
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)'
+          }}
+        />
+      )}
+    </Box>
+  )
+}
+
+function ActivityCell({
+  journey,
+  isTemplateCard,
+  onOpenBreakdown
+}: {
+  journey: Journey
+  isTemplateCard: boolean
+  onOpenBreakdown: () => void
+}): ReactElement {
+  const { t } = useTranslation('apps-journeys-admin')
+
+  if (isTemplateCard) {
+    return (
+      <Stack direction="row" justifyContent="flex-end" alignItems="center">
+        <TemplateAggregateAnalytics journeyId={journey.id} />
+        <IconButton
+          size="small"
+          aria-label={t('journey breakdown analytics')}
+          onClick={onOpenBreakdown}
+        >
+          <BarGroup3Icon fontSize="small" />
+        </IconButton>
+      </Stack>
+    )
+  }
+
+  return (
+    <Stack
+      direction="row"
+      justifyContent="flex-end"
+      alignItems="center"
+      sx={{
+        '& .MuiButtonBase-root': {
+          minWidth: 30,
+          width: 30,
+          height: 30
+        }
+      }}
+    >
+      <ResponsesItem
+        variant="icon-button"
+        fromJourneyList={true}
+        journeyId={journey.id}
+      />
+      <AnalyticsItem
+        variant="icon-button"
+        fromJourneyList={true}
+        journeyId={journey.id}
+      />
+    </Stack>
+  )
+}
+
+function OwnerCell({ journey }: { journey: Journey }): ReactElement {
+  const owner = journey.userJourneys?.find(
+    (userJourney) =>
+      userJourney.role === UserJourneyRole.owner &&
+      userJourney.user?.__typename === 'AuthenticatedUser'
+  )
+
+  if (owner?.user?.__typename !== 'AuthenticatedUser') {
+    return <Box sx={{ height: 24 }} />
+  }
+
+  const ownerName = [owner.user.firstName, owner.user.lastName]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <Stack direction="row" alignItems="center" spacing={1}>
+      <Avatar
+        apiUser={owner.user}
+        role={owner.role}
+        sx={{ width: 24, height: 24, fontSize: 10 }}
+      />
+      <Typography variant="body2" color="text.secondary" noWrap>
+        {ownerName}
+      </Typography>
+    </Stack>
+  )
+}
+
+function TagChip({
+  label,
+  icon
+}: {
+  label: string
+  icon?: ReactElement
+}): ReactElement {
+  return (
+    <Chip
+      size="small"
+      label={label}
+      icon={icon}
+      sx={{
+        height: 18,
+        fontSize: 10.5,
+        '& .MuiChip-icon': {
+          ml: 0.5,
+          color: 'inherit'
+        }
+      }}
+    />
+  )
+}

--- a/apps/journeys-admin/src/components/JourneyList/JourneyListRow/index.ts
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyListRow/index.ts
@@ -1,0 +1,2 @@
+export { JourneyListRows } from './JourneyListRow'
+export type { JourneyListRowItem } from './JourneyListRow'

--- a/apps/journeys-admin/src/components/JourneyList/JourneyListView/DisplayModes/Controls.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyListView/DisplayModes/Controls.tsx
@@ -1,4 +1,9 @@
 import Box from '@mui/material/Box'
+import ToggleButton from '@mui/material/ToggleButton'
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
+import ViewList from '@mui/icons-material/ViewList'
+import ViewModule from '@mui/icons-material/ViewModule'
+import { useTranslation } from 'next-i18next/pages'
 import { ReactElement } from 'react'
 
 import { JourneyListMenu } from '../../JourneyListMenu'
@@ -45,6 +50,49 @@ export const SortControl = ({
     <JourneySort sortOrder={sortOrder} onChange={setSortOrder} />
   </Box>
 )
+
+export const DisplayControl = ({
+  display = 'grid',
+  setDisplay
+}: Pick<SharedControlProps, 'display' | 'setDisplay'>): ReactElement => {
+  const { t } = useTranslation('apps-journeys-admin')
+
+  return (
+    <ToggleButtonGroup
+      exclusive
+      size="small"
+      value={display}
+      aria-label={t('Journey view')}
+      onChange={(_event, value) => {
+        if (value != null) setDisplay?.(value)
+      }}
+      sx={{
+        ml: { xs: 1, sm: 0 },
+        border: 1,
+        borderColor: 'divider',
+        borderRadius: 2,
+        p: 0.25,
+        '& .MuiToggleButton-root': {
+          border: 0,
+          borderRadius: 1.5,
+          p: 0.75,
+          color: 'secondary.light',
+          '&.Mui-selected': {
+            bgcolor: 'grey.200',
+            color: 'secondary.main'
+          }
+        }
+      }}
+    >
+      <ToggleButton value="grid" aria-label={t('Grid view')}>
+        <ViewModule sx={{ fontSize: 18 }} />
+      </ToggleButton>
+      <ToggleButton value="list" aria-label={t('List view')}>
+        <ViewList sx={{ fontSize: 18 }} />
+      </ToggleButton>
+    </ToggleButtonGroup>
+  )
+}
 
 // Menu component
 export const MenuControl = ({

--- a/apps/journeys-admin/src/components/JourneyList/JourneyListView/DisplayModes/SharedWithMeMode/SharedWithMeMode.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyListView/DisplayModes/SharedWithMeMode/SharedWithMeMode.tsx
@@ -1,7 +1,12 @@
 import Box from '@mui/material/Box'
 import { ReactElement } from 'react'
 
-import { MenuControl, SortControl, StatusFilterControl } from '../Controls'
+import {
+  DisplayControl,
+  MenuControl,
+  SortControl,
+  StatusFilterControl
+} from '../Controls'
 import type { SharedModeProps } from '../shared'
 
 export interface SharedWithMeModeProps extends SharedModeProps {}
@@ -11,6 +16,8 @@ export const SharedWithMeMode = ({
   handleStatusChange,
   sortOrder,
   setSortOrder,
+  display,
+  setDisplay,
   setActiveEvent,
   renderList
 }: SharedWithMeModeProps): ReactElement => (
@@ -30,6 +37,7 @@ export const SharedWithMeMode = ({
         handleStatusChange={handleStatusChange}
       />
       <SortControl sortOrder={sortOrder} setSortOrder={setSortOrder} />
+      <DisplayControl display={display} setDisplay={setDisplay} />
       <MenuControl setActiveEvent={setActiveEvent} />
     </Box>
     {/* Journeys content - rendered directly without TabPanel */}

--- a/apps/journeys-admin/src/components/JourneyList/JourneyListView/DisplayModes/TeamMode/TeamMode.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyListView/DisplayModes/TeamMode/TeamMode.tsx
@@ -7,7 +7,12 @@ import { ReactElement, SyntheticEvent } from 'react'
 import { TabPanel, tabA11yProps } from '@core/shared/ui/TabPanel'
 
 import type { ContentType } from '../../JourneyListView'
-import { MenuControl, SortControl, StatusFilterControl } from '../Controls'
+import {
+  DisplayControl,
+  MenuControl,
+  SortControl,
+  StatusFilterControl
+} from '../Controls'
 import type { SharedModeProps } from '../shared'
 
 export interface ContentTypeOption {
@@ -34,6 +39,8 @@ export const TeamMode = ({
   handleStatusChange,
   sortOrder,
   setSortOrder,
+  display,
+  setDisplay,
   setActiveEvent,
   router,
   renderList
@@ -78,6 +85,7 @@ export const TeamMode = ({
         handleStatusChange={handleStatusChange}
       />
       <SortControl sortOrder={sortOrder} setSortOrder={setSortOrder} />
+      <DisplayControl display={display} setDisplay={setDisplay} />
       <MenuControl
         setActiveEvent={setActiveEvent}
         menuMarginRight={{

--- a/apps/journeys-admin/src/components/JourneyList/JourneyListView/DisplayModes/shared.ts
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyListView/DisplayModes/shared.ts
@@ -2,13 +2,19 @@ import { Dispatch, ReactElement, SetStateAction } from 'react'
 
 import type { JourneyListEvent } from '../../JourneyList'
 import { SortOrder } from '../../JourneySort'
-import type { ContentType, JourneyStatus } from '../JourneyListView'
+import type {
+  ContentType,
+  JourneyListDisplay,
+  JourneyStatus
+} from '../JourneyListView'
 
 export interface SharedControlProps {
   selectedStatus: JourneyStatus
   handleStatusChange: (newStatus: JourneyStatus) => void
   sortOrder?: SortOrder
   setSortOrder: Dispatch<SetStateAction<SortOrder | undefined>>
+  display?: JourneyListDisplay
+  setDisplay?: (display: JourneyListDisplay) => void
   setActiveEvent: (event: JourneyListEvent) => void
 }
 

--- a/apps/journeys-admin/src/components/JourneyList/JourneyListView/JourneyListView.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyListView/JourneyListView.tsx
@@ -20,6 +20,7 @@ import { ContentTypeOption, TeamMode } from './DisplayModes/TeamMode/TeamMode'
 
 export type ContentType = 'journeys' | 'templates'
 export type JourneyStatus = 'active' | 'archived' | 'trashed'
+export type JourneyListDisplay = 'grid' | 'list'
 
 export interface JourneyListViewProps {
   // Render function that receives contentType and status to render the appropriate list
@@ -76,6 +77,7 @@ export function JourneyListView({
   const contentTypeFromQuery =
     (router?.query?.type as ContentType) ?? 'journeys'
   const statusFromQuery = (router?.query?.status as JourneyStatus) ?? 'active'
+  const displayFromQuery = router?.query?.view === 'list' ? 'list' : 'grid'
 
   // State management
   const contentTypeTabIndex =
@@ -86,6 +88,7 @@ export function JourneyListView({
     useState(contentTypeTabIndex)
   const [selectedStatus, setSelectedStatus] =
     useState<JourneyStatus>(statusFromQuery)
+  const [display, setDisplay] = useState<JourneyListDisplay>(displayFromQuery)
 
   // Force type=journeys in Shared With Me mode
   useEffect(() => {
@@ -176,6 +179,21 @@ export function JourneyListView({
     )
   }
 
+  const handleDisplayChange = (newDisplay: JourneyListDisplay): void => {
+    setDisplay(newDisplay)
+
+    void router.push(
+      {
+        query: {
+          ...router.query,
+          view: newDisplay
+        }
+      },
+      undefined,
+      { shallow: true }
+    )
+  }
+
   if (isSharedWithMeMode) {
     return (
       <SharedWithMeMode
@@ -183,6 +201,8 @@ export function JourneyListView({
         handleStatusChange={handleStatusChange}
         sortOrder={sortOrder}
         setSortOrder={setSortOrder}
+        display={display}
+        setDisplay={handleDisplayChange}
         setActiveEvent={setActiveEvent}
         renderList={renderList}
       />
@@ -198,6 +218,8 @@ export function JourneyListView({
       handleStatusChange={handleStatusChange}
       sortOrder={sortOrder}
       setSortOrder={setSortOrder}
+      display={display}
+      setDisplay={handleDisplayChange}
       setActiveEvent={setActiveEvent}
       router={router}
       renderList={renderList}

--- a/apps/journeys-admin/src/components/JourneyList/JourneyListView/index.ts
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyListView/index.ts
@@ -2,5 +2,6 @@ export { JourneyListView } from './JourneyListView'
 export type {
   JourneyListViewProps,
   ContentType,
+  JourneyListDisplay,
   JourneyStatus as JourneyStatusFilter
 } from './JourneyListView'


### PR DESCRIPTION
## Summary
- add a grid/list display toggle to the journeys admin list controls
- keep the existing grid card view as the default
- add a responsive list row view using existing journey data, actions, access avatars, and template analytics

## Notes
- no new journey functionality or data fetching was added; this is a presentation toggle over the existing list data

## Validation
- not run per request; local dependency/type-check setup was intentionally skipped for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a display toggle to switch between grid and list views for journeys.
  * List view: row-oriented layout with status indicators (New/Action Required), badges, language and last-modified info, owner avatars, activity/analytics panels, skeleton image placeholders, and per-row action menus.
  * Grid view behavior preserved; empty-state logic unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->