### PR TITLE
docs: correct NES-1601 plan API-surface bullet to reflect opt-in scope

### DIFF
--- a/docs/plans/2026-04-24-001-feat-default-copy-to-team-dialog-to-active-team-plan.md
+++ b/docs/plans/2026-04-24-001-feat-default-copy-to-team-dialog-to-active-team-plan.md
@@ -65,7 +65,7 @@ The `JourneyDuplicate` mutation (`libs/journeys/ui/src/libs/useJourneyDuplicateM
 - **Interaction graph:** User clicks _Use this Template_ (or _Duplicate_ in a journey menu) → dialog opens → Formik initializes with new default → user clicks Submit → `submitAction` → `JourneyDuplicate` mutation → `updateLastActiveTeamId` mutation → `GetAdminJourneys` refetch. The chain is unchanged; only the initial field value changes.
 - **Error propagation:** No new error paths. Form validation on `teamSelect` (`required`, line 156) still fires if somehow the default resolves to `''`.
 - **State lifecycle risks:** None. `resetForm()` is still called on submit (line 140) and on close (line 210), so subsequent opens pick up the latest `activeTeam` cleanly.
-- **API surface parity:** No mutation signature changes. Both callers (`CopyToTeamMenuItem`, `DuplicateJourneyMenuItem`) inherit the new default without code changes.
+- **API surface parity:** No mutation signature changes. `CreateJourneyButton` opts into the new default via `defaultToActiveTeam`; `CopyToTeamMenuItem` and `DuplicateJourneyMenuItem` remain on existing empty-default behavior.
 - **Integration test scenarios:** See **Acceptance Criteria** below; the new "multi-team user opens dialog" scenario is the one unit tests must cover.
 
 ## Acceptance Criteria


### PR DESCRIPTION
## Summary

Tiny doc-only fix to the merged NES-1601 plan. After the narrow-scope refactor, the **System-Wide Impact** section still carried a stale bullet from the original broad-scope draft:

> ~Both callers (`CopyToTeamMenuItem`, `DuplicateJourneyMenuItem`) inherit the new default without code changes.~

That sentence contradicts the rest of the document, which correctly describes the new behavior as opt-in via `defaultToActiveTeam`, with only `CreateJourneyButton` opting in. CodeRabbit flagged it on the original PR; the fix didn't make it in before merge.

Updated to:

> `CreateJourneyButton` opts into the new default via `defaultToActiveTeam`; `CopyToTeamMenuItem` and `DuplicateJourneyMenuItem` remain on existing empty-default behavior.

## Testing

- Single line in a markdown plan file. No code, no tests, no behavior change.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: plan-doc text only, zero runtime impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Active team is now pre-selected when copying team-specific journeys, streamlining the workflow and reducing manual selection steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->