### PR TITLE
fix(infra): pin atlantis terraform_version to 1.14.8

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -1,8 +1,13 @@
 version: 3
 automerge: true
 delete_source_branch_on_merge: true
+# terraform_version pinned to last stable before HashiCorp's release-signing
+# GPG key expired on 2026-04-18. Lifts the "openpgp: key expired" download
+# failure by reusing the Atlantis EFS-cached binary instead of re-downloading.
+# Remove once the Atlantis image is bumped to one shipping the renewed key.
 projects:
   - dir: 'infrastructure'
+    terraform_version: '1.14.8'
     autoplan:
       when_modified:
         [
@@ -15,5 +20,8 @@ projects:
           './.terraform.lock.hcl'
         ]
   - dir: 'infrastructure/resources/atlantis'
+    terraform_version: '1.14.8'
   - dir: 'infrastructure/resources/doppler'
+    terraform_version: '1.14.8'
   - dir: 'infrastructure/resources/terraform'
+    terraform_version: '1.14.8'


### PR DESCRIPTION
## Summary
- Pins `terraform_version` to `1.14.8` for every project in `atlantis.yaml`.
- Unblocks Atlantis plans that started failing with `error downloading terraform version 1.15.2: unable to verify checksums signature: openpgp: key expired`.

## Why
HashiCorp's release-signing GPG key (`72D7468F`) [expired on 2026-04-18](https://github.com/runatlantis/atlantis/issues/6405). OpenPGP key expiry invalidates *all* signatures from that key — even signatures made before the expiry date — so any fresh `tfenv`-style download by our Atlantis image fails the checksum verification step. None of our `.tf` files pin a `terraform_version` (they all just say `>= 1.0.9`), so Atlantis keeps resolving to the latest available (currently `1.15.2`) and re-downloading it.

`1.14.8` is the latest stable release prior to the key expiry and is the version most likely to already be cached on the Atlantis EFS volume from prior plans. Cached binaries skip the verification path, so pinning unblocks CI immediately.

## Follow-up
This is a temporary unblocker. The durable fix is to bump the Atlantis Docker image to a build that ships the renewed HashiCorp key (extended to 2030-03-01). I'll open a follow-up PR against `infrastructure/resources/atlantis/main.tf` to set `atlantis_image` on the `terraform-aws-modules/atlantis/aws` module.

## Test plan
- [ ] On merge, watch the next Atlantis plan on a `.tf`-touching PR succeed without the `openpgp: key expired` error.
- [ ] If `1.14.8` isn't cached on EFS, fall back to `1.13.x` (or whichever version was current during the most recent successful plan) and re-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarifying comments explaining Terraform version pinning strategy and infrastructure configuration best practices.

* **Chores**
  * Pinned Terraform version to 1.14.8 across three infrastructure project configurations, ensuring consistent and predictable deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->