### PR TITLE
fix(infra): pin atlantis_version to v0.43.0 for renewed HashiCorp PGP key

### DIFF
--- a/infrastructure/resources/atlantis/main.tf
+++ b/infrastructure/resources/atlantis/main.tf
@@ -8,6 +8,12 @@ module "atlantis" {
   version = "~> 3.0"
 
   name = "atlantis"
+  # Pinned to first stable Atlantis release built after HashiCorp's
+  # release-signing GPG key expired (2026-04-18). Earlier images (including
+  # the previously floating :latest) trust the now-expired key and fail
+  # terraform downloads with "openpgp: key expired". See
+  # https://github.com/runatlantis/atlantis/issues/6405.
+  atlantis_version = "v0.43.0"
   # user needed because of https://github.com/runatlantis/atlantis/issues/2221
   # this is atlantis user per the official docker image
   user = "100:1000"


### PR DESCRIPTION
## Summary
- Sets `atlantis_version = "v0.43.0"` on the `terraform-aws-modules/atlantis/aws` module in [infrastructure/resources/atlantis/main.tf](infrastructure/resources/atlantis/main.tf).
- Durable fix for the `openpgp: key expired` failure that #9168 worked around at the project level.

## Why
HashiCorp's release-signing GPG key (`72D7468F`) [expired on 2026-04-18](https://github.com/runatlantis/atlantis/issues/6405). Atlantis bakes the trusted key into its container image at build time and uses it to verify terraform binary downloads. Any image built before 2026-04-18 — including the previously floating `:latest` (which currently resolves to `v0.41.0`, built 2026-03-27) — trusts the expired key and fails `openpgp: key expired` on fresh downloads.

`v0.43.0` (2026-05-05) is the first stable release built after HashiCorp re-signed with an extended-expiry key (2030-03-01).

## Pairing with #9168
- #9168 pinned `terraform_version: '1.14.8'` in [atlantis.yaml](atlantis.yaml) so Atlantis would reuse its EFS-cached binary and skip re-verification. Quick unblock.
- This PR replaces the underlying broken trust chain. Once this lands and the new task is healthy, the `terraform_version` pin in `atlantis.yaml` becomes optional and can be removed in a separate cleanup PR.

## Heads-up: Atlantis version jump
Currently running ~`v0.41.0` (whatever `:latest` last pulled). v0.43.0 is two minor releases forward. Notable items from the upstream changelogs:
- **v0.42.0** introduced "targeted undiverged requirement" as a breaking change. Our [server-atlantis.yaml](infrastructure/resources/atlantis/server-atlantis.yaml) sets `apply_requirements: [mergeable, approved, undiverged]`, so worth confirming behavior is unchanged.
- **v0.42.0** also added GitHub ruleset required-reviewer-approval checking — should be a no-op for us unless we add rulesets.
- **v0.43.0** ships provider improvements + bug fixes; no flagged breaking changes for our usage.

Recommend reviewing the v0.42.0 / v0.43.0 release notes before applying in prod.

## Test plan
- [ ] Atlantis plan on this PR (touches `infrastructure/resources/atlantis`) produces a clean diff showing the new container image tag.
- [ ] After apply, ECS rolls a new task, the service stays healthy, and the Atlantis UI reports `v0.43.0`.
- [ ] Re-run a previously failing plan on a `.tf`-touching PR — the `openpgp: key expired` error is gone even with `terraform_version` removed.
- [ ] Verify `apply_requirements` (mergeable, approved, undiverged) still gates apply correctly.

## Follow-up
- Remove the `terraform_version: '1.14.8'` pin from [atlantis.yaml](atlantis.yaml) once this is healthy in stage/prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)