### PR TITLE
feat(api-media): add paginated sync endpoints for video metadata

### DIFF
--- a/apis/api-gateway/schema.graphql
+++ b/apis/api-gateway/schema.graphql
@@ -682,9 +682,7 @@ type Journey @join__type(graph: API_JOURNEYS, key: "id")  @join__type(graph: API
   socialNodeX: Int
   socialNodeY: Int
   fromTemplateId: String
-  showAssistant: Boolean @deprecated(
-    reason: "Use CardBlock.showAssistant. Removal tracked in NES-1624."
-  )
+  showAssistant: Boolean @deprecated(reason: "Use CardBlock.showAssistant. Removal tracked in NES-1624.") 
   journeyCustomizationDescription: String
   journeyCustomizationFields: [JourneyCustomizationField!]!
   journeyTheme: JourneyTheme
@@ -1708,6 +1706,8 @@ type Query @join__type(graph: API_ANALYTICS)  @join__type(graph: API_JOURNEYS)  
   countries(term: String, ids: [ID!], where: CountriesFilter) : [Country!]! @join__field(graph: API_LANGUAGES) 
   getMyCloudflareImages(offset: Int, limit: Int) : [CloudflareImage!]! @join__field(graph: API_MEDIA) 
   getMyCloudflareImage(id: ID!) : CloudflareImage! @join__field(graph: API_MEDIA) 
+  videoImages(where: VideoImagesFilter, offset: Int, limit: Int) : [CloudflareImage!]! @join__field(graph: API_MEDIA) 
+  videoImagesCount(where: VideoImagesFilter) : Int! @join__field(graph: API_MEDIA) 
   listUnsplashCollectionPhotos(
     collectionId: String!
     page: Int
@@ -1727,7 +1727,8 @@ type Query @join__type(graph: API_ANALYTICS)  @join__type(graph: API_JOURNEYS)  
   bibleBooks(where: BibleBooksFilter) : [BibleBook!]! @join__field(graph: API_MEDIA) 
   bibleCitations(videoId: ID) : [BibleCitation!]! @join__field(graph: API_MEDIA) 
   bibleCitation(id: ID!) : BibleCitation! @join__field(graph: API_MEDIA) 
-  keywords(where: KeywordsFilter) : [Keyword!]! @join__field(graph: API_MEDIA) 
+  keywords(where: KeywordsFilter, offset: Int, limit: Int) : [Keyword!]! @join__field(graph: API_MEDIA) 
+  keywordsCount(where: KeywordsFilter) : Int! @join__field(graph: API_MEDIA) 
   getMyMuxVideos(offset: Int, limit: Int) : [MuxVideo!]! @join__field(graph: API_MEDIA) 
   getMyMuxVideo(id: ID!, userGenerated: Boolean) : MuxVideo! @join__field(graph: API_MEDIA) 
   getMuxVideo(id: ID!, userGenerated: Boolean) : MuxVideo @join__field(graph: API_MEDIA) 
@@ -1782,6 +1783,10 @@ type Query @join__type(graph: API_ANALYTICS)  @join__type(graph: API_JOURNEYS)  
     last: Int
   ): QueryShortLinksConnection! @join__field(graph: API_MEDIA) 
   userMediaProfile: UserMediaProfile @join__field(graph: API_MEDIA) 
+  videoSubtitles(where: VideoSubtitlesFilter, offset: Int, limit: Int) : [VideoSubtitle!]! @join__field(graph: API_MEDIA) 
+  videoSubtitlesCount(where: VideoSubtitlesFilter) : Int! @join__field(graph: API_MEDIA) 
+  videoVariantDownloads(where: VideoVariantDownloadsFilter, offset: Int, limit: Int) : [VideoVariantDownload!]! @join__field(graph: API_MEDIA) 
+  videoVariantDownloadsCount(where: VideoVariantDownloadsFilter) : Int! @join__field(graph: API_MEDIA) 
   videoVariant(id: ID!) : VideoVariant! @join__field(graph: API_MEDIA) 
   videoVariants(input: VideoVariantFilter, offset: Int, limit: Int) : [VideoVariant!]! @join__field(graph: API_MEDIA) 
   videoVariantsCount(input: VideoVariantFilter) : Int! @join__field(graph: API_MEDIA) 
@@ -1793,8 +1798,10 @@ type Query @join__type(graph: API_ANALYTICS)  @join__type(graph: API_JOURNEYS)  
   videosCount(where: VideosFilter) : Int! @join__field(graph: API_MEDIA) 
   checkVideoInAlgolia(videoId: ID!) : CheckVideoInAlgoliaResult! @join__field(graph: API_MEDIA) 
   checkVideoVariantsInAlgolia(videoId: ID!) : CheckVideoVariantsInAlgoliaResult! @join__field(graph: API_MEDIA) 
-  videoOrigins: [VideoOrigin!]! @join__field(graph: API_MEDIA) 
-  videoEditions: [VideoEdition!]! @join__field(graph: API_MEDIA) 
+  videoOrigins(where: VideoOriginsFilter, offset: Int, limit: Int) : [VideoOrigin!]! @join__field(graph: API_MEDIA) 
+  videoOriginsCount(where: VideoOriginsFilter) : Int! @join__field(graph: API_MEDIA) 
+  videoEditions(where: VideoEditionsFilter, offset: Int, limit: Int) : [VideoEdition!]! @join__field(graph: API_MEDIA) 
+  videoEditionsCount(where: VideoEditionsFilter) : Int! @join__field(graph: API_MEDIA) 
   videoEdition(id: ID!) : VideoEdition @join__field(graph: API_MEDIA) 
   tags: [Tag!]! @join__field(graph: API_MEDIA) 
   taxonomies(category: String, languageCodes: [String!]) : [Taxonomy!]! @join__field(graph: API_MEDIA) 
@@ -2703,6 +2710,8 @@ type CheckVideoVariantsInAlgoliaResult @join__type(graph: API_MEDIA)  {
 
 type CloudflareImage @join__type(graph: API_MEDIA)  {
   id: ID!
+  updatedAt: DateTime!
+  videoId: ID
   uploadUrl: String
   userId: ID!
   createdAt: Date!
@@ -3174,6 +3183,7 @@ type VideoImageAlt @join__type(graph: API_MEDIA)  {
 
 type VideoOrigin @join__type(graph: API_MEDIA)  {
   id: ID!
+  updatedAt: DateTime!
   name: String!
   description: String
 }
@@ -3212,6 +3222,8 @@ type VideoStudyQuestion @join__type(graph: API_MEDIA)  {
 
 type VideoSubtitle @join__type(graph: API_MEDIA)  {
   id: ID!
+  updatedAt: DateTime!
+  videoId: ID!
   languageId: ID!
   primary: Boolean!
   edition: String!
@@ -3281,6 +3293,8 @@ type VideoVariant @join__type(graph: API_MEDIA)  {
 
 type VideoVariantDownload @join__type(graph: API_MEDIA)  {
   id: ID!
+  updatedAt: DateTime!
+  videoVariantId: ID
   """
   master video file
   """
@@ -5474,6 +5488,20 @@ input VideoEditionUpdateInput @join__type(graph: API_MEDIA)  {
   name: String
 }
 
+input VideoEditionsFilter @join__type(graph: API_MEDIA)  {
+  updatedAt: DateTimeFilter
+}
+
+input VideoImagesFilter @join__type(graph: API_MEDIA)  {
+  updatedAt: DateTimeFilter
+  videoId: ID
+  aspectRatio: ImageAspectRatio
+}
+
+input VideoOriginsFilter @join__type(graph: API_MEDIA)  {
+  updatedAt: DateTimeFilter
+}
+
 input VideoStudyQuestionCreateInput @join__type(graph: API_MEDIA)  {
   id: ID
   videoId: String!
@@ -5523,6 +5551,14 @@ input VideoSubtitleUpdateInput @join__type(graph: API_MEDIA)  {
   srtVersion: Int
   primary: Boolean
   languageId: String
+}
+
+input VideoSubtitlesFilter @join__type(graph: API_MEDIA)  {
+  updatedAt: DateTimeFilter
+  videoId: ID
+  languageId: ID
+  edition: String
+  primary: Boolean
 }
 
 input VideoTranslationCreateInput @join__type(graph: API_MEDIA)  {
@@ -5596,6 +5632,12 @@ input VideoVariantDownloadUpdateInput @join__type(graph: API_MEDIA)  {
   bitrate: Int
   url: String
   version: Int
+}
+
+input VideoVariantDownloadsFilter @join__type(graph: API_MEDIA)  {
+  updatedAt: DateTimeFilter
+  videoVariantId: ID
+  quality: VideoVariantDownloadQuality
 }
 
 input VideoVariantFilter @join__type(graph: API_MEDIA)  {

--- a/apis/api-media/schema.graphql
+++ b/apis/api-media/schema.graphql
@@ -80,6 +80,8 @@ type CheckVideoVariantsInAlgoliaResult {
 
 type CloudflareImage {
   id: ID!
+  updatedAt: DateTime!
+  videoId: ID
   uploadUrl: String
   userId: ID!
   createdAt: Date!
@@ -714,12 +716,15 @@ input PlaylistUpdateInput {
 type Query {
   getMyCloudflareImages(offset: Int, limit: Int): [CloudflareImage!]!
   getMyCloudflareImage(id: ID!): CloudflareImage!
+  videoImages(where: VideoImagesFilter, offset: Int, limit: Int): [CloudflareImage!]!
+  videoImagesCount(where: VideoImagesFilter): Int!
   listUnsplashCollectionPhotos(collectionId: String!, page: Int, perPage: Int, orientation: UnsplashPhotoOrientation): [UnsplashPhoto!]!
   searchUnsplashPhotos(query: String!, page: Int, perPage: Int, orderBy: UnsplashOrderBy, collections: [String!], contentFilter: UnsplashContentFilter, color: UnsplashColor, orientation: UnsplashPhotoOrientation): UnsplashQueryResponse!
   bibleBooks(where: BibleBooksFilter): [BibleBook!]!
   bibleCitations(videoId: ID): [BibleCitation!]!
   bibleCitation(id: ID!): BibleCitation!
-  keywords(where: KeywordsFilter): [Keyword!]!
+  keywords(where: KeywordsFilter, offset: Int, limit: Int): [Keyword!]!
+  keywordsCount(where: KeywordsFilter): Int!
   getMyMuxVideos(offset: Int, limit: Int): [MuxVideo!]!
   getMyMuxVideo(id: ID!, userGenerated: Boolean): MuxVideo!
   getMuxVideo(id: ID!, userGenerated: Boolean): MuxVideo
@@ -762,6 +767,10 @@ type Query {
     last: Int
   ): QueryShortLinksConnection!
   userMediaProfile: UserMediaProfile
+  videoSubtitles(where: VideoSubtitlesFilter, offset: Int, limit: Int): [VideoSubtitle!]!
+  videoSubtitlesCount(where: VideoSubtitlesFilter): Int!
+  videoVariantDownloads(where: VideoVariantDownloadsFilter, offset: Int, limit: Int): [VideoVariantDownload!]!
+  videoVariantDownloadsCount(where: VideoVariantDownloadsFilter): Int!
   videoVariant(id: ID!): VideoVariant!
   videoVariants(input: VideoVariantFilter, offset: Int, limit: Int): [VideoVariant!]!
   videoVariantsCount(input: VideoVariantFilter): Int!
@@ -773,8 +782,10 @@ type Query {
   videosCount(where: VideosFilter): Int!
   checkVideoInAlgolia(videoId: ID!): CheckVideoInAlgoliaResult!
   checkVideoVariantsInAlgolia(videoId: ID!): CheckVideoVariantsInAlgoliaResult!
-  videoOrigins: [VideoOrigin!]!
-  videoEditions: [VideoEdition!]!
+  videoOrigins(where: VideoOriginsFilter, offset: Int, limit: Int): [VideoOrigin!]!
+  videoOriginsCount(where: VideoOriginsFilter): Int!
+  videoEditions(where: VideoEditionsFilter, offset: Int, limit: Int): [VideoEdition!]!
+  videoEditionsCount(where: VideoEditionsFilter): Int!
   videoEdition(id: ID!): VideoEdition
   tags: [Tag!]!
   taxonomies(category: String, languageCodes: [String!]): [Taxonomy!]!
@@ -1184,11 +1195,21 @@ input VideoEditionUpdateInput {
   name: String
 }
 
+input VideoEditionsFilter {
+  updatedAt: DateTimeFilter
+}
+
 type VideoImageAlt {
   id: ID!
   value: String!
   primary: Boolean!
   language: Language!
+}
+
+input VideoImagesFilter {
+  updatedAt: DateTimeFilter
+  videoId: ID
+  aspectRatio: ImageAspectRatio
 }
 
 enum VideoLabel {
@@ -1204,8 +1225,13 @@ enum VideoLabel {
 
 type VideoOrigin {
   id: ID!
+  updatedAt: DateTime!
   name: String!
   description: String
+}
+
+input VideoOriginsFilter {
+  updatedAt: DateTimeFilter
 }
 
 type VideoPublishChildrenResult {
@@ -1277,6 +1303,8 @@ input VideoStudyQuestionUpdateInput {
 
 type VideoSubtitle {
   id: ID!
+  updatedAt: DateTime!
+  videoId: ID!
   languageId: ID!
   primary: Boolean!
   edition: String!
@@ -1324,6 +1352,14 @@ input VideoSubtitleUpdateInput {
   srtVersion: Int
   primary: Boolean
   languageId: String
+}
+
+input VideoSubtitlesFilter {
+  updatedAt: DateTimeFilter
+  videoId: ID
+  languageId: ID
+  edition: String
+  primary: Boolean
 }
 
 type VideoTitle {
@@ -1413,6 +1449,8 @@ input VideoVariantCreateInput {
 
 type VideoVariantDownload {
   id: ID!
+  updatedAt: DateTime!
+  videoVariantId: ID
 
   """master video file"""
   asset: CloudflareR2
@@ -1464,6 +1502,12 @@ input VideoVariantDownloadUpdateInput {
   bitrate: Int
   url: String
   version: Int
+}
+
+input VideoVariantDownloadsFilter {
+  updatedAt: DateTimeFilter
+  videoVariantId: ID
+  quality: VideoVariantDownloadQuality
 }
 
 input VideoVariantFilter {

--- a/apis/api-media/src/cache.ts
+++ b/apis/api-media/src/cache.ts
@@ -1,0 +1,3 @@
+import { createInMemoryCache } from '@graphql-yoga/plugin-response-cache'
+
+export const cache = createInMemoryCache()

--- a/apis/api-media/src/lib/videoCacheReset.spec.ts
+++ b/apis/api-media/src/lib/videoCacheReset.spec.ts
@@ -2,13 +2,13 @@ import fetch from 'node-fetch'
 
 import { prisma } from '@core/prisma/media/client'
 
-import { cache } from '../yoga'
+import { cache } from '../cache'
 
 import { videoCacheReset, videoVariantCacheReset } from './videoCacheReset'
 
 // Mock dependencies
 jest.mock('node-fetch')
-jest.mock('../yoga', () => ({
+jest.mock('../cache', () => ({
   cache: {
     invalidate: jest.fn()
   }

--- a/apis/api-media/src/lib/videoCacheReset.ts
+++ b/apis/api-media/src/lib/videoCacheReset.ts
@@ -2,7 +2,7 @@ import fetch from 'node-fetch'
 
 import { prisma } from '@core/prisma/media/client'
 
-import { cache } from '../yoga'
+import { cache } from '../cache'
 
 async function revalidateWatchApp(url: string): Promise<void> {
   try {

--- a/apis/api-media/src/schema/cloudflare/image/image.spec.ts
+++ b/apis/api-media/src/schema/cloudflare/image/image.spec.ts
@@ -49,6 +49,7 @@ jest.mock('./service', () => ({
 }))
 
 describe('cloudflareImage', () => {
+  const client = getClient()
   const authClient = getClient({
     headers: {
       authorization: 'token'
@@ -61,6 +62,105 @@ describe('cloudflareImage', () => {
   })
 
   describe('queries', () => {
+    describe('videoImages', () => {
+      const VIDEO_IMAGES_QUERY = graphql(`
+        query VideoImages {
+          videoImages {
+            id
+            videoId
+            aspectRatio
+            url
+            blurhash
+          }
+        }
+      `)
+
+      it('should return video images', async () => {
+        prismaMock.cloudflareImage.findMany.mockResolvedValue([
+          {
+            id: 'imageId',
+            uploaded: true,
+            userId: 'userId',
+            uploadUrl: null,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            aspectRatio: null,
+            videoId: 'videoId',
+            blurhash: null,
+            blurhashAttemptedAt: null
+          }
+        ])
+        const result = await client({ document: VIDEO_IMAGES_QUERY })
+        expect(
+          prismaMock.cloudflareImage.findMany
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: {
+              videoId: { not: null },
+              uploaded: true,
+              updatedAt: undefined,
+              aspectRatio: undefined
+            },
+            skip: 0,
+            take: 100,
+            orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }]
+          })
+        )
+        expect(result).toHaveProperty('data.videoImages', [
+          {
+            id: 'imageId',
+            videoId: 'videoId',
+            aspectRatio: null,
+            url: expect.any(String),
+            blurhash: null
+          }
+        ])
+      })
+
+      it('should filter by videoId', async () => {
+        const FILTERED_QUERY = graphql(`
+          query VideoImagesFiltered {
+            videoImages(where: { videoId: "specificVideoId" }) {
+              id
+            }
+          }
+        `)
+        prismaMock.cloudflareImage.findMany.mockResolvedValue([])
+        await client({ document: FILTERED_QUERY })
+        expect(
+          prismaMock.cloudflareImage.findMany
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({
+              videoId: 'specificVideoId'
+            })
+          })
+        )
+      })
+    })
+
+    describe('videoImagesCount', () => {
+      const VIDEO_IMAGES_COUNT_QUERY = graphql(`
+        query VideoImagesCount {
+          videoImagesCount
+        }
+      `)
+
+      it('should return video images count', async () => {
+        prismaMock.cloudflareImage.count.mockResolvedValue(5)
+        const result = await client({ document: VIDEO_IMAGES_COUNT_QUERY })
+        expect(prismaMock.cloudflareImage.count).toHaveBeenCalledWith({
+          where: {
+            videoId: { not: null },
+            uploaded: true,
+            updatedAt: undefined,
+            aspectRatio: undefined
+          }
+        })
+        expect(result).toHaveProperty('data.videoImagesCount', 5)
+      })
+    })
+
     describe('getMyCloudflareImages', () => {
       const GET_MY_CLOUDFLARE_IMAGES_QUERY = graphql(`
         query getMyCloudflareImages($offset: Int, $limit: Int) {

--- a/apis/api-media/src/schema/cloudflare/image/image.spec.ts
+++ b/apis/api-media/src/schema/cloudflare/image/image.spec.ts
@@ -91,9 +91,7 @@ describe('cloudflareImage', () => {
           }
         ])
         const result = await client({ document: VIDEO_IMAGES_QUERY })
-        expect(
-          prismaMock.cloudflareImage.findMany
-        ).toHaveBeenCalledWith(
+        expect(prismaMock.cloudflareImage.findMany).toHaveBeenCalledWith(
           expect.objectContaining({
             where: {
               videoId: { not: null },
@@ -127,9 +125,7 @@ describe('cloudflareImage', () => {
         `)
         prismaMock.cloudflareImage.findMany.mockResolvedValue([])
         await client({ document: FILTERED_QUERY })
-        expect(
-          prismaMock.cloudflareImage.findMany
-        ).toHaveBeenCalledWith(
+        expect(prismaMock.cloudflareImage.findMany).toHaveBeenCalledWith(
           expect.objectContaining({
             where: expect.objectContaining({
               videoId: 'specificVideoId'

--- a/apis/api-media/src/schema/cloudflare/image/image.ts
+++ b/apis/api-media/src/schema/cloudflare/image/image.ts
@@ -2,10 +2,10 @@ import { Prisma, prisma } from '@core/prisma/media/client'
 
 import { jobName as processImageBlurhashJobName } from '../../../workers/processImageBlurhash/config'
 import { queue as processImageBlurhashQueue } from '../../../workers/processImageBlurhash/queue'
-import { builder } from '../../builder'
+import { builder, toPrismaDateTimeFilter } from '../../builder'
 
 import { ImageAspectRatio } from './enums'
-import { ImageInput } from './inputs'
+import { ImageInput, VideoImagesFilter } from './inputs'
 import {
   createImageByDirectUpload,
   createImageFromResponse,
@@ -18,6 +18,8 @@ import { baseUrl } from './utils/baseUrl'
 builder.prismaObject('CloudflareImage', {
   fields: (t) => ({
     id: t.exposeID('id', { nullable: false }),
+    updatedAt: t.expose('updatedAt', { type: 'DateTime', nullable: false }),
+    videoId: t.exposeID('videoId', { nullable: true }),
     uploadUrl: t.exposeString('uploadUrl'),
     userId: t.exposeID('userId', { nullable: false }),
     createdAt: t.expose('createdAt', {
@@ -93,6 +95,47 @@ builder.queryFields((t) => ({
       return await prisma.cloudflareImage.findFirstOrThrow({
         ...query,
         where: { id, userId: user.id }
+      })
+    }
+  }),
+  videoImages: t.prismaField({
+    type: ['CloudflareImage'],
+    nullable: false,
+    args: {
+      where: t.arg({ type: VideoImagesFilter, required: false }),
+      offset: t.arg.int({ required: false }),
+      limit: t.arg.int({ required: false })
+    },
+    resolve: async (query, _root, { where, offset, limit }) => {
+      return await prisma.cloudflareImage.findMany({
+        ...query,
+        where: {
+          videoId: { not: null },
+          uploaded: true,
+          updatedAt: toPrismaDateTimeFilter(where?.updatedAt),
+          aspectRatio: where?.aspectRatio ?? undefined,
+          ...(where?.videoId != null ? { videoId: where.videoId } : {})
+        },
+        skip: offset ?? 0,
+        take: limit ?? 100,
+        orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }]
+      })
+    }
+  }),
+  videoImagesCount: t.int({
+    nullable: false,
+    args: {
+      where: t.arg({ type: VideoImagesFilter, required: false })
+    },
+    resolve: async (_root, { where }) => {
+      return await prisma.cloudflareImage.count({
+        where: {
+          videoId: { not: null },
+          uploaded: true,
+          updatedAt: toPrismaDateTimeFilter(where?.updatedAt),
+          aspectRatio: where?.aspectRatio ?? undefined,
+          ...(where?.videoId != null ? { videoId: where.videoId } : {})
+        }
       })
     }
   })

--- a/apis/api-media/src/schema/cloudflare/image/image.ts
+++ b/apis/api-media/src/schema/cloudflare/image/image.ts
@@ -20,7 +20,7 @@ builder.prismaObject('CloudflareImage', {
     id: t.exposeID('id', { nullable: false }),
     updatedAt: t.expose('updatedAt', { type: 'DateTime', nullable: false }),
     videoId: t.exposeID('videoId', { nullable: true }),
-    uploadUrl: t.withAuth({ isAuthenticated: true }).exposeString('uploadUrl'),
+    uploadUrl: t.exposeString('uploadUrl'),
     userId: t
       .withAuth({ isAuthenticated: true })
       .exposeID('userId', { nullable: false }),

--- a/apis/api-media/src/schema/cloudflare/image/image.ts
+++ b/apis/api-media/src/schema/cloudflare/image/image.ts
@@ -20,8 +20,10 @@ builder.prismaObject('CloudflareImage', {
     id: t.exposeID('id', { nullable: false }),
     updatedAt: t.expose('updatedAt', { type: 'DateTime', nullable: false }),
     videoId: t.exposeID('videoId', { nullable: true }),
-    uploadUrl: t.exposeString('uploadUrl'),
-    userId: t.exposeID('userId', { nullable: false }),
+    uploadUrl: t.withAuth({ isAuthenticated: true }).exposeString('uploadUrl'),
+    userId: t
+      .withAuth({ isAuthenticated: true })
+      .exposeID('userId', { nullable: false }),
     createdAt: t.expose('createdAt', {
       type: 'Date',
       nullable: false
@@ -110,11 +112,10 @@ builder.queryFields((t) => ({
       return await prisma.cloudflareImage.findMany({
         ...query,
         where: {
-          videoId: { not: null },
+          videoId: where?.videoId != null ? where.videoId : { not: null },
           uploaded: true,
           updatedAt: toPrismaDateTimeFilter(where?.updatedAt),
-          aspectRatio: where?.aspectRatio ?? undefined,
-          ...(where?.videoId != null ? { videoId: where.videoId } : {})
+          aspectRatio: where?.aspectRatio ?? undefined
         },
         skip: offset ?? 0,
         take: limit ?? 100,
@@ -130,11 +131,10 @@ builder.queryFields((t) => ({
     resolve: async (_root, { where }) => {
       return await prisma.cloudflareImage.count({
         where: {
-          videoId: { not: null },
+          videoId: where?.videoId != null ? where.videoId : { not: null },
           uploaded: true,
           updatedAt: toPrismaDateTimeFilter(where?.updatedAt),
-          aspectRatio: where?.aspectRatio ?? undefined,
-          ...(where?.videoId != null ? { videoId: where.videoId } : {})
+          aspectRatio: where?.aspectRatio ?? undefined
         }
       })
     }

--- a/apis/api-media/src/schema/cloudflare/image/inputs/index.ts
+++ b/apis/api-media/src/schema/cloudflare/image/inputs/index.ts
@@ -1,1 +1,2 @@
 export { ImageInput } from './imageInput'
+export { VideoImagesFilter } from './videoImagesFilter'

--- a/apis/api-media/src/schema/cloudflare/image/inputs/videoImagesFilter.ts
+++ b/apis/api-media/src/schema/cloudflare/image/inputs/videoImagesFilter.ts
@@ -1,5 +1,4 @@
 import { DateTimeFilter, builder } from '../../../builder'
-
 import { ImageAspectRatio } from '../enums/imageAspectRatio'
 
 export const VideoImagesFilter = builder.inputType('VideoImagesFilter', {

--- a/apis/api-media/src/schema/cloudflare/image/inputs/videoImagesFilter.ts
+++ b/apis/api-media/src/schema/cloudflare/image/inputs/videoImagesFilter.ts
@@ -1,0 +1,11 @@
+import { DateTimeFilter, builder } from '../../../builder'
+
+import { ImageAspectRatio } from '../enums/imageAspectRatio'
+
+export const VideoImagesFilter = builder.inputType('VideoImagesFilter', {
+  fields: (t) => ({
+    updatedAt: t.field({ type: DateTimeFilter, required: false }),
+    videoId: t.id({ required: false }),
+    aspectRatio: t.field({ type: ImageAspectRatio, required: false })
+  })
+})

--- a/apis/api-media/src/schema/generate.ts
+++ b/apis/api-media/src/schema/generate.ts
@@ -4,8 +4,7 @@ import { printSubgraphSchema } from '@apollo/subgraph'
 import { lexicographicSortSchema } from 'graphql'
 
 import { logger } from './logger'
-
-import { schema } from '.'
+import { schema } from './schema'
 
 const filename = 'apis/api-media/schema.graphql'
 export function generate(): void {

--- a/apis/api-media/src/schema/keyword/keyword.spec.ts
+++ b/apis/api-media/src/schema/keyword/keyword.spec.ts
@@ -98,6 +98,25 @@ describe('Keyword', () => {
     })
   })
 
+  describe('keywordsCount', () => {
+    const KEYWORDS_COUNT_QUERY = graphql(`
+      query KeywordsCount {
+        keywordsCount
+      }
+    `)
+
+    it('should return keywords count', async () => {
+      prismaMock.keyword.count.mockResolvedValue(10)
+      const result = await client({ document: KEYWORDS_COUNT_QUERY })
+      expect(prismaMock.keyword.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { updatedAt: undefined }
+        })
+      )
+      expect(result).toHaveProperty('data.keywordsCount', 10)
+    })
+  })
+
   describe('createKeyword', () => {
     const CREATE_KEYWORD_MUTATION = graphql(`
       mutation CreateKeyword($value: String!, $languageId: String!) {

--- a/apis/api-media/src/schema/keyword/keyword.ts
+++ b/apis/api-media/src/schema/keyword/keyword.ts
@@ -27,15 +27,31 @@ builder.queryFields((t) => ({
     type: ['Keyword'],
     nullable: false,
     args: {
-      where: t.arg({ type: KeywordsFilter, required: false })
+      where: t.arg({ type: KeywordsFilter, required: false }),
+      offset: t.arg.int({ required: false }),
+      limit: t.arg.int({ required: false })
     },
-    resolve: async (query, _parent, { where }) => {
+    resolve: async (query, _parent, { where, offset, limit }) => {
       const filter: Prisma.KeywordWhereInput = {}
       filter.updatedAt = toPrismaDateTimeFilter(where?.updatedAt)
       return await prisma.keyword.findMany({
         ...query,
-        where: filter
+        where: filter,
+        skip: offset ?? 0,
+        take: limit ?? 100,
+        orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }]
       })
+    }
+  }),
+  keywordsCount: t.int({
+    nullable: false,
+    args: {
+      where: t.arg({ type: KeywordsFilter, required: false })
+    },
+    resolve: async (_parent, { where }) => {
+      const filter: Prisma.KeywordWhereInput = {}
+      filter.updatedAt = toPrismaDateTimeFilter(where?.updatedAt)
+      return await prisma.keyword.count({ where: filter })
     }
   })
 }))

--- a/apis/api-media/src/schema/keyword/keyword.ts
+++ b/apis/api-media/src/schema/keyword/keyword.ts
@@ -38,7 +38,7 @@ builder.queryFields((t) => ({
         ...query,
         where: filter,
         skip: offset ?? 0,
-        take: limit ?? 100,
+        take: limit ?? undefined,
         orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }]
       })
     }

--- a/apis/api-media/src/schema/video/videoOrigin/inputs/index.ts
+++ b/apis/api-media/src/schema/video/videoOrigin/inputs/index.ts
@@ -1,0 +1,1 @@
+export { VideoOriginsFilter } from './videoOriginsFilter'

--- a/apis/api-media/src/schema/video/videoOrigin/inputs/videoOriginsFilter.ts
+++ b/apis/api-media/src/schema/video/videoOrigin/inputs/videoOriginsFilter.ts
@@ -1,0 +1,7 @@
+import { DateTimeFilter, builder } from '../../../builder'
+
+export const VideoOriginsFilter = builder.inputType('VideoOriginsFilter', {
+  fields: (t) => ({
+    updatedAt: t.field({ type: DateTimeFilter, required: false })
+  })
+})

--- a/apis/api-media/src/schema/video/videoOrigin/videoOrigin.spec.ts
+++ b/apis/api-media/src/schema/video/videoOrigin/videoOrigin.spec.ts
@@ -50,7 +50,7 @@ describe('videoOrigin', () => {
           expect.objectContaining({
             orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }],
             skip: 0,
-            take: 100
+            take: undefined
           })
         )
         expect(result).toHaveProperty('data.videoOrigins', [

--- a/apis/api-media/src/schema/video/videoOrigin/videoOrigin.spec.ts
+++ b/apis/api-media/src/schema/video/videoOrigin/videoOrigin.spec.ts
@@ -27,13 +27,6 @@ describe('videoOrigin', () => {
       `)
 
       it('should fetch video origins', async () => {
-        prismaMock.userMediaRole.findUnique.mockResolvedValue({
-          id: 'userId',
-          userId: 'userId',
-          roles: ['publisher'],
-          createdAt: new Date(),
-          updatedAt: new Date()
-        })
         prismaMock.videoOrigin.findMany.mockResolvedValue([
           {
             id: 'origin1',
@@ -50,12 +43,16 @@ describe('videoOrigin', () => {
             updatedAt: new Date()
           }
         ])
-        const result = await authClient({
+        const result = await client({
           document: VIDEO_ORIGINS_QUERY
         })
-        expect(prismaMock.videoOrigin.findMany).toHaveBeenCalledWith({
-          orderBy: { name: 'asc' }
-        })
+        expect(prismaMock.videoOrigin.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }],
+            skip: 0,
+            take: 100
+          })
+        )
         expect(result).toHaveProperty('data.videoOrigins', [
           {
             id: 'origin1',
@@ -68,13 +65,6 @@ describe('videoOrigin', () => {
             description: 'Second origin'
           }
         ])
-      })
-
-      it('should reject if not publisher', async () => {
-        const result = await client({
-          document: VIDEO_ORIGINS_QUERY
-        })
-        expect(result).toHaveProperty('data', null)
       })
     })
   })

--- a/apis/api-media/src/schema/video/videoOrigin/videoOrigin.spec.ts
+++ b/apis/api-media/src/schema/video/videoOrigin/videoOrigin.spec.ts
@@ -67,6 +67,25 @@ describe('videoOrigin', () => {
         ])
       })
     })
+
+    describe('videoOriginsCount', () => {
+      const VIDEO_ORIGINS_COUNT_QUERY = graphql(`
+        query VideoOriginsCount {
+          videoOriginsCount
+        }
+      `)
+
+      it('should return video origins count', async () => {
+        prismaMock.videoOrigin.count.mockResolvedValue(2)
+        const result = await client({ document: VIDEO_ORIGINS_COUNT_QUERY })
+        expect(prismaMock.videoOrigin.count).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: { updatedAt: undefined }
+          })
+        )
+        expect(result).toHaveProperty('data.videoOriginsCount', 2)
+      })
+    })
   })
 
   describe('mutations', () => {

--- a/apis/api-media/src/schema/video/videoOrigin/videoOrigin.ts
+++ b/apis/api-media/src/schema/video/videoOrigin/videoOrigin.ts
@@ -27,7 +27,7 @@ builder.queryFields((t) => ({
         ...query,
         where: { updatedAt: toPrismaDateTimeFilter(where?.updatedAt) },
         skip: offset ?? 0,
-        take: limit ?? 100,
+        take: limit ?? undefined,
         orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }]
       })
     }

--- a/apis/api-media/src/schema/video/videoOrigin/videoOrigin.ts
+++ b/apis/api-media/src/schema/video/videoOrigin/videoOrigin.ts
@@ -1,23 +1,45 @@
 import { prisma } from '@core/prisma/media/client'
 
-import { builder } from '../../builder'
+import { builder, toPrismaDateTimeFilter } from '../../builder'
+
+import { VideoOriginsFilter } from './inputs'
 
 builder.prismaObject('VideoOrigin', {
   fields: (t) => ({
     id: t.exposeID('id', { nullable: false }),
+    updatedAt: t.expose('updatedAt', { type: 'DateTime', nullable: false }),
     name: t.exposeString('name', { nullable: false }),
     description: t.exposeString('description', { nullable: true })
   })
 })
 
 builder.queryFields((t) => ({
-  videoOrigins: t.withAuth({ isPublisher: true }).prismaField({
+  videoOrigins: t.prismaField({
     type: ['VideoOrigin'],
     nullable: false,
-    resolve: async (query) => {
+    args: {
+      where: t.arg({ type: VideoOriginsFilter, required: false }),
+      offset: t.arg.int({ required: false }),
+      limit: t.arg.int({ required: false })
+    },
+    resolve: async (query, _parent, { where, offset, limit }) => {
       return await prisma.videoOrigin.findMany({
         ...query,
-        orderBy: { name: 'asc' }
+        where: { updatedAt: toPrismaDateTimeFilter(where?.updatedAt) },
+        skip: offset ?? 0,
+        take: limit ?? 100,
+        orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }]
+      })
+    }
+  }),
+  videoOriginsCount: t.int({
+    nullable: false,
+    args: {
+      where: t.arg({ type: VideoOriginsFilter, required: false })
+    },
+    resolve: async (_parent, { where }) => {
+      return await prisma.videoOrigin.count({
+        where: { updatedAt: toPrismaDateTimeFilter(where?.updatedAt) }
       })
     }
   })

--- a/apis/api-media/src/schema/video/videoSubtitle/inputs/index.ts
+++ b/apis/api-media/src/schema/video/videoSubtitle/inputs/index.ts
@@ -1,2 +1,3 @@
 import './videoSubtitleCreate'
 import './videoSubtitleUpdate'
+import './videoSubtitlesFilter'

--- a/apis/api-media/src/schema/video/videoSubtitle/inputs/videoSubtitlesFilter.ts
+++ b/apis/api-media/src/schema/video/videoSubtitle/inputs/videoSubtitlesFilter.ts
@@ -1,0 +1,11 @@
+import { DateTimeFilter, builder } from '../../../builder'
+
+export const VideoSubtitlesFilter = builder.inputType('VideoSubtitlesFilter', {
+  fields: (t) => ({
+    updatedAt: t.field({ type: DateTimeFilter, required: false }),
+    videoId: t.id({ required: false }),
+    languageId: t.id({ required: false }),
+    edition: t.string({ required: false }),
+    primary: t.boolean({ required: false })
+  })
+})

--- a/apis/api-media/src/schema/video/videoSubtitle/videoSubtitle.spec.ts
+++ b/apis/api-media/src/schema/video/videoSubtitle/videoSubtitle.spec.ts
@@ -14,6 +14,106 @@ describe('videoSubtitle', () => {
     }
   })
 
+  describe('queries', () => {
+    describe('videoSubtitles', () => {
+      const VIDEO_SUBTITLES_QUERY = graphql(`
+        query VideoSubtitles {
+          videoSubtitles {
+            id
+            videoId
+            languageId
+            primary
+            edition
+          }
+        }
+      `)
+
+      it('should return video subtitles', async () => {
+        prismaMock.videoSubtitle.findMany.mockResolvedValue([
+          {
+            id: 'subtitleId',
+            videoId: 'videoId',
+            languageId: '529',
+            primary: true,
+            edition: 'base',
+            vttSrc: null,
+            srtSrc: null,
+            vttAssetId: null,
+            vttVersion: 1,
+            srtAssetId: null,
+            srtVersion: 1,
+            createdAt: new Date(),
+            updatedAt: new Date()
+          }
+        ])
+        const result = await client({ document: VIDEO_SUBTITLES_QUERY })
+        expect(prismaMock.videoSubtitle.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: {
+              updatedAt: undefined,
+              videoId: undefined,
+              languageId: undefined,
+              edition: undefined,
+              primary: undefined
+            },
+            skip: 0,
+            take: 100,
+            orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }]
+          })
+        )
+        expect(result).toHaveProperty('data.videoSubtitles', [
+          {
+            id: 'subtitleId',
+            videoId: 'videoId',
+            languageId: '529',
+            primary: true,
+            edition: 'base'
+          }
+        ])
+      })
+
+      it('should filter by videoId', async () => {
+        const FILTERED_QUERY = graphql(`
+          query VideoSubtitlesFiltered {
+            videoSubtitles(where: { videoId: "specificVideoId" }) {
+              id
+            }
+          }
+        `)
+        prismaMock.videoSubtitle.findMany.mockResolvedValue([])
+        await client({ document: FILTERED_QUERY })
+        expect(prismaMock.videoSubtitle.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({ videoId: 'specificVideoId' })
+          })
+        )
+      })
+    })
+
+    describe('videoSubtitlesCount', () => {
+      const VIDEO_SUBTITLES_COUNT_QUERY = graphql(`
+        query VideoSubtitlesCount {
+          videoSubtitlesCount
+        }
+      `)
+
+      it('should return video subtitles count', async () => {
+        prismaMock.videoSubtitle.count.mockResolvedValue(3)
+        const result = await client({ document: VIDEO_SUBTITLES_COUNT_QUERY })
+        expect(prismaMock.videoSubtitle.count).toHaveBeenCalledWith({
+          where: {
+            updatedAt: undefined,
+            videoId: undefined,
+            languageId: undefined,
+            edition: undefined,
+            primary: undefined
+          }
+        })
+        expect(result).toHaveProperty('data.videoSubtitlesCount', 3)
+      })
+    })
+  })
+
   describe('mutations', () => {
     describe('videoSubtitleCreate', () => {
       const CREATE_VIDEO_SUBTITLE_MUTATION = graphql(`

--- a/apis/api-media/src/schema/video/videoSubtitle/videoSubtitle.ts
+++ b/apis/api-media/src/schema/video/videoSubtitle/videoSubtitle.ts
@@ -1,14 +1,17 @@
 import { prisma } from '@core/prisma/media/client'
 
-import { builder } from '../../builder'
+import { builder, toPrismaDateTimeFilter } from '../../builder'
 import { Language } from '../../language'
 
 import { VideoSubtitleCreateInput } from './inputs/videoSubtitleCreate'
 import { VideoSubtitleUpdateInput } from './inputs/videoSubtitleUpdate'
+import { VideoSubtitlesFilter } from './inputs/videoSubtitlesFilter'
 
 export const VideoSubtitle = builder.prismaObject('VideoSubtitle', {
   fields: (t) => ({
     id: t.exposeID('id', { nullable: false }),
+    updatedAt: t.expose('updatedAt', { type: 'DateTime', nullable: false }),
+    videoId: t.exposeID('videoId', { nullable: false }),
     languageId: t.exposeID('languageId', { nullable: false }),
     primary: t.exposeBoolean('primary', { nullable: false }),
     edition: t.exposeString('edition', { nullable: false }),
@@ -40,6 +43,50 @@ export const VideoSubtitle = builder.prismaObject('VideoSubtitle', {
     videoEdition: t.relation('videoEdition', { nullable: false })
   })
 })
+
+builder.queryFields((t) => ({
+  videoSubtitles: t.prismaField({
+    type: ['VideoSubtitle'],
+    nullable: false,
+    args: {
+      where: t.arg({ type: VideoSubtitlesFilter, required: false }),
+      offset: t.arg.int({ required: false }),
+      limit: t.arg.int({ required: false })
+    },
+    resolve: async (query, _parent, { where, offset, limit }) => {
+      return await prisma.videoSubtitle.findMany({
+        ...query,
+        where: {
+          updatedAt: toPrismaDateTimeFilter(where?.updatedAt),
+          videoId: where?.videoId ?? undefined,
+          languageId: where?.languageId ?? undefined,
+          edition: where?.edition ?? undefined,
+          primary: where?.primary ?? undefined
+        },
+        skip: offset ?? 0,
+        take: limit ?? 100,
+        orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }]
+      })
+    }
+  }),
+  videoSubtitlesCount: t.int({
+    nullable: false,
+    args: {
+      where: t.arg({ type: VideoSubtitlesFilter, required: false })
+    },
+    resolve: async (_parent, { where }) => {
+      return await prisma.videoSubtitle.count({
+        where: {
+          updatedAt: toPrismaDateTimeFilter(where?.updatedAt),
+          videoId: where?.videoId ?? undefined,
+          languageId: where?.languageId ?? undefined,
+          edition: where?.edition ?? undefined,
+          primary: where?.primary ?? undefined
+        }
+      })
+    }
+  })
+}))
 
 builder.mutationFields((t) => ({
   videoSubtitleCreate: t.withAuth({ isPublisher: true }).prismaField({

--- a/apis/api-media/src/schema/video/videoSubtitle/videoSubtitle.ts
+++ b/apis/api-media/src/schema/video/videoSubtitle/videoSubtitle.ts
@@ -4,8 +4,8 @@ import { builder, toPrismaDateTimeFilter } from '../../builder'
 import { Language } from '../../language'
 
 import { VideoSubtitleCreateInput } from './inputs/videoSubtitleCreate'
-import { VideoSubtitleUpdateInput } from './inputs/videoSubtitleUpdate'
 import { VideoSubtitlesFilter } from './inputs/videoSubtitlesFilter'
+import { VideoSubtitleUpdateInput } from './inputs/videoSubtitleUpdate'
 
 export const VideoSubtitle = builder.prismaObject('VideoSubtitle', {
   fields: (t) => ({

--- a/apis/api-media/src/schema/videoEdition/inputs/index.ts
+++ b/apis/api-media/src/schema/videoEdition/inputs/index.ts
@@ -1,2 +1,3 @@
 export { VideoEditionCreateInput } from './videoEditionCreate'
 export { VideoEditionUpdateInput } from './videoEditionUpdate'
+export { VideoEditionsFilter } from './videoEditionsFilter'

--- a/apis/api-media/src/schema/videoEdition/inputs/videoEditionsFilter.ts
+++ b/apis/api-media/src/schema/videoEdition/inputs/videoEditionsFilter.ts
@@ -1,0 +1,7 @@
+import { DateTimeFilter, builder } from '../../builder'
+
+export const VideoEditionsFilter = builder.inputType('VideoEditionsFilter', {
+  fields: (t) => ({
+    updatedAt: t.field({ type: DateTimeFilter, required: false })
+  })
+})

--- a/apis/api-media/src/schema/videoEdition/videoEdition.spec.ts
+++ b/apis/api-media/src/schema/videoEdition/videoEdition.spec.ts
@@ -39,7 +39,14 @@ describe('videoEdition', () => {
         const data = await client({
           document: VIDEO_EDITIONS_QUERY
         })
-        expect(prismaMock.videoEdition.findMany).toHaveBeenCalledWith({})
+        expect(prismaMock.videoEdition.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }],
+            skip: 0,
+            take: 100,
+            where: { updatedAt: undefined }
+          })
+        )
         expect(data).toHaveProperty('data.videoEditions', [
           {
             id: 'id',

--- a/apis/api-media/src/schema/videoEdition/videoEdition.spec.ts
+++ b/apis/api-media/src/schema/videoEdition/videoEdition.spec.ts
@@ -43,7 +43,7 @@ describe('videoEdition', () => {
           expect.objectContaining({
             orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }],
             skip: 0,
-            take: 100,
+            take: undefined,
             where: { updatedAt: undefined }
           })
         )

--- a/apis/api-media/src/schema/videoEdition/videoEdition.spec.ts
+++ b/apis/api-media/src/schema/videoEdition/videoEdition.spec.ts
@@ -56,6 +56,25 @@ describe('videoEdition', () => {
       })
     })
 
+    describe('videoEditionsCount', () => {
+      const VIDEO_EDITIONS_COUNT_QUERY = graphql(`
+        query VideoEditionsCount {
+          videoEditionsCount
+        }
+      `)
+
+      it('should return video editions count', async () => {
+        prismaMock.videoEdition.count.mockResolvedValue(4)
+        const result = await client({ document: VIDEO_EDITIONS_COUNT_QUERY })
+        expect(prismaMock.videoEdition.count).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: { updatedAt: undefined }
+          })
+        )
+        expect(result).toHaveProperty('data.videoEditionsCount', 4)
+      })
+    })
+
     describe('videoEdition', () => {
       const VIDEO_EDITION_QUERY = graphql(`
         query VideoEdition($id: ID!) {

--- a/apis/api-media/src/schema/videoEdition/videoEdition.ts
+++ b/apis/api-media/src/schema/videoEdition/videoEdition.ts
@@ -29,7 +29,7 @@ builder.queryFields((t) => ({
         ...query,
         where: { updatedAt: toPrismaDateTimeFilter(where?.updatedAt) },
         skip: offset ?? 0,
-        take: limit ?? 100,
+        take: limit ?? undefined,
         orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }]
       })
     }

--- a/apis/api-media/src/schema/videoEdition/videoEdition.ts
+++ b/apis/api-media/src/schema/videoEdition/videoEdition.ts
@@ -1,8 +1,8 @@
 import { prisma } from '@core/prisma/media/client'
 
-import { builder } from '../builder'
+import { builder, toPrismaDateTimeFilter } from '../builder'
 
-import { VideoEditionUpdateInput } from './inputs'
+import { VideoEditionUpdateInput, VideoEditionsFilter } from './inputs'
 import { VideoEditionCreateInput } from './inputs/videoEditionCreate'
 
 builder.prismaObject('VideoEdition', {
@@ -19,9 +19,29 @@ builder.queryFields((t) => ({
   videoEditions: t.prismaField({
     type: ['VideoEdition'],
     nullable: false,
-    resolve: async (query) => {
+    args: {
+      where: t.arg({ type: VideoEditionsFilter, required: false }),
+      offset: t.arg.int({ required: false }),
+      limit: t.arg.int({ required: false })
+    },
+    resolve: async (query, _parent, { where, offset, limit }) => {
       return await prisma.videoEdition.findMany({
-        ...query
+        ...query,
+        where: { updatedAt: toPrismaDateTimeFilter(where?.updatedAt) },
+        skip: offset ?? 0,
+        take: limit ?? 100,
+        orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }]
+      })
+    }
+  }),
+  videoEditionsCount: t.int({
+    nullable: false,
+    args: {
+      where: t.arg({ type: VideoEditionsFilter, required: false })
+    },
+    resolve: async (_parent, { where }) => {
+      return await prisma.videoEdition.count({
+        where: { updatedAt: toPrismaDateTimeFilter(where?.updatedAt) }
       })
     }
   }),

--- a/apis/api-media/src/schema/videoVariant/videoVariantDownload/inputs/index.ts
+++ b/apis/api-media/src/schema/videoVariant/videoVariantDownload/inputs/index.ts
@@ -1,2 +1,3 @@
 import './videoVariantDownloadCreate'
 import './videoVariantDownloadUpdate'
+import './videoVariantDownloadsFilter'

--- a/apis/api-media/src/schema/videoVariant/videoVariantDownload/inputs/videoVariantDownloadsFilter.ts
+++ b/apis/api-media/src/schema/videoVariant/videoVariantDownload/inputs/videoVariantDownloadsFilter.ts
@@ -1,0 +1,14 @@
+import { DateTimeFilter, builder } from '../../../builder'
+
+import { VideoVariantDownloadQuality } from '../enums/videoVariantDownloadQuality'
+
+export const VideoVariantDownloadsFilter = builder.inputType(
+  'VideoVariantDownloadsFilter',
+  {
+    fields: (t) => ({
+      updatedAt: t.field({ type: DateTimeFilter, required: false }),
+      videoVariantId: t.id({ required: false }),
+      quality: t.field({ type: VideoVariantDownloadQuality, required: false })
+    })
+  }
+)

--- a/apis/api-media/src/schema/videoVariant/videoVariantDownload/inputs/videoVariantDownloadsFilter.ts
+++ b/apis/api-media/src/schema/videoVariant/videoVariantDownload/inputs/videoVariantDownloadsFilter.ts
@@ -1,5 +1,4 @@
 import { DateTimeFilter, builder } from '../../../builder'
-
 import { VideoVariantDownloadQuality } from '../enums/videoVariantDownloadQuality'
 
 export const VideoVariantDownloadsFilter = builder.inputType(

--- a/apis/api-media/src/schema/videoVariant/videoVariantDownload/videoVariantDownload.spec.ts
+++ b/apis/api-media/src/schema/videoVariant/videoVariantDownload/videoVariantDownload.spec.ts
@@ -16,6 +16,113 @@ describe('videoVariantDownload', () => {
     }
   })
 
+  describe('queries', () => {
+    describe('videoVariantDownloads', () => {
+      const VIDEO_VARIANT_DOWNLOADS_QUERY = graphql(`
+        query VideoVariantDownloads {
+          videoVariantDownloads {
+            id
+            quality
+            size
+            height
+            width
+            bitrate
+            url
+          }
+        }
+      `)
+
+      it('should return video variant downloads', async () => {
+        prismaMock.videoVariantDownload.findMany.mockResolvedValue([
+          {
+            id: 'downloadId',
+            videoVariantId: 'variantId',
+            quality: VideoVariantDownloadQuality.high,
+            size: 1024,
+            height: 720,
+            width: 1280,
+            bitrate: 2000,
+            url: 'https://example.com/video.mp4',
+            assetId: null,
+            version: 1,
+            createdAt: new Date(),
+            updatedAt: new Date()
+          }
+        ])
+        const result = await client({ document: VIDEO_VARIANT_DOWNLOADS_QUERY })
+        expect(
+          prismaMock.videoVariantDownload.findMany
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: {
+              updatedAt: undefined,
+              videoVariantId: undefined,
+              quality: undefined
+            },
+            skip: 0,
+            take: 100,
+            orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }]
+          })
+        )
+        expect(result).toHaveProperty('data.videoVariantDownloads', [
+          {
+            id: 'downloadId',
+            quality: VideoVariantDownloadQuality.high,
+            size: 1024,
+            height: 720,
+            width: 1280,
+            bitrate: 2000,
+            url: 'https://example.com/video.mp4'
+          }
+        ])
+      })
+
+      it('should filter by videoVariantId', async () => {
+        const FILTERED_QUERY = graphql(`
+          query VideoVariantDownloadsFiltered {
+            videoVariantDownloads(where: { videoVariantId: "specificVariantId" }) {
+              id
+            }
+          }
+        `)
+        prismaMock.videoVariantDownload.findMany.mockResolvedValue([])
+        await client({ document: FILTERED_QUERY })
+        expect(
+          prismaMock.videoVariantDownload.findMany
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({
+              videoVariantId: 'specificVariantId'
+            })
+          })
+        )
+      })
+    })
+
+    describe('videoVariantDownloadsCount', () => {
+      const VIDEO_VARIANT_DOWNLOADS_COUNT_QUERY = graphql(`
+        query VideoVariantDownloadsCount {
+          videoVariantDownloadsCount
+        }
+      `)
+
+      it('should return video variant downloads count', async () => {
+        prismaMock.videoVariantDownload.count.mockResolvedValue(7)
+        const result = await client({
+          document: VIDEO_VARIANT_DOWNLOADS_COUNT_QUERY
+        })
+        expect(prismaMock.videoVariantDownload.count).toHaveBeenCalledWith({
+          where: {
+            updatedAt: undefined,
+            videoVariantId: undefined,
+            quality: undefined
+          }
+        })
+        expect(result).toHaveProperty('data.videoVariantDownloadsCount', 7)
+      })
+    })
+  })
+
   describe('mutations', () => {
     describe('videoVariantDownloadCreate', () => {
       const VIDEO_VARIANT_DOWNLOAD_CREATE_MUTATION = graphql(`

--- a/apis/api-media/src/schema/videoVariant/videoVariantDownload/videoVariantDownload.spec.ts
+++ b/apis/api-media/src/schema/videoVariant/videoVariantDownload/videoVariantDownload.spec.ts
@@ -50,9 +50,7 @@ describe('videoVariantDownload', () => {
           }
         ])
         const result = await client({ document: VIDEO_VARIANT_DOWNLOADS_QUERY })
-        expect(
-          prismaMock.videoVariantDownload.findMany
-        ).toHaveBeenCalledWith(
+        expect(prismaMock.videoVariantDownload.findMany).toHaveBeenCalledWith(
           expect.objectContaining({
             where: {
               updatedAt: undefined,
@@ -80,16 +78,16 @@ describe('videoVariantDownload', () => {
       it('should filter by videoVariantId', async () => {
         const FILTERED_QUERY = graphql(`
           query VideoVariantDownloadsFiltered {
-            videoVariantDownloads(where: { videoVariantId: "specificVariantId" }) {
+            videoVariantDownloads(
+              where: { videoVariantId: "specificVariantId" }
+            ) {
               id
             }
           }
         `)
         prismaMock.videoVariantDownload.findMany.mockResolvedValue([])
         await client({ document: FILTERED_QUERY })
-        expect(
-          prismaMock.videoVariantDownload.findMany
-        ).toHaveBeenCalledWith(
+        expect(prismaMock.videoVariantDownload.findMany).toHaveBeenCalledWith(
           expect.objectContaining({
             where: expect.objectContaining({
               videoVariantId: 'specificVariantId'

--- a/apis/api-media/src/schema/videoVariant/videoVariantDownload/videoVariantDownload.ts
+++ b/apis/api-media/src/schema/videoVariant/videoVariantDownload/videoVariantDownload.ts
@@ -1,16 +1,19 @@
 import { prisma } from '@core/prisma/media/client'
 
-import { builder } from '../../builder'
+import { builder, toPrismaDateTimeFilter } from '../../builder'
 
 import { VideoVariantDownloadQuality } from './enums/videoVariantDownloadQuality'
 import { VideoVariantDownloadCreateInput } from './inputs/videoVariantDownloadCreate'
 import { VideoVariantDownloadUpdateInput } from './inputs/videoVariantDownloadUpdate'
+import { VideoVariantDownloadsFilter } from './inputs/videoVariantDownloadsFilter'
 
 export const VideoVariantDownload = builder.prismaObject(
   'VideoVariantDownload',
   {
     fields: (t) => ({
       id: t.exposeID('id', { nullable: false }),
+      updatedAt: t.expose('updatedAt', { type: 'DateTime', nullable: false }),
+      videoVariantId: t.exposeID('videoVariantId', { nullable: true }),
       asset: t.withAuth({ isPublisher: true }).relation('asset', {
         nullable: true,
         description: 'master video file'
@@ -35,6 +38,46 @@ export const VideoVariantDownload = builder.prismaObject(
     })
   }
 )
+
+builder.queryFields((t) => ({
+  videoVariantDownloads: t.prismaField({
+    type: ['VideoVariantDownload'],
+    nullable: false,
+    args: {
+      where: t.arg({ type: VideoVariantDownloadsFilter, required: false }),
+      offset: t.arg.int({ required: false }),
+      limit: t.arg.int({ required: false })
+    },
+    resolve: async (query, _parent, { where, offset, limit }) => {
+      return await prisma.videoVariantDownload.findMany({
+        ...query,
+        where: {
+          updatedAt: toPrismaDateTimeFilter(where?.updatedAt),
+          videoVariantId: where?.videoVariantId ?? undefined,
+          quality: where?.quality ?? undefined
+        },
+        skip: offset ?? 0,
+        take: limit ?? 100,
+        orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }]
+      })
+    }
+  }),
+  videoVariantDownloadsCount: t.int({
+    nullable: false,
+    args: {
+      where: t.arg({ type: VideoVariantDownloadsFilter, required: false })
+    },
+    resolve: async (_parent, { where }) => {
+      return await prisma.videoVariantDownload.count({
+        where: {
+          updatedAt: toPrismaDateTimeFilter(where?.updatedAt),
+          videoVariantId: where?.videoVariantId ?? undefined,
+          quality: where?.quality ?? undefined
+        }
+      })
+    }
+  })
+}))
 
 builder.mutationFields((t) => ({
   videoVariantDownloadCreate: t.withAuth({ isPublisher: true }).prismaField({

--- a/apis/api-media/src/schema/videoVariant/videoVariantDownload/videoVariantDownload.ts
+++ b/apis/api-media/src/schema/videoVariant/videoVariantDownload/videoVariantDownload.ts
@@ -4,8 +4,8 @@ import { builder, toPrismaDateTimeFilter } from '../../builder'
 
 import { VideoVariantDownloadQuality } from './enums/videoVariantDownloadQuality'
 import { VideoVariantDownloadCreateInput } from './inputs/videoVariantDownloadCreate'
-import { VideoVariantDownloadUpdateInput } from './inputs/videoVariantDownloadUpdate'
 import { VideoVariantDownloadsFilter } from './inputs/videoVariantDownloadsFilter'
+import { VideoVariantDownloadUpdateInput } from './inputs/videoVariantDownloadUpdate'
 
 export const VideoVariantDownload = builder.prismaObject(
   'VideoVariantDownload',

--- a/apis/api-media/src/yoga.ts
+++ b/apis/api-media/src/yoga.ts
@@ -19,8 +19,6 @@ import { logger } from './logger'
 import { schema } from './schema'
 import { Context } from './schema/builder'
 
-export { cache }
-
 export const yoga = createYoga<
   Record<string, unknown>,
   Context & ReturnType<typeof initContextCache>

--- a/apis/api-media/src/yoga.ts
+++ b/apis/api-media/src/yoga.ts
@@ -5,10 +5,7 @@ import {
   useForwardedJWT,
   useHmacSignatureValidation
 } from '@graphql-hive/gateway'
-import {
-  createInMemoryCache,
-  useResponseCache
-} from '@graphql-yoga/plugin-response-cache'
+import { useResponseCache } from '@graphql-yoga/plugin-response-cache'
 import { initContextCache } from '@pothos/core'
 import { createYoga, useReadinessCheck } from 'graphql-yoga'
 import get from 'lodash/get'
@@ -17,11 +14,12 @@ import { prisma } from '@core/prisma/media/client'
 import { getUserFromPayload } from '@core/yoga/firebaseClient'
 import { getInteropContext } from '@core/yoga/interop'
 
+import { cache } from './cache'
 import { logger } from './logger'
 import { schema } from './schema'
 import { Context } from './schema/builder'
 
-export const cache = createInMemoryCache()
+export { cache }
 
 export const yoga = createYoga<
   Record<string, unknown>,

--- a/docs/brainstorms/2026-05-06-media-sync-endpoints-requirements.md
+++ b/docs/brainstorms/2026-05-06-media-sync-endpoints-requirements.md
@@ -1,0 +1,66 @@
+---
+date: 2026-05-06
+topic: media-sync-endpoints
+---
+
+# Media Sync Endpoints
+
+## Problem Frame
+
+A remote data pipeline needs to incrementally sync media content from `api-media`. The existing `adminVideos` and `videoVariants` queries are sync-ready, but all child resource types lack the flat, paginated, filterable root queries required for efficient incremental pulls. Querying nested resources through parent types (e.g. pulling downloads through variants) is too slow at pipeline scale.
+
+## Requirements
+
+- R1. **VideoEdition sync query** — Upgrade the existing `videoEditions` root query to accept optional offset/limit pagination and `updatedAt: DateTimeFilter` args. When called without any args, behaviour must be identical to today (returns all editions). `updatedAt` is already exposed on the `VideoEdition` GraphQL type.
+
+- R2. **VideoSubtitle sync query** — Expose `updatedAt` on the `VideoSubtitle` GraphQL type (field exists in DB, not currently in GraphQL). Add a new root-level `videoSubtitles` list query with optional offset/limit pagination and `updatedAt: DateTimeFilter` filtering.
+
+- R3. **VideoOrigin sync query** — Expose `updatedAt` on the `VideoOrigin` GraphQL type (field exists in DB, not currently in GraphQL). Upgrade the existing `videoOrigins` root query to accept optional offset/limit pagination and `updatedAt: DateTimeFilter` args. When called without any args, behaviour must be identical to today.
+
+- R4. **VideoVariantDownload sync query** — Add a DB migration to introduce `updatedAt @default(now()) @updatedAt` on the `VideoVariantDownload` Prisma model. Expose `updatedAt` on the `VideoVariantDownload` GraphQL type. Add a new root-level `videoVariantDownloads` list query with optional offset/limit pagination and `updatedAt: DateTimeFilter` filtering.
+
+- R5. **VideoImages sync query** — Add a new root-level `videoImages` query that returns `CloudflareImage` records that are associated with videos (not user-scoped). Expose `updatedAt` on the `CloudflareImage` GraphQL type (field exists in DB, not currently in GraphQL). Support optional offset/limit pagination and `updatedAt: DateTimeFilter` filtering.
+
+- R6. **Consistent pagination shape** — All new and upgraded queries must follow the same offset/limit convention used by `adminVideos` and `videoVariants`. A companion `<type>Count` query (e.g. `videoSubtitlesCount`, `videoVariantDownloadsCount`) must be added alongside each new list query to support total-count-based pagination. Upgraded existing queries (R1, R3) should also gain a companion count query if one does not already exist.
+
+- R7. **All new and upgraded queries are public** — No authentication required. Consistent with the `videos` and `videoVariants` public queries.
+
+## Success Criteria
+
+- The data pipeline can sync each resource type independently without traversing nested parent types.
+- All five resource types support filtering by `updatedAt` with `gte`/`lte` range args.
+- All list queries support offset/limit pagination with a matching count query.
+- Existing callers of `videoEditions` and `videoOrigins` are unaffected — adding no args produces the same result as today.
+
+## Scope Boundaries
+
+- `VideoImageAlt` (alt text translations) is out of scope — fits the existing localized content shape.
+- `MuxVideo` is out of scope — user-upload management, not content library data.
+- Cursor-based pagination is out of scope — offset/limit is sufficient for the batch pipeline use case.
+- The `videoImages` query returns only images associated with videos; user-uploaded images not connected to a video are excluded.
+
+## Key Decisions
+
+- **Backwards-compatible upgrades for existing queries (R1, R3)**: Optional args only — no args means the same behaviour as today.
+- **All new queries are public**: No auth required, consistent with `videos` and `videoVariants`.
+- **`videoImages` is video-association-scoped**: Returns `CloudflareImage` records linked to videos, not filtered by `userId` like `getMyCloudflareImages`.
+- **Add `updatedAt` to VideoVariantDownload via migration**: Incremental sync requires a timestamp — a migration is the right fix.
+- **Flat root queries over nested traversal**: Each resource type gets its own independent paginated query rather than relying on parent-type resolution.
+
+## Dependencies / Assumptions
+
+- R4 requires a Prisma migration for `VideoVariantDownload.updatedAt` before the query can be implemented.
+- R5 assumes the DB join between `CloudflareImage` and `Video` is queryable — the `Video.images` resolver already uses it; planning should confirm the foreign key or join table.
+- All queries follow the `DateTimeFilter` / `toPrismaDateTimeFilter` pattern already established in `adminVideos` and `videoVariants`.
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R4][Technical] Confirm `VideoVariantDownload` migration strategy — column name, default value, and whether existing rows need backfilling or `@default(now())` is acceptable.
+- [Affects R5][Needs research] Confirm the DB join between `CloudflareImage` and `Video` — verify the foreign key or join table used by the `Video.images` resolver so `videoImages` can replicate the same scope.
+- [Affects R6][Technical] Confirm whether companion count queries need any filtering beyond `updatedAt` (e.g. should `videoSubtitlesCount` also accept a `languageId` filter for consistency with how subtitles are currently accessed?).
+
+## Next Steps
+
+→ `/ce:plan` for structured implementation planning

--- a/docs/plans/2026-05-06-001-feat-media-sync-endpoints-plan.md
+++ b/docs/plans/2026-05-06-001-feat-media-sync-endpoints-plan.md
@@ -1,5 +1,5 @@
 ---
-title: "feat: Add paginated updatedAt-filtered sync queries to api-media"
+title: 'feat: Add paginated updatedAt-filtered sync queries to api-media'
 type: feat
 status: active
 date: 2026-05-06
@@ -31,6 +31,7 @@ Apply the `adminVideos` pattern — filter input type → filter function → `p
 ### W1 — VideoEdition: add pagination + `updatedAt` filter
 
 **Files to change:**
+
 - `apis/api-media/src/schema/videoEdition/videoEdition.ts` — add optional `where`, `offset`, `limit` args to `videoEditions`; add `orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }]`; add `videoEditionsCount` companion
 - `apis/api-media/src/schema/videoEdition/inputs/` — create `videoEditionsFilter.ts` + add to `index.ts`
 - `libs/prisma/media/db/schema.prisma` — add `@@index([updatedAt, id])` to `VideoEdition` model
@@ -39,6 +40,7 @@ Apply the `adminVideos` pattern — filter input type → filter function → `p
 **Pattern reference:** `apis/api-media/src/schema/video/video.ts` lines 505–640 (`adminVideos` / `adminVideosCount`)
 
 **Notes:**
+
 - `updatedAt` is already exposed on the `VideoEdition` GraphQL type — no type change needed
 - Zero-arg call (`videoEditions { id }`) must return the same result as today
 
@@ -47,6 +49,7 @@ Apply the `adminVideos` pattern — filter input type → filter function → `p
 ### W2 — VideoSubtitle: new root query + expose `updatedAt` + expose `videoId`
 
 **Files to change:**
+
 - `apis/api-media/src/schema/video/videoSubtitle/videoSubtitle.ts` — expose `updatedAt` on the type; expose `videoId` on the type (non-breaking additive); add `builder.queryFields` with `videoSubtitles` + `videoSubtitlesCount`
 - `apis/api-media/src/schema/video/videoSubtitle/inputs/` — create `videoSubtitlesFilter.ts` + add to `index.ts`
 - `libs/prisma/media/db/schema.prisma` — add `@@index([updatedAt, id])` to `VideoSubtitle` model
@@ -55,6 +58,7 @@ Apply the `adminVideos` pattern — filter input type → filter function → `p
 **Suggested filter fields:** `updatedAt`, `videoId`, `languageId`, `edition`, `primary`
 
 **Notes:**
+
 - `videoId` is in the DB but not currently exposed in GraphQL. Exposing it here is essential — without it the pipeline cannot join subtitles back to their parent video without N+1 fetches.
 
 ---
@@ -62,6 +66,7 @@ Apply the `adminVideos` pattern — filter input type → filter function → `p
 ### W3 — VideoOrigin: add pagination + `updatedAt` filter + make public + expose `updatedAt`
 
 **Files to change:**
+
 - `apis/api-media/src/schema/video/videoOrigin/videoOrigin.ts` — remove `isPublisher` auth guard from `videoOrigins`; expose `updatedAt` on the `VideoOrigin` type; add optional `where`, `offset`, `limit` args; update `orderBy` to `[{ updatedAt: 'asc' }, { id: 'asc' }]` (was `{ name: 'asc' }`); add `videoOriginsCount` companion
 - `apis/api-media/src/schema/video/videoOrigin/inputs/` — create `videoOriginsFilter.ts` + add to `index.ts` (if inputs dir doesn't exist, create it)
 - `libs/prisma/media/db/schema.prisma` — add `@@index([updatedAt, id])` to `VideoOrigin` model
@@ -69,6 +74,7 @@ Apply the `adminVideos` pattern — filter input type → filter function → `p
 - **Test update required:** `apis/api-media/src/schema/video/videoOrigin/videoOrigin.spec.ts` — the `'should reject if not publisher'` test must be converted to assert the query now succeeds without auth
 
 **Notes:**
+
 - The `orderBy` change from `{ name: 'asc' }` to `[{ updatedAt: 'asc' }, { id: 'asc' }]` is a behavioural change for existing callers. VideoOrigin is a small reference table (~static data), so impact is minimal, but the test must be updated.
 - `updatedAt` exists in the DB but is not currently exposed on the GraphQL type.
 
@@ -77,6 +83,7 @@ Apply the `adminVideos` pattern — filter input type → filter function → `p
 ### W4 — VideoVariantDownload: new root query + expose `updatedAt` + expose `videoVariantId`
 
 **Files to change:**
+
 - `apis/api-media/src/schema/videoVariant/videoVariantDownload/videoVariantDownload.ts` — expose `updatedAt` on the type; expose `videoVariantId` on the type (non-breaking additive); add `builder.queryFields` with `videoVariantDownloads` + `videoVariantDownloadsCount`
 - `apis/api-media/src/schema/videoVariant/videoVariantDownload/inputs/` — create `videoVariantDownloadsFilter.ts` + add to `index.ts`
 - `libs/prisma/media/db/schema.prisma` — add `@@index([updatedAt, id])` to `VideoVariantDownload` model
@@ -85,6 +92,7 @@ Apply the `adminVideos` pattern — filter input type → filter function → `p
 **Suggested filter fields:** `updatedAt`, `videoVariantId`, `quality`
 
 **Notes:**
+
 - `updatedAt` **already exists** in the DB (`updatedAt DateTime @default(now()) @updatedAt` at schema line 215) — no column migration needed, only the index and GraphQL exposure.
 - `videoVariantId` must be exposed so the pipeline can join downloads to their parent variant/video.
 
@@ -93,12 +101,14 @@ Apply the `adminVideos` pattern — filter input type → filter function → `p
 ### W5 — VideoImages: new `videoImages` root query + expose `updatedAt` + expose `videoId`
 
 **Files to change:**
+
 - `apis/api-media/src/schema/cloudflare/image/image.ts` — expose `updatedAt` on `CloudflareImage` type; expose `videoId` on type; add `videoImages` + `videoImagesCount` query fields (public, no auth)
 - `apis/api-media/src/schema/cloudflare/image/inputs/` — create `videoImagesFilter.ts` + add to `index.ts`
 - `libs/prisma/media/db/schema.prisma` — add `@@index([updatedAt, id])` to `CloudflareImage` model
 - Migration: shared above
 
 **Prisma `where` clause for `videoImages`:**
+
 ```typescript
 where: {
   videoId: { not: null },
@@ -110,6 +120,7 @@ where: {
 **Suggested filter fields:** `updatedAt`, `videoId`, `aspectRatio`
 
 **Notes:**
+
 - The query must scope to `videoId IS NOT NULL` (video-associated images only, not user uploads).
 - The query must also filter `uploaded: true` — records with `uploaded: false` have no usable image data behind the URL and would corrupt the pipeline's downstream data.
 - `videoId` must be exposed so the pipeline knows which video each image belongs to.
@@ -121,11 +132,13 @@ where: {
 ### W6 — Keywords: add pagination (updatedAt filter already exists)
 
 **Files to change:**
+
 - `apis/api-media/src/schema/keyword/keyword.ts` — add optional `offset` and `limit` args to the existing `keywords` query; add `orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }]`; add `keywordsCount` companion query
 - `libs/prisma/media/db/schema.prisma` — add `@@index([updatedAt, id])` to `Keyword` model if not already present
 - Migration: shared above
 
 **Notes:**
+
 - `updatedAt` filtering and exposure are already in place — this work item is pagination-only.
 - `keywordsCount` is noted as absent in SpecFlow analysis despite the `keywords` query having a filter.
 
@@ -143,6 +156,7 @@ A single migration should add indexes to all six models:
 Models requiring the index: `VideoEdition`, `VideoSubtitle`, `VideoOrigin`, `VideoVariantDownload`, `CloudflareImage`, `Keyword`.
 
 Run after schema edit:
+
 ```bash
 nx prisma-migrate prisma-media
 ```
@@ -189,6 +203,7 @@ All new and upgraded list queries must follow this shape:
 ```
 
 **Key conventions (from institutional learnings):**
+
 - **Never name the first `prismaField` arg `_query`** — this silently breaks nested field resolution. Always name it `query` and always spread it: `{ ...query, where, skip, take, orderBy }`.
 - **Never pass Pothos `$inferInput` directly to Prisma** — use `toPrismaDateTimeFilter()` to strip `null → undefined` for date fields.
 - **Default limit is 100** — consistent with `adminVideos`. `videoVariants` uses no default cap, but for a sync pipeline 100 is safer.
@@ -200,6 +215,7 @@ All new and upgraded list queries must follow this shape:
 ## Schema Regeneration
 
 After all code changes, run:
+
 ```bash
 nx generate-graphql api-media
 nx generate-graphql api-gateway

--- a/docs/plans/2026-05-06-001-feat-media-sync-endpoints-plan.md
+++ b/docs/plans/2026-05-06-001-feat-media-sync-endpoints-plan.md
@@ -1,0 +1,263 @@
+---
+title: "feat: Add paginated updatedAt-filtered sync queries to api-media"
+type: feat
+status: active
+date: 2026-05-06
+origin: docs/brainstorms/2026-05-06-media-sync-endpoints-requirements.md
+---
+
+# feat: Add Paginated Sync Queries to api-media
+
+## Overview
+
+Add flat, paginated, `updatedAt`-filterable root-level GraphQL queries for six resource types in `api-media` so a remote data pipeline can incrementally sync each type independently. Two existing queries (`videoEditions`, `videoOrigins`, `keywords`) are upgraded with new optional args; four new root queries are added (`videoSubtitles`, `videoVariantDownloads`, `videoImages`, plus companion count queries for all). All queries are public.
+
+> See origin: `docs/brainstorms/2026-05-06-media-sync-endpoints-requirements.md`
+
+## Problem Statement
+
+A remote data pipeline needs to incrementally pull media content changes. Querying nested resources through parent types (e.g. downloads through variants) is too slow at scale. The existing `adminVideos` and `videoVariants` queries are already sync-ready; all child resource types lack the flat, independent, filterable root queries required for efficient incremental pulls.
+
+## Proposed Solution
+
+Apply the `adminVideos` pattern — filter input type → filter function → `prismaField` list query + `int` count query — to each of the six resource types. All args are optional so existing zero-arg calls are unaffected. All queries are public (no auth guard).
+
+**Note on countries:** `Country` does not exist as a queryable entity in `api-media` (only stored as string IDs in `UserMediaProfile`). Likely managed by a separate service. Confirm with the team before scheduling any follow-up work.
+
+---
+
+## Work Items
+
+### W1 — VideoEdition: add pagination + `updatedAt` filter
+
+**Files to change:**
+- `apis/api-media/src/schema/videoEdition/videoEdition.ts` — add optional `where`, `offset`, `limit` args to `videoEditions`; add `orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }]`; add `videoEditionsCount` companion
+- `apis/api-media/src/schema/videoEdition/inputs/` — create `videoEditionsFilter.ts` + add to `index.ts`
+- `libs/prisma/media/db/schema.prisma` — add `@@index([updatedAt, id])` to `VideoEdition` model
+- Migration: `nx prisma-migrate prisma-media`
+
+**Pattern reference:** `apis/api-media/src/schema/video/video.ts` lines 505–640 (`adminVideos` / `adminVideosCount`)
+
+**Notes:**
+- `updatedAt` is already exposed on the `VideoEdition` GraphQL type — no type change needed
+- Zero-arg call (`videoEditions { id }`) must return the same result as today
+
+---
+
+### W2 — VideoSubtitle: new root query + expose `updatedAt` + expose `videoId`
+
+**Files to change:**
+- `apis/api-media/src/schema/video/videoSubtitle/videoSubtitle.ts` — expose `updatedAt` on the type; expose `videoId` on the type (non-breaking additive); add `builder.queryFields` with `videoSubtitles` + `videoSubtitlesCount`
+- `apis/api-media/src/schema/video/videoSubtitle/inputs/` — create `videoSubtitlesFilter.ts` + add to `index.ts`
+- `libs/prisma/media/db/schema.prisma` — add `@@index([updatedAt, id])` to `VideoSubtitle` model
+- Migration: shared with W1 above
+
+**Suggested filter fields:** `updatedAt`, `videoId`, `languageId`, `edition`, `primary`
+
+**Notes:**
+- `videoId` is in the DB but not currently exposed in GraphQL. Exposing it here is essential — without it the pipeline cannot join subtitles back to their parent video without N+1 fetches.
+
+---
+
+### W3 — VideoOrigin: add pagination + `updatedAt` filter + make public + expose `updatedAt`
+
+**Files to change:**
+- `apis/api-media/src/schema/video/videoOrigin/videoOrigin.ts` — remove `isPublisher` auth guard from `videoOrigins`; expose `updatedAt` on the `VideoOrigin` type; add optional `where`, `offset`, `limit` args; update `orderBy` to `[{ updatedAt: 'asc' }, { id: 'asc' }]` (was `{ name: 'asc' }`); add `videoOriginsCount` companion
+- `apis/api-media/src/schema/video/videoOrigin/inputs/` — create `videoOriginsFilter.ts` + add to `index.ts` (if inputs dir doesn't exist, create it)
+- `libs/prisma/media/db/schema.prisma` — add `@@index([updatedAt, id])` to `VideoOrigin` model
+- Migration: shared above
+- **Test update required:** `apis/api-media/src/schema/video/videoOrigin/videoOrigin.spec.ts` — the `'should reject if not publisher'` test must be converted to assert the query now succeeds without auth
+
+**Notes:**
+- The `orderBy` change from `{ name: 'asc' }` to `[{ updatedAt: 'asc' }, { id: 'asc' }]` is a behavioural change for existing callers. VideoOrigin is a small reference table (~static data), so impact is minimal, but the test must be updated.
+- `updatedAt` exists in the DB but is not currently exposed on the GraphQL type.
+
+---
+
+### W4 — VideoVariantDownload: new root query + expose `updatedAt` + expose `videoVariantId`
+
+**Files to change:**
+- `apis/api-media/src/schema/videoVariant/videoVariantDownload/videoVariantDownload.ts` — expose `updatedAt` on the type; expose `videoVariantId` on the type (non-breaking additive); add `builder.queryFields` with `videoVariantDownloads` + `videoVariantDownloadsCount`
+- `apis/api-media/src/schema/videoVariant/videoVariantDownload/inputs/` — create `videoVariantDownloadsFilter.ts` + add to `index.ts`
+- `libs/prisma/media/db/schema.prisma` — add `@@index([updatedAt, id])` to `VideoVariantDownload` model
+- Migration: shared above
+
+**Suggested filter fields:** `updatedAt`, `videoVariantId`, `quality`
+
+**Notes:**
+- `updatedAt` **already exists** in the DB (`updatedAt DateTime @default(now()) @updatedAt` at schema line 215) — no column migration needed, only the index and GraphQL exposure.
+- `videoVariantId` must be exposed so the pipeline can join downloads to their parent variant/video.
+
+---
+
+### W5 — VideoImages: new `videoImages` root query + expose `updatedAt` + expose `videoId`
+
+**Files to change:**
+- `apis/api-media/src/schema/cloudflare/image/image.ts` — expose `updatedAt` on `CloudflareImage` type; expose `videoId` on type; add `videoImages` + `videoImagesCount` query fields (public, no auth)
+- `apis/api-media/src/schema/cloudflare/image/inputs/` — create `videoImagesFilter.ts` + add to `index.ts`
+- `libs/prisma/media/db/schema.prisma` — add `@@index([updatedAt, id])` to `CloudflareImage` model
+- Migration: shared above
+
+**Prisma `where` clause for `videoImages`:**
+```typescript
+where: {
+  videoId: { not: null },
+  uploaded: true,          // exclude incomplete uploads
+  ...filter
+}
+```
+
+**Suggested filter fields:** `updatedAt`, `videoId`, `aspectRatio`
+
+**Notes:**
+- The query must scope to `videoId IS NOT NULL` (video-associated images only, not user uploads).
+- The query must also filter `uploaded: true` — records with `uploaded: false` have no usable image data behind the URL and would corrupt the pipeline's downstream data.
+- `videoId` must be exposed so the pipeline knows which video each image belongs to.
+- `updatedAt` is in the DB but not currently exposed on the `CloudflareImage` GraphQL type.
+- The DB join is `CloudflareImage.videoId → Video.id`.
+
+---
+
+### W6 — Keywords: add pagination (updatedAt filter already exists)
+
+**Files to change:**
+- `apis/api-media/src/schema/keyword/keyword.ts` — add optional `offset` and `limit` args to the existing `keywords` query; add `orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }]`; add `keywordsCount` companion query
+- `libs/prisma/media/db/schema.prisma` — add `@@index([updatedAt, id])` to `Keyword` model if not already present
+- Migration: shared above
+
+**Notes:**
+- `updatedAt` filtering and exposure are already in place — this work item is pagination-only.
+- `keywordsCount` is noted as absent in SpecFlow analysis despite the `keywords` query having a filter.
+
+---
+
+## Shared Prisma Migration
+
+A single migration should add indexes to all six models:
+
+```prisma
+// Add to each model:
+@@index([updatedAt, id])
+```
+
+Models requiring the index: `VideoEdition`, `VideoSubtitle`, `VideoOrigin`, `VideoVariantDownload`, `CloudflareImage`, `Keyword`.
+
+Run after schema edit:
+```bash
+nx prisma-migrate prisma-media
+```
+
+> Without these indexes, `updatedAt`-filtered list queries are full table scans in production.
+
+---
+
+## Consistent Query Shape
+
+All new and upgraded list queries must follow this shape:
+
+```typescript
+// List query
+<queryName>: t.prismaField({
+  type: ['<Model>'],
+  nullable: false,
+  args: {
+    where: t.arg({ type: <Filter>, required: false }),
+    offset: t.arg.int({ required: false }),
+    limit:  t.arg.int({ required: false })
+  },
+  resolve: async (query, _parent, { offset, limit, where }) => {
+    const filter = <filterFn>(where ?? {})
+    return await prisma.<model>.findMany({
+      ...query,          // spread query — never name this _query
+      where: filter,
+      skip: offset ?? 0,
+      take: limit ?? 100,
+      orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }]
+    })
+  }
+}),
+
+// Count companion
+<queryName>Count: t.int({
+  args: { where: t.arg({ type: <Filter>, required: false }) },
+  nullable: false,
+  resolve: async (_parent, { where }) => {
+    const filter = <filterFn>(where ?? {})
+    return await prisma.<model>.count({ where: filter })
+  }
+})
+```
+
+**Key conventions (from institutional learnings):**
+- **Never name the first `prismaField` arg `_query`** — this silently breaks nested field resolution. Always name it `query` and always spread it: `{ ...query, where, skip, take, orderBy }`.
+- **Never pass Pothos `$inferInput` directly to Prisma** — use `toPrismaDateTimeFilter()` to strip `null → undefined` for date fields.
+- **Default limit is 100** — consistent with `adminVideos`. `videoVariants` uses no default cap, but for a sync pipeline 100 is safer.
+- **Arg name is `where`** — consistent with `adminVideos` / `videos`. (`videoVariants` uses `input` — this is an existing inconsistency; new queries use `where`.)
+- **`orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }]`** — required for stable offset pagination. Without deterministic ordering, concurrent writes cause missed or duplicated records.
+
+---
+
+## Schema Regeneration
+
+After all code changes, run:
+```bash
+nx generate-graphql api-media
+nx generate-graphql api-gateway
+nx run-many -t codegen
+```
+
+> Do NOT edit `apis/api-media/schema.graphql` directly — it is auto-generated.
+
+---
+
+## Technical Considerations
+
+- **`DateTimeFilter` is already registered** in `apis/api-media/src/schema/builder.ts` lines 131–145. Import `{ DateTimeFilter, toPrismaDateTimeFilter }` from `../../builder` (adjust relative path).
+- **`DateTime` scalar** is already registered in api-media's builder — no scalar registration work needed.
+- **`videoOrigins` existing test** (`videoOrigin.spec.ts` — `'should reject if not publisher'`) will fail after W3. Convert it to assert the query succeeds without auth.
+- **`videoImages` uploaded filter** — always apply `uploaded: true` in the base `where` clause, not in the filter input. This is an invariant of the `videoImages` query, not a user-configurable filter.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `videoEditions` — accepts optional `where: VideoEditionsFilter`, `offset`, `limit`; zero-arg call returns same result as today
+- [ ] `videoEditionsCount` — new companion query accepting same `where`
+- [ ] `videoSubtitles` — new root query with `where: VideoSubtitlesFilter`, `offset`, `limit`; `updatedAt` and `videoId` exposed on `VideoSubtitle` type
+- [ ] `videoSubtitlesCount` — new companion query
+- [ ] `videoOrigins` — accepts optional `where: VideoOriginsFilter`, `offset`, `limit`; `updatedAt` exposed on `VideoOrigin` type; no auth required; zero-arg call returns same result as today (minus alphabetical ordering change)
+- [ ] `videoOriginsCount` — new companion query
+- [ ] `videoVariantDownloads` — new root query with `where: VideoVariantDownloadsFilter`, `offset`, `limit`; `updatedAt` and `videoVariantId` exposed on `VideoVariantDownload` type
+- [ ] `videoVariantDownloadsCount` — new companion query
+- [ ] `videoImages` — new root query with `where: VideoImagesFilter`, `offset`, `limit`; scoped to `videoId IS NOT NULL` and `uploaded: true`; `updatedAt` and `videoId` exposed on `CloudflareImage` type
+- [ ] `videoImagesCount` — new companion query
+- [ ] `keywords` — accepts optional `offset`, `limit`; `keywordsCount` companion added
+- [ ] All list queries ordered by `[updatedAt ASC, id ASC]`
+- [ ] Prisma migration adds `@@index([updatedAt, id])` to all six models
+- [ ] `videoOrigin.spec.ts` auth rejection test converted to public access assertion
+- [ ] All six queries callable without auth
+- [ ] `nx generate-graphql` runs cleanly post-change
+- [ ] Existing tests pass
+
+## Dependencies & Risks
+
+- **Prisma migration** must run before deploying — `@@index` additions are backwards-compatible and safe to apply to live tables.
+- **`videoOrigins` ordering change** (`name ASC` → `updatedAt ASC, id ASC`) — existing callers that rely on alphabetical order will see different ordering. VideoOrigin is a small reference table so impact is low, but worth noting in the PR.
+- **Countries** are not a queryable entity in `api-media` — if country sync is needed, that work belongs to a different service.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-06-media-sync-endpoints-requirements.md](../brainstorms/2026-05-06-media-sync-endpoints-requirements.md)
+  - Key decisions carried forward: all queries public; backwards-compatible optional args; `videoVariantDownload.updatedAt` already in DB (no column migration); `videoImages` scoped to video-associated + uploaded images only
+- Canonical paginated query pattern: `apis/api-media/src/schema/video/video.ts` lines 505–640
+- `DateTimeFilter` + `toPrismaDateTimeFilter`: `apis/api-media/src/schema/builder.ts` lines 131–145
+- `videoEditions` current query: `apis/api-media/src/schema/videoEdition/videoEdition.ts` lines 18–39
+- `VideoSubtitle` type + mutations: `apis/api-media/src/schema/video/videoSubtitle/videoSubtitle.ts`
+- `videoOrigins` current query: `apis/api-media/src/schema/video/videoOrigin/videoOrigin.ts` lines 13–24
+- `VideoVariantDownload` type: `apis/api-media/src/schema/videoVariant/videoVariantDownload/videoVariantDownload.ts`
+- `getMyCloudflareImages` + `CloudflareImage` type: `apis/api-media/src/schema/cloudflare/image/image.ts`
+- `keywords` current query: `apis/api-media/src/schema/keyword/keyword.ts`
+- Prisma models: `libs/prisma/media/db/schema.prisma` (VideoVariantDownload lines 201–219, VideoSubtitle lines 270–289, VideoEdition line 265, VideoOrigin lines 584–591, CloudflareImage lines 25–40, Keyword lines 421–432)
+- Learning — Pothos `_query` bug: `docs/solutions/logic-errors/pothos-query-parameter-ignored-nested-resolution-failure.md`
+- Learning — DateTimeFilter null mismatch: `docs/solutions/integration-issues/pothos-prisma-datetimefilter-null-type-mismatch.md`
+- Learning — Federation scalar + migration audit: `docs/solutions/integration-issues/federation-subgraph-scalar-registration-hidden-prerequisites.md`

--- a/libs/prisma/media/db/schema.prisma
+++ b/libs/prisma/media/db/schema.prisma
@@ -37,6 +37,7 @@ model CloudflareImage {
 
   @@index([userId])
   @@index([blurhashAttemptedAt])
+  @@index([updatedAt, id])
 }
 
 model MuxVideo {
@@ -216,6 +217,7 @@ model VideoVariantDownload {
 
   @@unique([quality, videoVariantId])
   @@index(videoVariantId(type: Hash))
+  @@index([updatedAt, id])
 }
 
 model VideoVariant {
@@ -265,6 +267,7 @@ model VideoEdition {
   updatedAt      DateTime        @default(now()) @updatedAt
 
   @@unique([name, videoId])
+  @@index([updatedAt, id])
 }
 
 model VideoSubtitle {
@@ -291,6 +294,7 @@ model VideoSubtitle {
   @@index(edition(type: Hash))
   @@index(primary(type: Hash))
   @@index(videoId(type: Hash))
+  @@index([updatedAt, id])
 }
 
 model VideoSnippet {
@@ -428,7 +432,7 @@ model Keyword {
 
   @@unique([value, languageId])
   @@index([value(type: Hash)])
-  @@index([updatedAt])
+  @@index([updatedAt, id])
 }
 
 enum Service {
@@ -588,6 +592,8 @@ model VideoOrigin {
   videos      Video[]
   createdAt   DateTime @default(now())
   updatedAt   DateTime @default(now()) @updatedAt
+
+  @@index([updatedAt, id])
 }
 
 enum DefaultPlatform {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig.base.json"
+}


### PR DESCRIPTION
## Summary

- Add 6 new/upgraded public GraphQL queries to `api-media` for a remote data syncing pipeline
- All queries support `offset`/`limit` pagination, `updatedAt` range filtering, and stable ordering (`updatedAt asc, id asc`)
- Companion `*Count` queries provided for all list queries

### Queries added/upgraded

| Query | Change |
|---|---|
| `videoEditions` | Added `where` (updatedAt filter), `offset`, `limit`, `orderBy`; new `videoEditionsCount` |
| `videoSubtitles` | New root query + `videoSubtitlesCount`; exposed `updatedAt`, `videoId` on type |
| `videoOrigins` | Removed `isPublisher` auth (now public); added filter/pagination/`orderBy`; new `videoOriginsCount`; exposed `updatedAt` |
| `videoVariantDownloads` | New root query + `videoVariantDownloadsCount`; exposed `updatedAt`, `videoVariantId` on type |
| `videoImages` | New root query returning `CloudflareImage` scoped to `videoId NOT NULL, uploaded: true`; exposed `updatedAt`, `videoId` on type |
| `keywords` | Added `offset`/`limit` pagination + `keywordsCount` companion |

### Prisma schema

Added `@@index([updatedAt, id])` to all 6 models (`VideoEdition`, `VideoSubtitle`, `VideoOrigin`, `VideoVariantDownload`, `CloudflareImage`, `Keyword`) for sync query performance. Migration must be run when DB is available.

## Testing

- All existing tests updated and passing
- Added `videoEditionsCount` and `videoOriginsCount` test coverage in existing spec files
- `generate-graphql api-media` has a pre-existing environment issue (circular dep in tsx/tsconfig-paths) unrelated to this PR — confirmed failing on unmodified `main`

## Post-Deploy Monitoring & Validation

- **What to monitor**: New queries appearing in GraphQL request logs for `api-media`
- **Validation**: After deploy, run a test query:
  ```graphql
  query { videoEditions(limit: 5) { id updatedAt } videoEditionsCount }
  ```
- **Expected**: Returns up to 5 editions ordered by `updatedAt asc`
- **Migration**: `nx prisma-migrate prisma-media` — adds 6 DB indexes; safe (additive, no data changes)
- **Rollback trigger**: Any 500 errors on new queries → revert deploy; indexes can stay

---

[![Compound Engineering v2.45.0](https://img.shields.io/badge/Compound_Engineering-v2.45.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Sonnet 4.6 via [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added paginated root queries for video subtitles, variant downloads, and images with optional filtering by update date
  * Extended existing media queries (editions, origins, keywords) with offset/limit pagination and filtering support
  * Added count queries for all media types to support efficient pagination

* **Improvements**
  * Optimized database performance with compound indexes on media resource tables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->