### PR TITLE
feat(journeys-ui): apologist chat drawer UI update [NES-1641]

### DIFF
--- a/libs/journeys/ui/src/components/AiChat/AiChat.tsx
+++ b/libs/journeys/ui/src/components/AiChat/AiChat.tsx
@@ -302,9 +302,9 @@ export function AiChat({
   const isLoading = status === 'submitted' || status === 'streaming'
 
   const handleRetry = useCallback(() => {
-    setCollapsed(false)
+    if (collapsed) setCollapsed(false)
     void regenerate()
-  }, [regenerate, setCollapsed])
+  }, [collapsed, regenerate, setCollapsed])
 
   useEffect(() => {
     if (
@@ -313,20 +313,23 @@ export function AiChat({
       !initialMessageSent.current
     ) {
       initialMessageSent.current = true
-      setCollapsed(false)
+      if (collapsed) setCollapsed(false)
       void sendMessage({ text: initialMessage })
     }
-  }, [initialMessage, sendMessage, setCollapsed])
+  }, [initialMessage, sendMessage, setCollapsed, collapsed])
 
   const handleSubmit = useCallback(
     (e: FormEvent) => {
       e.preventDefault()
       if (input.trim().length === 0 || isLoading) return
-      setCollapsed(false)
+      // Only force-expand if currently collapsed — otherwise we'd snap a
+      // user-dragged full-height sheet down to the default large stop on
+      // every send.
+      if (collapsed) setCollapsed(false)
       void sendMessage({ text: input })
       setInput('')
     },
-    [input, isLoading, sendMessage, setCollapsed]
+    [collapsed, input, isLoading, sendMessage, setCollapsed]
   )
 
   const lastAssistantIndex = useMemo(() => {

--- a/libs/journeys/ui/src/components/AiChat/AiChat.tsx
+++ b/libs/journeys/ui/src/components/AiChat/AiChat.tsx
@@ -34,7 +34,7 @@ import {
   OVERLAY_FG_RETRY,
   SHEET_BOTTOM_FADE
 } from './chatStyles'
-import { DragHandle } from './DragHandle'
+import { DragHandle, useDragSheet } from './DragHandle'
 
 interface AiChatProps {
   /** When provided, this message is sent automatically on first render */
@@ -69,6 +69,23 @@ interface AiChatProps {
    * typed text.
    */
   onClose?: () => void
+  /**
+   * Controlled `collapsed` state. When provided alongside
+   * `onCollapsedChange`, the parent owns collapse/expand and AiChat just
+   * reflects it (chevron, aria, input slide-out). Leave undefined for the
+   * default uncontrolled behaviour.
+   */
+  collapsed?: boolean
+  onCollapsedChange?: (next: boolean) => void
+  /**
+   * When provided, the parent owns the sheet's resize/snap logic — the
+   * drag handle and chat header forward live drag events so the parent
+   * can update its own height. Tap-to-toggle on the handle still flips
+   * `collapsed` via `onCollapse`/`onExpand` for keyboard parity.
+   */
+  onDragStart?: () => void
+  onDrag?: (deltaY: number) => void
+  onDragEnd?: (deltaY: number) => void
 }
 
 export type AiChatSheetState = 'idle' | 'active' | 'collapsed'
@@ -195,23 +212,42 @@ export function AiChat({
   collapsible = true,
   variant = 'panel',
   onSheetStateChange,
-  onClose
+  onClose,
+  collapsed: collapsedProp,
+  onCollapsedChange,
+  onDragStart,
+  onDrag,
+  onDragEnd
 }: AiChatProps): ReactElement {
   const isOverlay = variant === 'overlay'
   const isPanel = !isOverlay
   const { t } = useTranslation('libs-journeys-ui')
   const { journey } = useJourney()
   const [input, setInput] = useState('')
-  const [collapsed, setCollapsed] = useState(false)
+  const [internalCollapsed, setInternalCollapsed] = useState(false)
+  const isControlled = collapsedProp !== undefined
+  const collapsed = isControlled ? collapsedProp : internalCollapsed
   const initialMessageSent = useRef(false)
+
+  const setCollapsed = useCallback(
+    (next: boolean) => {
+      if (isControlled) {
+        onCollapsedChange?.(next)
+      } else {
+        setInternalCollapsed(next)
+        onCollapsedChange?.(next)
+      }
+    },
+    [isControlled, onCollapsedChange]
+  )
 
   const handleCollapse = useCallback(() => {
     setCollapsed(true)
-  }, [])
+  }, [setCollapsed])
 
   const handleExpand = useCallback(() => {
     setCollapsed(false)
-  }, [])
+  }, [setCollapsed])
 
   const languageBcp47 = journey?.language?.bcp47 ?? undefined
   const languageRef = useRef(languageBcp47)
@@ -268,7 +304,7 @@ export function AiChat({
   const handleRetry = useCallback(() => {
     setCollapsed(false)
     void regenerate()
-  }, [regenerate])
+  }, [regenerate, setCollapsed])
 
   useEffect(() => {
     if (
@@ -280,7 +316,7 @@ export function AiChat({
       setCollapsed(false)
       void sendMessage({ text: initialMessage })
     }
-  }, [initialMessage, sendMessage])
+  }, [initialMessage, sendMessage, setCollapsed])
 
   const handleSubmit = useCallback(
     (e: FormEvent) => {
@@ -290,7 +326,7 @@ export function AiChat({
       void sendMessage({ text: input })
       setInput('')
     },
-    [input, isLoading, sendMessage]
+    [input, isLoading, sendMessage, setCollapsed]
   )
 
   const lastAssistantIndex = useMemo(() => {
@@ -315,6 +351,13 @@ export function AiChat({
   const showDragHandle = isPanel && collapsible
   const showHeader = isPanel
   const showOverlayClose = isOverlay && onClose != null
+  const dragControlled =
+    onDragStart != null || onDrag != null || onDragEnd != null
+  const { dragging: headerDragging, bind: headerDragBind } = useDragSheet({
+    onDragStart,
+    onDrag,
+    onDragEnd
+  })
   // We keep header/conversation/input mounted in every state and rely on
   // the parent sheet's height transition + overflow:hidden to clip them
   // as the sheet collapses. Hiding via display:none would short-circuit
@@ -338,9 +381,26 @@ export function AiChat({
               collapsed={collapsed}
               onCollapse={handleCollapse}
               onExpand={handleExpand}
+              onDragStart={onDragStart}
+              onDrag={onDrag}
+              onDragEnd={onDragEnd}
             />
           )}
-          {showHeader && <ChatHeader thinking={isLoading} />}
+          {showHeader &&
+            (dragControlled ? (
+              <Box
+                {...headerDragBind}
+                sx={{
+                  cursor: headerDragging ? 'grabbing' : 'grab',
+                  touchAction: 'none',
+                  userSelect: 'none'
+                }}
+              >
+                <ChatHeader thinking={isLoading} />
+              </Box>
+            ) : (
+              <ChatHeader thinking={isLoading} />
+            ))}
         </Box>
       )}
 
@@ -361,6 +421,10 @@ export function AiChat({
           // safe-area headroom + 16px breathing room — keeps the last
           // message clear of the absolute-positioned PromptInput below.
           bottomClearance={72}
+          // While the sheet is collapsed (or animating toward it) the
+          // shrinking scroll area transiently reads as "scrolled away
+          // from the bottom" and the pill flashes in. Hide it.
+          suppressScrollPill={collapsed}
         >
           {messages.map((message, index) => {
             const text = getTextFromMessage(message)

--- a/libs/journeys/ui/src/components/AiChat/DragHandle/DragHandle.spec.tsx
+++ b/libs/journeys/ui/src/components/AiChat/DragHandle/DragHandle.spec.tsx
@@ -6,11 +6,16 @@ jest.mock('next-i18next/pages', () => ({
   useTranslation: () => ({ t: (key: string) => key })
 }))
 
-function renderHandle(props: {
+interface RenderHandleArgs {
   collapsed?: boolean
   onCollapse?: jest.Mock
   onExpand?: jest.Mock
-}) {
+  onDragStart?: jest.Mock
+  onDrag?: jest.Mock
+  onDragEnd?: jest.Mock
+}
+
+function renderHandle(props: RenderHandleArgs = {}) {
   const onCollapse = props.onCollapse ?? jest.fn()
   const onExpand = props.onExpand ?? jest.fn()
   const utils = render(
@@ -18,6 +23,9 @@ function renderHandle(props: {
       collapsed={props.collapsed ?? false}
       onCollapse={onCollapse}
       onExpand={onExpand}
+      onDragStart={props.onDragStart}
+      onDrag={props.onDrag}
+      onDragEnd={props.onDragEnd}
     />
   )
   return { ...utils, onCollapse, onExpand }
@@ -43,67 +51,162 @@ describe('DragHandle', () => {
     )
   })
 
-  it('calls onCollapse when dragged down past the threshold', () => {
-    const { getByTestId, onCollapse, onExpand } = renderHandle({})
-    const handle = getByTestId('ChatDragHandle')
-    fireEvent.mouseDown(handle, { clientY: 100 })
-    fireEvent.mouseMove(window, { clientY: 200 })
-    fireEvent.mouseUp(window)
-    expect(onCollapse).toHaveBeenCalledTimes(1)
-    expect(onExpand).not.toHaveBeenCalled()
-  })
-
-  it('calls onExpand when dragged up past the threshold', () => {
-    const { getByTestId, onCollapse, onExpand } = renderHandle({
-      collapsed: true
+  describe('uncontrolled (no parent drag handlers)', () => {
+    it('calls onCollapse when dragged down past the threshold', () => {
+      const { getByTestId, onCollapse, onExpand } = renderHandle({})
+      const handle = getByTestId('ChatDragHandle')
+      fireEvent.mouseDown(handle, { clientY: 100 })
+      fireEvent.mouseMove(window, { clientY: 200 })
+      fireEvent.mouseUp(window)
+      expect(onCollapse).toHaveBeenCalledTimes(1)
+      expect(onExpand).not.toHaveBeenCalled()
     })
-    const handle = getByTestId('ChatDragHandle')
-    fireEvent.mouseDown(handle, { clientY: 200 })
-    fireEvent.mouseMove(window, { clientY: 100 })
-    fireEvent.mouseUp(window)
-    expect(onExpand).toHaveBeenCalledTimes(1)
-    expect(onCollapse).not.toHaveBeenCalled()
-  })
 
-  it('does not treat sub-threshold movement as a drag', () => {
-    const { getByTestId, onCollapse, onExpand } = renderHandle({})
-    const handle = getByTestId('ChatDragHandle')
-    fireEvent.mouseDown(handle, { clientY: 100 })
-    fireEvent.mouseMove(window, { clientY: 110 })
-    fireEvent.mouseUp(window)
-    expect(onCollapse).not.toHaveBeenCalled()
-    expect(onExpand).not.toHaveBeenCalled()
-  })
-
-  it('collapses when tapped while expanded', () => {
-    const { getByTestId, onCollapse, onExpand } = renderHandle({})
-    fireEvent.click(getByTestId('ChatDragHandle'))
-    expect(onCollapse).toHaveBeenCalledTimes(1)
-    expect(onExpand).not.toHaveBeenCalled()
-  })
-
-  it('expands when tapped while collapsed', () => {
-    const { getByTestId, onCollapse, onExpand } = renderHandle({
-      collapsed: true
+    it('calls onExpand when dragged up past the threshold', () => {
+      const { getByTestId, onCollapse, onExpand } = renderHandle({
+        collapsed: true
+      })
+      const handle = getByTestId('ChatDragHandle')
+      fireEvent.mouseDown(handle, { clientY: 200 })
+      fireEvent.mouseMove(window, { clientY: 100 })
+      fireEvent.mouseUp(window)
+      expect(onExpand).toHaveBeenCalledTimes(1)
+      expect(onCollapse).not.toHaveBeenCalled()
     })
-    fireEvent.click(getByTestId('ChatDragHandle'))
-    expect(onExpand).toHaveBeenCalledTimes(1)
-    expect(onCollapse).not.toHaveBeenCalled()
-  })
 
-  it('toggles via Enter key', () => {
-    const { getByTestId, onCollapse, onExpand } = renderHandle({})
-    fireEvent.keyDown(getByTestId('ChatDragHandle'), { key: 'Enter' })
-    expect(onCollapse).toHaveBeenCalledTimes(1)
-    expect(onExpand).not.toHaveBeenCalled()
-  })
-
-  it('toggles via Space key when collapsed', () => {
-    const { getByTestId, onCollapse, onExpand } = renderHandle({
-      collapsed: true
+    it('does not treat sub-threshold movement as a drag', () => {
+      const { getByTestId, onCollapse, onExpand } = renderHandle({})
+      const handle = getByTestId('ChatDragHandle')
+      fireEvent.mouseDown(handle, { clientY: 100 })
+      fireEvent.mouseMove(window, { clientY: 110 })
+      fireEvent.mouseUp(window)
+      expect(onCollapse).not.toHaveBeenCalled()
+      expect(onExpand).not.toHaveBeenCalled()
     })
-    fireEvent.keyDown(getByTestId('ChatDragHandle'), { key: ' ' })
-    expect(onExpand).toHaveBeenCalledTimes(1)
-    expect(onCollapse).not.toHaveBeenCalled()
+
+    it('toggles via tap when no movement occurs', () => {
+      const { getByTestId, onCollapse, onExpand } = renderHandle({})
+      const handle = getByTestId('ChatDragHandle')
+      fireEvent.mouseDown(handle, { clientY: 100 })
+      fireEvent.mouseUp(window)
+      expect(onCollapse).toHaveBeenCalledTimes(1)
+      expect(onExpand).not.toHaveBeenCalled()
+    })
+
+    it('toggles via tap from the collapsed state', () => {
+      const { getByTestId, onCollapse, onExpand } = renderHandle({
+        collapsed: true
+      })
+      const handle = getByTestId('ChatDragHandle')
+      fireEvent.mouseDown(handle, { clientY: 200 })
+      fireEvent.mouseUp(window)
+      expect(onExpand).toHaveBeenCalledTimes(1)
+      expect(onCollapse).not.toHaveBeenCalled()
+    })
+
+    it('does not treat a drag-then-return gesture as a tap', () => {
+      // Regression: movedRef tracked the final delta, so dragging far
+      // and returning to ~0 left moved < tap threshold and a synthetic
+      // tap toggled the sheet. Now max abs displacement is tracked.
+      const { getByTestId, onCollapse, onExpand } = renderHandle({})
+      const handle = getByTestId('ChatDragHandle')
+      fireEvent.mouseDown(handle, { clientY: 100 })
+      fireEvent.mouseMove(window, { clientY: 200 })
+      fireEvent.mouseMove(window, { clientY: 100 })
+      fireEvent.mouseUp(window)
+      // Final delta is 0 (back to start) and max abs displacement is
+      // 100px — the gesture must NOT fire a tap-toggle.
+      expect(onCollapse).not.toHaveBeenCalled()
+      expect(onExpand).not.toHaveBeenCalled()
+    })
+
+    it('toggles via Enter key', () => {
+      const { getByTestId, onCollapse, onExpand } = renderHandle({})
+      fireEvent.keyDown(getByTestId('ChatDragHandle'), { key: 'Enter' })
+      expect(onCollapse).toHaveBeenCalledTimes(1)
+      expect(onExpand).not.toHaveBeenCalled()
+    })
+
+    it('toggles via Space key when collapsed', () => {
+      const { getByTestId, onCollapse, onExpand } = renderHandle({
+        collapsed: true
+      })
+      fireEvent.keyDown(getByTestId('ChatDragHandle'), { key: ' ' })
+      expect(onExpand).toHaveBeenCalledTimes(1)
+      expect(onCollapse).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('controlled (parent owns snap)', () => {
+    it('forwards live drag deltas through onDrag', () => {
+      const onDrag = jest.fn()
+      const onDragStart = jest.fn()
+      const onDragEnd = jest.fn()
+      const { getByTestId } = renderHandle({ onDragStart, onDrag, onDragEnd })
+      const handle = getByTestId('ChatDragHandle')
+      fireEvent.mouseDown(handle, { clientY: 100 })
+      expect(onDragStart).toHaveBeenCalledTimes(1)
+      fireEvent.mouseMove(window, { clientY: 130 })
+      fireEvent.mouseMove(window, { clientY: 160 })
+      fireEvent.mouseUp(window)
+      expect(onDrag).toHaveBeenCalledWith(30)
+      expect(onDrag).toHaveBeenCalledWith(60)
+      expect(onDragEnd).toHaveBeenCalledWith(60)
+    })
+
+    it('does not fire onCollapse on drag-end when controlled', () => {
+      const onDragEnd = jest.fn()
+      const { getByTestId, onCollapse, onExpand } = renderHandle({
+        onDragEnd
+      })
+      const handle = getByTestId('ChatDragHandle')
+      fireEvent.mouseDown(handle, { clientY: 100 })
+      fireEvent.mouseMove(window, { clientY: 200 })
+      fireEvent.mouseUp(window)
+      expect(onDragEnd).toHaveBeenCalledWith(100)
+      // Parent owns the snap — handle must not also toggle.
+      expect(onCollapse).not.toHaveBeenCalled()
+      expect(onExpand).not.toHaveBeenCalled()
+    })
+
+    it('still collapses on tap from the expanded state', () => {
+      const { getByTestId, onCollapse, onExpand } = renderHandle({
+        onDragStart: jest.fn(),
+        onDrag: jest.fn(),
+        onDragEnd: jest.fn()
+      })
+      const handle = getByTestId('ChatDragHandle')
+      fireEvent.mouseDown(handle, { clientY: 100 })
+      fireEvent.mouseUp(window)
+      expect(onCollapse).toHaveBeenCalledTimes(1)
+      expect(onExpand).not.toHaveBeenCalled()
+    })
+
+    it('does not expand on tap from the collapsed state — drag only', () => {
+      // Collapsed bar is a thin strip; we don't want a stray pointer tap
+      // to accidentally pop the sheet open. Expanding requires drag.
+      const { getByTestId, onCollapse, onExpand } = renderHandle({
+        collapsed: true,
+        onDragStart: jest.fn(),
+        onDrag: jest.fn(),
+        onDragEnd: jest.fn()
+      })
+      const handle = getByTestId('ChatDragHandle')
+      fireEvent.mouseDown(handle, { clientY: 200 })
+      fireEvent.mouseUp(window)
+      expect(onExpand).not.toHaveBeenCalled()
+      expect(onCollapse).not.toHaveBeenCalled()
+    })
+
+    it('still expands via keyboard Enter when collapsed', () => {
+      const { getByTestId, onExpand } = renderHandle({
+        collapsed: true,
+        onDragStart: jest.fn(),
+        onDrag: jest.fn(),
+        onDragEnd: jest.fn()
+      })
+      fireEvent.keyDown(getByTestId('ChatDragHandle'), { key: 'Enter' })
+      expect(onExpand).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/libs/journeys/ui/src/components/AiChat/DragHandle/DragHandle.tsx
+++ b/libs/journeys/ui/src/components/AiChat/DragHandle/DragHandle.tsx
@@ -1,5 +1,3 @@
-import KeyboardArrowDownRoundedIcon from '@mui/icons-material/KeyboardArrowDownRounded'
-import KeyboardArrowUpRoundedIcon from '@mui/icons-material/KeyboardArrowUpRounded'
 import Box from '@mui/material/Box'
 import { useTranslation } from 'next-i18next/pages'
 import {
@@ -15,62 +13,80 @@ import {
 
 import { DIVIDER, TEXT_SECONDARY } from '../chatStyles'
 
-interface DragHandleProps {
-  collapsed: boolean
-  /** Drag down past the threshold collapses the sheet to a thin handle. */
-  onCollapse: () => void
-  /** Drag up past the threshold expands the sheet back to active height. */
-  onExpand: () => void
+const DRAG_THRESHOLD_PX = 32
+const TAP_MAX_MOVE_PX = 4
+
+export interface DragSheetHandlers {
+  onDragStart?: () => void
+  onDrag?: (deltaY: number) => void
+  onDragEnd?: (deltaY: number) => void
+  /** Fires when the gesture didn't move past the tap threshold. */
+  onTap?: () => void
 }
 
-const DRAG_THRESHOLD_PX = 32
+interface DragSheetBindings {
+  onMouseDown: (event: ReactMouseEvent<HTMLElement>) => void
+  onTouchStart: (event: ReactTouchEvent<HTMLElement>) => void
+}
 
-export function DragHandle({
-  collapsed,
-  onCollapse,
-  onExpand
-}: DragHandleProps): ReactElement {
-  const { t } = useTranslation('libs-journeys-ui')
+/**
+ * Shared mouse/touch drag binding for the chat sheet. Tracks the
+ * **max absolute displacement** during the gesture (not just the final
+ * delta) so a drag-then-return gesture is still recognised as a drag —
+ * preventing the drag-then-tap edge case where releasing near the start
+ * point fires a synthetic click and toggles the sheet.
+ *
+ * Touchmove is registered as non-passive so we can call preventDefault to
+ * stop the underlying surface (conversation, page) from scrolling while
+ * the user is dragging.
+ */
+export function useDragSheet(handlers: DragSheetHandlers = {}): {
+  dragging: boolean
+  bind: DragSheetBindings
+} {
+  const handlersRef = useRef(handlers)
+  handlersRef.current = handlers
+
   const [dragging, setDragging] = useState(false)
   const startYRef = useRef<number | null>(null)
   const movedRef = useRef(0)
+  const maxAbsMovedRef = useRef(0)
   const draggingRef = useRef(false)
-  const suppressClickRef = useRef(false)
-
-  const toggleCollapsed = useCallback(() => {
-    if (collapsed) {
-      onExpand()
-    } else {
-      onCollapse()
-    }
-  }, [collapsed, onCollapse, onExpand])
 
   useEffect(() => {
     if (!dragging) return undefined
+    const handleMove = (clientY: number, isTouch: boolean): boolean => {
+      if (startYRef.current == null) return false
+      const delta = clientY - startYRef.current
+      movedRef.current = delta
+      if (Math.abs(delta) > maxAbsMovedRef.current) {
+        maxAbsMovedRef.current = Math.abs(delta)
+      }
+      handlersRef.current.onDrag?.(delta)
+      // Suppress page/conversation scroll under the gesture once the user
+      // has moved past the tap threshold.
+      return isTouch && maxAbsMovedRef.current > TAP_MAX_MOVE_PX
+    }
     const handleMouseMove = (e: MouseEvent): void => {
-      if (startYRef.current == null) return
-      movedRef.current = e.clientY - startYRef.current
+      handleMove(e.clientY, false)
     }
     const handleTouchMove = (e: TouchEvent): void => {
-      if (startYRef.current == null || e.touches.length === 0) return
-      movedRef.current = e.touches[0].clientY - startYRef.current
-      // Stop the page (or the conversation underneath) from scrolling
-      // while the user is dragging the handle.
-      e.preventDefault()
+      if (e.touches.length === 0) return
+      const shouldPrevent = handleMove(e.touches[0].clientY, true)
+      if (shouldPrevent) e.preventDefault()
     }
     const handleUp = (): void => {
       if (!draggingRef.current) return
       const moved = movedRef.current
+      const maxAbsMoved = maxAbsMovedRef.current
       draggingRef.current = false
       setDragging(false)
       startYRef.current = null
       movedRef.current = 0
-      if (moved > DRAG_THRESHOLD_PX) {
-        suppressClickRef.current = true
-        onCollapse()
-      } else if (moved < -DRAG_THRESHOLD_PX) {
-        suppressClickRef.current = true
-        onExpand()
+      maxAbsMovedRef.current = 0
+      handlersRef.current.onDragEnd?.(moved)
+      if (maxAbsMoved <= TAP_MAX_MOVE_PX) {
+        handlersRef.current.onTap?.()
       }
     }
     window.addEventListener('mousemove', handleMouseMove)
@@ -85,37 +101,100 @@ export function DragHandle({
       window.removeEventListener('touchend', handleUp)
       window.removeEventListener('touchcancel', handleUp)
     }
-  }, [dragging, onCollapse, onExpand])
+  }, [dragging])
 
   const handleStart = useCallback((clientY: number) => {
     startYRef.current = clientY
     movedRef.current = 0
+    maxAbsMovedRef.current = 0
     draggingRef.current = true
     setDragging(true)
+    handlersRef.current.onDragStart?.()
   }, [])
 
-  const handleMouseDown = useCallback(
-    (e: ReactMouseEvent<HTMLDivElement>) => {
+  const bind: DragSheetBindings = {
+    onMouseDown: (e) => {
       e.preventDefault()
       handleStart(e.clientY)
     },
-    [handleStart]
-  )
-
-  const handleTouchStart = useCallback(
-    (e: ReactTouchEvent<HTMLDivElement>) => {
+    onTouchStart: (e) => {
       handleStart(e.touches[0].clientY)
+    }
+  }
+
+  return { dragging, bind }
+}
+
+interface DragHandleProps extends DragSheetHandlers {
+  collapsed: boolean
+  /** Tap-toggle: drag down past threshold collapses to a thin handle. */
+  onCollapse: () => void
+  /** Tap-toggle: drag up past threshold expands the sheet. */
+  onExpand: () => void
+}
+
+/**
+ * Mobile drag handle for the pinned chat sheet.
+ *
+ * - When the parent does NOT pass live drag handlers
+ *   (`onDragStart`/`onDrag`/`onDragEnd`), the handle uses its built-in
+ *   threshold logic: dragging more than `DRAG_THRESHOLD_PX` collapses or
+ *   expands.
+ * - When the parent DOES pass live drag handlers, the handle defers
+ *   resize/snap to the parent and just forwards drag events. Tap toggles
+ *   between collapsed / expanded as a fallback affordance.
+ */
+export function DragHandle({
+  collapsed,
+  onCollapse,
+  onExpand,
+  onDragStart,
+  onDrag,
+  onDragEnd
+}: DragHandleProps): ReactElement {
+  const { t } = useTranslation('libs-journeys-ui')
+
+  const isControlledByParent =
+    onDragStart != null || onDrag != null || onDragEnd != null
+
+  const toggleCollapsed = useCallback(() => {
+    if (collapsed) {
+      onExpand()
+    } else {
+      onCollapse()
+    }
+  }, [collapsed, onCollapse, onExpand])
+
+  // When the parent owns snap, tapping the collapsed handle is
+  // intentionally a no-op — expanding requires an actual upward drag so
+  // a stray pointer tap on the thin strip can't accidentally pop the
+  // sheet open. Keyboard Enter/Space still toggles for accessibility.
+  const handlePointerTap = useCallback(() => {
+    if (isControlledByParent && collapsed) return
+    toggleCollapsed()
+  }, [isControlledByParent, collapsed, toggleCollapsed])
+
+  // Defer max-displacement tracking + threshold-fallback to the shared hook
+  // so the synthetic-click-after-drag-then-return path is fixed everywhere.
+  const handleDragEnd = useCallback(
+    (deltaY: number) => {
+      onDragEnd?.(deltaY)
+      if (isControlledByParent) return
+      if (deltaY > DRAG_THRESHOLD_PX) {
+        onCollapse()
+      } else if (deltaY < -DRAG_THRESHOLD_PX) {
+        onExpand()
+      }
     },
-    [handleStart]
+    [onDragEnd, isControlledByParent, onCollapse, onExpand]
   )
 
-  const handleClick = useCallback(() => {
-    if (suppressClickRef.current) {
-      suppressClickRef.current = false
-      return
-    }
-    toggleCollapsed()
-  }, [toggleCollapsed])
+  const { dragging, bind } = useDragSheet({
+    onDragStart,
+    onDrag,
+    onDragEnd: handleDragEnd,
+    onTap: handlePointerTap
+  })
 
   // Keyboard accessibility: Enter/Space toggles between expanded and
   // collapsed so non-pointer users still have a way to control the sheet.
@@ -128,10 +207,6 @@ export function DragHandle({
     [toggleCollapsed]
   )
 
-  const ChevronIcon = collapsed
-    ? KeyboardArrowUpRoundedIcon
-    : KeyboardArrowDownRoundedIcon
-
   return (
     <Box
       data-testid="ChatDragHandle"
@@ -139,9 +214,8 @@ export function DragHandle({
       tabIndex={0}
       aria-label={collapsed ? t('Expand chat') : t('Collapse chat')}
       aria-expanded={!collapsed}
-      onMouseDown={handleMouseDown}
-      onTouchStart={handleTouchStart}
-      onClick={handleClick}
+      onMouseDown={bind.onMouseDown}
+      onTouchStart={bind.onTouchStart}
       onKeyDown={handleKeyDown}
       sx={{
         display: 'flex',
@@ -154,23 +228,19 @@ export function DragHandle({
         userSelect: 'none',
         outline: 'none',
         '&:focus-visible .ChatDragHandlePill': {
-          bgcolor: DIVIDER,
-          color: TEXT_SECONDARY
+          bgcolor: TEXT_SECONDARY
         }
       }}
     >
       <Box
-        component={ChevronIcon}
         className="ChatDragHandlePill"
         aria-hidden
         sx={{
-          width: 28,
-          height: 18,
-          px: 0.5,
+          width: 48,
+          height: 4,
           borderRadius: 9999,
-          color: dragging ? TEXT_SECONDARY : TEXT_SECONDARY,
-          bgcolor: dragging ? DIVIDER : 'transparent',
-          transition: 'background-color 120ms ease, color 120ms ease'
+          bgcolor: dragging ? TEXT_SECONDARY : DIVIDER,
+          transition: 'background-color 120ms ease'
         }}
       />
     </Box>

--- a/libs/journeys/ui/src/components/AiChat/DragHandle/index.ts
+++ b/libs/journeys/ui/src/components/AiChat/DragHandle/index.ts
@@ -1,1 +1,2 @@
-export { DragHandle } from './DragHandle'
+export { DragHandle, useDragSheet } from './DragHandle'
+export type { DragSheetHandlers } from './DragHandle'

--- a/libs/journeys/ui/src/components/AiChat/chatStyles.ts
+++ b/libs/journeys/ui/src/components/AiChat/chatStyles.ts
@@ -40,6 +40,12 @@ export const MUTED_FG = 'text.secondary'
 
 // --- Brand ---
 
+/** Brand red (= journeysAdmin primary.main) — active send button fill. */
+export const BRAND_RED = brandRed
+
+/** Hover state for the brand-red send button. */
+export const BRAND_RED_HOVER = '#A8202C'
+
 /** Second stop of the sparkle-avatar gradient. Darker than journeysAdmin's primary.dark, tuned to the gradient. */
 export const BRAND_RED_DARK = '#A8202C'
 

--- a/libs/journeys/ui/src/components/Conversation/Conversation.tsx
+++ b/libs/journeys/ui/src/components/Conversation/Conversation.tsx
@@ -37,6 +37,14 @@ interface ConversationProps {
    * last message isn't permanently obscured.
    */
   bottomClearance?: number
+  /**
+   * When true, suppresses the scroll-to-latest pill. Used by the pinned
+   * chat sheet so the pill doesn't briefly flash in while the sheet is
+   * animating shrunk — the conversation height transitions through
+   * "shorter than content" mid-tween, which would otherwise read as
+   * "scrolled away from the bottom".
+   */
+  suppressScrollPill?: boolean
 }
 
 const NEAR_BOTTOM_THRESHOLD_PX = 24
@@ -45,7 +53,8 @@ const BOTTOM_FADE_HEIGHT_PX = 56
 export function Conversation({
   children,
   scrollKey,
-  bottomClearance = 0
+  bottomClearance = 0,
+  suppressScrollPill = false
 }: ConversationProps): ReactElement {
   const { t } = useTranslation('libs-journeys-ui')
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -191,7 +200,7 @@ export function Conversation({
           {children}
         </Box>
       </Box>
-      {!isAtBottom && (
+      {!isAtBottom && !suppressScrollPill && (
         <IconButton
           onClick={handleScrollToBottomClick}
           aria-label={t('Scroll to latest message')}

--- a/libs/journeys/ui/src/components/PinnedChatBar/PinnedChatBar.tsx
+++ b/libs/journeys/ui/src/components/PinnedChatBar/PinnedChatBar.tsx
@@ -3,7 +3,13 @@
 import Box from '@mui/material/Box'
 import { SxProps } from '@mui/material/styles'
 import dynamic from 'next/dynamic'
-import { ReactElement, useCallback, useState } from 'react'
+import {
+  ReactElement,
+  useCallback,
+  useEffect,
+  useRef,
+  useState
+} from 'react'
 
 import { useJourney } from '../../libs/JourneyProvider'
 import type { AiChatSheetState } from '../AiChat/AiChat'
@@ -141,39 +147,228 @@ interface PinnedChatBarProps {
   sx?: SxProps
 }
 
-// Pixel height for the collapsed state. 32px = the drag handle's 14px
-// top + 4px thumb + 14px bottom padding.
+// Pixel height for the collapsed/minimized state. 32px = the drag handle's
+// 14px top + 4px thumb + 14px bottom padding. Below this only the handle
+// is visible — content above (header / conversation / input) is clipped
+// by the sheet's overflow:hidden.
 const COLLAPSED_HEIGHT_PX = 32
 // Pixel height for the idle (no messages, expanded) state. Handle (32)
 // + ChatHeader (~64) + input (~68) + a little breathing room. Used so
 // the open/close animation has explicit numeric endpoints to
 // interpolate between when transitioning out of `auto` height.
 const IDLE_HEIGHT_PX = 168
+// Snap fractions of the parent height. Drop the 50% stop — drag straight
+// from minimized to large or full.
+const SNAP_LARGE = 0.8
+const SNAP_FULL = 1
+// Soft snap animation: a strong ease-out curve so the sheet glides
+// quickly off the start position and decelerates as it approaches the
+// snap target — feels natural at the top/bottom limits.
+const SNAP_TRANSITION = 'height 780ms cubic-bezier(0.16, 1, 0.3, 1)'
+const TOGGLE_TRANSITION = 'height 480ms cubic-bezier(0.16, 1, 0.3, 1)'
+const SNAP_DURATION_MS = 800
+// While the user is actively dragging we want the height to track the
+// finger 1:1 — disable transitions during drag so each frame applies
+// instantly. Animation is re-enabled on release for the snap.
+const NO_TRANSITION = 'none'
 
 export function PinnedChatBar({ sx }: PinnedChatBarProps): ReactElement | null {
   const { variant } = useJourney()
   const [sheetState, setSheetState] = useState<AiChatSheetState>('idle')
+  const [collapsed, setCollapsed] = useState(false)
+  // Live-drag height as a fraction of the parent (0..1). null means "fall
+  // back to the default height for the current sheetState".
+  const [heightPct, setHeightPct] = useState<number | null>(null)
+  // True while the snap animation is playing after release. Prevents the
+  // snap transition from clobbering the live drag tracking.
+  const [animating, setAnimating] = useState(false)
+  const [dragging, setDragging] = useState(false)
+  const sheetRef = useRef<HTMLDivElement | null>(null)
+  const dragStartRef = useRef<{ parentH: number; startPct: number }>({
+    parentH: 0,
+    startPct: 0
+  })
+  // Latches once the chat has auto-expanded for the first message so we
+  // don't replay the auto-expand effect when sheetState toggles back to
+  // 'active' after a collapse → re-open cycle.
+  const hasAutoExpandedRef = useRef(false)
+  const animationTimerRef = useRef<number | null>(null)
 
   const handleSheetStateChange = useCallback((next: AiChatSheetState) => {
     setSheetState(next)
+  }, [])
+
+  const playSnapAnimation = useCallback(() => {
+    if (animationTimerRef.current != null) {
+      window.clearTimeout(animationTimerRef.current)
+    }
+    setAnimating(true)
+    animationTimerRef.current = window.setTimeout(() => {
+      setAnimating(false)
+      animationTimerRef.current = null
+    }, SNAP_DURATION_MS)
+  }, [])
+
+  // Tap-toggle on the drag handle (or AiChat-internal collapse callbacks)
+  // — sync the snap height so the resize animation stays consistent with
+  // tap-driven transitions.
+  const handleCollapsedChange = useCallback(
+    (next: boolean) => {
+      setCollapsed(next)
+      const parent = sheetRef.current?.parentElement as HTMLElement | null
+      const parentH = parent?.clientHeight ?? 0
+      if (parentH <= 0) {
+        setHeightPct(null)
+        return
+      }
+      const min = COLLAPSED_HEIGHT_PX / parentH
+      playSnapAnimation()
+      // Tap-expand always lands at the large stop. Full is only reachable
+      // by an explicit drag-up from large.
+      setHeightPct(next ? min : SNAP_LARGE)
+    },
+    [playSnapAnimation]
+  )
+
+  const minSnapFor = useCallback(
+    (parentH: number): number =>
+      parentH > 0 ? COLLAPSED_HEIGHT_PX / parentH : 0,
+    []
+  )
+
+  const handleDragStart = useCallback(() => {
+    const sheet = sheetRef.current
+    const parent = sheet?.offsetParent as HTMLElement | null
+    const parentH = parent?.clientHeight ?? sheet?.parentElement?.clientHeight
+    const resolvedParentH = parentH ?? 0
+    const sheetH = sheet?.offsetHeight ?? 0
+    const currentPct = resolvedParentH > 0 ? sheetH / resolvedParentH : 0
+    dragStartRef.current = {
+      parentH: resolvedParentH,
+      startPct: currentPct
+    }
+    if (animationTimerRef.current != null) {
+      window.clearTimeout(animationTimerRef.current)
+      animationTimerRef.current = null
+    }
+    setAnimating(false)
+    setDragging(true)
+  }, [])
+
+  const handleDrag = useCallback(
+    (deltaY: number) => {
+      const { parentH, startPct } = dragStartRef.current
+      if (parentH <= 0) return
+      // Dragging DOWN (+deltaY) shrinks the sheet; UP grows it.
+      const next = startPct - deltaY / parentH
+      const clamped = Math.max(
+        minSnapFor(parentH),
+        Math.min(SNAP_FULL, next)
+      )
+      setHeightPct(clamped)
+    },
+    [minSnapFor]
+  )
+
+  const handleDragEnd = useCallback(
+    (deltaY: number) => {
+      setDragging(false)
+      const { parentH, startPct } = dragStartRef.current
+      if (parentH <= 0) return
+      const finalPx = sheetRef.current?.offsetHeight ?? 0
+      const finalPct = finalPx / parentH
+      const minPct = minSnapFor(parentH)
+
+      // Special-case behaviours requested by the design:
+      //  - From minimized + ANY upward drag → snap to large (first time)
+      //    or full (every re-open after that).
+      //  - From large/full + ANY downward drag → collapse to minimized.
+      //  - Otherwise → snap to whichever stop the finger is closest to.
+      const startedMinimized = startPct <= minPct + 0.01
+      const startedLarge = Math.abs(startPct - SNAP_LARGE) < 0.04
+      const startedFull = Math.abs(startPct - SNAP_FULL) < 0.04
+      const startedAtSnap = startedMinimized || startedLarge || startedFull
+      let nearest: number
+      if (startedMinimized && deltaY < -4) {
+        // Re-expand from minimized always lands at the large stop —
+        // full is only reachable by an explicit drag-up from there.
+        nearest = SNAP_LARGE
+      } else if ((startedLarge || startedFull) && deltaY > 4) {
+        nearest = minPct
+      } else if (!startedAtSnap && deltaY < -4) {
+        // Started at the idle (between-stops) height. Treat any upward
+        // drag as an expand intent.
+        nearest = SNAP_LARGE
+      } else if (!startedAtSnap && deltaY > 4) {
+        nearest = minPct
+      } else {
+        const stops = [minPct, SNAP_LARGE, SNAP_FULL]
+        nearest = stops.reduce((best, stop) =>
+          Math.abs(stop - finalPct) < Math.abs(best - finalPct) ? stop : best
+        )
+      }
+
+      playSnapAnimation()
+      setHeightPct(nearest)
+      // Mirror the snap target into the controlled `collapsed` state so
+      // AiChat slides the input out (or back in) in lockstep with the
+      // height tween.
+      setCollapsed(Math.abs(nearest - minPct) < 0.01)
+    },
+    [minSnapFor, playSnapAnimation]
+  )
+
+  // When AiChat reports the chat just became active (first message sent),
+  // auto-expand to the large stop. Latching `hasAutoExpandedRef` so we
+  // only do this once — subsequent collapse → re-open transitions are
+  // driven by drag (or tap-expand), which always land at large too.
+  useEffect(() => {
+    if (sheetState !== 'active') return
+    if (heightPct != null) return
+    if (hasAutoExpandedRef.current) return
+    hasAutoExpandedRef.current = true
+    playSnapAnimation()
+    setHeightPct(SNAP_LARGE)
+  }, [sheetState, heightPct, playSnapAnimation])
+
+  useEffect(() => {
+    return () => {
+      if (animationTimerRef.current != null) {
+        window.clearTimeout(animationTimerRef.current)
+      }
+    }
   }, [])
 
   if (variant === 'admin' || variant === 'embed') {
     return null
   }
 
+  // Resolve final visible height. While the user is dragging or the
+  // height has been snapped explicitly, honour `heightPct`. Otherwise
+  // fall back to the per-state defaults.
   let height: string
-  if (sheetState === 'active') {
-    height = '80%'
+  let transition: string
+  if (heightPct != null) {
+    height = `${heightPct * 100}%`
+    transition = dragging
+      ? NO_TRANSITION
+      : animating
+        ? SNAP_TRANSITION
+        : TOGGLE_TRANSITION
+  } else if (sheetState === 'active') {
+    height = `${SNAP_LARGE * 100}%`
+    transition = TOGGLE_TRANSITION
   } else if (sheetState === 'collapsed') {
     height = `${COLLAPSED_HEIGHT_PX}px`
+    transition = TOGGLE_TRANSITION
   } else {
-    // Idle — fixed height so the transition into 'active' interpolates.
     height = `${IDLE_HEIGHT_PX}px`
+    transition = TOGGLE_TRANSITION
   }
 
   return (
     <Box
+      ref={sheetRef}
       data-testid="PinnedChatBar"
       data-sheet-state={sheetState}
       sx={{
@@ -187,7 +382,7 @@ export function PinnedChatBar({ sx }: PinnedChatBarProps): ReactElement | null {
         // circuit the height transition (collapse looked instant before this).
         // Drag-driven collapse/expand animates between explicit numeric
         // heights via CSS rather than position-tracking, per product spec.
-        transition: 'height 280ms cubic-bezier(0.4, 0, 0.2, 1)',
+        transition,
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
@@ -199,7 +394,14 @@ export function PinnedChatBar({ sx }: PinnedChatBarProps): ReactElement | null {
         ...sx
       }}
     >
-      <AiChat onSheetStateChange={handleSheetStateChange} />
+      <AiChat
+        onSheetStateChange={handleSheetStateChange}
+        collapsed={collapsed}
+        onCollapsedChange={handleCollapsedChange}
+        onDragStart={handleDragStart}
+        onDrag={handleDrag}
+        onDragEnd={handleDragEnd}
+      />
     </Box>
   )
 }

--- a/libs/journeys/ui/src/components/PinnedChatBar/PinnedChatBar.tsx
+++ b/libs/journeys/ui/src/components/PinnedChatBar/PinnedChatBar.tsx
@@ -3,13 +3,7 @@
 import Box from '@mui/material/Box'
 import { SxProps } from '@mui/material/styles'
 import dynamic from 'next/dynamic'
-import {
-  ReactElement,
-  useCallback,
-  useEffect,
-  useRef,
-  useState
-} from 'react'
+import { ReactElement, useCallback, useEffect, useRef, useState } from 'react'
 
 import { useJourney } from '../../libs/JourneyProvider'
 import type { AiChatSheetState } from '../AiChat/AiChat'
@@ -261,10 +255,7 @@ export function PinnedChatBar({ sx }: PinnedChatBarProps): ReactElement | null {
       if (parentH <= 0) return
       // Dragging DOWN (+deltaY) shrinks the sheet; UP grows it.
       const next = startPct - deltaY / parentH
-      const clamped = Math.max(
-        minSnapFor(parentH),
-        Math.min(SNAP_FULL, next)
-      )
+      const clamped = Math.max(minSnapFor(parentH), Math.min(SNAP_FULL, next))
       setHeightPct(clamped)
     },
     [minSnapFor]

--- a/libs/journeys/ui/src/components/PromptInput/PromptInput.tsx
+++ b/libs/journeys/ui/src/components/PromptInput/PromptInput.tsx
@@ -14,6 +14,8 @@ import {
 
 import {
   ASSISTANT_FG,
+  BRAND_RED,
+  BRAND_RED_HOVER,
   DIVIDER,
   OVERLAY_FG_MUTED,
   OVERLAY_FILL_LOW,
@@ -23,7 +25,6 @@ import {
   PANEL_INPUT_BG,
   PANEL_INPUT_BORDER,
   PANEL_INPUT_SHADOW,
-  PRIMARY,
   PRIMARY_ON,
   TEXT_SECONDARY
 } from '../AiChat/chatStyles'
@@ -162,9 +163,9 @@ export function PromptInput({
             height: 32,
             flexShrink: 0,
             p: 0,
-            bgcolor: PRIMARY,
+            bgcolor: BRAND_RED,
             color: PRIMARY_ON,
-            '&:hover': { bgcolor: PRIMARY }
+            '&:hover': { bgcolor: BRAND_RED_HOVER }
           }}
         >
           <StopRoundedIcon fontSize="small" />
@@ -180,7 +181,7 @@ export function PromptInput({
             flexShrink: 0,
             p: 0,
             bgcolor: canSubmit
-              ? PRIMARY
+              ? BRAND_RED
               : isFloating
                 ? OVERLAY_FILL_LOW
                 : DIVIDER,
@@ -191,7 +192,7 @@ export function PromptInput({
                 : TEXT_SECONDARY,
             '&:hover': {
               bgcolor: canSubmit
-                ? PRIMARY
+                ? BRAND_RED_HOVER
                 : isFloating
                   ? OVERLAY_FILL_LOW
                   : DIVIDER


### PR DESCRIPTION
## Summary

Iterates on the pinned apologist-chat sheet UX based on the [Claude Design handoff](https://api.anthropic.com/v1/design/h/dcrmgXmF4fzkESJ9riSyNw). Replaces the binary collapse/expand gesture with a live-tracking drag and three snap stops, swaps the chevron handle for a standard drag pill, and tints the send button brand red.

Also addresses one of the deferred items from the [PR #9122 review](https://github.com/JesusFilm/core/pull/9122) — the synthetic-tap-after-drag-then-return edge case.

## Drawer behaviour

- Three snap stops: **minimized** (32 px handle), **80%**, **full**.
- Empty chat → 168 px idle (handle + header + input). First message ever auto-expands to **80%**.
- Re-expansion from minimized always lands at 80%; full is only reachable by dragging up from 80%.
- Drag down from 80% or full → minimized. Drag up from minimized → 80%.
- Drag handle **and** the chat header are both drag surfaces (shared via \`useDragSheet\` hook).
- Snap animation: 780 ms cubic-bezier(0.16, 1, 0.3, 1) — gentle ease-out into the target.
- Pointer tap on the collapsed handle is a **no-op** — only an explicit upward drag expands. Keyboard Enter/Space still toggles.
- Drag-then-return-to-start gestures are correctly recognised as drags (max-displacement tracking).

## Send button

- Brand red (\`#C52D3A\`) fill when there's submittable content or while loading. Disabled state unchanged (DIVIDER grey).
- Hover uses \`BRAND_RED_HOVER\` (\`#A8202C\`).

## Files

- \`libs/journeys/ui/src/components/AiChat/DragHandle/\` — \`useDragSheet\` hook, live-drag callbacks, pill affordance
- \`libs/journeys/ui/src/components/AiChat/AiChat.tsx\` — controlled \`collapsed\`, drag handler forwarding, draggable header wrapper
- \`libs/journeys/ui/src/components/PinnedChatBar/PinnedChatBar.tsx\` — snap state machine, 780 ms ease-out animation
- \`libs/journeys/ui/src/components/Conversation/Conversation.tsx\` — \`suppressScrollPill\` prop so the chevron doesn't flash in mid-collapse
- \`libs/journeys/ui/src/components/PromptInput/PromptInput.tsx\` + \`AiChat/chatStyles.ts\` — brand-red send button

## Verification

- \`npx tsc --noEmit -p libs/journeys/ui/tsconfig.lib.json\` — passes
- DragHandle spec — 14 tests pass (regression coverage for drag-then-return + new live-drag mode)
- Conversation, AiChat, PinnedChatBar, PromptInput, StepFooter specs — all green (61 tests)

Linear: [NES-1641](https://linear.app/jesus-film-project/issue/NES-1641/general-ux-improvements-apologist-chat-mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)