### PR TITLE
style(journeys-admin): drop secondary caption from upload dropzones [NES-1674]

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/ImageBlockEditor/CustomImage/ImageUpload/ImageUpload.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/ImageBlockEditor/CustomImage/ImageUpload/ImageUpload.spec.tsx
@@ -180,9 +180,6 @@ describe('ImageUpload', () => {
       </MockedProvider>
     )
     expect(screen.getByText('Drop an image here')).toBeInTheDocument()
-    expect(
-      screen.getByText('or click to browse your files')
-    ).toBeInTheDocument()
   })
 
   it('should render loading state', () => {

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/ImageBlockEditor/CustomImage/ImageUpload/ImageUpload.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/ImageBlockEditor/CustomImage/ImageUpload/ImageUpload.tsx
@@ -209,14 +209,9 @@ export function ImageUpload({
                   : t('Upload Failed!')}
             </Typography>
           ) : (
-            <>
-              <Typography variant="body1" color="secondary.main">
-                {t('Drop an image here')}
-              </Typography>
-              <Typography variant="caption" color="secondary.main">
-                {t('or click to browse your files')}
-              </Typography>
-            </>
+            <Typography variant="body1" color="secondary.main">
+              {t('Drop an image here')}
+            </Typography>
           )}
         </Stack>
         <Button

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromMux/AddByFile/AddByFile.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromMux/AddByFile/AddByFile.spec.tsx
@@ -194,9 +194,6 @@ describe('AddByFile', () => {
     expect(screen.getByTestId('AddByFile')).toBeInTheDocument()
     expect(screen.getByText('Drop a video here')).toBeInTheDocument()
     expect(
-      screen.getByText('or click to browse your files')
-    ).toBeInTheDocument()
-    expect(
       screen.getByText(
         'Upload a video (MP4 or MOV) at least 1 second long. Maximum file size: 1 GB'
       )

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromMux/AddByFile/AddByFile.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromMux/AddByFile/AddByFile.tsx
@@ -195,14 +195,9 @@ export function AddByFile({ onChange }: AddByFileProps): ReactElement {
               {statusLabel}
             </Typography>
           ) : (
-            <>
-              <Typography variant="body1" color="secondary.main">
-                {t('Drop a video here')}
-              </Typography>
-              <Typography variant="caption" color="secondary.main">
-                {t('or click to browse your files')}
-              </Typography>
-            </>
+            <Typography variant="body1" color="secondary.main">
+              {t('Drop a video here')}
+            </Typography>
           )}
         </Stack>
         {waiting || uploading || processing ? (


### PR DESCRIPTION
## Summary

Small UI polish: drop the second instructional line ("or click to browse your files") from both upload dropzones so they read cleaner.

- Image dropzone (`ImageUpload`)
- Mux video dropzone (`AddByFile`)

Behavior unchanged — dragging/clicking still works the same way.

## Test plan

- [x] `ImageUpload.spec.tsx` passes (14/14)
- [x] `AddByFile.spec.tsx` passes (12/12)
- [ ] Manual QA on preview: confirm dropzone still looks balanced in image + Mux video flows

Linear: [NES-1674](https://linear.app/jesus-film-project/issue/NES-1674/image-upload-dropzone-drop-second-line-of-instructional-text)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified the image upload dropzone interface by removing secondary instructional text, keeping only essential guidance for users.
  * Simplified the video upload dropzone interface by removing secondary instructional text, keeping only essential guidance for users.

* **Tests**
  * Updated corresponding unit tests for both image and video upload components to reflect the streamlined dropzone messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JesusFilm/core/pull/9216)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->