### PR TITLE
chore: bump next-firebase-auth-edge to 1.12.0 for Next 16 dev support

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "nestjs-ddtrace": "6.0.0",
     "nestjs-pino": "^4.0.0",
     "next": "^16.2.3",
-    "next-firebase-auth-edge": "^1.7.0-canary.2",
+    "next-firebase-auth-edge": "^1.12.0",
     "next-i18n-router": "^5.5.5",
     "next-i18next": "^16.0.5",
     "next-intl": "^4.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,8 +473,8 @@ importers:
         specifier: ^16.2.3
         version: 16.2.5(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.85.1)
       next-firebase-auth-edge:
-        specifier: ^1.7.0-canary.2
-        version: 1.9.1(next@16.2.5(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.85.1))
+        specifier: ^1.12.0
+        version: 1.12.0(next@16.2.5(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.85.1))
       next-i18n-router:
         specifier: ^5.5.5
         version: 5.5.5(next@16.2.5(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.85.1))
@@ -18983,11 +18983,11 @@ packages:
     resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
     engines: {node: '>= 0.4.0'}
 
-  next-firebase-auth-edge@1.9.1:
-    resolution: {integrity: sha512-jwyDvoZW/9Lt+TwLDOOBCCqs3VyrCOTjoh70OQ295IM7N8PKJ37fgUONNl+H9jvdGCalyKhyLbyBOgYLm1J7KQ==}
-    engines: {node: '>=16.0.0 <24.0.0', npm: '>=8.0.0 <12.0.0', yarn: '>=1.22.0 <2.0.0'}
+  next-firebase-auth-edge@1.12.0:
+    resolution: {integrity: sha512-713QS4bJC+REo9sYAyDCVGiEMX0k+5c4B7/+WSGAnW0UY90bmJjgyykku5uRWPcV3q8meECt+cRn8MlvqNUsYw==}
+    engines: {node: '>=16.0.0 <26.0.0', npm: '>=8.0.0 <12.0.0', yarn: '>=1.22.0 <2.0.0'}
     peerDependencies:
-      next: ^14.0.0 || 15.0.0-rc.0 || ^15.0.0
+      next: ^14.0.0 || 15.0.0-rc.0 || ^15.0.0 || ^16.0.0
 
   next-i18n-router@5.5.5:
     resolution: {integrity: sha512-soJD/JdC1Wew3LZqzFC3+9rdo4QT4cX6Xej4dSU/ObBFXhLHonMMBoa2nXsMHXPIcfdnSUDBTc6B2hrby4nzsg==}
@@ -24961,7 +24961,7 @@ snapshots:
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/parser': 7.29.2
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       chalk: 4.1.2
       fb-watchman: 2.0.2
       graphql: 16.10.0
@@ -36779,7 +36779,7 @@ snapshots:
 
   '@slorber/react-helmet-async@1.3.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       invariant: 2.2.4
       prop-types: 15.8.1
       react: 19.2.0
@@ -43954,7 +43954,7 @@ snapshots:
 
   fast-unique-numbers@8.0.13:
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       tslib: 2.8.1
 
   fast-uri@2.4.0: {}
@@ -45036,7 +45036,7 @@ snapshots:
 
   history@4.10.1:
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       loose-envify: 1.4.0
       resolve-pathname: 3.0.0
       tiny-invariant: 1.3.3
@@ -48230,7 +48230,7 @@ snapshots:
 
   netmask@2.1.1: {}
 
-  next-firebase-auth-edge@1.9.1(next@16.2.5(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.85.1)):
+  next-firebase-auth-edge@1.12.0(next@16.2.5(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.85.1)):
     dependencies:
       cookie: 0.7.2
       encoding: 0.1.13
@@ -49343,7 +49343,7 @@ snapshots:
 
   pkcs7@1.0.4:
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
 
   pkg-dir@4.2.0:
     dependencies:
@@ -51055,7 +51055,7 @@ snapshots:
 
   relay-runtime@12.0.0(encoding@0.1.13):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       fbjs: 3.0.5(encoding@0.1.13)
       invariant: 2.2.4
     transitivePeerDependencies:
@@ -54083,19 +54083,19 @@ snapshots:
 
   worker-timers-broker@6.1.8:
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       fast-unique-numbers: 8.0.13
       tslib: 2.8.1
       worker-timers-worker: 7.0.71
 
   worker-timers-worker@7.0.71:
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       tslib: 2.8.1
 
   worker-timers@7.1.8:
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       tslib: 2.8.1
       worker-timers-broker: 6.1.8
       worker-timers-worker: 7.0.71


### PR DESCRIPTION
## Summary

Bumps `next-firebase-auth-edge` from `1.9.1` to `^1.12.0`. Library's Next.js 16 support landed in 1.12.0; #8988 bumped Next without bumping this lib.

## Why

In `next dev`, the `proxy.ts` module fails to load through Next 16's rewritten edge-runtime loader on 1.9.1, so `/api/login` falls through to 404. Any developer running journeys-admin locally with a cleared session hits an infinite `/users/sign-in` ↔ `/users/verify` redirect loop and can't sign in.

Prod and stage are unaffected because they run pre-compiled `next build` artifacts that were compiled under the old loader contract and execute fine at runtime.

No code changes required — `proxy.ts` is already named correctly with a `proxy` default export, and the `authMiddleware` API is unchanged between 1.9 and 1.12.

## Test plan

- [x] `pnpm add next-firebase-auth-edge@^1.12.0 -w`
- [x] `rm -rf apps/journeys-admin/.next`
- [x] Restart `nx serve journeys-admin`
- [x] Hit `/api/login` directly → no longer 404
- [x] Full Google sign-in flow completes and sets the `journeys-admin` cookie
- [ ] CI build passes

Linear: [NES-1681](https://linear.app/jesus-film-project/issue/NES-1681/bump-next-firebase-auth-edge-to-1120-for-next-16-dev-support)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Firebase authentication dependency from pre-release to stable version for improved reliability and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JesusFilm/core/pull/9223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->