### PR TITLE
refactor(event-utils): replace visitor and journeyVisitor upsert with…

### DIFF
--- a/apis/api-journeys-modern/src/schema/event/button/buttonClickEventCreate.mutation.spec.ts
+++ b/apis/api-journeys-modern/src/schema/event/button/buttonClickEventCreate.mutation.spec.ts
@@ -68,11 +68,11 @@ describe('buttonClickEventCreate', () => {
       }
     )
 
-    prismaMock.visitor.upsert.mockResolvedValue({ id: 'visitorId' } as any)
-    prismaMock.journeyVisitor.upsert.mockResolvedValue({
-      journeyId: 'journeyId',
-      visitorId: 'visitorId'
-    } as any)
+    prismaMock.$queryRaw
+      .mockResolvedValueOnce([{ id: 'visitorId' }] as any)
+      .mockResolvedValueOnce([
+        { journeyId: 'journeyId', visitorId: 'visitorId' }
+      ] as any)
   })
 
   it('creates ButtonClickEvent', async () => {

--- a/apis/api-journeys-modern/src/schema/event/chat/chatOpenEventCreate.mutation.spec.ts
+++ b/apis/api-journeys-modern/src/schema/event/chat/chatOpenEventCreate.mutation.spec.ts
@@ -58,12 +58,15 @@ describe('chatOpenEventCreate', () => {
         return Promise.resolve(null as any)
       }
     )
-    prismaMock.visitor.upsert.mockResolvedValue({ id: 'visitorId' } as any)
-    prismaMock.journeyVisitor.upsert.mockResolvedValue({
-      journeyId: 'journeyId',
-      visitorId: 'visitorId',
-      activityCount: 0
-    } as any)
+    prismaMock.$queryRaw
+      .mockResolvedValueOnce([{ id: 'visitorId' }] as any)
+      .mockResolvedValueOnce([
+        {
+          journeyId: 'journeyId',
+          visitorId: 'visitorId',
+          activityCount: 0
+        }
+      ] as any)
   })
 
   it('creates ChatOpenEvent', async () => {

--- a/apis/api-journeys-modern/src/schema/event/journey/journeyViewEventCreate.mutation.spec.ts
+++ b/apis/api-journeys-modern/src/schema/event/journey/journeyViewEventCreate.mutation.spec.ts
@@ -28,14 +28,13 @@ describe('journeyViewEventCreate', () => {
   })
 
   it('creates a JourneyViewEvent when no recent event exists', async () => {
-    prismaMock.visitor.upsert.mockResolvedValue({
-      id: 'visitorId',
-      userAgent: 'existing-agent'
-    } as any)
-    prismaMock.journeyVisitor.upsert.mockResolvedValue({
-      journeyId: 'journeyId',
-      visitorId: 'visitorId'
-    } as any)
+    prismaMock.$queryRaw
+      .mockResolvedValueOnce([
+        { id: 'visitorId', userAgent: 'existing-agent' }
+      ] as any)
+      .mockResolvedValueOnce([
+        { journeyId: 'journeyId', visitorId: 'visitorId' }
+      ] as any)
     prismaMock.event.findFirst.mockResolvedValue(null)
 
     const createdEvent = {
@@ -94,14 +93,13 @@ describe('journeyViewEventCreate', () => {
   })
 
   it('returns null when a recent JourneyViewEvent already exists', async () => {
-    prismaMock.visitor.upsert.mockResolvedValue({
-      id: 'visitorId',
-      userAgent: 'existing-agent'
-    } as any)
-    prismaMock.journeyVisitor.upsert.mockResolvedValue({
-      journeyId: 'journeyId',
-      visitorId: 'visitorId'
-    } as any)
+    prismaMock.$queryRaw
+      .mockResolvedValueOnce([
+        { id: 'visitorId', userAgent: 'existing-agent' }
+      ] as any)
+      .mockResolvedValueOnce([
+        { journeyId: 'journeyId', visitorId: 'visitorId' }
+      ] as any)
     prismaMock.event.findFirst.mockResolvedValue({
       id: 'existingEventId',
       typename: 'JourneyViewEvent',
@@ -143,14 +141,11 @@ describe('journeyViewEventCreate', () => {
   })
 
   it('updates visitor userAgent when it is null', async () => {
-    prismaMock.visitor.upsert.mockResolvedValue({
-      id: 'visitorId',
-      userAgent: null
-    } as any)
-    prismaMock.journeyVisitor.upsert.mockResolvedValue({
-      journeyId: 'journeyId',
-      visitorId: 'visitorId'
-    } as any)
+    prismaMock.$queryRaw
+      .mockResolvedValueOnce([{ id: 'visitorId', userAgent: null }] as any)
+      .mockResolvedValueOnce([
+        { journeyId: 'journeyId', visitorId: 'visitorId' }
+      ] as any)
     prismaMock.event.findFirst.mockResolvedValue(null)
 
     const createdEvent = {
@@ -185,34 +180,17 @@ describe('journeyViewEventCreate', () => {
       where: { id: 'visitorId' },
       data: { userAgent: 'TestAgent/1.0' }
     })
-    expect(prismaMock.visitor.upsert).toHaveBeenCalledWith({
-      where: {
-        teamId_userId: { teamId: 'teamId', userId: 'testUserId' }
-      },
-      create: { teamId: 'teamId', userId: 'testUserId' },
-      update: {}
-    })
-    expect(prismaMock.journeyVisitor.upsert).toHaveBeenCalledWith({
-      where: {
-        journeyId_visitorId: {
-          journeyId: 'journeyId',
-          visitorId: 'visitorId'
-        }
-      },
-      create: { journeyId: 'journeyId', visitorId: 'visitorId' },
-      update: {}
-    })
+    expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(2)
   })
 
   it('handles optional fields (id, label, value)', async () => {
-    prismaMock.visitor.upsert.mockResolvedValue({
-      id: 'visitorId',
-      userAgent: 'existing-agent'
-    } as any)
-    prismaMock.journeyVisitor.upsert.mockResolvedValue({
-      journeyId: 'journeyId',
-      visitorId: 'visitorId'
-    } as any)
+    prismaMock.$queryRaw
+      .mockResolvedValueOnce([
+        { id: 'visitorId', userAgent: 'existing-agent' }
+      ] as any)
+      .mockResolvedValueOnce([
+        { journeyId: 'journeyId', visitorId: 'visitorId' }
+      ] as any)
     prismaMock.event.findFirst.mockResolvedValue(null)
 
     const createdEvent = {

--- a/apis/api-journeys-modern/src/schema/event/journey/journeyViewEventCreate.mutation.ts
+++ b/apis/api-journeys-modern/src/schema/event/journey/journeyViewEventCreate.mutation.ts
@@ -21,7 +21,8 @@ builder.mutationField('journeyViewEventCreate', (t) =>
       const userId = context.user?.id
 
       const journey = await prisma.journey.findUnique({
-        where: { id: input.journeyId, deletedAt: null }
+        where: { id: input.journeyId, deletedAt: null },
+        select: { id: true, teamId: true }
       })
 
       if (journey == null) {
@@ -30,18 +31,14 @@ builder.mutationField('journeyViewEventCreate', (t) =>
         })
       }
 
-      const visitorAndJourneyVisitor = await getByUserIdAndJourneyId(
+      // Pass teamId so the helper skips a redundant journey lookup. With
+      // teamId supplied, getByUserIdAndJourneyId cannot return null —
+      // the atomic upsert is guaranteed to return both rows.
+      const { visitor } = await getByUserIdAndJourneyId(
         userId,
-        input.journeyId
+        input.journeyId,
+        journey.teamId
       )
-
-      if (visitorAndJourneyVisitor == null) {
-        throw new GraphQLError('Visitor does not exist', {
-          extensions: { code: 'NOT_FOUND' }
-        })
-      }
-
-      const { visitor } = visitorAndJourneyVisitor
 
       const existingEvent = await prisma.event.findFirst({
         where: {

--- a/apis/api-journeys-modern/src/schema/event/multiselect/multiselectSubmissionEventCreate.mutation.spec.ts
+++ b/apis/api-journeys-modern/src/schema/event/multiselect/multiselectSubmissionEventCreate.mutation.spec.ts
@@ -64,12 +64,15 @@ describe.skip('multiselectSubmissionEventCreate', () => {
       journeyId: 'journeyId',
       deletedAt: null
     } as any)
-    prismaMock.visitor.upsert.mockResolvedValue({ id: 'visitorId' } as any)
-    prismaMock.journeyVisitor.upsert.mockResolvedValue({
-      journeyId: 'journeyId',
-      visitorId: 'visitorId',
-      activityCount: 0
-    } as any)
+    prismaMock.$queryRaw
+      .mockResolvedValueOnce([{ id: 'visitorId' }] as any)
+      .mockResolvedValueOnce([
+        {
+          journeyId: 'journeyId',
+          visitorId: 'visitorId',
+          activityCount: 0
+        }
+      ] as any)
   })
 
   it('creates MultiselectSubmissionEvent', async () => {

--- a/apis/api-journeys-modern/src/schema/event/utils.spec.ts
+++ b/apis/api-journeys-modern/src/schema/event/utils.spec.ts
@@ -1,7 +1,5 @@
 import { vi } from 'vitest'
 
-import { Prisma } from '@core/prisma/journeys/client'
-
 import { prismaMock } from '../../../test/prismaMock'
 
 import {
@@ -86,10 +84,9 @@ describe('event utils', () => {
 
       prismaMock.block.findUnique.mockResolvedValue(mockBlock as any)
       prismaMock.journey.findUnique.mockResolvedValue(mockJourney as any)
-      prismaMock.visitor.upsert.mockResolvedValue(mockVisitor as any)
-      prismaMock.journeyVisitor.upsert.mockResolvedValue(
-        mockJourneyVisitor as any
-      )
+      prismaMock.$queryRaw
+        .mockResolvedValueOnce([mockVisitor] as any)
+        .mockResolvedValueOnce([mockJourneyVisitor] as any)
       prismaMock.block.findFirst.mockResolvedValue({
         id: 'step-id',
         journeyId: 'journey-id',
@@ -98,13 +95,7 @@ describe('event utils', () => {
 
       const result = await validateBlockEvent('user-id', 'block-id', 'step-id')
 
-      expect(prismaMock.visitor.upsert).toHaveBeenCalledWith({
-        where: {
-          teamId_userId: { teamId: 'team-id', userId: 'user-id' }
-        },
-        create: { teamId: 'team-id', userId: 'user-id' },
-        update: {}
-      })
+      expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(2)
       expect(result).toEqual({
         visitor: mockVisitor,
         journeyVisitor: mockJourneyVisitor,
@@ -133,10 +124,9 @@ describe('event utils', () => {
 
       prismaMock.block.findUnique.mockResolvedValue(mockBlock as any)
       prismaMock.journey.findUnique.mockResolvedValue(mockJourney as any)
-      prismaMock.visitor.upsert.mockResolvedValue(mockVisitor as any)
-      prismaMock.journeyVisitor.upsert.mockResolvedValue(
-        mockJourneyVisitor as any
-      )
+      prismaMock.$queryRaw
+        .mockResolvedValueOnce([mockVisitor] as any)
+        .mockResolvedValueOnce([mockJourneyVisitor] as any)
       prismaMock.block.findFirst.mockResolvedValue({
         id: 'step-id',
         journeyId: 'journey-id',
@@ -145,17 +135,7 @@ describe('event utils', () => {
 
       const result = await validateBlockEvent('user-id', 'block-id', 'step-id')
 
-      expect(prismaMock.journeyVisitor.upsert).toHaveBeenCalledWith({
-        where: {
-          journeyId_visitorId: {
-            journeyId: 'journey-id',
-            visitorId: 'visitor-id'
-          }
-        },
-        create: { journeyId: 'journey-id', visitorId: 'visitor-id' },
-        update: {}
-      })
-
+      expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(2)
       expect(result.journeyVisitor).toEqual(mockJourneyVisitor)
       expect(result.teamId).toEqual('team-id')
     })
@@ -188,14 +168,15 @@ describe('event utils', () => {
       prismaMock.journey.findUnique.mockResolvedValue({
         teamId: 'team-id'
       } as any)
-      prismaMock.visitor.upsert.mockResolvedValue({
-        id: 'visitor-id'
-      } as any)
-      prismaMock.journeyVisitor.upsert.mockResolvedValue({
-        id: 'jv-id',
-        journeyId: 'journey-id',
-        visitorId: 'visitor-id'
-      } as any)
+      prismaMock.$queryRaw
+        .mockResolvedValueOnce([{ id: 'visitor-id' }] as any)
+        .mockResolvedValueOnce([
+          {
+            id: 'jv-id',
+            journeyId: 'journey-id',
+            visitorId: 'visitor-id'
+          }
+        ] as any)
       prismaMock.block.findFirst.mockResolvedValue(null)
 
       await expect(
@@ -262,112 +243,38 @@ describe('event utils', () => {
   })
 
   describe('getByUserIdAndJourneyId', () => {
-    it('should upsert visitor and journeyVisitor and return them', async () => {
-      const mockJourney = { teamId: 'team-id' }
-      const mockVisitor = {
-        id: 'visitor-id'
-      }
-      const mockJourneyVisitor = {
-        id: 'jv-id',
-        journeyId: 'journey-id',
-        visitorId: 'visitor-id'
-      }
-
-      prismaMock.journey.findUnique.mockResolvedValue(mockJourney as any)
-      prismaMock.visitor.upsert.mockResolvedValue(mockVisitor as any)
-      prismaMock.journeyVisitor.upsert.mockResolvedValue(
-        mockJourneyVisitor as any
-      )
-
-      const result = await getByUserIdAndJourneyId('user-id', 'journey-id')
-
-      expect(prismaMock.visitor.upsert).toHaveBeenCalledWith({
-        where: {
-          teamId_userId: { teamId: 'team-id', userId: 'user-id' }
-        },
-        create: { teamId: 'team-id', userId: 'user-id' },
-        update: {}
-      })
-      expect(prismaMock.journeyVisitor.upsert).toHaveBeenCalledWith({
-        where: {
-          journeyId_visitorId: {
-            journeyId: 'journey-id',
-            visitorId: 'visitor-id'
-          }
-        },
-        create: { journeyId: 'journey-id', visitorId: 'visitor-id' },
-        update: {}
-      })
-      expect(result).toEqual({
-        visitor: mockVisitor,
-        journeyVisitor: mockJourneyVisitor
-      })
-    })
-
-    it('should return null when journey does not exist', async () => {
-      prismaMock.journey.findUnique.mockResolvedValue(null)
-
-      const result = await getByUserIdAndJourneyId('user-id', 'journey-id')
-
-      expect(result).toBeNull()
-      expect(prismaMock.visitor.upsert).not.toHaveBeenCalled()
-    })
-
-    it('should retry on unique constraint violation and succeed', async () => {
-      const mockJourney = { teamId: 'team-id' }
+    it('should atomically upsert visitor and journeyVisitor and return them', async () => {
       const mockVisitor = { id: 'visitor-id' }
       const mockJourneyVisitor = {
         id: 'jv-id',
         journeyId: 'journey-id',
         visitorId: 'visitor-id'
       }
-      const uniqueErr = new Prisma.PrismaClientKnownRequestError('Unique', {
-        code: 'P2002',
-        clientVersion: '7.0.0'
-      })
 
-      prismaMock.journey.findUnique.mockResolvedValue(mockJourney as any)
-      prismaMock.visitor.upsert
-        .mockRejectedValueOnce(uniqueErr)
-        .mockResolvedValueOnce(mockVisitor as any)
-      prismaMock.journeyVisitor.upsert.mockResolvedValue(
-        mockJourneyVisitor as any
+      prismaMock.$queryRaw
+        .mockResolvedValueOnce([mockVisitor] as any)
+        .mockResolvedValueOnce([mockJourneyVisitor] as any)
+
+      const result = await getByUserIdAndJourneyId(
+        'user-id',
+        'journey-id',
+        'team-id'
       )
 
-      const result = await getByUserIdAndJourneyId('user-id', 'journey-id')
-
-      expect(prismaMock.visitor.upsert).toHaveBeenCalledTimes(2)
+      expect(prismaMock.journey.findUnique).not.toHaveBeenCalled()
+      expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(2)
       expect(result).toEqual({
         visitor: mockVisitor,
         journeyVisitor: mockJourneyVisitor
       })
     })
 
-    it('should rethrow non-unique-constraint errors', async () => {
-      prismaMock.journey.findUnique.mockResolvedValue({
-        teamId: 'team-id'
-      } as any)
-      prismaMock.visitor.upsert.mockRejectedValue(new Error('boom'))
+    it('should rethrow database errors from the atomic upsert', async () => {
+      prismaMock.$queryRaw.mockRejectedValue(new Error('boom'))
 
       await expect(
-        getByUserIdAndJourneyId('user-id', 'journey-id')
+        getByUserIdAndJourneyId('user-id', 'journey-id', 'team-id')
       ).rejects.toThrow('boom')
-    })
-
-    it('should give up after the max retry limit and rethrow', async () => {
-      const uniqueErr = new Prisma.PrismaClientKnownRequestError('Unique', {
-        code: 'P2002',
-        clientVersion: '7.0.0'
-      })
-      prismaMock.journey.findUnique.mockResolvedValue({
-        teamId: 'team-id'
-      } as any)
-      prismaMock.visitor.upsert.mockRejectedValue(uniqueErr)
-
-      await expect(
-        getByUserIdAndJourneyId('user-id', 'journey-id')
-      ).rejects.toBe(uniqueErr)
-      expect(prismaMock.visitor.upsert).toHaveBeenCalledTimes(3)
     })
   })
 

--- a/apis/api-journeys-modern/src/schema/event/utils.ts
+++ b/apis/api-journeys-modern/src/schema/event/utils.ts
@@ -1,17 +1,14 @@
 import { GraphQLError } from 'graphql'
+import { v4 as uuidv4 } from 'uuid'
 
 import {
   Block,
   JourneyVisitor,
-  Prisma,
   Visitor,
   prisma
 } from '@core/prisma/journeys/client'
 
 import { logger } from '../logger'
-
-const ERROR_PSQL_UNIQUE_CONSTRAINT_VIOLATED = 'P2002'
-const VISITOR_UPSERT_MAX_RETRIES = 3
 
 // Queue for visitor interaction emails
 let emailQueue: any
@@ -135,75 +132,34 @@ export async function validateBlock(
   return block != null ? block[type] === value : false
 }
 
+// Atomic Postgres upsert. `INSERT ... ON CONFLICT DO UPDATE ... RETURNING *`
+// executes as a single row-locked statement, so two concurrent calls cannot
+// both reach the insert step and race — Postgres serializes them on the
+// unique-key tuple. No retries needed, and both rows are guaranteed in the
+// result set. Caller must supply `teamId` (resolved from a prior journey
+// lookup), so the helper never has to verify the journey itself.
 export async function getByUserIdAndJourneyId(
   userId: string,
   journeyId: string,
-  teamId?: string
-): Promise<{
-  visitor: Visitor
-  journeyVisitor: JourneyVisitor
-} | null> {
-  let resolvedTeamId = teamId
-  if (resolvedTeamId == null) {
-    const journey = await prisma.journey.findUnique({
-      where: { id: journeyId },
-      select: { teamId: true }
-    })
+  teamId: string
+): Promise<{ visitor: Visitor; journeyVisitor: JourneyVisitor }> {
+  const [visitor] = await prisma.$queryRaw<Visitor[]>`
+    INSERT INTO "Visitor" ("id", "teamId", "userId", "createdAt", "updatedAt")
+    VALUES (${uuidv4()}, ${teamId}, ${userId}, NOW(), NOW())
+    ON CONFLICT ("teamId", "userId") DO UPDATE
+      SET "updatedAt" = NOW()
+    RETURNING *
+  `
 
-    if (journey == null) {
-      return null
-    }
-    resolvedTeamId = journey.teamId
-  }
+  const [journeyVisitor] = await prisma.$queryRaw<JourneyVisitor[]>`
+    INSERT INTO "JourneyVisitor" ("id", "journeyId", "visitorId", "createdAt", "updatedAt")
+    VALUES (${uuidv4()}, ${journeyId}, ${visitor.id}, NOW(), NOW())
+    ON CONFLICT ("journeyId", "visitorId") DO UPDATE
+      SET "updatedAt" = NOW()
+    RETURNING *
+  `
 
-  for (let attempt = 1; attempt <= VISITOR_UPSERT_MAX_RETRIES; attempt++) {
-    try {
-      const visitor = await prisma.visitor.upsert({
-        where: {
-          teamId_userId: {
-            teamId: resolvedTeamId,
-            userId
-          }
-        },
-        create: {
-          teamId: resolvedTeamId,
-          userId
-        },
-        update: {}
-      })
-      const journeyVisitor = await prisma.journeyVisitor.upsert({
-        where: {
-          journeyId_visitorId: {
-            journeyId,
-            visitorId: visitor.id
-          }
-        },
-        create: {
-          journeyId,
-          visitorId: visitor.id
-        },
-        update: {}
-      })
-
-      return { visitor, journeyVisitor }
-    } catch (err) {
-      if (
-        !(err instanceof Prisma.PrismaClientKnownRequestError) ||
-        err.code !== ERROR_PSQL_UNIQUE_CONSTRAINT_VIOLATED
-      ) {
-        throw err
-      }
-      logger.warn(
-        { userId, journeyId, attempt },
-        'Retrying visitor/journeyVisitor upsert after unique constraint race'
-      )
-      if (attempt === VISITOR_UPSERT_MAX_RETRIES) {
-        throw err
-      }
-    }
-  }
-
-  throw new Error('unreachable: upsert retry loop exited without return')
+  return { visitor, journeyVisitor }
 }
 
 // Helper function to get visitor and journey IDs


### PR DESCRIPTION
… atomic queryRaw operations

Updated the event utility functions to utilize atomic upsert operations via $queryRaw for visitors and journey visitors, improving performance and reducing the need for retries on unique constraint violations. Adjusted related tests to reflect these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal database access patterns for visitor and journey data tracking to improve system reliability and performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JesusFilm/core/pull/9226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->