### PR TITLE
fix(journeys): tag langfuse traces with deployment environment [NES-1688]

### DIFF
--- a/apps/journeys/src/libs/langfuse/client.spec.ts
+++ b/apps/journeys/src/libs/langfuse/client.spec.ts
@@ -19,6 +19,8 @@ describe('langfuse client', () => {
     delete process.env.LANGFUSE_SECRET_KEY
     delete process.env.LANGFUSE_BASE_URL
     delete process.env.VERCEL_ENV
+    delete process.env.VERCEL_GIT_COMMIT_REF
+    delete process.env.LANGFUSE_TRACING_ENVIRONMENT
   })
 
   afterEach(() => {
@@ -108,7 +110,8 @@ describe('langfuse client', () => {
       expect(mockLangfuseConstructor).toHaveBeenCalledWith({
         publicKey: 'pk-test',
         secretKey: 'sk-test',
-        baseUrl: 'https://lf.test'
+        baseUrl: 'https://lf.test',
+        environment: 'development'
       })
     })
 
@@ -122,6 +125,55 @@ describe('langfuse client', () => {
       const second = getLangfuse()
       expect(first).toBe(second)
       expect(mockLangfuseConstructor).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('environment resolution', () => {
+    beforeEach(() => {
+      process.env.LANGFUSE_PUBLIC_KEY = 'pk'
+      process.env.LANGFUSE_SECRET_KEY = 'sk'
+      process.env.LANGFUSE_BASE_URL = 'https://lf.test'
+    })
+
+    async function constructedEnvironment(): Promise<string> {
+      // eslint-disable-next-line import/dynamic-import-chunkname
+      const { getLangfuse } = await import('./client')
+      getLangfuse()
+      expect(mockLangfuseConstructor).toHaveBeenCalledTimes(1)
+      return mockLangfuseConstructor.mock.calls[0][0].environment
+    }
+
+    it("tags 'production' when VERCEL_ENV is 'production'", async () => {
+      process.env.VERCEL_ENV = 'production'
+      expect(await constructedEnvironment()).toBe('production')
+    })
+
+    it("tags 'stage' when VERCEL_ENV is 'preview' and branch is 'stage'", async () => {
+      process.env.VERCEL_ENV = 'preview'
+      process.env.VERCEL_GIT_COMMIT_REF = 'stage'
+      expect(await constructedEnvironment()).toBe('stage')
+    })
+
+    it("tags 'preview' when VERCEL_ENV is 'preview' on any other branch", async () => {
+      process.env.VERCEL_ENV = 'preview'
+      process.env.VERCEL_GIT_COMMIT_REF = 'jacobusbrink/nes-1234-something'
+      expect(await constructedEnvironment()).toBe('preview')
+    })
+
+    it("tags 'development' when VERCEL_ENV is unset", async () => {
+      expect(await constructedEnvironment()).toBe('development')
+    })
+
+    it('honours LANGFUSE_TRACING_ENVIRONMENT as an override', async () => {
+      process.env.VERCEL_ENV = 'production'
+      process.env.LANGFUSE_TRACING_ENVIRONMENT = 'load-test'
+      expect(await constructedEnvironment()).toBe('load-test')
+    })
+
+    it('ignores an empty LANGFUSE_TRACING_ENVIRONMENT override', async () => {
+      process.env.VERCEL_ENV = 'production'
+      process.env.LANGFUSE_TRACING_ENVIRONMENT = ''
+      expect(await constructedEnvironment()).toBe('production')
     })
   })
 

--- a/apps/journeys/src/libs/langfuse/client.ts
+++ b/apps/journeys/src/libs/langfuse/client.ts
@@ -30,10 +30,27 @@ export function getLangfuse(): Langfuse | null {
     return cached
   }
 
-  cached = new Langfuse({ publicKey, secretKey, baseUrl })
+  cached = new Langfuse({
+    publicKey,
+    secretKey,
+    baseUrl,
+    environment: resolveTracingEnvironment()
+  })
   return cached
 }
 
 export function getActivePromptLabel(): string {
   return process.env.VERCEL_ENV === 'production' ? 'production' : 'development'
+}
+
+// Without this, every trace ships as `environment: undefined` and Langfuse
+// buckets prod, stage, preview, and local-dev together as "default".
+function resolveTracingEnvironment(): string {
+  const override = process.env.LANGFUSE_TRACING_ENVIRONMENT
+  if (override != null && override !== '') return override
+  if (process.env.VERCEL_ENV === 'production') return 'production'
+  if (process.env.VERCEL_ENV === 'preview') {
+    return process.env.VERCEL_GIT_COMMIT_REF === 'stage' ? 'stage' : 'preview'
+  }
+  return 'development'
 }


### PR DESCRIPTION
## Summary

* Pass `environment` to the Langfuse SDK constructor so traces stop bucketing as `default`. Today **every** trace from `/api/chat` (prod, stage, preview, local) shows `environment: default` in the Langfuse UI, which breaks per-env filtering needed for World-Cup launch observability.
* Derive the value from `VERCEL_ENV` (and `VERCEL_GIT_COMMIT_REF` for the `stage` branch), with `LANGFUSE_TRACING_ENVIRONMENT` as a manual override.

## Mapping

| `VERCEL_ENV` | `VERCEL_GIT_COMMIT_REF` | Langfuse env  |
|--------------|-------------------------|---------------|
| `production` | —                       | `production`  |
| `preview`    | `stage`                 | `stage`       |
| `preview`    | other                   | `preview`     |
| unset        | —                       | `development` |

## Why this is a one-line fix in two places

Langfuse's SDK already supports `environment` on the constructor (`langfuse-core@3.38.20`, `lib/index.cjs.js:890`); we just weren't passing it. The fallback `getEnv("LANGFUSE_TRACING_ENVIRONMENT")` isn't set in Doppler either. Either knob alone fixes the bug; this PR wires both so we can override per environment without a redeploy if needed.

## Test plan

- [x] `npx vitest run --config apps/journeys/vitest.config.mts 'apps/journeys/src/libs/langfuse/client.spec.ts' --coverage=false` — 17 pass (was 11; added 6).
- [ ] After merge to preview: open Langfuse → confirm traces from the PR preview deployment appear under `preview` (not `default`).
- [ ] After merge to `stage` branch: traces appear under `stage`.
- [ ] After prod release: traces appear under `production`.

## Out of scope

* Per-trace `environment` overrides at the call site in `pages/api/chat/index.ts`. Constructor-level is sufficient.
* Folding `getActivePromptLabel()` into the new env helper — they answer different questions (prompt label vs Langfuse env). Tracked as a "could-do" if it ever bites.

## Linear

[NES-1688](https://linear.app/jesus-film-project/issue/NES-1688/fix-langfuse-pass-environment-to-constructor-so-prodstagedev-traces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)