### PR TITLE
refactor(journeys-admin): unify collection create/edit/publish flow

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Toolbar/JourneyDetails/JourneyDetails.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/JourneyDetails/JourneyDetails.tsx
@@ -32,7 +32,11 @@ export function JourneyDetails(): ReactElement {
           }}
         >
           <Stack
-            direction="row"
+            // QA-459: stack title + TEMPLATE chip vertically inside the
+            // mobile dropdown menu so the chip sits clearly below the
+            // title instead of getting squeezed against it. Desktop
+            // toolbar (md+) keeps the original side-by-side layout.
+            direction={{ xs: 'column', md: 'row' }}
             alignItems={{ xs: 'flex-start', md: 'center' }}
             gap={1}
             sx={{ minWidth: 0 }}

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.spec.tsx
@@ -58,7 +58,7 @@ describe('CollectionCard', () => {
     expect(screen.queryByText('Empty')).not.toBeInTheDocument()
   })
 
-  it('renders Edit / Publish / Remove menu items for a draft with templates', async () => {
+  it('renders Publish (not Edit) / Preview / Remove menu items for a draft with templates', async () => {
     render(
       <CollectionCard
         collection={makeCollection({ templates: [journeyRef('j1')] })}
@@ -67,7 +67,11 @@ describe('CollectionCard', () => {
     await userEvent.click(
       screen.getByRole('button', { name: 'Collection actions' })
     )
-    expect(screen.getByRole('menuitem', { name: 'Edit' })).toBeInTheDocument()
+    // Drafts surface "Publish" as the single entry point into the
+    // dialog; Edit only shows up on published collections.
+    expect(
+      screen.queryByRole('menuitem', { name: 'Edit' })
+    ).not.toBeInTheDocument()
     expect(
       screen.getByRole('menuitem', { name: 'Publish' })
     ).toBeInTheDocument()
@@ -79,18 +83,20 @@ describe('CollectionCard', () => {
     ).toBeInTheDocument()
   })
 
-  it('disables Publish for an empty draft collection', async () => {
+  it('keeps the Publish menu item enabled for an empty draft so the user can still open the dialog', async () => {
+    // The dialog's own Publish button is what gates emptiness — the
+    // menu item is the user's only way to access metadata, so it
+    // stays clickable even before any templates have been added.
     render(<CollectionCard collection={makeCollection()} />)
     await userEvent.click(
       screen.getByRole('button', { name: 'Collection actions' })
     )
-    expect(screen.getByRole('menuitem', { name: 'Publish' })).toHaveAttribute(
-      'aria-disabled',
-      'true'
-    )
+    expect(
+      screen.getByRole('menuitem', { name: 'Publish' })
+    ).not.toHaveAttribute('aria-disabled', 'true')
   })
 
-  it('replaces Publish with Unpublish for a published collection', async () => {
+  it('replaces Publish with Edit for a published collection (Unpublish now lives inside the dialog)', async () => {
     render(
       <CollectionCard
         collection={makeCollection({
@@ -106,19 +112,22 @@ describe('CollectionCard', () => {
     expect(
       screen.queryByRole('menuitem', { name: 'Publish' })
     ).not.toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: 'Edit' })).toBeInTheDocument()
+    // Unpublish was promoted into CollectionDialog's footer so the card
+    // menu has a single state-aware entry point.
     expect(
-      screen.getByRole('menuitem', { name: 'Unpublish' })
-    ).toBeInTheDocument()
+      screen.queryByRole('menuitem', { name: 'Unpublish' })
+    ).not.toBeInTheDocument()
   })
 
-  it('fires onEdit / onPublish / onUnpublish with the collection', async () => {
+  it('fires onPublish on a draft and onEdit on a published collection', async () => {
     const onEdit = jest.fn()
     const onPublish = jest.fn()
-    const collection = makeCollection({ templates: [journeyRef('j1')] })
+    const draft = makeCollection({ templates: [journeyRef('j1')] })
 
     const { rerender } = render(
       <CollectionCard
-        collection={collection}
+        collection={draft}
         onEdit={onEdit}
         onPublish={onPublish}
       />
@@ -126,29 +135,21 @@ describe('CollectionCard', () => {
     await userEvent.click(
       screen.getByRole('button', { name: 'Collection actions' })
     )
-    await userEvent.click(screen.getByRole('menuitem', { name: 'Edit' }))
-    expect(onEdit).toHaveBeenCalledWith(collection)
-
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Collection actions' })
-    )
     await userEvent.click(screen.getByRole('menuitem', { name: 'Publish' }))
-    expect(onPublish).toHaveBeenCalledWith(collection)
+    expect(onPublish).toHaveBeenCalledWith(draft)
+    expect(onEdit).not.toHaveBeenCalled()
 
-    const onUnpublish = jest.fn()
     const published = makeCollection({
       templates: [journeyRef('j1')],
       status: TemplateGalleryPageStatus.published,
       publishedAt: '2026-05-06T00:00:00Z'
     })
-    rerender(
-      <CollectionCard collection={published} onUnpublish={onUnpublish} />
-    )
+    rerender(<CollectionCard collection={published} onEdit={onEdit} />)
     await userEvent.click(
       screen.getByRole('button', { name: 'Collection actions' })
     )
-    await userEvent.click(screen.getByRole('menuitem', { name: 'Unpublish' }))
-    expect(onUnpublish).toHaveBeenCalledWith(published)
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Edit' }))
+    expect(onEdit).toHaveBeenCalledWith(published)
   })
 
   it('opens the ungroup confirmation dialog from the menu and fires onUngroup on confirm', async () => {

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
@@ -118,9 +118,16 @@ function CollectionCardImpl({
       data-testid={`CollectionCard-${collection.id}`}
       sx={{
         p: 2,
-        borderColor: 'divider',
+        // Match the surrounding page grey so the card reads as a
+        // panel of the same surface rather than a raised white card.
+        // The darker grey border + thicker stroke + soft shadow is
+        // what gives each collection its visual separation.
+        backgroundColor: 'background.default',
+        borderColor: 'grey.400',
         borderWidth: 1,
-        borderStyle: 'solid'
+        borderStyle: 'solid',
+        borderRadius: 3,
+        boxShadow: '0 2px 6px rgba(0, 0, 0, 0.08)'
       }}
       variant="outlined"
     >
@@ -219,9 +226,7 @@ function CollectionCardImpl({
         sx={{
           p: 0,
           '&:last-child': { pb: 0 },
-          minHeight: 100,
-          backgroundColor: (theme) => theme.palette.background.default,
-          borderRadius: 1
+          minHeight: 100
         }}
       >
         {isEmpty ? (

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
@@ -22,7 +22,6 @@ export interface CollectionCardProps {
   collection: TemplateGalleryPage
   onEdit?: (collection: TemplateGalleryPage) => void
   onPublish?: (collection: TemplateGalleryPage) => void
-  onUnpublish?: (collection: TemplateGalleryPage) => void
   onUngroup?: (collection: TemplateGalleryPage) => void
   busy?: boolean
   /**
@@ -48,7 +47,6 @@ function CollectionCardImpl({
   collection,
   onEdit,
   onPublish,
-  onUnpublish,
   onUngroup,
   busy,
   canPublish = true,
@@ -75,14 +73,14 @@ function CollectionCardImpl({
       ? t('Publish the collection to preview it.')
       : ''
 
-  // Publish disabled when: (1) collection is empty, or (2) custom domain
-  // gate. Custom-domain copy wins when both apply (the harder constraint).
-  const publishDisabled = isEmpty || !canPublish
-  const publishTooltip = !canPublish
-    ? (publishBlockedReason ?? '')
-    : isEmpty
-      ? t('Add at least one template before publishing')
-      : ''
+  // The Publish menu item is the user's single entry point into the
+  // dialog for a draft, so we only disable it for the harder
+  // constraint — custom-domain teams that can't publish at all.
+  // Empty collections still open the dialog (the user may want to
+  // fill in metadata before adding templates); the dialog's own
+  // Publish button is what gates emptiness.
+  const publishDisabled = !canPublish
+  const publishTooltip = !canPublish ? (publishBlockedReason ?? '') : ''
 
   function handleMenuOpen(event: MouseEvent<HTMLButtonElement>): void {
     setAnchorEl(event.currentTarget)
@@ -97,10 +95,6 @@ function CollectionCardImpl({
   function handlePublish(): void {
     handleMenuClose()
     onPublish?.(collection)
-  }
-  function handleUnpublish(): void {
-    handleMenuClose()
-    onUnpublish?.(collection)
   }
   function handlePreview(): void {
     handleMenuClose()
@@ -165,20 +159,15 @@ function CollectionCardImpl({
           open={anchorEl != null}
           onClose={handleMenuClose}
         >
-          <MenuItem onClick={handleEdit}>{t('Edit')}</MenuItem>
-          <Tooltip
-            title={previewTooltip}
-            placement="left"
-            disableHoverListener={!previewDisabled}
-            disableFocusListener={!previewDisabled}
-          >
-            <span>
-              <MenuItem onClick={handlePreview} disabled={previewDisabled}>
-                {t('Preview')}
-              </MenuItem>
-            </span>
-          </Tooltip>
-          {!isPublished && (
+          {/* Single state-aware entry point into CollectionDialog.
+              Draft collections expose "Publish" so the user has a
+              discoverable path to publishing; the dialog itself
+              renders a Save Draft secondary button so draft edits
+              don't require a publish. Published collections expose
+              "Edit" — Publish is no longer applicable. */}
+          {isPublished ? (
+            <MenuItem onClick={handleEdit}>{t('Edit')}</MenuItem>
+          ) : (
             <Tooltip
               title={publishTooltip}
               placement="left"
@@ -192,9 +181,18 @@ function CollectionCardImpl({
               </span>
             </Tooltip>
           )}
-          {isPublished && (
-            <MenuItem onClick={handleUnpublish}>{t('Unpublish')}</MenuItem>
-          )}
+          <Tooltip
+            title={previewTooltip}
+            placement="left"
+            disableHoverListener={!previewDisabled}
+            disableFocusListener={!previewDisabled}
+          >
+            <span>
+              <MenuItem onClick={handlePreview} disabled={previewDisabled}>
+                {t('Preview')}
+              </MenuItem>
+            </span>
+          </Tooltip>
           <MenuItem onClick={handleOpenUngroup}>
             {t('Remove Collection')}
           </MenuItem>

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/CollectionDialog.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/CollectionDialog.tsx
@@ -5,6 +5,7 @@ import ButtonBase from '@mui/material/ButtonBase'
 import Collapse from '@mui/material/Collapse'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
+import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import { Form, Formik } from 'formik'
 import { useTranslation } from 'next-i18next/pages'
@@ -25,7 +26,7 @@ import { useCollectionForm } from './useCollectionForm'
 
 export interface CollectionDialogProps {
   open: boolean
-  mode: 'create' | 'edit'
+  mode: 'create' | 'edit' | 'publish'
   teamId: string
   collection?: TemplateGalleryPage
   availableJourneys: readonly Journey[]
@@ -44,6 +45,8 @@ export interface CollectionDialogProps {
   /** Tooltip copy for the disabled preview button. */
   publishBlockedReason?: string | null
   onClose: () => void
+  /** Forwarded to useCollectionForm in publish mode. */
+  onPublished?: (collection: TemplateGalleryPage) => void
 }
 
 // Matches the Figma "Editor / Subtitle/2" type token on section headers.
@@ -64,12 +67,27 @@ export function CollectionDialog({
   parentBusy = false,
   canPublish = true,
   publishBlockedReason = null,
-  onClose
+  onClose,
+  onPublished
 }: CollectionDialogProps): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
 
-  const { initialValues, schema, isPublished, handleSubmit } =
-    useCollectionForm({ mode, teamId, collection, parentBusy, onClose })
+  const {
+    initialValues,
+    schema,
+    isPublished,
+    handleSubmit,
+    setSubmitIntent,
+    handleUnpublishAction,
+    isMutating
+  } = useCollectionForm({
+    mode,
+    teamId,
+    collection,
+    parentBusy,
+    onClose,
+    onPublished
+  })
 
   // O(1) lookup so the preview pane can resolve the user-pick-ordered
   // journey list per Formik render without an O(M) scan.
@@ -130,23 +148,124 @@ export function CollectionDialog({
               open={open}
               onClose={guardedClose}
               maxWidth="md"
-              // Disable the submit + close buttons while the mutation is in
-              // flight. Formik's submitForm has no internal double-click guard
-              // — without this, a fast second click before React re-renders
-              // would fire a second create/update mutation.
-              loading={isSubmitting}
+              // Disable the submit + close buttons while a mutation is in
+              // flight. Covers Formik's submitForm (isSubmitting) and
+              // the out-of-band unpublish action (isMutating). Without
+              // this, a fast second click before React re-renders would
+              // fire a duplicate mutation.
+              loading={isSubmitting || isMutating}
               dialogTitle={{
                 title:
                   mode === 'create'
                     ? t('New Collection')
-                    : t('Edit Collection'),
+                    : mode === 'publish'
+                      ? t('Publish Collection')
+                      : t('Edit Collection'),
                 closeButton: true
               }}
-              dialogAction={{
-                onSubmit: handleSubmit,
-                closeLabel: t('Cancel'),
-                submitLabel: mode === 'create' ? t('Create') : t('Save')
-              }}
+              dialogAction={
+                // Custom footer in publish mode (Save Draft + Publish)
+                // and in edit-while-published mode (Unpublish + Save).
+                // Create + draft-edit fall through to the default
+                // Cancel + Save footer.
+                mode === 'publish' || (mode === 'edit' && isPublished)
+                  ? undefined
+                  : {
+                      onSubmit: handleSubmit,
+                      closeLabel: t('Cancel'),
+                      submitLabel:
+                        mode === 'create' ? t('Create') : t('Save')
+                    }
+              }
+              dialogActionChildren={(() => {
+                const busy = isSubmitting || isMutating
+                if (mode === 'publish') {
+                  // Publish is gated by (a) custom-domain teams that
+                  // can't host gallery pages and (b) an empty selection
+                  // — same checks that previously lived on the card
+                  // menu, moved here so the menu item itself can
+                  // always open the dialog (the user may want to fill
+                  // in metadata before adding templates).
+                  const publishBlockedHere =
+                    !canPublish || values.journeyIds.length === 0
+                  const publishTooltip = !canPublish
+                    ? (publishBlockedReason ?? '')
+                    : values.journeyIds.length === 0
+                      ? t('Add at least one template before publishing')
+                      : ''
+                  return (
+                    <>
+                      <Button onClick={guardedClose} disabled={busy}>
+                        {t('Cancel')}
+                      </Button>
+                      <Button
+                        onClick={() => {
+                          setSubmitIntent('draft')
+                          handleSubmit()
+                        }}
+                        disabled={busy}
+                      >
+                        {t('Save Draft')}
+                      </Button>
+                      <Tooltip
+                        title={publishTooltip}
+                        placement="top"
+                        disableHoverListener={!publishBlockedHere}
+                        disableFocusListener={!publishBlockedHere}
+                      >
+                        <span>
+                          <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={() => {
+                              setSubmitIntent('publish')
+                              handleSubmit()
+                            }}
+                            loading={isSubmitting}
+                            disabled={publishBlockedHere || busy}
+                          >
+                            {t('Publish')}
+                          </Button>
+                        </span>
+                      </Tooltip>
+                    </>
+                  )
+                }
+                if (mode === 'edit' && isPublished) {
+                  // Unpublish lives inside the dialog so the card menu
+                  // has a single state-aware entry point. Skips
+                  // Formik on purpose — any pending field edits are
+                  // discarded, because "unpublish" is a deliberate
+                  // status change, not a save path.
+                  return (
+                    <>
+                      <Button onClick={guardedClose} disabled={busy}>
+                        {t('Cancel')}
+                      </Button>
+                      <Button
+                        color="error"
+                        onClick={() => {
+                          void handleUnpublishAction()
+                        }}
+                        loading={isMutating}
+                        disabled={busy}
+                      >
+                        {t('Unpublish')}
+                      </Button>
+                      <Button
+                        variant="contained"
+                        color="primary"
+                        onClick={() => handleSubmit()}
+                        loading={isSubmitting}
+                        disabled={busy}
+                      >
+                        {t('Save')}
+                      </Button>
+                    </>
+                  )
+                }
+                return undefined
+              })()}
               testId="CollectionDialog"
               sx={{
                 '& .MuiDialogContent-root': {
@@ -308,6 +427,65 @@ export function CollectionDialog({
                               />
                             </Stack>
 
+                            {mode !== 'create' && (
+                              <Stack spacing={1}>
+                                <Typography sx={SECTION_HEADER}>
+                                  {t('Slug')}
+                                </Typography>
+                                <TextField
+                                  id="slug"
+                                  name="slug"
+                                  placeholder={t('Type here')}
+                                  fullWidth
+                                  variant="filled"
+                                  hiddenLabel
+                                  value={values.slug}
+                                  inputProps={{
+                                    'aria-label': t('Slug')
+                                  }}
+                                  // Slugify on every keystroke so the input
+                                  // mirrors what the backend will accept: lowercase,
+                                  // swap whitespace + invalid chars for dashes,
+                                  // collapse runs, and clip leading dashes.
+                                  // Trailing dashes stay so the user can still
+                                  // type "foo-bar"; we strip them on blur.
+                                  onChange={async (event) => {
+                                    const slugified = event.target.value
+                                      .toLowerCase()
+                                      .replace(/[^a-z0-9-]+/g, '-')
+                                      .replace(/-+/g, '-')
+                                      .replace(/^-+/, '')
+                                    await setFieldValue('slug', slugified)
+                                  }}
+                                  onBlur={async (event) => {
+                                    // Strip trailing dashes on blur so the
+                                    // value satisfies SLUG_PATTERN once the
+                                    // user moves on; mid-typing dashes stay
+                                    // so "foo-" doesn't immediately surface
+                                    // a validation error.
+                                    const trimmed = values.slug.replace(
+                                      /-+$/,
+                                      ''
+                                    )
+                                    if (trimmed !== values.slug) {
+                                      await setFieldValue('slug', trimmed)
+                                    }
+                                    handleBlur(event)
+                                  }}
+                                  error={
+                                    touched.slug === true &&
+                                    Boolean(errors.slug)
+                                  }
+                                  helperText={
+                                    (touched.slug === true && errors.slug) ||
+                                    t(
+                                      'Used in the public URL. Must be unique across your collections — changing it breaks existing links.'
+                                    )
+                                  }
+                                />
+                              </Stack>
+                            )}
+
                             <Stack spacing={1}>
                               <Typography sx={SECTION_HEADER}>
                                 {t('Creator Details')}
@@ -409,51 +587,6 @@ export function CollectionDialog({
                                 preview in `CollectionPreviewPane` is also
                                 hidden. Replaces NES-1660 (helper-text
                                 approach was rejected by QA). */}
-
-                            {mode === 'edit' && (
-                              <TextField
-                                id="slug"
-                                name="slug"
-                                label={t('Slug')}
-                                fullWidth
-                                variant="filled"
-                                value={values.slug}
-                                // Slugify on every keystroke so the input
-                                // mirrors what the backend will accept: lowercase,
-                                // swap whitespace + invalid chars for dashes,
-                                // collapse runs, and clip leading dashes.
-                                // Trailing dashes stay so the user can still
-                                // type "foo-bar"; we strip them on blur.
-                                onChange={async (event) => {
-                                  const slugified = event.target.value
-                                    .toLowerCase()
-                                    .replace(/[^a-z0-9-]+/g, '-')
-                                    .replace(/-+/g, '-')
-                                    .replace(/^-+/, '')
-                                  await setFieldValue('slug', slugified)
-                                }}
-                                onBlur={async (event) => {
-                                  // Strip trailing dashes on blur so the value
-                                  // satisfies SLUG_PATTERN once the user moves
-                                  // on; mid-typing dashes stay so "foo-" doesn't
-                                  // immediately surface a validation error.
-                                  const trimmed = values.slug.replace(/-+$/, '')
-                                  if (trimmed !== values.slug) {
-                                    await setFieldValue('slug', trimmed)
-                                  }
-                                  handleBlur(event)
-                                }}
-                                error={
-                                  touched.slug === true && Boolean(errors.slug)
-                                }
-                                helperText={
-                                  (touched.slug === true && errors.slug) ||
-                                  t(
-                                    'Used in the public URL. Must be unique across your collections — changing it breaks existing links.'
-                                  )
-                                }
-                              />
-                            )}
                           </Stack>
                         </Collapse>
                       </Stack>

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/CollectionDialog.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/CollectionDialog.tsx
@@ -173,8 +173,7 @@ export function CollectionDialog({
                   : {
                       onSubmit: handleSubmit,
                       closeLabel: t('Cancel'),
-                      submitLabel:
-                        mode === 'create' ? t('Create') : t('Save')
+                      submitLabel: mode === 'create' ? t('Create') : t('Save')
                     }
               }
               dialogActionChildren={(() => {

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/CollectionDialog.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/CollectionDialog.tsx
@@ -5,7 +5,6 @@ import ButtonBase from '@mui/material/ButtonBase'
 import Collapse from '@mui/material/Collapse'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
-import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import { Form, Formik } from 'formik'
 import { useTranslation } from 'next-i18next/pages'
@@ -18,6 +17,7 @@ import Plus2Icon from '@core/shared/ui/icons/Plus2'
 import { GetAdminJourneys_journeys as Journey } from '../../../../__generated__/GetAdminJourneys'
 import { GetTemplateGalleryPages_templateGalleryPages as TemplateGalleryPage } from '../../../../__generated__/GetTemplateGalleryPages'
 
+import { CollectionDialogFooter } from './CollectionDialogFooter'
 import { CollectionPreviewPane } from './CollectionPreviewPane'
 import { CreatorImagePickerDrawer } from './CreatorImagePickerDrawer'
 import { DiscardConfirmDialog } from './DiscardConfirmDialog'
@@ -79,7 +79,7 @@ export function CollectionDialog({
     handleSubmit,
     setSubmitIntent,
     handleUnpublishAction,
-    isMutating
+    isUnpublishing
   } = useCollectionForm({
     mode,
     teamId,
@@ -124,18 +124,40 @@ export function CollectionDialog({
         setValues,
         isSubmitting
       }) => {
-        // Block close paths while a submit is in flight so the user can't
-        // dismiss the dialog mid-mutation (which would orphan the post-await
-        // side effects). Submit succeeds → onClose() runs explicitly.
-        // Also intercepts close paths when the form is dirty: opens the
-        // "discard changes?" confirmation instead of closing immediately.
+        // Block close paths while a mutation is in flight so the user
+        // can't dismiss the dialog mid-mutation (which would orphan the
+        // post-await side effects). Covers Formik submit (isSubmitting)
+        // and the out-of-band unpublish action (isUnpublishing). Submit
+        // succeeds → onClose() runs explicitly. Also intercepts close
+        // paths when the form is dirty: opens the "discard changes?"
+        // confirmation instead of closing immediately.
         const guardedClose = (): void => {
-          if (isSubmitting) return
+          if (isSubmitting || isUnpublishing) return
           if (dirty) {
             setDiscardConfirmOpen(true)
             return
           }
           onClose()
+        }
+        // Named handlers wired into the footer. Save Draft + Publish
+        // share Formik's submitForm and disambiguate via the intent
+        // ref; Unpublish bypasses Formik (see useCollectionForm).
+        const handleCreateClick = (): void => {
+          handleSubmit()
+        }
+        const handleSaveClick = (): void => {
+          handleSubmit()
+        }
+        const handleSaveDraftClick = (): void => {
+          setSubmitIntent('draft')
+          handleSubmit()
+        }
+        const handlePublishClick = (): void => {
+          setSubmitIntent('publish')
+          handleSubmit()
+        }
+        const handleUnpublishClick = (): void => {
+          void handleUnpublishAction()
         }
         // Selected journeys, ordered by the user's pick order, used for the
         // carousel preview on the left pane.
@@ -148,12 +170,12 @@ export function CollectionDialog({
               open={open}
               onClose={guardedClose}
               maxWidth="md"
-              // Disable the submit + close buttons while a mutation is in
-              // flight. Covers Formik's submitForm (isSubmitting) and
-              // the out-of-band unpublish action (isMutating). Without
-              // this, a fast second click before React re-renders would
-              // fire a duplicate mutation.
-              loading={isSubmitting || isMutating}
+              // Disable the submit + close buttons while any mutation
+              // is in flight. Covers Formik's submitForm (isSubmitting)
+              // and the out-of-band unpublish action (isUnpublishing).
+              // Without this, a fast second click before React
+              // re-renders would fire a duplicate mutation.
+              loading={isSubmitting || isUnpublishing}
               dialogTitle={{
                 title:
                   mode === 'create'
@@ -163,108 +185,27 @@ export function CollectionDialog({
                       : t('Edit Collection'),
                 closeButton: true
               }}
-              dialogAction={
-                // Custom footer in publish mode (Save Draft + Publish)
-                // and in edit-while-published mode (Unpublish + Save).
-                // Create + draft-edit fall through to the default
-                // Cancel + Save footer.
-                mode === 'publish' || (mode === 'edit' && isPublished)
-                  ? undefined
-                  : {
-                      onSubmit: handleSubmit,
-                      closeLabel: t('Cancel'),
-                      submitLabel: mode === 'create' ? t('Create') : t('Save')
-                    }
+              // Footer is always rendered via dialogActionChildren so
+              // CollectionDialogFooter owns the mode-based branching in
+              // one place — see that component for the four button
+              // configurations.
+              dialogActionChildren={
+                <CollectionDialogFooter
+                  mode={mode}
+                  isPublished={isPublished}
+                  canPublish={canPublish}
+                  publishBlockedReason={publishBlockedReason}
+                  journeyCount={values.journeyIds.length}
+                  isSubmitting={isSubmitting}
+                  isUnpublishing={isUnpublishing}
+                  onCancel={guardedClose}
+                  onCreate={handleCreateClick}
+                  onSave={handleSaveClick}
+                  onSaveDraft={handleSaveDraftClick}
+                  onPublish={handlePublishClick}
+                  onUnpublish={handleUnpublishClick}
+                />
               }
-              dialogActionChildren={(() => {
-                const busy = isSubmitting || isMutating
-                if (mode === 'publish') {
-                  // Publish is gated by (a) custom-domain teams that
-                  // can't host gallery pages and (b) an empty selection
-                  // — same checks that previously lived on the card
-                  // menu, moved here so the menu item itself can
-                  // always open the dialog (the user may want to fill
-                  // in metadata before adding templates).
-                  const publishBlockedHere =
-                    !canPublish || values.journeyIds.length === 0
-                  const publishTooltip = !canPublish
-                    ? (publishBlockedReason ?? '')
-                    : values.journeyIds.length === 0
-                      ? t('Add at least one template before publishing')
-                      : ''
-                  return (
-                    <>
-                      <Button onClick={guardedClose} disabled={busy}>
-                        {t('Cancel')}
-                      </Button>
-                      <Button
-                        onClick={() => {
-                          setSubmitIntent('draft')
-                          handleSubmit()
-                        }}
-                        disabled={busy}
-                      >
-                        {t('Save Draft')}
-                      </Button>
-                      <Tooltip
-                        title={publishTooltip}
-                        placement="top"
-                        disableHoverListener={!publishBlockedHere}
-                        disableFocusListener={!publishBlockedHere}
-                      >
-                        <span>
-                          <Button
-                            variant="contained"
-                            color="primary"
-                            onClick={() => {
-                              setSubmitIntent('publish')
-                              handleSubmit()
-                            }}
-                            loading={isSubmitting}
-                            disabled={publishBlockedHere || busy}
-                          >
-                            {t('Publish')}
-                          </Button>
-                        </span>
-                      </Tooltip>
-                    </>
-                  )
-                }
-                if (mode === 'edit' && isPublished) {
-                  // Unpublish lives inside the dialog so the card menu
-                  // has a single state-aware entry point. Skips
-                  // Formik on purpose — any pending field edits are
-                  // discarded, because "unpublish" is a deliberate
-                  // status change, not a save path.
-                  return (
-                    <>
-                      <Button onClick={guardedClose} disabled={busy}>
-                        {t('Cancel')}
-                      </Button>
-                      <Button
-                        color="error"
-                        onClick={() => {
-                          void handleUnpublishAction()
-                        }}
-                        loading={isMutating}
-                        disabled={busy}
-                      >
-                        {t('Unpublish')}
-                      </Button>
-                      <Button
-                        variant="contained"
-                        color="primary"
-                        onClick={() => handleSubmit()}
-                        loading={isSubmitting}
-                        disabled={busy}
-                      >
-                        {t('Save')}
-                      </Button>
-                    </>
-                  )
-                }
-                return undefined
-              })()}
               testId="CollectionDialog"
               sx={{
                 '& .MuiDialogContent-root': {

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/CollectionDialogFooter/CollectionDialogFooter.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/CollectionDialogFooter/CollectionDialogFooter.spec.tsx
@@ -1,0 +1,212 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import '../../../../../test/i18n'
+
+import {
+  CollectionDialogFooter,
+  CollectionDialogFooterProps
+} from './CollectionDialogFooter'
+
+function makeProps(
+  overrides: Partial<CollectionDialogFooterProps> = {}
+): CollectionDialogFooterProps {
+  return {
+    mode: 'edit',
+    isPublished: false,
+    canPublish: true,
+    publishBlockedReason: null,
+    journeyCount: 1,
+    isSubmitting: false,
+    isUnpublishing: false,
+    onCancel: jest.fn(),
+    onCreate: jest.fn(),
+    onSave: jest.fn(),
+    onSaveDraft: jest.fn(),
+    onPublish: jest.fn(),
+    onUnpublish: jest.fn(),
+    ...overrides
+  }
+}
+
+describe('CollectionDialogFooter', () => {
+  describe('create mode', () => {
+    it('renders Cancel + Create and wires the callbacks', async () => {
+      const onCancel = jest.fn()
+      const onCreate = jest.fn()
+      render(
+        <CollectionDialogFooter
+          {...makeProps({ mode: 'create', onCancel, onCreate })}
+        />
+      )
+      const cancel = screen.getByRole('button', { name: 'Cancel' })
+      const create = screen.getByRole('button', { name: 'Create' })
+      expect(cancel).toBeInTheDocument()
+      expect(create).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'Save' })
+      ).not.toBeInTheDocument()
+
+      await userEvent.click(cancel)
+      expect(onCancel).toHaveBeenCalledTimes(1)
+      await userEvent.click(create)
+      expect(onCreate).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('edit mode (draft)', () => {
+    it('renders Cancel + Save only', async () => {
+      const onCancel = jest.fn()
+      const onSave = jest.fn()
+      render(
+        <CollectionDialogFooter
+          {...makeProps({
+            mode: 'edit',
+            isPublished: false,
+            onCancel,
+            onSave
+          })}
+        />
+      )
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'Unpublish' })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'Save Draft' })
+      ).not.toBeInTheDocument()
+
+      await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+      expect(onSave).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('edit mode (published)', () => {
+    it('renders Cancel + Unpublish + Save and wires the callbacks', async () => {
+      const onCancel = jest.fn()
+      const onSave = jest.fn()
+      const onUnpublish = jest.fn()
+      render(
+        <CollectionDialogFooter
+          {...makeProps({
+            mode: 'edit',
+            isPublished: true,
+            onCancel,
+            onSave,
+            onUnpublish
+          })}
+        />
+      )
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'Unpublish' })
+      ).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'Save Draft' })
+      ).not.toBeInTheDocument()
+
+      await userEvent.click(screen.getByRole('button', { name: 'Unpublish' }))
+      expect(onUnpublish).toHaveBeenCalledTimes(1)
+      await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+      expect(onSave).toHaveBeenCalledTimes(1)
+    })
+
+    it('disables every button while unpublishing is in flight', () => {
+      render(
+        <CollectionDialogFooter
+          {...makeProps({
+            mode: 'edit',
+            isPublished: true,
+            isUnpublishing: true
+          })}
+        />
+      )
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: 'Unpublish' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+    })
+  })
+
+  describe('publish mode', () => {
+    it('renders Cancel + Save Draft + Publish and wires the callbacks', async () => {
+      const onCancel = jest.fn()
+      const onSaveDraft = jest.fn()
+      const onPublish = jest.fn()
+      render(
+        <CollectionDialogFooter
+          {...makeProps({
+            mode: 'publish',
+            onCancel,
+            onSaveDraft,
+            onPublish
+          })}
+        />
+      )
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'Save Draft' })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'Publish' })
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'Unpublish' })
+      ).not.toBeInTheDocument()
+
+      await userEvent.click(screen.getByRole('button', { name: 'Save Draft' }))
+      expect(onSaveDraft).toHaveBeenCalledTimes(1)
+      await userEvent.click(screen.getByRole('button', { name: 'Publish' }))
+      expect(onPublish).toHaveBeenCalledTimes(1)
+    })
+
+    it('disables Publish when journeyCount is 0 with the empty-collection tooltip', async () => {
+      render(
+        <CollectionDialogFooter
+          {...makeProps({ mode: 'publish', journeyCount: 0 })}
+        />
+      )
+      const publish = screen.getByRole('button', { name: 'Publish' })
+      expect(publish).toBeDisabled()
+      // Save Draft must stay enabled so the user can edit metadata
+      // before adding templates.
+      expect(screen.getByRole('button', { name: 'Save Draft' })).toBeEnabled()
+
+      await userEvent.hover(publish.parentElement as HTMLElement)
+      expect(await screen.findByRole('tooltip')).toHaveTextContent(
+        'Add at least one template before publishing'
+      )
+    })
+
+    it('disables Publish when canPublish is false and shows the custom-domain reason', async () => {
+      const reason = 'gate copy'
+      render(
+        <CollectionDialogFooter
+          {...makeProps({
+            mode: 'publish',
+            canPublish: false,
+            publishBlockedReason: reason,
+            journeyCount: 3
+          })}
+        />
+      )
+      const publish = screen.getByRole('button', { name: 'Publish' })
+      expect(publish).toBeDisabled()
+
+      await userEvent.hover(publish.parentElement as HTMLElement)
+      expect(await screen.findByRole('tooltip')).toHaveTextContent(reason)
+    })
+
+    it('disables every button while Formik submit is in flight', () => {
+      render(
+        <CollectionDialogFooter
+          {...makeProps({ mode: 'publish', isSubmitting: true })}
+        />
+      )
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: 'Save Draft' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: 'Publish' })).toBeDisabled()
+    })
+  })
+})

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/CollectionDialogFooter/CollectionDialogFooter.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/CollectionDialogFooter/CollectionDialogFooter.tsx
@@ -1,0 +1,191 @@
+import Button from '@mui/material/Button'
+import Tooltip from '@mui/material/Tooltip'
+import { useTranslation } from 'next-i18next/pages'
+import { ReactElement } from 'react'
+
+export interface CollectionDialogFooterProps {
+  mode: 'create' | 'edit' | 'publish'
+  /** True when the underlying collection is published. Only meaningful
+   *  in edit mode — toggles the Unpublish button on. */
+  isPublished: boolean
+  /** False when the active team has a `routeAllTeamJourneys` custom
+   *  domain. Gates the Publish button + drives its tooltip in publish
+   *  mode. */
+  canPublish: boolean
+  /** Tooltip copy shown on the disabled Publish button when canPublish
+   *  is false. Null falls back to the empty-selection copy. */
+  publishBlockedReason: string | null
+  /** Number of templates currently selected — Publish stays disabled
+   *  while this is zero, with a tooltip prompting the user to add at
+   *  least one. */
+  journeyCount: number
+  /** True while Formik's submitForm is in flight (Save, Save Draft,
+   *  Publish, Create). */
+  isSubmitting: boolean
+  /** True while the unpublish mutation is in flight. Disjoint from
+   *  isSubmitting because Unpublish bypasses Formik. */
+  isUnpublishing: boolean
+  /** Called for Cancel. The dialog's guardedClose() — handles
+   *  dirty-state confirmation + in-flight blocks. */
+  onCancel: () => void
+  /** Called for Create (create mode). Typically Formik submitForm. */
+  onCreate: () => void
+  /** Called for Save (edit modes). Typically Formik submitForm. */
+  onSave: () => void
+  /** Called for Save Draft (publish mode). Caller should setSubmitIntent('draft')
+   *  before invoking. */
+  onSaveDraft: () => void
+  /** Called for Publish (publish mode). Caller should setSubmitIntent('publish')
+   *  before invoking. */
+  onPublish: () => void
+  /** Called for Unpublish (edit + isPublished). Bypasses Formik. */
+  onUnpublish: () => void
+}
+
+/**
+ * Footer-button layout for CollectionDialog. One of four
+ * configurations renders based on (mode, isPublished):
+ *
+ *  - create               → Cancel | Create
+ *  - edit (draft)         → Cancel | Save
+ *  - edit (published)     → Cancel | Unpublish | Save
+ *  - publish              → Cancel | Save Draft | Publish
+ *
+ * Extracted out of CollectionDialog to keep the dialog's render
+ * tree readable — the previous IIFE-in-prop pattern stacked two
+ * unusual idioms (self-invoked arrow + JSX-as-prop-value) and
+ * pushed the testId/sx props ~90 lines below the prop it was on.
+ */
+export function CollectionDialogFooter({
+  mode,
+  isPublished,
+  canPublish,
+  publishBlockedReason,
+  journeyCount,
+  isSubmitting,
+  isUnpublishing,
+  onCancel,
+  onCreate,
+  onSave,
+  onSaveDraft,
+  onPublish,
+  onUnpublish
+}: CollectionDialogFooterProps): ReactElement {
+  const { t } = useTranslation('apps-journeys-admin')
+  const busy = isSubmitting || isUnpublishing
+
+  if (mode === 'create') {
+    return (
+      <>
+        <Button onClick={onCancel} disabled={busy}>
+          {t('Cancel')}
+        </Button>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={onCreate}
+          loading={isSubmitting}
+          disabled={busy}
+        >
+          {t('Create')}
+        </Button>
+      </>
+    )
+  }
+
+  if (mode === 'publish') {
+    // Publish is gated by (a) custom-domain teams that can't host
+    // gallery pages and (b) an empty selection — moved here from the
+    // card menu so the menu item can always open the dialog (the user
+    // may want to fill in metadata before adding templates). Save
+    // Draft stays enabled either way.
+    const publishBlocked = !canPublish || journeyCount === 0
+    const publishTooltip = !canPublish
+      ? (publishBlockedReason ?? '')
+      : journeyCount === 0
+        ? t('Add at least one template before publishing')
+        : ''
+    return (
+      <>
+        <Button onClick={onCancel} disabled={busy}>
+          {t('Cancel')}
+        </Button>
+        <Button onClick={onSaveDraft} disabled={busy}>
+          {t('Save Draft')}
+        </Button>
+        <Tooltip
+          title={publishTooltip}
+          placement="top"
+          disableHoverListener={!publishBlocked}
+          disableFocusListener={!publishBlocked}
+        >
+          {/* MUI requires a non-disabled wrapper so the Tooltip can
+              attach pointer events even when the Button is disabled. */}
+          <span>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={onPublish}
+              loading={isSubmitting}
+              disabled={publishBlocked || busy}
+            >
+              {t('Publish')}
+            </Button>
+          </span>
+        </Tooltip>
+      </>
+    )
+  }
+
+  // mode === 'edit'
+  if (isPublished) {
+    // Unpublish lives inside the dialog so the card menu has a single
+    // state-aware entry. Skips Formik on purpose — any pending field
+    // edits are discarded, because "unpublish" is a deliberate status
+    // change, not a save path.
+    return (
+      <>
+        <Button onClick={onCancel} disabled={busy}>
+          {t('Cancel')}
+        </Button>
+        <Button
+          color="error"
+          onClick={onUnpublish}
+          loading={isUnpublishing}
+          disabled={busy}
+        >
+          {t('Unpublish')}
+        </Button>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={onSave}
+          loading={isSubmitting}
+          disabled={busy}
+        >
+          {t('Save')}
+        </Button>
+      </>
+    )
+  }
+
+  // edit, draft — the default Cancel | Save pair, preserved for
+  // consistency with the other modes so the dialog only needs one
+  // footer-rendering branch.
+  return (
+    <>
+      <Button onClick={onCancel} disabled={busy}>
+        {t('Cancel')}
+      </Button>
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={onSave}
+        loading={isSubmitting}
+        disabled={busy}
+      >
+        {t('Save')}
+      </Button>
+    </>
+  )
+}

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/CollectionDialogFooter/CollectionDialogFooter.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/CollectionDialogFooter/CollectionDialogFooter.tsx
@@ -1,3 +1,4 @@
+import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Tooltip from '@mui/material/Tooltip'
 import { useTranslation } from 'next-i18next/pages'
@@ -13,7 +14,10 @@ export interface CollectionDialogFooterProps {
    *  mode. */
   canPublish: boolean
   /** Tooltip copy shown on the disabled Publish button when canPublish
-   *  is false. Null falls back to the empty-selection copy. */
+   *  is false. When null, no tooltip is shown — `useCanPublishCollection`
+   *  always provides a reason today, so a null reason here just leaves
+   *  the button silently disabled. Callers gating Publish should pass a
+   *  non-null string. */
   publishBlockedReason: string | null
   /** Number of templates currently selected — Publish stays disabled
    *  while this is zero, with a tooltip prompting the user to add at
@@ -120,8 +124,10 @@ export function CollectionDialogFooter({
           disableFocusListener={!publishBlocked}
         >
           {/* MUI requires a non-disabled wrapper so the Tooltip can
-              attach pointer events even when the Button is disabled. */}
-          <span>
+              attach pointer events even when the Button is disabled.
+              Using Box with component="span" keeps the inline flow
+              while satisfying the apps "MUI over raw HTML" rule. */}
+          <Box component="span">
             <Button
               variant="contained"
               color="primary"
@@ -131,7 +137,7 @@ export function CollectionDialogFooter({
             >
               {t('Publish')}
             </Button>
-          </span>
+          </Box>
         </Tooltip>
       </>
     )

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/CollectionDialogFooter/index.ts
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/CollectionDialogFooter/index.ts
@@ -1,0 +1,2 @@
+export { CollectionDialogFooter } from './CollectionDialogFooter'
+export type { CollectionDialogFooterProps } from './CollectionDialogFooter'

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/CollectionPreviewPane/CollectionPreviewPane.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/CollectionPreviewPane/CollectionPreviewPane.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'next-i18next/pages'
 import { useSnackbar } from 'notistack'
 import { ReactElement, memo } from 'react'
 
-import LinkAngledIcon from '@core/shared/ui/icons/LinkAngled'
+import CopyRightIcon from '@core/shared/ui/icons/CopyRight'
 import Play3Icon from '@core/shared/ui/icons/Play3'
 
 import { GetAdminJourneys_journeys as Journey } from '../../../../../__generated__/GetAdminJourneys'
@@ -147,7 +147,7 @@ function CollectionPreviewPaneImpl({
                       edge="end"
                       size="small"
                     >
-                      <LinkAngledIcon fontSize="small" />
+                      <CopyRightIcon fontSize="small" />
                     </IconButton>
                   </span>
                 </Tooltip>

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/useCollectionForm/useCollectionForm.ts
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/useCollectionForm/useCollectionForm.ts
@@ -3,7 +3,7 @@ import { FormikHelpers } from 'formik'
 import { TFunction } from 'i18next'
 import { useTranslation } from 'next-i18next/pages'
 import { useSnackbar } from 'notistack'
-import { useMemo, useRef } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { ObjectSchema, array, object, string } from 'yup'
 
 import { TEMPLATE_GALLERY_SLUG_RE } from '@core/journeys/ui/templateGallerySlug'
@@ -15,6 +15,8 @@ import {
   TemplateGalleryPageUpdateInput
 } from '../../../../../__generated__/globalTypes'
 import { useTemplateGalleryPageCreateMutation } from '../../../../libs/useTemplateGalleryPageCreateMutation'
+import { useTemplateGalleryPagePublishMutation } from '../../../../libs/useTemplateGalleryPagePublishMutation'
+import { useTemplateGalleryPageUnpublishMutation } from '../../../../libs/useTemplateGalleryPageUnpublishMutation'
 import { useTemplateGalleryPageUpdateMutation } from '../../../../libs/useTemplateGalleryPageUpdateMutation'
 
 export interface CollectionFormValues {
@@ -29,7 +31,7 @@ export interface CollectionFormValues {
 }
 
 export interface UseCollectionFormParams {
-  mode: 'create' | 'edit'
+  mode: 'create' | 'edit' | 'publish'
   teamId: string
   collection?: TemplateGalleryPage
   /** When true, submit is short-circuited with a snackbar — a sibling
@@ -37,6 +39,12 @@ export interface UseCollectionFormParams {
   parentBusy?: boolean
   /** Called once on a successful create or update. */
   onClose: () => void
+  /**
+   * Called after a successful publish (mode === 'publish') with the
+   * just-published collection so the parent can open the success
+   * dialog with the live public URL.
+   */
+  onPublished?: (collection: TemplateGalleryPage) => void
 }
 
 export interface UseCollectionFormResult {
@@ -46,10 +54,12 @@ export interface UseCollectionFormResult {
    * this to lock the membership picker. */
   isPublished: boolean
   /**
-   * Formik onSubmit. Branches on mode:
+   * Formik onSubmit. Branches on mode + intent:
    *  - create → templateGalleryPageCreate, then onClose
-   *  - edit → diff values vs the original collection, send only the
-   *    changed fields to templateGalleryPageUpdate, then onClose
+   *  - edit, or publish + intent 'draft' → diff vs original, send
+   *    only changed fields to templateGalleryPageUpdate, then onClose
+   *  - publish + intent 'publish' → diffed update (if any), then
+   *    templateGalleryPagePublish, then onClose
    * On ApolloError, maps `extensions.field` back to a Formik field error
    * for slug / mediaUrl / creatorImageSrc / title; falls back to a
    * snackbar otherwise.
@@ -58,6 +68,31 @@ export interface UseCollectionFormResult {
     values: CollectionFormValues,
     helpers: FormikHelpers<CollectionFormValues>
   ) => Promise<void>
+  /**
+   * Set the next submit's intent. Only meaningful in publish mode where
+   * the dialog renders both Save Draft and Publish buttons backed by a
+   * single Formik onSubmit. Call this synchronously before triggering
+   * `submitForm` so handleSubmit reads the right branch.
+   */
+  setSubmitIntent: (intent: 'publish' | 'draft') => void
+  /**
+   * Runs the unpublish mutation against the underlying collection and
+   * closes the dialog on success. Used by the Unpublish secondary
+   * button surfaced in edit mode for published collections. Bypasses
+   * Formik entirely — any pending field edits are discarded, on the
+   * assumption that "unpublish" is a deliberate action distinct from
+   * "save".
+   * No-op when called from create or publish mode, or when no
+   * collection is attached.
+   */
+  handleUnpublishAction: () => Promise<void>
+  /**
+   * True while either handleSubmit or handleUnpublishAction is
+   * mid-flight. The dialog binds this onto every footer button so a
+   * second click during the round-trip can't fire a duplicate
+   * mutation.
+   */
+  isMutating: boolean
 }
 
 const FIELD_ERROR_KEYS = new Set([
@@ -107,13 +142,18 @@ export function useCollectionForm({
   teamId,
   collection,
   parentBusy = false,
-  onClose
+  onClose,
+  onPublished
 }: UseCollectionFormParams): UseCollectionFormResult {
   const { t } = useTranslation('apps-journeys-admin')
   const { enqueueSnackbar } = useSnackbar()
 
   const [templateGalleryPageCreate] = useTemplateGalleryPageCreateMutation()
   const [templateGalleryPageUpdate] = useTemplateGalleryPageUpdateMutation()
+  const [templateGalleryPagePublish] = useTemplateGalleryPagePublishMutation()
+  const [templateGalleryPageUnpublish] =
+    useTemplateGalleryPageUnpublishMutation()
+  const [unpublishing, setUnpublishing] = useState(false)
 
   // Memoize so identity is stable across re-renders. Formik uses
   // initialValues identity to compute `dirty`; a fresh literal each
@@ -142,6 +182,18 @@ export function useCollectionForm({
   // same JS tick that fires the mutation, so the second invocation
   // returns immediately.
   const submittingRef = useRef(false)
+  // The dialog in publish mode renders both "Save Draft" and "Publish"
+  // buttons backed by a single Formik submitForm. Each button flips
+  // this ref before triggering submit so handleSubmit can branch
+  // without needing two different form `onSubmit` handlers (which
+  // would split validation + error mapping in two).
+  // Default 'publish' so an edit-mode submit (which doesn't read this
+  // ref) and a publish-mode submit triggered by Enter both land on the
+  // intended action.
+  const submitIntentRef = useRef<'publish' | 'draft'>('publish')
+  const setSubmitIntent = (intent: 'publish' | 'draft'): void => {
+    submitIntentRef.current = intent
+  }
 
   async function handleSubmit(
     values: CollectionFormValues,
@@ -211,13 +263,58 @@ export function useCollectionForm({
         if (initialIds !== nextIds) {
           input.journeyIds = values.journeyIds
         }
-        await templateGalleryPageUpdate({
-          variables: { id: collection.id, input }
-        })
-        enqueueSnackbar(t('Collection updated'), {
-          variant: 'success',
-          preventDuplicate: true
-        })
+        const shouldPublish =
+          mode === 'publish' && submitIntentRef.current === 'publish'
+        // Only fire the update when at least one field actually changed.
+        // In publish mode the dialog opens pre-filled and the user may
+        // submit without edits — an empty-input update is a wasted
+        // round-trip and would still emit the "Collection updated"
+        // snackbar, which is confusing when the only action they took
+        // was publish.
+        if (Object.keys(input).length > 0) {
+          await templateGalleryPageUpdate({
+            variables: { id: collection.id, input }
+          })
+          // Suppress the update snackbar when we're about to fire publish
+          // — the success dialog covers it, and stacking two toasts
+          // (Updated + Published) reads as noise.
+          if (!shouldPublish) {
+            enqueueSnackbar(t('Collection updated'), {
+              variant: 'success',
+              preventDuplicate: true
+            })
+          }
+        }
+        if (shouldPublish) {
+          const { data } = await templateGalleryPagePublish({
+            variables: { id: collection.id }
+          })
+          const result = data?.templateGalleryPagePublish
+          if (result == null) {
+            // Match the null-result trap in useCollectionMutations.publish:
+            // a partial GraphQL error reaches `errorPolicy: 'all'`
+            // consumers as `{ data: null, errors: [...] }`, so silently
+            // falling through would leave the user staring at no
+            // feedback after a publish click.
+            enqueueSnackbar(t("Couldn't publish collection"), {
+              variant: 'error',
+              preventDuplicate: true
+            })
+            return
+          }
+          // Merge server-set fields (status, publishedAt, updatedAt,
+          // slug) into the collection so the success dialog has the
+          // live public URL. Don't merge the form values: the
+          // collection's templates / team / fragment shape come from
+          // the cached gallery list, not from the form.
+          onPublished?.({
+            ...collection,
+            status: result.status,
+            publishedAt: result.publishedAt,
+            updatedAt: result.updatedAt,
+            slug: result.slug
+          })
+        }
       }
       onClose()
     } catch (error) {
@@ -242,5 +339,61 @@ export function useCollectionForm({
     }
   }
 
-  return { initialValues, schema, isPublished, handleSubmit }
+  async function handleUnpublishAction(): Promise<void> {
+    // Only the published-collection edit dialog surfaces this action,
+    // but guard anyway so a misuse from other modes is a no-op rather
+    // than a partial round-trip.
+    if (mode !== 'edit' || collection == null || !isPublished) return
+    if (submittingRef.current) return
+    if (parentBusy) {
+      enqueueSnackbar(t('Finishing previous action…'), {
+        variant: 'info',
+        preventDuplicate: true
+      })
+      return
+    }
+    submittingRef.current = true
+    setUnpublishing(true)
+    try {
+      const { data } = await templateGalleryPageUnpublish({
+        variables: { id: collection.id }
+      })
+      if (data?.templateGalleryPageUnpublish == null) {
+        // Same null-result trap as useCollectionMutations.unpublish:
+        // a partial GraphQL error reaches `errorPolicy: 'all'`
+        // consumers as `{ data: null, errors: [...] }`. Surface a
+        // snackbar so the user doesn't see a silent close.
+        enqueueSnackbar(t("Couldn't unpublish collection"), {
+          variant: 'error',
+          preventDuplicate: true
+        })
+        return
+      }
+      enqueueSnackbar(t('Collection unpublished'), {
+        variant: 'success',
+        preventDuplicate: true
+      })
+      onClose()
+    } catch (error) {
+      enqueueSnackbar(
+        error instanceof Error
+          ? error.message
+          : t("Couldn't unpublish collection"),
+        { variant: 'error', preventDuplicate: true }
+      )
+    } finally {
+      submittingRef.current = false
+      setUnpublishing(false)
+    }
+  }
+
+  return {
+    initialValues,
+    schema,
+    isPublished,
+    handleSubmit,
+    setSubmitIntent,
+    handleUnpublishAction,
+    isMutating: unpublishing
+  }
 }

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/useCollectionForm/useCollectionForm.ts
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/useCollectionForm/useCollectionForm.ts
@@ -87,12 +87,13 @@ export interface UseCollectionFormResult {
    */
   handleUnpublishAction: () => Promise<void>
   /**
-   * True while either handleSubmit or handleUnpublishAction is
-   * mid-flight. The dialog binds this onto every footer button so a
-   * second click during the round-trip can't fire a duplicate
-   * mutation.
+   * True only while handleUnpublishAction is in flight. Disjoint from
+   * Formik's `isSubmitting`, which still tracks the Save / Save Draft /
+   * Publish paths. Callers should OR the two together when binding the
+   * footer's `disabled` so neither path can fire a duplicate while the
+   * other is mid-mutation.
    */
-  isMutating: boolean
+  isUnpublishing: boolean
 }
 
 const FIELD_ERROR_KEYS = new Set([
@@ -394,6 +395,6 @@ export function useCollectionForm({
     handleSubmit,
     setSubmitIntent,
     handleUnpublishAction,
-    isMutating: unpublishing
+    isUnpublishing: unpublishing
   }
 }

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionPublishSuccessDialog/CollectionPublishSuccessDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionPublishSuccessDialog/CollectionPublishSuccessDialog.spec.tsx
@@ -100,16 +100,12 @@ describe('CollectionPublishSuccessDialog', () => {
 
   it('disables "View the page" when slug is null', () => {
     renderDialog({ slug: null })
-    expect(
-      screen.getByRole('button', { name: 'View the page' })
-    ).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'View the page' })).toBeDisabled()
   })
 
   it('disables "View the page" when publicUrl is null', () => {
     renderDialog({ publicUrl: null })
-    expect(
-      screen.getByRole('button', { name: 'View the page' })
-    ).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'View the page' })).toBeDisabled()
   })
 
   it('disables "View the page" and surfaces the gate copy when canPublish is false', () => {
@@ -119,8 +115,6 @@ describe('CollectionPublishSuccessDialog', () => {
       publishBlockedReason: 'gate copy'
     })
     expect(screen.getByText('gate copy')).toBeInTheDocument()
-    expect(
-      screen.getByRole('button', { name: 'View the page' })
-    ).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'View the page' })).toBeDisabled()
   })
 })

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionPublishSuccessDialog/CollectionPublishSuccessDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionPublishSuccessDialog/CollectionPublishSuccessDialog.spec.tsx
@@ -98,29 +98,29 @@ describe('CollectionPublishSuccessDialog', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
-  it('does not open a new tab when slug is null', async () => {
-    const { onClose } = renderDialog({ slug: null })
-    await userEvent.click(screen.getByRole('button', { name: 'View the page' }))
-    expect(window.open).not.toHaveBeenCalled()
-    expect(onClose).not.toHaveBeenCalled()
+  it('disables "View the page" when slug is null', () => {
+    renderDialog({ slug: null })
+    expect(
+      screen.getByRole('button', { name: 'View the page' })
+    ).toBeDisabled()
   })
 
-  it('does not open a new tab if publicUrl is null', async () => {
-    const { onClose } = renderDialog({ publicUrl: null })
-    await userEvent.click(screen.getByRole('button', { name: 'View the page' }))
-    expect(window.open).not.toHaveBeenCalled()
-    expect(onClose).not.toHaveBeenCalled()
+  it('disables "View the page" when publicUrl is null', () => {
+    renderDialog({ publicUrl: null })
+    expect(
+      screen.getByRole('button', { name: 'View the page' })
+    ).toBeDisabled()
   })
 
-  it('does not open a new tab and surfaces the gate copy when canPublish is false', async () => {
-    const { onClose } = renderDialog({
+  it('disables "View the page" and surfaces the gate copy when canPublish is false', () => {
+    renderDialog({
       slug: 'my-collection',
       canPublish: false,
       publishBlockedReason: 'gate copy'
     })
     expect(screen.getByText('gate copy')).toBeInTheDocument()
-    await userEvent.click(screen.getByRole('button', { name: 'View the page' }))
-    expect(window.open).not.toHaveBeenCalled()
-    expect(onClose).not.toHaveBeenCalled()
+    expect(
+      screen.getByRole('button', { name: 'View the page' })
+    ).toBeDisabled()
   })
 })

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionPublishSuccessDialog/CollectionPublishSuccessDialog.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionPublishSuccessDialog/CollectionPublishSuccessDialog.tsx
@@ -11,7 +11,7 @@ import { useSnackbar } from 'notistack'
 import { ReactElement } from 'react'
 
 import { Dialog } from '@core/shared/ui/Dialog'
-import LinkAngledIcon from '@core/shared/ui/icons/LinkAngled'
+import CopyRightIcon from '@core/shared/ui/icons/CopyRight'
 import LinkExternalIcon from '@core/shared/ui/icons/LinkExternal'
 
 import { copyToClipboard } from '../../../libs/copyToClipboard'
@@ -146,7 +146,7 @@ export function CollectionPublishSuccessDialog({
                       disabled={publicUrl == null}
                       edge="end"
                     >
-                      <LinkAngledIcon />
+                      <CopyRightIcon />
                     </IconButton>
                   </Box>
                 </Tooltip>

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionPublishSuccessDialog/CollectionPublishSuccessDialog.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionPublishSuccessDialog/CollectionPublishSuccessDialog.tsx
@@ -1,4 +1,5 @@
 import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
 import InputAdornment from '@mui/material/InputAdornment'
 import Stack from '@mui/material/Stack'
@@ -11,6 +12,7 @@ import { ReactElement } from 'react'
 
 import { Dialog } from '@core/shared/ui/Dialog'
 import LinkAngledIcon from '@core/shared/ui/icons/LinkAngled'
+import LinkExternalIcon from '@core/shared/ui/icons/LinkExternal'
 
 import { copyToClipboard } from '../../../libs/copyToClipboard'
 
@@ -76,16 +78,43 @@ export function CollectionPublishSuccessDialog({
     <Dialog
       open={open}
       onClose={onClose}
+      // Switching from `dialogAction` to `dialogActionChildren` flips
+      // the shared Dialog's default to `dividers={true}`. Force off so
+      // the success message + URL + action sit as one clean block.
+      divider={false}
       dialogTitle={{
         title: t('Your Template Page is Published!'),
         closeButton: true
       }}
-      dialogAction={{
-        onSubmit: handleView,
-        submitLabel: t('View the page'),
-        closeLabel: t('Close')
-      }}
+      dialogActionChildren={
+        <Button
+          variant="contained"
+          color="primary"
+          startIcon={<LinkExternalIcon />}
+          onClick={handleView}
+          disabled={viewDisabled}
+        >
+          {t('View the page')}
+        </Button>
+      }
       testId="CollectionPublishSuccessDialog"
+      // The shared Dialog defaults DialogActions to `padding: 8`, which
+      // tucks the action button into the corner — visually it doesn't
+      // line up with the content above (which has the standard 24px
+      // horizontal padding). Match the horizontal pad here so the
+      // button's left/right edges sit on the same vertical lines as
+      // the URL field and helper copy.
+      sx={{
+        // Align the action area with the 24px padding around title and
+        // content. Top stays at 0 so the button hugs the URL field
+        // above (its own 10px vertical padding gives the breathing
+        // room). Spacing token in this theme is 1 = 4px, so 6 = 24px.
+        '& .MuiDialogActions-root': {
+          pt: 0,
+          px: 6,
+          pb: 6
+        }
+      }}
     >
       <Stack spacing={2}>
         <Typography variant="body2" color="text.secondary">

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/Droppables/Droppables.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/Droppables/Droppables.tsx
@@ -70,12 +70,22 @@ interface DraggableJourneysGridProps {
   journeys: readonly Journey[]
   publishedLock: boolean
   dragInFlight: boolean
+  /**
+   * When true (default), wraps the grid in outer padding that matches
+   * the Grid's spacing so the gap from a card to the collection
+   * edge equals the gap between cards — the in-collection layout
+   * Sushma flagged in DM.
+   * Pass false in the All Templates section so cards line up with
+   * the collection-card edges above instead of inset by the padding.
+   */
+  outerPadding?: boolean
 }
 
 function DraggableJourneysGridImpl({
   journeys,
   publishedLock,
-  dragInFlight
+  dragInFlight,
+  outerPadding = true
 }: DraggableJourneysGridProps): ReactElement | null {
   if (journeys.length === 0) return null
   // SortableContext gives intra-collection ordering: each item is both a
@@ -84,10 +94,7 @@ function DraggableJourneysGridImpl({
   const ids = journeys.map((j) => j.id)
   return (
     <SortableContext items={ids} strategy={rectSortingStrategy}>
-      {/* Outer padding matches the Grid's spacing/rowSpacing so the gap
-          between a card and the collection edge equals the gap between
-          two cards — Sushma flagged the inconsistent 8px-vs-32px in DM. */}
-      <Box sx={{ p: { xs: 2.5, sm: 4 } }}>
+      <Box sx={outerPadding ? { p: { xs: 2.5, sm: 4 } } : undefined}>
         <Grid container spacing={4} rowSpacing={{ xs: 2.5, sm: 4 }}>
           {journeys.map((journey) => (
             <Grid

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.spec.tsx
@@ -1,5 +1,5 @@
 import { MockedProvider, MockedResponse } from '@apollo/client/testing'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { fireEvent, render, waitFor, within } from '@testing-library/react'
 import { SnackbarProvider } from 'notistack'
 
 import { TeamProvider } from '@core/journeys/ui/TeamProvider'
@@ -301,7 +301,7 @@ describe('TemplateGalleryPageList', () => {
   // NES-1666: original CollectionDialog case — kept to guard against
   // regressions in the v1 wiring after the v2 context plumbing landed.
   it('marks the DnD subtree inert while CollectionDialog is open (NES-1666)', async () => {
-    const { getByTestId } = render(
+    const { getByTestId, getByText } = render(
       <MockedProvider
         mocks={[getLastActiveTeamIdAndTeamsMock, collectionsMock, journeysMock]}
       >
@@ -316,17 +316,25 @@ describe('TemplateGalleryPageList', () => {
     )
 
     await waitFor(() =>
-      expect(getByTestId('CreateCollectionButton')).toBeInTheDocument()
+      expect(getByTestId('CollectionCard-page-1')).toBeInTheDocument()
     )
 
     const dndScope = getByTestId('TemplateGalleryDndScope')
     // Default state: no dialog open, subtree is interactive.
     expect(dndScope).not.toHaveAttribute('inert')
 
-    // Open the create-collection dialog and confirm the DnD subtree
-    // flips to inert. The CollectionDialog renders in a portal so it
-    // is unaffected.
-    fireEvent.click(getByTestId('CreateCollectionButton'))
+    // Open the publish dialog from the draft collection's action menu
+    // and confirm the DnD subtree flips to inert. The CollectionDialog
+    // renders in a portal so it is unaffected. (The create button no
+    // longer opens a dialog — it creates instantly with an auto-name —
+    // and drafts now surface "Publish" as the single dialog entry
+    // point in place of the old "Edit" item.)
+    fireEvent.click(
+      within(getByTestId('CollectionCard-page-1')).getByLabelText(
+        'Collection actions'
+      )
+    )
+    fireEvent.click(getByText('Publish'))
     await waitFor(() =>
       expect(getByTestId('TemplateGalleryDndScope')).toHaveAttribute('inert')
     )

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
@@ -41,6 +41,7 @@ import {
 } from '../../../__generated__/globalTypes'
 import { useAdminJourneysQuery } from '../../libs/useAdminJourneysQuery'
 import { useCanPublishCollection } from '../../libs/useCanPublishCollection'
+import { useTemplateGalleryPageCreateMutation } from '../../libs/useTemplateGalleryPageCreateMutation'
 import { useTemplateGalleryPagesQuery } from '../../libs/useTemplateGalleryPagesQuery'
 import { JourneyCard } from '../JourneyList/JourneyCard'
 import type { JourneyStatusFilter } from '../JourneyList/JourneyListView'
@@ -185,15 +186,12 @@ export function TemplateGalleryPageList({
     }
   }, [])
 
-  const {
-    busyId,
-    publish: rawPublish,
-    unpublish: handleUnpublish,
-    ungroup: handleUngroup
-  } = useCollectionMutations()
+  const { busyId, ungroup: handleUngroup } = useCollectionMutations()
 
-  const [createDialogOpen, setCreateDialogOpen] = useState(false)
+  const [templateGalleryPageCreate, { loading: createLoading }] =
+    useTemplateGalleryPageCreateMutation()
   const [editTargetId, setEditTargetId] = useState<string | null>(null)
+  const [publishTargetId, setPublishTargetId] = useState<string | null>(null)
   const [activeDragId, setActiveDragId] = useState<string | null>(null)
   // `dragInFlight` drives rendering (busy chips, droppable lock); the ref
   // is the synchronous source of truth for gating a second drop that
@@ -247,8 +245,8 @@ export function TemplateGalleryPageList({
   // dialog because the DragOverlay (z-index 999) tracks cursor position
   // beneath the dialog (z-index 1300) even while hidden.
   const dialogOpen =
-    createDialogOpen ||
     editTargetId != null ||
+    publishTargetId != null ||
     publishSuccessCollection != null ||
     openDialogCardIds.size > 0
   const interactionsLocked = dragInFlight || dialogOpen
@@ -259,11 +257,9 @@ export function TemplateGalleryPageList({
     }
   }, [dialogOpen])
 
-  async function handlePublish(collection: TemplateGalleryPage): Promise<void> {
-    const published = await rawPublish(collection)
-    if (published != null && mountedRef.current) {
-      setPublishSuccessCollection(published)
-    }
+  function handlePublished(collection: TemplateGalleryPage): void {
+    if (!mountedRef.current) return
+    setPublishSuccessCollection(collection)
   }
   function handleClosePublishSuccess(): void {
     setPublishSuccessCollection(null)
@@ -337,23 +333,39 @@ export function TemplateGalleryPageList({
 
   const editTarget =
     editTargetId != null ? (collectionsById.get(editTargetId) ?? null) : null
+  const publishTarget =
+    publishTargetId != null
+      ? (collectionsById.get(publishTargetId) ?? null)
+      : null
 
   // Pool the dialog's template picker draws from. Only ungrouped templates
-  // are addable, plus (in edit mode) the templates already in the collection
-  // being edited so the user can deselect them. Hides templates owned by
-  // other collections to prevent accidental dual-membership.
-  const editAvailableJourneys = useMemo<readonly Journey[]>(() => {
-    if (editTarget == null) return unsectioned
+  // are addable, plus the templates already in the collection being
+  // edited / published so the user can deselect them. Hides templates
+  // owned by other collections to prevent accidental dual-membership.
+  function buildAvailableJourneys(
+    target: TemplateGalleryPage | null
+  ): readonly Journey[] {
+    if (target == null) return unsectioned
     const seen = new Set(unsectioned.map((j) => j.id))
     // Resolve each template through journeyById so the picker always sees
     // the full Journey shape (the gallery fragment only carries id/title
     // and would not satisfy Journey on its own).
-    const own = editTarget.templates
+    const own = target.templates
       .filter((tpl) => !seen.has(tpl.id))
       .map((tpl) => journeyById.get(tpl.id))
       .filter((j): j is Journey => j != null)
     return [...unsectioned, ...own]
-  }, [unsectioned, editTarget, journeyById])
+  }
+  const editAvailableJourneys = useMemo<readonly Journey[]>(
+    () => buildAvailableJourneys(editTarget),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [unsectioned, editTarget, journeyById]
+  )
+  const publishAvailableJourneys = useMemo<readonly Journey[]>(
+    () => buildAvailableJourneys(publishTarget),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [unsectioned, publishTarget, journeyById]
+  )
 
   const sensors = useSensors(
     useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
@@ -362,17 +374,67 @@ export function TemplateGalleryPageList({
     })
   )
 
-  function handleOpenCreate(): void {
-    setCreateDialogOpen(true)
+  // Scan existing collection titles for the "Collection N" pattern and
+  // return the smallest unused N (>= 1). The match is case-sensitive
+  // and ignores extra whitespace — only the exact shape this handler
+  // produces counts as "ours", so a user-renamed collection like
+  // "Collection 7 — old" never collides with the next auto-name.
+  function nextCollectionName(): string {
+    const used = new Set<number>()
+    for (const c of collections) {
+      const match = /^Collection (\d+)$/.exec(c.title)
+      if (match != null) used.add(Number(match[1]))
+    }
+    let n = 1
+    while (used.has(n)) n += 1
+    return `Collection ${n}`
   }
-  function handleCloseCreate(): void {
-    setCreateDialogOpen(false)
+
+  async function handleCreate(): Promise<void> {
+    // Button is only rendered after the teamId == null guard returns
+    // early, so in practice teamId is always defined here. The runtime
+    // check is also the TS narrowing — without it, `input.teamId` widens
+    // to `string | undefined`.
+    if (createLoading || teamId == null) return
+    try {
+      await templateGalleryPageCreate({
+        variables: {
+          input: {
+            teamId,
+            title: nextCollectionName(),
+            creatorName: '',
+            journeyIds: []
+          }
+        }
+      })
+      if (mountedRef.current) {
+        enqueueSnackbar(t('Collection created'), {
+          variant: 'success',
+          preventDuplicate: true
+        })
+      }
+    } catch (error) {
+      if (mountedRef.current) {
+        enqueueSnackbar(
+          error instanceof Error
+            ? error.message
+            : t("Couldn't create collection"),
+          { variant: 'error', preventDuplicate: true }
+        )
+      }
+    }
   }
   function handleCloseEdit(): void {
     setEditTargetId(null)
   }
   function handleEdit(collection: TemplateGalleryPage): void {
     setEditTargetId(collection.id)
+  }
+  function handleOpenPublish(collection: TemplateGalleryPage): void {
+    setPublishTargetId(collection.id)
+  }
+  function handleClosePublish(): void {
+    setPublishTargetId(null)
   }
 
   function handleDragStart(event: DragStartEvent): void {
@@ -467,7 +529,10 @@ export function TemplateGalleryPageList({
             <Button
               variant="contained"
               color="primary"
-              onClick={handleOpenCreate}
+              onClick={() => {
+                void handleCreate()
+              }}
+              disabled={createLoading}
               sx={{ flexShrink: 0, whiteSpace: 'nowrap' }}
               data-testid="CreateCollectionButton"
             >
@@ -520,8 +585,7 @@ export function TemplateGalleryPageList({
                       <CollectionCard
                         collection={collection}
                         onEdit={handleEdit}
-                        onPublish={handlePublish}
-                        onUnpublish={handleUnpublish}
+                        onPublish={handleOpenPublish}
                         onUngroup={handleUngroup}
                         busy={busyId === collection.id || dragInFlight}
                         canPublish={canPublish}
@@ -586,20 +650,6 @@ export function TemplateGalleryPageList({
           </DndContext>
         </Box>
 
-        {createDialogOpen && (
-          <CollectionDialog
-            open
-            mode="create"
-            teamId={teamId}
-            availableJourneys={unsectioned}
-            parentBusy={dragInFlight}
-            canPublish={canPublish}
-            publishBlockedReason={
-              publishBlockedReason != null ? t(publishBlockedReason) : null
-            }
-            onClose={handleCloseCreate}
-          />
-        )}
         {editTarget != null && (
           <CollectionDialog
             key={editTarget.id}
@@ -614,6 +664,27 @@ export function TemplateGalleryPageList({
               publishBlockedReason != null ? t(publishBlockedReason) : null
             }
             onClose={handleCloseEdit}
+          />
+        )}
+        {publishTarget != null && (
+          <CollectionDialog
+            // Distinct key prefix so React tears down the Formik instance
+            // when the user pivots from Edit to Publish on the same
+            // collection — without it, the edit form's dirty state would
+            // leak into the publish dialog.
+            key={`publish-${publishTarget.id}`}
+            open
+            mode="publish"
+            teamId={teamId}
+            collection={publishTarget}
+            availableJourneys={publishAvailableJourneys}
+            parentBusy={dragInFlight}
+            canPublish={canPublish}
+            publishBlockedReason={
+              publishBlockedReason != null ? t(publishBlockedReason) : null
+            }
+            onClose={handleClosePublish}
+            onPublished={handlePublished}
           />
         )}
         <CollectionPublishSuccessDialog

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
@@ -631,6 +631,10 @@ export function TemplateGalleryPageList({
                     journeys={unsectioned}
                     publishedLock={false}
                     dragInFlight={interactionsLocked}
+                    // No collection-card edge to balance against here —
+                    // drop the outer padding so cards align with the
+                    // collection-card edges above.
+                    outerPadding={false}
                   />
                 )}
               </UnsectionedDroppable>

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
@@ -190,6 +190,15 @@ export function TemplateGalleryPageList({
 
   const [templateGalleryPageCreate, { loading: createLoading }] =
     useTemplateGalleryPageCreateMutation()
+  // Synchronous double-click guard for the instant-create flow. The
+  // button's `disabled={createLoading}` reflects Apollo's loading state,
+  // but that flips asynchronously — two clicks in the same tick both
+  // pass the React-state guard and fire two mutations (auto-name then
+  // hands out "Collection 1" + "Collection 2" for a single intent).
+  // A ref mutation is visible to the next synchronous read, so the
+  // second click sees `true` and returns immediately. Same pattern as
+  // `submittingRef` in useCollectionForm and `dragInFlightRef` above.
+  const creatingRef = useRef(false)
   const [editTargetId, setEditTargetId] = useState<string | null>(null)
   const [publishTargetId, setPublishTargetId] = useState<string | null>(null)
   const [activeDragId, setActiveDragId] = useState<string | null>(null)
@@ -395,7 +404,8 @@ export function TemplateGalleryPageList({
     // early, so in practice teamId is always defined here. The runtime
     // check is also the TS narrowing — without it, `input.teamId` widens
     // to `string | undefined`.
-    if (createLoading || teamId == null) return
+    if (creatingRef.current || createLoading || teamId == null) return
+    creatingRef.current = true
     try {
       await templateGalleryPageCreate({
         variables: {
@@ -422,6 +432,8 @@ export function TemplateGalleryPageList({
           { variant: 'error', preventDuplicate: true }
         )
       }
+    } finally {
+      creatingRef.current = false
     }
   }
   function handleCloseEdit(): void {

--- a/docs/solutions/conventions/mui-spacing-token-is-4px-2026-05-24.md
+++ b/docs/solutions/conventions/mui-spacing-token-is-4px-2026-05-24.md
@@ -1,0 +1,131 @@
+---
+title: MUI sx spacing token is 1 = 4px in this repo (not the default 8px)
+date: 2026-05-24
+category: conventions
+module: libs/shared/ui/themes
+problem_type: convention
+component: tooling
+severity: medium
+applies_when:
+  - "Writing MUI sx spacing props (p, m, px, py, pt, pb, gap, spacing, etc.) in any app or lib that consumes the shared themes (base, journeysAdmin, journeyUi, website)"
+  - "Converting a Figma or design-spec pixel value into sx token values"
+  - "Calling theme.spacing(n) directly in styled components, makeStyles blocks, or stories"
+  - "Reviewing PRs that introduce MUI sx spacing values — verify the px math against the 4× scale, not the 8× default"
+tags:
+  - mui
+  - theme
+  - spacing
+  - sx
+  - design-tokens
+  - convention
+related_components:
+  - tooling
+---
+
+# MUI sx spacing token is 1 = 4px in this repo (not the default 8px)
+
+## Context
+
+The default MUI spacing scale is `1 = 8px`. That's what every MUI tutorial, blog post, Stack Overflow answer, and LLM training set assumes. Contributors (and agents) reach for `p: 3` expecting 24px.
+
+This repo's themes override that scale to `1 = 4px`. Every sx prop that resolves through `theme.spacing(n)` is affected, and the friction is **silent**: code compiles, renders something, doesn't match design specs — nothing throws or warns. You just see the wrong pixels.
+
+The override is set in token files (not the top-level `theme.ts`), which makes it easy to miss when reading theme code:
+
+- `libs/shared/ui/src/libs/themes/journeysAdmin/tokens/spacing.ts:4` — `adminSpacing = { spacing: 4 }` (auto memory [claude])
+- `libs/shared/ui/src/libs/themes/base/tokens/spacing.ts:6` — `baseSpacing = { spacing: 4 }` (auto memory [claude])
+
+The `base` and `journeysAdmin` themes apply this, and the other shared themes (`journeyUi`, `website`) follow the same `1 = 4px` convention via their own `tokens/spacing.ts`. Treat this as **monorepo-wide**, not journeys-admin-specific.
+
+## Guidance
+
+When writing or reviewing any `sx` spacing prop in an app that consumes the shared themes, the conversion is **px = N × 4**, not N × 8.
+
+**Conversion reference:**
+
+| px   | token |
+| ---- | ----- |
+| 4px  | `1`   |
+| 8px  | `2`   |
+| 12px | `3`   |
+| 16px | `4`   |
+| 20px | `5`   |
+| 24px | `6`   |
+| 32px | `8`   |
+| 40px | `10`  |
+| 48px | `12`  |
+
+- When matching a design spec given in px, **divide by 4** to get the token.
+- Don't rely on MUI documentation pixel values when picking spacing tokens — translate first.
+- When iterating in the browser to eyeball a value, expect more `+1` increments to dial in (each step is only 4px, not 8px).
+- Raw CSS strings like `padding: '10px 20px'` bypass the spacing token entirely and render literal pixel values — use sparingly when the target isn't a multiple of 4.
+
+## Why This Matters
+
+- **Silent drift from design specs.** A button with `padding: 1` reads as 4px, not 8px. Designs based on default MUI math look off everywhere the convention isn't followed, and nothing in the toolchain catches it.
+- **LLM agents and new contributors default to wrong math.** Training data favors the MUI default, so `p: 3 = 24px` is the natural assumption. Without surfacing this convention, every new contributor and every fresh agent session repeats the mistake — exactly what prompted this doc.
+- **Tighter iteration loop.** Once you know the math, the 4px scale gives you finer-grained control. `mt: 5` (20px) is a real value here, where on a default theme it would be 40px.
+- **Raw CSS escape hatch exists.** For one-off pixel values that aren't a 4-multiple (e.g. 11px or 13px), drop to `padding: '11px'` and the token math doesn't apply. Use sparingly.
+
+## When to Apply
+
+Whenever writing or reviewing `sx` props in any app that consumes the shared themes (verify by checking `libs/shared/ui/src/libs/themes/`).
+
+Spacing-resolved props to watch for:
+
+- `p`, `m`
+- `px`, `py`, `pt`, `pb`, `pl`, `pr`
+- `mx`, `my`, `mt`, `mb`, `ml`, `mr`
+- `gap`, `rowGap`, `columnGap`
+- `spacing` (on `Stack`, `Grid`)
+- `margin`, `padding` when given as a **number** (string values bypass the token)
+
+Also applies to `theme.spacing(N)` calls in styled components, `makeStyles`, or stories.
+
+## Examples
+
+**Before (wrong, MUI default math):**
+
+```tsx
+// Intended: 24px padding around the dialog action area
+sx={{
+  '& .MuiDialogActions-root': {
+    pt: 0,
+    px: 3,  // resolves to 12px, not 24px
+    pb: 3   // resolves to 12px, not 24px
+  }
+}}
+```
+
+**After (correct, repo-theme math):**
+
+```tsx
+sx={{
+  '& .MuiDialogActions-root': {
+    pt: 0,
+    px: 6,  // 24px
+    pb: 6   // 24px
+  }
+}}
+```
+
+**Stack spacing:**
+
+```tsx
+// Want 16px gap between children
+<Stack spacing={4}>  // 4 × 4px = 16px (not 4 × 8px = 32px)
+```
+
+**Escape hatch for awkward values:**
+
+```tsx
+sx={{ padding: '11px' }}  // bypasses the token, renders 11px literally
+```
+
+**Session example that surfaced this convention:** I wrote `sx={{ px: 3, pb: 3 }}` on a dialog action area expecting 24px (MUI default math of `3 × 8`). It rendered 12px, because the theme's `spacing = 4` made it `3 × 4`. The user corrected: *"the sizing token is 1 = 4 px, so I think it should be six"*. Changing to `px: 6, pb: 6` produced the intended 24px.
+
+## Related
+
+- `libs/shared/ui/src/libs/themes/journeysAdmin/tokens/spacing.ts` — the override for the journeysAdmin theme
+- `libs/shared/ui/src/libs/themes/base/tokens/spacing.ts` — the override for the base theme; other shared themes follow the same pattern
+- [Badge alongside webkit-line-clamp title](../ui-bugs/badge-alongside-webkit-line-clamp-title.md) — example consumer where `gap={1}` resolves to 4px in journeys-admin

--- a/docs/solutions/conventions/mui-spacing-token-is-4px-2026-05-24.md
+++ b/docs/solutions/conventions/mui-spacing-token-is-4px-2026-05-24.md
@@ -7,10 +7,10 @@ problem_type: convention
 component: tooling
 severity: medium
 applies_when:
-  - "Writing MUI sx spacing props (p, m, px, py, pt, pb, gap, spacing, etc.) in any app or lib that consumes the shared themes (base, journeysAdmin, journeyUi, website)"
-  - "Converting a Figma or design-spec pixel value into sx token values"
-  - "Calling theme.spacing(n) directly in styled components, makeStyles blocks, or stories"
-  - "Reviewing PRs that introduce MUI sx spacing values — verify the px math against the 4× scale, not the 8× default"
+  - 'Writing MUI sx spacing props (p, m, px, py, pt, pb, gap, spacing, etc.) in any app or lib that consumes the shared themes (base, journeysAdmin, journeyUi, website)'
+  - 'Converting a Figma or design-spec pixel value into sx token values'
+  - 'Calling theme.spacing(n) directly in styled components, makeStyles blocks, or stories'
+  - 'Reviewing PRs that introduce MUI sx spacing values — verify the px math against the 4× scale, not the 8× default'
 tags:
   - mui
   - theme
@@ -122,7 +122,7 @@ sx={{
 sx={{ padding: '11px' }}  // bypasses the token, renders 11px literally
 ```
 
-**Session example that surfaced this convention:** I wrote `sx={{ px: 3, pb: 3 }}` on a dialog action area expecting 24px (MUI default math of `3 × 8`). It rendered 12px, because the theme's `spacing = 4` made it `3 × 4`. The user corrected: *"the sizing token is 1 = 4 px, so I think it should be six"*. Changing to `px: 6, pb: 6` produced the intended 24px.
+**Session example that surfaced this convention:** I wrote `sx={{ px: 3, pb: 3 }}` on a dialog action area expecting 24px (MUI default math of `3 × 8`). It rendered 12px, because the theme's `spacing = 4` made it `3 × 4`. The user corrected: _"the sizing token is 1 = 4 px, so I think it should be six"_. Changing to `px: 6, pb: 6` produced the intended 24px.
 
 ## Related
 

--- a/docs/solutions/design-patterns/formik-intent-ref-multi-button-submit-2026-05-24.md
+++ b/docs/solutions/design-patterns/formik-intent-ref-multi-button-submit-2026-05-24.md
@@ -7,9 +7,9 @@ problem_type: design_pattern
 component: tooling
 severity: medium
 applies_when:
-  - "A Formik form needs multiple submit-style buttons that share validation, field values, and error mapping but trigger different mutations"
-  - "Splitting onSubmit into separate handlers would duplicate validation, error mapping, or field normalization"
-  - "One footer action (e.g. Unpublish, Delete) should bypass Formik entirely and discard pending field edits"
+  - 'A Formik form needs multiple submit-style buttons that share validation, field values, and error mapping but trigger different mutations'
+  - 'Splitting onSubmit into separate handlers would duplicate validation, error mapping, or field normalization'
+  - 'One footer action (e.g. Unpublish, Delete) should bypass Formik entirely and discard pending field edits'
 related_components:
   - tooling
 tags:
@@ -54,8 +54,7 @@ const setSubmitIntent = (intent: 'publish' | 'draft'): void => {
 
 async function handleSubmit(values, helpers) {
   // ...diffed update logic shared by all modes...
-  const shouldPublish =
-    mode === 'publish' && submitIntentRef.current === 'publish'
+  const shouldPublish = mode === 'publish' && submitIntentRef.current === 'publish'
 
   if (Object.keys(input).length > 0) {
     await templateGalleryPageUpdate({ variables: { id, input } })
@@ -187,8 +186,7 @@ Problems: two `validateForm` calls, two `try/catch` blocks, two submitting flags
 ```ts
 async function handleSubmit(values, helpers) {
   const input = diff(values, initialValues)
-  const shouldPublish =
-    mode === 'publish' && submitIntentRef.current === 'publish'
+  const shouldPublish = mode === 'publish' && submitIntentRef.current === 'publish'
   if (Object.keys(input).length > 0) {
     await templateGalleryPageUpdate({ variables: { id, input } })
   }
@@ -244,10 +242,10 @@ Formik handles `isSubmitting`, error mapping runs once, Yup validates once, and 
 
 - **`outerPadding` prop on shared grid components.** When the same grid is used both inside a card (needs symmetric padding so the grid's gap visually matches the card's edge padding) and at the top level of a page (needs no padding so it aligns flush with sibling card edges), a single boolean prop is cleaner than two near-duplicate components or a wrapper div with margin hacks.
 
-- **Don't gate the entry point if it's the only path to a needed sub-action.** When consolidating menu items into one state-aware entry (e.g. "Edit" for published, "Publish" for draft), move any gating logic *down* into the dialog (disable the Publish button for empty drafts) rather than disabling the menu item itself. Otherwise the user loses access to legitimate sub-actions like editing draft metadata.
+- **Don't gate the entry point if it's the only path to a needed sub-action.** When consolidating menu items into one state-aware entry (e.g. "Edit" for published, "Publish" for draft), move any gating logic _down_ into the dialog (disable the Publish button for empty drafts) rather than disabling the menu item itself. Otherwise the user loses access to legitimate sub-actions like editing draft metadata.
 
 ## Related
 
 - [Template Gallery Page Collections patterns (NES-1539)](../best-practices/template-gallery-page-collections-patterns-nes1539.md) — the broader CollectionDialog patterns catalog. This intent-ref pattern is the next entry in that catalog and should be referenced from it.
-- [Local Template Dialog Consolidation (NES-1543)](../best-practices/local-template-dialog-consolidation-patterns-nes1543.md) — a sibling pattern: single Formik form firing multiple GraphQL mutations routed by dirty subset (`Promise.allSettled`). Orthogonal to submit-intent routing — that flavor routes on *what changed*, this one routes on *which button was pressed*.
+- [Local Template Dialog Consolidation (NES-1543)](../best-practices/local-template-dialog-consolidation-patterns-nes1543.md) — a sibling pattern: single Formik form firing multiple GraphQL mutations routed by dirty subset (`Promise.allSettled`). Orthogonal to submit-intent routing — that flavor routes on _what changed_, this one routes on _which button was pressed_.
 - PR [#9247](https://github.com/JesusFilm/core/pull/9247) — collection create/edit/publish flow rework where this pattern shipped.

--- a/docs/solutions/design-patterns/formik-intent-ref-multi-button-submit-2026-05-24.md
+++ b/docs/solutions/design-patterns/formik-intent-ref-multi-button-submit-2026-05-24.md
@@ -1,0 +1,253 @@
+---
+title: Multi-action Formik dialog footer with intent-ref submit handler
+date: 2026-05-24
+category: design-patterns
+module: journeys-admin/template-gallery
+problem_type: design_pattern
+component: tooling
+severity: medium
+applies_when:
+  - "A Formik form needs multiple submit-style buttons that share validation, field values, and error mapping but trigger different mutations"
+  - "Splitting onSubmit into separate handlers would duplicate validation, error mapping, or field normalization"
+  - "One footer action (e.g. Unpublish, Delete) should bypass Formik entirely and discard pending field edits"
+related_components:
+  - tooling
+tags:
+  - formik
+  - mui
+  - dialog
+  - multi-action-submit
+  - intent-ref
+  - template-gallery
+---
+
+# Multi-action Formik dialog footer with intent-ref submit handler
+
+## Context
+
+Dialog forms often grow beyond a single submit action. The Template Gallery `CollectionDialog` in `apps/journeys-admin/` has four distinct footer configurations depending on mode and publish state:
+
+- **Create mode**: `Cancel | Create`
+- **Edit mode (draft)**: `Cancel | Save`
+- **Edit mode (published)**: `Cancel | Unpublish | Save`
+- **Publish mode (draft)**: `Cancel | Save Draft | Publish`
+
+The friction: `Save Draft` and `Publish` differ only in whether a publish mutation fires after the update. They share the same Formik values, the same Yup validation, the same field-level error mapping, and the same `isSubmitting` lifecycle. Splitting them into two independent `onSubmit` handlers — or two separate Formik instances — duplicates all of that and creates two divergent error-handling paths that immediately drift.
+
+Meanwhile `Unpublish` is fundamentally different: it ignores form values entirely and just changes status. Forcing it through Formik would either run irrelevant validation or require special-case bypass logic inside `handleSubmit`.
+
+The pattern below resolves both: **one Formik path for actions that share validation, plus a parallel non-Formik path for orthogonal actions**.
+
+## Guidance
+
+### Part 1: Intent-ref for shared-validation actions
+
+Hold the user's intent in a `useRef`, flip it synchronously in the button's `onClick`, then call Formik's `submitForm`. The single `handleSubmit` reads the ref and branches:
+
+```ts
+// useCollectionForm.ts
+const submitIntentRef = useRef<'publish' | 'draft'>('publish')
+
+const setSubmitIntent = (intent: 'publish' | 'draft'): void => {
+  submitIntentRef.current = intent
+}
+
+async function handleSubmit(values, helpers) {
+  // ...diffed update logic shared by all modes...
+  const shouldPublish =
+    mode === 'publish' && submitIntentRef.current === 'publish'
+
+  if (Object.keys(input).length > 0) {
+    await templateGalleryPageUpdate({ variables: { id, input } })
+  }
+  if (shouldPublish) {
+    await templateGalleryPagePublish({ variables: { id } })
+    // ...
+  }
+  onClose()
+}
+```
+
+```tsx
+// CollectionDialog.tsx
+<Button onClick={() => { setSubmitIntent('draft'); handleSubmit() }}>
+  Save Draft
+</Button>
+<Button onClick={() => { setSubmitIntent('publish'); handleSubmit() }}>
+  Publish
+</Button>
+```
+
+### Part 2: Bypass-Formik for orthogonal actions
+
+For an action that doesn't logically submit the form (here, `Unpublish`), skip Formik entirely and manage its own lifecycle:
+
+```ts
+async function handleUnpublishAction() {
+  if (submittingRef.current) return
+  submittingRef.current = true
+  setUnpublishing(true) // separate flag; Formik's isSubmitting only tracks form submits
+  try {
+    const { data } = await templateGalleryPageUnpublish({
+      variables: { id: collection.id }
+    })
+    // ...snackbar + onClose...
+  } finally {
+    submittingRef.current = false
+    setUnpublishing(false)
+  }
+}
+```
+
+Then disable every footer button from a unified flag so neither path can double-fire while the other runs:
+
+```tsx
+<Button disabled={isSubmitting || isMutating} onClick={handleUnpublishAction}>
+  Unpublish
+</Button>
+```
+
+## Why This Matters
+
+**Why a ref, not state.** The click handler runs `setSubmitIntent(...)` and then `handleSubmit()` in the same tick. A `useState` setter schedules a re-render; the new value is not visible to a synchronous read that happens before React commits. A `useRef` mutation is visible immediately, which is exactly what same-tick branching needs. This is the canonical "imperative latch" use of refs.
+
+**Why default to `'publish'`.** In publish mode the form's primary action is Publish. Formik's default submit path fires on Enter inside any text input — and that path doesn't go through any button's `onClick`, so the ref keeps whatever value it had. Defaulting to `'publish'` makes Enter do the obvious thing instead of silently saving a draft.
+
+**Why bypass Formik for Unpublish.** Three reasons:
+
+1. Unpublish doesn't read form values, so running Yup validation on them is noise — a user with an invalid title shouldn't be blocked from unpublishing.
+2. Formik's `isSubmitting` is a single flag; piggybacking a non-submit action onto it confuses error mapping (`setFieldError` after an unpublish failure makes no sense).
+3. Conceptual clarity: the footer has two kinds of actions — "submit this form" and "change status of this entity". Keeping them on separate code paths matches the mental model.
+
+**Why one unified `disabled` flag across both paths.** Users can click fast. If `isSubmitting` only covers the Formik path and `isMutating` only covers Unpublish, a click on Unpublish during a Save-Draft submission still fires. Or-ing both flags into every button's `disabled` closes that race.
+
+## When to Apply
+
+Use the **intent-ref** pattern when:
+
+- A dialog or form footer has two or more actions that share validation, share field values, and share error mapping.
+- The actions differ only in a post-submit side effect (publish vs save, send vs schedule, submit vs submit-and-close).
+- You want one source of truth for `isSubmitting`, error display, and the submit lifecycle.
+
+Use the **bypass-Formik** pattern when:
+
+- An action in the same footer doesn't depend on form values (delete, unpublish, archive, reset).
+- The action shouldn't be gated by form validation.
+- The action's success/failure UX is independent of field-level errors.
+
+Do **not** use intent-ref when:
+
+- The actions actually need different validation schemas (use separate forms or conditional Yup).
+- The branching logic in `handleSubmit` would dwarf the shared logic (split the handlers instead).
+- Only one action exists — you don't need a ref to disambiguate a single path.
+
+## Examples
+
+### Before: two independent handlers (the anti-pattern)
+
+```ts
+async function handleSaveDraft(values) {
+  if (!(await validateForm(values))) return
+  try {
+    setSavingDraft(true)
+    const input = diff(values, initialValues)
+    if (Object.keys(input).length > 0) {
+      await templateGalleryPageUpdate({ variables: { id, input } })
+    }
+    onClose()
+  } catch (e) {
+    mapApolloErrorsToFields(e, setFieldError) // duplicated
+  } finally {
+    setSavingDraft(false)
+  }
+}
+
+async function handlePublish(values) {
+  if (!(await validateForm(values))) return
+  try {
+    setPublishing(true)
+    const input = diff(values, initialValues)
+    if (Object.keys(input).length > 0) {
+      await templateGalleryPageUpdate({ variables: { id, input } })
+    }
+    await templateGalleryPagePublish({ variables: { id } })
+    onClose()
+  } catch (e) {
+    mapApolloErrorsToFields(e, setFieldError) // duplicated again
+  } finally {
+    setPublishing(false)
+  }
+}
+```
+
+Problems: two `validateForm` calls, two `try/catch` blocks, two submitting flags, two divergent error-mapping copies, and Formik's own `isSubmitting`/`setSubmitting` is bypassed entirely so field-level error helpers behave inconsistently.
+
+### After: one handler, ref-disambiguated
+
+```ts
+async function handleSubmit(values, helpers) {
+  const input = diff(values, initialValues)
+  const shouldPublish =
+    mode === 'publish' && submitIntentRef.current === 'publish'
+  if (Object.keys(input).length > 0) {
+    await templateGalleryPageUpdate({ variables: { id, input } })
+  }
+  if (shouldPublish) {
+    await templateGalleryPagePublish({ variables: { id } })
+  }
+  onClose()
+}
+```
+
+Formik handles `isSubmitting`, error mapping runs once, Yup validates once, and the button intent is the only thing the buttons actually need to communicate.
+
+### The actual CollectionDialog footer
+
+```tsx
+// Publish mode (draft collection)
+<Button onClick={onClose}>Cancel</Button>
+<Button
+  disabled={isSubmitting || isMutating}
+  onClick={() => { setSubmitIntent('draft'); handleSubmit() }}
+>
+  Save Draft
+</Button>
+<Button
+  variant="contained"
+  disabled={isSubmitting || isMutating}
+  onClick={() => { setSubmitIntent('publish'); handleSubmit() }}
+>
+  Publish
+</Button>
+
+// Edit mode (published collection)
+<Button onClick={onClose}>Cancel</Button>
+<Button
+  color="error"
+  disabled={isSubmitting || isMutating}
+  onClick={handleUnpublishAction}
+>
+  Unpublish
+</Button>
+<Button
+  variant="contained"
+  disabled={isSubmitting || isMutating}
+  onClick={() => handleSubmit()}
+>
+  Save
+</Button>
+```
+
+### Related small patterns picked up alongside this work
+
+- **Auto-name with smallest-unused-N.** When generating default names like `Collection 3`, scan existing titles matching `^Collection (\d+)$` and return the smallest positive integer not in use. Survives deletions cleanly, unlike `count + 1`, which produces collisions after delete-then-create.
+
+- **`outerPadding` prop on shared grid components.** When the same grid is used both inside a card (needs symmetric padding so the grid's gap visually matches the card's edge padding) and at the top level of a page (needs no padding so it aligns flush with sibling card edges), a single boolean prop is cleaner than two near-duplicate components or a wrapper div with margin hacks.
+
+- **Don't gate the entry point if it's the only path to a needed sub-action.** When consolidating menu items into one state-aware entry (e.g. "Edit" for published, "Publish" for draft), move any gating logic *down* into the dialog (disable the Publish button for empty drafts) rather than disabling the menu item itself. Otherwise the user loses access to legitimate sub-actions like editing draft metadata.
+
+## Related
+
+- [Template Gallery Page Collections patterns (NES-1539)](../best-practices/template-gallery-page-collections-patterns-nes1539.md) — the broader CollectionDialog patterns catalog. This intent-ref pattern is the next entry in that catalog and should be referenced from it.
+- [Local Template Dialog Consolidation (NES-1543)](../best-practices/local-template-dialog-consolidation-patterns-nes1543.md) — a sibling pattern: single Formik form firing multiple GraphQL mutations routed by dirty subset (`Promise.allSettled`). Orthogonal to submit-intent routing — that flavor routes on *what changed*, this one routes on *which button was pressed*.
+- PR [#9247](https://github.com/JesusFilm/core/pull/9247) — collection create/edit/publish flow rework where this pattern shipped.

--- a/docs/solutions/ui-bugs/journey-details-chip-mobile-stacking-2026-05-24.md
+++ b/docs/solutions/ui-bugs/journey-details-chip-mobile-stacking-2026-05-24.md
@@ -1,0 +1,78 @@
+---
+title: TEMPLATE chip not visible beside title in mobile editor dropdown
+date: 2026-05-24
+category: ui-bugs
+module: journeys-admin/editor-toolbar
+problem_type: ui_bug
+component: tooling
+symptoms:
+  - "TEMPLATE chip squeezed beside the journey title inside the editor's mobile 3-dots dropdown menu"
+  - "On narrow viewports the title takes the full row and the chip wraps awkwardly or gets clipped"
+  - "Users on mobile can't tell at a glance whether they're editing a template vs a regular journey"
+root_cause: incomplete_setup
+resolution_type: code_fix
+severity: low
+tags:
+  - mui
+  - stack-direction
+  - responsive
+  - mobile
+  - journey-details
+  - qa-459
+---
+
+# TEMPLATE chip not visible beside title in mobile editor dropdown
+
+## Problem
+
+The journey editor toolbar shows a `TEMPLATE` chip next to the journey title so the user can see at a glance that they're editing a template. On desktop (md+) the title + chip render directly in the toolbar. On mobile (xs/sm) the toolbar hides the `JourneyDetails` component and re-parents it into the 3-dots overflow menu — but `JourneyDetails` was built with a fixed `direction="row"` Stack for the title + chip, so inside the narrower dropdown the chip ends up squeezed against the title and either wraps awkwardly or gets clipped (QA-459).
+
+## Symptoms
+
+- TEMPLATE chip squeezed beside the journey title inside the editor's mobile 3-dots dropdown menu.
+- On narrow viewports the title takes the full row and the chip wraps awkwardly or gets clipped.
+- Users on mobile can't tell at a glance whether they're editing a template vs a regular journey.
+
+## What Didn't Work
+
+- **Surfacing a second TEMPLATE chip in the mobile toolbar** (next to the logo or undo/redo). Adds a separate render path that has to be kept in sync with the desktop chip; the toolbar at ~375px is already crowded.
+- **Lowering the panel position / adding margin tricks** to free up toolbar space. Unrelated to the actual problem — the chip wasn't fighting for toolbar space, it was being re-parented into a container the original layout didn't anticipate.
+
+## Solution
+
+Change the inner Stack `direction` in `JourneyDetails` from a fixed `"row"` to a responsive `{ xs: 'column', md: 'row' }` so the chip stacks below the title at xs/sm (where the component renders inside the dropdown) and stays beside the title at md+ (where it renders directly in the toolbar):
+
+```tsx
+// apps/journeys-admin/src/components/Editor/Toolbar/JourneyDetails/JourneyDetails.tsx
+<Stack
+  // QA-459: stack title + TEMPLATE chip vertically inside the
+  // mobile dropdown menu so the chip sits clearly below the
+  // title instead of getting squeezed against it. Desktop
+  // toolbar (md+) keeps the original side-by-side layout.
+  direction={{ xs: 'column', md: 'row' }}
+  alignItems={{ xs: 'flex-start', md: 'center' }}
+  gap={1}
+  sx={{ minWidth: 0 }}
+>
+  <Typography>{journey.title}</Typography>
+  {journey.template === true && <Chip label={t('TEMPLATE')} ... />}
+</Stack>
+```
+
+The existing `alignItems="flex-start"` at xs already left-aligns the chip when stacked, so it falls into place naturally — no extra alignment props needed.
+
+## Why This Works
+
+`JourneyDetails` is rendered in two structurally different containers: the wide desktop toolbar and the narrow mobile dropdown. Hard-coding `direction="row"` assumes one container width; making it responsive lets the same component fit both contexts without forking the component or adding a parent-passed prop. Crucially, the breakpoint that flips the direction (`md`) matches the breakpoint that decides which container renders `JourneyDetails` — they're already coupled in the toolbar code, so reusing the same breakpoint here keeps the layout decision consistent.
+
+## Prevention
+
+- **When a component renders inside variable-width containers, audit fixed `direction`, `flexDirection`, and `width` props for responsive equivalents.** Especially true for shared components rendered by both a wide desktop layout and a narrower mobile overlay/dropdown/drawer.
+- **Match breakpoints to parent breakpoints.** If the parent flips containers at `md`, the child's responsive props should also flip at `md`. Different breakpoints create dead zones where the child's layout doesn't match its actual container.
+- **Avoid duplicating chip / badge render paths** to "fix" mobile placement. Adapt the existing render in place; a second copy will inevitably drift from the original.
+
+## Related Issues
+
+- Linear: [QA-459](https://linear.app/jesus-film-project/issue/QA-459)
+- Original feature: NES-1549 (TEMPLATE badge added on desktop)
+- PR [#9247](https://github.com/JesusFilm/core/pull/9247) — included this fix as a small follow-up to the collection flow refactor.

--- a/docs/solutions/ui-bugs/journey-details-chip-mobile-stacking-2026-05-24.md
+++ b/docs/solutions/ui-bugs/journey-details-chip-mobile-stacking-2026-05-24.md
@@ -7,7 +7,7 @@ problem_type: ui_bug
 component: tooling
 symptoms:
   - "TEMPLATE chip squeezed beside the journey title inside the editor's mobile 3-dots dropdown menu"
-  - "On narrow viewports the title takes the full row and the chip wraps awkwardly or gets clipped"
+  - 'On narrow viewports the title takes the full row and the chip wraps awkwardly or gets clipped'
   - "Users on mobile can't tell at a glance whether they're editing a template vs a regular journey"
 root_cause: incomplete_setup
 resolution_type: code_fix


### PR DESCRIPTION
## Summary

- **Create Collection** no longer opens a dialog — it creates a collection instantly with an auto-incremented name (`Collection 1`, `Collection 2`, …).
- **One state-aware card menu item** in place of separate Edit / Publish / Unpublish entries: drafts show **Publish**, published show **Edit**. Both open the same `CollectionDialog`.
- **Publish and Unpublish moved inside the dialog footer.** Drafts get `Cancel | Save Draft | Publish`; published get `Cancel | Unpublish | Save`. Empty / custom-domain gating moved from the card menu to the in-dialog Publish button.
- **Slug field** now visible in edit *and* publish modes (was edit-only), styled with a section header like the other fields, and reordered to sit directly under Page Description.
- **Collection card restyle** — sits on page grey with a 1px `grey.400` border, more rounded corners, and a soft drop shadow. All Templates grid drops its inset padding so cards line up with the collection-card edges above.
- **QA-459**: in the editor's mobile dropdown menu, the **TEMPLATE chip stacks below the journey title** instead of getting squeezed beside it. Desktop unchanged.

## Test plan

- [ ] Click **Create Collection** with no collections present — verify it appears named `Collection 1` with no modal
- [ ] Click **Create Collection** again with `Collection 1` and `Collection 3` present — verify the new one is named `Collection 2` (smallest unused number)
- [ ] On a draft collection card, open the menu — verify only **Publish** (no separate Edit) is shown; clicking it opens the dialog with `Cancel | Save Draft | Publish`
- [ ] On a published collection card, open the menu — verify only **Edit** (no separate Publish/Unpublish) is shown; clicking it opens the dialog with `Cancel | Unpublish | Save`
- [ ] In Publish dialog with no templates selected, verify Publish button is disabled with the "Add at least one template" tooltip; Save Draft still works
- [ ] In Publish dialog, hit Save Draft → collection remains draft with updated fields; hit Publish → success dialog opens with the live URL
- [ ] In Edit dialog on a published collection, hit Unpublish → collection flips back to draft, dialog closes, success snackbar appears
- [ ] On a custom-domain team, verify the Publish menu item is disabled with the gate-reason tooltip
- [ ] Visually verify collection cards have the new grey background + grey border + rounded corners + drop shadow, and that template cards in **All Templates** line up with the collection card edges
- [ ] Verify Slug field appears in both Edit and Publish dialogs, sits under Page Description, and renders with the "Slug" section header
- [ ] On mobile (~375px), open a template journey in the editor → open the 3-dots dropdown → verify the **TEMPLATE** chip sits below the journey title (stacked, not beside)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create‑and‑publish flow with a dedicated publish dialog and publish success handling.
  * Publish/unpublish actions available from dialog footer; slug editing normalized outside create mode.

* **UI/UX Improvements**
  * Collection card styling refreshed (background, border, shadow).
  * Journey title stacks vertically on mobile for clearer chip display.
  * Card menu entries reorganized for draft vs. published states.

* **Behavior & Tests**
  * "Publish" can be invoked for empty drafts (dialog enforces gating); tests updated for menu, dialog, and footer behaviors.

* **Documentation**
  * Added spacing and Formik multi‑action pattern guidance and a UI-bug note on mobile stacking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JesusFilm/core/pull/9247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->