### PR TITLE
feat(journeys-admin): template collection UX improvements [NES-1696]

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/TemplateInfoHelper/TemplateInfoHelper.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/TemplateInfoHelper/TemplateInfoHelper.spec.tsx
@@ -89,7 +89,7 @@ describe('TemplateInfoHelper', () => {
     const trigger = screen.getByTestId('TemplateInfoHelperTrigger')
     await user.click(trigger)
 
-    await user.click(screen.getByText('What templates are about:'))
+    await user.click(screen.getByText('What team templates are about:'))
 
     expect(trigger).toHaveAttribute('aria-expanded', 'true')
     expect(screen.getByTestId('TemplateInfoPanel')).toBeInTheDocument()

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/TemplateInfoHelper/TemplateInfoHelper.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/TemplateInfoHelper/TemplateInfoHelper.tsx
@@ -117,10 +117,14 @@ export function TemplateInfoHelper(): ReactElement {
           sx={{
             bgcolor: 'background.paper',
             color: 'text.primary',
-            borderRadius: 1.5,
+            // Match Figma 39661-67393: 16px radius, 1px Editor/Divider stroke,
+            // white surface, 20px padding around the 24px icons (NES-1696).
+            borderRadius: 4,
+            border: 1,
+            borderColor: 'divider',
             boxShadow: 2,
-            px: 2.5,
-            py: 1.5,
+            px: 5,
+            py: 5,
             '&:hover': {
               bgcolor: 'background.paper',
               boxShadow: 3
@@ -131,14 +135,14 @@ export function TemplateInfoHelper(): ReactElement {
             }
           }}
         >
-          <Stack direction="row" alignItems="center" spacing={1.5}>
+          <Stack direction="row" alignItems="center" spacing={2}>
             <InfoOutlinedIcon
               data-testid="TemplateInfoHelperTriggerInfoIcon"
-              sx={{ fontSize: 28 }}
+              sx={{ fontSize: 24 }}
             />
             <SouthEastIcon
               data-testid="TemplateInfoHelperTriggerArrowIcon"
-              sx={{ fontSize: 28 }}
+              sx={{ fontSize: 24 }}
             />
           </Stack>
         </ButtonBase>

--- a/apps/journeys-admin/src/components/Editor/Toolbar/JourneyDetails/JourneyDetails.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/JourneyDetails/JourneyDetails.tsx
@@ -1,5 +1,4 @@
 import Box from '@mui/material/Box'
-import Chip from '@mui/material/Chip'
 import Skeleton from '@mui/material/Skeleton'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
@@ -8,6 +7,8 @@ import { ReactElement } from 'react'
 
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import Globe1Icon from '@core/shared/ui/icons/Globe1'
+
+import { LabelChip } from '../../../LabelChip'
 
 export function JourneyDetails(): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
@@ -57,26 +58,10 @@ export function JourneyDetails(): ReactElement {
               {journey.title}
             </Typography>
             {journey.template === true && (
-              <Chip
+              <LabelChip
                 label={t('TEMPLATE')}
                 data-testid="TemplateBadge"
-                sx={{
-                  flexShrink: 0,
-                  height: 28,
-                  borderRadius: '4px',
-                  bgcolor: '#DEDFE0',
-                  color: '#444451',
-                  fontFamily: '"Open Sans", sans-serif',
-                  fontSize: 14,
-                  fontWeight: 600,
-                  lineHeight: '20px',
-                  px: 2,
-                  py: 1,
-                  '& .MuiChip-label': {
-                    px: 0,
-                    py: 0
-                  }
-                }}
+                sx={{ flexShrink: 0 }}
               />
             )}
           </Stack>

--- a/apps/journeys-admin/src/components/LabelChip/LabelChip.spec.tsx
+++ b/apps/journeys-admin/src/components/LabelChip/LabelChip.spec.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react'
+
+import { LabelChip } from './LabelChip'
+
+describe('LabelChip', () => {
+  it('renders the label and forwards data-testid', () => {
+    render(<LabelChip label="Draft" data-testid="status-chip" />)
+
+    expect(screen.getByTestId('status-chip')).toBeInTheDocument()
+    expect(screen.getByText('Draft')).toBeInTheDocument()
+  })
+
+  it('renders the success (Live) variant', () => {
+    render(<LabelChip label="Live" color="success" />)
+
+    expect(screen.getByText('Live')).toBeInTheDocument()
+  })
+})

--- a/apps/journeys-admin/src/components/LabelChip/LabelChip.tsx
+++ b/apps/journeys-admin/src/components/LabelChip/LabelChip.tsx
@@ -1,0 +1,54 @@
+import Chip from '@mui/material/Chip'
+import { SxProps, Theme } from '@mui/material/styles'
+import { ReactElement } from 'react'
+
+export type LabelChipColor = 'default' | 'success'
+
+interface LabelChipProps {
+  label: string
+  /**
+   * 'default' renders the neutral grey label used for TEMPLATE, DRAFT,
+   * EMPTY and RECOMMENDED. 'success' renders the green LIVE label.
+   */
+  color?: LabelChipColor
+  sx?: SxProps<Theme>
+  'data-testid'?: string
+}
+
+/**
+ * Shared status/label chip (NES-1696). A filled, squareish, uppercase chip
+ * standardised across the editor (TEMPLATE), collection cards (LIVE / DRAFT /
+ * EMPTY) and the template info panel (RECOMMENDED) so the labels stay
+ * visually consistent. Pass `color="success"` for the green LIVE state.
+ */
+export function LabelChip({
+  label,
+  color = 'default',
+  sx,
+  'data-testid': dataTestId
+}: LabelChipProps): ReactElement {
+  const isSuccess = color === 'success'
+  return (
+    <Chip
+      label={label}
+      data-testid={dataTestId}
+      sx={[
+        {
+          height: 28,
+          borderRadius: '4px',
+          bgcolor: isSuccess ? 'success.main' : 'divider',
+          color: isSuccess ? 'success.contrastText' : 'text.primary',
+          fontFamily: '"Open Sans", sans-serif',
+          fontSize: 14,
+          fontWeight: 600,
+          lineHeight: '20px',
+          textTransform: 'uppercase',
+          px: 2,
+          py: 1,
+          '& .MuiChip-label': { px: 0, py: 0 }
+        },
+        ...(Array.isArray(sx) ? sx : [sx])
+      ]}
+    />
+  )
+}

--- a/apps/journeys-admin/src/components/LabelChip/index.ts
+++ b/apps/journeys-admin/src/components/LabelChip/index.ts
@@ -1,0 +1,1 @@
+export * from './LabelChip'

--- a/apps/journeys-admin/src/components/LabelChip/index.ts
+++ b/apps/journeys-admin/src/components/LabelChip/index.ts
@@ -1,1 +1,1 @@
-export * from './LabelChip'
+export { LabelChip } from './LabelChip'

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.spec.tsx
@@ -44,7 +44,7 @@ describe('CollectionCard', () => {
     expect(screen.getByText('Empty')).toBeInTheDocument()
   })
 
-  it('shows a Published chip when the collection is published', () => {
+  it('shows a Live chip when the collection is published', () => {
     render(
       <CollectionCard
         collection={makeCollection({
@@ -54,7 +54,7 @@ describe('CollectionCard', () => {
         })}
       />
     )
-    expect(screen.getByText('Published')).toBeInTheDocument()
+    expect(screen.getByText('Live')).toBeInTheDocument()
     expect(screen.queryByText('Empty')).not.toBeInTheDocument()
   })
 

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
@@ -15,6 +15,10 @@ import MoreIcon from '@core/shared/ui/icons/More'
 import { GetTemplateGalleryPages_templateGalleryPages as TemplateGalleryPage } from '../../../../__generated__/GetTemplateGalleryPages'
 import { TemplateGalleryPageStatus } from '../../../../__generated__/globalTypes'
 import { LabelChip } from '../../LabelChip'
+import {
+  COLLECTION_CARD_BORDER_WIDTH,
+  COLLECTION_CARD_PADDING
+} from '../collectionLayout'
 
 import { CollectionUngroupDialog } from './CollectionUngroupDialog'
 
@@ -117,17 +121,17 @@ function CollectionCardImpl({
     <Card
       data-testid={`CollectionCard-${collection.id}`}
       sx={{
-        // 12px inner padding (p:3). The collections Stack bleeds each box
-        // outward by this padding + 1px border so the inner card grid lines
-        // up with the All Templates grid below — keep the two in sync.
-        p: 3,
+        // Inner padding (12px). The collections Stack bleeds each box outward
+        // by this padding + border so the inner card grid lines up with the
+        // All Templates grid — both derive from collectionLayout constants.
+        p: COLLECTION_CARD_PADDING,
         // NES-1696: a subtle transparent-white panel over the grey page
         // with a light grey stroke and no shadow, per the Figma design.
         // Spec: bg rgba(255,255,255,0.40), 1px solid divider (#DEDFE0),
         // 12px radius (borderRadius 3 × the 4px theme.shape.borderRadius).
         backgroundColor: 'rgba(255, 255, 255, 0.4)',
         borderColor: 'divider',
-        borderWidth: 1,
+        borderWidth: COLLECTION_CARD_BORDER_WIDTH,
         borderStyle: 'solid',
         borderRadius: 3,
         boxShadow: 'none'

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
@@ -117,7 +117,10 @@ function CollectionCardImpl({
     <Card
       data-testid={`CollectionCard-${collection.id}`}
       sx={{
-        p: 2,
+        // 12px inner padding (p:3). The collections Stack bleeds each box
+        // outward by this padding + 1px border so the inner card grid lines
+        // up with the All Templates grid below — keep the two in sync.
+        p: 3,
         // NES-1696: a subtle transparent-white panel over the grey page
         // with a light grey stroke and no shadow, per the Figma design.
         // Spec: bg rgba(255,255,255,0.40), 1px solid divider (#DEDFE0),

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
@@ -1,7 +1,6 @@
 import Box from '@mui/material/Box'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
-import Chip from '@mui/material/Chip'
 import IconButton from '@mui/material/IconButton'
 import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
@@ -15,6 +14,7 @@ import MoreIcon from '@core/shared/ui/icons/More'
 
 import { GetTemplateGalleryPages_templateGalleryPages as TemplateGalleryPage } from '../../../../__generated__/GetTemplateGalleryPages'
 import { TemplateGalleryPageStatus } from '../../../../__generated__/globalTypes'
+import { LabelChip } from '../../LabelChip'
 
 import { CollectionUngroupDialog } from './CollectionUngroupDialog'
 
@@ -142,14 +142,11 @@ function CollectionCardImpl({
       >
         <Stack direction="row" spacing={2} alignItems="center">
           <Typography variant="h6">{collection.title}</Typography>
-          <Chip
-            size="small"
+          <LabelChip
             color={isPublished ? 'success' : 'default'}
-            label={isPublished ? t('Published') : t('Draft')}
+            label={isPublished ? t('Live') : t('Draft')}
           />
-          {isEmpty && (
-            <Chip size="small" variant="outlined" label={t('Empty')} />
-          )}
+          {isEmpty && <LabelChip label={t('Empty')} />}
         </Stack>
         <IconButton
           aria-label={t('Collection actions')}

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
@@ -118,16 +118,16 @@ function CollectionCardImpl({
       data-testid={`CollectionCard-${collection.id}`}
       sx={{
         p: 2,
-        // Match the surrounding page grey so the card reads as a
-        // panel of the same surface rather than a raised white card.
-        // The darker grey border + thicker stroke + soft shadow is
-        // what gives each collection its visual separation.
-        backgroundColor: 'background.default',
-        borderColor: 'grey.400',
+        // NES-1696: a subtle transparent-white panel over the grey page
+        // with a light grey stroke and no shadow, per the Figma design.
+        // Spec: bg rgba(255,255,255,0.40), 1px solid divider (#DEDFE0),
+        // 12px radius (borderRadius 3 × the 4px theme.shape.borderRadius).
+        backgroundColor: 'rgba(255, 255, 255, 0.4)',
+        borderColor: 'divider',
         borderWidth: 1,
         borderStyle: 'solid',
         borderRadius: 3,
-        boxShadow: '0 2px 6px rgba(0, 0, 0, 0.08)'
+        boxShadow: 'none'
       }}
       variant="outlined"
     >

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/Droppables/Droppables.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/Droppables/Droppables.tsx
@@ -10,6 +10,7 @@ import { ReactElement, memo } from 'react'
 
 import { GetAdminJourneys_journeys as Journey } from '../../../../__generated__/GetAdminJourneys'
 import { JourneyCard } from '../../JourneyList/JourneyCard'
+import { COLLECTION_GRID_SPACING } from '../collectionLayout'
 
 // Drop zone identity is encoded into a string the dnd-kit `over.id` carries
 // back into the dispatcher. Wrappers use the encoder; the parent uses the
@@ -84,11 +85,11 @@ function DraggableJourneysGridImpl({
   const ids = journeys.map((j) => j.id)
   // No outer padding: the grid sits directly in its container so the
   // in-collection grid and the All Templates grid share identical
-  // geometry and their cards column-align (NES-1696). spacing 3 (12px)
-  // is the card gap, matched to the CollectionCard's inner padding.
+  // geometry and their cards column-align (NES-1696). The card gap is
+  // matched to the CollectionCard's inner padding via collectionLayout.
   return (
     <SortableContext items={ids} strategy={rectSortingStrategy}>
-      <Grid container spacing={3}>
+      <Grid container spacing={COLLECTION_GRID_SPACING}>
         {journeys.map((journey) => (
           <Grid key={journey.id} size={{ xs: 12, sm: 6, md: 6, lg: 3, xl: 3 }}>
             <DraggableJourney

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/Droppables/Droppables.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/Droppables/Droppables.tsx
@@ -70,45 +70,34 @@ interface DraggableJourneysGridProps {
   journeys: readonly Journey[]
   publishedLock: boolean
   dragInFlight: boolean
-  /**
-   * When true (default), wraps the grid in outer padding that matches
-   * the Grid's spacing so the gap from a card to the collection
-   * edge equals the gap between cards — the in-collection layout
-   * Sushma flagged in DM.
-   * Pass false in the All Templates section so cards line up with
-   * the collection-card edges above instead of inset by the padding.
-   */
-  outerPadding?: boolean
 }
 
 function DraggableJourneysGridImpl({
   journeys,
   publishedLock,
-  dragInFlight,
-  outerPadding = true
+  dragInFlight
 }: DraggableJourneysGridProps): ReactElement | null {
   if (journeys.length === 0) return null
   // SortableContext gives intra-collection ordering: each item is both a
   // draggable AND a drop target with a known index, so dnd-kit hands us
   // the over-item id in handleDragEnd.
   const ids = journeys.map((j) => j.id)
+  // No outer padding: the grid sits directly in its container so the
+  // in-collection grid and the All Templates grid share identical
+  // geometry and their cards column-align (NES-1696). spacing 3 (12px)
+  // is the card gap, matched to the CollectionCard's inner padding.
   return (
     <SortableContext items={ids} strategy={rectSortingStrategy}>
-      <Box sx={outerPadding ? { p: { xs: 2.5, sm: 4 } } : undefined}>
-        <Grid container spacing={4} rowSpacing={{ xs: 2.5, sm: 4 }}>
-          {journeys.map((journey) => (
-            <Grid
-              key={journey.id}
-              size={{ xs: 12, sm: 6, md: 6, lg: 3, xl: 3 }}
-            >
-              <DraggableJourney
-                journey={journey}
-                disabled={publishedLock || dragInFlight}
-              />
-            </Grid>
-          ))}
-        </Grid>
-      </Box>
+      <Grid container spacing={3}>
+        {journeys.map((journey) => (
+          <Grid key={journey.id} size={{ xs: 12, sm: 6, md: 6, lg: 3, xl: 3 }}>
+            <DraggableJourney
+              journey={journey}
+              disabled={publishedLock || dragInFlight}
+            />
+          </Grid>
+        ))}
+      </Grid>
     </SortableContext>
   )
 }

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.spec.tsx
@@ -192,11 +192,111 @@ describe('TemplateGalleryPageList', () => {
       </MockedProvider>
     )
 
+    // The only journey is archived, so there are no active templates — the
+    // Collections section is gated off (NES-1696). Wait on the post-load DnD
+    // scope (always rendered) rather than the collection card.
     await waitFor(() =>
-      expect(getByTestId('CollectionCard-page-1')).toBeInTheDocument()
+      expect(getByTestId('TemplateGalleryDndScope')).toBeInTheDocument()
     )
     // The archived journey should NOT appear in the unsectioned list.
     expect(queryByText('Welcome Tour')).not.toBeInTheDocument()
+  })
+
+  describe('Collections section visibility gate (NES-1696)', () => {
+    // No team templates at all — the gate hides the entire Collections
+    // section (heading + Create button + collection cards).
+    const journeysMockEmpty: MockedResponse<GetAdminJourneys> = {
+      request: {
+        query: GET_ADMIN_JOURNEYS,
+        variables: {
+          template: true,
+          teamId: TEAM_ID,
+          status: [JourneyStatus.draft, JourneyStatus.published]
+        }
+      },
+      result: { data: { journeys: [] } }
+    }
+
+    // The team's only active template lives inside the collection (the
+    // unsectioned pool is empty). In-collection templates still count toward
+    // the gate, so the section must render.
+    const collectionsMockWithTemplate: MockedResponse<GetTemplateGalleryPages> =
+      {
+        request: {
+          query: GET_TEMPLATE_GALLERY_PAGES,
+          variables: { teamId: TEAM_ID }
+        },
+        result: {
+          data: {
+            templateGalleryPages: [
+              {
+                ...(
+                  collectionsMock.result as { data: GetTemplateGalleryPages }
+                ).data.templateGalleryPages[0],
+                templates: [
+                  {
+                    __typename: 'TemplateGalleryItem',
+                    id: 'journey-1',
+                    title: 'Welcome Tour',
+                    primaryImageBlock: null
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+
+    it('hides the Collections section when the team has no active templates', async () => {
+      const { queryByText, queryByTestId, getByTestId } = render(
+        <MockedProvider
+          mocks={[
+            getLastActiveTeamIdAndTeamsMock,
+            collectionsMock,
+            journeysMockEmpty
+          ]}
+        >
+          <ThemeProvider>
+            <SnackbarProvider>
+              <TeamProvider>
+                <TemplateGalleryPageList />
+              </TeamProvider>
+            </SnackbarProvider>
+          </ThemeProvider>
+        </MockedProvider>
+      )
+
+      await waitFor(() =>
+        expect(getByTestId('TemplateGalleryDndScope')).toBeInTheDocument()
+      )
+      expect(queryByTestId('CreateCollectionButton')).not.toBeInTheDocument()
+      expect(queryByText('Featured Templates')).not.toBeInTheDocument()
+    })
+
+    it('shows the Collections section when the only active template lives inside a collection', async () => {
+      const { getByText, getByTestId } = render(
+        <MockedProvider
+          mocks={[
+            getLastActiveTeamIdAndTeamsMock,
+            collectionsMockWithTemplate,
+            journeysMock
+          ]}
+        >
+          <ThemeProvider>
+            <SnackbarProvider>
+              <TeamProvider>
+                <TemplateGalleryPageList />
+              </TeamProvider>
+            </SnackbarProvider>
+          </ThemeProvider>
+        </MockedProvider>
+      )
+
+      await waitFor(() =>
+        expect(getByText('Featured Templates')).toBeInTheDocument()
+      )
+      expect(getByTestId('CreateCollectionButton')).toBeInTheDocument()
+    })
   })
 
   describe('Template Info mobile trigger (NES-1686)', () => {

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.spec.tsx
@@ -230,9 +230,8 @@ describe('TemplateGalleryPageList', () => {
           data: {
             templateGalleryPages: [
               {
-                ...(
-                  collectionsMock.result as { data: GetTemplateGalleryPages }
-                ).data.templateGalleryPages[0],
+                ...(collectionsMock.result as { data: GetTemplateGalleryPages })
+                  .data.templateGalleryPages[0],
                 templates: [
                   {
                     __typename: 'TemplateGalleryItem',

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
@@ -294,6 +294,13 @@ export function TemplateGalleryPageList({
     )
   }, [journeysQuery.data, status])
 
+  // Collections only surface once the team has at least one active
+  // (draft/published) template to group (NES-1696). The status filter
+  // already excludes archived/trashed; templates inside existing
+  // collections still count because `allTemplates` is the team's full
+  // template set, not just the unsectioned pool.
+  const showCollectionsSection = showCollections && allTemplates.length > 0
+
   const journeyById = useMemo(() => {
     const map = new Map<string, Journey>()
     for (const journey of allTemplates) map.set(journey.id, journey)
@@ -504,7 +511,7 @@ export function TemplateGalleryPageList({
   return (
     <GalleryDialogLockContext.Provider value={galleryDialogLockValue}>
       <Box sx={{ p: 4 }} data-testid="TemplateGalleryPageList">
-        {showCollections && (
+        {showCollectionsSection && (
           <Stack
             direction="row"
             justifyContent="space-between"
@@ -574,7 +581,7 @@ export function TemplateGalleryPageList({
             onDragStart={handleDragStart}
             onDragEnd={handleDragEnd}
           >
-            {showCollections &&
+            {showCollectionsSection &&
               (collections.length === 0 ? (
                 <Alert severity="info" sx={{ mb: 3 }}>
                   {t(

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
@@ -592,7 +592,19 @@ export function TemplateGalleryPageList({
                   )}
                 </Alert>
               ) : (
-                <Stack spacing={2} sx={{ mb: 4 }}>
+                <Stack
+                  spacing={2}
+                  sx={{
+                    mb: 4,
+                    // Stretch each collection box outward by the
+                    // CollectionCard's inner horizontal padding (p:3 = 12px)
+                    // + 1px border, so the card grid inside spans the same
+                    // width as the All Templates grid below and the cards
+                    // column-align (NES-1696). Keep in sync with the
+                    // CollectionCard padding above.
+                    mx: (theme) => `calc(${theme.spacing(-3)} - 1px)`
+                  }}
+                >
                   {collections.map((collection) => (
                     <DroppableCollectionWrapper
                       key={collection.id}
@@ -647,10 +659,6 @@ export function TemplateGalleryPageList({
                   journeys={unsectioned}
                   publishedLock={false}
                   dragInFlight={interactionsLocked}
-                  // No collection-card edge to balance against here —
-                  // drop the outer padding so cards align with the
-                  // collection-card edges above.
-                  outerPadding={false}
                 />
               )}
             </UnsectionedDroppable>

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
@@ -517,31 +517,30 @@ export function TemplateGalleryPageList({
             spacing={2}
             sx={{ mb: 3 }}
           >
-            {/* min-width: 0 lets the description text wrap inside the flex
-              row instead of pushing into the button on narrow viewports
-              (NES-1652). */}
-            <Stack sx={{ minWidth: 0, flex: 1 }}>
-              <Stack direction="row" alignItems="center" spacing={0.5}>
-                <Typography variant="h4">{t('Collections')}</Typography>
-                {onOpenInfo != null && (
-                  <IconButton
-                    data-testid="TemplateInfoPanelMobileTrigger"
-                    aria-label={t('Open template info')}
-                    onClick={onOpenInfo}
-                    size="small"
-                    sx={{
-                      display: { xs: 'inline-flex', md: 'none' },
-                      color: 'text.secondary',
-                      p: 0.5
-                    }}
-                  >
-                    <InfoOutlinedIcon fontSize="small" />
-                  </IconButton>
-                )}
-              </Stack>
-              <Typography variant="body2" color="text.secondary">
-                {t('Group your team templates into a public gallery page.')}
-              </Typography>
+            {/* min-width: 0 lets the title row shrink instead of pushing into
+              the button on narrow viewports (NES-1652). */}
+            <Stack
+              direction="row"
+              alignItems="center"
+              spacing={0.5}
+              sx={{ minWidth: 0, flex: 1 }}
+            >
+              <Typography variant="h4">{t('Collections')}</Typography>
+              {onOpenInfo != null && (
+                <IconButton
+                  data-testid="TemplateInfoPanelMobileTrigger"
+                  aria-label={t('Open template info')}
+                  onClick={onOpenInfo}
+                  size="small"
+                  sx={{
+                    display: { xs: 'inline-flex', md: 'none' },
+                    color: 'text.secondary',
+                    p: 0.5
+                  }}
+                >
+                  <InfoOutlinedIcon fontSize="small" />
+                </IconButton>
+              )}
             </Stack>
             <IconButton
               aria-label={t('Create Collection')}
@@ -634,34 +633,27 @@ export function TemplateGalleryPageList({
                 </Stack>
               ))}
 
-            <Box>
-              <Typography variant="h6" sx={{ mb: 2 }}>
-                {t('All Templates')}
-              </Typography>
-              <UnsectionedDroppable disabled={interactionsLocked}>
-                {unsectioned.length === 0 ? (
-                  <Box
-                    sx={{ p: 2, color: 'text.disabled', textAlign: 'center' }}
-                  >
-                    <Typography variant="caption">
-                      {allTemplates.length === 0
-                        ? t('No team templates yet.')
-                        : t('All templates are in collections.')}
-                    </Typography>
-                  </Box>
-                ) : (
-                  <DraggableJourneysGrid
-                    journeys={unsectioned}
-                    publishedLock={false}
-                    dragInFlight={interactionsLocked}
-                    // No collection-card edge to balance against here —
-                    // drop the outer padding so cards align with the
-                    // collection-card edges above.
-                    outerPadding={false}
-                  />
-                )}
-              </UnsectionedDroppable>
-            </Box>
+            <UnsectionedDroppable disabled={interactionsLocked}>
+              {unsectioned.length === 0 ? (
+                <Box sx={{ p: 2, color: 'text.disabled', textAlign: 'center' }}>
+                  <Typography variant="caption">
+                    {allTemplates.length === 0
+                      ? t('No team templates yet.')
+                      : t('All templates are in collections.')}
+                  </Typography>
+                </Box>
+              ) : (
+                <DraggableJourneysGrid
+                  journeys={unsectioned}
+                  publishedLock={false}
+                  dragInFlight={interactionsLocked}
+                  // No collection-card edge to balance against here —
+                  // drop the outer padding so cards align with the
+                  // collection-card edges above.
+                  outerPadding={false}
+                />
+              )}
+            </UnsectionedDroppable>
 
             {/* Default dropAnimation snaps the card back to its origin when a
             drop is rejected (published, no-op, etc.) and runs the standard

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
@@ -11,7 +11,6 @@ import {
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import Alert from '@mui/material/Alert'
 import Box from '@mui/material/Box'
-import Button from '@mui/material/Button'
 import CircularProgress from '@mui/material/CircularProgress'
 import IconButton from '@mui/material/IconButton'
 import Stack from '@mui/material/Stack'
@@ -28,7 +27,7 @@ import {
 } from 'react'
 
 import { useTeam } from '@core/journeys/ui/TeamProvider'
-import { useBreakpoints } from '@core/shared/ui/useBreakpoints'
+import Plus2Icon from '@core/shared/ui/icons/Plus2'
 
 import {
   GetAdminJourneysVariables,
@@ -118,7 +117,6 @@ export function TemplateGalleryPageList({
   const { t } = useTranslation('apps-journeys-admin')
   const { activeTeam } = useTeam()
   const { enqueueSnackbar } = useSnackbar()
-  const breakpoints = useBreakpoints()
   const teamId = activeTeam?.id
 
   // Collections + DnD are only meaningful in the active view. In archived
@@ -545,18 +543,24 @@ export function TemplateGalleryPageList({
                 {t('Group your team templates into a public gallery page.')}
               </Typography>
             </Stack>
-            <Button
-              variant="contained"
-              color="primary"
+            <IconButton
+              aria-label={t('Create Collection')}
+              size="small"
               onClick={() => {
                 void handleCreate()
               }}
               disabled={createLoading}
-              sx={{ flexShrink: 0, whiteSpace: 'nowrap' }}
+              sx={{
+                flexShrink: 0,
+                border: 1.5,
+                borderColor: 'text.secondary',
+                borderRadius: 2,
+                color: 'text.secondary'
+              }}
               data-testid="CreateCollectionButton"
             >
-              {breakpoints.sm ? t('Create Collection') : t('Create')}
-            </Button>
+              <Plus2Icon fontSize="small" />
+            </IconButton>
           </Stack>
         )}
 

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
@@ -47,6 +47,10 @@ import type { JourneyStatusFilter } from '../JourneyList/JourneyListView'
 
 import { CollectionCard } from './CollectionCard'
 import { CollectionDialog } from './CollectionDialog'
+import {
+  COLLECTION_CARD_BORDER_WIDTH,
+  COLLECTION_CARD_PADDING
+} from './collectionLayout'
 import { CollectionPublishSuccessDialog } from './CollectionPublishSuccessDialog'
 import {
   DraggableJourneysGrid,
@@ -597,12 +601,12 @@ export function TemplateGalleryPageList({
                   sx={{
                     mb: 4,
                     // Stretch each collection box outward by the
-                    // CollectionCard's inner horizontal padding (p:3 = 12px)
-                    // + 1px border, so the card grid inside spans the same
-                    // width as the All Templates grid below and the cards
-                    // column-align (NES-1696). Keep in sync with the
-                    // CollectionCard padding above.
-                    mx: (theme) => `calc(${theme.spacing(-3)} - 1px)`
+                    // CollectionCard's inner horizontal padding + border, so
+                    // the card grid inside spans the same width as the All
+                    // Templates grid below and the cards column-align
+                    // (NES-1696). Both sides derive from collectionLayout.
+                    mx: (theme) =>
+                      `calc(${theme.spacing(-COLLECTION_CARD_PADDING)} - ${COLLECTION_CARD_BORDER_WIDTH}px)`
                   }}
                 >
                   {collections.map((collection) => (

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/collectionLayout.ts
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/collectionLayout.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared layout constants for the collections grid (NES-1696).
+ *
+ * Three values must stay in lockstep or the in-collection card grid stops
+ * column-aligning with the All Templates grid below:
+ *  - the CollectionCard's inner padding,
+ *  - the collections Stack's negative-margin bleed (= padding + border), and
+ *  - the DraggableJourneysGrid card gap (kept equal to the padding by design).
+ *
+ * Deriving the bleed and the gap from these constants removes the silent
+ * drift risk that hand-synced magic numbers carried.
+ */
+
+/** CollectionCard inner padding, in theme spacing units (3 → 12px). */
+export const COLLECTION_CARD_PADDING = 3
+
+/** CollectionCard border width, in pixels. */
+export const COLLECTION_CARD_BORDER_WIDTH = 1
+
+/**
+ * Card gap for the journey grid. Equal to the card padding so the gap from a
+ * card to the collection edge matches the gap between cards.
+ */
+export const COLLECTION_GRID_SPACING = COLLECTION_CARD_PADDING

--- a/apps/journeys-admin/src/components/TemplateInfoPanel/HowToCreateSection/HowToCreateSection.tsx
+++ b/apps/journeys-admin/src/components/TemplateInfoPanel/HowToCreateSection/HowToCreateSection.tsx
@@ -5,14 +5,13 @@ import { Trans, useTranslation } from 'next-i18next/pages'
 import { ReactElement } from 'react'
 
 import {
-  bodySx,
   bulletListSx,
   mediaSlotSx,
   numberedListSx,
   subHeadingSx
 } from '../styles'
 
-// Visual chrome only — font/size/color come from Typography variant="body1"
+// Visual chrome only — font/size/color come from Typography variant="body2"
 // + color="text.primary" applied on the consumer element.
 const calloutBoxSx = {
   p: 1,
@@ -52,7 +51,7 @@ export function HowToCreateSection(): ReactElement {
         loading="lazy"
         sx={mediaSlotSx}
       />
-      <Typography variant="body1" color="text.primary" sx={calloutBoxSx}>
+      <Typography variant="body2" color="text.primary" sx={calloutBoxSx}>
         {t(
           'If you want to have a Quick-Start template, you need to prepare it.'
         )}
@@ -75,7 +74,7 @@ export function HowToCreateSection(): ReactElement {
             )}
           </li>
         </Box>
-        <Typography sx={bodySx}>
+        <Typography variant="body2">
           {t(
             'Marked blocks will be available for editing in Step-by-step customisation.'
           )}
@@ -96,7 +95,7 @@ export function HowToCreateSection(): ReactElement {
             )}{' '}
             <Typography
               component="code"
-              variant="body1"
+              variant="body2"
               sx={{ fontStyle: 'italic' }}
             >
               {'{{date}}'}
@@ -108,7 +107,7 @@ export function HowToCreateSection(): ReactElement {
             )}{' '}
             <Typography
               component="code"
-              variant="body1"
+              variant="body2"
               sx={{ fontStyle: 'italic' }}
             >
               {'{{date: May, 8}}'}

--- a/apps/journeys-admin/src/components/TemplateInfoPanel/SharingAndPublishingSection/SharingAndPublishingSection.tsx
+++ b/apps/journeys-admin/src/components/TemplateInfoPanel/SharingAndPublishingSection/SharingAndPublishingSection.tsx
@@ -4,7 +4,7 @@ import Typography from '@mui/material/Typography'
 import { Trans, useTranslation } from 'next-i18next/pages'
 import { ReactElement } from 'react'
 
-import { bodySx, mediaSlotSx } from '../styles'
+import { mediaSlotSx } from '../styles'
 
 /**
  * SharingAndPublishingSection — Section 4 of TemplateInfoPanel (NES-1538).
@@ -17,22 +17,22 @@ export function SharingAndPublishingSection(): ReactElement {
 
   return (
     <Stack gap={1} data-testid="SharingAndPublishingSection">
-      <Typography sx={bodySx}>
+      <Typography variant="body2">
         {t(
           'When your template is ready (you set trackable and customizable items) you can publish it.'
         )}
       </Typography>
-      <Typography sx={bodySx}>
+      <Typography variant="body2">
         <Trans
           t={t}
           i18nKey="Select <0>Publish</0> in the three dots menu to get a link to share. Anyone with the link can use your project as template, and you can track its impact."
           components={[<strong key="emphasis" />]}
         />
       </Typography>
-      <Typography sx={bodySx}>
+      <Typography variant="body2">
         {t('You can add as many templates as you want!')}
       </Typography>
-      <Typography sx={bodySx}>
+      <Typography variant="body2">
         <Trans
           t={t}
           i18nKey="You also can use your template with any team you have access to. No publishing needed in this case. Select <0>Use in a team</0> in the three dots menu."

--- a/apps/journeys-admin/src/components/TemplateInfoPanel/TemplateInfoAccordion/TemplateInfoAccordion.tsx
+++ b/apps/journeys-admin/src/components/TemplateInfoPanel/TemplateInfoAccordion/TemplateInfoAccordion.tsx
@@ -23,8 +23,9 @@ interface TemplateInfoAccordionProps {
  * Generic single-row accordion used by `TemplateInfoPanel`. The component is
  * fully controlled: the parent owns `expanded` so it can enforce single-expand
  * semantics across the panel's sections. Visual styling matches Figma
- * `39653-66422` and its expanded-state siblings (Subtitle/1 token, 20px padding,
- * 1px `#DEDFE0` divider beneath every row except the last).
+ * `39653-66422` and its expanded-state siblings (Subtitle/1 token, 1px `#DEDFE0`
+ * divider beneath every row except the last). Horizontal padding was widened
+ * to 18px per NES-1696.
  */
 export function TemplateInfoAccordion({
   id,
@@ -60,28 +61,21 @@ export function TemplateInfoAccordion({
         aria-controls={`template-info-accordion-content-${id}`}
         expandIcon={<ExpandMoreIcon sx={{ color: 'text.primary' }} />}
         sx={{
-          p: 2.5,
+          px: 4.5,
+          py: 2.5,
           minHeight: 0,
           '&.Mui-expanded': { minHeight: 0 },
           '.MuiAccordionSummary-content': { m: 0 },
           '.MuiAccordionSummary-content.Mui-expanded': { m: 0 }
         }}
       >
-        <Typography
-          sx={{
-            fontFamily: 'Montserrat, sans-serif',
-            fontWeight: 600,
-            fontSize: 18,
-            lineHeight: '24px',
-            color: 'text.primary'
-          }}
-        >
+        <Typography variant="subtitle2" color="text.primary">
           {title}
         </Typography>
       </AccordionSummary>
       <AccordionDetails
         id={`template-info-accordion-content-${id}`}
-        sx={{ px: 2.5, pt: 0, pb: 2.5 }}
+        sx={{ px: 4.5, pt: 0, pb: 2.5 }}
       >
         {children}
       </AccordionDetails>

--- a/apps/journeys-admin/src/components/TemplateInfoPanel/TemplateInfoPanel.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateInfoPanel/TemplateInfoPanel.spec.tsx
@@ -6,7 +6,9 @@ describe('TemplateInfoPanel', () => {
   it('renders the always-visible header copy verbatim', () => {
     render(<TemplateInfoPanel />)
 
-    expect(screen.getByText('What templates are about:')).toBeInTheDocument()
+    expect(
+      screen.getByText('What team templates are about:')
+    ).toBeInTheDocument()
     expect(
       screen.getByText(
         'You can share projects created on our platform with others. This allows you to track the performance of every project generated from your template.'

--- a/apps/journeys-admin/src/components/TemplateInfoPanel/TemplateInfoPanel.tsx
+++ b/apps/journeys-admin/src/components/TemplateInfoPanel/TemplateInfoPanel.tsx
@@ -130,32 +130,17 @@ export function TemplateInfoPanel({
   const header = (
     <Stack
       sx={{
-        px: 2.5,
+        px: 4.5,
         pt: 3,
         pb: 2.5,
         gap: 1,
         color: 'text.primary'
       }}
     >
-      <Typography
-        component="h2"
-        sx={{
-          fontFamily: 'Montserrat, sans-serif',
-          fontWeight: 600,
-          fontSize: 22,
-          lineHeight: '27px'
-        }}
-      >
-        {t('What templates are about:')}
+      <Typography component="h2" variant="h6">
+        {t('What team templates are about:')}
       </Typography>
-      <Typography
-        sx={{
-          fontFamily: 'Open Sans, sans-serif',
-          fontWeight: 400,
-          fontSize: 16,
-          lineHeight: '24px'
-        }}
-      >
+      <Typography variant="body2">
         {t(
           'You can share projects created on our platform with others. This allows you to track the performance of every project generated from your template.'
         )}
@@ -269,7 +254,7 @@ export function TemplateInfoPanel({
                 flexShrink: 0,
                 width: '100%',
                 justifyContent: 'flex-end',
-                px: 2.5,
+                px: 4.5,
                 py: 1.5,
                 color: 'text.primary',
                 '&:hover': {

--- a/apps/journeys-admin/src/components/TemplateInfoPanel/TemplateTypesSection/TemplateTypesSection.tsx
+++ b/apps/journeys-admin/src/components/TemplateInfoPanel/TemplateTypesSection/TemplateTypesSection.tsx
@@ -1,10 +1,10 @@
 import Box from '@mui/material/Box'
-import Chip from '@mui/material/Chip'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { useTranslation } from 'next-i18next/pages'
 import { ReactElement } from 'react'
 
+import { LabelChip } from '../../LabelChip'
 import { bulletListSx, mediaSlotSx, subHeadingSx } from '../styles'
 
 /**
@@ -23,23 +23,7 @@ export function TemplateTypesSection(): ReactElement {
       <Stack gap={1}>
         <Stack direction="row" gap={1} alignItems="center">
           <Typography sx={subHeadingSx}>{t('Quick-Start')}</Typography>
-          <Chip
-            label={t('RECOMMENDED')}
-            size="small"
-            sx={{
-              bgcolor: '#DEDFE0',
-              color: 'text.primary',
-              borderRadius: 1,
-              height: 'auto',
-              fontFamily: 'Open Sans, sans-serif',
-              fontWeight: 600,
-              fontSize: 14,
-              lineHeight: '20px',
-              px: 1,
-              py: 0.5,
-              '& .MuiChip-label': { px: 0 }
-            }}
-          />
+          <LabelChip label={t('RECOMMENDED')} />
         </Stack>
         <Box component="ul" sx={bulletListSx}>
           <li>{t('Best for new or mobile users.')}</li>

--- a/apps/journeys-admin/src/components/TemplateInfoPanel/TrackingAndAnalyticsSection/TrackingAndAnalyticsSection.tsx
+++ b/apps/journeys-admin/src/components/TemplateInfoPanel/TrackingAndAnalyticsSection/TrackingAndAnalyticsSection.tsx
@@ -6,7 +6,7 @@ import { ReactElement } from 'react'
 
 import ActivityIcon from '@core/shared/ui/icons/Activity'
 
-import { bodySx, mediaSlotSx, numberedListSx } from '../styles'
+import { mediaSlotSx, numberedListSx } from '../styles'
 
 /**
  * TrackingAndAnalyticsSection — Section 3 of TemplateInfoPanel (NES-1538).
@@ -20,7 +20,7 @@ export function TrackingAndAnalyticsSection(): ReactElement {
 
   return (
     <Stack gap={2} data-testid="TrackingAndAnalyticsSection">
-      <Typography sx={bodySx}>
+      <Typography variant="body2">
         {t(
           'Track more than just views and responses. To track specific button clicks, video views, or card visits, you must tag those elements as "trackable."'
         )}
@@ -51,7 +51,7 @@ export function TrackingAndAnalyticsSection(): ReactElement {
         loading="lazy"
         sx={mediaSlotSx}
       />
-      <Typography sx={bodySx}>
+      <Typography variant="body2">
         {t(
           'After your shared projects generate activity, you will be able to see the statistics for your selected events in a detailed table.'
         )}

--- a/apps/journeys-admin/src/components/TemplateInfoPanel/styles.ts
+++ b/apps/journeys-admin/src/components/TemplateInfoPanel/styles.ts
@@ -8,52 +8,37 @@ import { SxProps, Theme } from '@mui/material/styles'
  * file. Per-section overrides spread these and override what they need.
  */
 
-/** Open Sans Regular 16/24 — `Body/1` token used for paragraph copy. */
-export const bodySx: SxProps<Theme> = {
-  fontFamily: 'Open Sans, sans-serif',
-  fontWeight: 400,
-  fontSize: 16,
-  lineHeight: '24px',
-  color: 'text.primary'
-}
+/**
+ * Open Sans Bold 14/22 (Editor/Secondary/Light grey) — in-body sub-headings
+ * above template variants and sub-sections (e.g. "Quick-Start", "Regular",
+ * "Links, Images, Video", "Text"). Derives from the `body2` variant (there is
+ * no bold-14 variant) so its size tracks the body copy (NES-1696).
+ */
+export const subHeadingSx: SxProps<Theme> = (theme) => ({
+  ...theme.typography.body2,
+  fontWeight: 700,
+  color: 'text.secondary'
+})
 
 /**
- * Open Sans Bold 16/24 in the Editor/Secondary/Light grey — used for the
- * in-body sub-headings above template variants and sub-sections (e.g.
- * "Quick-Start", "Regular", "Links, Images, Video", "Text", "Canva",
- * "Google Slides", "Troubleshooting").
+ * Decimal-style numbered list used for "do this, then this" step sequences.
+ * The <li> elements borrow the `body2` variant via `sx` (a raw <li> can't
+ * take a Typography `variant`).
  */
-export const subHeadingSx: SxProps<Theme> = {
-  fontFamily: 'Open Sans, sans-serif',
-  fontWeight: 700,
-  fontSize: 16,
-  lineHeight: '24px',
-  color: 'text.secondary'
-}
-
-const listItemSx: SxProps<Theme> = {
-  fontFamily: 'Open Sans, sans-serif',
-  fontWeight: 400,
-  fontSize: 16,
-  lineHeight: '24px',
-  color: 'text.primary'
-}
-
-/** Decimal-style numbered list used for "do this, then this" step sequences. */
-export const numberedListSx: SxProps<Theme> = {
+export const numberedListSx: SxProps<Theme> = (theme) => ({
   pl: 3,
   m: 0,
   listStyle: 'decimal',
-  '& li': listItemSx
-}
+  '& li': { ...theme.typography.body2, color: 'text.primary' }
+})
 
 /** Bullet-style list used for unordered enumerations inside a section body. */
-export const bulletListSx: SxProps<Theme> = {
+export const bulletListSx: SxProps<Theme> = (theme) => ({
   pl: 3,
   m: 0,
   listStyle: 'disc',
-  '& li': listItemSx
-}
+  '& li': { ...theme.typography.body2, color: 'text.primary' }
+})
 
 /**
  * Visual chrome for an embedded screenshot or GIF slot in a section body.

--- a/docs/solutions/design-patterns/collection-grid-bleed-column-alignment-nes1696.md
+++ b/docs/solutions/design-patterns/collection-grid-bleed-column-alignment-nes1696.md
@@ -1,0 +1,189 @@
+---
+title: "Column-aligning an inset bordered container's grid with a full-width sibling grid (MUI negative-margin bleed)"
+date: 2026-05-26
+category: design-patterns
+module: journeys-admin/template-gallery
+problem_type: design_pattern
+component: tooling
+severity: low
+applies_when:
+  - "A bordered/padded container (e.g. MUI Card variant=outlined) hosts a grid that must column-align with a full-width sibling grid"
+  - "Both grids share the same breakpoints and gap but sit in containers of different widths"
+  - "The container uses box-sizing: border-box so border + padding count inside its width"
+related_components:
+  - apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
+  - apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
+  - apps/journeys-admin/src/components/TemplateGalleryPageList/Droppables/Droppables.tsx
+  - apps/journeys-admin/src/components/TemplateGalleryPageList/collectionLayout.ts
+tags:
+  - mui
+  - grid-alignment
+  - negative-margin
+  - layout
+  - box-sizing
+  - shared-constants
+  - theme-spacing
+---
+
+# Column-aligning an inset bordered container's grid with a full-width sibling grid (MUI negative-margin bleed)
+
+## Context
+
+In the Team Templates gallery (`apps/journeys-admin`, NES-1696) the page stacks two grids of template cards:
+
+1. A **Collections** section — one or more bordered "collection boxes," each an MUI `<Card variant="outlined">` with a 1px border and inner padding, holding that collection's template cards.
+2. An **All Templates** (unsectioned) section — a full-width grid of every ungrouped template, with no surrounding box.
+
+Both are MUI `<Grid container>` with the **same breakpoints** (`{ xs: 12, sm: 6, md: 6, lg: 3, xl: 3 }`). You'd expect column 2 of a collection box to line up vertically with column 2 of the All Templates grid below. It didn't.
+
+The cause is a width mismatch. The collection grid lives **inside** the Card's content box, inset from the page width by `padding-left + padding-right + 2 × border`. The All Templates grid runs at the **full page content width**. The same breakpoint fractions over two different container widths produce different column boundaries and different card widths, so columns drift (worse toward the right) and cards aren't even the same size.
+
+A naive earlier version made it worse by stacking **two** inset layers: the Card's own padding *plus* a redundant inner padding wrapper inside the shared grid component (an `outerPadding` prop). The collection side was inset twice; the unsectioned side not at all.
+
+## Guidance
+
+Make the bordered container's **content box** occupy the same horizontal span `[L, R]` as the full-width sibling, then render the **same grid component** (same breakpoints, same gap) in both places. When the two grids share identical geometry, column alignment is free — there's no per-column math to keep in sync.
+
+1. **One inset layer, not two.** Render the same shared grid component in both sections and delete any redundant inner padding wrapper. The only inset on the collection side is the Card's own padding; the unsectioned side has none.
+2. **Bleed the box outward with a negative margin** equal to `(card horizontal padding + border width)`. With `box-sizing: border-box` (MUI's default), pulling the box's outer edges left/right by exactly that amount makes the Card's *content* box equal the page content box. The inner grid then spans the same `[L, R]` as the sibling.
+3. **Share the gap, too.** Use the same grid component for both so `spacing` is defined once — different gaps would diverge the interior column boundaries even at equal width.
+4. **Put the bleed on the layout wrapper, not the Card.** Here the negative margin lives on the collections `Stack` wrapping each droppable, so the per-collection drag-over outline (on the droppable `Box`) bleeds outward *with* the card instead of being clipped or offset.
+5. **Extract the coupled constants to one module** so the three values that must move in lockstep can't silently drift:
+
+```ts
+// collectionLayout.ts
+export const COLLECTION_CARD_PADDING = 3          // theme spacing units
+export const COLLECTION_CARD_BORDER_WIDTH = 1     // literal pixels
+export const COLLECTION_GRID_SPACING = COLLECTION_CARD_PADDING
+```
+
+The bleed is computed from the first two; the gap is the third (kept equal to the padding by design, so the card→edge gap matches the card→card gap).
+
+### The spacing-unit subtlety
+
+This repo customizes the MUI theme spacing unit to **1 = 4px** (not the default 8px) — see [conventions/mui-spacing-token-is-4px](../conventions/mui-spacing-token-is-4px-2026-05-24.md) *(auto memory [claude])*. So `theme.spacing(3)` resolves to **12px**, not 24px. The border is a literal `1px`, not a spacing unit. The bleed therefore combines a spacing-unit term with a raw-pixel term via `calc()`:
+
+```ts
+mx: (theme) =>
+  `calc(${theme.spacing(-COLLECTION_CARD_PADDING)} - ${COLLECTION_CARD_BORDER_WIDTH}px)`
+// → calc(-12px - 1px) = -13px each side
+```
+
+Keep it derived — don't collapse it to `-13px` — so editing the padding constant keeps the bleed correct automatically.
+
+## Why This Matters
+
+- **Alignment becomes structural, not coincidental.** Two grids with the same breakpoints only align if their containers are the same width. Equalizing width once removes the entire class of "off by a few px per column" bugs instead of patching individual columns.
+- **Eliminates silent drift.** The padding, the bleed, and the gap are three numbers that must agree. Hand-synced magic numbers across files drift the moment someone tweaks the padding. Deriving the bleed and gap from shared constants means one edit propagates correctly.
+- **Avoids the doubled-inset trap.** A single, well-understood inset (the Card's padding) is easier to reason about and to bleed against than two stacked layers.
+- **Keeps drag affordances correct.** Bleeding the wrapper (not the Card) keeps the drop-target outline tracking the visible card edges.
+
+## When to Apply
+
+Reach for the negative-margin bleed whenever a **bordered or padded container must host a grid (or any width-sensitive layout) that should column-align with a full-width sibling** rendered outside that container. Signals:
+
+- Two sections use the same responsive grid breakpoints but live at different container widths.
+- A card/panel/section has its own padding + border and sits inset from the page, while a sibling spans the full content width.
+- You catch yourself trying to *adjust the breakpoints* of one grid to compensate — that's the wrong layer; equalize the container width instead.
+
+Preconditions: the container uses `box-sizing: border-box` (MUI default) and the inset is computable (padding + border). If padding/border are responsive, the bleed must be responsive too (same breakpoints).
+
+## Examples
+
+### Before — two inset layers, box not bled
+
+The shared grid added its own inner padding *and* the Card added padding, so the collection grid was inset twice; nothing pulled the box back out to page width.
+
+```tsx
+// Droppables.tsx — grid carried a redundant inner inset (outerPadding)
+<SortableContext items={ids} strategy={rectSortingStrategy}>
+  <Box sx={outerPadding ? { p: { xs: 2.5, sm: 4 } } : undefined}>
+    <Grid container spacing={4}>
+      {/* cards */}
+    </Grid>
+  </Box>
+</SortableContext>
+```
+
+```tsx
+// TemplateGalleryPageList.tsx — collections Stack at default (inset) width
+<Stack spacing={2} sx={{ mb: 4 }}>
+  {collections.map((collection) => (
+    <DroppableCollectionWrapper /* ... */>
+      <CollectionCard /* p: 2 */>
+        <DraggableJourneysGrid /* outerPadding defaults true */ />
+      </CollectionCard>
+    </DroppableCollectionWrapper>
+  ))}
+</Stack>
+```
+
+Result: collection grid width = page width − (card padding ×2 + border ×2 + inner wrapper ×2); All Templates grid width = page width. Columns and card sizes don't match.
+
+### After — single inset layer, box bled to page width
+
+```ts
+// collectionLayout.ts — the three coupled constants
+export const COLLECTION_CARD_PADDING = 3        // 3 × 4px = 12px
+export const COLLECTION_CARD_BORDER_WIDTH = 1   // px
+export const COLLECTION_GRID_SPACING = COLLECTION_CARD_PADDING
+```
+
+```tsx
+// Droppables.tsx — no inner wrapper; gap derived from the constant
+<SortableContext items={ids} strategy={rectSortingStrategy}>
+  <Grid container spacing={COLLECTION_GRID_SPACING}>
+    {journeys.map((journey) => (
+      <Grid key={journey.id} size={{ xs: 12, sm: 6, md: 6, lg: 3, xl: 3 }}>
+        <DraggableJourney journey={journey} disabled={publishedLock || dragInFlight} />
+      </Grid>
+    ))}
+  </Grid>
+</SortableContext>
+```
+
+```tsx
+// CollectionCard.tsx — a single inset: the Card's own padding + border
+<Card
+  variant="outlined"
+  sx={{
+    p: COLLECTION_CARD_PADDING,                 // 12px
+    borderWidth: COLLECTION_CARD_BORDER_WIDTH,  // 1px
+    borderStyle: 'solid',
+    borderColor: 'divider',
+    borderRadius: 3,
+    boxShadow: 'none',
+    backgroundColor: 'rgba(255, 255, 255, 0.4)'
+  }}
+>
+  {/* header + DraggableJourneysGrid */}
+</Card>
+```
+
+```tsx
+// TemplateGalleryPageList.tsx — bleed the Stack outward by padding + border
+<Stack
+  spacing={2}
+  sx={{
+    mb: 4,
+    mx: (theme) =>
+      `calc(${theme.spacing(-COLLECTION_CARD_PADDING)} - ${COLLECTION_CARD_BORDER_WIDTH}px)`
+    // → calc(-12px - 1px) = -13px
+  }}
+>
+  {/* DroppableCollectionWrapper → CollectionCard → DraggableJourneysGrid */}
+</Stack>
+
+{/* unsectioned section renders the SAME grid at native page width */}
+<UnsectionedDroppable disabled={interactionsLocked}>
+  <DraggableJourneysGrid journeys={unsectioned} publishedLock={false} dragInFlight={interactionsLocked} />
+</UnsectionedDroppable>
+```
+
+With `box-sizing: border-box`, the bleed cancels the Card's padding + border at the outer edges, so the Card's content box spans the same `[L, R]` as the unsectioned grid. Identical breakpoints + identical spacing over identical width → columns and card sizes align exactly, with zero per-column compensation.
+
+## Related
+
+- [best-practices/template-gallery-page-collections-patterns-nes1539](../best-practices/template-gallery-page-collections-patterns-nes1539.md) — the sibling catalog of TemplateGalleryPageList patterns (cache, DnD, Formik, auth). This doc adds the layout/alignment pattern it doesn't cover.
+- [conventions/mui-spacing-token-is-4px](../conventions/mui-spacing-token-is-4px-2026-05-24.md) — the authority for the bleed offset math; this repo's `theme.spacing(n)` is `n × 4px`, so always combine spacing terms with literal-px terms (like the 1px border) via `calc()`.
+- Ticket: NES-1696. PR: #9252.

--- a/docs/solutions/design-patterns/collection-grid-bleed-column-alignment-nes1696.md
+++ b/docs/solutions/design-patterns/collection-grid-bleed-column-alignment-nes1696.md
@@ -7,9 +7,9 @@ problem_type: design_pattern
 component: tooling
 severity: low
 applies_when:
-  - "A bordered/padded container (e.g. MUI Card variant=outlined) hosts a grid that must column-align with a full-width sibling grid"
-  - "Both grids share the same breakpoints and gap but sit in containers of different widths"
-  - "The container uses box-sizing: border-box so border + padding count inside its width"
+  - 'A bordered/padded container (e.g. MUI Card variant=outlined) hosts a grid that must column-align with a full-width sibling grid'
+  - 'Both grids share the same breakpoints and gap but sit in containers of different widths'
+  - 'The container uses box-sizing: border-box so border + padding count inside its width'
 related_components:
   - apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
   - apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
@@ -38,22 +38,22 @@ Both are MUI `<Grid container>` with the **same breakpoints** (`{ xs: 12, sm: 6,
 
 The cause is a width mismatch. The collection grid lives **inside** the Card's content box, inset from the page width by `padding-left + padding-right + 2 × border`. The All Templates grid runs at the **full page content width**. The same breakpoint fractions over two different container widths produce different column boundaries and different card widths, so columns drift (worse toward the right) and cards aren't even the same size.
 
-A naive earlier version made it worse by stacking **two** inset layers: the Card's own padding *plus* a redundant inner padding wrapper inside the shared grid component (an `outerPadding` prop). The collection side was inset twice; the unsectioned side not at all.
+A naive earlier version made it worse by stacking **two** inset layers: the Card's own padding _plus_ a redundant inner padding wrapper inside the shared grid component (an `outerPadding` prop). The collection side was inset twice; the unsectioned side not at all.
 
 ## Guidance
 
 Make the bordered container's **content box** occupy the same horizontal span `[L, R]` as the full-width sibling, then render the **same grid component** (same breakpoints, same gap) in both places. When the two grids share identical geometry, column alignment is free — there's no per-column math to keep in sync.
 
 1. **One inset layer, not two.** Render the same shared grid component in both sections and delete any redundant inner padding wrapper. The only inset on the collection side is the Card's own padding; the unsectioned side has none.
-2. **Bleed the box outward with a negative margin** equal to `(card horizontal padding + border width)`. With `box-sizing: border-box` (MUI's default), pulling the box's outer edges left/right by exactly that amount makes the Card's *content* box equal the page content box. The inner grid then spans the same `[L, R]` as the sibling.
+2. **Bleed the box outward with a negative margin** equal to `(card horizontal padding + border width)`. With `box-sizing: border-box` (MUI's default), pulling the box's outer edges left/right by exactly that amount makes the Card's _content_ box equal the page content box. The inner grid then spans the same `[L, R]` as the sibling.
 3. **Share the gap, too.** Use the same grid component for both so `spacing` is defined once — different gaps would diverge the interior column boundaries even at equal width.
-4. **Put the bleed on the layout wrapper, not the Card.** Here the negative margin lives on the collections `Stack` wrapping each droppable, so the per-collection drag-over outline (on the droppable `Box`) bleeds outward *with* the card instead of being clipped or offset.
+4. **Put the bleed on the layout wrapper, not the Card.** Here the negative margin lives on the collections `Stack` wrapping each droppable, so the per-collection drag-over outline (on the droppable `Box`) bleeds outward _with_ the card instead of being clipped or offset.
 5. **Extract the coupled constants to one module** so the three values that must move in lockstep can't silently drift:
 
 ```ts
 // collectionLayout.ts
-export const COLLECTION_CARD_PADDING = 3          // theme spacing units
-export const COLLECTION_CARD_BORDER_WIDTH = 1     // literal pixels
+export const COLLECTION_CARD_PADDING = 3 // theme spacing units
+export const COLLECTION_CARD_BORDER_WIDTH = 1 // literal pixels
 export const COLLECTION_GRID_SPACING = COLLECTION_CARD_PADDING
 ```
 
@@ -61,11 +61,10 @@ The bleed is computed from the first two; the gap is the third (kept equal to th
 
 ### The spacing-unit subtlety
 
-This repo customizes the MUI theme spacing unit to **1 = 4px** (not the default 8px) — see [conventions/mui-spacing-token-is-4px](../conventions/mui-spacing-token-is-4px-2026-05-24.md) *(auto memory [claude])*. So `theme.spacing(3)` resolves to **12px**, not 24px. The border is a literal `1px`, not a spacing unit. The bleed therefore combines a spacing-unit term with a raw-pixel term via `calc()`:
+This repo customizes the MUI theme spacing unit to **1 = 4px** (not the default 8px) — see [conventions/mui-spacing-token-is-4px](../conventions/mui-spacing-token-is-4px-2026-05-24.md) _(auto memory [claude])_. So `theme.spacing(3)` resolves to **12px**, not 24px. The border is a literal `1px`, not a spacing unit. The bleed therefore combines a spacing-unit term with a raw-pixel term via `calc()`:
 
 ```ts
-mx: (theme) =>
-  `calc(${theme.spacing(-COLLECTION_CARD_PADDING)} - ${COLLECTION_CARD_BORDER_WIDTH}px)`
+mx: (theme) => `calc(${theme.spacing(-COLLECTION_CARD_PADDING)} - ${COLLECTION_CARD_BORDER_WIDTH}px)`
 // → calc(-12px - 1px) = -13px each side
 ```
 
@@ -84,7 +83,7 @@ Reach for the negative-margin bleed whenever a **bordered or padded container mu
 
 - Two sections use the same responsive grid breakpoints but live at different container widths.
 - A card/panel/section has its own padding + border and sits inset from the page, while a sibling spans the full content width.
-- You catch yourself trying to *adjust the breakpoints* of one grid to compensate — that's the wrong layer; equalize the container width instead.
+- You catch yourself trying to _adjust the breakpoints_ of one grid to compensate — that's the wrong layer; equalize the container width instead.
 
 Preconditions: the container uses `box-sizing: border-box` (MUI default) and the inset is computable (padding + border). If padding/border are responsive, the bleed must be responsive too (same breakpoints).
 
@@ -92,7 +91,7 @@ Preconditions: the container uses `box-sizing: border-box` (MUI default) and the
 
 ### Before — two inset layers, box not bled
 
-The shared grid added its own inner padding *and* the Card added padding, so the collection grid was inset twice; nothing pulled the box back out to page width.
+The shared grid added its own inner padding _and_ the Card added padding, so the collection grid was inset twice; nothing pulled the box back out to page width.
 
 ```tsx
 // Droppables.tsx — grid carried a redundant inner inset (outerPadding)
@@ -124,8 +123,8 @@ Result: collection grid width = page width − (card padding ×2 + border ×2 + 
 
 ```ts
 // collectionLayout.ts — the three coupled constants
-export const COLLECTION_CARD_PADDING = 3        // 3 × 4px = 12px
-export const COLLECTION_CARD_BORDER_WIDTH = 1   // px
+export const COLLECTION_CARD_PADDING = 3 // 3 × 4px = 12px
+export const COLLECTION_CARD_BORDER_WIDTH = 1 // px
 export const COLLECTION_GRID_SPACING = COLLECTION_CARD_PADDING
 ```
 
@@ -147,8 +146,8 @@ export const COLLECTION_GRID_SPACING = COLLECTION_CARD_PADDING
 <Card
   variant="outlined"
   sx={{
-    p: COLLECTION_CARD_PADDING,                 // 12px
-    borderWidth: COLLECTION_CARD_BORDER_WIDTH,  // 1px
+    p: COLLECTION_CARD_PADDING, // 12px
+    borderWidth: COLLECTION_CARD_BORDER_WIDTH, // 1px
     borderStyle: 'solid',
     borderColor: 'divider',
     borderRadius: 3,
@@ -162,20 +161,21 @@ export const COLLECTION_GRID_SPACING = COLLECTION_CARD_PADDING
 
 ```tsx
 // TemplateGalleryPageList.tsx — bleed the Stack outward by padding + border
-<Stack
+;<Stack
   spacing={2}
   sx={{
     mb: 4,
-    mx: (theme) =>
-      `calc(${theme.spacing(-COLLECTION_CARD_PADDING)} - ${COLLECTION_CARD_BORDER_WIDTH}px)`
+    mx: (theme) => `calc(${theme.spacing(-COLLECTION_CARD_PADDING)} - ${COLLECTION_CARD_BORDER_WIDTH}px)`
     // → calc(-12px - 1px) = -13px
   }}
 >
   {/* DroppableCollectionWrapper → CollectionCard → DraggableJourneysGrid */}
 </Stack>
 
-{/* unsectioned section renders the SAME grid at native page width */}
-<UnsectionedDroppable disabled={interactionsLocked}>
+{
+  /* unsectioned section renders the SAME grid at native page width */
+}
+;<UnsectionedDroppable disabled={interactionsLocked}>
   <DraggableJourneysGrid journeys={unsectioned} publishedLock={false} dragInFlight={interactionsLocked} />
 </UnsectionedDroppable>
 ```

--- a/libs/locales/en/apps-journeys-admin.json
+++ b/libs/locales/en/apps-journeys-admin.json
@@ -1174,7 +1174,7 @@
   "Open template info": "Open template info",
   "Close template info": "Close template info",
   "Template info": "Template info",
-  "What templates are about:": "What templates are about:",
+  "What team templates are about:": "What team templates are about:",
   "You can share projects created on our platform with others. This allows you to track the performance of every project generated from your template.": "You can share projects created on our platform with others. This allows you to track the performance of every project generated from your template.",
   "Template Types": "Template Types",
   "How to create": "How to create",


### PR DESCRIPTION
## What & why

UX polish for the Team Templates collection experience, per [NES-1696](https://linear.app/jesus-film-project/issue/NES-1696/ux-improvements) (design feedback from Lyuba). Builds on the now-merged collection-flow refactor (#9247).

## Changes

**Gallery page (`TemplateGalleryPageList`)**
- Only render the Collections section (heading + create button + cards) when the team has ≥1 active (draft/published) template. Archived/trashed don't count; in-collection templates do.
- Replaced the red "Create collection" button with a small outlined plus `IconButton` (`text.secondary`).
- Removed the misleading "All Templates" heading and the section's static helper text.

**Collection card (`CollectionCard`)**
- Restyled to match Figma: transparent-white background `rgba(255,255,255,0.4)`, 1px `divider` (#DEDFE0) stroke, 12px radius, no shadow.
- Box stretches outward (negative margin = padding + border) so the in-collection card grid column-aligns with the All Templates grid below; single 12px inner padding == card gap.

**Status labels (`LabelChip`)**
- New shared `LabelChip` (filled, squareish, uppercase, bold) standardizes the editor TEMPLATE badge, the collection card chips, and the info-panel RECOMMENDED chip. Published → **LIVE** (green); Draft/Empty/Template/Recommended use the neutral grey. Tokens instead of hardcoded hexes.

**Template info panel**
- Wider padding (18px). Body copy → theme `body2`, panel title → `h6`, accordion titles → `subtitle2` (no hardcoded font sizes). Title reworded to "What team templates are about:".

**Journey-map info helper (`TemplateInfoHelper`)**
- Trigger icons 28 → 24px; pill restyled to Figma `39661-67393` (16px radius, 1px `divider` border, 20px padding, 8px icon gap).

## Testing
- Updated existing specs and added a `LabelChip` unit spec + collection-visibility-gate tests; all affected suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `LabelChip` component for consistent status and label display across the template gallery.
  * Enhanced Collections section visibility based on template availability.

* **Style**
  * Updated status labels from "Published" to "Live".
  * Refined typography, spacing, and padding throughout Template Gallery and Info Panel.
  * Updated card backgrounds with improved visual styling.
  * Changed Create Collection control to icon-based action.

* **Documentation**
  * Updated header text from "What templates are about" to "What team templates are about".

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JesusFilm/core/pull/9252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->