### PR TITLE
test(journeys-admin-e2e): enable skipped tests and target admin-stage

### DIFF
--- a/apps/journeys-admin-e2e/playwright.config.ts
+++ b/apps/journeys-admin-e2e/playwright.config.ts
@@ -29,9 +29,9 @@ export default defineConfig({
     permissions: ['clipboard-read', 'clipboard-write'],
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL:
-      process.env.JOURNEYS_ADMIN_DAILY_E2E ??
       process.env.DEPLOYMENT_URL ??
-      'http://localhost:4200',
+      process.env.JOURNEYS_ADMIN_DAILY_E2E ??
+      'https://admin-stage.nextstep.is/',
     actionTimeout: 20000,
     navigationTimeout: 60000,
     screenshot: 'only-on-failure',

--- a/apps/journeys-admin-e2e/src/e2e/discover/active-archived-trash.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/active-archived-trash.spec.ts
@@ -36,11 +36,7 @@ test.describe('Verify user able to Active, Archived, Trash the journeys', () => 
     await journeyPage.createAndVerifyCustomJourney() // creating the custom journey and verifing the created journey is updated in the active tab list
   })
 
-  // ISSUE: After archiving a journey (or when the test runs), the Discover journey list (Active/Archived/Trash
-  // tabs) is not found – locator('button[id*="archived-status-panel-tab"]') times out. Likely environment- or
-  // routing-related (e.g. discover list not visible in this deployment). Re-enable when the discover journey
-  // list is available.
-  test.skip('Verify the user able to move the single journeys from Active, archived, Trash page', async ({
+  test('Verify the user able to move the single journeys from Active, archived, Trash page', async ({
     page
   }) => {
     const journeyPage = new JourneyPage(page)
@@ -66,7 +62,7 @@ test.describe('Verify user able to Active, Archived, Trash the journeys', () => 
   // ISSUE: After archiving (or when the test runs), the Discover journey list (Active/Archived/Trash tabs) is
   // not found – button[id*="archived-status-panel-tab"] times out. Likely environment- or routing-related.
   // Re-enable when the discover journey list is available.
-  test.skip('Verify the user able to move the all journeys from Active, archived, Trash page', async ({
+  test('Verify the user able to move the all journeys from Active, archived, Trash page', async ({
     page
   }) => {
     const journeyPage = new JourneyPage(page)

--- a/apps/journeys-admin-e2e/src/e2e/discover/card-level-actions.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/card-level-actions.spec.ts
@@ -81,7 +81,7 @@ test.describe('verify card level actions', () => {
   })
 
   // Video - create, update & delete
-  test.skip('Video - create, update & delete', async ({ page }) => {
+  test('Video - create, update & delete', async ({ page }) => {
     const cardLevelActionPage = new CardLevelActionPage(page)
     await cardLevelActionPage.deleteAllAddedCardProperties() // deleting all the added properties in the card
     await cardLevelActionPage.clickOnVideoJourneyCard() // clicking on the journey card
@@ -108,7 +108,7 @@ test.describe('verify card level actions', () => {
   })
 
   // Poll - create, update & delete
-  test.fixme('Poll - create, update & delete', async ({ page }) => {
+  test('Poll - create, update & delete', async ({ page }) => {
     const cardLevelActionPage = new CardLevelActionPage(page)
     await cardLevelActionPage.clickAddBlockBtn() // clicking on add block button
     await cardLevelActionPage.clickBtnInAddBlockDrawer('Poll') // clicking on poll button in add block drawer

--- a/apps/journeys-admin-e2e/src/e2e/discover/teams.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/teams.spec.ts
@@ -89,9 +89,7 @@ test.describe('Teams', () => {
     await journeyPage.validateUrlFieldInShareDialog(domainName) //Validate that the URL field from Share dialog contains the custom domain
   })
 
-  test('Verify Integrations option from Three dot menu', async ({
-    page
-  }) => {
+  test('Verify Integrations option from Three dot menu', async ({ page }) => {
     const teamPage = new TeamsPage(page)
 
     await teamPage.clickThreeDotOfTeams() //click three dot from the Discovery page teams section

--- a/apps/journeys-admin-e2e/src/e2e/discover/teams.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/discover/teams.spec.ts
@@ -89,10 +89,7 @@ test.describe('Teams', () => {
     await journeyPage.validateUrlFieldInShareDialog(domainName) //Validate that the URL field from Share dialog contains the custom domain
   })
 
-  // ISSUE: The Growth Spaces card on /integrations/new is only rendered when the teamIntegrations
-  // feature flag is on. When the flag is off, the test fails because the Growth Spaces link/button
-  // is missing (0 elements). Re-enable this test when the flag is available in the test environment.
-  test.skip('Verify Integrations option from Three dot menu', async ({
+  test('Verify Integrations option from Three dot menu', async ({
     page
   }) => {
     const teamPage = new TeamsPage(page)

--- a/apps/journeys-admin-e2e/src/e2e/publisher-and-templates/publisher-and-templates.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/publisher-and-templates/publisher-and-templates.spec.ts
@@ -10,7 +10,7 @@ import { LoginPage } from '../../pages/login-page'
 import { Publisher } from '../../pages/publisher-and-templates-page'
 import { TemplatePage } from '../../pages/template-page'
 
-test.describe.fixme('Publisher page - Single Template', () => {
+test.describe('Publisher page - Single Template', () => {
   test.beforeEach(async ({ page }) => {
     const landingPage = new LandingPage(page)
     const loginPage = new LoginPage(page)
@@ -46,7 +46,7 @@ test.describe.fixme('Publisher page - Single Template', () => {
   })
 })
 
-test.describe.fixme('Publisher page - All Templates', () => {
+test.describe('Publisher page - All Templates', () => {
   test.beforeEach(async ({ page }) => {
     const landingPage = new LandingPage(page)
     const loginPage = new LoginPage(page)
@@ -89,7 +89,7 @@ test.describe.fixme('Publisher page - All Templates', () => {
   })
 })
 
-test.describe.fixme('Publisher page', () => {
+test.describe('Publisher page', () => {
   test.beforeEach(
     'Create a journey and create a template from the existing journey',
     async ({ page }) => {
@@ -115,7 +115,7 @@ test.describe.fixme('Publisher page', () => {
 
   // Discover page -> Create a new journey with one card -> Three dots on top right -> Create Template
   // This test got covered in BeforeAll hook
-  test.skip('Create a template via existing journey', async ({ page }) => {
+  test('Create a template via existing journey', async ({ page }) => {
     const journeyPage = new JourneyPage(page)
     await journeyPage.selectExistingJourney() // clicking existing journey in the journey list of discover page
     await journeyPage.setExistingJourneyNameToJourneyName() // setting the journey name
@@ -248,7 +248,7 @@ test.describe.fixme('Publisher page', () => {
   })
 })
 
-test.describe.fixme('Template page - Journey from Template', () => {
+test.describe('Template page - Journey from Template', () => {
   test.beforeEach(async ({ page }) => {
     const landingPage = new LandingPage(page)
     const loginPage = new LoginPage(page)
@@ -282,7 +282,7 @@ test.describe.fixme('Template page - Journey from Template', () => {
   })
 })
 
-test.describe.fixme('Template page', () => {
+test.describe('Template page', () => {
   test.beforeEach('Login > Create a journey and template', async ({ page }) => {
     const landingPage = new LandingPage(page)
     const loginPage = new LoginPage(page)
@@ -296,7 +296,7 @@ test.describe.fixme('Template page', () => {
   })
 
   // Templates-> Select existing template -> Preview
-  test.skip('preview a template from the journey template page', async ({
+  test('preview a template from the journey template page', async ({
     page,
     context
   }) => {
@@ -346,7 +346,7 @@ test.describe.fixme('Template page', () => {
 
   // Filter: Topics, holidays, felt needs, collections
   // Skipped because this filter test is already covered in the 'Publisher-> Select existing template -> Three dots on top right -> Template Settings -> Categories' test.
-  test.skip('Filter: Topics, holidays, felt needs, collections', async ({
+  test('Filter: Topics, holidays, felt needs, collections', async ({
     page
   }) => {
     const templatesPage = new TemplatePage(page)
@@ -367,7 +367,7 @@ test.describe.fixme('Template page', () => {
 
   // Filter: Audience
   // Skipped because this filter test is already covered in the 'Publisher-> Select existing template -> Three dots on top right -> Template Settings -> Categories' test.
-  test.skip('Filter: Audience', async ({ page }) => {
+  test('Filter: Audience', async ({ page }) => {
     const templatesPage = new TemplatePage(page)
     await templatesPage.navigateToTemplatePage() // navigating to templates page
     await templatesPage.clickDropDownOpenIconForFilters('Audience') // clicking on the dropdown open icon
@@ -379,7 +379,7 @@ test.describe.fixme('Template page', () => {
 
   // Filter: Genre
   // Skipped because this filter test is already covered in the 'Publisher-> Select existing template -> Three dots on top right -> Template Settings -> Categories' test.
-  test.skip('Filter: Genre', async ({ page }) => {
+  test('Filter: Genre', async ({ page }) => {
     const templatesPage = new TemplatePage(page)
     await templatesPage.navigateToTemplatePage() // navigating to templates page
     await templatesPage.clickDropDownOpenIconForFilters('Genre') // clicking on the dropdown open icon

--- a/apps/journeys-admin-e2e/src/e2e/users/existing-user.spec.ts
+++ b/apps/journeys-admin-e2e/src/e2e/users/existing-user.spec.ts
@@ -6,25 +6,22 @@ import { LeftNav } from '../../pages/left-nav'
 import { LoginPage } from '../../pages/login-page'
 
 // Already created user should be able to login successfully
-test.fixme(
-  'Existing user can login and logout successfully',
-  async ({ page }) => {
-    const landingPage = new LandingPage(page)
-    const leftNav = new LeftNav(page)
-    const loginPage = new LoginPage(page)
+test('Existing user can login and logout successfully', async ({ page }) => {
+  const landingPage = new LandingPage(page)
+  const leftNav = new LeftNav(page)
+  const loginPage = new LoginPage(page)
 
-    await landingPage.goToAdminUrl()
+  await landingPage.goToAdminUrl()
 
-    await loginPage.login()
+  await loginPage.login()
 
-    await leftNav.clickProfile()
-    const email = await getEmail()
-    expect(await leftNav.getEmail()).toBe(email)
-    const firstAndLastName = await getUser()
-    expect(await leftNav.getName()).toBe(firstAndLastName)
-    await leftNav.logout()
+  await leftNav.clickProfile()
+  const email = await getEmail()
+  expect(await leftNav.getEmail()).toBe(email)
+  const firstAndLastName = await getUser()
+  expect(await leftNav.getName()).toBe(firstAndLastName)
+  await leftNav.logout()
 
-    const isLandingPageVisible = await landingPage.isLandingPage()
-    expect(isLandingPageVisible).toBe(true)
-  }
-)
+  const isLandingPageVisible = await landingPage.isLandingPage()
+  expect(isLandingPageVisible).toBe(true)
+})

--- a/apps/journeys-admin-e2e/src/framework/helpers.ts
+++ b/apps/journeys-admin-e2e/src/framework/helpers.ts
@@ -2,8 +2,7 @@ import dayjs from 'dayjs'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('dotenv').config()
 
-export const DEFAULT_JOURNEYS_ADMIN_E2E_URL =
-  'https://admin-stage.nextstep.is/'
+export const DEFAULT_JOURNEYS_ADMIN_E2E_URL = 'https://admin-stage.nextstep.is/'
 
 export type DiscoverListType = 'journeys' | 'templates'
 export type DiscoverStatus = 'active' | 'archived' | 'trashed'

--- a/apps/journeys-admin-e2e/src/framework/helpers.ts
+++ b/apps/journeys-admin-e2e/src/framework/helpers.ts
@@ -2,6 +2,21 @@ import dayjs from 'dayjs'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('dotenv').config()
 
+export const DEFAULT_JOURNEYS_ADMIN_E2E_URL =
+  'https://admin-stage.nextstep.is/'
+
+export type DiscoverListType = 'journeys' | 'templates'
+export type DiscoverStatus = 'active' | 'archived' | 'trashed'
+
+export function getDiscoverListUrl(
+  baseUrl: string,
+  type: DiscoverListType,
+  status: DiscoverStatus = 'active'
+): string {
+  const normalizedBaseUrl = baseUrl.replace(/\/$/, '')
+  return `${normalizedBaseUrl}/?type=${type}&status=${status}`
+}
+
 async function getCredentials(
   accountKey: string
 ): Promise<{ email: string; password: string }> {

--- a/apps/journeys-admin-e2e/src/framework/status-tabs.ts
+++ b/apps/journeys-admin-e2e/src/framework/status-tabs.ts
@@ -1,0 +1,73 @@
+import { type Page, expect } from '@playwright/test'
+
+import {
+  type DiscoverListType,
+  type DiscoverStatus,
+  getBaseUrl,
+  getDiscoverListUrl
+} from './helpers'
+
+const statusTabTimeout = 60000
+
+export type DiscoverListContext = DiscoverListType | 'publisher'
+export type StatusTabLabel = 'Active' | 'Archived' | 'Trash'
+
+const statusTabToQueryParam: Record<StatusTabLabel, DiscoverStatus> = {
+  Active: 'active',
+  Archived: 'archived',
+  Trash: 'trashed'
+}
+
+function journeyStatusTabs(page: Page) {
+  return page.getByRole('tablist', { name: 'journey status tabs' })
+}
+
+function getListUrl(
+  baseUrl: string,
+  context: DiscoverListContext,
+  status: DiscoverStatus
+): string {
+  const normalizedBaseUrl = baseUrl.replace(/\/$/, '')
+  if (context === 'publisher') {
+    return `${normalizedBaseUrl}/publisher?status=${status}`
+  }
+  return getDiscoverListUrl(baseUrl, context, status)
+}
+
+export async function ensureDiscoverListVisible(
+  page: Page,
+  context: DiscoverListContext,
+  status: DiscoverStatus = 'active'
+): Promise<void> {
+  const activeTab = journeyStatusTabs(page).getByRole('tab', { name: 'Active' })
+  if (await activeTab.isVisible().catch(() => false)) {
+    return
+  }
+
+  const baseUrl = await getBaseUrl()
+  await page.goto(getListUrl(baseUrl, context, status), {
+    waitUntil: 'domcontentloaded'
+  })
+
+  if (context === 'publisher') {
+    await expect(page.getByTestId('JourneysAdminTemplateList')).toBeVisible({
+      timeout: statusTabTimeout
+    })
+  }
+
+  await expect(activeTab).toBeVisible({ timeout: statusTabTimeout })
+}
+
+export async function clickDiscoverStatusTab(
+  page: Page,
+  tabLabel: StatusTabLabel,
+  context: DiscoverListContext = 'journeys'
+): Promise<void> {
+  const status = statusTabToQueryParam[tabLabel]
+  await ensureDiscoverListVisible(page, context, status)
+
+  const tab = journeyStatusTabs(page).getByRole('tab', { name: tabLabel })
+  await expect(tab).toBeVisible({ timeout: statusTabTimeout })
+  await tab.click()
+  await expect(tab).toHaveAttribute('aria-selected', 'true')
+}

--- a/apps/journeys-admin-e2e/src/global-setup.ts
+++ b/apps/journeys-admin-e2e/src/global-setup.ts
@@ -17,8 +17,8 @@ async function waitForHealthy(url: string, timeoutMs: number): Promise<void> {
 
 export default async function globalSetup(config: FullConfig) {
   const baseURL =
-    process.env.JOURNEYS_ADMIN_DAILY_E2E ??
     process.env.DEPLOYMENT_URL ??
-    'http://localhost:4200'
+    process.env.JOURNEYS_ADMIN_DAILY_E2E ??
+    'https://admin-stage.nextstep.is/'
   await waitForHealthy(baseURL, 120_000)
 }

--- a/apps/journeys-admin-e2e/src/pages/card-level-actions.ts
+++ b/apps/journeys-admin-e2e/src/pages/card-level-actions.ts
@@ -340,11 +340,12 @@ export class CardLevelActionPage {
         'div[data-testid="VideoFromMux"] span[role="progressbar"]'
       )
     ).toBeVisible({ timeout: sixtySecondsTimeout })
+    // 90s: Mux video processing on stage can exceed 60s for SampleVideo.mp4
     await expect(
       this.page.locator(
         'div[data-testid="VideoFromMux"] span[role="progressbar"]'
       )
-    ).toBeHidden({ timeout: sixtySecondsTimeout })
+    ).toBeHidden({ timeout: 90000 })
   }
 
   async verifyUploadVideoInJourney(uplodedType: string) {

--- a/apps/journeys-admin-e2e/src/pages/journey-page.ts
+++ b/apps/journeys-admin-e2e/src/pages/journey-page.ts
@@ -5,7 +5,8 @@ import path from 'path'
 import { expect } from '@playwright/test'
 import type { Page } from 'playwright-core'
 
-import { generateRandomNumber, getBaseUrl } from '../framework/helpers'
+import { generateRandomNumber } from '../framework/helpers'
+import { clickDiscoverStatusTab } from '../framework/status-tabs'
 import testData from '../utils/testData.json'
 
 let journeyName = ''
@@ -414,27 +415,7 @@ export class JourneyPage {
   }
 
   async clickArchivedTab() {
-    const archivedTab = this.page.locator(
-      'button[id*="archived-status-panel-tab"]'
-    )
-    const visible = await archivedTab
-      .first()
-      .isVisible()
-      .catch(() => false)
-    if (!visible) {
-      const baseUrl = await getBaseUrl()
-      const discoverUrl = baseUrl.replace(/\/$/, '') + '/?type=journeys'
-      await this.page.goto(discoverUrl, { waitUntil: 'domcontentloaded' })
-    }
-    await expect(archivedTab.first()).toBeVisible({
-      timeout: sixtySecondsTimeout
-    })
-    await archivedTab.first().click()
-    await expect(
-      this.page.locator(
-        'button[id*="archived-status-panel-tab"][aria-selected="true"]'
-      )
-    ).toBeVisible()
+    await clickDiscoverStatusTab(this.page, 'Archived', 'journeys')
   }
 
   async verifyCreatedNewTemplateMovedToArchiveOrNot() {
@@ -468,14 +449,7 @@ export class JourneyPage {
   }
 
   async clickTrashTab() {
-    const trashTab = this.page.locator('button[id*="trashed-status-panel-tab"]')
-    await expect(trashTab).toBeVisible({ timeout: sixtySecondsTimeout })
-    await trashTab.click()
-    await expect(
-      this.page.locator(
-        'button[id*="trashed-status-panel-tab"][aria-selected="true"]'
-      )
-    ).toBeVisible()
+    await clickDiscoverStatusTab(this.page, 'Trash', 'journeys')
   }
 
   async verifyCreatedNewTemplateMovedToTrashTabOrNot() {
@@ -515,14 +489,7 @@ export class JourneyPage {
   }
 
   async clickActiveTab() {
-    const activeTab = this.page.locator('button[id*="active-status-panel-tab"]')
-    await expect(activeTab).toBeVisible({ timeout: sixtySecondsTimeout })
-    await activeTab.click()
-    await expect(
-      this.page.locator(
-        'button[id*="active-status-panel-tab"][aria-selected="true"]'
-      )
-    ).toBeVisible()
+    await clickDiscoverStatusTab(this.page, 'Active', 'journeys')
   }
 
   async clickRestoreBtn() {

--- a/apps/journeys-admin-e2e/src/pages/publisher-and-templates-page.ts
+++ b/apps/journeys-admin-e2e/src/pages/publisher-and-templates-page.ts
@@ -2,6 +2,7 @@
 import { expect } from '@playwright/test'
 import type { Page } from 'playwright-core'
 
+import { clickDiscoverStatusTab } from '../framework/status-tabs'
 import testData from '../utils/testData.json'
 
 export class Publisher {

--- a/apps/journeys-admin-e2e/src/pages/template-page.ts
+++ b/apps/journeys-admin-e2e/src/pages/template-page.ts
@@ -202,7 +202,7 @@ export class TemplatePage {
   async verifyPreviewTemplateInJourneyTemplate() {
     const [newPage] = await Promise.all([
       this.context.waitForEvent('page'),
-      await this.clickPreviewBtnInJourneyTemplatePage()
+      this.clickPreviewBtnInJourneyTemplatePage()
     ])
     await newPage.waitForLoadState()
     const tabName: string = await newPage.title()
@@ -254,7 +254,7 @@ export class TemplatePage {
   async verifyTemplateIsEdited(editedText) {
     const [newPage] = await Promise.all([
       this.context.waitForEvent('page'),
-      await this.clickPreviewBtnInJourneyTemplatePage()
+      this.clickPreviewBtnInJourneyTemplatePage()
     ])
     await newPage.waitForLoadState()
     const tabName: string = await newPage.title()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Re-enables all previously skipped or `fixme` journeys-admin E2E tests and points the suite at **https://admin-stage.nextstep.is/** by default.

## Changes

- **Endpoint**: `playwright.config.ts`, `global-setup.ts`, and `helpers.ts` default to `https://admin-stage.nextstep.is/` (still overridable via `DEPLOYMENT_URL` or `JOURNEYS_ADMIN_DAILY_E2E`).
- **Enabled tests** (74 total, none skipped in `playwright test --list`):
  - Discover: active/archived/trash journeys, card video & poll, teams integrations
  - Publisher & templates: full publisher/template suites and filter tests
  - Users: existing-user login/logout
- **Stability fixes**:
  - New `status-tabs.ts` helper uses `getByRole('tab', …)` and navigates to the correct discover (`/?type=journeys&status=…`) or publisher (`/publisher?status=…`) URL when tabs are missing
  - Template preview: fixed `Promise.all` (removed erroneous `await` on click handler)
  - Video upload: 90s Mux processing timeout on stage

## Verification

- `pnpm exec nx run journeys-admin-e2e:type-check` — pass
- `pnpm exec nx run journeys-admin-e2e:lint` — pass (pre-existing warnings only)
- `DEPLOYMENT_URL=https://admin-stage.nextstep.is/ pnpm exec playwright test --list` — 74 tests, 0 skipped

Full run against stage requires CI secrets (`PLAYWRIGHT_EMAIL*`, `PLAYWRIGHT_PASSWORD*`, etc.) as in `.github/workflows/e2e-tests.yml`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf4fb4e0-0419-4d50-92bd-6206dcfc7f3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf4fb4e0-0419-4d50-92bd-6206dcfc7f3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

