### PR TITLE
feat(journeys-admin): flag journey tracking metrics editing [QA-485]

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Button/Button.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Button/Button.tsx
@@ -6,6 +6,7 @@ import { ReactElement, useEffect } from 'react'
 import type { TreeBlock } from '@core/journeys/ui/block'
 import { useEditor } from '@core/journeys/ui/EditorProvider'
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
+import { useFlags } from '@core/shared/ui/FlagsProvider'
 import ActivityIcon from '@core/shared/ui/icons/Activity'
 import AlertCircleIcon from '@core/shared/ui/icons/AlertCircle'
 import AlignLeft from '@core/shared/ui/icons/AlignLeft'
@@ -48,6 +49,7 @@ export function Button({
 }: TreeBlock<ButtonBlock>): ReactElement {
   const { dispatch } = useEditor()
   const { journey } = useJourney()
+  const { editJourneyTrackingMetrics } = useFlags()
   const { t } = useTranslation('apps-journeys-admin')
 
   const startIcon = children.find(
@@ -70,7 +72,7 @@ export function Button({
 
   return (
     <Box data-testid="ButtonProperties">
-      {journey?.template && (
+      {(journey?.template || editJourneyTrackingMetrics) && (
         <Accordion
           icon={<ActivityIcon />}
           id={`${id}-event-label`}

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/Card.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/Card.spec.tsx
@@ -130,6 +130,29 @@ describe('Card', () => {
       })
     })
 
+    it('shows event label for non-template journey when editJourneyTrackingMetrics is enabled', async () => {
+      const card = createCard()
+      renderWithProviders(<Card {...card} />, {
+        selectedBlock: card,
+        journey: { template: false },
+        flags: { editJourneyTrackingMetrics: true }
+      })
+      const trackingButton = screen.getByText('Tracking')
+      fireEvent.click(trackingButton)
+      await waitFor(() => {
+        expect(screen.getByTestId('EventLabelSelect')).toBeInTheDocument()
+      })
+    })
+
+    it('hides event label for non-template journey when editJourneyTrackingMetrics is disabled', () => {
+      const card = createCard()
+      renderWithProviders(<Card {...card} />, {
+        selectedBlock: card,
+        journey: { template: false }
+      })
+      expect(screen.queryByText('Tracking')).not.toBeInTheDocument()
+    })
+
     it('shows default attributes when no props provided', () => {
       const card = createCard()
       renderWithProviders(<Card {...card} />)

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/Card.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/Card.tsx
@@ -91,7 +91,7 @@ export function Card({
   } = useEditor()
   const { rtl, locale } = getJourneyRTL(journey)
   const { t } = useTranslation('apps-journeys-admin')
-  const { apologistChat } = useFlags()
+  const { apologistChat, editJourneyTrackingMetrics } = useFlags()
 
   const coverBlock = children.find((block) => block.id === coverBlockId)
 
@@ -154,7 +154,7 @@ export function Card({
 
   return (
     <Box data-testid="CardProperties">
-      {journey?.template && (
+      {(journey?.template || editJourneyTrackingMetrics) && (
         <Accordion
           icon={<ActivityIcon />}
           id={`${id}-event-label`}

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/RadioOption/RadioOption.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/RadioOption/RadioOption.tsx
@@ -6,6 +6,7 @@ import { ReactElement, useCallback, useEffect, useMemo } from 'react'
 import type { TreeBlock } from '@core/journeys/ui/block'
 import { useEditor } from '@core/journeys/ui/EditorProvider'
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
+import { useFlags } from '@core/shared/ui/FlagsProvider'
 import ActivityIcon from '@core/shared/ui/icons/Activity'
 import Image3Icon from '@core/shared/ui/icons/Image3'
 import LinkIcon from '@core/shared/ui/icons/Link'
@@ -29,6 +30,7 @@ export function RadioOption(props: TreeBlock<RadioOptionBlock>): ReactElement {
     dispatch
   } = useEditor()
   const { journey } = useJourney()
+  const { editJourneyTrackingMetrics } = useFlags()
   const selectedAction = getAction(t, props.action?.__typename)
   const selectedEventLabel = getEventLabelOption(t, props.eventLabel).label
 
@@ -59,7 +61,7 @@ export function RadioOption(props: TreeBlock<RadioOptionBlock>): ReactElement {
 
   return (
     <Box data-testid="RadioOptionProperties">
-      {journey?.template && (
+      {(journey?.template || editJourneyTrackingMetrics) && (
         <Accordion
           icon={<ActivityIcon />}
           id={`${props.id}-event-label`}

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Video/Video.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Video/Video.tsx
@@ -5,6 +5,7 @@ import { ReactElement, useEffect } from 'react'
 import type { TreeBlock } from '@core/journeys/ui/block'
 import { useEditor } from '@core/journeys/ui/EditorProvider'
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
+import { useFlags } from '@core/shared/ui/FlagsProvider'
 import ActivityIcon from '@core/shared/ui/icons/Activity'
 import LinkIcon from '@core/shared/ui/icons/Link'
 import Play1Icon from '@core/shared/ui/icons/Play1'
@@ -25,6 +26,7 @@ export function Video(block: TreeBlock<VideoBlock>): ReactElement {
 
   const { dispatch } = useEditor()
   const { journey } = useJourney()
+  const { editJourneyTrackingMetrics } = useFlags()
 
   const selectedAction = getAction(t, block.action?.__typename)
   const startEventLabel = getEventLabelOption(t, block.eventLabel).label
@@ -39,7 +41,7 @@ export function Video(block: TreeBlock<VideoBlock>): ReactElement {
 
   return (
     <Box data-testid="VideoProperties">
-      {journey?.template && (
+      {(journey?.template || editJourneyTrackingMetrics) && (
         <Accordion
           icon={<ActivityIcon />}
           id={`${id}-event-label`}


### PR DESCRIPTION
## Summary

- Shows the tracking-metric editor (the `EventLabel` control) on **regular, non-template journeys** when the `editJourneyTrackingMetrics` flag is enabled. Template behaviour is unchanged.
- Gate applied identically in the **Button**, **RadioOption**, **Video**, and **Card** property panels: `journey?.template` → `journey?.template || editJourneyTrackingMetrics`.

## Why (QA-485)

The template breakdown's "Decision for Christ" count came out far higher than the editor's button-click count. Root cause: the decision metric was attached to **both** the card (fires on *view*, via `Step.tsx`) **and** the "Yes" button (fires on *click*), and both land in the same `christDecisionCapture` column — a double count.

This PR is **temporary relief**: it exposes the metric editor on journeys so an editor can open the affected journey and clear the duplicate label (keep it on the button, remove it from the card). The deeper fixes — `Step.tsx` emitting the raw event name instead of routing through `fireCaptureEvent`, and `transformBreakdownResults` summing per-row unique counts instead of deduping like the page-view path does — are tracked separately.

## Notes

- `useFlags()` returns `{}` with no provider, so the flag is simply falsy when absent — no behaviour change when off.
- The control's helper text still reads "…every project created from your template", which is template-specific wording now also shown on journeys. Left as-is for this relief PR — can adjust if desired.

## Test plan

- [x] Existing `Button` / `RadioOption` / `Video` / `Card` specs pass (51) + 2 new `Card` flag tests (non-template shows with flag on, hidden with flag off).
- [ ] Flag OFF, non-template journey → no "Tracking" section on button/card/radio/video.
- [ ] Flag ON, non-template journey → "Tracking" section appears; event label can be changed/cleared.
- [ ] Templates still show the tracking editor regardless of the flag.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XavX9DG6XZam6RkBCw4yYV)_