### PR TITLE
feat: add abort signal handling and timeout error for AI operations

### DIFF
--- a/apis/api-journeys-modern/src/schema/journeyAiTranslate/journeyAiTranslate.ts
+++ b/apis/api-journeys-modern/src/schema/journeyAiTranslate/journeyAiTranslate.ts
@@ -11,6 +11,7 @@ import { hardenPrompt } from '@core/shared/ai/prompts'
 
 import { env } from '../../env'
 import { Action, ability, subject } from '../../lib/auth/ability'
+import { logger } from '../../logger'
 import { builder } from '../builder'
 import { JourneyRef } from '../journey/journey'
 
@@ -187,9 +188,9 @@ ${hardenPrompt(blocksInfo)}`
       ],
       output: Output.array({ element: BlockTranslationSchema }),
       onError: ({ error }) => {
-        console.warn(
-          `Error in translation stream for card ${cardBlock.id}:`,
-          error
+        logger.warn(
+          { error, cardBlockId: cardBlock.id },
+          'Error in translation stream for card'
         )
       }
     })
@@ -216,7 +217,10 @@ ${hardenPrompt(blocksInfo)}`
 
         onBlockUpdated?.(cleanBlockId, validatedUpdates)
       } catch (updateError) {
-        console.error(`Error updating block ${item.blockId}:`, updateError)
+        logger.error(
+          { error: updateError, blockId: item.blockId },
+          'Error updating block'
+        )
       }
     }
   })
@@ -508,9 +512,9 @@ builder.subscriptionField('journeyAiTranslateCreateSubscription', (t) =>
               },
               session
             }).catch((error) => {
-              console.warn(
-                `Error translating card ${cardBlocks[cardIndex].id}:`,
-                error
+              logger.warn(
+                { error, cardBlockId: cardBlocks[cardIndex].id },
+                'Error translating card'
               )
             })
           })
@@ -550,7 +554,7 @@ builder.subscriptionField('journeyAiTranslateCreateSubscription', (t) =>
           journey: finalJourney
         }
       } catch (error) {
-        console.error('Translation error:', error)
+        logger.error({ error }, 'Translation error')
         // Rethrow as a GraphQLError so the client subscription terminates with
         // an error (firing the frontend `onError`) instead of completing
         // normally. A normal completion would silently close the dialog with
@@ -562,9 +566,9 @@ builder.subscriptionField('journeyAiTranslateCreateSubscription', (t) =>
             'Translation timed out while contacting the AI service. Please try again.'
           )
         }
-        throw new GraphQLError(
-          error instanceof Error ? error.message : 'Translation failed'
-        )
+        // Keep unknown errors generic — the original error is logged above, so
+        // we avoid leaking provider/SDK internals to the client.
+        throw new GraphQLError('Translation failed')
       }
     },
     resolve: (progressUpdate) => progressUpdate
@@ -728,12 +732,15 @@ builder.mutationField('journeyAiTranslateCreate', (t) =>
               targetLanguageName,
               session
             }).catch((error) => {
-              console.warn(`Error translating card ${cardBlock.id}:`, error)
+              logger.warn(
+                { error, cardBlockId: cardBlock.id },
+                'Error translating card'
+              )
             })
           )
         )
       } catch (error: unknown) {
-        console.error('Error analyzing journey with Gemini:', error)
+        logger.error({ error }, 'Error analyzing journey with Gemini')
         const errorMessage =
           error instanceof Error ? error.message : 'Unknown error occurred'
         throw new Error(`Failed to analyze journey: ${errorMessage}`)

--- a/apis/api-journeys-modern/src/schema/journeyAiTranslate/journeyAiTranslate.ts
+++ b/apis/api-journeys-modern/src/schema/journeyAiTranslate/journeyAiTranslate.ts
@@ -3,7 +3,10 @@ import { GraphQLError } from 'graphql'
 import { z } from 'zod'
 
 import { Block, prisma } from '@core/prisma/journeys/client'
-import { createOpenrouterFallbackSession } from '@core/shared/ai/openrouterModel'
+import {
+  AiRequestTimeoutError,
+  createOpenrouterFallbackSession
+} from '@core/shared/ai/openrouterModel'
 import { hardenPrompt } from '@core/shared/ai/prompts'
 
 import { env } from '../../env'
@@ -170,9 +173,10 @@ ${hardenPrompt(cardContent)}
 Blocks to translate (use the EXACT IDs shown in square brackets as blockId):
 ${hardenPrompt(blocksInfo)}`
 
-  await session.execute(async (model) => {
+  await session.execute(async (model, abortSignal) => {
     const { elementStream } = streamText({
       model,
+      abortSignal,
       maxRetries: 0,
       messages: [
         { role: 'system', content: TRANSLATION_SYSTEM_PROMPT },
@@ -547,11 +551,20 @@ builder.subscriptionField('journeyAiTranslateCreateSubscription', (t) =>
         }
       } catch (error) {
         console.error('Translation error:', error)
-        yield {
-          progress: 100,
-          message: 'Translation failed: ' + (error as Error).message,
-          journey: null
+        // Rethrow as a GraphQLError so the client subscription terminates with
+        // an error (firing the frontend `onError`) instead of completing
+        // normally. A normal completion would silently close the dialog with
+        // no error surfaced. GraphQLErrors are not masked by the Yoga server,
+        // so the message reaches the client.
+        if (error instanceof GraphQLError) throw error
+        if (error instanceof AiRequestTimeoutError) {
+          throw new GraphQLError(
+            'Translation timed out while contacting the AI service. Please try again.'
+          )
         }
+        throw new GraphQLError(
+          error instanceof Error ? error.message : 'Translation failed'
+        )
       }
     },
     resolve: (progressUpdate) => progressUpdate

--- a/apis/api-journeys-modern/src/schema/journeyAiTranslate/translateCustomizationFields/translateCustomizationFields.ts
+++ b/apis/api-journeys-modern/src/schema/journeyAiTranslate/translateCustomizationFields/translateCustomizationFields.ts
@@ -73,9 +73,10 @@ Each translation must be the plain translated text only — do NOT wrap in quote
 ${numberedValues}`
 
   const { output } = await withOpenrouterFallback(
-    (model) =>
+    (model, abortSignal) =>
       generateText({
         model,
+        abortSignal,
         messages: [
           { role: 'system', content: CUSTOMIZATION_SYSTEM_PROMPT },
           {
@@ -275,9 +276,10 @@ Description:
 ${hardenPrompt(description)}`
 
   const { output } = await withOpenrouterFallback(
-    (model) =>
+    (model, abortSignal) =>
       generateText({
         model,
+        abortSignal,
         messages: [
           { role: 'system', content: CUSTOMIZATION_SYSTEM_PROMPT },
           {

--- a/apis/api-journeys-modern/src/schema/journeyAiTranslate/translateJourneyMetadata/translateJourneyMetadata.ts
+++ b/apis/api-journeys-modern/src/schema/journeyAiTranslate/translateJourneyMetadata/translateJourneyMetadata.ts
@@ -109,9 +109,10 @@ Return only the translated text — no field labels, no surrounding quotes, no e
 ${fieldName}:
 ${hardenPrompt(value)}`
 
-  const { output } = await session.execute((model) =>
+  const { output } = await session.execute((model, abortSignal) =>
     generateText({
       model,
+      abortSignal,
       maxRetries: 0,
       messages: [
         { role: 'system', content: TRANSLATION_SYSTEM_PROMPT },
@@ -176,19 +177,21 @@ export async function translateJourneyMetadata({
     cardBlocksContent
   })
 
-  const { output: analysisOutput } = await session.execute((model) =>
-    generateText({
-      model,
-      maxRetries: 0,
-      messages: [
-        { role: 'system', content: TRANSLATION_SYSTEM_PROMPT },
-        {
-          role: 'user',
-          content: [{ type: 'text', text: analysisPrompt }]
-        }
-      ],
-      output: Output.object({ schema: JourneyAnalysisSchema })
-    })
+  const { output: analysisOutput } = await session.execute(
+    (model, abortSignal) =>
+      generateText({
+        model,
+        abortSignal,
+        maxRetries: 0,
+        messages: [
+          { role: 'system', content: TRANSLATION_SYSTEM_PROMPT },
+          {
+            role: 'user',
+            content: [{ type: 'text', text: analysisPrompt }]
+          }
+        ],
+        output: Output.object({ schema: JourneyAnalysisSchema })
+      })
   )
 
   const analysis = analysisOutput.analysis

--- a/libs/shared/ai/src/openrouterModel/index.ts
+++ b/libs/shared/ai/src/openrouterModel/index.ts
@@ -1,4 +1,5 @@
 export {
+  AiRequestTimeoutError,
   createOpenrouterFallbackSession,
   withOpenrouterFallback
 } from './openrouterModel'

--- a/libs/shared/ai/src/openrouterModel/openrouterModel.spec.ts
+++ b/libs/shared/ai/src/openrouterModel/openrouterModel.spec.ts
@@ -1,6 +1,7 @@
 import { openrouter } from '@openrouter/ai-sdk-provider'
 
 import {
+  AiRequestTimeoutError,
   createOpenrouterFallbackSession,
   withOpenrouterFallback
 } from './openrouterModel'
@@ -34,6 +35,7 @@ describe('openrouterModel', () => {
   beforeEach(() => {
     process.env = { ...originalEnv }
     delete process.env.GEMINI_MAX_RETRIES
+    delete process.env.AI_REQUEST_TIMEOUT_MS
     mockedOpenrouter.chat.mockClear()
   })
 
@@ -58,7 +60,8 @@ describe('openrouterModel', () => {
       expect(result).toBe('ok')
       expect(operation).toHaveBeenCalledTimes(1)
       expect(operation).toHaveBeenCalledWith(
-        expect.objectContaining({ modelId: 'custom/free-model' })
+        expect.objectContaining({ modelId: 'custom/free-model' }),
+        expect.any(AbortSignal)
       )
     })
 
@@ -232,6 +235,58 @@ describe('openrouterModel', () => {
       await expect(session.execute(operation)).rejects.toThrow('rate limited')
       expect(operation).toHaveBeenCalledTimes(3)
     })
+
+    it('should pass an abort signal to the operation', async () => {
+      const session = createOpenrouterFallbackSession(TEST_MODELS)
+      const operation = vi.fn().mockResolvedValue('ok')
+
+      await session.execute(operation)
+
+      expect(operation.mock.calls[0][1]).toBeInstanceOf(AbortSignal)
+      expect(operation.mock.calls[0][1].aborted).toBe(false)
+    })
+
+    it('should time out and reject when an operation hangs', async () => {
+      process.env.AI_REQUEST_TIMEOUT_MS = '5000'
+      const session = createOpenrouterFallbackSession(['only/model'])
+      const operation = vi.fn(
+        (_model, signal: AbortSignal) =>
+          new Promise((_resolve, reject) => {
+            signal.addEventListener('abort', () => reject(signal.reason))
+          })
+      )
+
+      const promise = session.execute(operation)
+      const assertion = expect(promise).rejects.toBeInstanceOf(
+        AiRequestTimeoutError
+      )
+      await vi.advanceTimersByTimeAsync(5000)
+      await assertion
+    })
+
+    it('should fall to the next model when the first times out', async () => {
+      process.env.AI_REQUEST_TIMEOUT_MS = '5000'
+      const session = createOpenrouterFallbackSession(TEST_MODELS)
+      const operation = vi
+        .fn()
+        .mockImplementationOnce(
+          (_model, signal: AbortSignal) =>
+            new Promise((_resolve, reject) => {
+              signal.addEventListener('abort', () => reject(signal.reason))
+            })
+        )
+        .mockResolvedValueOnce('recovered')
+
+      const promise = session.execute(operation)
+      await vi.advanceTimersByTimeAsync(5000)
+      const result = await promise
+
+      expect(result).toBe('recovered')
+      expect(operation).toHaveBeenCalledTimes(2)
+      expect(operation.mock.calls[1][0]).toEqual(
+        expect.objectContaining({ modelId: 'custom/primary-model' })
+      )
+    })
   })
 
   describe('withOpenrouterFallback', () => {
@@ -241,7 +296,8 @@ describe('openrouterModel', () => {
 
       expect(result).toBe('ok')
       expect(operation).toHaveBeenCalledWith(
-        expect.objectContaining({ modelId: 'custom/free-model' })
+        expect.objectContaining({ modelId: 'custom/free-model' }),
+        expect.any(AbortSignal)
       )
     })
 

--- a/libs/shared/ai/src/openrouterModel/openrouterModel.spec.ts
+++ b/libs/shared/ai/src/openrouterModel/openrouterModel.spec.ts
@@ -252,7 +252,9 @@ describe('openrouterModel', () => {
       const operation = vi.fn(
         (_model, signal: AbortSignal) =>
           new Promise((_resolve, reject) => {
-            signal.addEventListener('abort', () => reject(signal.reason))
+            signal.addEventListener('abort', () =>
+              reject(signal.reason as Error)
+            )
           })
       )
 
@@ -272,7 +274,9 @@ describe('openrouterModel', () => {
         .mockImplementationOnce(
           (_model, signal: AbortSignal) =>
             new Promise((_resolve, reject) => {
-              signal.addEventListener('abort', () => reject(signal.reason))
+              signal.addEventListener('abort', () =>
+              reject(signal.reason as Error)
+            )
             })
         )
         .mockResolvedValueOnce('recovered')

--- a/libs/shared/ai/src/openrouterModel/openrouterModel.spec.ts
+++ b/libs/shared/ai/src/openrouterModel/openrouterModel.spec.ts
@@ -275,8 +275,8 @@ describe('openrouterModel', () => {
           (_model, signal: AbortSignal) =>
             new Promise((_resolve, reject) => {
               signal.addEventListener('abort', () =>
-              reject(signal.reason as Error)
-            )
+                reject(signal.reason as Error)
+              )
             })
         )
         .mockResolvedValueOnce('recovered')

--- a/libs/shared/ai/src/openrouterModel/openrouterModel.ts
+++ b/libs/shared/ai/src/openrouterModel/openrouterModel.ts
@@ -2,14 +2,46 @@ import { openrouter } from '@openrouter/ai-sdk-provider'
 
 type AIModel = ReturnType<typeof openrouter.chat>
 
+/**
+ * An AI operation receives the resolved model and an {@link AbortSignal}.
+ *
+ * Operations should forward the signal to the underlying AI SDK call
+ * (e.g. `generateText({ abortSignal })`) so a hung request can be
+ * cancelled when the per-request timeout elapses. Operations that ignore
+ * the signal still run, but will not be cancellable on timeout.
+ */
+type AIOperation<T> = (model: AIModel, abortSignal: AbortSignal) => Promise<T>
+
 const DEFAULT_MAX_RETRIES = 3
 const BACKOFF_BASE_MS = 1000
+const DEFAULT_REQUEST_TIMEOUT_MS = 60_000
+
+/**
+ * Thrown when an AI operation does not settle within the configured timeout.
+ *
+ * Treated as fallback-eligible so a hung provider triggers the next model in
+ * the chain rather than parking the caller forever.
+ */
+export class AiRequestTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`AI request timed out after ${timeoutMs}ms`)
+    this.name = 'AiRequestTimeoutError'
+  }
+}
 
 function getMaxRetries(): number {
   const envValue = process.env.GEMINI_MAX_RETRIES?.trim()
   if (envValue == null || envValue === '') return DEFAULT_MAX_RETRIES
   const parsed = Number(envValue)
   if (!Number.isInteger(parsed) || parsed < 0) return DEFAULT_MAX_RETRIES
+  return parsed
+}
+
+function getRequestTimeoutMs(): number {
+  const envValue = process.env.AI_REQUEST_TIMEOUT_MS?.trim()
+  if (envValue == null || envValue === '') return DEFAULT_REQUEST_TIMEOUT_MS
+  const parsed = Number(envValue)
+  if (!Number.isInteger(parsed) || parsed < 0) return DEFAULT_REQUEST_TIMEOUT_MS
   return parsed
 }
 
@@ -26,15 +58,48 @@ function isRateLimitError(error: unknown): boolean {
   return getStatusCode(error) === 429
 }
 
+function isTimeoutError(error: unknown): boolean {
+  return error instanceof AiRequestTimeoutError
+}
+
 function isFallbackEligible(error: unknown): boolean {
+  if (isTimeoutError(error)) return true
   const code = getStatusCode(error)
   return code === 429 || code === 403
 }
 
+/**
+ * Runs a single operation attempt, aborting it if it does not settle within
+ * `timeoutMs`. A timed-out attempt rejects with {@link AiRequestTimeoutError}
+ * regardless of how the underlying SDK surfaces the abort.
+ */
+async function runWithTimeout<T>(
+  model: AIModel,
+  operation: AIOperation<T>,
+  timeoutMs: number
+): Promise<T> {
+  const controller = new AbortController()
+  if (timeoutMs <= 0) return operation(model, controller.signal)
+
+  const timer = setTimeout(() => {
+    controller.abort(new AiRequestTimeoutError(timeoutMs))
+  }, timeoutMs)
+
+  try {
+    return await operation(model, controller.signal)
+  } catch (error) {
+    if (controller.signal.aborted) throw new AiRequestTimeoutError(timeoutMs)
+    throw error
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
 async function retryWithBackoff<T>(
   model: AIModel,
-  operation: (model: AIModel) => Promise<T>,
+  operation: AIOperation<T>,
   maxRetries: number,
+  timeoutMs: number,
   shouldAbort?: () => boolean
 ): Promise<T> {
   const clampedMaxRetries = Math.max(0, maxRetries)
@@ -46,7 +111,7 @@ async function retryWithBackoff<T>(
       if (shouldAbort?.()) break
     }
     try {
-      return await operation(model)
+      return await runWithTimeout(model, operation, timeoutMs)
     } catch (error) {
       if (!isRateLimitError(error)) throw error
       lastError = error
@@ -56,29 +121,33 @@ async function retryWithBackoff<T>(
 }
 
 export interface OpenrouterFallbackSession {
-  execute<T>(operation: (model: AIModel) => Promise<T>): Promise<T>
+  execute<T>(operation: AIOperation<T>): Promise<T>
 }
 
 /**
  * Creates a session-aware fallback from a list of model names.
  *
  * Models are tried in order. Once a model exhausts retries on a
- * 429 or returns a 403 (key/quota limit), the next model in the
- * chain is used. Once a model is exhausted, all subsequent calls
+ * 429, returns a 403 (key/quota limit), or times out, the next model
+ * in the chain is used. Once a model is exhausted, all subsequent calls
  * in the same session skip directly to the current active model.
+ *
+ * Each attempt is bounded by a per-request timeout (`AI_REQUEST_TIMEOUT_MS`,
+ * default 60s) so a hung provider request rejects instead of hanging forever.
  */
 export function createOpenrouterFallbackSession(
   modelNames: string[]
 ): OpenrouterFallbackSession {
   const models = modelNames.map((name) => openrouter.chat(name))
   const maxRetries = getMaxRetries()
+  const timeoutMs = getRequestTimeoutMs()
   let activeModelIndex = 0
 
   const hasAborted = (snapshot: number): boolean =>
     activeModelIndex !== snapshot
 
   return {
-    async execute<T>(operation: (model: AIModel) => Promise<T>): Promise<T> {
+    async execute<T>(operation: AIOperation<T>): Promise<T> {
       while (activeModelIndex < models.length) {
         const modelIndex = activeModelIndex
 
@@ -87,6 +156,7 @@ export function createOpenrouterFallbackSession(
             models[modelIndex],
             operation,
             maxRetries,
+            timeoutMs,
             () => hasAborted(modelIndex)
           )
         } catch (error) {
@@ -101,7 +171,12 @@ export function createOpenrouterFallbackSession(
         }
       }
 
-      return retryWithBackoff(models[models.length - 1], operation, maxRetries)
+      return retryWithBackoff(
+        models[models.length - 1],
+        operation,
+        maxRetries,
+        timeoutMs
+      )
     }
   }
 }
@@ -110,7 +185,7 @@ export function createOpenrouterFallbackSession(
  * Stateless fallback helper — thin wrapper around a single-use session.
  */
 export async function withOpenrouterFallback<T>(
-  operation: (model: AIModel) => Promise<T>,
+  operation: AIOperation<T>,
   modelNames: string[]
 ): Promise<T> {
   return createOpenrouterFallbackSession(modelNames).execute(operation)


### PR DESCRIPTION
- Introduced `AiRequestTimeoutError` to handle request timeouts.
- Updated AI operation functions to accept an `AbortSignal` for cancellable requests.
- Enhanced error handling in translation functions to throw GraphQLErrors on timeouts and other failures.
- Modified related tests to validate timeout behavior and signal passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-attempt AI request timeouts with cancellation support across translations, metadata, and customization flows.

* **Bug Fixes**
  * Clearer, user-facing timeout behavior in translation streams/subscriptions.
  * Proper propagation of cancellation through streaming and batch translations.
  * More reliable fallback retries when attempts time out.
  * Improved robustness and consistent logging for streaming and per-block/card translation failures.

* **Tests**
  * Added tests validating timeout and abort behavior in the fallback flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->