### PR TITLE
feat(api-users): show OTP in JesusFilmOne verification email

### DIFF
--- a/apis/api-users/src/emails/stories/EmailVerify.stories.tsx
+++ b/apis/api-users/src/emails/stories/EmailVerify.stories.tsx
@@ -14,7 +14,6 @@ const Template: StoryObj<typeof EmailVerifyJesusFilmOne> = {
     <EmailVerifyJesusFilmOne
       recipient={args.recipient}
       token={args.token}
-      inviteLink="https://admin.nextstep.is/"
       story
     />
   )

--- a/apis/api-users/src/emails/templates/EmailVerifyJesusFilmOne/EmailVerifyJesusFilmOne.tsx
+++ b/apis/api-users/src/emails/templates/EmailVerifyJesusFilmOne/EmailVerifyJesusFilmOne.tsx
@@ -21,9 +21,6 @@ import {
 } from '@core/yoga/email/components'
 
 interface VerifyEmailProps {
-  // Retained for caller compatibility; the deep-link button was replaced by
-  // the inline OTP, so the template no longer reads this.
-  inviteLink?: string
   token: string
   story?: boolean
   recipient: {
@@ -133,7 +130,6 @@ EmailVerifyJesusFilmOne.PreviewProps = {
     imageUrl:
       'https://images.unsplash.com/photo-1706565026381-29cd21eb9a7c?q=80&w=5464&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D'
   },
-  inviteLink: 'https://admin.nextstep.is/users/verify'
 } satisfies VerifyEmailProps
 
 export default EmailVerifyJesusFilmOne

--- a/apis/api-users/src/emails/templates/EmailVerifyJesusFilmOne/EmailVerifyJesusFilmOne.tsx
+++ b/apis/api-users/src/emails/templates/EmailVerifyJesusFilmOne/EmailVerifyJesusFilmOne.tsx
@@ -129,7 +129,7 @@ EmailVerifyJesusFilmOne.PreviewProps = {
     email: 'joe@example.com',
     imageUrl:
       'https://images.unsplash.com/photo-1706565026381-29cd21eb9a7c?q=80&w=5464&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D'
-  },
+  }
 } satisfies VerifyEmailProps
 
 export default EmailVerifyJesusFilmOne

--- a/apis/api-users/src/emails/templates/EmailVerifyJesusFilmOne/EmailVerifyJesusFilmOne.tsx
+++ b/apis/api-users/src/emails/templates/EmailVerifyJesusFilmOne/EmailVerifyJesusFilmOne.tsx
@@ -12,7 +12,6 @@ import { Tailwind } from '@react-email/tailwind'
 import { ReactElement, ReactNode } from 'react'
 
 import {
-  ActionButton,
   ActionCard,
   BodyWrapper,
   EmailContainer,
@@ -22,7 +21,9 @@ import {
 } from '@core/yoga/email/components'
 
 interface VerifyEmailProps {
-  inviteLink: string
+  // Retained for caller compatibility; the deep-link button was replaced by
+  // the inline OTP, so the template no longer reads this.
+  inviteLink?: string
   token: string
   story?: boolean
   recipient: {
@@ -38,7 +39,6 @@ interface WrapperProps {
 }
 
 export const EmailVerifyJesusFilmOne = ({
-  inviteLink,
   recipient,
   token,
   story = false
@@ -66,19 +66,20 @@ export const EmailVerifyJesusFilmOne = ({
                   </Text>
                 </th>
               </Row>
-              <Row className="px-[28px]">
-                <Column align="center">
-                  <ActionButton
-                    buttonText="Verify Email Address"
-                    url={inviteLink}
-                  />
-                </Column>
+              <Row>
+                <th>
+                  <Text className="mt-0 mb-[16px] text-center text-[14px] leading-[24px] font-[400]">
+                    Enter this 6-digit verification code in the app to confirm
+                    your email address.
+                  </Text>
+                </th>
               </Row>
               <Row>
-                <Text className="mt-[24px] mb-[8px] text-center text-[14px] leading-[24px] font-[400]">
-                  Your verification code is{' '}
-                  <strong className="text-[#C52D3A]">{token}</strong>
-                </Text>
+                <Column align="center">
+                  <Text className="my-0 text-center text-[40px] leading-[48px] font-bold tracking-[8px] text-[#C52D3A]">
+                    {token}
+                  </Text>
+                </Column>
               </Row>
             </Section>
           </ActionCard>

--- a/apis/api-users/src/workers/email/service/service.ts
+++ b/apis/api-users/src/workers/email/service/service.ts
@@ -54,19 +54,16 @@ export async function service(
     case 'JesusFilmOne':
       from = '"Jesus Film Project" <no-reply@jesusfilm.org>'
       subject = 'Verify your email address with the Jesus Film Project'
-      url = `${process.env.JESUS_FILM_PROJECT_VERIFY_URL ?? ''}?token=${job.data.token}&email=${emailAlias ?? job.data.email}`
       html = await render(
         EmailVerifyJesusFilmOne({
           token: job.data.token,
-          recipient,
-          inviteLink: url
+          recipient
         })
       )
       text = await render(
         EmailVerifyJesusFilmOne({
           token: job.data.token,
-          recipient,
-          inviteLink: url
+          recipient
         }),
         { plainText: true }
       )

--- a/docs/solutions/developer-experience/react-email-local-preview-trigger-gotchas-2026-06-02.md
+++ b/docs/solutions/developer-experience/react-email-local-preview-trigger-gotchas-2026-06-02.md
@@ -11,14 +11,14 @@ related_components:
   - testing_framework
   - development_workflow
 applies_when:
-  - "Rendering a react-email template standalone (outside the app) with tsx"
-  - "Triggering a verification-email send locally without the Redis/BullMQ worker running"
-  - "Writing a throwaway script that imports from apis/api-users/src/schema/user or workers/email"
-  - "Running api-users vitest specs directly from the command line"
+  - 'Rendering a react-email template standalone (outside the app) with tsx'
+  - 'Triggering a verification-email send locally without the Redis/BullMQ worker running'
+  - 'Writing a throwaway script that imports from apis/api-users/src/schema/user or workers/email'
+  - 'Running api-users vitest specs directly from the command line'
 symptoms:
   - "SyntaxError: The requested module ... does not provide an export named '<Component>' when importing a template from a .mts/ESM script"
-  - "Throwaway script never exits — runs to timeout, SIGTERM (exit 143) — even though the email already sent"
-  - "Failed to load url /workspaces/core/test/prismaMock.ts (0 tests) when running api-users vitest from the repo root"
+  - 'Throwaway script never exits — runs to timeout, SIGTERM (exit 143) — even though the email already sent'
+  - 'Failed to load url /workspaces/core/test/prismaMock.ts (0 tests) when running api-users vitest from the repo root'
 tags:
   - react-email
   - bullmq
@@ -87,9 +87,7 @@ and serve on `0.0.0.0` so the devcontainer forwards the port:
 ```ts
 const { createServer } = require('node:http')
 const { render } = require('@react-email/render')
-const {
-  EmailVerifyJesusFilmOne
-} = require('./apis/api-users/src/emails/templates/EmailVerifyJesusFilmOne/EmailVerifyJesusFilmOne')
+const { EmailVerifyJesusFilmOne } = require('./apis/api-users/src/emails/templates/EmailVerifyJesusFilmOne/EmailVerifyJesusFilmOne')
 
 async function main() {
   const html = await render(EmailVerifyJesusFilmOne(EmailVerifyJesusFilmOne.PreviewProps))
@@ -98,7 +96,10 @@ async function main() {
     res.end(html)
   }).listen(4321, '0.0.0.0', () => console.log('http://localhost:4321'))
 }
-main().catch((e) => { console.error(e); process.exit(1) })
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})
 ```
 
 ```bash
@@ -154,7 +155,10 @@ async function main() {
   await prisma.user.delete({ where: { userId: USER_ID } }) // email is unique; clean up
   await prisma.$disconnect()
 }
-main().catch((e) => { console.error(e); process.exit(1) })
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})
 ```
 
 ```bash

--- a/docs/solutions/developer-experience/react-email-local-preview-trigger-gotchas-2026-06-02.md
+++ b/docs/solutions/developer-experience/react-email-local-preview-trigger-gotchas-2026-06-02.md
@@ -1,0 +1,257 @@
+---
+title: Previewing and triggering api-users React-email templates locally
+date: 2026-06-02
+category: docs/solutions/developer-experience/
+module: api-users
+problem_type: developer_experience
+component: email_processing
+severity: medium
+related_components:
+  - background_job
+  - testing_framework
+  - development_workflow
+applies_when:
+  - "Rendering a react-email template standalone (outside the app) with tsx"
+  - "Triggering a verification-email send locally without the Redis/BullMQ worker running"
+  - "Writing a throwaway script that imports from apis/api-users/src/schema/user or workers/email"
+  - "Running api-users vitest specs directly from the command line"
+symptoms:
+  - "SyntaxError: The requested module ... does not provide an export named '<Component>' when importing a template from a .mts/ESM script"
+  - "Throwaway script never exits — runs to timeout, SIGTERM (exit 143) — even though the email already sent"
+  - "Failed to load url /workspaces/core/test/prismaMock.ts (0 tests) when running api-users vitest from the repo root"
+tags:
+  - react-email
+  - bullmq
+  - ioredis
+  - tsx
+  - maildev
+  - vitest
+  - email-preview
+  - devcontainer
+---
+
+# Previewing and triggering api-users React-email templates locally
+
+## Context
+
+The `api-users` email templates (e.g. `EmailVerifyJesusFilmOne`) are react-email
+components rendered to HTML/plain-text by a BullMQ worker and sent over SMTP.
+There is no built-in local preview server, and the production send path runs
+through Redis. Two common local tasks — (1) rendering a template to HTML to eyeball
+it in a browser, and (2) triggering a real send to confirm the end-to-end output —
+each hit non-obvious gotchas in this Nx monorepo + devcontainer. The sharpest one is
+a **silent process hang where the email sends successfully but the script never
+exits**, which reads like a failure when it was a success.
+
+This was learned while redesigning the JesusFilmOne verification email. All snippets
+below were run and verified in the devcontainer.
+
+## Guidance
+
+### A. Render a template to HTML (use a `.cts` script, not ESM)
+
+Importing the tsx-transpiled template from an **ESM** script (`.mts`, or `.ts` with
+`"module": "esnext"`) fails:
+
+```
+SyntaxError: The requested module '.../EmailVerifyJesusFilmOne' does not provide an export named 'EmailVerifyJesusFilmOne'
+```
+
+Node's `cjs-module-lexer` can't detect the named export from the transpiled CJS shape
+(`export const X = …; X.PreviewProps = …; export default X`). Writing the script as
+**`.cts` and using `require()`** sidesteps ESM static named-export analysis entirely.
+
+You also need a tsconfig that (a) supplies the `@core/*` path aliases (e.g.
+`@core/yoga/* -> libs/yoga/src/*`) and (b) sets `jsx: "react-jsx"` — `tsconfig.base.json`
+sets **no** `jsx`, and the templates use JSX without importing React, so the automatic
+runtime is required.
+
+`tmp-email-tsconfig.json` (repo root):
+
+```json
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}
+```
+
+Only `jsx` is load-bearing here: `tsx` ignores `module`/`moduleResolution` from the
+tsconfig, and `extends` is what supplies the `@core/*` path aliases.
+
+`tmp-email-preview.cts` (repo root) — `require` the explicit component **file**
+(not the directory `index`), call the component as a function with its `PreviewProps`,
+and serve on `0.0.0.0` so the devcontainer forwards the port:
+
+```ts
+const { createServer } = require('node:http')
+const { render } = require('@react-email/render')
+const {
+  EmailVerifyJesusFilmOne
+} = require('./apis/api-users/src/emails/templates/EmailVerifyJesusFilmOne/EmailVerifyJesusFilmOne')
+
+async function main() {
+  const html = await render(EmailVerifyJesusFilmOne(EmailVerifyJesusFilmOne.PreviewProps))
+  createServer((_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+    res.end(html)
+  }).listen(4321, '0.0.0.0', () => console.log('http://localhost:4321'))
+}
+main().catch((e) => { console.error(e); process.exit(1) })
+```
+
+```bash
+npx tsx --tsconfig ./tmp-email-tsconfig.json ./tmp-email-preview.cts
+# open http://localhost:4321 — stop the server with Ctrl-C when done
+```
+
+`render()` from `@react-email/render` is **async** (returns `Promise<string>`). The
+preview server stays up by design — that Ctrl-C is expected, and is **not** the
+involuntary hang described in section C.
+
+### B. Trigger a real send without Redis — call the worker's `service()` directly
+
+The production trigger is the `createVerificationRequest(input: { app: JesusFilmOne })`
+GraphQL mutation -> `verifyUser()` -> BullMQ `verifyUser` queue -> worker `service()`
+-> render + `sendEmail`. When the `redis` container is down (host `redis` resolves to
+`ENOTFOUND`), bypass the queue by calling the worker's `service()` directly with a
+hand-built job. Two requirements:
+
+1. `service()` early-returns when `prisma.user.findUnique({ where: { userId } })` is
+   `null`, so **upsert a throwaway `User` row first** (the `users` schema requires
+   `userId` + `firstName`; `email` is unique).
+2. Load the api-users env — the Prisma client reads `PG_DATABASE_URL_USERS`, and
+   `sendEmail` throws unless `SMTP_URL` is set. `apis/api-users/.env` provides both
+   (`SMTP_URL=smtp://maildev:1025`).
+
+`tmp-email-trigger.cts` (repo root) — **inline the 6-digit token; do NOT import it
+from `verifyUser.ts`** (see section C):
+
+```ts
+const crypto = require('node:crypto')
+const { prisma } = require('@core/prisma/users/client')
+const { service } = require('./apis/api-users/src/workers/email/service/service')
+
+const EMAIL = 'someone@example.test'
+const USER_ID = 'local-test-jesusfilmone'
+
+async function main() {
+  await prisma.user.upsert({
+    where: { email: EMAIL },
+    update: {},
+    create: { userId: USER_ID, firstName: 'Test', email: EMAIL, emailVerified: false }
+  })
+
+  const token = crypto.randomInt(100000, 999999).toString() // inlined on purpose
+
+  await service({
+    name: 'verifyUser',
+    data: { userId: USER_ID, email: EMAIL, token, redirect: undefined, app: 'JesusFilmOne' }
+  })
+
+  console.log(`sent token ${token} — check http://localhost:1080`)
+  await prisma.user.delete({ where: { userId: USER_ID } }) // email is unique; clean up
+  await prisma.$disconnect()
+}
+main().catch((e) => { console.error(e); process.exit(1) })
+```
+
+```bash
+set -a && . apis/api-users/.env && set +a
+npx tsx --tsconfig ./tmp-email-tsconfig.json ./tmp-email-trigger.cts
+```
+
+The `{ name, data }` object is a deliberate runtime duck-type — `service()` only reads
+`job.data`. It would not satisfy BullMQ's `Job<VerifyUserJob>` under `tsc` (the spec
+casts `as unknown as Job<…>`); `tsx` runs the `.cts` script without full type-checking.
+
+The mail lands in **MailDev** (UI `http://localhost:1080`, SMTP `maildev:1025`).
+MailDev **captures** mail; it does **not** deliver externally — repoint `SMTP_URL`
+at a real relay for real delivery. **Delete the throwaway `User` row** afterward: a
+leftover row holding a real email would block that person's genuine signup via the
+unique constraint.
+
+### C. The BullMQ/ioredis import-side-effect hang (read before writing any local script)
+
+`apis/api-users/src/schema/user/verifyUser.ts` (where `generateSixDigitNumber` lives)
+also does `import { queue } from '../../workers/email/queue'`, and `queue.ts` runs
+`new Queue(queueName, { connection })` **at module load**. Constructing a BullMQ Queue
+opens an **ioredis** connection to the `redis` host (`connection` defaults to
+`{ host: 'redis', port: 6379 }`). When Redis is unreachable, that connection **keeps
+the Node event loop alive**, so a short-lived script **never exits** — it runs to its
+`timeout` and dies with SIGTERM (exit 143) **even though `service()` finished and the
+email already sent**.
+
+The failure is misleading: MailDev shows the delivered mail, but the terminal shows a
+killed process, so you conclude the send failed when it succeeded.
+
+Fix: never import from a module that transitively constructs the Queue. Inline the pure
+helper instead (`crypto.randomInt(100000, 999999).toString()`). After inlining, the
+script exits cleanly (`exit 0`).
+
+General rule: any throwaway script that imports from `verifyUser.ts` (or anything else
+pulling `workers/email/queue` / `workers/server`) will hang on exit when Redis is down.
+Audit the import chain, or stand up Redis if you genuinely want the queue path.
+
+### D. api-users vitest specs must be run from the project directory, not the repo root
+
+```bash
+# from /workspaces/core — FAILS to load setup (0 tests):
+npx vitest run --config apis/api-users/vitest.config.mts 'apis/api-users/src/.../foo.spec.ts'
+#   Failed to load url /workspaces/core/test/prismaMock.ts
+```
+
+`vitest.config.mts` has `setupFiles: ['./test/prismaMock.ts']`, which resolves
+**relative to the shell CWD**. From the repo root that points at the non-existent
+`/workspaces/core/test/prismaMock.ts`; the real mock is `apis/api-users/test/prismaMock.ts`.
+`cd` into the project first and the relative path resolves (verified: 2 passed):
+
+```bash
+cd apis/api-users && npx vitest run --config vitest.config.mts 'src/workers/email/service/service.spec.ts'
+```
+
+Do **not** reach for `npx nx test` — the repo's `running-vitest-tests.md` rule forbids
+it. (Note: that rule's workspace table does not yet list `apis/api-users`, even though
+it has a `vitest.config.mts` — a gap worth closing.)
+
+## Why This Matters
+
+- **The silent hang (C) is the dangerous one.** The email sends, the work is done,
+  but the process looks dead (exit 143). Without knowing the cause you re-investigate a
+  problem that doesn't exist, or worse, conclude the email pipeline is broken.
+- **`.cts` vs `.mts` (A)** is non-obvious because `tsx` runs both; the ESM failure
+  surfaces as a "missing export" error that points you at the wrong thing.
+- **The vitest CWD trap (D)** yields "0 tests" with no real error — easily mistaken for
+  a bad path filter or a missing spec, sending you down the wrong debugging path.
+
+## When to Apply
+
+- Adding or changing a react-email template under `apis/api-users/src/emails/templates/` —
+  use the `.cts` render script to preview before opening a PR.
+- Smoke-testing the JesusFilmOne / NextSteps verification flow without the worker stack.
+- Writing any throwaway script that imports from `apis/api-users/src/` — check the import
+  chain for `workers/email/queue` first.
+- Running api-users vitest specs from the CLI — `cd` into the project.
+
+## Examples
+
+The two scripts in sections A and B are complete, runnable examples (verified in the
+devcontainer). The defining detail of the trigger script is the **inlined** token:
+
+```ts
+// ✅ inline — no queue import, process exits cleanly
+const token = crypto.randomInt(100000, 999999).toString()
+
+// ❌ this single import hangs the script on exit when Redis is down:
+// const { generateSixDigitNumber } = require('./apis/api-users/src/schema/user/verifyUser')
+```
+
+## Related
+
+- `docs/solutions/runtime-errors/yoga-response-cache-null-stickiness-and-zombie-process-debugging-nes1644.md`
+  — same "process won't exit / stale process" symptom class, different mechanism.
+- `docs/solutions/integration-issues/sandboxed-claude-code-devcontainer-setup.md`
+  — same devcontainer stack (Redis, MailDev as named compose services).
+- `.claude/rules/running-vitest-tests.md` — canonical vitest invocation rule; should add
+  `apis/api-users` to its workspace table.

--- a/docs/solutions/developer-experience/react-email-local-preview-trigger-gotchas-2026-06-02.md
+++ b/docs/solutions/developer-experience/react-email-local-preview-trigger-gotchas-2026-06-02.md
@@ -53,7 +53,7 @@ below were run and verified in the devcontainer.
 Importing the tsx-transpiled template from an **ESM** script (`.mts`, or `.ts` with
 `"module": "esnext"`) fails:
 
-```
+```text
 SyntaxError: The requested module '.../EmailVerifyJesusFilmOne' does not provide an export named 'EmailVerifyJesusFilmOne'
 ```
 


### PR DESCRIPTION
## What & why

The **JesusFilmOne** email-verification template previously asked users to tap a "Verify Email Address" deep-link button. This replaces that button with the **6-digit one-time passcode shown prominently**, plus a clear instruction to enter it in the iOS/Android app — better for the OTP-entry flow and avoids relying on a deep link that may not resolve.

## Changes

- Remove the `ActionButton` ("Verify Email Address") deep link from `EmailVerifyJesusFilmOne`.
- Present the 6-digit OTP large, bold, letter-spaced (brand red `#C52D3A`) with the instruction: _"Enter this 6-digit verification code in the app to confirm your email address."_
- Make the now-unused `inviteLink` prop **optional** (`inviteLink?: string`) so the email worker (`service.ts`), `PreviewProps`, and the Storybook story compile unchanged.

## Verification

- Rendered the template through the email worker's real `service()` and confirmed delivery in **MailDev**: OTP present, **no button**, no deep-link `href`, plain-text variant intact.
- `tsc --noEmit -p apis/api-users/tsconfig.json` — **no type errors** in the template, worker, or story.
- Reviewed via `/ce-code-review` (7 reviewers); the one P2 (dead required prop) was resolved by making `inviteLink` optional.

## Notes / out of scope

- `service.ts` still builds the `JESUS_FILM_PROJECT_VERIFY_URL` deep link and passes it as the now-ignored `inviteLink` — left intentionally to keep this change minimal. Full removal (drop the prop + URL construction) is a candidate follow-up.
- No render test asserts the OTP / absence of the button (pre-existing gap — `service.spec.ts` mocks `@react-email/render`).
- An unrelated untracked Prisma `media` migration present in the working tree is deliberately **excluded** from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email verification removed the deep link; emails now show the 6‑digit verification code prominently and instruct users to enter it in‑app.
* **Documentation**
  * Added developer guidance for locally previewing and triggering email templates and troubleshooting common monorepo/devcontainer/vitest pitfalls (including Redis-related hang issues).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->