### PR TITLE
fix(QA-500): handle email-collision on login instead of 500

### DIFF
--- a/apis/api-users/src/schema/user/findOrFetchUser.spec.ts
+++ b/apis/api-users/src/schema/user/findOrFetchUser.spec.ts
@@ -323,7 +323,11 @@ describe('findOrFetchUser', () => {
     prismaMock.user.create.mockRejectedValueOnce(
       new Prisma.PrismaClientKnownRequestError(
         'Unique constraint failed on the fields: (`userId`)',
-        { code: 'P2002', clientVersion: 'prismaVersion', meta: { target: ['userId'] } }
+        {
+          code: 'P2002',
+          clientVersion: 'prismaVersion',
+          meta: { target: ['userId'] }
+        }
       )
     )
     prismaMock.user.update.mockResolvedValueOnce(user)
@@ -348,7 +352,11 @@ describe('findOrFetchUser', () => {
     prismaMock.user.create.mockRejectedValueOnce(
       new Prisma.PrismaClientKnownRequestError(
         'Unique constraint failed on the fields: (`email`)',
-        { code: 'P2002', clientVersion: 'prismaVersion', meta: { target: ['email'] } }
+        {
+          code: 'P2002',
+          clientVersion: 'prismaVersion',
+          meta: { target: ['email'] }
+        }
       )
     )
 

--- a/apis/api-users/src/schema/user/findOrFetchUser.spec.ts
+++ b/apis/api-users/src/schema/user/findOrFetchUser.spec.ts
@@ -1,5 +1,6 @@
 import { Mock, vi } from 'vitest'
 
+import { Prisma } from '@core/prisma/users/client'
 import { auth } from '@core/yoga/firebaseClient'
 
 import { prismaMock } from '../../../test/prismaMock'
@@ -315,6 +316,61 @@ describe('findOrFetchUser', () => {
       undefined,
       'JesusFilmOne'
     )
+  })
+
+  it('should update by userId when create loses the concurrent create race', async () => {
+    prismaMock.user.findUnique.mockResolvedValueOnce(null)
+    prismaMock.user.create.mockRejectedValueOnce(
+      new Prisma.PrismaClientKnownRequestError(
+        'Unique constraint failed on the fields: (`userId`)',
+        { code: 'P2002', clientVersion: 'prismaVersion', meta: { target: ['userId'] } }
+      )
+    )
+    prismaMock.user.update.mockResolvedValueOnce(user)
+
+    const data = await findOrFetchUser({}, 'userId', undefined)
+    expect(data).toEqual(user)
+    expect(prismaMock.user.update).toHaveBeenCalledWith({
+      where: { userId: 'userId' },
+      data: {
+        email: 'amin@email.com',
+        emailVerified: false,
+        firstName: 'Amin',
+        imageUrl: 'https://bit.ly/3Gth4',
+        lastName: 'One',
+        userId: 'userId'
+      }
+    })
+  })
+
+  it('should throw "Email already in use" when create fails on the email unique constraint', async () => {
+    prismaMock.user.findUnique.mockResolvedValueOnce(null)
+    prismaMock.user.create.mockRejectedValueOnce(
+      new Prisma.PrismaClientKnownRequestError(
+        'Unique constraint failed on the fields: (`email`)',
+        { code: 'P2002', clientVersion: 'prismaVersion', meta: { target: ['email'] } }
+      )
+    )
+
+    await expect(findOrFetchUser({}, 'userId', undefined)).rejects.toThrow(
+      'Email already in use'
+    )
+    expect(prismaMock.user.update).not.toHaveBeenCalled()
+  })
+
+  it('should rethrow unexpected create errors without attempting an update', async () => {
+    prismaMock.user.findUnique.mockResolvedValueOnce(null)
+    prismaMock.user.create.mockRejectedValueOnce(
+      new Prisma.PrismaClientKnownRequestError('Connection lost', {
+        code: 'P1001',
+        clientVersion: 'prismaVersion'
+      })
+    )
+
+    await expect(findOrFetchUser({}, 'userId', undefined)).rejects.toThrow(
+      'Connection lost'
+    )
+    expect(prismaMock.user.update).not.toHaveBeenCalled()
   })
 
   it('should pass app type when provided', async () => {

--- a/apis/api-users/src/schema/user/findOrFetchUser.ts
+++ b/apis/api-users/src/schema/user/findOrFetchUser.ts
@@ -1,3 +1,5 @@
+import { GraphQLError } from 'graphql'
+
 import { Prisma, User, prisma } from '@core/prisma/users/client'
 import {
   type UserRecord,
@@ -95,7 +97,6 @@ export async function findOrFetchUser(
   }
 
   let user: User | null = null
-  let retry = 0
   let userCreated = false
   // this function can run in parallel as such it is possible for multiple
   // calls to reach this point and try to create the same user
@@ -106,15 +107,35 @@ export async function findOrFetchUser(
     })
     userCreated = true
   } catch (e) {
-    do {
-      user = await prisma.user.update({
-        where: {
-          userId
-        },
-        data
+    // The only create failure we can safely recover from is a userId
+    // unique-constraint violation caused by a concurrent call that won the
+    // race and already created this user — update by userId is then valid.
+    // A P2002 on email means a *different* user already owns this email, so
+    // updating by userId would target a non-existent row (P2025); surface a
+    // meaningful error instead. Anything else is unexpected and rethrown.
+    if (
+      !(e instanceof Prisma.PrismaClientKnownRequestError) ||
+      e.code !== 'P2002'
+    )
+      throw e
+
+    const target = e.meta?.target
+    const fields = Array.isArray(target) ? target : [target]
+    if (
+      fields.some(
+        (field) => typeof field === 'string' && field.includes('email')
+      )
+    )
+      throw new GraphQLError('Email already in use', {
+        extensions: { code: 'BAD_USER_INPUT' }
       })
-      retry++
-    } while (user == null && retry < 3)
+
+    user = await prisma.user.update({
+      where: {
+        userId
+      },
+      data
+    })
   }
   // after user create so it is only sent once
   if (email != null && userCreated && !emailVerified)


### PR DESCRIPTION
## Summary

Fixes the 500 error on staging login reported in [QA-500](https://linear.app/jesus-film-project/issue/QA-500/getting-500-error-when-logging-into-staging).

`findOrFetchUser` treated **every** `prisma.user.create` failure as a `userId` race and blindly ran `update({ where: { userId } })`. The `User` table has two unique constraints (`userId`, `email`). When a login created a *new* Firebase UID whose email already belonged to a different user row, `create` threw **P2002 on `email`**, the catch ran `update` on a `userId` with no row → **P2025**, surfacing as a 500 on every subsequent login attempt (sticky regardless of cache/restart).

### Repro path (matches QA-500)
1. User clicks "Create Account" with Google SSO → new Firebase UID.
2. `findUnique({ where: { userId } })` → null → falls through to `create`.
3. Email already owned by prior user row → `create` throws P2002 on `email`.
4. catch → `update({ where: { userId } })` → no row → P2025 → 500.

### Change
- Rethrow non-`P2002` errors (no longer masked by a doomed update).
- `P2002` on `email` → throw `GraphQLError('Email already in use')` (`BAD_USER_INPUT`), matching the existing pattern in `user.ts`.
- `P2002` on `userId` (the genuine race) → recover via `update` as before.
- Removed the dead `do/while` retry loop — `update` throws on not-found, never returns `null`.

## Scope / follow-up
This stops the 500 and returns a clean error. It does **not** by itself let a colliding user log in — that requires an account-reconciliation decision (re-point the existing row's `userId`, link accounts, or sign into the existing account) and an immediate manual unblock for the reporter on staging. Tracking separately.

## Verification
- `findOrFetchUser.spec.ts`: 16/16 pass (added 3 cases — userId-race recovery, email-collision error, unexpected-error rethrow).
- `user.spec.ts`: 19/19 pass (no regressions).
- `pnpm run build` not run: `nx` cannot process the project graph in this worktree (symlinked `node_modules`).

## Files changed
- `apis/api-users/src/schema/user/findOrFetchUser.ts`
- `apis/api-users/src/schema/user/findOrFetchUser.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for user creation conflicts with clearer error messaging when attempting to register with an email already in use, and improved recovery from concurrent user creation attempts.

* **Tests**
  * Expanded test coverage for database error handling scenarios during user creation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->