### PR TITLE
feat(api-users): add dd-trace APM with log injection for trace correlation

### DIFF
--- a/apis/api-users/Dockerfile
+++ b/apis/api-users/Dockerfile
@@ -4,6 +4,9 @@ EXPOSE 4002
 
 ARG SERVICE_VERSION=0.0.1
 ENV OTEL_RESOURCE_ATTRIBUTES="service.version=$SERVICE_VERSION"
+# Hand tracing to dd-trace (APM) so logs correlate with traces via dd.trace_id.
+# Scoped to this image; @core/yoga/tracer reads this to skip its OTLP provider.
+ENV DD_TRACE_OTEL_ENABLED="true"
 ENV PNPM_HOME="/usr/local/share/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 

--- a/apis/api-users/src/index.ts
+++ b/apis/api-users/src/index.ts
@@ -1,3 +1,5 @@
+import './tracer'
+
 import { createServer } from 'node:http'
 
 import { logger } from './logger'

--- a/apis/api-users/src/tracer.spec.ts
+++ b/apis/api-users/src/tracer.spec.ts
@@ -1,0 +1,73 @@
+const { init, use, register, TracerProvider } = vi.hoisted(() => {
+  const registerMock = vi.fn()
+  return {
+    init: vi.fn(),
+    use: vi.fn(),
+    register: registerMock,
+    TracerProvider: vi.fn(() => ({ register: registerMock }))
+  }
+})
+
+vi.mock('dd-trace', () => ({
+  default: { init, use, TracerProvider }
+}))
+
+describe('tracer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    vi.unstubAllEnvs()
+    vi.stubEnv('DD_TRACE_OTEL_ENABLED', '')
+    vi.stubEnv('SERVICE_NAME', '')
+    vi.stubEnv('SERVICE_ENV', '')
+    vi.stubEnv('OTEL_RESOURCE_ATTRIBUTES', '')
+  })
+
+  it('should initialize dd-trace with log injection and runtime metrics', async () => {
+    await import(/* webpackChunkName: "tracer" */ './tracer')
+
+    expect(init).toHaveBeenCalledWith(
+      expect.objectContaining({ logInjection: true, runtimeMetrics: true })
+    )
+  })
+
+  it('should pass service, env and parsed version to dd-trace', async () => {
+    vi.stubEnv('SERVICE_NAME', 'api-users')
+    vi.stubEnv('SERVICE_ENV', 'stage')
+    vi.stubEnv('OTEL_RESOURCE_ATTRIBUTES', 'service.version=1.2.3,foo=bar')
+
+    await import(/* webpackChunkName: "tracer" */ './tracer')
+
+    expect(init).toHaveBeenCalledWith(
+      expect.objectContaining({
+        service: 'api-users',
+        env: 'stage',
+        version: '1.2.3'
+      })
+    )
+  })
+
+  it('should register the OpenTelemetry TracerProvider when DD_TRACE_OTEL_ENABLED is true', async () => {
+    vi.stubEnv('DD_TRACE_OTEL_ENABLED', 'true')
+
+    await import(/* webpackChunkName: "tracer" */ './tracer')
+
+    expect(TracerProvider).toHaveBeenCalledTimes(1)
+    expect(register).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not register the OpenTelemetry TracerProvider when DD_TRACE_OTEL_ENABLED is unset', async () => {
+    await import(/* webpackChunkName: "tracer" */ './tracer')
+
+    expect(TracerProvider).not.toHaveBeenCalled()
+    expect(register).not.toHaveBeenCalled()
+  })
+
+  it('should exclude the health check path from http tracing', async () => {
+    await import(/* webpackChunkName: "tracer" */ './tracer')
+
+    expect(use).toHaveBeenCalledWith('http', {
+      blocklist: ['/.well-known/apollo/server-health']
+    })
+  })
+})

--- a/apis/api-users/src/tracer.ts
+++ b/apis/api-users/src/tracer.ts
@@ -1,0 +1,37 @@
+import tracer from 'dd-trace'
+
+// The deploy version is baked into OTEL_RESOURCE_ATTRIBUTES (e.g.
+// "service.version=1.2.3") by the Dockerfile. Parse it out for DD_VERSION.
+const otelResourceAttributes = process.env.OTEL_RESOURCE_ATTRIBUTES ?? ''
+const serviceVersion = otelResourceAttributes
+  .split(',')
+  .map((attribute) => attribute.split('='))
+  .find(([key]) => key?.trim() === 'service.version')?.[1]
+  ?.trim()
+
+// Initialized in its own file and imported first in index.ts so dd-trace patches
+// modules before anything requires them. logInjection adds dd.trace_id / dd.span_id
+// to the pino logs, letting Datadog link logs to the matching APM trace.
+// https://docs.datadoghq.com/tracing/connect_logs_and_traces/nodejs/
+tracer.init({
+  logInjection: true,
+  runtimeMetrics: true,
+  service: process.env.SERVICE_NAME,
+  env: process.env.SERVICE_ENV,
+  version: serviceVersion
+})
+
+// dd-trace backs the @opentelemetry/api that @core/yoga/tracer and the Pothos
+// builder use. Registering its TracerProvider routes those OTel spans through
+// dd-trace. The matching @core/yoga/tracer skips its own OTLP provider when this
+// flag is set, so tracing stays single-sourced and trace ids correlate with logs.
+if (process.env.DD_TRACE_OTEL_ENABLED === 'true') {
+  const { TracerProvider } = tracer
+  new TracerProvider().register()
+}
+
+tracer.use('http', {
+  blocklist: ['/.well-known/apollo/server-health']
+})
+
+export default tracer

--- a/libs/yoga/src/tracer/tracer.spec.ts
+++ b/libs/yoga/src/tracer/tracer.spec.ts
@@ -16,7 +16,9 @@ vi.mock('@opentelemetry/instrumentation-http', () => ({
 vi.mock('@opentelemetry/resources', () => ({
   resourceFromAttributes: vi.fn(() => ({}))
 }))
-vi.mock('@opentelemetry/sdk-trace-base', () => ({ SimpleSpanProcessor: vi.fn() }))
+vi.mock('@opentelemetry/sdk-trace-base', () => ({
+  SimpleSpanProcessor: vi.fn()
+}))
 vi.mock('@opentelemetry/sdk-trace-node', () => ({
   NodeTracerProvider: vi.fn(() => ({ register }))
 }))
@@ -25,7 +27,10 @@ vi.mock('@opentelemetry/semantic-conventions', () => ({
   ATTR_SERVICE_VERSION: 'service.version'
 }))
 vi.mock('@pothos/tracing-opentelemetry', () => ({
-  AttributeNames: { OPERATION_NAME: 'operation.name', SOURCE: 'graphql.source' },
+  AttributeNames: {
+    OPERATION_NAME: 'operation.name',
+    SOURCE: 'graphql.source'
+  },
   SpanNames: { EXECUTE: 'execute' }
 }))
 vi.mock('@prisma/instrumentation', () => ({ PrismaInstrumentation: vi.fn() }))

--- a/libs/yoga/src/tracer/tracer.spec.ts
+++ b/libs/yoga/src/tracer/tracer.spec.ts
@@ -1,0 +1,56 @@
+const { register, registerInstrumentations } = vi.hoisted(() => ({
+  register: vi.fn(),
+  registerInstrumentations: vi.fn()
+}))
+
+vi.mock('@opentelemetry/api', () => ({
+  trace: { getTracer: vi.fn(() => ({})) }
+}))
+vi.mock('@opentelemetry/exporter-trace-otlp-grpc', () => ({
+  OTLPTraceExporter: vi.fn()
+}))
+vi.mock('@opentelemetry/instrumentation', () => ({ registerInstrumentations }))
+vi.mock('@opentelemetry/instrumentation-http', () => ({
+  HttpInstrumentation: vi.fn()
+}))
+vi.mock('@opentelemetry/resources', () => ({
+  resourceFromAttributes: vi.fn(() => ({}))
+}))
+vi.mock('@opentelemetry/sdk-trace-base', () => ({ SimpleSpanProcessor: vi.fn() }))
+vi.mock('@opentelemetry/sdk-trace-node', () => ({
+  NodeTracerProvider: vi.fn(() => ({ register }))
+}))
+vi.mock('@opentelemetry/semantic-conventions', () => ({
+  ATTR_SERVICE_NAME: 'service.name',
+  ATTR_SERVICE_VERSION: 'service.version'
+}))
+vi.mock('@pothos/tracing-opentelemetry', () => ({
+  AttributeNames: { OPERATION_NAME: 'operation.name', SOURCE: 'graphql.source' },
+  SpanNames: { EXECUTE: 'execute' }
+}))
+vi.mock('@prisma/instrumentation', () => ({ PrismaInstrumentation: vi.fn() }))
+
+describe('tracer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    vi.unstubAllEnvs()
+    vi.stubEnv('DD_TRACE_OTEL_ENABLED', '')
+  })
+
+  it('should register the OTLP provider and instrumentations by default', async () => {
+    await import(/* webpackChunkName: "tracer" */ './tracer')
+
+    expect(register).toHaveBeenCalledTimes(1)
+    expect(registerInstrumentations).toHaveBeenCalledTimes(1)
+  })
+
+  it('should skip provider registration and instrumentation when dd-trace owns tracing', async () => {
+    vi.stubEnv('DD_TRACE_OTEL_ENABLED', 'true')
+
+    await import(/* webpackChunkName: "tracer" */ './tracer')
+
+    expect(register).not.toHaveBeenCalled()
+    expect(registerInstrumentations).not.toHaveBeenCalled()
+  })
+})

--- a/libs/yoga/src/tracer/tracer.ts
+++ b/libs/yoga/src/tracer/tracer.ts
@@ -33,6 +33,14 @@ const resource = resourceFromAttributes({
   [ATTR_SERVICE_VERSION]: attributes['service.version'] ?? '0.0.1'
 })
 
+// When DD_TRACE_OTEL_ENABLED is set, dd-trace registers itself as the global
+// OpenTelemetry TracerProvider and instruments HTTP/Prisma natively. Standing up
+// this OTLP provider on top would override dd-trace and double-instrument, so the
+// service that opts into dd-trace must skip this registration. The `tracer` and
+// `tracingPlugin` exports below keep working because they go through the
+// @opentelemetry/api, which dd-trace then backs.
+const datadogTracerEnabled = process.env.DD_TRACE_OTEL_ENABLED === 'true'
+
 export const provider = new NodeTracerProvider({
   resource,
   spanProcessors: [
@@ -44,17 +52,19 @@ export const provider = new NodeTracerProvider({
   ]
 })
 
-provider.register()
+if (!datadogTracerEnabled) {
+  provider.register()
 
-registerInstrumentations({
-  instrumentations: [
-    new HttpInstrumentation({
-      ignoreIncomingRequestHook: (req) =>
-        req.url?.includes('/.well-known/apollo/server-health') ?? false
-    }),
-    new PrismaInstrumentation()
-  ]
-})
+  registerInstrumentations({
+    instrumentations: [
+      new HttpInstrumentation({
+        ignoreIncomingRequestHook: (req) =>
+          req.url?.includes('/.well-known/apollo/server-health') ?? false
+      }),
+      new PrismaInstrumentation()
+    ]
+  })
+}
 
 export const tracingPlugin: Plugin = {
   onExecute: ({ setExecuteFn, executeFn }) => {


### PR DESCRIPTION
## Summary

Adds Datadog APM + log injection to **api-users** so logs carry `dd.trace_id` / `dd.span_id` and Datadog links logs to the matching APM trace. This is observability tooling for debugging the staging login 500s — [QA-500](https://linear.app/jesus-film-project/issue/QA-500/getting-500-error-when-logging-into-staging).

## Context: why this isn't a plain `pnpm add dd-trace`

api-users does **not** use dd-trace — it uses OpenTelemetry via the shared `@core/yoga/tracer` lib, exporting OTLP to the Datadog agent. Dropping dd-trace in on top would run **two tracers at once**: log `trace_id`s (dd-trace) wouldn't match APM `trace_id`s (OTel), so the Trace tab wouldn't link — defeating the purpose.

So this switches api-users to dd-trace as the single tracer, with dd-trace backing the OpenTelemetry API so the existing `trace.getTracer('graphql')` call sites keep working.

## Changes

- **`apis/api-users/src/tracer.ts`** (new) — init dd-trace first (`logInjection`, `runtimeMetrics`); `service`/`env`/`version` from the existing `SERVICE_NAME` / `SERVICE_ENV` / `OTEL_RESOURCE_ATTRIBUTES` env vars; register dd-trace's OpenTelemetry `TracerProvider` so the shared yoga tracer + Pothos builder spans route through dd-trace; blocklist the health-check path. Mirrors the proven `api-journeys` pattern.
- **`apis/api-users/src/index.ts`** — `import './tracer'` as the first import.
- **`libs/yoga/src/tracer/tracer.ts`** — skip the OTLP `NodeTracerProvider` registration + HTTP/Prisma instrumentation when `DD_TRACE_OTEL_ENABLED=true`. **Gated and default-off**, so the other four consumers (api-media, api-analytics, api-languages, api-journeys-modern) are unchanged.
- **`apis/api-users/Dockerfile`** — `ENV DD_TRACE_OTEL_ENABLED=true`, scoping the switch to the api-users image only. **No shared ECS module / terraform changes** — agent reachability (`localhost:8126`) and the Datadog agent sidecar are already provided by the shared ECS task module and proven by api-journeys.

## Verification

- `nx run api-users:type-check` — pass
- `nx run-many -t lint -p api-users yoga` — pass (0 errors; 2 pre-existing warnings on main, unrelated)
- `nx run api-users:build:production` — webpack success; `dd-trace` correctly externalized (`require("dd-trace")`, not bundled) and pinned in the generated `package.json` (`5.36.0`)
- Tests:
  - `apis/api-users/src/tracer.spec.ts` (new) — 5 pass (dd-trace config, conditional OTel registration, health-check blocklist)
  - `libs/yoga/src/tracer/tracer.spec.ts` (new) — 2 pass (gate on/off behavior)
  - Full suites: api-users 79/79, yoga 25/25

## Post-deploy check

After deploy to staging, api-users logs in Datadog should start showing `dd.trace_id` / `dd.span_id`, and the **Trace** tab should link logs to the APM request — enabling the QA-500 investigation.

Related: [QA-500](https://linear.app/jesus-film-project/issue/QA-500/getting-500-error-when-logging-into-staging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)