### PR TITLE
feat(NES-1714): gate journeys-admin AI chat editor on `aiChatEditor` flag

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/Card.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/Card.spec.tsx
@@ -623,7 +623,7 @@ describe('Card', () => {
   })
 
   describe('ChatAssistant Section', () => {
-    it('does not render the AI chat accordion when apologistChat flag is off', () => {
+    it('does not render the AI chat accordion when aiChatEditor flag is off', () => {
       const card = createCard()
       renderWithProviders(<Card {...card} />)
 
@@ -632,10 +632,10 @@ describe('Card', () => {
       ).not.toBeInTheDocument()
     })
 
-    it('renders the AI chat accordion when apologistChat flag is on', () => {
+    it('renders the AI chat accordion when aiChatEditor flag is on', () => {
       const card = createCard()
       renderWithProviders(<Card {...card} />, {
-        flags: { apologistChat: true }
+        flags: { aiChatEditor: true }
       })
 
       expect(
@@ -652,7 +652,7 @@ describe('Card', () => {
         expandChatByDefault: false
       })
       renderWithProviders(<Card {...card} />, {
-        flags: { apologistChat: true }
+        flags: { aiChatEditor: true }
       })
 
       expect(
@@ -666,7 +666,7 @@ describe('Card', () => {
         expandChatByDefault: true
       })
       renderWithProviders(<Card {...card} />, {
-        flags: { apologistChat: true }
+        flags: { aiChatEditor: true }
       })
 
       expect(

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/Card.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/Card.tsx
@@ -91,7 +91,7 @@ export function Card({
   } = useEditor()
   const { rtl, locale } = getJourneyRTL(journey)
   const { t } = useTranslation('apps-journeys-admin')
-  const { apologistChat, editJourneyTrackingMetrics } = useFlags()
+  const { aiChatEditor, editJourneyTrackingMetrics } = useFlags()
 
   const coverBlock = children.find((block) => block.id === coverBlockId)
 
@@ -172,7 +172,7 @@ export function Card({
       >
         <CardLayout disableExpanded={disableExpanded} />
       </Accordion>
-      {apologistChat === true && (
+      {aiChatEditor === true && (
         <Accordion
           icon={<MessageChat1Icon />}
           id={`${id}-chat-assistant`}


### PR DESCRIPTION
## Why

Today a single LaunchDarkly flag — `apologistChat` — gates the AI Chat feature in **both** the journeys-admin editor and the public journey viewer. To launch we must turn `apologistChat` **on globally** so the public can reach the chat. But the viewer evaluates flags **anonymously** (`allFlagsState({ key: uuidv4(), anonymous: true })`) — there's no session to target — so it's an all-or-nothing global switch. Because the same flag also reveals the editor's AI chat controls, flipping it public would simultaneously expose those controls to **every** authenticated creator, losing all control over *who* can enable chat on a journey.

This separates the two concerns.

## What changed

- **journeys-admin editor** now gates the "AI chat" accordion in the Card properties panel on a new, user-targetable flag **`aiChatEditor`** instead of `apologistChat`.
- **Viewer + chat API stay on `apologistChat`** (Conductor, StepFooter, OverlayContent, `pages/api/chat`) — unchanged. That flag becomes the public global switch.

Because journeys-admin evaluates flags against the **authenticated user** — `initAndAuthApp` builds the LD user with `key: user.id` **and** `email: user.email` — `aiChatEditor` can be targeted by email in LaunchDarkly, giving tight control over editor access.

The diff is small (2 prod lines + test renames): the `useFlags()` destructure and the accordion gate in `Card.tsx`, plus the matching `Card.spec.tsx` assertions.

## Out of scope / unchanged

- No viewer behaviour change; no change to `apologistChat`'s viewer/API usage.
- No DB/schema changes — the CardBlock fields the toggles write to (`showAssistant`, `expandChatByDefault`) are untouched. Existing card data continues to drive viewer behaviour regardless of the editor flag.
- The `aiChatEditor` LaunchDarkly flag itself (creation + targeting rules) is configured in the LaunchDarkly dashboard.

## Prerequisite

The `aiChatEditor` flag must exist in LaunchDarkly (already created) for the editor accordion to appear. With the flag absent/off, the accordion is hidden — matching the previous behaviour when `apologistChat` was off.

## Testing

- `apps/journeys-admin` Card vitest suite: **40/40 pass**, including the four AI-chat-accordion gating tests now keyed on `aiChatEditor` (covers both flag-on and flag-off branches).
- ESLint clean on the changed files.

## Acceptance criteria

- [x] Editor accordion visibility depends solely on `aiChatEditor`.
- [x] Viewer/API stay on `apologistChat`; the two flags are independent.
- [x] `aiChatEditor` is targetable by user email (admin passes the authenticated LD user with email).
- [x] CardBlock `showAssistant` / `expandChatByDefault` unchanged.

Closes NES-1714

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test coverage for the AI chat editor functionality.

* **Chores**
  * Updated internal feature flag configuration for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->