### PR TITLE
fix(NES-1616): defer Langfuse flush via waitUntil so first-message traces

### DIFF
--- a/apps/journeys-admin/__generated__/NewMuxVideo.ts
+++ b/apps/journeys-admin/__generated__/NewMuxVideo.ts
@@ -1,0 +1,16 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: NewMuxVideo
+// ====================================================
+
+export interface NewMuxVideo {
+  __typename: "MuxVideo";
+  id: string;
+  playbackId: string | null;
+  readyToStream: boolean;
+  duration: number | null;
+}

--- a/apps/journeys/pages/api/chat/index.spec.ts
+++ b/apps/journeys/pages/api/chat/index.spec.ts
@@ -799,9 +799,8 @@ describe('/api/chat handler', () => {
       // The promise handed to waitUntil is the one returned by flushAsync,
       // so Vercel waits on the actual batch ship — not on a stale resolved
       // promise.
-      const flushPromise = fake.flushAsync.mock.results[0].value as Promise<
-        unknown
-      >
+      const flushPromise = fake.flushAsync.mock.results[0]
+        .value as Promise<unknown>
       expect(mockWaitUntil).toHaveBeenCalledWith(flushPromise)
     })
 
@@ -816,9 +815,8 @@ describe('/api/chat handler', () => {
 
       expect(fake.flushAsync).toHaveBeenCalledTimes(1)
       expect(mockWaitUntil).toHaveBeenCalledTimes(1)
-      const flushPromise = fake.flushAsync.mock.results[0].value as Promise<
-        unknown
-      >
+      const flushPromise = fake.flushAsync.mock.results[0]
+        .value as Promise<unknown>
       expect(mockWaitUntil).toHaveBeenCalledWith(flushPromise)
     })
 

--- a/apps/journeys/pages/api/chat/index.spec.ts
+++ b/apps/journeys/pages/api/chat/index.spec.ts
@@ -1,4 +1,5 @@
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
+import { waitUntil } from '@vercel/functions'
 import { convertToModelMessages, streamText } from 'ai'
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { type Mock, type MockedFunction } from 'vitest'
@@ -27,6 +28,13 @@ vi.mock('@ai-sdk/openai-compatible', () => ({
   createOpenAICompatible: vi.fn(() => ({
     chatModel: vi.fn(() => ({ id: 'compat' }))
   }))
+}))
+// NES-1616: the handler defers Langfuse's batch flush to `waitUntil` so the
+// flush survives Vercel's serverless freeze. Mocking it lets us assert that
+// the lifecycle pattern stays intact and lets the flushAsync promise resolve
+// inside the test runtime.
+vi.mock('@vercel/functions', () => ({
+  waitUntil: vi.fn()
 }))
 vi.mock('ai', () => ({
   convertToModelMessages: vi.fn((messages) => messages),
@@ -59,6 +67,7 @@ const mockCreateOpenAICompatible =
   createOpenAICompatible as unknown as MockedFunction<
     typeof createOpenAICompatible
   >
+const mockWaitUntil = waitUntil as unknown as MockedFunction<typeof waitUntil>
 
 interface CapturedRes {
   res: NextApiResponse
@@ -584,17 +593,25 @@ describe('/api/chat handler', () => {
       expect(mockStreamText).toHaveBeenCalledTimes(1)
       expect(mockPipeStream).toHaveBeenCalledTimes(1)
 
-      await expect(
+      // Callbacks are sync after NES-1616 (no flush await in their body), so
+      // invoke directly and assert they don't throw rather than using the
+      // `.resolves` promise-modifier pattern.
+      expect(() =>
         lastStreamConfig?.onFinish?.({
           text: 'reply',
           usage: { inputTokens: 1, outputTokens: 2 },
           finishReason: 'stop'
         })
-      ).resolves.not.toThrow()
+      ).not.toThrow()
 
-      await expect(
+      expect(() =>
         lastStreamConfig?.onError?.({ error: new Error('mid-stream') })
-      ).resolves.not.toThrow()
+      ).not.toThrow()
+
+      // Critical: with no langfuse, the handler must not schedule a
+      // background flush. Bare `waitUntil(undefined)` would be a contract
+      // violation, and a wasted Vercel lifetime extension.
+      expect(mockWaitUntil).not.toHaveBeenCalled()
     })
 
     it('ends the generation with output + usage on a successful onFinish', async () => {
@@ -755,6 +772,54 @@ describe('/api/chat handler', () => {
         expect.objectContaining({ event: 'apologist_chat_stream_error' }),
         '[chat] streamText onError'
       )
+    })
+
+    // NES-1616: regression guard. The flush MUST be scheduled via
+    // `waitUntil`, not awaited inline, or Vercel will freeze the function
+    // before the batch ships (the original NES-801 symptom). If a future
+    // refactor moves the flush back to a bare `await langfuse.flushAsync()`
+    // this assertion fails immediately.
+    it('schedules the langfuse flush via waitUntil from onFinish (NES-1616 regression)', async () => {
+      const fake = makeFakeLangfuse()
+      mockGetLangfuse.mockReturnValue(fake as never)
+
+      await handler(postReq(), makeRes().res)
+      // waitUntil must not fire until the lifecycle callback runs — the
+      // handler's main body never schedules a flush on its own.
+      expect(mockWaitUntil).not.toHaveBeenCalled()
+
+      await lastStreamConfig?.onFinish?.({
+        text: 'reply',
+        usage: { inputTokens: 1, outputTokens: 2 },
+        finishReason: 'stop'
+      })
+
+      expect(fake.flushAsync).toHaveBeenCalledTimes(1)
+      expect(mockWaitUntil).toHaveBeenCalledTimes(1)
+      // The promise handed to waitUntil is the one returned by flushAsync,
+      // so Vercel waits on the actual batch ship — not on a stale resolved
+      // promise.
+      const flushPromise = fake.flushAsync.mock.results[0].value as Promise<
+        unknown
+      >
+      expect(mockWaitUntil).toHaveBeenCalledWith(flushPromise)
+    })
+
+    it('schedules the langfuse flush via waitUntil from onError (NES-1616 regression)', async () => {
+      const fake = makeFakeLangfuse()
+      mockGetLangfuse.mockReturnValue(fake as never)
+
+      await handler(postReq(), makeRes().res)
+      expect(mockWaitUntil).not.toHaveBeenCalled()
+
+      await lastStreamConfig?.onError?.({ error: new Error('mid-stream') })
+
+      expect(fake.flushAsync).toHaveBeenCalledTimes(1)
+      expect(mockWaitUntil).toHaveBeenCalledTimes(1)
+      const flushPromise = fake.flushAsync.mock.results[0].value as Promise<
+        unknown
+      >
+      expect(mockWaitUntil).toHaveBeenCalledWith(flushPromise)
     })
 
     it('ends the generation exactly once when onError fires before onFinish', async () => {

--- a/apps/journeys/pages/api/chat/index.ts
+++ b/apps/journeys/pages/api/chat/index.ts
@@ -1,6 +1,7 @@
 import { google } from '@ai-sdk/google'
 import { openai } from '@ai-sdk/openai'
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
+import { waitUntil } from '@vercel/functions'
 import {
   type LanguageModel,
   UIMessage,
@@ -169,6 +170,26 @@ function resolveChatModel():
   }
 }
 
+/**
+ * Schedule a Langfuse batch flush that survives Vercel's serverless freeze
+ * (NES-1616, prior art NES-801 / PR #7920).
+ *
+ * On Vercel the function instance is frozen the moment the response stream
+ * closes. Calling `await langfuse.flushAsync()` from inside `streamText`'s
+ * `onError` / `onFinish` races that freeze — the in-memory batch is shipped on
+ * the *next* invocation, which is why "first message in a session never
+ * traces" until a second message arrives.
+ *
+ * `waitUntil()` registers the flush promise with the Vercel runtime so the
+ * function lifetime is extended until the flush resolves. Off-Vercel (local
+ * dev, tests) `@vercel/functions` falls back to a transparent no-op while the
+ * promise still runs, so the symbol is safe to call unconditionally.
+ */
+function scheduleLangfuseFlush(langfuse: Langfuse | null): void {
+  if (langfuse == null) return
+  waitUntil(langfuse.flushAsync())
+}
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
@@ -310,7 +331,7 @@ export default async function handler(
       system,
       messages: modelMessages,
       maxOutputTokens: MAX_OUTPUT_TOKENS,
-      onError: async ({ error }) => {
+      onError: ({ error }) => {
         const err = error as Error
         logger.error(
           {
@@ -328,9 +349,9 @@ export default async function handler(
           level: 'ERROR',
           statusMessage: err?.message ?? 'stream error'
         })
-        await langfuse?.flushAsync()
+        scheduleLangfuseFlush(langfuse)
       },
-      onFinish: async ({ text, usage, finishReason }) => {
+      onFinish: ({ text, usage, finishReason }) => {
         if (finishReason === 'error') {
           endGenerationIfPending({
             level: 'ERROR',
@@ -373,7 +394,7 @@ export default async function handler(
             '[chat] completed'
           )
         }
-        await langfuse?.flushAsync()
+        scheduleLangfuseFlush(langfuse)
       }
     })
 
@@ -412,12 +433,13 @@ export default async function handler(
     )
     // Sync throws happen before the LLM call, but the trace + generation
     // were already created above — close the lifecycle so Langfuse
-    // doesn't carry a dangling unfinished span.
+    // doesn't carry a dangling unfinished span. waitUntil keeps the flush
+    // alive past the response without blocking the 500 to the client.
     endGenerationIfPending({
       level: 'ERROR',
       statusMessage: err?.message ?? 'sync throw'
     })
-    await langfuse?.flushAsync()
+    scheduleLangfuseFlush(langfuse)
     if (!res.headersSent) {
       res.status(500).json({ error: 'upstream streamText failed' })
     } else {

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "@types/mailchimp__mailchimp_marketing": "^3.0.19",
     "@types/node-fetch": "^2.6.13",
     "@upstash/redis": "^1.35.3",
+    "@vercel/functions": "^3.0.0",
     "@xyflow/react": "^12.4.4",
     "adal-node": "^0.2.3",
     "ai": "^6.0.116",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,6 +316,9 @@ importers:
       '@upstash/redis':
         specifier: ^1.35.3
         version: 1.35.5
+      '@vercel/functions':
+        specifier: ^3.0.0
+        version: 3.6.2(@aws-sdk/credential-provider-web-identity@3.933.0)
       '@xyflow/react':
         specifier: ^12.4.4
         version: 12.10.2(@types/react@19.2.2)(immer@9.0.21)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -12176,6 +12179,13 @@ packages:
     peerDependencies:
       typescript: ^4.0.0 || ^5.0.0
 
+  '@vercel/cli-config@0.2.0':
+    resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
+
+  '@vercel/cli-exec@0.1.1':
+    resolution: {integrity: sha512-LMRMEai3Z+BODyxGcU9+KiWrS/UElNiOLKiNRfGNt2Vu3NTEmXgFeXG9wBfocAnTe5yJCX/DY6k3k7S/LkPp/g==}
+    engines: {node: '>= 18'}
+
   '@vercel/detect-agent@1.2.3':
     resolution: {integrity: sha512-VYNCgUc0nOmC4WJmWw9GkrKdfr8Zl4/rxhC5SvgacBgxiW9W/9NRttUoHHXV8xdII3MaRgkZZVX8Ikzc/Jmjag==}
     engines: {node: '>=14'}
@@ -12195,6 +12205,15 @@ packages:
   '@vercel/fun@1.3.0':
     resolution: {integrity: sha512-8erw9uPe0dFg45THkNxmjtvMX143SkZebmjgSVbcM3XCkXu3RIiBaJMcMNG8aaS+rnTuw8+d4De9HVT0M/r3wg==}
     engines: {node: '>= 18'}
+
+  '@vercel/functions@3.6.2':
+    resolution: {integrity: sha512-AeWUppTKlHoeJ4zttStwAJ1PsSqucSK7NPy27wrb5cSBBo4VbRo7j6rFCcJrGg4jcV9Cv5Qmk4Dc2dHe6/1g5A==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
+        optional: true
 
   '@vercel/gatsby-plugin-vercel-analytics@1.0.11':
     resolution: {integrity: sha512-iTEA0vY6RBPuEzkwUTVzSHDATo1aF6bdLLspI68mQ/BTbi5UQEGjpjyzdKOVcSYApDtFU6M6vypZ1t4vIEnHvw==}
@@ -12241,6 +12260,10 @@ packages:
 
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
+  '@vercel/oidc@3.6.0':
+    resolution: {integrity: sha512-a2HjItW75qSZfyyDbZ2XDFTQAfNKM93uloZABPgx6t8IrdbCgf+EQBeSypQVP2jHrZ3LHApDgLFCf1frRgPwLg==}
     engines: {node: '>= 20'}
 
   '@vercel/prepare-flags-definitions@0.2.1':
@@ -24399,6 +24422,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
+
   zod@4.3.5:
     resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
 
@@ -28753,7 +28779,7 @@ snapshots:
       '@babel/preset-env': 7.29.2(@babel/core@7.29.0)
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       '@babel/runtime-corejs3': 7.28.4
       '@babel/traverse': 7.28.5
       '@docusaurus/logger': 3.9.2
@@ -33655,7 +33681,7 @@ snapshots:
 
   '@mui/private-theming@7.1.1(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       '@mui/utils': 7.1.1(@types/react@19.2.2)(react@19.2.0)
       prop-types: 15.8.1
       react: 19.2.0
@@ -33664,7 +33690,7 @@ snapshots:
 
   '@mui/styled-engine@7.1.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
       '@emotion/sheet': 1.4.0
@@ -33693,7 +33719,7 @@ snapshots:
 
   '@mui/types@7.4.3(@types/react@19.2.2)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
     optionalDependencies:
       '@types/react': 19.2.2
 
@@ -33711,7 +33737,7 @@ snapshots:
 
   '@mui/x-charts-vendor@8.5.2':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       '@types/d3-color': 3.1.3
       '@types/d3-delaunay': 6.0.4
       '@types/d3-interpolate': 3.0.4
@@ -33792,7 +33818,7 @@ snapshots:
 
   '@mui/x-internals@8.5.2(@mui/system@7.1.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       '@mui/system': 7.1.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0)
       '@mui/utils': 7.1.1(@types/react@19.2.2)(react@19.2.0)
       react: 19.2.0
@@ -39318,6 +39344,15 @@ snapshots:
       - rollup
       - supports-color
 
+  '@vercel/cli-config@0.2.0':
+    dependencies:
+      xdg-app-paths: 5.1.0
+      zod: 4.1.11
+
+  '@vercel/cli-exec@0.1.1':
+    dependencies:
+      execa: 5.1.1
+
   '@vercel/detect-agent@1.2.3': {}
 
   '@vercel/elysia@0.1.70(encoding@0.1.13)(rollup@4.52.5)':
@@ -39381,6 +39416,12 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@vercel/functions@3.6.2(@aws-sdk/credential-provider-web-identity@3.933.0)':
+    dependencies:
+      '@vercel/oidc': 3.6.0
+    optionalDependencies:
+      '@aws-sdk/credential-provider-web-identity': 3.933.0
 
   '@vercel/gatsby-plugin-vercel-analytics@1.0.11':
     dependencies:
@@ -39503,6 +39544,11 @@ snapshots:
   '@vercel/oidc@3.1.0': {}
 
   '@vercel/oidc@3.2.0': {}
+
+  '@vercel/oidc@3.6.0':
+    dependencies:
+      '@vercel/cli-config': 0.2.0
+      '@vercel/cli-exec': 0.1.1
 
   '@vercel/prepare-flags-definitions@0.2.1': {}
 
@@ -50737,7 +50783,7 @@ snapshots:
 
   react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@19.2.0))(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.21))(esbuild@0.19.12)):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.0)'
       webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.21))(esbuild@0.19.12)
 
@@ -50793,13 +50839,13 @@ snapshots:
 
   react-router-config@5.1.1(react-router@5.3.4(react@19.2.0))(react@19.2.0):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       react: 19.2.0
       react-router: 5.3.4(react@19.2.0)
 
   react-router-dom@5.3.4(react@19.2.0):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -50818,7 +50864,7 @@ snapshots:
 
   react-router@5.3.4(react@19.2.0):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
@@ -54399,6 +54445,8 @@ snapshots:
   zod@3.24.4: {}
 
   zod@3.25.76: {}
+
+  zod@4.1.11: {}
 
   zod@4.3.5: {}
 


### PR DESCRIPTION
## What

Defer the Langfuse batch flush via `waitUntil()` from `@vercel/functions` so the flush survives Vercel's serverless freeze in `apps/journeys/pages/api/chat/index.ts`.

Closes [NES-1616](https://linear.app/jesus-film-project/issue/NES-1616).

## Why

Awaiting `langfuse.flushAsync()` from inside `streamText`'s `onError` / `onFinish` races Vercel's serverless freeze: the function instance is frozen the moment the response stream closes, so the in-memory Langfuse batch ships on the **next** invocation. The user-visible symptom is _"first message in a session never traces"_ until a second message arrives.

This is the single most strategically valuable data point for the Apologist Chat project — single-turn / mobile drive-by conversations are exactly the ones that tell us what's on people's minds when they arrive. Silently dropping them destroys the regional-fingerprint signal that M3 depends on and blinds us to single-shot abuse patterns.

## How

- `scheduleLangfuseFlush(langfuse)` now centralises a `waitUntil(langfuse.flushAsync())` call. `waitUntil()` registers the flush promise with the Vercel runtime, which extends function lifetime until the batch actually ships.
- Replaces all three previous `await langfuse?.flushAsync()` sites: stream `onError`, stream `onFinish`, and the sync `catch`. The sync-catch path also benefits — the 500 response is now sent immediately while the flush ships in the background.
- Off-Vercel (local dev, Vitest, CI) `@vercel/functions` falls back to a transparent no-op while the promise still runs, so the symbol is safe to call unconditionally.

## Tests

- All 45 tests in `apps/journeys/pages/api/chat/index.spec.ts` pass.
- Two new focused regression tests assert the flush is scheduled **via `waitUntil`** with the actual `flushAsync()` promise, not awaited inline — guarding against future refactors quietly reintroducing the race.
- The "langfuse-is-null" test now also asserts `waitUntil` is never called when tracing is disabled (bare `waitUntil(undefined)` would be a contract violation and a wasted Vercel lifetime extension).

## Prior art

- [NES-801](https://linear.app/jesus-film-project/issue/NES-801) — same root cause, original Apologist Chat fix.
- [#7920 — "feat: upgrade to vercel-otel 2.0"](https://github.com/JesusFilm/core/pull/7920) — original fix in the OTel era, used Next.js's `after()` to schedule the flush post-response.
- [NES-1572](https://linear.app/jesus-film-project/issue/NES-1572) / [#9094](https://github.com/JesusFilm/core/pull/9094) — moved off OTel onto the direct Langfuse Node SDK; that's why this PR uses `waitUntil` instead of `langfuseSpanProcessor.forceFlush()`.

## Verification plan (staging)

1. Deploy the preview, set `LANGFUSE_*` env vars to the staging Langfuse project.
2. Send a single message in the apologist chat from a fresh session.
3. Wait ~5s, refresh Langfuse — the trace must appear **without** sending a second message.
4. Repeat on the stream-error path (induce a model failure / cancel mid-stream) and confirm the ERROR-level generation still ships.

## Risk

Low. The flush is the only behaviour that moves; the trace/generation lifecycle, response shape, error codes, and observability events are unchanged. `waitUntil` is a no-op outside Vercel, so non-Vercel deployments (local, CI) behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
