### PR TITLE
fix(prisma-journeys): guard orphaned TemplateGalleryPage creator-image migration

### DIFF
--- a/libs/prisma/journeys/db/migrations/20260504212913_replace_creator_image_block_with_scalars/migration.sql
+++ b/libs/prisma/journeys/db/migrations/20260504212913_replace_creator_image_block_with_scalars/migration.sql
@@ -1,7 +1,7 @@
 -- DropForeignKey
-ALTER TABLE "TemplateGalleryPage" DROP CONSTRAINT "TemplateGalleryPage_creatorImageBlockId_fkey";
+ALTER TABLE "TemplateGalleryPage" DROP CONSTRAINT IF EXISTS "TemplateGalleryPage_creatorImageBlockId_fkey";
 
 -- AlterTable
-ALTER TABLE "TemplateGalleryPage" DROP COLUMN "creatorImageBlockId",
-ADD COLUMN     "creatorImageAlt" TEXT,
-ADD COLUMN     "creatorImageSrc" TEXT;
+ALTER TABLE "TemplateGalleryPage" DROP COLUMN IF EXISTS "creatorImageBlockId";
+ALTER TABLE "TemplateGalleryPage" ADD COLUMN IF NOT EXISTS "creatorImageAlt" TEXT;
+ALTER TABLE "TemplateGalleryPage" ADD COLUMN IF NOT EXISTS "creatorImageSrc" TEXT;


### PR DESCRIPTION
## Problem

`prisma migrate reset` (and the shadow-DB check in `migrate dev`) fails for the **journeys** domain on a clean database, halting local DB setup for everyone:

```
Error: P3018
Migration name: 20260504212913_replace_creator_image_block_with_scalars
Database error code: 42704
ERROR: constraint "TemplateGalleryPage_creatorImageBlockId_fkey" of relation "TemplateGalleryPage" does not exist
```

## Root cause

Two `TemplateGalleryPage` migrations contradict each other:

- `20260429142347_add_template_gallery_page` **creates** the table already using scalar columns `creatorImageSrc` / `creatorImageAlt` — with **no** `creatorImageBlockId` column and **no** `..._creatorImageBlockId_fkey` constraint.
- `20260504212913_replace_creator_image_block_with_scalars` then tries to `DROP` that column and constraint.

The create migration was rewritten/squashed to its final scalar shape, but the now-orphaned "replace" migration was left behind. On a fresh DB the `DROP` targets things that never existed, throws, and a thrown migration **halts the entire replay chain** — so nothing after it runs and `reset` fails.

A forward-fix migration can't solve this: the broken one halts replay before any later migration is reached. The only options for a chain-halting migration are to edit it or delete it.

## Fix

Make the orphaned migration idempotent with `IF EXISTS` / `IF NOT EXISTS`:

- On a **fresh** DB it no-ops cleanly (column/constraint already absent, scalars already present).
- On any environment that still has the old block-based column, it still performs the real migration.

Final schema is unchanged (it already matches `schema.prisma`). Verified the migration now applies on a clean reset.

## Notes

- Affects every developer who resets after `adc88f6b2` — not a local-only issue.
- A separate empty migration dir under `libs/prisma/media/db/migrations/` was a local untracked artifact from a failed `migrate dev` run (causing the `media` P3015); removed locally, nothing to commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Database schema update applied to template gallery pages. Restructured how creator image data is managed and stored to provide a more scalable foundation. Changes include refinements to the underlying data structure while maintaining system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->