### PR TITLE
fix(NES-167): re-select English when the template language filter closes empty

### DIFF
--- a/libs/journeys/ui/src/components/TemplateGallery/HeaderAndLanguageFilter/LanguagesFilterPopper/LanguagesFilterPopper.spec.tsx
+++ b/libs/journeys/ui/src/components/TemplateGallery/HeaderAndLanguageFilter/LanguagesFilterPopper/LanguagesFilterPopper.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import noop from 'lodash/noop'
 
 import { LanguagesFilterPopper } from './LanguagesFilterPopper'
@@ -30,5 +30,63 @@ describe('LanguagesFilterPopper', () => {
     await waitFor(() => expect(onSubmit).toHaveBeenCalled())
     fireEvent.click(getByRole('button', { name: 'English' }))
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(2))
+  })
+
+  it('should re-select English when closed with no language selected', async () => {
+    const onSubmit = vi.fn()
+    const setOpen = vi.fn()
+    const sortedLanguages = [
+      { id: '529', localName: undefined, nativeName: 'English' },
+      { id: '496', localName: 'French', nativeName: 'Français' },
+      { id: '1106', localName: 'German, Standard', nativeName: 'Deutsch' }
+    ]
+    render(
+      <LanguagesFilterPopper
+        initialValues={[
+          { id: '529', localName: undefined, nativeName: 'English' }
+        ]}
+        open
+        setOpen={setOpen}
+        onSubmit={onSubmit}
+        anchorEl={null}
+        sortedLanguages={sortedLanguages}
+      />
+    )
+    // deselect English so nothing remains selected
+    fireEvent.click(screen.getByRole('button', { name: 'English' }))
+    // close the dropdown by clicking the backdrop
+    fireEvent.click(screen.getByTestId('PresentationLayer'))
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenLastCalledWith({
+        languages: [{ id: '529', localName: undefined, nativeName: 'English' }]
+      })
+    )
+    expect(setOpen).toHaveBeenCalledWith(false)
+  })
+
+  it('should keep the selection when closed with a language selected', async () => {
+    const onSubmit = vi.fn()
+    const setOpen = vi.fn()
+    const sortedLanguages = [
+      { id: '529', localName: undefined, nativeName: 'English' },
+      { id: '496', localName: 'French', nativeName: 'Français' },
+      { id: '1106', localName: 'German, Standard', nativeName: 'Deutsch' }
+    ]
+    render(
+      <LanguagesFilterPopper
+        initialValues={[
+          { id: '496', localName: 'French', nativeName: 'Français' }
+        ]}
+        open
+        setOpen={setOpen}
+        onSubmit={onSubmit}
+        anchorEl={null}
+        sortedLanguages={sortedLanguages}
+      />
+    )
+    // close the dropdown without changing the selection
+    fireEvent.click(screen.getByTestId('PresentationLayer'))
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(setOpen).toHaveBeenCalledWith(false)
   })
 })

--- a/libs/journeys/ui/src/components/TemplateGallery/HeaderAndLanguageFilter/LanguagesFilterPopper/LanguagesFilterPopper.tsx
+++ b/libs/journeys/ui/src/components/TemplateGallery/HeaderAndLanguageFilter/LanguagesFilterPopper/LanguagesFilterPopper.tsx
@@ -29,6 +29,9 @@ interface LanguageOptions {
   languages: LanguageOption[]
 }
 
+// English is the default language used when no other language is selected.
+const ENGLISH_LANGUAGE_ID = '529'
+
 const StyledPopperOption = styled(ButtonBase)(() => ({
   backgroundColor: 'transparent',
   display: 'flex',
@@ -60,7 +63,16 @@ export function LanguagesFilterPopper({
           <Box
             data-testid="PresentationLayer"
             onClick={() => {
-              setOpen(!open)
+              // When the dropdown is closed with nothing selected, fall back
+              // to English so it is ticked the next time the dropdown opens.
+              if (values.languages.length === 0) {
+                const englishOption = sortedLanguages.find(
+                  ({ id }) => id === ENGLISH_LANGUAGE_ID
+                )
+                if (englishOption != null)
+                  onSubmit({ languages: [englishOption] })
+              }
+              setOpen(false)
             }}
             sx={{
               position: 'absolute',


### PR DESCRIPTION
## NES-167 — Templates language filter: English not re-ticked when last language deselected

[Linear NES-167](https://linear.app/jesus-film-project/issue/NES-167)

> ⚠️ **Heads-up before review/merge:** NES-167 is currently marked **Done** in Linear. It was closed on 2026-01-18 by QA with the note _"The issue is no longer present; I retested and it may have been resolved by a recent push."_ — i.e. closed as not-reproducible, **not** via a deliberate fix. There is no on-close guard in the code for this case, so the deterministic behaviour the reporter asked for was never actually implemented. This PR implements it. Please confirm you still want this before merging.

### The bug
English (`529`) is the default language used when no other language is selected. When the user unticked the **last** remaining language and closed the language dropdown, English did not reliably re-appear as ticked.

### Root cause
`TemplateGallery` only defaults to `['529']` when `router.query.languageIds` is **`undefined`** — not when it is an explicit empty array. `LanguagesFilterPopper`'s backdrop close handler simply toggled `setOpen` with no guard, so closing with an empty selection left nothing ticked. In production the empty array often dropped out of the URL and English snapped back reactively (likely the "recent push" QA observed), but that path is timing-dependent and not guaranteed.

### The fix
When the dropdown is closed (backdrop click) with no language selected, re-select English before closing — exactly the behaviour requested in the ticket ("English automatically re-selected and ticked if no other languages are selected"). This restores English on close only, so a user can still untick English and pick a different single language without English fighting them.

Note: `LanguageFilterDialog` in the same folder is dead code (no usages); the single responsive `LanguagesFilterPopper` serves both mobile and desktop, so this one change covers "both mobile and PC."

### Files changed
- `LanguagesFilterPopper.tsx` — re-select English (`529`) on backdrop close when the selection is empty.
- `LanguagesFilterPopper.spec.tsx` — two new tests (re-selects English when closed empty; leaves a non-empty selection untouched).

### Testing
- `npx vitest run --config libs/journeys/ui/vitest.config.mts --coverage=false 'libs/journeys/ui/src/components/TemplateGallery'` — **all pass** (10 files / 45 tests + new cases).
- `prettier --check` ✓, `eslint` ✓ (no errors on changed files).

### How to verify manually
1. Go to the Templates gallery (`/templates`). English shows ticked by default.
2. Open the language dropdown, untick English (now nothing selected).
3. Click outside the dropdown to close it.
4. Reopen the dropdown — English is ticked again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
