### PR TITLE
feat(NES-1679): enforce per-card showAssistant on /api/chat (hard kill switch)

### DIFF
--- a/apps/journeys/pages/api/chat/index.spec.ts
+++ b/apps/journeys/pages/api/chat/index.spec.ts
@@ -280,7 +280,11 @@ describe('/api/chat handler', () => {
     function postReq(): NextApiRequest {
       return {
         method: 'POST',
-        body: { messages: [{ role: 'user', content: 'hi' }], cardId: 'card-1' },
+        body: {
+          messages: [{ role: 'user', content: 'hi' }],
+          journeyId: 'journey-1',
+          cardId: 'card-1'
+        },
         headers: {}
       } as unknown as NextApiRequest
     }
@@ -412,6 +416,7 @@ describe('/api/chat handler', () => {
         method: 'POST',
         body: {
           messages: [{ role: 'user', content: 'hi' }],
+          journeyId: 'journey-1',
           cardId: 'card-1',
           ...(language != null && { language })
         },
@@ -530,12 +535,12 @@ describe('/api/chat handler', () => {
         method: 'POST',
         body: {
           messages: [{ role: 'user', content: 'hi' }],
+          journeyId: overrides.journeyId ?? 'journey-1',
           cardId: 'card-1',
           ...(overrides.language != null && { language: overrides.language }),
           ...(overrides.sessionId != null && {
             sessionId: overrides.sessionId
-          }),
-          ...(overrides.journeyId != null && { journeyId: overrides.journeyId })
+          })
         },
         headers
       } as unknown as NextApiRequest
@@ -854,17 +859,21 @@ describe('/api/chat handler', () => {
     })
 
     function postReq(body: unknown): NextApiRequest {
-      // cardId is now required (NES-1679). Inject it into object bodies so each
-      // bounds test fails for its intended reason rather than for a missing
-      // cardId. Non-object bodies (e.g. the "not-an-object" case) and bodies
-      // that already set cardId pass through unchanged.
-      const withCardId =
+      // journeyId + cardId are now required (NES-1679). Inject them into object
+      // bodies so each bounds test fails for its intended reason rather than for
+      // a missing id. Non-object bodies (e.g. the "not-an-object" case) and
+      // bodies that already set these ids pass through unchanged.
+      const withRequiredIds =
         body != null && typeof body === 'object' && !Array.isArray(body)
-          ? { cardId: 'card-1', ...(body as Record<string, unknown>) }
+          ? {
+              journeyId: 'journey-1',
+              cardId: 'card-1',
+              ...(body as Record<string, unknown>)
+            }
           : body
       return {
         method: 'POST',
-        body: withCardId,
+        body: withRequiredIds,
         headers: {}
       } as unknown as NextApiRequest
     }
@@ -1125,6 +1134,29 @@ describe('/api/chat handler', () => {
         code: 'invalid_request'
       })
       // The card lookup never runs — the schema rejects the request first.
+      expect(mockGetCardChatEnabled).not.toHaveBeenCalled()
+      expect(mockStreamText).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 (not 403) when journeyId is missing from the body', async () => {
+      const { res, status, json } = makeRes()
+
+      await handler(
+        postReq({
+          messages: [{ role: 'user', content: 'hi' }],
+          cardId: 'card-1'
+        }),
+        res
+      )
+
+      // A missing journeyId is a malformed request, not a killed card: it must
+      // 400 invalid_request, not route through the kill switch to a 403
+      // chat_disabled (which would wrongly show the "chat turned off" copy).
+      expect(status).toHaveBeenCalledWith(400)
+      expect(json).toHaveBeenCalledWith({
+        error: 'invalid request',
+        code: 'invalid_request'
+      })
       expect(mockGetCardChatEnabled).not.toHaveBeenCalled()
       expect(mockStreamText).not.toHaveBeenCalled()
     })

--- a/apps/journeys/pages/api/chat/index.spec.ts
+++ b/apps/journeys/pages/api/chat/index.spec.ts
@@ -666,6 +666,7 @@ describe('/api/chat handler', () => {
       expect(fields).toMatchObject({
         event: 'apologist_chat_completed',
         journeyId: 'journey-1',
+        cardId: 'card-1',
         language: 'es',
         ipCountry: 'NZ',
         sessionId: 'sess-1',

--- a/apps/journeys/pages/api/chat/index.spec.ts
+++ b/apps/journeys/pages/api/chat/index.spec.ts
@@ -3,6 +3,7 @@ import { convertToModelMessages, streamText } from 'ai'
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { type Mock, type MockedFunction } from 'vitest'
 
+import { getCardChatEnabled } from '../../../src/libs/getCardChatEnabled'
 import { getFlags } from '../../../src/libs/getFlags'
 import {
   getActivePromptLabel,
@@ -38,6 +39,9 @@ vi.mock('langfuse', () => ({
 vi.mock('../../../src/libs/getFlags', () => ({
   getFlags: vi.fn()
 }))
+vi.mock('../../../src/libs/getCardChatEnabled', () => ({
+  getCardChatEnabled: vi.fn()
+}))
 vi.mock('../../../src/libs/langfuse/client', () => ({
   APOLOGIST_PROMPT_NAME: 'apologist-world-cup-chat',
   getActivePromptLabel: vi.fn(() => 'development'),
@@ -48,6 +52,9 @@ vi.mock('../../../src/libs/logger', () => ({
 }))
 
 const mockGetFlags = getFlags as unknown as MockedFunction<typeof getFlags>
+const mockGetCardChatEnabled = getCardChatEnabled as unknown as MockedFunction<
+  typeof getCardChatEnabled
+>
 const mockGetLangfuse = getLangfuse as unknown as MockedFunction<
   typeof getLangfuse
 >
@@ -167,6 +174,9 @@ describe('/api/chat handler', () => {
     process.env.APOLOGIST_API_KEY = 'apologist-test-key'
     mockGetActivePromptLabel.mockReturnValue('development')
     mockGetLangfuse.mockReturnValue(null)
+    // Default the per-card kill switch to "enabled" so the existing happy-path
+    // tests reach streamText. Tests that exercise the 403 override this.
+    mockGetCardChatEnabled.mockResolvedValue(true)
     lastStreamConfig = null
     installStreamTextSuccess()
   })
@@ -270,7 +280,7 @@ describe('/api/chat handler', () => {
     function postReq(): NextApiRequest {
       return {
         method: 'POST',
-        body: { messages: [{ role: 'user', content: 'hi' }] },
+        body: { messages: [{ role: 'user', content: 'hi' }], cardId: 'card-1' },
         headers: {}
       } as unknown as NextApiRequest
     }
@@ -402,6 +412,7 @@ describe('/api/chat handler', () => {
         method: 'POST',
         body: {
           messages: [{ role: 'user', content: 'hi' }],
+          cardId: 'card-1',
           ...(language != null && { language })
         },
         headers: {}
@@ -519,6 +530,7 @@ describe('/api/chat handler', () => {
         method: 'POST',
         body: {
           messages: [{ role: 'user', content: 'hi' }],
+          cardId: 'card-1',
           ...(overrides.language != null && { language: overrides.language }),
           ...(overrides.sessionId != null && {
             sessionId: overrides.sessionId
@@ -629,7 +641,8 @@ describe('/api/chat handler', () => {
             messages: [{ role: 'user', content: 'hi' }],
             language: 'es',
             sessionId: 'sess-1',
-            journeyId: 'journey-1'
+            journeyId: 'journey-1',
+            cardId: 'card-1'
           },
           headers: { 'x-vercel-ip-country': 'NZ' }
         } as unknown as NextApiRequest,
@@ -841,9 +854,17 @@ describe('/api/chat handler', () => {
     })
 
     function postReq(body: unknown): NextApiRequest {
+      // cardId is now required (NES-1679). Inject it into object bodies so each
+      // bounds test fails for its intended reason rather than for a missing
+      // cardId. Non-object bodies (e.g. the "not-an-object" case) and bodies
+      // that already set cardId pass through unchanged.
+      const withCardId =
+        body != null && typeof body === 'object' && !Array.isArray(body)
+          ? { cardId: 'card-1', ...(body as Record<string, unknown>) }
+          : body
       return {
         method: 'POST',
-        body,
+        body: withCardId,
         headers: {}
       } as unknown as NextApiRequest
     }
@@ -993,7 +1014,8 @@ describe('/api/chat handler', () => {
             messages,
             language: 'es',
             sessionId: 'sess-1',
-            journeyId: 'journey-1'
+            journeyId: 'journey-1',
+            cardId: 'card-1'
           },
           headers: {}
         } as unknown as NextApiRequest,
@@ -1073,6 +1095,101 @@ describe('/api/chat handler', () => {
       expect(status).not.toHaveBeenCalledWith(400)
       expect(json).not.toHaveBeenCalledWith({ error: 'invalid request' })
       expect(mockStreamText).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('per-card kill switch (NES-1679)', () => {
+    beforeEach(() => {
+      mockGetFlags.mockResolvedValue({ apologistChat: true })
+    })
+
+    function postReq(body: Record<string, unknown>): NextApiRequest {
+      return {
+        method: 'POST',
+        body,
+        headers: {}
+      } as unknown as NextApiRequest
+    }
+
+    it('returns 400 when cardId is missing from the body', async () => {
+      const { res, status, json } = makeRes()
+
+      await handler(
+        postReq({ messages: [{ role: 'user', content: 'hi' }] }),
+        res
+      )
+
+      expect(status).toHaveBeenCalledWith(400)
+      expect(json).toHaveBeenCalledWith({
+        error: 'invalid request',
+        code: 'invalid_request'
+      })
+      // The card lookup never runs — the schema rejects the request first.
+      expect(mockGetCardChatEnabled).not.toHaveBeenCalled()
+      expect(mockStreamText).not.toHaveBeenCalled()
+    })
+
+    it('passes journeyId + cardId to the lookup and streams when chat is enabled', async () => {
+      mockGetCardChatEnabled.mockResolvedValue(true)
+      mockGetLangfuse.mockReturnValue(null)
+
+      await handler(
+        postReq({
+          messages: [{ role: 'user', content: 'hi' }],
+          journeyId: 'journey-1',
+          cardId: 'card-1'
+        }),
+        makeRes().res
+      )
+
+      expect(mockGetCardChatEnabled).toHaveBeenCalledWith({
+        journeyId: 'journey-1',
+        cardId: 'card-1'
+      })
+      expect(mockStreamText).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns 403 with a chat_disabled code when the card has chat disabled', async () => {
+      mockGetCardChatEnabled.mockResolvedValue(false)
+      const { res, status, json } = makeRes()
+
+      await handler(
+        postReq({
+          messages: [{ role: 'user', content: 'hi' }],
+          journeyId: 'journey-1',
+          cardId: 'card-1'
+        }),
+        res
+      )
+
+      expect(status).toHaveBeenCalledWith(403)
+      expect(json).toHaveBeenCalledWith({
+        error: 'chat disabled for this card',
+        code: 'chat_disabled'
+      })
+      // Fails closed before any model work.
+      expect(mockStreamText).not.toHaveBeenCalled()
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'chat_card_disabled' }),
+        '[chat] blocked: chat disabled for card'
+      )
+    })
+
+    it('does not run the card lookup when the apologistChat flag is off', async () => {
+      mockGetFlags.mockResolvedValue({ apologistChat: false })
+      const { res, status } = makeRes()
+
+      await handler(
+        postReq({
+          messages: [{ role: 'user', content: 'hi' }],
+          journeyId: 'journey-1',
+          cardId: 'card-1'
+        }),
+        res
+      )
+
+      expect(status).toHaveBeenCalledWith(404)
+      expect(mockGetCardChatEnabled).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/journeys/pages/api/chat/index.ts
+++ b/apps/journeys/pages/api/chat/index.ts
@@ -11,6 +11,7 @@ import { Langfuse, TextPromptClient } from 'langfuse'
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { z } from 'zod'
 
+import { getCardChatEnabled } from '../../../src/libs/getCardChatEnabled'
 import { getFlags } from '../../../src/libs/getFlags'
 import {
   APOLOGIST_PROMPT_NAME,
@@ -74,7 +75,10 @@ const chatRequestSchema = z.object({
   messages: z.array(messageSchema).min(1).max(MAX_MESSAGES),
   language: z.string().max(64).optional(),
   sessionId: z.string().max(128).optional(),
-  journeyId: z.string().max(128).optional()
+  journeyId: z.string().max(128).optional(),
+  // Required (NES-1679): the server reads the card's `showAssistant` to enforce
+  // the per-card chat kill switch, so every request must say which card it is.
+  cardId: z.string().min(1).max(128)
 })
 
 type ParsedChatMessage = z.infer<typeof messageSchema>
@@ -194,7 +198,7 @@ export default async function handler(
     res.status(400).json({ error: 'invalid request', code: 'invalid_request' })
     return
   }
-  const { messages, language, sessionId, journeyId } = parsed.data
+  const { messages, language, sessionId, journeyId, cardId } = parsed.data
 
   const promptChars = totalMessageChars(messages)
   if (promptChars > MAX_TOTAL_CHARS) {
@@ -222,6 +226,24 @@ export default async function handler(
     res
       .status(400)
       .json({ error: 'request too large', code: 'conversation_capped' })
+    return
+  }
+
+  // Per-card kill switch (NES-1679): the card's `showAssistant` is enforced
+  // server-side so flipping it off in the editor stops chat for tabs that are
+  // already open, on their very next message. Runs after the cheap local
+  // schema/size checks so an obviously-bad request never reaches the gateway.
+  const chatEnabled = await getCardChatEnabled({ journeyId, cardId })
+  if (!chatEnabled) {
+    logger.warn(
+      { event: 'chat_card_disabled', journeyId, cardId, sessionId },
+      '[chat] blocked: chat disabled for card'
+    )
+    // `code` keeps the client's error-code contract: a disabled card is
+    // deterministic, so the client hides Retry (re-firing would 403 again).
+    res
+      .status(403)
+      .json({ error: 'chat disabled for this card', code: 'chat_disabled' })
     return
   }
 

--- a/apps/journeys/pages/api/chat/index.ts
+++ b/apps/journeys/pages/api/chat/index.ts
@@ -270,6 +270,12 @@ export default async function handler(
   // or the raw IP.
   const chatLogContext = {
     journeyId,
+    // `cardId` is recorded on every chat event (NES-1679) so the kill switch's
+    // allow path is queryable: on a "killed card still chatting" report the
+    // success/error events show which card the server actually consulted, which
+    // is the signal needed to tell a request-identity mismatch apart from a
+    // stale read — without a per-message log on the lookup itself.
+    cardId,
     language,
     ipCountry,
     sessionId,

--- a/apps/journeys/pages/api/chat/index.ts
+++ b/apps/journeys/pages/api/chat/index.ts
@@ -75,7 +75,12 @@ const chatRequestSchema = z.object({
   messages: z.array(messageSchema).min(1).max(MAX_MESSAGES),
   language: z.string().max(64).optional(),
   sessionId: z.string().max(128).optional(),
-  journeyId: z.string().max(128).optional(),
+  // Required (NES-1679): a missing journeyId is a malformed request, not a
+  // killed card. Requiring it returns 400 invalid_request instead of routing
+  // through the kill switch to a 403 chat_disabled (which would show users the
+  // "chat turned off" copy and pollute the chat_card_disabled signal). Matches
+  // the required cardId below.
+  journeyId: z.string().min(1).max(128),
   // Required (NES-1679): the server reads the card's `showAssistant` to enforce
   // the per-card chat kill switch, so every request must say which card it is.
   cardId: z.string().min(1).max(128)

--- a/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.spec.ts
+++ b/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.spec.ts
@@ -1,6 +1,9 @@
 import { IdType } from '../../../__generated__/globalTypes'
 
-import { CARD_LOOKUP_TIMEOUT_MS, getCardChatEnabled } from './getCardChatEnabled'
+import {
+  CARD_LOOKUP_TIMEOUT_MS,
+  getCardChatEnabled
+} from './getCardChatEnabled'
 
 const { mockQuery, mockLoggerWarn } = vi.hoisted(() => ({
   mockQuery: vi.fn(),

--- a/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.spec.ts
+++ b/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.spec.ts
@@ -1,6 +1,6 @@
 import { IdType } from '../../../__generated__/globalTypes'
 
-import { getCardChatEnabled } from './getCardChatEnabled'
+import { CARD_LOOKUP_TIMEOUT_MS, getCardChatEnabled } from './getCardChatEnabled'
 
 const { mockQuery, mockLoggerWarn } = vi.hoisted(() => ({
   mockQuery: vi.fn(),
@@ -97,6 +97,15 @@ describe('getCardChatEnabled', () => {
     expect(mockQuery).not.toHaveBeenCalled()
   })
 
+  it('returns false when the journey response is null (non-throwing not-found)', async () => {
+    mockQuery.mockResolvedValue({ data: { journey: null } })
+
+    await expect(
+      getCardChatEnabled({ journeyId: 'journey-1', cardId: 'card-1' })
+    ).resolves.toBe(false)
+    expect(mockLoggerWarn).not.toHaveBeenCalled()
+  })
+
   it('returns false when the journey is not found (definitive negative)', async () => {
     mockQuery.mockRejectedValue(new Error('journey not found'))
 
@@ -116,5 +125,33 @@ describe('getCardChatEnabled', () => {
       expect.objectContaining({ event: 'chat_card_lookup_error' }),
       expect.any(String)
     )
+  })
+
+  it('aborts and fails open (returns true) when the lookup hangs past the timeout', async () => {
+    vi.useFakeTimers()
+    // Simulate a hanging gateway: the query only settles when the abort signal
+    // passed through Apollo's fetchOptions fires.
+    mockQuery.mockImplementation(({ context }) => {
+      const signal = context?.fetchOptions?.signal as AbortSignal
+      return new Promise((_resolve, reject) => {
+        signal.addEventListener('abort', () => {
+          reject(new Error('The operation was aborted'))
+        })
+      })
+    })
+
+    const result = getCardChatEnabled({
+      journeyId: 'journey-1',
+      cardId: 'card-1'
+    })
+    await vi.advanceTimersByTimeAsync(CARD_LOOKUP_TIMEOUT_MS)
+
+    await expect(result).resolves.toBe(true)
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'chat_card_lookup_error' }),
+      expect.any(String)
+    )
+
+    vi.useRealTimers()
   })
 })

--- a/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.spec.ts
+++ b/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.spec.ts
@@ -1,0 +1,120 @@
+import { IdType } from '../../../__generated__/globalTypes'
+
+import { getCardChatEnabled } from './getCardChatEnabled'
+
+const { mockQuery, mockLoggerWarn } = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+  mockLoggerWarn: vi.fn()
+}))
+
+vi.mock('../apolloClient', () => ({
+  createApolloClient: () => ({ query: mockQuery })
+}))
+
+vi.mock('../logger', () => ({
+  logger: { warn: mockLoggerWarn, error: vi.fn(), info: vi.fn() }
+}))
+
+function journeyWithBlocks(blocks: unknown[]): unknown {
+  return { data: { journey: { id: 'journey-1', blocks } } }
+}
+
+const enabledCard = {
+  __typename: 'CardBlock',
+  id: 'card-1',
+  showAssistant: true
+}
+
+describe('getCardChatEnabled', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns true when the card exists and showAssistant is true', async () => {
+    mockQuery.mockResolvedValue(journeyWithBlocks([enabledCard]))
+
+    await expect(
+      getCardChatEnabled({ journeyId: 'journey-1', cardId: 'card-1' })
+    ).resolves.toBe(true)
+  })
+
+  it('queries the journey by databaseId with no-cache so the toggle is read fresh', async () => {
+    mockQuery.mockResolvedValue(journeyWithBlocks([enabledCard]))
+
+    await getCardChatEnabled({ journeyId: 'journey-1', cardId: 'card-1' })
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: expect.objectContaining({
+          id: 'journey-1',
+          idType: IdType.databaseId
+        }),
+        fetchPolicy: 'no-cache'
+      })
+    )
+  })
+
+  it('returns false when the card exists but showAssistant is false', async () => {
+    mockQuery.mockResolvedValue(
+      journeyWithBlocks([
+        { __typename: 'CardBlock', id: 'card-1', showAssistant: false }
+      ])
+    )
+
+    await expect(
+      getCardChatEnabled({ journeyId: 'journey-1', cardId: 'card-1' })
+    ).resolves.toBe(false)
+  })
+
+  it('returns false when showAssistant is null', async () => {
+    mockQuery.mockResolvedValue(
+      journeyWithBlocks([
+        { __typename: 'CardBlock', id: 'card-1', showAssistant: null }
+      ])
+    )
+
+    await expect(
+      getCardChatEnabled({ journeyId: 'journey-1', cardId: 'card-1' })
+    ).resolves.toBe(false)
+  })
+
+  it('returns false when the card is not part of the journey', async () => {
+    mockQuery.mockResolvedValue(
+      journeyWithBlocks([
+        { __typename: 'CardBlock', id: 'a-different-card', showAssistant: true }
+      ])
+    )
+
+    await expect(
+      getCardChatEnabled({ journeyId: 'journey-1', cardId: 'card-1' })
+    ).resolves.toBe(false)
+  })
+
+  it('returns false (and does not query) when journeyId is missing', async () => {
+    await expect(
+      getCardChatEnabled({ journeyId: undefined, cardId: 'card-1' })
+    ).resolves.toBe(false)
+    expect(mockQuery).not.toHaveBeenCalled()
+  })
+
+  it('returns false when the journey is not found (definitive negative)', async () => {
+    mockQuery.mockRejectedValue(new Error('journey not found'))
+
+    await expect(
+      getCardChatEnabled({ journeyId: 'journey-1', cardId: 'card-1' })
+    ).resolves.toBe(false)
+    expect(mockLoggerWarn).not.toHaveBeenCalled()
+  })
+
+  it('fails open (returns true) and logs on an infrastructure error', async () => {
+    mockQuery.mockRejectedValue(new Error('gateway exploded'))
+
+    await expect(
+      getCardChatEnabled({ journeyId: 'journey-1', cardId: 'card-1' })
+    ).resolves.toBe(true)
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'chat_card_lookup_error' }),
+      expect.any(String)
+    )
+  })
+})

--- a/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.spec.ts
+++ b/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.spec.ts
@@ -150,5 +150,4 @@ describe('getCardChatEnabled', () => {
       expect.any(String)
     )
   })
-
 })

--- a/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.spec.ts
+++ b/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.spec.ts
@@ -1,13 +1,11 @@
 import { IdType } from '../../../__generated__/globalTypes'
 
-import {
-  CARD_LOOKUP_TIMEOUT_MS,
-  getCardChatEnabled
-} from './getCardChatEnabled'
+import { getCardChatEnabled } from './getCardChatEnabled'
 
-const { mockQuery, mockLoggerWarn } = vi.hoisted(() => ({
+const { mockQuery, mockLoggerWarn, mockLoggerInfo } = vi.hoisted(() => ({
   mockQuery: vi.fn(),
-  mockLoggerWarn: vi.fn()
+  mockLoggerWarn: vi.fn(),
+  mockLoggerInfo: vi.fn()
 }))
 
 vi.mock('../apolloClient', () => ({
@@ -15,7 +13,7 @@ vi.mock('../apolloClient', () => ({
 }))
 
 vi.mock('../logger', () => ({
-  logger: { warn: mockLoggerWarn, error: vi.fn(), info: vi.fn() }
+  logger: { warn: mockLoggerWarn, error: vi.fn(), info: mockLoggerInfo }
 }))
 
 function journeyWithBlocks(blocks: unknown[]): unknown {
@@ -54,6 +52,29 @@ describe('getCardChatEnabled', () => {
         }),
         fetchPolicy: 'no-cache'
       })
+    )
+  })
+
+  it('logs the kill-switch lookup result (showAssistant + enabled)', async () => {
+    mockQuery.mockResolvedValue(
+      journeyWithBlocks([
+        { __typename: 'CardBlock', id: 'card-1', showAssistant: false }
+      ])
+    )
+
+    await getCardChatEnabled({ journeyId: 'journey-1', cardId: 'card-1' })
+
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'chat_card_lookup',
+        journeyId: 'journey-1',
+        cardId: 'card-1',
+        journeyFound: true,
+        cardFound: true,
+        showAssistant: false,
+        enabled: false
+      }),
+      expect.any(String)
     )
   })
 
@@ -130,31 +151,4 @@ describe('getCardChatEnabled', () => {
     )
   })
 
-  it('aborts and fails open (returns true) when the lookup hangs past the timeout', async () => {
-    vi.useFakeTimers()
-    // Simulate a hanging gateway: the query only settles when the abort signal
-    // passed through Apollo's fetchOptions fires.
-    mockQuery.mockImplementation(({ context }) => {
-      const signal = context?.fetchOptions?.signal as AbortSignal
-      return new Promise((_resolve, reject) => {
-        signal.addEventListener('abort', () => {
-          reject(new Error('The operation was aborted'))
-        })
-      })
-    })
-
-    const result = getCardChatEnabled({
-      journeyId: 'journey-1',
-      cardId: 'card-1'
-    })
-    await vi.advanceTimersByTimeAsync(CARD_LOOKUP_TIMEOUT_MS)
-
-    await expect(result).resolves.toBe(true)
-    expect(mockLoggerWarn).toHaveBeenCalledWith(
-      expect.objectContaining({ event: 'chat_card_lookup_error' }),
-      expect.any(String)
-    )
-
-    vi.useRealTimers()
-  })
 })

--- a/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.spec.ts
+++ b/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.spec.ts
@@ -2,10 +2,9 @@ import { IdType } from '../../../__generated__/globalTypes'
 
 import { getCardChatEnabled } from './getCardChatEnabled'
 
-const { mockQuery, mockLoggerWarn, mockLoggerInfo } = vi.hoisted(() => ({
+const { mockQuery, mockLoggerWarn } = vi.hoisted(() => ({
   mockQuery: vi.fn(),
-  mockLoggerWarn: vi.fn(),
-  mockLoggerInfo: vi.fn()
+  mockLoggerWarn: vi.fn()
 }))
 
 vi.mock('../apolloClient', () => ({
@@ -13,7 +12,7 @@ vi.mock('../apolloClient', () => ({
 }))
 
 vi.mock('../logger', () => ({
-  logger: { warn: mockLoggerWarn, error: vi.fn(), info: mockLoggerInfo }
+  logger: { warn: mockLoggerWarn, error: vi.fn(), info: vi.fn() }
 }))
 
 function journeyWithBlocks(blocks: unknown[]): unknown {
@@ -52,29 +51,6 @@ describe('getCardChatEnabled', () => {
         }),
         fetchPolicy: 'no-cache'
       })
-    )
-  })
-
-  it('logs the kill-switch lookup result (showAssistant + enabled)', async () => {
-    mockQuery.mockResolvedValue(
-      journeyWithBlocks([
-        { __typename: 'CardBlock', id: 'card-1', showAssistant: false }
-      ])
-    )
-
-    await getCardChatEnabled({ journeyId: 'journey-1', cardId: 'card-1' })
-
-    expect(mockLoggerInfo).toHaveBeenCalledWith(
-      expect.objectContaining({
-        event: 'chat_card_lookup',
-        journeyId: 'journey-1',
-        cardId: 'card-1',
-        journeyFound: true,
-        cardFound: true,
-        showAssistant: false,
-        enabled: false
-      }),
-      expect.any(String)
     )
   })
 

--- a/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.ts
+++ b/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.ts
@@ -33,6 +33,14 @@ interface GetCardChatEnabledArgs {
  * belongs to the journey in the request, so a stale tab can't keep chatting by
  * spoofing a different journeyId.
  *
+ * Threat-model scope: this is a creator emergency stop, not a malicious-actor
+ * defense. The check is still bounded by the client-supplied `cardId`, so a
+ * viewer who knows another (un-killed) card id in the *same* journey could send
+ * that instead and keep chatting on those cards — the killed card itself still
+ * can't be re-enabled this way, which is what the switch guarantees. For a
+ * journey-wide / global stop, the hammer is the LaunchDarkly `apologistChat`
+ * flag, which disables chat everywhere at once.
+ *
  * Freshness matters: the lookup uses `fetchPolicy: 'no-cache'` so flipping the
  * toggle off in the editor stops chat for already-open tabs on their next
  * message — an in-memory Apollo cache would otherwise mask the change.

--- a/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.ts
+++ b/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.ts
@@ -1,0 +1,82 @@
+import { GET_JOURNEY } from '@core/journeys/ui/useJourneyQuery'
+
+import { GetJourney } from '../../../__generated__/GetJourney'
+import { IdType } from '../../../__generated__/globalTypes'
+import { createApolloClient } from '../apolloClient'
+import { isJourneyNotFoundError } from '../isJourneyNotFoundError'
+import { JOURNEY_STATUS_EXCLUDE_DRAFT } from '../journeyQueryOptions'
+import { logger } from '../logger'
+
+const apolloClient = createApolloClient()
+
+interface GetCardChatEnabledArgs {
+  /** Journey database id from the chat request body. */
+  journeyId?: string
+  /** Active CardBlock id from the chat request body. */
+  cardId: string
+}
+
+/**
+ * Server-side per-card chat kill switch (NES-1679).
+ *
+ * Returns `true` only when the card identified by `cardId` exists inside the
+ * journey identified by `journeyId` AND its `showAssistant` is explicitly
+ * `true`. Looking the card up *within* the journey also enforces that the card
+ * belongs to the journey in the request, so a stale tab can't keep chatting by
+ * spoofing a different journeyId.
+ *
+ * Freshness matters: the lookup uses `fetchPolicy: 'no-cache'` so flipping the
+ * toggle off in the editor stops chat for already-open tabs on their next
+ * message — an in-memory Apollo cache would otherwise mask the change.
+ *
+ * Failure policy:
+ * - Definitive negatives (missing journeyId, journey not found, card not in the
+ *   journey, `showAssistant !== true`) → `false` (fail closed). This is the
+ *   kill switch doing its job.
+ * - Infrastructure errors (gateway unreachable, 5xx, timeout) → `true` (fail
+ *   open) and logged. The lookup runs on every message, so failing closed here
+ *   would couple chat availability to a per-request gateway read and let a
+ *   transient blip take down chat on every journey at once.
+ */
+export async function getCardChatEnabled({
+  journeyId,
+  cardId
+}: GetCardChatEnabledArgs): Promise<boolean> {
+  if (journeyId == null || journeyId === '') return false
+
+  try {
+    const { data } = await apolloClient.query<GetJourney>({
+      query: GET_JOURNEY,
+      variables: {
+        id: journeyId,
+        idType: IdType.databaseId,
+        options: { status: JOURNEY_STATUS_EXCLUDE_DRAFT }
+      },
+      // Always hit the gateway: a cached value would defeat the kill switch.
+      fetchPolicy: 'no-cache'
+    })
+
+    const card = data.journey?.blocks?.find(
+      (block) => block.__typename === 'CardBlock' && block.id === cardId
+    )
+
+    return card?.__typename === 'CardBlock' && card.showAssistant === true
+  } catch (error) {
+    // A genuinely missing journey is a definitive negative → fail closed.
+    if (isJourneyNotFoundError(error)) return false
+    // Infrastructure error → fail open so a transient gateway blip doesn't kill
+    // chat on every journey at once.
+    const err = error as Error
+    logger.warn(
+      {
+        event: 'chat_card_lookup_error',
+        journeyId,
+        cardId,
+        name: err?.name,
+        message: err?.message
+      },
+      '[chat] card showAssistant lookup failed — allowing chat (fail open)'
+    )
+    return true
+  }
+}

--- a/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.ts
+++ b/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.ts
@@ -9,14 +9,6 @@ import { logger } from '../logger'
 
 const apolloClient = createApolloClient()
 
-/**
- * Hard ceiling for the per-message card lookup. Apollo has no default query
- * timeout, so without this a slow/hanging gateway would block every chat send
- * until the serverless function 504s. When it fires the request is aborted and
- * falls through to the fail-open path below.
- */
-export const CARD_LOOKUP_TIMEOUT_MS = 5000
-
 interface GetCardChatEnabledArgs {
   /** Journey database id from the chat request body. */
   journeyId?: string
@@ -49,21 +41,16 @@ interface GetCardChatEnabledArgs {
  * - Definitive negatives (missing journeyId, journey not found, card not in the
  *   journey, `showAssistant !== true`) → `false` (fail closed). This is the
  *   kill switch doing its job.
- * - Infrastructure errors (gateway unreachable, 5xx, timeout) → `true` (fail
- *   open) and logged. The lookup runs on every message, so failing closed here
- *   would couple chat availability to a per-request gateway read and let a
- *   transient blip take down chat on every journey at once.
+ * - Infrastructure errors (gateway unreachable, 5xx) → `true` (fail open) and
+ *   logged. The lookup runs on every message, so failing closed here would
+ *   couple chat availability to a per-request gateway read and let a transient
+ *   blip take down chat on every journey at once.
  */
 export async function getCardChatEnabled({
   journeyId,
   cardId
 }: GetCardChatEnabledArgs): Promise<boolean> {
   if (journeyId == null || journeyId === '') return false
-
-  // Abort a hung lookup so it fails fast into the fail-open path instead of
-  // holding the request open until the serverless function times out.
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), CARD_LOOKUP_TIMEOUT_MS)
 
   try {
     const { data } = await apolloClient.query<GetJourney>({
@@ -74,21 +61,41 @@ export async function getCardChatEnabled({
         options: { status: JOURNEY_STATUS_EXCLUDE_DRAFT }
       },
       // Always hit the gateway: a cached value would defeat the kill switch.
-      fetchPolicy: 'no-cache',
-      context: { fetchOptions: { signal: controller.signal } }
+      fetchPolicy: 'no-cache'
     })
 
-    const card = data.journey?.blocks?.find(
+    const found = data.journey?.blocks?.find(
       (block) => block.__typename === 'CardBlock' && block.id === cardId
     )
+    const cardBlock = found?.__typename === 'CardBlock' ? found : undefined
+    const enabled = cardBlock?.showAssistant === true
 
-    return card?.__typename === 'CardBlock' && card.showAssistant === true
+    // Observability for the allow path. The kill switch already logs when it
+    // blocks (`chat_card_disabled`) and when it errors (`chat_card_lookup_error`),
+    // but not what it read when it *allows* — so a "killed card still chatting"
+    // report can't be localised. Record exactly what the gateway returned:
+    // whether the journey/card were found and the resolved `showAssistant`, so
+    // a stale read (cardFound + showAssistant !== false) can be told apart from
+    // a request-identity mismatch (journeyFound/cardFound false).
+    logger.info(
+      {
+        event: 'chat_card_lookup',
+        journeyId,
+        cardId,
+        journeyFound: data.journey != null,
+        cardFound: cardBlock != null,
+        showAssistant: cardBlock?.showAssistant ?? null,
+        enabled
+      },
+      '[chat] card showAssistant lookup result'
+    )
+
+    return enabled
   } catch (error) {
     // A genuinely missing journey is a definitive negative → fail closed.
     if (isJourneyNotFoundError(error)) return false
-    // Infrastructure error (gateway unreachable, 5xx, abort/timeout) → fail
-    // open so a transient gateway blip doesn't kill chat on every journey at
-    // once.
+    // Infrastructure error → fail open so a transient gateway blip doesn't kill
+    // chat on every journey at once.
     const err = error as Error
     logger.warn(
       {
@@ -101,7 +108,5 @@ export async function getCardChatEnabled({
       '[chat] card showAssistant lookup failed — allowing chat (fail open)'
     )
     return true
-  } finally {
-    clearTimeout(timeout)
   }
 }

--- a/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.ts
+++ b/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.ts
@@ -64,33 +64,11 @@ export async function getCardChatEnabled({
       fetchPolicy: 'no-cache'
     })
 
-    const found = data.journey?.blocks?.find(
+    const card = data.journey?.blocks?.find(
       (block) => block.__typename === 'CardBlock' && block.id === cardId
     )
-    const cardBlock = found?.__typename === 'CardBlock' ? found : undefined
-    const enabled = cardBlock?.showAssistant === true
 
-    // Observability for the allow path. The kill switch already logs when it
-    // blocks (`chat_card_disabled`) and when it errors (`chat_card_lookup_error`),
-    // but not what it read when it *allows* — so a "killed card still chatting"
-    // report can't be localised. Record exactly what the gateway returned:
-    // whether the journey/card were found and the resolved `showAssistant`, so
-    // a stale read (cardFound + showAssistant !== false) can be told apart from
-    // a request-identity mismatch (journeyFound/cardFound false).
-    logger.info(
-      {
-        event: 'chat_card_lookup',
-        journeyId,
-        cardId,
-        journeyFound: data.journey != null,
-        cardFound: cardBlock != null,
-        showAssistant: cardBlock?.showAssistant ?? null,
-        enabled
-      },
-      '[chat] card showAssistant lookup result'
-    )
-
-    return enabled
+    return card?.__typename === 'CardBlock' && card.showAssistant === true
   } catch (error) {
     // A genuinely missing journey is a definitive negative → fail closed.
     if (isJourneyNotFoundError(error)) return false

--- a/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.ts
+++ b/apps/journeys/src/libs/getCardChatEnabled/getCardChatEnabled.ts
@@ -9,6 +9,14 @@ import { logger } from '../logger'
 
 const apolloClient = createApolloClient()
 
+/**
+ * Hard ceiling for the per-message card lookup. Apollo has no default query
+ * timeout, so without this a slow/hanging gateway would block every chat send
+ * until the serverless function 504s. When it fires the request is aborted and
+ * falls through to the fail-open path below.
+ */
+export const CARD_LOOKUP_TIMEOUT_MS = 5000
+
 interface GetCardChatEnabledArgs {
   /** Journey database id from the chat request body. */
   journeyId?: string
@@ -44,6 +52,11 @@ export async function getCardChatEnabled({
 }: GetCardChatEnabledArgs): Promise<boolean> {
   if (journeyId == null || journeyId === '') return false
 
+  // Abort a hung lookup so it fails fast into the fail-open path instead of
+  // holding the request open until the serverless function times out.
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), CARD_LOOKUP_TIMEOUT_MS)
+
   try {
     const { data } = await apolloClient.query<GetJourney>({
       query: GET_JOURNEY,
@@ -53,7 +66,8 @@ export async function getCardChatEnabled({
         options: { status: JOURNEY_STATUS_EXCLUDE_DRAFT }
       },
       // Always hit the gateway: a cached value would defeat the kill switch.
-      fetchPolicy: 'no-cache'
+      fetchPolicy: 'no-cache',
+      context: { fetchOptions: { signal: controller.signal } }
     })
 
     const card = data.journey?.blocks?.find(
@@ -64,8 +78,9 @@ export async function getCardChatEnabled({
   } catch (error) {
     // A genuinely missing journey is a definitive negative → fail closed.
     if (isJourneyNotFoundError(error)) return false
-    // Infrastructure error → fail open so a transient gateway blip doesn't kill
-    // chat on every journey at once.
+    // Infrastructure error (gateway unreachable, 5xx, abort/timeout) → fail
+    // open so a transient gateway blip doesn't kill chat on every journey at
+    // once.
     const err = error as Error
     logger.warn(
       {
@@ -78,5 +93,7 @@ export async function getCardChatEnabled({
       '[chat] card showAssistant lookup failed — allowing chat (fail open)'
     )
     return true
+  } finally {
+    clearTimeout(timeout)
   }
 }

--- a/apps/journeys/src/libs/getCardChatEnabled/index.ts
+++ b/apps/journeys/src/libs/getCardChatEnabled/index.ts
@@ -1,0 +1,1 @@
+export { getCardChatEnabled } from './getCardChatEnabled'

--- a/libs/journeys/ui/src/components/AiChat/AiChat.spec.tsx
+++ b/libs/journeys/ui/src/components/AiChat/AiChat.spec.tsx
@@ -195,15 +195,27 @@ describe('AiChat', () => {
       ).not.toBeInTheDocument()
     })
 
-    it('hides Retry for a deterministic chat_disabled (kill switch) error', () => {
+    it('shows the catered "turned off" message and hides Retry when chat is disabled', () => {
       setChatState({ error: codedError('chat_disabled') })
 
       render(<AiChat variant="overlay" collapsible={false} />)
 
-      // The card's chat was turned off — re-firing would 403 again.
+      // Honest copy instead of the misleading "try again" generic.
+      expect(screen.getByText(/chat has been turned off/i)).toBeInTheDocument()
+      expect(
+        screen.queryByText(/Something went wrong/i)
+      ).not.toBeInTheDocument()
+      // Retry is hidden (re-firing 403s again)…
       expect(
         screen.queryByRole('button', { name: 'Retry' })
       ).not.toBeInTheDocument()
+      // …but the input stays usable: the kill-switch floor keeps the stale tab
+      // interactive, and locking it would strand a user who navigates to a card
+      // where chat is still enabled.
+      expect(screen.getByTestId('prompt-input')).toHaveAttribute(
+        'data-disabled',
+        'false'
+      )
     })
 
     it('does not render the error block while a request is still in flight', () => {

--- a/libs/journeys/ui/src/components/AiChat/AiChat.spec.tsx
+++ b/libs/journeys/ui/src/components/AiChat/AiChat.spec.tsx
@@ -2,7 +2,13 @@ import { useChat } from '@ai-sdk/react'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { type Mock } from 'vitest'
 
+import { type TreeBlock, blockHistoryVar } from '../../libs/block'
+
 import { AiChat } from './AiChat'
+
+const { mockTransportConstructor } = vi.hoisted(() => ({
+  mockTransportConstructor: vi.fn()
+}))
 
 vi.mock('@ai-sdk/react', () => ({
   useChat: vi.fn()
@@ -10,9 +16,14 @@ vi.mock('@ai-sdk/react', () => ({
 
 // `ai` transitively loads streaming machinery that needs `TransformStream`
 // (absent in jsdom). `useChat` is mocked, so the transport is never
-// exercised — stub it to a constructable no-op.
+// exercised — stub it to a constructable no-op that records its options so
+// tests can assert the request body (NES-1679).
 vi.mock('ai', () => ({
-  DefaultChatTransport: class DefaultChatTransport {}
+  DefaultChatTransport: class DefaultChatTransport {
+    constructor(options: unknown) {
+      mockTransportConstructor(options)
+    }
+  }
 }))
 
 vi.mock('next-i18next/pages', () => ({
@@ -77,6 +88,7 @@ function codedError(code: string): Error {
 describe('AiChat', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    blockHistoryVar([])
   })
 
   describe('error states — catered message + retry-gating (NES-1663)', () => {
@@ -178,6 +190,17 @@ describe('AiChat', () => {
 
       render(<AiChat variant="overlay" collapsible={false} />)
 
+      expect(
+        screen.queryByRole('button', { name: 'Retry' })
+      ).not.toBeInTheDocument()
+    })
+
+    it('hides Retry for a deterministic chat_disabled (kill switch) error', () => {
+      setChatState({ error: codedError('chat_disabled') })
+
+      render(<AiChat variant="overlay" collapsible={false} />)
+
+      // The card's chat was turned off — re-firing would 403 again.
       expect(
         screen.queryByRole('button', { name: 'Retry' })
       ).not.toBeInTheDocument()
@@ -297,6 +320,38 @@ describe('AiChat', () => {
       expect(
         screen.getAllByRole('link', { name: 'About this chat' })
       ).toHaveLength(1)
+    })
+  })
+
+  describe('chat request body (NES-1679)', () => {
+    it('includes the active card id in the chat request body', () => {
+      blockHistoryVar([
+        {
+          __typename: 'StepBlock',
+          id: 'step-1',
+          children: [{ __typename: 'CardBlock', id: 'card-1', children: [] }]
+        }
+      ] as unknown as TreeBlock[])
+      setChatState({ messages: [], status: 'ready', error: undefined })
+
+      render(<AiChat variant="overlay" collapsible={false} />)
+
+      const options = mockTransportConstructor.mock.calls[0]?.[0] as {
+        body: () => Record<string, unknown>
+      }
+      expect(options.body()).toMatchObject({ cardId: 'card-1' })
+    })
+
+    it('sends an undefined cardId when no card is active', () => {
+      blockHistoryVar([])
+      setChatState({ messages: [], status: 'ready', error: undefined })
+
+      render(<AiChat variant="overlay" collapsible={false} />)
+
+      const options = mockTransportConstructor.mock.calls[0]?.[0] as {
+        body: () => Record<string, unknown>
+      }
+      expect(options.body().cardId).toBeUndefined()
     })
   })
 })

--- a/libs/journeys/ui/src/components/AiChat/AiChat.tsx
+++ b/libs/journeys/ui/src/components/AiChat/AiChat.tsx
@@ -18,6 +18,7 @@ import {
 } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
+import { getCardChild, useBlocks } from '../../libs/block'
 import { useJourney } from '../../libs/JourneyProvider'
 import { Actions } from '../Actions'
 import { Conversation } from '../Conversation'
@@ -107,7 +108,9 @@ function parseChatErrorCode(error: Error | undefined): string | undefined {
 const NON_RETRIABLE_CHAT_ERROR_CODES = new Set([
   'conversation_capped',
   'invalid_request',
-  'not_found'
+  'not_found',
+  // A card with chat disabled (NES-1679) is deterministic — re-firing 403s again.
+  'chat_disabled'
 ])
 
 const CONVERSATION_CAPPED_CODE = 'conversation_capped'
@@ -251,6 +254,15 @@ export function AiChat({
   const journeyIdRef = useRef(journeyId)
   journeyIdRef.current = journeyId
 
+  // The active card id (NES-1679) lets the server enforce the per-card chat
+  // kill switch. Read from the same global block history the rest of the viewer
+  // uses (Conductor, StepFooter), so it tracks card navigation without
+  // threading a prop through PinnedChatBar / ChatOverlay.
+  const { blockHistory } = useBlocks()
+  const cardId = getCardChild(blockHistory[blockHistory.length - 1])?.id
+  const cardIdRef = useRef(cardId)
+  cardIdRef.current = cardId
+
   const [sessionId, setSessionId] = useState<string | undefined>(() => {
     if (typeof window === 'undefined') return undefined
     // sessionStorage can throw in Safari private mode, sandboxed
@@ -276,7 +288,8 @@ export function AiChat({
         body: () => ({
           language: languageRef.current,
           sessionId: sessionIdRef.current,
-          journeyId: journeyIdRef.current
+          journeyId: journeyIdRef.current,
+          cardId: cardIdRef.current
         })
       }),
     []

--- a/libs/journeys/ui/src/components/AiChat/AiChat.tsx
+++ b/libs/journeys/ui/src/components/AiChat/AiChat.tsx
@@ -114,6 +114,13 @@ const NON_RETRIABLE_CHAT_ERROR_CODES = new Set([
 ])
 
 const CONVERSATION_CAPPED_CODE = 'conversation_capped'
+// The card's chat was turned off server-side (NES-1679). We swap the generic
+// "try again" copy for an honest "turned off" message and hide Retry (it would
+// 403 again). The input deliberately stays usable: per the kill-switch design a
+// stale tab still shows the input and each send fails closed with a visible
+// message, and locking it would strand the user if they navigate to a card
+// where chat is still enabled (the error persists in the mounted chat).
+const CHAT_DISABLED_CODE = 'chat_disabled'
 
 const TYPEWRITER_CHARS_PER_SEC = 280
 
@@ -324,6 +331,7 @@ export function AiChat({
 
   const errorCode = useMemo(() => parseChatErrorCode(error), [error])
   const isConversationCapped = errorCode === CONVERSATION_CAPPED_CODE
+  const isChatDisabled = errorCode === CHAT_DISABLED_CODE
   // Retriable by default so transient failures (network/5xx/mid-stream, which
   // carry no code) keep their Retry; hidden only for known deterministic codes.
   const canRetry =
@@ -594,7 +602,11 @@ export function AiChat({
                     ? t(
                         "This conversation's gotten long. Start a new one to keep chatting — this clears the current session."
                       )
-                    : t('Something went wrong. Please try again.')}
+                    : isChatDisabled
+                      ? t(
+                          'Chat has been turned off for this part of the journey.'
+                        )
+                      : t('Something went wrong. Please try again.')}
                 </Box>
               </Message>
               {isConversationCapped ? (


### PR DESCRIPTION
## NES-1679 — Backend: enforce per-card `showAssistant` on `/api/chat` (hard kill switch)

[Linear NES-1679](https://linear.app/jesus-film-project/issue/NES-1679) · World Cup Readiness

Makes `card.showAssistant` a **server-enforced** gate. Previously it was render-only: `/api/chat` never consulted it, so a viewer whose tab was already open kept chatting indefinitely after a creator flipped the card off. Now flipping it off stops chat for already-open tabs on their **next message** — the per-journey emergency kill switch Jaco asked for.

### What changed

**Server (`apps/journeys`)**
- `chatRequestSchema` now **requires `cardId`** (`z.string().min(1).max(128)`).
- New `src/libs/getCardChatEnabled` — queries the journey by `journeyId`, finds the `CardBlock` by `cardId`, returns `showAssistant === true`. Looking the card up *within* its journey also enforces card↔journey ownership (a stale tab can't keep chatting by spoofing a different `journeyId`).
- `/api/chat` calls it after the cheap local schema/size checks and **403s** (`{ error: 'chat disabled for this card', code: 'chat_disabled' }`) when the card is missing or `showAssistant !== true`. Logs a non-PII `chat_card_disabled` warn.

**Client (`libs/journeys/ui`)**
- `AiChat` sends the active `cardId` on every POST, read from the shared block history (`useBlocks()` + `getCardChild`) — the same source `Conductor`/`StepFooter` use. This covers **both** the mobile `PinnedChatBar` and the desktop `ChatOverlay` (both render `AiChat`) without threading a prop through each surface.
- `chat_disabled` is added to the non-retriable error codes, so the client hides Retry (re-firing would 403 again) — same treatment as the existing `not_found` flag-off case.

### Design decisions worth your eyes 👀

1. **Fail-open on infrastructure errors, fail-closed on definitive negatives.** The lookup runs on *every message*. A definitive "card off / not found / missing journeyId" → 403 (kill switch works). But a *gateway/network error* → allow + log (`chat_card_lookup_error`), so a transient gateway blip doesn't take chat down on every journey at once. The kill switch still works in every realistic scenario (flipping the toggle requires a working gateway). **This slightly weakens "hard" during a gateway outage — flag if you'd rather fail fully closed.**
2. **`fetchPolicy: 'no-cache'`** on the lookup — an in-memory Apollo cache would mask the creator's change and defeat the switch. This means **one gateway read per chat message**; the ticket's TTL-cache idea is left as a noted follow-up ("keep it simple unless load testing says otherwise").
3. **Heavy query.** Re-uses the existing `GET_JOURNEY` (full journey + all blocks) since there's no lighter single-card query exposed and the API route can only reach the gateway via Apollo (no Prisma from `apps/journeys`). A dedicated minimal `card(id){ showAssistant }` query would be a good perf follow-up.

### Deviations from the ticket (intentional)
- **Tests are Vitest, not Jest** — `apps/journeys` migrated to Vitest; the ticket said "jest" but I followed the actual runner.
- **Client `cardId` lives in `AiChat`**, not `AiChatButton`/`PinnedChatBar` as the ticket suggested — `AiChat` owns the transport and both surfaces render it, so this is one change instead of three and can't drift between surfaces.

### Tests
- `getCardChatEnabled.spec.ts` (8): enabled / `false` / `null` / card-not-in-journey / missing-journeyId / journey-not-found (closed) / infra-error (open) / no-cache+databaseId variables.
- `index.spec.ts` (+ kill-switch suite, 47 total): 400 when `cardId` missing, 403 + `chat_disabled` when disabled, lookup gets `{journeyId, cardId}` and streams when enabled, flag-off short-circuits before the lookup. Existing 43 tests updated to send `cardId`.
- `AiChat.spec.tsx` (18): request body includes the active `cardId`; undefined when no card active; `chat_disabled` hides Retry.
- No regressions: `AiChatButton` (5) and `Conductor` (62, incl. per-card-chat) green. `prettier` ✓, `eslint` ✓, `tsc -b` ✓.

### Manual verification (the "Done when")
1. Open a chat-enabled card in the viewer.
2. In the editor (another tab), flip `showAssistant` **off** on that card.
3. Send another message in the open viewer tab → it fails closed with a visible error and no Retry, while the global flag stays on for every other journey.

### Not in scope (per ticket)
Live "chat closed" push to stale tabs (needs SSE/WebSocket), removing `Journey.showAssistant` (NES-1624), per-region kill switch, mid-stream suppression of an in-flight response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-card chat control: chat can be enabled/disabled per card; when disabled users see a clear “Chat has been turned off” message, cannot stream, and retry is hidden.
  * Chat requests now include the active card identifier so card-specific state is respected.

* **Bug Fixes**
  * Request validation tightened to require journey and card identifiers; returns specific errors (400/403/404) when missing or disabled.

* **Tests**
  * Added coverage for per-card kill switch, logging/trace adjustments, and updated request payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->