### PR TITLE
feat(NES-1717): collapsible collection headers + DnD drop-zone fixes

### DIFF
--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.spec.tsx
@@ -321,8 +321,9 @@ describe('CollectionCard', () => {
           <div data-testid="children-payload" />
         </CollectionCard>
       )
+      // Expanded → the announced action is "Collapse".
       const toggle = screen.getByRole('button', {
-        name: 'Toggle My Collection collection'
+        name: 'Collapse My Collection collection'
       })
       expect(toggle).toHaveAttribute('aria-expanded', 'true')
       // Expanded: the grid (children) is visible and there's no count badge.
@@ -343,8 +344,9 @@ describe('CollectionCard', () => {
           <div data-testid="children-payload" />
         </CollectionCard>
       )
+      // Collapsed → the announced action is "Expand".
       const toggle = screen.getByRole('button', {
-        name: 'Toggle My Collection collection'
+        name: 'Expand My Collection collection'
       })
       expect(toggle).toHaveAttribute('aria-expanded', 'false')
       // Collapsed: grid unmounted, count badge reflects the template count.

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.spec.tsx
@@ -349,9 +349,9 @@ describe('CollectionCard', () => {
       expect(toggle).toHaveAttribute('aria-expanded', 'false')
       // Collapsed: grid unmounted, count badge reflects the template count.
       expect(screen.queryByTestId('children-payload')).not.toBeInTheDocument()
-      expect(screen.getByTestId('CollectionCardCount-page-1')).toHaveTextContent(
-        '2'
-      )
+      expect(
+        screen.getByTestId('CollectionCardCount-page-1')
+      ).toHaveTextContent('2')
     })
 
     it('does not show a count badge for an empty collapsed collection', () => {
@@ -371,9 +371,7 @@ describe('CollectionCard', () => {
           onToggleCollapse={onToggleCollapse}
         />
       )
-      await userEvent.click(
-        screen.getByTestId('CollectionCardToggle-page-1')
-      )
+      await userEvent.click(screen.getByTestId('CollectionCardToggle-page-1'))
       expect(onToggleCollapse).toHaveBeenCalledWith(collection)
     })
 

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.spec.tsx
@@ -311,4 +311,107 @@ describe('CollectionCard', () => {
     ).not.toBeInTheDocument()
     expect(screen.getByTestId('children-payload')).toBeInTheDocument()
   })
+
+  describe('collapse (NES-1717)', () => {
+    it('renders the header as an expanded toggle button by default', () => {
+      render(
+        <CollectionCard
+          collection={makeCollection({ templates: [journeyRef('j1')] })}
+        >
+          <div data-testid="children-payload" />
+        </CollectionCard>
+      )
+      const toggle = screen.getByRole('button', {
+        name: 'Toggle My Collection collection'
+      })
+      expect(toggle).toHaveAttribute('aria-expanded', 'true')
+      // Expanded: the grid (children) is visible and there's no count badge.
+      expect(screen.getByTestId('children-payload')).toBeInTheDocument()
+      expect(
+        screen.queryByTestId('CollectionCardCount-page-1')
+      ).not.toBeInTheDocument()
+    })
+
+    it('hides the grid and shows a template-count badge when collapsed', () => {
+      render(
+        <CollectionCard
+          collection={makeCollection({
+            templates: [journeyRef('j1'), journeyRef('j2')]
+          })}
+          collapsed
+        >
+          <div data-testid="children-payload" />
+        </CollectionCard>
+      )
+      const toggle = screen.getByRole('button', {
+        name: 'Toggle My Collection collection'
+      })
+      expect(toggle).toHaveAttribute('aria-expanded', 'false')
+      // Collapsed: grid unmounted, count badge reflects the template count.
+      expect(screen.queryByTestId('children-payload')).not.toBeInTheDocument()
+      expect(screen.getByTestId('CollectionCardCount-page-1')).toHaveTextContent(
+        '2'
+      )
+    })
+
+    it('does not show a count badge for an empty collapsed collection', () => {
+      render(<CollectionCard collection={makeCollection()} collapsed />)
+      expect(
+        screen.queryByTestId('CollectionCardCount-page-1')
+      ).not.toBeInTheDocument()
+      expect(screen.getByText('Empty')).toBeInTheDocument()
+    })
+
+    it('fires onToggleCollapse when the header is clicked', async () => {
+      const onToggleCollapse = vi.fn()
+      const collection = makeCollection({ templates: [journeyRef('j1')] })
+      render(
+        <CollectionCard
+          collection={collection}
+          onToggleCollapse={onToggleCollapse}
+        />
+      )
+      await userEvent.click(
+        screen.getByTestId('CollectionCardToggle-page-1')
+      )
+      expect(onToggleCollapse).toHaveBeenCalledWith(collection)
+    })
+
+    it('toggles on Enter and Space for keyboard users', async () => {
+      const onToggleCollapse = vi.fn()
+      const collection = makeCollection({ templates: [journeyRef('j1')] })
+      render(
+        <CollectionCard
+          collection={collection}
+          onToggleCollapse={onToggleCollapse}
+        />
+      )
+      const toggle = screen.getByTestId('CollectionCardToggle-page-1')
+      toggle.focus()
+      await userEvent.keyboard('{Enter}')
+      await userEvent.keyboard(' ')
+      expect(onToggleCollapse).toHaveBeenCalledTimes(2)
+      expect(onToggleCollapse).toHaveBeenNthCalledWith(1, collection)
+      expect(onToggleCollapse).toHaveBeenNthCalledWith(2, collection)
+    })
+
+    it('does not collapse the actions menu trigger into the toggle button', async () => {
+      // The actions menu must stay a sibling of the toggle so it opens the
+      // menu instead of toggling collapse, and so we never nest buttons.
+      const onToggleCollapse = vi.fn()
+      render(
+        <CollectionCard
+          collection={makeCollection({ templates: [journeyRef('j1')] })}
+          onToggleCollapse={onToggleCollapse}
+        />
+      )
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Collection actions' })
+      )
+      expect(onToggleCollapse).not.toHaveBeenCalled()
+      expect(
+        screen.getByRole('menuitem', { name: 'Publish' })
+      ).toBeInTheDocument()
+    })
+  })
 })

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.spec.tsx
@@ -413,5 +413,62 @@ describe('CollectionCard', () => {
         screen.getByRole('menuitem', { name: 'Publish' })
       ).toBeInTheDocument()
     })
+
+    it('points aria-controls at the mounted content region when expanded and drops it when collapsed', () => {
+      const { rerender } = render(
+        <CollectionCard
+          collection={makeCollection({ templates: [journeyRef('j1')] })}
+        >
+          <div data-testid="children-payload" />
+        </CollectionCard>
+      )
+      const toggle = screen.getByTestId('CollectionCardToggle-page-1')
+      const controls = toggle.getAttribute('aria-controls')
+      expect(controls).toBe('collection-content-page-1')
+      // The referenced element must actually exist while expanded.
+      expect(document.getElementById(controls as string)).toBeInTheDocument()
+
+      // Collapsed: the region unmounts, so we must not dangle a reference.
+      rerender(
+        <CollectionCard
+          collection={makeCollection({ templates: [journeyRef('j1')] })}
+          collapsed
+        >
+          <div data-testid="children-payload" />
+        </CollectionCard>
+      )
+      expect(
+        screen.getByTestId('CollectionCardToggle-page-1')
+      ).not.toHaveAttribute('aria-controls')
+    })
+
+    it('does not toggle while busy (a drop mutation is settling)', async () => {
+      // Collapsing mid-settle would unmount the SortableContext under dnd-kit.
+      const onToggleCollapse = vi.fn()
+      render(
+        <CollectionCard
+          collection={makeCollection({ templates: [journeyRef('j1')] })}
+          onToggleCollapse={onToggleCollapse}
+          busy
+        />
+      )
+      const toggle = screen.getByTestId('CollectionCardToggle-page-1')
+      expect(toggle).toHaveAttribute('aria-disabled', 'true')
+      await userEvent.click(toggle)
+      toggle.focus()
+      await userEvent.keyboard('{Enter}')
+      expect(onToggleCollapse).not.toHaveBeenCalled()
+    })
+
+    it('does not throw when the header is toggled without an onToggleCollapse handler', async () => {
+      render(
+        <CollectionCard
+          collection={makeCollection({ templates: [journeyRef('j1')] })}
+        />
+      )
+      await expect(
+        userEvent.click(screen.getByTestId('CollectionCardToggle-page-1'))
+      ).resolves.not.toThrow()
+    })
   })
 })

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import '../../../../test/i18n'
@@ -458,6 +458,34 @@ describe('CollectionCard', () => {
       toggle.focus()
       await userEvent.keyboard('{Enter}')
       expect(onToggleCollapse).not.toHaveBeenCalled()
+    })
+
+    it('lets Space scroll natively while busy instead of swallowing the keypress', () => {
+      // While busy the toggle is inert; it must NOT preventDefault on Space,
+      // or the user loses native page scroll for no effect.
+      render(
+        <CollectionCard
+          collection={makeCollection({ templates: [journeyRef('j1')] })}
+          onToggleCollapse={vi.fn()}
+          busy
+        />
+      )
+      const toggle = screen.getByTestId('CollectionCardToggle-page-1')
+      // fireEvent returns false when the event was cancelled (preventDefault).
+      const notCancelledWhenBusy = fireEvent.keyDown(toggle, { key: ' ' })
+      expect(notCancelledWhenBusy).toBe(true)
+    })
+
+    it('prevents default on Space when not busy (suppresses page scroll while toggling)', () => {
+      render(
+        <CollectionCard
+          collection={makeCollection({ templates: [journeyRef('j1')] })}
+          onToggleCollapse={vi.fn()}
+        />
+      )
+      const toggle = screen.getByTestId('CollectionCardToggle-page-1')
+      const notCancelled = fireEvent.keyDown(toggle, { key: ' ' })
+      expect(notCancelled).toBe(false)
     })
 
     it('does not throw when the header is toggled without an onToggleCollapse handler', async () => {

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
@@ -151,13 +151,15 @@ function CollectionCardImpl({
   }
   function handleToggleKeyDown(event: KeyboardEvent<HTMLDivElement>): void {
     // Enter / Space activate a button per WAI-ARIA; the header is a div with
-    // role="button" so we wire them by hand. preventDefault stops Space from
-    // scrolling the page.
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault()
-      if (busy === true) return
-      onToggleCollapse?.(collection)
-    }
+    // role="button" so we wire them by hand.
+    if (event.key !== 'Enter' && event.key !== ' ') return
+    // While busy the toggle is inert — bail before preventDefault so a Space
+    // press still does its native thing (page scroll) instead of being
+    // swallowed to no effect.
+    if (busy === true) return
+    // preventDefault stops Space from scrolling the page when we do toggle.
+    event.preventDefault()
+    onToggleCollapse?.(collection)
   }
 
   return (

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
@@ -142,6 +142,11 @@ function CollectionCardImpl({
     onUngroup?.(collection)
   }
   function handleToggleCollapse(): void {
+    // Refuse toggles while busy — `busy` is true while a drop's mutation is in
+    // flight (parent passes `dragInFlight`), and collapsing then would unmount
+    // this collection's SortableContext under dnd-kit's settling drop,
+    // corrupting its measured rects (NES-1717 review).
+    if (busy === true) return
     onToggleCollapse?.(collection)
   }
   function handleToggleKeyDown(event: KeyboardEvent<HTMLDivElement>): void {
@@ -150,6 +155,7 @@ function CollectionCardImpl({
     // scrolling the page.
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
+      if (busy === true) return
       onToggleCollapse?.(collection)
     }
   }
@@ -192,7 +198,12 @@ function CollectionCardImpl({
           role="button"
           tabIndex={0}
           aria-expanded={!collapsed}
-          aria-controls={contentId}
+          // Only reference the content region while it's mounted. `Collapse
+          // unmountOnExit` removes it from the DOM when collapsed, so a static
+          // aria-controls would dangle for screen readers (mirrors the
+          // TemplateInfoHelper pattern). aria-expanded still conveys state.
+          aria-controls={collapsed ? undefined : contentId}
+          aria-disabled={busy === true}
           aria-label={t('Toggle {{title}} collection', {
             title: collection.title
           })}
@@ -202,7 +213,7 @@ function CollectionCardImpl({
           sx={{
             flex: 1,
             minWidth: 0,
-            cursor: 'pointer',
+            cursor: busy === true ? 'default' : 'pointer',
             userSelect: 'none',
             borderRadius: 1
           }}

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
@@ -206,9 +206,13 @@ function CollectionCardImpl({
           // TemplateInfoHelper pattern). aria-expanded still conveys state.
           aria-controls={collapsed ? undefined : contentId}
           aria-disabled={busy === true}
-          aria-label={t('Toggle {{title}} collection', {
-            title: collection.title
-          })}
+          // State-aware label: screen readers announce the action before
+          // aria-expanded, so "Expand/Collapse" reads better than "Toggle".
+          aria-label={
+            collapsed
+              ? t('Expand {{title}} collection', { title: collection.title })
+              : t('Collapse {{title}} collection', { title: collection.title })
+          }
           onClick={handleToggleCollapse}
           onKeyDown={handleToggleKeyDown}
           data-testid={`CollectionCardToggle-${collection.id}`}

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionCard/CollectionCard.tsx
@@ -1,6 +1,7 @@
 import Box from '@mui/material/Box'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
+import Collapse from '@mui/material/Collapse'
 import IconButton from '@mui/material/IconButton'
 import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
@@ -8,8 +9,16 @@ import Stack from '@mui/material/Stack'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import { useTranslation } from 'next-i18next/pages'
-import { MouseEvent, ReactElement, ReactNode, memo, useState } from 'react'
+import {
+  KeyboardEvent,
+  MouseEvent,
+  ReactElement,
+  ReactNode,
+  memo,
+  useState
+} from 'react'
 
+import ChevronDownIcon from '@core/shared/ui/icons/ChevronDown'
 import MoreIcon from '@core/shared/ui/icons/More'
 
 import { GetTemplateGalleryPages_templateGalleryPages as TemplateGalleryPage } from '../../../../__generated__/GetTemplateGalleryPages'
@@ -43,6 +52,19 @@ export interface CollectionCardProps {
    * tooltip when canPublish is false).
    */
   publishBlockedReason?: string | null
+  /**
+   * NES-1717: when true the card's body (description + templates grid) is
+   * hidden, leaving only the header. The header stays inside the parent's
+   * droppable wrapper so it remains a valid drop target while collapsed.
+   * Defaults to false (expanded).
+   */
+  collapsed?: boolean
+  /**
+   * Fired when the user toggles the header. The parent owns and persists the
+   * collapsed state; when omitted the header still renders but toggling is a
+   * no-op.
+   */
+  onToggleCollapse?: (collection: TemplateGalleryPage) => void
   /** Rendered inside the card's templates area; the parent owns drag wiring. */
   children?: ReactNode
 }
@@ -55,6 +77,8 @@ function CollectionCardImpl({
   busy,
   canPublish = true,
   publishBlockedReason = null,
+  collapsed = false,
+  onToggleCollapse,
   children
 }: CollectionCardProps): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
@@ -63,6 +87,7 @@ function CollectionCardImpl({
 
   const isPublished = collection.status === TemplateGalleryPageStatus.published
   const isEmpty = collection.templates.length === 0
+  const contentId = `collection-content-${collection.id}`
 
   // Preview (a) only makes sense once the page is publicly reachable, (b) is
   // also gated by custom-domain teams — same constraint as Publish, and (c)
@@ -116,6 +141,18 @@ function CollectionCardImpl({
     setUngroupOpen(false)
     onUngroup?.(collection)
   }
+  function handleToggleCollapse(): void {
+    onToggleCollapse?.(collection)
+  }
+  function handleToggleKeyDown(event: KeyboardEvent<HTMLDivElement>): void {
+    // Enter / Space activate a button per WAI-ARIA; the header is a div with
+    // role="button" so we wire them by hand. preventDefault stops Space from
+    // scrolling the page.
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      onToggleCollapse?.(collection)
+    }
+  }
 
   return (
     <Card
@@ -142,15 +179,56 @@ function CollectionCardImpl({
         direction="row"
         justifyContent="space-between"
         alignItems="center"
-        sx={{ mb: 1 }}
+        sx={{ mb: collapsed ? 0 : 1 }}
       >
-        <Stack direction="row" spacing={2} alignItems="center">
-          <Typography variant="h6">{collection.title}</Typography>
+        {/* The whole header (chevron + title + chips) is the toggle, so it's
+            an easy touch target. It's a div with role="button" — not a real
+            <button> — because the actions IconButton (and its Menu) is a
+            sibling, and nesting a button inside a button is invalid HTML. */}
+        <Stack
+          direction="row"
+          spacing={2}
+          alignItems="center"
+          role="button"
+          tabIndex={0}
+          aria-expanded={!collapsed}
+          aria-controls={contentId}
+          aria-label={t('Toggle {{title}} collection', {
+            title: collection.title
+          })}
+          onClick={handleToggleCollapse}
+          onKeyDown={handleToggleKeyDown}
+          data-testid={`CollectionCardToggle-${collection.id}`}
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            cursor: 'pointer',
+            userSelect: 'none',
+            borderRadius: 1
+          }}
+        >
+          <ChevronDownIcon
+            sx={{
+              flexShrink: 0,
+              color: 'text.secondary',
+              transition: 'transform 0.2s ease',
+              transform: collapsed ? 'rotate(-90deg)' : 'rotate(0deg)'
+            }}
+          />
+          <Typography variant="h6" noWrap sx={{ minWidth: 0 }}>
+            {collection.title}
+          </Typography>
           <LabelChip
             color={isPublished ? 'success' : 'default'}
             label={isPublished ? t('Live') : t('Draft')}
           />
           {isEmpty && <LabelChip label={t('Empty')} />}
+          {collapsed && !isEmpty && (
+            <LabelChip
+              label={String(collection.templates.length)}
+              data-testid={`CollectionCardCount-${collection.id}`}
+            />
+          )}
         </Stack>
         <IconButton
           aria-label={t('Collection actions')}
@@ -210,45 +288,52 @@ function CollectionCardImpl({
         </Menu>
       </Stack>
 
-      {collection.description != null && collection.description !== '' && (
-        <Typography
-          variant="body2"
-          color="text.secondary"
-          sx={{
-            mb: 1,
-            display: '-webkit-box',
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: 'vertical',
-            overflow: 'hidden'
-          }}
-        >
-          {collection.description}
-        </Typography>
-      )}
-
-      <CardContent
-        sx={{
-          p: 0,
-          '&:last-child': { pb: 0 },
-          minHeight: 100
-        }}
-      >
-        {isEmpty ? (
-          <Box
+      {/* unmountOnExit so a settled-collapsed card has no mounted templates
+          grid — the grid's sortable items would otherwise stay registered as
+          drop targets and skew dnd-kit's collision detection. While collapsed
+          the header alone fills the parent's droppable, so dropping onto it
+          still lands the template in this collection (NES-1717). */}
+      <Collapse in={!collapsed} unmountOnExit id={contentId}>
+        {collection.description != null && collection.description !== '' && (
+          <Typography
+            variant="body2"
+            color="text.secondary"
             sx={{
-              p: 2,
-              textAlign: 'center',
-              color: 'text.disabled'
+              mb: 1,
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden'
             }}
           >
-            <Typography variant="caption">
-              {t('Drag templates here to add them to this collection.')}
-            </Typography>
-          </Box>
-        ) : (
-          children
+            {collection.description}
+          </Typography>
         )}
-      </CardContent>
+
+        <CardContent
+          sx={{
+            p: 0,
+            '&:last-child': { pb: 0 },
+            minHeight: 100
+          }}
+        >
+          {isEmpty ? (
+            <Box
+              sx={{
+                p: 2,
+                textAlign: 'center',
+                color: 'text.disabled'
+              }}
+            >
+              <Typography variant="caption">
+                {t('Drag templates here to add them to this collection.')}
+              </Typography>
+            </Box>
+          ) : (
+            children
+          )}
+        </CardContent>
+      </Collapse>
 
       <CollectionUngroupDialog
         open={ungroupOpen}

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/Droppables/Droppables.spec.ts
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/Droppables/Droppables.spec.ts
@@ -1,4 +1,10 @@
-import { encodeDropZoneId, parseDropZoneId } from './Droppables'
+import { Collision } from '@dnd-kit/core'
+
+import {
+  encodeDropZoneId,
+  parseDropZoneId,
+  resolveSectionDropCollisions
+} from './Droppables'
 
 describe('encodeDropZoneId / parseDropZoneId', () => {
   it('round-trips an unsectioned zone', () => {
@@ -31,5 +37,93 @@ describe('encodeDropZoneId / parseDropZoneId', () => {
     // Bare ids (e.g. journey-card uuids) don't match either prefix and
     // signal "this is a sortable item, not a zone wrapper" to the caller.
     expect(parseDropZoneId('j-uuid-123')).toBe(null)
+  })
+})
+
+describe('resolveSectionDropCollisions', () => {
+  const collision = (id: string): Collision => ({ id })
+  const ids = (collisions: Collision[]): string[] =>
+    collisions.map((c) => String(c.id))
+  const collectionX = encodeDropZoneId({ kind: 'collection', id: 'X' })
+  const unsectioned = encodeDropZoneId({ kind: 'unsectioned' })
+  const membership = (
+    entries: Array<[string, string]>
+  ): ReadonlyMap<string, { id: string }> =>
+    new Map(entries.map(([templateId, colId]) => [templateId, { id: colId }]))
+
+  it('returns the input unchanged when there are no collisions', () => {
+    expect(resolveSectionDropCollisions([], 'j1', membership([]))).toEqual([])
+  })
+
+  it('remaps a card hit to its collection when moving in from the unsectioned pool', () => {
+    // Cursor over card j-in-x (which lives in collection X); the dragged card
+    // is unsectioned → the whole collection is the drop zone.
+    const collisions = [collision('j-in-x'), collision(collectionX)]
+    const result = resolveSectionDropCollisions(
+      collisions,
+      'j-unsectioned',
+      membership([['j-in-x', 'X']])
+    )
+    expect(ids(result)).toEqual([collectionX])
+  })
+
+  it('remaps a card hit to its collection when moving in from a different collection', () => {
+    const collisions = [collision('j-in-x'), collision(collectionX)]
+    const result = resolveSectionDropCollisions(
+      collisions,
+      'j-src',
+      membership([
+        ['j-in-x', 'X'],
+        ['j-src', 'Y']
+      ])
+    )
+    expect(ids(result)).toEqual([collectionX])
+  })
+
+  it('keeps the specific card for a reorder within the same collection', () => {
+    // Dragged card j1 and the hovered card j2 both live in X → keep the card
+    // target so the existing reorder path lands it at that slot.
+    const collisions = [collision('j2'), collision(collectionX)]
+    const result = resolveSectionDropCollisions(
+      collisions,
+      'j1',
+      membership([
+        ['j1', 'X'],
+        ['j2', 'X']
+      ])
+    )
+    expect(result).toBe(collisions)
+  })
+
+  it('returns the collection container when the cursor is over the empty area', () => {
+    const collisions = [collision(collectionX)]
+    const result = resolveSectionDropCollisions(
+      collisions,
+      'j-unsectioned',
+      membership([])
+    )
+    expect(ids(result)).toEqual([collectionX])
+  })
+
+  it('targets the unsectioned zone when dragging a collection card over it', () => {
+    // Moving a collection card out to the unsectioned pool, cursor over one of
+    // its cards → the whole unsectioned pool is the drop zone.
+    const collisions = [collision('j-unsectioned'), collision(unsectioned)]
+    const result = resolveSectionDropCollisions(
+      collisions,
+      'j-src',
+      membership([['j-src', 'A']])
+    )
+    expect(ids(result)).toEqual([unsectioned])
+  })
+
+  it('leaves card-only collisions untouched (no section under the cursor)', () => {
+    const collisions = [collision('jA'), collision('jB')]
+    const result = resolveSectionDropCollisions(
+      collisions,
+      'jA',
+      membership([])
+    )
+    expect(result).toBe(collisions)
   })
 })

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/Droppables/Droppables.spec.ts
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/Droppables/Droppables.spec.ts
@@ -3,7 +3,7 @@ import { Collision } from '@dnd-kit/core'
 import {
   encodeDropZoneId,
   parseDropZoneId,
-  resolveSectionDropCollisions
+  resolveSectionDrop
 } from './Droppables'
 
 describe('encodeDropZoneId / parseDropZoneId', () => {
@@ -40,10 +40,8 @@ describe('encodeDropZoneId / parseDropZoneId', () => {
   })
 })
 
-describe('resolveSectionDropCollisions', () => {
+describe('resolveSectionDrop', () => {
   const collision = (id: string): Collision => ({ id })
-  const ids = (collisions: Collision[]): string[] =>
-    collisions.map((c) => String(c.id))
   const collectionX = encodeDropZoneId({ kind: 'collection', id: 'X' })
   const unsectioned = encodeDropZoneId({ kind: 'unsectioned' })
   const membership = (
@@ -51,25 +49,31 @@ describe('resolveSectionDropCollisions', () => {
   ): ReadonlyMap<string, { id: string }> =>
     new Map(entries.map(([templateId, colId]) => [templateId, { id: colId }]))
 
-  it('returns the input unchanged when there are no collisions', () => {
-    expect(resolveSectionDropCollisions([], 'j1', membership([]))).toEqual([])
+  it('passes through when no section is under the cursor', () => {
+    const collisions = [collision('jA'), collision('jB')]
+    expect(resolveSectionDrop(collisions, 'jA', membership([]))).toEqual({
+      kind: 'passthrough'
+    })
   })
 
-  it('remaps a card hit to its collection when moving in from the unsectioned pool', () => {
-    // Cursor over card j-in-x (which lives in collection X); the dragged card
-    // is unsectioned → the whole collection is the drop zone.
+  it('targets the collection when moving in from the unsectioned pool', () => {
+    // Cursor over card j-in-x (in collection X); dragged card is unsectioned →
+    // the whole collection is the drop zone.
     const collisions = [collision('j-in-x'), collision(collectionX)]
-    const result = resolveSectionDropCollisions(
+    const result = resolveSectionDrop(
       collisions,
       'j-unsectioned',
       membership([['j-in-x', 'X']])
     )
-    expect(ids(result)).toEqual([collectionX])
+    expect(result).toEqual({
+      kind: 'section',
+      collision: collision(collectionX)
+    })
   })
 
-  it('remaps a card hit to its collection when moving in from a different collection', () => {
+  it('targets the collection when moving in from a different collection', () => {
     const collisions = [collision('j-in-x'), collision(collectionX)]
-    const result = resolveSectionDropCollisions(
+    const result = resolveSectionDrop(
       collisions,
       'j-src',
       membership([
@@ -77,14 +81,19 @@ describe('resolveSectionDropCollisions', () => {
         ['j-src', 'Y']
       ])
     )
-    expect(ids(result)).toEqual([collectionX])
+    expect(result).toEqual({
+      kind: 'section',
+      collision: collision(collectionX)
+    })
   })
 
-  it('keeps the specific card for a reorder within the same collection', () => {
-    // Dragged card j1 and the hovered card j2 both live in X → keep the card
-    // target so the existing reorder path lands it at that slot.
-    const collisions = [collision('j2'), collision(collectionX)]
-    const result = resolveSectionDropCollisions(
+  it('signals a reorder when the dragged card belongs to the collection under the cursor', () => {
+    // Whether the cursor is over a card OR the container gap, a same-collection
+    // drag resolves to reorder so the caller can find the nearest in-collection
+    // slot. Here the container ranks first (cursor in a gap) — must still
+    // reorder, not no-op.
+    const collisions = [collision(collectionX), collision('j2')]
+    const result = resolveSectionDrop(
       collisions,
       'j1',
       membership([
@@ -92,38 +101,34 @@ describe('resolveSectionDropCollisions', () => {
         ['j2', 'X']
       ])
     )
-    expect(result).toBe(collisions)
+    expect(result).toEqual({ kind: 'reorder', collectionId: 'X' })
   })
 
-  it('returns the collection container when the cursor is over the empty area', () => {
+  it('targets the collection when the cursor is over its empty area', () => {
     const collisions = [collision(collectionX)]
-    const result = resolveSectionDropCollisions(
+    const result = resolveSectionDrop(
       collisions,
       'j-unsectioned',
       membership([])
     )
-    expect(ids(result)).toEqual([collectionX])
+    expect(result).toEqual({
+      kind: 'section',
+      collision: collision(collectionX)
+    })
   })
 
   it('targets the unsectioned zone when dragging a collection card over it', () => {
-    // Moving a collection card out to the unsectioned pool, cursor over one of
-    // its cards → the whole unsectioned pool is the drop zone.
+    // Moving a collection card out to the unsectioned pool → the whole pool is
+    // the drop zone (unsectioned has no reorder, so it's a plain section).
     const collisions = [collision('j-unsectioned'), collision(unsectioned)]
-    const result = resolveSectionDropCollisions(
+    const result = resolveSectionDrop(
       collisions,
       'j-src',
       membership([['j-src', 'A']])
     )
-    expect(ids(result)).toEqual([unsectioned])
-  })
-
-  it('leaves card-only collisions untouched (no section under the cursor)', () => {
-    const collisions = [collision('jA'), collision('jB')]
-    const result = resolveSectionDropCollisions(
-      collisions,
-      'jA',
-      membership([])
-    )
-    expect(result).toBe(collisions)
+    expect(result).toEqual({
+      kind: 'section',
+      collision: collision(unsectioned)
+    })
   })
 })

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/Droppables/Droppables.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/Droppables/Droppables.tsx
@@ -37,44 +37,59 @@ export function parseDropZoneId(raw: string): DropZoneId | null {
 }
 
 /**
- * Makes a whole section (a collection, or the unsectioned pool) a single drop
- * zone. dnd-kit's pointer/closest collision returns the specific card under
- * the cursor first, but the gallery's intent when the cursor is anywhere
- * inside a section is "drop into this section" — so a card hit is remapped to
- * its enclosing section container, which also drives the section's drop
- * highlight. The one exception is reordering within the same section: when the
- * dragged card already belongs to the section under the cursor, the specific
- * card is kept as the target so the drop lands at that position.
- *
- * Pure and dnd-kit-geometry-free so it's unit-testable: the caller runs the
- * real collision strategy, this just rewrites the result.
+ * The drop intent for a pointer position, decoded from the section under the
+ * cursor and the dragged card's origin:
+ *  - `reorder`  — the dragged card already belongs to the collection under the
+ *    cursor; the caller should target the nearest card *within that collection*
+ *    so the drop lands at a slot (works even when the cursor is in the gap
+ *    between cards, where `pointerWithin` only sees the container).
+ *  - `section`  — moving into a different section (or the unsectioned pool);
+ *    the whole section is the drop zone, so target its container.
+ *  - `passthrough` — the cursor isn't over any section container; the caller
+ *    keeps the raw collision result.
  */
-export function resolveSectionDropCollisions(
-  collisions: Collision[],
+export type SectionDropResolution =
+  | { kind: 'reorder'; collectionId: string }
+  | { kind: 'section'; collision: Collision }
+  | { kind: 'passthrough' }
+
+/**
+ * Decides, from the pointer collisions, how to target the gallery's nested
+ * droppables so a whole collection acts as one drop zone without breaking
+ * intra-collection reorder. Pure and dnd-kit-geometry-free so it's unit
+ * testable; the caller runs the real collision strategies and applies the
+ * decision (notably a collection-scoped `closestCenter` for `reorder`).
+ *
+ * Only pointer-derived collisions should be passed in. A drop in dead space
+ * (cursor outside every droppable) must NOT be promoted to a section — that
+ * would silently reassign membership on a missed drop — so the caller handles
+ * the empty case before calling this.
+ */
+export function resolveSectionDrop(
+  pointerCollisions: Collision[],
   activeId: string,
   templateIdToCollection: ReadonlyMap<string, { id: string }>
-): Collision[] {
-  if (collisions.length === 0) return collisions
-  // A section container present anywhere under the cursor (collection or
-  // unsectioned). Cards have raw journey ids, which parse to null.
-  const sectionCollision = collisions.find(
+): SectionDropResolution {
+  // The section container under the cursor (collection or unsectioned). Cards
+  // carry raw journey ids, which parse to null.
+  const sectionCollision = pointerCollisions.find(
     (collision) => parseDropZoneId(String(collision.id)) != null
   )
-  if (sectionCollision == null) return collisions
+  if (sectionCollision == null) return { kind: 'passthrough' }
 
-  const topId = String(collisions[0].id)
-  const topIsCard = parseDropZoneId(topId) == null
-  if (topIsCard) {
-    const sourceCollectionId = templateIdToCollection.get(activeId)?.id ?? null
-    const cardCollectionId = templateIdToCollection.get(topId)?.id ?? null
-    // Same-collection drag over one of its own cards → keep the card so the
-    // existing reorder path fires for that slot. (Both null = unsectioned over
-    // unsectioned, which is a no-op downstream either way.)
-    if (cardCollectionId != null && cardCollectionId === sourceCollectionId) {
-      return collisions
-    }
+  const zone = parseDropZoneId(String(sectionCollision.id))
+  const sectionCollectionId = zone?.kind === 'collection' ? zone.id : null
+  const sourceCollectionId = templateIdToCollection.get(activeId)?.id ?? null
+
+  // Dragging a card around its own collection → reorder within it.
+  if (
+    sectionCollectionId != null &&
+    sectionCollectionId === sourceCollectionId
+  ) {
+    return { kind: 'reorder', collectionId: sectionCollectionId }
   }
-  return [sectionCollision]
+
+  return { kind: 'section', collision: sectionCollision }
 }
 
 interface DroppableCollectionWrapperProps {

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/Droppables/Droppables.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/Droppables/Droppables.tsx
@@ -1,4 +1,4 @@
-import { useDroppable } from '@dnd-kit/core'
+import { Collision, useDroppable } from '@dnd-kit/core'
 import {
   SortableContext,
   rectSortingStrategy,
@@ -34,6 +34,47 @@ export function parseDropZoneId(raw: string): DropZoneId | null {
     return { kind: 'collection', id: raw.slice(COLLECTION_PREFIX.length) }
   }
   return null
+}
+
+/**
+ * Makes a whole section (a collection, or the unsectioned pool) a single drop
+ * zone. dnd-kit's pointer/closest collision returns the specific card under
+ * the cursor first, but the gallery's intent when the cursor is anywhere
+ * inside a section is "drop into this section" — so a card hit is remapped to
+ * its enclosing section container, which also drives the section's drop
+ * highlight. The one exception is reordering within the same section: when the
+ * dragged card already belongs to the section under the cursor, the specific
+ * card is kept as the target so the drop lands at that position.
+ *
+ * Pure and dnd-kit-geometry-free so it's unit-testable: the caller runs the
+ * real collision strategy, this just rewrites the result.
+ */
+export function resolveSectionDropCollisions(
+  collisions: Collision[],
+  activeId: string,
+  templateIdToCollection: ReadonlyMap<string, { id: string }>
+): Collision[] {
+  if (collisions.length === 0) return collisions
+  // A section container present anywhere under the cursor (collection or
+  // unsectioned). Cards have raw journey ids, which parse to null.
+  const sectionCollision = collisions.find(
+    (collision) => parseDropZoneId(String(collision.id)) != null
+  )
+  if (sectionCollision == null) return collisions
+
+  const topId = String(collisions[0].id)
+  const topIsCard = parseDropZoneId(topId) == null
+  if (topIsCard) {
+    const sourceCollectionId = templateIdToCollection.get(activeId)?.id ?? null
+    const cardCollectionId = templateIdToCollection.get(topId)?.id ?? null
+    // Same-collection drag over one of its own cards → keep the card so the
+    // existing reorder path fires for that slot. (Both null = unsectioned over
+    // unsectioned, which is a no-op downstream either way.)
+    if (cardCollectionId != null && cardCollectionId === sourceCollectionId) {
+      return collisions
+    }
+  }
+  return [sectionCollision]
 }
 
 interface DroppableCollectionWrapperProps {

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/Droppables/index.ts
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/Droppables/index.ts
@@ -5,6 +5,6 @@ export {
   UnsectionedDroppable,
   encodeDropZoneId,
   parseDropZoneId,
-  resolveSectionDropCollisions
+  resolveSectionDrop
 } from './Droppables'
-export type { DropZoneId } from './Droppables'
+export type { DropZoneId, SectionDropResolution } from './Droppables'

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/Droppables/index.ts
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/Droppables/index.ts
@@ -4,6 +4,7 @@ export {
   DroppableCollectionWrapper,
   UnsectionedDroppable,
   encodeDropZoneId,
-  parseDropZoneId
+  parseDropZoneId,
+  resolveSectionDropCollisions
 } from './Droppables'
 export type { DropZoneId } from './Droppables'

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.spec.tsx
@@ -438,4 +438,115 @@ describe('TemplateGalleryPageList', () => {
       expect(getByTestId('TemplateGalleryDndScope')).toHaveAttribute('inert')
     )
   })
+
+  // NES-1717: collapse wiring through the parent — proves collapsed /
+  // onToggleCollapse are connected to a real CollectionCard and that the
+  // state round-trips through localStorage on remount.
+  describe('collapsible collection headers (NES-1717)', () => {
+    beforeEach(() => localStorage.clear())
+
+    afterEach(() => localStorage.clear())
+
+    // page-1 holds journey-1 so the grid renders a card we can watch
+    // appear/disappear, and the count badge has something to count.
+    const collectionsMockWithTemplate: MockedResponse<GetTemplateGalleryPages> =
+      {
+        request: {
+          query: GET_TEMPLATE_GALLERY_PAGES,
+          variables: { teamId: TEAM_ID }
+        },
+        result: {
+          data: {
+            templateGalleryPages: [
+              {
+                ...(collectionsMock.result as { data: GetTemplateGalleryPages })
+                  .data.templateGalleryPages[0],
+                templates: [
+                  {
+                    __typename: 'TemplateGalleryItem',
+                    id: 'journey-1',
+                    title: 'Welcome Tour',
+                    primaryImageBlock: null
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+
+    function renderList() {
+      return render(
+        <MockedProvider
+          mocks={[
+            getLastActiveTeamIdAndTeamsMock,
+            collectionsMockWithTemplate,
+            journeysMock
+          ]}
+        >
+          <ThemeProvider>
+            <SnackbarProvider>
+              <TeamProvider>
+                <TemplateGalleryPageList />
+              </TeamProvider>
+            </SnackbarProvider>
+          </ThemeProvider>
+        </MockedProvider>
+      )
+    }
+
+    it('collapses then expands a collection from its header', async () => {
+      const { getByTestId, queryByTestId } = renderList()
+
+      await waitFor(() =>
+        expect(getByTestId('CollectionCard-page-1')).toBeInTheDocument()
+      )
+      // Expanded by default: the in-collection card is visible, no count badge.
+      expect(getByTestId('JourneyCard-journey-1')).toBeInTheDocument()
+      expect(queryByTestId('CollectionCardCount-page-1')).toBeNull()
+
+      // Collapse: grid unmounts, count badge appears.
+      fireEvent.click(getByTestId('CollectionCardToggle-page-1'))
+      await waitFor(() =>
+        expect(queryByTestId('JourneyCard-journey-1')).toBeNull()
+      )
+      expect(getByTestId('CollectionCardCount-page-1')).toHaveTextContent('1')
+      expect(getByTestId('CollectionCardToggle-page-1')).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      )
+
+      // Expand again: the card returns.
+      fireEvent.click(getByTestId('CollectionCardToggle-page-1'))
+      await waitFor(() =>
+        expect(getByTestId('JourneyCard-journey-1')).toBeInTheDocument()
+      )
+    })
+
+    it('restores the collapsed state from localStorage on remount', async () => {
+      const first = renderList()
+      await waitFor(() =>
+        expect(first.getByTestId('CollectionCard-page-1')).toBeInTheDocument()
+      )
+      fireEvent.click(first.getByTestId('CollectionCardToggle-page-1'))
+      await waitFor(() =>
+        expect(
+          first.getByTestId('CollectionCardCount-page-1')
+        ).toBeInTheDocument()
+      )
+      first.unmount()
+
+      // Fresh mount, same team: the collection comes back collapsed.
+      const second = renderList()
+      await waitFor(() =>
+        expect(
+          second.getByTestId('CollectionCardCount-page-1')
+        ).toBeInTheDocument()
+      )
+      expect(second.getByTestId('CollectionCardToggle-page-1')).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      )
+    })
+  })
 })

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
@@ -191,17 +191,6 @@ export function TemplateGalleryPageList({
 
   const { busyId, ungroup: handleUngroup } = useCollectionMutations()
 
-  // NES-1717: per-collection collapse state, persisted per team in
-  // localStorage. Default is expanded; a collapsed collection hides its grid
-  // but its header stays a valid drop target.
-  const { isCollapsed, toggle: toggleCollapse } = useCollectionCollapse(teamId)
-  const handleToggleCollapse = useCallback(
-    (collection: TemplateGalleryPage): void => {
-      toggleCollapse(collection.id)
-    },
-    [toggleCollapse]
-  )
-
   const [templateGalleryPageCreate, { loading: createLoading }] =
     useTemplateGalleryPageCreateMutation()
   // Synchronous double-click guard for the instant-create flow. The
@@ -291,6 +280,25 @@ export function TemplateGalleryPageList({
   const collections = useMemo<readonly TemplateGalleryPage[]>(
     () => collectionsQuery.data?.templateGalleryPages ?? [],
     [collectionsQuery.data]
+  )
+
+  // NES-1717: per-collection collapse state, persisted per team in
+  // localStorage. Default is expanded; a collapsed collection hides its grid
+  // but its header stays a valid drop target. The live ids let the hook
+  // prune persisted entries for deleted collections.
+  const collectionIds = useMemo(
+    () => collections.map((collection) => collection.id),
+    [collections]
+  )
+  const { isCollapsed, toggle: toggleCollapse } = useCollectionCollapse(
+    teamId,
+    collectionIds
+  )
+  const handleToggleCollapse = useCallback(
+    (collection: TemplateGalleryPage): void => {
+      toggleCollapse(collection.id)
+    },
+    [toggleCollapse]
   )
   // Filter the cached journeys list to the statuses this view allows.
   // The server-side query is already keyed on `status:

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
@@ -1,10 +1,12 @@
 import {
+  CollisionDetection,
   DndContext,
   DragOverlay,
   DragStartEvent,
   MouseSensor,
   TouchSensor,
   closestCenter,
+  pointerWithin,
   useSensor,
   useSensors
 } from '@dnd-kit/core'
@@ -55,7 +57,8 @@ import { CollectionPublishSuccessDialog } from './CollectionPublishSuccessDialog
 import {
   DraggableJourneysGrid,
   DroppableCollectionWrapper,
-  UnsectionedDroppable
+  UnsectionedDroppable,
+  resolveSectionDropCollisions
 } from './Droppables'
 import {
   GalleryDialogLockContext,
@@ -412,6 +415,33 @@ export function TemplateGalleryPageList({
     })
   )
 
+  // Pointer-based collision detection. `closestCenter` resolves the drop
+  // target from the *dragged card's* centre, which is offset from the cursor
+  // by wherever the user grabbed the card and competes with the wide
+  // collection / All-Templates droppables — so the resolved target drifted
+  // away from where the user was actually pointing, leaving bands (notably the
+  // row edges) where a drop did nothing. `pointerWithin` keys off the real
+  // cursor; falling back to `closestCenter` only when the cursor is outside
+  // every droppable preserves edge-of-canvas forgiveness.
+  //
+  // `resolveSectionDropCollisions` then makes the whole collection a single
+  // drop zone: hovering anywhere inside it — including over its cards — targets
+  // the collection (and lights its highlight), except when reordering within
+  // the same collection, where the card under the cursor is kept as the slot.
+  const collisionDetection = useCallback<CollisionDetection>(
+    (args) => {
+      const pointerCollisions = pointerWithin(args)
+      const collisions =
+        pointerCollisions.length > 0 ? pointerCollisions : closestCenter(args)
+      return resolveSectionDropCollisions(
+        collisions,
+        String(args.active.id),
+        templateIdToCollection
+      )
+    },
+    [templateIdToCollection]
+  )
+
   // Scan existing collection titles for the "Collection N" pattern and
   // return the smallest unused N (>= 1). The match is case-sensitive
   // and ignores extra whitespace — only the exact shape this handler
@@ -604,7 +634,7 @@ export function TemplateGalleryPageList({
           sx={{ display: 'contents' }}
         >
           <DndContext
-            collisionDetection={closestCenter}
+            collisionDetection={collisionDetection}
             sensors={sensors}
             onDragStart={handleDragStart}
             onDragEnd={handleDragEnd}

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
@@ -61,6 +61,7 @@ import {
   GalleryDialogLockContext,
   GalleryDialogLockContextValue
 } from './GalleryDialogLockContext'
+import { useCollectionCollapse } from './useCollectionCollapse'
 import { useCollectionMutations } from './useCollectionMutations'
 import { useDragEndHandler } from './useDragEndHandler'
 
@@ -189,6 +190,17 @@ export function TemplateGalleryPageList({
   }, [])
 
   const { busyId, ungroup: handleUngroup } = useCollectionMutations()
+
+  // NES-1717: per-collection collapse state, persisted per team in
+  // localStorage. Default is expanded; a collapsed collection hides its grid
+  // but its header stays a valid drop target.
+  const { isCollapsed, toggle: toggleCollapse } = useCollectionCollapse(teamId)
+  const handleToggleCollapse = useCallback(
+    (collection: TemplateGalleryPage): void => {
+      toggleCollapse(collection.id)
+    },
+    [toggleCollapse]
+  )
 
   const [templateGalleryPageCreate, { loading: createLoading }] =
     useTemplateGalleryPageCreateMutation()
@@ -480,7 +492,8 @@ export function TemplateGalleryPageList({
     collectionsById,
     dragInFlightRef,
     setDragInFlight,
-    setActiveDragId
+    setActiveDragId,
+    isCollectionCollapsed: isCollapsed
   })
 
   if (teamId == null) {
@@ -632,6 +645,8 @@ export function TemplateGalleryPageList({
                             ? t(publishBlockedReason)
                             : null
                         }
+                        collapsed={isCollapsed(collection.id)}
+                        onToggleCollapse={handleToggleCollapse}
                       >
                         <DraggableJourneysGrid
                           journeys={

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/TemplateGalleryPageList.tsx
@@ -58,7 +58,8 @@ import {
   DraggableJourneysGrid,
   DroppableCollectionWrapper,
   UnsectionedDroppable,
-  resolveSectionDropCollisions
+  parseDropZoneId,
+  resolveSectionDrop
 } from './Droppables'
 import {
   GalleryDialogLockContext,
@@ -415,29 +416,47 @@ export function TemplateGalleryPageList({
     })
   )
 
-  // Pointer-based collision detection. `closestCenter` resolves the drop
-  // target from the *dragged card's* centre, which is offset from the cursor
-  // by wherever the user grabbed the card and competes with the wide
-  // collection / All-Templates droppables — so the resolved target drifted
-  // away from where the user was actually pointing, leaving bands (notably the
-  // row edges) where a drop did nothing. `pointerWithin` keys off the real
-  // cursor; falling back to `closestCenter` only when the cursor is outside
-  // every droppable preserves edge-of-canvas forgiveness.
+  // Pointer-based collision detection, two-level (the dnd-kit "multiple
+  // containers" pattern). `closestCenter` alone resolved the target from the
+  // *dragged card's* centre — offset from the cursor by the grab point and
+  // competing with the wide section droppables — leaving dead bands where a
+  // drop landed nowhere. `pointerWithin` keys off the real cursor instead.
   //
-  // `resolveSectionDropCollisions` then makes the whole collection a single
-  // drop zone: hovering anywhere inside it — including over its cards — targets
-  // the collection (and lights its highlight), except when reordering within
-  // the same collection, where the card under the cursor is kept as the slot.
+  // From the pointer collisions, `resolveSectionDrop` decides intent: moving
+  // into a section targets the whole section (so the collection is one drop
+  // zone and its highlight lights anywhere inside it); reordering within a
+  // collection targets the nearest card *within that collection* via a scoped
+  // `closestCenter`, so the slot resolves even when the cursor is in the gap
+  // between cards (where `pointerWithin` only sees the container).
+  //
+  // When the cursor is outside every droppable we fall back to the raw
+  // `closestCenter` WITHOUT promoting to a section — a drop in dead space must
+  // not silently reassign a template's collection.
   const collisionDetection = useCallback<CollisionDetection>(
     (args) => {
       const pointerCollisions = pointerWithin(args)
-      const collisions =
-        pointerCollisions.length > 0 ? pointerCollisions : closestCenter(args)
-      return resolveSectionDropCollisions(
-        collisions,
+      if (pointerCollisions.length === 0) return closestCenter(args)
+
+      const resolution = resolveSectionDrop(
+        pointerCollisions,
         String(args.active.id),
         templateIdToCollection
       )
+      if (resolution.kind === 'passthrough') return pointerCollisions
+      if (resolution.kind === 'section') return [resolution.collision]
+
+      // reorder: nearest card within the dragged card's own collection.
+      const cardCollisions = closestCenter({
+        ...args,
+        droppableContainers: args.droppableContainers.filter((container) => {
+          const id = String(container.id)
+          return (
+            parseDropZoneId(id) == null &&
+            templateIdToCollection.get(id)?.id === resolution.collectionId
+          )
+        })
+      })
+      return cardCollisions.length > 0 ? cardCollisions : pointerCollisions
     },
     [templateIdToCollection]
   )

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/collectionCollapseStorage.ts
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/collectionCollapseStorage.ts
@@ -1,0 +1,34 @@
+// Per-device persistence for which collections the user has collapsed on the
+// Team Templates tab (NES-1717). Keyed per team so collapse choices don't
+// bleed across teams. Only collapsed ids are stored — the default is
+// expanded, so an absent/empty entry means "everything open".
+
+const STORAGE_KEY_PREFIX = 'templateCollectionsCollapse'
+
+function storageKey(teamId: string): string {
+  return `${STORAGE_KEY_PREFIX}:${teamId}`
+}
+
+export function getCollapsedCollectionIds(teamId: string): string[] {
+  try {
+    const raw = localStorage.getItem(storageKey(teamId))
+    if (raw == null) return []
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((id): id is string => typeof id === 'string')
+  } catch {
+    // localStorage may be unavailable (SSR, private browsing, etc.)
+    return []
+  }
+}
+
+export function setCollapsedCollectionIds(
+  teamId: string,
+  ids: readonly string[]
+): void {
+  try {
+    localStorage.setItem(storageKey(teamId), JSON.stringify([...ids]))
+  } catch {
+    // localStorage may be unavailable (SSR, private browsing, etc.)
+  }
+}

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/collectionCollapseStorage.ts
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/collectionCollapseStorage.ts
@@ -27,6 +27,13 @@ export function setCollapsedCollectionIds(
   ids: readonly string[]
 ): void {
   try {
+    // An empty set and an absent entry mean the same thing ("everything
+    // open"), so remove the key rather than storing `[]` — teams the user
+    // never collapses anything in leave no entry behind.
+    if (ids.length === 0) {
+      localStorage.removeItem(storageKey(teamId))
+      return
+    }
     localStorage.setItem(storageKey(teamId), JSON.stringify([...ids]))
   } catch {
     // localStorage may be unavailable (SSR, private browsing, etc.)

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/index.ts
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/index.ts
@@ -1,6 +1,2 @@
 export { useCollectionCollapse } from './useCollectionCollapse'
 export type { UseCollectionCollapseResult } from './useCollectionCollapse'
-export {
-  getCollapsedCollectionIds,
-  setCollapsedCollectionIds
-} from './collectionCollapseStorage'

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/index.ts
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/index.ts
@@ -1,0 +1,6 @@
+export { useCollectionCollapse } from './useCollectionCollapse'
+export type { UseCollectionCollapseResult } from './useCollectionCollapse'
+export {
+  getCollapsedCollectionIds,
+  setCollapsedCollectionIds
+} from './collectionCollapseStorage'

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.spec.tsx
@@ -85,4 +85,23 @@ describe('useCollectionCollapse', () => {
     const second = renderHook(() => useCollectionCollapse('team-1'))
     expect(second.result.current.isCollapsed('a')).toBe(true)
   })
+
+  it('prunes stored ids for collections that no longer exist', () => {
+    setCollapsedCollectionIds('team-1', ['a', 'b'])
+    // 'b' is no longer among the live collections → it must be dropped from
+    // both state and storage so the persisted set can't grow unbounded.
+    const { result } = renderHook(() =>
+      useCollectionCollapse('team-1', ['a'])
+    )
+    expect(result.current.isCollapsed('a')).toBe(true)
+    expect(result.current.isCollapsed('b')).toBe(false)
+    expect(getCollapsedCollectionIds('team-1')).toEqual(['a'])
+  })
+
+  it('does not prune while the collections list is empty (still loading)', () => {
+    setCollapsedCollectionIds('team-1', ['a'])
+    const { result } = renderHook(() => useCollectionCollapse('team-1', []))
+    expect(result.current.isCollapsed('a')).toBe(true)
+    expect(getCollapsedCollectionIds('team-1')).toEqual(['a'])
+  })
 })

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.spec.tsx
@@ -1,0 +1,76 @@
+import { act, renderHook } from '@testing-library/react'
+
+import {
+  getCollapsedCollectionIds,
+  setCollapsedCollectionIds
+} from './collectionCollapseStorage'
+import { useCollectionCollapse } from './useCollectionCollapse'
+
+describe('collectionCollapseStorage', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('returns an empty list when nothing is stored', () => {
+    expect(getCollapsedCollectionIds('team-1')).toEqual([])
+  })
+
+  it('round-trips collapsed ids isolated per team', () => {
+    setCollapsedCollectionIds('team-1', ['a', 'b'])
+    setCollapsedCollectionIds('team-2', ['c'])
+    expect(getCollapsedCollectionIds('team-1')).toEqual(['a', 'b'])
+    expect(getCollapsedCollectionIds('team-2')).toEqual(['c'])
+  })
+
+  it('returns an empty list for malformed stored values', () => {
+    localStorage.setItem('templateCollectionsCollapse:team-1', 'not json')
+    expect(getCollapsedCollectionIds('team-1')).toEqual([])
+  })
+})
+
+describe('useCollectionCollapse', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('defaults every collection to expanded', () => {
+    const { result } = renderHook(() => useCollectionCollapse('team-1'))
+    expect(result.current.isCollapsed('a')).toBe(false)
+  })
+
+  it('toggles collapsed state and persists it per team', () => {
+    const { result } = renderHook(() => useCollectionCollapse('team-1'))
+
+    act(() => result.current.toggle('a'))
+    expect(result.current.isCollapsed('a')).toBe(true)
+    expect(getCollapsedCollectionIds('team-1')).toEqual(['a'])
+
+    act(() => result.current.toggle('a'))
+    expect(result.current.isCollapsed('a')).toBe(false)
+    expect(getCollapsedCollectionIds('team-1')).toEqual([])
+  })
+
+  it('loads persisted collapsed ids on mount', () => {
+    setCollapsedCollectionIds('team-1', ['x'])
+    const { result } = renderHook(() => useCollectionCollapse('team-1'))
+    expect(result.current.isCollapsed('x')).toBe(true)
+  })
+
+  it('reloads the collapsed set when the team changes', () => {
+    setCollapsedCollectionIds('team-1', ['x'])
+    setCollapsedCollectionIds('team-2', ['y'])
+    const { result, rerender } = renderHook(
+      ({ teamId }: { teamId: string | undefined }) =>
+        useCollectionCollapse(teamId),
+      { initialProps: { teamId: 'team-1' as string | undefined } }
+    )
+    expect(result.current.isCollapsed('x')).toBe(true)
+    expect(result.current.isCollapsed('y')).toBe(false)
+
+    rerender({ teamId: 'team-2' })
+    expect(result.current.isCollapsed('y')).toBe(true)
+    expect(result.current.isCollapsed('x')).toBe(false)
+  })
+
+  it('is a no-op when there is no active team', () => {
+    const { result } = renderHook(() => useCollectionCollapse(undefined))
+    act(() => result.current.toggle('a'))
+    expect(result.current.isCollapsed('a')).toBe(false)
+  })
+})

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.spec.tsx
@@ -74,6 +74,27 @@ describe('useCollectionCollapse', () => {
     expect(result.current.isCollapsed('a')).toBe(false)
   })
 
+  it('prunes against the new team after a team switch, not the old', () => {
+    // Regression guard: on switching teams the freshly-loaded set must be
+    // pruned against the NEW team's live ids — never the previous team's.
+    setCollapsedCollectionIds('team-1', ['a'])
+    setCollapsedCollectionIds('team-2', ['y', 'stale'])
+    const { result, rerender } = renderHook(
+      ({ teamId, ids }: { teamId: string | undefined; ids: string[] }) =>
+        useCollectionCollapse(teamId, ids),
+      { initialProps: { teamId: 'team-1' as string | undefined, ids: ['a'] } }
+    )
+    expect(result.current.isCollapsed('a')).toBe(true)
+
+    rerender({ teamId: 'team-2', ids: ['y'] })
+    // team-2's stored 'stale' id (no live collection) is pruned; 'y' survives.
+    expect(result.current.isCollapsed('y')).toBe(true)
+    expect(result.current.isCollapsed('stale')).toBe(false)
+    expect(getCollapsedCollectionIds('team-2')).toEqual(['y'])
+    // team-1's storage is untouched by team-2's prune.
+    expect(getCollapsedCollectionIds('team-1')).toEqual(['a'])
+  })
+
   it('survives a full unmount/remount via localStorage alone', () => {
     // Proves the toggle->persist->reload loop end-to-end without re-seeding
     // storage by hand: a fresh hook instance must recover the state.

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.spec.tsx
@@ -73,4 +73,16 @@ describe('useCollectionCollapse', () => {
     act(() => result.current.toggle('a'))
     expect(result.current.isCollapsed('a')).toBe(false)
   })
+
+  it('survives a full unmount/remount via localStorage alone', () => {
+    // Proves the toggle->persist->reload loop end-to-end without re-seeding
+    // storage by hand: a fresh hook instance must recover the state.
+    const first = renderHook(() => useCollectionCollapse('team-1'))
+    act(() => first.result.current.toggle('a'))
+    expect(first.result.current.isCollapsed('a')).toBe(true)
+    first.unmount()
+
+    const second = renderHook(() => useCollectionCollapse('team-1'))
+    expect(second.result.current.isCollapsed('a')).toBe(true)
+  })
 })

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.spec.tsx
@@ -20,6 +20,14 @@ describe('collectionCollapseStorage', () => {
     expect(getCollapsedCollectionIds('team-2')).toEqual(['c'])
   })
 
+  it('removes the entry when an empty set is stored', () => {
+    // Absent and empty mean the same thing ("everything open"), so an empty
+    // write must clean up the key rather than leave `[]` behind.
+    setCollapsedCollectionIds('team-1', ['a'])
+    setCollapsedCollectionIds('team-1', [])
+    expect(localStorage.getItem('templateCollectionsCollapse:team-1')).toBeNull()
+  })
+
   it('returns an empty list for malformed stored values', () => {
     localStorage.setItem('templateCollectionsCollapse:team-1', 'not json')
     expect(getCollapsedCollectionIds('team-1')).toEqual([])

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.spec.tsx
@@ -25,7 +25,9 @@ describe('collectionCollapseStorage', () => {
     // write must clean up the key rather than leave `[]` behind.
     setCollapsedCollectionIds('team-1', ['a'])
     setCollapsedCollectionIds('team-1', [])
-    expect(localStorage.getItem('templateCollectionsCollapse:team-1')).toBeNull()
+    expect(
+      localStorage.getItem('templateCollectionsCollapse:team-1')
+    ).toBeNull()
   })
 
   it('returns an empty list for malformed stored values', () => {

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.spec.tsx
@@ -111,9 +111,7 @@ describe('useCollectionCollapse', () => {
     setCollapsedCollectionIds('team-1', ['a', 'b'])
     // 'b' is no longer among the live collections → it must be dropped from
     // both state and storage so the persisted set can't grow unbounded.
-    const { result } = renderHook(() =>
-      useCollectionCollapse('team-1', ['a'])
-    )
+    const { result } = renderHook(() => useCollectionCollapse('team-1', ['a']))
     expect(result.current.isCollapsed('a')).toBe(true)
     expect(result.current.isCollapsed('b')).toBe(false)
     expect(getCollapsedCollectionIds('team-1')).toEqual(['a'])

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.ts
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.ts
@@ -20,9 +20,15 @@ export interface UseCollectionCollapseResult {
  * localStorage is read in an effect (client-only) so the first render
  * matches the SSR markup (all expanded) and the stored set is applied after
  * mount. State is also reset and reloaded whenever the active team changes.
+ *
+ * @param liveCollectionIds the ids of the collections currently shown. When
+ *   provided, stored ids that no longer match a live collection (e.g. the
+ *   collection was deleted) are pruned from state and storage so the
+ *   persisted set can't grow unbounded.
  */
 export function useCollectionCollapse(
-  teamId: string | undefined
+  teamId: string | undefined,
+  liveCollectionIds?: readonly string[]
 ): UseCollectionCollapseResult {
   const [collapsedIds, setCollapsedIds] = useState<ReadonlySet<string>>(
     () => new Set()
@@ -35,6 +41,27 @@ export function useCollectionCollapse(
     }
     setCollapsedIds(new Set(getCollapsedCollectionIds(teamId)))
   }, [teamId])
+
+  // Garbage-collect ids for collections that no longer exist. Guarded on a
+  // non-empty list so a still-loading (or genuinely empty) collections query
+  // can't wipe the freshly-loaded set. Runs after the load effect; the
+  // functional updater sees the loaded set.
+  useEffect(() => {
+    if (teamId == null || liveCollectionIds == null) return
+    if (liveCollectionIds.length === 0) return
+    const live = new Set(liveCollectionIds)
+    setCollapsedIds((prev) => {
+      let changed = false
+      const next = new Set<string>()
+      for (const id of prev) {
+        if (live.has(id)) next.add(id)
+        else changed = true
+      }
+      if (!changed) return prev
+      setCollapsedCollectionIds(teamId, [...next])
+      return next
+    })
+  }, [teamId, liveCollectionIds])
 
   const isCollapsed = useCallback(
     (collectionId: string): boolean => collapsedIds.has(collectionId),

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.ts
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import {
+  getCollapsedCollectionIds,
+  setCollapsedCollectionIds
+} from './collectionCollapseStorage'
+
+export interface UseCollectionCollapseResult {
+  /** True when the collection is currently collapsed. Default is expanded. */
+  isCollapsed: (collectionId: string) => boolean
+  /** Flip a collection's collapsed state and persist the change. */
+  toggle: (collectionId: string) => void
+}
+
+/**
+ * Tracks which collections are collapsed on the Team Templates tab and
+ * persists the set per team in localStorage (NES-1717). The default is
+ * expanded — a collection is collapsed only if the user collapsed it.
+ *
+ * localStorage is read in an effect (client-only) so the first render
+ * matches the SSR markup (all expanded) and the stored set is applied after
+ * mount. State is also reset and reloaded whenever the active team changes.
+ */
+export function useCollectionCollapse(
+  teamId: string | undefined
+): UseCollectionCollapseResult {
+  const [collapsedIds, setCollapsedIds] = useState<ReadonlySet<string>>(
+    () => new Set()
+  )
+
+  useEffect(() => {
+    if (teamId == null) {
+      setCollapsedIds(new Set())
+      return
+    }
+    setCollapsedIds(new Set(getCollapsedCollectionIds(teamId)))
+  }, [teamId])
+
+  const isCollapsed = useCallback(
+    (collectionId: string): boolean => collapsedIds.has(collectionId),
+    [collapsedIds]
+  )
+
+  const toggle = useCallback(
+    (collectionId: string): void => {
+      if (teamId == null) return
+      const next = new Set(collapsedIds)
+      if (next.has(collectionId)) next.delete(collectionId)
+      else next.add(collectionId)
+      setCollapsedIds(next)
+      setCollapsedCollectionIds(teamId, [...next])
+    },
+    [collapsedIds, teamId]
+  )
+
+  return { isCollapsed, toggle }
+}

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.ts
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.ts
@@ -12,6 +12,20 @@ export interface UseCollectionCollapseResult {
   toggle: (collectionId: string) => void
 }
 
+interface CollapseState {
+  /**
+   * The team whose storage `ids` was loaded from, or `undefined` before the
+   * first load / when no team is active. The persist and prune effects key
+   * everything off this field — never the (possibly newer) `teamId` prop —
+   * so one team's ids can never be written to another team's storage, even
+   * transiently during a team switch.
+   */
+  teamId: string | undefined
+  ids: ReadonlySet<string>
+}
+
+const EMPTY_STATE: CollapseState = { teamId: undefined, ids: new Set() }
+
 /**
  * Tracks which collections are collapsed on the Team Templates tab and
  * persists the set per team in localStorage (NES-1717). The default is
@@ -24,68 +38,81 @@ export interface UseCollectionCollapseResult {
  * @param liveCollectionIds the ids of the collections currently shown. When
  *   provided, stored ids that no longer match a live collection (e.g. the
  *   collection was deleted) are pruned from state and storage so the
- *   persisted set can't grow unbounded.
+ *   persisted set can't grow unbounded. Callers must derive this from a
+ *   query keyed on the same `teamId` in the same render; a loading query
+ *   should yield `undefined` or `[]` (both are no-ops below), never another
+ *   team's ids.
  */
 export function useCollectionCollapse(
   teamId: string | undefined,
   liveCollectionIds?: readonly string[]
 ): UseCollectionCollapseResult {
-  const [collapsedIds, setCollapsedIds] = useState<ReadonlySet<string>>(
-    () => new Set()
-  )
+  const [state, setState] = useState<CollapseState>(EMPTY_STATE)
 
   useEffect(() => {
     if (teamId == null) {
-      setCollapsedIds(new Set())
+      setState(EMPTY_STATE)
       return
     }
-    setCollapsedIds(new Set(getCollapsedCollectionIds(teamId)))
+    setState({ teamId, ids: new Set(getCollapsedCollectionIds(teamId)) })
   }, [teamId])
 
-  // Garbage-collect ids for collections that no longer exist. Guarded on a
-  // non-empty list so a still-loading (or genuinely empty) collections query
-  // can't wipe the freshly-loaded set. Runs after the load effect; the
-  // functional updater sees the loaded set.
+  // Persist whenever the in-memory set changes. A separate effect — rather
+  // than a write inside the state updaters below — so StrictMode's
+  // double-invoked updaters can't double-write. Skipped until the load
+  // effect has seeded `state.teamId`, so the pre-load empty set is never
+  // written; re-writing a just-loaded set is an identical, harmless write.
+  useEffect(() => {
+    if (state.teamId == null) return
+    setCollapsedCollectionIds(state.teamId, [...state.ids])
+  }, [state])
+
+  // Garbage-collect ids for collections that no longer exist. Three guards
+  // make this safe across loading states and team switches:
+  // 1. `liveCollectionIds == null` — collections query not started/loading:
+  //    nothing to prune against, skip.
+  // 2. `length === 0` — still-loading (or genuinely empty) list: skip, so a
+  //    transient empty list can't wipe a freshly-loaded set.
+  // 3. `prev.teamId !== teamId` — state still belongs to the previous team
+  //    mid-switch: skip until the load effect above has re-seeded. (The load
+  //    effect runs first in the same commit, so by the time this updater is
+  //    applied the seeded state is what `prev` holds.)
   useEffect(() => {
     if (teamId == null || liveCollectionIds == null) return
     if (liveCollectionIds.length === 0) return
     const live = new Set(liveCollectionIds)
-    setCollapsedIds((prev) => {
+    setState((prev) => {
+      if (prev.teamId !== teamId) return prev
       let changed = false
       const next = new Set<string>()
-      for (const id of prev) {
+      for (const id of prev.ids) {
         if (live.has(id)) next.add(id)
         else changed = true
       }
       if (!changed) return prev
-      setCollapsedCollectionIds(teamId, [...next])
-      return next
+      return { teamId: prev.teamId, ids: next }
     })
   }, [teamId, liveCollectionIds])
 
   const isCollapsed = useCallback(
-    (collectionId: string): boolean => collapsedIds.has(collectionId),
-    [collapsedIds]
+    (collectionId: string): boolean => state.ids.has(collectionId),
+    [state.ids]
   )
 
-  const toggle = useCallback(
-    (collectionId: string): void => {
-      if (teamId == null) return
-      // Functional updater so `toggle` doesn't close over `collapsedIds`: its
-      // identity stays stable across toggles (preserving the React.memo on
-      // each CollectionCard) and two toggles in the same tick can't clobber
-      // each other. Persisting inside the updater keeps the write in lockstep
-      // with the state it derives from.
-      setCollapsedIds((prev) => {
-        const next = new Set(prev)
-        if (next.has(collectionId)) next.delete(collectionId)
-        else next.add(collectionId)
-        setCollapsedCollectionIds(teamId, [...next])
-        return next
-      })
-    },
-    [teamId]
-  )
+  const toggle = useCallback((collectionId: string): void => {
+    // Functional updater so `toggle` doesn't close over state: its identity
+    // stays stable across toggles (preserving the React.memo on each
+    // CollectionCard) and two toggles in the same tick can't clobber each
+    // other. Persistence happens in the effect above, keyed to the team the
+    // state was loaded for.
+    setState((prev) => {
+      if (prev.teamId == null) return prev
+      const next = new Set(prev.ids)
+      if (next.has(collectionId)) next.delete(collectionId)
+      else next.add(collectionId)
+      return { teamId: prev.teamId, ids: next }
+    })
+  }, [])
 
   return { isCollapsed, toggle }
 }

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.ts
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useCollectionCollapse/useCollectionCollapse.ts
@@ -44,13 +44,20 @@ export function useCollectionCollapse(
   const toggle = useCallback(
     (collectionId: string): void => {
       if (teamId == null) return
-      const next = new Set(collapsedIds)
-      if (next.has(collectionId)) next.delete(collectionId)
-      else next.add(collectionId)
-      setCollapsedIds(next)
-      setCollapsedCollectionIds(teamId, [...next])
+      // Functional updater so `toggle` doesn't close over `collapsedIds`: its
+      // identity stays stable across toggles (preserving the React.memo on
+      // each CollectionCard) and two toggles in the same tick can't clobber
+      // each other. Persisting inside the updater keeps the write in lockstep
+      // with the state it derives from.
+      setCollapsedIds((prev) => {
+        const next = new Set(prev)
+        if (next.has(collectionId)) next.delete(collectionId)
+        else next.add(collectionId)
+        setCollapsedCollectionIds(teamId, [...next])
+        return next
+      })
     },
-    [collapsedIds, teamId]
+    [teamId]
   )
 
   return { isCollapsed, toggle }

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useDragEndHandler/useDragEndHandler.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useDragEndHandler/useDragEndHandler.spec.tsx
@@ -596,7 +596,11 @@ describe('useDragEndHandler', () => {
     })
 
     expect(assignMock.result).toHaveBeenCalledTimes(1)
-    expect(screen.queryByText('Added to page-B')).not.toBeInTheDocument()
+    // waitFor so the check runs after notistack has settled — a synchronous
+    // negative assertion could pass before a (wrongly) enqueued toast renders.
+    await waitFor(() =>
+      expect(screen.queryByText('Added to page-B')).not.toBeInTheDocument()
+    )
   })
 
   it('shows the rejection error (not the added toast) when a collapsed-target drop is rejected', async () => {

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useDragEndHandler/useDragEndHandler.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useDragEndHandler/useDragEndHandler.spec.tsx
@@ -1,7 +1,7 @@
 import { InMemoryCache } from '@apollo/client'
 import { MockedProvider, MockedResponse } from '@apollo/client/testing'
 import { DragEndEvent } from '@dnd-kit/core'
-import { act, renderHook } from '@testing-library/react'
+import { act, renderHook, screen, waitFor } from '@testing-library/react'
 import { SnackbarProvider } from 'notistack'
 import { ReactNode } from 'react'
 
@@ -520,5 +520,82 @@ describe('useDragEndHandler', () => {
       (p) => p.id === 'page-A'
     )
     expect(sourceAfter?.templates.map((t) => t.id)).toEqual(['j1'])
+  })
+
+  // NES-1717: dropping onto a collapsed collection lands the template out of
+  // sight, so the handler surfaces an "Added to {collection}" toast.
+  it('toasts when a template is added to a collapsed collection', async () => {
+    const j1 = journey('j1', 'A')
+    const source = makeCollection('page-A', [j1])
+    const target = makeCollection('page-B', [])
+    const indexes = buildIndexes({
+      collections: [source, target],
+      journeys: [j1]
+    })
+
+    // Server confirms the move (target now contains j1) so `accepted` is true.
+    const assignMock = getTemplateGalleryPageAssignJourneyMock(
+      { journeyId: 'j1', pageId: 'page-B' },
+      { id: 'page-B', title: 'page-B', templates: [templateRef(j1)] }
+    )
+
+    const { result } = renderHook(
+      () =>
+        useDragEndHandler({
+          ...indexes,
+          dragInFlightRef: { current: false },
+          setDragInFlight: vi.fn(),
+          setActiveDragId: vi.fn(),
+          isCollectionCollapsed: (id) => id === 'page-B'
+        }),
+      { wrapper: wrapperWithMocks([assignMock]) }
+    )
+
+    await act(async () => {
+      await result.current(
+        dropEvent('j1', encodeDropZoneId({ kind: 'collection', id: 'page-B' }))
+      )
+    })
+
+    expect(assignMock.result).toHaveBeenCalledTimes(1)
+    await waitFor(() =>
+      expect(screen.getByText('Added to page-B')).toBeInTheDocument()
+    )
+  })
+
+  it('does not toast when the target collection is expanded', async () => {
+    const j1 = journey('j1', 'A')
+    const source = makeCollection('page-A', [j1])
+    const target = makeCollection('page-B', [])
+    const indexes = buildIndexes({
+      collections: [source, target],
+      journeys: [j1]
+    })
+
+    const assignMock = getTemplateGalleryPageAssignJourneyMock(
+      { journeyId: 'j1', pageId: 'page-B' },
+      { id: 'page-B', title: 'page-B', templates: [templateRef(j1)] }
+    )
+
+    const { result } = renderHook(
+      () =>
+        useDragEndHandler({
+          ...indexes,
+          dragInFlightRef: { current: false },
+          setDragInFlight: vi.fn(),
+          setActiveDragId: vi.fn(),
+          isCollectionCollapsed: () => false
+        }),
+      { wrapper: wrapperWithMocks([assignMock]) }
+    )
+
+    await act(async () => {
+      await result.current(
+        dropEvent('j1', encodeDropZoneId({ kind: 'collection', id: 'page-B' }))
+      )
+    })
+
+    expect(assignMock.result).toHaveBeenCalledTimes(1)
+    expect(screen.queryByText('Added to page-B')).not.toBeInTheDocument()
   })
 })

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useDragEndHandler/useDragEndHandler.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useDragEndHandler/useDragEndHandler.spec.tsx
@@ -598,4 +598,47 @@ describe('useDragEndHandler', () => {
     expect(assignMock.result).toHaveBeenCalledTimes(1)
     expect(screen.queryByText('Added to page-B')).not.toBeInTheDocument()
   })
+
+  it('shows the rejection error (not the added toast) when a collapsed-target drop is rejected', async () => {
+    const j1 = journey('j1', 'A')
+    const source = makeCollection('page-A', [j1])
+    const target = makeCollection('page-B', [])
+    const indexes = buildIndexes({
+      collections: [source, target],
+      journeys: [j1]
+    })
+
+    // Server returns the target WITHOUT j1 → silent rejection (accepted false).
+    const assignMock = getTemplateGalleryPageAssignJourneyMock(
+      { journeyId: 'j1', pageId: 'page-B' },
+      { id: 'page-B', title: 'page-B', templates: [] }
+    )
+
+    const { result } = renderHook(
+      () =>
+        useDragEndHandler({
+          ...indexes,
+          dragInFlightRef: { current: false },
+          setDragInFlight: vi.fn(),
+          setActiveDragId: vi.fn(),
+          isCollectionCollapsed: () => true
+        }),
+      { wrapper: wrapperWithMocks([assignMock]) }
+    )
+
+    await act(async () => {
+      await result.current(
+        dropEvent('j1', encodeDropZoneId({ kind: 'collection', id: 'page-B' }))
+      )
+    })
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "Couldn't move template — the server rejected the move."
+        )
+      ).toBeInTheDocument()
+    )
+    expect(screen.queryByText('Added to page-B')).not.toBeInTheDocument()
+  })
 })

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useDragEndHandler/useDragEndHandler.spec.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useDragEndHandler/useDragEndHandler.spec.tsx
@@ -641,4 +641,39 @@ describe('useDragEndHandler', () => {
     )
     expect(screen.queryByText('Added to page-B')).not.toBeInTheDocument()
   })
+
+  it('uses a generic confirmation when the collapsed target has no resolvable name', async () => {
+    const j1 = journey('j1', 'A')
+    const source = makeCollection('page-A', [j1])
+    // page-B is a collapsed drop target that is NOT in collectionsById and the
+    // server returns an empty title → the toast must not interpolate a blank.
+    const indexes = buildIndexes({ collections: [source], journeys: [j1] })
+
+    const assignMock = getTemplateGalleryPageAssignJourneyMock(
+      { journeyId: 'j1', pageId: 'page-B' },
+      { id: 'page-B', title: '', templates: [templateRef(j1)] }
+    )
+
+    const { result } = renderHook(
+      () =>
+        useDragEndHandler({
+          ...indexes,
+          dragInFlightRef: { current: false },
+          setDragInFlight: vi.fn(),
+          setActiveDragId: vi.fn(),
+          isCollectionCollapsed: () => true
+        }),
+      { wrapper: wrapperWithMocks([assignMock]) }
+    )
+
+    await act(async () => {
+      await result.current(
+        dropEvent('j1', encodeDropZoneId({ kind: 'collection', id: 'page-B' }))
+      )
+    })
+
+    await waitFor(() =>
+      expect(screen.getByText('Added to collection')).toBeInTheDocument()
+    )
+  })
 })

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useDragEndHandler/useDragEndHandler.ts
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useDragEndHandler/useDragEndHandler.ts
@@ -30,6 +30,13 @@ export interface UseDragEndHandlerParams {
   setDragInFlight: (next: boolean) => void
   /** Setter for the active drag id — the hook clears it on drop. */
   setActiveDragId: (next: string | null) => void
+  /**
+   * NES-1717: true when the given collection is currently collapsed. A drop
+   * onto a collapsed collection lands via its header (the only visible part),
+   * so the user can't see the template arrive — we surface a confirmation
+   * toast instead. Defaults to "never collapsed" when omitted.
+   */
+  isCollectionCollapsed?: (collectionId: string) => boolean
 }
 
 /**
@@ -52,7 +59,8 @@ export function useDragEndHandler(
     collectionsById,
     dragInFlightRef,
     setDragInFlight,
-    setActiveDragId
+    setActiveDragId,
+    isCollectionCollapsed
   } = params
   const { t } = useTranslation('apps-journeys-admin')
   const { enqueueSnackbar } = useSnackbar()
@@ -286,6 +294,16 @@ export function useDragEndHandler(
             enqueueSnackbar(
               t("Couldn't move template — the server rejected the move."),
               { variant: 'error', preventDuplicate: true }
+            )
+          } else if (isCollectionCollapsed?.(targetCollectionId) === true) {
+            // The template landed in a collapsed collection the user can't
+            // see — confirm the drop so the move doesn't feel like it
+            // vanished (NES-1717).
+            enqueueSnackbar(
+              t('Added to {{collection}}', {
+                collection: targetCollection?.title ?? ''
+              }),
+              { variant: 'success', preventDuplicate: true }
             )
           }
         }

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useDragEndHandler/useDragEndHandler.ts
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useDragEndHandler/useDragEndHandler.ts
@@ -305,12 +305,13 @@ export function useDragEndHandler(
           } else if (targetWasCollapsed) {
             // The template landed in a collapsed collection the user can't
             // see — confirm the drop so the move doesn't feel like it
-            // vanished (NES-1717).
+            // vanished (NES-1717). Fall back to a generic message rather than
+            // interpolating an empty name if the title can't be resolved.
+            const targetName = targetCollection?.title ?? returnedPage?.title
             enqueueSnackbar(
-              t('Added to {{collection}}', {
-                collection:
-                  targetCollection?.title ?? returnedPage?.title ?? ''
-              }),
+              targetName != null && targetName !== ''
+                ? t('Added to {{collection}}', { collection: targetName })
+                : t('Added to collection'),
               { variant: 'success', preventDuplicate: true }
             )
           }

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/useDragEndHandler/useDragEndHandler.ts
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/useDragEndHandler/useDragEndHandler.ts
@@ -183,6 +183,13 @@ export function useDragEndHandler(
           targetCollectionId != null
             ? collectionsById.get(targetCollectionId)
             : null
+        // Capture collapse state at drop time, before the await — the toast
+        // confirms "you dropped onto something you couldn't see", which is a
+        // fact about the moment of the drop, not about whatever the state has
+        // become by the time the network round-trip resolves (NES-1717 review).
+        const targetWasCollapsed =
+          targetCollectionId != null &&
+          isCollectionCollapsed?.(targetCollectionId) === true
         const assignResult = await templateGalleryPageAssignJourney({
           variables: { journeyId: templateId, pageId: targetCollectionId },
           // NES-1668: in production the source-page `cache.modify` below
@@ -295,13 +302,14 @@ export function useDragEndHandler(
               t("Couldn't move template — the server rejected the move."),
               { variant: 'error', preventDuplicate: true }
             )
-          } else if (isCollectionCollapsed?.(targetCollectionId) === true) {
+          } else if (targetWasCollapsed) {
             // The template landed in a collapsed collection the user can't
             // see — confirm the drop so the move doesn't feel like it
             // vanished (NES-1717).
             enqueueSnackbar(
               t('Added to {{collection}}', {
-                collection: targetCollection?.title ?? ''
+                collection:
+                  targetCollection?.title ?? returnedPage?.title ?? ''
               }),
               { variant: 'success', preventDuplicate: true }
             )


### PR DESCRIPTION
## What & why

[NES-1717](https://linear.app/jesus-film-project/issue/NES-1717/collapsable-collection-headers) — the Team Templates tab rendered every collection's full card grid stacked vertically, making the page tall and drag-and-drop painful. This adds collapsible collection headers so users can hide collections they aren't working with, while still being able to drop templates into collapsed ones.

Along the way it also fixes a **pre-existing** drag-and-drop dead-zone bug (the gallery's collision detection), surfaced during review of this work.

## Collapsible headers

- Each collection header is a toggle (`role="button"`, `aria-expanded`, Enter/Space, full-width touch target) with a rotating chevron and a template-count badge when collapsed.
- A collapsed card hides its grid (`Collapse unmountOnExit`) but keeps the header inside the existing collection droppable, so **dropping a template onto a collapsed header lands it in that collection** with no changes to the drop dispatcher's routing. Because the card is hidden, the drop surfaces an "Added to {collection}" toast.
- Collapse state persists **per team in localStorage** (default: expanded). Stale ids for deleted collections are pruned so the stored set can't grow unbounded.
- The toggle is inert while a drop mutation is settling, so collapsing can't unmount a `SortableContext` mid-drop.

## DnD drop-zone fixes (pre-existing bug)

The gallery used `closestCenter`, which resolves the target from the *dragged card's centre* — offset from the cursor by the grab point and competing with the wide section droppables — leaving dead bands (notably row edges) where a drop landed nowhere, and never lighting a collection's highlight when hovering its cards.

Reworked to the dnd-kit **multiple-containers** pattern:
- `pointerWithin` keys off the real cursor; `resolveSectionDrop` (pure, unit-tested) decides intent.
- **Moving into a section** targets the whole section → the collection is one drop zone that highlights anywhere inside it.
- **Reordering within a collection** targets the nearest card *within that collection* via a scoped `closestCenter`, so the slot resolves even in the gaps between cards.
- A drop in **dead space** (cursor outside every droppable) returns raw `closestCenter` with **no** section promotion, so a missed drop never silently reassigns membership.

## Review

Authored, then run through **4 review rounds** (correctness, dnd-races, TypeScript, testing, adversarial, maintainability, simplicity). Findings fixed across the fix-commits: dangling `aria-controls`, toggle-during-settle unmount race, unstable `toggle` identity defeating `React.memo`, drop-time vs post-await toast state, unbounded localStorage growth, Space-key swallow while busy, and two DnD regressions (reorder no-op, dead-space write).

## Testing

- 159 unit tests pass (collapse hook, storage, CollectionCard toggle/a11y, drag dispatcher toasts, collision **decision** logic), `nx type-check` clean, ESLint clean.
- ⚠️ **Needs preview QA:** collision *geometry* can't run in jsdom. On the preview, verify: reorder within a collection lands at the slot (incl. dropping in gaps/header); dropping anywhere in a collection adds membership + highlights; a dead-space drop doesn't reassign; drag onto a collapsed header lands + toasts; collapse persists across reload.

## Notes
- Frontend only; no schema/backend changes. No LaunchDarkly flag (per scope decision).
- Default policy is **always-expanded** (the ticket's "default-collapsed over threshold N" was intentionally dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template collections can be collapsed/expanded; collapsed state persists per team across sessions.
  * Collapsed collections show a templates-count badge and remove their contents from view to save space.
  * Drag-and-drop targeting improved for more accurate drops; dropping into a collapsed collection shows a confirmation toast.

* **Accessibility & Interaction**
  * Header toggles support keyboard (Enter/Space), proper ARIA states, and robust behavior while busy.

* **Tests**
  * Expanded test coverage for collapsible headers, persistence, and drag-drop scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->