### PR TITLE
fix(videos-admin): refresh upload auth before mutations

### DIFF
--- a/apps/videos-admin/src/app/_UploadVideoVariantProvider/UploadVideoVariantProvider.tsx
+++ b/apps/videos-admin/src/app/_UploadVideoVariantProvider/UploadVideoVariantProvider.tsx
@@ -271,9 +271,16 @@ export function UploadVideoVariantProvider({
   const syncUploadAuthToken = async () => {
     const refreshedToken = await refreshToken()
 
-    if (refreshedToken == null) return
+    if (refreshedToken == null) return false
 
     apolloClient.defaultContext.token = refreshedToken
+    return true
+  }
+
+  const requireUploadAuthToken = async () => {
+    if (await syncUploadAuthToken()) return
+
+    throw new Error('Unable to refresh authentication for video upload')
   }
 
   const startUploadAuthRefresh = () => {
@@ -382,6 +389,8 @@ export function UploadVideoVariantProvider({
     })
 
     try {
+      await requireUploadAuthToken()
+
       const result = await createVideoVariant({
         variables: {
           input: variantInput
@@ -495,6 +504,7 @@ export function UploadVideoVariantProvider({
         ...logContext,
         r2FileName: fileName
       })
+      await requireUploadAuthToken()
       const r2Response = await prepareR2Multipart({
         variables: {
           input: {
@@ -705,6 +715,7 @@ export function UploadVideoVariantProvider({
         r2FileName: multipartData.fileName,
         r2UploadId: multipartData.uploadId
       })
+      await requireUploadAuthToken()
       await completeR2Multipart({
         variables: {
           input: {
@@ -721,6 +732,7 @@ export function UploadVideoVariantProvider({
         r2UploadId: multipartData.uploadId
       })
 
+      await requireUploadAuthToken()
       const muxResponse = await createMuxVideo({
         variables: {
           url: multipartData.publicUrl,
@@ -749,6 +761,7 @@ export function UploadVideoVariantProvider({
       })
 
       // Start polling for Mux video status
+      await requireUploadAuthToken()
       void getMyMuxVideo({
         variables: {
           id: muxResponse.data.createMuxVideoUploadByUrl.id,

--- a/apps/videos-admin/src/app/api/index.ts
+++ b/apps/videos-admin/src/app/api/index.ts
@@ -49,11 +49,20 @@ export async function refreshToken(): Promise<string | null> {
   }
 
   // Fallback for cases where the browser Firebase user is unavailable.
-  await fetch('/api/refresh-token', {
+  const refreshResponse = await fetch('/api/refresh-token', {
     method: 'GET',
     headers: {},
-    cache: 'no-store'
+    cache: 'no-store',
+    credentials: 'same-origin'
   })
 
-  return null
+  if (!refreshResponse.ok) return null
+
+  try {
+    const { idToken } = (await refreshResponse.json()) as { idToken?: unknown }
+
+    return typeof idToken === 'string' ? idToken : null
+  } catch {
+    return null
+  }
 }


### PR DESCRIPTION
## Summary

Long video uploads now refresh Apollo's in-memory auth token before each authenticated upload mutation, so a refreshed browser cookie no longer leaves the GraphQL client sending a stale JWT.

The previous refresh fallback called `/api/refresh-token` but returned `null` when Firebase's browser user was unavailable. That refreshed cookies but skipped updating `apolloClient.defaultContext.token`, which could surface as a 401 from `api-gateway` after a slow R2 multipart upload.

## Changes

- Return the refreshed `idToken` from the `/api/refresh-token` fallback when available.
- Sync Apollo's default auth token immediately before the R2 prepare/complete, Mux create/poll, and video variant create GraphQL operations.

## Verification

- Reproduced the prod-shaped failure locally by forcing a stale Apollo token before the R2 complete mutation.
- Verified the same stale-token repro gets past R2 complete, creates the Mux video, and completes successfully when using a non-overlapping language.
- `pnpm dlx nx run videos-admin:test`
- `pnpm dlx nx run videos-admin:type-check`
- `pnpm dlx nx run videos-admin:lint`

Closes QA-520


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication token synchronization during video upload and variant creation processes. Token refresh now properly handles responses and is enforced at critical points throughout the upload workflow to ensure uninterrupted operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->