### PR TITLE
fix(NES-1724): translate about-chat legal page via journey language

### DIFF
--- a/apps/journeys/__tests__/pages/home/legal/about-chat.spec.tsx
+++ b/apps/journeys/__tests__/pages/home/legal/about-chat.spec.tsx
@@ -14,14 +14,29 @@ vi.mock('next-i18next/pages/serverSideTranslations', () => ({
   serverSideTranslations: vi.fn().mockResolvedValue({ _nextI18Next: {} })
 }))
 
-// Mutable i18n state lets the dir tests flip the resolved language without
+// Mutable i18n state lets the dir tests model which translation bundles
+// actually loaded (the component walks the fallback chain) without
 // re-mocking the module per test.
-const i18nState = vi.hoisted(() => ({ language: 'en' }))
+const i18nState = vi.hoisted(() => ({
+  languages: ['en'],
+  bundles: { en: { loaded: 'yes' } } as Record<
+    string,
+    Record<string, string> | undefined
+  >
+}))
+
+function resetI18nState(): void {
+  i18nState.languages = ['en']
+  i18nState.bundles = { en: { loaded: 'yes' } }
+}
 
 vi.mock('next-i18next/pages', () => ({
   useTranslation: () => ({
     t: (key: string) => key,
-    i18n: { language: i18nState.language }
+    i18n: {
+      languages: i18nState.languages,
+      getResourceBundle: (language: string) => i18nState.bundles[language]
+    }
   })
 }))
 
@@ -40,14 +55,52 @@ function makeContext(
 describe('about-chat getServerSideProps', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    i18nState.language = 'en'
+    resetI18nState()
   })
 
-  it('translates by ?lang when it is shaped like a BCP-47 tag', async () => {
+  it('resolves short language codes to their translation folder (NES-1731)', async () => {
     await getServerSideProps(makeContext({ query: { lang: 'es' } }))
 
     expect(mockServerSideTranslations).toHaveBeenCalledWith(
-      'es',
+      'es-ES',
+      ['apps-journeys', 'libs-journeys-ui'],
+      expect.anything()
+    )
+
+    mockServerSideTranslations.mockClear()
+    await getServerSideProps(makeContext({ query: { lang: 'ar' } }))
+
+    expect(mockServerSideTranslations).toHaveBeenCalledWith(
+      'ar-SA',
+      ['apps-journeys', 'libs-journeys-ui'],
+      expect.anything()
+    )
+  })
+
+  it('canonicalizes letter case before resolving (NES-1729)', async () => {
+    await getServerSideProps(makeContext({ query: { lang: 'ES' } }))
+
+    expect(mockServerSideTranslations).toHaveBeenCalledWith(
+      'es-ES',
+      ['apps-journeys', 'libs-journeys-ui'],
+      expect.anything()
+    )
+
+    mockServerSideTranslations.mockClear()
+    await getServerSideProps(makeContext({ query: { lang: 'AR-sa' } }))
+
+    expect(mockServerSideTranslations).toHaveBeenCalledWith(
+      'ar-SA',
+      ['apps-journeys', 'libs-journeys-ui'],
+      expect.anything()
+    )
+  })
+
+  it('passes valid-but-unmapped tags through for i18next fallback', async () => {
+    await getServerSideProps(makeContext({ query: { lang: 'fa' } }))
+
+    expect(mockServerSideTranslations).toHaveBeenCalledWith(
+      'fa',
       ['apps-journeys', 'libs-journeys-ui'],
       expect.anything()
     )
@@ -118,7 +171,7 @@ describe('about-chat getServerSideProps', () => {
 
 describe('AboutChatPage', () => {
   beforeEach(() => {
-    i18nState.language = 'en'
+    resetI18nState()
   })
 
   it('renders the notice content left-to-right by default', () => {
@@ -130,11 +183,30 @@ describe('AboutChatPage', () => {
     expect(screen.getByTestId('AboutChatPage')).toHaveAttribute('dir', 'ltr')
   })
 
-  it('renders right-to-left for RTL languages', () => {
-    i18nState.language = 'ar'
+  it('renders right-to-left when an RTL translation bundle loaded', () => {
+    i18nState.languages = ['ar-SA', 'ar', 'en']
+    i18nState.bundles = {
+      'ar-SA': { loaded: 'yes' },
+      en: { loaded: 'yes' }
+    }
 
     render(<AboutChatPage />)
 
     expect(screen.getByTestId('AboutChatPage')).toHaveAttribute('dir', 'rtl')
+  })
+
+  it('renders left-to-right when a requested RTL language has no translations (NES-1731)', () => {
+    // `fa` was requested but no Farsi bundle exists — the text falls back to
+    // English, so the layout must NOT be right-aligned. Empty bundles (i18next
+    // marks failed loads as {}) must be skipped, not counted as loaded.
+    i18nState.languages = ['fa', 'en']
+    i18nState.bundles = {
+      fa: {},
+      en: { loaded: 'yes' }
+    }
+
+    render(<AboutChatPage />)
+
+    expect(screen.getByTestId('AboutChatPage')).toHaveAttribute('dir', 'ltr')
   })
 })

--- a/apps/journeys/__tests__/pages/home/legal/about-chat.spec.tsx
+++ b/apps/journeys/__tests__/pages/home/legal/about-chat.spec.tsx
@@ -14,29 +14,23 @@ vi.mock('next-i18next/pages/serverSideTranslations', () => ({
   serverSideTranslations: vi.fn().mockResolvedValue({ _nextI18Next: {} })
 }))
 
-// Mutable i18n state lets the dir tests model which translation bundles
-// actually loaded (the component walks the fallback chain) without
-// re-mocking the module per test.
+// Mutable i18n state lets the dir tests model the resolved language and
+// which strings actually have translations (the component keys direction
+// off whether its own copy translated) without re-mocking per test.
 const i18nState = vi.hoisted(() => ({
-  languages: ['en'],
-  bundles: { en: { loaded: 'yes' } } as Record<
-    string,
-    Record<string, string> | undefined
-  >
+  language: 'en',
+  translations: {} as Record<string, string>
 }))
 
 function resetI18nState(): void {
-  i18nState.languages = ['en']
-  i18nState.bundles = { en: { loaded: 'yes' } }
+  i18nState.language = 'en'
+  i18nState.translations = {}
 }
 
 vi.mock('next-i18next/pages', () => ({
   useTranslation: () => ({
-    t: (key: string) => key,
-    i18n: {
-      languages: i18nState.languages,
-      getResourceBundle: (language: string) => i18nState.bundles[language]
-    }
+    t: (key: string) => i18nState.translations[key] ?? key,
+    i18n: { language: i18nState.language }
   })
 }))
 
@@ -210,12 +204,9 @@ describe('AboutChatPage', () => {
     expect(screen.getByTestId('AboutChatPage')).toHaveAttribute('dir', 'ltr')
   })
 
-  it('renders right-to-left when an RTL translation bundle loaded', () => {
-    i18nState.languages = ['ar-SA', 'ar', 'en']
-    i18nState.bundles = {
-      'ar-SA': { loaded: 'yes' },
-      en: { loaded: 'yes' }
-    }
+  it('renders right-to-left when the page copy is translated into an RTL language', () => {
+    i18nState.language = 'ar-SA'
+    i18nState.translations = { 'About this chat': 'حول هذه المحادثة' }
 
     render(<AboutChatPage />)
 
@@ -223,14 +214,23 @@ describe('AboutChatPage', () => {
   })
 
   it('renders left-to-right when a requested RTL language has no translations (NES-1731)', () => {
-    // `fa` was requested but no Farsi bundle exists — the text falls back to
-    // English, so the layout must NOT be right-aligned. Empty bundles (i18next
-    // marks failed loads as {}) must be skipped, not counted as loaded.
-    i18nState.languages = ['fa', 'en']
-    i18nState.bundles = {
-      fa: {},
-      en: { loaded: 'yes' }
-    }
+    // `fa` was requested but no Farsi files exist — the text falls back to
+    // English, so the layout must NOT be right-aligned.
+    i18nState.language = 'fa'
+    i18nState.translations = {}
+
+    render(<AboutChatPage />)
+
+    expect(screen.getByTestId('AboutChatPage')).toHaveAttribute('dir', 'ltr')
+  })
+
+  it('renders left-to-right for a partially translated RTL locale (NES-1731)', () => {
+    // ur-PK has translation files with other strings in them, but this
+    // page's copy is still untranslated (pending Crowdin) — the rendered
+    // text is the English fallback, so direction must stay LTR even though
+    // the locale resolved and its files loaded.
+    i18nState.language = 'ur-PK'
+    i18nState.translations = { 'Some other string': 'کچھ اور' }
 
     render(<AboutChatPage />)
 

--- a/apps/journeys/__tests__/pages/home/legal/about-chat.spec.tsx
+++ b/apps/journeys/__tests__/pages/home/legal/about-chat.spec.tsx
@@ -1,8 +1,12 @@
+import { readdirSync } from 'node:fs'
+import path from 'node:path'
+
 import { render, screen } from '@testing-library/react'
 import { GetServerSidePropsContext } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
 import { type Mock } from 'vitest'
 
+import i18nConfig from '../../../../next-i18next.config'
 import HostnameAboutChatPage, {
   getServerSideProps as hostnameGetServerSideProps
 } from '../../../../pages/[hostname]/legal/about-chat'
@@ -115,6 +119,44 @@ describe('about-chat getServerSideProps', () => {
       ['apps-journeys', 'libs-journeys-ui'],
       expect.anything()
     )
+  })
+
+  it('derives the folder lookup from the i18n config fallbackLng', async () => {
+    // The page's map is built from next-i18next.config.js (PR #9292 review) —
+    // every entry there must round-trip through ?lang to its folder.
+    const fallbackLng = i18nConfig.fallbackLng as Record<string, string[]>
+
+    for (const [language, [folder]] of Object.entries(fallbackLng)) {
+      if (language === 'default') continue
+      mockServerSideTranslations.mockClear()
+      await getServerSideProps(makeContext({ query: { lang: language } }))
+
+      expect(mockServerSideTranslations).toHaveBeenCalledWith(
+        folder,
+        ['apps-journeys', 'libs-journeys-ui'],
+        expect.anything()
+      )
+    }
+  })
+
+  it('maps every libs/locales translation folder in the config fallbackLng', () => {
+    // The sync the single-sourcing buys (PR #9292 review): a new locale
+    // folder without a fallbackLng entry would silently render English for
+    // that language's short code — fail here instead.
+    // cwd is apps/journeys whenever this suite runs at all (setupTests.ts
+    // resolves relative to it), so the locales root is two levels up.
+    const localesDir = path.resolve(process.cwd(), '../../libs/locales')
+    const folders = readdirSync(localesDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && entry.name !== 'en')
+      .map((entry) => entry.name)
+    const mappedFolders = Object.values(
+      i18nConfig.fallbackLng as Record<string, string[]>
+    ).map(([folder]) => folder)
+
+    expect(folders.length).toBeGreaterThan(0)
+    for (const folder of folders) {
+      expect(mappedFolders).toContain(folder)
+    }
   })
 
   it('passes valid-but-unmapped tags through for i18next fallback', async () => {

--- a/apps/journeys/__tests__/pages/home/legal/about-chat.spec.tsx
+++ b/apps/journeys/__tests__/pages/home/legal/about-chat.spec.tsx
@@ -96,6 +96,33 @@ describe('about-chat getServerSideProps', () => {
     )
   })
 
+  it('resolves dialect tags by prefix to their base-language folder (NES-1731)', async () => {
+    // Real Arabic journeys carry dialect codes — Gulf (ar-afb), Saidi
+    // (ar-aec), MSA Egyptian (ar-arb-EG) — and all must reach the Arabic
+    // translations, not fall back to English.
+    for (const dialect of ['ar-afb', 'ar-aec', 'ar-arb-EG']) {
+      mockServerSideTranslations.mockClear()
+      await getServerSideProps(makeContext({ query: { lang: dialect } }))
+
+      expect(mockServerSideTranslations).toHaveBeenCalledWith(
+        'ar-SA',
+        ['apps-journeys', 'libs-journeys-ui'],
+        expect.anything()
+      )
+    }
+
+    // The longer zh-Hant key must win over the bare zh prefix — Traditional
+    // must never resolve to the Simplified folder.
+    mockServerSideTranslations.mockClear()
+    await getServerSideProps(makeContext({ query: { lang: 'zh-Hant-TW' } }))
+
+    expect(mockServerSideTranslations).toHaveBeenCalledWith(
+      'zh-Hant-TW',
+      ['apps-journeys', 'libs-journeys-ui'],
+      expect.anything()
+    )
+  })
+
   it('passes valid-but-unmapped tags through for i18next fallback', async () => {
     await getServerSideProps(makeContext({ query: { lang: 'fa' } }))
 

--- a/apps/journeys/__tests__/pages/home/legal/about-chat.spec.tsx
+++ b/apps/journeys/__tests__/pages/home/legal/about-chat.spec.tsx
@@ -1,4 +1,4 @@
-import { readdirSync } from 'node:fs'
+import { existsSync, readdirSync } from 'node:fs'
 import path from 'node:path'
 
 import { render, screen } from '@testing-library/react'
@@ -143,9 +143,16 @@ describe('about-chat getServerSideProps', () => {
     // The sync the single-sourcing buys (PR #9292 review): a new locale
     // folder without a fallbackLng entry would silently render English for
     // that language's short code — fail here instead.
-    // cwd is apps/journeys whenever this suite runs at all (setupTests.ts
-    // resolves relative to it), so the locales root is two levels up.
-    const localesDir = path.resolve(process.cwd(), '../../libs/locales')
+    // The runner's cwd varies (apps/journeys locally, the repo root in CI)
+    // — walk up from it to wherever libs/locales actually lives.
+    let repoDir = process.cwd()
+    while (!existsSync(path.join(repoDir, 'libs/locales'))) {
+      const parent = path.dirname(repoDir)
+      if (parent === repoDir)
+        throw new Error('libs/locales not found above cwd')
+      repoDir = parent
+    }
+    const localesDir = path.join(repoDir, 'libs/locales')
     const folders = readdirSync(localesDir, { withFileTypes: true })
       .filter((entry) => entry.isDirectory() && entry.name !== 'en')
       .map((entry) => entry.name)

--- a/apps/journeys/__tests__/pages/home/legal/about-chat.spec.tsx
+++ b/apps/journeys/__tests__/pages/home/legal/about-chat.spec.tsx
@@ -1,0 +1,140 @@
+import { render, screen } from '@testing-library/react'
+import { GetServerSidePropsContext } from 'next'
+import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
+import { type Mock } from 'vitest'
+
+import HostnameAboutChatPage, {
+  getServerSideProps as hostnameGetServerSideProps
+} from '../../../../pages/[hostname]/legal/about-chat'
+import AboutChatPage, {
+  getServerSideProps
+} from '../../../../pages/home/legal/about-chat'
+
+vi.mock('next-i18next/pages/serverSideTranslations', () => ({
+  serverSideTranslations: vi.fn().mockResolvedValue({ _nextI18Next: {} })
+}))
+
+// Mutable i18n state lets the dir tests flip the resolved language without
+// re-mocking the module per test.
+const i18nState = vi.hoisted(() => ({ language: 'en' }))
+
+vi.mock('next-i18next/pages', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: i18nState.language }
+  })
+}))
+
+vi.mock('next-seo', () => ({
+  NextSeo: () => <div data-testid="NextSeoMock" />
+}))
+
+const mockServerSideTranslations = serverSideTranslations as unknown as Mock
+
+function makeContext(
+  overrides: Partial<{ query: unknown; locale: string }> = {}
+): GetServerSidePropsContext {
+  return { query: {}, ...overrides } as unknown as GetServerSidePropsContext
+}
+
+describe('about-chat getServerSideProps', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    i18nState.language = 'en'
+  })
+
+  it('translates by ?lang when it is shaped like a BCP-47 tag', async () => {
+    await getServerSideProps(makeContext({ query: { lang: 'es' } }))
+
+    expect(mockServerSideTranslations).toHaveBeenCalledWith(
+      'es',
+      ['apps-journeys', 'libs-journeys-ui'],
+      expect.anything()
+    )
+  })
+
+  it('accepts multi-subtag languages like zh-Hans-CN', async () => {
+    await getServerSideProps(makeContext({ query: { lang: 'zh-Hans-CN' } }))
+
+    expect(mockServerSideTranslations).toHaveBeenCalledWith(
+      'zh-Hans-CN',
+      ['apps-journeys', 'libs-journeys-ui'],
+      expect.anything()
+    )
+  })
+
+  it('falls back to the URL locale when no ?lang is given', async () => {
+    await getServerSideProps(makeContext({ locale: 'fr' }))
+
+    expect(mockServerSideTranslations).toHaveBeenCalledWith(
+      'fr',
+      ['apps-journeys', 'libs-journeys-ui'],
+      expect.anything()
+    )
+  })
+
+  it('defaults to English when neither ?lang nor a locale is present', async () => {
+    await getServerSideProps(makeContext())
+
+    expect(mockServerSideTranslations).toHaveBeenCalledWith(
+      'en',
+      ['apps-journeys', 'libs-journeys-ui'],
+      expect.anything()
+    )
+  })
+
+  it('ignores values that are not shaped like a BCP-47 tag', async () => {
+    // ?lang feeds i18next's filesystem loader — anything that doesn't look
+    // like a language tag (traversal attempts, repeated params, junk) must
+    // fall back rather than reach the loader.
+    const rejected: unknown[] = [
+      '../../../../etc/passwd',
+      'es/../en',
+      'e',
+      'es!',
+      'aa-bb-cc-dd-ee-ff',
+      ['es', 'fr']
+    ]
+
+    for (const lang of rejected) {
+      mockServerSideTranslations.mockClear()
+      await getServerSideProps(makeContext({ query: { lang } }))
+
+      expect(mockServerSideTranslations).toHaveBeenCalledWith(
+        'en',
+        ['apps-journeys', 'libs-journeys-ui'],
+        expect.anything()
+      )
+    }
+  })
+
+  it('is shared as-is by the [hostname] route', () => {
+    // The custom-hostname route re-exports the home page wholesale — if
+    // these ever diverge, custom domains lose journey-language translations.
+    expect(hostnameGetServerSideProps).toBe(getServerSideProps)
+    expect(HostnameAboutChatPage).toBe(AboutChatPage)
+  })
+})
+
+describe('AboutChatPage', () => {
+  beforeEach(() => {
+    i18nState.language = 'en'
+  })
+
+  it('renders the notice content left-to-right by default', () => {
+    render(<AboutChatPage />)
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'About this chat' })
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('AboutChatPage')).toHaveAttribute('dir', 'ltr')
+  })
+
+  it('renders right-to-left for RTL languages', () => {
+    i18nState.language = 'ar'
+
+    render(<AboutChatPage />)
+
+    expect(screen.getByTestId('AboutChatPage')).toHaveAttribute('dir', 'rtl')
+  })
+})

--- a/apps/journeys/next-i18next.config.js
+++ b/apps/journeys/next-i18next.config.js
@@ -29,17 +29,35 @@ const i18nConfig = {
     ],
     localeDetection: false
   },
+  // One entry per translation folder in libs/locales, mapping the language
+  // (or language-script) code to the folder that holds its files. URL locales
+  // only ever activate a few of these, but legal/about-chat resolves journey
+  // languages (?lang=<bcp47>) through this same map (NES-1724/NES-1731) —
+  // when adding a locale folder, add its language here too.
   fallbackLng: {
     default: ['en'],
+    am: ['am-ET'],
+    ar: ['ar-SA'],
+    bn: ['bn-BD'],
+    de: ['de-DE'],
     es: ['es-ES'],
     fr: ['fr-FR'],
+    hi: ['hi-IN'],
     id: ['id-ID'],
-    th: ['th-TH'],
     ja: ['ja-JP'],
     ko: ['ko-KR'],
+    ms: ['ms-MY'],
+    my: ['my-MM'],
+    ne: ['ne-NP'],
+    pt: ['pt-BR'],
     ru: ['ru-RU'],
+    th: ['th-TH'],
+    tl: ['tl-PH'],
     tr: ['tr-TR'],
-    zh: ['zh-Hans-CN']
+    ur: ['ur-PK'],
+    vi: ['vi-VN'],
+    zh: ['zh-Hans-CN'],
+    'zh-Hant': ['zh-Hant-TW']
   },
   localePath
 }

--- a/apps/journeys/pages/[hostname]/legal/about-chat.tsx
+++ b/apps/journeys/pages/[hostname]/legal/about-chat.tsx
@@ -1,27 +1,8 @@
-import { GetStaticPaths, GetStaticProps } from 'next'
-import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
-
-import i18nConfig from '../../../next-i18next.config'
-
-// The page is hostname-agnostic — same static content under both the
-// root domain (routed to `pages/home/legal/about-chat.tsx`) and any
-// custom hostname (routed here by the `apps/journeys/proxy.ts` Next.js
-// middleware, which rewrites `/{path}` → `/{hostname}/{path}`).
-// We re-export the component and provide a getStaticProps that only
-// loads translations.
-export { default } from '../../home/legal/about-chat'
-
-export const getStaticProps: GetStaticProps = async (context) => ({
-  props: {
-    ...(await serverSideTranslations(
-      context.locale ?? 'en',
-      ['apps-journeys', 'libs-journeys-ui'],
-      i18nConfig
-    ))
-  }
-})
-
-export const getStaticPaths: GetStaticPaths = async () => ({
-  paths: [],
-  fallback: 'blocking'
-})
+// The page is hostname-agnostic — same content under both the root
+// domain (routed to `pages/home/legal/about-chat.tsx`) and any custom
+// hostname (routed here by the `apps/journeys/proxy.ts` Next.js
+// middleware, which rewrites `/{path}` → `/{hostname}/{path}`; the query
+// string survives the rewrite). The component and its getServerSideProps
+// (journey-language translations via `?lang`, NES-1724) are shared via
+// re-export.
+export { default, getServerSideProps } from '../../home/legal/about-chat'

--- a/apps/journeys/pages/home/legal/about-chat.tsx
+++ b/apps/journeys/pages/home/legal/about-chat.tsx
@@ -17,11 +17,18 @@ import logo from '../../../public/logo.svg'
 
 function AboutChatPage(): ReactElement {
   const { t, i18n } = useTranslation('apps-journeys')
-  // Flip layout direction for RTL languages (ar, ur, fa, …) so translated
-  // copy reads correctly. `i18n.language` is the locale resolved by
-  // getServerSideProps below; it can be undefined when the component renders
-  // outside appWithTranslation (tests), so default to LTR.
-  const dir = getLocaleRTL(i18n.language ?? '') ? 'rtl' : 'ltr'
+  // Direction must follow the words actually rendered, not the requested
+  // language: a requested-but-untranslated RTL language (e.g. `fa`) falls
+  // back to English text and must therefore render LTR — never RTL-aligned
+  // English (NES-1731). Walk i18next's fallback chain to the first language
+  // whose translation bundle actually loaded.
+  const renderedLanguage =
+    i18n.languages?.find(
+      (language) =>
+        Object.keys(i18n.getResourceBundle(language, 'apps-journeys') ?? {})
+          .length > 0
+    ) ?? ''
+  const dir = getLocaleRTL(renderedLanguage) ? 'rtl' : 'ltr'
 
   return (
     <>
@@ -101,11 +108,63 @@ function AboutChatPage(): ReactElement {
 // loader, so only accept values shaped like a BCP-47 tag.
 const LANG_PARAM_PATTERN = /^[a-z]{2,3}(-[a-z0-9]{2,8}){0,4}$/i
 
+// Language tags are case-insensitive by spec, but the folder lookup below is
+// case-exact — canonicalize before resolving: 'ES' → 'es', 'AR-sa' → 'ar-SA',
+// 'zh-hans-cn' → 'zh-Hans-CN' (NES-1729).
+function canonicalizeLangParam(value: string): string {
+  const [language, ...subtags] = value.split('-')
+  return [
+    language.toLowerCase(),
+    ...subtags.map((subtag) => {
+      if (subtag.length === 2) return subtag.toUpperCase()
+      if (subtag.length === 4)
+        return subtag[0].toUpperCase() + subtag.slice(1).toLowerCase()
+      return subtag.toLowerCase()
+    })
+  ].join('-')
+}
+
+// Journeys store short language codes (`ar`, `pt`) while the translation
+// folders in libs/locales are named with full region tags (`ar-SA`, `pt-BR`)
+// — resolve every short code to the folder that actually holds its files
+// (NES-1731). Tags not listed here pass through unchanged and either match a
+// folder directly (`ar-SA`) or fall back to English. The journeys i18n
+// config's own fallbackLng only covers 9 of these, so this map is the single
+// source of resolution for the `lang` param.
+const LANG_FOLDER_BY_LANGUAGE: Record<string, string> = {
+  am: 'am-ET',
+  ar: 'ar-SA',
+  bn: 'bn-BD',
+  de: 'de-DE',
+  es: 'es-ES',
+  fr: 'fr-FR',
+  hi: 'hi-IN',
+  id: 'id-ID',
+  ja: 'ja-JP',
+  ko: 'ko-KR',
+  ms: 'ms-MY',
+  my: 'my-MM',
+  ne: 'ne-NP',
+  pt: 'pt-BR',
+  ru: 'ru-RU',
+  th: 'th-TH',
+  tl: 'tl-PH',
+  tr: 'tr-TR',
+  ur: 'ur-PK',
+  vi: 'vi-VN',
+  zh: 'zh-Hans-CN',
+  'zh-Hant': 'zh-Hant-TW'
+}
+
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const langParam = context.query.lang
-  const lang =
+  const canonical =
     typeof langParam === 'string' && LANG_PARAM_PATTERN.test(langParam)
-      ? langParam
+      ? canonicalizeLangParam(langParam)
+      : undefined
+  const lang =
+    canonical != null
+      ? (LANG_FOLDER_BY_LANGUAGE[canonical] ?? canonical)
       : undefined
 
   return {

--- a/apps/journeys/pages/home/legal/about-chat.tsx
+++ b/apps/journeys/pages/home/legal/about-chat.tsx
@@ -156,16 +156,27 @@ const LANG_FOLDER_BY_LANGUAGE: Record<string, string> = {
   'zh-Hant': 'zh-Hant-TW'
 }
 
+// Real journey languages are mostly dialect tags — the languages API has 24
+// Arabic entries and only one is plain `ar`; the rest look like `ar-afb`
+// (Gulf), `ar-aec` (Saidi), `ar-arb-EG` (MSA Egyptian). Walk the tag from
+// most- to least-specific so every `ar-*` dialect resolves to the Arabic
+// translations (and `zh-Hant-TW` still hits `zh-Hant` before `zh`).
+function resolveLangFolder(canonical: string): string {
+  const subtags = canonical.split('-')
+  for (let length = subtags.length; length >= 1; length--) {
+    const folder = LANG_FOLDER_BY_LANGUAGE[subtags.slice(0, length).join('-')]
+    if (folder != null) return folder
+  }
+  return canonical
+}
+
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const langParam = context.query.lang
   const canonical =
     typeof langParam === 'string' && LANG_PARAM_PATTERN.test(langParam)
       ? canonicalizeLangParam(langParam)
       : undefined
-  const lang =
-    canonical != null
-      ? (LANG_FOLDER_BY_LANGUAGE[canonical] ?? canonical)
-      : undefined
+  const lang = canonical != null ? resolveLangFolder(canonical) : undefined
 
   return {
     props: {

--- a/apps/journeys/pages/home/legal/about-chat.tsx
+++ b/apps/journeys/pages/home/legal/about-chat.tsx
@@ -1,13 +1,14 @@
 import Container from '@mui/material/Container'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
-import { GetStaticProps } from 'next'
+import { GetServerSideProps } from 'next'
 import Image from 'next/image'
 import { useTranslation } from 'next-i18next/pages'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
 import { NextSeo } from 'next-seo'
 import { ReactElement } from 'react'
 
+import { getLocaleRTL } from '@core/shared/ui/rtl'
 import { ThemeProvider } from '@core/shared/ui/ThemeProvider'
 
 import { ThemeMode, ThemeName } from '../../../__generated__/globalTypes'
@@ -15,7 +16,12 @@ import i18nConfig from '../../../next-i18next.config'
 import logo from '../../../public/logo.svg'
 
 function AboutChatPage(): ReactElement {
-  const { t } = useTranslation('apps-journeys')
+  const { t, i18n } = useTranslation('apps-journeys')
+  // Flip layout direction for RTL languages (ar, ur, fa, …) so translated
+  // copy reads correctly. `i18n.language` is the locale resolved by
+  // getServerSideProps below; it can be undefined when the component renders
+  // outside appWithTranslation (tests), so default to LTR.
+  const dir = getLocaleRTL(i18n.language ?? '') ? 'rtl' : 'ltr'
 
   return (
     <>
@@ -23,7 +29,7 @@ function AboutChatPage(): ReactElement {
           page title here — the template appends the site name centrally. */}
       <NextSeo title={t('About this chat')} nofollow noindex />
       <ThemeProvider themeName={ThemeName.base} themeMode={ThemeMode.light}>
-        <Container maxWidth="sm">
+        <Container maxWidth="sm" dir={dir} data-testid="AboutChatPage">
           <Stack spacing={5} py={{ xs: 5, sm: 7 }}>
             <Image
               src={logo}
@@ -83,14 +89,34 @@ function AboutChatPage(): ReactElement {
   )
 }
 
-export const getStaticProps: GetStaticProps = async (context) => ({
-  props: {
-    ...(await serverSideTranslations(
-      context.locale ?? 'en',
-      ['apps-journeys', 'libs-journeys-ui'],
-      i18nConfig
-    ))
+// The journey viewer translates its UI by `journey.language.bcp47`, not by
+// URL locale — and the chat surfaces link here without a locale prefix, so
+// `context.locale` is always `en`. The links carry the journey language as
+// `?lang=<bcp47>` instead (NES-1724); resolve translations from it exactly
+// the way the journey page does, with the i18n config's `fallbackLng`
+// mapping short codes (es → es-ES) and falling back to English for
+// languages without translation files.
+//
+// `lang` is untrusted query input that ends up in i18next's filesystem
+// loader, so only accept values shaped like a BCP-47 tag.
+const LANG_PARAM_PATTERN = /^[a-z]{2,3}(-[a-z0-9]{2,8}){0,4}$/i
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const langParam = context.query.lang
+  const lang =
+    typeof langParam === 'string' && LANG_PARAM_PATTERN.test(langParam)
+      ? langParam
+      : undefined
+
+  return {
+    props: {
+      ...(await serverSideTranslations(
+        lang ?? context.locale ?? 'en',
+        ['apps-journeys', 'libs-journeys-ui'],
+        i18nConfig
+      ))
+    }
   }
-})
+}
 
 export default AboutChatPage

--- a/apps/journeys/pages/home/legal/about-chat.tsx
+++ b/apps/journeys/pages/home/legal/about-chat.tsx
@@ -128,34 +128,16 @@ function canonicalizeLangParam(value: string): string {
 // Journeys store short language codes (`ar`, `pt`) while the translation
 // folders in libs/locales are named with full region tags (`ar-SA`, `pt-BR`)
 // — resolve every short code to the folder that actually holds its files
-// (NES-1731). Tags not listed here pass through unchanged and either match a
-// folder directly (`ar-SA`) or fall back to English. The journeys i18n
-// config's own fallbackLng only covers 9 of these, so this map is the single
-// source of resolution for the `lang` param.
-const LANG_FOLDER_BY_LANGUAGE: Record<string, string> = {
-  am: 'am-ET',
-  ar: 'ar-SA',
-  bn: 'bn-BD',
-  de: 'de-DE',
-  es: 'es-ES',
-  fr: 'fr-FR',
-  hi: 'hi-IN',
-  id: 'id-ID',
-  ja: 'ja-JP',
-  ko: 'ko-KR',
-  ms: 'ms-MY',
-  my: 'my-MM',
-  ne: 'ne-NP',
-  pt: 'pt-BR',
-  ru: 'ru-RU',
-  th: 'th-TH',
-  tl: 'tl-PH',
-  tr: 'tr-TR',
-  ur: 'ur-PK',
-  vi: 'vi-VN',
-  zh: 'zh-Hans-CN',
-  'zh-Hant': 'zh-Hant-TW'
-}
+// (NES-1731). The i18n config's `fallbackLng` is the single source of that
+// mapping (one entry per libs/locales folder) — derive the lookup from it so
+// the two can't drift. `default` is i18next's catch-all, not a language tag.
+// Tags not in the map pass through unchanged and either match a folder
+// directly (`ar-SA`) or fall back to English.
+const LANG_FOLDER_BY_LANGUAGE: Record<string, string> = Object.fromEntries(
+  Object.entries(i18nConfig.fallbackLng as Record<string, string[]>)
+    .filter(([language]) => language !== 'default')
+    .map(([language, folders]) => [language, folders[0]] as const)
+)
 
 // Real journey languages are mostly dialect tags — the languages API has 24
 // Arabic entries and only one is plain `ar`; the rest look like `ar-afb`

--- a/apps/journeys/pages/home/legal/about-chat.tsx
+++ b/apps/journeys/pages/home/legal/about-chat.tsx
@@ -18,23 +18,24 @@ import logo from '../../../public/logo.svg'
 function AboutChatPage(): ReactElement {
   const { t, i18n } = useTranslation('apps-journeys')
   // Direction must follow the words actually rendered, not the requested
-  // language: a requested-but-untranslated RTL language (e.g. `fa`) falls
-  // back to English text and must therefore render LTR — never RTL-aligned
-  // English (NES-1731). Walk i18next's fallback chain to the first language
-  // whose translation bundle actually loaded.
-  const renderedLanguage =
-    i18n.languages?.find(
-      (language) =>
-        Object.keys(i18n.getResourceBundle(language, 'apps-journeys') ?? {})
-          .length > 0
-    ) ?? ''
-  const dir = getLocaleRTL(renderedLanguage) ? 'rtl' : 'ltr'
+  // language (NES-1731): an untranslated RTL language falls back to English
+  // text and must render LTR — never RTL-aligned English. Bundle-level
+  // checks aren't enough: a partially translated locale (e.g. ur-PK before
+  // its Crowdin round-trip) has a non-empty bundle while this page's strings
+  // still fall back to their English keys. The page title is the sentinel —
+  // keys ARE the English source strings, so t() returning the key verbatim
+  // means the page is rendering the English fallback.
+  const title = t('About this chat')
+  const dir =
+    title !== 'About this chat' && getLocaleRTL(i18n.language ?? '')
+      ? 'rtl'
+      : 'ltr'
 
   return (
     <>
       {/* `_app.tsx` sets titleTemplate '%s | Next Steps', so pass the bare
           page title here — the template appends the site name centrally. */}
-      <NextSeo title={t('About this chat')} nofollow noindex />
+      <NextSeo title={title} nofollow noindex />
       <ThemeProvider themeName={ThemeName.base} themeMode={ThemeMode.light}>
         <Container maxWidth="sm" dir={dir} data-testid="AboutChatPage">
           <Stack spacing={5} py={{ xs: 5, sm: 7 }}>
@@ -52,7 +53,7 @@ function AboutChatPage(): ReactElement {
             <Stack spacing={4} component="article">
               <Stack spacing={2}>
                 <Typography variant="h4" component="h1">
-                  {t('About this chat')}
+                  {title}
                 </Typography>
                 <Typography variant="body1">
                   {t(

--- a/libs/journeys/ui/src/components/AiChat/AiChat.spec.tsx
+++ b/libs/journeys/ui/src/components/AiChat/AiChat.spec.tsx
@@ -6,8 +6,9 @@ import { type TreeBlock, blockHistoryVar } from '../../libs/block'
 
 import { AiChat } from './AiChat'
 
-const { mockTransportConstructor } = vi.hoisted(() => ({
-  mockTransportConstructor: vi.fn()
+const { mockTransportConstructor, mockUseJourney } = vi.hoisted(() => ({
+  mockTransportConstructor: vi.fn(),
+  mockUseJourney: vi.fn()
 }))
 
 vi.mock('@ai-sdk/react', () => ({
@@ -31,7 +32,7 @@ vi.mock('next-i18next/pages', () => ({
 }))
 
 vi.mock('../../libs/JourneyProvider', () => ({
-  useJourney: () => ({ journey: undefined })
+  useJourney: mockUseJourney
 }))
 
 // Conversation owns scroll/ResizeObserver machinery that jsdom lacks; the
@@ -88,6 +89,9 @@ function codedError(code: string): Error {
 describe('AiChat', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // `clearAllMocks` clears calls but not return values — reset the journey
+    // explicitly so a per-test `mockReturnValue` can't leak across tests.
+    mockUseJourney.mockReturnValue({ journey: undefined })
     blockHistoryVar([])
   })
 
@@ -332,6 +336,19 @@ describe('AiChat', () => {
       expect(
         screen.getAllByRole('link', { name: 'About this chat' })
       ).toHaveLength(1)
+    })
+
+    it('carries the journey language as ?lang on the disclosure link (NES-1724)', () => {
+      mockUseJourney.mockReturnValue({
+        journey: { language: { bcp47: 'es' } }
+      })
+      setChatState({ messages: [], status: 'ready', error: undefined })
+
+      render(<AiChat variant="overlay" collapsible={false} />)
+
+      expect(
+        screen.getByRole('link', { name: 'About this chat' })
+      ).toHaveAttribute('href', '/legal/about-chat?lang=es')
     })
   })
 

--- a/libs/journeys/ui/src/components/AiChat/AiChat.tsx
+++ b/libs/journeys/ui/src/components/AiChat/AiChat.tsx
@@ -37,6 +37,7 @@ import {
   SHEET_BOTTOM_FADE
 } from './chatStyles'
 import { DragHandle } from './DragHandle'
+import { getAboutChatHref } from './getAboutChatHref'
 
 interface AiChatProps {
   /** When provided, this message is sent automatically on first render */
@@ -721,7 +722,7 @@ export function AiChat({
             {t('Replies may not be perfect')}
             {' · '}
             <Link
-              href="/legal/about-chat"
+              href={getAboutChatHref(languageBcp47)}
               target="_blank"
               rel="noopener noreferrer"
               underline="always"

--- a/libs/journeys/ui/src/components/AiChat/ChatHeader/ChatHeader.spec.tsx
+++ b/libs/journeys/ui/src/components/AiChat/ChatHeader/ChatHeader.spec.tsx
@@ -1,5 +1,8 @@
 import { render } from '@testing-library/react'
 
+import { JourneyProvider } from '../../../libs/JourneyProvider'
+import { JourneyFields as Journey } from '../../../libs/JourneyProvider/__generated__/JourneyFields'
+
 import { ChatHeader } from './ChatHeader'
 
 vi.mock('next-i18next/pages', () => ({
@@ -15,6 +18,19 @@ describe('ChatHeader', () => {
     expect(link).toHaveAttribute('href', '/legal/about-chat')
     expect(link).toHaveAttribute('target', '_blank')
     expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('carries the journey language as ?lang on the about-this-chat link (NES-1724)', () => {
+    const journey = { language: { bcp47: 'es' } } as unknown as Journey
+    const { getByRole } = render(
+      <JourneyProvider value={{ journey, variant: 'default' }}>
+        <ChatHeader />
+      </JourneyProvider>
+    )
+    expect(getByRole('link', { name: 'About this chat' })).toHaveAttribute(
+      'href',
+      '/legal/about-chat?lang=es'
+    )
   })
 
   it('renders the animated mark in both states', () => {

--- a/libs/journeys/ui/src/components/AiChat/ChatHeader/ChatHeader.tsx
+++ b/libs/journeys/ui/src/components/AiChat/ChatHeader/ChatHeader.tsx
@@ -4,6 +4,7 @@ import Typography from '@mui/material/Typography'
 import { useTranslation } from 'next-i18next/pages'
 import { ReactElement } from 'react'
 
+import { useJourney } from '../../../libs/JourneyProvider'
 import {
   ASSISTANT_FG,
   DIVIDER,
@@ -13,6 +14,7 @@ import {
   SPARKLE_GRADIENT,
   TEXT_SECONDARY
 } from '../chatStyles'
+import { getAboutChatHref } from '../getAboutChatHref'
 
 interface ChatHeaderProps {
   /**
@@ -27,6 +29,7 @@ export function ChatHeader({
   thinking = false
 }: ChatHeaderProps): ReactElement {
   const { t } = useTranslation('libs-journeys-ui')
+  const { journey } = useJourney()
 
   return (
     <Box
@@ -147,7 +150,7 @@ export function ChatHeader({
           {t('Replies may not be perfect')}
           {' · '}
           <Link
-            href="/legal/about-chat"
+            href={getAboutChatHref(journey?.language?.bcp47)}
             target="_blank"
             rel="noopener noreferrer"
             underline="always"

--- a/libs/journeys/ui/src/components/AiChat/getAboutChatHref.spec.ts
+++ b/libs/journeys/ui/src/components/AiChat/getAboutChatHref.spec.ts
@@ -1,0 +1,24 @@
+import { getAboutChatHref } from './getAboutChatHref'
+
+describe('getAboutChatHref', () => {
+  it('carries a non-English journey language as ?lang', () => {
+    expect(getAboutChatHref('es')).toBe('/legal/about-chat?lang=es')
+    expect(getAboutChatHref('zh-Hans-CN')).toBe(
+      '/legal/about-chat?lang=zh-Hans-CN'
+    )
+  })
+
+  it('returns the bare href for English', () => {
+    expect(getAboutChatHref('en')).toBe('/legal/about-chat')
+  })
+
+  it('returns the bare href when the journey has no bcp47 language', () => {
+    expect(getAboutChatHref(undefined)).toBe('/legal/about-chat')
+    expect(getAboutChatHref(null)).toBe('/legal/about-chat')
+    expect(getAboutChatHref('')).toBe('/legal/about-chat')
+  })
+
+  it('URL-encodes the language so the href stays well-formed', () => {
+    expect(getAboutChatHref('a&b=c')).toBe('/legal/about-chat?lang=a%26b%3Dc')
+  })
+})

--- a/libs/journeys/ui/src/components/AiChat/getAboutChatHref.ts
+++ b/libs/journeys/ui/src/components/AiChat/getAboutChatHref.ts
@@ -1,0 +1,14 @@
+// The about-this-chat notice page translates by Next.js URL locale, which
+// is always `en` when reached from the chat surfaces (the links carry no
+// locale prefix and the journeys app sets `localeDetection: false`). The
+// journey viewer translates its UI by `journey.language.bcp47` instead, so
+// carry that language to the notice page as a query param — its
+// getServerSideProps resolves translations from `?lang` the same way the
+// journey page does (NES-1724). English (the default locale) and journeys
+// without a bcp47 tag keep the bare href.
+export function getAboutChatHref(languageBcp47?: string | null): string {
+  if (languageBcp47 == null || languageBcp47 === '' || languageBcp47 === 'en')
+    return '/legal/about-chat'
+
+  return `/legal/about-chat?lang=${encodeURIComponent(languageBcp47)}`
+}


### PR DESCRIPTION
## Problem

[NES-1724](https://linear.app/jesus-film-project/issue/NES-1724/legal-about-chat-page-renders-english-only-pass-journey-language)

The `/legal/about-chat` notice (NES-1588) always renders in English, even when opened from a journey in another language. Translations are not the problem — the Crowdin round-trip completed in #9291 and all 12 page strings exist for ~20 locales. The problem is that the journey's language never reaches the page:

- the **journey viewer** translates its UI by `journey.language.bcp47` (`getJourneyRTL` → `serverSideTranslations`); the URL plays no role
- the **notice page** translated by Next.js URL locale (`context.locale ?? 'en'`), and both chat links were bare `/legal/about-chat` — no locale prefix, no language info. With `localeDetection: false`, `context.locale` is always `en`.

## Fix

Mirror the journey page's own pattern — translate by journey language, carried via query param:

- **`getAboutChatHref(bcp47)`** (new, `libs/journeys/ui/.../AiChat/`): builds `/legal/about-chat?lang=<bcp47>`; bare href for English / missing bcp47. Used by both link sites (ChatHeader + AiChat overlay caption), which read the language from `useJourney()`.
- **Both about-chat pages** switch from `getStaticProps` to a single shared `getServerSideProps` (the `[hostname]` route now re-exports the home page wholesale) that resolves translations from `query.lang ?? context.locale ?? 'en'`. The existing `fallbackLng` config maps short codes (`es` → `es-ES`) and falls back to English for untranslated languages.
- **`?lang` is validated** against a strict BCP-47 shape before it reaches i18next's filesystem loader (it's untrusted query input).
- **RTL**: the notice content flips to `dir="rtl"` for RTL languages (ar, ur, fa) via the existing `getLocaleRTL` helper.

No new user-facing strings — all copy already exists in `libs/locales`.

## Testing

- `libs/journeys/ui` AiChat suite: 39 passed (incl. 4 new helper tests + new `?lang` link tests for both surfaces)
- `apps/journeys` new page spec: 8 passed (lang selection, fallbacks, malformed/traversal rejection, `[hostname]` re-export identity, ltr/rtl rendering)
- lint clean on all changed files; `apps/journeys` typecheck clean

## QA on preview

1. Open a Spanish (or any translated-language) journey with chat enabled → tap **Acerca de este chat** → notice renders in Spanish (`…/legal/about-chat?lang=es`)
2. English journey → link stays bare `/legal/about-chat` → English
3. Direct visit `/legal/about-chat` (no param) → English, unchanged behaviour
4. `/legal/about-chat?lang=ar` → Arabic, right-to-left layout
5. `/legal/about-chat?lang=../../junk` → falls back to English (param rejected)
6. Repeat 1 on a custom-hostname journey — the `[hostname]` route shares the same implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "About this chat" link now dynamically adapts to display content in the chat's selected language.

* **Bug Fixes**
  * Improved right-to-left language rendering on the about-chat page.
  * Enhanced language resolution and fallback handling for multi-language support.

* **Tests**
  * Added comprehensive test coverage for language-specific behavior and internationalization on the about-chat page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->