### PR TITLE
feat(watch-modern): reuse legacy Watch Datadog setup

### DIFF
--- a/apps/watch-modern/project.json
+++ b/apps/watch-modern/project.json
@@ -40,6 +40,7 @@
           "echo \"VERCEL_ENV=\\\"$NEXT_PUBLIC_VERCEL_ENV\\\"\" >> .vercel/.env.preview.local",
           "echo \"VERCEL_GIT_COMMIT_SHA=\\\"$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA\\\"\" >> .vercel/.env.preview.local",
           "pnpm exec vercel build",
+          "pnpm exec tsx apps/watch-modern/scripts/datadog-sourcemaps.ts remove-public",
           "VERCEL_PROJECT_ID=$WATCH_MODERN_VERCEL_PROJECT_ID pnpm exec vercel deploy --prebuilt --token=$VERCEL_TOKEN --archive=tgz > apps/watch-modern/.vercel-url"
         ],
         "parallel": false
@@ -51,6 +52,7 @@
             "echo \"VERCEL_ENV=\\\"$NEXT_PUBLIC_VERCEL_ENV\\\"\" >> .vercel/.env.production.local",
             "echo \"VERCEL_GIT_COMMIT_SHA=\\\"$NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA\\\"\" >> .vercel/.env.production.local",
             "pnpm exec vercel build --prod",
+            "pnpm exec tsx apps/watch-modern/scripts/datadog-sourcemaps.ts remove-public",
             "VERCEL_PROJECT_ID=$WATCH_MODERN_VERCEL_PROJECT_ID pnpm exec vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --archive=tgz > apps/watch-modern/.vercel-url"
           ]
         }
@@ -60,7 +62,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "pnpm dlx @datadog/datadog-ci@5.8.0 sourcemaps upload dist/apps/watch-modern/.next/static --service=watch-modern --release-version=$GIT_COMMIT_SHA --minified-path-prefix=/_next/static/"
+          "pnpm exec tsx apps/watch-modern/scripts/datadog-sourcemaps.ts upload"
         ],
         "parallel": false
       }

--- a/apps/watch-modern/project.spec.ts
+++ b/apps/watch-modern/project.spec.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+interface NxRunCommandsTarget {
+  options: {
+    commands: Array<string | { command: string }>
+  }
+}
+
+interface WatchModernProjectConfig {
+  targets: {
+    deploy: NxRunCommandsTarget & {
+      configurations: {
+        production: NxRunCommandsTarget['options']
+      }
+    }
+    'upload-sourcemaps': NxRunCommandsTarget
+  }
+}
+
+function readWatchModernProjectConfig(): WatchModernProjectConfig {
+  return JSON.parse(
+    readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), 'project.json'),
+      'utf8'
+    )
+  ) as WatchModernProjectConfig
+}
+
+function commandText(command: string | { command: string }): string {
+  return typeof command === 'string' ? command : command.command
+}
+
+describe('watch-modern project Datadog configuration', () => {
+  it('uploads sourcemaps through the Watch Datadog upload script', () => {
+    const project = readWatchModernProjectConfig()
+    const uploadCommands =
+      project.targets['upload-sourcemaps'].options.commands.map(commandText)
+
+    expect(uploadCommands).toEqual([
+      'pnpm exec tsx apps/watch-modern/scripts/datadog-sourcemaps.ts upload'
+    ])
+    expect(uploadCommands.join(' ')).not.toContain('--service=watch-modern')
+  })
+
+  it('removes public JavaScript sourcemaps before Vercel deploys preview and production artifacts', () => {
+    const project = readWatchModernProjectConfig()
+    const previewCommands =
+      project.targets.deploy.options.commands.map(commandText)
+    const productionCommands =
+      project.targets.deploy.configurations.production.commands.map(commandText)
+    const removeCommand =
+      'pnpm exec tsx apps/watch-modern/scripts/datadog-sourcemaps.ts remove-public'
+
+    expect(previewCommands).toContain(removeCommand)
+    expect(productionCommands).toContain(removeCommand)
+    expect(previewCommands.indexOf(removeCommand)).toBeLessThan(
+      previewCommands.findIndex((command) =>
+        command.includes('vercel deploy --prebuilt')
+      )
+    )
+    expect(productionCommands.indexOf(removeCommand)).toBeLessThan(
+      productionCommands.findIndex((command) =>
+        command.includes('vercel deploy --prebuilt --prod')
+      )
+    )
+  })
+})

--- a/apps/watch-modern/scripts/datadog-sourcemaps.spec.ts
+++ b/apps/watch-modern/scripts/datadog-sourcemaps.spec.ts
@@ -1,0 +1,79 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  buildDatadogSourcemapUploadArgs,
+  getWatchModernMinifiedPathPrefix,
+  removePublicJavaScriptSourceMaps
+} from './datadog-sourcemaps'
+
+describe('getWatchModernMinifiedPathPrefix', () => {
+  it.each(['production', 'prod', 'stage'])(
+    'uses the asset-prefix static path for %s deploys',
+    (environment) => {
+      expect(
+        getWatchModernMinifiedPathPrefix({
+          NEXT_PUBLIC_VERCEL_ENV: environment
+        })
+      ).toBe('/watch/modern/_next/static/')
+    }
+  )
+
+  it.each(['preview', 'development', undefined])(
+    'uses the basePath static path for %s deploys',
+    (environment) => {
+      expect(
+        getWatchModernMinifiedPathPrefix({
+          NEXT_PUBLIC_VERCEL_ENV: environment
+        })
+      ).toBe('/watch/_next/static/')
+    }
+  )
+})
+
+describe('buildDatadogSourcemapUploadArgs', () => {
+  it('builds a Datadog upload command aligned to the Watch RUM service and release', () => {
+    expect(
+      buildDatadogSourcemapUploadArgs({
+        GIT_COMMIT_SHA: 'abc123',
+        NEXT_PUBLIC_VERCEL_ENV: 'prod'
+      })
+    ).toEqual([
+      'dlx',
+      '@datadog/datadog-ci@5.8.0',
+      'sourcemaps',
+      'upload',
+      'dist/apps/watch-modern/.next/static',
+      '--service=watch',
+      '--release-version=abc123',
+      '--minified-path-prefix=/watch/modern/_next/static/'
+    ])
+  })
+
+  it('requires the deploy commit SHA used by RUM version tags', () => {
+    expect(() => buildDatadogSourcemapUploadArgs({})).toThrow(
+      'GIT_COMMIT_SHA is required to upload Datadog sourcemaps'
+    )
+  })
+})
+
+describe('removePublicJavaScriptSourceMaps', () => {
+  it('removes public JavaScript sourcemaps without deleting other files', () => {
+    const root = mkdtempSync(join(tmpdir(), 'watch-modern-sourcemaps-'))
+    const staticDir = join(root, 'static', 'chunks')
+    mkdirSync(staticDir, { recursive: true })
+    const sourceMapPath = join(staticDir, 'app.js.map')
+    const chunkPath = join(staticDir, 'app.js')
+    const cssMapPath = join(staticDir, 'app.css.map')
+
+    writeFileSync(sourceMapPath, '{}')
+    writeFileSync(chunkPath, 'console.log("chunk")')
+    writeFileSync(cssMapPath, '{}')
+
+    expect(removePublicJavaScriptSourceMaps(root)).toEqual([sourceMapPath])
+    expect(readFileSync(chunkPath, 'utf8')).toBe('console.log("chunk")')
+    expect(readFileSync(cssMapPath, 'utf8')).toBe('{}')
+    expect(() => readFileSync(sourceMapPath, 'utf8')).toThrow()
+  })
+})

--- a/apps/watch-modern/scripts/datadog-sourcemaps.ts
+++ b/apps/watch-modern/scripts/datadog-sourcemaps.ts
@@ -1,0 +1,110 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, readdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+
+export const DATADOG_SOURCEMAP_SERVICE = 'watch'
+export const DATADOG_CI_PACKAGE = '@datadog/datadog-ci@5.8.0'
+export const WATCH_MODERN_STATIC_DIR = 'dist/apps/watch-modern/.next/static'
+export const VERCEL_OUTPUT_DIR = '.vercel/output'
+
+const PRODUCTION_STATIC_PREFIX = '/watch/modern/_next/static/'
+const PREVIEW_STATIC_PREFIX = '/watch/_next/static/'
+const PRODUCTION_ENVIRONMENTS = new Set(['production', 'prod', 'stage'])
+
+export interface SourcemapEnvironment {
+  [key: string]: string | undefined
+  GIT_COMMIT_SHA?: string | undefined
+  NEXT_PUBLIC_VERCEL_ENV?: string | undefined
+  VERCEL_ENV?: string | undefined
+}
+
+export function resolveWatchModernDeployEnvironment(
+  env: SourcemapEnvironment = process.env
+): string {
+  return env.NEXT_PUBLIC_VERCEL_ENV ?? env.VERCEL_ENV ?? 'preview'
+}
+
+export function getWatchModernMinifiedPathPrefix(
+  env: SourcemapEnvironment = process.env
+): string {
+  return PRODUCTION_ENVIRONMENTS.has(resolveWatchModernDeployEnvironment(env))
+    ? PRODUCTION_STATIC_PREFIX
+    : PREVIEW_STATIC_PREFIX
+}
+
+export function buildDatadogSourcemapUploadArgs(
+  env: SourcemapEnvironment = process.env
+): string[] {
+  if (!env.GIT_COMMIT_SHA) {
+    throw new Error('GIT_COMMIT_SHA is required to upload Datadog sourcemaps')
+  }
+
+  return [
+    'dlx',
+    DATADOG_CI_PACKAGE,
+    'sourcemaps',
+    'upload',
+    WATCH_MODERN_STATIC_DIR,
+    `--service=${DATADOG_SOURCEMAP_SERVICE}`,
+    `--release-version=${env.GIT_COMMIT_SHA}`,
+    `--minified-path-prefix=${getWatchModernMinifiedPathPrefix(env)}`
+  ]
+}
+
+export function removePublicJavaScriptSourceMaps(
+  rootDir = VERCEL_OUTPUT_DIR
+): string[] {
+  if (!existsSync(rootDir)) {
+    return []
+  }
+
+  const removedFiles: string[] = []
+
+  function removeSourceMapsFromDir(directory: string): void {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name)
+
+      if (entry.isDirectory()) {
+        removeSourceMapsFromDir(path)
+        continue
+      }
+
+      if (entry.isFile() && entry.name.endsWith('.js.map')) {
+        rmSync(path)
+        removedFiles.push(path)
+      }
+    }
+  }
+
+  removeSourceMapsFromDir(rootDir)
+  return removedFiles
+}
+
+function uploadSourcemaps(): void {
+  const result = spawnSync('pnpm', buildDatadogSourcemapUploadArgs(), {
+    stdio: 'inherit'
+  })
+
+  if (result.error != null) {
+    throw result.error
+  }
+
+  process.exit(result.status ?? 1)
+}
+
+function removePublicSourcemaps(): void {
+  const removedFiles = removePublicJavaScriptSourceMaps()
+  console.log(
+    `Removed ${removedFiles.length} public JavaScript sourcemap file(s) from ${VERCEL_OUTPUT_DIR}`
+  )
+}
+
+const command = process.argv[2]
+
+if (command === 'upload') {
+  uploadSourcemaps()
+} else if (command === 'remove-public') {
+  removePublicSourcemaps()
+} else if (command != null) {
+  throw new Error(`Unknown Datadog sourcemap command: ${command}`)
+}

--- a/apps/watch-modern/src/components/Datadog/ErrorBoundary/ErrorBoundary.spec.tsx
+++ b/apps/watch-modern/src/components/Datadog/ErrorBoundary/ErrorBoundary.spec.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+import DatadogErrorBoundary from './ErrorBoundary'
+
+vi.mock('@datadog/browser-rum-react', () => ({
+  ErrorBoundary: ({ children }: { children: ReactNode }) => (
+    <div data-testid="datadog-error-boundary">{children}</div>
+  )
+}))
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key
+}))
+
+describe('DatadogErrorBoundary', () => {
+  it('keeps children mounted inside the Datadog RUM error boundary', () => {
+    render(
+      <DatadogErrorBoundary>
+        <main>Watch content</main>
+      </DatadogErrorBoundary>
+    )
+
+    expect(screen.getByTestId('datadog-error-boundary')).toContainElement(
+      screen.getByText('Watch content')
+    )
+  })
+})

--- a/apps/watch-modern/src/components/Datadog/Init/Init.spec.tsx
+++ b/apps/watch-modern/src/components/Datadog/Init/Init.spec.tsx
@@ -1,0 +1,96 @@
+import { render, waitFor } from '@testing-library/react'
+import { StrictMode } from 'react'
+
+import DatadogInit from './Init'
+
+const mocks = vi.hoisted(() => ({
+  datadogInit: vi.fn(),
+  env: {
+    NEXT_PUBLIC_DATADOG_APPLICATION_ID: 'application-id',
+    NEXT_PUBLIC_DATADOG_CLIENT_TOKEN: 'client-token',
+    NEXT_PUBLIC_DATADOG_ENV: 'prod',
+    NEXT_PUBLIC_DATADOG_SITE: 'datadoghq.com',
+    NEXT_PUBLIC_DATADOG_VERSION: 'commit-sha'
+  } as Record<string, string | undefined>,
+  reactPlugin: vi.fn(() => ({ name: 'react-plugin' }))
+}))
+
+vi.mock('@datadog/browser-rum', () => ({
+  datadogRum: {
+    init: mocks.datadogInit
+  }
+}))
+
+vi.mock('@datadog/browser-rum-react', () => ({
+  reactPlugin: mocks.reactPlugin
+}))
+
+vi.mock('@/env', () => ({
+  env: mocks.env
+}))
+
+describe('DatadogInit', () => {
+  const baseEnv = { ...mocks.env }
+
+  beforeEach(() => {
+    Object.assign(mocks.env, baseEnv)
+    mocks.datadogInit.mockReset()
+    mocks.reactPlugin.mockClear()
+  })
+
+  it('initializes Datadog RUM once with the legacy Watch service config', async () => {
+    render(
+      <StrictMode>
+        <DatadogInit />
+      </StrictMode>
+    )
+
+    await waitFor(() => expect(mocks.datadogInit).toHaveBeenCalledTimes(1))
+    expect(mocks.datadogInit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        applicationId: 'application-id',
+        clientToken: 'client-token',
+        site: 'datadoghq.com',
+        service: 'watch',
+        env: 'prod',
+        version: 'commit-sha',
+        sessionSampleRate: 50,
+        sessionReplaySampleRate: 10,
+        trackUserInteractions: true,
+        trackResources: true,
+        trackLongTasks: true,
+        defaultPrivacyLevel: 'mask-user-input',
+        beforeSend: expect.any(Function),
+        plugins: [{ name: 'react-plugin' }]
+      })
+    )
+  })
+
+  it('does not initialize Datadog RUM without required public credentials', () => {
+    mocks.env['NEXT_PUBLIC_DATADOG_CLIENT_TOKEN'] = undefined
+
+    render(<DatadogInit />)
+
+    expect(mocks.datadogInit).not.toHaveBeenCalled()
+  })
+
+  it('catches Datadog initialization failures without breaking render', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    mocks.datadogInit.mockImplementationOnce(() => {
+      throw new Error('Datadog unavailable')
+    })
+
+    render(<DatadogInit />)
+
+    await waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith(
+        'Failed to initialize Datadog RUM:',
+        expect.any(Error)
+      )
+    )
+
+    consoleError.mockRestore()
+  })
+})

--- a/apps/watch-modern/src/components/Datadog/Init/Init.tsx
+++ b/apps/watch-modern/src/components/Datadog/Init/Init.tsx
@@ -4,48 +4,38 @@ import { datadogRum } from '@datadog/browser-rum'
 import { reactPlugin } from '@datadog/browser-rum-react'
 import { useEffect, useRef } from 'react'
 
+import { buildDatadogRumConfig } from './config'
+
 import { env } from '@/env'
 
 export default function DatadogInit(): null {
   const isInitialized = useRef(false)
 
   useEffect(() => {
-    if (
-      !isInitialized.current &&
-      env.NEXT_PUBLIC_DATADOG_APPLICATION_ID &&
-      env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN
-    ) {
-      try {
-        datadogRum.init({
-          applicationId: env.NEXT_PUBLIC_DATADOG_APPLICATION_ID,
-          clientToken: env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN,
-          site: env.NEXT_PUBLIC_DATADOG_SITE,
-          service: 'watch-modern',
-          env: env.NEXT_PUBLIC_DATADOG_ENV,
-          version: env.NEXT_PUBLIC_DATADOG_VERSION,
-          sessionSampleRate: 50,
-          sessionReplaySampleRate: 10,
-          trackUserInteractions: true,
-          trackResources: true,
-          trackLongTasks: true,
-          defaultPrivacyLevel: 'mask-user-input',
-          allowedTracingUrls: [
-            {
-              match: 'https://api-gateway.central.jesusfilm.org/',
-              propagatorTypes: ['tracecontext']
-            },
-            {
-              match: 'https://api-gateway.stage.central.jesusfilm.org/',
-              propagatorTypes: ['tracecontext']
-            }
-          ],
-          plugins: [reactPlugin()]
-        })
+    if (isInitialized.current) {
+      return
+    }
 
-        isInitialized.current = true
-      } catch (error) {
-        console.error('Failed to initialize Datadog RUM:', error)
-      }
+    const rumConfig = buildDatadogRumConfig(
+      {
+        applicationId: env.NEXT_PUBLIC_DATADOG_APPLICATION_ID,
+        clientToken: env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN,
+        site: env.NEXT_PUBLIC_DATADOG_SITE,
+        env: env.NEXT_PUBLIC_DATADOG_ENV,
+        version: env.NEXT_PUBLIC_DATADOG_VERSION
+      },
+      [reactPlugin()]
+    )
+
+    if (rumConfig == null) {
+      return
+    }
+
+    try {
+      datadogRum.init(rumConfig)
+      isInitialized.current = true
+    } catch (error) {
+      console.error('Failed to initialize Datadog RUM:', error)
     }
   }, [])
 

--- a/apps/watch-modern/src/components/Datadog/Init/config.spec.ts
+++ b/apps/watch-modern/src/components/Datadog/Init/config.spec.ts
@@ -1,0 +1,155 @@
+import {
+  buildDatadogRumConfig,
+  isDatadogTracingAllowed,
+  redactDatadogRumEvent,
+  redactSensitiveText,
+  redactSensitiveUrl
+} from './config'
+
+describe('buildDatadogRumConfig', () => {
+  const datadogEnv = {
+    applicationId: 'application-id',
+    clientToken: 'client-token',
+    site: 'datadoghq.com' as const,
+    env: 'prod',
+    version: 'commit-sha'
+  }
+
+  it('builds the legacy Watch RUM config', () => {
+    const plugin = { name: 'react-plugin' }
+
+    expect(buildDatadogRumConfig(datadogEnv, [plugin] as never)).toMatchObject({
+      applicationId: 'application-id',
+      clientToken: 'client-token',
+      site: 'datadoghq.com',
+      service: 'watch',
+      env: 'prod',
+      version: 'commit-sha',
+      sessionSampleRate: 50,
+      sessionReplaySampleRate: 10,
+      trackUserInteractions: true,
+      trackResources: true,
+      trackLongTasks: true,
+      defaultPrivacyLevel: 'mask-user-input',
+      plugins: [plugin]
+    })
+  })
+
+  it('skips initialization when Datadog credentials are missing', () => {
+    expect(
+      buildDatadogRumConfig({ ...datadogEnv, applicationId: undefined })
+    ).toBeUndefined()
+    expect(
+      buildDatadogRumConfig({ ...datadogEnv, clientToken: undefined })
+    ).toBeUndefined()
+  })
+})
+
+describe('redactSensitiveUrl', () => {
+  it('removes query strings, fragments, and email-like values from absolute URLs', () => {
+    expect(
+      redactSensitiveUrl(
+        'https://www.jesusfilm.org/watch?email=person@example.com#player'
+      )
+    ).toBe('https://www.jesusfilm.org/watch')
+  })
+
+  it('preserves relative paths without query strings or fragments', () => {
+    expect(
+      redactSensitiveUrl('/watch/search?q=person@example.com#results')
+    ).toBe('/watch/search')
+  })
+})
+
+describe('redactSensitiveText', () => {
+  it('redacts email-like values and URL query data inside text fields', () => {
+    expect(
+      redactSensitiveText(
+        'Failed for person@example.com at https://example.com/watch?token=abc#frag'
+      )
+    ).toBe('Failed for [REDACTED_EMAIL] at https://example.com/watch')
+  })
+})
+
+describe('redactDatadogRumEvent', () => {
+  it('redacts mutable URL and string fields Datadog allows before send', () => {
+    const event = {
+      view: {
+        url: 'https://www.jesusfilm.org/watch?email=person@example.com#player',
+        referrer: 'https://referrer.example/?from=person@example.com',
+        name: 'Watch person@example.com',
+        performance: {
+          lcp: {
+            resource_url:
+              'https://cdn.example/image.jpg?email=person@example.com'
+          }
+        }
+      },
+      resource: {
+        url: 'https://api.example/videos?email=person@example.com'
+      },
+      error: {
+        message:
+          'Failed for person@example.com at https://example.com/watch?token=abc#frag',
+        stack: 'Error for person@example.com',
+        resource: {
+          url: 'https://api.example/error?email=person@example.com#frag'
+        }
+      },
+      action: {
+        target: {
+          name: 'Search person@example.com'
+        }
+      },
+      long_task: {
+        scripts: [
+          {
+            source_url:
+              'https://static.example/app.js?email=person@example.com',
+            invoker: 'invoke person@example.com'
+          }
+        ]
+      }
+    }
+
+    expect(redactDatadogRumEvent(event as never)).toBe(true)
+    const firstLongTaskScript = event.long_task.scripts[0]
+
+    expect(event.view.url).toBe('https://www.jesusfilm.org/watch')
+    expect(event.view.referrer).toBe('https://referrer.example/')
+    expect(event.view.name).toBe('Watch [REDACTED_EMAIL]')
+    expect(event.view.performance.lcp.resource_url).toBe(
+      'https://cdn.example/image.jpg'
+    )
+    expect(event.resource.url).toBe('https://api.example/videos')
+    expect(event.error.message).toBe(
+      'Failed for [REDACTED_EMAIL] at https://example.com/watch'
+    )
+    expect(event.error.stack).toBe('Error for [REDACTED_EMAIL]')
+    expect(event.error.resource.url).toBe('https://api.example/error')
+    expect(event.action.target.name).toBe('Search [REDACTED_EMAIL]')
+    expect(firstLongTaskScript?.source_url).toBe(
+      'https://static.example/app.js'
+    )
+    expect(firstLongTaskScript?.invoker).toBe('invoke [REDACTED_EMAIL]')
+  })
+})
+
+describe('isDatadogTracingAllowed', () => {
+  it.each([
+    'https://api-gateway.central.jesusfilm.org/graphql',
+    'https://api-gateway.stage.central.jesusfilm.org/graphql'
+  ])('allows trace propagation to gateway URL %s', (url) => {
+    expect(isDatadogTracingAllowed(url)).toBe(true)
+  })
+
+  it.each([
+    'https://stream.mux.com/video',
+    'https://video-variants-prd.algolia.net/1/indexes',
+    'https://browser-intake-datadoghq.com/api/v2/rum',
+    'https://www.jesusfilm.org/watch/modern/_next/static/chunk.js',
+    'https://example.com/graphql'
+  ])('does not allow trace propagation to %s', (url) => {
+    expect(isDatadogTracingAllowed(url)).toBe(false)
+  })
+})

--- a/apps/watch-modern/src/components/Datadog/Init/config.spec.ts
+++ b/apps/watch-modern/src/components/Datadog/Init/config.spec.ts
@@ -69,6 +69,14 @@ describe('redactSensitiveText', () => {
       )
     ).toBe('Failed for [REDACTED_EMAIL] at https://example.com/watch')
   })
+
+  it('redacts relative URL query data inside text fields', () => {
+    expect(
+      redactSensitiveText(
+        'Search failed at /watch/search?q=person@example.com#results'
+      )
+    ).toBe('Search failed at /watch/search')
+  })
 })
 
 describe('redactDatadogRumEvent', () => {

--- a/apps/watch-modern/src/components/Datadog/Init/config.ts
+++ b/apps/watch-modern/src/components/Datadog/Init/config.ts
@@ -1,0 +1,181 @@
+import type { RumInitConfiguration } from '@datadog/browser-rum'
+
+export const DATADOG_RUM_SERVICE = 'watch'
+export const DATADOG_TRACE_PROPAGATOR_TYPES = ['tracecontext'] as const
+
+const DATADOG_ALLOWED_TRACING_ORIGINS = [
+  'https://api-gateway.central.jesusfilm.org/',
+  'https://api-gateway.stage.central.jesusfilm.org/'
+] as const
+
+const EMAIL_PATTERN = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi
+const URL_PATTERN = /https?:\/\/[^\s'"<>]+/gi
+
+type DatadogBeforeSend = NonNullable<RumInitConfiguration['beforeSend']>
+type DatadogRumEvent = Parameters<DatadogBeforeSend>[0] & {
+  action?: {
+    target?: {
+      name?: string
+    }
+  }
+  error?: {
+    message?: string
+    resource?: {
+      url?: string
+    }
+    stack?: string
+  }
+  long_task?: {
+    scripts?:
+      | {
+          invoker?: string
+          source_url?: string
+        }
+      | Array<{
+          invoker?: string
+          source_url?: string
+        }>
+  }
+  resource?: {
+    url?: string
+  }
+  view?: {
+    name?: string
+    performance?: {
+      lcp?: {
+        resource_url?: string
+      }
+    }
+    referrer?: string
+    url?: string
+  }
+}
+
+export interface DatadogRumEnv {
+  applicationId?: string | undefined
+  clientToken?: string | undefined
+  env?: string | undefined
+  site: RumInitConfiguration['site']
+  version?: string | undefined
+}
+
+export const DATADOG_ALLOWED_TRACING_URLS = DATADOG_ALLOWED_TRACING_ORIGINS.map(
+  (origin) => ({
+    match: origin,
+    propagatorTypes: [...DATADOG_TRACE_PROPAGATOR_TYPES]
+  })
+) satisfies NonNullable<RumInitConfiguration['allowedTracingUrls']>
+
+function redactEmailLikeValues(value: string): string {
+  return value.replace(EMAIL_PATTERN, '[REDACTED_EMAIL]')
+}
+
+export function redactSensitiveUrl(value: string): string {
+  const redactedValue = redactEmailLikeValues(value)
+
+  try {
+    const url = new URL(redactedValue, 'https://www.jesusfilm.org')
+    const pathOnly = `${url.pathname}${url.pathname.endsWith('/') ? '' : ''}`
+
+    if (redactedValue.startsWith('/')) {
+      return pathOnly
+    }
+
+    return `${url.origin}${pathOnly}`
+  } catch {
+    return redactedValue.replace(/\?[^#\s]*/g, '').replace(/#[^\s]*/g, '')
+  }
+}
+
+export function redactSensitiveText(value: string): string {
+  return redactEmailLikeValues(
+    value.replace(URL_PATTERN, (url) => redactSensitiveUrl(url))
+  )
+}
+
+function redactUrlField(
+  container: { [key: string]: unknown } | undefined,
+  key: string
+): void {
+  if (container == null) {
+    return
+  }
+
+  const value = container?.[key]
+
+  if (typeof value === 'string') {
+    container[key] = redactSensitiveUrl(value)
+  }
+}
+
+function redactTextField(
+  container: { [key: string]: unknown } | undefined,
+  key: string
+): void {
+  if (container == null) {
+    return
+  }
+
+  const value = container?.[key]
+
+  if (typeof value === 'string') {
+    container[key] = redactSensitiveText(value)
+  }
+}
+
+export function redactDatadogRumEvent(event: DatadogRumEvent): boolean {
+  const redactedEvent = event
+
+  redactUrlField(redactedEvent.view, 'url')
+  redactUrlField(redactedEvent.view, 'referrer')
+  redactTextField(redactedEvent.view, 'name')
+  redactUrlField(redactedEvent.view?.performance?.lcp, 'resource_url')
+  redactUrlField(redactedEvent.resource, 'url')
+  redactUrlField(redactedEvent.error?.resource, 'url')
+  redactTextField(redactedEvent.error, 'message')
+  redactTextField(redactedEvent.error, 'stack')
+  redactTextField(redactedEvent.action?.target, 'name')
+
+  const scripts = redactedEvent.long_task?.scripts
+  const scriptList = Array.isArray(scripts) ? scripts : scripts ? [scripts] : []
+
+  for (const script of scriptList) {
+    redactUrlField(script, 'source_url')
+    redactTextField(script, 'invoker')
+  }
+
+  return true
+}
+
+export function isDatadogTracingAllowed(url: string): boolean {
+  return DATADOG_ALLOWED_TRACING_ORIGINS.some((origin) =>
+    url.startsWith(origin)
+  )
+}
+
+export function buildDatadogRumConfig(
+  datadogEnv: DatadogRumEnv,
+  plugins: RumInitConfiguration['plugins'] = []
+): RumInitConfiguration | undefined {
+  if (!datadogEnv.applicationId || !datadogEnv.clientToken) {
+    return undefined
+  }
+
+  return {
+    applicationId: datadogEnv.applicationId,
+    clientToken: datadogEnv.clientToken,
+    site: datadogEnv.site,
+    service: DATADOG_RUM_SERVICE,
+    env: datadogEnv.env,
+    version: datadogEnv.version,
+    sessionSampleRate: 50,
+    sessionReplaySampleRate: 10,
+    trackUserInteractions: true,
+    trackResources: true,
+    trackLongTasks: true,
+    defaultPrivacyLevel: 'mask-user-input',
+    allowedTracingUrls: DATADOG_ALLOWED_TRACING_URLS,
+    beforeSend: redactDatadogRumEvent as DatadogBeforeSend,
+    plugins
+  }
+}

--- a/apps/watch-modern/src/components/Datadog/Init/config.ts
+++ b/apps/watch-modern/src/components/Datadog/Init/config.ts
@@ -9,7 +9,9 @@ const DATADOG_ALLOWED_TRACING_ORIGINS = [
 ] as const
 
 const EMAIL_PATTERN = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi
-const URL_PATTERN = /https?:\/\/[^\s'"<>]+/gi
+const ABSOLUTE_URL_PATTERN = /https?:\/\/[^\s'"<>]+/gi
+const RELATIVE_URL_PATTERN =
+  /(^|[\s(["'])(\/[A-Z0-9._~!$&'()*+,;=:@%/-]+(?:\?[^#\s'"<>]*)?(?:#[^\s'"<>]*)?)/gi
 
 type DatadogBeforeSend = NonNullable<RumInitConfiguration['beforeSend']>
 type DatadogRumEvent = Parameters<DatadogBeforeSend>[0] & {
@@ -89,7 +91,13 @@ export function redactSensitiveUrl(value: string): string {
 
 export function redactSensitiveText(value: string): string {
   return redactEmailLikeValues(
-    value.replace(URL_PATTERN, (url) => redactSensitiveUrl(url))
+    value
+      .replace(ABSOLUTE_URL_PATTERN, (url) => redactSensitiveUrl(url))
+      .replace(
+        RELATIVE_URL_PATTERN,
+        (_match, prefix: string, url: string) =>
+          `${prefix}${redactSensitiveUrl(url)}`
+      )
   )
 }
 

--- a/docs/observability/watch-modern-datadog.md
+++ b/docs/observability/watch-modern-datadog.md
@@ -1,0 +1,59 @@
+# Watch Modern Datadog Verification
+
+`apps/watch-modern` reuses the legacy public Watch Datadog service name:
+
+- RUM service: `watch`
+- Production URL prefix: `https://www.jesusfilm.org/watch`
+- Staging URL prefix: `https://watch.jesusfilm.org/watch` unless deployment configuration proves another mounted path
+- Release version: the deploy commit SHA passed to the browser as `NEXT_PUBLIC_DATADOG_VERSION` and to sourcemap upload as `GIT_COMMIT_SHA`
+
+`watch.jesusfilm.org` is a staging or development validation surface. Do not use it as the production Watch URL in launch reports or dashboard assumptions.
+
+## RUM Smoke Query
+
+Use these dimensions when checking a staging or production deploy:
+
+```text
+service:watch env:<deploy env> version:<commit sha> @view.url:<mounted Watch URL prefix>
+```
+
+For production launch proof, the URL prefix must be `https://www.jesusfilm.org/watch`.
+
+If legacy Watch and Watch Modern emit `service:watch` at the same time, separate traffic by URL prefix and release version.
+
+## Staging Smoke
+
+1. Visit the mounted Watch Modern URL.
+2. Confirm a RUM view event appears with `service:watch`, the expected env, the deploy commit SHA version, and the staging URL prefix.
+3. Exercise representative search, language, player, and recoverable error paths when they are available in the deployed build.
+4. Confirm RUM URL fields and replay/action/error text do not expose query strings, URL fragments, or email-like values.
+5. Confirm trace headers are sent only to the central and stage gateway origins.
+6. Confirm representative emitted `.js.map` URLs return `403` or `404`.
+
+## Sourcemap Correlation
+
+The `watch-modern` sourcemap upload must use the same service and release as RUM:
+
+```text
+service=watch
+release-version=$GIT_COMMIT_SHA
+```
+
+The upload script chooses the minified path prefix by deploy environment:
+
+- `production`, `prod`, and `stage`: `/watch/modern/_next/static/`
+- preview and development: `/watch/_next/static/`
+
+Vercel prebuilt output should have public `.js.map` files removed before `vercel deploy --prebuilt`; Datadog upload still uses the build output under `dist/apps/watch-modern/.next/static`.
+
+## Environment Matrix
+
+Verify these values read-only before release. Missing or over-broad values are release blockers or follow-up tasks; do not mutate external Datadog, Vercel, Doppler, or GitHub secret configuration as part of the Datadog parity PR.
+
+| Context    | Public RUM values                                                                                                                                   | Secret values                 | Notes                                                                                        |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | -------------------------------------------------------------------------------------------- |
+| Production | `NEXT_PUBLIC_DATADOG_APPLICATION_ID`, `NEXT_PUBLIC_DATADOG_CLIENT_TOKEN`, `NEXT_PUBLIC_DATADOG_SITE`, `VERCEL_ENV=prod`, `VERCEL_GIT_COMMIT_SHA`    | `DATADOG_API_KEY`             | API key must remain CI/server-only and must not use a `NEXT_PUBLIC_` name.                   |
+| Staging    | `NEXT_PUBLIC_DATADOG_APPLICATION_ID`, `NEXT_PUBLIC_DATADOG_CLIENT_TOKEN`, `NEXT_PUBLIC_DATADOG_SITE`, `VERCEL_ENV=stage`, `VERCEL_GIT_COMMIT_SHA`   | `DATADOG_API_KEY`             | Validate against the staging mounted Watch URL, not production.                              |
+| Preview    | `NEXT_PUBLIC_DATADOG_APPLICATION_ID`, `NEXT_PUBLIC_DATADOG_CLIENT_TOKEN`, `NEXT_PUBLIC_DATADOG_SITE`, `VERCEL_ENV=preview`, `VERCEL_GIT_COMMIT_SHA` | Only if deliberately approved | Preview should not receive production upload authority unless the release owner approves it. |
+
+Record the rotation owner for Datadog public RUM values and `DATADOG_API_KEY` in the release checklist or deployment notes.

--- a/docs/plans/2026-06-11-002-feat-watch-modern-datadog-parity-plan.md
+++ b/docs/plans/2026-06-11-002-feat-watch-modern-datadog-parity-plan.md
@@ -1,0 +1,283 @@
+---
+title: 'feat: Reuse legacy Watch Datadog setup in watch-modern'
+type: feat
+status: active
+date: 2026-06-11
+---
+
+# feat: Reuse legacy Watch Datadog setup in watch-modern
+
+## Summary
+
+Align `apps/watch-modern` Datadog RUM and sourcemap behavior with the legacy public Watch setup while keeping the App Router SDK integration already present on `origin/main`. Production telemetry must represent the user-facing app at `https://www.jesusfilm.org/watch`, not the staging or preview host.
+
+This plan targets `apps/watch-modern` as it exists on `origin/main` and in the linked GitHub tree at `https://github.com/JesusFilm/core/tree/main/apps/watch-modern`. If an implementation worktree does not have that app materialized locally, sync to current `origin/main` before execution.
+
+---
+
+## Problem Frame
+
+Legacy `apps/watch` initialized Datadog RUM with `service: 'watch'`, `site: 'datadoghq.com'`, Vercel environment and commit SHA tags, 50 percent session sampling, 10 percent session replay sampling, interaction tracking, and `mask-user-input` privacy. It uploaded sourcemaps under the same `watch` service and release SHA.
+
+`apps/watch-modern` already has a modern SDK-based RUM integration using `@datadog/browser-rum`, `@datadog/browser-rum-react`, `trackResources`, `trackLongTasks`, gateway trace propagation, and a React error boundary. The gap is that it currently tags RUM and sourcemaps as `watch-modern`, which breaks old Watch dashboard/query continuity and violates the user's request to reuse the old website setup.
+
+---
+
+## Requirements
+
+**RUM Parity**
+
+- R1. `apps/watch-modern` must tag production RUM events with the legacy Watch service name `watch`.
+- R2. RUM events must keep the old Watch sampling and privacy behavior: 50 percent session sample, 10 percent session replay sample, user interaction tracking enabled, and `mask-user-input`.
+- R3. RUM `env` and `version` must continue to come from Vercel environment and deploy commit SHA values so release filtering matches deploys. The deploy flow writes `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA` into Vercel's `VERCEL_GIT_COMMIT_SHA`; `apps/watch-modern/src/env.ts` must expose that same SHA as `NEXT_PUBLIC_DATADOG_VERSION`.
+- R4. Missing Datadog application id or client token must disable RUM initialization without throwing.
+- R5. React runtime errors in the App Router tree must continue to be captured by Datadog and show a recoverable user-facing fallback.
+
+**Production Domain and Routing**
+
+- R6. Production validation must treat `https://www.jesusfilm.org/watch` as the user-facing Watch surface.
+- R7. Staging or preview hosts, including `watch.jesusfilm.org`, must be treated as non-production validation surfaces and must not drive production Datadog dashboard assumptions.
+- R8. Datadog validation queries and sourcemap minified path prefixes must account for `basePath: '/watch'` and the current production/stage `assetPrefix: '/watch/modern'`. Do not add new RUM view/resource filtering code unless built/runtime evidence proves current SDK event paths are wrong.
+
+**Sourcemaps and Release Correlation**
+
+- R9. Datadog sourcemap upload for `watch-modern` must use `service=watch` and a release version equal to the same deploy commit SHA emitted by RUM as `version`.
+- R10. Sourcemap `--minified-path-prefix` must match the actual public URL path where Next serves `watch-modern` JavaScript chunks after `basePath` and `assetPrefix` are applied.
+- R11. Production browser source maps must remain enabled for the Next build so Datadog can unminify production stack traces, but `*.js.map` files must not be publicly fetchable after deployment. Upload maps to Datadog, then delete them from the deployed artifact or block them at the host/CDN, and prove representative map URLs return `403` or `404`.
+
+**Observability Scope**
+
+- R12. Existing modern additions such as resource tracking, long-task tracking, React plugin support, and gateway trace propagation may stay if they preserve R1-R11. Trace propagation must stay limited to the central and stage gateway origins/patterns already intended for API calls, with no trace headers sent to Mux, Algolia, Datadog intake, static assets, or arbitrary third-party URLs.
+- R13. Datadog RUM must not replace Mux playback analytics or future first-party watch event collection.
+- R14. RUM and replay privacy must go beyond `mask-user-input`: redact query strings, URL fragments, and email-like values from view/referrer/resource/error URLs and action/error strings, and add `data-dd-privacy` annotations for sensitive DOM regions discovered during smoke testing.
+
+**Verification**
+
+- R15. Automated tests must cover Datadog initialization, disabled initialization, config values, redaction behavior, trace-propagation allowlists, and the mounted error-boundary wrapper. A project-config test or reviewed config check must cover sourcemap service, release, and per-environment minified path prefix alignment.
+- R16. A staging smoke check must prove RUM events appear under `service:watch`, the expected `env` and `version`, and a URL beginning with the staging mounted Watch path, expected as `https://watch.jesusfilm.org/watch` unless deployment config proves another path. Production launch smoke must use `https://www.jesusfilm.org/watch`.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  Browser["Browser at www.jesusfilm.org/watch"] --> Layout["apps/watch-modern App Router layout"]
+  Layout --> Init["DatadogInit client component"]
+  Layout --> Boundary["DatadogErrorBoundary"]
+  Init --> RUM["Datadog RUM event stream"]
+  Boundary --> RUM
+  Init --> Gateway["api-gateway.central.jesusfilm.org"]
+  Gateway --> Trace["tracecontext propagation when enabled"]
+  Build["watch-modern production build"] --> Static["public Next static chunks"]
+  Static --> Upload["datadog-ci sourcemaps upload"]
+  Upload --> Symbols["Datadog debug symbols"]
+  RUM --> Match["service=watch + version=commit SHA"]
+  Symbols --> Match
+```
+
+The implementation should centralize the RUM constants used by the init component and tests. The deployment target then uses the same service and release version for sourcemap upload, with the minified path prefix matched to the actual served Next asset path.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. Use `service: 'watch'` for `apps/watch-modern`: The user's goal is old Watch Datadog setup reuse. Keeping `watch-modern` would create clean migration telemetry, but it would fragment existing Watch RUM dashboards, monitors, and sourcemap symbol lookup.
+- KTD2. Keep the SDK integration instead of restoring the old script tag: `apps/watch-modern` already imports `@datadog/browser-rum` and `@datadog/browser-rum-react`, which is the right shape for App Router and testability. Parity should come from matching service/env/version/sampling/privacy behavior, not from reintroducing inline script injection.
+- KTD3. Match sourcemaps to RUM tags: Datadog sourcemap upload `--service` and `--release-version` must match the RUM `service` and `version` tags. The `watch-modern` upload target should therefore stop uploading symbols as `service=watch-modern`, and `GIT_COMMIT_SHA` must equal the runtime `NEXT_PUBLIC_DATADOG_VERSION` SHA for the same deploy.
+- KTD4. Make asset URL prefixes environment-aware: Current config combines `basePath: '/watch'` with `assetPrefix: '/watch/modern'` for production/stage, while preview can serve a different static chunk path. A single hard-coded `--minified-path-prefix=/_next/static/` is not enough. Use an env-driven upload script or per-environment upload targets, then capture built HTML script URLs as evidence.
+- KTD5. Keep Datadog observability separate from product analytics: RUM can cover page views, errors, resources, long tasks, and frontend trace correlation. Playback behavior stays with Mux analytics, and future first-party watch events stay out of this plan.
+- KTD6. Use `www.jesusfilm.org/watch` for production validation: `watch.jesusfilm.org` may remain useful for staging or development, but production RUM queries and smoke proof should filter for the mounted public URL.
+- KTD7. Keep source maps private after upload: `productionBrowserSourceMaps: true` is acceptable only when deploy artifacts or edge controls prevent public `*.js.map` downloads.
+
+---
+
+## Implementation Units
+
+### U1. Centralize Datadog RUM Configuration
+
+- **Goal:** Make the Watch Datadog config explicit, testable, and aligned with the legacy `watch` service.
+- **Requirements:** R1, R2, R3, R4, R12, R14, R15.
+- **Dependencies:** None.
+- **Files:** `apps/watch-modern/src/components/Datadog/Init/Init.tsx`, `apps/watch-modern/src/components/Datadog/Init/config.ts`, `apps/watch-modern/src/components/Datadog/Init/Init.spec.tsx`, `apps/watch-modern/src/env.ts`.
+- **Approach:** Extract a small Datadog config builder or constants module that returns no config when required public credentials are absent. Preserve `sessionSampleRate: 50`, `sessionReplaySampleRate: 10`, `trackUserInteractions: true`, `trackResources: true`, `trackLongTasks: true`, `defaultPrivacyLevel: 'mask-user-input'`, React plugin setup, and current gateway trace propagation. Change the service constant to `watch`. Add a `beforeSend` redaction helper for query strings, fragments, and email-like values in URL/string event fields. Pin `allowedTracingUrls` to the central and stage gateway origins/patterns only.
+- **Patterns to Follow:** `apps/watch-modern/src/components/Datadog/Init/Init.tsx` for current SDK integration; `apps/watch/pages/_app.tsx` for legacy Watch service, sample, replay, env, version, and privacy values.
+- **Test Scenarios:** Use an explicit env-subset config builder or mock `@/env` before importing `Init` so unrelated env validation, such as Cloudflare Stream settings, cannot fail the Datadog tests. With application id and client token present, `datadogRum.init` is called once with `service: 'watch'`, Vercel env, commit SHA version, sample/replay rates, privacy level, resource/long-task tracking, and gateway trace propagation. With either credential missing, `datadogRum.init` is not called. Re-rendering under React strict-mode style effects does not initialize twice. An init exception is caught and logged without breaking render. Redaction tests cover query strings, fragments, and email-like values. Trace tests prove only gateway URLs match the allowlist and representative Mux, Algolia, Datadog intake, static asset, and arbitrary third-party URLs do not.
+- **Verification:** Unit tests prove the config values, and the code exposes one authoritative service constant used by later units.
+
+### U2. Preserve Datadog Error Boundary Coverage
+
+- **Goal:** Verify the existing Datadog React error boundary remains mounted in the App Router tree.
+- **Requirements:** R5, R15.
+- **Dependencies:** U1.
+- **Files:** `apps/watch-modern/src/app/layout.tsx`, `apps/watch-modern/src/components/Datadog/ErrorBoundary/ErrorBoundary.spec.tsx`, `apps/watch-modern/setupTests.tsx`.
+- **Approach:** Keep the existing `DatadogErrorBoundary` component behavior unchanged. Add only the smallest useful test coverage around the mounted wrapper and fallback behavior if current coverage is insufficient for confidence. Do not refactor the fallback UI as part of Datadog service parity.
+- **Patterns to Follow:** Existing `DatadogErrorBoundary` component and `next-intl` test setup patterns in `apps/watch-modern/setupTests.tsx`.
+- **Test Scenarios:** The layout or wrapper path keeps children inside `DatadogErrorBoundary`. If fallback coverage is added, a child render error shows the existing fallback, reset still works, and normal children render without showing fallback text.
+- **Verification:** Error-boundary tests pass without needing live Datadog credentials.
+
+### U3. Align Sourcemap Upload with RUM Service and Asset Paths
+
+- **Goal:** Make production stack traces unminify under the same Datadog service/version that RUM emits.
+- **Requirements:** R6, R8, R9, R10, R11, R15.
+- **Dependencies:** U1.
+- **Files:** `apps/watch-modern/project.json`, `apps/watch-modern/next.config.mjs`, `apps/watch-modern/scripts/upload-sourcemaps.mjs`, `apps/watch-modern/project.spec.ts`.
+- **Approach:** Replace the single hard-coded upload command with an env-driven script or explicit per-environment upload targets. The upload must use `--service=watch` and `--release-version=$GIT_COMMIT_SHA`, where `$GIT_COMMIT_SHA` is the same commit SHA exposed to RUM as `NEXT_PUBLIC_DATADOG_VERSION`. Select the minified path prefix from the deployment context and captured built HTML script URLs: production/stage are expected to use `/watch/modern/_next/static/` with the current `assetPrefix`, while preview may use `/watch/_next/static/` if no asset prefix is applied. Keep `productionBrowserSourceMaps: true`, upload maps, and then remove or block public access to `*.js.map`.
+- **Patterns to Follow:** `apps/watch/project.json` for legacy `--service=watch` and release SHA upload; `.github/workflows/app-deploy.yml` for deploy-time `GIT_COMMIT_SHA` and `DATADOG_API_KEY` handoff.
+- **Test Scenarios:** Add a Vitest project-config test at `apps/watch-modern/project.spec.ts` that reads `apps/watch-modern/project.json` as JSON and asserts the upload path uses `service=watch`, release `$GIT_COMMIT_SHA`, and the env-driven script or per-env targets. Unit-test the upload script's prefix selection for production, stage, and preview contexts. Build-output inspection confirms selected minified path prefixes match emitted script URLs.
+- **Verification:** A dry-run or reviewed CI log shows sourcemaps uploaded for the same service/version pair used by RUM. Staging and production smoke confirm representative emitted `.js.map` URLs return `403` or `404` while Datadog unminification still works.
+
+### U4. Validate Environment and Deployment Wiring
+
+- **Goal:** Ensure staging and production deploys provide the same Datadog env/version inputs the old Watch setup used.
+- **Requirements:** R3, R6, R7, R16.
+- **Dependencies:** U1, U3.
+- **Files:** `apps/watch-modern/src/env.ts`, `apps/watch-modern/project.json`, `.github/workflows/app-deploy.yml`, `apps/watch-modern/README.md` or `docs/observability/watch-modern-datadog.md`.
+- **Approach:** Keep `NEXT_PUBLIC_DATADOG_ENV` derived from `VERCEL_ENV` and `NEXT_PUBLIC_DATADOG_VERSION` derived from `VERCEL_GIT_COMMIT_SHA`, because `watch-modern` deploy already writes those values into Vercel build env files. Add a read-only environment matrix for production, staging, and preview: public RUM application id, public client token, Datadog site, RUM env, secret `DATADOG_API_KEY`, allowed deploy contexts, and rotation owner. `DATADOG_API_KEY` must remain CI/server-only and never use a `NEXT_PUBLIC_` name. If a value is missing or preview has production upload permissions without approval, record it as a release blocker or follow-up rather than mutating external configuration in this PR.
+- **Patterns to Follow:** `apps/watch-modern/src/env.ts` runtime mapping; `apps/watch-modern/project.json` deploy commands; legacy `apps/watch/pages/_app.tsx` env/version usage.
+- **Test Scenarios:** Env unit tests verify default Datadog site is `datadoghq.com`, `VERCEL_ENV=prod` maps to RUM env `prod`, and `VERCEL_GIT_COMMIT_SHA` maps to RUM version. Staging smoke confirms events appear with staging env and `https://watch.jesusfilm.org/watch` unless deployment config proves another mounted path. Production smoke confirms events appear with `https://www.jesusfilm.org/watch` URL after launch.
+- **Verification:** Deployment configuration has the required Datadog public values and CI still passes sourcemap upload with `DATADOG_API_KEY`.
+
+### U5. Add Datadog Smoke and Query Handoff Notes
+
+- **Goal:** Give release reviewers a repeatable proof path for old Watch Datadog parity.
+- **Requirements:** R6, R7, R13, R14, R16.
+- **Dependencies:** U1, U3, U4.
+- **Files:** `apps/watch-modern-e2e/src/e2e/page/watch.spec.ts`, `apps/watch-modern-e2e/playwright.config.ts`, `apps/watch-modern/README.md` or `docs/observability/watch-modern-datadog.md`.
+- **Approach:** Extend e2e or operational docs with a staging smoke that visits `/watch`, triggers representative search, language, player, and recoverable error flows, and records the Datadog query reviewers should use. Add `data-dd-privacy` annotations only where the smoke reveals sensitive DOM text not protected by default masking and redaction. Keep the smoke from requiring real Datadog tokens in CI unless the environment already supplies them.
+- **Patterns to Follow:** `apps/watch-modern-e2e/src/e2e/page/watch.spec.ts` for the current mounted route smoke; existing live Watch monitor paths under `apps/watch-e2e/src/monitoring/` and `apps/resources-e2e/src/monitoring/` for production URL expectations.
+- **Test Scenarios:** E2E still opens `/watch` locally with no Datadog credentials. Staging manual smoke verifies RUM events under `service:watch`, the expected env/version, replay sampling enabled, privacy redaction applied, trace headers limited to gateway requests, and URL matching the staging mounted Watch route. Production launch smoke verifies URL filtering against `https://www.jesusfilm.org/watch`.
+- **Verification:** Release notes or docs tell reviewers exactly how to distinguish production `www.jesusfilm.org/watch` events from staging/preview events.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Production RUM continuity**
+  - **Given:** `watch-modern` is deployed to the user-facing domain.
+  - **When:** A visitor opens `https://www.jesusfilm.org/watch`.
+  - **Then:** Datadog receives RUM events under `service:watch` with the deploy env and commit SHA version.
+  - **Covers:** R1, R3, R6.
+
+- AE2. **Sourcemaps match RUM**
+  - **Given:** The same deploy emits a browser error from a minified chunk.
+  - **When:** Datadog receives the error.
+  - **Then:** The stack trace can resolve against symbols uploaded with `service=watch` and the same release SHA, while direct requests for representative `.js.map` URLs return `403` or `404`.
+  - **Covers:** R9, R10, R11.
+
+- AE3. **Credentials missing is safe**
+  - **Given:** A local or test environment omits the Datadog application id or client token.
+  - **When:** The App Router layout renders.
+  - **Then:** RUM initialization is skipped and the page still renders.
+  - **Covers:** R4.
+
+- AE4. **Staging does not define production truth**
+  - **Given:** QA tests the staging or preview host.
+  - **When:** Datadog events arrive.
+  - **Then:** They are filtered by staging env and URL, while launch proof still uses `www.jesusfilm.org/watch`.
+  - **Covers:** R7, R16.
+
+- AE5. **Privacy and trace boundaries hold**
+  - **Given:** A visitor uses search, language selection, player flows, and one recoverable error path.
+  - **When:** RUM, replay, resource, and trace events are inspected.
+  - **Then:** URL/string fields do not expose query strings, fragments, or email-like values, and trace headers are sent only to approved gateway origins.
+  - **Covers:** R12, R14, R16.
+
+---
+
+## Scope Boundaries
+
+**In Scope**
+
+- Datadog RUM initialization parity for `apps/watch-modern`.
+- Datadog React error boundary tests.
+- Sourcemap upload service/version/path alignment.
+- Env and deploy wiring needed for RUM and sourcemap correlation.
+- Staging and launch smoke documentation for Datadog verification.
+
+**Deferred to Follow-Up Work**
+
+- Adding user identity to Datadog RUM after account work lands.
+- Datadog browser logs collection, unless a separate observability requirement asks for it.
+- First-party product analytics or recommendation events.
+- Mux playback analytics changes.
+- Broader cleanup of stale `watch.jesusfilm.org` production wording outside the narrow Datadog handoff note.
+
+**Out of Scope**
+
+- Datadog dashboard, monitor, alert, or saved-view changes. This plan only emits compatible RUM/sourcemap tags and documents query filters.
+- External Datadog, Vercel, Doppler, or GitHub secret mutation. This plan may verify configuration read-only and record release blockers.
+- Datadog user context. If added later, it must avoid direct PII and clear on sign-out.
+- GTM, GA4, Meta Pixel, Google Ads, and Algolia Insights parity.
+- Cloudflare caching or edge route rollout.
+- Backend Datadog tracing changes outside the browser-to-gateway trace propagation already configured in `watch-modern`.
+
+---
+
+## System-Wide Impact
+
+This change affects observability naming and release-debuggability for the public Watch migration. Switching `watch-modern` RUM to `service=watch` preserves old dashboard continuity but blends modern app traffic with legacy Watch traffic while both are live. Reviewers should filter by URL path, env, and version during overlap windows.
+
+Sourcemap changes affect CI deployment behavior. If the minified path prefix is wrong, uploads may succeed while Datadog still cannot unminify production errors.
+
+---
+
+## Risks and Dependencies
+
+- **Service-name ambiguity:** `service=watch` supports old dashboard continuity, while `service=watch-modern` supports migration isolation. This plan chooses continuity because the user asked to reuse the old setup.
+- **Asset prefix mismatch:** Current `assetPrefix: '/watch/modern'` means the existing `--minified-path-prefix=/_next/static/` may not match served chunk URLs.
+- **Environment-specific sourcemap paths:** Preview, stage, and production can serve different static chunk prefixes, so a single upload command can succeed while Datadog cannot unminify.
+- **Public source-map exposure:** `productionBrowserSourceMaps: true` creates useful Datadog artifacts but can expose source if maps remain publicly fetchable.
+- **Dual-app overlap:** If legacy Watch and `watch-modern` emit `service=watch` at the same time, dashboard queries need URL/version filters to separate them.
+- **Stale subdomain references:** Some repo docs may still name `watch.jesusfilm.org`; launch validation should treat those as staging/dev references unless product explicitly says otherwise.
+- **Datadog quota and privacy:** Keeping replay at 10 percent and masking inputs matches old behavior, but replay can still expose sensitive visible DOM or URL-derived strings unless redaction and smoke proof are in place.
+- **Network trace propagation:** Existing `allowedTracingUrls` sends trace context to central and stage gateways. That is additive to old Watch RUM and must stay on an exact allowlist with staging CORS proof.
+- **External configuration:** Datadog application id, client token, site, and API key live outside the repo in Vercel, Doppler, and GitHub secrets.
+
+---
+
+## Documentation and Operational Notes
+
+- Add a short operational note with the launch Datadog query dimensions: `service:watch`, `env:<deploy env>`, `version:<commit sha>`, and URL beginning with `https://www.jesusfilm.org/watch`.
+- Note that `watch.jesusfilm.org` is staging or development context, not the production Watch URL.
+- Mention any stale `watch.jesusfilm.org` production wording discovered during implementation, but defer a broad docs sweep unless it directly affects Datadog release review.
+- Document the chosen sourcemap minified path prefix and the built asset URL evidence that justified it.
+- Document how public `.js.map` access is blocked or removed after Datadog upload.
+- If old and modern Watch run concurrently under `service=watch`, document the temporary URL filters needed to separate traffic.
+
+---
+
+## Validation Plan
+
+- Run `pnpm exec vitest run --config apps/watch-modern/vitest.config.mts` for Datadog component and config tests.
+- Run `pnpm exec tsc -b apps/watch-modern/tsconfig.json`.
+- Run `pnpm exec eslint apps/watch-modern`.
+- For local e2e, start `watch-modern` first, then run `pnpm exec nx run watch-modern-e2e:e2e`; for deployed e2e, run with `DEPLOYMENT_URL=<preview-or-stage-url>` or the existing deployed-e2e environment flag.
+- Inspect preview, staging, and production build/deploy emitted script URLs before finalizing sourcemap minified path prefixes.
+- After staging deploy, query Datadog RUM for `service:watch`, staging env, deploy version, and the staging mounted Watch URL. Also confirm representative `.js.map` URLs return `403` or `404`.
+- During staging smoke, verify trace headers are sent only to central/stage gateway origins and required gateway CORS headers allow those traces.
+- During staging smoke, verify RUM/replay redaction across search, language, player, and recoverable error flows.
+- After production launch, query Datadog RUM for `service:watch`, production env, deploy version, and `https://www.jesusfilm.org/watch`.
+
+---
+
+## Sources and Research
+
+- `apps/watch/pages/_app.tsx`: legacy Watch Datadog RUM values: `service: 'watch'`, Vercel env/version, 50 percent sample, 10 percent replay, interaction tracking, and masked inputs.
+- `apps/watch/project.json`: legacy Watch sourcemap upload uses `--service=watch` and `--release-version=$GIT_COMMIT_SHA`.
+- `apps/watch-modern/src/components/Datadog/Init/Init.tsx`: current SDK-based RUM integration, React plugin, resource/long-task tracking, and gateway trace propagation.
+- `apps/watch-modern/src/components/Datadog/ErrorBoundary/ErrorBoundary.tsx`: current Datadog React error boundary.
+- `apps/watch-modern/src/env.ts`: current Datadog env validation and Vercel env/version mapping.
+- `apps/watch-modern/project.json`: current deploy and sourcemap upload target, including `--service=watch-modern`.
+- `apps/watch-modern/next.config.mjs`: `basePath: '/watch'`, `assetPrefix: '/watch/modern'` for production/stage, and `productionBrowserSourceMaps: true`.
+- `.github/workflows/app-deploy.yml`: deploy and sourcemap upload steps provide `NEXT_PUBLIC_VERCEL_ENV`, `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA`, `GIT_COMMIT_SHA`, and `DATADOG_API_KEY`.
+- `apps/watch-modern-e2e/src/e2e/page/watch.spec.ts`: current `/watch` e2e smoke.
+- `apps/watch-e2e/src/monitoring/watch.monitor.ts` and `apps/resources-e2e/src/monitoring/watch.monitor.ts`: existing production Watch monitor target `https://www.jesusfilm.org/watch`.
+- `apps/docs/docs/06-quick-links.md`: known place to audit for stale `watch.jesusfilm.org` production wording.
+- `docs/solutions/performance-issues/watch-non-cloudflare-performance-hardening-20260611.md`: prior launch-readiness guidance to prove app-owned route health before edge caching masks behavior.
+- GitHub target tree from the request: `https://github.com/JesusFilm/core/tree/main/apps/watch-modern`.
+- Next.js `productionBrowserSourceMaps` docs: `https://nextjs.org/docs/app/api-reference/config/next-config-js/productionBrowserSourceMaps`.
+- Datadog Browser RUM setup docs: `https://docs.datadoghq.com/real_user_monitoring/application_monitoring/browser/setup/client/`.
+- Datadog RUM advanced configuration docs for `beforeSend`: `https://docs.datadoghq.com/real_user_monitoring/application_monitoring/browser/advanced_configuration/`.
+- Datadog Session Replay privacy options docs: `https://docs.datadoghq.com/session_replay/browser/privacy_options/`.
+- Datadog JavaScript sourcemap upload docs: `https://docs.datadoghq.com/real_user_monitoring/guide/upload-javascript-source-maps/`.


### PR DESCRIPTION
## Summary

Watch Modern now emits Datadog RUM and sourcemap metadata under the legacy public Watch service, so launch validation and existing Watch observability can follow `service:watch` at `https://www.jesusfilm.org/watch` instead of splitting traffic under `watch-modern`.

This keeps the current SDK-based App Router integration, but centralizes the config so the legacy sample/replay rates, masked inputs, deploy env, commit SHA version, gateway-only trace propagation, and redaction rules are all covered by tests.

## What Changed

- RUM config now uses `service:watch`, preserves the existing Datadog React plugin, and skips initialization safely when public Datadog credentials are absent.
- RUM `beforeSend` redacts query strings, URL fragments, and email-like values from URL/action/error fields before events leave the browser.
- Sourcemap upload now uses an environment-aware script so preview, staging, and production prefixes match the mounted Watch asset paths while uploads use the same commit SHA as RUM.
- Vercel deploy commands remove public `.js.map` files from prebuilt output before deploy, while retaining local build maps for Datadog upload.
- Added an operational handoff doc for Datadog query dimensions, production vs staging URL filters, source-map exposure proof, and read-only env/secret verification.

## Validation

- `pnpm exec vitest run --config vitest.config.mts --coverage=false`
- `pnpm exec tsc -b apps/watch-modern/tsconfig.json`
- `pnpm exec eslint --config apps/watch-modern/eslint.config.mjs apps/watch-modern`
- `DEPLOYMENT_URL=http://localhost:4800 pnpm exec playwright test --config apps/watch-modern-e2e/playwright.config.ts`

Browser note: `agent-browser` was attempted first per the CE browser workflow, but this local install rejected `localhost` through its allowed-domain policy even with overrides. The repo Playwright smoke passed against the same local Watch Modern server.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Datadog RUM (Real User Monitoring) initialization with error boundary support
  * Automated sourcemap uploads with privacy-aware event redaction
  * Enhanced monitoring configuration for production and staging environments

* **Tests**
  * Added comprehensive test coverage for RUM configuration, error handling, and sourcemap management

* **Documentation**
  * Added observability verification guidelines and integration specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->