### PR TITLE
feat(NES-1725): guide AiChat copy toward faith questions (desktop + mobile)

### DIFF
--- a/libs/journeys/ui/src/components/AiChat/AiChat.spec.tsx
+++ b/libs/journeys/ui/src/components/AiChat/AiChat.spec.tsx
@@ -245,7 +245,9 @@ describe('AiChat', () => {
 
       render(<AiChat variant="overlay" collapsible={false} />)
 
-      expect(screen.getByTestId('overlay-hero')).toBeInTheDocument()
+      const hero = screen.getByTestId('overlay-hero')
+      expect(hero).toBeInTheDocument()
+      expect(hero).toHaveTextContent('Ask your questions about faith')
     })
 
     it('hides while a request is in flight (submitted)', () => {

--- a/libs/journeys/ui/src/components/AiChat/AiChat.tsx
+++ b/libs/journeys/ui/src/components/AiChat/AiChat.tsx
@@ -431,7 +431,7 @@ export function AiChat({
   // greeting wave-lifts as one unit — still on-tone.
   const heroWords = useMemo(
     () =>
-      t('Ask me anything')
+      t('Ask your questions about faith')
         .split(/\s+/)
         .filter((w) => w.length > 0),
     [t]

--- a/libs/journeys/ui/src/components/AiChat/ChatHeader/ChatHeader.spec.tsx
+++ b/libs/journeys/ui/src/components/AiChat/ChatHeader/ChatHeader.spec.tsx
@@ -9,7 +9,7 @@ vi.mock('next-i18next/pages', () => ({
 describe('ChatHeader', () => {
   it('renders the title and caption', () => {
     const { getByText, getByRole } = render(<ChatHeader />)
-    expect(getByText('Ask a question')).toBeInTheDocument()
+    expect(getByText('Ask your questions about faith')).toBeInTheDocument()
     expect(getByText(/Replies may not be perfect/)).toBeInTheDocument()
     const link = getByRole('link', { name: 'About this chat' })
     expect(link).toHaveAttribute('href', '/legal/about-chat')

--- a/libs/journeys/ui/src/components/AiChat/ChatHeader/ChatHeader.tsx
+++ b/libs/journeys/ui/src/components/AiChat/ChatHeader/ChatHeader.tsx
@@ -132,7 +132,7 @@ export function ChatHeader({
             letterSpacing: 0
           }}
         >
-          {t('Ask a question')}
+          {t('Ask your questions about faith')}
         </Typography>
         <Typography
           variant="caption"

--- a/libs/journeys/ui/src/components/PromptInput/PromptInput.spec.tsx
+++ b/libs/journeys/ui/src/components/PromptInput/PromptInput.spec.tsx
@@ -154,6 +154,22 @@ describe('PromptInput', () => {
     })
   })
 
+  describe('placeholder copy (NES-1725)', () => {
+    it('prompts visitors to ask their questions about faith', () => {
+      render(
+        <PromptInput
+          input=""
+          onInputChange={noop}
+          onSubmit={noop}
+          isLoading={false}
+        />
+      )
+      expect(
+        screen.getByPlaceholderText('Ask your questions about faith')
+      ).toBeInTheDocument()
+    })
+  })
+
   describe('disabled state (NES-1663)', () => {
     it('disables the textarea and the send button when disabled', () => {
       render(

--- a/libs/journeys/ui/src/components/PromptInput/PromptInput.tsx
+++ b/libs/journeys/ui/src/components/PromptInput/PromptInput.tsx
@@ -230,7 +230,7 @@ export function PromptInput({
         onChange={handleInputChange}
         onKeyDown={handleKeyDown}
         onPaste={handlePaste}
-        placeholder={t('Ask anything…')}
+        placeholder={t('Ask your questions about faith')}
         disabled={isLoading || disabled}
         inputProps={{
           'aria-label': t('Chat message input'),

--- a/libs/locales/ar-SA/libs-journeys-ui.json
+++ b/libs/locales/ar-SA/libs-journeys-ui.json
@@ -118,6 +118,7 @@
   "A short description of your collection will appear here.": "سيظهر هنا وصف موجز لمجموعتك.",
   "Creator name": "اسم المنشئ",
   "Ask anything…": "اسأل أي شيء…",
+  "Ask your questions about faith": "اطرح أسئلتك حول الإيمان",
   "Scroll to latest message": "قم بالتمرير إلى آخر رسالة",
   "Use {{title}}": "استخدم {{title}}",
   "Preview {{title}}": "معاينة {{title}}",

--- a/libs/locales/de-DE/libs-journeys-ui.json
+++ b/libs/locales/de-DE/libs-journeys-ui.json
@@ -118,6 +118,7 @@
   "A short description of your collection will appear here.": "Hier wird eine kurze Beschreibung deiner Sammlung angezeigt.",
   "Creator name": "Name des Schöpfers",
   "Ask anything…": "Frag alles…",
+  "Ask your questions about faith": "Stell deine Fragen zum Glauben",
   "Scroll to latest message": "Zur letzten Nachricht blättern",
   "Use {{title}}": "Verwende {{title}}",
   "Preview {{title}}": "Vorschau {{title}}",

--- a/libs/locales/en/libs-journeys-ui.json
+++ b/libs/locales/en/libs-journeys-ui.json
@@ -131,6 +131,7 @@
   "A short description of your collection will appear here.": "A short description of your collection will appear here.",
   "Creator name": "Creator name",
   "Ask anything…": "Ask anything…",
+  "Ask your questions about faith": "Ask your questions about faith",
   "Scroll to latest message": "Scroll to latest message",
   "Use {{title}}": "Use {{title}}",
   "Preview {{title}}": "Preview {{title}}",

--- a/libs/locales/es-ES/libs-journeys-ui.json
+++ b/libs/locales/es-ES/libs-journeys-ui.json
@@ -118,6 +118,7 @@
   "A short description of your collection will appear here.": "Aquí aparecerá una breve descripción de tu colección.",
   "Creator name": "Nombre del creador",
   "Ask anything…": "Pregunta cualquier cosa a…",
+  "Ask your questions about faith": "Haz tus preguntas sobre la fe",
   "Scroll to latest message": "Desplázate hasta el último mensaje",
   "Use {{title}}": "Utiliza {{title}}",
   "Preview {{title}}": "Vista previa {{title}}",

--- a/libs/locales/fr-FR/libs-journeys-ui.json
+++ b/libs/locales/fr-FR/libs-journeys-ui.json
@@ -118,6 +118,7 @@
   "A short description of your collection will appear here.": "Une courte description de ta collection apparaîtra ici.",
   "Creator name": "Nom du créateur",
   "Ask anything…": "Demande tout ce que tu veux…",
+  "Ask your questions about faith": "Pose tes questions sur la foi",
   "Scroll to latest message": "Défile jusqu'au dernier message",
   "Use {{title}}": "Utilise {{title}}",
   "Preview {{title}}": "Prévisualisation {{title}}",

--- a/libs/locales/id-ID/libs-journeys-ui.json
+++ b/libs/locales/id-ID/libs-journeys-ui.json
@@ -118,6 +118,7 @@
   "A short description of your collection will appear here.": "Deskripsi singkat mengenai koleksi Anda akan muncul di sini.",
   "Creator name": "Nama pencipta",
   "Ask anything…": "Tanyakan apa saja…",
+  "Ask your questions about faith": "Tanyakan pertanyaanmu tentang iman",
   "Scroll to latest message": "Gulir ke pesan terbaru",
   "Use {{title}}": "Gunakan {{title}}",
   "Preview {{title}}": "Pratinjau {{title}}",

--- a/libs/locales/ja-JP/libs-journeys-ui.json
+++ b/libs/locales/ja-JP/libs-journeys-ui.json
@@ -118,6 +118,7 @@
   "A short description of your collection will appear here.": "あなたのコレクションの簡単な説明がここに表示されます。",
   "Creator name": "クリエイター名",
   "Ask anything…": "何でも聞いてください…",
+  "Ask your questions about faith": "信仰についての質問をどうぞ",
   "Scroll to latest message": "最新のメッセージまでスクロール",
   "Use {{title}}": "{{title}}",
   "Preview {{title}}": "プレビュー {{title}}",

--- a/libs/locales/ko-KR/libs-journeys-ui.json
+++ b/libs/locales/ko-KR/libs-journeys-ui.json
@@ -118,6 +118,7 @@
   "A short description of your collection will appear here.": "컬렉션에 대한 간단한 설명이 여기에 표시됩니다.",
   "Creator name": "크리에이터 이름",
   "Ask anything…": "무엇이든 물어보세요…",
+  "Ask your questions about faith": "신앙에 대한 질문을 해보세요",
   "Scroll to latest message": "최신 메시지로 스크롤",
   "Use {{title}}": "{{title}} 사용",
   "Preview {{title}}": "미리보기 {{title}}",

--- a/libs/locales/ms-MY/libs-journeys-ui.json
+++ b/libs/locales/ms-MY/libs-journeys-ui.json
@@ -117,6 +117,7 @@
   "A short description of your collection will appear here.": "Keterangan ringkas tentang koleksi anda akan muncul di sini.",
   "Creator name": "Nama pencipta",
   "Ask anything…": "Tanya apa sahaja…",
+  "Ask your questions about faith": "Tanya soalan anda tentang iman",
   "Scroll to latest message": "Tatal ke mesej terkini",
   "Use {{title}}": "Gunakan {{title}}",
   "Preview {{title}}": "Praperintihan {{title}}",

--- a/libs/locales/ne-NP/libs-journeys-ui.json
+++ b/libs/locales/ne-NP/libs-journeys-ui.json
@@ -117,6 +117,7 @@
   "A short description of your collection will appear here.": "तपाईंको सङ्ग्रहको संक्षिप्त विवरण यहाँ देखा पर्नेछ।",
   "Creator name": "सर्जकको नाम",
   "Ask anything…": "केही पनि सोध्नुहोस्…",
+  "Ask your questions about faith": "विश्वासको बारेमा आफ्ना प्रश्नहरू सोध्नुहोस्",
   "Scroll to latest message": "नवीनतम सन्देशमा स्क्रोल गर्नुहोस्",
   "Use {{title}}": "प्रयोग गर्नुहोस् {{title}}",
   "Preview {{title}}": "अग्रिम अवलोकन {{title}}",

--- a/libs/locales/pt-BR/libs-journeys-ui.json
+++ b/libs/locales/pt-BR/libs-journeys-ui.json
@@ -118,6 +118,7 @@
   "A short description of your collection will appear here.": "Uma breve descrição da sua coleção aparecerá aqui.",
   "Creator name": "Nome do criador",
   "Ask anything…": "Pergunte o que você quiser…",
+  "Ask your questions about faith": "Faça suas perguntas sobre a fé",
   "Scroll to latest message": "Role até a mensagem mais recente",
   "Use {{title}}": "Use {{title}}",
   "Preview {{title}}": "Visualizar {{title}}",

--- a/libs/locales/ru-RU/libs-journeys-ui.json
+++ b/libs/locales/ru-RU/libs-journeys-ui.json
@@ -118,6 +118,7 @@
   "A short description of your collection will appear here.": "Здесь появится краткое описание твоей коллекции.",
   "Creator name": "Имя создателя",
   "Ask anything…": "Спрашивай о чем угодно…",
+  "Ask your questions about faith": "Задай свои вопросы о вере",
   "Scroll to latest message": "Прокрутите до последнего сообщения",
   "Use {{title}}": "Используй {{title}}",
   "Preview {{title}}": "Предварительный просмотр {{title}}",

--- a/libs/locales/th-TH/libs-journeys-ui.json
+++ b/libs/locales/th-TH/libs-journeys-ui.json
@@ -117,6 +117,7 @@
   "A short description of your collection will appear here.": "คำอธิบายสั้น ๆ ของคอลเล็กชันของคุณจะปรากฏที่นี่",
   "Creator name": "ชื่อผู้สร้าง",
   "Ask anything…": "ถามอะไรก็ได้…",
+  "Ask your questions about faith": "ถามคำถามเกี่ยวกับความเชื่อได้เลย",
   "Scroll to latest message": "เลื่อนไปที่ข้อความล่าสุด",
   "Use {{title}}": "ใช้ {{title}}",
   "Preview {{title}}": "ตัวอย่าง {{title}}",

--- a/libs/locales/tr-TR/libs-journeys-ui.json
+++ b/libs/locales/tr-TR/libs-journeys-ui.json
@@ -118,6 +118,7 @@
   "A short description of your collection will appear here.": "Koleksiyonunuzun kısa bir açıklaması burada görünecektir.",
   "Creator name": "Yaratıcı adı",
   "Ask anything…": "Her şeyi sorun…",
+  "Ask your questions about faith": "İnançla ilgili sorularınızı sorun",
   "Scroll to latest message": "En son mesaja kaydırın",
   "Use {{title}}": "{{title}} adresini kullanın",
   "Preview {{title}}": "Önizleme {{title}}",

--- a/libs/locales/zh-Hans-CN/libs-journeys-ui.json
+++ b/libs/locales/zh-Hans-CN/libs-journeys-ui.json
@@ -118,6 +118,7 @@
   "A short description of your collection will appear here.": "这里将显示对您收藏的简短描述。",
   "Creator name": "创作者姓名",
   "Ask anything…": "询问任何问题…",
+  "Ask your questions about faith": "询问关于信仰的问题",
   "Scroll to latest message": "滚动到最新信息",
   "Use {{title}}": "使用 {{title}}",
   "Preview {{title}}": "预览 {{title}}",

--- a/libs/locales/zh-Hant-TW/libs-journeys-ui.json
+++ b/libs/locales/zh-Hant-TW/libs-journeys-ui.json
@@ -118,6 +118,7 @@
   "A short description of your collection will appear here.": "此處會出現您收藏的簡短說明。",
   "Creator name": "創作者姓名",
   "Ask anything…": "詢問任何問題…",
+  "Ask your questions about faith": "詢問關於信仰的問題",
   "Scroll to latest message": "捲動至最新訊息",
   "Use {{title}}": "使用 {{title}}",
   "Preview {{title}}": "預覽 {{title}}",


### PR DESCRIPTION
## What changed

All user-facing AiChat copy now reads **"Ask your questions about faith"**, replacing the open-ended invitations that led to off-topic questions. Three strings, one new translation key:

| Surface | Location | Before | After |
|---|---|---|---|
| Desktop overlay floating label | `libs/journeys/ui/src/components/AiChat/AiChat.tsx` | Ask me anything | Ask your questions about faith |
| Mobile drawer title | `libs/journeys/ui/src/components/AiChat/ChatHeader/ChatHeader.tsx` | Ask a question | Ask your questions about faith |
| Input placeholder (shared by desktop + mobile) | `libs/journeys/ui/src/components/PromptInput/PromptInput.tsx` | Ask anything… | Ask your questions about faith |

## Translations

The new key is added **directly to the locale files** (`libs/locales/<locale>/libs-journeys-ui.json`) so the change ships translated immediately, without waiting for the weekly Crowdin sync — same approach and same 15 locales as #9291:

`ar-SA`, `de-DE`, `es-ES`, `fr-FR`, `id-ID`, `ja-JP`, `ko-KR`, `ms-MY`, `ne-NP`, `pt-BR`, `ru-RU`, `th-TH`, `tr-TR`, `zh-Hans-CN`, `zh-Hant-TW`

Old keys are left in place per the extraction config (`removeUnusedKeys: false`); `i18next-cli extract` was run and produces no further diff.

## Tests

- `ChatHeader.spec.tsx` — title assertion updated to the new copy
- `AiChat.spec.tsx` — overlay hero test now also asserts the hero text
- `PromptInput.spec.tsx` — new placeholder assertion (NES-1725)

All 44 tests in the AiChat/PromptInput suites pass; `nx lint journeys-ui` passes with no new warnings.

## QA / how to verify on the Vercel preview

1. Open a journey with chat enabled on **desktop** → the overlay's floating label and the input placeholder both read "Ask your questions about faith".
2. Open the same journey on **mobile** → the drawer title and the input placeholder both read "Ask your questions about faith".
3. Switch the journey language (try `es-ES`, `fr-FR`, `ar-SA`) → the new copy appears translated, not in English.

Linear: [NES-1725](https://linear.app/jesus-film-project/issue/NES-1725/update-aichat-display-text-to-ask-your-questions-about-faith-desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refreshed AI Chat interface messaging with faith-focused prompts and placeholder text across the application, improving contextual clarity for users.

* **Internationalization**
  * Extended translations for updated messaging strings across 16+ supported languages, including Arabic, Chinese, French, German, Japanese, Korean, Portuguese, Russian, Spanish, and additional regional variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->