### PR TITLE
fix(NES-1728): pin stylis to emotion's bundled 4.2.0 to fix RTL journey crash

### DIFF
--- a/libs/shared/ui/src/libs/createEmotionCache/createEmotionCache.spec.tsx
+++ b/libs/shared/ui/src/libs/createEmotionCache/createEmotionCache.spec.tsx
@@ -40,10 +40,12 @@ describe('createEmotionCache', () => {
 
   it('keeps the workspace stylis pinned to the version @emotion/cache bundles', () => {
     const requireModule = createRequire(import.meta.url)
-    const workspaceStylisVersion: string =
-      requireModule('stylis/package.json').version
-    const emotionBundledStylisVersion: string =
-      requireModule('@emotion/cache/package.json').dependencies.stylis
+    const workspaceStylisVersion: string = requireModule(
+      'stylis/package.json'
+    ).version
+    const emotionBundledStylisVersion: string = requireModule(
+      '@emotion/cache/package.json'
+    ).dependencies.stylis
 
     expect(
       workspaceStylisVersion,

--- a/libs/shared/ui/src/libs/createEmotionCache/createEmotionCache.spec.tsx
+++ b/libs/shared/ui/src/libs/createEmotionCache/createEmotionCache.spec.tsx
@@ -26,7 +26,7 @@ const InputWithPseudoRules = styled('input')({
 })
 
 function getInsertedCss(): string {
-  return Array.from(document.head.querySelectorAll('style'))
+  return Array.from(document.head.querySelectorAll('style[data-emotion]'))
     .map((style) => style.textContent)
     .join('\n')
 }

--- a/libs/shared/ui/src/libs/createEmotionCache/createEmotionCache.spec.tsx
+++ b/libs/shared/ui/src/libs/createEmotionCache/createEmotionCache.spec.tsx
@@ -1,3 +1,5 @@
+import { createRequire } from 'node:module'
+
 import { CacheProvider } from '@emotion/react'
 import styled from '@emotion/styled'
 import { render } from '@testing-library/react'
@@ -34,6 +36,22 @@ describe('createEmotionCache', () => {
     document.head
       .querySelectorAll('style[data-emotion]')
       .forEach((style) => style.remove())
+  })
+
+  it('keeps the workspace stylis pinned to the version @emotion/cache bundles', () => {
+    const requireModule = createRequire(import.meta.url)
+    const workspaceStylisVersion: string =
+      requireModule('stylis/package.json').version
+    const emotionBundledStylisVersion: string =
+      requireModule('@emotion/cache/package.json').dependencies.stylis
+
+    expect(
+      workspaceStylisVersion,
+      'The workspace stylis (root package.json) must exactly match the ' +
+        'version @emotion/cache depends on. Mixing versions crashes every ' +
+        'RTL-language journey (NES-1728). If an @emotion upgrade changed ' +
+        'its bundled stylis, re-align the root package.json pin.'
+    ).toBe(emotionBundledStylisVersion)
   })
 
   it('compiles ::placeholder and :read-only rules in RTL mode without crashing', () => {

--- a/libs/shared/ui/src/libs/createEmotionCache/createEmotionCache.spec.tsx
+++ b/libs/shared/ui/src/libs/createEmotionCache/createEmotionCache.spec.tsx
@@ -1,0 +1,66 @@
+import { CacheProvider } from '@emotion/react'
+import styled from '@emotion/styled'
+import { render } from '@testing-library/react'
+
+import { createEmotionCache } from '.'
+
+// NES-1728 regression: emotion compiles styles with its own bundled stylis
+// (pinned 4.2.0). The prefixer and rtl plugin passed in by createEmotionCache
+// come from the workspace's stylis. If those versions diverge (e.g. 4.3.x),
+// the 4.3.x prefixer reads `element.siblings` — a field 4.2.0 nodes don't
+// have — and crashes with "Cannot read properties of undefined (reading
+// 'push')" whenever a bare ::placeholder or :read-only rule compiles in RTL
+// mode. In production this took down every RTL-language journey containing a
+// text input. The workspace stylis must stay pinned to the version emotion
+// ships.
+const InputWithPseudoRules = styled('input')({
+  paddingLeft: '8px',
+  '&::placeholder': {
+    opacity: 0.4
+  },
+  '&:read-only': {
+    opacity: 0.6
+  }
+})
+
+function getInsertedCss(): string {
+  return Array.from(document.head.querySelectorAll('style'))
+    .map((style) => style.textContent)
+    .join('\n')
+}
+
+describe('createEmotionCache', () => {
+  afterEach(() => {
+    document.head
+      .querySelectorAll('style[data-emotion]')
+      .forEach((style) => style.remove())
+  })
+
+  it('compiles ::placeholder and :read-only rules in RTL mode without crashing', () => {
+    const cache = createEmotionCache({ rtl: true })
+
+    expect(() =>
+      render(
+        <CacheProvider value={cache}>
+          <InputWithPseudoRules placeholder="اكتب سؤالك" />
+        </CacheProvider>
+      )
+    ).not.toThrow()
+
+    // stylis-plugin-rtl must have flipped the physical property, proving the
+    // rtl pipeline ran rather than being skipped
+    expect(getInsertedCss()).toContain('padding-right:8px')
+  })
+
+  it('leaves styles unflipped in LTR mode', () => {
+    const cache = createEmotionCache({ rtl: false })
+
+    render(
+      <CacheProvider value={cache}>
+        <InputWithPseudoRules placeholder="type your question" />
+      </CacheProvider>
+    )
+
+    expect(getInsertedCss()).toContain('padding-left:8px')
+  })
+})

--- a/libs/shared/ui/src/libs/createEmotionCache/createEmotionCache.ts
+++ b/libs/shared/ui/src/libs/createEmotionCache/createEmotionCache.ts
@@ -16,6 +16,9 @@ export function createEmotionCache({
   return createEmotionCacheNext({
     key: 'css',
     prepend,
+    // prefixer and rtlPlugin must come from the same stylis version emotion
+    // bundles, or RTL compilation crashes — enforced by
+    // createEmotionCache.spec.tsx (NES-1728)
     stylisPlugins: rtl === true ? [prefixer, rtlPlugin] : []
   })
 }

--- a/package.json
+++ b/package.json
@@ -234,7 +234,7 @@
     "sharp": "^0.33.0",
     "short-unique-id": "^5.2.0",
     "slugify": "^1.6.6",
-    "stylis": "^4.3.0",
+    "stylis": "4.2.0",
     "stylis-plugin-rtl": "^2.1.1",
     "subscriptions-transport-ws": "^0.11.0",
     "swiper": "^12.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -611,11 +611,11 @@ importers:
         specifier: ^1.6.6
         version: 1.6.6
       stylis:
-        specifier: ^4.3.0
-        version: 4.3.6
+        specifier: 4.2.0
+        version: 4.2.0
       stylis-plugin-rtl:
         specifier: ^2.1.1
-        version: 2.1.1(stylis@4.3.6)
+        version: 2.1.1(stylis@4.2.0)
       subscriptions-transport-ws:
         specifier: ^0.11.0
         version: 0.11.0(graphql@16.10.0)
@@ -28753,7 +28753,7 @@ snapshots:
       '@babel/preset-env': 7.29.2(@babel/core@7.29.0)
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       '@babel/runtime-corejs3': 7.28.4
       '@babel/traverse': 7.28.5
       '@docusaurus/logger': 3.9.2
@@ -33655,7 +33655,7 @@ snapshots:
 
   '@mui/private-theming@7.1.1(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       '@mui/utils': 7.1.1(@types/react@19.2.2)(react@19.2.0)
       prop-types: 15.8.1
       react: 19.2.0
@@ -33664,7 +33664,7 @@ snapshots:
 
   '@mui/styled-engine@7.1.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
       '@emotion/sheet': 1.4.0
@@ -33693,7 +33693,7 @@ snapshots:
 
   '@mui/types@7.4.3(@types/react@19.2.2)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
     optionalDependencies:
       '@types/react': 19.2.2
 
@@ -33711,7 +33711,7 @@ snapshots:
 
   '@mui/x-charts-vendor@8.5.2':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       '@types/d3-color': 3.1.3
       '@types/d3-delaunay': 6.0.4
       '@types/d3-interpolate': 3.0.4
@@ -33792,7 +33792,7 @@ snapshots:
 
   '@mui/x-internals@8.5.2(@mui/system@7.1.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       '@mui/system': 7.1.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0))(@types/react@19.2.2)(react@19.2.0)
       '@mui/utils': 7.1.1(@types/react@19.2.2)(react@19.2.0)
       react: 19.2.0
@@ -50737,7 +50737,7 @@ snapshots:
 
   react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@19.2.0))(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.21))(esbuild@0.19.12)):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.0)'
       webpack: 5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.21))(esbuild@0.19.12)
 
@@ -50793,13 +50793,13 @@ snapshots:
 
   react-router-config@5.1.1(react-router@5.3.4(react@19.2.0))(react@19.2.0):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       react: 19.2.0
       react-router: 5.3.4(react@19.2.0)
 
   react-router-dom@5.3.4(react@19.2.0):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -50818,7 +50818,7 @@ snapshots:
 
   react-router@5.3.4(react@19.2.0):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
@@ -52404,10 +52404,10 @@ snapshots:
       postcss: 8.5.10
       postcss-selector-parser: 7.1.1
 
-  stylis-plugin-rtl@2.1.1(stylis@4.3.6):
+  stylis-plugin-rtl@2.1.1(stylis@4.2.0):
     dependencies:
       cssjanus: 2.1.0
-      stylis: 4.3.6
+      stylis: 4.2.0
 
   stylis@4.2.0: {}
 


### PR DESCRIPTION
Fixes [NES-1728](https://linear.app/jesus-film-project/issue/NES-1728/rtl-rendering-error-in-arabic-chat-page)

## Problem

Every RTL-language journey (language code `ar`, `ar-*`, `fa`, `ur`, `he`, …) containing a text input crashes on load with an application-error screen, on stage and production today. Confirmed branch-independent in the ticket — repro is simply: Arabic-language journey + a Text Response block + open as visitor.

Console error:

```
TypeError: Cannot read properties of undefined (reading 'push')
  at … stylis Tokenizer.js / Middleware.js / Serializer.js
  at emotion-cache insert
```

## Root cause

Emotion compiles styles with its own bundled **stylis 4.2.0** (exact pin inside `@emotion/cache`). But `createEmotionCache` (`libs/shared/ui`) feeds that pipeline the `prefixer` + `stylis-plugin-rtl` resolved from the workspace's **stylis 4.3.6** — only when the cache is created in RTL mode, which `apps/journeys/pages/_app.tsx` does whenever the journey's language is RTL.

stylis 4.3.x added a `siblings` field to its CSS nodes. Nodes compiled by emotion's 4.2.0 don't have it, so when the 4.3.6 prefixer's `lift()` helper processes a bare `::placeholder` / `:read-only` rule it does `element.siblings.push(…)` → `undefined.push` → the page dies. LTR journeys never enter this code path, which is why only RTL journeys crash.

The mismatch has been latent since stylis was bumped to `^4.3` in #1864 (2023); it became reachable once bare `::placeholder` rules entered the journey viewer.

## Fix

Pin the workspace `stylis` to `4.2.0` — the exact version emotion ships and the pairing MUI documents for `stylis-plugin-rtl` — so one version serves the whole pipeline. This also fixes the identical pattern in `FramePortal` (`libs/journeys/ui`).

Deliberately a direct-dependency pin rather than a global pnpm override: the only other `stylis@4.3.6` consumer is `@mermaid-js/mermaid-cli` (dev-only diagram tooling, never in app runtime), and there's no reason to touch its internals.

The lockfile diff also contains a handful of `@babel/runtime` 7.28.4 → 7.29.2 snapshot dedupes — pnpm consolidating onto a version already present in the lockfile, no new packages.

## Test illustrating failure → fix

New regression spec `libs/shared/ui/src/libs/createEmotionCache/createEmotionCache.spec.tsx` compiles bare `&::placeholder` and `&:read-only` rules through the RTL cache (the exact crashing recipe) and asserts the rtl plugin actually flipped `padding-left` → `padding-right`, so the pipeline can't silently regress to "no plugins".

**Before the pin** (stylis 4.3.6, original lockfile) — reproduces the production error exactly, LTR control passes:

```
× createEmotionCache > compiles ::placeholder and :read-only rules in RTL mode without crashing
  → expected [Function] to not throw an error but
    'TypeError: Cannot read properties of undefined (reading 'push')' was thrown
✓ createEmotionCache > leaves styles unflipped in LTR mode
Tests  1 failed | 1 passed (2)
```

**After the pin**:

```
✓ createEmotionCache > compiles ::placeholder and :read-only rules in RTL mode without crashing
✓ createEmotionCache > leaves styles unflipped in LTR mode
Tests  2 passed (2)
```

Also verified: `FramePortal.spec.tsx` (the other RTL cache consumer) and all 44 `libs/shared/ui/src/libs` spec files pass against stylis 4.2.0.

## QA

Per the ticket's confirmed repro recipe:

1. Journey whose **language** is any `ar`/`ar-*` entry (e.g. Arabic Modern Standard), with a **Text Response block** on a card → open as visitor. Expect: renders RTL, no application error.
2. Same journey with **chat enabled** (`showAssistant`) → chat input (`PromptInput`, the viewer's only bare `::placeholder`) renders without crashing.
3. LTR journey smoke test — styles unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated styling dependency to resolve potential right-to-left (RTL) rendering issues and ensure correct CSS property flipping during compilation.

* **Tests**
  * Added comprehensive test coverage validating RTL functionality, CSS property handling, and dependency version compatibility to prevent future regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->