### PR TITLE
fix(videos-admin): update publish-all workflow

### DIFF
--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/layout.spec.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/layout.spec.tsx
@@ -1,0 +1,72 @@
+import { useSuspenseQuery as apolloClient_useSuspenseQuery } from '@apollo/client'
+import { render, screen } from '@testing-library/react'
+import { type Mock } from 'vitest'
+
+import VideoViewLayout from './layout'
+
+const mockPush = vi.fn()
+const mockSegment = vi.fn()
+const mockVideoInformation = vi.fn(() => (
+  <div data-testid="video-information" />
+))
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ videoId: 'video123' }),
+  useRouter: () => ({ push: mockPush }),
+  useSelectedLayoutSegment: () => mockSegment()
+}))
+
+vi.mock('@apollo/client', async () => {
+  const original = await vi.importActual('@apollo/client')
+  return {
+    ...original,
+    useSuspenseQuery: vi.fn()
+  }
+})
+
+vi.mock('./_VideoInformation', () => ({
+  VideoInformation: () => mockVideoInformation()
+}))
+
+vi.mock('./_VideoTabs', () => ({
+  VideoTabView: ({ currentTab }: { currentTab: string }) => (
+    <div data-testid="current-tab">{currentTab}</div>
+  )
+}))
+
+describe('VideoViewLayout', () => {
+  const useSuspenseQuery = vi.mocked(
+    apolloClient_useSuspenseQuery as unknown as Mock
+  )
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSegment.mockReturnValue('metadata')
+    useSuspenseQuery.mockReturnValue({
+      data: {
+        adminVideo: {
+          id: 'video123',
+          locked: false,
+          published: true,
+          publishedAt: '2026-01-01T00:00:00.000Z',
+          label: 'series',
+          title: [{ id: 'title1', value: 'Series Title' }]
+        }
+      }
+    })
+  })
+
+  it('uses the children tab behind the publish all dialog without rendering metadata queries', () => {
+    mockSegment.mockReturnValue('publishAll')
+
+    render(
+      <VideoViewLayout studyQuestions={<div>Study questions</div>}>
+        <div data-testid="publish-all-dialog">Publish all dialog</div>
+      </VideoViewLayout>
+    )
+
+    expect(screen.getByTestId('current-tab')).toHaveTextContent('children')
+    expect(screen.getByTestId('publish-all-dialog')).toBeInTheDocument()
+    expect(mockVideoInformation).not.toHaveBeenCalled()
+  })
+})

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/layout.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/layout.tsx
@@ -9,7 +9,6 @@ import Divider from '@mui/material/Divider'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { useParams, useRouter, useSelectedLayoutSegment } from 'next/navigation'
-import { useSnackbar } from 'notistack'
 import { ReactNode, useCallback } from 'react'
 
 import { graphql } from '@core/shared/gql'
@@ -46,29 +45,6 @@ const GET_TAB_DATA = graphql(`
   }
 `)
 
-const GET_VIDEO_CHILDREN_FOR_PUBLISH = graphql(`
-  query GetVideoChildrenForPublish($id: ID!) {
-    adminVideo(id: $id) {
-      id
-      label
-      children {
-        id
-        published
-        variants(input: { onlyPublished: false }) {
-          id
-          published
-          language {
-            id
-            name(primary: true) {
-              value
-            }
-          }
-        }
-      }
-    }
-  }
-`)
-
 interface VideoViewLayoutProps {
   children: ReactNode
   studyQuestions: ReactNode
@@ -79,7 +55,6 @@ export default function VideoViewLayout({
   studyQuestions
 }: VideoViewLayoutProps): ReactNode {
   const router = useRouter()
-  const { enqueueSnackbar } = useSnackbar()
   const { videoId } = useParams<{ videoId: string }>()
   // keep metadata visible when modal is open
   const availableTabs = [
@@ -90,8 +65,9 @@ export default function VideoViewLayout({
     'troubleshooting'
   ]
   const segment = useSelectedLayoutSegment() ?? 'metadata'
-  const currentTab = availableTabs.includes(segment ?? '')
-    ? segment
+  const tabSegment = segment === 'publishAll' ? 'children' : segment
+  const currentTab = availableTabs.includes(tabSegment ?? '')
+    ? tabSegment
     : 'metadata'
 
   const { data } = useSuspenseQuery(GET_TAB_DATA, {
@@ -100,13 +76,6 @@ export default function VideoViewLayout({
       languageId: DEFAULT_VIDEO_LANGUAGE_ID
     }
   })
-
-  const { data: childrenData } = useSuspenseQuery(
-    GET_VIDEO_CHILDREN_FOR_PUBLISH,
-    {
-      variables: { id: videoId }
-    }
-  )
 
   if (data.adminVideo == null) {
     return <VideoViewFallback />
@@ -128,20 +97,9 @@ export default function VideoViewLayout({
     video.label === 'series' ||
     video.label === 'featureFilm'
 
-  // Get unpublished children for publish all functionality
-  const unpublishedChildren =
-    childrenData?.adminVideo?.children?.filter((child) => !child.published) ??
-    []
-
   const handlePublishAllClick = useCallback(() => {
-    if (unpublishedChildren.length === 0) {
-      enqueueSnackbar('No unpublished children to publish', {
-        variant: 'info'
-      })
-      return
-    }
     router.push(`/videos/${videoId}/publishAll`, { scroll: false })
-  }, [enqueueSnackbar, router, unpublishedChildren.length, videoId])
+  }, [router, videoId])
 
   return (
     <Stack

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/publishAll/_PublishAllChildren/PublishAllDialogBody.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/publishAll/_PublishAllChildren/PublishAllDialogBody.tsx
@@ -2,6 +2,7 @@
 
 import Button from '@mui/material/Button'
 import Stack from '@mui/material/Stack'
+import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import { ReactElement } from 'react'
 
@@ -31,6 +32,9 @@ export function PublishAllDialogBody({
     latestResult != null ? (
       <PublishAllResultPanel latestResult={latestResult} />
     ) : null
+  const canPublishVideosOnly = unpublishedChildrenCount > 0
+  const canPublishVideosAndLanguages =
+    unpublishedChildrenCount > 0 || allUnpublishedVariantsCount > 0
 
   return (
     <Stack spacing={2} sx={{ mt: 1 }}>
@@ -58,46 +62,82 @@ export function PublishAllDialogBody({
 
       <Stack spacing={1.5} sx={{ pt: 1 }}>
         <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }}>
-          <Button
-            onClick={onPublishVideosOnly}
-            color="primary"
-            variant="outlined"
-            disabled={isSubmitting}
-            sx={{ whiteSpace: 'nowrap' }}
+          <Tooltip
+            title={canPublishVideosOnly ? '' : 'No videos to publish'}
+            describeChild
           >
-            Publish Videos Only
-          </Button>
-          <Button
-            onClick={() => void onDryRun('childrenVideosOnly')}
-            color="primary"
-            variant="text"
-            disabled={isSubmitting}
-            sx={{ whiteSpace: 'nowrap' }}
+            <span>
+              <Button
+                onClick={onPublishVideosOnly}
+                color="primary"
+                variant="outlined"
+                disabled={isSubmitting || !canPublishVideosOnly}
+                sx={{ whiteSpace: 'nowrap' }}
+              >
+                Publish Videos Only
+              </Button>
+            </span>
+          </Tooltip>
+          <Tooltip
+            title={canPublishVideosOnly ? '' : 'No videos to publish'}
+            describeChild
           >
-            Dry Run
-          </Button>
+            <span>
+              <Button
+                onClick={() => void onDryRun('childrenVideosOnly')}
+                color="primary"
+                variant="text"
+                disabled={isSubmitting || !canPublishVideosOnly}
+                sx={{ whiteSpace: 'nowrap' }}
+              >
+                Dry Run
+              </Button>
+            </span>
+          </Tooltip>
         </Stack>
 
         <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }}>
-          <Button
-            onClick={onPublishVideosAndLanguages}
-            color="primary"
-            variant="contained"
-            disabled={isSubmitting}
-            autoFocus
-            sx={{ whiteSpace: 'nowrap' }}
+          <Tooltip
+            title={
+              canPublishVideosAndLanguages
+                ? ''
+                : 'No videos or audio languages to publish'
+            }
+            describeChild
           >
-            Publish Videos and Audio Languages
-          </Button>
-          <Button
-            onClick={() => void onDryRun('childrenVideosAndVariants')}
-            color="primary"
-            variant="text"
-            disabled={isSubmitting}
-            sx={{ whiteSpace: 'nowrap' }}
+            <span>
+              <Button
+                onClick={onPublishVideosAndLanguages}
+                color="primary"
+                variant="contained"
+                disabled={isSubmitting || !canPublishVideosAndLanguages}
+                autoFocus
+                sx={{ whiteSpace: 'nowrap' }}
+              >
+                Publish Videos and Audio Languages
+              </Button>
+            </span>
+          </Tooltip>
+          <Tooltip
+            title={
+              canPublishVideosAndLanguages
+                ? ''
+                : 'No videos or audio languages to publish'
+            }
+            describeChild
           >
-            Dry Run
-          </Button>
+            <span>
+              <Button
+                onClick={() => void onDryRun('childrenVideosAndVariants')}
+                color="primary"
+                variant="text"
+                disabled={isSubmitting || !canPublishVideosAndLanguages}
+                sx={{ whiteSpace: 'nowrap' }}
+              >
+                Dry Run
+              </Button>
+            </span>
+          </Tooltip>
         </Stack>
 
         <Stack direction="row" justifyContent="flex-end">

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/publishAll/_PublishAllChildren/publishAll.documents.ts
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/publishAll/_PublishAllChildren/publishAll.documents.ts
@@ -4,6 +4,10 @@ export const GET_VIDEO_CHILDREN_FOR_PUBLISH = graphql(`
   query GetVideoChildrenForPublish($id: ID!) {
     adminVideo(id: $id) {
       id
+      variants(input: { onlyPublished: false }) {
+        id
+        published
+      }
       children {
         id
         published

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/publishAll/page.spec.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/publishAll/page.spec.tsx
@@ -179,6 +179,296 @@ describe('PublishAllChildrenDialog (route)', () => {
     })
   })
 
+  it('publishes languages when all child videos are already published', async () => {
+    useSuspenseQuery.mockReturnValueOnce({
+      data: {
+        adminVideo: {
+          id: 'video123',
+          variants: [],
+          children: [
+            {
+              id: 'child1',
+              published: true,
+              variants: [
+                { id: 'v1', published: false },
+                { id: 'v2', published: true }
+              ]
+            }
+          ]
+        }
+      }
+    })
+    mockPublishChildren.mockResolvedValueOnce({
+      data: {
+        videoPublishChildren: {
+          dryRun: true,
+          publishedVideoCount: 0,
+          publishedVideoIds: [],
+          publishedVariantsCount: 1,
+          publishedVariantIds: ['v1'],
+          videosFailedValidation: []
+        }
+      }
+    })
+    mockPublishChildren.mockResolvedValueOnce({
+      data: {
+        videoPublishChildren: {
+          dryRun: false,
+          publishedVideoCount: 0,
+          publishedVideoIds: [],
+          publishedVariantsCount: 1,
+          publishedVariantIds: ['v1'],
+          videosFailedValidation: []
+        }
+      }
+    })
+
+    render(
+      <MockedProvider>
+        <PublishAllChildrenDialog params={{ videoId: 'video123' }} />
+      </MockedProvider>
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Publish Videos Only' })
+    ).toBeDisabled()
+    expect(
+      screen.getByRole('button', {
+        name: 'Publish Videos and Audio Languages'
+      })
+    ).toBeEnabled()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Publish Videos and Audio Languages'
+      })
+    )
+
+    await waitFor(() => {
+      expect(mockPublishChildren).toHaveBeenCalledWith({
+        variables: {
+          id: 'video123',
+          mode: 'childrenVideosAndVariants',
+          dryRun: false
+        }
+      })
+      expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
+        'Successfully published 0 videos and 1 audio language variant(s)',
+        { variant: 'success' }
+      )
+      expect(mockPush).toHaveBeenCalledWith('/videos/video123', {
+        scroll: false
+      })
+    })
+  })
+
+  it('asks before partially publishing valid videos when validation fails', async () => {
+    mockPublishChildren.mockResolvedValueOnce({
+      data: {
+        videoPublishChildren: {
+          dryRun: true,
+          publishedVideoCount: 1,
+          publishedVideoIds: ['child-valid'],
+          publishedVariantsCount: 0,
+          publishedVariantIds: [],
+          videosFailedValidation: [
+            {
+              videoId: 'child-invalid',
+              message: 'child-invalid not published, missing: Description',
+              missingFields: ['Description']
+            }
+          ]
+        }
+      }
+    })
+    mockPublishChildren.mockResolvedValueOnce({
+      data: {
+        videoPublishChildren: {
+          dryRun: false,
+          publishedVideoCount: 1,
+          publishedVideoIds: ['child-valid'],
+          publishedVariantsCount: 0,
+          publishedVariantIds: [],
+          videosFailedValidation: [
+            {
+              videoId: 'child-invalid',
+              message: 'child-invalid not published, missing: Description',
+              missingFields: ['Description']
+            }
+          ]
+        }
+      }
+    })
+
+    render(
+      <MockedProvider>
+        <PublishAllChildrenDialog params={{ videoId: 'video123' }} />
+      </MockedProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Publish Videos Only' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Publish Valid Videos?')
+      ).toBeInTheDocument()
+      expect(screen.getByText(/Could not publish:/)).toBeInTheDocument()
+    })
+    expect(mockPublishChildren).toHaveBeenCalledTimes(1)
+    expect(mockPublishChildren).toHaveBeenCalledWith({
+      variables: {
+        id: 'video123',
+        mode: 'childrenVideosOnly',
+        dryRun: true
+      }
+    })
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Publish Valid Videos' })
+    )
+
+    await waitFor(() => {
+      expect(mockPublishChildren).toHaveBeenCalledWith({
+        variables: {
+          id: 'video123',
+          mode: 'childrenVideosOnly',
+          dryRun: false
+        }
+      })
+      expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
+        'Successfully published 1 videos',
+        { variant: 'success' }
+      )
+    })
+  })
+
+  it('does not partially publish when validation confirmation is cancelled', async () => {
+    mockPublishChildren.mockResolvedValueOnce({
+      data: {
+        videoPublishChildren: {
+          dryRun: true,
+          publishedVideoCount: 1,
+          publishedVideoIds: ['child-valid'],
+          publishedVariantsCount: 0,
+          publishedVariantIds: [],
+          videosFailedValidation: [
+            {
+              videoId: 'child-invalid',
+              message: 'child-invalid not published, missing: Description',
+              missingFields: ['Description']
+            }
+          ]
+        }
+      }
+    })
+
+    render(
+      <MockedProvider>
+        <PublishAllChildrenDialog params={{ videoId: 'video123' }} />
+      </MockedProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Publish Videos Only' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Publish Valid Videos?')
+      ).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Publish Valid Videos?')
+      ).not.toBeInTheDocument()
+    })
+    expect(mockPublishChildren).toHaveBeenCalledTimes(1)
+  })
+
+  it('enables language publishing for draft variants on the parent video', async () => {
+    useSuspenseQuery.mockReturnValueOnce({
+      data: {
+        adminVideo: {
+          id: 'video123',
+          variants: [
+            { id: 'parent-v1', published: false },
+            { id: 'parent-v2', published: true }
+          ],
+          children: [
+            {
+              id: 'child1',
+              published: true,
+              variants: [{ id: 'child-v1', published: true }]
+            }
+          ]
+        }
+      }
+    })
+    mockPublishChildren.mockResolvedValueOnce({
+      data: {
+        videoPublishChildren: {
+          dryRun: true,
+          publishedVideoCount: 0,
+          publishedVideoIds: [],
+          publishedVariantsCount: 1,
+          publishedVariantIds: ['parent-v1'],
+          videosFailedValidation: []
+        }
+      }
+    })
+    mockPublishChildren.mockResolvedValueOnce({
+      data: {
+        videoPublishChildren: {
+          dryRun: false,
+          publishedVideoCount: 0,
+          publishedVideoIds: [],
+          publishedVariantsCount: 1,
+          publishedVariantIds: ['parent-v1'],
+          videosFailedValidation: []
+        }
+      }
+    })
+
+    render(
+      <MockedProvider>
+        <PublishAllChildrenDialog params={{ videoId: 'video123' }} />
+      </MockedProvider>
+    )
+
+    expect(
+      screen.getByText(/0 unpublished child video\(s\) and 1 unpublished variant\(s\)/)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Publish Videos Only' })
+    ).toBeDisabled()
+    expect(
+      screen.getByRole('button', {
+        name: 'Publish Videos and Audio Languages'
+      })
+    ).toBeEnabled()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Publish Videos and Audio Languages'
+      })
+    )
+
+    await waitFor(() => {
+      expect(mockPublishChildren).toHaveBeenCalledWith({
+        variables: {
+          id: 'video123',
+          mode: 'childrenVideosAndVariants',
+          dryRun: false
+        }
+      })
+      expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
+        'Successfully published 0 videos and 1 audio language variant(s)',
+        { variant: 'success' }
+      )
+    })
+  })
+
   it('closes on Cancel', async () => {
     render(
       <MockedProvider>
@@ -190,8 +480,7 @@ describe('PublishAllChildrenDialog (route)', () => {
     expect(mockPush).toHaveBeenCalledWith('/videos/video123', { scroll: false })
   })
 
-  it('shows info and redirects if no unpublished children', async () => {
-    // All children published
+  it('keeps the dialog open when no unpublished children or languages exist', () => {
     useSuspenseQuery.mockReturnValueOnce({
       data: { adminVideo: { id: 'video123', children: [] } }
     })
@@ -202,15 +491,20 @@ describe('PublishAllChildrenDialog (route)', () => {
       </MockedProvider>
     )
 
-    await waitFor(() => {
-      expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
-        'No unpublished children to publish',
-        { variant: 'info' }
-      )
-      expect(mockPush).toHaveBeenCalledWith('/videos/video123', {
-        scroll: false
+    expect(screen.getByText('Publish All Children')).toBeInTheDocument()
+    expect(
+      screen.getByText(/0 unpublished child video\(s\)/)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Publish Videos Only' })
+    ).toBeDisabled()
+    expect(
+      screen.getByRole('button', {
+        name: 'Publish Videos and Audio Languages'
       })
-    })
+    ).toBeDisabled()
+    expect(mockEnqueueSnackbar).not.toHaveBeenCalled()
+    expect(mockPush).not.toHaveBeenCalled()
   })
 
   it('shows latest dry run in results panel without closing', async () => {

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/publishAll/page.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/publishAll/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useMutation, useSuspenseQuery } from '@apollo/client'
+import Typography from '@mui/material/Typography'
 import { useRouter } from 'next/navigation'
 import { useSnackbar } from 'notistack'
 import { ReactElement, use, useCallback, useMemo, useState } from 'react'
@@ -32,6 +33,8 @@ export default function PublishAllChildrenDialog({
   const [latestResult, setLatestResult] = useState<PublishSummaryEntry | null>(
     null
   )
+  const [pendingPartialPublishMode, setPendingPartialPublishMode] =
+    useState<VideoPublishMode | null>(null)
 
   const { data } = useSuspenseQuery(GET_VIDEO_CHILDREN_FOR_PUBLISH, {
     variables: { id: videoId }
@@ -40,87 +43,148 @@ export default function PublishAllChildrenDialog({
   const [publishChildren] = useMutation(PUBLISH_CHILDREN)
 
   const { unpublishedChildren, allUnpublishedVariants } = useMemo(() => {
-    const children = data?.adminVideo?.children ?? []
+    const video = data?.adminVideo
+    const children = video?.children ?? []
+    const parentVariants = video?.variants ?? []
     const unpublished = children.filter((child) => !child.published)
-    const unpublishedVariants = children.flatMap(
-      (child) => child.variants?.filter((v) => !v.published) ?? []
-    )
+    const unpublishedVariants = [
+      ...parentVariants.filter((variant) => !variant.published),
+      ...children.flatMap(
+        (child) => child.variants?.filter((v) => !v.published) ?? []
+      )
+    ]
     return {
       unpublishedChildren: unpublished,
       allUnpublishedVariants: unpublishedVariants
     }
-  }, [data?.adminVideo?.children])
+  }, [data?.adminVideo])
 
   const replaceLatestResult = useCallback((entry: PublishSummaryEntry) => {
     setLatestResult(entry)
   }, [])
 
-  if ((unpublishedChildren?.length ?? 0) === 0) {
-    enqueueSnackbar('No unpublished children to publish', { variant: 'info' })
-    router.push(`/videos/${videoId}`, { scroll: false })
-    return <></>
-  }
-
   const handleClose = useCallback(() => {
     router.push(`/videos/${videoId}`, { scroll: false })
   }, [router, videoId])
 
-  const handlePublishChildren = useCallback(async () => {
-    if (unpublishedChildren.length === 0) {
-      handleClose()
-      return
-    }
-    setIsSubmitting(true)
-    try {
+  const resultToSummaryEntry = useCallback(
+    (
+      result: NonNullable<
+        Awaited<ReturnType<typeof publishChildren>>['data']
+      >['videoPublishChildren']
+    ): PublishSummaryEntry => ({
+      dryRun: result.dryRun === true,
+      publishedVideoIds: result.publishedVideoIds ?? [],
+      publishedVariantIds: result.publishedVariantIds ?? [],
+      videosFailedValidation: result.videosFailedValidation ?? []
+    }),
+    []
+  )
+
+  const runPublishMutation = useCallback(
+    async (mode: VideoPublishMode, dryRun: boolean) => {
       const { data: mutationData, errors } = await publishChildren({
         variables: {
           id: videoId,
-          mode: 'childrenVideosOnly',
-          dryRun: false
+          mode,
+          dryRun
         }
       })
       if (errors != null && errors.length > 0) {
-        throw new Error('Failed to publish children')
+        throw new Error('Failed to publish')
       }
       const result = mutationData?.videoPublishChildren
       if (result == null) {
         throw new Error('No publish result')
       }
-      replaceLatestResult({
-        dryRun: false,
-        publishedVideoIds: result.publishedVideoIds ?? [],
-        publishedVariantIds: result.publishedVariantIds ?? [],
-        videosFailedValidation: result.videosFailedValidation ?? []
-      })
-      const failures = result.videosFailedValidation ?? []
-      if (failures.length > 0) {
+      return result
+    },
+    [publishChildren, videoId]
+  )
+
+  const executePublish = useCallback(
+    async (mode: VideoPublishMode) => {
+      setIsSubmitting(true)
+      try {
+        const result = await runPublishMutation(mode, false)
+        replaceLatestResult(resultToSummaryEntry(result))
+
         enqueueSnackbar(
-          `${failures.length} video(s) could not be published. Fix issues using the links below, then try again.`,
-          { variant: 'warning' }
+          mode === 'childrenVideosOnly'
+            ? `Successfully published ${result.publishedVideoCount} videos`
+            : `Successfully published ${result.publishedVideoCount} videos and ${result.publishedVariantsCount} audio language variant(s)`,
+          { variant: 'success' }
+        )
+        router.refresh()
+        handleClose()
+      } catch {
+        enqueueSnackbar(
+          mode === 'childrenVideosOnly'
+            ? 'Failed to publish children'
+            : 'Failed to publish children and languages',
+          { variant: 'error' }
         )
         setIsSubmitting(false)
-        router.refresh()
-        return
       }
-      enqueueSnackbar(
-        `Successfully published ${result.publishedVideoCount} videos`,
-        { variant: 'success' }
-      )
-      router.refresh()
-      handleClose()
-    } catch {
-      enqueueSnackbar('Failed to publish children', { variant: 'error' })
-      setIsSubmitting(false)
-    }
-  }, [
-    replaceLatestResult,
-    enqueueSnackbar,
-    handleClose,
-    publishChildren,
-    router,
-    unpublishedChildren.length,
-    videoId
-  ])
+    },
+    [
+      enqueueSnackbar,
+      handleClose,
+      replaceLatestResult,
+      resultToSummaryEntry,
+      router,
+      runPublishMutation
+    ]
+  )
+
+  const requestPublish = useCallback(
+    async (mode: VideoPublishMode) => {
+      setIsSubmitting(true)
+      try {
+        const dryRunResult = await runPublishMutation(mode, true)
+        replaceLatestResult(resultToSummaryEntry(dryRunResult))
+
+        const failures = dryRunResult.videosFailedValidation ?? []
+        const publishableCount =
+          (dryRunResult.publishedVideoIds?.length ?? 0) +
+          (dryRunResult.publishedVariantIds?.length ?? 0)
+
+        if (failures.length > 0) {
+          if (publishableCount > 0) {
+            setPendingPartialPublishMode(mode)
+          } else {
+            enqueueSnackbar(
+              `${failures.length} video(s) could not be published. Fix issues using the links below, then try again.`,
+              { variant: 'warning' }
+            )
+          }
+          setIsSubmitting(false)
+          return
+        }
+
+        await executePublish(mode)
+      } catch {
+        enqueueSnackbar(
+          mode === 'childrenVideosOnly'
+            ? 'Failed to publish children'
+            : 'Failed to publish children and languages',
+          { variant: 'error' }
+        )
+        setIsSubmitting(false)
+      }
+    },
+    [
+      enqueueSnackbar,
+      executePublish,
+      replaceLatestResult,
+      resultToSummaryEntry,
+      runPublishMutation
+    ]
+  )
+
+  const handlePublishChildren = useCallback(() => {
+    void requestPublish('childrenVideosOnly')
+  }, [requestPublish])
 
   const handleDryRun = useCallback(
     async (mode: VideoPublishMode) => {
@@ -155,83 +219,59 @@ export default function PublishAllChildrenDialog({
     [replaceLatestResult, enqueueSnackbar, publishChildren, videoId]
   )
 
-  const handlePublishChildrenAndLanguages = useCallback(async () => {
-    if (unpublishedChildren.length === 0) {
-      handleClose()
+  const handlePublishChildrenAndLanguages = useCallback(() => {
+    void requestPublish('childrenVideosAndVariants')
+  }, [requestPublish])
+
+  const handleConfirmPartialPublish = useCallback(() => {
+    if (pendingPartialPublishMode == null) {
       return
     }
-    setIsSubmitting(true)
-    try {
-      const { data: mutationData, errors } = await publishChildren({
-        variables: {
-          id: videoId,
-          mode: 'childrenVideosAndVariants',
-          dryRun: false
-        }
-      })
-      if (errors != null && errors.length > 0) {
-        throw new Error('Failed to publish children and languages')
-      }
-      const result = mutationData?.videoPublishChildren
-      if (result == null) {
-        throw new Error('No publish result')
-      }
-      replaceLatestResult({
-        dryRun: false,
-        publishedVideoIds: result.publishedVideoIds ?? [],
-        publishedVariantIds: result.publishedVariantIds ?? [],
-        videosFailedValidation: result.videosFailedValidation ?? []
-      })
-      const failures = result.videosFailedValidation ?? []
-      if (failures.length > 0) {
-        enqueueSnackbar(
-          `${failures.length} video(s) could not be published. Fix issues using the links below, then try again.`,
-          { variant: 'warning' }
-        )
-        setIsSubmitting(false)
-        router.refresh()
-        return
-      }
-      enqueueSnackbar(
-        `Successfully published ${result.publishedVideoCount} videos and ${result.publishedVariantsCount} audio language variant(s)`,
-        { variant: 'success' }
-      )
-      router.refresh()
-      handleClose()
-    } catch {
-      enqueueSnackbar('Failed to publish children and languages', {
-        variant: 'error'
-      })
-      setIsSubmitting(false)
-    }
-  }, [
-    replaceLatestResult,
-    enqueueSnackbar,
-    handleClose,
-    publishChildren,
-    router,
-    unpublishedChildren.length,
-    videoId
-  ])
+    const mode = pendingPartialPublishMode
+    setPendingPartialPublishMode(null)
+    void executePublish(mode)
+  }, [executePublish, pendingPartialPublishMode])
+
+  const handleCancelPartialPublish = useCallback(() => {
+    setPendingPartialPublishMode(null)
+  }, [])
 
   return (
-    <Dialog
-      open={true}
-      onClose={handleClose}
-      dialogTitle={{ title: 'Publish All Children', closeButton: true }}
-      divider
-      loading={isSubmitting}
-    >
-      <PublishAllDialogBody
-        unpublishedChildrenCount={unpublishedChildren.length}
-        allUnpublishedVariantsCount={allUnpublishedVariants.length}
-        isSubmitting={isSubmitting}
-        latestResult={latestResult}
-        onPublishVideosOnly={handlePublishChildren}
-        onDryRun={handleDryRun}
-        onPublishVideosAndLanguages={handlePublishChildrenAndLanguages}
+    <>
+      <Dialog
+        open={true}
         onClose={handleClose}
-      />
-    </Dialog>
+        dialogTitle={{ title: 'Publish All Children', closeButton: true }}
+        divider
+        loading={isSubmitting}
+      >
+        <PublishAllDialogBody
+          unpublishedChildrenCount={unpublishedChildren.length}
+          allUnpublishedVariantsCount={allUnpublishedVariants.length}
+          isSubmitting={isSubmitting}
+          latestResult={latestResult}
+          onPublishVideosOnly={handlePublishChildren}
+          onDryRun={handleDryRun}
+          onPublishVideosAndLanguages={handlePublishChildrenAndLanguages}
+          onClose={handleClose}
+        />
+      </Dialog>
+      <Dialog
+        open={pendingPartialPublishMode != null}
+        onClose={handleCancelPartialPublish}
+        dialogTitle={{ title: 'Publish Valid Videos?', closeButton: true }}
+        dialogAction={{
+          onSubmit: handleConfirmPartialPublish,
+          submitLabel: 'Publish Valid Videos',
+          closeLabel: 'Cancel'
+        }}
+        loading={isSubmitting}
+      >
+        <Typography variant="body1">
+          Some videos cannot be published yet. Publish the valid videos and
+          audio languages listed in the dry run anyway?
+        </Typography>
+      </Dialog>
+    </>
   )
 }


### PR DESCRIPTION
## Summary

Updates the videos-admin Publish All workflow to support language-only publishing and make partial publish explicit.

This PR is stacked on the QA-525 backend PR because it relies on the API dry-run/publish results for accurate counts and validation decisions.

## Changes

- Keeps Publish All available for parent videos and maps the `publishAll` segment to the Children tab so metadata does not mount behind the dialog.
- Counts draft variants on both the parent and children in the current draft scope.
- Disables no-op publish/dry-run actions with explanatory tooltips.
- Runs a dry-run preflight before real publish actions.
- Shows `Publish Valid Videos?` before allowing partial publish when validation failures exist.
- Adds route coverage for language-only, parent-variant, no-op, and partial-publish confirmation flows.

## QA

- `pnpm exec nx test videos-admin --runInBand -- apps/videos-admin/src/app/\(dashboard\)/videos/\[videoId\]/layout.spec.tsx apps/videos-admin/src/app/\(dashboard\)/videos/\[videoId\]/publishAll/page.spec.tsx`
- `pnpm exec nx run videos-admin:type-check`

Stage testing should happen after this PR and the backend PR are both deployed. See QA-400 parent ticket notes for the full stage checklist.

Depends on #9299
Closes QA-526
