### PR TITLE
fix(video-importer): restore node sea packaging

### DIFF
--- a/apps/video-importer/AGENTS.md
+++ b/apps/video-importer/AGENTS.md
@@ -3,8 +3,8 @@
 ## Context & stack
 
 - **Location:** `apps/video-importer` in the Nx monorepo.
-- **Purpose:** Bun-powered CLI for batch importing videos, subtitles, and audio previews into the Jesus Film Media platform.
-- **Runtime:** Source runs with Bun for local importer execution and is compiled into standalone binaries for non-developer users.
+- **Purpose:** Node-powered CLI for batch importing videos, subtitles, and audio previews into the Jesus Film Media platform.
+- **Runtime:** Source runs with Node/tsx for local importer execution and is packaged into Node SEA executables for non-developer users.
 - **External systems:** Cloudflare R2 uploads, GraphQL mutations/queries, Firebase auth, and `ffprobe` metadata extraction.
 
 ## Workspace setup
@@ -21,7 +21,7 @@
 - `pnpm dlx nx run video-importer:lint` - Lint the importer.
 - `pnpm dlx nx run video-importer:type-check` - Type-check with `tsc -b`.
 - `pnpm dlx nx run video-importer:build` - Compile TypeScript.
-- `pnpm dlx nx run video-importer:compile` - Build the standalone Bun executable.
+- `pnpm dlx nx run video-importer:compile` - Build the Node SEA executables.
 - `pnpm dlx nx run video-importer:package` - Build cross-platform release artifacts and copy the README.
 
 ## Import contracts
@@ -45,9 +45,9 @@
 ## Packaging constraints
 
 - The packaged binary is for non-developers. Keep console output direct, actionable, and free of developer-only jargon.
-- Prefer dependencies and APIs that work in both Bun source execution and Bun standalone executable mode.
-- Preserve default folder behavior: source execution defaults to `process.cwd()`, standalone executable mode defaults to the binary directory.
-- If dynamic imports are used for packaging compatibility, verify the compiled executable path still works.
+- Prefer dependencies and APIs that work in Node source execution and Node SEA executable mode.
+- Preserve default folder behavior: source execution defaults to `process.cwd()`, Node SEA executable mode defaults to the executable directory.
+- If dynamic imports are used for packaging compatibility, verify the packaged executable path still works.
 
 ## Testing expectations
 

--- a/apps/video-importer/README.md
+++ b/apps/video-importer/README.md
@@ -48,20 +48,6 @@ Both must be set. If they are missing, the importer exits with a configuration e
 
 The bot needs the `chat:write` scope (and access to the chosen channel).
 
-### 6. Slack notifications (optional)
-
-After a real run (not `--dry-run`), the importer can post a summary to Slack using a bot token and the Web API (`chat.postMessage`).
-
-1. Create a Slack app for your workspace, enable **Bots**, and install it to the workspace.
-2. Under **OAuth & Permissions**, copy the **Bot User OAuth Token** (`xoxb-…`).
-3. Invite the bot to the target channel (`/invite @YourBot`), then copy the channel ID (right-click the channel → **View channel details** → scroll to the bottom for the ID, or open the channel in a browser and read it from the URL).
-4. Add to your `.env` (same folder as the binary):
-   - `SLACK_BOT_TOKEN` — bot token (`xoxb-…`)
-   - `SLACK_CHANNEL_ID` — channel ID (starts with `C` for public channels)
-
-Both must be set for notifications to send. Omit them if you do not want Slack. Use `--no-slack` on the command line to skip posting even when these variables are set.
-
-The bot needs the `chat:write` scope (and access to the chosen channel).
 
 ---
 

--- a/apps/video-importer/README.md
+++ b/apps/video-importer/README.md
@@ -2,13 +2,13 @@
 
 ## Overview
 
-The Video Importer packaged binary is a command-line tool for batch importing video files, subtitles, and audio previews into the Jesus Film Media platform. It uploads assets to Cloudflare R2, creates Mux video assets, and updates the backend via GraphQL. This tool is designed for non-developers and requires no Node.js or npm setup—just run the binary!
+The Video Importer packaged executable is a command-line tool for batch importing video files, subtitles, and audio previews into the Jesus Film Media platform. It uploads assets to Cloudflare R2, creates Mux video assets, and updates the backend via GraphQL. This tool is designed for non-developers and requires no Node.js or npm setup on the target machine.
 
 ---
 
 ## Requirements
 
-Before you can use the Video Importer binary, make sure you have the following:
+Before you can use the Video Importer executable, make sure you have the following:
 
 ### 1. .env File (Environment Variables)
 
@@ -48,7 +48,7 @@ Both must be set. If they are missing, the importer exits with a configuration e
 
 The bot needs the `chat:write` scope (and access to the chosen channel).
 
-### 5. Slack notifications (optional)
+### 6. Slack notifications (optional)
 
 After a real run (not `--dry-run`), the importer can post a summary to Slack using a bot token and the Web API (`chat.postMessage`).
 
@@ -123,7 +123,7 @@ The bot needs the `chat:write` scope (and access to the chosen channel).
    - Ensure all files follow the naming conventions and use the correct file extensions.
 
 2. **Run the Executable**
-   - Open a terminal in the folder containing the binary or specify the folder with your files.
+   - Open a terminal in the folder containing the executable or specify the folder with your files.
    - Run the binary:
      ```sh
      ./video-importer

--- a/apps/video-importer/README.md
+++ b/apps/video-importer/README.md
@@ -48,7 +48,6 @@ Both must be set. If they are missing, the importer exits with a configuration e
 
 The bot needs the `chat:write` scope (and access to the chosen channel).
 
-
 ---
 
 ## Supported File Types & Formatting

--- a/apps/video-importer/build-scripts/build-cross-platform.sh
+++ b/apps/video-importer/build-scripts/build-cross-platform.sh
@@ -35,6 +35,11 @@ if ! command -v curl >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! command -v unzip >/dev/null 2>&1; then
+  echo "unzip is required to extract Windows runtime archives." >&2
+  exit 1
+fi
+
 if [ ! -f "$ENTRYPOINT" ]; then
   echo "Entrypoint not found: $ENTRYPOINT" >&2
   exit 1

--- a/apps/video-importer/build-scripts/build-cross-platform.sh
+++ b/apps/video-importer/build-scripts/build-cross-platform.sh
@@ -1,55 +1,123 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
+NODE_VERSION="v22.16.0"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-DIST_DIR="$PROJECT_DIR/../../dist/apps/video-importer-executable"
+REPO_ROOT="$(cd "$PROJECT_DIR/../.." && pwd)"
+DIST_DIR="$REPO_ROOT/dist/apps/video-importer-executable"
+BUNDLE_DIR="$REPO_ROOT/dist/apps/video-importer"
+ENTRYPOINT="$PROJECT_DIR/src/video-importer.ts"
+BUNDLE="$BUNDLE_DIR/video-importer-bundled.cjs"
+SEA_BLOB="$PROJECT_DIR/sea-prep.blob"
+SEA_CONFIG="$PROJECT_DIR/sea-config.json"
+POSTJECT_SENTINEL="NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2"
 
-echo "Cross-platform build for video-importer"
+echo "Node SEA cross-platform build for video-importer"
+echo "Node.js runtime version: $NODE_VERSION"
 echo "Project dir: $PROJECT_DIR"
 
-# Create output directory
-mkdir -p "$DIST_DIR"
+mkdir -p "$DIST_DIR" "$BUNDLE_DIR"
+rm -f "$DIST_DIR/video-importer" "$DIST_DIR/video-importer.cmd" "$DIST_DIR/video-importer.cjs"
 
-export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
-export PATH="$BUN_INSTALL/bin:$PATH"
-
-if ! command -v bun >/dev/null 2>&1; then
-  echo "❌ Bun is required to build the standalone executables. Please install Bun and retry." >&2
-  echo "   Install: https://bun.sh" >&2
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js is required to build the video-importer SEA executables." >&2
   exit 1
 fi
 
-ENTRYPOINT="$PROJECT_DIR/src/video-importer.ts"
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "pnpm is required to build the video-importer SEA executables." >&2
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required to download Node.js runtime binaries." >&2
+  exit 1
+fi
 
 if [ ! -f "$ENTRYPOINT" ]; then
-  echo "❌ Entrypoint not found: $ENTRYPOINT" >&2
+  echo "Entrypoint not found: $ENTRYPOINT" >&2
   exit 1
 fi
 
-# Build for Linux x64
-echo "Building for Linux x64..."
-bun build --compile "$ENTRYPOINT" --target=bun-linux-x64 --outfile="$DIST_DIR/video-importer-linux"
+echo "Bundling Node CLI..."
+(cd "$REPO_ROOT" && pnpm exec esbuild "$ENTRYPOINT" \
+  --bundle \
+  --platform=node \
+  --target=node22 \
+  --format=cjs \
+  --outfile="$BUNDLE")
+
+download_node_binary() (
+  local platform=$1
+  local arch=$2
+  local filename="node-${NODE_VERSION}-${platform}-${arch}"
+  local url="https://nodejs.org/dist/${NODE_VERSION}/${filename}.tar.gz"
+  local binary_path="$DIST_DIR/${filename}/bin/node"
+
+  if [ "$platform" = "win" ]; then
+    url="https://nodejs.org/dist/${NODE_VERSION}/${filename}.zip"
+    binary_path="$DIST_DIR/${filename}/node.exe"
+  fi
+
+  if [ ! -f "$binary_path" ]; then
+    echo "Downloading Node.js for $platform-$arch..." >&2
+    cd "$DIST_DIR"
+
+    if [ "$platform" = "win" ]; then
+      curl -s -L "$url" -o "${filename}.zip"
+      unzip -q "${filename}.zip"
+      rm "${filename}.zip"
+    else
+      curl -s -L "$url" -o "${filename}.tar.gz"
+      tar -xzf "${filename}.tar.gz"
+      rm "${filename}.tar.gz"
+    fi
+  fi
+
+  echo "$binary_path"
+)
+
+inject_sea_blob() {
+  local binary=$1
+  shift
+
+  pnpm exec postject "$binary" NODE_SEA_BLOB "$SEA_BLOB" \
+    --sentinel-fuse "$POSTJECT_SENTINEL" \
+    "$@"
+}
+
+echo "Preparing Node.js linux-x64 runtime for SEA blob generation..."
+linux_binary=$(download_node_binary "linux" "x64")
+
+echo "Generating SEA blob..."
+(cd "$PROJECT_DIR" && "$linux_binary" --experimental-sea-config "$SEA_CONFIG")
+
+echo "Building Linux x64 executable..."
+cp "$linux_binary" "$DIST_DIR/video-importer-linux"
+inject_sea_blob "$DIST_DIR/video-importer-linux"
 chmod +x "$DIST_DIR/video-importer-linux"
-echo "✅ Linux executable created"
+echo "Linux executable created: $DIST_DIR/video-importer-linux"
 
-# Build for macOS x64
-echo "Building for macOS x64..."
-bun build --compile "$ENTRYPOINT" --target=bun-darwin-x64 --outfile="$DIST_DIR/video-importer-macos"
+echo "Building macOS x64 executable..."
+macos_binary=$(download_node_binary "darwin" "x64")
+cp "$macos_binary" "$DIST_DIR/video-importer-macos"
+inject_sea_blob "$DIST_DIR/video-importer-macos" --macho-segment-name NODE_SEA
 chmod +x "$DIST_DIR/video-importer-macos"
-echo "✅ macOS executable created"
+echo "macOS executable created: $DIST_DIR/video-importer-macos"
 
-# Build for Windows x64
-echo "Building for Windows x64..."
-bun build --compile "$ENTRYPOINT" --target=bun-windows-x64 --outfile="$DIST_DIR/video-importer.exe"
-echo "✅ Windows executable created"
+echo "Building Windows x64 executable..."
+windows_binary=$(download_node_binary "win" "x64")
+cp "$windows_binary" "$DIST_DIR/video-importer.exe"
+inject_sea_blob "$DIST_DIR/video-importer.exe"
+echo "Windows executable created: $DIST_DIR/video-importer.exe"
 
 echo ""
-echo "🎉 Cross-platform build complete!"
+echo "Node SEA build complete."
 echo "Executables created:"
 echo "  Linux:   $DIST_DIR/video-importer-linux"
-echo "  macOS:   $DIST_DIR/video-importer-macos" 
+echo "  macOS:   $DIST_DIR/video-importer-macos"
 echo "  Windows: $DIST_DIR/video-importer.exe"
 echo ""
-echo "Note: macOS and Windows binaries may be unsigned."
+echo "Note: macOS and Windows binaries are unsigned."
 echo "For distribution, sign them on their respective platforms."

--- a/apps/video-importer/build-scripts/build-cross-platform.sh
+++ b/apps/video-importer/build-scripts/build-cross-platform.sh
@@ -92,13 +92,31 @@ inject_sea_blob() {
     "$@"
 }
 
-echo "Preparing Node.js linux-x64 runtime for SEA blob generation..."
-linux_binary=$(download_node_binary "linux" "x64")
+host_os="$(uname -s)"
+case "$host_os" in
+  Linux*)
+    host_platform="linux"
+    ;;
+  Darwin*)
+    host_platform="darwin"
+    ;;
+  MINGW*|MSYS*|CYGWIN*)
+    host_platform="win"
+    ;;
+  *)
+    echo "Unsupported host OS for SEA blob generation: $host_os" >&2
+    exit 1
+    ;;
+esac
+
+echo "Preparing Node.js ${host_platform}-x64 runtime for SEA blob generation..."
+host_binary=$(download_node_binary "$host_platform" "x64")
 
 echo "Generating SEA blob..."
-(cd "$PROJECT_DIR" && "$linux_binary" --experimental-sea-config "$SEA_CONFIG")
+(cd "$PROJECT_DIR" && "$host_binary" --experimental-sea-config "$SEA_CONFIG")
 
 echo "Building Linux x64 executable..."
+linux_binary=$(download_node_binary "linux" "x64")
 cp "$linux_binary" "$DIST_DIR/video-importer-linux"
 inject_sea_blob "$DIST_DIR/video-importer-linux"
 chmod +x "$DIST_DIR/video-importer-linux"

--- a/apps/video-importer/project.json
+++ b/apps/video-importer/project.json
@@ -14,7 +14,7 @@
     "run": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "BUN_INSTALL=${BUN_INSTALL:-$HOME/.bun} PATH=\"$BUN_INSTALL/bin:$PATH\" bun apps/video-importer/src/video-importer.ts --folder apps/video-importer/test-videos"
+        "command": "node --import tsx apps/video-importer/src/video-importer.ts --folder apps/video-importer/test-videos"
       }
     },
     "package": {
@@ -31,7 +31,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "BUN_INSTALL=${BUN_INSTALL:-$HOME/.bun} PATH=\"$BUN_INSTALL/bin:$PATH\" bun build --compile apps/video-importer/src/video-importer.ts --outfile dist/apps/video-importer-executable/video-importer",
+          "cd apps/video-importer && ./build-scripts/build-cross-platform.sh",
           "mkdir -p dist/apps/video-importer-executable && cp -f apps/video-importer/README.md dist/apps/video-importer-executable/README.md"
         ],
         "parallel": false

--- a/apps/video-importer/project.json
+++ b/apps/video-importer/project.json
@@ -14,7 +14,7 @@
     "run": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "node --import tsx apps/video-importer/src/video-importer.ts --folder apps/video-importer/test-videos"
+        "command": "node --import tsx apps/video-importer/src/video-importer.ts --folder apps/video-importer/test-videos --dry-run"
       }
     },
     "package": {

--- a/apps/video-importer/sea-config.json
+++ b/apps/video-importer/sea-config.json
@@ -1,0 +1,6 @@
+{
+  "main": "../../dist/apps/video-importer/video-importer-bundled.cjs",
+  "output": "sea-prep.blob",
+  "useCodeCache": false,
+  "useSnapshot": false
+}

--- a/apps/video-importer/src/env.ts
+++ b/apps/video-importer/src/env.ts
@@ -1,4 +1,4 @@
-import 'dotenv/config'
+import './loadEnv'
 
 import { createEnv } from '@t3-oss/env-core'
 import { z } from 'zod'

--- a/apps/video-importer/src/importerFilenamePatterns.ts
+++ b/apps/video-importer/src/importerFilenamePatterns.ts
@@ -1,6 +1,6 @@
 /**
  * Filename patterns only — safe to import from Slack / CLI helpers without
- * loading Bun (R2) or other importer side effects.
+ * loading R2 or other importer side effects.
  */
 
 export const VIDEO_FILENAME_REGEX =

--- a/apps/video-importer/src/importers/audiopreview.spec.ts
+++ b/apps/video-importer/src/importers/audiopreview.spec.ts
@@ -1,56 +1,332 @@
 import assert from 'node:assert/strict'
-import { afterEach, describe, it, mock } from 'node:test'
+import { afterEach, before, describe, it, mock } from 'node:test'
+
+import { createProcessingSummary, type ProcessingSummary } from '../types'
+
+const validateLanguageMock = mock.fn()
+const getAudioMetadataMock = mock.fn()
+const uploadFileToR2DirectMock = mock.fn()
+const requestMock = mock.fn()
+const markFileAsCompletedMock = mock.fn()
+
+mock.module('../env', {
+  namedExports: {
+    env: {
+      CLOUDFLARE_R2_BUCKET: 'test-bucket'
+    }
+  }
+})
+
+mock.module('../utils/videoEditionValidator', {
+  namedExports: {
+    validateLanguage: validateLanguageMock
+  }
+})
+
+mock.module('../utils/fileMetadataHelpers', {
+  namedExports: {
+    getAudioMetadata: getAudioMetadataMock
+  }
+})
+
+mock.module('../services/r2', {
+  namedExports: {
+    uploadFileToR2Direct: uploadFileToR2DirectMock
+  }
+})
+
+mock.module('../gql/graphqlClient', {
+  namedExports: {
+    getGraphQLClient: async () => ({
+      request: requestMock
+    })
+  }
+})
+
+mock.module('../utils/fileUtils', {
+  namedExports: {
+    markFileAsCompleted: markFileAsCompletedMock
+  }
+})
 
 function getModuleExports<T>(module: T): any {
   return (module as any)['module.exports'] ?? (module as any).default ?? module
 }
 
-describe('processAudioPreviewFile', () => {
-  afterEach(() => {
-    mock.reset()
+function resetMockCalls(): void {
+  validateLanguageMock.mock.resetCalls()
+  getAudioMetadataMock.mock.resetCalls()
+  uploadFileToR2DirectMock.mock.resetCalls()
+  requestMock.mock.resetCalls()
+  markFileAsCompletedMock.mock.resetCalls()
+}
+
+let AUDIO_PREVIEW_FILENAME_REGEX: RegExp
+let processAudioPreviewFile: (
+  file: string,
+  filePath: string,
+  contentLength: number,
+  summary: ProcessingSummary
+) => Promise<void>
+let importOrUpdateAudioPreview: typeof import('./audiopreview').importOrUpdateAudioPreview
+
+before(async () => {
+  const audioPreviewModule = await import('./audiopreview')
+  const exports = getModuleExports(audioPreviewModule)
+  AUDIO_PREVIEW_FILENAME_REGEX = exports.AUDIO_PREVIEW_FILENAME_REGEX
+  processAudioPreviewFile = exports.processAudioPreviewFile
+  importOrUpdateAudioPreview = exports.importOrUpdateAudioPreview
+})
+
+describe('AUDIO_PREVIEW_FILENAME_REGEX', () => {
+  afterEach(resetMockCalls)
+
+  it('matches language-id AAC filenames only', () => {
+    assert.equal(AUDIO_PREVIEW_FILENAME_REGEX.test('3934.aac'), true)
+    assert.equal(AUDIO_PREVIEW_FILENAME_REGEX.test('3934.mp3'), false)
   })
+})
+
+describe('processAudioPreviewFile', () => {
+  afterEach(resetMockCalls)
 
   it('should fail before uploading audio preview content when languageId is blank', async () => {
-    const originalSkipEnvValidation = process.env.SKIP_ENV_VALIDATION
-    process.env.SKIP_ENV_VALIDATION = '1'
+    const consoleErrorMock = mock.method(console, 'error', () => {})
+    const summary = createProcessingSummary(1)
 
-    try {
-      const audioPreviewModule = await import('./audiopreview')
-      const { processAudioPreviewFile } = getModuleExports(audioPreviewModule)
+    await processAudioPreviewFile('   .aac', '/tmp/   .aac', 100, summary)
 
-      const consoleErrorMock = mock.method(console, 'error', () => {})
+    assert.equal(consoleErrorMock.mock.calls.length, 1)
+    assert.deepEqual(summary, {
+      total: 1,
+      successful: 0,
+      failed: 1,
+      successfulFiles: [],
+      failedFiles: ['   .aac'],
+      failureDetails: [
+        {
+          file: '   .aac',
+          reason: 'Missing languageId in filename'
+        }
+      ]
+    })
+    assert.equal(validateLanguageMock.mock.calls.length, 0)
+  })
 
-      const summary = {
-        total: 1,
-        successful: 0,
-        failed: 0,
-        successfulFiles: [] as string[],
-        failedFiles: [] as string[],
-        failureDetails: [] as { file: string; reason: string }[]
+  it('creates a new audio preview and marks the file completed', async () => {
+    validateLanguageMock.mock.mockImplementation(async () => undefined)
+    getAudioMetadataMock.mock.mockImplementation(async () => ({
+      duration: 4,
+      bitrate: 99913,
+      codec: 'AAC'
+    }))
+    uploadFileToR2DirectMock.mock.mockImplementation(
+      async () => 'https://cdn.example.com/audiopreview/3934.aac'
+    )
+    requestMock.mock.mockImplementation(async () => ({
+      language: { audioPreview: null }
+    }))
+    markFileAsCompletedMock.mock.mockImplementation(async () => undefined)
+
+    const summary = createProcessingSummary(1)
+
+    await processAudioPreviewFile('3934.aac', '/tmp/3934.aac', 49748, summary)
+
+    assert.equal(summary.successful, 1)
+    assert.equal(summary.failed, 0)
+    assert.equal(validateLanguageMock.mock.calls.length, 1)
+    assert.equal(getAudioMetadataMock.mock.calls.length, 1)
+    assert.deepEqual(uploadFileToR2DirectMock.mock.calls[0].arguments[0], {
+      bucket: 'test-bucket',
+      key: 'audiopreview/3934.aac',
+      filePath: '/tmp/3934.aac',
+      contentType: 'audio/aac',
+      contentLength: 49748
+    })
+    assert.equal(requestMock.mock.calls.length, 2)
+    assert.equal(markFileAsCompletedMock.mock.calls.length, 1)
+  })
+
+  it('updates an existing audio preview', async () => {
+    validateLanguageMock.mock.mockImplementation(async () => undefined)
+    getAudioMetadataMock.mock.mockImplementation(async () => ({
+      duration: 4,
+      bitrate: 99913,
+      codec: 'AAC'
+    }))
+    uploadFileToR2DirectMock.mock.mockImplementation(
+      async () => 'https://cdn.example.com/audiopreview/3934.aac'
+    )
+    requestMock.mock.mockImplementation(async () => ({
+      language: {
+        audioPreview: {
+          languageId: '3934',
+          value: 'https://cdn.example.com/old.aac',
+          duration: 2,
+          size: 123,
+          bitrate: 64000,
+          codec: 'AAC'
+        }
       }
+    }))
+    markFileAsCompletedMock.mock.mockImplementation(async () => undefined)
 
-      await processAudioPreviewFile('   .aac', '/tmp/   .aac', 100, summary)
+    const summary = createProcessingSummary(1)
 
-      assert.equal(consoleErrorMock.mock.calls.length, 1)
-      assert.deepEqual(summary, {
-        total: 1,
-        successful: 0,
-        failed: 1,
-        successfulFiles: [],
-        failedFiles: ['   .aac'],
-        failureDetails: [
-          {
-            file: '   .aac',
-            reason: 'Missing languageId in filename'
+    await processAudioPreviewFile('3934.aac', '/tmp/3934.aac', 49748, summary)
+
+    assert.equal(summary.successful, 1)
+    assert.deepEqual(requestMock.mock.calls[1].arguments[1].input, {
+      languageId: '3934',
+      value: 'https://cdn.example.com/audiopreview/3934.aac',
+      duration: 4,
+      size: 49748,
+      bitrate: 99913,
+      codec: 'AAC'
+    })
+  })
+
+  it('fails before metadata when language validation fails', async () => {
+    validateLanguageMock.mock.mockImplementation(async () => {
+      throw new Error('Language does not exist')
+    })
+    const consoleErrorMock = mock.method(console, 'error', () => {})
+    const summary = createProcessingSummary(1)
+
+    await processAudioPreviewFile('999999.aac', '/tmp/999999.aac', 100, summary)
+
+    assert.equal(consoleErrorMock.mock.calls.length, 1)
+    assert.equal(summary.failed, 1)
+    assert.equal(getAudioMetadataMock.mock.calls.length, 0)
+    assert.equal(uploadFileToR2DirectMock.mock.calls.length, 0)
+  })
+
+  it('records metadata, R2 upload, and GraphQL failures', async () => {
+    validateLanguageMock.mock.mockImplementation(async () => undefined)
+    getAudioMetadataMock.mock.mockImplementationOnce(async () => {
+      throw new Error('Invalid bitrate value')
+    })
+    const consoleErrorMock = mock.method(console, 'error', () => {})
+    const metadataSummary = createProcessingSummary(1)
+
+    await processAudioPreviewFile(
+      '3934.aac',
+      '/tmp/3934.aac',
+      49748,
+      metadataSummary
+    )
+
+    assert.equal(metadataSummary.failed, 1)
+    assert.match(metadataSummary.failureDetails[0].reason, /Audio metadata/)
+
+    resetMockCalls()
+    validateLanguageMock.mock.mockImplementation(async () => undefined)
+    getAudioMetadataMock.mock.mockImplementation(async () => ({
+      duration: 4,
+      bitrate: 99913,
+      codec: 'AAC'
+    }))
+    uploadFileToR2DirectMock.mock.mockImplementation(async () => {
+      throw new Error('R2 unavailable')
+    })
+    const uploadSummary = createProcessingSummary(1)
+
+    await processAudioPreviewFile(
+      '3934.aac',
+      '/tmp/3934.aac',
+      49748,
+      uploadSummary
+    )
+
+    assert.equal(uploadSummary.failed, 1)
+    assert.match(uploadSummary.failureDetails[0].reason, /R2 upload/)
+
+    resetMockCalls()
+    validateLanguageMock.mock.mockImplementation(async () => undefined)
+    getAudioMetadataMock.mock.mockImplementation(async () => ({
+      duration: 4,
+      bitrate: 99913,
+      codec: 'AAC'
+    }))
+    uploadFileToR2DirectMock.mock.mockImplementation(
+      async () => 'https://cdn.example.com/audiopreview/3934.aac'
+    )
+    requestMock.mock.mockImplementation(async () => {
+      throw new Error('query failed')
+    })
+    const graphQLSummary = createProcessingSummary(1)
+
+    await processAudioPreviewFile(
+      '3934.aac',
+      '/tmp/3934.aac',
+      49748,
+      graphQLSummary
+    )
+
+    assert.equal(consoleErrorMock.mock.calls.length >= 3, true)
+    assert.equal(graphQLSummary.failed, 1)
+    assert.match(
+      graphQLSummary.failureDetails[0].reason,
+      /GraphQL audio preview create\/update returned failure/
+    )
+    assert.equal(markFileAsCompletedMock.mock.calls.length, 0)
+  })
+})
+
+describe('importOrUpdateAudioPreview', () => {
+  afterEach(resetMockCalls)
+
+  it('returns failed when creating or updating audio preview fails', async () => {
+    let callCount = 0
+    requestMock.mock.mockImplementation(async () => {
+      callCount += 1
+      if (callCount === 1) return { language: { audioPreview: null } }
+      throw new Error('create failed')
+    })
+
+    assert.equal(
+      await importOrUpdateAudioPreview({
+        languageId: '3934',
+        publicUrl: 'https://cdn.example.com/audiopreview/3934.aac',
+        duration: 4,
+        size: 49748,
+        bitrate: 99913,
+        codec: 'AAC'
+      }),
+      'failed'
+    )
+
+    resetMockCalls()
+    callCount = 0
+    requestMock.mock.mockImplementation(async () => {
+      callCount += 1
+      if (callCount === 1) {
+        return {
+          language: {
+            audioPreview: {
+              languageId: '3934',
+              value: 'https://cdn.example.com/old.aac',
+              duration: 2,
+              size: 123,
+              bitrate: 64000,
+              codec: 'AAC'
+            }
           }
-        ]
-      })
-    } finally {
-      if (originalSkipEnvValidation === undefined) {
-        delete process.env.SKIP_ENV_VALIDATION
-      } else {
-        process.env.SKIP_ENV_VALIDATION = originalSkipEnvValidation
+        }
       }
-    }
+      throw new Error('update failed')
+    })
+
+    assert.equal(
+      await importOrUpdateAudioPreview({
+        languageId: '3934',
+        publicUrl: 'https://cdn.example.com/audiopreview/3934.aac',
+        duration: 4,
+        size: 49748,
+        bitrate: 99913,
+        codec: 'AAC'
+      }),
+      'failed'
+    )
   })
 })

--- a/apps/video-importer/src/importers/subtitle.spec.ts
+++ b/apps/video-importer/src/importers/subtitle.spec.ts
@@ -1,61 +1,301 @@
 import assert from 'node:assert/strict'
-import { afterEach, describe, it, mock } from 'node:test'
+import { afterEach, before, describe, it, mock } from 'node:test'
+
+import { createProcessingSummary, type ProcessingSummary } from '../types'
+
+const validateVideoAndEditionMock = mock.fn()
+const createR2AssetMock = mock.fn()
+const uploadToR2Mock = mock.fn()
+const formatR2AssetDiagnosticMock = mock.fn(() => ' (assetId=test-asset)')
+const requestMock = mock.fn()
+const markFileAsCompletedMock = mock.fn()
+
+mock.module('../env', {
+  namedExports: {
+    env: {
+      CLOUDFLARE_R2_BUCKET: 'test-bucket'
+    }
+  }
+})
+
+mock.module('../utils/videoEditionValidator', {
+  namedExports: {
+    validateVideoAndEdition: validateVideoAndEditionMock
+  }
+})
+
+mock.module('../services/r2', {
+  namedExports: {
+    createR2Asset: createR2AssetMock,
+    formatR2AssetDiagnostic: formatR2AssetDiagnosticMock,
+    uploadToR2: uploadToR2Mock
+  }
+})
+
+mock.module('../gql/graphqlClient', {
+  namedExports: {
+    getGraphQLClient: async () => ({
+      request: requestMock
+    })
+  }
+})
+
+mock.module('../utils/fileUtils', {
+  namedExports: {
+    markFileAsCompleted: markFileAsCompletedMock
+  }
+})
 
 function getModuleExports<T>(module: T): any {
   return (module as any)['module.exports'] ?? (module as any).default ?? module
 }
 
-describe('processSubtitleFile', () => {
-  afterEach(() => {
-    mock.reset()
+function resetMockCalls(): void {
+  validateVideoAndEditionMock.mock.resetCalls()
+  createR2AssetMock.mock.resetCalls()
+  uploadToR2Mock.mock.resetCalls()
+  formatR2AssetDiagnosticMock.mock.resetCalls()
+  requestMock.mock.resetCalls()
+  markFileAsCompletedMock.mock.resetCalls()
+}
+
+let SUBTITLE_FILENAME_REGEX: RegExp
+let processSubtitleFile: (
+  file: string,
+  filePath: string,
+  contentLength: number,
+  summary: ProcessingSummary
+) => Promise<void>
+let importOrUpdateSubtitle: typeof import('./subtitle').importOrUpdateSubtitle
+
+before(async () => {
+  const subtitleModule = await import('./subtitle')
+  const exports = getModuleExports(subtitleModule)
+  SUBTITLE_FILENAME_REGEX = exports.SUBTITLE_FILENAME_REGEX
+  processSubtitleFile = exports.processSubtitleFile
+  importOrUpdateSubtitle = exports.importOrUpdateSubtitle
+})
+
+describe('SUBTITLE_FILENAME_REGEX', () => {
+  afterEach(resetMockCalls)
+
+  it('matches srt and vtt subtitle filenames', () => {
+    assert.equal(
+      SUBTITLE_FILENAME_REGEX.test('0_JesusVisionJohn---base---3934.srt'),
+      true
+    )
+    assert.equal(
+      SUBTITLE_FILENAME_REGEX.test('0_JesusVisionJohn---base---3934.vtt'),
+      true
+    )
   })
+})
+
+describe('processSubtitleFile', () => {
+  afterEach(resetMockCalls)
 
   it('should fail before uploading subtitle content when languageId is blank', async () => {
-    const originalSkipEnvValidation = process.env.SKIP_ENV_VALIDATION
-    process.env.SKIP_ENV_VALIDATION = '1'
+    const consoleErrorMock = mock.method(console, 'error', () => {})
+    const summary = createProcessingSummary(1)
 
-    try {
-      const subtitleModule = await import('./subtitle')
-      const { processSubtitleFile } = getModuleExports(subtitleModule)
+    await processSubtitleFile(
+      'video123---ot---   .srt',
+      '/tmp/video123---ot---   .srt',
+      100,
+      summary
+    )
 
-      const consoleErrorMock = mock.method(console, 'error', () => {})
+    assert.equal(consoleErrorMock.mock.calls.length, 1)
+    assert.deepEqual(summary, {
+      total: 1,
+      successful: 0,
+      failed: 1,
+      successfulFiles: [],
+      failedFiles: ['video123---ot---   .srt'],
+      failureDetails: [
+        {
+          file: 'video123---ot---   .srt',
+          reason: 'Missing languageId in filename'
+        }
+      ]
+    })
+    assert.equal(validateVideoAndEditionMock.mock.calls.length, 0)
+  })
 
-      const summary = {
-        total: 1,
-        successful: 0,
-        failed: 0,
-        successfulFiles: [] as string[],
-        failedFiles: [] as string[],
-        failureDetails: [] as { file: string; reason: string }[]
-      }
+  it('creates a new SRT subtitle and marks the file completed', async () => {
+    validateVideoAndEditionMock.mock.mockImplementation(async () => undefined)
+    createR2AssetMock.mock.mockImplementation(async () => ({
+      id: 'srt-asset',
+      uploadUrl: 'https://upload.example.com/subtitle.srt',
+      publicUrl: 'https://cdn.example.com/subtitle.srt'
+    }))
+    uploadToR2Mock.mock.mockImplementation(async () => undefined)
+    requestMock.mock.mockImplementation(async () => ({
+      video: { subtitles: [] }
+    }))
+    markFileAsCompletedMock.mock.mockImplementation(async () => undefined)
 
-      await processSubtitleFile(
-        'video123---ot---   .srt',
-        '/tmp/video123---ot---   .srt',
-        100,
-        summary
-      )
+    const summary = createProcessingSummary(1)
 
-      assert.equal(consoleErrorMock.mock.calls.length, 1)
-      assert.deepEqual(summary, {
-        total: 1,
-        successful: 0,
-        failed: 1,
-        successfulFiles: [],
-        failedFiles: ['video123---ot---   .srt'],
-        failureDetails: [
+    await processSubtitleFile(
+      '0_JesusVisionJohn---base---3934.srt',
+      '/tmp/0_JesusVisionJohn---base---3934.srt',
+      126,
+      summary
+    )
+
+    assert.equal(summary.successful, 1)
+    assert.equal(summary.failed, 0)
+    assert.equal(validateVideoAndEditionMock.mock.calls.length, 1)
+    assert.equal(createR2AssetMock.mock.calls.length, 1)
+    assert.deepEqual(createR2AssetMock.mock.calls[0].arguments[0], {
+      fileName:
+        '0_JesusVisionJohn/editions/base/subtitles/3934_base_0_JesusVisionJohn.srt',
+      contentType: 'text/srt',
+      originalFilename: '0_JesusVisionJohn---base---3934.srt',
+      videoId: '0_JesusVisionJohn',
+      contentLength: 126
+    })
+    assert.equal(uploadToR2Mock.mock.calls.length, 1)
+    assert.equal(requestMock.mock.calls.length, 2)
+    assert.equal(markFileAsCompletedMock.mock.calls.length, 1)
+  })
+
+  it('updates an existing VTT subtitle and increments only the VTT version', async () => {
+    validateVideoAndEditionMock.mock.mockImplementation(async () => undefined)
+    createR2AssetMock.mock.mockImplementation(async () => ({
+      id: 'vtt-asset-new',
+      uploadUrl: 'https://upload.example.com/subtitle.vtt',
+      publicUrl: 'https://cdn.example.com/subtitle.vtt'
+    }))
+    uploadToR2Mock.mock.mockImplementation(async () => undefined)
+    requestMock.mock.mockImplementation(async () => ({
+      video: {
+        subtitles: [
           {
-            file: 'video123---ot---   .srt',
-            reason: 'Missing languageId in filename'
+            id: 'subtitle-id',
+            videoId: '0_JesusVisionJohn',
+            edition: 'base',
+            languageId: '3934',
+            primary: false,
+            srtSrc: 'https://cdn.example.com/subtitle.srt',
+            srtAssetId: 'srt-asset-old',
+            srtVersion: 3,
+            vttSrc: 'https://cdn.example.com/old.vtt',
+            vttAssetId: 'vtt-asset-old',
+            vttVersion: 4
           }
         ]
-      })
-    } finally {
-      if (originalSkipEnvValidation === undefined) {
-        delete process.env.SKIP_ENV_VALIDATION
-      } else {
-        process.env.SKIP_ENV_VALIDATION = originalSkipEnvValidation
       }
-    }
+    }))
+    markFileAsCompletedMock.mock.mockImplementation(async () => undefined)
+
+    const summary = createProcessingSummary(1)
+
+    await processSubtitleFile(
+      '0_JesusVisionJohn---base---3934.vtt',
+      '/tmp/0_JesusVisionJohn---base---3934.vtt',
+      130,
+      summary
+    )
+
+    const updateInput = requestMock.mock.calls[1].arguments[1].input
+    assert.equal(updateInput.srtSrc, 'https://cdn.example.com/subtitle.srt')
+    assert.equal(updateInput.srtAssetId, 'srt-asset-old')
+    assert.equal(updateInput.srtVersion, undefined)
+    assert.equal(updateInput.vttSrc, 'https://cdn.example.com/subtitle.vtt')
+    assert.equal(updateInput.vttAssetId, 'vtt-asset-new')
+    assert.equal(updateInput.vttVersion, 5)
+    assert.equal(summary.successful, 1)
+  })
+
+  it('fails before R2 asset creation when video validation fails', async () => {
+    validateVideoAndEditionMock.mock.mockImplementation(async () => {
+      throw new Error('Video does not exist')
+    })
+    const consoleErrorMock = mock.method(console, 'error', () => {})
+    const summary = createProcessingSummary(1)
+
+    await processSubtitleFile(
+      'missing_0_JesusVisionJohn---base---3934.srt',
+      '/tmp/missing_0_JesusVisionJohn---base---3934.srt',
+      126,
+      summary
+    )
+
+    assert.equal(consoleErrorMock.mock.calls.length, 1)
+    assert.equal(summary.failed, 1)
+    assert.equal(createR2AssetMock.mock.calls.length, 0)
+  })
+
+  it('records R2 create and upload failures without marking completed', async () => {
+    validateVideoAndEditionMock.mock.mockImplementation(async () => undefined)
+    createR2AssetMock.mock.mockImplementationOnce(async () => {
+      throw new Error('create failed')
+    })
+    const consoleErrorMock = mock.method(console, 'error', () => {})
+    const createSummary = createProcessingSummary(1)
+
+    await processSubtitleFile(
+      '0_JesusVisionJohn---base---3934.srt',
+      '/tmp/0_JesusVisionJohn---base---3934.srt',
+      126,
+      createSummary
+    )
+
+    assert.equal(createSummary.failed, 1)
+    assert.match(createSummary.failureDetails[0].reason, /R2 create asset/)
+
+    resetMockCalls()
+    validateVideoAndEditionMock.mock.mockImplementation(async () => undefined)
+    createR2AssetMock.mock.mockImplementation(async () => ({
+      id: 'asset-id',
+      uploadUrl: 'https://upload.example.com/subtitle.srt',
+      publicUrl: 'https://cdn.example.com/subtitle.srt'
+    }))
+    uploadToR2Mock.mock.mockImplementation(async () => {
+      throw new Error('upload failed')
+    })
+    const uploadSummary = createProcessingSummary(1)
+
+    await processSubtitleFile(
+      '0_JesusVisionJohn---base---3934.srt',
+      '/tmp/0_JesusVisionJohn---base---3934.srt',
+      126,
+      uploadSummary
+    )
+
+    assert.equal(consoleErrorMock.mock.calls.length >= 2, true)
+    assert.equal(uploadSummary.failed, 1)
+    assert.match(uploadSummary.failureDetails[0].reason, /R2 upload/)
+    assert.match(uploadSummary.failureDetails[0].reason, /assetId=test-asset/)
+    assert.equal(markFileAsCompletedMock.mock.calls.length, 0)
+  })
+})
+
+describe('importOrUpdateSubtitle', () => {
+  afterEach(resetMockCalls)
+
+  it('throws a friendly fetch error when existing subtitles cannot be read', async () => {
+    requestMock.mock.mockImplementation(async () => {
+      throw new Error('query failed')
+    })
+    const consoleErrorMock = mock.method(console, 'error', () => {})
+
+    await assert.rejects(
+      importOrUpdateSubtitle({
+        videoId: '0_JesusVisionJohn',
+        editionName: 'base',
+        languageId: '3934',
+        fileType: 'text/srt',
+        r2Asset: {
+          id: 'asset-id',
+          uploadUrl: 'https://upload.example.com/subtitle.srt',
+          publicUrl: 'https://cdn.example.com/subtitle.srt'
+        }
+      }),
+      /Failed to fetch existing subtitle/
+    )
+    assert.equal(consoleErrorMock.mock.calls.length, 1)
   })
 })

--- a/apps/video-importer/src/importers/video.spec.ts
+++ b/apps/video-importer/src/importers/video.spec.ts
@@ -53,6 +53,12 @@ mock.module('../utils/fileUtils', {
   }
 })
 
+mock.module('uuid', {
+  namedExports: {
+    v4: () => '00000000-0000-4000-8000-000000000000'
+  }
+})
+
 function getModuleExports<T>(module: T): any {
   return (module as any)['module.exports'] ?? (module as any).default ?? module
 }
@@ -211,5 +217,184 @@ describe('processVideoFile', () => {
     assert.equal(createR2AssetMock.mock.calls.length, 0)
     assert.equal(uploadToR2Mock.mock.calls.length, 0)
     assert.equal(requestMock.mock.calls.length, 0)
+  })
+
+  it('should process a burned-in video using the burned-in language/version pair', async () => {
+    validateVideoAndEditionMock.mock.mockImplementation(async () => ({
+      editionId: 'edition-id'
+    }))
+    getVideoMetadataMock.mock.mockImplementation(async () => ({
+      durationMs: 11083,
+      duration: 11,
+      width: 2560,
+      height: 1440
+    }))
+    createR2AssetMock.mock.mockImplementation(async () => ({
+      id: 'asset-id',
+      uploadUrl: 'https://upload.example.com/video.mp4',
+      publicUrl: 'https://cdn.example.com/video.mp4'
+    }))
+    uploadToR2Mock.mock.mockImplementation(async () => undefined)
+    requestMock.mock.mockImplementation(async () => undefined)
+    markFileAsCompletedMock.mock.mockImplementation(async () => undefined)
+
+    const summary = createProcessingSummary(1)
+
+    await processVideoFile(
+      '0_JesusVisionJohn---base---3934---1---496---2.mp4',
+      '/tmp/0_JesusVisionJohn---base---3934---1---496---2.mp4',
+      3429652,
+      summary
+    )
+
+    assert.equal(summary.successful, 1)
+    assert.deepEqual(validateVideoAndEditionMock.mock.calls[0].arguments, [
+      '0_JesusVisionJohn',
+      'base',
+      '496'
+    ])
+    const r2CreateInput = createR2AssetMock.mock.calls[0].arguments[0]
+    assert.match(
+      r2CreateInput.fileName,
+      /^0_JesusVisionJohn\/variants\/496\/videos\/[0-9a-f-]+\/496_0_JesusVisionJohn\.mp4$/
+    )
+    assert.equal(r2CreateInput.contentType, 'video/mp4')
+    assert.equal(
+      r2CreateInput.originalFilename,
+      '0_JesusVisionJohn---base---3934---1---496---2.mp4'
+    )
+    assert.equal(r2CreateInput.videoId, '0_JesusVisionJohn')
+    assert.equal(r2CreateInput.contentLength, 3429652)
+    assert.equal(requestMock.mock.calls[0].arguments[1].languageId, '496')
+    assert.equal(requestMock.mock.calls[0].arguments[1].version, 2)
+  })
+
+  it('records R2 create, R2 upload, GraphQL, and rename failures', async () => {
+    validateVideoAndEditionMock.mock.mockImplementation(async () => ({
+      editionId: 'edition-id'
+    }))
+    getVideoMetadataMock.mock.mockImplementation(async () => ({
+      durationMs: 10000,
+      duration: 10,
+      width: 1920,
+      height: 1080
+    }))
+    createR2AssetMock.mock.mockImplementationOnce(async () => {
+      throw new Error('create failed')
+    })
+    const consoleErrorMock = mock.method(console, 'error', () => {})
+    const createSummary = createProcessingSummary(1)
+
+    await processVideoFile(
+      '0_JesusVisionJohn---base---3934---1.mp4',
+      '/tmp/0_JesusVisionJohn---base---3934---1.mp4',
+      1024,
+      createSummary
+    )
+
+    assert.equal(createSummary.failed, 1)
+    assert.match(createSummary.failureDetails[0].reason, /R2 create asset/)
+
+    resetMockCalls()
+    validateVideoAndEditionMock.mock.mockImplementation(async () => ({
+      editionId: 'edition-id'
+    }))
+    getVideoMetadataMock.mock.mockImplementation(async () => ({
+      durationMs: 10000,
+      duration: 10,
+      width: 1920,
+      height: 1080
+    }))
+    createR2AssetMock.mock.mockImplementation(async () => ({
+      id: 'asset-id',
+      fileName: 'video-file-name',
+      uploadUrl: 'https://upload.example.com/video.mp4',
+      publicUrl: 'https://cdn.example.com/video.mp4'
+    }))
+    uploadToR2Mock.mock.mockImplementation(async () => {
+      throw new Error('upload failed')
+    })
+    const uploadSummary = createProcessingSummary(1)
+
+    await processVideoFile(
+      '0_JesusVisionJohn---base---3934---1.mp4',
+      '/tmp/0_JesusVisionJohn---base---3934---1.mp4',
+      1024,
+      uploadSummary
+    )
+
+    assert.equal(uploadSummary.failed, 1)
+    assert.match(uploadSummary.failureDetails[0].reason, /R2 upload/)
+    assert.match(uploadSummary.failureDetails[0].reason, /assetId=test-asset/)
+    assert.equal(requestMock.mock.calls.length, 0)
+
+    resetMockCalls()
+    validateVideoAndEditionMock.mock.mockImplementation(async () => ({
+      editionId: 'edition-id'
+    }))
+    getVideoMetadataMock.mock.mockImplementation(async () => ({
+      durationMs: 10000,
+      duration: 10,
+      width: 1920,
+      height: 1080
+    }))
+    createR2AssetMock.mock.mockImplementation(async () => ({
+      uploadUrl: 'https://upload.example.com/video.mp4',
+      publicUrl: 'https://cdn.example.com/video.mp4'
+    }))
+    uploadToR2Mock.mock.mockImplementation(async () => undefined)
+    requestMock.mock.mockImplementation(async () => {
+      throw new Error('GraphQL failed')
+    })
+    const graphQLSummary = createProcessingSummary(1)
+
+    await processVideoFile(
+      '0_JesusVisionJohn---base---3934---1.mp4',
+      '/tmp/0_JesusVisionJohn---base---3934---1.mp4',
+      1024,
+      graphQLSummary
+    )
+
+    assert.equal(graphQLSummary.failed, 1)
+    assert.match(
+      graphQLSummary.failureDetails[0].reason,
+      /GraphQL \/ Mux enqueue/
+    )
+    assert.equal(markFileAsCompletedMock.mock.calls.length, 0)
+
+    resetMockCalls()
+    validateVideoAndEditionMock.mock.mockImplementation(async () => ({
+      editionId: 'edition-id'
+    }))
+    getVideoMetadataMock.mock.mockImplementation(async () => ({
+      durationMs: 10000,
+      duration: 10,
+      width: 1920,
+      height: 1080
+    }))
+    createR2AssetMock.mock.mockImplementation(async () => ({
+      uploadUrl: 'https://upload.example.com/video.mp4',
+      publicUrl: 'https://cdn.example.com/video.mp4'
+    }))
+    uploadToR2Mock.mock.mockImplementation(async () => undefined)
+    requestMock.mock.mockImplementation(async () => undefined)
+    markFileAsCompletedMock.mock.mockImplementation(async () => {
+      throw new Error('rename failed')
+    })
+    const renameSummary = createProcessingSummary(1)
+
+    await processVideoFile(
+      '0_JesusVisionJohn---base---3934---1.mp4',
+      '/tmp/0_JesusVisionJohn---base---3934---1.mp4',
+      1024,
+      renameSummary
+    )
+
+    assert.equal(consoleErrorMock.mock.calls.length >= 4, true)
+    assert.equal(renameSummary.failed, 1)
+    assert.match(
+      renameSummary.failureDetails[0].reason,
+      /Rename to \.completed/
+    )
   })
 })

--- a/apps/video-importer/src/loadEnv.ts
+++ b/apps/video-importer/src/loadEnv.ts
@@ -1,0 +1,25 @@
+import fs from 'fs'
+import path from 'path'
+
+import dotenv from 'dotenv'
+
+import { getPackagedAppDir } from './runtime'
+
+function getEnvFilePath(): string {
+  const packagedAppDir = getPackagedAppDir()
+
+  const candidateDirs = [
+    packagedAppDir,
+    path.resolve(process.cwd(), 'apps/video-importer'),
+    process.cwd()
+  ].filter((dir): dir is string => dir != null && dir.trim().length > 0)
+
+  for (const dir of candidateDirs) {
+    const envPath = path.join(dir, '.env')
+    if (fs.existsSync(envPath)) return envPath
+  }
+
+  return path.join(candidateDirs[0] ?? process.cwd(), '.env')
+}
+
+dotenv.config({ path: getEnvFilePath() })

--- a/apps/video-importer/src/runtime.ts
+++ b/apps/video-importer/src/runtime.ts
@@ -11,8 +11,9 @@ export function isSingleExecutableApplication(): boolean {
 export function getPackagedAppDir(): string | undefined {
   const configuredAppDir = process.env.VIDEO_IMPORTER_APP_DIR
 
-  if (configuredAppDir != null && configuredAppDir.trim().length > 0) {
-    return configuredAppDir
+  if (configuredAppDir != null) {
+    const normalizedAppDir = configuredAppDir.trim()
+    if (normalizedAppDir.length > 0) return normalizedAppDir
   }
 
   if (isSingleExecutableApplication()) {

--- a/apps/video-importer/src/runtime.ts
+++ b/apps/video-importer/src/runtime.ts
@@ -1,0 +1,23 @@
+export function isSingleExecutableApplication(): boolean {
+  try {
+    const sea = require('node:sea') as { isSea?: () => boolean }
+
+    return sea.isSea?.() === true
+  } catch {
+    return false
+  }
+}
+
+export function getPackagedAppDir(): string | undefined {
+  const configuredAppDir = process.env.VIDEO_IMPORTER_APP_DIR
+
+  if (configuredAppDir != null && configuredAppDir.trim().length > 0) {
+    return configuredAppDir
+  }
+
+  if (isSingleExecutableApplication()) {
+    return require('path').dirname(process.execPath)
+  }
+
+  return undefined
+}

--- a/apps/video-importer/src/services/r2.ts
+++ b/apps/video-importer/src/services/r2.ts
@@ -1,18 +1,24 @@
-import { S3Client } from 'bun'
+import { createReadStream } from 'fs'
+
+import { HeadObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { Upload } from '@aws-sdk/lib-storage'
 
 import { env } from '../env'
 import { getGraphQLClient } from '../gql/graphqlClient'
 import { CREATE_CLOUDFLARE_R2_ASSET } from '../gql/mutations'
 import { R2Asset } from '../types'
 
-function getR2BucketClient(bucket: string): S3Client {
+const MULTIPART_PART_SIZE = 20 * 1024 * 1024
+const MULTIPART_QUEUE_SIZE = 2
+
+function getR2BucketClient(): S3Client {
   return new S3Client({
-    accessKeyId: env.CLOUDFLARE_R2_ACCESS_KEY_ID,
-    secretAccessKey: env.CLOUDFLARE_R2_SECRET_ACCESS_KEY,
     endpoint: env.CLOUDFLARE_R2_ENDPOINT,
-    // Cloudflare R2 uses "auto" region in most S3-compatible SDKs
     region: 'auto',
-    bucket
+    credentials: {
+      accessKeyId: env.CLOUDFLARE_R2_ACCESS_KEY_ID,
+      secretAccessKey: env.CLOUDFLARE_R2_SECRET_ACCESS_KEY
+    }
   })
 }
 
@@ -83,30 +89,70 @@ export async function uploadToR2({
     `[R2 Service] Uploading ${(contentLength / 1024 / 1024).toFixed(1)}MB to R2 using multipart...`
   )
 
-  const r2BucketClient = getR2BucketClient(bucket)
-  const bytesWritten = await r2BucketClient.write(key, Bun.file(filePath), {
-    type: contentType,
-    // Match prior behavior (20MB parts, queueSize=2) for large files
-    partSize: 20 * 1024 * 1024,
-    queueSize: 2
+  const r2BucketClient = getR2BucketClient()
+  await uploadFileStream({
+    r2BucketClient,
+    bucket,
+    key,
+    filePath,
+    contentType,
+    contentLength
   })
 
-  console.log(`[R2 Service] Upload completed (${bytesWritten} bytes written)`)
+  console.log(`[R2 Service] Upload completed (${contentLength} bytes written)`)
 
   // Verify R2 has the exact object before handing the public URL to downstream consumers.
-  await verifyFileUpload(r2BucketClient, key, contentLength)
+  await verifyFileUpload(r2BucketClient, bucket, key, contentLength)
   console.log('[R2 Service] File verification completed')
+}
+
+async function uploadFileStream({
+  r2BucketClient,
+  bucket,
+  key,
+  filePath,
+  contentType,
+  contentLength
+}: {
+  r2BucketClient: S3Client
+  bucket: string
+  key: string
+  filePath: string
+  contentType: string
+  contentLength: number
+}): Promise<void> {
+  const upload = new Upload({
+    client: r2BucketClient,
+    params: {
+      Bucket: bucket,
+      Key: key,
+      Body: createReadStream(filePath),
+      ContentType: contentType,
+      ContentLength: contentLength
+    },
+    partSize: MULTIPART_PART_SIZE,
+    queueSize: MULTIPART_QUEUE_SIZE
+  })
+
+  await upload.done()
 }
 
 async function verifyFileUpload(
   r2BucketClient: S3Client,
+  bucket: string,
   key: string,
   expectedContentLength: number
 ): Promise<void> {
   console.log('[R2 Service] Verifying uploaded file...')
 
   try {
-    const uploadedSize = await r2BucketClient.size(key)
+    const head = await r2BucketClient.send(
+      new HeadObjectCommand({
+        Bucket: bucket,
+        Key: key
+      })
+    )
+    const uploadedSize = head.ContentLength ?? 0
     if (uploadedSize !== expectedContentLength) {
       throw new Error(
         `File verification failed: Expected ${expectedContentLength} bytes, got ${uploadedSize} bytes`
@@ -148,12 +194,19 @@ export async function uploadFileToR2Direct({
   contentLength: number
 }): Promise<string> {
   console.log(`[R2 Service] Uploading file to R2: ${key}`)
-  const r2BucketClient = getR2BucketClient(bucket)
-  await r2BucketClient.write(key, Bun.file(filePath), { type: contentType })
+  const r2BucketClient = getR2BucketClient()
+  await uploadFileStream({
+    r2BucketClient,
+    bucket,
+    key,
+    filePath,
+    contentType,
+    contentLength
+  })
 
   console.log(`[R2 Service] Direct upload completed: ${key}`)
 
-  await verifyFileUpload(r2BucketClient, key, contentLength)
+  await verifyFileUpload(r2BucketClient, bucket, key, contentLength)
 
   return `${env.CLOUDFLARE_R2_CUSTOM_DOMAIN.replace(/\/$/, '')}/${key}`
 }

--- a/apps/video-importer/src/services/r2.ts
+++ b/apps/video-importer/src/services/r2.ts
@@ -11,6 +11,15 @@ import { R2Asset } from '../types'
 const MULTIPART_PART_SIZE = 20 * 1024 * 1024
 const MULTIPART_QUEUE_SIZE = 2
 
+type UploadFileStreamParams = {
+  r2BucketClient: S3Client
+  bucket: string
+  key: string
+  filePath: string
+  contentType: string
+  contentLength: number
+}
+
 function getR2BucketClient(): S3Client {
   return new S3Client({
     endpoint: env.CLOUDFLARE_R2_ENDPOINT,
@@ -113,14 +122,7 @@ async function uploadFileStream({
   filePath,
   contentType,
   contentLength
-}: {
-  r2BucketClient: S3Client
-  bucket: string
-  key: string
-  filePath: string
-  contentType: string
-  contentLength: number
-}): Promise<void> {
+}: UploadFileStreamParams): Promise<void> {
   const upload = new Upload({
     client: r2BucketClient,
     params: {

--- a/apps/video-importer/src/startupPreflight.ts
+++ b/apps/video-importer/src/startupPreflight.ts
@@ -1,4 +1,4 @@
-import 'dotenv/config'
+import './loadEnv'
 
 import { z } from 'zod'
 

--- a/apps/video-importer/src/utils/fileMetadataHelpers.spec.ts
+++ b/apps/video-importer/src/utils/fileMetadataHelpers.spec.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+import { describe, it } from 'node:test'
+
+import { getAudioMetadata, getVideoMetadata } from './fileMetadataHelpers'
+
+const fixtureDir = path.resolve('apps/video-importer/test-videos')
+const validVideoFixture = path.join(
+  fixtureDir,
+  '0_JesusVisionJohn---base---3934---1.mp4'
+)
+const invalidVideoFixture = path.join(
+  fixtureDir,
+  '0_JesusVisionJohn---base---3934---999.mp4'
+)
+const audioPreviewFixture = path.join(fixtureDir, '3934.aac')
+
+describe('fileMetadataHelpers local fixtures', () => {
+  it(
+    'reads video metadata from the generated importer MP4 fixture',
+    { skip: !existsSync(validVideoFixture) },
+    async () => {
+      const metadata = await getVideoMetadata(validVideoFixture)
+
+      assert.equal(metadata.width, 2560)
+      assert.equal(metadata.height, 1440)
+      assert.equal(metadata.duration, 11)
+      assert.equal(metadata.durationMs, 11083)
+    }
+  )
+
+  it(
+    'rejects importer-shaped MP4 fixture with invalid bytes before upload work',
+    { skip: !existsSync(invalidVideoFixture) },
+    async () => {
+      await assert.rejects(
+        getVideoMetadata(invalidVideoFixture),
+        /Failed to parse ffprobe output|No video streams found|ffprobe/
+      )
+    }
+  )
+
+  it(
+    'reads audio metadata from the generated AAC preview fixture',
+    { skip: !existsSync(audioPreviewFixture) },
+    async () => {
+      const metadata = await getAudioMetadata(audioPreviewFixture)
+
+      assert.equal(metadata.codec, 'AAC')
+      assert.equal(metadata.duration, 4)
+      assert.ok(metadata.bitrate > 0)
+    }
+  )
+})

--- a/apps/video-importer/src/video-importer.ts
+++ b/apps/video-importer/src/video-importer.ts
@@ -22,7 +22,7 @@ const program = new Command()
 program
   .option(
     '-f, --folder <path>',
-    "Folder containing video files. Defaults to the executable's directory."
+    "Folder containing video files. Defaults to process.cwd() in source runs and the executable's directory in packaged SEA runs."
   )
   .option('--dry-run', 'Print actions without uploading', false)
   .option('--no-slack', 'Do not post a Slack summary after the run')

--- a/apps/video-importer/src/video-importer.ts
+++ b/apps/video-importer/src/video-importer.ts
@@ -8,6 +8,7 @@ import {
   SUBTITLE_FILENAME_REGEX,
   VIDEO_FILENAME_REGEX
 } from './importerFilenamePatterns'
+import { getPackagedAppDir } from './runtime'
 import { checkStartupEnvironment } from './startupPreflight'
 import {
   type ProcessingSummary,
@@ -32,13 +33,11 @@ const options = program.opts()
 // Regex patterns are imported from the respective importers
 
 function getDefaultFolderPath(): string {
-  const runningAsStandaloneExecutable =
-    typeof Bun !== 'undefined' && Bun.embeddedFiles.length > 0
+  const packagedAppDir = getPackagedAppDir()
 
-  if (!runningAsStandaloneExecutable) return process.cwd()
+  if (packagedAppDir != null) return path.resolve(packagedAppDir)
 
-  // In Bun standalone executable mode, `process.execPath` is the path to the compiled binary.
-  return path.dirname(process.execPath)
+  return process.cwd()
 }
 
 async function main() {

--- a/apps/video-importer/test-videos/.gitignore
+++ b/apps/video-importer/test-videos/.gitignore
@@ -3,5 +3,7 @@
 *.mp4.completed
 *.srt
 *.srt.completed
+*.vtt
+*.vtt.completed
 *.aac
 *.aac.completed

--- a/apps/video-importer/test-videos/README.md
+++ b/apps/video-importer/test-videos/README.md
@@ -4,14 +4,14 @@ This folder is for local/manual importer sanity runs. The media files are intent
 
 ## Reset / Generate Local Fixtures
 
-Place a small local source MP4 in this folder named `Big_Buck_Bunny_1080_10s_5MB.mp4`, or pass another source MP4 path:
+Place a small local source MP4 in this folder named `6672301-uhd_3840_2160_24fps.mp4`, or pass another source MP4 path:
 
 ```sh
 ./reset-fixtures.sh
 ./reset-fixtures.sh /path/to/source.mp4
 ```
 
-The script restores `.completed` files back to runnable names when present and creates any missing generated fixtures from the source MP4. It also recreates the intentionally invalid MP4 and subtitle fixture.
+The script restores `.completed` files back to runnable names when present and creates any missing generated fixtures from the source MP4. It also recreates the intentionally invalid MP4 and subtitle fixtures. If the source MP4 has no audio stream, the AAC fixture is generated from a short sine tone so audio metadata tests remain deterministic.
 
 ## Generated Fixture Names
 
@@ -21,7 +21,7 @@ The script restores `.completed` files back to runnable names when present and c
 - `missing_0_JesusVisionJohn---base---3934---1.mp4` - video import filename for the no-video-found validation path.
 - `0_JesusVisionJohn---base---3934---999.mp4` - intentionally invalid MP4 bytes; should fail metadata extraction before R2 asset creation.
 - `0_JesusVisionJohn---base---3934.srt` - subtitle import filename.
-
-No audio preview fixture is generated because real AAC imports update shared language-level data.
+- `0_JesusVisionJohn---base---3934.vtt` - WebVTT subtitle import filename.
+- `3934.aac` - audio preview import filename.
 
 Use `--dry-run` for fixture discovery unless you intentionally want to test real uploads and GraphQL mutations.

--- a/apps/video-importer/test-videos/reset-fixtures.sh
+++ b/apps/video-importer/test-videos/reset-fixtures.sh
@@ -3,8 +3,10 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-SOURCE_MP4="${1:-Big_Buck_Bunny_1080_10s_5MB.mp4}"
-SUBTITLE_FILE="0_JesusVisionJohn---base---3934.srt"
+SOURCE_MP4="${1:-6672301-uhd_3840_2160_24fps.mp4}"
+SUBTITLE_SRT="0_JesusVisionJohn---base---3934.srt"
+SUBTITLE_VTT="0_JesusVisionJohn---base---3934.vtt"
+AUDIO_PREVIEW="3934.aac"
 
 restore_completed() {
   local completed="$1.completed"
@@ -41,24 +43,67 @@ ensure_video_fixture() {
   echo "created $target from $SOURCE_MP4"
 }
 
-ensure_subtitle_fixture() {
-  if restore_completed "$SUBTITLE_FILE"; then
+ensure_srt_fixture() {
+  if restore_completed "$SUBTITLE_SRT"; then
     return 0
   fi
 
-  cat > "$SUBTITLE_FILE" <<'EOF'
+  cat > "$SUBTITLE_SRT" <<'EOF'
 1
 00:00:00,000 --> 00:00:02,000
 Test subtitle fixture.
+
+2
+00:00:02,500 --> 00:00:04,000
+Second caption for update-path tests.
 EOF
-  echo "created $SUBTITLE_FILE"
+  echo "created $SUBTITLE_SRT"
+}
+
+ensure_vtt_fixture() {
+  if restore_completed "$SUBTITLE_VTT"; then
+    return 0
+  fi
+
+  cat > "$SUBTITLE_VTT" <<'EOF'
+WEBVTT
+
+00:00:00.000 --> 00:00:02.000
+Test subtitle fixture.
+
+00:00:02.500 --> 00:00:04.000
+Second caption for update-path tests.
+EOF
+  echo "created $SUBTITLE_VTT"
+}
+
+ensure_audio_preview_fixture() {
+  if restore_completed "$AUDIO_PREVIEW"; then
+    return 0
+  fi
+
+  if [[ ! -f "$SOURCE_MP4" ]]; then
+    echo "missing $AUDIO_PREVIEW and source MP4 $SOURCE_MP4" >&2
+    echo "Place a small local MP4 at $SOURCE_MP4 or pass a source path as the first argument." >&2
+    return 1
+  fi
+
+  if ffmpeg -y -loglevel error -i "$SOURCE_MP4" -vn -t 4 -c:a aac -b:a 96k "$AUDIO_PREVIEW"; then
+    echo "created $AUDIO_PREVIEW from $SOURCE_MP4"
+    return 0
+  fi
+
+  ffmpeg -y -loglevel error -f lavfi -i sine=frequency=1000:duration=4 -c:a aac -b:a 96k "$AUDIO_PREVIEW"
+  echo "created $AUDIO_PREVIEW from generated sine audio because $SOURCE_MP4 has no audio stream"
 }
 
 ensure_video_fixture "0_JesusVisionJohn---base---3934---1.mp4"
 ensure_video_fixture "0_JesusVisionJohn---base---3934---1---496---2.mp4"
 ensure_video_fixture "0_JesusVisionJohn---base---   ---1.mp4"
 ensure_video_fixture "missing_0_JesusVisionJohn---base---3934---1.mp4"
-ensure_subtitle_fixture
+ensure_srt_fixture
+ensure_vtt_fixture
+ensure_audio_preview_fixture
 
 cat > "0_JesusVisionJohn---base---3934---999.mp4" <<'EOF'
 This is intentionally not an MP4 file. It has a valid importer filename so ffprobe should fail before any R2 asset is created.

--- a/apps/video-importer/tsconfig.json
+++ b/apps/video-importer/tsconfig.json
@@ -5,7 +5,7 @@
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
     "moduleResolution": "bundler",
-    "types": ["node", "bun-types"],
+    "types": ["node"],
     "outDir": "../../dist/apps/video-importer",
     "rootDir": "src"
   },

--- a/apps/video-importer/tsconfig.lint.json
+++ b/apps/video-importer/tsconfig.lint.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "types": ["node", "bun-types"]
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"],
   "exclude": []

--- a/package.json
+++ b/package.json
@@ -341,7 +341,6 @@
     "babel-loader": "^9.1.3",
     "babel-plugin-react-compiler": "^19.1.0-rc.2",
     "baseline-browser-mapping": "^2.9.7",
-    "bun-types": "^1.3.5",
     "chalk": "^4.1.2",
     "checkly": "^6.8.2",
     "chromatic": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -926,9 +926,6 @@ importers:
       baseline-browser-mapping:
         specifier: ^2.9.7
         version: 2.9.7
-      bun-types:
-        specifier: ^1.3.5
-        version: 1.3.5
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -13340,9 +13337,6 @@ packages:
 
   bullmq@5.45.2:
     resolution: {integrity: sha512-wHZfcD4z4aLolxREmwNNDSbfh7USeq2e3yu5W2VGkzHMUcrH0fzZuRuCMsjD0XKS9ViK1U854oM9yWR6ftPeDA==}
-
-  bun-types@1.3.5:
-    resolution: {integrity: sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -40987,10 +40981,6 @@ snapshots:
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
-
-  bun-types@1.3.5:
-    dependencies:
-      '@types/node': 20.5.1
 
   bundle-name@4.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

The video importer can be packaged as Node SEA executables again, removing the Bun runtime dependency that was failing on the client Windows VM. The importer now uploads R2 assets through the AWS SDK's streaming multipart uploader with the same 20MB part size and queue settings, then verifies the uploaded object by exact byte count before continuing.

This keeps the non-developer workflow intact: users still receive standalone platform executables and a colocated `.env`, while local development runs the same CLI through Node and `tsx`. The packaging script builds Linux, macOS, and Windows SEA binaries from a bundled CommonJS entrypoint, and the executable resolves `.env` and default folders from the packaged app directory when running as SEA.

## Coverage

- Restores cross-platform Node SEA packaging for `video-importer-linux`, `video-importer-macos`, and `video-importer.exe`.
- Replaces Bun-specific R2 upload APIs with `@aws-sdk/client-s3` and `@aws-sdk/lib-storage` streaming multipart uploads.
- Adds packaged-runtime helpers so SEA binaries load `.env` beside the executable, with `VIDEO_IMPORTER_APP_DIR` available as an override.
- Expands importer tests across video, burned-in video, subtitle create/update, VTT handling, audio preview create/update, metadata failures, R2 failures, GraphQL failures, and completed-file rename failures.
- Updates local fixture generation to create MP4, invalid MP4, SRT, VTT, and AAC test inputs without tracking generated media.

## Validation

- `pnpm dlx nx run video-importer:test`
- `pnpm dlx nx run video-importer:type-check`
- `pnpm dlx nx run video-importer:lint`
- `pnpm dlx nx run video-importer:compile`
- `dist/apps/video-importer-executable/video-importer-linux --dry-run --folder apps/video-importer/test-videos --no-slack`
- Real stage/light run processed expected valid fixtures and failed only the intentional invalid cases.
- Real 7.96GB stage run uploaded via multipart, verified `7,967,010,842` bytes in R2, marked the file completed, and finished with 1 success and 0 failures.

Closes QA-524