### PR TITLE
feat(NES-1738): reveal card behind chat — Option A (fixed 80% overlay)

### DIFF
--- a/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.spec.tsx
+++ b/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.spec.tsx
@@ -37,7 +37,9 @@ describe('ChatOverlay', () => {
   it('calls onClose when the backdrop is clicked', () => {
     const onClose = vi.fn()
     render(<ChatOverlay open onClose={onClose} />)
-    const backdrop = screen.getByTestId('ChatOverlay').querySelector('[aria-hidden]')
+    const backdrop = screen
+      .getByTestId('ChatOverlay')
+      .querySelector('[aria-hidden]')
     expect(backdrop).not.toBeNull()
     fireEvent.click(backdrop as Element)
     expect(onClose).toHaveBeenCalledTimes(1)

--- a/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.spec.tsx
+++ b/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.spec.tsx
@@ -42,6 +42,30 @@ describe('ChatOverlay', () => {
     expect(backdrop).toHaveStyle({ height: '80%' })
   })
 
+  it("delineates the dark backdrop's top edge with rounded corners and a hairline border (NES-1738 Option A feedback)", () => {
+    render(<ChatOverlay open onClose={vi.fn()} />)
+    const backdrop = screen
+      .getByTestId('ChatOverlay')
+      .querySelector('[aria-hidden]') as HTMLElement
+    expect(backdrop).toHaveStyle({
+      borderTopLeftRadius: '16px',
+      borderTopRightRadius: '16px',
+      // OVERLAY_INPUT_BORDER — the same hairline the overlay input pill uses.
+      borderTop: '1px solid rgba(255, 255, 255, 0.12)'
+    })
+  })
+
+  it('anchors the close button onto the chat surface, not the viewport top (NES-1738 Option A feedback)', () => {
+    render(<ChatOverlay open onClose={vi.fn()} />)
+    const closeButton = screen.getByRole('button', { name: 'Close chat' })
+    // The dark surface starts 20% down the screen; the button sits just inside
+    // its rounded top-right corner — no longer at the viewport's safe-area top.
+    expect(closeButton).toHaveStyle({
+      top: 'calc(20% + 12px)',
+      right: '12px'
+    })
+  })
+
   it('calls onClose when the backdrop is clicked', () => {
     const onClose = vi.fn()
     render(<ChatOverlay open onClose={onClose} />)

--- a/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.spec.tsx
+++ b/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.spec.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { ChatOverlay } from './ChatOverlay'
+
+// AiChat is loaded via next/dynamic and pulls in heavy streaming/markdown
+// machinery jsdom lacks; the overlay layout under test doesn't depend on its
+// internals, so stub it to a lightweight marker.
+vi.mock('../AiChat', () => ({
+  __esModule: true,
+  AiChat: ({ variant }: { variant?: string }) => (
+    <div data-testid="AiChatMock" data-variant={variant} />
+  )
+}))
+
+describe('ChatOverlay', () => {
+  it('renders nothing when closed', () => {
+    const { container } = render(<ChatOverlay open={false} onClose={vi.fn()} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the overlay when open', () => {
+    render(<ChatOverlay open onClose={vi.fn()} />)
+    expect(screen.getByTestId('ChatOverlay')).toBeInTheDocument()
+    expect(screen.getByTestId('AiChatMock')).toHaveAttribute(
+      'data-variant',
+      'overlay'
+    )
+  })
+
+  it('renders the inner panel at 80% height (Option A — reveals the card behind)', () => {
+    render(<ChatOverlay open onClose={vi.fn()} />)
+    // The panel is the AiChat mock's parent Box.
+    const panel = screen.getByTestId('AiChatMock').parentElement as HTMLElement
+    expect(panel).toHaveStyle({ height: '80%' })
+  })
+
+  it('calls onClose when the backdrop is clicked', () => {
+    const onClose = vi.fn()
+    render(<ChatOverlay open onClose={onClose} />)
+    const backdrop = screen.getByTestId('ChatOverlay').querySelector('[aria-hidden]')
+    expect(backdrop).not.toBeNull()
+    fireEvent.click(backdrop as Element)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = vi.fn()
+    render(<ChatOverlay open onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Close chat' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.spec.tsx
+++ b/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.spec.tsx
@@ -34,6 +34,14 @@ describe('ChatOverlay', () => {
     expect(panel).toHaveStyle({ height: '80%' })
   })
 
+  it('scales the dark backdrop to 80% so the card shows above (not full-screen)', () => {
+    render(<ChatOverlay open onClose={vi.fn()} />)
+    const backdrop = screen
+      .getByTestId('ChatOverlay')
+      .querySelector('[aria-hidden]') as HTMLElement
+    expect(backdrop).toHaveStyle({ height: '80%' })
+  })
+
   it('calls onClose when the backdrop is clicked', () => {
     const onClose = vi.fn()
     render(<ChatOverlay open onClose={onClose} />)

--- a/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.tsx
+++ b/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.tsx
@@ -8,7 +8,11 @@ import dynamic from 'next/dynamic'
 import { useTranslation } from 'next-i18next/pages'
 import { ReactElement } from 'react'
 
-import { OVERLAY_CLOSE_BG, OVERLAY_CLOSE_BG_HOVER } from '../AiChat/chatStyles'
+import {
+  OVERLAY_CLOSE_BG,
+  OVERLAY_CLOSE_BG_HOVER,
+  OVERLAY_INPUT_BORDER
+} from '../AiChat/chatStyles'
 
 const AiChat = dynamic(
   async () =>
@@ -58,7 +62,15 @@ export function ChatOverlay({
           // Colour/opacity unchanged from NES-1654 (near-opaque 98%, no blur);
           // only the size changed.
           height: '80%',
-          bgcolor: (theme) => alpha(theme.palette.grey[900], 0.98)
+          bgcolor: (theme) => alpha(theme.palette.grey[900], 0.98),
+          // The dark surface is the same colour as the journey backdrop behind
+          // it, so its top edge would vanish. Round the top corners (16, the
+          // same radius as the mobile sheet in PinnedChatBar) and draw the same
+          // 1px hairline the overlay input pill uses (OVERLAY_INPUT_BORDER) so
+          // the chat surface reads as a distinct, delineated panel.
+          borderTopLeftRadius: 16,
+          borderTopRightRadius: 16,
+          borderTop: `1px solid ${OVERLAY_INPUT_BORDER}`
         }}
       />
       <IconButton
@@ -67,8 +79,13 @@ export function ChatOverlay({
         disableRipple
         sx={{
           position: 'absolute',
-          top: 'calc(env(safe-area-inset-top) + 24px)',
-          right: 24,
+          // Attach the close control to the dark chat surface, not the viewport
+          // (NES-1738 Option A feedback): the surface starts 20% down the
+          // screen, so anchor just below that top edge and inside the rounded
+          // top-right corner. This reads as "close the chat" rather than
+          // "close the page" (which the old viewport-top placement implied).
+          top: 'calc(20% + 12px)',
+          right: 12,
           zIndex: 1,
           // Matches PromptInput's submit/stop icon button (32×32) so the
           // two affordances at opposite corners of the overlay feel

--- a/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.tsx
+++ b/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.tsx
@@ -49,13 +49,15 @@ export function ChatOverlay({
         aria-hidden
         sx={{
           position: 'absolute',
-          inset: 0,
-          // Near-opaque (98%) — Lucinda's original feedback was that the
-          // previous 88% + 6px blur showed too much of the journey card.
-          // Fully opaque (100%) read as a flat slab; 98% gives a hint of
-          // depth without compromising legibility. No backdrop blur — at
-          // this opacity the 2% bleed-through doesn't justify the GPU
-          // cost. Tune-in-place value (NES-1654 iter).
+          left: 0,
+          right: 0,
+          bottom: 0,
+          // Dark surface scales WITH the chat (NES-1738 Option A): it covers
+          // only the bottom 80% — the same height as the panel — so the freed
+          // top 20% reveals the journey card instead of a full-screen slab.
+          // Colour/opacity unchanged from NES-1654 (near-opaque 98%, no blur);
+          // only the size changed.
+          height: '80%',
           bgcolor: (theme) => alpha(theme.palette.grey[900], 0.98)
         }}
       />
@@ -89,11 +91,11 @@ export function ChatOverlay({
           position: 'relative',
           width: '100%',
           maxWidth: '48rem',
-          // 80%-height panel, bottom-aligned, so the top 20% stays the
-          // dark backdrop — revealing more of the journey card behind and
-          // signalling the chat is closeable by tapping above it (NES-1738
-          // Option A). The AiChat flex column still gets real height for the
-          // conversation-container (flex:1) to fill.
+          // 80%-height panel, bottom-aligned. The dark surface behind is now
+          // sized to match (also 80%), so the freed top 20% reveals the
+          // journey card — signalling the chat is closeable to reach the card's
+          // CTA (NES-1738 Option A). The AiChat flex column still gets real
+          // height for the conversation-container (flex:1) to fill.
           height: '80%',
           display: 'flex',
           flexDirection: 'column',

--- a/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.tsx
+++ b/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.tsx
@@ -89,12 +89,12 @@ export function ChatOverlay({
           position: 'relative',
           width: '100%',
           maxWidth: '48rem',
-          // Full-height panel so the AiChat flex column has real height
-          // for the conversation-container (flex:1) to fill — that gives
-          // the absolutely-positioned empty-state hero proper space to
-          // centre within the viewport rather than collapsing to the
-          // bottom (NES-1654 iteration).
-          height: '100%',
+          // 80%-height panel, bottom-aligned, so the top 20% stays the
+          // dark backdrop — revealing more of the journey card behind and
+          // signalling the chat is closeable by tapping above it (NES-1738
+          // Option A). The AiChat flex column still gets real height for the
+          // conversation-container (flex:1) to fill.
+          height: '80%',
           display: 'flex',
           flexDirection: 'column',
           minHeight: 0


### PR DESCRIPTION
## What this is

This is **Option A** of two options for NES-1738 ("Reveal more of the card behind the AI chat (desktop)").

On desktop (viewport >= sm / 600px) the AI chat opens as a full-screen overlay. The full-height panel hid the journey card's call-to-action button, and users didn't realise they could close the chat to see what was behind it.

## The change

The desktop overlay panel is now **80% tall and bottom-aligned** (was full height). Because the outer container already bottom-aligns the panel, the **top 20% of the screen stays the existing dark backdrop** — revealing more of the journey card behind, and signalling that the chat is closeable by tapping above it (the backdrop already closes the chat on click).

This is an essentially one-file change: `height: '100%'` → `height: '80%'` on the inner panel in `ChatOverlay.tsx`.

The **dark backdrop is unchanged for now** — still full-screen, `alpha(grey[900], 0.98)`, click-to-close. Per the product decision, backdrop opacity/blur tweaks come later once a direction is picked.

## Why it's a draft

This PR is intentionally a **DRAFT** so the stage deploy lets Aaron compare **Option A** (this PR) vs **Option B** (separate PR) side-by-side and pick which he meant. Do not merge yet.

## Tests

Added a focused `ChatOverlay.spec.tsx` (Vitest) asserting: renders nothing when closed, renders the overlay + `AiChat variant="overlay"` when open, the inner panel renders at **80%** height, and both the backdrop and the close button call `onClose`. All green (5/5; 18/18 including the related `ChatOverlayProvider` and `PinnedChatBar` suites).

## Caveat to check on stage

The empty-state hero inside `AiChat` (variant="overlay") is centered within the panel; at 80% panel height its vertical centering may sit slightly higher than before. This is acceptable for this draft — worth an eyeball on the stage deploy.

Linear: https://linear.app/jesus-film-project/issue/NES-1738

🤖 Generated with [Claude Code](https://claude.com/claude-code)