### PR TITLE
fix(NES-1740): add interim Hindi AI chat + about-chat translations

### DIFF
--- a/libs/locales/hi-IN/apps-journeys.json
+++ b/libs/locales/hi-IN/apps-journeys.json
@@ -11,5 +11,13 @@
   "Privacy Policy": "Privacy Policy",
   "NextSteps © {{year}}": "NextSteps © {{year}}",
   "Use": "उपयोग करें",
-  "Preview": "Preview"
+  "Preview": "Preview",
+  "About this chat": "इस चैट के बारे में",
+  "The chat on this journey is powered by an AI assistant. To help us improve future replies, the messages you send and the assistant’s replies are saved.": "इस यात्रा पर चैट एक AI सहायक द्वारा संचालित है। भविष्य के उत्तरों को बेहतर बनाने में हमारी मदद करने के लिए, आपके द्वारा भेजे गए संदेश और सहायक के उत्तर सहेजे जाते हैं।",
+  "We do not save your name, email address, or any account details, and we do not link conversations to your identity.": "हम आपका नाम, ईमेल पता, या कोई भी खाता विवरण नहीं सहेजते हैं, और हम बातचीत को आपकी पहचान से नहीं जोड़ते हैं।",
+  "Where the messages go": "संदेश कहाँ जाते हैं",
+  "Your messages and the assistant’s replies pass through two third-party services: an AI service that generates the replies, and an analytics service called Langfuse where the conversations are stored so the team can review them in aggregate to improve the experience. They are not sold and they are not used for advertising.": "आपके संदेश और सहायक के उत्तर दो तृतीय-पक्ष सेवाओं से होकर गुज़रते हैं: एक AI सेवा जो उत्तर उत्पन्न करती है, और Langfuse नामक एक एनालिटिक्स सेवा जहाँ बातचीत संग्रहीत की जाती है ताकि टीम अनुभव को बेहतर बनाने के लिए उनकी समग्र रूप से समीक्षा कर सके। उन्हें बेचा नहीं जाता और उनका उपयोग विज्ञापन के लिए नहीं किया जाता।",
+  "If you prefer not to take part": "यदि आप भाग नहीं लेना चाहते",
+  "There is no chat-specific opt-out today. If you would rather not have your messages saved, please do not use the chat — the rest of the journey works without it.": "फ़िलहाल चैट के लिए कोई विशेष ऑप्ट-आउट विकल्प उपलब्ध नहीं है। यदि आप नहीं चाहते कि आपके संदेश सहेजे जाएँ, तो कृपया चैट का उपयोग न करें — बाकी यात्रा इसके बिना भी काम करती है।",
+  "Last updated: June 2026": "अंतिम बार अपडेट किया गया: जून 2026"
 }

--- a/libs/locales/hi-IN/libs-journeys-ui.json
+++ b/libs/locales/hi-IN/libs-journeys-ui.json
@@ -117,6 +117,8 @@
   "A short description of your collection will appear here.": "आपके संग्रह का एक संक्षिप्त विवरण यहाँ दिखाई देगा।",
   "Creator name": "निर्माता का नाम",
   "Ask anything…": "कुछ भी पूछें…",
+  "Ask your questions about faith": "विश्वास के बारे में अपने प्रश्न पूछें",
+  "About this chat": "इस चैट के बारे में",
   "Scroll to latest message": "नवीनतम संदेश पर स्क्रॉल करें",
   "Use {{title}}": "उपयोग करें {{title}}",
   "Preview {{title}}": "पूर्वावलोकन {{title}}",


### PR DESCRIPTION
## What

Adds interim Hindi (`hi-IN`) translations for the AI chat surfaces and the `/legal/about-chat` page, which were rendering in **English** on Hindi journeys.

Closes NES-1740 · Milestone: **Aaron Feedback**

## Why

Arran (Aaron) tested a Hindi World Cup journey and opened the AI chat. The journey card content was Hindi, but several chat surfaces fell back to English:

| Surface | Driving key |
|---|---|
| Chat header title + empty-state hero + input placeholder | `Ask your questions about faith` |
| "About this chat" link (header + overlay caption) | `About this chat` |
| `/legal/about-chat` page (title, 3 headings, 4 paragraphs, "Last updated") | 8 keys |

This is the **expected behaviour of the localization pipeline**, not a code bug: `libs/locales/en/*.json` is the source of truth and every other language is populated from Crowdin (`crowdin.yml`, `skip_untranslated_files: true`). The Hindi keys simply hadn't come through the crowd process yet. (`Replies may not be perfect` was already translated — that line shows Hindi in Arran's screenshot.)

## How

Added the missing keys directly to the Hindi locale files:

- `libs/locales/hi-IN/libs-journeys-ui.json` — `Ask your questions about faith`, `About this chat`
- `libs/locales/hi-IN/apps-journeys.json` — the full `/legal/about-chat` block

No code changed — locale data only. Each added key byte-exactly matches its English source key (verified), so i18next resolves it instead of falling back.

## ⚠️ Interim, AI-generated translations

Per Arran's request to not wait for the official Crowdin round-trip, **these Hindi strings were generated by an LLM**, not the crowd-translation process. They are a stop-gap:

- `en` remains the source of truth; **Crowdin will reconcile / overwrite these** when the official Hindi translations land.
- They should get a **native-speaker review** before being treated as final.
- "AI" terminology is intentionally retained in the `/legal/about-chat` translations — that page is a deliberate transparency disclosure about the AI assistant.

## Test plan

- [x] Both JSON files parse (`jq empty`)
- [x] Every added key exists in the corresponding `en` source file (no typos / orphan keys)
- [ ] Manual QA: open a `hi-IN` journey → chat header, placeholder, "About this chat" link, and the linked legal page all render in Hindi

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Hindi language translations for chat interface text, including information about message handling, privacy practices, and data opt-out options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->