### PR TITLE
[codex] route Forge Watch traffic explicitly

### DIFF
--- a/workers/jf-proxy/README.md
+++ b/workers/jf-proxy/README.md
@@ -7,8 +7,8 @@ A Cloudflare worker that acts as a proxy server for the Jesus Film website, hand
 The worker sits in front of the Jesus Film website and:
 
 1. Forwards incoming requests to the configured destination based on path and cookie matching
-2. Routes `/watch` paths with `EXPERIMENTAL` cookie to `WATCH_PROXY_DEST`
-3. Routes all other paths to `RESOURCES_PROXY_DEST`
+2. Routes Forge Watch pages and generated assets to `FORGE_PROXY_DEST`
+3. Keeps legacy Watch support paths on `WATCH_PROXY_DEST`
 4. Handles error cases (404, 500) by serving a custom error page
 5. Preserves request properties (method, headers, body)
 6. Sanitizes response headers
@@ -16,23 +16,28 @@ The worker sits in front of the Jesus Film website and:
 ### Request Flow
 
 1. Request comes in to the worker
-2. Worker checks if the path starts with `/watch` and if the request has an `EXPERIMENTAL` cookie
+2. Worker checks for explicit Forge Watch and legacy Watch path ownership
 3. Worker modifies the hostname to the appropriate destination:
-   - `WATCH_PROXY_DEST` for `/watch` paths with `EXPERIMENTAL` cookie
-   - `RESOURCES_PROXY_DEST` for all other paths
+   - `FORGE_PROXY_DEST` for `/forge-watch-static/*` and Forge Watch content pages
+   - `WATCH_PROXY_DEST` for legacy Watch support paths and legacy experimental Watch routes
+   - `RESOURCES_PROXY_DEST` for default resource and WordPress routes
 4. Worker forwards the request with all original properties
 5. If the response is a 404 or 500:
    - Attempts to serve `/not-found.html`
    - Falls back to a basic error message if that fails
 6. Returns the response with sanitized headers
 
-### Path Routing
+### Watch Path Routing
 
-The worker supports cookie-based routing for watch paths:
+Forge public Watch pages live under `/watch/...`. Forge generated static assets live under `/forge-watch-static/_next/static/...`. Legacy Watch keeps `/watch/_next/*` and `/watch/images/*`. The split exists because both apps are Next.js apps and cannot safely share `/watch/_next/*`.
 
-- **Watch Paths with EXPERIMENTAL Cookie**: Routes `/watch/*` paths with `EXPERIMENTAL` cookie to `WATCH_PROXY_DEST`
-- **Watch Paths without EXPERIMENTAL Cookie**: Routes `/watch/*` paths without the cookie to `RESOURCES_PROXY_DEST`
-- **All Other Paths**: Routes all non-`/watch` paths to `RESOURCES_PROXY_DEST` regardless of cookies
+The worker supports explicit routing for shared Watch paths:
+
+- **Forge Watch Static Assets**: Routes `/forge-watch-static/*` to `FORGE_PROXY_DEST`
+- **Forge Watch Content Pages**: Routes single video/page/language URLs like `/watch/jesus.html/english.html` to `FORGE_PROXY_DEST`
+- **Legacy Watch Support Paths**: Routes `/watch/_next/*` and `/watch/images/*` to `WATCH_PROXY_DEST`
+- **Legacy Experimental Watch Paths**: Routes other `/watch/*` paths with the `EXPERIMENTAL` cookie to `WATCH_PROXY_DEST`
+- **All Other Paths**: Routes to `RESOURCES_PROXY_DEST`
 
 ## Configuration
 
@@ -42,20 +47,36 @@ The worker is configured through environment variables:
 # Required
 RESOURCES_PROXY_DEST="www.example.com"  # The default destination hostname to proxy requests to
 
-# Optional - for cookie-based watch routing
-WATCH_PROXY_DEST="watch.example.com"  # Destination for /watch paths with EXPERIMENTAL cookie
+# Optional - for Forge Watch routing
+FORGE_PROXY_DEST="forge.example.com"  # Destination for Forge Watch pages and /forge-watch-static assets
+
+# Optional - for legacy watch routing
+WATCH_PROXY_DEST="watch.example.com"  # Destination for legacy Watch support paths and experimental watch routes
 ```
+
+If `FORGE_PROXY_DEST` is not configured, Forge Watch routes fall back to `RESOURCES_PROXY_DEST` and then to the original request hostname.
+
+Current `wrangler.toml` Forge destination values are placeholders until the real Forge origin hostnames are assigned:
+
+- Development: `localhost:4320`
+- Stage: `9136815d-0dbe-4417-9dcd-5406c31ce723.jesusfilm.org`
+- Production: `dd541ea7-e468-4159-af6c-25a59cba326c.jesusfilm.org`
 
 ### Routing Examples
 
-| Path               | Cookie              | Destination            |
-| ------------------ | ------------------- | ---------------------- |
-| `/watch`           | `EXPERIMENTAL=true` | `WATCH_PROXY_DEST`     |
-| `/watch`           | (none)              | `RESOURCES_PROXY_DEST` |
-| `/watch/video/123` | `EXPERIMENTAL=true` | `WATCH_PROXY_DEST`     |
-| `/watch/video/123` | `other=value`       | `RESOURCES_PROXY_DEST` |
-| `/api/test`        | `EXPERIMENTAL=true` | `RESOURCES_PROXY_DEST` |
-| `/resources`       | (any)               | `RESOURCES_PROXY_DEST` |
+| Path                                             | Cookie              | Destination            |
+| ------------------------------------------------ | ------------------- | ---------------------- |
+| `/forge-watch-static/_next/static/chunks/app.js` | (any)               | `FORGE_PROXY_DEST`     |
+| `/watch/jesus.html/english.html`                 | (any)               | `FORGE_PROXY_DEST`     |
+| `/watch/_next/static/chunks/legacy.js`           | (any)               | `WATCH_PROXY_DEST`     |
+| `/watch/_next/image?url=/foo.jpg&w=828&q=75`     | (any)               | `WATCH_PROXY_DEST`     |
+| `/watch/images/foo.jpg`                          | (any)               | `WATCH_PROXY_DEST`     |
+| `/watch`                                         | `EXPERIMENTAL=true` | `WATCH_PROXY_DEST`     |
+| `/watch`                                         | (none)              | `RESOURCES_PROXY_DEST` |
+| `/watch/video/123`                               | `EXPERIMENTAL=true` | `WATCH_PROXY_DEST`     |
+| `/watch/video/123`                               | `other=value`       | `RESOURCES_PROXY_DEST` |
+| `/api/test`                                      | `EXPERIMENTAL=true` | `RESOURCES_PROXY_DEST` |
+| `/resources`                                     | (any)               | `RESOURCES_PROXY_DEST` |
 
 ### Environment-Specific Configuration
 
@@ -67,7 +88,7 @@ The worker supports different configurations for development, staging, and produ
 
 The worker handles routing for various website sections including:
 
-- Watch pages (with cookie-based routing)
+- Watch pages, Forge Watch static assets, and legacy Watch support paths
 - Journeys
 - Calendar
 - Products
@@ -131,7 +152,7 @@ The GitHub Actions workflow:
 The test suite covers:
 
 - Basic request proxying
-- Cookie-based routing for `/watch` paths
+- Forge Watch and legacy Watch routing
 - Error handling (404, 500)
 - Network error handling
 - Missing configuration handling
@@ -148,8 +169,10 @@ nx test workers/jf-proxy
 The test suite includes verification for:
 
 - Successful proxying of requests
-- Cookie-based routing: `/watch` paths with `EXPERIMENTAL` cookie route to `WATCH_PROXY_DEST`
-- Cookie-based routing: `/watch` paths without cookie route to `RESOURCES_PROXY_DEST`
+- Forge Watch static assets route to `FORGE_PROXY_DEST`
+- Forge Watch content pages route to `FORGE_PROXY_DEST`
+- Legacy Watch support paths route to `WATCH_PROXY_DEST`
+- Legacy experimental `/watch` paths route to `WATCH_PROXY_DEST`
 - Non-`/watch` paths always route to `RESOURCES_PROXY_DEST` regardless of cookies
 - Handling of 404 responses with custom error page
 - Handling of 500 responses with custom error page

--- a/workers/jf-proxy/src/index.spec.ts
+++ b/workers/jf-proxy/src/index.spec.ts
@@ -224,6 +224,120 @@ describe('test the worker', () => {
     expect(await res.text()).toBe('resources video content')
   })
 
+  it('should route Forge Watch static assets to FORGE_PROXY_DEST', async () => {
+    fetchMock
+      .get('http://forge.example.com')
+      .intercept({ path: '/forge-watch-static/_next/static/chunks/app.js' })
+      .reply(200, 'forge static content')
+
+    const res = await app.request(
+      'http://localhost/forge-watch-static/_next/static/chunks/app.js',
+      {},
+      {
+        RESOURCES_PROXY_DEST: 'resources.example.com',
+        FORGE_PROXY_DEST: 'forge.example.com',
+        WATCH_PROXY_DEST: 'watch.example.com'
+      }
+    )
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('forge static content')
+  })
+
+  it('should route Forge Watch content pages to FORGE_PROXY_DEST', async () => {
+    fetchMock
+      .get('http://forge.example.com')
+      .intercept({ path: '/watch/jesus.html/english.html' })
+      .reply(200, 'forge watch page')
+
+    const res = await app.request(
+      'http://localhost/watch/jesus.html/english.html',
+      {
+        headers: {
+          cookie: 'EXPERIMENTAL=true'
+        }
+      },
+      {
+        RESOURCES_PROXY_DEST: 'resources.example.com',
+        FORGE_PROXY_DEST: 'forge.example.com',
+        WATCH_PROXY_DEST: 'watch.example.com'
+      }
+    )
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('forge watch page')
+  })
+
+  it('should fall back to RESOURCES_PROXY_DEST for Forge routes when FORGE_PROXY_DEST is missing', async () => {
+    fetchMock
+      .get('http://resources.example.com')
+      .intercept({ path: '/forge-watch-static/_next/static/chunks/app.js' })
+      .reply(200, 'forge fallback content')
+
+    const res = await app.request(
+      'http://localhost/forge-watch-static/_next/static/chunks/app.js',
+      {},
+      {
+        RESOURCES_PROXY_DEST: 'resources.example.com',
+        WATCH_PROXY_DEST: 'watch.example.com'
+      }
+    )
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('forge fallback content')
+  })
+
+  it('should route legacy Watch static assets to WATCH_PROXY_DEST', async () => {
+    fetchMock
+      .get('http://watch.example.com')
+      .intercept({ path: '/watch/_next/static/chunks/legacy.js' })
+      .reply(200, 'legacy static content')
+
+    const res = await app.request(
+      'http://localhost/watch/_next/static/chunks/legacy.js',
+      {},
+      {
+        RESOURCES_PROXY_DEST: 'resources.example.com',
+        WATCH_PROXY_DEST: 'watch.example.com'
+      }
+    )
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('legacy static content')
+  })
+
+  it('should route legacy Watch optimized images to WATCH_PROXY_DEST', async () => {
+    fetchMock
+      .get('http://watch.example.com')
+      .intercept({ path: '/watch/_next/image?url=/foo.jpg&w=828&q=75' })
+      .reply(200, 'legacy optimized image')
+
+    const res = await app.request(
+      'http://localhost/watch/_next/image?url=/foo.jpg&w=828&q=75',
+      {},
+      {
+        RESOURCES_PROXY_DEST: 'resources.example.com',
+        WATCH_PROXY_DEST: 'watch.example.com'
+      }
+    )
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('legacy optimized image')
+  })
+
+  it('should route legacy Watch images to WATCH_PROXY_DEST', async () => {
+    fetchMock
+      .get('http://watch.example.com')
+      .intercept({ path: '/watch/images/foo.jpg' })
+      .reply(200, 'legacy image')
+
+    const res = await app.request(
+      'http://localhost/watch/images/foo.jpg',
+      {},
+      {
+        RESOURCES_PROXY_DEST: 'resources.example.com',
+        WATCH_PROXY_DEST: 'watch.example.com'
+      }
+    )
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('legacy image')
+  })
+
   it('should route non-/watch paths to RESOURCES_PROXY_DEST regardless of cookie', async () => {
     fetchMock
       .get('http://resources.example.com')

--- a/workers/jf-proxy/src/index.ts
+++ b/workers/jf-proxy/src/index.ts
@@ -1,10 +1,17 @@
 import { Hono } from 'hono'
 
 const CACHE_MAX_AGE = 86400 // 24 hours
+const FORGE_WATCH_STATIC_PATH_PREFIX = '/forge-watch-static/'
+const WATCH_PATH_PREFIX = '/watch'
+const WATCH_NEXT_PATH_PREFIX = '/watch/_next/'
+const WATCH_IMAGES_PATH_PREFIX = '/watch/images/'
+const FORGE_WATCH_CONTENT_PAGE_PATTERN =
+  /^\/watch\/[^/]+\.html\/[^/]+\.html\/?$/
 
 const app = new Hono<{
   Bindings: {
     RESOURCES_PROXY_DEST?: string
+    FORGE_PROXY_DEST?: string
     WATCH_PROXY_DEST?: string
     IOS_APP_ID?: string
     ANDROID_PACKAGE_NAME?: string
@@ -68,16 +75,15 @@ app.get('*', async (c) => {
   const url = new URL(c.req.url)
   const pathname = url.pathname
 
-  // Check if path is /watch and has EXPERIMENTAL cookie
   const cookieHeader = c.req.header('cookie')
-  const hasExperimentalCookie = cookieHeader?.includes('EXPERIMENTAL')
-  const isWatchPath = pathname.startsWith('/watch')
-
-  // Set destination based on path and cookie
-  const proxyDest =
-    isWatchPath && hasExperimentalCookie
-      ? (c.env.WATCH_PROXY_DEST ?? url.hostname)
-      : (c.env.RESOURCES_PROXY_DEST ?? url.hostname)
+  const proxyDest = getProxyDest({
+    pathname,
+    cookieHeader,
+    hostname: url.hostname,
+    resourcesProxyDest: c.env.RESOURCES_PROXY_DEST,
+    forgeProxyDest: c.env.FORGE_PROXY_DEST,
+    watchProxyDest: c.env.WATCH_PROXY_DEST
+  })
 
   url.hostname = proxyDest
 
@@ -144,5 +150,58 @@ app.get('*', async (c) => {
     headers: sanitizedHeaders
   })
 })
+
+function getProxyDest({
+  pathname,
+  cookieHeader,
+  hostname,
+  resourcesProxyDest,
+  forgeProxyDest,
+  watchProxyDest
+}: {
+  pathname: string
+  cookieHeader?: string
+  hostname: string
+  resourcesProxyDest?: string
+  forgeProxyDest?: string
+  watchProxyDest?: string
+}): string {
+  if (isForgeWatchStaticPath(pathname) || isForgeWatchContentPage(pathname)) {
+    return forgeProxyDest ?? resourcesProxyDest ?? hostname
+  }
+
+  if (isLegacyWatchSupportPath(pathname)) {
+    return watchProxyDest ?? hostname
+  }
+
+  const hasExperimentalCookie = cookieHeader?.includes('EXPERIMENTAL')
+  if (isWatchPath(pathname) && hasExperimentalCookie) {
+    return watchProxyDest ?? hostname
+  }
+
+  return resourcesProxyDest ?? hostname
+}
+
+function isForgeWatchStaticPath(pathname: string): boolean {
+  return pathname.startsWith(FORGE_WATCH_STATIC_PATH_PREFIX)
+}
+
+function isForgeWatchContentPage(pathname: string): boolean {
+  return FORGE_WATCH_CONTENT_PAGE_PATTERN.test(pathname)
+}
+
+function isLegacyWatchSupportPath(pathname: string): boolean {
+  return (
+    pathname.startsWith(WATCH_NEXT_PATH_PREFIX) ||
+    pathname.startsWith(WATCH_IMAGES_PATH_PREFIX)
+  )
+}
+
+function isWatchPath(pathname: string): boolean {
+  return (
+    pathname === WATCH_PATH_PREFIX ||
+    pathname.startsWith(`${WATCH_PATH_PREFIX}/`)
+  )
+}
 
 export default app

--- a/workers/jf-proxy/wrangler.toml
+++ b/workers/jf-proxy/wrangler.toml
@@ -5,6 +5,7 @@ main = "src/index.ts"
 
 [vars]
 RESOURCES_PROXY_DEST = "localhost:4310"
+FORGE_PROXY_DEST = "localhost:4320"
 WATCH_PROXY_DEST = "localhost:4300"
 IOS_APP_ID = "DQ48D9BF2V.com.InspirationalFilms.JesusFilm"
 ANDROID_PACKAGE_NAME = "com.jesusfilmmedia.android.jesusfilm.debug"
@@ -14,6 +15,7 @@ ANDROID_SHA256_CERT_FINGERPRINT = "F3:9F:C4:4D:42:F5:25:90:CD:4D:75:67:2C:9F:5F:
 name = "jf-proxy-stage"
 logpush = true
 routes = [
+  { pattern = "develop.jesusfilm.org/forge-watch-static*", zone_name = "jesusfilm.org" },
   { pattern = "develop.jesusfilm.org/watch*", zone_name = "jesusfilm.org" },
   { pattern = "develop.jesusfilm.org/journeys*", zone_name = "jesusfilm.org" },
   { pattern = "develop.jesusfilm.org/resources", zone_name = "jesusfilm.org" },
@@ -28,6 +30,7 @@ routes = [
 
 [env.stage.vars]
 RESOURCES_PROXY_DEST = "f92c2b4c-6a7f-4d56-9c1b-dc8c1e8e0c37.jesusfilm.org"
+FORGE_PROXY_DEST = "9136815d-0dbe-4417-9dcd-5406c31ce723.jesusfilm.org"
 WATCH_PROXY_DEST = "c89a34d4-4b06-4219-ad8b-c7289106424d.jesusfilm.org"
 IOS_APP_ID = "DQ48D9BF2V.com.InspirationalFilms.JesusFilm"
 ANDROID_PACKAGE_NAME = "com.jesusfilmmedia.android.jesusfilm.debug"
@@ -41,6 +44,7 @@ enabled = true
 name = "jf-proxy-prod"
 logpush = true
 routes = [
+  { pattern = "www.jesusfilm.org/forge-watch-static*", zone_name = "jesusfilm.org" },
   { pattern = "www.jesusfilm.org/watch*", zone_name = "jesusfilm.org" },
   { pattern = "www.jesusfilm.org/journeys*", zone_name = "jesusfilm.org" },
   { pattern = "www.jesusfilm.org/resources", zone_name = "jesusfilm.org" },
@@ -55,6 +59,7 @@ routes = [
 
 [env.prod.vars]
 RESOURCES_PROXY_DEST = "a3f6b24e-8d57-4c79-b25f-9e2a7d3f421c.jesusfilm.org"
+FORGE_PROXY_DEST = "dd541ea7-e468-4159-af6c-25a59cba326c.jesusfilm.org"
 WATCH_PROXY_DEST = "1ee8fdb1-3cb5-40fd-9258-35d589917b4a.jesusfilm.org"
 IOS_APP_ID = "DQ48D9BF2V.com.InspirationalFilms.JesusFilm"
 ANDROID_PACKAGE_NAME = "com.jesusfilmmedia.android.jesusfilm"
@@ -62,4 +67,3 @@ ANDROID_SHA256_CERT_FINGERPRINT = "4F:C6:5E:9F:18:CC:D3:CF:C1:68:8E:23:CB:4C:B2:
 
 [env.prod.observability.logs]
 enabled = true
-


### PR DESCRIPTION
## What changed

- Added explicit Forge Watch routing in the Cloudflare proxy worker.
- Routes /forge-watch-static/* and single Watch content pages like /watch/jesus.html/english.html to FORGE_PROXY_DEST.
- Keeps legacy Watch support paths on WATCH_PROXY_DEST, including /watch/_next/* and /watch/images/*.
- Adds FORGE_PROXY_DEST bindings in Wrangler config with UUID-style placeholder stage/prod origins.
- Documents the Watch split contract and expands worker route-selection tests.

## Why

Forge and legacy Watch both use the public /watch namespace, but Forge generated assets now live under /forge-watch-static. The proxy needs to send Forge-owned pages and assets to Forge without taking over legacy Watch Next.js support paths.

## Validation

- pnpm nx test jf-proxy --skip-nx-cache

## Notes

The configured Forge stage/prod destinations are random UUID-style placeholders until the real Forge origin hostnames are assigned.