### PR TITLE
fix(useLanguages): handle JSON error responses gracefully in API calls

### DIFF
--- a/apps/resources/src/libs/useLanguages/useLanguages.spec.tsx
+++ b/apps/resources/src/libs/useLanguages/useLanguages.spec.tsx
@@ -353,6 +353,28 @@ describe('useLanguages', () => {
       })
     })
 
+    it('should handle a JSON error body without crashing', async () => {
+      // The API returns `{ error: '...' }` with a 500 when the gateway query
+      // fails. This is valid JSON, so it reaches transformData and must not
+      // throw (which would crash the whole page).
+      server.use(
+        http.get('/api/languages', () => {
+          return HttpResponse.json(
+            { error: 'Failed to fetch languages' },
+            { status: 500 }
+          )
+        })
+      )
+
+      const wrapper = await createI18nWrapper()
+      const { result } = renderHook(() => useLanguages(), { wrapper })
+
+      await waitFor(() => {
+        expect(result.current.languages).toEqual([])
+        expect(result.current.isLoading).toBe(false)
+      })
+    })
+
     it('should handle network error', async () => {
       server.use(
         http.get('/api/languages', () => {

--- a/apps/resources/src/libs/useLanguages/useLanguages.ts
+++ b/apps/resources/src/libs/useLanguages/useLanguages.ts
@@ -4,7 +4,13 @@ import useSWR from 'swr'
 
 import { transformData } from './util/transformData'
 
-const fetcher = (url: string) => fetch(url).then((res) => res.json())
+const fetcher = async (url: string) => {
+  const res = await fetch(url)
+  // Treat a non-ok response (e.g. a 500 `{ error: '...' }`) as a SWR error so
+  // the error body never reaches transformData and isLoading resolves.
+  if (!res.ok) throw new Error(`Failed to load languages: ${res.status}`)
+  return res.json()
+}
 
 export interface LanguageName {
   id: string

--- a/apps/resources/src/libs/useLanguages/util/transformData.ts
+++ b/apps/resources/src/libs/useLanguages/util/transformData.ts
@@ -5,7 +5,12 @@ import { type Language } from '../useLanguages'
 
 export function transformData(data: unknown, locale: string): Language[] {
   const currentLanguageId = getLanguageIdFromLocale(locale)
-  const parsedData = z.array(z.array(z.string())).parse(data)
+  // The languages API can return a non-array error body (e.g. a 500
+  // `{ error: '...' }`). Degrade gracefully instead of throwing, which would
+  // crash the entire page rather than just leaving the language filter empty.
+  const result = z.array(z.array(z.string())).safeParse(data)
+  if (!result.success) return []
+  const parsedData = result.data
 
   return parsedData.map((language) => {
     const [languageIdSlugNative, ...names] = language

--- a/apps/watch/src/libs/useLanguages/useLanguages.spec.tsx
+++ b/apps/watch/src/libs/useLanguages/useLanguages.spec.tsx
@@ -347,6 +347,28 @@ describe('useLanguages', () => {
       })
     })
 
+    it('should handle a JSON error body without crashing', async () => {
+      // The API returns `{ error: '...' }` with a 500 when the gateway query
+      // fails. This is valid JSON, so it reaches transformData and must not
+      // throw (which would crash the whole page).
+      server.use(
+        http.get('/watch/api/languages', () => {
+          return HttpResponse.json(
+            { error: 'Failed to fetch languages' },
+            { status: 500 }
+          )
+        })
+      )
+
+      const wrapper = await createI18nWrapper()
+      const { result } = renderHook(() => useLanguages(), { wrapper })
+
+      await waitFor(() => {
+        expect(result.current.languages).toEqual([])
+        expect(result.current.isLoading).toBe(false)
+      })
+    })
+
     it('should handle network error', async () => {
       server.use(
         http.get('/watch/api/languages', () => {

--- a/apps/watch/src/libs/useLanguages/useLanguages.ts
+++ b/apps/watch/src/libs/useLanguages/useLanguages.ts
@@ -4,7 +4,13 @@ import useSWR from 'swr'
 
 import { transformData } from './util/transformData'
 
-const fetcher = (url: string) => fetch(url).then((res) => res.json())
+const fetcher = async (url: string) => {
+  const res = await fetch(url)
+  // Treat a non-ok response (e.g. a 500 `{ error: '...' }`) as a SWR error so
+  // the error body never reaches transformData and isLoading resolves.
+  if (!res.ok) throw new Error(`Failed to load languages: ${res.status}`)
+  return res.json()
+}
 
 export interface LanguageName {
   id: string

--- a/apps/watch/src/libs/useLanguages/util/transformData.ts
+++ b/apps/watch/src/libs/useLanguages/util/transformData.ts
@@ -5,7 +5,12 @@ import { type Language } from '../useLanguages'
 
 export function transformData(data: unknown, locale: string): Language[] {
   const currentLanguageId = getLanguageIdFromLocale(locale)
-  const parsedData = z.array(z.array(z.string())).parse(data)
+  // The languages API can return a non-array error body (e.g. a 500
+  // `{ error: '...' }`). Degrade gracefully instead of throwing, which would
+  // crash the entire page rather than just leaving the language filter empty.
+  const result = z.array(z.array(z.string())).safeParse(data)
+  if (!result.success) return []
+  const parsedData = result.data
 
   return parsedData.map((language) => {
     const [languageIdSlugNative, ...names] = language


### PR DESCRIPTION
- Updated fetcher to throw an error for non-ok responses, preventing invalid data from reaching transformData.
- Enhanced transformData to safely parse potential error responses, returning an empty array instead of crashing.
- Added tests to ensure the application handles JSON error bodies without crashing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for language API failures to prevent crashes when the API returns error responses; the app now gracefully defaults to an empty state instead of breaking the page.

* **Tests**
  * Added test coverage for API failure scenarios across both application environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->