### PR TITLE
fix(api-media): make team resolution best-effort on asset upload [QA-529]

### DIFF
--- a/apis/api-media/src/lib/journeysAccess/journeysAccess.spec.ts
+++ b/apis/api-media/src/lib/journeysAccess/journeysAccess.spec.ts
@@ -1,6 +1,7 @@
 import { GraphQLError } from 'graphql'
 
 import { journeysPrismaMock } from '../../../test/journeysPrismaMock'
+import { logger } from '../../logger'
 
 import {
   assertTeamMembership,
@@ -122,6 +123,37 @@ describe('journeysAccess', () => {
       })
 
       expect(teamId).toBe('teamId')
+    })
+
+    it('should return null (not throw) when the caller is not a member of the team', async () => {
+      journeysPrismaMock.journey.findUnique.mockResolvedValue({
+        teamId: 'teamId',
+        team: { userTeams: [] }
+      } as never)
+
+      const teamId = await maybeResolveTeamId({
+        journeyId: 'journeyId',
+        userId: 'userId'
+      })
+
+      expect(teamId).toBeNull()
+    })
+
+    it('should return null and log when the team lookup throws', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger)
+      journeysPrismaMock.journey.findUnique.mockRejectedValue(
+        new Error('journeys database unreachable')
+      )
+
+      const teamId = await maybeResolveTeamId({
+        journeyId: 'journeyId',
+        userId: 'userId'
+      })
+
+      expect(teamId).toBeNull()
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+
+      warnSpy.mockRestore()
     })
   })
 })

--- a/apis/api-media/src/lib/journeysAccess/journeysAccess.ts
+++ b/apis/api-media/src/lib/journeysAccess/journeysAccess.ts
@@ -2,6 +2,8 @@ import { GraphQLError } from 'graphql'
 
 import { prisma as journeysPrisma } from '@core/prisma/journeys/client'
 
+import { logger } from '../../logger'
+
 /**
  * Throws FORBIDDEN if the user is not a member of the given team. Uses a uniform
  * error shape regardless of whether the team exists, so callers cannot probe for
@@ -59,8 +61,18 @@ export async function resolveAuthorizedTeamId({
 /**
  * Optionally resolves the home team for an upload. Returns null when no journeyId
  * is supplied (preserving v1 behavior). When a journeyId is supplied, an
- * authenticated user is required — throws FORBIDDEN otherwise — and the resolved
- * team is authorized via resolveAuthorizedTeamId.
+ * authenticated user is required — throws FORBIDDEN otherwise, since a journeyId
+ * is only meaningful for an authenticated caller.
+ *
+ * The team lookup itself is best-effort: team tagging must never block an asset
+ * upload, so if resolveAuthorizedTeamId fails for any reason (journeys DB
+ * unreachable, journey missing, or the caller is not a member of its team) we
+ * log a warning and return null. The asset is still owned by the uploader via
+ * userId; a null team only means it won't surface in the team-shared library.
+ *
+ * Note: this is the write/upload path. The read path (`getMyCloudflareImages`
+ * with an explicit teamId) keeps its strict `assertTeamMembership` check, since
+ * that guards against viewing another team's assets.
  */
 export async function maybeResolveTeamId({
   journeyId,
@@ -76,5 +88,13 @@ export async function maybeResolveTeamId({
       extensions: { code: 'FORBIDDEN' }
     })
 
-  return await resolveAuthorizedTeamId({ journeyId, userId })
+  try {
+    return await resolveAuthorizedTeamId({ journeyId, userId })
+  } catch (error) {
+    logger.warn(
+      { journeyId, userId, error },
+      'failed to resolve team for asset upload; tagging as personal'
+    )
+    return null
+  }
 }

--- a/apis/api-media/src/schema/cloudflare/image/image.spec.ts
+++ b/apis/api-media/src/schema/cloudflare/image/image.spec.ts
@@ -539,11 +539,18 @@ describe('cloudflareImage', () => {
         )
       })
 
-      it('should not create a row when caller lacks access to the journey team', async () => {
+      it('should create the asset without a teamId when caller lacks access to the journey team', async () => {
+        mockCreateImageByDirectUpload.mockResolvedValue({
+          id: 'id',
+          uploadURL: 'testUrl'
+        })
         journeysPrismaMock.journey.findUnique.mockResolvedValue({
           teamId: 'teamId',
           team: { userTeams: [] }
         } as never)
+        prismaMock.cloudflareImage.create.mockResolvedValue({
+          id: 'id'
+        } as unknown as CloudflareImage)
 
         const result = (await authClient({
           document: CREATE_BY_FILE_WITH_JOURNEY_MUTATION,
@@ -553,8 +560,12 @@ describe('cloudflareImage', () => {
           errors?: { extensions?: { code?: string } }[]
         }
 
-        expect(result.errors?.[0]?.extensions?.code).toBe('FORBIDDEN')
-        expect(prismaMock.cloudflareImage.create).not.toHaveBeenCalled()
+        expect(result.errors).toBeUndefined()
+        expect(prismaMock.cloudflareImage.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({ teamId: null })
+          })
+        )
       })
     })
 
@@ -662,11 +673,15 @@ describe('cloudflareImage', () => {
         )
       })
 
-      it('should not create a row when caller lacks access to the journey team', async () => {
+      it('should create the asset without a teamId when caller lacks access to the journey team', async () => {
+        mockCreateImageFromUrl.mockResolvedValue({ id: 'id' })
         journeysPrismaMock.journey.findUnique.mockResolvedValue({
           teamId: 'teamId',
           team: { userTeams: [] }
         } as never)
+        prismaMock.cloudflareImage.create.mockResolvedValue({
+          id: 'id'
+        } as unknown as CloudflareImage)
 
         const result = (await authClient({
           document: CREATE_BY_URL_WITH_JOURNEY_MUTATION,
@@ -676,8 +691,12 @@ describe('cloudflareImage', () => {
           errors?: { extensions?: { code?: string } }[]
         }
 
-        expect(result.errors?.[0]?.extensions?.code).toBe('FORBIDDEN')
-        expect(prismaMock.cloudflareImage.create).not.toHaveBeenCalled()
+        expect(result.errors).toBeUndefined()
+        expect(prismaMock.cloudflareImage.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({ teamId: null })
+          })
+        )
       })
     })
 
@@ -790,11 +809,16 @@ describe('cloudflareImage', () => {
         )
       })
 
-      it('should not create a row when caller lacks access to the journey team', async () => {
+      it('should create the asset without a teamId when caller lacks access to the journey team', async () => {
+        mockCreateImageFromText.mockResolvedValue(new Response())
+        mockCreateImageFromResponse.mockResolvedValue({ id: 'id' })
         journeysPrismaMock.journey.findUnique.mockResolvedValue({
           teamId: 'teamId',
           team: { userTeams: [] }
         } as never)
+        prismaMock.cloudflareImage.create.mockResolvedValue({
+          id: 'id'
+        } as unknown as CloudflareImage)
 
         const result = (await authClient({
           document: CREATE_FROM_PROMPT_WITH_JOURNEY_MUTATION,
@@ -804,8 +828,12 @@ describe('cloudflareImage', () => {
           errors?: { extensions?: { code?: string } }[]
         }
 
-        expect(result.errors?.[0]?.extensions?.code).toBe('FORBIDDEN')
-        expect(prismaMock.cloudflareImage.create).not.toHaveBeenCalled()
+        expect(result.errors).toBeUndefined()
+        expect(prismaMock.cloudflareImage.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({ teamId: null })
+          })
+        )
       })
     })
 

--- a/apis/api-media/src/schema/mux/video/video.spec.ts
+++ b/apis/api-media/src/schema/mux/video/video.spec.ts
@@ -756,7 +756,7 @@ describe('mux/video', () => {
         )
       })
 
-      it('should not create a row when caller lacks access to the journey team', async () => {
+      it('should create the asset without a teamId when caller lacks access to the journey team', async () => {
         ;(prismaMock.userMediaRole.findUnique as Mock).mockResolvedValue({
           id: 'userId',
           userId: 'userId',
@@ -766,6 +766,9 @@ describe('mux/video', () => {
           teamId: 'teamId',
           team: { userTeams: [] }
         } as never)
+        ;(prismaMock.muxVideo.create as Mock).mockResolvedValue({
+          id: 'videoId'
+        })
 
         const result = (await authClient({
           document: CREATE_BY_FILE_WITH_JOURNEY,
@@ -775,8 +778,12 @@ describe('mux/video', () => {
           errors?: { extensions?: { code?: string } }[]
         }
 
-        expect(result.errors?.[0]?.extensions?.code).toBe('FORBIDDEN')
-        expect(prismaMock.muxVideo.create).not.toHaveBeenCalled()
+        expect(result.errors).toBeUndefined()
+        expect(prismaMock.muxVideo.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({ teamId: null })
+          })
+        )
       })
 
       it('should create video with generated subtitles when generateSubtitlesInput is provided', async () => {
@@ -993,7 +1000,7 @@ describe('mux/video', () => {
         )
       })
 
-      it('should not create a row when caller lacks access to the journey team', async () => {
+      it('should create the asset without a teamId when caller lacks access to the journey team', async () => {
         ;(prismaMock.userMediaRole.findUnique as Mock).mockResolvedValue({
           id: 'userId',
           userId: 'userId',
@@ -1003,6 +1010,9 @@ describe('mux/video', () => {
           teamId: 'teamId',
           team: { userTeams: [] }
         } as never)
+        ;(prismaMock.muxVideo.create as Mock).mockResolvedValue({
+          id: 'videoId'
+        })
 
         const result = (await authClient({
           document: CREATE_BY_URL_WITH_JOURNEY,
@@ -1015,8 +1025,12 @@ describe('mux/video', () => {
           errors?: { extensions?: { code?: string } }[]
         }
 
-        expect(result.errors?.[0]?.extensions?.code).toBe('FORBIDDEN')
-        expect(prismaMock.muxVideo.create).not.toHaveBeenCalled()
+        expect(result.errors).toBeUndefined()
+        expect(prismaMock.muxVideo.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({ teamId: null })
+          })
+        )
       })
     })
 


### PR DESCRIPTION
## Problem

Custom **image** uploads in the NextSteps editor fail with `INTERNAL_SERVER_ERROR` from api-media ([QA-529](https://linear.app/jesus-film-project/issue/QA-529)). Video upload is unaffected.

## Root cause

The `createCloudflareUploadByFile` resolver resolves a `teamId` from the journey being edited via `maybeResolveTeamId`, which reads the **journeys database from inside api-media** (`@core/prisma/journeys/client`). That cross-database read is failing in production, and because the lookup *threw*, it took the whole upload down with it.

Two changes lined up to surface it:
- NES-1633 (#9272) added the `teamId` resolution + the api-media→journeys DB dependency. It stayed dormant because nothing sent a `journeyId`.
- NES-1634 (#9303) made the editor start sending `journeyId`, which activates the failing path on every editor image upload.

Video only escaped because its frontend doesn't send a `journeyId` yet — the same trap is dormant in the Mux resolvers.

## Fix (mitigation)

Make `maybeResolveTeamId` **best-effort**: if the team lookup fails for any reason (journeys DB unreachable, journey missing, or caller not a member), log a warning and return `null` so the upload still completes, tagged as a **personal** asset.

- The asset is still owned by the uploader via `userId`; a null team only means it won't surface in the team-shared library (`teamId` is already a nullable column and is not exposed in GraphQL).
- The **read** path (`getMyCloudflareImages` with an explicit `teamId`) keeps its strict `assertTeamMembership` check — that boundary guards against viewing another team's assets and is unchanged.
- The warning log keeps the underlying outage diagnosable in production.

No schema changes — this is pure resolver logic, so no codegen/migration is involved.

## Follow-up (not in this PR)

This stops the 500s but does not restore team tagging. The real fix is wiring api-media's connection to the journeys database in production (`PG_DATABASE_URL_JOURNEYS` secret / Terraform apply / security-group path). That's a call for @edmonday, who built NES-1633.

## Tests

Updated the specs that asserted "not a member → blocked" to "not a member → upload succeeds with `teamId: null`", and added a case for the lookup throwing (DB unreachable). All 64 tests across the three affected suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Uploads are now more resilient when team authorization information is unavailable, allowing operations to complete instead of failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->