### PR TITLE
fix(api-media): use native fetch instead of node-fetch for image/unsplash [QA-530]

### DIFF
--- a/apis/api-media/src/schema/cloudflare/image/image.spec.ts
+++ b/apis/api-media/src/schema/cloudflare/image/image.spec.ts
@@ -1,4 +1,3 @@
-import { Response } from 'node-fetch'
 import { type Mocked, type MockedFunction, vi } from 'vitest'
 
 import { CloudflareImage, ImageAspectRatio } from '@core/prisma/media/client'

--- a/apis/api-media/src/schema/cloudflare/image/service.spec.ts
+++ b/apis/api-media/src/schema/cloudflare/image/service.spec.ts
@@ -1,7 +1,6 @@
 import Cloudflare from 'cloudflare'
 import { APIPromise } from 'cloudflare/core'
 import clone from 'lodash/clone'
-import { Response } from 'node-fetch'
 import { vi } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
 

--- a/apis/api-media/src/schema/cloudflare/image/service.ts
+++ b/apis/api-media/src/schema/cloudflare/image/service.ts
@@ -1,8 +1,13 @@
+// Force the Cloudflare SDK onto its "web" runtime so it uses Node's native
+// global fetch (undici) + native Response/FormData. Without this, the SDK
+// auto-detects the Node runtime and loads node-fetch@2, whose gzip stream
+// handling throws "Premature close" on the alpine/musl prod runtime. This
+// side-effect import MUST run before `cloudflare` so its setShims() wins over
+// the SDK's auto-detection. [QA-530]
+import 'cloudflare/shims/web'
+
 import Cloudflare from 'cloudflare'
 
-// Use Node's native global `fetch` (undici) rather than node-fetch@2, whose gzip
-// stream handling throws "Premature close" on the alpine/musl prod runtime. The
-// Cloudflare SDK defaults to the global fetch when none is supplied. [QA-530]
 export function getClient(): Cloudflare {
   if (process.env.CLOUDFLARE_IMAGES_TOKEN == null)
     throw new Error('Missing CLOUDFLARE_IMAGES_TOKEN')

--- a/apis/api-media/src/schema/cloudflare/image/service.ts
+++ b/apis/api-media/src/schema/cloudflare/image/service.ts
@@ -1,15 +1,14 @@
-import 'cloudflare/shims/node'
-
 import Cloudflare from 'cloudflare'
-import fetch, { Response } from 'node-fetch'
 
+// Use Node's native global `fetch` (undici) rather than node-fetch@2, whose gzip
+// stream handling throws "Premature close" on the alpine/musl prod runtime. The
+// Cloudflare SDK defaults to the global fetch when none is supplied. [QA-530]
 export function getClient(): Cloudflare {
   if (process.env.CLOUDFLARE_IMAGES_TOKEN == null)
     throw new Error('Missing CLOUDFLARE_IMAGES_TOKEN')
 
   return new Cloudflare({
-    apiToken: process.env.CLOUDFLARE_IMAGES_TOKEN,
-    fetch
+    apiToken: process.env.CLOUDFLARE_IMAGES_TOKEN
   })
 }
 

--- a/apis/api-media/src/schema/unsplash/service.ts
+++ b/apis/api-media/src/schema/unsplash/service.ts
@@ -1,4 +1,3 @@
-import nodeFetch from 'node-fetch'
 import { createApi } from 'unsplash-js'
 
 import { UnsplashColorEnum } from './enums/UnsplashColor'
@@ -9,9 +8,9 @@ import { UnsplashPhoto } from './objects/UnsplashPhoto'
 import { UnsplashQueryResponse } from './objects/UnsplashQueryResponse'
 
 function getClient(): ReturnType<typeof createApi> {
+  // Use Node's native global `fetch` (undici) rather than node-fetch@2. [QA-530]
   return createApi({
-    accessKey: process.env.UNSPLASH_ACCESS_KEY ?? '',
-    fetch: nodeFetch as unknown as typeof fetch
+    accessKey: process.env.UNSPLASH_ACCESS_KEY ?? ''
   })
 }
 


### PR DESCRIPTION
## Problem
api-media 500s on **custom image upload**, **AI image generation**, and **segmind generation** in stage/prod (not reproducible locally). Datadog:

```
Invalid response body while trying to fetch
https://api.cloudflare.com/client/v4/accounts/.../images/v2/direct_upload: Premature close
    at Gunzip.<anonymous> (.../node-fetch@2.7.0/.../node-fetch/lib/index.js:400:12)
  service: api-media
```

## Root cause
The fault is **`node-fetch@2.7.0`**, not app logic. Its gzip stream handling (the `Gunzip` frame above) throws "Premature close" when a gzipped response ends before it finishes reading. It's **environment-sensitive** — triggers on the `node:24-alpine` (musl) runtime + container networking, but not on the local glibc devcontainer, which is why it was never reproducible locally.

Two code paths were on node-fetch, in **two different ways** — and that's why a naive fix only half-works:

| | Unsplash | Cloudflare |
|---|---|---|
| How node-fetch got in | we passed it: `createApi({ fetch: nodeFetch })` | the **Cloudflare SDK** pulled it in itself |
| Fix that worked | remove the `fetch:` option → native fetch | remove option **+** `import 'cloudflare/shims/web'` |

For Cloudflare, removing our injection isn't enough: the SDK auto-detects the runtime at load and (seeing Node) loads `cloudflare/_shims/node-runtime.js` → `require("node-fetch")`, so it keeps using node-fetch internally. Importing `cloudflare/shims/web` **before** `cloudflare` makes its `setShims()` register Node 24's native `fetch`/`Response`/`FormData` and win over auto-detection.

**Why native fetch (undici) fixes it:** undici handles gzip decoding + keep-alive termination correctly, so the response stream completes instead of closing prematurely.

## Change
- `unsplash/service.ts` — drop the `fetch: nodeFetch` injection from `createApi`
- `cloudflare/image/service.ts` — drop the node-fetch injection **and** `import 'cloudflare/shims/web'` to force the SDK onto native fetch; `Response` → global type
- specs updated to use the global `Response`

## Why prior attempts missed it
- **#9321** ("best-effort team resolution") wrapped `maybeResolveTeamId` in try/catch — but the throw is in the Cloudflare HTTP call, *outside* that catch. Right instinct, wrong layer.
- **First commit here** fixed Unsplash (direct injection) but not Cloudflare (SDK-internal) — matching what we saw on stage: Unsplash gallery fixed, custom upload still 500ing. Resolved by the web-shim commit.

## Verification
- `nx type-check api-media` ✅
- api-media specs (cloudflare image, unsplash, segmind) ✅
- **Stage:** Unsplash gallery ✅ and custom upload ✅ confirmed working. AI generate + segmind use the same Cloudflare path.

## Out of scope
- Unsplash empty-gallery collection/key behavior (separate; not node-fetch related)

Linear: [QA-530](https://linear.app/jesus-film-project/issue/QA-530/nextsteps-image-upload-ai-generate-still-500-node-fetch-premature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal API client runtime configurations and dependencies to leverage native runtime environments instead of external libraries, improving compatibility and reducing external dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->