### PR TITLE
fix(NES-1636): defer team switch so copy-to-team AI translation completes

### DIFF
--- a/apps/journeys-admin/src/components/Team/CopyToTeamMenuItem/CopyToTeamMenuItem.spec.tsx
+++ b/apps/journeys-admin/src/components/Team/CopyToTeamMenuItem/CopyToTeamMenuItem.spec.tsx
@@ -47,6 +47,17 @@ describe('CopyToTeamMenuItem', () => {
   beforeEach(() => {
     handleCloseMenu.mockClear()
     refetchTemplateStats.mockClear()
+    // These result mocks are shared across tests; clear their call counts so
+    // assertions on whether the team switch fired aren't polluted by earlier
+    // tests in this file.
+    ;(
+      updateLastActiveTeamIdMock.result as MockedFunction<() => unknown>
+    ).mockClear()
+    ;(
+      updateLastActiveTeamIdMockForTranslation.result as MockedFunction<
+        () => unknown
+      >
+    ).mockClear()
     mockedUseTemplateFamilyStatsAggregateLazyQuery.mockReturnValue({
       query: [
         vi.fn(),
@@ -498,6 +509,9 @@ describe('CopyToTeamMenuItem', () => {
   })
 
   it('should handle translation errors', async () => {
+    // Clear leaked active-team state so TeamProvider doesn't fire its own
+    // mount-sync updateLastActiveTeamId and pollute the no-switch assertion.
+    window.sessionStorage.clear()
     const translateSubscriptionErrorMock = {
       request: {
         query: JOURNEY_AI_TRANSLATE_CREATE_SUBSCRIPTION,
@@ -593,6 +607,9 @@ describe('CopyToTeamMenuItem', () => {
       expect(screen.getByText('Translation failed')).toBeInTheDocument()
     })
     expect(handleCloseMenu).toHaveBeenCalled()
+    // The team must NOT switch when translation fails — the duplicate exists in
+    // the destination but the user should stay put (NES-1636 follow-up).
+    expect(updateLastActiveTeamIdMock.result).not.toHaveBeenCalled()
   })
 
   it('should call handleKeepMounted when provided', async () => {

--- a/apps/journeys-admin/src/components/Team/CopyToTeamMenuItem/CopyToTeamMenuItem.tsx
+++ b/apps/journeys-admin/src/components/Team/CopyToTeamMenuItem/CopyToTeamMenuItem.tsx
@@ -1,15 +1,11 @@
-import { useMutation } from '@apollo/client'
 import { useTranslation } from 'next-i18next/pages'
 import { useSnackbar } from 'notistack'
 import { ReactElement, useState } from 'react'
 
 import { CopyToTeamDialog } from '@core/journeys/ui/CopyToTeamDialog'
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
-import { useTeam } from '@core/journeys/ui/TeamProvider'
 import { useJourneyAiTranslateSubscription } from '@core/journeys/ui/useJourneyAiTranslateSubscription'
 import { useJourneyDuplicateMutation } from '@core/journeys/ui/useJourneyDuplicateMutation'
-import { UPDATE_LAST_ACTIVE_TEAM_ID } from '@core/journeys/ui/useUpdateLastActiveTeamIdMutation'
-import { UpdateLastActiveTeamId } from '@core/journeys/ui/useUpdateLastActiveTeamIdMutation/__generated__/UpdateLastActiveTeamId'
 import CopyToIcon from '@core/shared/ui/icons/CopyTo'
 
 import { GetAdminJourneys_journeys as Journey } from '../../../../__generated__/GetAdminJourneys'
@@ -60,10 +56,6 @@ export function CopyToTeamMenuItem({
   const [journeyDuplicate] = useJourneyDuplicateMutation()
   const { enqueueSnackbar } = useSnackbar()
   const { t } = useTranslation('apps-journeys-admin')
-  const { query, setActiveTeam } = useTeam()
-  const teams = query?.data?.teams ?? []
-  const [updateLastActiveTeamId, { client }] =
-    useMutation<UpdateLastActiveTeamId>(UPDATE_LAST_ACTIVE_TEAM_ID)
   const [loading, setLoading] = useState(false)
   const [translationVariables, setTranslationVariables] = useState<
     | {
@@ -77,24 +69,15 @@ export function CopyToTeamMenuItem({
       }
     | undefined
   >(undefined)
-  const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null)
   const { journey: journeyFromContext } = useJourney()
   const journeyData = journey ?? journeyFromContext
   const { refetchTemplateStats } = useTemplateFamilyStatsAggregateLazyQuery()
 
-  const updateTeamState = (teamId: string): void => {
-    setActiveTeam(teams.find((team) => team.id === teamId) ?? null)
-    void updateLastActiveTeamId({
-      variables: {
-        input: {
-          lastActiveTeamId: teamId
-        }
-      },
-      onCompleted() {
-        void client.refetchQueries({ include: ['GetAdminJourneys'] })
-      }
-    })
-  }
+  // The shared CopyToTeamDialog owns the team switch: it switches immediately
+  // for a plain copy, and defers the switch until it closes on completion for
+  // the translation flow (so the refetch doesn't unmount this component's
+  // subscription mid-translation — NES-1636). This component no longer
+  // switches teams itself.
 
   // Set up the subscription for translation
   const { data: translationData } = useJourneyAiTranslateSubscription({
@@ -112,14 +95,9 @@ export function CopyToTeamMenuItem({
       })
       setLoading(false)
       setTranslationVariables(undefined) // Reset to stop subscription
-
-      // Update team state when translation completes
-      if (selectedTeamId) {
-        updateTeamState(selectedTeamId)
-      }
       handleCloseMenu() // Close menu when translation completes
-      setDuplicateTeamDialogOpen(false) // Close dialog when translation completes
-      setSelectedTeamId(null) // Reset selected team
+      // Closing the dialog triggers its deferred switch to the destination team.
+      setDuplicateTeamDialogOpen(false)
     },
     onError(error) {
       enqueueSnackbar(error.message, {
@@ -130,7 +108,6 @@ export function CopyToTeamMenuItem({
       setTranslationVariables(undefined)
       handleCloseMenu() // Close menu on translation error
       setDuplicateTeamDialogOpen(false) // Close dialog on translation error
-      setSelectedTeamId(null) // Reset selected team
     }
   })
 
@@ -163,14 +140,11 @@ export function CopyToTeamMenuItem({
             variant: 'success',
             preventDuplicate: true
           })
-          updateTeamState(teamId) // Update team state immediately for non-translation scenarios
+          // The dialog switches to the destination team and closes itself.
           handleCloseMenu()
           setDuplicateTeamDialogOpen(false)
           return
         }
-
-        // Store the team ID for later team state update when translation completes
-        setSelectedTeamId(teamId)
 
         const currentLanguageName =
           journeyData.language.name.find(({ primary }) => !primary)?.value ?? ''

--- a/apps/journeys-admin/src/components/Team/CopyToTeamMenuItem/CopyToTeamMenuItem.tsx
+++ b/apps/journeys-admin/src/components/Team/CopyToTeamMenuItem/CopyToTeamMenuItem.tsx
@@ -224,6 +224,13 @@ export function CopyToTeamMenuItem({
         onClose={() => {
           setHasOpenDialog?.(false)
           setDuplicateTeamDialogOpen(false)
+          // Cancel any in-flight translation so closing the dialog stops the
+          // subscription cleanly instead of firing onComplete on a dismissed
+          // dialog (defensive: the wrapper hides the buttons and blocks
+          // backdrop/escape while translating, so this is not user-reachable
+          // mid-translation today).
+          setLoading(false)
+          setTranslationVariables(undefined)
         }}
         submitAction={handleDuplicateJourney}
         translationProgress={{

--- a/apps/journeys-admin/src/components/Team/CopyToTeamMenuItem/CopyToTeamMenuItem.tsx
+++ b/apps/journeys-admin/src/components/Team/CopyToTeamMenuItem/CopyToTeamMenuItem.tsx
@@ -6,6 +6,7 @@ import { CopyToTeamDialog } from '@core/journeys/ui/CopyToTeamDialog'
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import { useJourneyAiTranslateSubscription } from '@core/journeys/ui/useJourneyAiTranslateSubscription'
 import { useJourneyDuplicateMutation } from '@core/journeys/ui/useJourneyDuplicateMutation'
+import { useUpdateActiveTeam } from '@core/journeys/ui/useUpdateActiveTeam'
 import CopyToIcon from '@core/shared/ui/icons/CopyTo'
 
 import { GetAdminJourneys_journeys as Journey } from '../../../../__generated__/GetAdminJourneys'
@@ -56,6 +57,7 @@ export function CopyToTeamMenuItem({
   const [journeyDuplicate] = useJourneyDuplicateMutation()
   const { enqueueSnackbar } = useSnackbar()
   const { t } = useTranslation('apps-journeys-admin')
+  const updateTeamState = useUpdateActiveTeam()
   const [loading, setLoading] = useState(false)
   const [translationVariables, setTranslationVariables] = useState<
     | {
@@ -69,15 +71,10 @@ export function CopyToTeamMenuItem({
       }
     | undefined
   >(undefined)
+  const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null)
   const { journey: journeyFromContext } = useJourney()
   const journeyData = journey ?? journeyFromContext
   const { refetchTemplateStats } = useTemplateFamilyStatsAggregateLazyQuery()
-
-  // The shared CopyToTeamDialog owns the team switch: it switches immediately
-  // for a plain copy, and defers the switch until it closes on completion for
-  // the translation flow (so the refetch doesn't unmount this component's
-  // subscription mid-translation — NES-1636). This component no longer
-  // switches teams itself.
 
   // Set up the subscription for translation
   const { data: translationData } = useJourneyAiTranslateSubscription({
@@ -95,9 +92,14 @@ export function CopyToTeamMenuItem({
       })
       setLoading(false)
       setTranslationVariables(undefined) // Reset to stop subscription
+
+      // Update team state when translation completes
+      if (selectedTeamId) {
+        updateTeamState(selectedTeamId)
+      }
       handleCloseMenu() // Close menu when translation completes
-      // Closing the dialog triggers its deferred switch to the destination team.
-      setDuplicateTeamDialogOpen(false)
+      setDuplicateTeamDialogOpen(false) // Close dialog when translation completes
+      setSelectedTeamId(null) // Reset selected team
     },
     onError(error) {
       enqueueSnackbar(error.message, {
@@ -108,6 +110,7 @@ export function CopyToTeamMenuItem({
       setTranslationVariables(undefined)
       handleCloseMenu() // Close menu on translation error
       setDuplicateTeamDialogOpen(false) // Close dialog on translation error
+      setSelectedTeamId(null) // Reset selected team
     }
   })
 
@@ -140,11 +143,14 @@ export function CopyToTeamMenuItem({
             variant: 'success',
             preventDuplicate: true
           })
-          // The dialog switches to the destination team and closes itself.
+          // The dialog switches to the destination team for a plain copy.
           handleCloseMenu()
           setDuplicateTeamDialogOpen(false)
           return
         }
+
+        // Store the team ID for later team state update when translation completes
+        setSelectedTeamId(teamId)
 
         const currentLanguageName =
           journeyData.language.name.find(({ primary }) => !primary)?.value ?? ''
@@ -199,12 +205,13 @@ export function CopyToTeamMenuItem({
           setHasOpenDialog?.(false)
           setDuplicateTeamDialogOpen(false)
           // Cancel any in-flight translation so closing the dialog stops the
-          // subscription cleanly instead of firing onComplete on a dismissed
-          // dialog (defensive: the wrapper hides the buttons and blocks
-          // backdrop/escape while translating, so this is not user-reachable
-          // mid-translation today).
+          // subscription cleanly and a stale selectedTeamId can't drive a
+          // later team switch (defensive: the wrapper hides the buttons and
+          // blocks backdrop/escape while translating, so this isn't
+          // user-reachable mid-translation today).
           setLoading(false)
           setTranslationVariables(undefined)
+          setSelectedTeamId(null)
         }}
         submitAction={handleDuplicateJourney}
         translationProgress={{

--- a/apps/journeys-admin/src/components/UseTemplateDeepLink/UseTemplateDeepLink.tsx
+++ b/apps/journeys-admin/src/components/UseTemplateDeepLink/UseTemplateDeepLink.tsx
@@ -7,6 +7,7 @@ import { CopyToTeamDialog } from '@core/journeys/ui/CopyToTeamDialog'
 import { useJourneyAiTranslateSubscription } from '@core/journeys/ui/useJourneyAiTranslateSubscription'
 import { useJourneyDuplicateMutation } from '@core/journeys/ui/useJourneyDuplicateMutation'
 import { useJourneyQuery } from '@core/journeys/ui/useJourneyQuery'
+import { useUpdateActiveTeam } from '@core/journeys/ui/useUpdateActiveTeam'
 
 import { IdType } from '../../../__generated__/globalTypes'
 
@@ -56,12 +57,17 @@ function ActiveUseTemplateDeepLink({
   const { t } = useTranslation('apps-journeys-admin')
   const { enqueueSnackbar } = useSnackbar()
   const router = useRouter()
+  // The dialog switches teams itself for a plain copy, but defers the
+  // translation flow to the consumer so the switch fires only on success
+  // (NES-1636) — see onComplete below.
+  const updateTeamState = useUpdateActiveTeam()
 
   const [open, setOpen] = useState(true)
   const [loading, setLoading] = useState(false)
   const [translationVariables, setTranslationVariables] = useState<
     TranslationVariables | undefined
   >(undefined)
+  const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null)
 
   // Set true the moment a success/error path issues `router.replace` to the
   // journey list. CopyToTeamDialog calls `onClose()` after submitAction
@@ -108,6 +114,10 @@ function ActiveUseTemplateDeepLink({
       setLoading(false)
       setTranslationVariables(undefined)
       setOpen(false)
+      // Switch to the destination team only on success, before navigating to
+      // its journey list.
+      if (selectedTeamId != null) updateTeamState(selectedTeamId)
+      setSelectedTeamId(null)
       navigateToJourneyList()
     },
     onError(error) {
@@ -117,6 +127,7 @@ function ActiveUseTemplateDeepLink({
       })
       setLoading(false)
       setTranslationVariables(undefined)
+      setSelectedTeamId(null)
       setOpen(false)
       // The duplicate mutation already succeeded before translation began,
       // so the (untranslated) journey exists. Take the user to the list
@@ -136,9 +147,9 @@ function ActiveUseTemplateDeepLink({
 
       // Translation needs the source journey's language metadata. Throwing
       // (instead of a plain return) halts CopyToTeamDialog's submit pipeline
-      // BEFORE updateTeamState + resetForm run, so the user's selections
-      // survive the retry. The throw fires before `setLoading(true)` and
-      // outside the try block below — no "duplication failed" snackbar leaks.
+      // BEFORE resetForm runs, so the user's selections survive the retry.
+      // The throw fires before `setLoading(true)` and outside the try block
+      // below — no "duplication failed" snackbar leaks.
       if (wantsTranslation && journey == null) {
         enqueueSnackbar(t('Loading template — please retry'), {
           variant: 'info',
@@ -181,6 +192,9 @@ function ActiveUseTemplateDeepLink({
 
         const currentLanguageName =
           journey.language.name.find(({ primary }) => !primary)?.value ?? ''
+
+        // Remember the destination so onComplete can switch to it on success.
+        setSelectedTeamId(teamId)
 
         setTranslationVariables({
           journeyId: data.journeyDuplicate.id,

--- a/libs/journeys/ui/src/components/CopyToTeamDialog/CopyToTeamDialog.spec.tsx
+++ b/libs/journeys/ui/src/components/CopyToTeamDialog/CopyToTeamDialog.spec.tsx
@@ -2,10 +2,13 @@ import { type FetchResult } from '@apollo/client'
 import { MockedProvider, MockedResponse } from '@apollo/client/testing'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { SnackbarProvider } from 'notistack'
+import { type ReactElement } from 'react'
 import { type Mock } from 'vitest'
 
 import { JourneyProvider } from '../../libs/JourneyProvider'
+import { SUPPORTED_LANGUAGE_IDS } from '../../libs/useJourneyAiTranslateSubscription/supportedLanguages'
 import { GetJourney_journey as Journey } from '../../libs/useJourneyQuery/__generated__/GetJourney'
+import { GET_LANGUAGES } from '../../libs/useLanguagesQuery'
 import { UPDATE_LAST_ACTIVE_TEAM_ID } from '../../libs/useUpdateLastActiveTeamIdMutation'
 import { UpdateLastActiveTeamId } from '../../libs/useUpdateLastActiveTeamIdMutation/__generated__/UpdateLastActiveTeamId'
 import {
@@ -647,6 +650,157 @@ describe('CopyToTeamDialog', () => {
 
       // Dialog should close normally when translation is not enabled
       expect(handleCloseMenuMock).toHaveBeenCalled()
+    })
+
+    it('defers the team switch until the dialog closes when translation is enabled', async () => {
+      // NES-1636: switching teams immediately refetches GetAdminJourneys and
+      // unmounts the consumer that owns the translation subscription before it
+      // completes, so the copied journey lands untranslated. The switch must be
+      // held until the consumer closes the dialog on completion.
+      //
+      // Clear leaked active-team state so TeamProvider doesn't fire its own
+      // mount-sync updateLastActiveTeamId and pollute the assertion below.
+      window.sessionStorage.clear()
+
+      const teamsResult = vi.fn(() => ({
+        data: {
+          teams: [
+            { id: 'teamId', title: 'Team Name', __typename: 'Team' },
+            { id: 'teamId2', title: 'Team Name Two', __typename: 'Team' }
+          ],
+          getJourneyProfile: {
+            __typename: 'JourneyProfile',
+            lastActiveTeamId: 'teamId2'
+          }
+        }
+      }))
+
+      const updateLastActiveTeamIdMock: MockedResponse<UpdateLastActiveTeamId> =
+        {
+          request: {
+            query: UPDATE_LAST_ACTIVE_TEAM_ID,
+            variables: { input: { lastActiveTeamId: 'teamId' } }
+          },
+          result: vi.fn(
+            (): FetchResult<UpdateLastActiveTeamId> => ({
+              data: {
+                journeyProfileUpdate: {
+                  __typename: 'JourneyProfile',
+                  id: 'teamId'
+                }
+              }
+            })
+          )
+        }
+
+      const languagesMock = {
+        request: {
+          query: GET_LANGUAGES,
+          variables: {
+            languageId: '529',
+            where: { ids: [...SUPPORTED_LANGUAGE_IDS] }
+          }
+        },
+        result: {
+          data: {
+            languages: [
+              {
+                __typename: 'Language',
+                id: '529',
+                slug: 'english',
+                name: [
+                  { value: 'English', primary: true, __typename: 'LanguageName' }
+                ]
+              },
+              {
+                __typename: 'Language',
+                id: '528',
+                slug: 'spanish',
+                name: [
+                  {
+                    value: 'Spanish',
+                    primary: false,
+                    __typename: 'LanguageName'
+                  },
+                  { value: 'Español', primary: true, __typename: 'LanguageName' }
+                ]
+              }
+            ]
+          }
+        }
+      }
+
+      const mocks = [
+        { request: { query: GET_LAST_ACTIVE_TEAM_ID_AND_TEAMS }, result: teamsResult },
+        languagesMock,
+        updateLastActiveTeamIdMock
+      ]
+
+      const ui = (open: boolean): ReactElement => (
+        <MockedProvider mocks={mocks}>
+          <SnackbarProvider>
+            <JourneyProvider
+              value={{
+                journey: { id: 'journeyId' } as unknown as Journey,
+                variant: 'admin'
+              }}
+            >
+              <TeamProvider>
+                <CopyToTeamDialog
+                  open={open}
+                  title="Copy To Journey"
+                  submitLabel="Copy"
+                  onClose={handleCloseMenuMock}
+                  submitAction={handleSubmitActionMock}
+                />
+              </TeamProvider>
+            </JourneyProvider>
+          </SnackbarProvider>
+        </MockedProvider>
+      )
+
+      const { rerender } = render(ui(true))
+
+      await waitFor(() => expect(teamsResult).toHaveBeenCalled())
+
+      // Select a different team than the active one
+      fireEvent.mouseDown(screen.getByRole('combobox', { name: 'Select Team' }))
+      fireEvent.click(screen.getByRole('option', { name: 'Team Name' }))
+
+      // Enable translation and pick a target language
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Translation' }))
+      await waitFor(() =>
+        expect(screen.getByTestId('LanguageAutocomplete')).not.toHaveAttribute(
+          'aria-disabled',
+          'true'
+        )
+      )
+      fireEvent.focus(screen.getByTestId('LanguageAutocomplete'))
+      fireEvent.keyDown(screen.getByTestId('LanguageAutocomplete'), {
+        key: 'ArrowDown'
+      })
+      fireEvent.click(screen.getByRole('option', { name: 'Spanish Español' }))
+
+      fireEvent.click(screen.getByRole('button', { name: 'Copy' }))
+
+      await waitFor(() =>
+        expect(handleSubmitActionMock).toHaveBeenCalledWith(
+          'teamId',
+          expect.objectContaining({ id: '528' }),
+          true
+        )
+      )
+
+      // Team switch is deferred: the dialog is still open mid-translation.
+      expect(updateLastActiveTeamIdMock.result).not.toHaveBeenCalled()
+      expect(handleCloseMenuMock).not.toHaveBeenCalled()
+
+      // Consumer closes the dialog when the translation subscription completes.
+      rerender(ui(false))
+
+      await waitFor(() =>
+        expect(updateLastActiveTeamIdMock.result).toHaveBeenCalled()
+      )
     })
   })
 

--- a/libs/journeys/ui/src/components/CopyToTeamDialog/CopyToTeamDialog.spec.tsx
+++ b/libs/journeys/ui/src/components/CopyToTeamDialog/CopyToTeamDialog.spec.tsx
@@ -718,7 +718,7 @@ describe('CopyToTeamDialog', () => {
               },
               {
                 __typename: 'Language',
-                id: '528',
+                id: '21028',
                 slug: 'spanish',
                 name: [
                   {
@@ -797,7 +797,7 @@ describe('CopyToTeamDialog', () => {
       await waitFor(() =>
         expect(handleSubmitActionMock).toHaveBeenCalledWith(
           'teamId',
-          expect.objectContaining({ id: '528' }),
+          expect.objectContaining({ id: '21028' }),
           true
         )
       )

--- a/libs/journeys/ui/src/components/CopyToTeamDialog/CopyToTeamDialog.spec.tsx
+++ b/libs/journeys/ui/src/components/CopyToTeamDialog/CopyToTeamDialog.spec.tsx
@@ -709,7 +709,11 @@ describe('CopyToTeamDialog', () => {
                 id: '529',
                 slug: 'english',
                 name: [
-                  { value: 'English', primary: true, __typename: 'LanguageName' }
+                  {
+                    value: 'English',
+                    primary: true,
+                    __typename: 'LanguageName'
+                  }
                 ]
               },
               {
@@ -722,7 +726,11 @@ describe('CopyToTeamDialog', () => {
                     primary: false,
                     __typename: 'LanguageName'
                   },
-                  { value: 'Español', primary: true, __typename: 'LanguageName' }
+                  {
+                    value: 'Español',
+                    primary: true,
+                    __typename: 'LanguageName'
+                  }
                 ]
               }
             ]
@@ -731,7 +739,10 @@ describe('CopyToTeamDialog', () => {
       }
 
       const mocks = [
-        { request: { query: GET_LAST_ACTIVE_TEAM_ID_AND_TEAMS }, result: teamsResult },
+        {
+          request: { query: GET_LAST_ACTIVE_TEAM_ID_AND_TEAMS },
+          result: teamsResult
+        },
         languagesMock,
         updateLastActiveTeamIdMock
       ]

--- a/libs/journeys/ui/src/components/CopyToTeamDialog/CopyToTeamDialog.spec.tsx
+++ b/libs/journeys/ui/src/components/CopyToTeamDialog/CopyToTeamDialog.spec.tsx
@@ -652,11 +652,12 @@ describe('CopyToTeamDialog', () => {
       expect(handleCloseMenuMock).toHaveBeenCalled()
     })
 
-    it('defers the team switch until the dialog closes when translation is enabled', async () => {
-      // NES-1636: switching teams immediately refetches GetAdminJourneys and
-      // unmounts the consumer that owns the translation subscription before it
-      // completes, so the copied journey lands untranslated. The switch must be
-      // held until the consumer closes the dialog on completion.
+    it('does not switch teams for the translation path — the consumer owns it', async () => {
+      // NES-1636: switching teams here refetches GetAdminJourneys and unmounts
+      // the consumer that owns the translation subscription before it finishes,
+      // so the copied journey lands untranslated. For the translation path the
+      // dialog must NOT switch at all; the consumer switches on its own
+      // onComplete (success only). The dialog only switches for a plain copy.
       //
       // Clear leaked active-team state so TeamProvider doesn't fire its own
       // mount-sync updateLastActiveTeamId and pollute the assertion below.
@@ -802,16 +803,14 @@ describe('CopyToTeamDialog', () => {
         )
       )
 
-      // Team switch is deferred: the dialog is still open mid-translation.
+      // The dialog does not switch teams on the translation path...
       expect(updateLastActiveTeamIdMock.result).not.toHaveBeenCalled()
       expect(handleCloseMenuMock).not.toHaveBeenCalled()
 
-      // Consumer closes the dialog when the translation subscription completes.
+      // ...not even once the consumer closes the dialog on completion — the
+      // consumer is responsible for the success-only switch.
       rerender(ui(false))
-
-      await waitFor(() =>
-        expect(updateLastActiveTeamIdMock.result).toHaveBeenCalled()
-      )
+      expect(updateLastActiveTeamIdMock.result).not.toHaveBeenCalled()
     })
   })
 

--- a/libs/journeys/ui/src/components/CopyToTeamDialog/CopyToTeamDialog.tsx
+++ b/libs/journeys/ui/src/components/CopyToTeamDialog/CopyToTeamDialog.tsx
@@ -1,4 +1,3 @@
-import { useMutation } from '@apollo/client'
 import FormControl from '@mui/material/FormControl'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import MenuItem from '@mui/material/MenuItem'
@@ -9,7 +8,7 @@ import Typography from '@mui/material/Typography'
 import { Formik, FormikHelpers } from 'formik'
 import sortBy from 'lodash/sortBy'
 import { useTranslation } from 'next-i18next/pages'
-import { ReactElement, useCallback, useEffect, useState } from 'react'
+import { ReactElement } from 'react'
 import { boolean, object, string } from 'yup'
 
 import ChevronDownIcon from '@core/shared/ui/icons/ChevronDown'
@@ -17,8 +16,7 @@ import { LanguageAutocomplete } from '@core/shared/ui/LanguageAutocomplete'
 
 import { SUPPORTED_LANGUAGE_IDS } from '../../libs/useJourneyAiTranslateSubscription/supportedLanguages'
 import { useLanguagesQuery } from '../../libs/useLanguagesQuery'
-import { UPDATE_LAST_ACTIVE_TEAM_ID } from '../../libs/useUpdateLastActiveTeamIdMutation'
-import { UpdateLastActiveTeamId } from '../../libs/useUpdateLastActiveTeamIdMutation/__generated__/UpdateLastActiveTeamId'
+import { useUpdateActiveTeam } from '../../libs/useUpdateActiveTeam'
 import { useTeam } from '../TeamProvider'
 import { TranslationDialogWrapper } from '../TranslationDialogWrapper'
 
@@ -87,11 +85,9 @@ export function CopyToTeamDialog({
   defaultToActiveTeam = false
 }: CopyToTeamDialogProps): ReactElement {
   const { t } = useTranslation('libs-journeys-ui')
-  const { query, setActiveTeam, activeTeam } = useTeam()
+  const { query, activeTeam } = useTeam()
   const teams = query?.data?.teams ?? []
-  const [updateLastActiveTeamId, { client }] =
-    useMutation<UpdateLastActiveTeamId>(UPDATE_LAST_ACTIVE_TEAM_ID)
-  const [pendingTeamId, setPendingTeamId] = useState<string | null>(null)
+  const updateTeamState = useUpdateActiveTeam()
 
   const { data: languagesData, loading: languagesLoading } = useLanguagesQuery({
     languageId: '529',
@@ -99,35 +95,6 @@ export function CopyToTeamDialog({
       ids: [...SUPPORTED_LANGUAGE_IDS]
     }
   })
-
-  const updateTeamState = useCallback(
-    (teamId: string): void => {
-      setActiveTeam(teams.find((team) => team.id === teamId) ?? null)
-      void updateLastActiveTeamId({
-        variables: {
-          input: {
-            lastActiveTeamId: teamId
-          }
-        },
-        onCompleted() {
-          void client.refetchQueries({ include: ['GetAdminJourneys'] })
-        }
-      })
-    },
-    [setActiveTeam, teams, updateLastActiveTeamId, client]
-  )
-
-  // When translation is enabled the team switch is deferred (see handleSubmit)
-  // and applied here, once the consumer closes the dialog on completion.
-  // Switching immediately would refetch GetAdminJourneys and unmount the
-  // consumer that owns the translation subscription before it finishes,
-  // leaving the copied journey untranslated (NES-1636).
-  useEffect(() => {
-    if (!open && pendingTeamId != null) {
-      updateTeamState(pendingTeamId)
-      setPendingTeamId(null)
-    }
-  }, [open, pendingTeamId, updateTeamState])
 
   async function handleSubmit(
     values: FormValues,
@@ -142,15 +109,17 @@ export function CopyToTeamDialog({
     // Always reset the form after submission
     resetForm()
 
-    if (values.showTranslation) {
-      // Defer the team switch until the translation subscription completes and
-      // the consumer closes the dialog (open -> false). See the effect above.
-      setPendingTeamId(values.teamSelect)
-    } else {
-      // No translation: switch teams and close the dialog immediately.
+    if (!values.showTranslation) {
+      // Plain copy: switch to the destination team and close immediately.
       updateTeamState(values.teamSelect)
       onClose()
+      return
     }
+
+    // Translation: the consumer switches the team and closes the dialog only
+    // when the subscription completes successfully. Switching here would both
+    // fire on an error/cancel close and refetch GetAdminJourneys, unmounting
+    // the consumer that owns the translation subscription mid-run (NES-1636).
   }
 
   const baseLanguageShape = {

--- a/libs/journeys/ui/src/components/CopyToTeamDialog/CopyToTeamDialog.tsx
+++ b/libs/journeys/ui/src/components/CopyToTeamDialog/CopyToTeamDialog.tsx
@@ -9,7 +9,7 @@ import Typography from '@mui/material/Typography'
 import { Formik, FormikHelpers } from 'formik'
 import sortBy from 'lodash/sortBy'
 import { useTranslation } from 'next-i18next/pages'
-import { ReactElement } from 'react'
+import { ReactElement, useCallback, useEffect, useState } from 'react'
 import { boolean, object, string } from 'yup'
 
 import ChevronDownIcon from '@core/shared/ui/icons/ChevronDown'
@@ -91,6 +91,7 @@ export function CopyToTeamDialog({
   const teams = query?.data?.teams ?? []
   const [updateLastActiveTeamId, { client }] =
     useMutation<UpdateLastActiveTeamId>(UPDATE_LAST_ACTIVE_TEAM_ID)
+  const [pendingTeamId, setPendingTeamId] = useState<string | null>(null)
 
   const { data: languagesData, loading: languagesLoading } = useLanguagesQuery({
     languageId: '529',
@@ -99,19 +100,34 @@ export function CopyToTeamDialog({
     }
   })
 
-  const updateTeamState = (teamId: string): void => {
-    setActiveTeam(teams.find((team) => team.id === teamId) ?? null)
-    void updateLastActiveTeamId({
-      variables: {
-        input: {
-          lastActiveTeamId: teamId
+  const updateTeamState = useCallback(
+    (teamId: string): void => {
+      setActiveTeam(teams.find((team) => team.id === teamId) ?? null)
+      void updateLastActiveTeamId({
+        variables: {
+          input: {
+            lastActiveTeamId: teamId
+          }
+        },
+        onCompleted() {
+          void client.refetchQueries({ include: ['GetAdminJourneys'] })
         }
-      },
-      onCompleted() {
-        void client.refetchQueries({ include: ['GetAdminJourneys'] })
-      }
-    })
-  }
+      })
+    },
+    [setActiveTeam, teams, updateLastActiveTeamId, client]
+  )
+
+  // When translation is enabled the team switch is deferred (see handleSubmit)
+  // and applied here, once the consumer closes the dialog on completion.
+  // Switching immediately would refetch GetAdminJourneys and unmount the
+  // consumer that owns the translation subscription before it finishes,
+  // leaving the copied journey untranslated (NES-1636).
+  useEffect(() => {
+    if (!open && pendingTeamId != null) {
+      updateTeamState(pendingTeamId)
+      setPendingTeamId(null)
+    }
+  }, [open, pendingTeamId, updateTeamState])
 
   async function handleSubmit(
     values: FormValues,
@@ -123,15 +139,16 @@ export function CopyToTeamDialog({
       values.showTranslation
     )
 
-    // Update team state
-    updateTeamState(values.teamSelect)
-
     // Always reset the form after submission
     resetForm()
 
-    // Only close dialog immediately if translation is not enabled
-    // If translation is enabled, the dialog will be closed when translation completes
-    if (!values.showTranslation) {
+    if (values.showTranslation) {
+      // Defer the team switch until the translation subscription completes and
+      // the consumer closes the dialog (open -> false). See the effect above.
+      setPendingTeamId(values.teamSelect)
+    } else {
+      // No translation: switch teams and close the dialog immediately.
+      updateTeamState(values.teamSelect)
       onClose()
     }
   }

--- a/libs/journeys/ui/src/libs/useUpdateActiveTeam/index.ts
+++ b/libs/journeys/ui/src/libs/useUpdateActiveTeam/index.ts
@@ -1,0 +1,1 @@
+export { useUpdateActiveTeam } from './useUpdateActiveTeam'

--- a/libs/journeys/ui/src/libs/useUpdateActiveTeam/useUpdateActiveTeam.ts
+++ b/libs/journeys/ui/src/libs/useUpdateActiveTeam/useUpdateActiveTeam.ts
@@ -1,0 +1,37 @@
+import { useMutation } from '@apollo/client'
+
+import { useTeam } from '../../components/TeamProvider'
+import { UPDATE_LAST_ACTIVE_TEAM_ID } from '../useUpdateLastActiveTeamIdMutation'
+import { UpdateLastActiveTeamId } from '../useUpdateLastActiveTeamIdMutation/__generated__/UpdateLastActiveTeamId'
+
+/**
+ * Returns a function that switches the user's active team to `teamId`,
+ * persists it as the last active team, and refetches the admin journey list so
+ * the destination team's journeys load.
+ *
+ * Shared by the copy-to-team and use-template flows so the team switch — and
+ * the GetAdminJourneys refetch it triggers — lives in one place.
+ *
+ * @returns {(teamId: string) => void} `updateActiveTeam` — switches to the team
+ *   with the given id (or clears the active team if it isn't in the list).
+ */
+export function useUpdateActiveTeam(): (teamId: string) => void {
+  const { query, setActiveTeam } = useTeam()
+  const [updateLastActiveTeamId, { client }] =
+    useMutation<UpdateLastActiveTeamId>(UPDATE_LAST_ACTIVE_TEAM_ID)
+
+  return (teamId: string): void => {
+    const teams = query?.data?.teams ?? []
+    setActiveTeam(teams.find((team) => team.id === teamId) ?? null)
+    void updateLastActiveTeamId({
+      variables: {
+        input: {
+          lastActiveTeamId: teamId
+        }
+      },
+      onCompleted() {
+        void client.refetchQueries({ include: ['GetAdminJourneys'] })
+      }
+    })
+  }
+}


### PR DESCRIPTION
## Summary

Copying a journey to **another team** with the **AI translation** toggle on left the journey in the destination team **untranslated** ([NES-1636](https://linear.app/jesus-film-project/issue/NES-1636/ai-translation-does-not-work-when-copying-a-journey-to-another-team), Production).

Root cause is a lifecycle race in the shared `CopyToTeamDialog`. After `submitAction` resolved — which, on the translation path, only *starts* the AI-translate subscription — the dialog immediately called `updateTeamState`. That switches the active team and refetches `GetAdminJourneys`, which unmounts the source-team journey card and the `CopyToTeamMenuItem` that **owns the translation subscription**, before translation completes. The duplicate lands in the destination team in the source language, with no feedback.

## The fix — the team switch happens only on translation *success*

Ownership of the team switch moved to whichever component actually knows the outcome:

- **`CopyToTeamDialog`** no longer switches teams on the translation path at all. A **plain copy** (no translation) still switches to the destination team and closes immediately, exactly as before.
- **`CopyToTeamMenuItem`** and **`UseTemplateDeepLink`** switch the active team in their subscription **`onComplete`** (success only). On **`onError`** they clear the pending team and do **not** switch; closing/cancelling the dialog resets state without switching.
- **`CreateJourneyButton`** is unchanged — it navigates to the new journey by id, so it intentionally doesn't switch teams.

Because the switch now runs *after* the subscription completes (instead of right after it starts), the source card stays mounted through the translation, so it actually finishes — and a failed translation no longer drags the user to the destination team.

The shared switch logic (`setActiveTeam` + `updateLastActiveTeamId` + `GetAdminJourneys` refetch) is extracted into a small **`useUpdateActiveTeam`** hook, so the dialog and the two admin consumers share one implementation instead of duplicating it.

## What changed

| File | Change |
| --- | --- |
| `libs/journeys/ui/.../CopyToTeamDialog.tsx` | Stops switching on the translation path; plain-copy path unchanged |
| `libs/journeys/ui/src/libs/useUpdateActiveTeam/*` | New shared hook for the active-team switch + refetch |
| `apps/.../Team/CopyToTeamMenuItem.tsx` | Switches on `onComplete` (success only); no switch on error/cancel |
| `apps/.../UseTemplateDeepLink.tsx` | Same success-only switch before navigating |

## Test coverage

- `CopyToTeamDialog` spec asserts the dialog does **not** switch teams on the translation path (even after it closes).
- `CopyToTeamMenuItem` spec asserts **no team switch on a translation error**, alongside the existing success-path test.
- All consumer suites pass: `CopyToTeamDialog`, `CopyToTeamMenuItem`, `UseTemplateDeepLink`, `CreateJourneyButton`.

## Note

The unreachable `CopyToTeamDialog` inside `DuplicateJourneyMenuItem` (its dialog only opens when `activeTeam == null`, but the menu item only renders when `activeTeam != null`) is intentionally left untouched — the reachable "Copy to ..." flow is `CopyToTeamMenuItem`, which is what this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)