### PR TITLE
fix(api-journeys): stop journey AI translation from leaving untranslated blocks

### DIFF
--- a/apis/api-journeys/src/schema/journeyAiTranslate/blockTranslation.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/blockTranslation.ts
@@ -43,13 +43,20 @@ export function getTranslatableFields(
   if (block.typename === 'TextResponseBlock') {
     return {
       label: block.label,
-      placeholder: block.placeholder
+      placeholder: block.placeholder,
+      hint: block.hint
     }
   }
 
   if (block.typename === 'RadioOptionBlock') {
     return {
       label: block.label
+    }
+  }
+
+  if (block.typename === 'SignUpBlock') {
+    return {
+      submitLabel: block.submitLabel
     }
   }
 

--- a/apis/api-journeys/src/schema/journeyAiTranslate/blockTranslation.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/blockTranslation.ts
@@ -54,6 +54,12 @@ export function getTranslatableFields(
     }
   }
 
+  if (block.typename === 'MultiselectOptionBlock') {
+    return {
+      label: block.label
+    }
+  }
+
   if (block.typename === 'SignUpBlock') {
     return {
       submitLabel: block.submitLabel

--- a/apis/api-journeys/src/schema/journeyAiTranslate/blockTranslation.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/blockTranslation.ts
@@ -70,16 +70,22 @@ export function getTranslatableFields(
 }
 
 /**
- * Creates translation info string for a block
+ * Creates translation info string for a block.
+ *
+ * Pass `fields` to restrict the serialized fields to a subset (e.g. when
+ * re-requesting only the fields a previous attempt left untranslated).
  */
-export function createTranslationInfo(block: Block): string {
+export function createTranslationInfo(
+  block: Block,
+  fields?: readonly string[]
+): string {
   const fieldInfo = []
   const translateableFields = getTranslatableFields(block)
 
   for (const [field, value] of Object.entries(translateableFields)) {
-    if (value !== undefined && value !== null) {
-      fieldInfo.push(`${field}: "${value}"`)
-    }
+    if (value === undefined || value === null) continue
+    if (fields != null && !fields.includes(field)) continue
+    fieldInfo.push(`${field}: "${value}"`)
   }
 
   return `[${block.id}] ${block.typename}: ${fieldInfo.join(', ')}`

--- a/apis/api-journeys/src/schema/journeyAiTranslate/getCardBlocksContent/getBlockContent.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/getCardBlocksContent/getBlockContent.ts
@@ -2,6 +2,7 @@ import { Block } from '@core/prisma/journeys/client'
 
 import { getButtonBlockContent } from './getButtonBlockContent'
 import { getImageBlockContent } from './getImageBlockContent'
+import { getMultiselectBlockContent } from './getMultiselectBlockContent'
 import { getRadioQuestionBlockContent } from './getRadioQuestionBlockContent'
 import { getVideoBlockContent } from './getVideoBlockContent'
 
@@ -30,6 +31,11 @@ export async function getBlockContent({
       })
     case 'RadioQuestionBlock':
       return getRadioQuestionBlockContent({
+        blocks,
+        block
+      })
+    case 'MultiselectBlock':
+      return getMultiselectBlockContent({
         blocks,
         block
       })

--- a/apis/api-journeys/src/schema/journeyAiTranslate/getCardBlocksContent/getMultiselectBlockContent.spec.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/getCardBlocksContent/getMultiselectBlockContent.spec.ts
@@ -1,0 +1,66 @@
+import { Block } from '@core/prisma/journeys/client'
+
+import { getMultiselectBlockContent } from './getMultiselectBlockContent'
+
+describe('getMultiselectBlockContent', () => {
+  const multiselect: Partial<Block> = {
+    id: 'm1',
+    typename: 'MultiselectBlock',
+    label: 'Pick any'
+  }
+  const option1: Partial<Block> = {
+    id: 'o1',
+    typename: 'MultiselectOptionBlock',
+    parentBlockId: 'm1',
+    label: 'Option A'
+  }
+  const option2: Partial<Block> = {
+    id: 'o2',
+    typename: 'MultiselectOptionBlock',
+    parentBlockId: 'm1',
+    label: 'Option B'
+  }
+  const otherOption: Partial<Block> = {
+    id: 'o3',
+    typename: 'MultiselectOptionBlock',
+    parentBlockId: 'm2',
+    label: 'Belongs to another multiselect'
+  }
+
+  it('includes block id and question label in output', () => {
+    const result = getMultiselectBlockContent({
+      blocks: [multiselect as Block],
+      block: multiselect as Block
+    })
+    expect(result).toContain('Block ID: m1')
+    expect(result).toContain('Question: Pick any')
+    expect(result).toContain('### Options:')
+  })
+
+  it('lists the option labels belonging to this multiselect', () => {
+    const result = getMultiselectBlockContent({
+      blocks: [multiselect as Block, option1 as Block, option2 as Block],
+      block: multiselect as Block
+    })
+    expect(result).toContain('Option A')
+    expect(result).toContain('Option B')
+  })
+
+  it('does not include options belonging to other multiselects', () => {
+    const result = getMultiselectBlockContent({
+      blocks: [multiselect as Block, option1 as Block, otherOption as Block],
+      block: multiselect as Block
+    })
+    expect(result).toContain('Option A')
+    expect(result).not.toContain('Belongs to another multiselect')
+  })
+
+  it('handles a multiselect with no options', () => {
+    const result = getMultiselectBlockContent({
+      blocks: [multiselect as Block],
+      block: multiselect as Block
+    })
+    expect(result).toContain('Block ID: m1')
+    expect(result).toContain('### Options:')
+  })
+})

--- a/apis/api-journeys/src/schema/journeyAiTranslate/getCardBlocksContent/getMultiselectBlockContent.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/getCardBlocksContent/getMultiselectBlockContent.ts
@@ -1,0 +1,25 @@
+import { Block } from '@core/prisma/journeys/client'
+
+export function getMultiselectBlockContent({
+  blocks,
+  block
+}: {
+  blocks: Block[]
+  block: Block
+}): string {
+  let result = `
+## Multiselect Question:
+- Block ID: ${block.id}
+${block.label != null && block.label !== '' ? `- Question: ${block.label}\n` : ''}
+### Options:
+`
+  const options = blocks.filter(
+    (childBlock) =>
+      childBlock.parentBlockId === block.id &&
+      childBlock.typename === 'MultiselectOptionBlock'
+  )
+  for (const option of options) {
+    result += `- ${option.label}\n`
+  }
+  return result
+}

--- a/apis/api-journeys/src/schema/journeyAiTranslate/getCardBlocksContent/getRadioQuestionBlockContent.spec.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/getCardBlocksContent/getRadioQuestionBlockContent.spec.ts
@@ -5,53 +5,63 @@ import { getRadioQuestionBlockContent } from './getRadioQuestionBlockContent'
 describe('getRadioQuestionBlockContent', () => {
   const radio1: Partial<Block> = {
     id: 'r1',
-    typename: 'RadioQuestionBlock'
+    typename: 'RadioQuestionBlock',
+    label: 'Pick one'
   }
-  const radio2: Partial<Block> = {
-    id: 'r2',
-    typename: 'RadioQuestionBlock'
+  const option1: Partial<Block> = {
+    id: 'o1',
+    typename: 'RadioOptionBlock',
+    parentBlockId: 'r1',
+    label: 'Option A'
   }
-  const notRadio: Partial<Block> = {
-    id: 'n1',
-    typename: 'TypographyBlock',
-    label: 'NotQ'
+  const option2: Partial<Block> = {
+    id: 'o2',
+    typename: 'RadioOptionBlock',
+    parentBlockId: 'r1',
+    label: 'Option B'
+  }
+  const otherOption: Partial<Block> = {
+    id: 'o3',
+    typename: 'RadioOptionBlock',
+    parentBlockId: 'r2',
+    label: 'Belongs to another question'
   }
 
-  it('includes block id in output', () => {
+  it('includes block id and question label in output', () => {
     const result = getRadioQuestionBlockContent({
       blocks: [radio1 as Block],
       block: radio1 as Block
     })
     expect(result).toContain('Block ID: r1')
+    expect(result).toContain('Question: Pick one')
+    expect(result).toContain('### Options:')
   })
 
-  it('includes radio question blocks without labels', () => {
+  it('lists the option labels belonging to this question', () => {
     const result = getRadioQuestionBlockContent({
-      blocks: [radio1 as Block, radio2 as Block],
+      blocks: [radio1 as Block, option1 as Block, option2 as Block],
       block: radio1 as Block
     })
-    expect(result).toContain('### Questions:')
-    // Should not contain any label text since labels are removed
-    expect(result).not.toContain('Q1')
-    expect(result).not.toContain('Q2')
+    expect(result).toContain('Option A')
+    expect(result).toContain('Option B')
   })
 
-  it('does not include non-radio-question blocks', () => {
+  it('does not include options belonging to other questions', () => {
     const result = getRadioQuestionBlockContent({
-      blocks: [radio1 as Block, notRadio as Block],
+      blocks: [radio1 as Block, option1 as Block, otherOption as Block],
       block: radio1 as Block
     })
-    expect(result).toContain('### Questions:')
-    expect(result).not.toContain('NotQ')
+    expect(result).toContain('Option A')
+    expect(result).not.toContain('Belongs to another question')
   })
 
-  it('handles no other radio question blocks', () => {
+  it('handles a question with no options', () => {
     const result = getRadioQuestionBlockContent({
       blocks: [radio1 as Block],
       block: radio1 as Block
     })
     expect(result).toContain('Block ID: r1')
-    expect(result).toContain('### Questions:')
+    expect(result).toContain('### Options:')
   })
 
   it('handles empty blocks array', () => {
@@ -60,6 +70,6 @@ describe('getRadioQuestionBlockContent', () => {
       block: radio1 as Block
     })
     expect(result).toContain('Block ID: r1')
-    expect(result).toContain('### Questions:')
+    expect(result).toContain('### Options:')
   })
 })

--- a/apis/api-journeys/src/schema/journeyAiTranslate/getCardBlocksContent/getRadioQuestionBlockContent.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/getCardBlocksContent/getRadioQuestionBlockContent.ts
@@ -8,16 +8,18 @@ export function getRadioQuestionBlockContent({
   block: Block
 }): string {
   let result = `
-## Radio Question List:
+## Radio Question:
 - Block ID: ${block.id}
-
-### Questions:
+${block.label != null && block.label !== '' ? `- Question: ${block.label}\n` : ''}
+### Options:
 `
-  const questions = blocks.filter(
-    (childBlock) => childBlock.typename === 'RadioQuestionBlock'
+  const options = blocks.filter(
+    (childBlock) =>
+      childBlock.parentBlockId === block.id &&
+      childBlock.typename === 'RadioOptionBlock'
   )
-  for (const question of questions) {
-    result += `- ${question.label}\n`
+  for (const option of options) {
+    result += `- ${option.label}\n`
   }
   return result
 }

--- a/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.spec.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.spec.ts
@@ -972,6 +972,157 @@ describe('journeyAiTranslateCreate mutation', () => {
     )
   })
 
+  it('injects the default "Submit" label for an empty submit button and translates only the result', async () => {
+    prismaMock.journey.findUnique.mockResolvedValueOnce({
+      ...mockJourney,
+      blocks: [
+        { id: 'card1', typename: 'CardBlock', parentOrder: 0 },
+        {
+          id: 'button1',
+          typename: 'ButtonBlock',
+          parentBlockId: 'card1',
+          label: '',
+          submitEnabled: true
+        }
+      ]
+    } as any)
+
+    mockStreamText.mockReturnValueOnce({
+      elementStream: createMockAsyncIterator([
+        { blockId: 'button1', updates: { label: 'Enviar' } }
+      ])
+    } as any)
+
+    await authClient({
+      document: JOURNEY_AI_TRANSLATE_CREATE_MUTATION,
+      variables: { input: mockInput }
+    })
+
+    // The default is injected into the prompt sent to the model...
+    const prompt = (mockStreamText.mock.calls[0][0] as any).messages[1]
+      .content[0].text as string
+    expect(prompt).toContain('label: "Submit"')
+
+    // ...but only the translated value is written — the English default is never
+    // persisted (no extra database write).
+    expect(prismaMock.block.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: 'button1' }),
+        data: { label: 'Enviar' }
+      })
+    )
+    expect(prismaMock.block.update).not.toHaveBeenCalledWith(
+      expect.objectContaining({ data: { label: 'Submit' } })
+    )
+  })
+
+  it('injects the default "Button" label for an empty non-submit button', async () => {
+    prismaMock.journey.findUnique.mockResolvedValueOnce({
+      ...mockJourney,
+      blocks: [
+        { id: 'card1', typename: 'CardBlock', parentOrder: 0 },
+        {
+          id: 'button1',
+          typename: 'ButtonBlock',
+          parentBlockId: 'card1',
+          label: '',
+          submitEnabled: false
+        }
+      ]
+    } as any)
+
+    mockStreamText.mockReturnValueOnce({
+      elementStream: createMockAsyncIterator([
+        { blockId: 'button1', updates: { label: 'Botón' } }
+      ])
+    } as any)
+
+    await authClient({
+      document: JOURNEY_AI_TRANSLATE_CREATE_MUTATION,
+      variables: { input: mockInput }
+    })
+
+    const prompt = (mockStreamText.mock.calls[0][0] as any).messages[1]
+      .content[0].text as string
+    expect(prompt).toContain('label: "Button"')
+
+    expect(prismaMock.block.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: 'button1' }),
+        data: { label: 'Botón' }
+      })
+    )
+  })
+
+  it('injects the default submit label for a sign-up block with no submit text', async () => {
+    prismaMock.journey.findUnique.mockResolvedValueOnce({
+      ...mockJourney,
+      blocks: [
+        { id: 'card1', typename: 'CardBlock', parentOrder: 0 },
+        {
+          id: 'signup1',
+          typename: 'SignUpBlock',
+          parentBlockId: 'card1',
+          submitLabel: ''
+        }
+      ]
+    } as any)
+
+    mockStreamText.mockReturnValueOnce({
+      elementStream: createMockAsyncIterator([
+        { blockId: 'signup1', updates: { submitLabel: 'Enviar' } }
+      ])
+    } as any)
+
+    await authClient({
+      document: JOURNEY_AI_TRANSLATE_CREATE_MUTATION,
+      variables: { input: mockInput }
+    })
+
+    const prompt = (mockStreamText.mock.calls[0][0] as any).messages[1]
+      .content[0].text as string
+    expect(prompt).toContain('submitLabel: "Submit"')
+
+    expect(prismaMock.block.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: 'signup1' }),
+        data: { submitLabel: 'Enviar' }
+      })
+    )
+  })
+
+  it('leaves a button that already has a label untouched (uses its real text)', async () => {
+    prismaMock.journey.findUnique.mockResolvedValueOnce({
+      ...mockJourney,
+      blocks: [
+        { id: 'card1', typename: 'CardBlock', parentOrder: 0 },
+        {
+          id: 'button1',
+          typename: 'ButtonBlock',
+          parentBlockId: 'card1',
+          label: 'Watch now',
+          submitEnabled: false
+        }
+      ]
+    } as any)
+
+    mockStreamText.mockReturnValueOnce({
+      elementStream: createMockAsyncIterator([
+        { blockId: 'button1', updates: { label: 'Ver ahora' } }
+      ])
+    } as any)
+
+    await authClient({
+      document: JOURNEY_AI_TRANSLATE_CREATE_MUTATION,
+      variables: { input: mockInput }
+    })
+
+    const prompt = (mockStreamText.mock.calls[0][0] as any).messages[1]
+      .content[0].text as string
+    expect(prompt).toContain('label: "Watch now"')
+    expect(prompt).not.toContain('label: "Button"')
+  })
+
   it('translates both radio and multiselect option labels on the same card', async () => {
     prismaMock.journey.findUnique.mockResolvedValueOnce({
       ...mockJourney,

--- a/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.spec.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.spec.ts
@@ -167,6 +167,7 @@ describe('journeyAiTranslateCreate mutation', () => {
     analysis:
       'This journey is about example content. Cultural adaptations include...',
     title: 'Título del Viaje Traducido',
+    displayTitle: '',
     description: 'Descripción del viaje traducida',
     seoTitle: '',
     seoDescription: ''
@@ -682,6 +683,151 @@ describe('journeyAiTranslateCreate mutation', () => {
       }
     })
   })
+
+  it('translates displayTitle when the journey has one', async () => {
+    prismaMock.journey.findUnique.mockResolvedValueOnce({
+      ...mockJourney,
+      displayTitle: 'Original Display Title'
+    } as any)
+
+    mockTranslateJourneyMetadata.mockResolvedValueOnce({
+      ...mockAnalysisAndTranslation,
+      displayTitle: 'Título de Visualización Traducido'
+    })
+
+    await authClient({
+      document: JOURNEY_AI_TRANSLATE_CREATE_MUTATION,
+      variables: { input: mockInput }
+    })
+
+    // The journey's display title is forwarded for translation...
+    expect(mockTranslateJourneyMetadata).toHaveBeenCalledWith(
+      expect.objectContaining({
+        journeyDisplayTitle: 'Original Display Title'
+      })
+    )
+
+    // ...and written back to the journey.
+    expect(prismaMock.journey.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: mockInput.journeyId },
+        data: expect.objectContaining({
+          displayTitle: 'Título de Visualización Traducido'
+        })
+      })
+    )
+  })
+
+  it('does not set displayTitle when the journey has none', async () => {
+    await authClient({
+      document: JOURNEY_AI_TRANSLATE_CREATE_MUTATION,
+      variables: { input: mockInput }
+    })
+
+    expect(prismaMock.journey.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.not.objectContaining({
+          displayTitle: expect.anything()
+        })
+      })
+    )
+  })
+
+  it('re-requests blocks the model omits on the first attempt', async () => {
+    // First attempt translates only typography1 and omits the rest.
+    mockStreamText.mockReturnValueOnce({
+      elementStream: createMockAsyncIterator([
+        { blockId: 'typography1', updates: { content: 'Contenido traducido' } }
+      ])
+    } as any)
+    // Retry attempt returns the previously-omitted blocks.
+    mockStreamText.mockReturnValueOnce({
+      elementStream: createMockAsyncIterator([
+        { blockId: 'button1', updates: { label: 'Botón traducido' } },
+        { blockId: 'option1', updates: { label: 'Opción traducida' } },
+        {
+          blockId: 'text1',
+          updates: { label: 'Texto', placeholder: 'Escriba' }
+        }
+      ])
+    } as any)
+
+    await authClient({
+      document: JOURNEY_AI_TRANSLATE_CREATE_MUTATION,
+      variables: { input: mockInput }
+    })
+
+    // A second AI call is made to fetch the omitted blocks.
+    expect(mockStreamText).toHaveBeenCalledTimes(2)
+
+    // Every block ends up translated despite the first-attempt omission.
+    for (const id of ['typography1', 'button1', 'option1', 'text1']) {
+      expect(prismaMock.block.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id })
+        })
+      )
+    }
+  })
+
+  it('translates SignUpBlock submitLabel and TextResponseBlock hint', async () => {
+    prismaMock.journey.findUnique.mockResolvedValueOnce({
+      ...mockJourney,
+      blocks: [
+        { id: 'card1', typename: 'CardBlock', parentOrder: 0 },
+        {
+          id: 'signup1',
+          typename: 'SignUpBlock',
+          parentBlockId: 'card1',
+          submitLabel: 'Submit'
+        },
+        {
+          id: 'text1',
+          typename: 'TextResponseBlock',
+          parentBlockId: 'card1',
+          label: 'Name',
+          placeholder: 'Your name',
+          hint: 'We keep it private'
+        }
+      ]
+    } as any)
+
+    mockStreamText.mockReturnValueOnce({
+      elementStream: createMockAsyncIterator([
+        { blockId: 'signup1', updates: { submitLabel: 'Enviar' } },
+        {
+          blockId: 'text1',
+          updates: {
+            label: 'Nombre',
+            placeholder: 'Tu nombre',
+            hint: 'Lo mantenemos privado'
+          }
+        }
+      ])
+    } as any)
+
+    await authClient({
+      document: JOURNEY_AI_TRANSLATE_CREATE_MUTATION,
+      variables: { input: mockInput }
+    })
+
+    expect(prismaMock.block.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: 'signup1' }),
+        data: { submitLabel: 'Enviar' }
+      })
+    )
+    expect(prismaMock.block.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: 'text1' }),
+        data: {
+          label: 'Nombre',
+          placeholder: 'Tu nombre',
+          hint: 'Lo mantenemos privado'
+        }
+      })
+    )
+  })
 })
 
 describe('journeyAiTranslateCreateSubscription', () => {
@@ -783,6 +929,7 @@ describe('journeyAiTranslateCreateSubscription', () => {
     analysis:
       'This journey is about example content. Cultural adaptations include...',
     title: 'Título del Viaje Traducido',
+    displayTitle: 'Título de Visualización Traducido',
     description: 'Descripción del viaje traducida',
     seoTitle: 'Título SEO Traducido',
     seoDescription: 'Descripción SEO Traducida'

--- a/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.spec.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.spec.ts
@@ -733,6 +733,33 @@ describe('journeyAiTranslateCreate mutation', () => {
     )
   })
 
+  it('does not overwrite an existing displayTitle with an empty translation', async () => {
+    prismaMock.journey.findUnique.mockResolvedValueOnce({
+      ...mockJourney,
+      displayTitle: 'Original Display Title'
+    } as any)
+
+    // Translation came back empty for displayTitle (e.g. model omitted it).
+    mockTranslateJourneyMetadata.mockResolvedValueOnce({
+      ...mockAnalysisAndTranslation,
+      displayTitle: ''
+    })
+
+    await authClient({
+      document: JOURNEY_AI_TRANSLATE_CREATE_MUTATION,
+      variables: { input: mockInput }
+    })
+
+    // The real displayTitle must be preserved, not cleared.
+    expect(prismaMock.journey.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.not.objectContaining({
+          displayTitle: expect.anything()
+        })
+      })
+    )
+  })
+
   it('re-requests blocks the model omits on the first attempt', async () => {
     // First attempt translates only typography1 and omits the rest.
     mockStreamText.mockReturnValueOnce({

--- a/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.spec.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.spec.ts
@@ -972,6 +972,80 @@ describe('journeyAiTranslateCreate mutation', () => {
     )
   })
 
+  it('translates both radio and multiselect option labels on the same card', async () => {
+    prismaMock.journey.findUnique.mockResolvedValueOnce({
+      ...mockJourney,
+      blocks: [
+        { id: 'card1', typename: 'CardBlock', parentOrder: 0 },
+        {
+          id: 'radio1',
+          typename: 'RadioQuestionBlock',
+          parentBlockId: 'card1',
+          label: 'Pick one'
+        },
+        {
+          id: 'ropt1',
+          typename: 'RadioOptionBlock',
+          parentBlockId: 'radio1',
+          label: 'Red'
+        },
+        {
+          id: 'ropt2',
+          typename: 'RadioOptionBlock',
+          parentBlockId: 'radio1',
+          label: 'Blue'
+        },
+        {
+          id: 'multi1',
+          typename: 'MultiselectBlock',
+          parentBlockId: 'card1',
+          label: 'Pick any'
+        },
+        {
+          id: 'mopt1',
+          typename: 'MultiselectOptionBlock',
+          parentBlockId: 'multi1',
+          label: 'Cat'
+        },
+        {
+          id: 'mopt2',
+          typename: 'MultiselectOptionBlock',
+          parentBlockId: 'multi1',
+          label: 'Dog'
+        }
+      ]
+    } as any)
+
+    mockStreamText.mockReturnValueOnce({
+      elementStream: createMockAsyncIterator([
+        { blockId: 'ropt1', updates: { label: 'Rojo' } },
+        { blockId: 'ropt2', updates: { label: 'Azul' } },
+        { blockId: 'mopt1', updates: { label: 'Gato' } },
+        { blockId: 'mopt2', updates: { label: 'Perro' } }
+      ])
+    } as any)
+
+    await authClient({
+      document: JOURNEY_AI_TRANSLATE_CREATE_MUTATION,
+      variables: { input: mockInput }
+    })
+
+    const expected: Array<[string, string]> = [
+      ['ropt1', 'Rojo'],
+      ['ropt2', 'Azul'],
+      ['mopt1', 'Gato'],
+      ['mopt2', 'Perro']
+    ]
+    for (const [id, label] of expected) {
+      expect(prismaMock.block.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id }),
+          data: { label }
+        })
+      )
+    }
+  })
+
   it('collects and translates blocks nested deeper than one level under the card', async () => {
     prismaMock.journey.findUnique.mockResolvedValueOnce({
       ...mockJourney,

--- a/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.spec.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.spec.ts
@@ -856,6 +856,122 @@ describe('journeyAiTranslateCreate mutation', () => {
     )
   })
 
+  it('re-requests an individual field the model omits (field-level completeness)', async () => {
+    prismaMock.journey.findUnique.mockResolvedValueOnce({
+      ...mockJourney,
+      blocks: [
+        { id: 'card1', typename: 'CardBlock', parentOrder: 0 },
+        {
+          id: 'text1',
+          typename: 'TextResponseBlock',
+          parentBlockId: 'card1',
+          label: 'Name',
+          placeholder: 'Your name',
+          hint: 'We keep it private'
+        }
+      ]
+    } as any)
+
+    // First attempt translates label + placeholder but omits hint.
+    mockStreamText.mockReturnValueOnce({
+      elementStream: createMockAsyncIterator([
+        {
+          blockId: 'text1',
+          updates: { label: 'Nombre', placeholder: 'Tu nombre' }
+        }
+      ])
+    } as any)
+    // Retry returns the omitted hint.
+    mockStreamText.mockReturnValueOnce({
+      elementStream: createMockAsyncIterator([
+        { blockId: 'text1', updates: { hint: 'Lo mantenemos privado' } }
+      ])
+    } as any)
+
+    await authClient({
+      document: JOURNEY_AI_TRANSLATE_CREATE_MUTATION,
+      variables: { input: mockInput }
+    })
+
+    // A second call is made because hint was still missing after the first.
+    expect(mockStreamText).toHaveBeenCalledTimes(2)
+
+    // The retry prompt asks only for the missing hint field.
+    const retryPrompt = (mockStreamText.mock.calls[1][0] as any).messages[1]
+      .content[0].text as string
+    expect(retryPrompt).toContain('hint:')
+    expect(retryPrompt).not.toContain('label:')
+
+    // label + placeholder written first, hint written on the retry.
+    expect(prismaMock.block.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: 'text1' }),
+        data: { label: 'Nombre', placeholder: 'Tu nombre' }
+      })
+    )
+    expect(prismaMock.block.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: 'text1' }),
+        data: { hint: 'Lo mantenemos privado' }
+      })
+    )
+  })
+
+  it('escalates to a per-block request when batched passes keep omitting a block', async () => {
+    prismaMock.journey.findUnique.mockResolvedValueOnce({
+      ...mockJourney,
+      blocks: [
+        { id: 'card1', typename: 'CardBlock', parentOrder: 0 },
+        {
+          id: 'radio1',
+          typename: 'RadioQuestionBlock',
+          parentBlockId: 'card1',
+          label: 'Pick one'
+        },
+        {
+          id: 'option1',
+          typename: 'RadioOptionBlock',
+          parentBlockId: 'radio1',
+          label: 'Option A'
+        }
+      ]
+    } as any)
+
+    // Three batched passes all drop the option, then the per-block escalation
+    // request returns it.
+    mockStreamText
+      .mockReturnValueOnce({
+        elementStream: createMockAsyncIterator([])
+      } as any)
+      .mockReturnValueOnce({
+        elementStream: createMockAsyncIterator([])
+      } as any)
+      .mockReturnValueOnce({
+        elementStream: createMockAsyncIterator([])
+      } as any)
+      .mockReturnValueOnce({
+        elementStream: createMockAsyncIterator([
+          { blockId: 'option1', updates: { label: 'Opción A' } }
+        ])
+      } as any)
+
+    await authClient({
+      document: JOURNEY_AI_TRANSLATE_CREATE_MUTATION,
+      variables: { input: mockInput }
+    })
+
+    // 3 batched attempts + 1 per-block escalation attempt.
+    expect(mockStreamText).toHaveBeenCalledTimes(4)
+
+    // The option is ultimately translated.
+    expect(prismaMock.block.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: 'option1' }),
+        data: { label: 'Opción A' }
+      })
+    )
+  })
+
   it('translates MultiselectOptionBlock labels nested under a MultiselectBlock', async () => {
     prismaMock.journey.findUnique.mockResolvedValueOnce({
       ...mockJourney,

--- a/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.spec.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.spec.ts
@@ -972,6 +972,59 @@ describe('journeyAiTranslateCreate mutation', () => {
     )
   })
 
+  it('collects and translates blocks nested deeper than one level under the card', async () => {
+    prismaMock.journey.findUnique.mockResolvedValueOnce({
+      ...mockJourney,
+      blocks: [
+        { id: 'card1', typename: 'CardBlock', parentOrder: 0 },
+        {
+          id: 'wrapper1',
+          typename: 'MultiselectBlock',
+          parentBlockId: 'card1'
+        },
+        // A TypographyBlock two levels under the card (card → wrapper → text).
+        // The previous one-level collection would have missed this.
+        {
+          id: 'nestedtypo',
+          typename: 'TypographyBlock',
+          parentBlockId: 'wrapper1',
+          content: 'Nested text'
+        },
+        {
+          id: 'option1',
+          typename: 'MultiselectOptionBlock',
+          parentBlockId: 'wrapper1',
+          label: 'Opt'
+        }
+      ]
+    } as any)
+
+    mockStreamText.mockReturnValueOnce({
+      elementStream: createMockAsyncIterator([
+        { blockId: 'nestedtypo', updates: { content: 'Texto anidado' } },
+        { blockId: 'option1', updates: { label: 'Opción' } }
+      ])
+    } as any)
+
+    await authClient({
+      document: JOURNEY_AI_TRANSLATE_CREATE_MUTATION,
+      variables: { input: mockInput }
+    })
+
+    expect(prismaMock.block.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: 'nestedtypo' }),
+        data: { content: 'Texto anidado' }
+      })
+    )
+    expect(prismaMock.block.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: 'option1' }),
+        data: { label: 'Opción' }
+      })
+    )
+  })
+
   it('translates MultiselectOptionBlock labels nested under a MultiselectBlock', async () => {
     prismaMock.journey.findUnique.mockResolvedValueOnce({
       ...mockJourney,

--- a/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.spec.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.spec.ts
@@ -828,6 +828,57 @@ describe('journeyAiTranslateCreate mutation', () => {
       })
     )
   })
+
+  it('translates MultiselectOptionBlock labels nested under a MultiselectBlock', async () => {
+    prismaMock.journey.findUnique.mockResolvedValueOnce({
+      ...mockJourney,
+      blocks: [
+        { id: 'card1', typename: 'CardBlock', parentOrder: 0 },
+        {
+          id: 'multiselect1',
+          typename: 'MultiselectBlock',
+          parentBlockId: 'card1'
+        },
+        {
+          id: 'msoption1',
+          typename: 'MultiselectOptionBlock',
+          parentBlockId: 'multiselect1',
+          label: 'Red'
+        },
+        {
+          id: 'msoption2',
+          typename: 'MultiselectOptionBlock',
+          parentBlockId: 'multiselect1',
+          label: 'Blue'
+        }
+      ]
+    } as any)
+
+    mockStreamText.mockReturnValueOnce({
+      elementStream: createMockAsyncIterator([
+        { blockId: 'msoption1', updates: { label: 'Rojo' } },
+        { blockId: 'msoption2', updates: { label: 'Azul' } }
+      ])
+    } as any)
+
+    await authClient({
+      document: JOURNEY_AI_TRANSLATE_CREATE_MUTATION,
+      variables: { input: mockInput }
+    })
+
+    expect(prismaMock.block.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: 'msoption1' }),
+        data: { label: 'Rojo' }
+      })
+    )
+    expect(prismaMock.block.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: 'msoption2' }),
+        data: { label: 'Azul' }
+      })
+    )
+  })
 })
 
 describe('journeyAiTranslateCreateSubscription', () => {

--- a/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.spec.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.spec.ts
@@ -856,6 +856,54 @@ describe('journeyAiTranslateCreate mutation', () => {
     )
   })
 
+  it('does not write an empty translation and re-requests the field', async () => {
+    prismaMock.journey.findUnique.mockResolvedValueOnce({
+      ...mockJourney,
+      blocks: [
+        { id: 'card1', typename: 'CardBlock', parentOrder: 0 },
+        {
+          id: 'typography1',
+          typename: 'TypographyBlock',
+          parentBlockId: 'card1',
+          content: 'Hello'
+        }
+      ]
+    } as any)
+
+    // First attempt returns an empty string — a failed translation that must not
+    // blank the block or be treated as complete.
+    mockStreamText.mockReturnValueOnce({
+      elementStream: createMockAsyncIterator([
+        { blockId: 'typography1', updates: { content: '' } }
+      ])
+    } as any)
+    // Retry returns a real translation.
+    mockStreamText.mockReturnValueOnce({
+      elementStream: createMockAsyncIterator([
+        { blockId: 'typography1', updates: { content: 'Hola' } }
+      ])
+    } as any)
+
+    await authClient({
+      document: JOURNEY_AI_TRANSLATE_CREATE_MUTATION,
+      variables: { input: mockInput }
+    })
+
+    // The empty value is never written...
+    expect(prismaMock.block.update).not.toHaveBeenCalledWith(
+      expect.objectContaining({ data: { content: '' } })
+    )
+    // ...the field stays missing, so a second call is made and the real
+    // translation lands.
+    expect(mockStreamText).toHaveBeenCalledTimes(2)
+    expect(prismaMock.block.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: 'typography1' }),
+        data: { content: 'Hola' }
+      })
+    )
+  })
+
   it('re-requests an individual field the model omits (field-level completeness)', async () => {
     prismaMock.journey.findUnique.mockResolvedValueOnce({
       ...mockJourney,

--- a/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.ts
@@ -116,24 +116,29 @@ function getTranslatableBlocksForCard(
   allBlocks: Block[],
   cardBlock: Block
 ): Block[] {
-  const cardChildren = allBlocks.filter(
-    (block) => block.parentBlockId === cardBlock.id
-  )
+  const childrenByParent = new Map<string, Block[]>()
+  for (const block of allBlocks) {
+    if (block.parentBlockId == null) continue
+    const siblings = childrenByParent.get(block.parentBlockId) ?? []
+    siblings.push(block)
+    childrenByParent.set(block.parentBlockId, siblings)
+  }
 
-  // Option blocks are grandchildren of the card: RadioOptionBlocks hang off a
-  // RadioQuestionBlock and MultiselectOptionBlocks hang off a MultiselectBlock,
-  // both of which are direct card children. Collect them so their labels are
-  // translated too.
-  const nestedOptionBlocks = cardChildren.flatMap((child) =>
-    allBlocks.filter(
-      (block) =>
-        block.parentBlockId === child.id &&
-        (block.typename === 'RadioOptionBlock' ||
-          block.typename === 'MultiselectOptionBlock')
-    )
-  )
+  // Collect every descendant of the card, at any depth, so nested translatable
+  // content (e.g. RadioOptionBlocks under a RadioQuestionBlock, or
+  // MultiselectOptionBlocks under a MultiselectBlock) is never missed regardless
+  // of how deeply it is nested.
+  const descendants: Block[] = []
+  const stack = [...(childrenByParent.get(cardBlock.id) ?? [])]
+  while (stack.length > 0) {
+    const block = stack.pop()
+    if (block == null) continue
+    descendants.push(block)
+    const children = childrenByParent.get(block.id)
+    if (children != null) stack.push(...children)
+  }
 
-  return [...cardChildren, ...nestedOptionBlocks].filter((block) => {
+  return descendants.filter((block) => {
     const fields = getTranslatableFields(block)
     return Object.values(fields).some((v) => v != null && v !== '')
   })

--- a/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.ts
@@ -63,7 +63,9 @@ const BlockTranslationUpdatesSchema = z
   .object({
     content: z.string().optional(),
     label: z.string().optional(),
-    placeholder: z.string().optional()
+    placeholder: z.string().optional(),
+    hint: z.string().optional(),
+    submitLabel: z.string().optional()
   })
   .refine((updates) => Object.keys(updates).length > 0, {
     message: 'At least one supported update field is required'
@@ -82,7 +84,8 @@ const allowedTranslationFieldsByBlockType = {
   TypographyBlock: ['content'],
   ButtonBlock: ['label'],
   RadioOptionBlock: ['label'],
-  TextResponseBlock: ['label', 'placeholder']
+  TextResponseBlock: ['label', 'placeholder', 'hint'],
+  SignUpBlock: ['submitLabel']
 } as const satisfies Record<string, readonly TranslatableBlockField[]>
 
 function getValidatedBlockUpdates(
@@ -131,6 +134,137 @@ function getTranslatableBlocksForCard(
   })
 }
 
+// The model is asked to echo back one structured-output entry per block it is
+// given. It probabilistically omits some, so we re-request only the blocks that
+// were not translated, up to this many total attempts per card.
+const MAX_CARD_TRANSLATION_ATTEMPTS = 3
+
+interface TranslateBlocksArgs {
+  blocksToTranslate: Block[]
+  allBlocks: Block[]
+  cardBlockId: string
+  journeyId: string
+  cardContent: string
+  journeyAnalysis: string
+  sourceLanguageName: string
+  targetLanguageName: string
+  onBlockUpdated?: (
+    blockId: string,
+    updates: Partial<Record<TranslatableBlockField, string>>
+  ) => void
+  session: ReturnType<typeof createOpenrouterFallbackSession>
+}
+
+/**
+ * Streams translations for a specific set of blocks and writes each validated
+ * result to the database. Returns the IDs of the blocks that were actually
+ * translated so the caller can re-request the ones the model omitted.
+ *
+ * Never throws — a failed attempt resolves to whatever it managed to translate,
+ * leaving the rest for the caller's retry loop.
+ */
+async function translateBlocksOnce({
+  blocksToTranslate,
+  allBlocks,
+  cardBlockId,
+  journeyId,
+  cardContent,
+  journeyAnalysis,
+  sourceLanguageName,
+  targetLanguageName,
+  onBlockUpdated,
+  session
+}: TranslateBlocksArgs): Promise<Set<string>> {
+  const allowedBlockIds = new Set(blocksToTranslate.map((b) => b.id))
+  const updatedBlockIds = new Set<string>()
+  const blocksInfo = blocksToTranslate
+    .map((block) => createTranslationInfo(block))
+    .join('\n')
+
+  const prompt = `Context from journey analysis:
+${hardenPrompt(journeyAnalysis)}
+
+Translate from ${hardenPrompt(sourceLanguageName)} to ${hardenPrompt(targetLanguageName)}.
+
+Card context:
+${hardenPrompt(cardContent)}
+
+Blocks to translate (use the EXACT IDs shown in square brackets as blockId):
+${hardenPrompt(blocksInfo)}
+
+Return exactly one entry for every block ID listed above — do not skip, merge, or invent blocks. If a block does not need changes, still return it with its text translated.`
+
+  try {
+    await session.execute(async (model, abortSignal) => {
+      let streamError: unknown
+      const { elementStream } = streamText({
+        model,
+        abortSignal,
+        maxRetries: 0,
+        messages: [
+          { role: 'system', content: TRANSLATION_SYSTEM_PROMPT },
+          {
+            role: 'user',
+            content: [{ type: 'text', text: prompt }]
+          }
+        ],
+        output: Output.array({ element: BlockTranslationSchema }),
+        onError: ({ error }) => {
+          streamError = error
+          logger.warn(
+            { error, cardBlockId },
+            'Error in translation stream for card'
+          )
+        }
+      })
+
+      for await (const item of elementStream) {
+        try {
+          const cleanBlockId = item.blockId.replace(/^\[|\]$/g, '')
+
+          if (!allowedBlockIds.has(cleanBlockId)) continue
+          if (updatedBlockIds.has(cleanBlockId)) continue
+
+          const blockToUpdate = allBlocks.find((b) => b.id === cleanBlockId)
+          if (blockToUpdate == null) continue
+
+          const validatedUpdates = getValidatedBlockUpdates(
+            blockToUpdate,
+            item.updates
+          )
+          if (validatedUpdates == null) continue
+
+          await prisma.block.update({
+            where: { id: cleanBlockId, journeyId },
+            data: validatedUpdates
+          })
+
+          updatedBlockIds.add(cleanBlockId)
+          onBlockUpdated?.(cleanBlockId, validatedUpdates)
+        } catch (updateError) {
+          logger.error(
+            { error: updateError, blockId: item.blockId },
+            'Error updating block'
+          )
+        }
+      }
+
+      // The AI SDK reports stream failures to onError and ends the stream
+      // instead of throwing, which silently truncates the array. Re-throw so a
+      // fallback-eligible error (timeout/429/403) advances the session to the
+      // next model. Only escalate while blocks remain untranslated — a late
+      // error after every block landed is not worth a fallback round-trip.
+      if (streamError != null && updatedBlockIds.size < allowedBlockIds.size) {
+        throw streamError
+      }
+    })
+  } catch (error) {
+    logger.warn({ error, cardBlockId }, 'Card translation attempt failed')
+  }
+
+  return updatedBlockIds
+}
+
 async function translateCardBlocks({
   allBlocks,
   cardBlock,
@@ -158,72 +292,40 @@ async function translateCardBlocks({
   const blocksToTranslate = getTranslatableBlocksForCard(allBlocks, cardBlock)
   if (blocksToTranslate.length === 0) return
 
-  const allowedBlockIds = new Set(blocksToTranslate.map((b) => b.id))
-  const blocksInfo = blocksToTranslate
-    .map((block) => createTranslationInfo(block))
-    .join('\n')
+  const blocksById = new Map(blocksToTranslate.map((b) => [b.id, b]))
+  const pendingBlockIds = new Set(blocksById.keys())
 
-  const prompt = `Context from journey analysis:
-${hardenPrompt(journeyAnalysis)}
+  for (
+    let attempt = 1;
+    attempt <= MAX_CARD_TRANSLATION_ATTEMPTS && pendingBlockIds.size > 0;
+    attempt++
+  ) {
+    const pendingBlocks = Array.from(pendingBlockIds, (id) =>
+      blocksById.get(id)
+    ).filter((block): block is Block => block != null)
 
-Translate from ${hardenPrompt(sourceLanguageName)} to ${hardenPrompt(targetLanguageName)}.
-
-Card context:
-${hardenPrompt(cardContent)}
-
-Blocks to translate (use the EXACT IDs shown in square brackets as blockId):
-${hardenPrompt(blocksInfo)}`
-
-  await session.execute(async (model, abortSignal) => {
-    const { elementStream } = streamText({
-      model,
-      abortSignal,
-      maxRetries: 0,
-      messages: [
-        { role: 'system', content: TRANSLATION_SYSTEM_PROMPT },
-        {
-          role: 'user',
-          content: [{ type: 'text', text: prompt }]
-        }
-      ],
-      output: Output.array({ element: BlockTranslationSchema }),
-      onError: ({ error }) => {
-        logger.warn(
-          { error, cardBlockId: cardBlock.id },
-          'Error in translation stream for card'
-        )
-      }
+    const updatedBlockIds = await translateBlocksOnce({
+      blocksToTranslate: pendingBlocks,
+      allBlocks,
+      cardBlockId: cardBlock.id,
+      journeyId,
+      cardContent,
+      journeyAnalysis,
+      sourceLanguageName,
+      targetLanguageName,
+      onBlockUpdated,
+      session
     })
 
-    for await (const item of elementStream) {
-      try {
-        const cleanBlockId = item.blockId.replace(/^\[|\]$/g, '')
+    for (const id of updatedBlockIds) pendingBlockIds.delete(id)
+  }
 
-        if (!allowedBlockIds.has(cleanBlockId)) continue
-
-        const blockToUpdate = allBlocks.find((b) => b.id === cleanBlockId)
-        if (blockToUpdate == null) continue
-
-        const validatedUpdates = getValidatedBlockUpdates(
-          blockToUpdate,
-          item.updates
-        )
-        if (validatedUpdates == null) continue
-
-        await prisma.block.update({
-          where: { id: cleanBlockId, journeyId },
-          data: validatedUpdates
-        })
-
-        onBlockUpdated?.(cleanBlockId, validatedUpdates)
-      } catch (updateError) {
-        logger.error(
-          { error: updateError, blockId: item.blockId },
-          'Error updating block'
-        )
-      }
-    }
-  })
+  if (pendingBlockIds.size > 0) {
+    logger.warn(
+      { cardBlockId: cardBlock.id, missingBlockIds: Array.from(pendingBlockIds) },
+      'Card translation incomplete: some blocks were not translated after retries'
+    )
+  }
 }
 
 // Define the shared input type
@@ -359,6 +461,7 @@ builder.subscriptionField('journeyAiTranslateCreateSubscription', (t) =>
           sourceLanguageName: input.journeyLanguageName,
           targetLanguageName: input.textLanguageName,
           journeyTitle: input.name,
+          journeyDisplayTitle: journey.displayTitle,
           journeyDescription: journey.description,
           seoTitle: journey.seoTitle,
           seoDescription: journey.seoDescription,
@@ -430,6 +533,7 @@ builder.subscriptionField('journeyAiTranslateCreateSubscription', (t) =>
         const updateData: {
           title: string
           languageId: string
+          displayTitle?: string
           description?: string
           seoTitle?: string
           seoDescription?: string
@@ -437,6 +541,10 @@ builder.subscriptionField('journeyAiTranslateCreateSubscription', (t) =>
         } = {
           title: analysisResult.title,
           languageId: input.textLanguageId
+        }
+
+        if (journey.displayTitle && analysisResult.displayTitle) {
+          updateData.displayTitle = analysisResult.displayTitle
         }
 
         if (hasDescription && analysisResult.description) {
@@ -639,6 +747,7 @@ builder.mutationField('journeyAiTranslateCreate', (t) =>
           sourceLanguageName,
           targetLanguageName,
           journeyTitle: input.name,
+          journeyDisplayTitle: journey.displayTitle,
           journeyDescription: journey.description,
           seoTitle: journey.seoTitle,
           seoDescription: journey.seoDescription,
@@ -696,6 +805,10 @@ builder.mutationField('journeyAiTranslateCreate', (t) =>
           where: { id: input.journeyId },
           data: {
             title: analysisAndTranslation.title,
+            // Only update displayTitle if the original journey had one
+            ...(journey.displayTitle
+              ? { displayTitle: analysisAndTranslation.displayTitle }
+              : {}),
             // Only update description if the original journey had one
             ...(hasDescription
               ? { description: analysisAndTranslation.description }

--- a/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.ts
@@ -284,8 +284,7 @@ Return exactly one entry for every block ID listed above, and translate every fi
           // Only write fields we asked for this pass and have not already
           // written, so a later retry can't overwrite an earlier field's value.
           const alreadyWritten =
-            writtenFields.get(cleanBlockId) ??
-            new Set<TranslatableBlockField>()
+            writtenFields.get(cleanBlockId) ?? new Set<TranslatableBlockField>()
           const updates = Object.fromEntries(
             Object.entries(validatedUpdates).filter(
               ([field]) =>
@@ -301,7 +300,9 @@ Return exactly one entry for every block ID listed above, and translate every fi
             data: updates
           })
 
-          for (const field of Object.keys(updates) as TranslatableBlockField[]) {
+          for (const field of Object.keys(
+            updates
+          ) as TranslatableBlockField[]) {
             alreadyWritten.add(field)
           }
           writtenFields.set(cleanBlockId, alreadyWritten)
@@ -392,7 +393,10 @@ async function translateCardBlocks({
     blockIds: string[]
   ): Promise<Map<string, Set<TranslatableBlockField>>> => {
     const requests = blockIds
-      .map((id) => ({ block: blocksById.get(id), fields: missingFieldsFor(id) }))
+      .map((id) => ({
+        block: blocksById.get(id),
+        fields: missingFieldsFor(id)
+      }))
       .filter(
         (request): request is BlockTranslationRequest =>
           request.block != null && request.fields.length > 0

--- a/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.ts
@@ -165,8 +165,10 @@ interface TranslateBlocksArgs {
  * result to the database. Returns the IDs of the blocks that were actually
  * translated so the caller can re-request the ones the model omitted.
  *
- * Never throws — a failed attempt resolves to whatever it managed to translate,
- * leaving the rest for the caller's retry loop.
+ * Always resolves (never rejects) — although a fallback-eligible stream error is
+ * re-thrown internally to advance the session to the next model, the outer
+ * try/catch absorbs it, so a failed attempt resolves to whatever it managed to
+ * translate and leaves the rest for the caller's retry loop.
  */
 async function translateBlocksOnce({
   blocksToTranslate,

--- a/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.ts
@@ -103,7 +103,13 @@ function getValidatedBlockUpdates(
   const validatedUpdates = Object.fromEntries(
     allowedFields.flatMap((field) => {
       const value = updates[field]
-      return typeof value === 'string' ? [[field, value]] : []
+      // Reject empty / whitespace-only translations: every requested field has a
+      // non-empty source, so an empty return is a failed translation. Dropping
+      // it here avoids blanking the block and keeps the field "missing" so the
+      // retry/escalation loop re-requests it.
+      return typeof value === 'string' && value.trim() !== ''
+        ? [[field, value]]
+        : []
     })
   ) as Partial<Record<TranslatableBlockField, string>>
 

--- a/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.ts
@@ -813,8 +813,10 @@ builder.mutationField('journeyAiTranslateCreate', (t) =>
           where: { id: input.journeyId },
           data: {
             title: analysisAndTranslation.title,
-            // Only update displayTitle if the original journey had one
-            ...(journey.displayTitle
+            // Only update displayTitle if the original journey had one and a
+            // non-empty translation came back, so an omitted translation never
+            // clears an existing displayTitle (matches the subscription path).
+            ...(journey.displayTitle && analysisAndTranslation.displayTitle
               ? { displayTitle: analysisAndTranslation.displayTitle }
               : {}),
             // Only update description if the original journey had one

--- a/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.ts
@@ -112,6 +112,30 @@ function getValidatedBlockUpdates(
 
 // --- Shared helpers for mutation and subscription ---
 
+// Buttons and sign-up submit buttons render a UI-language fallback ("Submit" /
+// "Button", see libs/journeys/ui Button.tsx / SignUp.tsx) when their label is
+// blank. That default text is never stored on the block, so it never reaches
+// the AI and stays English for the 33 languages the i18n dictionary doesn't
+// cover. Fill the blank with its canonical default for translation purposes
+// ONLY — this returns a clone used to build the prompt; the default itself is
+// never written to the database. The model's translated value lands on the real
+// block through the normal write path, so no extra database call is needed.
+function withDefaultButtonLabel(block: Block): Block {
+  if (
+    block.typename === 'ButtonBlock' &&
+    (block.label == null || block.label === '')
+  ) {
+    return { ...block, label: block.submitEnabled ? 'Submit' : 'Button' }
+  }
+  if (
+    block.typename === 'SignUpBlock' &&
+    (block.submitLabel == null || block.submitLabel === '')
+  ) {
+    return { ...block, submitLabel: 'Submit' }
+  }
+  return block
+}
+
 function getTranslatableBlocksForCard(
   allBlocks: Block[],
   cardBlock: Block
@@ -138,7 +162,7 @@ function getTranslatableBlocksForCard(
     if (children != null) stack.push(...children)
   }
 
-  return descendants.filter((block) => {
+  return descendants.map(withDefaultButtonLabel).filter((block) => {
     const fields = getTranslatableFields(block)
     return Object.values(fields).some((v) => v != null && v !== '')
   })

--- a/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.ts
@@ -322,7 +322,10 @@ async function translateCardBlocks({
 
   if (pendingBlockIds.size > 0) {
     logger.warn(
-      { cardBlockId: cardBlock.id, missingBlockIds: Array.from(pendingBlockIds) },
+      {
+        cardBlockId: cardBlock.id,
+        missingBlockIds: Array.from(pendingBlockIds)
+      },
       'Card translation incomplete: some blocks were not translated after retries'
     )
   }

--- a/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.ts
@@ -84,6 +84,7 @@ const allowedTranslationFieldsByBlockType = {
   TypographyBlock: ['content'],
   ButtonBlock: ['label'],
   RadioOptionBlock: ['label'],
+  MultiselectOptionBlock: ['label'],
   TextResponseBlock: ['label', 'placeholder', 'hint'],
   SignUpBlock: ['submitLabel']
 } as const satisfies Record<string, readonly TranslatableBlockField[]>
@@ -119,16 +120,20 @@ function getTranslatableBlocksForCard(
     (block) => block.parentBlockId === cardBlock.id
   )
 
-  const radioOptionBlocks = cardChildren
-    .filter((block) => block.typename === 'RadioQuestionBlock')
-    .flatMap((rq) =>
-      allBlocks.filter(
-        (block) =>
-          block.parentBlockId === rq.id && block.typename === 'RadioOptionBlock'
-      )
+  // Option blocks are grandchildren of the card: RadioOptionBlocks hang off a
+  // RadioQuestionBlock and MultiselectOptionBlocks hang off a MultiselectBlock,
+  // both of which are direct card children. Collect them so their labels are
+  // translated too.
+  const nestedOptionBlocks = cardChildren.flatMap((child) =>
+    allBlocks.filter(
+      (block) =>
+        block.parentBlockId === child.id &&
+        (block.typename === 'RadioOptionBlock' ||
+          block.typename === 'MultiselectOptionBlock')
     )
+  )
 
-  return [...cardChildren, ...radioOptionBlocks].filter((block) => {
+  return [...cardChildren, ...nestedOptionBlocks].filter((block) => {
     const fields = getTranslatableFields(block)
     return Object.values(fields).some((v) => v != null && v !== '')
   })

--- a/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/journeyAiTranslate.ts
@@ -139,13 +139,21 @@ function getTranslatableBlocksForCard(
   })
 }
 
-// The model is asked to echo back one structured-output entry per block it is
-// given. It probabilistically omits some, so we re-request only the blocks that
-// were not translated, up to this many total attempts per card.
-const MAX_CARD_TRANSLATION_ATTEMPTS = 3
+// Per-card translation is resilient to the model omitting whole blocks OR
+// individual fields from its structured output. We make a few batched passes
+// re-requesting only the still-missing fields, then escalate any stubborn block
+// to its own isolated request — a one-block request cannot be dropped off the
+// tail of a long array or merged into a sibling's entry.
+const MAX_CARD_BATCH_ATTEMPTS = 3
+const MAX_PER_BLOCK_ATTEMPTS = 2
+
+interface BlockTranslationRequest {
+  block: Block
+  fields: TranslatableBlockField[]
+}
 
 interface TranslateBlocksArgs {
-  blocksToTranslate: Block[]
+  requests: BlockTranslationRequest[]
   allBlocks: Block[]
   cardBlockId: string
   journeyId: string
@@ -161,9 +169,28 @@ interface TranslateBlocksArgs {
 }
 
 /**
- * Streams translations for a specific set of blocks and writes each validated
- * result to the database. Returns the IDs of the blocks that were actually
- * translated so the caller can re-request the ones the model omitted.
+ * The translatable fields of a block that actually carry a source value,
+ * restricted to the fields allowed for that block type. These are the fields a
+ * complete translation must cover.
+ */
+function getRequiredFields(block: Block): TranslatableBlockField[] {
+  const allowedFields =
+    allowedTranslationFieldsByBlockType[
+      block.typename as keyof typeof allowedTranslationFieldsByBlockType
+    ]
+  if (allowedFields == null) return []
+
+  const fields = getTranslatableFields(block)
+  return allowedFields.filter((field) => {
+    const value = fields[field]
+    return value != null && value !== ''
+  })
+}
+
+/**
+ * Streams translations for a specific set of (block, fields) requests and writes
+ * each validated result to the database. Returns, per block, the set of fields
+ * that were actually written this pass so the caller can re-request the rest.
  *
  * Always resolves (never rejects) — although a fallback-eligible stream error is
  * re-thrown internally to advance the session to the next model, the outer
@@ -171,7 +198,7 @@ interface TranslateBlocksArgs {
  * translate and leaves the rest for the caller's retry loop.
  */
 async function translateBlocksOnce({
-  blocksToTranslate,
+  requests,
   allBlocks,
   cardBlockId,
   journeyId,
@@ -181,11 +208,24 @@ async function translateBlocksOnce({
   targetLanguageName,
   onBlockUpdated,
   session
-}: TranslateBlocksArgs): Promise<Set<string>> {
-  const allowedBlockIds = new Set(blocksToTranslate.map((b) => b.id))
-  const updatedBlockIds = new Set<string>()
-  const blocksInfo = blocksToTranslate
-    .map((block) => createTranslationInfo(block))
+}: TranslateBlocksArgs): Promise<Map<string, Set<TranslatableBlockField>>> {
+  const requestedFieldsByBlock = new Map(
+    requests.map((request) => [
+      request.block.id,
+      new Set<TranslatableBlockField>(request.fields)
+    ])
+  )
+  const writtenFields = new Map<string, Set<TranslatableBlockField>>()
+  const totalRequested = requests.reduce(
+    (sum, request) => sum + request.fields.length,
+    0
+  )
+  let totalWritten = 0
+
+  if (totalRequested === 0) return writtenFields
+
+  const blocksInfo = requests
+    .map((request) => createTranslationInfo(request.block, request.fields))
     .join('\n')
 
   const prompt = `Context from journey analysis:
@@ -199,7 +239,7 @@ ${hardenPrompt(cardContent)}
 Blocks to translate (use the EXACT IDs shown in square brackets as blockId):
 ${hardenPrompt(blocksInfo)}
 
-Return exactly one entry for every block ID listed above — do not skip, merge, or invent blocks. If a block does not need changes, still return it with its text translated.`
+Return exactly one entry for every block ID listed above, and translate every field shown for it — do not skip, merge, or invent blocks or fields.`
 
   try {
     await session.execute(async (model, abortSignal) => {
@@ -229,8 +269,8 @@ Return exactly one entry for every block ID listed above — do not skip, merge,
         try {
           const cleanBlockId = item.blockId.replace(/^\[|\]$/g, '')
 
-          if (!allowedBlockIds.has(cleanBlockId)) continue
-          if (updatedBlockIds.has(cleanBlockId)) continue
+          const requestedFields = requestedFieldsByBlock.get(cleanBlockId)
+          if (requestedFields == null) continue
 
           const blockToUpdate = allBlocks.find((b) => b.id === cleanBlockId)
           if (blockToUpdate == null) continue
@@ -241,13 +281,33 @@ Return exactly one entry for every block ID listed above — do not skip, merge,
           )
           if (validatedUpdates == null) continue
 
+          // Only write fields we asked for this pass and have not already
+          // written, so a later retry can't overwrite an earlier field's value.
+          const alreadyWritten =
+            writtenFields.get(cleanBlockId) ??
+            new Set<TranslatableBlockField>()
+          const updates = Object.fromEntries(
+            Object.entries(validatedUpdates).filter(
+              ([field]) =>
+                requestedFields.has(field as TranslatableBlockField) &&
+                !alreadyWritten.has(field as TranslatableBlockField)
+            )
+          ) as Partial<Record<TranslatableBlockField, string>>
+
+          if (Object.keys(updates).length === 0) continue
+
           await prisma.block.update({
             where: { id: cleanBlockId, journeyId },
-            data: validatedUpdates
+            data: updates
           })
 
-          updatedBlockIds.add(cleanBlockId)
-          onBlockUpdated?.(cleanBlockId, validatedUpdates)
+          for (const field of Object.keys(updates) as TranslatableBlockField[]) {
+            alreadyWritten.add(field)
+          }
+          writtenFields.set(cleanBlockId, alreadyWritten)
+          totalWritten += Object.keys(updates).length
+
+          onBlockUpdated?.(cleanBlockId, updates)
         } catch (updateError) {
           logger.error(
             { error: updateError, blockId: item.blockId },
@@ -259,9 +319,9 @@ Return exactly one entry for every block ID listed above — do not skip, merge,
       // The AI SDK reports stream failures to onError and ends the stream
       // instead of throwing, which silently truncates the array. Re-throw so a
       // fallback-eligible error (timeout/429/403) advances the session to the
-      // next model. Only escalate while blocks remain untranslated — a late
-      // error after every block landed is not worth a fallback round-trip.
-      if (streamError != null && updatedBlockIds.size < allowedBlockIds.size) {
+      // next model. Only escalate while fields remain untranslated — a late
+      // error after everything landed is not worth a fallback round-trip.
+      if (streamError != null && totalWritten < totalRequested) {
         throw streamError
       }
     })
@@ -269,7 +329,7 @@ Return exactly one entry for every block ID listed above — do not skip, merge,
     logger.warn({ error, cardBlockId }, 'Card translation attempt failed')
   }
 
-  return updatedBlockIds
+  return writtenFields
 }
 
 async function translateCardBlocks({
@@ -300,19 +360,46 @@ async function translateCardBlocks({
   if (blocksToTranslate.length === 0) return
 
   const blocksById = new Map(blocksToTranslate.map((b) => [b.id, b]))
-  const pendingBlockIds = new Set(blocksById.keys())
+  const requiredFieldsByBlock = new Map(
+    blocksToTranslate.map((b) => [b.id, getRequiredFields(b)])
+  )
+  const translatedFieldsByBlock = new Map<string, Set<TranslatableBlockField>>(
+    blocksToTranslate.map((b) => [b.id, new Set()])
+  )
 
-  for (
-    let attempt = 1;
-    attempt <= MAX_CARD_TRANSLATION_ATTEMPTS && pendingBlockIds.size > 0;
-    attempt++
-  ) {
-    const pendingBlocks = Array.from(pendingBlockIds, (id) =>
-      blocksById.get(id)
-    ).filter((block): block is Block => block != null)
+  const missingFieldsFor = (blockId: string): TranslatableBlockField[] => {
+    const required = requiredFieldsByBlock.get(blockId) ?? []
+    const done = translatedFieldsByBlock.get(blockId) ?? new Set()
+    return required.filter((field) => !done.has(field))
+  }
 
-    const updatedBlockIds = await translateBlocksOnce({
-      blocksToTranslate: pendingBlocks,
+  const incompleteBlockIds = (): string[] =>
+    Array.from(blocksById.keys()).filter(
+      (id) => missingFieldsFor(id).length > 0
+    )
+
+  const recordWritten = (
+    written: Map<string, Set<TranslatableBlockField>>
+  ): void => {
+    for (const [blockId, fields] of written) {
+      const done = translatedFieldsByBlock.get(blockId)
+      if (done == null) continue
+      for (const field of fields) done.add(field)
+    }
+  }
+
+  const translate = (
+    blockIds: string[]
+  ): Promise<Map<string, Set<TranslatableBlockField>>> => {
+    const requests = blockIds
+      .map((id) => ({ block: blocksById.get(id), fields: missingFieldsFor(id) }))
+      .filter(
+        (request): request is BlockTranslationRequest =>
+          request.block != null && request.fields.length > 0
+      )
+
+    return translateBlocksOnce({
+      requests,
       allBlocks,
       cardBlockId: cardBlock.id,
       journeyId,
@@ -323,17 +410,47 @@ async function translateCardBlocks({
       onBlockUpdated,
       session
     })
-
-    for (const id of updatedBlockIds) pendingBlockIds.delete(id)
   }
 
-  if (pendingBlockIds.size > 0) {
+  // Phase 1: batched passes — one request covering every still-missing field
+  // across the card. Handles the common case cheaply.
+  for (
+    let attempt = 1;
+    attempt <= MAX_CARD_BATCH_ATTEMPTS && incompleteBlockIds().length > 0;
+    attempt++
+  ) {
+    recordWritten(await translate(incompleteBlockIds()))
+  }
+
+  // Phase 2: per-block escalation — translate each stubborn block on its own,
+  // requesting only the fields still missing.
+  const stubbornBlockIds = incompleteBlockIds()
+  if (stubbornBlockIds.length > 0) {
+    await Promise.all(
+      stubbornBlockIds.map(async (blockId) => {
+        for (
+          let attempt = 1;
+          attempt <= MAX_PER_BLOCK_ATTEMPTS &&
+          missingFieldsFor(blockId).length > 0;
+          attempt++
+        ) {
+          recordWritten(await translate([blockId]))
+        }
+      })
+    )
+  }
+
+  const stillMissing = incompleteBlockIds()
+  if (stillMissing.length > 0) {
     logger.warn(
       {
         cardBlockId: cardBlock.id,
-        missingBlockIds: Array.from(pendingBlockIds)
+        missing: stillMissing.map((id) => ({
+          blockId: id,
+          fields: missingFieldsFor(id)
+        }))
       },
-      'Card translation incomplete: some blocks were not translated after retries'
+      'Card translation incomplete: some block fields were not translated after retries and escalation'
     )
   }
 }

--- a/apis/api-journeys/src/schema/journeyAiTranslate/translateJourneyMetadata/translateJourneyMetadata.spec.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/translateJourneyMetadata/translateJourneyMetadata.spec.ts
@@ -55,6 +55,9 @@ function defaultImplementation(): void {
     if (text.includes('produce only the analysis')) {
       return aiResult({ analysis: 'ANALYSIS CONTEXT' })
     }
+    if (text.includes('Translate the journey display title below')) {
+      return aiResult({ translation: 'Título visible traducido' })
+    }
     if (text.includes('Translate the journey title below')) {
       return aiResult({ translation: 'Título traducido' })
     }
@@ -75,6 +78,7 @@ const baseInput = {
   sourceLanguageName: 'English',
   targetLanguageName: 'Spanish',
   journeyTitle: 'My Journey Title',
+  journeyDisplayTitle: 'My Display Title',
   journeyDescription: 'My journey description',
   seoTitle: 'My SEO Title',
   seoDescription: 'My SEO Description',
@@ -94,6 +98,7 @@ describe('translateJourneyMetadata', () => {
     expect(result).toEqual({
       analysis: 'ANALYSIS CONTEXT',
       title: 'Título traducido',
+      displayTitle: 'Título visible traducido',
       description: 'Descripción traducida',
       seoTitle: 'Título SEO traducido',
       seoDescription: 'Descripción SEO traducida'
@@ -133,7 +138,7 @@ describe('translateJourneyMetadata', () => {
       (call) => !promptOf(call).includes('produce only the analysis')
     )
 
-    expect(fieldCalls).toHaveLength(4)
+    expect(fieldCalls).toHaveLength(5)
     for (const call of fieldCalls) {
       expect(promptOf(call)).toContain('<hardened>ANALYSIS CONTEXT</hardened>')
     }
@@ -142,12 +147,14 @@ describe('translateJourneyMetadata', () => {
   it('returns empty strings for absent fields without making AI calls for them', async () => {
     const result = await translateJourneyMetadata({
       ...baseInput,
+      journeyDisplayTitle: null,
       journeyDescription: null,
       seoTitle: null,
       seoDescription: '   '
     })
 
     expect(result.title).toBe('Título traducido')
+    expect(result.displayTitle).toBe('')
     expect(result.description).toBe('')
     expect(result.seoTitle).toBe('')
     expect(result.seoDescription).toBe('')
@@ -170,6 +177,7 @@ describe('translateJourneyMetadata', () => {
 
     const result = await translateJourneyMetadata({
       ...baseInput,
+      journeyDisplayTitle: null,
       seoTitle: null,
       seoDescription: null
     })

--- a/apis/api-journeys/src/schema/journeyAiTranslate/translateJourneyMetadata/translateJourneyMetadata.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/translateJourneyMetadata/translateJourneyMetadata.ts
@@ -131,6 +131,7 @@ ${hardenPrompt(value)}`
 export interface JourneyMetadataTranslation {
   analysis: string
   title: string
+  displayTitle: string
   description: string
   seoTitle: string
   seoDescription: string
@@ -148,6 +149,7 @@ export async function translateJourneyMetadata({
   sourceLanguageName,
   targetLanguageName,
   journeyTitle,
+  journeyDisplayTitle,
   journeyDescription,
   seoTitle,
   seoDescription,
@@ -157,12 +159,14 @@ export async function translateJourneyMetadata({
   sourceLanguageName: string
   targetLanguageName: string
   journeyTitle: string
+  journeyDisplayTitle: string | null
   journeyDescription: string | null
   seoTitle: string | null
   seoDescription: string | null
   cardBlocksContent: string[]
   session: OpenrouterFallbackSession
 }): Promise<JourneyMetadataTranslation> {
+  const trimmedDisplayTitle = journeyDisplayTitle?.trim() ?? ''
   const trimmedDescription = journeyDescription?.trim() ?? ''
   const trimmedSeoTitle = seoTitle?.trim() ?? ''
   const trimmedSeoDescription = seoDescription?.trim() ?? ''
@@ -196,51 +200,67 @@ export async function translateJourneyMetadata({
 
   const analysis = analysisOutput.analysis
 
-  const [title, description, translatedSeoTitle, translatedSeoDescription] =
-    await Promise.all([
-      translateJourneyField({
-        fieldName: 'journey title',
-        value: journeyTitle,
-        sourceLanguageName,
-        targetLanguageName,
-        journeyAnalysis: analysis,
-        session
-      }),
-      trimmedDescription
-        ? translateJourneyField({
-            fieldName: 'journey description',
-            value: trimmedDescription,
-            sourceLanguageName,
-            targetLanguageName,
-            journeyAnalysis: analysis,
-            session
-          })
-        : Promise.resolve(''),
-      trimmedSeoTitle
-        ? translateJourneyField({
-            fieldName: 'SEO title',
-            value: trimmedSeoTitle,
-            sourceLanguageName,
-            targetLanguageName,
-            journeyAnalysis: analysis,
-            session
-          })
-        : Promise.resolve(''),
-      trimmedSeoDescription
-        ? translateJourneyField({
-            fieldName: 'SEO description',
-            value: trimmedSeoDescription,
-            sourceLanguageName,
-            targetLanguageName,
-            journeyAnalysis: analysis,
-            session
-          })
-        : Promise.resolve('')
-    ])
+  const [
+    title,
+    displayTitle,
+    description,
+    translatedSeoTitle,
+    translatedSeoDescription
+  ] = await Promise.all([
+    translateJourneyField({
+      fieldName: 'journey title',
+      value: journeyTitle,
+      sourceLanguageName,
+      targetLanguageName,
+      journeyAnalysis: analysis,
+      session
+    }),
+    trimmedDisplayTitle
+      ? translateJourneyField({
+          fieldName: 'journey display title',
+          value: trimmedDisplayTitle,
+          sourceLanguageName,
+          targetLanguageName,
+          journeyAnalysis: analysis,
+          session
+        })
+      : Promise.resolve(''),
+    trimmedDescription
+      ? translateJourneyField({
+          fieldName: 'journey description',
+          value: trimmedDescription,
+          sourceLanguageName,
+          targetLanguageName,
+          journeyAnalysis: analysis,
+          session
+        })
+      : Promise.resolve(''),
+    trimmedSeoTitle
+      ? translateJourneyField({
+          fieldName: 'SEO title',
+          value: trimmedSeoTitle,
+          sourceLanguageName,
+          targetLanguageName,
+          journeyAnalysis: analysis,
+          session
+        })
+      : Promise.resolve(''),
+    trimmedSeoDescription
+      ? translateJourneyField({
+          fieldName: 'SEO description',
+          value: trimmedSeoDescription,
+          sourceLanguageName,
+          targetLanguageName,
+          journeyAnalysis: analysis,
+          session
+        })
+      : Promise.resolve('')
+  ])
 
   return {
     analysis,
     title,
+    displayTitle,
     description,
     seoTitle: translatedSeoTitle,
     seoDescription: translatedSeoDescription


### PR DESCRIPTION
## Problem

Linear: [QA-493](https://linear.app/jesus-film-project/issue/QA-493/nextsteps-translation-not-working-for-a-page)

AI translation of a journey was flaky — Typography blocks, radio options, display titles, and other fields intermittently stayed in the source language, with no reliable repro.

The cause was architectural, not the prompt. Each card's blocks were translated in a single streamed AI call, and the code applied whatever came back while **trusting the model to return an entry for every block**. Models routinely omit items from long structured-array outputs, so omissions were silently dropped — worst on content-heavy cards. Two aggravators: `onError` swallowed mid-stream failures (truncating the array without throwing, so no retry/fallback fired), and `Journey.displayTitle` was never sent for translation at all.

## What changed

All in `apis/api-journeys/src/schema/journeyAiTranslate/`:

1. **Completeness/verify-retry loop** — after each card's stream, compare requested vs. returned blocks and re-request **only the omitted ones** (up to 3 attempts), logging any that still fail. Core fix for the flaky gaps.
2. **Stop swallowing stream errors** — surface mid-stream failures so fallback-eligible errors (timeout/429/403) advance to the next model instead of silently truncating.
3. **Translate `displayTitle`** — added as its own isolated single-field translation, written back in both the mutation and subscription paths.
4. **Added missing translatable fields** — `SignUpBlock.submitLabel` and `TextResponseBlock.hint` (translatable in schema but previously excluded).
5. **Prompt hardening** — require one entry per listed block id.
6. **Radio context fix** — `getRadioQuestionBlockContent` now lists the question's own option labels as context instead of sibling question labels.

No schema/GraphQL changes were needed — all fields already exist in Prisma.

## Testing

All 80 tests in the `journeyAiTranslate` suite pass, including new tests for displayTitle translation, the omit-then-retry path, and the new submitLabel/hint fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added translation support for journey `displayTitle`.
  * Added/expanded card-block translation for additional fields (text placeholder/hint, sign-up submit label) and option labels in multiselect/radio.
* **Bug Fixes**
  * Improved AI translation reliability with field-level completeness tracking, retries, and escalation when fields are omitted.
  * Prevented empty/whitespace translations from being written; card/block traversal now covers all translatable descendants.
  * Ensured blank labels use prompt defaults without clearing existing stored values.
* **Tests**
  * Updated radio-question rendering expectations, added multiselect block content tests, and expanded journey-metadata streaming/persistence coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->