### PR TITLE
feat(videos-admin): add video restrictions tab

### DIFF
--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/_RestrictAutoTranslations/RestrictAutoTranslations.spec.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/_RestrictAutoTranslations/RestrictAutoTranslations.spec.tsx
@@ -1,0 +1,199 @@
+import { MockedProvider } from '@apollo/client/testing'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SnackbarProvider } from 'notistack'
+import { Suspense } from 'react'
+
+import {
+  GET_RESTRICT_AUTO_TRANSLATIONS,
+  RestrictAutoTranslations,
+  UPDATE_RESTRICT_AUTO_TRANSLATIONS
+} from './RestrictAutoTranslations'
+
+vi.mock('@apollo/client', async () => {
+  const original = await vi.importActual('@apollo/client')
+  return {
+    ...original,
+    useSuspenseQuery: vi.fn(
+      (query: unknown, options?: { variables?: { id?: string } }) => {
+        const id = options?.variables?.id
+        return {
+          data: {
+            adminVideo: {
+              id: id ?? 'video1',
+              restrictAutoTranslations: id === 'video2'
+            }
+          }
+        }
+      }
+    )
+  }
+})
+
+const mockVideoWithRestrictionDisabled = [
+  {
+    request: {
+      query: GET_RESTRICT_AUTO_TRANSLATIONS,
+      variables: {
+        id: 'video1'
+      }
+    },
+    result: {
+      data: {
+        adminVideo: {
+          id: 'video1',
+          restrictAutoTranslations: false
+        }
+      }
+    }
+  }
+]
+
+const mockVideoWithRestrictionEnabled = [
+  {
+    request: {
+      query: GET_RESTRICT_AUTO_TRANSLATIONS,
+      variables: {
+        id: 'video2'
+      }
+    },
+    result: {
+      data: {
+        adminVideo: {
+          id: 'video2',
+          restrictAutoTranslations: true
+        }
+      }
+    }
+  }
+]
+
+const mockEnableMutation = {
+  request: {
+    query: UPDATE_RESTRICT_AUTO_TRANSLATIONS,
+    variables: {
+      input: {
+        id: 'video1',
+        restrictAutoTranslations: true
+      }
+    }
+  },
+  result: {
+    data: {
+      videoUpdate: {
+        id: 'video1',
+        restrictAutoTranslations: true
+      }
+    }
+  }
+}
+
+const TestWrapper = ({
+  children,
+  mocks
+}: {
+  children: React.ReactNode
+  mocks: any[]
+}) => (
+  <MockedProvider mocks={mocks} addTypename={false}>
+    <SnackbarProvider>
+      <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>
+    </SnackbarProvider>
+  </MockedProvider>
+)
+
+describe('RestrictAutoTranslations', () => {
+  it('renders disabled when the restriction is off', async () => {
+    render(
+      <TestWrapper mocks={mockVideoWithRestrictionDisabled}>
+        <RestrictAutoTranslations videoId="video1" />
+      </TestWrapper>
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('Restrict automatic translations')
+      ).not.toBeChecked()
+    })
+  })
+
+  it('renders locked when the restriction is on', async () => {
+    render(
+      <TestWrapper mocks={mockVideoWithRestrictionEnabled}>
+        <RestrictAutoTranslations videoId="video2" />
+      </TestWrapper>
+    )
+
+    await waitFor(() => {
+      const switchInput = screen.getByLabelText(
+        'Restrict automatic translations'
+      )
+      expect(switchInput).toBeChecked()
+      expect(switchInput).toBeDisabled()
+      expect(screen.getByRole('button', { name: /save/i })).toBeDisabled()
+    })
+  })
+
+  it('enables save and shows cancel when changed', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <TestWrapper mocks={[mockVideoWithRestrictionDisabled[0]]}>
+        <RestrictAutoTranslations videoId="video1" />
+      </TestWrapper>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save/i })).toBeDisabled()
+      expect(
+        screen.queryByRole('button', { name: /cancel/i })
+      ).not.toBeInTheDocument()
+    })
+
+    await user.click(screen.getByLabelText('Restrict automatic translations'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save/i })).toBeEnabled()
+      expect(
+        screen.getByRole('button', { name: /cancel/i })
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('saves when enabling the restriction', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <TestWrapper
+        mocks={[...mockVideoWithRestrictionDisabled, mockEnableMutation]}
+      >
+        <RestrictAutoTranslations videoId="video1" />
+      </TestWrapper>
+    )
+
+    await user.click(screen.getByLabelText('Restrict automatic translations'))
+    await user.click(screen.getByRole('button', { name: /save/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Successfully updated automatic translation restriction'
+        )
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('displays descriptive text about the feature', async () => {
+    render(
+      <TestWrapper mocks={mockVideoWithRestrictionDisabled}>
+        <RestrictAutoTranslations videoId="video1" />
+      </TestWrapper>
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Once enabled, this restriction cannot be disabled/)
+      ).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/_RestrictAutoTranslations/RestrictAutoTranslations.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/_RestrictAutoTranslations/RestrictAutoTranslations.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import { useMutation, useSuspenseQuery } from '@apollo/client'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import Stack from '@mui/material/Stack'
+import Switch from '@mui/material/Switch'
+import Typography from '@mui/material/Typography'
+import { Form, Formik, FormikProps, FormikValues } from 'formik'
+import { useSnackbar } from 'notistack'
+import { ReactElement } from 'react'
+
+import { graphql } from '@core/shared/gql'
+
+import { CancelButton } from '../../../../../components/CancelButton'
+import { SaveButton } from '../../../../../components/SaveButton'
+
+interface RestrictAutoTranslationsProps {
+  videoId: string
+}
+
+export const GET_RESTRICT_AUTO_TRANSLATIONS = graphql(`
+  query GetRestrictAutoTranslations($id: ID!) {
+    adminVideo(id: $id) {
+      id
+      restrictAutoTranslations
+    }
+  }
+`)
+
+export const UPDATE_RESTRICT_AUTO_TRANSLATIONS = graphql(`
+  mutation UpdateRestrictAutoTranslations($input: VideoUpdateInput!) {
+    videoUpdate(input: $input) {
+      id
+      restrictAutoTranslations
+    }
+  }
+`)
+
+export function RestrictAutoTranslations({
+  videoId
+}: RestrictAutoTranslationsProps): ReactElement {
+  const { enqueueSnackbar } = useSnackbar()
+  const [updateRestrictAutoTranslations] = useMutation(
+    UPDATE_RESTRICT_AUTO_TRANSLATIONS
+  )
+
+  const { data } = useSuspenseQuery(GET_RESTRICT_AUTO_TRANSLATIONS, {
+    variables: { id: videoId }
+  })
+  const restrictionLocked = data.adminVideo.restrictAutoTranslations === true
+
+  async function handleUpdateRestrictAutoTranslations(
+    values: FormikValues,
+    { resetForm }: FormikProps<FormikValues>
+  ): Promise<void> {
+    await updateRestrictAutoTranslations({
+      variables: {
+        input: {
+          id: videoId,
+          restrictAutoTranslations: values.restrictAutoTranslations
+        }
+      },
+      onCompleted: () => {
+        enqueueSnackbar(
+          'Successfully updated automatic translation restriction',
+          {
+            variant: 'success'
+          }
+        )
+        void resetForm({ values })
+      },
+      onError: () => {
+        enqueueSnackbar('Failed to update automatic translation restriction', {
+          variant: 'error'
+        })
+      }
+    })
+  }
+
+  return (
+    <Formik
+      initialValues={{
+        restrictAutoTranslations:
+          data.adminVideo.restrictAutoTranslations ?? false
+      }}
+      onSubmit={handleUpdateRestrictAutoTranslations}
+    >
+      {({ values, setFieldValue, isSubmitting, dirty, resetForm }) => (
+        <Form>
+          <Stack gap={2}>
+            <Stack gap={1}>
+              <Typography variant="body2" color="text.secondary">
+                When enabled, automated systems must not add translated audio
+                variants or subtitle tracks to this video without express
+                permission. Metadata translations (title, description, study
+                questions) are unaffected. Once enabled, this restriction cannot
+                be disabled.
+              </Typography>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={values.restrictAutoTranslations}
+                    onChange={(event) => {
+                      void setFieldValue(
+                        'restrictAutoTranslations',
+                        event.target.checked
+                      )
+                    }}
+                    name="restrictAutoTranslations"
+                    disabled={restrictionLocked}
+                  />
+                }
+                label="Restrict automatic translations"
+              />
+            </Stack>
+            <Stack direction="row" justifyContent="flex-end" gap={1}>
+              <CancelButton
+                show={dirty}
+                handleCancel={() => void resetForm()}
+              />
+              <SaveButton disabled={isSubmitting || !dirty} />
+            </Stack>
+          </Stack>
+        </Form>
+      )}
+    </Formik>
+  )
+}

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/_RestrictAutoTranslations/index.ts
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/_RestrictAutoTranslations/index.ts
@@ -1,0 +1,1 @@
+export { RestrictAutoTranslations } from './RestrictAutoTranslations'

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/_VideoTabs/VideoTabs.spec.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/_VideoTabs/VideoTabs.spec.tsx
@@ -139,6 +139,8 @@ describe('VideoTabView', () => {
     expect(screen.getByText('Children')).toBeInTheDocument()
     expect(screen.getByText('Audio Languages')).toBeInTheDocument()
     expect(screen.getByText('Editions')).toBeInTheDocument()
+    expect(screen.getByText('Restrictions')).toBeInTheDocument()
+    expect(screen.getByText('Troubleshooting')).toBeInTheDocument()
 
     // Verify counts are displayed
     expect(screen.getByText('5')).toBeInTheDocument() // Children count
@@ -160,6 +162,8 @@ describe('VideoTabView', () => {
     expect(screen.getByText('Children')).toBeInTheDocument()
     expect(screen.getByText('Audio Languages')).toBeInTheDocument()
     expect(screen.getByText('Editions')).toBeInTheDocument()
+    expect(screen.getByText('Restrictions')).toBeInTheDocument()
+    expect(screen.getByText('Troubleshooting')).toBeInTheDocument()
 
     // Verify counts are displayed
     expect(screen.getByText('10')).toBeInTheDocument() // Children count
@@ -181,6 +185,8 @@ describe('VideoTabView', () => {
     expect(screen.queryByText('Children')).not.toBeInTheDocument() // Verify Children tab is not present
     expect(screen.getByText('Audio Languages')).toBeInTheDocument()
     expect(screen.getByText('Editions')).toBeInTheDocument()
+    expect(screen.getByText('Restrictions')).toBeInTheDocument()
+    expect(screen.getByText('Troubleshooting')).toBeInTheDocument()
   })
 
   it('should have correct hrefs', () => {
@@ -199,5 +205,7 @@ describe('VideoTabView', () => {
     expect(tabs[1]).toHaveAttribute('href', '/videos/video-123/children')
     expect(tabs[2]).toHaveAttribute('href', '/videos/video-123/audio')
     expect(tabs[3]).toHaveAttribute('href', '/videos/video-123/editions')
+    expect(tabs[4]).toHaveAttribute('href', '/videos/video-123/restrictions')
+    expect(tabs[5]).toHaveAttribute('href', '/videos/video-123/troubleshooting')
   })
 })

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/_VideoTabs/VideoTabs.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/_VideoTabs/VideoTabs.tsx
@@ -73,6 +73,12 @@ export function VideoTabView({
       href: `/videos/${videoId}/editions`
     },
     {
+      label: 'Restrictions',
+      value: 'restrictions',
+      count: null,
+      href: `/videos/${videoId}/restrictions`
+    },
+    {
       label: 'Troubleshooting',
       value: 'troubleshooting',
       count: null,

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/layout.spec.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/layout.spec.tsx
@@ -6,6 +6,7 @@ import VideoViewLayout from './layout'
 
 const mockPush = vi.fn()
 const mockSegment = vi.fn()
+const mockScrollTo = vi.fn()
 const mockVideoInformation = vi.fn(() => (
   <div data-testid="video-information" />
 ))
@@ -13,6 +14,7 @@ const mockVideoInformation = vi.fn(() => (
 vi.mock('next/navigation', () => ({
   useParams: () => ({ videoId: 'video123' }),
   useRouter: () => ({ push: mockPush }),
+  usePathname: () => '/videos/video123',
   useSelectedLayoutSegment: () => mockSegment()
 }))
 
@@ -28,6 +30,26 @@ vi.mock('./_VideoInformation', () => ({
   VideoInformation: () => mockVideoInformation()
 }))
 
+vi.mock('./_VideoImages', () => ({
+  VideoImages: () => <div data-testid="video-images" />
+}))
+
+vi.mock('./_VideoImageAlt', () => ({
+  VideoImageAlt: () => <div data-testid="video-image-alt" />
+}))
+
+vi.mock('./_VideoSnippet', () => ({
+  VideoSnippet: () => <div data-testid="video-snippet" />
+}))
+
+vi.mock('./_VideoDescription', () => ({
+  VideoDescription: () => <div data-testid="video-description" />
+}))
+
+vi.mock('./_VideoBibleCitation', () => ({
+  VideoBibleCitation: () => <div data-testid="video-bible-citation" />
+}))
+
 vi.mock('./_VideoTabs', () => ({
   VideoTabView: ({ currentTab }: { currentTab: string }) => (
     <div data-testid="current-tab">{currentTab}</div>
@@ -41,6 +63,7 @@ describe('VideoViewLayout', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    window.scrollTo = mockScrollTo
     mockSegment.mockReturnValue('metadata')
     useSuspenseQuery.mockReturnValue({
       data: {
@@ -56,6 +79,16 @@ describe('VideoViewLayout', () => {
     })
   })
 
+  it('scrolls to the top when the video detail page loads', () => {
+    render(
+      <VideoViewLayout studyQuestions={<div>Study questions</div>}>
+        <div />
+      </VideoViewLayout>
+    )
+
+    expect(mockScrollTo).toHaveBeenCalledWith({ top: 0, left: 0 })
+  })
+
   it('uses the children tab behind the publish all dialog without rendering metadata queries', () => {
     mockSegment.mockReturnValue('publishAll')
 
@@ -68,5 +101,31 @@ describe('VideoViewLayout', () => {
     expect(screen.getByTestId('current-tab')).toHaveTextContent('children')
     expect(screen.getByTestId('publish-all-dialog')).toBeInTheDocument()
     expect(mockVideoInformation).not.toHaveBeenCalled()
+  })
+
+  it('uses the restrictions tab for the restrictions route without rendering metadata queries', () => {
+    mockSegment.mockReturnValue('restrictions')
+
+    render(
+      <VideoViewLayout studyQuestions={<div>Study questions</div>}>
+        <div data-testid="restrictions-page">Restrictions page</div>
+      </VideoViewLayout>
+    )
+
+    expect(screen.getByTestId('current-tab')).toHaveTextContent('restrictions')
+    expect(screen.getByTestId('restrictions-page')).toBeInTheDocument()
+    expect(mockVideoInformation).not.toHaveBeenCalled()
+  })
+
+  it('does not render restriction sections on the metadata tab', () => {
+    render(
+      <VideoViewLayout studyQuestions={<div>Study questions</div>}>
+        <div />
+      </VideoViewLayout>
+    )
+
+    expect(screen.getByTestId('VideoMetadata')).toBeInTheDocument()
+    expect(screen.queryByText('Restricted Downloads')).not.toBeInTheDocument()
+    expect(screen.queryByText('Restricted Views')).not.toBeInTheDocument()
   })
 })

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/layout.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/layout.tsx
@@ -9,7 +9,7 @@ import Divider from '@mui/material/Divider'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { useParams, useRouter, useSelectedLayoutSegment } from 'next/navigation'
-import { ReactNode, useCallback } from 'react'
+import { ReactNode, useCallback, useEffect, useRef } from 'react'
 
 import { graphql } from '@core/shared/gql'
 
@@ -18,8 +18,6 @@ import { Section } from '../../../../components/Section'
 import { DEFAULT_VIDEO_LANGUAGE_ID } from '../constants'
 
 import { LockedVideoView } from './_LockedVideo'
-import { RestrictedDownloads } from './_RestrictedDownloads'
-import { RestrictedViews } from './_RestrictedViews'
 import { VideoBibleCitation } from './_VideoBibleCitation'
 import { VideoDescription } from './_VideoDescription'
 import { VideoViewFallback } from './_VideoFallback'
@@ -56,12 +54,22 @@ export default function VideoViewLayout({
 }: VideoViewLayoutProps): ReactNode {
   const router = useRouter()
   const { videoId } = useParams<{ videoId: string }>()
+  const previousVideoId = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (previousVideoId.current !== videoId) {
+      window.scrollTo({ top: 0, left: 0 })
+      previousVideoId.current = videoId
+    }
+  }, [videoId])
+
   // keep metadata visible when modal is open
   const availableTabs = [
     'metadata',
     'audio',
     'children',
     'editions',
+    'restrictions',
     'troubleshooting'
   ]
   const segment = useSelectedLayoutSegment() ?? 'metadata'
@@ -185,12 +193,6 @@ export default function VideoViewLayout({
                 </Section>
                 <VideoBibleCitation videoId={videoId} />
                 {studyQuestions}
-                <Section title="Restricted Downloads" variant="outlined">
-                  <RestrictedDownloads videoId={videoId} />
-                </Section>
-                <Section title="Restricted Views" variant="outlined">
-                  <RestrictedViews videoId={videoId} />
-                </Section>
               </Stack>
             </>
           )}

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/restrictions/page.spec.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/restrictions/page.spec.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react'
+
+import VideoRestrictionsPage from './page'
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ videoId: 'video123' })
+}))
+
+vi.mock('../_RestrictAutoTranslations', () => ({
+  RestrictAutoTranslations: ({ videoId }: { videoId: string }) => (
+    <div data-testid="restrict-auto-translations">{videoId}</div>
+  )
+}))
+
+vi.mock('../_RestrictedViews', () => ({
+  RestrictedViews: ({ videoId }: { videoId: string }) => (
+    <div data-testid="restricted-views">{videoId}</div>
+  )
+}))
+
+vi.mock('../_RestrictedDownloads', () => ({
+  RestrictedDownloads: ({ videoId }: { videoId: string }) => (
+    <div data-testid="restricted-downloads">{videoId}</div>
+  )
+}))
+
+describe('VideoRestrictionsPage', () => {
+  it('renders automatic translation, view, and download restrictions', () => {
+    render(<VideoRestrictionsPage />)
+
+    expect(screen.getByText('Automatic Translations')).toBeInTheDocument()
+    expect(screen.getByText('Restricted Views')).toBeInTheDocument()
+    expect(screen.getByText('Restricted Downloads')).toBeInTheDocument()
+    expect(screen.getByTestId('restrict-auto-translations')).toHaveTextContent(
+      'video123'
+    )
+    expect(screen.getByTestId('restricted-views')).toHaveTextContent('video123')
+    expect(screen.getByTestId('restricted-downloads')).toHaveTextContent(
+      'video123'
+    )
+  })
+})

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/restrictions/page.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/restrictions/page.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+import { ReactElement } from 'react'
+
+import { Section } from '../../../../../components/Section'
+
+import { RestrictAutoTranslations } from '../_RestrictAutoTranslations'
+import { RestrictedDownloads } from '../_RestrictedDownloads'
+import { RestrictedViews } from '../_RestrictedViews'
+
+export default function VideoRestrictionsPage(): ReactElement {
+  const { videoId } = useParams<{ videoId: string }>()
+
+  return (
+    <>
+      <Section title="Automatic Translations" variant="outlined">
+        <RestrictAutoTranslations videoId={videoId} />
+      </Section>
+      <Section title="Restricted Views" variant="outlined">
+        <RestrictedViews videoId={videoId} />
+      </Section>
+      <Section title="Restricted Downloads" variant="outlined">
+        <RestrictedDownloads videoId={videoId} />
+      </Section>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary

Videos-admin now has a dedicated Restrictions tab for video-level restriction controls. The page adds the automatic translation restriction switch, keeps it locked once enabled, and moves Restricted Views and Restricted Downloads out of metadata so all restriction settings live together.

This PR is stacked on the backend PR because the new UI queries and mutates `restrictAutoTranslations`. It also resets scroll to the top when loading a different `/videos/[videoId]` detail page so the detail layout no longer opens at the previous scroll position.

## Testing

- `pnpm exec nx run videos-admin:type-check`
- `pnpm exec vitest run 'src/app/(dashboard)/videos/[videoId]/_RestrictAutoTranslations/RestrictAutoTranslations.spec.tsx' --config vitest.config.mts`
- `pnpm exec nx test videos-admin`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
