### PR TITLE
fix(api-journeys): count card capture goals & paginate Plausible breakdown

### DIFF
--- a/apis/api-journeys/src/schema/plausible/journeysPlausibleStatsBreakdown.query.spec.ts
+++ b/apis/api-journeys/src/schema/plausible/journeysPlausibleStatsBreakdown.query.spec.ts
@@ -133,6 +133,34 @@ describe('journeysPlausibleStatsBreakdown', () => {
     })
   })
 
+  it('makes a single request and does not paginate even on a full page', async () => {
+    prismaMock.journey.findUnique.mockResolvedValue({
+      id: 'journey-id',
+      userJourneys: [],
+      team: { userTeams: [] }
+    } as any)
+    // A full page would trigger another fetch if this passthrough paginated.
+    mockAxios.get.mockResolvedValue({
+      data: {
+        results: Array.from({ length: 1000 }, (_, i) => ({
+          goal: `event-${i}`,
+          visitors: 1
+        }))
+      }
+    } as any)
+
+    await authClient({
+      document: QUERY,
+      variables: {
+        id: 'journey-id',
+        idType: 'databaseId',
+        where: { property: 'event:goal' }
+      }
+    })
+
+    expect(mockAxios.get).toHaveBeenCalledTimes(1)
+  })
+
   it('returns error when journey not found', async () => {
     prismaMock.journey.findUnique.mockResolvedValue(null)
 

--- a/apis/api-journeys/src/schema/plausible/service.spec.ts
+++ b/apis/api-journeys/src/schema/plausible/service.spec.ts
@@ -1,0 +1,185 @@
+import axios, { isAxiosError } from 'axios'
+import { type Mocked, type MockedFunction, vi } from 'vitest'
+
+import { getJourneyStatsBreakdown } from './service'
+
+vi.mock('axios')
+
+const mockAxios = axios as Mocked<typeof axios>
+const mockIsAxiosError = isAxiosError as unknown as MockedFunction<
+  typeof isAxiosError
+>
+
+function buildRows(
+  count: number,
+  startIndex = 0
+): Array<Record<string, number | string | null>> {
+  return Array.from({ length: count }, (_, i) => ({
+    'event:props:templateKey': `key-${startIndex + i}`,
+    visitors: 1
+  }))
+}
+
+function mockPage(rows: Array<Record<string, number | string | null>>): void {
+  mockAxios.get.mockResolvedValueOnce({ data: { results: rows } } as never)
+}
+
+describe('getJourneyStatsBreakdown', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env = {
+      ...originalEnv,
+      PLAUSIBLE_URL: 'https://plausible.example',
+      PLAUSIBLE_API_KEY: 'plausible-key'
+    }
+    mockIsAxiosError.mockReturnValue(false)
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  it('maps the property key and camelCases remaining metrics', async () => {
+    mockPage([{ goal: 'event-name', visitors: 10, events: 5 }])
+
+    const result = await getJourneyStatsBreakdown('journey-id', {
+      property: 'event:goal',
+      metrics: 'visitors,events'
+    })
+
+    expect(result).toEqual([
+      { property: 'event-name', visitors: 10, events: 5 }
+    ])
+    expect(mockAxios.get).toHaveBeenCalledTimes(1)
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      'https://plausible.example/api/v1/stats/breakdown',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer plausible-key' },
+        params: expect.objectContaining({
+          site_id: 'api-journeys-journey-journey-id',
+          property: 'event:goal',
+          metrics: 'visitors,events',
+          limit: 1000,
+          page: 1
+        })
+      })
+    )
+  })
+
+  it('stops after a single request when the first page is short', async () => {
+    mockPage(buildRows(42))
+
+    const result = await getJourneyStatsBreakdown('journey-id', {
+      property: 'event:props:templateKey',
+      metrics: 'visitors'
+    })
+
+    expect(result).toHaveLength(42)
+    expect(mockAxios.get).toHaveBeenCalledTimes(1)
+  })
+
+  it('paginates through every page until a short page is returned', async () => {
+    mockPage(buildRows(1000, 0))
+    mockPage(buildRows(1000, 1000))
+    mockPage(buildRows(3, 2000))
+
+    const result = await getJourneyStatsBreakdown('journey-id', {
+      property: 'event:props:templateKey',
+      metrics: 'visitors'
+    })
+
+    expect(result).toHaveLength(2003)
+    expect(mockAxios.get).toHaveBeenCalledTimes(3)
+    expect(mockAxios.get).toHaveBeenNthCalledWith(
+      1,
+      expect.any(String),
+      expect.objectContaining({
+        params: expect.objectContaining({ page: 1, limit: 1000 })
+      })
+    )
+    expect(mockAxios.get).toHaveBeenNthCalledWith(
+      2,
+      expect.any(String),
+      expect.objectContaining({
+        params: expect.objectContaining({ page: 2, limit: 1000 })
+      })
+    )
+    expect(mockAxios.get).toHaveBeenNthCalledWith(
+      3,
+      expect.any(String),
+      expect.objectContaining({
+        params: expect.objectContaining({ page: 3, limit: 1000 })
+      })
+    )
+  })
+
+  it('makes one extra request when the total is an exact multiple of the page size', async () => {
+    mockPage(buildRows(1000, 0))
+    mockPage([])
+
+    const result = await getJourneyStatsBreakdown('journey-id', {
+      property: 'event:props:templateKey',
+      metrics: 'visitors'
+    })
+
+    expect(result).toHaveLength(1000)
+    expect(mockAxios.get).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not auto-paginate when the caller specifies an explicit limit', async () => {
+    mockPage(buildRows(1000))
+
+    const result = await getJourneyStatsBreakdown('journey-id', {
+      property: 'event:props:templateKey',
+      metrics: 'visitors',
+      limit: 1000
+    })
+
+    expect(result).toHaveLength(1000)
+    expect(mockAxios.get).toHaveBeenCalledTimes(1)
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        params: expect.objectContaining({ limit: 1000, page: 1 })
+      })
+    )
+  })
+
+  it('honors an explicit page without paginating further', async () => {
+    mockPage(buildRows(1000, 1000))
+
+    const result = await getJourneyStatsBreakdown('journey-id', {
+      property: 'event:props:templateKey',
+      metrics: 'visitors',
+      page: 2
+    })
+
+    expect(result).toHaveLength(1000)
+    expect(mockAxios.get).toHaveBeenCalledTimes(1)
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        params: expect.objectContaining({ page: 2, limit: 1000 })
+      })
+    )
+  })
+
+  it('throws a BAD_USER_INPUT GraphQLError when Plausible returns an error', async () => {
+    mockIsAxiosError.mockReturnValueOnce(true)
+    mockAxios.get.mockRejectedValueOnce({
+      response: { data: { error: 'Invalid property' } }
+    } as never)
+
+    await expect(
+      getJourneyStatsBreakdown('journey-id', {
+        property: 'event:goal',
+        metrics: 'visitors'
+      })
+    ).rejects.toMatchObject({
+      message: 'Invalid property',
+      extensions: { code: 'BAD_USER_INPUT' }
+    })
+  })
+})

--- a/apis/api-journeys/src/schema/plausible/service.spec.ts
+++ b/apis/api-journeys/src/schema/plausible/service.spec.ts
@@ -128,6 +128,30 @@ describe('getJourneyStatsBreakdown', () => {
     expect(mockAxios.get).toHaveBeenCalledTimes(2)
   })
 
+  it('stops at the max page cap and logs when every page stays full', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    // Every page returns a full 1000 rows, simulating a runaway loop.
+    mockAxios.get.mockResolvedValue({
+      data: { results: buildRows(1000) }
+    } as never)
+
+    const result = await getJourneyStatsBreakdown('journey-id', {
+      property: 'event:props:templateKey',
+      metrics: 'visitors'
+    })
+
+    expect(mockAxios.get).toHaveBeenCalledTimes(50)
+    expect(result).toHaveLength(50000)
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('hit max page cap'),
+      expect.objectContaining({ siteId: 'api-journeys-journey-journey-id' })
+    )
+
+    consoleErrorSpy.mockRestore()
+  })
+
   it('does not auto-paginate when the caller specifies an explicit limit', async () => {
     mockPage(buildRows(1000))
 

--- a/apis/api-journeys/src/schema/plausible/service.spec.ts
+++ b/apis/api-journeys/src/schema/plausible/service.spec.ts
@@ -80,6 +80,18 @@ describe('getJourneyStatsBreakdown', () => {
     expect(mockAxios.get).toHaveBeenCalledTimes(1)
   })
 
+  it('returns an empty array after a single request when the first page is empty', async () => {
+    mockPage([])
+
+    const result = await getJourneyStatsBreakdown('journey-id', {
+      property: 'event:props:templateKey',
+      metrics: 'visitors'
+    })
+
+    expect(result).toEqual([])
+    expect(mockAxios.get).toHaveBeenCalledTimes(1)
+  })
+
   it('paginates through every page until a short page is returned', async () => {
     mockPage(buildRows(1000, 0))
     mockPage(buildRows(1000, 1000))
@@ -190,6 +202,26 @@ describe('getJourneyStatsBreakdown', () => {
     )
   })
 
+  it('makes a single request passing through an explicit limit and page together', async () => {
+    mockPage(buildRows(500, 1000))
+
+    const result = await getJourneyStatsBreakdown('journey-id', {
+      property: 'event:props:templateKey',
+      metrics: 'visitors',
+      limit: 500,
+      page: 3
+    })
+
+    expect(result).toHaveLength(500)
+    expect(mockAxios.get).toHaveBeenCalledTimes(1)
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        params: expect.objectContaining({ limit: 500, page: 3 })
+      })
+    )
+  })
+
   it('throws a BAD_USER_INPUT GraphQLError when Plausible returns an error', async () => {
     mockIsAxiosError.mockReturnValueOnce(true)
     mockAxios.get.mockRejectedValueOnce({
@@ -205,5 +237,30 @@ describe('getJourneyStatsBreakdown', () => {
       message: 'Invalid property',
       extensions: { code: 'BAD_USER_INPUT' }
     })
+  })
+
+  it('rethrows the original error when it is not an axios error', async () => {
+    mockIsAxiosError.mockReturnValue(false)
+    mockAxios.get.mockRejectedValueOnce(new Error('boom'))
+
+    await expect(
+      getJourneyStatsBreakdown('journey-id', {
+        property: 'event:goal',
+        metrics: 'visitors'
+      })
+    ).rejects.toThrow('boom')
+  })
+
+  it('rethrows the original axios error when it carries no string error message', async () => {
+    mockIsAxiosError.mockReturnValueOnce(true)
+    const axiosError = { response: { data: {} } }
+    mockAxios.get.mockRejectedValueOnce(axiosError as never)
+
+    await expect(
+      getJourneyStatsBreakdown('journey-id', {
+        property: 'event:goal',
+        metrics: 'visitors'
+      })
+    ).rejects.toBe(axiosError)
   })
 })

--- a/apis/api-journeys/src/schema/plausible/service.spec.ts
+++ b/apis/api-journeys/src/schema/plausible/service.spec.ts
@@ -10,12 +10,14 @@ const mockIsAxiosError = isAxiosError as unknown as MockedFunction<
   typeof isAxiosError
 >
 
+// Plausible returns the breakdown value under the property's last segment, e.g.
+// property `event:props:templateKey` -> row field `templateKey`.
 function buildRows(
   count: number,
   startIndex = 0
 ): Array<Record<string, number | string | null>> {
   return Array.from({ length: count }, (_, i) => ({
-    'event:props:templateKey': `key-${startIndex + i}`,
+    templateKey: `key-${startIndex + i}`,
     visitors: 1
   }))
 }
@@ -29,6 +31,9 @@ describe('getJourneyStatsBreakdown', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // Reset the implementation too so a persistent mock (mockResolvedValue /
+    // mockImplementation) from one test cannot leak into the next.
+    mockAxios.get.mockReset()
     process.env = {
       ...originalEnv,
       PLAUSIBLE_URL: 'https://plausible.example',
@@ -41,226 +46,240 @@ describe('getJourneyStatsBreakdown', () => {
     process.env = originalEnv
   })
 
-  it('maps the property key and camelCases remaining metrics', async () => {
-    mockPage([{ goal: 'event-name', visitors: 10, events: 5 }])
+  describe('default (single request)', () => {
+    it('maps the property key and camelCases remaining metrics', async () => {
+      mockPage([{ goal: 'event-name', visitors: 10, events: 5 }])
 
-    const result = await getJourneyStatsBreakdown('journey-id', {
-      property: 'event:goal',
-      metrics: 'visitors,events'
-    })
+      const result = await getJourneyStatsBreakdown('journey-id', {
+        property: 'event:goal',
+        metrics: 'visitors,events'
+      })
 
-    expect(result).toEqual([
-      { property: 'event-name', visitors: 10, events: 5 }
-    ])
-    expect(mockAxios.get).toHaveBeenCalledTimes(1)
-    expect(mockAxios.get).toHaveBeenCalledWith(
-      'https://plausible.example/api/v1/stats/breakdown',
-      expect.objectContaining({
-        headers: { Authorization: 'Bearer plausible-key' },
-        params: expect.objectContaining({
-          site_id: 'api-journeys-journey-journey-id',
-          property: 'event:goal',
-          metrics: 'visitors,events',
-          limit: 1000,
-          page: 1
+      expect(result).toEqual([
+        { property: 'event-name', visitors: 10, events: 5 }
+      ])
+      expect(mockAxios.get).toHaveBeenCalledTimes(1)
+      expect(mockAxios.get).toHaveBeenCalledWith(
+        'https://plausible.example/api/v1/stats/breakdown',
+        expect.objectContaining({
+          headers: { Authorization: 'Bearer plausible-key' },
+          params: expect.objectContaining({
+            site_id: 'api-journeys-journey-journey-id',
+            property: 'event:goal',
+            metrics: 'visitors,events'
+          })
         })
-      })
-    )
-  })
-
-  it('stops after a single request when the first page is short', async () => {
-    mockPage(buildRows(42))
-
-    const result = await getJourneyStatsBreakdown('journey-id', {
-      property: 'event:props:templateKey',
-      metrics: 'visitors'
+      )
     })
 
-    expect(result).toHaveLength(42)
-    expect(mockAxios.get).toHaveBeenCalledTimes(1)
-  })
+    it('does not force a limit or page when the caller supplies none', async () => {
+      mockPage(buildRows(1000))
 
-  it('returns an empty array after a single request when the first page is empty', async () => {
-    mockPage([])
-
-    const result = await getJourneyStatsBreakdown('journey-id', {
-      property: 'event:props:templateKey',
-      metrics: 'visitors'
-    })
-
-    expect(result).toEqual([])
-    expect(mockAxios.get).toHaveBeenCalledTimes(1)
-  })
-
-  it('paginates through every page until a short page is returned', async () => {
-    mockPage(buildRows(1000, 0))
-    mockPage(buildRows(1000, 1000))
-    mockPage(buildRows(3, 2000))
-
-    const result = await getJourneyStatsBreakdown('journey-id', {
-      property: 'event:props:templateKey',
-      metrics: 'visitors'
-    })
-
-    expect(result).toHaveLength(2003)
-    expect(mockAxios.get).toHaveBeenCalledTimes(3)
-    expect(mockAxios.get).toHaveBeenNthCalledWith(
-      1,
-      expect.any(String),
-      expect.objectContaining({
-        params: expect.objectContaining({ page: 1, limit: 1000 })
-      })
-    )
-    expect(mockAxios.get).toHaveBeenNthCalledWith(
-      2,
-      expect.any(String),
-      expect.objectContaining({
-        params: expect.objectContaining({ page: 2, limit: 1000 })
-      })
-    )
-    expect(mockAxios.get).toHaveBeenNthCalledWith(
-      3,
-      expect.any(String),
-      expect.objectContaining({
-        params: expect.objectContaining({ page: 3, limit: 1000 })
-      })
-    )
-  })
-
-  it('makes one extra request when the total is an exact multiple of the page size', async () => {
-    mockPage(buildRows(1000, 0))
-    mockPage([])
-
-    const result = await getJourneyStatsBreakdown('journey-id', {
-      property: 'event:props:templateKey',
-      metrics: 'visitors'
-    })
-
-    expect(result).toHaveLength(1000)
-    expect(mockAxios.get).toHaveBeenCalledTimes(2)
-  })
-
-  it('stops at the max page cap and logs when every page stays full', async () => {
-    const consoleErrorSpy = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => undefined)
-    // Every page returns a full 1000 rows, simulating a runaway loop.
-    mockAxios.get.mockResolvedValue({
-      data: { results: buildRows(1000) }
-    } as never)
-
-    const result = await getJourneyStatsBreakdown('journey-id', {
-      property: 'event:props:templateKey',
-      metrics: 'visitors'
-    })
-
-    expect(mockAxios.get).toHaveBeenCalledTimes(50)
-    expect(result).toHaveLength(50000)
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('hit max page cap'),
-      expect.objectContaining({ siteId: 'api-journeys-journey-journey-id' })
-    )
-
-    consoleErrorSpy.mockRestore()
-  })
-
-  it('does not auto-paginate when the caller specifies an explicit limit', async () => {
-    mockPage(buildRows(1000))
-
-    const result = await getJourneyStatsBreakdown('journey-id', {
-      property: 'event:props:templateKey',
-      metrics: 'visitors',
-      limit: 1000
-    })
-
-    expect(result).toHaveLength(1000)
-    expect(mockAxios.get).toHaveBeenCalledTimes(1)
-    expect(mockAxios.get).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        params: expect.objectContaining({ limit: 1000, page: 1 })
-      })
-    )
-  })
-
-  it('honors an explicit page without paginating further', async () => {
-    mockPage(buildRows(1000, 1000))
-
-    const result = await getJourneyStatsBreakdown('journey-id', {
-      property: 'event:props:templateKey',
-      metrics: 'visitors',
-      page: 2
-    })
-
-    expect(result).toHaveLength(1000)
-    expect(mockAxios.get).toHaveBeenCalledTimes(1)
-    expect(mockAxios.get).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        params: expect.objectContaining({ page: 2, limit: 1000 })
-      })
-    )
-  })
-
-  it('makes a single request passing through an explicit limit and page together', async () => {
-    mockPage(buildRows(500, 1000))
-
-    const result = await getJourneyStatsBreakdown('journey-id', {
-      property: 'event:props:templateKey',
-      metrics: 'visitors',
-      limit: 500,
-      page: 3
-    })
-
-    expect(result).toHaveLength(500)
-    expect(mockAxios.get).toHaveBeenCalledTimes(1)
-    expect(mockAxios.get).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        params: expect.objectContaining({ limit: 500, page: 3 })
-      })
-    )
-  })
-
-  it('throws a BAD_USER_INPUT GraphQLError when Plausible returns an error', async () => {
-    mockIsAxiosError.mockReturnValueOnce(true)
-    mockAxios.get.mockRejectedValueOnce({
-      response: { data: { error: 'Invalid property' } }
-    } as never)
-
-    await expect(
-      getJourneyStatsBreakdown('journey-id', {
-        property: 'event:goal',
+      await getJourneyStatsBreakdown('journey-id', {
+        property: 'event:props:templateKey',
         metrics: 'visitors'
       })
-    ).rejects.toMatchObject({
-      message: 'Invalid property',
-      extensions: { code: 'BAD_USER_INPUT' }
+
+      expect(mockAxios.get).toHaveBeenCalledTimes(1)
+      expect(mockAxios.get).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          params: expect.objectContaining({ limit: 1000 })
+        })
+      )
+    })
+
+    it('passes through an explicit limit and page in a single request', async () => {
+      mockPage(buildRows(500, 1000))
+
+      const result = await getJourneyStatsBreakdown('journey-id', {
+        property: 'event:props:templateKey',
+        metrics: 'visitors',
+        limit: 500,
+        page: 3
+      })
+
+      expect(result).toHaveLength(500)
+      expect(mockAxios.get).toHaveBeenCalledTimes(1)
+      expect(mockAxios.get).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          params: expect.objectContaining({ limit: 500, page: 3 })
+        })
+      )
     })
   })
 
-  it('rethrows the original error when it is not an axios error', async () => {
-    mockIsAxiosError.mockReturnValue(false)
-    mockAxios.get.mockRejectedValueOnce(new Error('boom'))
+  describe('paginate: true', () => {
+    it('paginates through every page until a short page is returned', async () => {
+      mockPage(buildRows(1000, 0))
+      mockPage(buildRows(1000, 1000))
+      mockPage(buildRows(3, 2000))
 
-    await expect(
-      getJourneyStatsBreakdown('journey-id', {
-        property: 'event:goal',
-        metrics: 'visitors'
+      const result = await getJourneyStatsBreakdown(
+        'journey-id',
+        { property: 'event:props:templateKey', metrics: 'visitors' },
+        undefined,
+        { paginate: true }
+      )
+
+      expect(result).toHaveLength(2003)
+      expect(mockAxios.get).toHaveBeenCalledTimes(3)
+      expect(mockAxios.get).toHaveBeenNthCalledWith(
+        1,
+        expect.any(String),
+        expect.objectContaining({
+          params: expect.objectContaining({ page: 1, limit: 1000 })
+        })
+      )
+      expect(mockAxios.get).toHaveBeenNthCalledWith(
+        3,
+        expect.any(String),
+        expect.objectContaining({
+          params: expect.objectContaining({ page: 3, limit: 1000 })
+        })
+      )
+    })
+
+    it('stops after one request when the first page is short', async () => {
+      mockPage(buildRows(42))
+
+      const result = await getJourneyStatsBreakdown(
+        'journey-id',
+        { property: 'event:props:templateKey', metrics: 'visitors' },
+        undefined,
+        { paginate: true }
+      )
+
+      expect(result).toHaveLength(42)
+      expect(mockAxios.get).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns an empty array when the first page is empty', async () => {
+      mockPage([])
+
+      const result = await getJourneyStatsBreakdown(
+        'journey-id',
+        { property: 'event:props:templateKey', metrics: 'visitors' },
+        undefined,
+        { paginate: true }
+      )
+
+      expect(result).toEqual([])
+      expect(mockAxios.get).toHaveBeenCalledTimes(1)
+    })
+
+    it('makes one extra request when the total is an exact multiple of the page size', async () => {
+      mockPage(buildRows(1000, 0))
+      mockPage([])
+
+      const result = await getJourneyStatsBreakdown(
+        'journey-id',
+        { property: 'event:props:templateKey', metrics: 'visitors' },
+        undefined,
+        { paginate: true }
+      )
+
+      expect(result).toHaveLength(1000)
+      expect(mockAxios.get).toHaveBeenCalledTimes(2)
+    })
+
+    it('de-dupes repeated rows and stops when a page adds nothing new', async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined)
+      // Every page returns the SAME 1000 rows — e.g. an upstream that ignores
+      // the page param. Without de-duping this would 50x-inflate the counts.
+      mockAxios.get.mockResolvedValue({
+        data: { results: buildRows(1000) }
+      } as never)
+
+      const result = await getJourneyStatsBreakdown(
+        'journey-id',
+        { property: 'event:props:templateKey', metrics: 'visitors' },
+        undefined,
+        { paginate: true }
+      )
+
+      // First page fills the set; the second adds nothing new and breaks.
+      expect(mockAxios.get).toHaveBeenCalledTimes(2)
+      expect(result).toHaveLength(1000)
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
+
+      consoleErrorSpy.mockRestore()
+    })
+
+    it('stops at the max page cap and logs when every page is full and distinct', async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined)
+      let call = 0
+      // Each page returns a full page of distinct rows, so it never short-pages.
+      mockAxios.get.mockImplementation(async () => {
+        const rows = buildRows(1000, call * 1000)
+        call += 1
+        return { data: { results: rows } } as never
       })
-    ).rejects.toThrow('boom')
+
+      const result = await getJourneyStatsBreakdown(
+        'journey-id',
+        { property: 'event:props:templateKey', metrics: 'visitors' },
+        undefined,
+        { paginate: true }
+      )
+
+      expect(mockAxios.get).toHaveBeenCalledTimes(50)
+      expect(result).toHaveLength(50000)
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('hit max page cap'),
+        expect.objectContaining({ siteId: 'api-journeys-journey-journey-id' })
+      )
+
+      consoleErrorSpy.mockRestore()
+    })
   })
 
-  it('rethrows the original axios error when it carries no string error message', async () => {
-    mockIsAxiosError.mockReturnValueOnce(true)
-    const axiosError = { response: { data: {} } }
-    mockAxios.get.mockRejectedValueOnce(axiosError as never)
+  describe('error handling', () => {
+    it('throws a BAD_USER_INPUT GraphQLError when Plausible returns an error', async () => {
+      mockIsAxiosError.mockReturnValueOnce(true)
+      mockAxios.get.mockRejectedValueOnce({
+        response: { data: { error: 'Invalid property' } }
+      } as never)
 
-    await expect(
-      getJourneyStatsBreakdown('journey-id', {
-        property: 'event:goal',
-        metrics: 'visitors'
+      await expect(
+        getJourneyStatsBreakdown('journey-id', {
+          property: 'event:goal',
+          metrics: 'visitors'
+        })
+      ).rejects.toMatchObject({
+        message: 'Invalid property',
+        extensions: { code: 'BAD_USER_INPUT' }
       })
-    ).rejects.toBe(axiosError)
+    })
+
+    it('rethrows the original error when it is not an axios error', async () => {
+      mockIsAxiosError.mockReturnValue(false)
+      mockAxios.get.mockRejectedValueOnce(new Error('boom'))
+
+      await expect(
+        getJourneyStatsBreakdown('journey-id', {
+          property: 'event:goal',
+          metrics: 'visitors'
+        })
+      ).rejects.toThrow('boom')
+    })
+
+    it('rethrows the original axios error when it carries no string error message', async () => {
+      mockIsAxiosError.mockReturnValueOnce(true)
+      const axiosError = { response: { data: {} } }
+      mockAxios.get.mockRejectedValueOnce(axiosError as never)
+
+      await expect(
+        getJourneyStatsBreakdown('journey-id', {
+          property: 'event:goal',
+          metrics: 'visitors'
+        })
+      ).rejects.toBe(axiosError)
+    })
   })
 })

--- a/apis/api-journeys/src/schema/plausible/service.spec.ts
+++ b/apis/api-journeys/src/schema/plausible/service.spec.ts
@@ -63,6 +63,7 @@ describe('getJourneyStatsBreakdown', () => {
         'https://plausible.example/api/v1/stats/breakdown',
         expect.objectContaining({
           headers: { Authorization: 'Bearer plausible-key' },
+          timeout: 30000,
           params: expect.objectContaining({
             site_id: 'api-journeys-journey-journey-id',
             property: 'event:goal',

--- a/apis/api-journeys/src/schema/plausible/service.ts
+++ b/apis/api-journeys/src/schema/plausible/service.ts
@@ -13,6 +13,13 @@ type PlausibleBreakdownParams = {
   metrics: string
 } & typeof PlausibleStatsBreakdownFilter.$inferInput
 
+// Plausible's breakdown endpoint caps `limit` at 1000 rows per page. To fetch
+// more, callers must paginate with `page=1,2,…`. See
+// https://plausible.io/docs/stats-api#get-apiv1statsbreakdown
+const PLAUSIBLE_MAX_BREAKDOWN_LIMIT = 1000
+
+type PlausibleBreakdownRow = Record<string, number | string | null>
+
 export function buildJourneySiteId(journeyId: string): string {
   return `api-journeys-journey-${journeyId}`
 }
@@ -36,36 +43,72 @@ export async function getJourneyStatsBreakdown(
 ): Promise<PlausibleStatsResponse[]> {
   const { baseUrl, headers } = getPlausibleConfig()
   const endpoint = `${baseUrl}/api/v1/stats/breakdown`
+  const resolvedSiteId = siteId ?? buildJourneySiteId(journeyId)
+  const propertyKey = params.property?.split(':').pop() ?? ''
+
+  const fetchPage = async (
+    page: number,
+    limit: number
+  ): Promise<PlausibleBreakdownRow[]> => {
+    const response = await axios.get<{ results: PlausibleBreakdownRow[] }>(
+      endpoint,
+      {
+        headers,
+        params: {
+          site_id: resolvedSiteId,
+          ...params,
+          limit,
+          page
+        }
+      }
+    )
+    return response.data?.results ?? []
+  }
+
+  const toStatsResponse = (
+    row: PlausibleBreakdownRow
+  ): PlausibleStatsResponse => {
+    const propertyValue = (row[propertyKey] as string) ?? ''
+    const accumulator: PlausibleStatsResponse = {
+      property: propertyValue
+    }
+    return reduce(
+      row,
+      (acc, value, key) => {
+        if (key !== propertyKey) {
+          ;(acc as unknown as Record<string, number | null>)[camelCase(key)] =
+            (value as number | null) ?? null
+        }
+        return acc
+      },
+      accumulator
+    )
+  }
 
   try {
-    const response = await axios.get<{
-      results: Array<Record<string, number | string | null>>
-    }>(endpoint, {
-      headers,
-      params: {
-        site_id: siteId ?? buildJourneySiteId(journeyId),
-        ...params
-      }
-    })
-
-    const propertyKey = params.property?.split(':').pop() ?? ''
-    return (response.data?.results ?? []).map((result) => {
-      const propertyValue = (result[propertyKey] as string) ?? ''
-      const accumulator: PlausibleStatsResponse = {
-        property: propertyValue
-      }
-      return reduce(
-        result,
-        (acc, value, key) => {
-          if (key !== propertyKey) {
-            ;(acc as unknown as Record<string, number | null>)[camelCase(key)] =
-              (value as number | null) ?? null
-          }
-          return acc
-        },
-        accumulator
+    // When the caller pins a specific limit or page, honor it with a single
+    // request — they are intentionally asking for a bounded slice of results.
+    if (params.limit != null || params.page != null) {
+      const rows = await fetchPage(
+        params.page ?? 1,
+        params.limit ?? PLAUSIBLE_MAX_BREAKDOWN_LIMIT
       )
-    })
+      return rows.map(toStatsResponse)
+    }
+
+    // Otherwise page through every result. Plausible returns only the top 100
+    // rows by default, so low-volume rows (e.g. capture conversions) silently
+    // drop off as a site accumulates data. Loop with the max page size until a
+    // short page signals the last one.
+    const allRows: PlausibleBreakdownRow[] = []
+    let page = 1
+    for (;;) {
+      const rows = await fetchPage(page, PLAUSIBLE_MAX_BREAKDOWN_LIMIT)
+      allRows.push(...rows)
+      if (rows.length < PLAUSIBLE_MAX_BREAKDOWN_LIMIT) break
+      page += 1
+    }
+    return allRows.map(toStatsResponse)
   } catch (error) {
     if (isAxiosError(error)) {
       const message = get(error, 'response.data.error')

--- a/apis/api-journeys/src/schema/plausible/service.ts
+++ b/apis/api-journeys/src/schema/plausible/service.ts
@@ -23,6 +23,10 @@ const PLAUSIBLE_MAX_BREAKDOWN_LIMIT = 1000
 // `page` param and keeps returning full pages) capping the fetch at 50k rows.
 const PLAUSIBLE_MAX_BREAKDOWN_PAGES = 50
 
+// Per-request timeout. A paginated report can issue many sequential calls, so a
+// single hung connection must not block the resolver indefinitely.
+const PLAUSIBLE_REQUEST_TIMEOUT_MS = 30000
+
 type PlausibleBreakdownRow = Record<string, number | string | null>
 
 export function buildJourneySiteId(journeyId: string): string {
@@ -70,6 +74,7 @@ export async function getJourneyStatsBreakdown(
       endpoint,
       {
         headers,
+        timeout: PLAUSIBLE_REQUEST_TIMEOUT_MS,
         params: {
           site_id: resolvedSiteId,
           ...params,

--- a/apis/api-journeys/src/schema/plausible/service.ts
+++ b/apis/api-journeys/src/schema/plausible/service.ts
@@ -18,6 +18,11 @@ type PlausibleBreakdownParams = {
 // https://plausible.io/docs/stats-api#get-apiv1statsbreakdown
 const PLAUSIBLE_MAX_BREAKDOWN_LIMIT = 1000
 
+// Safety bound on auto-pagination. The loop normally stops when a short page is
+// returned; this guards against a runaway loop (e.g. if Plausible ignores the
+// `page` param and keeps returning full pages) capping the fetch at 50k rows.
+const PLAUSIBLE_MAX_BREAKDOWN_PAGES = 50
+
 type PlausibleBreakdownRow = Record<string, number | string | null>
 
 export function buildJourneySiteId(journeyId: string): string {
@@ -102,11 +107,16 @@ export async function getJourneyStatsBreakdown(
     // short page signals the last one.
     const allRows: PlausibleBreakdownRow[] = []
     let page = 1
-    for (;;) {
+    for (; page <= PLAUSIBLE_MAX_BREAKDOWN_PAGES; page++) {
       const rows = await fetchPage(page, PLAUSIBLE_MAX_BREAKDOWN_LIMIT)
       allRows.push(...rows)
       if (rows.length < PLAUSIBLE_MAX_BREAKDOWN_LIMIT) break
-      page += 1
+    }
+    if (page > PLAUSIBLE_MAX_BREAKDOWN_PAGES) {
+      console.error(
+        '[getJourneyStatsBreakdown] hit max page cap; results may be truncated',
+        { siteId: resolvedSiteId, property: params.property }
+      )
     }
     return allRows.map(toStatsResponse)
   } catch (error) {

--- a/apis/api-journeys/src/schema/plausible/service.ts
+++ b/apis/api-journeys/src/schema/plausible/service.ts
@@ -21,6 +21,11 @@ const PLAUSIBLE_MAX_BREAKDOWN_LIMIT = 1000
 // Safety bound on auto-pagination. The loop normally stops when a short page is
 // returned; this guards against a runaway loop (e.g. if Plausible ignores the
 // `page` param and keeps returning full pages) capping the fetch at 50k rows.
+// 50 is also a deliberate ceiling against Plausible's rate limits: a report
+// issues up to this many pages per breakdown (and templateFamilyStatsBreakdown
+// runs two), so ~100 sequential calls already sits at Plausible cloud's
+// ~100 req/60s burst limit (600/hr per team). Raising it trades a rare tail
+// truncation for 429s. Truncation is logged below rather than surfaced.
 const PLAUSIBLE_MAX_BREAKDOWN_PAGES = 50
 
 // Per-request timeout. A paginated report can issue many sequential calls, so a

--- a/apis/api-journeys/src/schema/plausible/service.ts
+++ b/apis/api-journeys/src/schema/plausible/service.ts
@@ -41,19 +41,30 @@ export function getPlausibleConfig(): {
   }
 }
 
+interface GetJourneyStatsBreakdownOptions {
+  /**
+   * When true, page through the entire breakdown (every row) instead of making
+   * a single request. Plausible returns only the top 100 rows by default, which
+   * silently drops low-volume rows (e.g. capture conversions) from reports that
+   * aggregate across many journeys. Defaults to false so callers that want a
+   * single bounded request (e.g. per-journey analytics) keep their behavior.
+   */
+  paginate?: boolean
+}
+
 export async function getJourneyStatsBreakdown(
   journeyId: string,
   params: PlausibleBreakdownParams,
-  siteId?: string
+  siteId?: string,
+  { paginate = false }: GetJourneyStatsBreakdownOptions = {}
 ): Promise<PlausibleStatsResponse[]> {
   const { baseUrl, headers } = getPlausibleConfig()
   const endpoint = `${baseUrl}/api/v1/stats/breakdown`
   const resolvedSiteId = siteId ?? buildJourneySiteId(journeyId)
   const propertyKey = params.property?.split(':').pop() ?? ''
 
-  const fetchPage = async (
-    page: number,
-    limit: number
+  const requestRows = async (
+    overrides: Record<string, number> = {}
   ): Promise<PlausibleBreakdownRow[]> => {
     const response = await axios.get<{ results: PlausibleBreakdownRow[] }>(
       endpoint,
@@ -62,8 +73,7 @@ export async function getJourneyStatsBreakdown(
         params: {
           site_id: resolvedSiteId,
           ...params,
-          limit,
-          page
+          ...overrides
         }
       }
     )
@@ -91,28 +101,40 @@ export async function getJourneyStatsBreakdown(
   }
 
   try {
-    // When the caller pins a specific limit or page, honor it with a single
-    // request — they are intentionally asking for a bounded slice of results.
-    if (params.limit != null || params.page != null) {
-      const rows = await fetchPage(
-        params.page ?? 1,
-        params.limit ?? PLAUSIBLE_MAX_BREAKDOWN_LIMIT
-      )
+    // Default: a single request that passes the caller's params through
+    // unchanged (Plausible applies its own default limit). Used for bounded,
+    // per-journey queries that must not fan out into many calls.
+    if (!paginate) {
+      const rows = await requestRows()
       return rows.map(toStatsResponse)
     }
 
-    // Otherwise page through every result. Plausible returns only the top 100
-    // rows by default, so low-volume rows (e.g. capture conversions) silently
-    // drop off as a site accumulates data. Loop with the max page size until a
-    // short page signals the last one.
+    // Reports page through every row. Force the max page size and ignore any
+    // caller limit/page. De-dupe by the breakdown's property value so that a
+    // page-ignoring or unstable upstream cannot re-send rows and inflate the
+    // downstream per-event sums; stop on a short page, a page that adds nothing
+    // new, or the page cap.
+    const seen = new Set<string>()
     const allRows: PlausibleBreakdownRow[] = []
     let page = 1
+    let cappedWithMore = false
     for (; page <= PLAUSIBLE_MAX_BREAKDOWN_PAGES; page++) {
-      const rows = await fetchPage(page, PLAUSIBLE_MAX_BREAKDOWN_LIMIT)
-      allRows.push(...rows)
-      if (rows.length < PLAUSIBLE_MAX_BREAKDOWN_LIMIT) break
+      const rows = await requestRows({
+        limit: PLAUSIBLE_MAX_BREAKDOWN_LIMIT,
+        page
+      })
+      let newRows = 0
+      for (const row of rows) {
+        const rowKey = String(row[propertyKey] ?? '')
+        if (seen.has(rowKey)) continue
+        seen.add(rowKey)
+        allRows.push(row)
+        newRows++
+      }
+      if (rows.length < PLAUSIBLE_MAX_BREAKDOWN_LIMIT || newRows === 0) break
+      if (page === PLAUSIBLE_MAX_BREAKDOWN_PAGES) cappedWithMore = true
     }
-    if (page > PLAUSIBLE_MAX_BREAKDOWN_PAGES) {
+    if (cappedWithMore) {
       console.error(
         '[getJourneyStatsBreakdown] hit max page cap; results may be truncated',
         { siteId: resolvedSiteId, property: params.property }

--- a/apis/api-journeys/src/schema/plausible/templateFamilyStatsAggregate/templateFamilyStatsAggregate.query.ts
+++ b/apis/api-journeys/src/schema/plausible/templateFamilyStatsAggregate/templateFamilyStatsAggregate.query.ts
@@ -67,10 +67,14 @@ builder.queryField('templateFamilyStatsAggregate', (t) =>
       let breakdownResults: PlausibleStatsResponse[] = []
       if (templateJourney.templateSite === true) {
         const templateSiteId = `api-journeys-template-${templateJourney.id}`
+        // This aggregate sums every journey's views, so it always needs the
+        // full result set. Drop any client-supplied limit/page so the fetch
+        // paginates instead of collapsing to a single (top-100) page.
+        const fullFetchWhere = { ...where, limit: undefined, page: undefined }
         breakdownResults = await getJourneyStatsBreakdown(
           templateJourney.id,
           {
-            ...where,
+            ...fullFetchWhere,
             property: 'event:page',
             metrics: 'visitors'
           },

--- a/apis/api-journeys/src/schema/plausible/templateFamilyStatsAggregate/templateFamilyStatsAggregate.query.ts
+++ b/apis/api-journeys/src/schema/plausible/templateFamilyStatsAggregate/templateFamilyStatsAggregate.query.ts
@@ -67,18 +67,18 @@ builder.queryField('templateFamilyStatsAggregate', (t) =>
       let breakdownResults: PlausibleStatsResponse[] = []
       if (templateJourney.templateSite === true) {
         const templateSiteId = `api-journeys-template-${templateJourney.id}`
-        // This aggregate sums every journey's views, so it always needs the
-        // full result set. Drop any client-supplied limit/page so the fetch
-        // paginates instead of collapsing to a single (top-100) page.
-        const fullFetchWhere = { ...where, limit: undefined, page: undefined }
+        // This aggregate sums every journey's views, so it must read the full
+        // breakdown. paginate: true pages through all rows (and ignores any
+        // client-supplied limit/page) instead of collapsing to a single page.
         breakdownResults = await getJourneyStatsBreakdown(
           templateJourney.id,
           {
-            ...fullFetchWhere,
+            ...where,
             property: 'event:page',
             metrics: 'visitors'
           },
-          templateSiteId
+          templateSiteId,
+          { paginate: true }
         )
       }
 

--- a/apis/api-journeys/src/schema/plausible/templateFamilyStatsBreakdown/templateFamilyStatsBreakdown.query.spec.ts
+++ b/apis/api-journeys/src/schema/plausible/templateFamilyStatsBreakdown/templateFamilyStatsBreakdown.query.spec.ts
@@ -229,6 +229,59 @@ describe('templateFamilyStatsBreakdown', () => {
     }
   })
 
+  it('ignores client-supplied limit/page so the report still fetches every page', async () => {
+    const templateJourney = {
+      id: 'template-journey-id',
+      slug: 'template-slug',
+      title: 'Template Journey',
+      userJourneys: [],
+      team: { userTeams: [] }
+    }
+
+    prismaMock.journey.findUnique.mockResolvedValue(
+      templateJourney as unknown as JourneyWithAcl
+    )
+    prismaMock.journey.findMany.mockResolvedValue([])
+    ;(prismaMock.journeyVisitor.groupBy as any).mockResolvedValue([])
+
+    // Both breakdown calls return a short first page, so each makes one request.
+    mockAxios.get.mockResolvedValue({
+      data: { results: [] }
+    } as unknown as AxiosResponse)
+
+    await authClient({
+      document: QUERY,
+      variables: {
+        id: 'template-journey-id',
+        idType: 'databaseId',
+        where: {
+          property: 'event:goal',
+          limit: 100,
+          page: 5
+        }
+      }
+    })
+
+    // The client's limit/page must be dropped: the fetch paginates from page 1
+    // at the max page size rather than honoring the client's bounded slice.
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/stats/breakdown'),
+      expect.objectContaining({
+        params: expect.objectContaining({
+          property: 'event:props:templateKey',
+          limit: 1000,
+          page: 1
+        })
+      })
+    )
+    expect(mockAxios.get).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        params: expect.objectContaining({ limit: 100 })
+      })
+    )
+  })
+
   it('returns error when template journey not found', async () => {
     prismaMock.journey.findUnique.mockResolvedValue(null)
 

--- a/apis/api-journeys/src/schema/plausible/templateFamilyStatsBreakdown/templateFamilyStatsBreakdown.query.ts
+++ b/apis/api-journeys/src/schema/plausible/templateFamilyStatsBreakdown/templateFamilyStatsBreakdown.query.ts
@@ -94,10 +94,15 @@ builder.queryField('templateFamilyStatsBreakdown', (t) =>
 
       const templateSiteId = `api-journeys-template-${templateJourney.id}`
 
+      // This report must aggregate every journey, so it always needs the full
+      // result set. Drop any client-supplied limit/page so getJourneyStatsBreakdown
+      // paginates instead of collapsing to a single (top-100) page.
+      const fullFetchWhere = { ...where, limit: undefined, page: undefined }
+
       const breakdownResults = await getJourneyStatsBreakdown(
         templateJourney.id,
         {
-          ...where,
+          ...fullFetchWhere,
           property: 'event:props:templateKey',
           metrics: 'visitors'
         },
@@ -179,7 +184,7 @@ builder.queryField('templateFamilyStatsBreakdown', (t) =>
           ? getJourneyStatsBreakdown(
               templateJourney.id,
               {
-                ...where,
+                ...fullFetchWhere,
                 property: 'event:page',
                 metrics: 'visitors'
               },

--- a/apis/api-journeys/src/schema/plausible/templateFamilyStatsBreakdown/templateFamilyStatsBreakdown.query.ts
+++ b/apis/api-journeys/src/schema/plausible/templateFamilyStatsBreakdown/templateFamilyStatsBreakdown.query.ts
@@ -94,19 +94,18 @@ builder.queryField('templateFamilyStatsBreakdown', (t) =>
 
       const templateSiteId = `api-journeys-template-${templateJourney.id}`
 
-      // This report must aggregate every journey, so it always needs the full
-      // result set. Drop any client-supplied limit/page so getJourneyStatsBreakdown
-      // paginates instead of collapsing to a single (top-100) page.
-      const fullFetchWhere = { ...where, limit: undefined, page: undefined }
-
+      // This report aggregates every journey in the family, so it must read the
+      // full breakdown. paginate: true pages through all rows (and ignores any
+      // client-supplied limit/page) instead of collapsing to a single top-100 page.
       const breakdownResults = await getJourneyStatsBreakdown(
         templateJourney.id,
         {
-          ...fullFetchWhere,
+          ...where,
           property: 'event:props:templateKey',
           metrics: 'visitors'
         },
-        templateSiteId
+        templateSiteId,
+        { paginate: true }
       )
 
       const transformedResults = transformBreakdownResults(
@@ -184,11 +183,12 @@ builder.queryField('templateFamilyStatsBreakdown', (t) =>
           ? getJourneyStatsBreakdown(
               templateJourney.id,
               {
-                ...fullFetchWhere,
+                ...where,
                 property: 'event:page',
                 metrics: 'visitors'
               },
-              templateSiteId
+              templateSiteId,
+              { paginate: true }
             )
           : Promise.resolve([])
       ])

--- a/libs/journeys/ui/src/components/Step/Step.spec.tsx
+++ b/libs/journeys/ui/src/components/Step/Step.spec.tsx
@@ -309,6 +309,50 @@ describe('Step', () => {
     )
   })
 
+  it('fires only pageview for a card whose eventLabel has no capture goal', async () => {
+    const mockPlausible = vi.fn()
+    mockUsePlausible.mockReturnValue(mockPlausible)
+
+    const blockWithShareCard: TreeBlock<StepFields> = {
+      ...block,
+      children: [
+        {
+          __typename: 'CardBlock',
+          id: 'Card1',
+          parentBlockId: 'Step1',
+          parentOrder: 0,
+          backgroundColor: null,
+          coverBlockId: null,
+          themeMode: null,
+          themeName: null,
+          fullscreen: false,
+          backdropBlur: null,
+          eventLabel: BlockEventLabel.share,
+          children: [],
+          showAssistant: null,
+          expandChatByDefault: null
+        }
+      ]
+    }
+
+    treeBlocksVar([blockWithShareCard])
+    blockHistoryVar([blockWithShareCard])
+
+    render(
+      <MockedProvider mocks={[mockStepViewEventCreate]}>
+        <JourneyProvider value={{ journey }}>
+          <Step {...blockWithShareCard} />
+        </JourneyProvider>
+      </MockedProvider>
+    )
+    await waitFor(() =>
+      expect(mockStepViewEventCreate.result).toHaveBeenCalled()
+    )
+    // share has no registered Plausible goal, so only pageview should fire.
+    expect(mockPlausible).toHaveBeenCalledWith('pageview', expect.any(Object))
+    expect(mockPlausible).toHaveBeenCalledTimes(1)
+  })
+
   it.skip('should create a stepViewEvent with a UTM code', async () => {
     // disabled due to Jest v30 compatibility issues
     const mockSearch = '?utm_source=source&utm_campaign=campaign'

--- a/libs/journeys/ui/src/components/Step/Step.spec.tsx
+++ b/libs/journeys/ui/src/components/Step/Step.spec.tsx
@@ -238,7 +238,7 @@ describe('Step', () => {
     })
   })
 
-  it('should call plausible with eventLabel for pageview events', async () => {
+  it('should call plausible with the capture goal for card eventLabel', async () => {
     const mockPlausible = vi.fn()
     mockUsePlausible.mockReturnValue(mockPlausible)
 
@@ -278,7 +278,7 @@ describe('Step', () => {
       expect(mockStepViewEventCreate.result).toHaveBeenCalled()
     )
     expect(mockPlausible).toHaveBeenCalledWith('pageview', expect.any(Object))
-    expect(mockPlausible).toHaveBeenCalledWith(BlockEventLabel.custom1, {
+    expect(mockPlausible).toHaveBeenCalledWith('custom1Capture', {
       u: expect.stringContaining(`/journeyId/Step1`),
       props: {
         id: 'uuid',
@@ -286,22 +286,27 @@ describe('Step', () => {
         value: 'Step 1',
         key: keyify({
           stepId: 'Step1',
-          event: BlockEventLabel.custom1,
+          event: 'custom1Capture',
           blockId: 'Step1',
           journeyId: 'journeyId'
         }),
         simpleKey: keyify({
           stepId: 'Step1',
-          event: BlockEventLabel.custom1,
+          event: 'custom1Capture',
           blockId: 'Step1',
           journeyId: 'journeyId'
         }),
         templateKey: templateKeyify({
-          event: BlockEventLabel.custom1,
+          event: 'custom1Capture',
           journeyId: 'journeyId'
         })
       }
     })
+    // Raw event labels are no longer fired; only the registered capture goal is.
+    expect(mockPlausible).not.toHaveBeenCalledWith(
+      BlockEventLabel.custom1,
+      expect.anything()
+    )
   })
 
   it.skip('should create a stepViewEvent with a UTM code', async () => {

--- a/libs/journeys/ui/src/components/Step/Step.tsx
+++ b/libs/journeys/ui/src/components/Step/Step.tsx
@@ -13,6 +13,7 @@ import { getStepHeading } from '../../libs/getStepHeading'
 import { useJourney } from '../../libs/JourneyProvider/JourneyProvider'
 import {
   JourneyPlausibleEvents,
+  fireCaptureEvent,
   keyify,
   templateKeyify
 } from '../../libs/plausibleHelpers'
@@ -99,26 +100,16 @@ export function Step({
           children[0]?.__typename === 'CardBlock'
             ? children[0].eventLabel
             : null
-        if (eventLabel != null) {
-          const eventLabelKey = keyify({
-            stepId: input.blockId,
-            event: eventLabel,
-            blockId: input.blockId,
-            journeyId: journey?.id
-          })
-          plausible(eventLabel, {
-            u: `${window.location.origin}/${journey.id}/${input.blockId}`,
-            props: {
-              ...input,
-              key: eventLabelKey,
-              simpleKey: eventLabelKey,
-              templateKey: templateKeyify({
-                event: eventLabel,
-                journeyId: journey?.id
-              })
-            }
-          })
-        }
+        // Fire the registered Capture goal (e.g. christDecisionCapture) instead of
+        // the raw event label so card conversions are counted in the Plausible
+        // dashboard, matching how buttons/videos/radio questions report captures.
+        fireCaptureEvent(plausible, eventLabel, {
+          u: `${window.location.origin}/${journey.id}/${input.blockId}`,
+          input,
+          stepId: input.blockId,
+          blockId: input.blockId,
+          journeyId: journey?.id
+        })
       }
       sendGTMEvent({
         event: 'step_view',

--- a/libs/journeys/ui/src/libs/plausibleHelpers/plausibleHelpers.spec.ts
+++ b/libs/journeys/ui/src/libs/plausibleHelpers/plausibleHelpers.spec.ts
@@ -5,6 +5,7 @@ import { BlockFields_ButtonBlock_action as ButtonBlockAction } from '../block/__
 import {
   BLOCK_EVENT_LABEL_TO_PLAUSIBLE_EVENT,
   actionToTarget,
+  fireCaptureEvent,
   getTargetEventKey,
   templateKeyify
 } from './plausibleHelpers'
@@ -311,6 +312,55 @@ describe('PlausibleHelpers', () => {
       expect(
         BLOCK_EVENT_LABEL_TO_PLAUSIBLE_EVENT[BlockEventLabel.share]
       ).toBeNull()
+    })
+  })
+
+  describe('fireCaptureEvent', () => {
+    const options = {
+      u: 'https://example.com/journeyId/Step1',
+      input: { id: 'eventId' },
+      stepId: 'Step1',
+      blockId: 'Block1',
+      journeyId: 'journeyId'
+    }
+
+    it('fires the mapped capture goal for a mapped event label', () => {
+      const plausible = vi.fn()
+      fireCaptureEvent(plausible, BlockEventLabel.decisionForChrist, options)
+
+      expect(plausible).toHaveBeenCalledTimes(1)
+      expect(plausible).toHaveBeenCalledWith(
+        'christDecisionCapture',
+        expect.objectContaining({
+          u: options.u,
+          props: expect.objectContaining({
+            id: 'eventId',
+            blockId: 'Block1',
+            key: expect.any(String),
+            simpleKey: expect.any(String),
+            templateKey: expect.any(String)
+          })
+        })
+      )
+    })
+
+    it('does not fire for share (no registered Plausible goal)', () => {
+      const plausible = vi.fn()
+      fireCaptureEvent(plausible, BlockEventLabel.share, options)
+      expect(plausible).not.toHaveBeenCalled()
+    })
+
+    it('does not fire for inviteFriend (no registered Plausible goal)', () => {
+      const plausible = vi.fn()
+      fireCaptureEvent(plausible, BlockEventLabel.inviteFriend, options)
+      expect(plausible).not.toHaveBeenCalled()
+    })
+
+    it('does not fire when the event label is null or undefined', () => {
+      const plausible = vi.fn()
+      fireCaptureEvent(plausible, null, options)
+      fireCaptureEvent(plausible, undefined, options)
+      expect(plausible).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
Resolves [QA-537](https://linear.app/jesus-film-project/issue/QA-537/fix-team-templates-analytics-decline-capture-event-naming-mismatch).

Capture counts (Decisions for Christ, Gospel Started, …) on the team-templates breakdown report were declining over time even though they should only ever rise. Two distinct fixes:

## A. Fire registered capture goals from card events
Cards in `Step.tsx` fired the **raw** event labels (`decisionForChrist`, `custom1`, …) straight to Plausible, but only the `*Capture` names are registered goals — so card conversions were missing from the Plausible dashboard's conversions panel. Buttons/videos/radio questions were migrated to `fireCaptureEvent` in #9075; cards never were.

- `Step.tsx` now calls `fireCaptureEvent`, firing the registered capture goal (e.g. `christDecisionCapture`) consistently with the other block types.
- The team-templates report is unaffected — it maps raw→capture and is idempotent for capture names.

## B. Paginate the Plausible breakdown fetch
`getJourneyStatsBreakdown` issued a single un-paginated request, so Plausible returned only the **top 100 rows by visitors**. Low-volume capture rows sit at the bottom of that ranked list and silently dropped past rank 100 as a template family accumulated data — the prime suspect for the decline.

- Page through every row (`limit=1000`, looping `page=1,2,…` until a short/empty page) and combine results.
- An explicit `limit`/`page` from a caller is still honored with a single bounded request, so callers that intentionally request a slice are unaffected.

## Tests
- Updated `Step.spec.tsx` to assert the capture goal is fired and the raw label is not.
- New `service.spec.ts` covering single short page, full multi-page loop, exact-multiple boundary, explicit limit/page passthrough, key mapping, and error handling.
- All 62 `plausible` specs pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced journey analytics breakdown fetching with controlled pagination to handle large result sets and aggregate across all pages.
* **Bug Fixes**
  * Fixed card capture analytics so the correct capture goal is tracked (including proper key mapping) rather than the raw label.
  * Improved Plausible breakdown error handling by returning a clearer, user-facing error for invalid inputs.
* **Tests**
  * Added coverage for pagination edge cases and analytics capture behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->