### PR TITLE
fix(journeys-admin): use all-time range for template card analytics

### DIFF
--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCard.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/JourneyCard.spec.tsx
@@ -1,5 +1,6 @@
 import { MockedProvider, MockedResponse } from '@apollo/client/testing'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { formatISO } from 'date-fns'
 import { SnackbarProvider } from 'notistack'
 import { type MockedFunction } from 'vitest'
 
@@ -288,7 +289,12 @@ describe('JourneyCard', () => {
         variables: {
           id: publishedLocalTemplate.id,
           idType: IdType.databaseId,
-          where: {}
+          where: {
+            period: 'custom',
+            date: `2024-06-01,${formatISO(new Date(), {
+              representation: 'date'
+            })}`
+          }
         }
       },
       result: {

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/TemplateAggregateAnalytics/TemplateAggregateAnalytics.spec.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/TemplateAggregateAnalytics/TemplateAggregateAnalytics.spec.tsx
@@ -1,5 +1,7 @@
 import { MockedProvider, MockedResponse } from '@apollo/client/testing'
 import { render, screen, waitFor } from '@testing-library/react'
+import { formatISO } from 'date-fns'
+import { type MockedFunction } from 'vitest'
 
 import {
   GetTemplateFamilyStatsAggregate,
@@ -17,6 +19,15 @@ vi.mock('next-i18next/pages', () => ({
   })
 }))
 
+vi.mock('date-fns', async () => {
+  return {
+    ...(await vi.importActual('date-fns')),
+    formatISO: vi.fn()
+  }
+})
+
+const mockFormatIso = formatISO as MockedFunction<typeof formatISO>
+
 const mockEnqueueSnackbar = vi.fn()
 
 vi.mock('notistack', () => ({
@@ -26,6 +37,10 @@ vi.mock('notistack', () => ({
 }))
 
 describe('TemplateAggregateAnalytics', () => {
+  beforeEach(() => {
+    mockFormatIso.mockReturnValue('2024-09-26')
+  })
+
   afterEach(() => {
     vi.clearAllMocks()
   })
@@ -54,7 +69,10 @@ describe('TemplateAggregateAnalytics', () => {
         variables: {
           id: 'journeyId',
           idType: IdType.databaseId,
-          where: {}
+          where: {
+            period: 'custom',
+            date: '2024-06-01,2024-09-26'
+          }
         }
       },
       result: vi.fn(() => ({
@@ -97,7 +115,10 @@ describe('TemplateAggregateAnalytics', () => {
         variables: {
           id: 'journeyId',
           idType: IdType.databaseId,
-          where: {}
+          where: {
+            period: 'custom',
+            date: '2024-06-01,2024-09-26'
+          }
         }
       },
       error: new Error('Failed to fetch template stats')

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/TemplateAggregateAnalytics/TemplateAggregateAnalytics.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/TemplateAggregateAnalytics/TemplateAggregateAnalytics.tsx
@@ -1,7 +1,6 @@
 import Box from '@mui/material/Box'
 import Skeleton from '@mui/material/Skeleton'
 import Typography from '@mui/material/Typography'
-import { formatISO } from 'date-fns'
 import { useTranslation } from 'next-i18next/pages'
 import { useSnackbar } from 'notistack'
 import { ReactElement, useEffect } from 'react'
@@ -11,8 +10,10 @@ import EyeOpenIcon from '@core/shared/ui/icons/EyeOpen'
 import Inbox2Icon from '@core/shared/ui/icons/Inbox2'
 
 import { IdType } from '../../../../../__generated__/globalTypes'
-import { useTemplateFamilyStatsAggregateLazyQuery } from '../../../../libs/useTemplateFamilyStatsAggregateLazyQuery'
-import { earliestStatsCollected } from '../../../Editor/Slider/JourneyFlow/AnalyticsOverlaySwitch/buildPresetDateRange'
+import {
+  buildAllTimeStatsFilter,
+  useTemplateFamilyStatsAggregateLazyQuery
+} from '../../../../libs/useTemplateFamilyStatsAggregateLazyQuery'
 import { Item } from '../../../Editor/Toolbar/Items/Item'
 
 import { localizeAndRound } from './localizeAndRound'
@@ -36,12 +37,7 @@ export function TemplateAggregateAnalytics({
         variables: {
           id: journeyId,
           idType: IdType.databaseId,
-          where: {
-            period: 'custom',
-            date: `${earliestStatsCollected},${formatISO(new Date(), {
-              representation: 'date'
-            })}`
-          }
+          where: buildAllTimeStatsFilter()
         }
       })
     }

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/TemplateAggregateAnalytics/TemplateAggregateAnalytics.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/TemplateAggregateAnalytics/TemplateAggregateAnalytics.tsx
@@ -1,6 +1,7 @@
 import Box from '@mui/material/Box'
 import Skeleton from '@mui/material/Skeleton'
 import Typography from '@mui/material/Typography'
+import { formatISO } from 'date-fns'
 import { useTranslation } from 'next-i18next/pages'
 import { useSnackbar } from 'notistack'
 import { ReactElement, useEffect } from 'react'
@@ -11,6 +12,7 @@ import Inbox2Icon from '@core/shared/ui/icons/Inbox2'
 
 import { IdType } from '../../../../../__generated__/globalTypes'
 import { useTemplateFamilyStatsAggregateLazyQuery } from '../../../../libs/useTemplateFamilyStatsAggregateLazyQuery'
+import { earliestStatsCollected } from '../../../Editor/Slider/JourneyFlow/AnalyticsOverlaySwitch/buildPresetDateRange'
 import { Item } from '../../../Editor/Toolbar/Items/Item'
 
 import { localizeAndRound } from './localizeAndRound'
@@ -34,7 +36,12 @@ export function TemplateAggregateAnalytics({
         variables: {
           id: journeyId,
           idType: IdType.databaseId,
-          where: {}
+          where: {
+            period: 'custom',
+            date: `${earliestStatsCollected},${formatISO(new Date(), {
+              representation: 'date'
+            })}`
+          }
         }
       })
     }

--- a/apps/journeys-admin/src/components/JourneyList/JourneyCard/TemplateAggregateAnalytics/TemplateAggregateAnalytics.tsx
+++ b/apps/journeys-admin/src/components/JourneyList/JourneyCard/TemplateAggregateAnalytics/TemplateAggregateAnalytics.tsx
@@ -10,10 +10,8 @@ import EyeOpenIcon from '@core/shared/ui/icons/EyeOpen'
 import Inbox2Icon from '@core/shared/ui/icons/Inbox2'
 
 import { IdType } from '../../../../../__generated__/globalTypes'
-import {
-  buildAllTimeStatsFilter,
-  useTemplateFamilyStatsAggregateLazyQuery
-} from '../../../../libs/useTemplateFamilyStatsAggregateLazyQuery'
+import { buildAllTimeStatsFilter } from '../../../../libs/buildAllTimeStatsFilter'
+import { useTemplateFamilyStatsAggregateLazyQuery } from '../../../../libs/useTemplateFamilyStatsAggregateLazyQuery'
 import { Item } from '../../../Editor/Toolbar/Items/Item'
 
 import { localizeAndRound } from './localizeAndRound'

--- a/apps/journeys-admin/src/libs/buildAllTimeStatsFilter/buildAllTimeStatsFilter.ts
+++ b/apps/journeys-admin/src/libs/buildAllTimeStatsFilter/buildAllTimeStatsFilter.ts
@@ -1,0 +1,19 @@
+import { formatISO } from 'date-fns'
+
+import { PlausibleStatsAggregateFilter } from '../../../__generated__/globalTypes'
+import { earliestStatsCollected } from '../../components/Editor/Slider/JourneyFlow/AnalyticsOverlaySwitch/buildPresetDateRange'
+
+/**
+ * Builds the all-time stats filter shared by every template-stats query.
+ * Omitting period/date makes the Plausible Stats API silently default to
+ * the last 30 days, and every call site must send the same `where` args so
+ * queries and refetches read/write the same Apollo cache entry.
+ */
+export function buildAllTimeStatsFilter(): PlausibleStatsAggregateFilter {
+  return {
+    period: 'custom',
+    date: `${earliestStatsCollected},${formatISO(new Date(), {
+      representation: 'date'
+    })}`
+  }
+}

--- a/apps/journeys-admin/src/libs/buildAllTimeStatsFilter/index.ts
+++ b/apps/journeys-admin/src/libs/buildAllTimeStatsFilter/index.ts
@@ -1,0 +1,1 @@
+export { buildAllTimeStatsFilter } from './buildAllTimeStatsFilter'

--- a/apps/journeys-admin/src/libs/useTemplateFamilyStatsAggregateLazyQuery/index.ts
+++ b/apps/journeys-admin/src/libs/useTemplateFamilyStatsAggregateLazyQuery/index.ts
@@ -1,5 +1,6 @@
 export {
   GET_TEMPLATE_FAMILY_STATS_AGGREGATE,
+  buildAllTimeStatsFilter,
   useTemplateFamilyStatsAggregateLazyQuery
 } from './useTemplateFamilyStatsAggregateLazyQuery'
 export { extractTemplateIdsFromJourneys } from './extractTemplateIdsFromJourneys'

--- a/apps/journeys-admin/src/libs/useTemplateFamilyStatsAggregateLazyQuery/index.ts
+++ b/apps/journeys-admin/src/libs/useTemplateFamilyStatsAggregateLazyQuery/index.ts
@@ -1,6 +1,5 @@
 export {
   GET_TEMPLATE_FAMILY_STATS_AGGREGATE,
-  buildAllTimeStatsFilter,
   useTemplateFamilyStatsAggregateLazyQuery
 } from './useTemplateFamilyStatsAggregateLazyQuery'
 export { extractTemplateIdsFromJourneys } from './extractTemplateIdsFromJourneys'

--- a/apps/journeys-admin/src/libs/useTemplateFamilyStatsAggregateLazyQuery/useTemplateFamilyStatsAggregateLazyQuery.ts
+++ b/apps/journeys-admin/src/libs/useTemplateFamilyStatsAggregateLazyQuery/useTemplateFamilyStatsAggregateLazyQuery.ts
@@ -4,13 +4,18 @@ import {
   useApolloClient,
   useLazyQuery
 } from '@apollo/client'
+import { formatISO } from 'date-fns'
 import { useCallback } from 'react'
 
 import {
   GetTemplateFamilyStatsAggregate,
   GetTemplateFamilyStatsAggregateVariables
 } from '../../../__generated__/GetTemplateFamilyStatsAggregate'
-import { IdType } from '../../../__generated__/globalTypes'
+import {
+  IdType,
+  PlausibleStatsAggregateFilter
+} from '../../../__generated__/globalTypes'
+import { earliestStatsCollected } from '../../components/Editor/Slider/JourneyFlow/AnalyticsOverlaySwitch/buildPresetDateRange'
 
 export const GET_TEMPLATE_FAMILY_STATS_AGGREGATE = gql`
   query GetTemplateFamilyStatsAggregate(
@@ -25,6 +30,21 @@ export const GET_TEMPLATE_FAMILY_STATS_AGGREGATE = gql`
     }
   }
 `
+
+/**
+ * Builds the all-time stats filter shared by every template-stats query.
+ * Omitting period/date makes the Plausible Stats API silently default to
+ * the last 30 days, and every call site must send the same `where` args so
+ * queries and refetches read/write the same Apollo cache entry.
+ */
+export function buildAllTimeStatsFilter(): PlausibleStatsAggregateFilter {
+  return {
+    period: 'custom',
+    date: `${earliestStatsCollected},${formatISO(new Date(), {
+      representation: 'date'
+    })}`
+  }
+}
 
 /**
  * Hook that provides functions to fetch and refetch template family stats.
@@ -63,7 +83,7 @@ export function useTemplateFamilyStatsAggregateLazyQuery(): {
             variables: {
               id: templateId,
               idType: IdType.databaseId,
-              where: {}
+              where: buildAllTimeStatsFilter()
             },
             fetchPolicy: 'network-only'
           })

--- a/apps/journeys-admin/src/libs/useTemplateFamilyStatsAggregateLazyQuery/useTemplateFamilyStatsAggregateLazyQuery.ts
+++ b/apps/journeys-admin/src/libs/useTemplateFamilyStatsAggregateLazyQuery/useTemplateFamilyStatsAggregateLazyQuery.ts
@@ -4,18 +4,14 @@ import {
   useApolloClient,
   useLazyQuery
 } from '@apollo/client'
-import { formatISO } from 'date-fns'
 import { useCallback } from 'react'
 
 import {
   GetTemplateFamilyStatsAggregate,
   GetTemplateFamilyStatsAggregateVariables
 } from '../../../__generated__/GetTemplateFamilyStatsAggregate'
-import {
-  IdType,
-  PlausibleStatsAggregateFilter
-} from '../../../__generated__/globalTypes'
-import { earliestStatsCollected } from '../../components/Editor/Slider/JourneyFlow/AnalyticsOverlaySwitch/buildPresetDateRange'
+import { IdType } from '../../../__generated__/globalTypes'
+import { buildAllTimeStatsFilter } from '../buildAllTimeStatsFilter'
 
 export const GET_TEMPLATE_FAMILY_STATS_AGGREGATE = gql`
   query GetTemplateFamilyStatsAggregate(
@@ -30,21 +26,6 @@ export const GET_TEMPLATE_FAMILY_STATS_AGGREGATE = gql`
     }
   }
 `
-
-/**
- * Builds the all-time stats filter shared by every template-stats query.
- * Omitting period/date makes the Plausible Stats API silently default to
- * the last 30 days, and every call site must send the same `where` args so
- * queries and refetches read/write the same Apollo cache entry.
- */
-export function buildAllTimeStatsFilter(): PlausibleStatsAggregateFilter {
-  return {
-    period: 'custom',
-    date: `${earliestStatsCollected},${formatISO(new Date(), {
-      representation: 'date'
-    })}`
-  }
-}
 
 /**
  * Hook that provides functions to fetch and refetch template family stats.

--- a/docs/solutions/integration-issues/plausible-default-30-day-window-when-period-omitted.md
+++ b/docs/solutions/integration-issues/plausible-default-30-day-window-when-period-omitted.md
@@ -36,7 +36,7 @@ Template card analytics (`TemplateAggregateAnalytics`) showed a **declining View
 
 ## What Didn't Work
 
-- Hunting for Plausible-side data loss (ClickHouse TTL/retention, sampling, salt rotation) or backend subtractive steps. Those were plausible for the *breakdown* surface but the template card decline had a much simpler cause: the frontend never sent a date range at all.
+- Hunting for Plausible-side data loss (ClickHouse TTL/retention, sampling, salt rotation) or backend subtractive steps. Those were plausible for the _breakdown_ surface but the template card decline had a much simpler cause: the frontend never sent a date range at all.
 - Expecting the type system to catch it: `period` and `date` are optional on `PlausibleStatsAggregateFilter`, so `where: {}` compiles and passes GraphQL validation.
 
 ## Solution
@@ -74,12 +74,12 @@ void getTemplateStats({
 
 Audit of all four analytics surfaces (QA-540, 2026-07-02):
 
-| Surface | Component | Date range |
-| --- | --- | --- |
-| Journey card analytics | `AnalyticsItem` (via `JourneyCardInfo`) | ✅ all time (explicit custom range) |
-| Template card analytics | `TemplateAggregateAnalytics` | ⚠️ was `where: {}` → fixed in PR #9340 |
-| Template breakdown analytics | `TemplateBreakdownAnalyticsDialog` | ✅ all time (explicit custom range) |
-| Analytics dialog (editor overlay) | `AnalyticsOverlaySwitch` | ✅ all time by default (`allTime` preset) |
+| Surface                           | Component                               | Date range                                |
+| --------------------------------- | --------------------------------------- | ----------------------------------------- |
+| Journey card analytics            | `AnalyticsItem` (via `JourneyCardInfo`) | ✅ all time (explicit custom range)       |
+| Template card analytics           | `TemplateAggregateAnalytics`            | ⚠️ was `where: {}` → fixed in PR #9340    |
+| Template breakdown analytics      | `TemplateBreakdownAnalyticsDialog`      | ✅ all time (explicit custom range)       |
+| Analytics dialog (editor overlay) | `AnalyticsOverlaySwitch`                | ✅ all time by default (`allTime` preset) |
 
 When updating call sites, remember Apollo `MockedProvider` matches variables **exactly**: update spec mocks to the new `where`, and mock `formatISO` for determinism (see `AnalyticsItem.spec.tsx` for the pattern) or compute the expected date under the suite's faked system time (see `JourneyCard.spec.tsx`).
 

--- a/docs/solutions/integration-issues/plausible-default-30-day-window-when-period-omitted.md
+++ b/docs/solutions/integration-issues/plausible-default-30-day-window-when-period-omitted.md
@@ -55,7 +55,7 @@ void getTemplateStats({
 })
 ```
 
-After — both template-stats call sites share one builder, exported from `useTemplateFamilyStatsAggregateLazyQuery`:
+After — both template-stats call sites share one builder, `libs/buildAllTimeStatsFilter` (its own module, NOT exported from the hook lib: ~10 specs mock the hook module with `vi.mock` factories, and adding a new export there crashed every tree that consumed it):
 
 ```ts
 export function buildAllTimeStatsFilter(): PlausibleStatsAggregateFilter {
@@ -91,7 +91,7 @@ The chain has no default on our side: the frontend `where` is spread by the api-
 ## Prevention
 
 - Any new frontend query against `journeysPlausibleStatsAggregate`, `journeysPlausibleStatsBreakdown`, `templateFamilyStatsAggregate`, or `templateFamilyStatsBreakdown` must pass an explicit `period`/`date`. Never send an empty `where` — it compiles, runs, and silently means "last 30 days".
-- Build the range from `earliestStatsCollected`, not a hardcoded date, so the floor stays consistent across surfaces. For template stats specifically, reuse `buildAllTimeStatsFilter()` from `useTemplateFamilyStatsAggregateLazyQuery`.
+- Build the range from `earliestStatsCollected`, not a hardcoded date, so the floor stays consistent across surfaces. For template stats specifically, reuse `buildAllTimeStatsFilter()` from `libs/buildAllTimeStatsFilter`.
 - When changing a query's variables, grep for **every** use of the query document (the `GET_*` constant) — imperative `client.query` refetch call sites are easy to miss, and a `where` mismatch between query and refetch splits the Apollo cache entry, silently breaking the refresh.
 - If declining analytics numbers are reported again, check the date range each surface actually sends **first** — it is far cheaper to verify than Plausible-side data-loss theories.
 - Frontend-only enforcement was evaluated and deliberately skipped (few call sites): baking the filter into hooks doesn't bind future queries, and lint can't see runtime variable values. If this recurs, the real fix is server-side — make `period`/`date` required on the filter inputs (codegen then makes `where: {}` a frontend compile error) or default omitted filters to all-time in the resolvers.

--- a/docs/solutions/integration-issues/plausible-default-30-day-window-when-period-omitted.md
+++ b/docs/solutions/integration-issues/plausible-default-30-day-window-when-period-omitted.md
@@ -55,22 +55,23 @@ void getTemplateStats({
 })
 ```
 
-After:
+After — both template-stats call sites share one builder, exported from `useTemplateFamilyStatsAggregateLazyQuery`:
 
 ```ts
-void getTemplateStats({
-  variables: {
-    id: journeyId,
-    idType: IdType.databaseId,
-    where: {
-      period: 'custom',
-      date: `${earliestStatsCollected},${formatISO(new Date(), {
-        representation: 'date'
-      })}`
-    }
+export function buildAllTimeStatsFilter(): PlausibleStatsAggregateFilter {
+  return {
+    period: 'custom',
+    date: `${earliestStatsCollected},${formatISO(new Date(), {
+      representation: 'date'
+    })}`
   }
-})
+}
+
+// TemplateAggregateAnalytics.tsx and refetchTemplateStats both use:
+where: buildAllTimeStatsFilter()
 ```
+
+The first fix pass changed only the component's initial query and **missed the second call site in the same lib**: `refetchTemplateStats` (run after duplicate/trash/restore/translate/copy-to-team across many components) still sent `where: {}`. Caught in PR review. Beyond re-introducing the 30-day window, the mismatch had a second consequence: Apollo keys `templateFamilyStatsAggregate` by its `where` args, so the refetch wrote a **different cache entry** than the card was reading — making the refetch a silent UI no-op.
 
 Audit of all four analytics surfaces (QA-540, 2026-07-02):
 
@@ -90,7 +91,8 @@ The chain has no default on our side: the frontend `where` is spread by the api-
 ## Prevention
 
 - Any new frontend query against `journeysPlausibleStatsAggregate`, `journeysPlausibleStatsBreakdown`, `templateFamilyStatsAggregate`, or `templateFamilyStatsBreakdown` must pass an explicit `period`/`date`. Never send an empty `where` — it compiles, runs, and silently means "last 30 days".
-- Build the range from `earliestStatsCollected`, not a hardcoded date, so the floor stays consistent across surfaces.
+- Build the range from `earliestStatsCollected`, not a hardcoded date, so the floor stays consistent across surfaces. For template stats specifically, reuse `buildAllTimeStatsFilter()` from `useTemplateFamilyStatsAggregateLazyQuery`.
+- When changing a query's variables, grep for **every** use of the query document (the `GET_*` constant) — imperative `client.query` refetch call sites are easy to miss, and a `where` mismatch between query and refetch splits the Apollo cache entry, silently breaking the refresh.
 - If declining analytics numbers are reported again, check the date range each surface actually sends **first** — it is far cheaper to verify than Plausible-side data-loss theories.
 - Frontend-only enforcement was evaluated and deliberately skipped (few call sites): baking the filter into hooks doesn't bind future queries, and lint can't see runtime variable values. If this recurs, the real fix is server-side — make `period`/`date` required on the filter inputs (codegen then makes `where: {}` a frontend compile error) or default omitted filters to all-time in the resolvers.
 - `PlausibleEmbedDashboard` (the reports-page iframe) also opens on Plausible's own 30-day UI default; known, unaddressed as of 2026-07-02.

--- a/docs/solutions/integration-issues/plausible-default-30-day-window-when-period-omitted.md
+++ b/docs/solutions/integration-issues/plausible-default-30-day-window-when-period-omitted.md
@@ -1,0 +1,103 @@
+---
+title: 'Plausible stats silently use a 30-day window when period/date is omitted'
+category: integration-issues
+date: '2026-07-02'
+module: 'apps/journeys-admin, apis/api-journeys'
+problem_type: integration_issue
+component: 'journeys-admin analytics components, api-journeys plausible schema'
+symptoms:
+  - 'Analytics counts (e.g. template card Views) go DOWN over time for a fixed journey'
+  - 'Numbers on one analytics surface disagree with another surface for the same journey'
+  - 'Stats look correct for recently active journeys but shrink for older ones'
+root_cause: wrong_api
+resolution_type: code_fix
+severity: high
+tags:
+  - plausible
+  - analytics
+  - date-range
+  - template-card
+  - journeys-admin
+  - api-journeys
+  - all-time
+---
+
+# Plausible stats silently use a 30-day window when period/date is omitted
+
+## Problem
+
+Template card analytics (`TemplateAggregateAnalytics`) showed a **declining Views count** over time. Users reported analytics numbers "going down" (QA-536: Decisions for Christ declining Friday → Monday), which should be impossible for an all-time count over immutable event data. The template card query sent an empty filter (`where: {}`), so the Plausible Stats API applied its own default period: **the last 30 days**. As high-traffic days aged out of the rolling window, the displayed number dropped.
+
+## Symptoms
+
+- A count that should be monotonically increasing (all-time visitors) decreases day over day.
+- The same journey shows different totals on different analytics surfaces (e.g. template card vs. breakdown dialog).
+- No error anywhere: the query succeeds, the resolver succeeds, Plausible returns 200.
+
+## What Didn't Work
+
+- Hunting for Plausible-side data loss (ClickHouse TTL/retention, sampling, salt rotation) or backend subtractive steps. Those were plausible for the *breakdown* surface but the template card decline had a much simpler cause: the frontend never sent a date range at all.
+- Expecting the type system to catch it: `period` and `date` are optional on `PlausibleStatsAggregateFilter`, so `where: {}` compiles and passes GraphQL validation.
+
+## Solution
+
+Always send an explicit all-time range. Every Plausible stats query in journeys-admin must pass `period: 'custom'` with a date range built from the shared `earliestStatsCollected` constant (`'2024-06-01'`, exported from `apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/AnalyticsOverlaySwitch/buildPresetDateRange.tsx`).
+
+Before (`TemplateAggregateAnalytics.tsx`):
+
+```ts
+void getTemplateStats({
+  variables: {
+    id: journeyId,
+    idType: IdType.databaseId,
+    where: {}
+  }
+})
+```
+
+After:
+
+```ts
+void getTemplateStats({
+  variables: {
+    id: journeyId,
+    idType: IdType.databaseId,
+    where: {
+      period: 'custom',
+      date: `${earliestStatsCollected},${formatISO(new Date(), {
+        representation: 'date'
+      })}`
+    }
+  }
+})
+```
+
+Audit of all four analytics surfaces (QA-540, 2026-07-02):
+
+| Surface | Component | Date range |
+| --- | --- | --- |
+| Journey card analytics | `AnalyticsItem` (via `JourneyCardInfo`) | ✅ all time (explicit custom range) |
+| Template card analytics | `TemplateAggregateAnalytics` | ⚠️ was `where: {}` → fixed in PR #9340 |
+| Template breakdown analytics | `TemplateBreakdownAnalyticsDialog` | ✅ all time (explicit custom range) |
+| Analytics dialog (editor overlay) | `AnalyticsOverlaySwitch` | ✅ all time by default (`allTime` preset) |
+
+When updating call sites, remember Apollo `MockedProvider` matches variables **exactly**: update spec mocks to the new `where`, and mock `formatISO` for determinism (see `AnalyticsItem.spec.tsx` for the pattern) or compute the expected date under the suite's faked system time (see `JourneyCard.spec.tsx`).
+
+## Why This Works
+
+The chain has no default on our side: the frontend `where` is spread by the api-journeys resolver (`{ metrics, ...where }`) straight into the Plausible HTTP request params (`getJourneyStatsBreakdown` / `journeysPlausibleStatsAggregate`). When `period`/`date` are absent from the request, [Plausible's Stats API defaults to `30d`](https://plausible.io/docs/stats-api#time-periods) — the GraphQL filter's own doc string says so. Sending `period: 'custom'` with an explicit `earliestStatsCollected..today` range pins the window to all recorded history, so counts can only grow.
+
+## Prevention
+
+- Any new frontend query against `journeysPlausibleStatsAggregate`, `journeysPlausibleStatsBreakdown`, `templateFamilyStatsAggregate`, or `templateFamilyStatsBreakdown` must pass an explicit `period`/`date`. Never send an empty `where` — it compiles, runs, and silently means "last 30 days".
+- Build the range from `earliestStatsCollected`, not a hardcoded date, so the floor stays consistent across surfaces.
+- If declining analytics numbers are reported again, check the date range each surface actually sends **first** — it is far cheaper to verify than Plausible-side data-loss theories.
+- Frontend-only enforcement was evaluated and deliberately skipped (few call sites): baking the filter into hooks doesn't bind future queries, and lint can't see runtime variable values. If this recurs, the real fix is server-side — make `period`/`date` required on the filter inputs (codegen then makes `where: {}` a frontend compile error) or default omitted filters to all-time in the resolvers.
+- `PlausibleEmbedDashboard` (the reports-page iframe) also opens on Plausible's own 30-day UI default; known, unaddressed as of 2026-07-02.
+
+## Related Issues
+
+- Linear QA-536 — [NextSteps] decisions for Christ go down (parent investigation)
+- Linear QA-540 — audit of the four analytics surfaces (this fix)
+- JesusFilm/core#9340 — fix(journeys-admin): use all-time range for template card analytics
+- JesusFilm/core#9339 — capture-goal counting + Plausible breakdown pagination (related QA-536 work)


### PR DESCRIPTION
Template cards showed a declining **Views** count: `TemplateAggregateAnalytics` sent `where: {}` to `templateFamilyStatsAggregate`, so the Plausible request carried no period and silently inherited Plausible's default 30-day rolling window. As high-traffic days aged out of that window, the number went down. The query now sends `period: 'custom'` with `2024-06-01,<today>` (the shared `earliestStatsCollected` constant), matching how `AnalyticsItem` and `TemplateBreakdownAnalyticsDialog` already build their all-time ranges.

Only Views is affected: Template uses and Responses on the card are computed from Postgres with no time window. The full audit of all four analytics surfaces (journey card, template card, template breakdown, analytics dialog) is documented on [QA-540](https://linear.app/jesus-film-project/issue/QA-540/verify-analytics-queries-use-all-time-date-range-instead-of-default-30), part of the QA-536 declining-numbers investigation.

Apollo mocks updated to the new variables in `TemplateAggregateAnalytics.spec.tsx` (deterministic `formatISO` mock, same pattern as `AnalyticsItem.spec`) and `JourneyCard.spec.tsx` (computed under the suite's faked system time).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved journey template analytics to always query a clearly defined custom date range, making displayed counts more consistent and accurate.
* **Tests**
  * Updated journey card analytics tests to match the new query variables and to control date formatting deterministically.
* **Documentation**
  * Added guidance on preventing Plausible integration issues caused by omitted `period`/`date`, including example before/after fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->