### PR TITLE
fix(QA-538): let journey buttons work while AI chat is open

### DIFF
--- a/docs/solutions/logic-errors/handleaction-crossorigin-linkaction-reload-race-2026-07-03.md
+++ b/docs/solutions/logic-errors/handleaction-crossorigin-linkaction-reload-race-2026-07-03.md
@@ -1,0 +1,134 @@
+---
+title: 'handleAction LinkAction never opens on non-whitelisted origins (router.push + reload race)'
+date: 2026-07-03
+category: logic-errors
+module: journeys-ui/action
+problem_type: logic_error
+component: journeys-ui/handleAction
+symptoms:
+  - 'Link button ripples and fires analytics, but the link never opens; the page reloads in place instead'
+  - 'Same button works on your.nextstep.is and your-stage.nextstep.is but fails on Vercel preview deployments'
+  - 'No console error visible to the user (unhandled promise at most)'
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+related_components:
+  - journeys-ui/Button
+  - journeys-ui/RadioOption
+  - journeys-ui/SignUp
+  - journeys-ui/VideoTrigger
+tags:
+  - handleaction
+  - linkaction
+  - router-push
+  - cross-origin
+  - vercel-preview
+  - custom-domain
+  - navigation
+---
+
+# handleAction LinkAction never opens on non-whitelisted origins (router.push + reload race)
+
+> **Status:** diagnosed and source-verified (Next 16.2.5); fix not yet
+> implemented — surfaced during QA-538 verification and belongs in its own
+> ticket. This bug exists on `main` and predates the AI chat entirely.
+
+## Problem
+
+`LinkAction`/`ChatAction` URLs that contain a journeys host
+(`your.nextstep.is`, `your-stage.nextstep.is`, `localhost:4100`) — or any
+relative/scheme-less URL — are navigated via
+`void router.push(url)?.then(() => window.location.reload())` in
+`libs/journeys/ui/src/libs/action/action.ts`. When the page's origin differs
+from the URL's origin, the navigation is silently cancelled: the click
+visibly registers but the link never opens.
+
+## Symptoms
+
+- On a Vercel preview (`journeys-<pr>-jesusfilm.vercel.app`), localhost, or a
+  custom journey domain, clicking a link button holding a full
+  `https://your.nextstep.is/...` URL reloads the page in place.
+- The identical button works on production `your.nextstep.is` and stage
+  `your-stage.nextstep.is` (same-origin there).
+- Relative journey-to-journey links (`/other-journey`) work everywhere.
+
+## What Didn't Work
+
+- **Blaming the newest change.** The failure was first attributed to the
+  chat-overlay PR because "main works, the PR doesn't" — but main had been
+  tested on production/stage (whitelisted origins) and the PR on its Vercel
+  preview (cross-origin). The variable was the domain, not the code: the PR
+  diff touched only `ChatOverlay`, which renders `null` when the chat is
+  closed, yet the buttons failed with the chat closed too. Holding the
+  environment constant (main's own Vercel preview) reproduced the failure on
+  unmodified main.
+- **Overlay geometry.** Ruled out: at desktop sizes the card CTA sits well
+  clear of the chat band, and a scrim-eaten click shows a different
+  signature (no ripple, chat visibly closes).
+
+## Solution
+
+Verified mechanism, in Next 16.2.5 pages router
+(`next/dist/shared/lib/router/router.js`):
+
+1. `change()` calls `isLocalURL(url)`; a cross-origin absolute URL fails it.
+2. It then calls `handleHardNavigation` → `window.location.href = url` and
+   **resolves `false` immediately** (no throw).
+3. Back in `handleAction`, `.then(() => window.location.reload())` runs in
+   the next microtask — the reload supersedes the still-pending cross-origin
+   navigation. The page reloads in place; the link is lost.
+
+Proposed fix (pending): replace the host-substring whitelist with a real
+origin comparison —
+
+```ts
+case 'LinkAction': {
+  if (action.url === '') break
+  const resolved = new URL(action.url, window.location.origin)
+  if (resolved.origin === window.location.origin) {
+    // same-origin: SPA navigation (keep the reload that resets journey state)
+    void router.push(resolved.pathname + resolved.search + resolved.hash)
+      ?.then(() => window.location.reload())
+  } else {
+    // different origin: hand the whole navigation to the browser — no reload
+    window.open(resolved.href, '_blank') ?? window.location.assign(resolved.href)
+  }
+  break
+}
+```
+
+This also fixes scheme-less URLs (`www.example.com`) that bypass the current
+`startsWith('http')` check, and creates the hook for honoring
+`LinkAction.target` (currently ignored).
+
+## Why This Works
+
+The race only exists because a hard (cross-origin) navigation and a reload
+are queued back-to-back — the later one wins. Same-origin URLs never hard
+navigate (`router.push` completes the SPA transition before the chained
+reload), which is exactly why production and stage appear fine: they are the
+whitelisted origins. Comparing `resolved.origin === location.origin` makes
+the decision match what Next itself does internally, instead of guessing via
+host substrings that go stale (preview domains and custom journey domains
+are not in the list and never will be).
+
+## Prevention
+
+- Never chain `window.location.reload()` (or any second navigation) onto a
+  `router.push` whose URL may be external — in the pages router a
+  cross-origin push resolves immediately while its hard navigation is still
+  pending.
+- Classify URLs by **origin comparison**, not host-substring whitelists.
+- Check `window.open`'s return value (null = popup blocked) on paths that
+  `await` before opening — submit-enabled Buttons and SignUp navigate after
+  network round-trips, and `VideoTrigger` fires with no user gesture at all,
+  so external links there are popup-blocker prone.
+- When debugging "works in env A, fails in env B", hold the environment
+  constant while varying the code (e.g. main's Vercel preview vs the PR's
+  Vercel preview) before blaming the diff.
+
+## Related Issues
+
+- Surfaced while verifying QA-538 (PR #9342) — see
+  [chat overlay full-viewport click blocking](../ui-bugs/chat-overlay-fullscreen-layer-blocks-journey-clicks-qa538-2026-07-03.md).
+- Affects any journey served on a custom domain in production today.

--- a/docs/solutions/ui-bugs/chat-overlay-fullscreen-layer-blocks-journey-clicks-qa538-2026-07-03.md
+++ b/docs/solutions/ui-bugs/chat-overlay-fullscreen-layer-blocks-journey-clicks-qa538-2026-07-03.md
@@ -1,0 +1,118 @@
+---
+title: "AI chat overlay's invisible full-viewport layer swallowed all journey clicks"
+date: 2026-07-03
+category: ui-bugs
+linear: QA-538
+module: journeys/ChatOverlay
+problem_type: ui_bug
+component: journeys-ui/ChatOverlay
+symptoms:
+  - 'Once the AI chat opened on a card, every button outside the chat went dead on desktop (poll options, nav arrows, footer)'
+  - 'Keyboard left-arrow still navigated backwards while all pointer clicks were silently swallowed'
+  - 'Only the chat frame stayed interactive; no error anywhere'
+  - 'Mobile was unaffected; only sm+ (ChatOverlay) breakpoints broke'
+root_cause: logic_error
+resolution_type: code_fix
+severity: critical
+related_components:
+  - journeys/Conductor
+  - journeys-ui/AiChatButton
+  - journeys-ui/PinnedChatBar
+tags:
+  - pointer-events
+  - overlay
+  - z-index
+  - apologist-chat
+  - hit-testing
+  - journeys
+---
+
+# AI chat overlay's invisible full-viewport layer swallowed all journey clicks
+
+## Problem
+
+When the apologist AI chat engaged on a journey card (desktop, sm+), every
+interactive element outside the chat stopped responding to clicks — poll
+options, navigation arrows, footer buttons. Since NES-1734 auto-opens the
+chat, journeys entered this state with zero user action, ending the journey
+for the visitor.
+
+## Symptoms
+
+- Buttons unclickable the moment the chat surface appears; no hover/ripple.
+- Keyboard hotkeys still worked (document-level listeners bypass hit-testing).
+- Only the chat panel and its scrim responded to the pointer.
+- Desktop-only: the xs `PinnedChatBar` drawer never covered the card.
+
+## What Didn't Work
+
+- **NES-1738 ("reveal card behind chat") shrank only the visible surface.**
+  The dark backdrop became a bottom sheet (144px idle / 80% active), but the
+  overlay's root `Box` stayed `position: fixed; inset: 0` at
+  `theme.zIndex.modal` with default pointer-events — a transparent
+  full-viewport click shield. The card was *visually* revealed but not
+  interactively.
+- **Existing tests couldn't catch it.** jsdom performs no hit-testing
+  (`fireEvent.click` dispatches on the target regardless of covering
+  layers), and `Conductor.spec.tsx` mocks `ChatOverlay` away entirely, so
+  its nav-click tests never ran against the real overlay.
+- **An interim `pointerEvents: 'none'` root + `'auto'` children fix worked**
+  but was superseded: it kept the full-viewport layer and relied on
+  inheritance staying correct forever (fail-open for future children).
+
+## Solution
+
+Size the overlay container to the chat itself instead of the viewport
+(`libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.tsx`):
+
+```tsx
+// Before: full-viewport layer, children sized to the sheet
+<Box sx={{ position: 'fixed', inset: 0, zIndex: (t) => t.zIndex.modal, ... }}>
+  <Box onClick={onClose} sx={{ position: 'absolute', bottom: 0, height, ... }} />
+  <Box sx={{ maxWidth: '48rem', height, ... }}><AiChat ... /></Box>
+</Box>
+
+// After: bottom-anchored band exactly as tall as the sheet; children fill it
+<Box sx={{ position: 'fixed', bottom: 0, left: 0, right: 0, height, // 144px idle / '80%' active
+           transition: HEIGHT_TRANSITION, zIndex: (t) => t.zIndex.modal, ... }}>
+  <Box onClick={onClose} sx={{ position: 'absolute', top: 0, right: 0, bottom: 0, left: 0, ... }} />
+  <Box sx={{ maxWidth: '48rem', height: '100%', ... }}><AiChat ... /></Box>
+</Box>
+```
+
+Regression tests pin the band geometry at the style level in
+`ChatOverlay.spec.tsx` (bottom-anchored, 144px idle → 80% active, scrim and
+panel filling the band).
+
+## Why This Works
+
+Nothing chat-related exists above the sheet anymore, so the journey above it
+is natively interactive by construction — no pointer-events juggling to keep
+correct. `height: '80%'` on a `position: fixed` element resolves against the
+viewport exactly as the old inset-0 root did, and px↔% height transitions
+interpolate via calc() in all supported browsers, so the idle→active grow
+animation is unchanged. This mirrors how the mobile `PinnedChatBar` was
+already shaped (bottom-anchored drawer), which is why mobile never had the
+bug.
+
+## Prevention
+
+- Never leave a `position: fixed; inset: 0` container with default
+  pointer-events over content that must stay interactive. Size overlay
+  containers to their visual surface; reach for full-viewport layers only
+  when true modality (focus trap, backdrop) is intended.
+- When a design change "reveals" content behind an overlay, the interactive
+  half of the reveal must ship with the visual half — grep the overlay for
+  `inset: 0` / full-viewport styles whenever its visible footprint shrinks.
+- jsdom cannot catch occlusion bugs. Pin the overlay's geometry with
+  `toHaveStyle` assertions, and verify hit-testing manually or via e2e
+  (clicking a card button while the chat is open).
+- Children of the band must stay within it — an escapee with its own fixed
+  positioning silently reintroduces the bug (comment now in the component).
+
+## Related Issues
+
+- Linear QA-538; regression introduced by NES-1738 (PR #9308), amplified by
+  the NES-1734 auto-open default. Fixed in PR #9342.
+- While verifying the fix, a separate latent navigation bug surfaced — see
+  [handleAction cross-origin LinkAction reload race](../logic-errors/handleaction-crossorigin-linkaction-reload-race-2026-07-03.md).

--- a/docs/solutions/ui-bugs/chat-overlay-fullscreen-layer-blocks-journey-clicks-qa538-2026-07-03.md
+++ b/docs/solutions/ui-bugs/chat-overlay-fullscreen-layer-blocks-journey-clicks-qa538-2026-07-03.md
@@ -50,7 +50,7 @@ for the visitor.
   The dark backdrop became a bottom sheet (144px idle / 80% active), but the
   overlay's root `Box` stayed `position: fixed; inset: 0` at
   `theme.zIndex.modal` with default pointer-events — a transparent
-  full-viewport click shield. The card was *visually* revealed but not
+  full-viewport click shield. The card was _visually_ revealed but not
   interactively.
 - **Existing tests couldn't catch it.** jsdom performs no hit-testing
   (`fireEvent.click` dispatches on the target regardless of covering

--- a/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.spec.tsx
+++ b/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.spec.tsx
@@ -125,4 +125,26 @@ describe('ChatOverlay', () => {
     fireEvent.click(backdrop)
     expect(onClose).toHaveBeenCalledTimes(1)
   })
+
+  // QA-538: the full-viewport root is a layout-only layer. Since NES-1738 the
+  // visible chat surfaces occupy just the bottom band, so the journey card
+  // revealed above must keep receiving clicks (poll options, nav arrows).
+  // jsdom does no hit-testing, so pin the pointer-events styles directly.
+  it('lets clicks pass through the root layer to the journey card (QA-538)', () => {
+    render(<ChatOverlay open onClose={vi.fn()} />)
+    expect(screen.getByTestId('ChatOverlay')).toHaveStyle({
+      pointerEvents: 'none'
+    })
+  })
+
+  it('keeps the backdrop and chat panel interactive despite the pass-through root', () => {
+    render(<ChatOverlay open onClose={vi.fn()} />)
+    const backdrop = screen
+      .getByTestId('ChatOverlay')
+      .querySelector('[aria-hidden]') as HTMLElement
+    expect(backdrop).toHaveStyle({ pointerEvents: 'auto' })
+    expect(screen.getByTestId('ChatOverlayPanel')).toHaveStyle({
+      pointerEvents: 'auto'
+    })
+  })
 })

--- a/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.spec.tsx
+++ b/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.spec.tsx
@@ -69,22 +69,27 @@ describe('ChatOverlay', () => {
 
   it('opens compact at 144px in the idle state', () => {
     render(<ChatOverlay open onClose={vi.fn()} />)
-    const panel = screen.getByTestId('ChatOverlayPanel')
-    expect(panel).toHaveAttribute('data-sheet-state', 'idle')
-    expect(panel).toHaveStyle({ height: '144px' })
+    expect(screen.getByTestId('ChatOverlay')).toHaveStyle({ height: '144px' })
+    expect(screen.getByTestId('ChatOverlayPanel')).toHaveAttribute(
+      'data-sheet-state',
+      'idle'
+    )
   })
 
   it('grows to 80% once AiChat reports messages (active state)', async () => {
     render(<ChatOverlay open onClose={vi.fn()} />)
-    const panel = screen.getByTestId('ChatOverlayPanel')
-    expect(panel).toHaveStyle({ height: '144px' })
+    const overlay = screen.getByTestId('ChatOverlay')
+    expect(overlay).toHaveStyle({ height: '144px' })
 
     fireEvent.click(
       await screen.findByRole('button', { name: 'mock-activate' })
     )
 
-    expect(panel).toHaveAttribute('data-sheet-state', 'active')
-    expect(panel).toHaveStyle({ height: '80%' })
+    expect(screen.getByTestId('ChatOverlayPanel')).toHaveAttribute(
+      'data-sheet-state',
+      'active'
+    )
+    expect(overlay).toHaveStyle({ height: '80%' })
   })
 
   it('closes via the AiChat panel close control (no separate corner X)', async () => {
@@ -101,19 +106,6 @@ describe('ChatOverlay', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('scales the dark backdrop with the chat (144px idle → 80% active)', async () => {
-    render(<ChatOverlay open onClose={vi.fn()} />)
-    const backdrop = screen
-      .getByTestId('ChatOverlay')
-      .querySelector('[aria-hidden]') as HTMLElement
-    expect(backdrop).toHaveStyle({ height: '144px' })
-
-    fireEvent.click(
-      await screen.findByRole('button', { name: 'mock-activate' })
-    )
-    expect(backdrop).toHaveStyle({ height: '80%' })
-  })
-
   it('closes when the backdrop is clicked', () => {
     const onClose = vi.fn()
     render(<ChatOverlay open onClose={onClose} />)
@@ -126,25 +118,35 @@ describe('ChatOverlay', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
-  // QA-538: the full-viewport root is a layout-only layer. Since NES-1738 the
-  // visible chat surfaces occupy just the bottom band, so the journey card
-  // revealed above must keep receiving clicks (poll options, nav arrows).
-  // jsdom does no hit-testing, so pin the pointer-events styles directly.
-  it('lets clicks pass through the root layer to the journey card (QA-538)', () => {
+  // QA-538: the overlay must never cover the journey above the chat. It used
+  // to be a full-viewport fixed layer that silently swallowed clicks on the
+  // revealed card (poll options, nav arrows); the container is now a
+  // bottom-anchored band exactly as tall as the sheet, so everything above it
+  // stays natively interactive. jsdom does no hit-testing, so pin the band
+  // geometry directly (grow-to-80% is covered by the active-state test).
+  it('only occupies the chat band, leaving the journey above interactive (QA-538)', () => {
     render(<ChatOverlay open onClose={vi.fn()} />)
     expect(screen.getByTestId('ChatOverlay')).toHaveStyle({
-      pointerEvents: 'none'
+      position: 'fixed',
+      bottom: '0px',
+      height: '144px'
     })
   })
 
-  it('keeps the backdrop and chat panel interactive despite the pass-through root', () => {
+  it('fills the band with the dark surface and the chat panel', () => {
     render(<ChatOverlay open onClose={vi.fn()} />)
     const backdrop = screen
       .getByTestId('ChatOverlay')
       .querySelector('[aria-hidden]') as HTMLElement
-    expect(backdrop).toHaveStyle({ pointerEvents: 'auto' })
+    expect(backdrop).toHaveStyle({
+      position: 'absolute',
+      top: '0px',
+      right: '0px',
+      bottom: '0px',
+      left: '0px'
+    })
     expect(screen.getByTestId('ChatOverlayPanel')).toHaveStyle({
-      pointerEvents: 'auto'
+      height: '100%'
     })
   })
 })

--- a/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.tsx
+++ b/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.tsx
@@ -50,44 +50,45 @@ export function ChatOverlay({
     <Box
       data-testid="ChatOverlay"
       sx={{
+        // Bottom-anchored band exactly as tall as the chat sheet (144px idle
+        // → 80% active). The overlay used to be a full-viewport fixed layer
+        // that silently swallowed clicks on the card revealed above the chat
+        // (QA-538); sizing the container to the sheet means nothing
+        // chat-related exists above it, so the journey stays natively
+        // interactive. Children must stay within the band — an escapee
+        // (negative offset, own fixed positioning) would cover the journey
+        // and silently reintroduce QA-538.
         position: 'fixed',
-        inset: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+        height,
+        transition: HEIGHT_TRANSITION,
         zIndex: (theme) => theme.zIndex.modal,
         display: 'flex',
         justifyContent: 'center',
-        alignItems: 'flex-end',
-        px: 2,
+        px: 2
         // No bottom padding: the chat sheet sits flush to the screen bottom so
         // its top edge aligns exactly with the bordered dark overlay (otherwise
         // the panel floats ~24px above the border and the header reads as
         // jammed against it). Mirrors the mobile drawer's flush-to-bottom
         // sheet (NES-1738 feedback).
-        //
-        // Layout-only layer: since NES-1738 the visible surfaces occupy just
-        // the bottom band, so the card revealed above must stay clickable
-        // (poll options, nav arrows — QA-538). The interactive children opt
-        // back in with pointerEvents: 'auto'.
-        pointerEvents: 'none'
       }}
     >
       <Box
         onClick={onClose}
         aria-hidden
         sx={{
+          // Dark surface fills the band behind the centred panel: absolute so
+          // it ignores the px gutter and stays full-width, and it tracks the
+          // band's height transition automatically. Clicking it closes the
+          // chat. Colour/opacity unchanged from NES-1654 (near-opaque 98%,
+          // no blur).
           position: 'absolute',
-          left: 0,
+          top: 0,
           right: 0,
           bottom: 0,
-          // Dark surface scales WITH the chat (NES-1738 Option B): it grows
-          // from the 144px idle bar to 80% in lockstep with the panel, so the
-          // journey card is revealed above the chat instead of being hidden by
-          // a full-screen layer. Colour/opacity unchanged from NES-1654
-          // (near-opaque 98%, no blur); only the size now tracks the sheet.
-          height,
-          transition: HEIGHT_TRANSITION,
-          // Re-enable pointer events (the root layer is pointerEvents: 'none')
-          // so clicking the scrim beside the panel still closes the chat.
-          pointerEvents: 'auto',
+          left: 0,
           bgcolor: (theme) => alpha(theme.palette.grey[900], 0.98),
           // Rounded top + a 1px translucent-white top border on the FULL-WIDTH
           // background overlay (not the centred chat panel) so its top edge
@@ -105,19 +106,15 @@ export function ChatOverlay({
           position: 'relative',
           width: '100%',
           maxWidth: '48rem',
-          // Compact-then-grow height (Option B). The panel variant's
+          // Fills the band (Option B, NES-1738). The panel variant's
           // ChatHeader + inline input fill the 144px idle bar exactly like
           // the mobile drawer; on the first message AiChat reports 'active'
-          // and the bar grows to 80%, revealing the card's CTA while the
+          // and the band grows to 80%, revealing the card's CTA while the
           // bar sits idle.
-          height,
-          transition: HEIGHT_TRANSITION,
+          height: '100%',
           display: 'flex',
           flexDirection: 'column',
-          minHeight: 0,
-          // Re-enable pointer events (the root layer is pointerEvents: 'none')
-          // so the chat panel stays fully interactive.
-          pointerEvents: 'auto'
+          minHeight: 0
         }}
       >
         <AiChat

--- a/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.tsx
+++ b/libs/journeys/ui/src/components/ChatOverlay/ChatOverlay.tsx
@@ -56,12 +56,18 @@ export function ChatOverlay({
         display: 'flex',
         justifyContent: 'center',
         alignItems: 'flex-end',
-        px: 2
+        px: 2,
         // No bottom padding: the chat sheet sits flush to the screen bottom so
         // its top edge aligns exactly with the bordered dark overlay (otherwise
         // the panel floats ~24px above the border and the header reads as
         // jammed against it). Mirrors the mobile drawer's flush-to-bottom
         // sheet (NES-1738 feedback).
+        //
+        // Layout-only layer: since NES-1738 the visible surfaces occupy just
+        // the bottom band, so the card revealed above must stay clickable
+        // (poll options, nav arrows — QA-538). The interactive children opt
+        // back in with pointerEvents: 'auto'.
+        pointerEvents: 'none'
       }}
     >
       <Box
@@ -79,6 +85,9 @@ export function ChatOverlay({
           // (near-opaque 98%, no blur); only the size now tracks the sheet.
           height,
           transition: HEIGHT_TRANSITION,
+          // Re-enable pointer events (the root layer is pointerEvents: 'none')
+          // so clicking the scrim beside the panel still closes the chat.
+          pointerEvents: 'auto',
           bgcolor: (theme) => alpha(theme.palette.grey[900], 0.98),
           // Rounded top + a 1px translucent-white top border on the FULL-WIDTH
           // background overlay (not the centred chat panel) so its top edge
@@ -105,7 +114,10 @@ export function ChatOverlay({
           transition: HEIGHT_TRANSITION,
           display: 'flex',
           flexDirection: 'column',
-          minHeight: 0
+          minHeight: 0,
+          // Re-enable pointer events (the root layer is pointerEvents: 'none')
+          // so the chat panel stays fully interactive.
+          pointerEvents: 'auto'
         }}
       >
         <AiChat


### PR DESCRIPTION
Once the AI conversational chat engaged on a journey card, every button outside the chat went dead on desktop: poll options and the nav arrows stopped responding, and only the chat frame stayed interactive ([QA-538](https://linear.app/jesus-film-project/issue/QA-538)).

Root cause: NES-1738 (JesusFilm/core#9308) shrank the ChatOverlay's visible dark surface to a bottom sheet so the journey card is revealed above the chat, but the overlay's invisible root wrapper stayed `position: fixed; inset: 0` at modal z-index, silently swallowing every click above the sheet. Since NES-1734 auto-opens the chat, journeys entered this state with no user action.

The fix is structural: the overlay container is now a bottom-anchored fixed band exactly as tall as the chat sheet (144px idle, 80% once the conversation is active — the heights it already animated between), with the dark click-to-close scrim filling the band behind the centred panel. Nothing chat-related exists above the sheet anymore, so the journey stays natively interactive by construction — no full-viewport layer, no pointer-events juggling. Same z-index, same look, same scrim-click-to-close; mobile is unaffected (the xs `PinnedChatBar` was already band-shaped). An adversarial review verified the geometry is equivalent across breakpoints, RTL, and the panel's internal absolute positioning.

Regression tests in `ChatOverlay.spec.tsx` pin the band geometry (bottom-anchored, 144px/80%, scrim and panel filling it) at the style level: jsdom does no hit-testing (and `Conductor.spec.tsx` mocks ChatOverlay away), which is why the existing nav-click tests never caught this.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the AI chat overlay to be bottom-anchored and only occupy the chat band, preventing it from blocking journey card clicks.
  * Improved the overlay’s compact/active sizing and ensured the dark backdrop and chat panel fill the band correctly.
* **Tests**
  * Strengthened UI tests to validate band height and overlay panel state in both compact and active modes, including backdrop and panel sizing.
  * Kept existing close interactions covered.
* **Documentation**
  * Added solution pages covering a cross-origin navigation reload race and the chat overlay click regression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->