### PR TITLE
fix(api-media): sync languages to Algolia whenever they have videos (QA-375)

### DIFF
--- a/apis/api-media/project.json
+++ b/apis/api-media/project.json
@@ -161,6 +161,13 @@
         "command": "pnpm exec tsx apis/api-media/src/scripts/mux-videos.ts"
       }
     },
+    "reindex-languages-algolia": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["prisma-languages:prisma-generate"],
+      "options": {
+        "command": "pnpm exec tsx --tsconfig apis/api-media/tsconfig.app.json apis/api-media/src/scripts/algolia-helpers/reindex-languages-with-videos.ts"
+      }
+    },
     "run-daily-video-slack-summary": {
       "executor": "nx:run-commands",
       "dependsOn": ["prisma-media:prisma-generate"],

--- a/apis/api-media/src/lib/languages/ensureLanguageHasVideos.spec.ts
+++ b/apis/api-media/src/lib/languages/ensureLanguageHasVideos.spec.ts
@@ -1,0 +1,73 @@
+import { type DeepMockProxy, mockDeep } from 'vitest-mock-extended'
+
+import {
+  type PrismaClient as LanguagesPrismaClient,
+  prisma as languagesPrisma
+} from '@core/prisma/languages/client'
+
+import { logger } from '../../logger'
+
+import { ensureLanguageHasVideosTrue } from './ensureLanguageHasVideos'
+import { updateLanguageInAlgoliaFromMedia } from './updateLanguageInAlgolia'
+
+vi.mock('@core/prisma/languages/client', () => ({
+  __esModule: true,
+  prisma: mockDeep<LanguagesPrismaClient>()
+}))
+
+vi.mock('./updateLanguageInAlgolia', () => ({
+  updateLanguageInAlgoliaFromMedia: vi.fn()
+}))
+
+const languagesPrismaMock =
+  languagesPrisma as unknown as DeepMockProxy<LanguagesPrismaClient>
+const mockedUpdateAlgolia = vi.mocked(updateLanguageInAlgoliaFromMedia)
+
+describe('ensureLanguageHasVideosTrue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does nothing for an empty language id', async () => {
+    await ensureLanguageHasVideosTrue('   ')
+
+    expect(languagesPrismaMock.language.findUnique).not.toHaveBeenCalled()
+    expect(mockedUpdateAlgolia).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the language does not exist', async () => {
+    languagesPrismaMock.language.findUnique.mockResolvedValue(null)
+
+    await ensureLanguageHasVideosTrue('missing')
+
+    expect(languagesPrismaMock.language.update).not.toHaveBeenCalled()
+    expect(mockedUpdateAlgolia).not.toHaveBeenCalled()
+  })
+
+  it('flips hasVideos and updates algolia when previously false', async () => {
+    languagesPrismaMock.language.findUnique.mockResolvedValue({
+      id: '1234',
+      hasVideos: false
+    } as any)
+
+    await ensureLanguageHasVideosTrue('1234')
+
+    expect(languagesPrismaMock.language.update).toHaveBeenCalledWith({
+      where: { id: '1234' },
+      data: { hasVideos: true }
+    })
+    expect(mockedUpdateAlgolia).toHaveBeenCalledWith('1234', logger)
+  })
+
+  it('still updates algolia when hasVideos was already true without a db write', async () => {
+    languagesPrismaMock.language.findUnique.mockResolvedValue({
+      id: '1234',
+      hasVideos: true
+    } as any)
+
+    await ensureLanguageHasVideosTrue('1234')
+
+    expect(languagesPrismaMock.language.update).not.toHaveBeenCalled()
+    expect(mockedUpdateAlgolia).toHaveBeenCalledWith('1234', logger)
+  })
+})

--- a/apis/api-media/src/lib/languages/ensureLanguageHasVideos.spec.ts
+++ b/apis/api-media/src/lib/languages/ensureLanguageHasVideos.spec.ts
@@ -23,6 +23,18 @@ const languagesPrismaMock =
   languagesPrisma as unknown as DeepMockProxy<LanguagesPrismaClient>
 const mockedUpdateAlgolia = vi.mocked(updateLanguageInAlgoliaFromMedia)
 
+// ensureLanguageHasVideosTrue queries with `select: { id, hasVideos }`, so the
+// resolved value is this narrow payload rather than the full Language model the
+// prisma mock is typed against.
+interface LanguageHasVideosPayload {
+  id: string
+  hasVideos: boolean
+}
+
+function mockFindUnique(language: LanguageHasVideosPayload | null): void {
+  languagesPrismaMock.language.findUnique.mockResolvedValue(language as never)
+}
+
 describe('ensureLanguageHasVideosTrue', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -36,7 +48,7 @@ describe('ensureLanguageHasVideosTrue', () => {
   })
 
   it('does nothing when the language does not exist', async () => {
-    languagesPrismaMock.language.findUnique.mockResolvedValue(null)
+    mockFindUnique(null)
 
     await ensureLanguageHasVideosTrue('missing')
 
@@ -45,10 +57,7 @@ describe('ensureLanguageHasVideosTrue', () => {
   })
 
   it('flips hasVideos and updates algolia when previously false', async () => {
-    languagesPrismaMock.language.findUnique.mockResolvedValue({
-      id: '1234',
-      hasVideos: false
-    } as any)
+    mockFindUnique({ id: '1234', hasVideos: false })
 
     await ensureLanguageHasVideosTrue('1234')
 
@@ -60,10 +69,7 @@ describe('ensureLanguageHasVideosTrue', () => {
   })
 
   it('still updates algolia when hasVideos was already true without a db write', async () => {
-    languagesPrismaMock.language.findUnique.mockResolvedValue({
-      id: '1234',
-      hasVideos: true
-    } as any)
+    mockFindUnique({ id: '1234', hasVideos: true })
 
     await ensureLanguageHasVideosTrue('1234')
 

--- a/apis/api-media/src/lib/languages/ensureLanguageHasVideos.ts
+++ b/apis/api-media/src/lib/languages/ensureLanguageHasVideos.ts
@@ -1,5 +1,7 @@
 import { prisma as languagesPrisma } from '@core/prisma/languages/client'
 
+import { logger } from '../../logger'
+
 import { updateLanguageInAlgoliaFromMedia } from './updateLanguageInAlgolia'
 
 export async function ensureLanguageHasVideosTrue(
@@ -13,12 +15,16 @@ export async function ensureLanguageHasVideosTrue(
   })
 
   if (existing == null) return
-  if (existing.hasVideos === true) return
 
-  await languagesPrisma.language.update({
-    where: { id: languageId },
-    data: { hasVideos: true }
-  })
+  if (existing.hasVideos !== true) {
+    await languagesPrisma.language.update({
+      where: { id: languageId },
+      data: { hasVideos: true }
+    })
+  }
 
-  await updateLanguageInAlgoliaFromMedia(languageId)
+  // Always (re)upsert into the Algolia languages index. A language can already
+  // be hasVideos: true (the schema default) yet be absent from the index, so
+  // gating this on the flag transition leaves such languages unsearchable.
+  await updateLanguageInAlgoliaFromMedia(languageId, logger)
 }

--- a/apis/api-media/src/lib/languages/updateLanguageInAlgolia.spec.ts
+++ b/apis/api-media/src/lib/languages/updateLanguageInAlgolia.spec.ts
@@ -27,7 +27,28 @@ vi.mock('@core/prisma/languages/client', () => ({
 const languagesPrismaMock =
   languagesPrisma as unknown as DeepMockProxy<LanguagesPrismaClient>
 
-function createLanguage(overrides: Record<string, unknown> = {}): any {
+// The exact selected-payload shape buildAlgoliaLanguageRecord consumes, so the
+// fixtures stay checked against the Algolia record contract.
+type AlgoliaLanguageInput = Parameters<typeof buildAlgoliaLanguageRecord>[0]
+
+// The prisma mock is typed against the full Language model, but every call
+// under test passes `select: languageAlgoliaSelect`, so the value that actually
+// comes back is the narrower AlgoliaLanguageInput. These two helpers keep that
+// one unavoidable widening in a single named place instead of `any` at every
+// fixture.
+function mockFindUnique(language: AlgoliaLanguageInput | null): void {
+  languagesPrismaMock.language.findUnique.mockResolvedValue(language as never)
+}
+
+function mockFindManyOnce(languages: AlgoliaLanguageInput[]): void {
+  languagesPrismaMock.language.findMany.mockResolvedValueOnce(
+    languages as never
+  )
+}
+
+function createLanguage(
+  overrides: Partial<AlgoliaLanguageInput> = {}
+): AlgoliaLanguageInput {
   return {
     id: '1234',
     bcp47: 'plu',
@@ -111,9 +132,7 @@ describe('updateLanguageInAlgolia', () => {
 
   describe('updateLanguageInAlgoliaFromMedia', () => {
     it('saves the language record to the languages index', async () => {
-      languagesPrismaMock.language.findUnique.mockResolvedValue(
-        createLanguage()
-      )
+      mockFindUnique(createLanguage())
 
       await updateLanguageInAlgoliaFromMedia('1234')
 
@@ -125,7 +144,7 @@ describe('updateLanguageInAlgolia', () => {
     })
 
     it('does not save when the language is not found', async () => {
-      languagesPrismaMock.language.findUnique.mockResolvedValue(null)
+      mockFindUnique(null)
 
       await updateLanguageInAlgoliaFromMedia('missing')
 
@@ -138,9 +157,8 @@ describe('updateLanguageInAlgolia', () => {
       const fullBatch = Array.from({ length: 1000 }, (_, index) =>
         createLanguage({ id: `id-${index}` })
       )
-      languagesPrismaMock.language.findMany
-        .mockResolvedValueOnce(fullBatch)
-        .mockResolvedValueOnce([createLanguage({ id: 'last' })])
+      mockFindManyOnce(fullBatch)
+      mockFindManyOnce([createLanguage({ id: 'last' })])
 
       const result = await reindexLanguagesWithVideosInAlgolia()
 
@@ -166,9 +184,7 @@ describe('updateLanguageInAlgolia', () => {
     })
 
     it('stops after a partial batch without an extra query', async () => {
-      languagesPrismaMock.language.findMany.mockResolvedValueOnce([
-        createLanguage({ id: 'a' })
-      ])
+      mockFindManyOnce([createLanguage({ id: 'a' })])
 
       const result = await reindexLanguagesWithVideosInAlgolia()
 
@@ -178,7 +194,7 @@ describe('updateLanguageInAlgolia', () => {
     })
 
     it('returns zero and does not save when no languages have videos', async () => {
-      languagesPrismaMock.language.findMany.mockResolvedValueOnce([])
+      mockFindManyOnce([])
 
       const result = await reindexLanguagesWithVideosInAlgolia()
 
@@ -187,9 +203,7 @@ describe('updateLanguageInAlgolia', () => {
     })
 
     it('propagates a batch failure so the caller exits non-zero', async () => {
-      languagesPrismaMock.language.findMany.mockResolvedValueOnce([
-        createLanguage({ id: 'a' })
-      ])
+      mockFindManyOnce([createLanguage({ id: 'a' })])
       saveObjectsSpy.mockRejectedValueOnce(new Error('algolia unavailable'))
 
       await expect(reindexLanguagesWithVideosInAlgolia()).rejects.toThrow(

--- a/apis/api-media/src/lib/languages/updateLanguageInAlgolia.spec.ts
+++ b/apis/api-media/src/lib/languages/updateLanguageInAlgolia.spec.ts
@@ -1,0 +1,200 @@
+import { type DeepMockProxy, mockDeep } from 'vitest-mock-extended'
+
+import {
+  type PrismaClient as LanguagesPrismaClient,
+  prisma as languagesPrisma
+} from '@core/prisma/languages/client'
+
+import {
+  buildAlgoliaLanguageRecord,
+  reindexLanguagesWithVideosInAlgolia,
+  updateLanguageInAlgoliaFromMedia
+} from './updateLanguageInAlgolia'
+
+const saveObjectsSpy = vi.fn()
+
+vi.mock('algoliasearch', () => ({
+  algoliasearch: () => ({
+    saveObjects: saveObjectsSpy
+  })
+}))
+
+vi.mock('@core/prisma/languages/client', () => ({
+  __esModule: true,
+  prisma: mockDeep<LanguagesPrismaClient>()
+}))
+
+const languagesPrismaMock =
+  languagesPrisma as unknown as DeepMockProxy<LanguagesPrismaClient>
+
+function createLanguage(overrides: Record<string, unknown> = {}): any {
+  return {
+    id: '1234',
+    bcp47: 'plu',
+    iso3: 'plu',
+    name: [
+      {
+        value: 'Palikur',
+        primary: false,
+        language: { id: '529', bcp47: 'en' }
+      },
+      {
+        value: 'Parikwaki',
+        primary: true,
+        language: { id: '1234', bcp47: 'plu' }
+      }
+    ],
+    countryLanguages: [
+      {
+        speakers: 100,
+        suggested: false,
+        primary: true,
+        country: { id: 'BR' }
+      },
+      {
+        speakers: 50,
+        suggested: true,
+        primary: false,
+        country: { id: 'GF' }
+      }
+    ],
+    ...overrides
+  }
+}
+
+describe('updateLanguageInAlgolia', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // clearAllMocks leaves queued mockResolvedValueOnce values in place, so
+    // reset the prisma methods to isolate each test.
+    languagesPrismaMock.language.findUnique.mockReset()
+    languagesPrismaMock.language.findMany.mockReset()
+    process.env.ALGOLIA_APPLICATION_ID = 'app-id'
+    process.env.ALGOLIA_API_KEY = 'api-key'
+    process.env.ALGOLIA_INDEX_LANGUAGES = 'languages-index'
+    saveObjectsSpy.mockResolvedValue([{ taskID: 'task-1' }])
+  })
+
+  describe('buildAlgoliaLanguageRecord', () => {
+    it('includes the English name in the searchable names array', () => {
+      const record = buildAlgoliaLanguageRecord(createLanguage())
+
+      expect(record).toEqual({
+        objectID: '1234',
+        languageId: '1234',
+        bcp47: 'plu',
+        iso3: 'plu',
+        nameNative: 'Parikwaki',
+        speakersCount: 100,
+        primaryCountryId: 'BR',
+        names: [
+          { value: 'Palikur', languageId: '529', bcp47: 'en' },
+          { value: 'Parikwaki', languageId: '1234', bcp47: 'plu' }
+        ]
+      })
+    })
+
+    it('only counts speakers from non-suggested country languages', () => {
+      const record = buildAlgoliaLanguageRecord(createLanguage())
+
+      expect(record.speakersCount).toBe(100)
+    })
+
+    it('falls back to US when no country languages exist', () => {
+      const record = buildAlgoliaLanguageRecord(
+        createLanguage({ countryLanguages: [] })
+      )
+
+      expect(record.primaryCountryId).toBe('US')
+    })
+  })
+
+  describe('updateLanguageInAlgoliaFromMedia', () => {
+    it('saves the language record to the languages index', async () => {
+      languagesPrismaMock.language.findUnique.mockResolvedValue(
+        createLanguage()
+      )
+
+      await updateLanguageInAlgoliaFromMedia('1234')
+
+      expect(saveObjectsSpy).toHaveBeenCalledWith({
+        indexName: 'languages-index',
+        objects: [expect.objectContaining({ objectID: '1234' })],
+        waitForTasks: true
+      })
+    })
+
+    it('does not save when the language is not found', async () => {
+      languagesPrismaMock.language.findUnique.mockResolvedValue(null)
+
+      await updateLanguageInAlgoliaFromMedia('missing')
+
+      expect(saveObjectsSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('reindexLanguagesWithVideosInAlgolia', () => {
+    it('paginates full batches by cursor and saves each batch', async () => {
+      const fullBatch = Array.from({ length: 1000 }, (_, index) =>
+        createLanguage({ id: `id-${index}` })
+      )
+      languagesPrismaMock.language.findMany
+        .mockResolvedValueOnce(fullBatch)
+        .mockResolvedValueOnce([createLanguage({ id: 'last' })])
+
+      const result = await reindexLanguagesWithVideosInAlgolia()
+
+      expect(result).toEqual({ count: 1001 })
+      expect(languagesPrismaMock.language.findMany).toHaveBeenCalledTimes(2)
+      // first page: no cursor
+      expect(languagesPrismaMock.language.findMany).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ where: { hasVideos: true }, take: 1000 })
+      )
+      // second page: continues from the last id of the previous batch
+      expect(languagesPrismaMock.language.findMany).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ skip: 1, cursor: { id: 'id-999' } })
+      )
+      expect(saveObjectsSpy).toHaveBeenCalledTimes(2)
+      expect(saveObjectsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          indexName: 'languages-index',
+          waitForTasks: true
+        })
+      )
+    })
+
+    it('stops after a partial batch without an extra query', async () => {
+      languagesPrismaMock.language.findMany.mockResolvedValueOnce([
+        createLanguage({ id: 'a' })
+      ])
+
+      const result = await reindexLanguagesWithVideosInAlgolia()
+
+      expect(result).toEqual({ count: 1 })
+      expect(languagesPrismaMock.language.findMany).toHaveBeenCalledTimes(1)
+      expect(saveObjectsSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns zero and does not save when no languages have videos', async () => {
+      languagesPrismaMock.language.findMany.mockResolvedValueOnce([])
+
+      const result = await reindexLanguagesWithVideosInAlgolia()
+
+      expect(result).toEqual({ count: 0 })
+      expect(saveObjectsSpy).not.toHaveBeenCalled()
+    })
+
+    it('propagates a batch failure so the caller exits non-zero', async () => {
+      languagesPrismaMock.language.findMany.mockResolvedValueOnce([
+        createLanguage({ id: 'a' })
+      ])
+      saveObjectsSpy.mockRejectedValueOnce(new Error('algolia unavailable'))
+
+      await expect(reindexLanguagesWithVideosInAlgolia()).rejects.toThrow(
+        'algolia unavailable'
+      )
+    })
+  })
+})

--- a/apis/api-media/src/lib/languages/updateLanguageInAlgolia.ts
+++ b/apis/api-media/src/lib/languages/updateLanguageInAlgolia.ts
@@ -1,7 +1,10 @@
-import { algoliasearch } from 'algoliasearch'
+import { type SearchClient, algoliasearch } from 'algoliasearch'
 import type { Logger } from 'pino'
 
-import { prisma as languagesPrisma } from '@core/prisma/languages/client'
+import {
+  Prisma,
+  prisma as languagesPrisma
+} from '@core/prisma/languages/client'
 
 function getRequiredEnv(name: string): string {
   const value = process.env[name]
@@ -11,46 +14,118 @@ function getRequiredEnv(name: string): string {
   return value
 }
 
-export async function updateLanguageInAlgoliaFromMedia(
-  languageId: string,
-  logger?: Logger
-): Promise<void> {
+interface AlgoliaLanguagesClient {
+  client: SearchClient
+  languagesIndex: string
+}
+
+// Deliberately local rather than reusing lib/algolia/algoliaClient, whose
+// getAlgoliaConfig also requires the video index env vars. Coupling the
+// languages sync to those would break video indexing wherever they are unset.
+function getAlgoliaLanguagesClient(): AlgoliaLanguagesClient {
   const appId = getRequiredEnv('ALGOLIA_APPLICATION_ID')
   const apiKey = getRequiredEnv('ALGOLIA_API_KEY')
   const languagesIndex = getRequiredEnv('ALGOLIA_INDEX_LANGUAGES')
 
-  const client = algoliasearch(appId, apiKey)
+  return { client: algoliasearch(appId, apiKey), languagesIndex }
+}
 
-  try {
-    const language = await languagesPrisma.language.findUnique({
-      where: { id: languageId },
-      select: {
-        id: true,
-        bcp47: true,
-        iso3: true,
-        name: {
-          select: {
-            value: true,
-            primary: true,
-            language: {
-              select: {
-                id: true,
-                bcp47: true
-              }
-            }
-          }
-        },
-        countryLanguages: {
-          select: {
-            speakers: true,
-            suggested: true,
-            primary: true,
-            country: {
-              select: { id: true }
-            }
-          }
+const languageAlgoliaSelect = {
+  id: true,
+  bcp47: true,
+  iso3: true,
+  name: {
+    select: {
+      value: true,
+      primary: true,
+      language: {
+        select: {
+          id: true,
+          bcp47: true
         }
       }
+    }
+  },
+  countryLanguages: {
+    select: {
+      speakers: true,
+      suggested: true,
+      primary: true,
+      country: {
+        select: { id: true }
+      }
+    }
+  }
+} satisfies Prisma.LanguageSelect
+
+type AlgoliaLanguage = Prisma.LanguageGetPayload<{
+  select: typeof languageAlgoliaSelect
+}>
+
+// A type alias (not an interface) so it keeps an implicit index signature and
+// stays assignable to Algolia's `Record<string, unknown>` object type.
+type AlgoliaLanguageRecord = {
+  objectID: string
+  languageId: string
+  bcp47: string | null
+  iso3: string | null
+  nameNative: string
+  speakersCount: number
+  primaryCountryId: string
+  names: Array<{ value: string; languageId: string; bcp47: string }>
+}
+
+export function buildAlgoliaLanguageRecord(
+  language: AlgoliaLanguage
+): AlgoliaLanguageRecord {
+  const nonSuggestedCountryLanguages = language.countryLanguages.filter(
+    ({ suggested }) => !suggested
+  )
+  const speakersCount = nonSuggestedCountryLanguages.reduce(
+    (acc, { speakers }) => acc + speakers,
+    0
+  )
+
+  const primaryCountryLanguage = language.countryLanguages.find(
+    ({ primary }) => primary
+  )
+  const primaryCountryId =
+    primaryCountryLanguage?.country.id ??
+    language.countryLanguages[0]?.country.id ??
+    'US'
+
+  const nameNative =
+    language.name.find(({ primary }) => primary)?.value ??
+    language.name[0]?.value ??
+    ''
+
+  const names = language.name.map((name) => ({
+    value: name.value,
+    languageId: name.language?.id ?? '',
+    bcp47: name.language?.bcp47 ?? ''
+  }))
+
+  return {
+    objectID: language.id,
+    languageId: language.id,
+    bcp47: language.bcp47,
+    iso3: language.iso3,
+    nameNative,
+    speakersCount,
+    primaryCountryId,
+    names
+  }
+}
+
+export async function updateLanguageInAlgoliaFromMedia(
+  languageId: string,
+  logger?: Logger
+): Promise<void> {
+  try {
+    const { client, languagesIndex } = getAlgoliaLanguagesClient()
+    const language = await languagesPrisma.language.findUnique({
+      where: { id: languageId },
+      select: languageAlgoliaSelect
     })
 
     if (language == null) {
@@ -58,50 +133,61 @@ export async function updateLanguageInAlgoliaFromMedia(
       return
     }
 
-    const nonSuggestedCountryLanguages = language.countryLanguages.filter(
-      ({ suggested }) => !suggested
-    )
-    const speakersCount = nonSuggestedCountryLanguages.reduce(
-      (acc, { speakers }) => acc + speakers,
-      0
-    )
-
-    const primaryCountryLanguage = language.countryLanguages.find(
-      ({ primary }) => primary
-    )
-    const primaryCountryId =
-      primaryCountryLanguage?.country.id ??
-      language.countryLanguages[0]?.country.id ??
-      'US'
-
-    const nameNative =
-      language.name.find(({ primary }) => primary)?.value ??
-      language.name[0]?.value ??
-      ''
-
-    const names = language.name.map((name) => ({
-      value: name.value,
-      languageId: name.language?.id ?? '',
-      bcp47: name.language?.bcp47 ?? ''
-    }))
-
-    const transformedLanguage = {
-      objectID: language.id,
-      languageId: language.id,
-      bcp47: language.bcp47,
-      iso3: language.iso3,
-      nameNative,
-      speakersCount,
-      primaryCountryId,
-      names
-    }
-
     await client.saveObjects({
       indexName: languagesIndex,
-      objects: [transformedLanguage],
+      objects: [buildAlgoliaLanguageRecord(language)],
       waitForTasks: true
     })
   } catch (error) {
     logger?.error(error, `failed to update language ${languageId} in algolia`)
   }
+}
+
+const REINDEX_BATCH_SIZE = 1000
+
+interface ReindexLanguagesResult {
+  count: number
+}
+
+/**
+ * Pushes every language that has videos into the Algolia languages index.
+ *
+ * The incremental sync only fires on a hasVideos false -> true transition, so
+ * languages that were already marked hasVideos: true (the schema default) never
+ * reach Algolia and are missing from search. This repairs the index by
+ * re-upserting all of them in batches.
+ */
+export async function reindexLanguagesWithVideosInAlgolia(
+  logger?: Logger
+): Promise<ReindexLanguagesResult> {
+  const { client, languagesIndex } = getAlgoliaLanguagesClient()
+
+  let count = 0
+  let cursor: string | undefined
+
+  for (;;) {
+    const languages = await languagesPrisma.language.findMany({
+      where: { hasVideos: true },
+      select: languageAlgoliaSelect,
+      orderBy: { id: 'asc' },
+      take: REINDEX_BATCH_SIZE,
+      ...(cursor != null ? { skip: 1, cursor: { id: cursor } } : {})
+    })
+
+    if (languages.length === 0) break
+
+    await client.saveObjects({
+      indexName: languagesIndex,
+      objects: languages.map(buildAlgoliaLanguageRecord),
+      waitForTasks: true
+    })
+
+    count += languages.length
+    cursor = languages[languages.length - 1].id
+    logger?.info(`reindexed ${count} languages in algolia`)
+
+    if (languages.length < REINDEX_BATCH_SIZE) break
+  }
+
+  return { count }
 }

--- a/apis/api-media/src/scripts/algolia-helpers/reindex-languages-with-videos.ts
+++ b/apis/api-media/src/scripts/algolia-helpers/reindex-languages-with-videos.ts
@@ -1,0 +1,30 @@
+/**
+ * Pushes every language with videos into the Algolia languages index.
+ *
+ * Languages default to hasVideos: true in the schema, so the incremental sync
+ * (which only fired on a false -> true transition) never pushed them and they
+ * are missing from search. This repairs the index in one pass.
+ *
+ * Errors are not caught: the run stops on the first failing batch and exits
+ * non-zero. Re-running is safe, because saveObjects upserts derived data.
+ *
+ * Usage: nx run api-media:reindex-languages-algolia
+ */
+
+import { reindexLanguagesWithVideosInAlgolia } from '../../lib/languages/updateLanguageInAlgolia'
+import { logger } from '../../logger'
+
+async function main(): Promise<void> {
+  logger.info('reindexing languages with videos in algolia')
+
+  const { count } = await reindexLanguagesWithVideosInAlgolia(logger)
+
+  logger.info(`reindexed ${count} languages in algolia`)
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    logger.error(error, 'failed to reindex languages in algolia')
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Problem (QA-375)

Searching a language like **Palikur** in the search bar returns nothing on apps and web, even though the language is playable and shows up in the video's language list.

**Root cause:** the only code path that writes a language into the Algolia *languages* index (`ensureLanguageHasVideos` → `updateLanguageInAlgoliaFromMedia`) was gated behind a `hasVideos` **false → true transition**. But `hasVideos` defaults to `true` in the Prisma schema, so pre-existing languages are already `true` — the push was skipped and never happened. There is no full/backfill reindex anywhere in the repo, so any language that gained videos after the last one-off index build is missing from search.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved language search index updates when video availability changes.
  * Added bulk reindexing for all languages with videos, including progress reporting.
  * Added a command to run the language reindexing process.

* **Bug Fixes**
  * Ensured languages already marked as having videos still receive refreshed search index data.

* **Tests**
  * Added coverage for language updates, indexing, pagination, failures, and empty results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->