### PR TITLE
chore(api-media): add missing migration for updatedAt+id sync pagination indexes

### DIFF
--- a/libs/prisma/media/db/migrations/20260705203730_20260705203728/migration.sql
+++ b/libs/prisma/media/db/migrations/20260705203730_20260705203728/migration.sql
@@ -1,0 +1,20 @@
+-- DropIndex
+DROP INDEX "Keyword_updatedAt_idx";
+
+-- CreateIndex
+CREATE INDEX "CloudflareImage_updatedAt_id_idx" ON "CloudflareImage"("updatedAt", "id");
+
+-- CreateIndex
+CREATE INDEX "Keyword_updatedAt_id_idx" ON "Keyword"("updatedAt", "id");
+
+-- CreateIndex
+CREATE INDEX "VideoEdition_updatedAt_id_idx" ON "VideoEdition"("updatedAt", "id");
+
+-- CreateIndex
+CREATE INDEX "VideoOrigin_updatedAt_id_idx" ON "VideoOrigin"("updatedAt", "id");
+
+-- CreateIndex
+CREATE INDEX "VideoSubtitle_updatedAt_id_idx" ON "VideoSubtitle"("updatedAt", "id");
+
+-- CreateIndex
+CREATE INDEX "VideoVariantDownload_updatedAt_id_idx" ON "VideoVariantDownload"("updatedAt", "id");


### PR DESCRIPTION
## What

Adds the Prisma migration that should have shipped with #9171 (`5a9c47314`, *feat(api-media): add paginated sync endpoints for video metadata*). That PR added `@@index([updatedAt, id])` to six models in `libs/prisma/media/db/schema.prisma` but the matching migration was never generated, leaving schema drift — the next `prisma migrate dev` run on a clean setup auto-generates exactly this migration.

## Changes

One migration (`20260705203730_20260705203728`) that:

- Creates `(updatedAt, id)` composite indexes on `CloudflareImage`, `Keyword`, `VideoEdition`, `VideoOrigin`, `VideoSubtitle`, `VideoVariantDownload`
- Drops `Keyword_updatedAt_idx` — the single-column index superseded by the composite (created in `20260324194149`)

## Why it matters

These are the keyset-pagination indexes backing the paginated sync endpoints from #9171, which are already live — without them those queries order by `(updatedAt, id)` unindexed. Verified none of the six composite indexes exist in any committed migration; the migration matches the schema drift exactly (index creation only, no data changes, safe to apply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved database indexing across several content-related records.
  * Replaced an older single-field index with new combined indexes to better support sorting and lookups by update time and record ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->