### PR TITLE
feat(NES-1759): add Thai (Sarabun) font support to journeys & journeys-admin

### DIFF
--- a/apps/journeys-admin/pages/_document.tsx
+++ b/apps/journeys-admin/pages/_document.tsx
@@ -7,6 +7,7 @@ import Document, { Head, Html, Main, NextScript } from 'next/document'
 import { ReactElement } from 'react'
 
 import { createEmotionCache } from '@core/shared/ui/createEmotionCache'
+import { SARABUN_FONTS_QUERY } from '@core/shared/ui/themes'
 
 export default class MyDocument extends Document<DocumentHeadTagsProps> {
   render(): ReactElement {
@@ -20,7 +21,7 @@ export default class MyDocument extends Document<DocumentHeadTagsProps> {
             crossOrigin=""
           />
           <link
-            href="https://fonts.googleapis.com/css2?family=Montserrat:wght@500;600;700;800&family=Open+Sans&display=swap"
+            href={`https://fonts.googleapis.com/css2?family=Montserrat:wght@500;600;700;800&family=Open+Sans&${SARABUN_FONTS_QUERY}&display=swap`}
             rel="stylesheet"
           />
           <link

--- a/apps/journeys-admin/src/components/LabelChip/LabelChip.tsx
+++ b/apps/journeys-admin/src/components/LabelChip/LabelChip.tsx
@@ -2,6 +2,8 @@ import Chip from '@mui/material/Chip'
 import { SxProps, Theme } from '@mui/material/styles'
 import { ReactElement } from 'react'
 
+import { THAI_FALLBACK_FONT } from '@core/shared/ui/themes'
+
 export type LabelChipColor = 'default' | 'success'
 
 interface LabelChipProps {
@@ -38,7 +40,7 @@ export function LabelChip({
           borderRadius: '4px',
           bgcolor: isSuccess ? 'success.main' : 'divider',
           color: isSuccess ? 'success.contrastText' : 'text.primary',
-          fontFamily: '"Open Sans", sans-serif',
+          fontFamily: `"Open Sans", ${THAI_FALLBACK_FONT}, sans-serif`,
           fontSize: 14,
           fontWeight: 600,
           lineHeight: '20px',

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/CollectionDialog.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/CollectionDialog.tsx
@@ -20,6 +20,7 @@ import {
 import { Dialog } from '@core/shared/ui/Dialog'
 import Edit2Icon from '@core/shared/ui/icons/Edit2'
 import Plus2Icon from '@core/shared/ui/icons/Plus2'
+import { THAI_FALLBACK_FONT } from '@core/shared/ui/themes'
 
 import { GetAdminJourneys_journeys as Journey } from '../../../../__generated__/GetAdminJourneys'
 import { GetTemplateGalleryPages_templateGalleryPages as TemplateGalleryPage } from '../../../../__generated__/GetTemplateGalleryPages'
@@ -65,7 +66,7 @@ export interface CollectionDialogProps {
 
 // Matches the Figma "Editor / Subtitle/2" type token on section headers.
 const SECTION_HEADER = {
-  fontFamily: 'Montserrat, sans-serif',
+  fontFamily: `Montserrat, ${THAI_FALLBACK_FONT}, sans-serif`,
   fontWeight: 600,
   fontSize: 16,
   lineHeight: '24px',

--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/JourneyPickerField/JourneyPickerField.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/JourneyPickerField/JourneyPickerField.tsx
@@ -6,10 +6,12 @@ import Typography from '@mui/material/Typography'
 import { useTranslation } from 'next-i18next/pages'
 import { ReactElement, memo, useMemo } from 'react'
 
+import { THAI_FALLBACK_FONT } from '@core/shared/ui/themes'
+
 import { GetAdminJourneys_journeys as Journey } from '../../../../../__generated__/GetAdminJourneys'
 
 const SECTION_HEADER = {
-  fontFamily: 'Montserrat, sans-serif',
+  fontFamily: `Montserrat, ${THAI_FALLBACK_FONT}, sans-serif`,
   fontWeight: 600,
   fontSize: 16,
   lineHeight: '24px',

--- a/apps/journeys/pages/_document.tsx
+++ b/apps/journeys/pages/_document.tsx
@@ -35,11 +35,11 @@ export default class MyDocument extends Document<{
           {this.props.rtl && this.props.locale !== 'ur' ? (
             <>
               <link
-                href="https://fonts.googleapis.com/css2?family=El+Messiri:wght@400;600;700&family=Tajawal:wght@400;700&display=swap"
+                href={`https://fonts.googleapis.com/css2?family=El+Messiri:wght@400;600;700&family=Tajawal:wght@400;700&${SARABUN_FONTS_QUERY}&display=swap`}
                 rel="stylesheet"
               />
               <link
-                href="https://fonts.googleapis.com/css2?family=El+Messiri:wght@400;600;700&family=Tajawal:wght@400;700&display=swap"
+                href={`https://fonts.googleapis.com/css2?family=El+Messiri:wght@400;600;700&family=Tajawal:wght@400;700&${SARABUN_FONTS_QUERY}&display=swap`}
                 rel="preload"
                 as="style"
               />

--- a/apps/journeys/pages/_document.tsx
+++ b/apps/journeys/pages/_document.tsx
@@ -7,7 +7,7 @@ import { ReactElement } from 'react'
 
 import { getJourneyRTL } from '@core/journeys/ui/rtl'
 import { createEmotionCache } from '@core/shared/ui/createEmotionCache'
-import { getTheme } from '@core/shared/ui/themes'
+import { SARABUN_FONTS_QUERY, getTheme } from '@core/shared/ui/themes'
 
 import { ThemeMode, ThemeName } from '../__generated__/globalTypes'
 import { JourneyFields } from '../__generated__/JourneyFields'
@@ -47,11 +47,11 @@ export default class MyDocument extends Document<{
           ) : (
             <>
               <link
-                href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600;800&family=Open+Sans&display=swap"
+                href={`https://fonts.googleapis.com/css2?family=Montserrat:wght@600;800&family=Open+Sans&${SARABUN_FONTS_QUERY}&display=swap`}
                 rel="stylesheet"
               />
               <link
-                href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600;800&family=Open+Sans&display=swap"
+                href={`https://fonts.googleapis.com/css2?family=Montserrat:wght@600;800&family=Open+Sans&${SARABUN_FONTS_QUERY}&display=swap`}
                 rel="preload"
                 as="style"
               />

--- a/apps/journeys/pages/home/[journeySlug].tsx
+++ b/apps/journeys/pages/home/[journeySlug].tsx
@@ -7,6 +7,7 @@ import { ReactElement } from 'react'
 
 import { getJourneyRTL } from '@core/journeys/ui/rtl'
 import { GET_JOURNEY } from '@core/journeys/ui/useJourneyQuery'
+import { DEFAULT_FONTS } from '@core/shared/ui/themes'
 
 import {
   GetJourney,
@@ -36,9 +37,8 @@ function JourneyPage({ journey, locale, rtl }: JourneyPageProps): ReactElement {
   }
 
   // Get journey-specific fonts if they exist
-  const defaultFonts = ['Montserrat', 'Open Sans', 'El Messiri']
   const journeyFonts = getSortedValidFonts([
-    ...defaultFonts,
+    ...DEFAULT_FONTS,
     journey?.journeyTheme?.headerFont ?? '',
     journey?.journeyTheme?.bodyFont ?? '',
     journey?.journeyTheme?.labelFont ?? ''

--- a/docs/brainstorms/thai-font-support-requirements.md
+++ b/docs/brainstorms/thai-font-support-requirements.md
@@ -1,0 +1,99 @@
+---
+date: 2026-07-06
+topic: thai-font-support
+---
+
+# Thai Font Support for journeys & journeys-admin
+
+## Summary
+
+Add Sarabun as a universal, `unicode-range`-scoped Thai fallback across `apps/journeys` and `apps/journeys-admin`, so Thai glyphs render in Sarabun everywhere they appear — viewer content, the admin editor canvas, and the UI chrome — while Latin text stays Montserrat. Per-glyph font selection means no locale detection or theme branching is required.
+
+---
+
+## Problem Frame
+
+Both apps load a Latin-only type system (Montserrat + Open Sans) via Google Fonts `<link>` tags. These families have no Thai glyphs, so any Thai character falls through to whatever system font the browser happens to pick. The result reads as visually broken next to the polished English experience — inconsistent weight, mismatched metrics, and no relationship to the surrounding Latin type.
+
+Thai (`th`) is already a supported i18n locale in both apps, and journeys can carry a Thai `language.bcp47` and Thai-authored content, so Thai text reaches all three surfaces today. The theme system already branches fonts for RTL scripts (Arabic → `El Messiri`/`Tajawal`, Urdu → `Arial`) but has no path for LTR non-Latin scripts like Thai. Thai users see degraded rendering in the viewer, in the editor while authoring, and in the app UI whenever the interface is shown in Thai.
+
+---
+
+## Actors
+
+- A1. Journey visitor: views a published journey in the viewer app; may see Thai content, mixed Thai/English content, or all-English content.
+- A2. Journey author: builds a journey in the admin editor, previewing Thai (or mixed) content on the canvas as they type.
+- A3. Thai-locale UI user: uses journeys-admin or the viewer with the interface set to the Thai (`th`) locale.
+
+---
+
+## Requirements
+
+**Font availability**
+- R1. Sarabun must be loaded via the Google Fonts `<link>` on every page of both apps (a global link), so the fallback works for any Thai text regardless of the journey's language or the UI locale.
+- R2. Sarabun must be loaded such that its `unicode-range` (Thai block) subsetting is preserved, so the Thai `.woff2` downloads only when Thai characters are actually rendered — English-only pages must not download the Thai font file.
+
+**Font application (per-script)**
+- R3. Sarabun must be appended to the application-default type stack so that Thai glyphs resolve to Sarabun while Latin glyphs continue to resolve to Montserrat, per glyph.
+- R4. The per-script fallback must apply to all typography roles that carry the default stack — header, body, and label — across both apps.
+- R5. The fallback must also apply to author-selected fonts (`journeyTheme.headerFont`/`bodyFont`/`labelFont`): when an author picks a Latin font for a journey, Thai characters within that journey must still resolve to Sarabun rather than a system fallback.
+- R6. The journey player theme (`journeyUi`) must apply the Thai fallback. It currently does not consume author `fontFamilies`, so the fallback must be wired into the player path explicitly, not only into the `base` theme.
+- R7. The editor canvas preview (the iframe-portal render path used by the admin editor) must load Sarabun and apply the same fallback, so authored Thai text renders correctly while building a journey.
+
+**No locale branching**
+- R8. Thai support must not introduce a locale- or journey-language-conditional typography variant (unlike the existing Arabic/Urdu branches). Per-glyph `unicode-range` selection is the sole mechanism; the same font stack is used regardless of locale.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R3, R8.** Given a journey card containing "สวัสดี Welcome", when it renders in the viewer, then the Thai characters display in Sarabun and the Latin characters display in Montserrat within the same line, with no system-fallback tofu.
+- AE2. **Covers R1, R5.** Given a journey whose `language.bcp47` is English and whose author selected a Latin body font, when a visitor views a card that contains a Thai phrase, then the Thai phrase renders in Sarabun.
+- AE3. **Covers R2.** Given an all-English, all-Latin journey, when a visitor loads it, then no Sarabun font file (`.woff2`) is downloaded (only the shared Google Fonts stylesheet, if not already cached).
+- AE4. **Covers R6, R7.** Given an author typing Thai text into a card in the admin editor, when the canvas preview updates, then the Thai text renders in Sarabun in the preview.
+- AE5. **Covers R1.** Given the journeys-admin UI set to the Thai (`th`) locale, when any Thai chrome string renders (menus, buttons, labels), then it displays in Sarabun.
+
+---
+
+## Success Criteria
+
+- Thai text on all three surfaces (viewer content, editor canvas, UI chrome) is legible and visually coherent with the surrounding design — no boxes, no arbitrary system fallback.
+- English-only journeys are visually unchanged and incur no additional font download; the Thai `.woff2` loads only when Thai characters are present.
+- A downstream implementer can identify every insertion point (both `_document.tsx` files, the base typography fallback and `createFontFamilyString`, the `journeyUi` player theme, and the editor/player dynamic font injection) without needing to reverse-engineer product intent.
+
+---
+
+## Scope Boundaries
+
+- Not building a generalized script→font mapping framework for other non-Latin scripts (CJK, Devanagari, etc.); this ships Sarabun only.
+- Not adding Thai-specific options to the author-facing font picker; authors keep the existing picker, and Thai fallback applies underneath whatever they choose.
+- Not migrating font loading from Google Fonts `<link>` tags to `next/font`.
+- Not authoring or translating Thai UI strings or journey content; the i18n `th` locale strings already exist.
+- Not changing the existing Arabic/Urdu RTL font behavior.
+- Not promoting Sarabun to lead the stack on Thai surfaces (English within a Thai surface stays Montserrat — the per-script decision).
+
+---
+
+## Key Decisions
+
+- Typeface is Sarabun: reads as native and professional to Thai readers; the Thai government's official document font.
+- Universal fallback over locale branching: because `unicode-range` selects fonts per glyph, a single global stack (`Montserrat, Sarabun, sans-serif`) renders Thai in Sarabun and Latin in Montserrat automatically. This makes the Arabic-style locale-conditional typography variant redundant for Thai — less code, and it also covers mixed content and author-picked Latin fonts for free.
+- Global `<link>` over conditional loading: the stylesheet is included on every page so the fallback is truly universal (Thai text in a non-Thai journey still renders). Cost is near-zero because `unicode-range` subsetting keeps the Thai `.woff2` from downloading until Thai characters are painted.
+- Per-script rendering (Thai→Sarabun, English→Montserrat) over unified Sarabun: keeps the established English look unchanged and puts each script in a font designed for it; the least-visual-change option.
+
+---
+
+## Dependencies / Assumptions
+
+- Assumes Google Fonts serves Sarabun with per-subset `unicode-range` `@font-face` rules (its standard behavior for the `css2` API), which is what enables lazy Thai-file loading.
+- Assumes Sarabun's Latin glyph coverage is not relied upon, since Latin continues to resolve to Montserrat under the per-script decision.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R1, R2][Technical] Exact `<link>` composition — whether Sarabun is added to the existing conditional Google Fonts link blocks or a single unconditional link, in each `_document.tsx`.
+- [Affects R6, R7][Technical] How the player/editor dynamic font injection (the iframe-portal font list) should include Sarabun and whether the fallback belongs in the injected stylesheet, the theme stack, or both.
+- [Affects R2][Needs research] Confirm in the running app that an all-English journey downloads no Sarabun `.woff2` (verify the `unicode-range` gating behaves as expected end-to-end).

--- a/docs/brainstorms/thai-font-support-requirements.md
+++ b/docs/brainstorms/thai-font-support-requirements.md
@@ -30,10 +30,12 @@ Thai (`th`) is already a supported i18n locale in both apps, and journeys can ca
 ## Requirements
 
 **Font availability**
+
 - R1. Sarabun must be loaded via the Google Fonts `<link>` on every page of both apps (a global link), so the fallback works for any Thai text regardless of the journey's language or the UI locale.
 - R2. Sarabun must be loaded such that its `unicode-range` (Thai block) subsetting is preserved, so the Thai `.woff2` downloads only when Thai characters are actually rendered — English-only pages must not download the Thai font file.
 
 **Font application (per-script)**
+
 - R3. Sarabun must be appended to the application-default type stack so that Thai glyphs resolve to Sarabun while Latin glyphs continue to resolve to Montserrat, per glyph.
 - R4. The per-script fallback must apply to all typography roles that carry the default stack — header, body, and label — across both apps.
 - R5. The fallback must also apply to author-selected fonts (`journeyTheme.headerFont`/`bodyFont`/`labelFont`): when an author picks a Latin font for a journey, Thai characters within that journey must still resolve to Sarabun rather than a system fallback.
@@ -41,6 +43,7 @@ Thai (`th`) is already a supported i18n locale in both apps, and journeys can ca
 - R7. The editor canvas preview (the iframe-portal render path used by the admin editor) must load Sarabun and apply the same fallback, so authored Thai text renders correctly while building a journey.
 
 **No locale branching**
+
 - R8. Thai support must not introduce a locale- or journey-language-conditional typography variant (unlike the existing Arabic/Urdu branches). Per-glyph `unicode-range` selection is the sole mechanism; the same font stack is used regardless of locale.
 
 ---

--- a/docs/plans/2026-07-06-001-feat-thai-font-support-plan.md
+++ b/docs/plans/2026-07-06-001-feat-thai-font-support-plan.md
@@ -1,0 +1,302 @@
+---
+title: "feat: Thai font (Sarabun) support for journeys & journeys-admin"
+type: feat
+status: active
+date: 2026-07-06
+origin: docs/brainstorms/thai-font-support-requirements.md
+---
+
+# feat: Thai font (Sarabun) support for journeys & journeys-admin
+
+## Summary
+
+Add Sarabun as a `unicode-range`-scoped Thai fallback across `apps/journeys` and `apps/journeys-admin` by appending it (after the Latin fonts) to every MUI typography font stack and loading it via the existing Google Fonts `<link>` tags and the editor/player iframe font injection. Per-glyph selection means Thai renders in Sarabun and Latin stays Montserrat everywhere, with no locale-conditional theme branch.
+
+---
+
+## Problem Frame
+
+Both apps ship a Latin-only type system (Montserrat + Open Sans) with no Thai glyphs, so Thai text falls to an arbitrary system font and looks broken next to the English experience. Thai (`th`) is already a supported i18n locale and journeys can carry Thai content, so Thai text reaches the viewer, the admin editor canvas, and the UI chrome today. The theme system branches fonts only for RTL scripts (Arabic/Urdu); there is no path for LTR non-Latin scripts. (See origin: `docs/brainstorms/thai-font-support-requirements.md`.)
+
+---
+
+## Requirements
+
+- R1. Sarabun loaded globally in both apps so the fallback works regardless of journey language or UI locale.
+- R2. Sarabun loaded so its `unicode-range` subsetting is preserved — the Sarabun Thai `.woff2` downloads only when Thai (or other Sarabun-only) glyphs render; Basic-Latin-only pages download no Sarabun file.
+- R3. Thai glyphs resolve to Sarabun while Latin glyphs continue resolving to Montserrat, per glyph.
+- R4. Per-script fallback applies to all default-stack roles (header, body, label) across both apps.
+- R5. Fallback applies to author-selected fonts (`journeyTheme.headerFont/bodyFont/labelFont`): Thai in a journey with an author-picked Latin font still resolves to Sarabun.
+- R6. The player theme (`journeyUi`) applies the Thai fallback (it does not consume author `fontFamilies`, so this is wired in the player path explicitly).
+- R7. The editor canvas preview (iframe-portal render path) loads Sarabun and applies the fallback.
+- R8. No locale- or journey-language-conditional typography variant is introduced; per-glyph `unicode-range` is the sole mechanism.
+
+**Origin actors:** A1 (journey visitor), A2 (journey author), A3 (Thai-locale UI user)
+**Origin acceptance examples:** AE1 (covers R3, R8), AE2 (covers R1, R5), AE3 (covers R2), AE4 (covers R6, R7), AE5 (covers R1)
+
+---
+
+## Scope Boundaries
+
+- No generalized script→font mapping for other non-Latin scripts (CJK, Devanagari, etc.); Sarabun only.
+- No new Thai-specific options in the author font picker.
+- No migration from Google Fonts `<link>` to `next/font`.
+- No authoring/translation of Thai UI or content strings (i18n `th` strings already exist).
+- No change to existing Arabic/Urdu RTL font behavior — those branches are left untouched.
+- Sarabun does not lead any stack; English within a Thai surface stays Montserrat (the per-script decision, see origin Key Decisions).
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `libs/shared/ui/src/libs/themes/base/tokens/typography.ts` — `createFontFamilyString` (author-font stack builder, line 12), `baseTypography` top-level `fontFamily` (line 23) and per-variant `body1/body2/caption` fontFamily strings; `createCustomTypography` (applies author fonts). Arabic/Urdu variants live here and stay unchanged.
+- `libs/shared/ui/src/libs/themes/journeyUi/tokens/typography.ts` — player LTR typography; `subtitle1/subtitle2/body2/caption` hardcode `'"Open Sans"'` with no fallback (lines 21–44).
+- `libs/shared/ui/src/libs/themes/journeysAdmin/tokens/typography.ts` — admin chrome typography; explicit fontFamily strings on top-level, `subtitle3`, `body1`, `body2`, `overline2`, `caption`.
+- `libs/shared/ui/src/libs/themes/base/theme.ts` / `journeyUi/theme.ts` — RTL/locale typography selection (`rtl ? (ur ? Urdu : Arabic) : LTR`). No change needed (R8) — Thai stays on the LTR branch.
+- `libs/shared/ui/src/libs/themes/journeysAdmin/tokens/components.ts` — component-level font overrides on `MuiButton` root (~L17) and `MuiListItemText` primary (~L205) hardcode `'Montserrat', sans-serif`, applied above typography defaults. (`base/tokens/components.ts` L102 uses `createFontFamilyString` — already covered by U2.)
+- `apps/journeys/pages/_document.tsx` — conditional Google Fonts links; LTR (`else`) branch loads Montserrat + Open Sans (lines 47–59). `getInitialProps` never populates `pageProps`, so `rtl` is always `false` and the `else` branch is effectively unconditional today.
+- `apps/journeys/pages/home/[journeySlug].tsx` — standalone published-journey viewer; builds its **own** Google Fonts URL from a local `defaultFonts` array (~L38–59) and injects a `<link>` (~L74), independent of `_document` and `FramePortal`.
+- `apps/journeys/src/components/Conductor/Conductor.tsx` — player: chrome via `journeyUi` `ThemeProvider` (L216, no `fontFamilies`); card content via nested `ThemeProvider` with `getStepTheme` (defaults `base`) + author `fontFamilies` (L256–262). Confirms content renders through the base theme.
+- `apps/journeys-admin/pages/_document.tsx` — single Montserrat + Open Sans link (lines 22–25).
+- `libs/journeys/ui/src/components/FramePortal/FramePortal.tsx` — `defaultFonts = ['Montserrat', 'Open Sans', 'El Messiri']` (line 35) drives the dynamic Google Fonts URL injected into the editor/player iframe.
+
+### Institutional Learnings
+
+- No relevant `docs/solutions/` entries for fonts/i18n/typography.
+
+### External References
+
+- Not gathered — `unicode-range` subsetting via the Google Fonts `css2` API is a well-established, decided mechanism (see origin Key Decisions / Dependencies).
+
+---
+
+## Key Technical Decisions
+
+- **Append, never lead; order after Latin fonts.** Sarabun is placed after Montserrat/Open Sans in every stack. Because its `@font-face` is `unicode-range`-scoped to the Thai block, Latin glyphs resolve to Montserrat (Sarabun's Latin subset is never used, so never downloaded) and only Thai glyphs fall to Sarabun. This is what makes R2 and R3 hold simultaneously. Reversing the order would download Sarabun's Latin subset and change the English look — regression.
+- **Shared constants over scattered literals.** Introduce a single `THAI_FALLBACK_FONT` constant (typography name) and a single Sarabun Google-Fonts family-query constant, imported by the typography tokens, both `_document.tsx` files, and `FramePortal`. Avoids drift across ~12 font strings and 3 load sites (DRY).
+- **No theme branch (R8).** `base/theme.ts` and `journeyUi/theme.ts` selection logic is untouched; the fallback lives in the token strings themselves, so it applies on the LTR branch that Thai already uses.
+- **Player content uses the base theme; `journeyUi` is chrome only.** In `Conductor.tsx`, journey *card content* renders through a nested `ThemeProvider` using `getStepTheme` (defaults to `ThemeName.base`) with author `fontFamilies` — so R5 (author-font Thai fallback) is delivered by `createFontFamilyString` in the **base** theme, not by `journeyUi`. `journeyUi` styles only the player *chrome* (header/footer/nav) and takes no `fontFamilies`. It still needs patching because its chrome strings must carry the fallback, and it inherits base's top-level `fontFamily` + `body1` via `...baseTypography.typography` spread — so base's top-level and `body1` edits are load-bearing for `journeyUi`, while its own `subtitle1/subtitle2/body2/caption` overrides need direct edits.
+- **Thai metrics: accept shared line-heights, verify visually, adjust only on clipping.** Line-height stays a single shared value per role (no locale branch — preserves R8, and it's per-block so mixed lines can't be per-script anyway). Implementation includes a visual-QA pass rendering real stacked-tone-mark Thai (e.g. "ก้อนน้ำแข็ง") in each role across the surfaces; bump an individual line-height only where clipping/crowding is observed. Body roles (~1.5) are low-risk; tight headings (~1.25) are the ones to check. Mixed-script x-height/baseline balance and the `display=swap` FOUT reflow for Thai are accepted trade-offs (consistent with existing `display=swap` usage), noted in the QA pass rather than pre-engineered.
+- **Sarabun weight list is a visual-matching decision, not incidental.** The Sarabun Google-Fonts query must request a superset of every numeric `fontWeight` used across the base/journeyUi/admin tokens (400, 500, 600, 700, 800) — omitting one makes the browser synthesize-bold Thai, compounding mismatch. Numeric-weight parity is necessary but not sufficient: Sarabun and Montserrat render different visual boldness at the same numeric weight, so bold Thai headings need a visual spot-check against their Montserrat counterparts.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Where does the fallback live so it applies without a locale branch? In the token font-family strings + `createFontFamilyString`, which the existing LTR selection path already uses.
+- Do we touch the Arabic/Urdu variants? No — Thai never reaches the RTL branch; leaving them unchanged avoids regression.
+
+### Deferred to Implementation
+
+- Whether the shared constants module is a new file under `libs/shared/ui/src/libs/themes/` or an export added to an existing tokens file, and whether to extract a shared `DEFAULT_FONTS` for U5/U6 — implementer's call based on import ergonomics.
+- Whether to keep the redundant `baseTypography.body2`/`caption` fallback edits (see U2 Approach) as defense-in-depth or drop them.
+
+<!-- Resolved: Sarabun weight list — must be a superset of every fontWeight used (400,500,600,700,800). See Key Technical Decisions. -->
+<!-- Resolved: apps/journeys _document — Sarabun added to the LTR else-branch, which is unconditional today (see U4 Approach). -->
+
+<!-- Resolved: Thai vertical metrics — accept shared line-heights + visual-QA pass, adjust only on observed clipping. No locale branch (R8 preserved). See Key Technical Decisions. -->
+- Which specific heading line-heights (if any) need bumping for Thai — determined empirically during the visual-QA pass, not pre-decided.
+
+---
+
+## Implementation Units
+
+- U1. **Shared Sarabun constants**
+
+**Goal:** Single source of truth for the Thai fallback font name and the Sarabun Google-Fonts family query, so typography tokens and all load sites reference one value.
+
+**Requirements:** R1, R3 (supports)
+
+**Dependencies:** None
+
+**Files:**
+- Create or extend: `libs/shared/ui/src/libs/themes/` (e.g. a small `fonts` constants module) exporting `THAI_FALLBACK_FONT` (e.g. `'"Sarabun"'`) and the Sarabun Google-Fonts family query fragment.
+
+**Approach:**
+- Export a typography-side constant (the quoted family name for font stacks) and a loader-side constant (the `family=Sarabun:wght@...` fragment). Re-export from the themes barrel so `_document.tsx` and `FramePortal` can import cleanly.
+
+**Patterns to follow:**
+- Existing named exports from `libs/shared/ui/src/libs/themes/index.ts`.
+
+**Test scenarios:**
+- Test expectation: none — pure constants, exercised via the units that consume them.
+
+**Verification:**
+- Constants importable from both apps and from `FramePortal`; typecheck passes.
+
+---
+
+- U2. **Thai fallback in base + player typography**
+
+**Goal:** Thai glyphs resolve to Sarabun in the viewer content and player, including author-selected fonts.
+
+**Requirements:** R3, R4, R5, R6, R8
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `libs/shared/ui/src/libs/themes/base/tokens/typography.ts` — append `THAI_FALLBACK_FONT` (after Latin fonts, before `sans-serif`) in `createFontFamilyString`, in `baseTypography` top-level `fontFamily`, and in the `body1/body2/caption` fontFamily strings.
+- Modify: `libs/shared/ui/src/libs/themes/journeyUi/tokens/typography.ts` — append the fallback to the `subtitle1/subtitle2/body2/caption` strings that currently hardcode `'"Open Sans"'`.
+- Test: `libs/shared/ui/src/libs/themes/base/tokens/typography.spec.ts` (new)
+
+**Approach:**
+- Leave Arabic/Urdu token variants untouched. `createCustomTypography` overrides per-variant fontFamily via `createFontFamilyString`, so fixing that helper covers author + default header/body/label roles; the top-level `fontFamily` covers variants that inherit it.
+- Load-bearing edits: `createFontFamilyString`, `baseTypography` top-level `fontFamily`, and `baseTypography.body1` (the last reaches `journeyUi.body1` via the `...baseTypography.typography` spread). Note: `baseTypography.body2`/`caption` static strings are overridden by `createCustomTypography` in the base theme and overridden again by `journeyUi`'s own `body2`/`caption` — appending the fallback there is harmless but redundant; keep it only for defense-in-depth if a future refactor drops those overrides.
+
+**Patterns to follow:**
+- Existing `createFontFamilyString` structure and the inline fontFamily strings already present in these tokens.
+
+**Test scenarios:**
+- Happy path: `createFontFamilyString('Custom')` returns a stack containing `"Custom"`, then `Montserrat`, `"Open Sans"`, then `THAI_FALLBACK_FONT`, then `sans-serif`, in that order.
+- Happy path: `createFontFamilyString('')` returns `Montserrat,"Open Sans",<Sarabun>,sans-serif` (no empty leading entry).
+- Edge case: `THAI_FALLBACK_FONT` appears after `"Open Sans"` and before `sans-serif` in `baseTypography` top-level `fontFamily` and in `body1/body2/caption`.
+- Covers AE1, AE2. Edge case: `journeyUi` `subtitle1/subtitle2/body2/caption` fontFamily strings include the Thai fallback after `"Open Sans"`.
+
+**Verification:**
+- Every base and player token font stack ends with `...,<Sarabun>,sans-serif` (or `...,<Sarabun>` where no `sans-serif` was present); Arabic/Urdu variants unchanged.
+- Visual QA: render stacked-tone-mark Thai (e.g. "ก้อนน้ำแข็ง") in heading and body roles; confirm no tone-mark clipping/crowding. Bump an individual role's line-height only if clipping is observed.
+
+---
+
+- U3. **Thai fallback in admin typography and component overrides**
+
+**Goal:** Thai UI chrome (menus, buttons, labels) in the `th` locale renders in Sarabun — including components whose font stack is set at the components layer, not typography.
+
+**Requirements:** R1, R3, R4
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `libs/shared/ui/src/libs/themes/journeysAdmin/tokens/typography.ts` — append the Thai fallback (after Latin fonts, before `sans-serif`) to the top-level `fontFamily` and the `subtitle3/body1/body2/overline2/caption` fontFamily strings.
+- Modify: `libs/shared/ui/src/libs/themes/journeysAdmin/tokens/components.ts` — append the Thai fallback to the hardcoded `'Montserrat', sans-serif` stacks on `MuiButton` root (~L17) and `MuiListItemText` primary (~L205). These are applied at higher specificity than typography variant defaults, so typography-only edits do not reach them.
+- Test: `libs/shared/ui/src/libs/themes/journeysAdmin/tokens/typography.spec.ts` (new)
+
+**Approach:**
+- Mirror U2 ordering. Variants without an explicit fontFamily inherit the top-level stack, so both the top-level and the explicit strings need the fallback.
+- Component-level font stacks bypass typography entirely — MUI applies `components` overrides above variant defaults. Buttons and list/menu items are exactly the admin chrome R3/R4 name, so their hardcoded stacks must carry the fallback too. (`base/tokens/components.ts` uses `createFontFamilyString` and is already covered by U2.)
+- Bounded residual sweep: grep the admin app for inline `fontFamily:` literals (known: `apps/journeys-admin/src/components/LabelChip/LabelChip.tsx:41`, `CollectionDialog.tsx:68`) and append the fallback where a stack ends in a bare `sans-serif` without it.
+
+**Patterns to follow:**
+- U2; existing admin token and component-override strings.
+
+**Test scenarios:**
+- Covers AE5. Edge case: admin top-level `fontFamily` and each explicit-fontFamily variant include the Thai fallback after `"Open Sans"`/Latin fonts and before `sans-serif`.
+- Edge case: `MuiButton` and `MuiListItemText` component-override font stacks include the Thai fallback before the terminal `sans-serif`.
+
+**Verification:**
+- All admin token AND theme-level component-override font stacks carry the Thai fallback in the correct position; no theme-level stack ends in a bare `sans-serif` without it.
+
+---
+
+- U4. **Load Sarabun stylesheet in both apps**
+
+**Goal:** The Sarabun stylesheet is present on every page so the fallback is available (with lazy Thai `.woff2`).
+
+**Requirements:** R1, R2
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `apps/journeys/pages/_document.tsx` — add the Sarabun family query to the LTR (`else`) branch links (both `rel="stylesheet"` and `rel="preload"`).
+- Modify: `apps/journeys-admin/pages/_document.tsx` — add the Sarabun family query to the single Montserrat/Open Sans link.
+
+**Approach:**
+- Append `&family=Sarabun:wght@...` to the existing `css2` URLs using the U1 loader constant, preserving `display=swap`. Google returns per-subset `@font-face` with `unicode-range`, so the Thai `.woff2` stays deferred until Thai is painted.
+- In `apps/journeys/pages/_document.tsx`, add Sarabun to the LTR (`else`) branch. Note the current reality: `getInitialProps` never populates `pageProps`, so `getJourneyRTL(undefined)` yields `rtl = false` and the `else` branch renders **unconditionally** for every journey today — so the Sarabun link is always present (satisfies R1). This means the plan's correctness does not depend on branch selection. **Caveat:** if `pageProps` is ever wired up so RTL journeys correctly hit the RTL branch, U4's change must also add Sarabun to the RTL branch to keep R1 for Thai embedded in RTL-locale content.
+
+**Patterns to follow:**
+- Existing `css2?family=...&display=swap` link composition in both files.
+
+**Test scenarios:**
+- Test expectation: none (SSR `<link>` markup) — covered by AE3 in end-to-end verification below rather than a unit test.
+
+**Verification:**
+- Covers AE3. In the running apps: a **Basic-Latin-only** page loads the Sarabun stylesheet but downloads no Sarabun `.woff2` (Network tab); a page with Thai text downloads the Sarabun Thai subset and renders Thai in Sarabun with Latin still in Montserrat.
+
+---
+
+- U5. **Load Sarabun in the editor/player iframe**
+
+**Goal:** Authored Thai text renders in Sarabun in the admin editor canvas preview and the iframe-portal player.
+
+**Requirements:** R2, R6, R7
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `libs/journeys/ui/src/components/FramePortal/FramePortal.tsx` — add Sarabun to `defaultFonts` so the injected Google Fonts URL always includes it.
+- Test: `libs/journeys/ui/src/components/FramePortal/FramePortal.spec.tsx` (extend)
+
+**Approach:**
+- Add `'Sarabun'` to the `defaultFonts` array; existing `getSortedValidFonts`/`formatFontName`/URL builder handle the rest. The fallback is applied by the theme (U2) inside the iframe; this unit only guarantees the font is loaded.
+
+**Patterns to follow:**
+- Existing `defaultFonts` merge and URL construction in `FramePortal.tsx`; existing assertions in `FramePortal.spec.tsx`.
+
+**Test scenarios:**
+- Covers AE4. Happy path: the injected Google Fonts `<link>` href includes `family=Sarabun` even when no author `fontFamilies` are supplied.
+- Edge case: with author `fontFamilies` provided, the href includes both the author fonts and Sarabun, de-duplicated and sorted as today.
+
+**Verification:**
+- Editor canvas preview renders authored Thai text in Sarabun; injected iframe href contains Sarabun.
+
+---
+
+- U6. **Load Sarabun on the standalone journey page**
+
+**Goal:** The published standalone journey viewer loads Sarabun so Thai journey content renders correctly on the primary viewer surface.
+
+**Requirements:** R1, R2
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `apps/journeys/pages/home/[journeySlug].tsx` — this page builds its **own** Google Fonts URL from a local `defaultFonts = ['Montserrat', 'Open Sans', 'El Messiri']` array (~L38–59) and injects a `<link>` (~L74), independent of both `_document.tsx` (U4) and `FramePortal` (U5). Add Sarabun via the U1 constant.
+- Test: co-located spec if one exists; otherwise verify in the running app.
+
+**Approach:**
+- This is the third and final Google Fonts load site (confirmed: `grep -rln defaultFonts` returns `FramePortal.tsx`, this page, and the typography token file). Without it, Thai content on a published journey downloads no Sarabun and tofus — the exact AE1/AE2 surface.
+- The `defaultFonts` array here duplicates `FramePortal`'s. Prefer extracting a shared `DEFAULT_FONTS` (including Sarabun) into the U1 module and consuming it in both `FramePortal` (U5) and this page, so Sarabun is added once — consistent with U1's DRY rationale. If extraction is disproportionate, add Sarabun to this local array directly.
+
+**Patterns to follow:**
+- `FramePortal.tsx` font-URL builder (`getSortedValidFonts`, `formatFontName`); U5.
+
+**Test scenarios:**
+- Covers AE1, AE2. Happy path: the page's injected Google Fonts href includes `family=Sarabun`.
+
+**Verification:**
+- A published journey containing Thai renders Thai in Sarabun on the standalone `[journeySlug]` page; injected href contains Sarabun.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Touches shared theme typography tokens (`base`, `journeyUi`, `journeysAdmin`) and the admin `components` overrides, consumed via `ThemeProvider`, plus **three** Google Fonts load sites — the two `_document.tsx` loaders (U4), the `FramePortal` iframe injector (U5), and the standalone `home/[journeySlug].tsx` builder (U6). No theme selection-logic change.
+- **API surface parity:** `apps/journeys` viewer (both the `_document` shell and the standalone journey page), `apps/journeys-admin` editor + chrome (typography + component overrides), and the iframe-portal player must all carry the fallback — covered by U2–U6.
+- **Unchanged invariants:** Arabic/Urdu typography variants and the RTL/locale theme-selection branches are explicitly unchanged; English-only rendering is byte-for-byte the same font stack lead (Montserrat), so existing English journeys are visually unaffected.
+- **State lifecycle risks:** None — static token strings and stylesheet links; no runtime state.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Sarabun placed before Latin fonts → English renders in Sarabun and Latin subset downloads (regression, breaks R2/R3). | Ordering is a stated decision and a test scenario in U2/U3 asserts position (after `"Open Sans"`, before `sans-serif`). |
+| Font stacks set at the **components** layer (admin `MuiButton`/`MuiListItemText`) or inline in app code bypass the typography tokens → Thai tofu in buttons/menus. | U3 patches `journeysAdmin/tokens/components.ts` and runs a bounded inline-literal sweep; verification asserts no theme-level stack ends in a bare `sans-serif`. |
+| A third Google Fonts load site (`home/[journeySlug].tsx`) builds its own font URL → Thai tofu on the published viewer. | U6 adds Sarabun to that builder; `grep defaultFonts` confirmed exactly three load sites. |
+| Player *content* fallback missed by focusing on `journeyUi`. | Corrected model: content renders via the **base** theme (`createCustomTypography`), covered by U2's `createFontFamilyString` edit; `journeyUi` chrome patched separately. |
+| Google Fonts `css2` stops serving `unicode-range` subsets (assumption in origin). | Standard, long-stable behavior; U4 verification confirms lazy Thai-subset loading in the running app. |
+| A typography variant inherits the top-level stack and is missed. | U2/U3 update both the top-level `fontFamily` and every explicit per-variant string; base `body1` (inherited by `journeyUi` via spread) is explicitly load-bearing. |
+| Latent `_document` bug (unpopulated `pageProps`) later fixed → RTL branch activates without Sarabun. | U4 Approach documents the caveat: wiring `pageProps` requires adding Sarabun to the RTL branch too. |
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/thai-font-support-requirements.md](docs/brainstorms/thai-font-support-requirements.md)
+- Related code: `libs/shared/ui/src/libs/themes/`, `apps/journeys/pages/_document.tsx`, `apps/journeys-admin/pages/_document.tsx`, `libs/journeys/ui/src/components/FramePortal/FramePortal.tsx`

--- a/docs/plans/2026-07-06-001-feat-thai-font-support-plan.md
+++ b/docs/plans/2026-07-06-001-feat-thai-font-support-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Thai font (Sarabun) support for journeys & journeys-admin"
 type: feat
-status: active
+status: completed
 date: 2026-07-06
 origin: docs/brainstorms/thai-font-support-requirements.md
 ---

--- a/docs/plans/2026-07-06-001-feat-thai-font-support-plan.md
+++ b/docs/plans/2026-07-06-001-feat-thai-font-support-plan.md
@@ -1,5 +1,5 @@
 ---
-title: "feat: Thai font (Sarabun) support for journeys & journeys-admin"
+title: 'feat: Thai font (Sarabun) support for journeys & journeys-admin'
 type: feat
 status: completed
 date: 2026-07-06
@@ -77,7 +77,7 @@ Both apps ship a Latin-only type system (Montserrat + Open Sans) with no Thai gl
 - **Append, never lead; order after Latin fonts.** Sarabun is placed after Montserrat/Open Sans in every stack. Because its `@font-face` is `unicode-range`-scoped to the Thai block, Latin glyphs resolve to Montserrat (Sarabun's Latin subset is never used, so never downloaded) and only Thai glyphs fall to Sarabun. This is what makes R2 and R3 hold simultaneously. Reversing the order would download Sarabun's Latin subset and change the English look — regression.
 - **Shared constants over scattered literals.** Introduce a single `THAI_FALLBACK_FONT` constant (typography name) and a single Sarabun Google-Fonts family-query constant, imported by the typography tokens, both `_document.tsx` files, and `FramePortal`. Avoids drift across ~12 font strings and 3 load sites (DRY).
 - **No theme branch (R8).** `base/theme.ts` and `journeyUi/theme.ts` selection logic is untouched; the fallback lives in the token strings themselves, so it applies on the LTR branch that Thai already uses.
-- **Player content uses the base theme; `journeyUi` is chrome only.** In `Conductor.tsx`, journey *card content* renders through a nested `ThemeProvider` using `getStepTheme` (defaults to `ThemeName.base`) with author `fontFamilies` — so R5 (author-font Thai fallback) is delivered by `createFontFamilyString` in the **base** theme, not by `journeyUi`. `journeyUi` styles only the player *chrome* (header/footer/nav) and takes no `fontFamilies`. It still needs patching because its chrome strings must carry the fallback, and it inherits base's top-level `fontFamily` + `body1` via `...baseTypography.typography` spread — so base's top-level and `body1` edits are load-bearing for `journeyUi`, while its own `subtitle1/subtitle2/body2/caption` overrides need direct edits.
+- **Player content uses the base theme; `journeyUi` is chrome only.** In `Conductor.tsx`, journey _card content_ renders through a nested `ThemeProvider` using `getStepTheme` (defaults to `ThemeName.base`) with author `fontFamilies` — so R5 (author-font Thai fallback) is delivered by `createFontFamilyString` in the **base** theme, not by `journeyUi`. `journeyUi` styles only the player _chrome_ (header/footer/nav) and takes no `fontFamilies`. It still needs patching because its chrome strings must carry the fallback, and it inherits base's top-level `fontFamily` + `body1` via `...baseTypography.typography` spread — so base's top-level and `body1` edits are load-bearing for `journeyUi`, while its own `subtitle1/subtitle2/body2/caption` overrides need direct edits.
 - **Thai metrics: accept shared line-heights, verify visually, adjust only on clipping.** Line-height stays a single shared value per role (no locale branch — preserves R8, and it's per-block so mixed lines can't be per-script anyway). Implementation includes a visual-QA pass rendering real stacked-tone-mark Thai (e.g. "ก้อนน้ำแข็ง") in each role across the surfaces; bump an individual line-height only where clipping/crowding is observed. Body roles (~1.5) are low-risk; tight headings (~1.25) are the ones to check. Mixed-script x-height/baseline balance and the `display=swap` FOUT reflow for Thai are accepted trade-offs (consistent with existing `display=swap` usage), noted in the QA pass rather than pre-engineered.
 - **Sarabun weight list is a visual-matching decision, not incidental.** The Sarabun Google-Fonts query must request a superset of every numeric `fontWeight` used across the base/journeyUi/admin tokens (400, 500, 600, 700, 800) — omitting one makes the browser synthesize-bold Thai, compounding mismatch. Numeric-weight parity is necessary but not sufficient: Sarabun and Montserrat render different visual boldness at the same numeric weight, so bold Thai headings need a visual spot-check against their Montserrat counterparts.
 
@@ -99,6 +99,7 @@ Both apps ship a Latin-only type system (Montserrat + Open Sans) with no Thai gl
 <!-- Resolved: apps/journeys _document — Sarabun added to the LTR else-branch, which is unconditional today (see U4 Approach). -->
 
 <!-- Resolved: Thai vertical metrics — accept shared line-heights + visual-QA pass, adjust only on observed clipping. No locale branch (R8 preserved). See Key Technical Decisions. -->
+
 - Which specific heading line-heights (if any) need bumping for Thai — determined empirically during the visual-QA pass, not pre-decided.
 
 ---
@@ -114,18 +115,23 @@ Both apps ship a Latin-only type system (Montserrat + Open Sans) with no Thai gl
 **Dependencies:** None
 
 **Files:**
+
 - Create or extend: `libs/shared/ui/src/libs/themes/` (e.g. a small `fonts` constants module) exporting `THAI_FALLBACK_FONT` (e.g. `'"Sarabun"'`) and the Sarabun Google-Fonts family query fragment.
 
 **Approach:**
+
 - Export a typography-side constant (the quoted family name for font stacks) and a loader-side constant (the `family=Sarabun:wght@...` fragment). Re-export from the themes barrel so `_document.tsx` and `FramePortal` can import cleanly.
 
 **Patterns to follow:**
+
 - Existing named exports from `libs/shared/ui/src/libs/themes/index.ts`.
 
 **Test scenarios:**
+
 - Test expectation: none — pure constants, exercised via the units that consume them.
 
 **Verification:**
+
 - Constants importable from both apps and from `FramePortal`; typecheck passes.
 
 ---
@@ -139,24 +145,29 @@ Both apps ship a Latin-only type system (Montserrat + Open Sans) with no Thai gl
 **Dependencies:** U1
 
 **Files:**
+
 - Modify: `libs/shared/ui/src/libs/themes/base/tokens/typography.ts` — append `THAI_FALLBACK_FONT` (after Latin fonts, before `sans-serif`) in `createFontFamilyString`, in `baseTypography` top-level `fontFamily`, and in the `body1/body2/caption` fontFamily strings.
 - Modify: `libs/shared/ui/src/libs/themes/journeyUi/tokens/typography.ts` — append the fallback to the `subtitle1/subtitle2/body2/caption` strings that currently hardcode `'"Open Sans"'`.
 - Test: `libs/shared/ui/src/libs/themes/base/tokens/typography.spec.ts` (new)
 
 **Approach:**
+
 - Leave Arabic/Urdu token variants untouched. `createCustomTypography` overrides per-variant fontFamily via `createFontFamilyString`, so fixing that helper covers author + default header/body/label roles; the top-level `fontFamily` covers variants that inherit it.
 - Load-bearing edits: `createFontFamilyString`, `baseTypography` top-level `fontFamily`, and `baseTypography.body1` (the last reaches `journeyUi.body1` via the `...baseTypography.typography` spread). Note: `baseTypography.body2`/`caption` static strings are overridden by `createCustomTypography` in the base theme and overridden again by `journeyUi`'s own `body2`/`caption` — appending the fallback there is harmless but redundant; keep it only for defense-in-depth if a future refactor drops those overrides.
 
 **Patterns to follow:**
+
 - Existing `createFontFamilyString` structure and the inline fontFamily strings already present in these tokens.
 
 **Test scenarios:**
+
 - Happy path: `createFontFamilyString('Custom')` returns a stack containing `"Custom"`, then `Montserrat`, `"Open Sans"`, then `THAI_FALLBACK_FONT`, then `sans-serif`, in that order.
 - Happy path: `createFontFamilyString('')` returns `Montserrat,"Open Sans",<Sarabun>,sans-serif` (no empty leading entry).
 - Edge case: `THAI_FALLBACK_FONT` appears after `"Open Sans"` and before `sans-serif` in `baseTypography` top-level `fontFamily` and in `body1/body2/caption`.
 - Covers AE1, AE2. Edge case: `journeyUi` `subtitle1/subtitle2/body2/caption` fontFamily strings include the Thai fallback after `"Open Sans"`.
 
 **Verification:**
+
 - Every base and player token font stack ends with `...,<Sarabun>,sans-serif` (or `...,<Sarabun>` where no `sans-serif` was present); Arabic/Urdu variants unchanged.
 - Visual QA: render stacked-tone-mark Thai (e.g. "ก้อนน้ำแข็ง") in heading and body roles; confirm no tone-mark clipping/crowding. Bump an individual role's line-height only if clipping is observed.
 
@@ -171,23 +182,28 @@ Both apps ship a Latin-only type system (Montserrat + Open Sans) with no Thai gl
 **Dependencies:** U1
 
 **Files:**
+
 - Modify: `libs/shared/ui/src/libs/themes/journeysAdmin/tokens/typography.ts` — append the Thai fallback (after Latin fonts, before `sans-serif`) to the top-level `fontFamily` and the `subtitle3/body1/body2/overline2/caption` fontFamily strings.
 - Modify: `libs/shared/ui/src/libs/themes/journeysAdmin/tokens/components.ts` — append the Thai fallback to the hardcoded `'Montserrat', sans-serif` stacks on `MuiButton` root (~L17) and `MuiListItemText` primary (~L205). These are applied at higher specificity than typography variant defaults, so typography-only edits do not reach them.
 - Test: `libs/shared/ui/src/libs/themes/journeysAdmin/tokens/typography.spec.ts` (new)
 
 **Approach:**
+
 - Mirror U2 ordering. Variants without an explicit fontFamily inherit the top-level stack, so both the top-level and the explicit strings need the fallback.
 - Component-level font stacks bypass typography entirely — MUI applies `components` overrides above variant defaults. Buttons and list/menu items are exactly the admin chrome R3/R4 name, so their hardcoded stacks must carry the fallback too. (`base/tokens/components.ts` uses `createFontFamilyString` and is already covered by U2.)
 - Bounded residual sweep: grep the admin app for inline `fontFamily:` literals (known: `apps/journeys-admin/src/components/LabelChip/LabelChip.tsx:41`, `CollectionDialog.tsx:68`) and append the fallback where a stack ends in a bare `sans-serif` without it.
 
 **Patterns to follow:**
+
 - U2; existing admin token and component-override strings.
 
 **Test scenarios:**
+
 - Covers AE5. Edge case: admin top-level `fontFamily` and each explicit-fontFamily variant include the Thai fallback after `"Open Sans"`/Latin fonts and before `sans-serif`.
 - Edge case: `MuiButton` and `MuiListItemText` component-override font stacks include the Thai fallback before the terminal `sans-serif`.
 
 **Verification:**
+
 - All admin token AND theme-level component-override font stacks carry the Thai fallback in the correct position; no theme-level stack ends in a bare `sans-serif` without it.
 
 ---
@@ -201,20 +217,25 @@ Both apps ship a Latin-only type system (Montserrat + Open Sans) with no Thai gl
 **Dependencies:** U1
 
 **Files:**
+
 - Modify: `apps/journeys/pages/_document.tsx` — add the Sarabun family query to the LTR (`else`) branch links (both `rel="stylesheet"` and `rel="preload"`).
 - Modify: `apps/journeys-admin/pages/_document.tsx` — add the Sarabun family query to the single Montserrat/Open Sans link.
 
 **Approach:**
+
 - Append `&family=Sarabun:wght@...` to the existing `css2` URLs using the U1 loader constant, preserving `display=swap`. Google returns per-subset `@font-face` with `unicode-range`, so the Thai `.woff2` stays deferred until Thai is painted.
 - In `apps/journeys/pages/_document.tsx`, add Sarabun to the LTR (`else`) branch. Note the current reality: `getInitialProps` never populates `pageProps`, so `getJourneyRTL(undefined)` yields `rtl = false` and the `else` branch renders **unconditionally** for every journey today — so the Sarabun link is always present (satisfies R1). This means the plan's correctness does not depend on branch selection. **Caveat:** if `pageProps` is ever wired up so RTL journeys correctly hit the RTL branch, U4's change must also add Sarabun to the RTL branch to keep R1 for Thai embedded in RTL-locale content.
 
 **Patterns to follow:**
+
 - Existing `css2?family=...&display=swap` link composition in both files.
 
 **Test scenarios:**
+
 - Test expectation: none (SSR `<link>` markup) — covered by AE3 in end-to-end verification below rather than a unit test.
 
 **Verification:**
+
 - Covers AE3. In the running apps: a **Basic-Latin-only** page loads the Sarabun stylesheet but downloads no Sarabun `.woff2` (Network tab); a page with Thai text downloads the Sarabun Thai subset and renders Thai in Sarabun with Latin still in Montserrat.
 
 ---
@@ -228,20 +249,25 @@ Both apps ship a Latin-only type system (Montserrat + Open Sans) with no Thai gl
 **Dependencies:** U1
 
 **Files:**
+
 - Modify: `libs/journeys/ui/src/components/FramePortal/FramePortal.tsx` — add Sarabun to `defaultFonts` so the injected Google Fonts URL always includes it.
 - Test: `libs/journeys/ui/src/components/FramePortal/FramePortal.spec.tsx` (extend)
 
 **Approach:**
+
 - Add `'Sarabun'` to the `defaultFonts` array; existing `getSortedValidFonts`/`formatFontName`/URL builder handle the rest. The fallback is applied by the theme (U2) inside the iframe; this unit only guarantees the font is loaded.
 
 **Patterns to follow:**
+
 - Existing `defaultFonts` merge and URL construction in `FramePortal.tsx`; existing assertions in `FramePortal.spec.tsx`.
 
 **Test scenarios:**
+
 - Covers AE4. Happy path: the injected Google Fonts `<link>` href includes `family=Sarabun` even when no author `fontFamilies` are supplied.
 - Edge case: with author `fontFamilies` provided, the href includes both the author fonts and Sarabun, de-duplicated and sorted as today.
 
 **Verification:**
+
 - Editor canvas preview renders authored Thai text in Sarabun; injected iframe href contains Sarabun.
 
 ---
@@ -255,20 +281,25 @@ Both apps ship a Latin-only type system (Montserrat + Open Sans) with no Thai gl
 **Dependencies:** U1
 
 **Files:**
+
 - Modify: `apps/journeys/pages/home/[journeySlug].tsx` — this page builds its **own** Google Fonts URL from a local `defaultFonts = ['Montserrat', 'Open Sans', 'El Messiri']` array (~L38–59) and injects a `<link>` (~L74), independent of both `_document.tsx` (U4) and `FramePortal` (U5). Add Sarabun via the U1 constant.
 - Test: co-located spec if one exists; otherwise verify in the running app.
 
 **Approach:**
+
 - This is the third and final Google Fonts load site (confirmed: `grep -rln defaultFonts` returns `FramePortal.tsx`, this page, and the typography token file). Without it, Thai content on a published journey downloads no Sarabun and tofus — the exact AE1/AE2 surface.
 - The `defaultFonts` array here duplicates `FramePortal`'s. Prefer extracting a shared `DEFAULT_FONTS` (including Sarabun) into the U1 module and consuming it in both `FramePortal` (U5) and this page, so Sarabun is added once — consistent with U1's DRY rationale. If extraction is disproportionate, add Sarabun to this local array directly.
 
 **Patterns to follow:**
+
 - `FramePortal.tsx` font-URL builder (`getSortedValidFonts`, `formatFontName`); U5.
 
 **Test scenarios:**
+
 - Covers AE1, AE2. Happy path: the page's injected Google Fonts href includes `family=Sarabun`.
 
 **Verification:**
+
 - A published journey containing Thai renders Thai in Sarabun on the standalone `[journeySlug]` page; injected href contains Sarabun.
 
 ---
@@ -284,15 +315,15 @@ Both apps ship a Latin-only type system (Montserrat + Open Sans) with no Thai gl
 
 ## Risks & Dependencies
 
-| Risk | Mitigation |
-|------|------------|
-| Sarabun placed before Latin fonts → English renders in Sarabun and Latin subset downloads (regression, breaks R2/R3). | Ordering is a stated decision and a test scenario in U2/U3 asserts position (after `"Open Sans"`, before `sans-serif`). |
-| Font stacks set at the **components** layer (admin `MuiButton`/`MuiListItemText`) or inline in app code bypass the typography tokens → Thai tofu in buttons/menus. | U3 patches `journeysAdmin/tokens/components.ts` and runs a bounded inline-literal sweep; verification asserts no theme-level stack ends in a bare `sans-serif`. |
-| A third Google Fonts load site (`home/[journeySlug].tsx`) builds its own font URL → Thai tofu on the published viewer. | U6 adds Sarabun to that builder; `grep defaultFonts` confirmed exactly three load sites. |
-| Player *content* fallback missed by focusing on `journeyUi`. | Corrected model: content renders via the **base** theme (`createCustomTypography`), covered by U2's `createFontFamilyString` edit; `journeyUi` chrome patched separately. |
-| Google Fonts `css2` stops serving `unicode-range` subsets (assumption in origin). | Standard, long-stable behavior; U4 verification confirms lazy Thai-subset loading in the running app. |
-| A typography variant inherits the top-level stack and is missed. | U2/U3 update both the top-level `fontFamily` and every explicit per-variant string; base `body1` (inherited by `journeyUi` via spread) is explicitly load-bearing. |
-| Latent `_document` bug (unpopulated `pageProps`) later fixed → RTL branch activates without Sarabun. | U4 Approach documents the caveat: wiring `pageProps` requires adding Sarabun to the RTL branch too. |
+| Risk                                                                                                                                                               | Mitigation                                                                                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Sarabun placed before Latin fonts → English renders in Sarabun and Latin subset downloads (regression, breaks R2/R3).                                              | Ordering is a stated decision and a test scenario in U2/U3 asserts position (after `"Open Sans"`, before `sans-serif`).                                                   |
+| Font stacks set at the **components** layer (admin `MuiButton`/`MuiListItemText`) or inline in app code bypass the typography tokens → Thai tofu in buttons/menus. | U3 patches `journeysAdmin/tokens/components.ts` and runs a bounded inline-literal sweep; verification asserts no theme-level stack ends in a bare `sans-serif`.           |
+| A third Google Fonts load site (`home/[journeySlug].tsx`) builds its own font URL → Thai tofu on the published viewer.                                             | U6 adds Sarabun to that builder; `grep defaultFonts` confirmed exactly three load sites.                                                                                  |
+| Player _content_ fallback missed by focusing on `journeyUi`.                                                                                                       | Corrected model: content renders via the **base** theme (`createCustomTypography`), covered by U2's `createFontFamilyString` edit; `journeyUi` chrome patched separately. |
+| Google Fonts `css2` stops serving `unicode-range` subsets (assumption in origin).                                                                                  | Standard, long-stable behavior; U4 verification confirms lazy Thai-subset loading in the running app.                                                                     |
+| A typography variant inherits the top-level stack and is missed.                                                                                                   | U2/U3 update both the top-level `fontFamily` and every explicit per-variant string; base `body1` (inherited by `journeyUi` via spread) is explicitly load-bearing.        |
+| Latent `_document` bug (unpopulated `pageProps`) later fixed → RTL branch activates without Sarabun.                                                               | U4 Approach documents the caveat: wiring `pageProps` requires adding Sarabun to the RTL branch too.                                                                       |
 
 ---
 

--- a/libs/journeys/ui/src/components/FramePortal/FramePortal.spec.tsx
+++ b/libs/journeys/ui/src/components/FramePortal/FramePortal.spec.tsx
@@ -22,4 +22,47 @@ describe('FramePortal', () => {
       'background-color: rgba(0, 0, 0, 0)'
     )
   })
+
+  it('should load Sarabun in the injected Google Fonts link when no author fonts are supplied', async () => {
+    const { baseElement } = render(
+      <div>
+        <FramePortal dir="ltr">
+          <Typography>hello world</Typography>
+        </FramePortal>
+      </div>
+    )
+    const iframe = baseElement.getElementsByTagName('iframe')[0]
+    await waitFor(() => {
+      const link = iframe.contentDocument?.head.querySelector(
+        'link[href*="fonts.googleapis.com"]'
+      )
+      expect(link?.getAttribute('href')).toContain('family=Sarabun')
+    })
+  })
+
+  it('should load author fonts alongside Sarabun in the injected Google Fonts link', async () => {
+    const { baseElement } = render(
+      <div>
+        <FramePortal
+          dir="ltr"
+          fontFamilies={{
+            headerFont: 'Playfair Display',
+            bodyFont: 'Lora',
+            labelFont: 'Lora'
+          }}
+        >
+          <Typography>hello world</Typography>
+        </FramePortal>
+      </div>
+    )
+    const iframe = baseElement.getElementsByTagName('iframe')[0]
+    await waitFor(() => {
+      const href = iframe.contentDocument?.head
+        .querySelector('link[href*="fonts.googleapis.com"]')
+        ?.getAttribute('href')
+      expect(href).toContain('family=Playfair+Display')
+      expect(href).toContain('family=Sarabun')
+      expect(href?.match(/family=Lora/g)).toHaveLength(1)
+    })
+  })
 })

--- a/libs/journeys/ui/src/components/FramePortal/FramePortal.tsx
+++ b/libs/journeys/ui/src/components/FramePortal/FramePortal.tsx
@@ -18,7 +18,7 @@ import { createPortal } from 'react-dom'
 import { prefixer } from 'stylis'
 import rtlPlugin from 'stylis-plugin-rtl'
 
-import { FontFamilies } from '@core/shared/ui/themes'
+import { DEFAULT_FONTS, FontFamilies } from '@core/shared/ui/themes'
 
 interface ContentProps {
   children: ReactNode
@@ -32,9 +32,8 @@ function Content({
   fontFamilies
 }: ContentProps): ReactElement {
   const cache = useMemo(() => {
-    const defaultFonts = ['Montserrat', 'Open Sans', 'El Messiri']
     const validFonts = getSortedValidFonts([
-      ...defaultFonts,
+      ...DEFAULT_FONTS,
       ...Object.values(fontFamilies ?? {})
     ])
 

--- a/libs/shared/ui/src/libs/themes/base/tokens/typography.spec.ts
+++ b/libs/shared/ui/src/libs/themes/base/tokens/typography.spec.ts
@@ -1,16 +1,21 @@
-import { TypographyStyle } from '@mui/material/styles'
+import { ThemeOptions } from '@mui/material/styles'
 
 import { THAI_FALLBACK_FONT } from '../../fonts'
 import { journeyUiTypography } from '../../journeyUi/tokens/typography'
 
 import { baseTypography, createFontFamilyString } from './typography'
 
+type TypographyTokens = Pick<ThemeOptions, 'typography'>
+
 function getFontFamily(
-  typography: unknown,
+  tokens: TypographyTokens,
   variant: string
 ): string | undefined {
-  const variants = typography as Record<string, TypographyStyle>
-  return variants[variant]?.fontFamily as string | undefined
+  const variants = tokens.typography as Record<
+    string,
+    { fontFamily?: string } | undefined
+  >
+  return variants[variant]?.fontFamily
 }
 
 describe('createFontFamilyString', () => {
@@ -28,19 +33,19 @@ describe('createFontFamilyString', () => {
 })
 
 describe('baseTypography', () => {
-  it('should include the Thai fallback after the Latin fonts in the top-level fontFamily', () => {
+  it('should place the Thai fallback after the Latin webfonts and before Tahoma in the top-level fontFamily', () => {
     expect(
       (baseTypography.typography as { fontFamily?: string }).fontFamily
     ).toBe(
-      `Montserrat,"Open Sans",Tahoma,Verdana,${THAI_FALLBACK_FONT},sans-serif`
+      `Montserrat,"Open Sans",${THAI_FALLBACK_FONT},Tahoma,Verdana,sans-serif`
     )
   })
 
   it.each(['body1', 'body2', 'caption'])(
-    'should include the Thai fallback before sans-serif in %s',
+    'should place the Thai fallback before Tahoma in %s',
     (variant) => {
-      expect(getFontFamily(baseTypography.typography, variant)).toBe(
-        `"Open Sans","Tahoma","Verdana",${THAI_FALLBACK_FONT},sans-serif`
+      expect(getFontFamily(baseTypography, variant)).toBe(
+        `"Open Sans",${THAI_FALLBACK_FONT},"Tahoma","Verdana",sans-serif`
       )
     }
   )
@@ -50,7 +55,7 @@ describe('journeyUiTypography', () => {
   it.each(['subtitle1', 'subtitle2', 'body2', 'caption'])(
     'should include the Thai fallback after Open Sans in %s',
     (variant) => {
-      expect(getFontFamily(journeyUiTypography.typography, variant)).toBe(
+      expect(getFontFamily(journeyUiTypography, variant)).toBe(
         `"Open Sans",${THAI_FALLBACK_FONT},sans-serif`
       )
     }

--- a/libs/shared/ui/src/libs/themes/base/tokens/typography.spec.ts
+++ b/libs/shared/ui/src/libs/themes/base/tokens/typography.spec.ts
@@ -1,0 +1,58 @@
+import { TypographyStyle } from '@mui/material/styles'
+
+import { THAI_FALLBACK_FONT } from '../../fonts'
+import { journeyUiTypography } from '../../journeyUi/tokens/typography'
+
+import { baseTypography, createFontFamilyString } from './typography'
+
+function getFontFamily(
+  typography: unknown,
+  variant: string
+): string | undefined {
+  const variants = typography as Record<string, TypographyStyle>
+  return variants[variant]?.fontFamily as string | undefined
+}
+
+describe('createFontFamilyString', () => {
+  it('should place the custom font first and the Thai fallback after the Latin fonts', () => {
+    expect(createFontFamilyString('Custom')).toBe(
+      `"Custom",Montserrat,"Open Sans",${THAI_FALLBACK_FONT},sans-serif`
+    )
+  })
+
+  it('should omit the leading entry when no font is provided', () => {
+    expect(createFontFamilyString('')).toBe(
+      `Montserrat,"Open Sans",${THAI_FALLBACK_FONT},sans-serif`
+    )
+  })
+})
+
+describe('baseTypography', () => {
+  it('should include the Thai fallback after the Latin fonts in the top-level fontFamily', () => {
+    expect(
+      (baseTypography.typography as { fontFamily?: string }).fontFamily
+    ).toBe(
+      `Montserrat,"Open Sans",Tahoma,Verdana,${THAI_FALLBACK_FONT},sans-serif`
+    )
+  })
+
+  it.each(['body1', 'body2', 'caption'])(
+    'should include the Thai fallback before sans-serif in %s',
+    (variant) => {
+      expect(getFontFamily(baseTypography.typography, variant)).toBe(
+        `"Open Sans","Tahoma","Verdana",${THAI_FALLBACK_FONT},sans-serif`
+      )
+    }
+  )
+})
+
+describe('journeyUiTypography', () => {
+  it.each(['subtitle1', 'subtitle2', 'body2', 'caption'])(
+    'should include the Thai fallback after Open Sans in %s',
+    (variant) => {
+      expect(getFontFamily(journeyUiTypography.typography, variant)).toBe(
+        `"Open Sans",${THAI_FALLBACK_FONT},sans-serif`
+      )
+    }
+  )
+})

--- a/libs/shared/ui/src/libs/themes/base/tokens/typography.ts
+++ b/libs/shared/ui/src/libs/themes/base/tokens/typography.ts
@@ -21,12 +21,14 @@ export function createFontFamilyString(font: string): string {
 
 export const baseTypography: Pick<ThemeOptions, 'typography'> = {
   typography: {
+    // THAI_FALLBACK_FONT must precede Tahoma: Tahoma ships Thai glyphs on
+    // Windows and would otherwise intercept Thai before Sarabun.
     fontFamily: [
       'Montserrat',
       '"Open Sans"',
+      THAI_FALLBACK_FONT,
       'Tahoma',
       'Verdana',
-      THAI_FALLBACK_FONT,
       'sans-serif'
     ].join(','),
     h1: {
@@ -73,13 +75,13 @@ export const baseTypography: Pick<ThemeOptions, 'typography'> = {
       letterSpacing: 2
     },
     body1: {
-      fontFamily: `"Open Sans","Tahoma","Verdana",${THAI_FALLBACK_FONT},sans-serif`,
+      fontFamily: `"Open Sans",${THAI_FALLBACK_FONT},"Tahoma","Verdana",sans-serif`,
       fontSize: 16,
       fontWeight: 400,
       lineHeight: '24px'
     },
     body2: {
-      fontFamily: `"Open Sans","Tahoma","Verdana",${THAI_FALLBACK_FONT},sans-serif`,
+      fontFamily: `"Open Sans",${THAI_FALLBACK_FONT},"Tahoma","Verdana",sans-serif`,
       fontSize: 14,
       fontWeight: 400,
       lineHeight: '20px'
@@ -92,7 +94,7 @@ export const baseTypography: Pick<ThemeOptions, 'typography'> = {
       marginBottom: '4px'
     },
     caption: {
-      fontFamily: `"Open Sans","Tahoma","Verdana",${THAI_FALLBACK_FONT},sans-serif`,
+      fontFamily: `"Open Sans",${THAI_FALLBACK_FONT},"Tahoma","Verdana",sans-serif`,
       fontSize: 12,
       fontWeight: 400,
       lineHeight: '20px'

--- a/libs/shared/ui/src/libs/themes/base/tokens/typography.ts
+++ b/libs/shared/ui/src/libs/themes/base/tokens/typography.ts
@@ -1,6 +1,7 @@
 import { ThemeOptions } from '@mui/material/styles'
 
 import { FontFamilies } from '../..'
+import { THAI_FALLBACK_FONT } from '../../fonts'
 
 // Update the Typography's variant prop options
 declare module '@mui/material/styles' {
@@ -14,7 +15,7 @@ export function createFontFamilyString(font: string): string {
   if (font !== '') {
     fonts.push(`"${font}"`)
   }
-  fonts.push('Montserrat', '"Open Sans"', 'sans-serif')
+  fonts.push('Montserrat', '"Open Sans"', THAI_FALLBACK_FONT, 'sans-serif')
   return fonts.join(',')
 }
 
@@ -25,6 +26,7 @@ export const baseTypography: Pick<ThemeOptions, 'typography'> = {
       '"Open Sans"',
       'Tahoma',
       'Verdana',
+      THAI_FALLBACK_FONT,
       'sans-serif'
     ].join(','),
     h1: {
@@ -71,13 +73,13 @@ export const baseTypography: Pick<ThemeOptions, 'typography'> = {
       letterSpacing: 2
     },
     body1: {
-      fontFamily: '"Open Sans","Tahoma","Verdana",sans-serif',
+      fontFamily: `"Open Sans","Tahoma","Verdana",${THAI_FALLBACK_FONT},sans-serif`,
       fontSize: 16,
       fontWeight: 400,
       lineHeight: '24px'
     },
     body2: {
-      fontFamily: '"Open Sans","Tahoma","Verdana",sans-serif',
+      fontFamily: `"Open Sans","Tahoma","Verdana",${THAI_FALLBACK_FONT},sans-serif`,
       fontSize: 14,
       fontWeight: 400,
       lineHeight: '20px'
@@ -90,7 +92,7 @@ export const baseTypography: Pick<ThemeOptions, 'typography'> = {
       marginBottom: '4px'
     },
     caption: {
-      fontFamily: '"Open Sans","Tahoma","Verdana",sans-serif',
+      fontFamily: `"Open Sans","Tahoma","Verdana",${THAI_FALLBACK_FONT},sans-serif`,
       fontSize: 12,
       fontWeight: 400,
       lineHeight: '20px'

--- a/libs/shared/ui/src/libs/themes/fonts.ts
+++ b/libs/shared/ui/src/libs/themes/fonts.ts
@@ -1,7 +1,9 @@
-// Sarabun is appended after the Latin fonts in every font stack as a
-// unicode-range-scoped Thai fallback: Latin glyphs keep resolving to
-// Montserrat/Open Sans while Thai glyphs fall through to Sarabun, and the
-// Sarabun Thai .woff2 only downloads when Thai glyphs actually render.
+// Sarabun sits after the Latin webfonts (Montserrat/Open Sans) in every font
+// stack as a unicode-range-scoped Thai fallback: Latin glyphs keep resolving
+// to Montserrat/Open Sans while Thai glyphs fall through to Sarabun, and the
+// Sarabun Thai .woff2 only downloads when Thai glyphs actually render. It
+// must precede any Thai-capable system font (Tahoma ships Thai glyphs on
+// Windows) or that font intercepts Thai before Sarabun.
 export const THAI_FALLBACK_FONT = '"Sarabun"'
 
 // Weight list must be a superset of every fontWeight used across the

--- a/libs/shared/ui/src/libs/themes/fonts.ts
+++ b/libs/shared/ui/src/libs/themes/fonts.ts
@@ -1,0 +1,19 @@
+// Sarabun is appended after the Latin fonts in every font stack as a
+// unicode-range-scoped Thai fallback: Latin glyphs keep resolving to
+// Montserrat/Open Sans while Thai glyphs fall through to Sarabun, and the
+// Sarabun Thai .woff2 only downloads when Thai glyphs actually render.
+export const THAI_FALLBACK_FONT = '"Sarabun"'
+
+// Weight list must be a superset of every fontWeight used across the
+// base/journeyUi/journeysAdmin typography tokens (400, 500, 600, 700, 800),
+// otherwise the browser synthesizes missing Thai weights.
+export const SARABUN_FONTS_QUERY = 'family=Sarabun:wght@400;500;600;700;800'
+
+// Google Fonts families always loaded by the iframe portal and the standalone
+// journey page, merged with any author-selected fonts.
+export const DEFAULT_FONTS = [
+  'Montserrat',
+  'Open Sans',
+  'El Messiri',
+  'Sarabun'
+]

--- a/libs/shared/ui/src/libs/themes/index.ts
+++ b/libs/shared/ui/src/libs/themes/index.ts
@@ -5,6 +5,8 @@ import { adminLight } from './journeysAdmin/theme'
 import { getJourneyUiDark, getJourneyUiLight } from './journeyUi/theme'
 import { websiteDark, websiteLight } from './website/theme'
 
+export { DEFAULT_FONTS, SARABUN_FONTS_QUERY, THAI_FALLBACK_FONT } from './fonts'
+
 export enum ThemeMode {
   dark = 'dark',
   light = 'light'

--- a/libs/shared/ui/src/libs/themes/journeyUi/tokens/typography.ts
+++ b/libs/shared/ui/src/libs/themes/journeyUi/tokens/typography.ts
@@ -5,6 +5,7 @@ import {
   baseTypographyArabic,
   baseTypographyUrdu
 } from '../../base/tokens/typography'
+import { THAI_FALLBACK_FONT } from '../../fonts'
 
 // should match base values until we have a need for different values
 
@@ -18,27 +19,27 @@ export const journeyUiTypography: Pick<ThemeOptions, 'typography'> = {
   typography: {
     ...baseTypography.typography,
     subtitle1: {
-      fontFamily: '"Open Sans"',
+      fontFamily: `"Open Sans",${THAI_FALLBACK_FONT},sans-serif`,
       fontSize: 12,
       fontWeight: 600,
       lineHeight: '18px',
       fontFeatureSettings: '"clig" off, "liga"'
     },
     subtitle2: {
-      fontFamily: '"Open Sans"',
+      fontFamily: `"Open Sans",${THAI_FALLBACK_FONT},sans-serif`,
       fontSize: 10,
       fontWeight: 600,
       lineHeight: '15px',
       fontFeatureSettings: '"clig" off, "liga"'
     },
     body2: {
-      fontFamily: '"Open Sans"',
+      fontFamily: `"Open Sans",${THAI_FALLBACK_FONT},sans-serif`,
       fontSize: 14,
       fontWeight: 400,
       lineHeight: '22px'
     },
     caption: {
-      fontFamily: '"Open Sans"',
+      fontFamily: `"Open Sans",${THAI_FALLBACK_FONT},sans-serif`,
       fontSize: 12,
       fontWeight: 400,
       lineHeight: '18px'

--- a/libs/shared/ui/src/libs/themes/journeysAdmin/tokens/components.ts
+++ b/libs/shared/ui/src/libs/themes/journeysAdmin/tokens/components.ts
@@ -1,5 +1,7 @@
 import { ThemeOptions } from '@mui/material/styles'
 
+import { THAI_FALLBACK_FONT } from '../../fonts'
+
 import { palette } from './colors'
 
 declare module '@mui/material/Button' {
@@ -14,7 +16,7 @@ export const adminComponents: Required<Pick<ThemeOptions, 'components'>> = {
     MuiButton: {
       styleOverrides: {
         root: {
-          fontFamily: "'Montserrat', sans-serif",
+          fontFamily: `'Montserrat', ${THAI_FALLBACK_FONT}, sans-serif`,
           fontWeight: 800,
           borderRadius: '12px',
           textTransform: 'none'
@@ -202,7 +204,7 @@ export const adminComponents: Required<Pick<ThemeOptions, 'components'>> = {
       styleOverrides: {
         primary: {
           fontWeight: 600,
-          fontFamily: "'Montserrat', sans-serif"
+          fontFamily: `'Montserrat', ${THAI_FALLBACK_FONT}, sans-serif`
         },
         secondary: {
           color: palette[800]

--- a/libs/shared/ui/src/libs/themes/journeysAdmin/tokens/typography.spec.ts
+++ b/libs/shared/ui/src/libs/themes/journeysAdmin/tokens/typography.spec.ts
@@ -1,0 +1,60 @@
+import { TypographyStyle } from '@mui/material/styles'
+
+import { THAI_FALLBACK_FONT } from '../../fonts'
+
+import { adminComponents } from './components'
+import { adminTypography } from './typography'
+
+function getFontFamily(
+  typography: unknown,
+  variant: string
+): string | undefined {
+  const variants = typography as Record<string, TypographyStyle>
+  return variants[variant]?.fontFamily as string | undefined
+}
+
+describe('adminTypography', () => {
+  it('should include the Thai fallback after the Latin fonts in the top-level fontFamily', () => {
+    expect(
+      (adminTypography.typography as { fontFamily?: string }).fontFamily
+    ).toBe(
+      `"Montserrat", "Open Sans", "Tahoma", "Verdana", ${THAI_FALLBACK_FONT}, sans-serif`
+    )
+  })
+
+  it.each(['subtitle3', 'overline2'])(
+    'should include the Thai fallback before sans-serif in %s',
+    (variant) => {
+      expect(getFontFamily(adminTypography.typography, variant)).toBe(
+        `"Montserrat", "Open Sans", "Tahoma", "Verdana", ${THAI_FALLBACK_FONT}, sans-serif`
+      )
+    }
+  )
+
+  it.each(['body1', 'body2', 'caption'])(
+    'should include the Thai fallback before sans-serif in %s',
+    (variant) => {
+      expect(getFontFamily(adminTypography.typography, variant)).toBe(
+        `"Open Sans", "Tahoma", "Verdana", ${THAI_FALLBACK_FONT}, sans-serif`
+      )
+    }
+  )
+})
+
+describe('adminComponents', () => {
+  it('should include the Thai fallback in the MuiButton root font stack', () => {
+    const root = adminComponents.components.MuiButton?.styleOverrides
+      ?.root as Record<string, string>
+    expect(root.fontFamily).toBe(
+      `'Montserrat', ${THAI_FALLBACK_FONT}, sans-serif`
+    )
+  })
+
+  it('should include the Thai fallback in the MuiListItemText primary font stack', () => {
+    const primary = adminComponents.components.MuiListItemText?.styleOverrides
+      ?.primary as Record<string, string>
+    expect(primary.fontFamily).toBe(
+      `'Montserrat', ${THAI_FALLBACK_FONT}, sans-serif`
+    )
+  })
+})

--- a/libs/shared/ui/src/libs/themes/journeysAdmin/tokens/typography.spec.ts
+++ b/libs/shared/ui/src/libs/themes/journeysAdmin/tokens/typography.spec.ts
@@ -1,41 +1,46 @@
-import { TypographyStyle } from '@mui/material/styles'
+import { ThemeOptions } from '@mui/material/styles'
 
 import { THAI_FALLBACK_FONT } from '../../fonts'
 
 import { adminComponents } from './components'
 import { adminTypography } from './typography'
 
+type TypographyTokens = Pick<ThemeOptions, 'typography'>
+
 function getFontFamily(
-  typography: unknown,
+  tokens: TypographyTokens,
   variant: string
 ): string | undefined {
-  const variants = typography as Record<string, TypographyStyle>
-  return variants[variant]?.fontFamily as string | undefined
+  const variants = tokens.typography as Record<
+    string,
+    { fontFamily?: string } | undefined
+  >
+  return variants[variant]?.fontFamily
 }
 
 describe('adminTypography', () => {
-  it('should include the Thai fallback after the Latin fonts in the top-level fontFamily', () => {
+  it('should place the Thai fallback after the Latin webfonts and before Tahoma in the top-level fontFamily', () => {
     expect(
       (adminTypography.typography as { fontFamily?: string }).fontFamily
     ).toBe(
-      `"Montserrat", "Open Sans", "Tahoma", "Verdana", ${THAI_FALLBACK_FONT}, sans-serif`
+      `"Montserrat", "Open Sans", ${THAI_FALLBACK_FONT}, "Tahoma", "Verdana", sans-serif`
     )
   })
 
   it.each(['subtitle3', 'overline2'])(
-    'should include the Thai fallback before sans-serif in %s',
+    'should place the Thai fallback before Tahoma in %s',
     (variant) => {
-      expect(getFontFamily(adminTypography.typography, variant)).toBe(
-        `"Montserrat", "Open Sans", "Tahoma", "Verdana", ${THAI_FALLBACK_FONT}, sans-serif`
+      expect(getFontFamily(adminTypography, variant)).toBe(
+        `"Montserrat", "Open Sans", ${THAI_FALLBACK_FONT}, "Tahoma", "Verdana", sans-serif`
       )
     }
   )
 
   it.each(['body1', 'body2', 'caption'])(
-    'should include the Thai fallback before sans-serif in %s',
+    'should place the Thai fallback before Tahoma in %s',
     (variant) => {
-      expect(getFontFamily(adminTypography.typography, variant)).toBe(
-        `"Open Sans", "Tahoma", "Verdana", ${THAI_FALLBACK_FONT}, sans-serif`
+      expect(getFontFamily(adminTypography, variant)).toBe(
+        `"Open Sans", ${THAI_FALLBACK_FONT}, "Tahoma", "Verdana", sans-serif`
       )
     }
   )

--- a/libs/shared/ui/src/libs/themes/journeysAdmin/tokens/typography.ts
+++ b/libs/shared/ui/src/libs/themes/journeysAdmin/tokens/typography.ts
@@ -1,5 +1,7 @@
 import { ThemeOptions } from '@mui/material/styles'
 
+import { THAI_FALLBACK_FONT } from '../../fonts'
+
 // Update the Typography's variant prop options
 declare module '@mui/material/styles' {
   interface TypographyPropsVariantOverrides {
@@ -32,7 +34,7 @@ declare module '@mui/material/Typography' {
 export const adminTypography: Pick<ThemeOptions, 'typography'> = {
   typography: {
     fontFamily: [
-      '"Montserrat", "Open Sans", "Tahoma", "Verdana", sans-serif'
+      `"Montserrat", "Open Sans", "Tahoma", "Verdana", ${THAI_FALLBACK_FONT}, sans-serif`
     ].join(','),
     h1: {
       fontWeight: 500,
@@ -79,16 +81,16 @@ export const adminTypography: Pick<ThemeOptions, 'typography'> = {
       fontSize: 14,
       fontWeight: 600,
       lineHeight: '19px',
-      fontFamily: '"Montserrat", "Open Sans", "Tahoma", "Verdana", sans-serif'
+      fontFamily: `"Montserrat", "Open Sans", "Tahoma", "Verdana", ${THAI_FALLBACK_FONT}, sans-serif`
     },
     body1: {
-      fontFamily: '"Open Sans", "Tahoma", "Verdana", sans-serif',
+      fontFamily: `"Open Sans", "Tahoma", "Verdana", ${THAI_FALLBACK_FONT}, sans-serif`,
       fontWeight: 400,
       fontSize: 16,
       lineHeight: '24px'
     },
     body2: {
-      fontFamily: '"Open Sans", "Tahoma", "Verdana", sans-serif',
+      fontFamily: `"Open Sans", "Tahoma", "Verdana", ${THAI_FALLBACK_FONT}, sans-serif`,
       fontWeight: 400,
       fontSize: 14,
       lineHeight: '22px'
@@ -106,10 +108,10 @@ export const adminTypography: Pick<ThemeOptions, 'typography'> = {
       lineHeight: '16px',
       letterSpacing: 1,
       textTransform: 'uppercase',
-      fontFamily: '"Montserrat", "Open Sans", "Tahoma", "Verdana", sans-serif'
+      fontFamily: `"Montserrat", "Open Sans", "Tahoma", "Verdana", ${THAI_FALLBACK_FONT}, sans-serif`
     },
     caption: {
-      fontFamily: '"Open Sans", "Tahoma", "Verdana", sans-serif',
+      fontFamily: `"Open Sans", "Tahoma", "Verdana", ${THAI_FALLBACK_FONT}, sans-serif`,
       fontWeight: 400,
       fontSize: 12,
       lineHeight: '18px'

--- a/libs/shared/ui/src/libs/themes/journeysAdmin/tokens/typography.ts
+++ b/libs/shared/ui/src/libs/themes/journeysAdmin/tokens/typography.ts
@@ -34,7 +34,7 @@ declare module '@mui/material/Typography' {
 export const adminTypography: Pick<ThemeOptions, 'typography'> = {
   typography: {
     fontFamily: [
-      `"Montserrat", "Open Sans", "Tahoma", "Verdana", ${THAI_FALLBACK_FONT}, sans-serif`
+      `"Montserrat", "Open Sans", ${THAI_FALLBACK_FONT}, "Tahoma", "Verdana", sans-serif`
     ].join(','),
     h1: {
       fontWeight: 500,
@@ -81,16 +81,16 @@ export const adminTypography: Pick<ThemeOptions, 'typography'> = {
       fontSize: 14,
       fontWeight: 600,
       lineHeight: '19px',
-      fontFamily: `"Montserrat", "Open Sans", "Tahoma", "Verdana", ${THAI_FALLBACK_FONT}, sans-serif`
+      fontFamily: `"Montserrat", "Open Sans", ${THAI_FALLBACK_FONT}, "Tahoma", "Verdana", sans-serif`
     },
     body1: {
-      fontFamily: `"Open Sans", "Tahoma", "Verdana", ${THAI_FALLBACK_FONT}, sans-serif`,
+      fontFamily: `"Open Sans", ${THAI_FALLBACK_FONT}, "Tahoma", "Verdana", sans-serif`,
       fontWeight: 400,
       fontSize: 16,
       lineHeight: '24px'
     },
     body2: {
-      fontFamily: `"Open Sans", "Tahoma", "Verdana", ${THAI_FALLBACK_FONT}, sans-serif`,
+      fontFamily: `"Open Sans", ${THAI_FALLBACK_FONT}, "Tahoma", "Verdana", sans-serif`,
       fontWeight: 400,
       fontSize: 14,
       lineHeight: '22px'
@@ -108,10 +108,10 @@ export const adminTypography: Pick<ThemeOptions, 'typography'> = {
       lineHeight: '16px',
       letterSpacing: 1,
       textTransform: 'uppercase',
-      fontFamily: `"Montserrat", "Open Sans", "Tahoma", "Verdana", ${THAI_FALLBACK_FONT}, sans-serif`
+      fontFamily: `"Montserrat", "Open Sans", ${THAI_FALLBACK_FONT}, "Tahoma", "Verdana", sans-serif`
     },
     caption: {
-      fontFamily: `"Open Sans", "Tahoma", "Verdana", ${THAI_FALLBACK_FONT}, sans-serif`,
+      fontFamily: `"Open Sans", ${THAI_FALLBACK_FONT}, "Tahoma", "Verdana", sans-serif`,
       fontWeight: 400,
       fontSize: 12,
       lineHeight: '18px'


### PR DESCRIPTION
## Summary

Adds Sarabun as a `unicode-range`-scoped Thai fallback across `apps/journeys` and `apps/journeys-admin`. Thai glyphs resolve to Sarabun while Latin stays Montserrat/Open Sans, per glyph — no locale- or journey-language-conditional theme branch. Implements U1–U6 of [the plan](docs/plans/2026-07-06-001-feat-thai-font-support-plan.md).

- **U1** — shared `THAI_FALLBACK_FONT`, `SARABUN_FONTS_QUERY`, and `DEFAULT_FONTS` constants in `libs/shared/ui/src/libs/themes/fonts.ts`
- **U2** — fallback appended in `createFontFamilyString` (covers author-selected fonts) and the base + journeyUi typography tokens
- **U3** — fallback in journeysAdmin typography tokens, `MuiButton`/`MuiListItemText` component overrides, and inline admin literals (LabelChip, CollectionDialog, JourneyPickerField)
- **U4** — Sarabun added to both `_document.tsx` Google Fonts links (LTR and RTL branches)
- **U5/U6** — local `defaultFonts` arrays in `FramePortal` and `home/[journeySlug].tsx` replaced with shared `DEFAULT_FONTS` (now includes Sarabun)

Key decision: Sarabun sits **after** the Latin webfonts but **before Tahoma/Verdana** — Tahoma ships Thai glyphs on Windows and would otherwise intercept Thai before Sarabun (caught in code review). Sarabun's weight list (400–800) is a superset of every `fontWeight` used by the tokens, so no faux-bold Thai.

Intentional side effect: journeyUi `subtitle1/subtitle2/body2/caption` previously ended at `"Open Sans"` with no generic family; they now end in `sans-serif`.

## Verification

- `pnpm` builds pass: `nx build journeys`, `nx build journeys-admin` ✅
- `type-check` passes for `journeys`, `journeys-admin`, `shared-ui`, `journeys-ui` ✅
- New specs: `base/tokens/typography.spec.ts` (10), `journeysAdmin/tokens/typography.spec.ts` (8), extended `FramePortal.spec.tsx` (3) — all passing; stack-order assertions pin Sarabun's position
- Multi-angle code review run; confirmed findings fixed (Tahoma ordering, RTL link, spec typing)
- Manual QA still recommended (plan AE3/visual QA): Basic-Latin page loads the Sarabun stylesheet but **no** Sarabun `.woff2`; a Thai page (e.g. "ก้อนน้ำแข็ง") downloads the Thai subset, renders Thai in Sarabun/Latin in Montserrat, no tone-mark clipping in headings

## Known Residuals (accepted cleanup, not blocking)

- Google Fonts weight list + URL building duplicated across `SARABUN_FONTS_QUERY`, `FramePortal`, `[journeySlug].tsx`, admin `FontLoader` — a shared query builder would remove drift risk
- Sarabun `@font-face` CSS delivered twice on the standalone journey page (via `_document` and the page URL) — mirrors pre-existing Montserrat/Open Sans behavior; fonts themselves are not double-downloaded
- `SECTION_HEADER` style duplicated in CollectionDialog/JourneyPickerField rather than sourced from the theme

## Post-Deploy Monitoring & Validation

- **Signals to watch:** Vercel/CDN error rates for `fonts.googleapis.com` CSS on journeys + journeys-admin pages; visual regression reports on English journeys (Latin rendering must be unchanged)
- **Healthy:** Latin-only pages show no `Sarabun*.woff2` requests; Thai pages request exactly one Sarabun Thai subset per weight used
- **Failure signal / rollback:** English text visibly rendering in Sarabun (ordering regression) or Thai tofu on any surface → revert this PR (pure additive font-stack change, safe revert)
- **Window/owner:** first 24h after deploy, Edmond

Linear: [NES-1759](https://linear.app/jesus-film-project/issue/NES-1759/add-thai-sarabun-font-support-to-journeys-and-journeys-admin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZotAWqGARNmRTGpWSYGaP