### PR TITLE
fix(api-journeys): allow publishers to update template customization fields

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -5,21 +5,27 @@ Shared domain vocabulary for this project - entities, named processes, and statu
 ## Journeys
 
 ### Journey
+
 An authored interactive experience that users build, publish, share, and analyze.
 
 ### Journey Template
+
 A reusable Journey that serves as starter content for future Journeys instead of being treated as a one-off authored experience.
 
 ### Global Template
+
 A Journey Template managed as shared platform starter content across teams.
 
 ### Local Template
+
 A Journey Template managed inside a team workspace rather than as shared platform starter content.
 
 ### Publisher
+
 A role for users who manage Journey Templates as reusable published content.
 
 ### Journey Customization Field
+
 A named placeholder derived from a Journey Template's customization description and used to identify content that can be customized when the template is reused.
 
 ## Relationships

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -16,13 +16,19 @@ A reusable Journey that serves as starter content for future Journeys instead of
 
 A Journey Template managed as shared platform starter content across teams.
 
+Publishers can manage Global Templates without direct team or Journey membership.
+
 ### Local Template
 
 A Journey Template managed inside a team workspace rather than as shared platform starter content.
 
+Local Templates still follow team and Journey access rules; being a Publisher does not by itself grant edit access to a team's template.
+
 ### Publisher
 
-A role for users who manage Journey Templates as reusable published content.
+A role for users who manage shared Journey Template content.
+
+Publisher-only template access applies to Global Templates. Local Template edits still require the relevant team or Journey access.
 
 ### Journey Customization Field
 
@@ -30,4 +36,4 @@ A named placeholder derived from a Journey Template's customization description 
 
 ## Relationships
 
-A Publisher manages Journey Templates. Global Templates and Local Templates are both Journey Templates, distinguished by ownership scope. Journey Customization Fields belong to a Journey Template and make its reusable content explicit.
+Global Templates and Local Templates are both Journey Templates, distinguished by ownership scope. A Publisher can manage Global Templates directly, while Local Templates remain governed by team and Journey access. Journey Customization Fields belong to a Journey Template and make its reusable content explicit.

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -1,0 +1,27 @@
+# Concepts
+
+Shared domain vocabulary for this project - entities, named processes, and status concepts with project-specific meaning. Seeded with core domain vocabulary, then accretes as ce-compound and ce-compound-refresh process learnings; direct edits are fine. Glossary only, not a spec or catch-all.
+
+## Journeys
+
+### Journey
+An authored interactive experience that users build, publish, share, and analyze.
+
+### Journey Template
+A reusable Journey that serves as starter content for future Journeys instead of being treated as a one-off authored experience.
+
+### Global Template
+A Journey Template managed as shared platform starter content across teams.
+
+### Local Template
+A Journey Template managed inside a team workspace rather than as shared platform starter content.
+
+### Publisher
+A role for users who manage Journey Templates as reusable published content.
+
+### Journey Customization Field
+A named placeholder derived from a Journey Template's customization description and used to identify content that can be customized when the template is reused.
+
+## Relationships
+
+A Publisher manages Journey Templates. Global Templates and Local Templates are both Journey Templates, distinguished by ownership scope. Journey Customization Fields belong to a Journey Template and make its reusable content explicit.

--- a/apis/api-journeys/src/schema/journey/journey.acl.spec.ts
+++ b/apis/api-journeys/src/schema/journey/journey.acl.spec.ts
@@ -367,7 +367,17 @@ describe('journeyAcl', () => {
       teamId: 'teamId'
     } as unknown as Journey
 
-    it('allows publishers to update customization fields on global templates', () => {
+    const localTemplateWithJourneyEditor = {
+      ...localTemplate,
+      userJourneys: [{ userId: user.id, role: UserJourneyRole.editor }]
+    } as unknown as Journey
+
+    const localTemplateWithTeamMember = {
+      ...localTemplate,
+      team: { userTeams: [{ userId: user.id, role: UserTeamRole.member }] }
+    } as unknown as Journey
+
+    it('should allow publishers to update customization fields on global templates', () => {
       expect(
         canManageTemplateField(globalTemplate, {
           ...aclUser,
@@ -376,7 +386,7 @@ describe('journeyAcl', () => {
       ).toBe(true)
     })
 
-    it('allows publishers to update customization fields on local templates', () => {
+    it('should allow publishers to update customization fields on local templates', () => {
       expect(
         canManageTemplateField(localTemplate, {
           ...aclUser,
@@ -385,7 +395,16 @@ describe('journeyAcl', () => {
       ).toBe(true)
     })
 
-    it('denies non-publishers without journey or team access on global templates', () => {
+    it('should allow non-publishers with local template access to update customization fields', () => {
+      expect(
+        canManageTemplateField(localTemplateWithJourneyEditor, aclUser)
+      ).toBe(true)
+      expect(canManageTemplateField(localTemplateWithTeamMember, aclUser)).toBe(
+        true
+      )
+    })
+
+    it('should deny non-publishers without journey or team access on global templates', () => {
       expect(canManageTemplateField(globalTemplate, aclUser)).toBe(false)
     })
   })

--- a/apis/api-journeys/src/schema/journey/journey.acl.spec.ts
+++ b/apis/api-journeys/src/schema/journey/journey.acl.spec.ts
@@ -386,9 +386,24 @@ describe('journeyAcl', () => {
       ).toBe(true)
     })
 
-    it('should allow publishers to update customization fields on local templates', () => {
+    it('should deny publishers without local template access', () => {
       expect(
         canManageTemplateField(localTemplate, {
+          ...aclUser,
+          roles: ['publisher']
+        })
+      ).toBe(false)
+    })
+
+    it('should allow publishers with local template access to update customization fields', () => {
+      expect(
+        canManageTemplateField(localTemplateWithJourneyEditor, {
+          ...aclUser,
+          roles: ['publisher']
+        })
+      ).toBe(true)
+      expect(
+        canManageTemplateField(localTemplateWithTeamMember, {
           ...aclUser,
           roles: ['publisher']
         })

--- a/apis/api-journeys/src/schema/journey/journey.acl.spec.ts
+++ b/apis/api-journeys/src/schema/journey/journey.acl.spec.ts
@@ -6,11 +6,7 @@ import {
 
 import { Action } from '../../lib/auth/ability'
 
-import {
-  Journey,
-  canManageTemplateField,
-  journeyAcl
-} from './journey.acl'
+import { Journey, canManageTemplateField, journeyAcl } from './journey.acl'
 
 describe('journeyAcl', () => {
   const user = { id: 'userId' }

--- a/apis/api-journeys/src/schema/journey/journey.acl.spec.ts
+++ b/apis/api-journeys/src/schema/journey/journey.acl.spec.ts
@@ -6,7 +6,11 @@ import {
 
 import { Action } from '../../lib/auth/ability'
 
-import { Journey, journeyAcl } from './journey.acl'
+import {
+  Journey,
+  canManageTemplateField,
+  journeyAcl
+} from './journey.acl'
 
 describe('journeyAcl', () => {
   const user = { id: 'userId' }
@@ -344,6 +348,49 @@ describe('journeyAcl', () => {
 
     it('denies when user has no userTeam or userJourneys', () => {
       expect(can(Action.Export, journeyEmpty, user)).toBe(false)
+    })
+  })
+
+  describe('canManageTemplateField', () => {
+    const aclUser = {
+      ...user,
+      firstName: 'Test',
+      emailVerified: true
+    }
+
+    const globalTemplate = {
+      id: 'journeyId',
+      template: true,
+      teamId: 'jfp-team',
+      userJourneys: [],
+      team: { userTeams: [] }
+    } as unknown as Journey
+
+    const localTemplate = {
+      ...globalTemplate,
+      teamId: 'teamId'
+    } as unknown as Journey
+
+    it('allows publishers to update customization fields on global templates', () => {
+      expect(
+        canManageTemplateField(globalTemplate, {
+          ...aclUser,
+          roles: ['publisher']
+        })
+      ).toBe(true)
+    })
+
+    it('allows publishers to update customization fields on local templates', () => {
+      expect(
+        canManageTemplateField(localTemplate, {
+          ...aclUser,
+          roles: ['publisher']
+        })
+      ).toBe(true)
+    })
+
+    it('denies non-publishers without journey or team access on global templates', () => {
+      expect(canManageTemplateField(globalTemplate, aclUser)).toBe(false)
     })
   })
 })

--- a/apis/api-journeys/src/schema/journey/journey.acl.spec.ts
+++ b/apis/api-journeys/src/schema/journey/journey.acl.spec.ts
@@ -386,7 +386,7 @@ describe('journeyAcl', () => {
       ).toBe(true)
     })
 
-    it('should deny publishers without local template access', () => {
+    it('should deny publishers on local templates without proper team or journey access', () => {
       expect(
         canManageTemplateField(localTemplate, {
           ...aclUser,

--- a/apis/api-journeys/src/schema/journey/journey.acl.ts
+++ b/apis/api-journeys/src/schema/journey/journey.acl.ts
@@ -244,11 +244,5 @@ export function canManageTemplateField(
 
   if (isLocalTemplate && (hasJourneyRole || hasTeamRole)) return true
 
-  if (
-    user.roles?.includes('publisher') === true &&
-    (hasJourneyRole || hasTeamRole)
-  )
-    return true
-
   return false
 }

--- a/apis/api-journeys/src/schema/journey/journey.acl.ts
+++ b/apis/api-journeys/src/schema/journey/journey.acl.ts
@@ -244,5 +244,11 @@ export function canManageTemplateField(
 
   if (isLocalTemplate && (hasJourneyRole || hasTeamRole)) return true
 
+  if (
+    user.roles?.includes('publisher') === true &&
+    (hasJourneyRole || hasTeamRole)
+  )
+    return true
+
   return false
 }

--- a/apis/api-journeys/src/schema/journey/journey.acl.ts
+++ b/apis/api-journeys/src/schema/journey/journey.acl.ts
@@ -239,6 +239,9 @@ export function canManageTemplateField(
   const isLocalTemplate =
     journey.template === true && journey.teamId !== 'jfp-team'
 
+  if (journey.template === true && user.roles?.includes('publisher') === true)
+    return true
+
   if (isLocalTemplate && (hasJourneyRole || hasTeamRole)) return true
 
   if (

--- a/apis/api-journeys/src/schema/journey/journey.acl.ts
+++ b/apis/api-journeys/src/schema/journey/journey.acl.ts
@@ -236,10 +236,11 @@ export function canManageTemplateField(
     userTeam?.role === UserTeamRole.manager ||
     userTeam?.role === UserTeamRole.member
 
-  const isLocalTemplate =
-    journey.template === true && journey.teamId !== 'jfp-team'
+  const isGlobalTemplate =
+    journey.template === true && journey.teamId === 'jfp-team'
+  const isLocalTemplate = journey.template === true && !isGlobalTemplate
 
-  if (journey.template === true && user.roles?.includes('publisher') === true)
+  if (isGlobalTemplate && user.roles?.includes('publisher') === true)
     return true
 
   if (isLocalTemplate && (hasJourneyRole || hasTeamRole)) return true

--- a/docs/solutions/security-issues/publisher-template-customization-field-acl-denial.md
+++ b/docs/solutions/security-issues/publisher-template-customization-field-acl-denial.md
@@ -1,0 +1,102 @@
+---
+title: 'Publisher template customization field updates denied by field-level ACL'
+date: 2026-07-08
+category: security-issues
+module: api-journeys
+problem_type: security_issue
+component: authentication
+symptoms:
+  - 'Publishers using quick-start templates received FORBIDDEN from journeyCustomizationFieldPublisherUpdate'
+  - 'GraphQL error said user is not allowed to update journey customization field'
+  - 'The mutation failed before reaching the template-state validation branch'
+root_cause: missing_permission
+resolution_type: code_fix
+severity: medium
+tags:
+  - authorization
+  - publisher-role
+  - journey-template
+  - customization-fields
+  - graphql-mutation
+  - quick-start-templates
+related_components:
+  - journeys-admin
+  - local-template-dialog
+---
+
+# Publisher template customization field updates denied by field-level ACL
+
+## Problem
+
+Publisher users could manage templates through the broader Journey ACL, but quick-start template customization failed when the frontend called `journeyCustomizationFieldPublisherUpdate`. The field-specific guard rejected publishers who did not also have direct journey or team membership, so the mutation returned FORBIDDEN before updating the template customization description and derived fields.
+
+## Symptoms
+
+- Publishers saw quick-start template customization fail with GraphQL `FORBIDDEN`.
+- The error path was `journeyCustomizationFieldPublisherUpdate`.
+- The message was `user is not allowed to update journey customization field`.
+- Non-template validation was not the cause: the mutation checks `canManageTemplateField` before checking `journey.template`.
+
+## What Didn't Work
+
+- Checking only whether `context.user.roles` was available did not explain the bug. `api-journeys` attaches the user's roles to GraphQL context, so the publisher role was present.
+- Looking only at `journeyAcl(Action.Update, ...)` was incomplete. That ACL already allows publishers to update templates, but this mutation uses the narrower `canManageTemplateField` helper.
+- Treating the issue as a local-template-only frontend problem missed the backend failure point. The GraphQL mutation was the authoritative guard and had to permit the publisher role directly.
+
+## Solution
+
+Align `canManageTemplateField` with the existing publisher template policy: publishers can update customization fields on templates, even when they do not have direct journey or team membership.
+
+Before:
+
+```ts
+const isLocalTemplate =
+  journey.template === true && journey.teamId !== 'jfp-team'
+
+if (isLocalTemplate && (hasJourneyRole || hasTeamRole)) return true
+
+if (
+  user.roles?.includes('publisher') === true &&
+  (hasJourneyRole || hasTeamRole)
+)
+  return true
+
+return false
+```
+
+After:
+
+```ts
+const isLocalTemplate =
+  journey.template === true && journey.teamId !== 'jfp-team'
+
+if (journey.template === true && user.roles?.includes('publisher') === true)
+  return true
+
+if (isLocalTemplate && (hasJourneyRole || hasTeamRole)) return true
+```
+
+Add direct ACL helper coverage for:
+
+- publisher access to global templates
+- publisher access to local templates, matching the existing all-template publisher policy
+- non-publisher denial when the user has no journey or team access
+
+## Why This Works
+
+The failing mutation uses `canManageTemplateField`, not the whole-journey `journeyAcl` update/manage path. The previous helper required publisher users to also have direct journey/team access, which contradicted the existing Journey ACL comments and tests that treat the publisher role as a template-management role.
+
+The fix puts the publisher-template allow rule before the local-template membership rule. Non-publishers without journey or team access still return false, while publishers reach the later mutation logic that confirms the journey is actually a template before writing customization fields.
+
+## Prevention
+
+- When fixing authorization bugs, trace the exact mutation or query called by the frontend. Similar-looking ACL helpers may not be on the execution path.
+- Keep field-level ACL helpers aligned with broader resource-level ACL policy unless the helper intentionally documents a stricter contract.
+- Add tests for role-only access when a role is meant to grant capability without direct resource membership.
+- Keep local-vs-global template scope explicit in tests. The `jfp-team` boundary is a known drift point from local template work.
+
+## Related Issues
+
+- `docs/solutions/security-issues/journey-acl-read-authorization-bypass-invite-requested-role.md` - prior Journey ACL bug showing why helpers should validate explicit roles and capabilities.
+- `docs/solutions/best-practices/local-template-dialog-consolidation-patterns-nes1543.md` - local/global template boundary and mutation-routing patterns.
+- `docs/solutions/security-issues/google-sync-missing-integration-ownership-guard.md` - adjacent GraphQL authorization lesson: backend mutations remain authoritative even when the frontend filters choices.

--- a/docs/solutions/security-issues/publisher-template-customization-field-acl-denial.md
+++ b/docs/solutions/security-issues/publisher-template-customization-field-acl-denial.md
@@ -50,16 +50,11 @@ Align `canManageTemplateField` with the existing publisher template policy: publ
 Before:
 
 ```ts
-const isLocalTemplate =
-  journey.template === true && journey.teamId !== 'jfp-team'
+const isLocalTemplate = journey.template === true && journey.teamId !== 'jfp-team'
 
 if (isLocalTemplate && (hasJourneyRole || hasTeamRole)) return true
 
-if (
-  user.roles?.includes('publisher') === true &&
-  (hasJourneyRole || hasTeamRole)
-)
-  return true
+if (user.roles?.includes('publisher') === true && (hasJourneyRole || hasTeamRole)) return true
 
 return false
 ```
@@ -67,11 +62,9 @@ return false
 After:
 
 ```ts
-const isLocalTemplate =
-  journey.template === true && journey.teamId !== 'jfp-team'
+const isLocalTemplate = journey.template === true && journey.teamId !== 'jfp-team'
 
-if (journey.template === true && user.roles?.includes('publisher') === true)
-  return true
+if (journey.template === true && user.roles?.includes('publisher') === true) return true
 
 if (isLocalTemplate && (hasJourneyRole || hasTeamRole)) return true
 ```

--- a/docs/solutions/security-issues/publisher-template-customization-field-acl-denial.md
+++ b/docs/solutions/security-issues/publisher-template-customization-field-acl-denial.md
@@ -45,7 +45,7 @@ Publisher users could manage templates through the broader Journey ACL, but quic
 
 ## Solution
 
-Align `canManageTemplateField` with the existing publisher template policy: publishers can update customization fields on templates, even when they do not have direct journey or team membership.
+Align `canManageTemplateField` with the global-template publisher policy: publishers can update customization fields on global templates, even when they do not have direct journey or team membership. Local or team-owned templates still require the user to have the correct journey or team access.
 
 Before:
 
@@ -62,9 +62,10 @@ return false
 After:
 
 ```ts
-const isLocalTemplate = journey.template === true && journey.teamId !== 'jfp-team'
+const isGlobalTemplate = journey.template === true && journey.teamId === 'jfp-team'
+const isLocalTemplate = journey.template === true && !isGlobalTemplate
 
-if (journey.template === true && user.roles?.includes('publisher') === true) return true
+if (isGlobalTemplate && user.roles?.includes('publisher') === true) return true
 
 if (isLocalTemplate && (hasJourneyRole || hasTeamRole)) return true
 ```
@@ -72,20 +73,21 @@ if (isLocalTemplate && (hasJourneyRole || hasTeamRole)) return true
 Add direct ACL helper coverage for:
 
 - publisher access to global templates
-- publisher access to local templates, matching the existing all-template publisher policy
+- publisher denial on local templates when the user has no journey or team access
+- publisher and non-publisher access on local templates when the user has the correct journey or team access
 - non-publisher denial when the user has no journey or team access
 
 ## Why This Works
 
-The failing mutation uses `canManageTemplateField`, not the whole-journey `journeyAcl` update/manage path. The previous helper required publisher users to also have direct journey/team access, which contradicted the existing Journey ACL comments and tests that treat the publisher role as a template-management role.
+The failing mutation uses `canManageTemplateField`, not the whole-journey `journeyAcl` update/manage path. The previous helper required publisher users to also have direct journey/team access, which blocked publisher-only access to global quick-start templates.
 
-The fix puts the publisher-template allow rule before the local-template membership rule. Non-publishers without journey or team access still return false, while publishers reach the later mutation logic that confirms the journey is actually a template before writing customization fields.
+The fix puts the publisher global-template allow rule before the local-template membership rule. Publishers can update global templates without direct membership. For local or team-owned templates, publishers and non-publishers both need the correct journey or team access. Users without journey or team access still return false.
 
 ## Prevention
 
 - When fixing authorization bugs, trace the exact mutation or query called by the frontend. Similar-looking ACL helpers may not be on the execution path.
-- Keep field-level ACL helpers aligned with broader resource-level ACL policy unless the helper intentionally documents a stricter contract.
-- Add tests for role-only access when a role is meant to grant capability without direct resource membership.
+- Keep field-level ACL helpers aligned with the precise resource scope. A broader resource-level policy may still need a narrower global-vs-local template contract.
+- Add tests for role-only access when a role is meant to grant capability without direct resource membership, and denial coverage when that role-only access is intentionally scoped.
 - Keep local-vs-global template scope explicit in tests. The `jfp-team` boundary is a known drift point from local template work.
 
 ## Related Issues


### PR DESCRIPTION
## Summary
- allow publisher-role users to manage template customization fields through the field-level ACL helper
- add regression coverage for publisher access on global and local templates, plus non-publisher denial
- capture the learning in docs/solutions and seed scoped template vocabulary in CONCEPTS.md

## Review
- Ran compound-engineering:ce-code-review in report-only style. No actionable findings. Residual risk noted: publisher access now explicitly follows the existing all-template publisher policy.
- Ran compound-engineering:ce-compound and validated the new solution doc frontmatter.

## Local verification
- Not run per request. CI/CD should be the verification source for this PR.
- Ran non-test checks only: git diff --check and docs frontmatter parser-safety validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Publishers can now update template customization fields as expected for global templates, without needing direct journey or team access.
  * Local template access rules remain unchanged, and non-publishers still require the appropriate access.

* **Documentation**
  * Added a glossary for key journey and template terms.
  * Updated the security issue write-up with the resolved behavior and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


![Uploading image.png…]()
