### PR TITLE
fix(infra): repoint kubernetes-dashboard helm dep to reachable gh-pages url

### DIFF
--- a/infrastructure/kube/kubernetes-dashboard/Chart.yaml
+++ b/infrastructure/kube/kubernetes-dashboard/Chart.yaml
@@ -5,7 +5,12 @@ type: application
 version: 0.1.0
 appVersion: 'v7.11.1'
 
+# The kubernetes/dashboard project was archived on 2026-01-21 and its GitHub
+# Pages Helm repo (https://kubernetes.github.io/dashboard/) no longer serves
+# index.yaml, which broke Renovate lookups and Helm dependency resolution.
+# The gh-pages branch (frozen at chart 7.14.0) is still reachable via raw
+# GitHub content, so point the dependency there to keep the same chart.
 dependencies:
   - name: kubernetes-dashboard
     version: '7.11.1'
-    repository: https://kubernetes.github.io/dashboard/
+    repository: https://raw.githubusercontent.com/kubernetes/dashboard/gh-pages


### PR DESCRIPTION
## Problem

The `kubernetes/dashboard` project was **archived on 2026-01-21** and GitHub Pages for it was disabled. The Helm repo the chart dependency points at — `https://kubernetes.github.io/dashboard/index.yaml` — now returns **404**. This breaks:

- **Renovate** helm datasource lookups (the CI failure this PR addresses)
- `helm dependency update` / ArgoCD dependency resolution

## Fix

Repoint the dependency in `infrastructure/kube/kubernetes-dashboard/Chart.yaml` to the still-reachable **gh-pages branch via raw GitHub content**:

```
https://kubernetes.github.io/dashboard/  →  https://raw.githubusercontent.com/kubernetes/dashboard/gh-pages
```

This serves a valid Helm `index.yaml` (HTTP 200) with the same chart tarballs (hosted on GitHub Releases), through the final frozen `7.14.0`. Chart version is left pinned at `7.11.1`; once merged, Renovate can resolve again and open its normal `7.11.1 → 7.14.0` bump.

## Verification

`helm dependency update` succeeds and downloads `kubernetes-dashboard-7.11.1` from the new URL:

```
Successfully got an update from the "https://raw.githubusercontent.com/kubernetes/dashboard/gh-pages" chart repository
Downloading kubernetes-dashboard from repo https://raw.githubusercontent.com/kubernetes/dashboard/gh-pages
Saving 1 charts
```

## Notes / follow-ups (out of scope here)

- The gh-pages source is **frozen** — the project is dead; the SIG-UI replacement is **Headlamp**. A future migration is the real long-term path; this just unblocks CI.
- Separately, the ArgoCD apps (`applications/{prod,stage}/kubernetes-dashboard.yaml`) reference `path: infrastructure/kube/dashboard`, but the directory is `infrastructure/kube/kubernetes-dashboard` — a pre-existing mismatch worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Kubernetes Dashboard chart source to use the archived project’s raw GitHub content, helping ensure the app can continue to install the dashboard dependency reliably.
* **Documentation**
  * Added notes explaining the repository source change for future reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->