### PR TITLE
fix(journeys): customisable collection page templates

### DIFF
--- a/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/CollectionPreviewPane/CollectionPreviewPane.tsx
+++ b/apps/journeys-admin/src/components/TemplateGalleryPageList/CollectionDialog/CollectionPreviewPane/CollectionPreviewPane.tsx
@@ -83,6 +83,7 @@ function toData(
       title: journey.title,
       description: journey.description,
       slug: journey.slug,
+      customizable: journey.customizable,
       // String-coerce defensively: if Apollo ever returns a custom DateTime
       // scalar or a Date here, parseISO downstream silently yields Invalid
       // Date and the meta line drops the date without warning.

--- a/apps/journeys-admin/src/components/UseTemplateDeepLink/UseTemplateDeepLink.spec.tsx
+++ b/apps/journeys-admin/src/components/UseTemplateDeepLink/UseTemplateDeepLink.spec.tsx
@@ -343,6 +343,17 @@ describe('UseTemplateDeepLink', () => {
     expect(push).not.toHaveBeenCalled()
   })
 
+  it('shows a loading indicator while the journey query resolves', async () => {
+    setup()
+    expect(screen.getByTestId('UseTemplateDeepLinkLoading')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.getByTestId('CopyToTeamDialog')).toBeInTheDocument()
+    )
+    expect(
+      screen.queryByTestId('UseTemplateDeepLinkLoading')
+    ).not.toBeInTheDocument()
+  })
+
   it('duplicates the journey and replaces the URL with /?type=journeys&refresh=true', async () => {
     const { push, replace } = setup()
     await waitFor(() =>

--- a/apps/journeys-admin/src/components/UseTemplateDeepLink/UseTemplateDeepLink.spec.tsx
+++ b/apps/journeys-admin/src/components/UseTemplateDeepLink/UseTemplateDeepLink.spec.tsx
@@ -104,7 +104,9 @@ const languagesMock: MockedResponse = {
 
 const sourceJourneyId = 'template-id'
 
-function buildJourneyMock(): MockedResponse {
+function buildJourneyMock(
+  options: { customizable?: boolean | null } = {}
+): MockedResponse {
   return {
     request: {
       query: GET_JOURNEY,
@@ -121,6 +123,7 @@ function buildJourneyMock(): MockedResponse {
           id: sourceJourneyId,
           title: 'Sample Template',
           template: true,
+          customizable: options.customizable ?? false,
           fromTemplateId: null,
           language: {
             __typename: 'Language',
@@ -231,6 +234,7 @@ interface SetupOptions {
   useTemplate?: string | string[] | null
   duplicateError?: boolean
   includeJourneyMock?: boolean
+  customizable?: boolean | null
   translationError?: boolean
   push?: Mock
   replace?: Mock
@@ -261,7 +265,11 @@ function setup(options: SetupOptions = {}): {
       { shouldError: options.duplicateError }
     )
   ]
-  if (options.includeJourneyMock !== false) mocks.push(buildJourneyMock())
+  if (options.includeJourneyMock !== false) {
+    mocks.push(
+      buildJourneyMock({ customizable: options.customizable ?? false })
+    )
+  }
   if (options.translationError != null) {
     mocks.push(
       buildTranslateSubscriptionMock({ shouldError: options.translationError })
@@ -322,6 +330,17 @@ describe('UseTemplateDeepLink', () => {
     await waitFor(() =>
       expect(screen.getByTestId('CopyToTeamDialog')).toBeInTheDocument()
     )
+  })
+
+  it('redirects customizable templates to the customize flow', async () => {
+    const { push, replace } = setup({ customizable: true })
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith(
+        `/templates/${sourceJourneyId}/customize`
+      )
+    )
+    expect(screen.queryByTestId('CopyToTeamDialog')).not.toBeInTheDocument()
+    expect(push).not.toHaveBeenCalled()
   })
 
   it('duplicates the journey and replaces the URL with /?type=journeys&refresh=true', async () => {

--- a/apps/journeys-admin/src/components/UseTemplateDeepLink/UseTemplateDeepLink.tsx
+++ b/apps/journeys-admin/src/components/UseTemplateDeepLink/UseTemplateDeepLink.tsx
@@ -1,3 +1,5 @@
+import Backdrop from '@mui/material/Backdrop'
+import CircularProgress from '@mui/material/CircularProgress'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next/pages'
 import { useSnackbar } from 'notistack'
@@ -95,7 +97,7 @@ function ActiveUseTemplateDeepLink({
     // Full navigation — not shallow. Shallow routing only applies to query
     // changes on the *same* page; using it across pathnames skips
     // getServerSideProps and surfaces a 404 on /templates/[journeyId]/customize.
-    void router.replace(`/templates/${journeyId}/customize`)
+    void router.replace(`/templates/${encodeURIComponent(journeyId)}/customize`)
   }, [journeyLoading, isCustomizable, journeyId, router])
 
   useEffect(() => {
@@ -255,7 +257,20 @@ function ActiveUseTemplateDeepLink({
     stripParamFromUrl()
   }, [loading, translationVariables, stripParamFromUrl])
 
-  if (journeyLoading || isCustomizable) return null
+  // Deep links land here directly, so show a blocking spinner instead of a
+  // blank page while we decide between the dialog and the customize redirect
+  // (and while the redirect itself is in flight).
+  if (journeyLoading || isCustomizable) {
+    return (
+      <Backdrop
+        open
+        data-testid="UseTemplateDeepLinkLoading"
+        sx={{ zIndex: (theme) => theme.zIndex.modal }}
+      >
+        <CircularProgress sx={{ color: 'common.white' }} />
+      </Backdrop>
+    )
+  }
 
   return (
     <CopyToTeamDialog

--- a/apps/journeys-admin/src/components/UseTemplateDeepLink/UseTemplateDeepLink.tsx
+++ b/apps/journeys-admin/src/components/UseTemplateDeepLink/UseTemplateDeepLink.tsx
@@ -53,7 +53,7 @@ interface ActiveUseTemplateDeepLinkProps {
 
 function ActiveUseTemplateDeepLink({
   journeyId
-}: ActiveUseTemplateDeepLinkProps): ReactElement {
+}: ActiveUseTemplateDeepLinkProps): ReactElement | null {
   const { t } = useTranslation('apps-journeys-admin')
   const { enqueueSnackbar } = useSnackbar()
   const router = useRouter()

--- a/apps/journeys-admin/src/components/UseTemplateDeepLink/UseTemplateDeepLink.tsx
+++ b/apps/journeys-admin/src/components/UseTemplateDeepLink/UseTemplateDeepLink.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next/pages'
 import { useSnackbar } from 'notistack'
-import { ReactElement, useCallback, useRef, useState } from 'react'
+import { ReactElement, useCallback, useEffect, useRef, useState } from 'react'
 
 import { CopyToTeamDialog } from '@core/journeys/ui/CopyToTeamDialog'
 import { useJourneyAiTranslateSubscription } from '@core/journeys/ui/useJourneyAiTranslateSubscription'
@@ -62,7 +62,7 @@ function ActiveUseTemplateDeepLink({
   // (NES-1636) — see onComplete below.
   const updateTeamState = useUpdateActiveTeam()
 
-  const [open, setOpen] = useState(true)
+  const [open, setOpen] = useState(false)
   const [loading, setLoading] = useState(false)
   const [translationVariables, setTranslationVariables] = useState<
     TranslationVariables | undefined
@@ -78,12 +78,30 @@ function ActiveUseTemplateDeepLink({
   // across deep-link sessions.
   const navigatedAwayRef = useRef(false)
 
-  const { data: journeyData } = useJourneyQuery({
+  const { data: journeyData, loading: journeyLoading } = useJourneyQuery({
     id: journeyId,
     idType: IdType.databaseId,
     options: { skipRoutingFilter: true }
   })
   const journey = journeyData?.journey
+
+  const isCustomizable = journey?.customizable === true
+
+  // Customizable templates skip the copy-to-team dialog and enter the guided
+  // customization flow — matching TemplateActionButton on the template page.
+  useEffect(() => {
+    if (journeyLoading || !isCustomizable) return
+    navigatedAwayRef.current = true
+    // Full navigation — not shallow. Shallow routing only applies to query
+    // changes on the *same* page; using it across pathnames skips
+    // getServerSideProps and surfaces a 404 on /templates/[journeyId]/customize.
+    void router.replace(`/templates/${journeyId}/customize`)
+  }, [journeyLoading, isCustomizable, journeyId, router])
+
+  useEffect(() => {
+    if (journeyLoading || isCustomizable) return
+    setOpen(true)
+  }, [journeyLoading, isCustomizable])
 
   const [journeyDuplicate] = useJourneyDuplicateMutation()
 
@@ -236,6 +254,8 @@ function ActiveUseTemplateDeepLink({
     }
     stripParamFromUrl()
   }, [loading, translationVariables, stripParamFromUrl])
+
+  if (journeyLoading || isCustomizable) return null
 
   return (
     <CopyToTeamDialog

--- a/apps/journeys-admin/src/components/UseTemplateDeepLink/UseTemplateDeepLink.tsx
+++ b/apps/journeys-admin/src/components/UseTemplateDeepLink/UseTemplateDeepLink.tsx
@@ -55,7 +55,7 @@ interface ActiveUseTemplateDeepLinkProps {
 
 function ActiveUseTemplateDeepLink({
   journeyId
-}: ActiveUseTemplateDeepLinkProps): ReactElement | null {
+}: ActiveUseTemplateDeepLinkProps): ReactElement {
   const { t } = useTranslation('apps-journeys-admin')
   const { enqueueSnackbar } = useSnackbar()
   const router = useRouter()

--- a/apps/journeys/src/components/TemplateGalleryView/TemplateGalleryView.spec.tsx
+++ b/apps/journeys/src/components/TemplateGalleryView/TemplateGalleryView.spec.tsx
@@ -27,6 +27,20 @@ describe('TemplateGalleryView', () => {
     )
   })
 
+  it('links customizable templates into the customize flow', () => {
+    render(
+      <TemplateGalleryView
+        gallery={makeGallery({
+          templates: [{ ...mockTemplate, customizable: true }]
+        })}
+      />
+    )
+    expect(screen.getByTestId('GalleryTemplateCardUseButton')).toHaveAttribute(
+      'href',
+      'https://admin.nextstep.is/templates/template-1/customize'
+    )
+  })
+
   it('maps link media into the media section', () => {
     render(
       <TemplateGalleryView

--- a/apps/journeys/src/components/TemplateGalleryView/TemplateGalleryView.tsx
+++ b/apps/journeys/src/components/TemplateGalleryView/TemplateGalleryView.tsx
@@ -50,6 +50,7 @@ function toData(gallery: TemplateGalleryPage): PublicGalleryPageData {
       title: template.title,
       description: template.description,
       slug: template.slug,
+      customizable: template.customizable,
       // String-coerce defensively: if Apollo ever returns a custom DateTime
       // scalar or a Date here, parseISO downstream silently yields Invalid
       // Date and the meta line drops the date without warning.

--- a/libs/journeys/ui/src/components/PublicGalleryPage/JourneyView/FeaturedRow.tsx
+++ b/libs/journeys/ui/src/components/PublicGalleryPage/JourneyView/FeaturedRow.tsx
@@ -160,6 +160,7 @@ export function FeaturedRow({
           <Box sx={{ pt: 1 }}>
             <JourneyViewCardActions
               itemId={item.id}
+              customizable={item.customizable}
               itemTitle={item.title}
               itemSlug={item.slug}
               fullWidth="responsive"

--- a/libs/journeys/ui/src/components/PublicGalleryPage/JourneyView/JourneyViewCard.tsx
+++ b/libs/journeys/ui/src/components/PublicGalleryPage/JourneyView/JourneyViewCard.tsx
@@ -139,6 +139,7 @@ export function JourneyViewCard({
           <Box sx={{ pt: 1, mt: 'auto' }}>
             <JourneyViewCardActions
               itemId={item.id}
+              customizable={item.customizable}
               itemTitle={item.title}
               itemSlug={item.slug}
               fullWidth
@@ -221,6 +222,7 @@ export function JourneyViewCard({
 
       <JourneyViewCardActions
         itemId={item.id}
+        customizable={item.customizable}
         itemTitle={item.title}
         itemSlug={item.slug}
         fullWidth

--- a/libs/journeys/ui/src/components/PublicGalleryPage/JourneyView/JourneyViewCardActions.tsx
+++ b/libs/journeys/ui/src/components/PublicGalleryPage/JourneyView/JourneyViewCardActions.tsx
@@ -9,6 +9,10 @@ import { ReactElement } from 'react'
 import Play3Icon from '@core/shared/ui/icons/Play3'
 
 import {
+  buildCustomizeHref,
+  buildUseTemplateHref
+} from '../../../libs/adminTemplateLinks'
+import {
   GALLERY_ACTION_COLOR,
   GALLERY_ACTION_SIZE,
   GALLERY_USE_BUTTON_MIN_WIDTH
@@ -52,48 +56,6 @@ interface JourneyViewCardActionsProps {
    * link or focus target.
    */
   decorative?: boolean
-}
-
-/**
- * Normalise `NEXT_PUBLIC_JOURNEYS_ADMIN_URL` into an absolute https base.
- * Guards against schemeless values (e.g. `admin.staging.local`) which would
- * otherwise throw inside `new URL` and crash the page at render.
- */
-function sanitiseAdminBase(adminUrl: string): string {
-  try {
-    return new URL('/', adminUrl).origin
-  } catch {
-    const sanitised = adminUrl.trim().replace(/^\/+/, '').replace(/\/+$/, '')
-    return `https://${sanitised}`
-  }
-}
-
-/**
- * Build the admin "Use Template" deep link (`/?useTemplate=<id>`).
- */
-function buildUseTemplateHref(adminUrl: string, itemId: string): string {
-  try {
-    const url = new URL('/', adminUrl)
-    url.searchParams.set('useTemplate', itemId)
-    return url.toString()
-  } catch {
-    return `${sanitiseAdminBase(adminUrl)}/?useTemplate=${encodeURIComponent(itemId)}`
-  }
-}
-
-/**
- * Build the admin template customization entry point. Customizable templates
- * skip the "Copy to team" dialog and land directly in the guided editor.
- */
-function buildCustomizeHref(adminUrl: string, itemId: string): string {
-  try {
-    return new URL(
-      `/templates/${encodeURIComponent(itemId)}/customize`,
-      adminUrl
-    ).toString()
-  } catch {
-    return `${sanitiseAdminBase(adminUrl)}/templates/${encodeURIComponent(itemId)}/customize`
-  }
 }
 
 function buildUseHref(

--- a/libs/journeys/ui/src/components/PublicGalleryPage/JourneyView/JourneyViewCardActions.tsx
+++ b/libs/journeys/ui/src/components/PublicGalleryPage/JourneyView/JourneyViewCardActions.tsx
@@ -17,6 +17,8 @@ import {
 interface JourneyViewCardActionsProps {
   /** Template id used in the admin "Use Template" deep link. */
   itemId: string
+  /** When true, link into the customize flow instead of the copy-to-team deep link. */
+  customizable?: boolean | null
   /**
    * Template title — used to disambiguate the Use/Preview controls on a page
    * with many cards (every card otherwise has an identical "Use"/"Preview"
@@ -53,13 +55,21 @@ interface JourneyViewCardActionsProps {
 }
 
 /**
- * Build the admin "Use Template" deep link, guarding against a schemeless
- * `NEXT_PUBLIC_JOURNEYS_ADMIN_URL` value (e.g. `admin.staging.local`) which
- * would otherwise throw inside `new URL` and crash the page at render.
- * In the fallback path we re-prepend `https://` so the resulting href is an
- * absolute URL — without the scheme, the browser resolves it as a relative
- * path against the current host (`https://gallery.host/admin.staging.local/...`)
- * instead of navigating to the admin app.
+ * Normalise `NEXT_PUBLIC_JOURNEYS_ADMIN_URL` into an absolute https base.
+ * Guards against schemeless values (e.g. `admin.staging.local`) which would
+ * otherwise throw inside `new URL` and crash the page at render.
+ */
+function sanitiseAdminBase(adminUrl: string): string {
+  try {
+    return new URL('/', adminUrl).origin
+  } catch {
+    const sanitised = adminUrl.trim().replace(/^\/+/, '').replace(/\/+$/, '')
+    return `https://${sanitised}`
+  }
+}
+
+/**
+ * Build the admin "Use Template" deep link (`/?useTemplate=<id>`).
  */
 function buildUseTemplateHref(adminUrl: string, itemId: string): string {
   try {
@@ -67,19 +77,39 @@ function buildUseTemplateHref(adminUrl: string, itemId: string): string {
     url.searchParams.set('useTemplate', itemId)
     return url.toString()
   } catch {
-    // Trim whitespace before stripping `/` so a misconfigured env var with
-    // padding still produces a parsable URL — `https://  admin.local  /...`
-    // would be rejected by the browser; `https://admin.local/...` works.
-    const sanitisedBase = adminUrl
-      .trim()
-      .replace(/^\/+/, '')
-      .replace(/\/+$/, '')
-    return `https://${sanitisedBase}/?useTemplate=${encodeURIComponent(itemId)}`
+    return `${sanitiseAdminBase(adminUrl)}/?useTemplate=${encodeURIComponent(itemId)}`
   }
+}
+
+/**
+ * Build the admin template customization entry point. Customizable templates
+ * skip the "Copy to team" dialog and land directly in the guided editor.
+ */
+function buildCustomizeHref(adminUrl: string, itemId: string): string {
+  try {
+    return new URL(
+      `/templates/${encodeURIComponent(itemId)}/customize`,
+      adminUrl
+    ).toString()
+  } catch {
+    return `${sanitiseAdminBase(adminUrl)}/templates/${encodeURIComponent(itemId)}/customize`
+  }
+}
+
+function buildUseHref(
+  adminUrl: string,
+  itemId: string,
+  customizable?: boolean | null
+): string {
+  if (customizable === true) {
+    return buildCustomizeHref(adminUrl, itemId)
+  }
+  return buildUseTemplateHref(adminUrl, itemId)
 }
 
 export function JourneyViewCardActions({
   itemId,
+  customizable,
   itemTitle,
   itemSlug,
   fullWidth = false,
@@ -157,7 +187,7 @@ export function JourneyViewCardActions({
   // and the URL searchParams handle encoding the template id. Fall back to a
   // sanitised template string if the env var is ever a schemeless value
   // (e.g. `admin.staging.local`) — `new URL` would throw and crash render.
-  const useTemplateHref = buildUseTemplateHref(adminUrl, itemId)
+  const useTemplateHref = buildUseHref(adminUrl, itemId, customizable)
   // Public viewer route on the same root domain; the journeys middleware
   // rewrites `/<slug>` → `/home/<slug>`.
   const previewHref = `/${itemSlug}`

--- a/libs/journeys/ui/src/components/PublicGalleryPage/PublicGalleryPage.spec.tsx
+++ b/libs/journeys/ui/src/components/PublicGalleryPage/PublicGalleryPage.spec.tsx
@@ -266,7 +266,7 @@ describe('PublicGalleryPage', () => {
 
       it('falls back to an absolute https:// href when the env value is schemeless', () => {
         // `new URL('/', 'admin.staging.local')` throws because the base isn't a
-        // valid absolute URL. The guard in buildUseTemplateHref catches it and
+        // valid absolute URL. The guard in buildUseHref catches it and
         // hand-builds the href with an `https://` scheme so the browser resolves
         // it as an absolute URL — without the scheme it would otherwise be
         // treated as a path relative to the current host.
@@ -282,6 +282,19 @@ describe('PublicGalleryPage', () => {
         ).toHaveAttribute(
           'href',
           'https://admin.staging.local/?useTemplate=template-0'
+        )
+      })
+
+      it('links customizable templates into the customize flow', () => {
+        const items = [{ ...mockItem, id: 'custom-tmpl', customizable: true }]
+        render(
+          <PublicGalleryPage variant="journey" data={makeData({ items })} />
+        )
+        expect(
+          screen.getAllByTestId('GalleryTemplateCardUseButton')[0]
+        ).toHaveAttribute(
+          'href',
+          'https://admin.nextstep.is/templates/custom-tmpl/customize'
         )
       })
     })

--- a/libs/journeys/ui/src/components/PublicGalleryPage/galleryTokens.ts
+++ b/libs/journeys/ui/src/components/PublicGalleryPage/galleryTokens.ts
@@ -93,6 +93,11 @@ export interface PublicGalleryPageItem {
   title: string
   description?: string | null
   slug: string
+  /**
+   * When true, the "Use" action opens the template customization flow
+   * instead of the admin "Copy to team" deep link.
+   */
+  customizable?: boolean | null
   /** ISO timestamp; used to derive the "Month Year" meta label. */
   createdAt?: string | null
   /** Language name entries (primary + local) used for the meta label. */

--- a/libs/journeys/ui/src/components/TemplateView/TemplateFooter/TemplateFooter.spec.tsx
+++ b/libs/journeys/ui/src/components/TemplateView/TemplateFooter/TemplateFooter.spec.tsx
@@ -78,11 +78,7 @@ describe('TemplateFooter', () => {
     fireEvent.click(getByRole('button', { name: 'Use This Template' }))
 
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith(
-        '/templates/journeyId/customize',
-        undefined,
-        { shallow: true }
-      )
+      expect(push).toHaveBeenCalledWith('/templates/journeyId/customize')
     })
   })
 

--- a/libs/journeys/ui/src/components/TemplateView/TemplateViewHeader/TemplateActionButton/TemplateActionButton.spec.tsx
+++ b/libs/journeys/ui/src/components/TemplateView/TemplateViewHeader/TemplateActionButton/TemplateActionButton.spec.tsx
@@ -183,9 +183,7 @@ describe('TemplateActionButton', () => {
 
       await waitFor(() => {
         expect(mockUseRouter().push).toHaveBeenCalledWith(
-          `/templates/${journey.id}/customize`,
-          undefined,
-          { shallow: true }
+          `/templates/${journey.id}/customize`
         )
       })
     })
@@ -314,9 +312,7 @@ describe('TemplateActionButton', () => {
 
       await waitFor(() => {
         expect(mockUseRouter().push).toHaveBeenCalledWith(
-          `/templates/${customizableTemplateJourney.id}/customize`,
-          undefined,
-          { shallow: true }
+          `/templates/${customizableTemplateJourney.id}/customize`
         )
       })
     })

--- a/libs/journeys/ui/src/components/TemplateView/TemplateViewHeader/TemplateViewHeader.spec.tsx
+++ b/libs/journeys/ui/src/components/TemplateView/TemplateViewHeader/TemplateViewHeader.spec.tsx
@@ -348,11 +348,7 @@ describe('TemplateViewHeader', () => {
     fireEvent.click(getAllByRole('button', { name: 'Use This Template' })[0])
 
     await waitFor(() => {
-      expect(push).toHaveBeenCalledWith(
-        '/templates/journeyId/customize',
-        undefined,
-        { shallow: true }
-      )
+      expect(push).toHaveBeenCalledWith('/templates/journeyId/customize')
     })
   })
 

--- a/libs/journeys/ui/src/components/TemplateView/UseThisTemplateButton/UseThisTemplateButton.spec.tsx
+++ b/libs/journeys/ui/src/components/TemplateView/UseThisTemplateButton/UseThisTemplateButton.spec.tsx
@@ -121,11 +121,7 @@ describe('UseThisTemplateButton', () => {
         )
 
         await waitFor(() => {
-          expect(push).toHaveBeenCalledWith(
-            `/templates/${journeyId}/customize`,
-            undefined,
-            { shallow: true }
-          )
+          expect(push).toHaveBeenCalledWith(`/templates/${journeyId}/customize`)
         })
       })
 
@@ -177,11 +173,7 @@ describe('UseThisTemplateButton', () => {
           expect(screen.getByRole('progressbar')).toBeInTheDocument()
         })
         await waitFor(() => {
-          expect(push).toHaveBeenCalledWith(
-            `/templates/${journeyId}/customize`,
-            undefined,
-            { shallow: true }
-          )
+          expect(push).toHaveBeenCalledWith(`/templates/${journeyId}/customize`)
         })
       })
     })

--- a/libs/journeys/ui/src/components/TemplateView/UseThisTemplateButton/UseThisTemplateButton.spec.tsx
+++ b/libs/journeys/ui/src/components/TemplateView/UseThisTemplateButton/UseThisTemplateButton.spec.tsx
@@ -205,11 +205,7 @@ describe('UseThisTemplateButton', () => {
 
       afterEach(() => {
         if (originalLocationDescriptor != null) {
-          Object.defineProperty(
-            window,
-            'location',
-            originalLocationDescriptor
-          )
+          Object.defineProperty(window, 'location', originalLocationDescriptor)
         }
         process.env = originalEnv
       })

--- a/libs/journeys/ui/src/components/TemplateView/UseThisTemplateButton/UseThisTemplateButton.spec.tsx
+++ b/libs/journeys/ui/src/components/TemplateView/UseThisTemplateButton/UseThisTemplateButton.spec.tsx
@@ -178,6 +178,125 @@ describe('UseThisTemplateButton', () => {
       })
     })
 
+    describe('when signed in and rendered outside journeys-admin', () => {
+      // jsdom marks Location members unforgeable (assign is own,
+      // non-configurable, non-writable), so the only way to observe the
+      // cross-app hand-off is to swap the whole window.location object —
+      // the window property itself is configurable.
+      const originalLocationDescriptor = Object.getOwnPropertyDescriptor(
+        window,
+        'location'
+      )
+      const assign = vi.fn()
+
+      beforeEach(() => {
+        mockUseRouter.mockReturnValue({
+          prefetch,
+          push,
+          query: { createNew: false }
+        } as unknown as NextRouter)
+
+        Object.defineProperty(window, 'location', {
+          configurable: true,
+          enumerable: false,
+          value: { ...window.location, assign }
+        })
+      })
+
+      afterEach(() => {
+        if (originalLocationDescriptor != null) {
+          Object.defineProperty(
+            window,
+            'location',
+            originalLocationDescriptor
+          )
+        }
+        process.env = originalEnv
+      })
+
+      it('hands off to the admin app when the env origin differs', async () => {
+        const journeyId = customizableTemplateJourney?.id ?? journey?.id ?? ''
+        process.env = {
+          ...originalEnv,
+          NEXT_PUBLIC_JOURNEYS_ADMIN_URL: 'https://admin.example.com'
+        }
+
+        render(
+          <JourneyProvider value={{ journey }}>
+            <UseThisTemplateButton
+              signedIn
+              journeyId={customizableTemplateJourney?.id}
+            />
+          </JourneyProvider>
+        )
+
+        fireEvent.click(
+          screen.getByRole('button', { name: 'Use This Template' })
+        )
+
+        await waitFor(() => {
+          expect(assign).toHaveBeenCalledWith(
+            `https://admin.example.com/templates/${journeyId}/customize`
+          )
+        })
+        expect(push).not.toHaveBeenCalled()
+      })
+
+      it('re-prepends https:// when the env value is schemeless', async () => {
+        const journeyId = customizableTemplateJourney?.id ?? journey?.id ?? ''
+        process.env = {
+          ...originalEnv,
+          NEXT_PUBLIC_JOURNEYS_ADMIN_URL: 'admin.example.com'
+        }
+
+        render(
+          <JourneyProvider value={{ journey }}>
+            <UseThisTemplateButton
+              signedIn
+              journeyId={customizableTemplateJourney?.id}
+            />
+          </JourneyProvider>
+        )
+
+        fireEvent.click(
+          screen.getByRole('button', { name: 'Use This Template' })
+        )
+
+        await waitFor(() => {
+          expect(assign).toHaveBeenCalledWith(
+            `https://admin.example.com/templates/${journeyId}/customize`
+          )
+        })
+        expect(push).not.toHaveBeenCalled()
+      })
+
+      it('navigates in-app when the env origin matches', async () => {
+        const journeyId = customizableTemplateJourney?.id ?? journey?.id ?? ''
+        process.env = {
+          ...originalEnv,
+          NEXT_PUBLIC_JOURNEYS_ADMIN_URL: window.location.origin
+        }
+
+        render(
+          <JourneyProvider value={{ journey }}>
+            <UseThisTemplateButton
+              signedIn
+              journeyId={customizableTemplateJourney?.id}
+            />
+          </JourneyProvider>
+        )
+
+        fireEvent.click(
+          screen.getByRole('button', { name: 'Use This Template' })
+        )
+
+        await waitFor(() => {
+          expect(push).toHaveBeenCalledWith(`/templates/${journeyId}/customize`)
+        })
+        expect(assign).not.toHaveBeenCalled()
+      })
+    })
+
     describe('when not signed in', () => {
       beforeEach(() => {
         mockUseRouter.mockReturnValue({

--- a/libs/journeys/ui/src/components/TemplateView/UseThisTemplateButton/UseThisTemplateButton.tsx
+++ b/libs/journeys/ui/src/components/TemplateView/UseThisTemplateButton/UseThisTemplateButton.tsx
@@ -10,6 +10,10 @@ import { type ReactElement, useEffect, useState } from 'react'
 import { useFlags } from '@core/shared/ui/FlagsProvider'
 import LayoutTopIcon from '@core/shared/ui/icons/LayoutTop'
 
+import {
+  buildCustomizeHref,
+  sanitiseAdminBase
+} from '../../../libs/adminTemplateLinks'
 import { useJourney } from '../../../libs/JourneyProvider'
 import { JourneyFields } from '../../../libs/JourneyProvider/__generated__/JourneyFields'
 import { AccountCheckDialog } from '../AccountCheckDialog'
@@ -35,32 +39,24 @@ export function UseThisTemplateButton({
   const [loading, setLoading] = useState(false)
 
   async function handleCustomizeNavigation(): Promise<void> {
-    const customizePath = `/templates/${journeyDataId ?? ''}/customize`
-    const adminBase =
-      process.env.NEXT_PUBLIC_JOURNEYS_ADMIN_URL ??
-      (typeof window !== 'undefined'
-        ? window.location.origin
-        : 'https://admin.nextstep.is')
+    const adminBase = process.env.NEXT_PUBLIC_JOURNEYS_ADMIN_URL
 
-    const onAdminApp =
-      typeof window !== 'undefined' &&
-      (() => {
-        try {
-          return new URL(adminBase).origin === window.location.origin
-        } catch {
-          return window.location.origin.includes(adminBase.replace(/^\/+/, ''))
-        }
-      })()
-
-    if (onAdminApp) {
+    if (
+      adminBase == null ||
+      typeof window === 'undefined' ||
+      sanitiseAdminBase(adminBase) === window.location.origin
+    ) {
       // Full navigation — shallow routing is only valid for query changes on
       // the same page, not for crossing into /templates/[journeyId]/customize.
-      void router.push(customizePath)
+      void router.push(`/templates/${journeyDataId ?? ''}/customize`)
       return
     }
 
-    const sanitizedBase = adminBase.replace(/\/+$/, '')
-    window.location.assign(`${sanitizedBase}${customizePath}`)
+    // Rendered outside journeys-admin (e.g. resources): hand off to the admin
+    // app with an absolute href — buildCustomizeHref re-prepends https:// for
+    // schemeless env values so the browser doesn't resolve the target as a
+    // path relative to the current host.
+    window.location.assign(buildCustomizeHref(adminBase, journeyDataId ?? ''))
   }
 
   const handleCheckSignIn = async (): Promise<void> => {

--- a/libs/journeys/ui/src/components/TemplateView/UseThisTemplateButton/UseThisTemplateButton.tsx
+++ b/libs/journeys/ui/src/components/TemplateView/UseThisTemplateButton/UseThisTemplateButton.tsx
@@ -35,9 +35,32 @@ export function UseThisTemplateButton({
   const [loading, setLoading] = useState(false)
 
   async function handleCustomizeNavigation(): Promise<void> {
-    void router.push(`/templates/${journeyDataId ?? ''}/customize`, undefined, {
-      shallow: true
-    })
+    const customizePath = `/templates/${journeyDataId ?? ''}/customize`
+    const adminBase =
+      process.env.NEXT_PUBLIC_JOURNEYS_ADMIN_URL ??
+      (typeof window !== 'undefined'
+        ? window.location.origin
+        : 'https://admin.nextstep.is')
+
+    const onAdminApp =
+      typeof window !== 'undefined' &&
+      (() => {
+        try {
+          return new URL(adminBase).origin === window.location.origin
+        } catch {
+          return window.location.origin.includes(adminBase.replace(/^\/+/, ''))
+        }
+      })()
+
+    if (onAdminApp) {
+      // Full navigation — shallow routing is only valid for query changes on
+      // the same page, not for crossing into /templates/[journeyId]/customize.
+      void router.push(customizePath)
+      return
+    }
+
+    const sanitizedBase = adminBase.replace(/\/+$/, '')
+    window.location.assign(`${sanitizedBase}${customizePath}`)
   }
 
   const handleCheckSignIn = async (): Promise<void> => {

--- a/libs/journeys/ui/src/libs/adminTemplateLinks/adminTemplateLinks.spec.ts
+++ b/libs/journeys/ui/src/libs/adminTemplateLinks/adminTemplateLinks.spec.ts
@@ -26,9 +26,9 @@ describe('sanitiseAdminBase', () => {
 
 describe('buildUseTemplateHref', () => {
   it('builds the deep link from a valid base', () => {
-    expect(buildUseTemplateHref('https://admin.nextstep.is', 'template-1')).toBe(
-      'https://admin.nextstep.is/?useTemplate=template-1'
-    )
+    expect(
+      buildUseTemplateHref('https://admin.nextstep.is', 'template-1')
+    ).toBe('https://admin.nextstep.is/?useTemplate=template-1')
   })
 
   it('falls back to an absolute https href for schemeless bases', () => {

--- a/libs/journeys/ui/src/libs/adminTemplateLinks/adminTemplateLinks.spec.ts
+++ b/libs/journeys/ui/src/libs/adminTemplateLinks/adminTemplateLinks.spec.ts
@@ -1,0 +1,59 @@
+import {
+  buildCustomizeHref,
+  buildUseTemplateHref,
+  sanitiseAdminBase
+} from './adminTemplateLinks'
+
+describe('sanitiseAdminBase', () => {
+  it('returns the origin of a valid absolute url', () => {
+    expect(sanitiseAdminBase('https://admin.nextstep.is/some/path')).toBe(
+      'https://admin.nextstep.is'
+    )
+  })
+
+  it('re-prepends https:// for schemeless values', () => {
+    expect(sanitiseAdminBase('admin.staging.local')).toBe(
+      'https://admin.staging.local'
+    )
+  })
+
+  it('trims whitespace and slashes in the fallback path', () => {
+    expect(sanitiseAdminBase('  admin.staging.local/  ')).toBe(
+      'https://admin.staging.local'
+    )
+  })
+})
+
+describe('buildUseTemplateHref', () => {
+  it('builds the deep link from a valid base', () => {
+    expect(buildUseTemplateHref('https://admin.nextstep.is', 'template-1')).toBe(
+      'https://admin.nextstep.is/?useTemplate=template-1'
+    )
+  })
+
+  it('falls back to an absolute https href for schemeless bases', () => {
+    expect(buildUseTemplateHref('admin.staging.local', 'template-1')).toBe(
+      'https://admin.staging.local/?useTemplate=template-1'
+    )
+  })
+})
+
+describe('buildCustomizeHref', () => {
+  it('builds the customize entry point from a valid base', () => {
+    expect(buildCustomizeHref('https://admin.nextstep.is', 'template-1')).toBe(
+      'https://admin.nextstep.is/templates/template-1/customize'
+    )
+  })
+
+  it('falls back to an absolute https href for schemeless bases', () => {
+    expect(buildCustomizeHref('admin.staging.local', 'template-1')).toBe(
+      'https://admin.staging.local/templates/template-1/customize'
+    )
+  })
+
+  it('encodes the journey id', () => {
+    expect(buildCustomizeHref('https://admin.nextstep.is', 'a/b')).toBe(
+      'https://admin.nextstep.is/templates/a%2Fb/customize'
+    )
+  })
+})

--- a/libs/journeys/ui/src/libs/adminTemplateLinks/adminTemplateLinks.ts
+++ b/libs/journeys/ui/src/libs/adminTemplateLinks/adminTemplateLinks.ts
@@ -1,0 +1,56 @@
+/**
+ * Normalise a configured admin URL (`NEXT_PUBLIC_JOURNEYS_ADMIN_URL`) into an
+ * absolute https base. Guards against schemeless values (e.g.
+ * `admin.staging.local`) which would otherwise throw inside `new URL` and
+ * crash the page at render. In the fallback path we re-prepend `https://` so
+ * the resulting href is an absolute URL — without the scheme, the browser
+ * resolves it as a relative path against the current host
+ * (`https://gallery.host/admin.staging.local/...`) instead of navigating to
+ * the admin app.
+ */
+export function sanitiseAdminBase(adminUrl: string): string {
+  try {
+    return new URL('/', adminUrl).origin
+  } catch {
+    // Trim whitespace before stripping `/` so a misconfigured env var with
+    // padding still produces a parsable URL — `https://  admin.local  /...`
+    // would be rejected by the browser; `https://admin.local/...` works.
+    const sanitised = adminUrl.trim().replace(/^\/+/, '').replace(/\/+$/, '')
+    return `https://${sanitised}`
+  }
+}
+
+/**
+ * Build the admin "Use Template" deep link (`/?useTemplate=<id>`).
+ */
+export function buildUseTemplateHref(
+  adminUrl: string,
+  journeyId: string
+): string {
+  try {
+    const url = new URL('/', adminUrl)
+    url.searchParams.set('useTemplate', journeyId)
+    return url.toString()
+  } catch {
+    return `${sanitiseAdminBase(adminUrl)}/?useTemplate=${encodeURIComponent(journeyId)}`
+  }
+}
+
+/**
+ * Build the admin template customization entry point
+ * (`/templates/<id>/customize`). Customizable templates skip the
+ * "Copy to team" dialog and land directly in the guided editor.
+ */
+export function buildCustomizeHref(
+  adminUrl: string,
+  journeyId: string
+): string {
+  try {
+    return new URL(
+      `/templates/${encodeURIComponent(journeyId)}/customize`,
+      adminUrl
+    ).toString()
+  } catch {
+    return `${sanitiseAdminBase(adminUrl)}/templates/${encodeURIComponent(journeyId)}/customize`
+  }
+}

--- a/libs/journeys/ui/src/libs/adminTemplateLinks/index.ts
+++ b/libs/journeys/ui/src/libs/adminTemplateLinks/index.ts
@@ -1,0 +1,5 @@
+export {
+  buildCustomizeHref,
+  buildUseTemplateHref,
+  sanitiseAdminBase
+} from './adminTemplateLinks'


### PR DESCRIPTION
Open customize flow for customizable templates from Use button

Clicking "Use" on a customizable template in the public collection gallery now routes into the template customization flow instead of the admin "Copy to team" dialog, restoring the behavior from the previous system.

The admin deep-link handler also redirects customizable templates to /templates/[journeyId]/customize, and cross-page navigations no longer use shallow routing, which previously skipped getServerSideProps and surfaced 404s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Templates marked as **customizable** now route to the guided customization flow (e.g., `/templates/<id>/customize`) across “Use” actions, public gallery cards, and admin previews.

* **Bug Fixes**
  * Improved customization navigation behavior: shows a loading overlay while determining the destination, then redirects appropriately for customizable vs non-customizable templates.
  * Updated navigation to avoid shallow in-app routing when handing off to the admin app and to correctly sanitize/construct admin URLs.

* **Tests**
  * Added/updated unit tests covering customizable routing and URL construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->