### PR TITLE
docs(context-map): add NextSteps bug-diagnosis intake layer (journeys-admin)

### DIFF
--- a/.agents/skills/diagnosing-bugs/SKILL.md
+++ b/.agents/skills/diagnosing-bugs/SKILL.md
@@ -9,6 +9,8 @@ A discipline for hard bugs. Skip phases only when explicitly justified.
 
 When exploring the codebase, read `CONTEXT.md` (if it exists) to get a clear mental model of the relevant modules, and check ADRs in the area you're touching.
 
+For a **reported bug**, also read the area's `CONTEXT-intake.md` (if present) — the diagnosis layer holding failure signatures, the question that localizes a report, and where to look first. Start from the `CONTEXT-MAP-intake.md` index: match the report's wording to an area's `trigger_phrases`, then open only that area's `CONTEXT-intake.md`. This feeds the diagnosis at the start of the loop rather than by luck, and the index-first fetch keeps context lean.
+
 ## Phase 1 — Build a feedback loop
 
 **This is the skill.** Everything else is mechanical. If you have a **tight** pass/fail signal for the bug — one that goes red on _this_ bug — you will find the cause; bisection, hypothesis-testing, and instrumentation all just consume it. If you don't have one, no amount of staring at code will save you.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,15 @@ The five canonical triage roles use their default label strings verbatim: `needs
 
 Multi-context: `CONTEXT-MAP.md` at the repo root points to per-workspace `CONTEXT.md` files (created lazily by `/domain-modeling`). See `docs/agents/domain.md`.
 
+### Bug-diagnosis layer
+
+Selected NextSteps areas add a `CONTEXT-intake.md` beside their `CONTEXT.md` — the diagnosis layer for reported bugs (failure signatures, the question that localizes a report, where to look first, tagged by failure type T1–T11).
+
+- Read `CONTEXT.md` to understand or build in an area.
+- Read `CONTEXT-intake.md` **only** when triaging or debugging a _reported bug_ in that area.
+
+Start from the intake index (`CONTEXT-MAP-intake.md`): match the reporter's words to an area's `trigger_phrases`, then open that area's `CONTEXT-intake.md`.
+
 ## Conventions
 
 This is an **Nx monorepo** (TypeScript). Apps live in `apps/`, GraphQL APIs in `apis/`, shared libraries in `libs/`, Cloudflare Workers in `workers/`, infrastructure in `infrastructure/`.

--- a/CONTEXT-MAP-intake.md
+++ b/CONTEXT-MAP-intake.md
@@ -1,0 +1,33 @@
+# Intake INDEX — bug-diagnosis retrieval entry point
+
+Always-in-context index for **diagnosing reported bugs** (distinct from the domain map in
+`CONTEXT-MAP.md`). One line per area: its domain file, its intake file, and the reporter
+trigger-phrases that route a report to it. The ENG-3707 accessor fetches an area's
+`CONTEXT-intake.md` on demand using this index; agents match a report's wording against
+`triggers`, then open that area's intake file.
+
+**Line format:** `area | domain: <path> | intake: <path> | triggers: …`
+
+## Areas (NextSteps)
+
+- **journeys-admin** | domain: `apps/journeys-admin/CONTEXT.md` | intake: `apps/journeys-admin/CONTEXT-intake.md` | triggers: "block won't save", "changes not showing in preview", "have to refresh", "can't translate into <language>", "template won't let me customize", "transfer ownership", "analytics numbers are wrong", "historical data disappeared"
+
+_Seeded with journeys-admin (ENG-3685). Remaining NextSteps areas — journeys (viewer),
+api-journeys, libs/journeys/ui — are added as their `CONTEXT-intake.md` files land._
+
+## Failure-type taxonomy (T1–T11)
+
+Referenced by intake entries. Canonical source: repo-root `AGENTS.md` (routing paragraph added by
+ENG-3686). Distilled from 2 years of #nextsteps-bugs history (AI Bug-Intake Playbook).
+
+- **T1** data-semantics / nullable-column / query-filter mismatch
+- **T2** auth / sign-in / session & redirect
+- **T3** analytics / event mapping & counting
+- **T4** cache / revalidation / stale page
+- **T5** client-side state sync / optimistic-update drift
+- **T6** rendering / visual / UI display
+- **T7** editor / canvas block-state
+- **T8** i18n / translation / language lists
+- **T9** template duplication / language-id collision — *resolved by removal (#9151); reports stale*
+- **T10** media / video / external-content pipeline
+- **T11** permissions / ACL / data-privacy

--- a/CONTEXT-MAP-intake.md
+++ b/CONTEXT-MAP-intake.md
@@ -30,6 +30,6 @@ ENG-3686). Distilled from 2 years of #nextsteps-bugs history (AI Bug-Intake Play
 - **T6** rendering / visual / UI display
 - **T7** editor / canvas block-state
 - **T8** i18n / translation / language lists
-- **T9** template duplication / language-id collision — *resolved by removal (#9151); reports stale*
+- **T9** template duplication / language-id collision — _resolved by removal (#9151); reports stale_
 - **T10** media / video / external-content pipeline
 - **T11** permissions / ACL / data-privacy

--- a/CONTEXT-MAP-intake.md
+++ b/CONTEXT-MAP-intake.md
@@ -10,10 +10,12 @@ trigger-phrases that route a report to it. The ENG-3707 accessor fetches an area
 
 ## Areas (NextSteps)
 
-- **journeys-admin** | domain: `apps/journeys-admin/CONTEXT.md` | intake: `apps/journeys-admin/CONTEXT-intake.md` | triggers: "block won't save", "changes not showing in preview", "have to refresh", "can't translate into <language>", "template won't let me customize", "transfer ownership", "analytics numbers are wrong", "historical data disappeared"
+- **journeys-admin** (creator/editor surface) | domain: `apps/journeys-admin/CONTEXT.md` | intake: `apps/journeys-admin/CONTEXT-intake.md` | triggers: "block won't save", "changes not showing in preview", "have to refresh", "can't translate into <language>", "template won't let me customize", "transfer ownership", "analytics numbers are wrong", "historical data disappeared"
+- **journeys (published viewer)** (audience surface) | domain: `apps/journeys/CONTEXT.md` | intake: `apps/journeys/CONTEXT-intake.md` | triggers: "button doesn't go to the next card", "goes to the wrong card", "video won't load", "video is slow", "image is cropped / wrong fit", "can't click / can't type on the card", "looks wrong when published", "custom domain / embed not working"
 
-_Seeded with journeys-admin (ENG-3685). Remaining NextSteps areas — journeys (viewer),
-api-journeys, libs/journeys/ui — are added as their `CONTEXT-intake.md` files land._
+_The two intake surfaces are where bugs are **reported** (creator editor, audience viewer). The
+backend (`api-journeys`) and shared kernel (`libs/journeys/ui`) are reached via each surface's
+"look first" pointers, not separate intake files — reporters don't file bugs against them directly._
 
 ## Failure-type taxonomy (T1–T11)
 

--- a/apps/journeys-admin/CONTEXT-intake.md
+++ b/apps/journeys-admin/CONTEXT-intake.md
@@ -59,9 +59,11 @@ looks off.
 it to count (raw events vs unique users), and — for template families — "are you 100% sure this is
 the only journey from that template?" (aggregate-vs-child mix-ups are common).
 **Heuristic:** an analytics discrepancy is almost always a **name/unit mismatch, not bad math.**
-**Look first (fixer):** TODO — the drop-off %, card-duration, and event-aggregation code in
-`api-journeys` analytics resolvers + the Plausible integration; the Analytics-Mode overlay in
-journeys-admin. (Code-dig pending.)
+**Look first (fixer):** drop-off % and time-on-card are computed **client-side** in
+`libs/journeys/ui/src/libs/useJourneyAnalyticsQuery/transformJourneyAnalytics/transformJourneyAnalytics.ts`
+(these are the numbers shown in reports); the underlying Plausible aggregates come from
+`apis/api-journeys/src/schema/plausible/journeysPlausibleStatsAggregate.query.ts` + `plausible/service.ts`;
+the event-sync worker is `apis/api-journeys/src/workers/plausible/service.ts`.
 **Handoff:** route to a human — not safe for autonomous fixing.
 
 ## Translation & language lists — T8 (largest historical cluster)
@@ -104,12 +106,18 @@ logo, menu) lives in **Journey Appearance** in the Drawer; the shared-on-social 
 Preview**; custom-domain / microwebsite settings live in the hosting/custom-domain settings.
 **Handoff:** how-to / FAQ.
 
-## Submit-button logic — FLAGGED (low confidence, needs a code dig)
+## Submit-button / action logic — FLAGGED (low frequency; signatures unconfirmed)
 **Signatures (suspected):** questions about how submit buttons behave — the action/logic wiring is
 complex on the code side.
-**Look first (fixer):** TODO — block Actions / TextResponseBlock / button-triggered navigation.
-(Code-dig pending; confirm the real confusion before writing this up.)
-**Handoff:** unknown until dug.
+**Mental model:** every button/submit is a block **Action**. The viewer dispatches them in
+`libs/journeys/ui/src/libs/action/action.ts` + `components/Actions/Actions.tsx` (resolves
+NavigateToBlock / link / email / phone); the text-answer submit is
+`libs/journeys/ui/src/components/TextResponse/TextResponse.tsx`.
+**Look first (fixer):** viewer dispatch → `libs/journeys/ui/src/libs/action/action.ts`,
+`components/Actions/Actions.tsx`; server action schema → `apis/api-journeys/src/schema/action/`
+(`navigateToBlockAction/`, `linkAction/`, …); editor-side edits →
+`apps/journeys-admin/src/components/Editor/utils/useActionCommand/` + `src/libs/useBlockAction*UpdateMutation/`.
+**Handoff:** navigation/dispatch defects → agent-able; "how does X action work" → how-to.
 
 ## Teams / access / ownership — T11 (ACL)
 **Signatures:** invite email not arriving; "requested access" not showing; confusion over who can
@@ -138,7 +146,10 @@ the single most diagnostic auth signal.
 ## Integrations — Google Sheets Sync live; Growth Spaces dormant
 **Google Sheets Sync (real):** recurring **auth** (OAuth) issues and **sync reliability** (rows not
 created / sync not running).
-- Look first (fixer): TODO — the Google OAuth connection + the sheets-sync job. (Code-dig pending.)
+- Look first (fixer): OAuth connection → `apis/api-journeys/src/schema/integration/google/`
+  (`googleCreate.mutation.ts`, `googleUpdate.mutation.ts`); the sync worker →
+  `apis/api-journeys/src/workers/googleSheetsSync/`; the row/header build + write-to-sheet →
+  `apis/api-journeys/src/schema/journeyVisitor/export/googleSheetsLiveSync.ts`.
 - Handoff: OAuth reconnect → often human; sync-job defects → agent-able.
 **Growth Spaces:** dormant — no recent reports, believed unused. Map stays thin; route to a human.
 

--- a/apps/journeys-admin/CONTEXT-intake.md
+++ b/apps/journeys-admin/CONTEXT-intake.md
@@ -1,0 +1,148 @@
+---
+area: journeys-admin
+domain_ref: ./CONTEXT.md
+code_paths:
+  - apps/journeys-admin/src/components/Editor/**
+  - apps/journeys-admin/src/components/JourneyList/**
+  - apps/journeys-admin/src/components/TemplateCustomization/**
+trigger_phrases:
+  - "block won't save"
+  - "changes not showing in preview"
+  - "have to refresh to see it"
+  - "can't translate into <language>"
+  - "template won't let me customize"
+  - "transfer ownership"
+  - "analytics numbers are wrong"
+  - "historical data disappeared"
+type_tags: [T1, T2, T3, T4, T5, T8, T11]
+updated: 2026-07-15
+---
+
+> Diagnosis layer for reported bugs in journeys-admin. Read this when triaging or debugging a
+> reported issue — not for feature work. Domain model: ./CONTEXT.md.
+> Failure types (T1–T11) reference the shared taxonomy in the repo-root AGENTS.md.
+> Each entry: what it looks like → the question that localizes it (reporter can answer) →
+> where the fixer looks first → whether it is safe for an autonomous agent.
+
+## Saving / preview / cache — T4 (cache) · T5 (optimistic drift)
+**Signatures:** a block edit doesn't save (most visible on typography, image, video blocks); an
+edit shows in the Editor but not on the journey preview; a newly-created block needs a refresh.
+**Localizing question (reporter): does a refresh fix it?**
+- refresh fixes it → cache bug (the manual Apollo cache update on block-create was wrong)
+- refresh doesn't fix it, the change is gone → it genuinely didn't save
+- saved, correct in the Editor, wrong only in preview → rendering bug, not here — see
+  `apps/journeys/CONTEXT-intake.md`
+**Look first (fixer):** Network tab → the block create/update mutation (did it fire? payload
+correct? error code?); if it fired cleanly but the UI is stale → the manual cache `update` in
+`Editor/utils/useBlockCreateCommand` and `Editor/utils/blockCreateUpdate`.
+**Handoff:** agent-able.
+
+## Data semantics / historical data disappearing — T1
+**Status:** quiet lately, but a latent structural risk — kept here *because* it is rare enough to
+forget. Any future migration can reintroduce it.
+**Signatures:** "all my historical X is gone, recent ones are fine," a list silently drops older
+rows — usually shortly after a schema change / migration.
+**Localizing question (reporter):** is it *all* the old data and only the old data (recent fine)?
+That "all-historical-vs-recent-fine" split is the tell.
+**Look first (fixer):** the recent migration + the query filter on the affected list. Classic cause:
+a new column is `NULL` on existing rows but the query filters `column = false/true`, and `NULL`
+matches neither in SQL, so old rows vanish.
+**Handoff:** agent-able (real backend defect when it occurs).
+
+## Analytics correctness — T3
+**Status:** known-fuzzy. Stats are **never** live/real-time; some mismatch is expected. Events get
+"squished/unsquished" over a time window (aggregation behavior). Not every discrepancy is a bug.
+**Signatures:** numbers don't add up (many arrive but few reach the first card; "this many clicked
+the button, why don't that many show on the next card?"), drop-off rate looks off, card-duration
+looks off.
+**Localizing question (reporter):** which surface (summary vs card analytics), what did you expect
+it to count (raw events vs unique users), and — for template families — "are you 100% sure this is
+the only journey from that template?" (aggregate-vs-child mix-ups are common).
+**Heuristic:** an analytics discrepancy is almost always a **name/unit mismatch, not bad math.**
+**Look first (fixer):** TODO — the drop-off %, card-duration, and event-aggregation code in
+`api-journeys` analytics resolvers + the Plausible integration; the Analytics-Mode overlay in
+journeys-admin. (Code-dig pending.)
+**Handoff:** route to a human — not safe for autonomous fixing.
+
+## Translation & language lists — T8 (largest historical cluster)
+**Signatures:** "can't translate into X"; text not translated, or translated incorrectly.
+**Disambiguate FIRST — there are four different language lists (constantly conflated):**
+- builder = the full language library (`libs/journeys/ui/src/libs/useLanguagesQuery`, `limit: 5000`,
+  narrowed per screen by a `where` filter)
+- AI-translation = the hardcoded allowlist `SUPPORTED_LANGUAGE_IDS` (currently 58) in
+  `libs/journeys/ui/src/libs/useJourneyAiTranslateSubscription/supportedLanguages.ts`
+- website / UI strings = Crowdin
+- template-gallery filter = the gallery's own list
+**Localizing question (reporter):** is the wrong/missing text the *journey's own content* (blocks,
+titles) or the *app's UI/labels*? And which language?
+**Look first (fixer):** content translation → `apis/api-journeys/.../journeyAiTranslate.ts` +
+`translateCustomizationFields`. "Can't translate into language X" is usually X not being in
+`SUPPORTED_LANGUAGE_IDS` — the fix is often just adding the ID.
+**Handoff:** allowlist gap → agent-able; translation *quality* → human.
+**Stale-report note:** the old same-language-id duplication collision (T9) was resolved by removal
+in #9151 (child translation templates deleted). Do **not** diagnose new duplication issues as that
+class; those reports are stale.
+
+## Customizable templates (how-to) — the gate is derived, not a toggle
+**Question people ask:** "what has to be enabled for a template to be customizable?"
+**Answer:** `journey.customizable` is **auto-derived**, recalculated by
+`recalculateJourneyCustomizable` (`apis/api-journeys/src/lib/recalculateJourneyCustomizable/`) on
+block/action changes. The journey must be a `template`; then it becomes customizable if **any** of:
+1. editable text — a customization *description* AND ≥1 customization *field* (both required)
+2. a customizable *link* — a button / radio-option / video block whose action is `customizable`
+   (a plain "navigate to next card" action does **not** count)
+3. customizable *media* — an image/video marked customizable, or the website logo (logo only counts
+   when the journey is in `website` mode)
+**Common "why won't it customize?" answers:** it isn't a template; the marked thing is a navigation
+action; or the logo isn't counting because website mode is off.
+**Handoff:** how-to / FAQ.
+
+## Header / footer settings ("where do I change this?") — how-to
+**Signatures:** "how do I change the title / host / logo / microwebsite?"
+**Answer (route to the surface):** journey-wide look-and-feel (chat buttons, display title, Host,
+logo, menu) lives in **Journey Appearance** in the Drawer; the shared-on-social mock-up is **Social
+Preview**; custom-domain / microwebsite settings live in the hosting/custom-domain settings.
+**Handoff:** how-to / FAQ.
+
+## Submit-button logic — FLAGGED (low confidence, needs a code dig)
+**Signatures (suspected):** questions about how submit buttons behave — the action/logic wiring is
+complex on the code side.
+**Look first (fixer):** TODO — block Actions / TextResponseBlock / button-triggered navigation.
+(Code-dig pending; confirm the real confusion before writing this up.)
+**Handoff:** unknown until dug.
+
+## Teams / access / ownership — T11 (ACL)
+**Signatures:** invite email not arriving; "requested access" not showing; confusion over who can
+edit; "I want to transfer ownership to someone else."
+**Known non-bug (set expectation):** transferring a journey's ownership does **not** move it to
+another team — it stays in its owning team. This is by design (a known limitation), and is
+frequently reported as a bug.
+**High severity:** any cross-team data exposure ("I can see another team's data") → escalate to a
+human, never auto-fix.
+**Look first (fixer):** the resolver auth guard + `UserJourney` / `UserTeam` roles in api-journeys;
+for invite emails, the invite-email pipeline.
+**Handoff:** how-to / access → human or FAQ; invite-email pipeline → agent-able; cross-team exposure
+→ human.
+
+## Sign-in & the Firebase desync — T2 (auth)
+**Signatures:** sign-in doesn't work; "name shows Unknown"; unexpected behavior for a specific user.
+**Mental model:** the app's user record (Users context) is a **read-through projection of Firebase
+Auth** — the two can diverge (a record existing in one but not the other causes odd behavior).
+**Localizing question (reporter): does it work in incognito?** Incognito working ⇒ a stale token —
+the single most diagnostic auth signal.
+**Look first (fixer):** `getAuthTokens.ts`, `checkConditionalRedirect.ts`, `verify.tsx`,
+`SignIn.tsx`, `findOrFetchUser.ts`, `firebase.ts` (the projection reconciliation lives around
+`findOrFetchUser`).
+**Handoff:** agent-able for token/redirect defects; account-identity issues → human.
+
+## Integrations — Google Sheets Sync live; Growth Spaces dormant
+**Google Sheets Sync (real):** recurring **auth** (OAuth) issues and **sync reliability** (rows not
+created / sync not running).
+- Look first (fixer): TODO — the Google OAuth connection + the sheets-sync job. (Code-dig pending.)
+- Handoff: OAuth reconnect → often human; sync-job defects → agent-able.
+**Growth Spaces:** dormant — no recent reports, believed unused. Map stays thin; route to a human.
+
+## Email notifications
+**Signatures:** journey-event emails not arriving; unsubscribe vs the per-journey toggle confusion.
+**Status:** had issues historically; relatively quiet recently.
+**Handoff:** delivery defects → agent-able; preference confusion → FAQ.

--- a/apps/journeys-admin/CONTEXT-intake.md
+++ b/apps/journeys-admin/CONTEXT-intake.md
@@ -7,13 +7,13 @@ code_paths:
   - apps/journeys-admin/src/components/TemplateCustomization/**
 trigger_phrases:
   - "block won't save"
-  - "changes not showing in preview"
-  - "have to refresh to see it"
+  - 'changes not showing in preview'
+  - 'have to refresh to see it'
   - "can't translate into <language>"
   - "template won't let me customize"
-  - "transfer ownership"
-  - "analytics numbers are wrong"
-  - "historical data disappeared"
+  - 'transfer ownership'
+  - 'analytics numbers are wrong'
+  - 'historical data disappeared'
 type_tags: [T1, T2, T3, T4, T5, T8, T11]
 updated: 2026-07-15
 ---
@@ -25,24 +25,27 @@ updated: 2026-07-15
 > where the fixer looks first → whether it is safe for an autonomous agent.
 
 ## Saving / preview / cache — T4 (cache) · T5 (optimistic drift)
+
 **Signatures:** a block edit doesn't save (most visible on typography, image, video blocks); an
 edit shows in the Editor but not on the journey preview; a newly-created block needs a refresh.
 **Localizing question (reporter): does a refresh fix it?**
+
 - refresh fixes it → cache bug (the manual Apollo cache update on block-create was wrong)
 - refresh doesn't fix it, the change is gone → it genuinely didn't save
 - saved, correct in the Editor, wrong only in preview → rendering bug, not here — see
   `apps/journeys/CONTEXT-intake.md`
-**Look first (fixer):** Network tab → the block create/update mutation (did it fire? payload
-correct? error code?); if it fired cleanly but the UI is stale → the manual cache `update` in
-`Editor/utils/useBlockCreateCommand` and `Editor/utils/blockCreateUpdate`.
-**Handoff:** agent-able.
+  **Look first (fixer):** Network tab → the block create/update mutation (did it fire? payload
+  correct? error code?); if it fired cleanly but the UI is stale → the manual cache `update` in
+  `Editor/utils/useBlockCreateCommand` and `Editor/utils/blockCreateUpdate`.
+  **Handoff:** agent-able.
 
 ## Data semantics / historical data disappearing — T1
-**Status:** quiet lately, but a latent structural risk — kept here *because* it is rare enough to
+
+**Status:** quiet lately, but a latent structural risk — kept here _because_ it is rare enough to
 forget. Any future migration can reintroduce it.
 **Signatures:** "all my historical X is gone, recent ones are fine," a list silently drops older
 rows — usually shortly after a schema change / migration.
-**Localizing question (reporter):** is it *all* the old data and only the old data (recent fine)?
+**Localizing question (reporter):** is it _all_ the old data and only the old data (recent fine)?
 That "all-historical-vs-recent-fine" split is the tell.
 **Look first (fixer):** the recent migration + the query filter on the affected list. Classic cause:
 a new column is `NULL` on existing rows but the query filters `column = false/true`, and `NULL`
@@ -50,6 +53,7 @@ matches neither in SQL, so old rows vanish.
 **Handoff:** agent-able (real backend defect when it occurs).
 
 ## Analytics correctness — T3
+
 **Status:** known-fuzzy. Stats are **never** live/real-time; some mismatch is expected. Events get
 "squished/unsquished" over a time window (aggregation behavior). Not every discrepancy is a bug.
 **Signatures:** numbers don't add up (many arrive but few reach the first card; "this many clicked
@@ -67,39 +71,44 @@ the event-sync worker is `apis/api-journeys/src/workers/plausible/service.ts`.
 **Handoff:** route to a human — not safe for autonomous fixing.
 
 ## Translation & language lists — T8 (largest historical cluster)
+
 **Signatures:** "can't translate into X"; text not translated, or translated incorrectly.
 **Disambiguate FIRST — there are four different language lists (constantly conflated):**
+
 - builder = the full language library (`libs/journeys/ui/src/libs/useLanguagesQuery`, `limit: 5000`,
   narrowed per screen by a `where` filter)
 - AI-translation = the hardcoded allowlist `SUPPORTED_LANGUAGE_IDS` (currently 58) in
   `libs/journeys/ui/src/libs/useJourneyAiTranslateSubscription/supportedLanguages.ts`
 - website / UI strings = Crowdin
 - template-gallery filter = the gallery's own list
-**Localizing question (reporter):** is the wrong/missing text the *journey's own content* (blocks,
-titles) or the *app's UI/labels*? And which language?
-**Look first (fixer):** content translation → `apis/api-journeys/.../journeyAiTranslate.ts` +
-`translateCustomizationFields`. "Can't translate into language X" is usually X not being in
-`SUPPORTED_LANGUAGE_IDS` — the fix is often just adding the ID.
-**Handoff:** allowlist gap → agent-able; translation *quality* → human.
-**Stale-report note:** the old same-language-id duplication collision (T9) was resolved by removal
-in #9151 (child translation templates deleted). Do **not** diagnose new duplication issues as that
-class; those reports are stale.
+  **Localizing question (reporter):** is the wrong/missing text the _journey's own content_ (blocks,
+  titles) or the _app's UI/labels_? And which language?
+  **Look first (fixer):** content translation → `apis/api-journeys/.../journeyAiTranslate.ts` +
+  `translateCustomizationFields`. "Can't translate into language X" is usually X not being in
+  `SUPPORTED_LANGUAGE_IDS` — the fix is often just adding the ID.
+  **Handoff:** allowlist gap → agent-able; translation _quality_ → human.
+  **Stale-report note:** the old same-language-id duplication collision (T9) was resolved by removal
+  in #9151 (child translation templates deleted). Do **not** diagnose new duplication issues as that
+  class; those reports are stale.
 
 ## Customizable templates (how-to) — the gate is derived, not a toggle
+
 **Question people ask:** "what has to be enabled for a template to be customizable?"
 **Answer:** `journey.customizable` is **auto-derived**, recalculated by
 `recalculateJourneyCustomizable` (`apis/api-journeys/src/lib/recalculateJourneyCustomizable/`) on
 block/action changes. The journey must be a `template`; then it becomes customizable if **any** of:
-1. editable text — a customization *description* AND ≥1 customization *field* (both required)
-2. a customizable *link* — a button / radio-option / video block whose action is `customizable`
+
+1. editable text — a customization _description_ AND ≥1 customization _field_ (both required)
+2. a customizable _link_ — a button / radio-option / video block whose action is `customizable`
    (a plain "navigate to next card" action does **not** count)
-3. customizable *media* — an image/video marked customizable, or the website logo (logo only counts
+3. customizable _media_ — an image/video marked customizable, or the website logo (logo only counts
    when the journey is in `website` mode)
-**Common "why won't it customize?" answers:** it isn't a template; the marked thing is a navigation
-action; or the logo isn't counting because website mode is off.
-**Handoff:** how-to / FAQ.
+   **Common "why won't it customize?" answers:** it isn't a template; the marked thing is a navigation
+   action; or the logo isn't counting because website mode is off.
+   **Handoff:** how-to / FAQ.
 
 ## Header / footer settings ("where do I change this?") — how-to
+
 **Signatures:** "how do I change the title / host / logo / microwebsite?"
 **Answer (route to the surface):** journey-wide look-and-feel (chat buttons, display title, Host,
 logo, menu) lives in **Journey Appearance** in the Drawer; the shared-on-social mock-up is **Social
@@ -107,6 +116,7 @@ Preview**; custom-domain / microwebsite settings live in the hosting/custom-doma
 **Handoff:** how-to / FAQ.
 
 ## Submit-button / action logic — FLAGGED (low frequency; signatures unconfirmed)
+
 **Signatures (suspected):** questions about how submit buttons behave — the action/logic wiring is
 complex on the code side.
 **Mental model:** every button/submit is a block **Action**. The viewer dispatches them in
@@ -120,6 +130,7 @@ NavigateToBlock / link / email / phone); the text-answer submit is
 **Handoff:** navigation/dispatch defects → agent-able; "how does X action work" → how-to.
 
 ## Teams / access / ownership — T11 (ACL)
+
 **Signatures:** invite email not arriving; "requested access" not showing; confusion over who can
 edit; "I want to transfer ownership to someone else."
 **Known non-bug (set expectation):** transferring a journey's ownership does **not** move it to
@@ -133,6 +144,7 @@ for invite emails, the invite-email pipeline.
 → human.
 
 ## Sign-in & the Firebase desync — T2 (auth)
+
 **Signatures:** sign-in doesn't work; "name shows Unknown"; unexpected behavior for a specific user.
 **Mental model:** the app's user record (Users context) is a **read-through projection of Firebase
 Auth** — the two can diverge (a record existing in one but not the other causes odd behavior).
@@ -144,16 +156,19 @@ the single most diagnostic auth signal.
 **Handoff:** agent-able for token/redirect defects; account-identity issues → human.
 
 ## Integrations — Google Sheets Sync live; Growth Spaces dormant
+
 **Google Sheets Sync (real):** recurring **auth** (OAuth) issues and **sync reliability** (rows not
 created / sync not running).
+
 - Look first (fixer): OAuth connection → `apis/api-journeys/src/schema/integration/google/`
   (`googleCreate.mutation.ts`, `googleUpdate.mutation.ts`); the sync worker →
   `apis/api-journeys/src/workers/googleSheetsSync/`; the row/header build + write-to-sheet →
   `apis/api-journeys/src/schema/journeyVisitor/export/googleSheetsLiveSync.ts`.
 - Handoff: OAuth reconnect → often human; sync-job defects → agent-able.
-**Growth Spaces:** dormant — no recent reports, believed unused. Map stays thin; route to a human.
+  **Growth Spaces:** dormant — no recent reports, believed unused. Map stays thin; route to a human.
 
 ## Email notifications
+
 **Signatures:** journey-event emails not arriving; unsubscribe vs the per-journey toggle confusion.
 **Status:** had issues historically; relatively quiet recently.
 **Handoff:** delivery defects → agent-able; preference confusion → FAQ.

--- a/apps/journeys/CONTEXT-intake.md
+++ b/apps/journeys/CONTEXT-intake.md
@@ -1,0 +1,84 @@
+---
+area: journeys (published viewer)
+domain_ref: ./CONTEXT.md
+code_paths:
+  - apps/journeys/src/**
+  - libs/journeys/ui/src/**
+trigger_phrases:
+  - "button doesn't go to the next card"
+  - "goes to the wrong card"
+  - "video won't load"
+  - "video is slow to load"
+  - "image is cropped / wrong fit"
+  - "can't click / can't type on the card"
+  - "looks wrong when published"
+  - "custom domain / embed not working"
+type_tags: [T6, T10]
+updated: 2026-07-15
+---
+
+> Diagnosis layer for reported bugs in the **published journey viewer** (what the audience sees).
+> Read this when triaging or debugging a reported bug in a live/published journey — not for feature
+> work. Domain model: ./CONTEXT.md.
+> Note: most rendering and navigation lives in the shared kernel `libs/journeys/ui`, consumed by
+> both this viewer and the journeys-admin editor — so many "look first" pointers reach into that lib.
+> Failure types (T1–T11) reference the shared taxonomy in the repo-root AGENTS.md.
+
+## Rendering — published looks different from the Editor — T6
+**Signatures:** a block/card renders correctly in the Editor but wrong only in the published/preview
+view (the "saved fine, wrong only in preview" branch handed over from journeys-admin).
+**Localizing question (reporter):** does it look right while editing but wrong once published?
+**Look first (fixer):** the shared Block Renderer + Card rendering in `libs/journeys/ui`
+(`src/components/BlockRenderer`, `src/components/Card/Card.tsx`) — the viewer injects different
+Wrappers than the admin, so a divergence is usually in render-mode / wrapper handling, not the data.
+**Handoff:** agent-able.
+
+## Default next step (navigation)
+**Signatures:** clicking a button doesn't advance, or goes to the wrong card; "nothing happens on
+the last card." Often an **authoring mistake** — the step's next action was never linked, so it
+falls back to default-next-step behavior.
+**Localizing question (reporter):** does the step have an explicit next action set, or is it relying
+on the default next step?
+**Look first (fixer):** `apps/journeys/src/components/Conductor/Conductor.tsx` (advances steps,
+wires swipe/hotkey/button nav) → `libs/journeys/ui/src/libs/block/block.ts` (`getNextBlock` /
+`nextActiveBlock`: resolves `nextBlockId` or falls back to the following step) →
+`libs/journeys/ui/src/libs/getNextStepSlug/` (URL-level next-step).
+**Handoff:** authoring "didn't link it" → how-to; genuine resolution bug → agent-able.
+
+## Video won't load / slow to load — T10 (known weak spot)
+**Signatures:** videos don't load fast enough; a video won't play; background video doesn't render
+(notably first card / Android).
+**Status:** preloading is a **known weak spot** — attempted a few times, never much success. Treat
+"slow to load" as a known limitation, not a fresh regression, unless something clearly broke.
+**Localizing question (reporter):** which video source (library / YouTube / upload), which
+device/OS/browser, and a **working-vs-failing** example if possible.
+**Look first (fixer):** `libs/journeys/ui/src/components/Video/Video.tsx` (video.js setup, poster,
+autoplay/preload) → `libs/journeys/ui/src/components/Video/InitAndPlay/InitAndPlay.tsx` (init + play
+lifecycle — load/preload timing) → `libs/journeys/ui/src/components/Card/ContainedCover/BackgroundVideo/BackgroundVideo.tsx`
+(cover-card background video).
+**Handoff:** old browser/OS → not-a-code-bug (explain); genuine load bug → agent-able.
+
+## Image fit (crop / fit / fill) — T6, expectation mismatch
+**Signatures:** an image looks cropped / doesn't fit as expected; confusion over crop vs fit vs fill.
+**Status:** the code is generally **correct** here — this is usually expectation-setting, not a bug.
+**Handoff:** set expectation / how-to; only escalate if the rendered result contradicts the chosen mode.
+
+## Interaction — can't click / type / stay focused — T6 (event bubbling)
+**Signatures:** can't click a button, can't type, or a field un-focuses while typing.
+**Heuristic (high-value):** rare, and when it happens it's **almost always tied to a recent code
+change** that altered how cards are structured/layered → check recent commits touching card layout.
+The cards are heavily layered, so these are event-bubbling bugs in that stack.
+**Look first (fixer):** `libs/journeys/ui/src/components/Card/Card.tsx` (layered cover/overlay/content
+stacking) → `Card/OverlayContent/OverlayContent.tsx` + `Card/ContainedCover/ContainedCover.tsx` (the
+layers that sit above content and intercept pointer/type events) → `components/Actions/Actions.tsx`
+(attaches the click handlers on interactive blocks).
+**Handoff:** agent-able — and bisect to the recent card-structure change first.
+
+## Custom domains / embeds — LOW SIGNAL, thin on purpose
+**Status:** low usage → few/no regular reports; little institutional knowledge to encode yet.
+**Handoff:** route to a human. (Embed-specific issues, if they arise, are usually X-Frame/CSP or
+oEmbed-shape — but treat as human-diagnosed until we have real cases.)
+
+## Chat / AI assistant — TOO NEW, out of scope
+**Status:** still new, behind a flag, not widely used, not officially released → no accurate failure
+data yet. Don't encode a diagnosis layer; route to a human. Revisit after release.

--- a/apps/journeys/CONTEXT-intake.md
+++ b/apps/journeys/CONTEXT-intake.md
@@ -6,13 +6,13 @@ code_paths:
   - libs/journeys/ui/src/**
 trigger_phrases:
   - "button doesn't go to the next card"
-  - "goes to the wrong card"
+  - 'goes to the wrong card'
   - "video won't load"
-  - "video is slow to load"
-  - "image is cropped / wrong fit"
+  - 'video is slow to load'
+  - 'image is cropped / wrong fit'
   - "can't click / can't type on the card"
-  - "looks wrong when published"
-  - "custom domain / embed not working"
+  - 'looks wrong when published'
+  - 'custom domain / embed not working'
 type_tags: [T6, T10]
 updated: 2026-07-15
 ---
@@ -25,6 +25,7 @@ updated: 2026-07-15
 > Failure types (T1–T11) reference the shared taxonomy in the repo-root AGENTS.md.
 
 ## Rendering — published looks different from the Editor — T6
+
 **Signatures:** a block/card renders correctly in the Editor but wrong only in the published/preview
 view (the "saved fine, wrong only in preview" branch handed over from journeys-admin).
 **Localizing question (reporter):** does it look right while editing but wrong once published?
@@ -34,6 +35,7 @@ Wrappers than the admin, so a divergence is usually in render-mode / wrapper han
 **Handoff:** agent-able.
 
 ## Default next step (navigation)
+
 **Signatures:** clicking a button doesn't advance, or goes to the wrong card; "nothing happens on
 the last card." Often an **authoring mistake** — the step's next action was never linked, so it
 falls back to default-next-step behavior.
@@ -46,6 +48,7 @@ wires swipe/hotkey/button nav) → `libs/journeys/ui/src/libs/block/block.ts` (`
 **Handoff:** authoring "didn't link it" → how-to; genuine resolution bug → agent-able.
 
 ## Video won't load / slow to load — T10 (known weak spot)
+
 **Signatures:** videos don't load fast enough; a video won't play; background video doesn't render
 (notably first card / Android).
 **Status:** preloading is a **known weak spot** — attempted a few times, never much success. Treat
@@ -59,11 +62,13 @@ lifecycle — load/preload timing) → `libs/journeys/ui/src/components/Card/Con
 **Handoff:** old browser/OS → not-a-code-bug (explain); genuine load bug → agent-able.
 
 ## Image fit (crop / fit / fill) — T6, expectation mismatch
+
 **Signatures:** an image looks cropped / doesn't fit as expected; confusion over crop vs fit vs fill.
 **Status:** the code is generally **correct** here — this is usually expectation-setting, not a bug.
 **Handoff:** set expectation / how-to; only escalate if the rendered result contradicts the chosen mode.
 
 ## Interaction — can't click / type / stay focused — T6 (event bubbling)
+
 **Signatures:** can't click a button, can't type, or a field un-focuses while typing.
 **Heuristic (high-value):** rare, and when it happens it's **almost always tied to a recent code
 change** that altered how cards are structured/layered → check recent commits touching card layout.
@@ -75,10 +80,12 @@ layers that sit above content and intercept pointer/type events) → `components
 **Handoff:** agent-able — and bisect to the recent card-structure change first.
 
 ## Custom domains / embeds — LOW SIGNAL, thin on purpose
+
 **Status:** low usage → few/no regular reports; little institutional knowledge to encode yet.
 **Handoff:** route to a human. (Embed-specific issues, if they arise, are usually X-Frame/CSP or
 oEmbed-shape — but treat as human-diagnosed until we have real cases.)
 
 ## Chat / AI assistant — TOO NEW, out of scope
+
 **Status:** still new, behind a flag, not widely used, not officially released → no accurate failure
 data yet. Don't encode a diagnosis layer; route to a human. Revisit after release.


### PR DESCRIPTION
## What
The NextSteps bug-diagnosis "intake" layer, **stacked on #9375** so the discovery hook + skill wiring slot into the refactored `AGENTS.md`.

- `apps/journeys-admin/CONTEXT-intake.md` — diagnosis layer for journeys-admin (failure signatures, reporter-answerable localizing questions, fixer "look first" pointers, T1–T11 tags).
- `CONTEXT-MAP-intake.md` — the always-in-context intake INDEX (accessor entry point for ENG-3707).
- root `AGENTS.md` — a `### Bug-diagnosis layer` section (discovery hook) registering the `CONTEXT.md` vs `CONTEXT-intake.md` split at the top level.
- `.agents/skills/diagnosing-bugs/SKILL.md` — now reads the area's `CONTEXT-intake.md` (via the intake index) at the **start** of the diagnosis loop, so the layer actually gets used.

## Stacked PR
Base is `siyangcao/eng-3686-migrate-claudemd-agentsmd` (#9375), not `main`. **Merge #9375 first**; this diff shows only the intake changes (4 files, +192).

## Provenance
Grilled + cross-checked against 2 years of #nextsteps-bugs history. Corrected three stale spots: T9 collision resolved by #9151; the four language lists (builder = full library, AI-translate = 58-ID `SUPPORTED_LANGUAGE_IDS`); customizable-template auto-derived.

## Draft — remaining
- Code-dig "look first" pointers: analytics counting, submit-button logic, Google Sheets Sync.
- Other NextSteps areas (viewer, api-journeys, libs/journeys/ui) — raw notes on ENG-3685, not files yet.

Part of ENG-3685.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
