### PR TITLE
docs(agents): route agents to the NextSteps bug-diagnosis layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,12 @@ The five canonical triage roles use their default label strings verbatim: `needs
 ### Domain docs
 
 Multi-context: `CONTEXT-MAP.md` at the repo root points to per-workspace `CONTEXT.md` files (created lazily by `/domain-modeling`). See `docs/agents/domain.md`.
+
+### Bug-diagnosis layer (NextSteps)
+
+Selected areas add a `CONTEXT-intake.md` beside their `CONTEXT.md` (e.g. `apps/journeys-admin/CONTEXT-intake.md`).
+
+- Read `CONTEXT.md` to understand or build in an area.
+- Read `CONTEXT-intake.md` **only** when triaging or debugging a _reported bug_ — it holds failure signatures, the question that localizes a report, and where to look first, tagged by failure type (T1–T11).
+
+Start from the intake index (`CONTEXT-MAP-intake.md`): match the reporter's words to an area's `trigger_phrases`, then open that area's `CONTEXT-intake.md`. The diagnosis-layer contract is defined in ENG-3685; the intake files themselves land on that ticket's branch.


### PR DESCRIPTION
## What
Adds a "Bug-diagnosis layer (NextSteps)" routing section to the root `AGENTS.md`, so any agent working core (not just the Ordo harnesses) knows the intake diagnosis layer exists and when to read `CONTEXT-intake.md` vs `CONTEXT.md`.

## Why
The context map lives in-repo, so it's read by everyone's agents — routing must be carried by the repo itself. `AGENTS.md` is the tool-agnostic entry point that Cursor / Claude Code / Codex all read.

## Scope (honest)
A small first slice of ENG-3686. The ticket's main body — auditing CLAUDE.md + `.claude/rules` + `.cursor` mirrors and slimming to a lean, model-agnostic AGENTS.md while retiring the duplication — is NOT in this PR; it's follow-up. This work must reconcile with the `AGENTS.md` files already added by #9354.

## Dependency
References the `CONTEXT-intake.md` / `CONTEXT-MAP-intake.md` files produced by the ENG-3685 PR; land them close together.

Part of ENG-3686.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
