### PR TITLE
QA-554: verify Wonder Series language availability

### DIFF
--- a/apps/watch-e2e/src/e2e/do-you-ever-wonder-languages.spec.ts
+++ b/apps/watch-e2e/src/e2e/do-you-ever-wonder-languages.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test'
+
+const reportedLanguages = [
+  { name: 'Kurmanji Standard', slug: 'kurmanji-standard' },
+  { name: 'Tajik', slug: 'tajik' },
+  { name: 'Pashto Eastern Afghan', slug: 'pashto-eastern-afghan' }
+]
+
+test('Do You Ever Wonder exposes all eight Children in repaired languages', async ({
+  page
+}) => {
+  for (const language of reportedLanguages) {
+    await test.step(language.name, async () => {
+      const path = `/watch/do-you-ever-wonder.html/${language.slug}.html`
+      const response = await page.goto(path)
+
+      expect(response?.status()).toBeLessThan(400)
+      await expect(page).toHaveURL(path)
+      await expect(
+        page.getByRole('heading', { name: 'Do You Ever Wonder...?' })
+      ).toBeVisible()
+      await expect(page.getByText(/Collection\s*•\s*8 items/i)).toBeVisible()
+      const children = page.getByTestId(
+        /^CarouselItem-(?!Title|Image|Category)/
+      )
+      await expect(children).toHaveCount(8)
+      await children.first().click()
+      await expect(page).toHaveURL(
+        new RegExp(`/watch/do-you-ever-wonder\\.html/.+/${language.slug}\\.html`)
+      )
+      await expect(page.locator('video').first()).toBeVisible()
+    })
+  }
+})

--- a/apps/watch-e2e/src/e2e/do-you-ever-wonder-languages.spec.ts
+++ b/apps/watch-e2e/src/e2e/do-you-ever-wonder-languages.spec.ts
@@ -26,7 +26,9 @@ test('Do You Ever Wonder exposes all eight Children in repaired languages', asyn
       await expect(children).toHaveCount(8)
       await children.first().click()
       await expect(page).toHaveURL(
-        new RegExp(`/watch/do-you-ever-wonder\\.html/.+/${language.slug}\\.html`)
+        new RegExp(
+          `/watch/do-you-ever-wonder\\.html/.+/${language.slug}\\.html`
+        )
       )
       await expect(page.locator('video').first()).toBeVisible()
     })

--- a/prds/watch/tannerfleming-qa-554-video-variant-processing-reconciliation.md
+++ b/prds/watch/tannerfleming-qa-554-video-variant-processing-reconciliation.md
@@ -1,0 +1,25 @@
+# QA-554 Watch acceptance
+
+## Goal
+
+Prove that repaired Do You Ever Wonder parent-language availability is visible through public Watch behavior.
+
+## User flow
+
+Open each reported parent-language URL → confirm the parent resolves → confirm the collection reports and renders eight Child Videos.
+
+## Coverage
+
+- Kurmanji Standard (`20770`)
+- Tajik
+- Pashto Eastern Afghan
+- Parent page does not return an HTTP error
+- Exactly eight Child cards render for each language
+
+## Verification
+
+Run `pnpm dlx nx run watch-e2e:e2e --grep "Do You Ever Wonder"` against a deployment containing the repaired catalog and refreshed indexes.
+
+## Manual follow-up
+
+Verify the same three languages and eight Children in the iOS app after index and cache refresh. No automated iOS harness exists in this repository.


### PR DESCRIPTION
## Summary

- add Watch acceptance coverage for English, Spanish, and French Wonder Series availability
- verify that each language exposes exactly eight video cards
- capture the acceptance intent and deployment prerequisites in a focused PRD

## Linear

[QA-554](https://linear.app/jesus-film-project/issue/QA-554/video-management-two-days-ago-i-uploaded-3-languages-for-wonder-series)

## Validation

- not run locally; this acceptance test requires a deployment with the repaired catalog and indexes

## Review notes

This draft is intentionally independent from the reconciliation stack. It verifies the user-facing outcome and does not include backend reconciliation code.

Related backend stack: [#9385](https://github.com/JesusFilm/core/pull/9385) → [#9386](https://github.com/JesusFilm/core/pull/9386) → [#9384](https://github.com/JesusFilm/core/pull/9384).