### PR TITLE
feat(api-media): activate video variant reconciliation (QA-554)

### DIFF
--- a/apis/api-media/src/schema/video/video.spec.ts
+++ b/apis/api-media/src/schema/video/video.spec.ts
@@ -23,6 +23,7 @@ import { ResultOf, graphql } from '@core/shared/gql'
 import { getClient } from '../../../test/client'
 import { prismaMock } from '../../../test/prismaMock'
 import { enqueueVideoAlgoliaSync } from '../../workers/videoAlgoliaSync'
+import { requestVideoVariantReconciliation } from '../videoVariantReconciliation/requestVideoVariantReconciliation'
 
 import {
   findContainerParentIds,
@@ -46,8 +47,18 @@ vi.mock('../../workers/videoAlgoliaSync', () => ({
   }
 }))
 
+vi.mock(
+  '../videoVariantReconciliation/requestVideoVariantReconciliation',
+  () => ({
+    requestVideoVariantReconciliation: vi.fn()
+  })
+)
+
 const mockedFindContainerParentIds = vi.mocked(findContainerParentIds)
 const mockedEnqueueVideoAlgoliaSync = vi.mocked(enqueueVideoAlgoliaSync)
+const mockedRequestVideoVariantReconciliation = vi.mocked(
+  requestVideoVariantReconciliation
+)
 
 describe('video', () => {
   const client = getClient()
@@ -3063,6 +3074,68 @@ describe('video', () => {
         expect(result).toHaveProperty('data.videoUpdate', {
           id: 'parent-id'
         })
+      })
+
+      it('should continue even if a reconciliation request for an affected child fails (Bug D)', async () => {
+        mockedRequestVideoVariantReconciliation.mockRejectedValueOnce(
+          new Error('Reconciliation request failed')
+        )
+
+        prismaMock.userMediaRole.findUnique.mockResolvedValue({
+          id: 'userId',
+          userId: 'userId',
+          roles: ['publisher'],
+          createdAt: new Date(),
+          updatedAt: new Date()
+        })
+        // existingParent lookup for the childIds diff
+        prismaMock.video.findUnique.mockResolvedValue({
+          childIds: ['child1', 'child2']
+        } as any)
+        prismaMock.video.findMany.mockResolvedValue([
+          { id: 'child1' },
+          { id: 'child2' },
+          { id: 'parent-id' }
+        ] as any)
+        prismaMock.video.update.mockResolvedValue({
+          id: 'parent-id',
+          label: VideoLabel.series,
+          childIds: ['child2'],
+          children: [{ id: 'child2' }]
+        } as unknown as Video)
+        // One affected child still has a published Variant, so the
+        // affectedChildIds reconciliation loop actually reaches
+        // requestVideoVariantReconciliation.
+        prismaMock.videoVariant.findMany.mockResolvedValue([
+          {
+            id: 'variant-1',
+            videoId: 'child1',
+            languageId: 'en',
+            edition: 'base'
+          }
+        ] as any)
+
+        const result = await authClient({
+          document: VIDEO_UPDATE_MUTATION,
+          variables: {
+            input: {
+              id: 'parent-id',
+              childIds: ['child2']
+            }
+          }
+        })
+
+        // The mutation still succeeds — a reconciliation-request failure for
+        // one affected child must not fail the whole GraphQL mutation.
+        expect(result).toHaveProperty('data.videoUpdate', {
+          id: 'parent-id'
+        })
+        expect(mockedRequestVideoVariantReconciliation).toHaveBeenCalledWith(
+          expect.objectContaining({
+            videoVariantId: 'variant-1',
+            reason: 'video-relationship-change'
+          })
+        )
       })
 
       it('should set publishedAt when updating from unpublished to published', async () => {

--- a/apis/api-media/src/schema/video/video.ts
+++ b/apis/api-media/src/schema/video/video.ts
@@ -29,6 +29,7 @@ import {
   handleParentVariantCleanup,
   handleParentVariantCreation
 } from '../videoVariant/videoVariant'
+import { requestVideoVariantReconciliation } from '../videoVariantReconciliation/requestVideoVariantReconciliation'
 
 import { Platform } from './enums/platform'
 import { VideoLabel } from './enums/videoLabel'
@@ -782,7 +783,12 @@ builder.mutationFields((t) => ({
 
       // Handle child relation synchronization if childIds is being updated
       let childRelationUpdate = {}
+      let affectedChildIds: string[] = []
       if (input.childIds !== undefined) {
+        const existingParent = await prisma.video.findUnique({
+          where: { id: input.id },
+          select: { childIds: true }
+        })
         // Get all existing video IDs to validate child IDs
         const videos = await prisma.video.findMany({
           select: { id: true }
@@ -792,6 +798,9 @@ builder.mutationFields((t) => ({
         // Filter out any child IDs that don't exist
         const validChildIds = (input.childIds || []).filter((id) =>
           existingVideoIds.has(id)
+        )
+        affectedChildIds = Array.from(
+          new Set([...(existingParent?.childIds ?? []), ...validChildIds])
         )
 
         // Update the children relation
@@ -847,6 +856,42 @@ builder.mutationFields((t) => ({
           )
         }
         throw e
+      }
+
+      // Known gap (not fixed here, needs a product/design decision): this
+      // fires reconciliation for every child added to OR removed from
+      // childIds, but reconcileParentVariants only ever ADDS a language to
+      // the parent's availableLanguages — it never removes one. So removing
+      // the last child providing a given language leaves that language
+      // stale on the parent indefinitely. See PR #9386 discussion.
+      if (input.childIds !== undefined && affectedChildIds.length > 0) {
+        const affectedVariants =
+          (await prisma.videoVariant.findMany({
+            where: {
+              videoId: { in: affectedChildIds },
+              published: true
+            },
+            select: {
+              id: true,
+              videoId: true,
+              languageId: true,
+              edition: true
+            }
+          })) ?? []
+        for (const variant of affectedVariants) {
+          try {
+            await requestVideoVariantReconciliation({
+              videoVariantId: variant.id,
+              videoId: variant.videoId,
+              languageId: variant.languageId,
+              edition: variant.edition,
+              published: true,
+              reason: 'video-relationship-change'
+            })
+          } catch (error) {
+            console.error('Video variant reconciliation request error:', error)
+          }
+        }
       }
 
       // Handle parent variant changes if video published status changed

--- a/apis/api-media/src/schema/videoVariant/videoVariant.spec.ts
+++ b/apis/api-media/src/schema/videoVariant/videoVariant.spec.ts
@@ -25,6 +25,15 @@ import {
   removeLanguageFromVideoIfUnused,
   updateParentCollectionLanguages
 } from '../video/lib/updateAvailableLanguages'
+import { requestVideoVariantReconciliation } from '../videoVariantReconciliation/requestVideoVariantReconciliation'
+
+// Mock the reconciliation request boundary
+vi.mock(
+  '../videoVariantReconciliation/requestVideoVariantReconciliation',
+  () => ({
+    requestVideoVariantReconciliation: vi.fn()
+  })
+)
 
 // Mock the cache reset functions
 vi.mock('../../lib/videoCacheReset', () => ({
@@ -74,6 +83,9 @@ const mockedRemoveLanguageFromVideoIfUnused = vi.mocked(
 )
 const mockedUpdateParentCollectionLanguages = vi.mocked(
   updateParentCollectionLanguages
+)
+const mockedRequestVideoVariantReconciliation = vi.mocked(
+  requestVideoVariantReconciliation
 )
 
 type VideoVariantAndIncludes = VideoVariant & {
@@ -887,7 +899,9 @@ describe('videoVariant', () => {
           skip: 10,
           take: 5,
           where: {
-            published: true
+            published: true,
+            languageId: undefined,
+            updatedAt: undefined
           }
         })
       )
@@ -1257,7 +1271,9 @@ describe('videoVariant', () => {
             videoId: 'videoId',
             share: 'share',
             downloadable: true,
-            published: true
+            published: false,
+            muxVideoId: undefined,
+            version: undefined
           }
         })
         expect(result).toHaveProperty('data.videoVariantCreate', {
@@ -1434,6 +1450,74 @@ describe('videoVariant', () => {
         // Skip the videoCacheReset verification since we know it's being called in the implementation
         // The function throws an error but our code handles it properly
         // expect(mockedVideoCacheReset).toHaveBeenCalledWith('videoId')
+      })
+
+      it('should continue even if the reconciliation request fails (Bug D)', async () => {
+        mockedRequestVideoVariantReconciliation.mockRejectedValueOnce(
+          new Error('Reconciliation request failed')
+        )
+
+        prismaMock.userMediaRole.findUnique.mockResolvedValue({
+          id: 'userId',
+          userId: 'userId',
+          roles: ['publisher'],
+          createdAt: new Date(),
+          updatedAt: new Date()
+        })
+        prismaMock.videoVariant.create.mockResolvedValue({
+          id: 'id',
+          hls: 'hls',
+          duration: 1024,
+          lengthInMilliseconds: 123456,
+          dash: 'dash',
+          edition: 'base',
+          slug: 'videoSlug',
+          videoId: 'videoId',
+          languageId: 'languageId',
+          published: true,
+          share: 'share',
+          downloadable: true,
+          muxVideoId: null,
+          masterUrl: 'masterUrl',
+          masterWidth: 320,
+          masterHeight: 180,
+          assetId: null,
+          version: 1,
+          brightcoveId: null,
+          createdAt: new Date(),
+          updatedAt: new Date()
+        })
+
+        const result = await authClient({
+          document: VIDEO_VARIANT_CREATE_MUTATION,
+          variables: {
+            input: {
+              id: 'id',
+              hls: 'hls',
+              dash: 'dash',
+              duration: 1024,
+              lengthInMilliseconds: 123456,
+              languageId: 'languageId',
+              edition: 'base',
+              slug: 'videoSlug',
+              videoId: 'videoId',
+              share: 'share',
+              downloadable: true
+            }
+          }
+        })
+
+        // The mutation still succeeds — a reconciliation-request failure
+        // must not fail the whole GraphQL mutation after the Variant has
+        // already been created.
+        expect(result).toHaveProperty('data.videoVariantCreate', {
+          id: 'id'
+        })
+        expect(mockedNotifyMediaSlackOfOperationFailure).toHaveBeenCalledWith(
+          expect.objectContaining({
+            operation: 'Video variant reconciliation request failed'
+          })
+        )
       })
 
       it('should fail if not publisher', async () => {
@@ -1709,6 +1793,74 @@ describe('videoVariant', () => {
         expect(mockedVideoVariantCacheReset).toHaveBeenCalledWith('id')
       })
 
+      it('should continue even if the reconciliation request fails (Bug D)', async () => {
+        mockedRequestVideoVariantReconciliation.mockRejectedValueOnce(
+          new Error('Reconciliation request failed')
+        )
+
+        prismaMock.userMediaRole.findUnique.mockResolvedValue({
+          id: 'userId',
+          userId: 'userId',
+          roles: ['publisher'],
+          createdAt: new Date(),
+          updatedAt: new Date()
+        })
+        // published status changes true -> false so the reconciliation
+        // request is actually reached
+        prismaMock.videoVariant.findUnique.mockResolvedValue({
+          published: true,
+          videoId: 'videoId',
+          languageId: 'languageId',
+          edition: 'base'
+        } as any)
+        prismaMock.videoVariant.update.mockResolvedValue({
+          id: 'id',
+          hls: 'hls',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          duration: 1024,
+          lengthInMilliseconds: 123456,
+          dash: 'dash',
+          edition: 'base',
+          slug: 'videoSlug',
+          videoId: 'videoId',
+          languageId: 'languageId',
+          published: false,
+          share: 'share',
+          downloadable: false,
+          muxVideoId: null,
+          masterUrl: 'masterUrl',
+          masterWidth: 320,
+          masterHeight: 180,
+          assetId: null,
+          version: 1,
+          brightcoveId: null
+        })
+
+        const result = await authClient({
+          document: VIDEO_VARIANT_UPDATE_MUTATION,
+          variables: {
+            input: {
+              id: 'id',
+              videoId: 'videoId',
+              published: false
+            }
+          }
+        })
+
+        // The mutation still succeeds — a reconciliation-request failure
+        // must not fail the whole GraphQL mutation after the Variant has
+        // already been updated.
+        expect(result).toHaveProperty('data.videoVariantUpdate', {
+          id: 'id'
+        })
+        expect(mockedNotifyMediaSlackOfOperationFailure).toHaveBeenCalledWith(
+          expect.objectContaining({
+            operation: 'Video variant reconciliation request failed'
+          })
+        )
+      })
+
       it('should fail if not publisher', async () => {
         const result = await client({
           document: VIDEO_VARIANT_UPDATE_MUTATION,
@@ -1911,6 +2063,88 @@ describe('videoVariant', () => {
         // Skip the videoCacheReset verification since we know it's being called in the implementation
         // The function throws an error but our code handles it properly
         // expect(mockedVideoCacheReset).toHaveBeenCalledWith('videoId')
+      })
+
+      it('should continue even if the reconciliation request fails (Bug D)', async () => {
+        mockedRequestVideoVariantReconciliation.mockRejectedValueOnce(
+          new Error('Reconciliation request failed')
+        )
+
+        prismaMock.userMediaRole.findUnique.mockResolvedValue({
+          id: 'userId',
+          userId: 'userId',
+          roles: ['publisher'],
+          createdAt: new Date(),
+          updatedAt: new Date()
+        })
+        prismaMock.videoVariant.findUnique.mockResolvedValue({
+          id: 'id',
+          videoId: 'videoId',
+          hls: 'hls',
+          duration: 1024,
+          lengthInMilliseconds: 123456,
+          dash: 'dash',
+          edition: 'base',
+          slug: 'videoSlug',
+          languageId: 'languageId',
+          published: true,
+          share: 'share',
+          downloadable: true,
+          muxVideoId: null,
+          masterUrl: 'masterUrl',
+          masterWidth: 320,
+          masterHeight: 180,
+          assetId: null,
+          version: 1,
+          downloads: [],
+          asset: null,
+          muxVideo: null
+        } as any)
+        prismaMock.videoVariant.delete.mockResolvedValue({
+          id: 'id',
+          hls: 'hls',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          duration: 1024,
+          lengthInMilliseconds: 123456,
+          dash: 'dash',
+          edition: 'base',
+          slug: 'videoSlug',
+          videoId: 'videoId',
+          languageId: 'languageId',
+          published: true,
+          share: 'share',
+          downloadable: true,
+          muxVideoId: null,
+          masterUrl: 'masterUrl',
+          masterWidth: 320,
+          masterHeight: 180,
+          assetId: null,
+          version: 1,
+          brightcoveId: null
+        })
+
+        const result = await authClient({
+          document: VIDEO_VARIANT_DELETE_MUTATION,
+          variables: {
+            id: 'id'
+          }
+        })
+
+        // The mutation still succeeds — a reconciliation-request failure
+        // must not fail the whole GraphQL mutation, and the Variant is
+        // still deleted.
+        expect(result).toHaveProperty('data.videoVariantDelete', {
+          id: 'id'
+        })
+        expect(prismaMock.videoVariant.delete).toHaveBeenCalledWith({
+          where: { id: 'id' }
+        })
+        expect(mockedNotifyMediaSlackOfOperationFailure).toHaveBeenCalledWith(
+          expect.objectContaining({
+            operation: 'Video variant reconciliation request failed'
+          })
+        )
       })
 
       it('should fail if not publisher', async () => {

--- a/apis/api-media/src/schema/videoVariant/videoVariant.ts
+++ b/apis/api-media/src/schema/videoVariant/videoVariant.ts
@@ -15,12 +15,8 @@ import { deleteR2File } from '../cloudflare/r2/asset'
 import { Language } from '../language'
 import { logger } from '../logger'
 import { deleteVideo } from '../mux/video/service'
-import {
-  addLanguageToVideo,
-  removeLanguageFromVideoIfUnused,
-  updateParentCollectionLanguages
-} from '../video/lib/updateAvailableLanguages'
 import { VideoSubtitle } from '../video/videoSubtitle'
+import { requestVideoVariantReconciliation } from '../videoVariantReconciliation/requestVideoVariantReconciliation'
 
 import { VideoVariantCreateInput } from './inputs/videoVariantCreate'
 import { VideoVariantFilter } from './inputs/videoVariantFilter'
@@ -493,6 +489,7 @@ builder.mutationFields((t) => ({
       input: t.arg({ type: VideoVariantCreateInput, required: true })
     },
     resolve: async (query, _parent, { input }) => {
+      const publicationIntent = input.published ?? true
       const hadAnyVariantsForLanguage =
         (await prisma.videoVariant.findFirst({
           where: { languageId: input.languageId },
@@ -506,7 +503,7 @@ builder.mutationFields((t) => ({
           data: {
             ...input,
             muxVideoId: input.muxVideoId ?? undefined,
-            published: input.published ?? true,
+            published: false,
             version: input.version ?? undefined
           }
         })
@@ -524,11 +521,33 @@ builder.mutationFields((t) => ({
         })
         throw error
       }
-      // Update video's availableLanguages and cascade to parent collections only for published variants
-      if (newVariant.published) {
-        await addLanguageToVideo(newVariant.videoId, newVariant.languageId)
-        await updateParentCollectionLanguages(newVariant.videoId)
+      try {
+        await requestVideoVariantReconciliation({
+          videoVariantId: newVariant.id,
+          videoId: newVariant.videoId,
+          languageId: newVariant.languageId,
+          edition: newVariant.edition,
+          published: publicationIntent,
+          reason: 'video-variant-create'
+        })
+      } catch (error) {
+        console.error('Video variant reconciliation request error:', error)
+        notifyMediaSlackOfOperationFailure({
+          operation: 'Video variant reconciliation request failed',
+          error,
+          context: {
+            variantId: newVariant.id,
+            videoId: newVariant.videoId,
+            languageId: newVariant.languageId,
+            reason: 'video-variant-create'
+          }
+        })
       }
+      // availableLanguages / parent-collection cascade for a newly-created
+      // Variant now happens once reconciliation confirms the Variant is
+      // publication-ready (see reconcileVideoVariantReconciliation) — the
+      // Variant is always created unpublished above, so this used to be
+      // unreachable dead code.
 
       try {
         if (!hadAnyVariantsForLanguage) {
@@ -536,25 +555,6 @@ builder.mutationFields((t) => ({
         }
       } catch (error) {
         console.error('Language hasVideos update error:', error)
-      }
-
-      // Handle parent variant creation for child videos
-      try {
-        await handleParentVariantCreation(
-          newVariant.videoId,
-          newVariant.languageId
-        )
-      } catch (error) {
-        console.error('Parent variant creation error:', error)
-        notifyMediaSlackOfOperationFailure({
-          operation: 'Video variant parent creation failed',
-          error,
-          context: {
-            videoId: newVariant.videoId,
-            languageId: newVariant.languageId,
-            variantId: newVariant.id
-          }
-        })
       }
 
       // Save the videoId before the try/catch block
@@ -592,7 +592,12 @@ builder.mutationFields((t) => ({
       // Get the current variant to check if published status is changing
       const currentVariant = await prisma.videoVariant.findUnique({
         where: { id: input.id },
-        select: { published: true, videoId: true, languageId: true }
+        select: {
+          published: true,
+          videoId: true,
+          languageId: true,
+          edition: true
+        }
       })
 
       if (!currentVariant) {
@@ -624,7 +629,10 @@ builder.mutationFields((t) => ({
             videoId: input.videoId ?? undefined,
             edition: input.edition ?? undefined,
             downloadable: input.downloadable ?? undefined,
-            published: input.published ?? undefined,
+            published:
+              input.published === undefined
+                ? undefined
+                : currentVariant.published,
             muxVideoId: input.muxVideoId ?? undefined,
             assetId: input.assetId ?? undefined,
             version: input.version ?? undefined,
@@ -651,61 +659,29 @@ builder.mutationFields((t) => ({
       const wasPublished = currentVariant.published
       const isNowPublished = input.published ?? currentVariant.published
 
-      if (wasPublished !== isNowPublished) {
+      if (wasPublished !== isNowPublished || languageChanged) {
+        const reason = languageChanged
+          ? 'video-variant-language-change'
+          : 'video-variant-publication-change'
         try {
-          if (isNowPublished) {
-            // Variant was unpublished and is now published - create parent variants
-            await handleParentVariantCreation(
-              currentVariant.videoId,
-              currentVariant.languageId
-            )
-          } else {
-            // Variant was published and is now unpublished - cleanup parent variants
-            await handleParentVariantCleanup(
-              currentVariant.videoId,
-              currentVariant.languageId
-            )
-          }
-        } catch (error) {
-          console.error('Parent variant update error:', error)
-          notifyMediaSlackOfOperationFailure({
-            operation: 'Video variant parent update failed',
-            error,
-            context: {
-              variantId: input.id,
-              videoId: currentVariant.videoId,
-              languageId: currentVariant.languageId,
-              published: isNowPublished
-            }
+          await requestVideoVariantReconciliation({
+            videoVariantId: updated.id,
+            videoId: input.videoId ?? currentVariant.videoId,
+            languageId: nextLanguageId,
+            edition: input.edition ?? currentVariant.edition,
+            published: isNowPublished,
+            reason
           })
-        }
-
-        // Update availableLanguages array based on published status change
-        try {
-          if (isNowPublished) {
-            await addLanguageToVideo(
-              currentVariant.videoId,
-              currentVariant.languageId
-            )
-          } else {
-            await removeLanguageFromVideoIfUnused(
-              currentVariant.videoId,
-              currentVariant.languageId
-            )
-          }
-
-          // Cascade update to parent collections
-          await updateParentCollectionLanguages(currentVariant.videoId)
         } catch (error) {
-          console.error('Language management update error:', error)
+          console.error('Video variant reconciliation request error:', error)
           notifyMediaSlackOfOperationFailure({
-            operation: 'Video variant language update failed',
+            operation: 'Video variant reconciliation request failed',
             error,
             context: {
-              variantId: input.id,
-              videoId: currentVariant.videoId,
-              languageId: currentVariant.languageId,
-              published: isNowPublished
+              variantId: updated.id,
+              videoId: input.videoId ?? currentVariant.videoId,
+              languageId: nextLanguageId,
+              reason
             }
           })
         }
@@ -858,6 +834,29 @@ builder.mutationFields((t) => ({
         }
       }
 
+      try {
+        await requestVideoVariantReconciliation({
+          videoVariantId: variant.id,
+          videoId,
+          languageId,
+          edition: variant.edition,
+          published: false,
+          reason: 'video-variant-delete'
+        })
+      } catch (error) {
+        console.error('Video variant reconciliation request error:', error)
+        notifyMediaSlackOfOperationFailure({
+          operation: 'Video variant reconciliation request failed',
+          error,
+          context: {
+            variantId: variant.id,
+            videoId,
+            languageId,
+            reason: 'video-variant-delete'
+          }
+        })
+      }
+
       // Delete the video variant
       let deleted: PrismaVideoVariant
       try {
@@ -878,40 +877,22 @@ builder.mutationFields((t) => ({
         throw error
       }
 
-      // Handle parent variant cleanup for child videos
-      try {
-        await handleParentVariantCleanup(videoId, languageId)
-      } catch (error) {
-        console.error('Parent variant cleanup error:', error)
-        notifyMediaSlackOfOperationFailure({
-          operation: 'Video variant parent cleanup failed',
-          error,
-          context: {
-            variantId: id,
-            videoId,
-            languageId
-          }
-        })
-      }
-
-      // Update availableLanguages array when variant is deleted
-      try {
-        await removeLanguageFromVideoIfUnused(videoId, languageId)
-
-        // Cascade update to parent collections
-        await updateParentCollectionLanguages(videoId)
-      } catch (error) {
-        console.error('Language management cleanup error:', error)
-        notifyMediaSlackOfOperationFailure({
-          operation: 'Video variant language cleanup failed',
-          error,
-          context: {
-            variantId: id,
-            videoId,
-            languageId
-          }
-        })
-      }
+      // availableLanguages / parent-collection cascade for a deleted Variant
+      // now happens once reconciliation processes the 'video-variant-delete'
+      // request above (see reconcileReasonSpecificVariant's
+      // video-variant-delete branch, which calls
+      // removeLanguageFromVideoIfUnused + updateParentCollectionLanguages) —
+      // mirrors the same cascade already removed from videoVariantCreate and
+      // videoVariantUpdate.
+      //
+      // Known gap (not fixed here): the old handleParentVariantCleanup call
+      // that used to run here also deleted the orphaned, still-empty
+      // generated parent VideoVariant row (hls: '', no muxVideoId) once no
+      // published child in that language remained. Reconciliation has no
+      // equivalent step, so that placeholder row can now be left behind
+      // after this kind of delete. handleParentVariantCleanup itself is
+      // unchanged and still runs from video.ts's videoUpdate, so this only
+      // affects the direct-variant-delete trigger. See PR #9386 discussion.
 
       await enqueueVideoAlgoliaSync(
         videoId,

--- a/apis/api-media/src/schema/videoVariantUpload/service.ts
+++ b/apis/api-media/src/schema/videoVariantUpload/service.ts
@@ -28,6 +28,7 @@ import {
   addLanguageToVideo,
   updateParentCollectionLanguages
 } from '../video/lib/updateAvailableLanguages'
+import { requestVideoVariantReconciliation } from '../videoVariantReconciliation/requestVideoVariantReconciliation'
 
 const FIVE_DAYS = 5 * 24 * 60 * 60
 
@@ -260,7 +261,7 @@ export async function createOrUpdateVideoVariant({
       duration: metadata.duration,
       lengthInMilliseconds: metadata.durationMs,
       muxVideoId,
-      published,
+      published: false,
       downloadable: true,
       version
     }
@@ -302,6 +303,15 @@ export async function createOrUpdateVideoVariant({
         }
       })
     }
+
+    await requestVideoVariantReconciliation({
+      videoVariantId: variant.id,
+      videoId,
+      languageId,
+      edition,
+      published,
+      reason: 'process-video-upload'
+    })
 
     return variant
   } catch (error) {

--- a/apis/api-media/src/workers/processVideoUploads/service/service.spec.ts
+++ b/apis/api-media/src/workers/processVideoUploads/service/service.spec.ts
@@ -60,6 +60,9 @@ const mockJob = {
 describe('processVideoUploads service', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    prismaMock.$transaction.mockImplementation(async (transaction) => {
+      return await transaction(prismaMock)
+    })
   })
 
   it('creates or updates variant when mux video is ready', async () => {
@@ -83,7 +86,9 @@ describe('processVideoUploads service', () => {
       id: 'variant-id',
       slug: 'variant-slug'
     } as any)
-    prismaMock.videoVariant.update.mockResolvedValue({} as any)
+    prismaMock.videoVariant.update.mockResolvedValue({
+      id: 'variant-id'
+    } as any)
 
     await service(mockJob, mockLogger)
 
@@ -117,8 +122,16 @@ describe('processVideoUploads service', () => {
       data: expect.objectContaining({
         muxVideoId: 'mux-video-id',
         downloadable: true,
-        published: true,
+        published: false,
         version: 1
+      })
+    })
+    expect(prismaMock.videoVariantReconciliation.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        reason: 'process-video-upload',
+        published: true,
+        videoVariantId: 'variant-id',
+        status: 'processing'
       })
     })
     expect(prismaMock.$executeRaw).toHaveBeenCalledTimes(1)
@@ -167,7 +180,7 @@ describe('processVideoUploads service', () => {
       data: expect.objectContaining({
         muxVideoId: 'mux-video-id',
         downloadable: true,
-        published: true,
+        published: false,
         version: 1
       })
     })


### PR DESCRIPTION
Part of #9381 (PRD: Reconcile Variant processing and parent-language availability).

## Summary

- reconcile upload state when video variants are created, updated, and deleted
- defer publication until processing has completed successfully
- integrate reconciliation with the upload-processing worker
- register the reconciliation workers with the API media worker server

## Stack

1. [#9385](https://github.com/JesusFilm/core/pull/9385) — additive foundation
2. **This PR** — runtime integration
3. [#9384](https://github.com/JesusFilm/core/pull/9384) — Videos Admin processing UI

## Linear

[QA-554](https://linear.app/jesus-film-project/issue/QA-554/video-management-two-days-ago-i-uploaded-3-languages-for-wonder-series)

## Validation

- video-variant and upload-processing Vitest specs: 45 tests passed
- api-media TypeScript compile: passed

## Review notes

This is a draft stacked on [#9385](https://github.com/JesusFilm/core/pull/9385). Review the diff against its configured base branch.
