### PR TITLE
ci(guards): schema regen no-diff + prisma migration checks (ENG-3689, ENG-3690)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,9 @@ trim_trailing_whitespace = true
 [*.md]
 max_line_length = off
 trim_trailing_whitespace = false
+
+# Generated GraphQL schema artifacts: the hive/pothos generators emit trailing
+# spaces on some lines; stripping them on save creates drift that the
+# graphql-schema-check CI guard rejects. Never hand-edit these files.
+[apis/*/schema.graphql]
+trim_trailing_whitespace = false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,6 +116,24 @@ jobs:
             echo "To fix: run 'nx generate-graphql <api>' for each API you changed, then 'nx generate-graphql api-gateway', and commit the updated schema.graphql files."
             exit 1
           fi
+  prisma-migration-check:
+    # ENG-3690: a schema.prisma change with no matching migration passes
+    # `prisma generate` and only fails at deploy time — require every PR that
+    # edits a domain's schema to add a migration in that same domain.
+    # Only meaningful on PRs (needs a base branch to diff against). The
+    # 'skip-migration-check' label is the escape hatch for schema edits that
+    # genuinely need no migration (comments, formatting) — after adding the
+    # label, re-run the failed job to pick it up.
+    runs-on: blacksmith-2vcpu-ubuntu-2204
+    if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-migration-check') }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Fetch other branches
+        run: git fetch --no-tags --prune --depth=5 origin $GITHUB_BASE_REF
+      - name: check prisma schema changes include a migration
+        run: ./tools/scripts/check-prisma-migrations.sh "origin/$GITHUB_BASE_REF"
   test:
     runs-on: blacksmith-4vcpu-ubuntu-2204
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,8 +73,9 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2204
     permissions:
       contents: read
-    env:
-      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+    # No NX_CLOUD_ACCESS_TOKEN here on purpose: generate-graphql and
+    # prisma-generate are not cacheable targets, so the token adds nothing —
+    # it would only expose a secret to code the PR author controls.
     steps:
       - uses: actions/checkout@v4
       - name: Setup pnpm
@@ -95,7 +96,9 @@ jobs:
         env:
           DISABLE_ERD: true
       - name: regenerate subgraph schemas
-        run: pnpm exec nx run-many -t generate-graphql --projects api-analytics,api-journeys,api-languages,api-media,api-users
+        # --exclude rather than a hardcoded project list so a future API with
+        # a generate-graphql target is guarded automatically.
+        run: pnpm exec nx run-many -t generate-graphql --exclude api-gateway
         env:
           # Schema generation writes SDL and exits before serving anything,
           # but some modules validate env or construct clients at import time
@@ -110,6 +113,9 @@ jobs:
         run: pnpm exec nx run api-gateway:generate-graphql
       - name: fail if regenerated schemas differ from committed
         run: |
+          # Make regenerated-but-untracked schema files (e.g. a schema.graphql
+          # deleted by the PR and recreated by the regen) visible to git diff.
+          git add --intent-to-add -- 'apis/*/schema.graphql'
           if git diff --exit-code -- 'apis/*/schema.graphql'; then
             echo "✅ - committed schema.graphql files match generated output"
           else
@@ -124,20 +130,40 @@ jobs:
     # edits a domain's schema to add a migration in that same domain.
     # Only meaningful on PRs (needs a base branch to diff against). The
     # 'skip-migration-check' label is the escape hatch for schema edits that
-    # genuinely need no migration (comments, formatting) — after adding the
-    # label, re-run the failed job to pick it up.
+    # genuinely need no migration (comments, formatting). The job-level if
+    # only sees labels present when the triggering event fired, so the step
+    # below re-checks labels via the API — that way adding the label and
+    # re-running the failed job works.
     runs-on: blacksmith-2vcpu-ubuntu-2204
     permissions:
       contents: read
+      issues: read
+      pull-requests: read
     if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-migration-check') }}
     steps:
+      # fetch-depth: 0 fetches full history for all branches, which is what
+      # merge-base needs. No extra shallow fetch of the base branch here — a
+      # --depth-limited fetch into a full clone writes .git/shallow and can
+      # make merge-base fail once the base has advanced past the cut.
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Fetch other branches
-        run: git fetch --no-tags --prune --depth=5 origin $GITHUB_BASE_REF
       - name: check prisma schema changes include a migration
-        run: ./tools/scripts/check-prisma-migrations.sh "origin/$GITHUB_BASE_REF"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Labels added after the triggering event are invisible to the
+          # job-level if on re-runs, so re-check them at runtime. If the API
+          # call fails we fall through and run the check (fail closed).
+          labels=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" \
+            | jq -r '.[].name' || true)
+          if echo "$labels" | grep -qx 'skip-migration-check'; then
+            echo "⏭️ - 'skip-migration-check' label present; skipping migration check"
+            exit 0
+          fi
+          ./tools/scripts/check-prisma-migrations.sh "origin/$GITHUB_BASE_REF"
   test:
     runs-on: blacksmith-4vcpu-ubuntu-2204
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,8 +130,7 @@ jobs:
     # edits a domain's schema to add a migration in that same domain.
     # Only meaningful on PRs (needs a base branch to diff against). The
     # 'skip-migration-check' label is the escape hatch for schema edits that
-    # genuinely need no migration (comments, formatting) — see the label
-    # re-check in the step below for why it's checked twice.
+    # genuinely need no migration (comments, formatting).
     runs-on: blacksmith-2vcpu-ubuntu-2204
     permissions:
       contents: read
@@ -154,10 +153,9 @@ jobs:
           # Labels added after the triggering event are invisible to the
           # job-level if on re-runs, so re-check them at runtime. per_page=100
           # covers GitHub's per-issue label cap in one page.
-          if ! labels=$(curl -sSf --max-time 10 --retry 3 --retry-delay 2 \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels?per_page=100" \
-            | jq -r '.[].name'); then
+          if ! labels=$(timeout 30 gh api \
+            "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels?per_page=100" \
+            --jq '.[].name'); then
             echo "⚠️ - could not fetch PR labels (error above); running the check anyway (fail closed)."
             echo "If you added the 'skip-migration-check' label, re-run this job."
             labels=""

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,57 @@ jobs:
           DOPPLER_CONFIG: stg
         with:
           targets: fetch-secrets,build
+  graphql-schema-check:
+    # ENG-3689: regenerating every schema.graphql from code must produce no
+    # diff — the committed schema files are generated artifacts, and drift
+    # between them and the code that generates them otherwise fails silently
+    # (subgraph-check only validates composition against the registry).
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    env:
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: generate prisma imports
+        uses: mansagroup/nrwl-nx-action@v3
+        with:
+          targets: prisma-generate
+          all: true
+        env:
+          DISABLE_ERD: true
+      - name: regenerate subgraph schemas
+        run: pnpm exec nx run-many -t generate-graphql --projects api-analytics,api-journeys,api-languages,api-media,api-users
+        env:
+          # Schema generation writes SDL and exits before serving anything,
+          # but some modules validate env or construct clients at import time
+          # (api-journeys env.ts, api-media crowdinClient). Values are never
+          # used during generation, so placeholders are safe here.
+          SKIP_ENV_VALIDATION: '1'
+          CROWDIN_API_KEY: ci-schema-regen-placeholder
+          CROWDIN_PROJECT_ID: '1'
+      - name: recompose gateway supergraph
+        # Runs after the subgraphs so the compose reads freshly generated
+        # schema files, not the committed ones.
+        run: pnpm exec nx run api-gateway:generate-graphql
+      - name: fail if regenerated schemas differ from committed
+        run: |
+          if git diff --exit-code -- 'apis/*/schema.graphql'; then
+            echo "✅ - committed schema.graphql files match generated output"
+          else
+            echo ""
+            echo "🛑 - committed schema.graphql files are out of date with the code that generates them (see diff above)."
+            echo "To fix: run 'nx generate-graphql <api>' for each API you changed, then 'nx generate-graphql api-gateway', and commit the updated schema.graphql files."
+            exit 1
+          fi
   test:
     runs-on: blacksmith-4vcpu-ubuntu-2204
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,8 @@ jobs:
     # between them and the code that generates them otherwise fails silently
     # (subgraph-check only validates composition against the registry).
     runs-on: blacksmith-4vcpu-ubuntu-2204
+    permissions:
+      contents: read
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     steps:
@@ -125,6 +127,8 @@ jobs:
     # genuinely need no migration (comments, formatting) — after adding the
     # label, re-run the failed job to pick it up.
     runs-on: blacksmith-2vcpu-ubuntu-2204
+    permissions:
+      contents: read
     if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-migration-check') }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,10 +130,8 @@ jobs:
     # edits a domain's schema to add a migration in that same domain.
     # Only meaningful on PRs (needs a base branch to diff against). The
     # 'skip-migration-check' label is the escape hatch for schema edits that
-    # genuinely need no migration (comments, formatting). The job-level if
-    # only sees labels present when the triggering event fired, so the step
-    # below re-checks labels via the API — that way adding the label and
-    # re-running the failed job works.
+    # genuinely need no migration (comments, formatting) — see the label
+    # re-check in the step below for why it's checked twice.
     runs-on: blacksmith-2vcpu-ubuntu-2204
     permissions:
       contents: read
@@ -154,11 +152,16 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # Labels added after the triggering event are invisible to the
-          # job-level if on re-runs, so re-check them at runtime. If the API
-          # call fails we fall through and run the check (fail closed).
-          labels=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
-            "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" \
-            | jq -r '.[].name' || true)
+          # job-level if on re-runs, so re-check them at runtime. per_page=100
+          # covers GitHub's per-issue label cap in one page.
+          if ! labels=$(curl -sSf --max-time 10 --retry 3 --retry-delay 2 \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels?per_page=100" \
+            | jq -r '.[].name'); then
+            echo "⚠️ - could not fetch PR labels (error above); running the check anyway (fail closed)."
+            echo "If you added the 'skip-migration-check' label, re-run this job."
+            labels=""
+          fi
           if echo "$labels" | grep -qx 'skip-migration-check'; then
             echo "⏭️ - 'skip-migration-check' label present; skipping migration check"
             exit 0

--- a/apis/AGENTS.md
+++ b/apis/AGENTS.md
@@ -69,6 +69,8 @@ This creates a SQL migration file with a timestamped name and runs it against yo
 
 > **Exception:** The `analytics` domain does not use migrations. Its database is managed externally. Use `nx prisma-introspect prisma-analytics` to pull the current schema instead of running `prisma-migrate`.
 
+CI enforces this: the `prisma-migration-check` job fails any PR that edits a `schema.prisma` without adding a migration in the same domain. If the edit genuinely needs no migration (comments, formatting), add the `skip-migration-check` label to the PR and re-run the failed job.
+
 ##### GraphQL Steps (when the change affects GraphQL)
 
 **Step 4: Update GraphQL type definitions**
@@ -172,7 +174,7 @@ See `docs/solutions/build-errors/apollo-codegen-deprecated-directive-input-field
 
 #### Common Mistakes to Avoid
 
-- **Do NOT edit `schema.graphql` directly** in any API — it is auto-generated. Edit the Pothos schema code instead.
+- **Do NOT edit `schema.graphql` directly** in any API — it is auto-generated. Edit the Pothos schema code instead. The `graphql-schema-check` CI job regenerates every schema and fails on any diff, so stale or hand-edited schema files fail CI rather than merging silently.
 - **Do NOT forget `generate-graphql api-gateway`** after updating any subgraph schema — the gateway supergraph must be recomposed.
 - **Do NOT forget `nx run-many -t codegen`** — frontend TypeScript types will be stale until codegen runs.
 - **Do NOT skip generating for all APIs that share a prisma domain** — when multiple APIs share one Prisma schema, regenerate GraphQL for each of them.

--- a/apis/api-gateway/schema.graphql
+++ b/apis/api-gateway/schema.graphql
@@ -2155,7 +2155,7 @@ type Video @join__type(graph: API_JOURNEYS_MODERN, key: "id primaryLanguageId", 
   """
   When true, generated translated audio variants or generated subtitle tracks should not be created for this video. Metadata translations (title, description, study questions) are unaffected.
   """
-  restrictTranslations: Boolean! @join__field(graph: API_MEDIA)
+  restrictTranslations: Boolean! @join__field(graph: API_MEDIA) 
   published: Boolean! @join__field(graph: API_MEDIA) 
   cloudflareAssets: [CloudflareR2!]! @join__field(graph: API_MEDIA) 
   videoEditions: [VideoEdition!]! @join__field(graph: API_MEDIA) 

--- a/tools/scripts/check-prisma-migrations.sh
+++ b/tools/scripts/check-prisma-migrations.sh
@@ -11,8 +11,9 @@ set -euo pipefail
 #
 # Changes are diffed from merge-base(<base-ref>, <head-ref>) to <head-ref>, so
 # commits already on the base branch are never blamed on the PR. A migration
-# counts only when a *new* file is added under the domain's migrations
-# directory (--diff-filter=A) — edits to already-committed migrations don't.
+# counts only when a *new* <timestamp>_<name>/migration.sql is added under the
+# domain's migrations directory (--diff-filter=A) — edits to already-committed
+# migrations don't count, and neither do other added files (e.g. a README).
 #
 # Escape hatch: schema edits that genuinely need no migration (comments,
 # formatting, attributes that don't affect the database) can add the
@@ -38,7 +39,9 @@ for domain in "${DOMAINS[@]}"; do
     continue
   fi
 
-  added_migrations=$(git diff --name-only --diff-filter=A "$MERGE_BASE" "$HEAD_REF" -- "$migrations")
+  # Only a real, deployable migration counts — a new */migration.sql — not
+  # just any file added under the migrations directory (e.g. a README).
+  added_migrations=$(git diff --name-only --diff-filter=A "$MERGE_BASE" "$HEAD_REF" -- "$migrations/*/migration.sql")
   if [ -z "$added_migrations" ]; then
     echo "🛑 - $schema changed but no migration was added in $migrations"
     FAILED_DOMAINS+=("$domain")

--- a/tools/scripts/check-prisma-migrations.sh
+++ b/tools/scripts/check-prisma-migrations.sh
@@ -11,28 +11,46 @@ set -euo pipefail
 #
 # Changes are diffed from merge-base(<base-ref>, <head-ref>) to <head-ref>, so
 # commits already on the base branch are never blamed on the PR. A migration
-# counts only when a *new* <timestamp>_<name>/migration.sql is added under the
-# domain's migrations directory (--diff-filter=A) — edits to already-committed
-# migrations don't count, and neither do other added files (e.g. a README).
+# counts only when a non-empty <timestamp>_<name>/migration.sql is added under
+# the domain's migrations directory (--diff-filter=A, --no-renames so a
+# delete+re-add or moved migration still counts at its new path) — edits to
+# already-committed migrations don't count, and neither do other added files
+# (e.g. a README). The SQL content itself is not validated against the schema
+# diff — that would require `prisma migrate diff` and a shadow database.
+#
+# Domains are discovered from libs/prisma/*/db/schema.prisma at <head-ref>, so
+# a newly added domain is guarded automatically (its initial migration is
+# required) and a domain deleted by the PR is not flagged.
 #
 # Escape hatch: schema edits that genuinely need no migration (comments,
 # formatting, attributes that don't affect the database) can add the
-# 'skip-migration-check' PR label, which skips this job entirely (see
-# .github/workflows/main.yml), then re-run the failed job.
+# 'skip-migration-check' PR label — checked at runtime by the workflow step,
+# so adding the label and re-running the failed job works (see
+# .github/workflows/main.yml).
 #
 # The analytics domain is deliberately excluded: its database is managed
 # externally and its schema is pulled via `nx prisma-introspect
 # prisma-analytics` — it has no prisma-migrate target and no migrations
 # directory (see apis/AGENTS.md).
-DOMAINS=(journeys languages media users)
+EXCLUDED_DOMAINS=(analytics)
 
 BASE_REF="${1:?usage: check-prisma-migrations.sh <base-ref> [head-ref]}"
 HEAD_REF="${2:-HEAD}"
-MERGE_BASE=$(git merge-base "$BASE_REF" "$HEAD_REF")
+
+if ! MERGE_BASE=$(git merge-base "$BASE_REF" "$HEAD_REF"); then
+  echo "🛑 - could not compute merge-base($BASE_REF, $HEAD_REF)."
+  echo "The checkout is likely shallow — this check needs full history (fetch-depth: 0)."
+  exit 1
+fi
 
 FAILED_DOMAINS=()
-for domain in "${DOMAINS[@]}"; do
-  schema="libs/prisma/$domain/db/schema.prisma"
+for schema in $(git ls-tree -r --name-only "$HEAD_REF" libs/prisma | grep -E '^libs/prisma/[^/]+/db/schema\.prisma$'); do
+  domain=$(basename "$(dirname "$(dirname "$schema")")")
+  for excluded in "${EXCLUDED_DOMAINS[@]}"; do
+    if [ "$domain" = "$excluded" ]; then
+      continue 2
+    fi
+  done
   migrations="libs/prisma/$domain/db/migrations"
 
   if git diff --quiet "$MERGE_BASE" "$HEAD_REF" -- "$schema"; then
@@ -41,20 +59,33 @@ for domain in "${DOMAINS[@]}"; do
 
   # Only a real, deployable migration counts — a new */migration.sql — not
   # just any file added under the migrations directory (e.g. a README).
-  added_migrations=$(git diff --name-only --diff-filter=A "$MERGE_BASE" "$HEAD_REF" -- "$migrations/*/migration.sql")
+  added_migrations=$(git diff --name-only --no-renames --diff-filter=A "$MERGE_BASE" "$HEAD_REF" -- "$migrations/*/migration.sql")
   if [ -z "$added_migrations" ]; then
     echo "🛑 - $schema changed but no migration was added in $migrations"
     FAILED_DOMAINS+=("$domain")
-  else
-    echo "✅ - $schema changed and new migration(s) added:"
-    echo "$added_migrations" | sed 's/^/      /'
+    continue
   fi
+
+  empty_migrations=$(echo "$added_migrations" | while read -r f; do
+    if ! git cat-file blob "$HEAD_REF:$f" | grep -q '[^[:space:]]'; then
+      echo "$f"
+    fi
+  done)
+  if [ -n "$empty_migrations" ]; then
+    echo "🛑 - $schema changed but the added migration(s) are empty:"
+    echo "$empty_migrations" | sed 's/^/      /'
+    FAILED_DOMAINS+=("$domain")
+    continue
+  fi
+
+  echo "✅ - $schema changed and new migration(s) added:"
+  echo "$added_migrations" | sed 's/^/      /'
 done
 
 if [ "${#FAILED_DOMAINS[@]}" -gt 0 ]; then
   echo ""
-  echo "A schema.prisma change must ship with a migration in the same domain."
-  echo "To fix, run:"
+  echo "A schema.prisma change must ship with a non-empty migration in the"
+  echo "same domain. To fix, run:"
   for domain in "${FAILED_DOMAINS[@]}"; do
     echo "  nx prisma-migrate prisma-$domain"
   done

--- a/tools/scripts/check-prisma-migrations.sh
+++ b/tools/scripts/check-prisma-migrations.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+# CI guard (ENG-3690): a PR that changes a Prisma schema must add a migration
+# in the same domain. `prisma generate` succeeds without one, so a schema
+# change with no migration otherwise sails through CI and only explodes at
+# deploy time against prod.
+#
+# Usage: check-prisma-migrations.sh <base-ref> [head-ref]
+#   e.g. check-prisma-migrations.sh origin/main
+#
+# Changes are diffed from merge-base(<base-ref>, <head-ref>) to <head-ref>, so
+# commits already on the base branch are never blamed on the PR. A migration
+# counts only when a *new* file is added under the domain's migrations
+# directory (--diff-filter=A) — edits to already-committed migrations don't.
+#
+# Escape hatch: schema edits that genuinely need no migration (comments,
+# formatting, attributes that don't affect the database) can add the
+# 'skip-migration-check' PR label, which skips this job entirely (see
+# .github/workflows/main.yml), then re-run the failed job.
+#
+# The analytics domain is deliberately excluded: its database is managed
+# externally and its schema is pulled via `nx prisma-introspect
+# prisma-analytics` — it has no prisma-migrate target and no migrations
+# directory (see apis/AGENTS.md).
+DOMAINS=(journeys languages media users)
+
+BASE_REF="${1:?usage: check-prisma-migrations.sh <base-ref> [head-ref]}"
+HEAD_REF="${2:-HEAD}"
+MERGE_BASE=$(git merge-base "$BASE_REF" "$HEAD_REF")
+
+FAILED_DOMAINS=()
+for domain in "${DOMAINS[@]}"; do
+  schema="libs/prisma/$domain/db/schema.prisma"
+  migrations="libs/prisma/$domain/db/migrations"
+
+  if git diff --quiet "$MERGE_BASE" "$HEAD_REF" -- "$schema"; then
+    continue
+  fi
+
+  added_migrations=$(git diff --name-only --diff-filter=A "$MERGE_BASE" "$HEAD_REF" -- "$migrations")
+  if [ -z "$added_migrations" ]; then
+    echo "🛑 - $schema changed but no migration was added in $migrations"
+    FAILED_DOMAINS+=("$domain")
+  else
+    echo "✅ - $schema changed and new migration(s) added:"
+    echo "$added_migrations" | sed 's/^/      /'
+  fi
+done
+
+if [ "${#FAILED_DOMAINS[@]}" -gt 0 ]; then
+  echo ""
+  echo "A schema.prisma change must ship with a migration in the same domain."
+  echo "To fix, run:"
+  for domain in "${FAILED_DOMAINS[@]}"; do
+    echo "  nx prisma-migrate prisma-$domain"
+  done
+  echo "and commit the generated migration directory."
+  echo ""
+  echo "If this change genuinely needs no migration (comments, formatting,"
+  echo "attributes that don't affect the database), add the"
+  echo "'skip-migration-check' label to the PR and re-run this job."
+  exit 1
+fi
+
+echo "✅ - all changed prisma schemas have matching migrations"

--- a/tools/scripts/check-prisma-migrations.sh
+++ b/tools/scripts/check-prisma-migrations.sh
@@ -22,11 +22,8 @@ set -euo pipefail
 # a newly added domain is guarded automatically (its initial migration is
 # required) and a domain deleted by the PR is not flagged.
 #
-# Escape hatch: schema edits that genuinely need no migration (comments,
-# formatting, attributes that don't affect the database) can add the
-# 'skip-migration-check' PR label — checked at runtime by the workflow step,
-# so adding the label and re-running the failed job works (see
-# .github/workflows/main.yml).
+# Escape hatch: the 'skip-migration-check' PR label, handled entirely by the
+# calling workflow — see .github/workflows/main.yml.
 #
 # The analytics domain is deliberately excluded: its database is managed
 # externally and its schema is pulled via `nx prisma-introspect
@@ -46,11 +43,9 @@ fi
 FAILED_DOMAINS=()
 for schema in $(git ls-tree -r --name-only "$HEAD_REF" libs/prisma | grep -E '^libs/prisma/[^/]+/db/schema\.prisma$'); do
   domain=$(basename "$(dirname "$(dirname "$schema")")")
-  for excluded in "${EXCLUDED_DOMAINS[@]}"; do
-    if [ "$domain" = "$excluded" ]; then
-      continue 2
-    fi
-  done
+  if [[ " ${EXCLUDED_DOMAINS[*]} " == *" $domain "* ]]; then
+    continue
+  fi
   migrations="libs/prisma/$domain/db/migrations"
 
   if git diff --quiet "$MERGE_BASE" "$HEAD_REF" -- "$schema"; then
@@ -59,21 +54,28 @@ for schema in $(git ls-tree -r --name-only "$HEAD_REF" libs/prisma | grep -E '^l
 
   # Only a real, deployable migration counts — a new */migration.sql — not
   # just any file added under the migrations directory (e.g. a README).
-  added_migrations=$(git diff --name-only --no-renames --diff-filter=A "$MERGE_BASE" "$HEAD_REF" -- "$migrations/*/migration.sql")
+  # core.quotePath=false keeps non-ASCII migration names usable as paths.
+  added_migrations=$(git -c core.quotePath=false diff --name-only --no-renames --diff-filter=A "$MERGE_BASE" "$HEAD_REF" -- "$migrations/*/migration.sql")
   if [ -z "$added_migrations" ]; then
     echo "🛑 - $schema changed but no migration was added in $migrations"
     FAILED_DOMAINS+=("$domain")
     continue
   fi
 
-  empty_migrations=$(echo "$added_migrations" | while read -r f; do
-    if ! git cat-file blob "$HEAD_REF:$f" | grep -q '[^[:space:]]'; then
-      echo "$f"
+  # Read each blob into a variable rather than piping into grep -q: grep
+  # exiting early would SIGPIPE git cat-file on large files and, under
+  # pipefail, misreport a real migration as empty. A genuine cat-file
+  # failure aborts the script loudly here (set -e) instead.
+  empty_migrations=""
+  while IFS= read -r f; do
+    content=$(git cat-file blob "$HEAD_REF:$f")
+    if [[ ! "$content" =~ [^[:space:]] ]]; then
+      empty_migrations+="$f"$'\n'
     fi
-  done)
+  done <<<"$added_migrations"
   if [ -n "$empty_migrations" ]; then
     echo "🛑 - $schema changed but the added migration(s) are empty:"
-    echo "$empty_migrations" | sed 's/^/      /'
+    printf '%s' "$empty_migrations" | sed 's/^/      /'
     FAILED_DOMAINS+=("$domain")
     continue
   fi

--- a/tools/scripts/check-prisma-migrations.sh
+++ b/tools/scripts/check-prisma-migrations.sh
@@ -6,70 +6,63 @@ set -euo pipefail
 # change with no migration otherwise sails through CI and only explodes at
 # deploy time against prod.
 #
-# Usage: check-prisma-migrations.sh <base-ref> [head-ref]
+# Usage: check-prisma-migrations.sh <base-ref>
 #   e.g. check-prisma-migrations.sh origin/main
 #
-# Changes are diffed from merge-base(<base-ref>, <head-ref>) to <head-ref>, so
-# commits already on the base branch are never blamed on the PR. A migration
-# counts only when a non-empty <timestamp>_<name>/migration.sql is added under
-# the domain's migrations directory (--diff-filter=A, --no-renames so a
-# delete+re-add or moved migration still counts at its new path) — edits to
-# already-committed migrations don't count, and neither do other added files
-# (e.g. a README). The SQL content itself is not validated against the schema
-# diff — that would require `prisma migrate diff` and a shadow database.
+# Assumes a clean checkout of the commit under test (as in CI). Changes are
+# diffed from merge-base(<base-ref>, HEAD) to HEAD, so commits already on the
+# base branch are never blamed on the PR. A migration counts only when a new
+# non-empty */migration.sql is added in the same domain. The SQL content is
+# not validated against the schema diff — that would require
+# `prisma migrate diff` and a shadow database.
 #
-# Domains are discovered from libs/prisma/*/db/schema.prisma at <head-ref>, so
-# a newly added domain is guarded automatically (its initial migration is
-# required) and a domain deleted by the PR is not flagged.
+# Domains are discovered from libs/prisma/*/db/schema.prisma, so a new domain
+# is guarded automatically (its initial migration is required) and a domain
+# deleted by the PR is not flagged.
 #
 # Escape hatch: the 'skip-migration-check' PR label, handled entirely by the
 # calling workflow — see .github/workflows/main.yml.
-#
-# The analytics domain is deliberately excluded: its database is managed
-# externally and its schema is pulled via `nx prisma-introspect
-# prisma-analytics` — it has no prisma-migrate target and no migrations
-# directory (see apis/AGENTS.md).
-EXCLUDED_DOMAINS=(analytics)
 
-BASE_REF="${1:?usage: check-prisma-migrations.sh <base-ref> [head-ref]}"
-HEAD_REF="${2:-HEAD}"
+BASE_REF="${1:?usage: check-prisma-migrations.sh <base-ref>}"
 
-if ! MERGE_BASE=$(git merge-base "$BASE_REF" "$HEAD_REF"); then
-  echo "🛑 - could not compute merge-base($BASE_REF, $HEAD_REF)."
+if ! MERGE_BASE=$(git merge-base "$BASE_REF" HEAD); then
+  echo "🛑 - could not compute merge-base($BASE_REF, HEAD)."
   echo "The checkout is likely shallow — this check needs full history (fetch-depth: 0)."
   exit 1
 fi
 
 FAILED_DOMAINS=()
-for schema in $(git ls-tree -r --name-only "$HEAD_REF" libs/prisma | grep -E '^libs/prisma/[^/]+/db/schema\.prisma$'); do
+for schema in libs/prisma/*/db/schema.prisma; do
+  [ -f "$schema" ] || continue
   domain=$(basename "$(dirname "$(dirname "$schema")")")
-  if [[ " ${EXCLUDED_DOMAINS[*]} " == *" $domain "* ]]; then
+
+  # The analytics database is managed externally and its schema is pulled via
+  # `nx prisma-introspect prisma-analytics` — it has no prisma-migrate target
+  # and no migrations directory (see apis/AGENTS.md).
+  if [ "$domain" = "analytics" ]; then
     continue
   fi
   migrations="libs/prisma/$domain/db/migrations"
 
-  if git diff --quiet "$MERGE_BASE" "$HEAD_REF" -- "$schema"; then
+  if git diff --quiet "$MERGE_BASE" HEAD -- "$schema"; then
     continue
   fi
 
   # Only a real, deployable migration counts — a new */migration.sql — not
   # just any file added under the migrations directory (e.g. a README).
-  # core.quotePath=false keeps non-ASCII migration names usable as paths.
-  added_migrations=$(git -c core.quotePath=false diff --name-only --no-renames --diff-filter=A "$MERGE_BASE" "$HEAD_REF" -- "$migrations/*/migration.sql")
+  # --no-renames so a moved or replaced migration registers as added at its
+  # new path; core.quotePath=false keeps non-ASCII names usable as paths.
+  added_migrations=$(git -c core.quotePath=false diff --name-only --no-renames --diff-filter=A "$MERGE_BASE" HEAD -- "$migrations/*/migration.sql")
   if [ -z "$added_migrations" ]; then
     echo "🛑 - $schema changed but no migration was added in $migrations"
     FAILED_DOMAINS+=("$domain")
     continue
   fi
 
-  # Read each blob into a variable rather than piping into grep -q: grep
-  # exiting early would SIGPIPE git cat-file on large files and, under
-  # pipefail, misreport a real migration as empty. A genuine cat-file
-  # failure aborts the script loudly here (set -e) instead.
+  # Reject empty/whitespace-only files created just to satisfy this check.
   empty_migrations=""
   while IFS= read -r f; do
-    content=$(git cat-file blob "$HEAD_REF:$f")
-    if [[ ! "$content" =~ [^[:space:]] ]]; then
+    if ! grep -q '[^[:space:]]' "$f"; then
       empty_migrations+="$f"$'\n'
     fi
   done <<<"$added_migrations"


### PR DESCRIPTION
Adds the first two "AI friendly" CI guards that turn silent-failure coupling points into loud, deterministic checks. Two small self-contained jobs in `.github/workflows/main.yml` — no new infrastructure, no app-code changes.

## ⚠️ Pre-existing drift found (committed here)

Verifying the first guard on clean `main` surfaced real drift: `apis/api-gateway/schema.graphql` differs from what `nx generate-graphql api-gateway` produces by **one trailing space** on the `restrictTranslations` line — the hive compose emits a trailing space after `@join__field(graph: API_MEDIA)` and the committed file lost it, most likely from a hand edit whose editor trimmed it. The regenerated file is committed separately as `fix(api-gateway): recompose supergraph schema to match generated output` so the guard starts green. A new `.editorconfig` rule exempts `apis/*/schema.graphql` from `trim_trailing_whitespace` so editors stop reintroducing exactly this drift.

## Guard 1 — `graphql-schema-check` (ENG-3689)

**What it catches:** a committed `schema.graphql` that no longer matches the code that generates it. The existing `subgraph-check` only validates federation composition against the Hive registry — nothing verified code↔schema agreement.

**How it works:** regenerates every subgraph schema (`nx run-many -t generate-graphql --exclude api-gateway`, so a future API with the target is guarded automatically), then recomposes the gateway supergraph (ordering matters: the compose must read fresh subgraph files), then fails if `git diff -- 'apis/*/schema.graphql'` is non-empty, printing the diff. `git add --intent-to-add` first, so a schema deleted by a PR and recreated by the regen (untracked) still fails rather than passing silently.

- Runs all regens unconditionally rather than using Nx affected / path filters — correctness over cleverness; the regen itself takes seconds and the job cost is dominated by `pnpm install` + `prisma-generate`, which every other job in this workflow already pays.
- Schema generation writes SDL and exits (`GENERATE_SCHEMA=true`), but two modules require env at import time (`api-journeys` env validation, `api-media`'s module-scope Crowdin client), so the step sets `SKIP_ENV_VALIDATION=1` and placeholder Crowdin vars. Values are never used during generation.
- No `NX_CLOUD_ACCESS_TOKEN` in this job: the regen targets aren't cacheable, so the token would only expose a secret to PR-controlled code.
- Compose output verified deterministic across repeated runs.

**When it fires:** run `nx generate-graphql <api>` for each API you changed, then `nx generate-graphql api-gateway`, and commit the updated `schema.graphql` files (the printed diff shows exactly what's stale).

## Guard 2 — `prisma-migration-check` (ENG-3690)

**What it catches:** a `schema.prisma` edit with no matching migration — today `prisma generate` succeeds regardless and the mismatch only explodes at deploy time against prod.

**How it works:** `tools/scripts/check-prisma-migrations.sh` diffs the PR against its merge-base with the base branch. For each domain discovered from `libs/prisma/*/db/schema.prisma` (so new domains are guarded automatically), a changed schema requires a newly added, **non-empty** `*/migration.sql` in that same domain's `db/migrations/`. Per-domain: a migration in a different domain doesn't count; edits to existing migrations don't count; `--no-renames` so a moved/replaced migration still counts at its new path.

- **`analytics` is deliberately excluded:** its database is managed externally and its schema is introspected (`nx prisma-introspect prisma-analytics`) — it has no `prisma-migrate` target and no migrations directory (see `apis/AGENTS.md`).
- **Trade-off:** `prisma migrate diff --from-migrations` would detect "schema changed but needs no migration" precisely, but it requires a shadow database in CI. Diff-based detection needs no database and has no false positives on typical PRs (audited recent history: every real schema change shipped with a migration), at the cost of flagging rare comment/formatting-only edits — covered by the escape hatch below.
- **Escape hatch:** add the `skip-migration-check` PR label and re-run the failed job. The job-level `if` can't see labels added after the triggering event, so the step re-checks labels via the API at runtime — that's what makes label-then-re-run actually work. If the API call fails, the check runs anyway (fail closed).
- Only runs on `pull_request` events (needs a base to diff against). Both guards are documented in `apis/AGENTS.md` where the schema workflow lives.

**When it fires:** run `nx prisma-migrate prisma-<domain>` and commit the generated migration directory — or use the label if the edit genuinely needs no migration.

## Review hardening

Beyond the CodeRabbit/CodeQL feedback (require a real `*/migration.sql`, not just any file; least-privilege `permissions` on both jobs), three review rounds hardened the guards:

- Removed the `--depth=5` base-branch fetch: a depth-limited fetch into a `fetch-depth: 0` clone writes `.git/shallow` and makes `merge-base` fail silently once the base advances past the cut (worst on re-runs). Note: the pre-existing `build`/`test` jobs still use this pattern but don't call `merge-base` directly.
- Runtime label re-check via `gh api` (bounded with `timeout`), with an explicit fail-closed warning when the API call fails.
- Empty-migration detection reads the working-tree file with `grep` — no `git cat-file` pipe, so no SIGPIPE misclassification of large migrations; `core.quotePath=false` keeps non-ASCII migration names working.

**Tested** against 14 simulated cases: schema change with/without migration, migration in the wrong domain, edits to existing migrations only, base-branch advancement (merge-base isolation), analytics exclusion, empty and >64KB migrations, moved migrations, non-ASCII migration names, new-domain and deleted-domain handling — all behave as intended. The full regen sequence was re-verified locally to produce zero diff.

Refs ENG-3689, ENG-3690

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzcuEZkzdjY7yUdsM2Sd6A