### PR TITLE
fix(watch): avoid duplicate base path on language change

### DIFF
--- a/apps/watch/src/components/PageCollection/PageCollection.spec.tsx
+++ b/apps/watch/src/components/PageCollection/PageCollection.spec.tsx
@@ -8,6 +8,7 @@ import type { MockedFunction } from 'vitest'
 import { VideoContentFields } from '../../../__generated__/VideoContentFields'
 import { PlayerProvider } from '../../libs/playerContext'
 import { useLanguages } from '../../libs/useLanguages'
+import { GET_VARIANT_LANGUAGES_ID_AND_SLUG } from '../../libs/useVariantLanguagesIdAndSlugQuery'
 import { VideoProvider } from '../../libs/videoContext'
 import { videos } from '../Videos/__generated__/testData'
 
@@ -91,6 +92,64 @@ describe('PageCollection', () => {
     const grid = screen.getByTestId('SectionVideoGrid')
     expect(grid).toHaveAttribute('data-primary', collectionVideo.id)
     expect(grid).toHaveAttribute('data-language', 'language-1')
+  })
+
+  it('navigates to the selected collection language with an app-relative path', async () => {
+    mockRouter.query = {
+      part1: 'the-way-of-st-james.html',
+      part2: 'english.html'
+    }
+    const routerPush = vi.spyOn(mockRouter, 'push')
+
+    render(
+      <MockedProvider
+        mocks={[
+          {
+            request: {
+              query: GET_VARIANT_LANGUAGES_ID_AND_SLUG,
+              variables: { id: collectionVideo.id }
+            },
+            result: {
+              data: {
+                video: {
+                  __typename: 'Video',
+                  variantLanguages: [
+                    {
+                      __typename: 'Language',
+                      id: 'language-1',
+                      slug: 'english'
+                    },
+                    {
+                      __typename: 'Language',
+                      id: 'language-2',
+                      slug: 'spanish'
+                    }
+                  ],
+                  subtitles: []
+                }
+              }
+            }
+          }
+        ]}
+      >
+        <SnackbarProvider>
+          <PlayerProvider>
+            <VideoProvider value={{ content: collectionVideo }}>
+              <PageCollection />
+            </VideoProvider>
+          </PlayerProvider>
+        </SnackbarProvider>
+      </MockedProvider>
+    )
+
+    await userEvent.click(await screen.findByRole('combobox'))
+    await userEvent.click(await screen.findByText('Spanish'))
+
+    expect(routerPush).toHaveBeenCalledWith(
+      '/the-way-of-st-james.html/spanish.html',
+      undefined,
+      { locale: undefined }
+    )
   })
 
   it('opens share dialog when share button clicked', async () => {

--- a/apps/watch/src/components/PageCollection/PageCollection.tsx
+++ b/apps/watch/src/components/PageCollection/PageCollection.tsx
@@ -73,7 +73,7 @@ export function PageCollection(): ReactElement {
     (slug: string) => {
       if (collectionSegment == null) return
       const normalizedSlug = slug.replace('.html', '')
-      const path = `/watch/${collectionSegment}/${encodeURIComponent(
+      const path = `/${collectionSegment}/${encodeURIComponent(
         normalizedSlug
       )}.html`
       void router.push(path, undefined, { locale: router.locale })


### PR DESCRIPTION
Fixes QA-555

Collection language switching in Watch now uses an app-relative route, allowing Next.js to apply the configured `/watch` base path exactly once. This prevents selections such as French from navigating to the malformed `/watch/watch/...` URL. A regression test exercises the rendered language picker and verifies the router destination.

Verified with the focused `PageCollection` Vitest suite, Prettier, and the Watch TypeScript build.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed language selection navigation so it opens the selected language at the correct app-relative URL.
  * Added coverage to verify navigation works correctly when switching languages in a collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
