### PR TITLE
fix(jf-proxy): forward Watch server-action POSTs

### DIFF
--- a/apps/watch-e2e/src/monitoring/search.monitor.ts
+++ b/apps/watch-e2e/src/monitoring/search.monitor.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * @check
+ * @name Watch Search Monitoring
+ * @retries 8
+ * @retryInterval 10
+ * @maxRetryTime 600
+ */
+
+test('Watch Search Monitoring: submitting JESUS returns search results', async ({
+  page
+}) => {
+  const response = await page.goto('https://www.jesusfilm.org/watch')
+  expect(response?.status()).toEqual(200)
+
+  await page.getByRole('button', { name: 'Search videos' }).click()
+
+  const searchDialog = page.getByRole('dialog', {
+    name: 'Search and browse videos'
+  })
+  await expect(searchDialog).toBeVisible()
+
+  const searchInput = searchDialog.getByRole('textbox', {
+    name: 'Search videos by keyword'
+  })
+  await searchInput.fill('JESUS')
+
+  const searchResponsePromise = page.waitForResponse((searchResponse) => {
+    const request = searchResponse.request()
+    return (
+      request.method() === 'POST' &&
+      request.headers()['next-action'] != null &&
+      new URL(searchResponse.url()).hostname === 'www.jesusfilm.org'
+    )
+  })
+
+  await searchInput.press('Enter')
+
+  const searchResponse = await searchResponsePromise
+  expect(searchResponse.ok()).toBeTruthy()
+  await expect(searchDialog.getByText('JESUS', { exact: true })).toBeVisible()
+})

--- a/apps/watch-e2e/src/monitoring/search.monitor.ts
+++ b/apps/watch-e2e/src/monitoring/search.monitor.ts
@@ -28,10 +28,16 @@ test('Watch Search Monitoring: submitting JESUS returns search results', async (
 
   const searchResponsePromise = page.waitForResponse((searchResponse) => {
     const request = searchResponse.request()
+    const actionUrl = new URL(searchResponse.url())
+    const actionPayload = request.postData()
+
     return (
       request.method() === 'POST' &&
       request.headers()['next-action'] != null &&
-      new URL(searchResponse.url()).hostname === 'www.jesusfilm.org'
+      actionUrl.origin === 'https://www.jesusfilm.org' &&
+      actionUrl.pathname === '/watch' &&
+      actionPayload?.includes('"query":"JESUS"') === true &&
+      actionPayload.includes('"surface":"watch-search"')
     )
   })
 

--- a/docs/plans/2026-07-23-002-fix-jf-proxy-post-search-monitor-plan.md
+++ b/docs/plans/2026-07-23-002-fix-jf-proxy-post-search-monitor-plan.md
@@ -1,0 +1,250 @@
+---
+title: Forward Watch POST requests and monitor production search
+type: fix
+date: 2026-07-23
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: production-incident
+execution: code
+deepened: 2026-07-23
+---
+
+# Forward Watch POST requests and monitor production search
+
+## Goal Capsule
+
+- **Objective:** Make the existing `jf-proxy` forward every Watch HTTP method,
+  request header, and request body to the configured Watch destination, then
+  add a real Checkly browser check that opens canonical production search,
+  submits `JESUS`, and requires a visible `JESUS` result.
+- **Authority:** Production evidence on 2026-07-23 showed canonical
+  `GET https://www.jesusfilm.org/watch` succeeds while a Next.js server-action
+  `POST` to the same URL returns the proxy's plain `404`. The same action sent
+  to Forge's comparison host succeeds.
+- **Execution profile:** Small, high-impact Cloudflare Worker routing fix plus
+  one outside-in Playwright/Checkly monitor.
+- **Stop conditions:** Stop if forwarding a request body requires buffering or
+  changes the existing GET contract, if a non-GET upstream failure is replaced
+  by the legacy HTML fallback, or if the browser monitor can pass without
+  submitting the search form.
+- **Tail ownership:** Ship through the repository pull-request flow. Merging to
+  `main` lets the existing Worker Deploy workflow publish `jf-proxy`; the
+  existing Checkly project is configured to discover `**/*.monitor.ts`.
+
+## Product Contract
+
+### Summary
+
+The production `www.jesusfilm.org/watch*` Cloudflare Route already belongs to
+`workers/jf-proxy`. Its generic proxy is registered with `app.get('*')`, so
+Hono never invokes it for server-action POSTs. Even if it did, the upstream
+`fetch` currently forwards method and headers but omits the request body.
+
+The repair belongs in that existing Worker, not a competing route or a
+search-specific endpoint. The synthetic belongs beside the current Watch
+Checkly browser checks and must prove the exact interaction a GET healthcheck
+missed.
+
+### Requirements
+
+- **R1.** Requests claimed by the existing Worker routes continue to select
+  `WATCH_PROXY_DEST` for `/watch*` and `RESOURCES_PROXY_DEST` elsewhere.
+- **R2.** The generic proxy handles all HTTP methods, including Next.js
+  server-action `POST`s.
+- **R3.** The upstream request preserves path, query, method, headers, cookies,
+  and body without buffering or decoding the body.
+- **R4.** Trusted forwarding metadata represents the public request origin so
+  Next.js can compare `Origin` with the effective forwarded host.
+- **R5.** GET-only legacy error fallback remains available for document
+  navigation, while non-GET 4xx/5xx responses pass through unchanged.
+- **R6.** Existing legacy redirect handlers, App Association handlers, GET
+  proxying, manual redirect behavior, destination bindings, and route patterns
+  remain unchanged.
+- **R7.** A browser monitor navigates to
+  `https://www.jesusfilm.org/watch`, clicks the English `Search videos`
+  control, fills the English `Search videos by keyword` textbox with `JESUS`,
+  presses Enter, and requires exact visible `JESUS` result text inside the
+  search dialog.
+- **R8.** The monitor uses only user-visible roles and labels, relies on
+  Playwright soft waits, and contains no fallback selector or hard wait.
+- **R9.** Focused Worker tests prove a representative Next.js action request
+  reaches the Watch destination byte-for-byte and its RSC response reaches the
+  caller.
+
+### Acceptance Examples
+
+- **AE1.** Given `POST /watch` with `Next-Action`,
+  `Next-Router-State-Tree`, `Origin`, cookies, and an encoded body, when
+  `jf-proxy` handles it, then the Watch destination receives the same method,
+  framework headers, cookies, and body.
+- **AE2.** Given the Watch destination returns `200 text/x-component` for that
+  action, then `jf-proxy` returns the same status, content type, and body.
+- **AE3.** Given a non-GET Watch request receives `404` or `500` upstream, then
+  the proxy returns that upstream response instead of requesting
+  `/not-found.html`.
+- **AE4.** Given a GET Watch document receives the existing fallback-triggering
+  status, then current not-found behavior remains intact.
+- **AE5.** Given a fresh production browser, when Checkly opens search, enters
+  `JESUS`, and presses Enter, then exact `JESUS` result text becomes visible in
+  the search dialog.
+
+### Scope Boundaries
+
+- Do not create a second Cloudflare Worker or change the Wrangler route/destination
+  configuration shipped in PR #9405.
+- Do not change Forge search ranking, UI, server actions, or production
+  selectors; the current English accessible names are sufficient.
+- Do not redesign the proxy's historical GET 404/500 fallback beyond preventing
+  it from swallowing non-GET responses.
+- Do not replace Checkly with a GET API check; the browser interaction is the
+  required outage detector.
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- **KTD1. Extend the existing Hono catch-all to all methods.** The route already
+  owns `www.jesusfilm.org/watch*`; changing its generic handler fixes the
+  production boundary without creating competing infrastructure.
+- **KTD2. Rebuild the upstream `Request` from the incoming raw request and the
+  rewritten destination URL.** The platform `Request` contract carries method,
+  headers, cookies, and body stream together and avoids an allowlist that will
+  drift with Next.js action protocol changes.
+- **KTD3. Overwrite only forwarding host/protocol from the trusted incoming
+  URL.** The public `Origin` header must agree with the effective forwarded
+  host for Next.js action-origin checks; caller-supplied forwarding metadata
+  must not be trusted.
+- **KTD4. Restrict the legacy fallback to GET.** A server-action 404 or 500 is
+  protocol data and must not be replaced with a legacy HTML not-found page.
+- **KTD5. Add a separate search monitor.** Search submission deserves an
+  independently named Checkly browser check so its failure clearly identifies
+  the canonical POST/application boundary rather than being buried in video
+  playback diagnostics.
+- **KTD6. Assert within the dialog using user-facing semantics.** An exact
+  `JESUS` result inside the search dialog proves the interaction completed and
+  cannot pass from unrelated JESUS text already present on the home page.
+
+### System-Wide Impact
+
+- **Edge routing:** The catch-all is shared by all Worker-owned paths, so
+  Resources and legacy GET behavior need regression coverage even though the
+  incident is Watch-specific.
+- **Request streams:** The proxy must pass the original body stream through
+  once. Reading it for logging or assertions in production would consume it
+  before the origin.
+- **CSRF/origin checks:** Rewriting only the URL changes the upstream host while
+  the browser's `Origin` remains `www`; canonical forwarding headers must close
+  that intentional proxy boundary.
+- **Failure semantics:** Non-GET upstream failures must remain non-GET protocol
+  responses. The current HTML fallback is navigation behavior, not an
+  all-method recovery policy.
+- **Monitoring:** Existing video and redirect checks stay intact. The new check
+  adds the missing canonical search transaction to the Checkly project matched
+  by `checkly.config.ts`.
+
+### Assumptions
+
+- PR #9405's Watch destination and unconditional `/watch*` path routing are
+  intentional and remain authoritative.
+- Forge's English production search opener and textbox retain the current
+  accessible names `Search videos` and `Search videos by keyword`.
+- Search for `JESUS` returns at least one result with exact visible title text
+  `JESUS`; this is the library title the incident report requires.
+- `checkly.config.ts` defines the repository's browser-check discovery, but the
+  repository contains no Checkly deploy workflow or Checkly API credentials.
+  An authorized operator must verify the connected Checkly project
+  materializes the new `*.monitor.ts` from `main`; this change does not invent a
+  second monitor deployment system without account context.
+
+## Implementation Units
+
+### U1. Forward all proxy methods and bodies
+
+- **Goal:** Make the generic Worker proxy transport-complete for Watch server
+  actions without changing destination selection.
+- **Requirements:** R1-R6, R9; AE1-AE4; KTD1-KTD4.
+- **Dependencies:** None.
+- **Files:** `workers/jf-proxy/src/index.ts`,
+  `workers/jf-proxy/src/index.spec.ts`.
+- **Approach:** Register the generic proxy for all methods, derive the upstream
+  URL through the existing destination selection, construct the upstream
+  request from the incoming raw `Request`, overwrite canonical forwarding
+  metadata, preserve manual redirects, and gate the existing error fallback to
+  GET requests.
+- **Test scenarios:**
+  - POST a representative Next action with framework headers, cookie, query,
+    and body; assert the Watch mock receives each unchanged plus canonical
+    forwarding metadata.
+  - Return a representative `text/x-component` response and assert status,
+    content type, and body reach the caller.
+  - Return 404 and 500 for non-GET Watch requests and assert no not-found fetch
+    occurs.
+  - Keep current GET document, cookie forwarding, Resources destination,
+    redirect, association-file, and not-found tests green.
+- **Verification:** The focused Worker suite and Worker TypeScript/lint checks
+  pass; a production-shaped server-action replay is represented by the unit
+  fixture.
+
+### U2. Add the canonical Watch search browser monitor
+
+- **Goal:** Detect the user-visible search outage that GET checks cannot see.
+- **Requirements:** R7-R8; AE5; KTD5-KTD6.
+- **Dependencies:** U1 for production success, but the monitor source can be
+  authored and linted independently.
+- **Files:** Add `apps/watch-e2e/src/monitoring/search.monitor.ts`.
+- **Approach:** Follow the repository's existing `@check` Playwright monitor
+  pattern. Start on canonical `www`, scope actions and assertions to the search
+  dialog, use visible English roles/labels, press Enter explicitly, and assert
+  exact `JESUS` result text.
+- **Test scenarios:**
+  - The current broken production route causes the monitor to fail after
+    submission rather than pass on the initial GET.
+  - After the Worker deploy, a fresh run submits the query and renders the exact
+    title within the dialog.
+- **Verification:** Playwright/Checkly discovery sees the new monitor, Watch E2E
+  TypeScript and lint pass, and a browser run captures the expected pre-deploy
+  failure or post-deploy success without fallback selectors.
+
+## Risks and Mitigations
+
+- **Request body is consumed or dropped.** Build the subrequest from the raw
+  incoming Request and never read the body in production code; assert bytes at
+  the mock origin.
+- **Next.js rejects the action as cross-origin.** Overwrite forwarded host and
+  protocol from `c.req.url`, preserve the browser `Origin`, and assert both in
+  the POST fixture.
+- **POST errors become HTML.** Gate fallback logic on GET and test both 404 and
+  500 non-GET responses.
+- **Shared proxy regression.** Retain the full existing Worker suite and avoid
+  destination or Wrangler changes.
+- **Monitor passes on unrelated page content.** Scope exact result text to the
+  open dialog and require click, fill, and Enter first.
+- **Monitor flakes on timing.** Use Playwright locator auto-waiting and the
+  repository default timeout; add no sleeps or conditional fallbacks.
+
+## Verification Contract
+
+| Gate                                 | Applies to | Done signal                                                          |
+| ------------------------------------ | ---------- | -------------------------------------------------------------------- |
+| Focused `jf-proxy` Vitest suite      | U1         | Existing coverage plus POST/body/error cases pass.                   |
+| Worker TypeScript and scoped lint    | U1         | Changed proxy source is type-safe and lint-clean.                    |
+| Watch E2E TypeScript and scoped lint | U2         | New monitor compiles and follows Playwright rules.                   |
+| Checkly/Playwright monitor discovery | U2         | The new `*.monitor.ts` is selected as a browser check.               |
+| Production canonical browser run     | U2         | Search submits `JESUS` and exact dialog result appears after deploy. |
+| Connected Checkly project read-back  | U2         | The new named browser check exists and is active after merge.        |
+| Formatting and diff integrity        | U1, U2     | Changed files are formatted and contain no whitespace errors.        |
+
+## Definition of Done
+
+- Worker tests prove a production-shaped server-action POST reaches the Watch
+  destination with its headers and body and returns the RSC response.
+- Non-GET origin errors pass through; existing GET fallback behavior remains
+  green.
+- The new Checkly monitor opens canonical production search, submits `JESUS`,
+  and requires an exact result inside the dialog.
+- Review finds no unresolved issue introduced by the change.
+- The branch is committed, pushed, opened as a PR, and required checks are
+  green.
+- Production resolution is confirmed only after merge deploys `jf-proxy` and a
+  connected-project read-back shows the active Checkly check and a fresh
+  Checkly/browser run passes. A successful GET alone is not completion evidence.

--- a/docs/plans/2026-07-23-002-fix-jf-proxy-post-search-monitor-plan.md
+++ b/docs/plans/2026-07-23-002-fix-jf-proxy-post-search-monitor-plan.md
@@ -49,8 +49,9 @@ missed.
 
 - **R1.** Requests claimed by the existing Worker routes continue to select
   `WATCH_PROXY_DEST` for `/watch*` and `RESOURCES_PROXY_DEST` elsewhere.
-- **R2.** The generic proxy handles all HTTP methods, including Next.js
-  server-action `POST`s.
+- **R2.** The generic proxy handles every HTTP method on `/watch*`, including
+  Next.js server-action `POST`s, while non-Watch proxy paths retain their
+  existing GET/HEAD-only contract.
 - **R3.** The upstream request preserves path, query, method, headers, cookies,
   and body without buffering or decoding the body.
 - **R4.** Trusted forwarding metadata represents the public request origin so
@@ -103,9 +104,10 @@ missed.
 
 ### Key Technical Decisions
 
-- **KTD1. Extend the existing Hono catch-all to all methods.** The route already
-  owns `www.jesusfilm.org/watch*`; changing its generic handler fixes the
-  production boundary without creating competing infrastructure.
+- **KTD1. Extend the existing Hono catch-all for all Watch methods.** The route
+  already owns `www.jesusfilm.org/watch*`; allowing every method there fixes
+  the production boundary without widening non-Watch mutation surfaces or
+  creating competing infrastructure.
 - **KTD2. Rebuild the upstream `Request` from the incoming raw request and the
   rewritten destination URL.** The platform `Request` contract carries method,
   headers, cookies, and body stream together and avoids an allowlist that will
@@ -127,8 +129,9 @@ missed.
 ### System-Wide Impact
 
 - **Edge routing:** The catch-all is shared by all Worker-owned paths, so
-  Resources and legacy GET behavior need regression coverage even though the
-  incident is Watch-specific.
+  non-Watch non-GET requests must remain rejected and Resources/legacy GET
+  behavior needs regression coverage even though the incident is
+  Watch-specific.
 - **Request streams:** The proxy must pass the original body stream through
   once. Reading it for logging or assertions in production would consume it
   before the origin.
@@ -167,10 +170,10 @@ missed.
 - **Files:** `workers/jf-proxy/src/index.ts`,
   `workers/jf-proxy/src/index.spec.ts`.
 - **Approach:** Register the generic proxy for all methods, derive the upstream
-  URL through the existing destination selection, construct the upstream
-  request from the incoming raw `Request`, overwrite canonical forwarding
-  metadata, preserve manual redirects, and gate the existing error fallback to
-  GET requests.
+  URL through the existing destination selection, reject non-Watch non-read
+  methods before proxying, construct the upstream request from the incoming
+  raw `Request`, overwrite canonical forwarding metadata, preserve manual
+  redirects, and gate the existing error fallback to GET requests.
 - **Test scenarios:**
   - POST a representative Next action with framework headers, cookie, query,
     and body; assert the Watch mock receives each unchanged plus canonical
@@ -179,6 +182,8 @@ missed.
     content type, and body reach the caller.
   - Return 404 and 500 for non-GET Watch requests and assert no not-found fetch
     occurs.
+  - Submit a non-Watch POST and assert it retains the existing edge 404 instead
+    of reaching the Resources destination.
   - Keep current GET document, cookie forwarding, Resources destination,
     redirect, association-file, and not-found tests green.
 - **Verification:** The focused Worker suite and Worker TypeScript/lint checks

--- a/workers/jf-proxy/src/index.spec.ts
+++ b/workers/jf-proxy/src/index.spec.ts
@@ -4,6 +4,15 @@ import app from '.'
 
 const graphQlEndpoint = 'http://graphql.example.com'
 
+function decodeRequestBody(body: unknown): string {
+  if (typeof body === 'string') return body
+  if (body instanceof Uint8Array) return new TextDecoder().decode(body)
+  if (body instanceof ArrayBuffer) {
+    return new TextDecoder().decode(new Uint8Array(body))
+  }
+  throw new TypeError('Expected the intercepted request to have a text body')
+}
+
 function workerEnv(
   overrides: Record<string, string | undefined> = {}
 ): Record<string, string | undefined> {
@@ -26,12 +35,7 @@ function expectGraphQlRequest(
     .get(graphQlEndpoint)
     .intercept({ path: '/', method: 'POST' })
     .reply(({ body }) => {
-      const bodyText =
-        typeof body === 'string'
-          ? body
-          : body instanceof Uint8Array
-            ? new TextDecoder().decode(body)
-            : String(body)
+      const bodyText = decodeRequestBody(body)
       const requestBody = JSON.parse(bodyText)
       assertBody?.(requestBody)
       return {
@@ -461,6 +465,90 @@ describe('test the worker', () => {
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('watch video content')
   })
+
+  it('should forward a Next.js server action POST to WATCH_PROXY_DEST', async () => {
+    const actionBody = '1_{"query":"JESUS"}'
+    let capturedBody: string | undefined
+    let capturedHeaders: Headers | Record<string, string> | undefined
+
+    fetchMock
+      .get('http://watch.example.com')
+      .intercept({ path: '/watch?source=synthetic', method: 'POST' })
+      .reply((request) => {
+        capturedBody = decodeRequestBody(request.body)
+        capturedHeaders = request.headers
+        return {
+          statusCode: 200,
+          data: '1:{"ok":true}',
+          responseOptions: {
+            headers: { 'Content-Type': 'text/x-component' }
+          }
+        }
+      })
+
+    const res = await app.request(
+      'http://localhost/watch?source=synthetic',
+      {
+        method: 'POST',
+        headers: {
+          accept: 'text/x-component',
+          cookie: 'forge_web_session=session-value',
+          'next-action': 'action-id',
+          'next-router-state-tree': '%5B%22%22%5D',
+          origin: 'https://www.jesusfilm.org',
+          'x-forwarded-host': 'attacker.example.com',
+          'x-forwarded-proto': 'http'
+        },
+        body: actionBody
+      },
+      workerEnv()
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('text/x-component')
+    expect(await res.text()).toBe('1:{"ok":true}')
+    expect(capturedBody).toBe(actionBody)
+    expect(capturedHeaders).toBeDefined()
+
+    const getCapturedHeader = (name: string): string | null | undefined =>
+      capturedHeaders instanceof Headers
+        ? capturedHeaders.get(name)
+        : capturedHeaders?.[name]
+
+    expect(getCapturedHeader('accept')).toBe('text/x-component')
+    expect(getCapturedHeader('cookie')).toBe('forge_web_session=session-value')
+    expect(getCapturedHeader('next-action')).toBe('action-id')
+    expect(getCapturedHeader('next-router-state-tree')).toBe('%5B%22%22%5D')
+    expect(getCapturedHeader('origin')).toBe('https://www.jesusfilm.org')
+    expect(getCapturedHeader('x-forwarded-host')).toBe('localhost')
+    expect(getCapturedHeader('x-forwarded-proto')).toBe('http')
+  })
+
+  it.each([
+    [404, 'action not found'],
+    [500, 'action failed']
+  ])(
+    'should pass through a %s response for a non-GET Watch request',
+    async (status, responseBody) => {
+      fetchMock
+        .get('http://watch.example.com')
+        .intercept({ path: '/watch', method: 'POST' })
+        .reply(status, responseBody)
+
+      const res = await app.request(
+        'http://localhost/watch',
+        {
+          method: 'POST',
+          headers: { 'next-action': 'stale-action-id' },
+          body: 'action-payload'
+        },
+        workerEnv()
+      )
+
+      expect(res.status).toBe(status)
+      expect(await res.text()).toBe(responseBody)
+    }
+  )
 
   it('should route other worker paths to RESOURCES_PROXY_DEST', async () => {
     fetchMock

--- a/workers/jf-proxy/src/index.spec.ts
+++ b/workers/jf-proxy/src/index.spec.ts
@@ -472,7 +472,7 @@ describe('test the worker', () => {
     let capturedHeaders: Headers | Record<string, string> | undefined
 
     fetchMock
-      .get('http://watch.example.com')
+      .get('https://watch.example.com')
       .intercept({ path: '/watch?source=synthetic', method: 'POST' })
       .reply((request) => {
         capturedBody = decodeRequestBody(request.body)
@@ -487,7 +487,7 @@ describe('test the worker', () => {
       })
 
     const res = await app.request(
-      'http://localhost/watch?source=synthetic',
+      'https://www.jesusfilm.org/watch?source=synthetic',
       {
         method: 'POST',
         headers: {
@@ -520,8 +520,8 @@ describe('test the worker', () => {
     expect(getCapturedHeader('next-action')).toBe('action-id')
     expect(getCapturedHeader('next-router-state-tree')).toBe('%5B%22%22%5D')
     expect(getCapturedHeader('origin')).toBe('https://www.jesusfilm.org')
-    expect(getCapturedHeader('x-forwarded-host')).toBe('localhost')
-    expect(getCapturedHeader('x-forwarded-proto')).toBe('http')
+    expect(getCapturedHeader('x-forwarded-host')).toBe('www.jesusfilm.org')
+    expect(getCapturedHeader('x-forwarded-proto')).toBe('https')
   })
 
   it.each([
@@ -570,6 +570,19 @@ describe('test the worker', () => {
     )
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('api content')
+  })
+
+  it('should not forward non-GET requests for non-Watch paths', async () => {
+    const res = await app.request(
+      'http://localhost/api/test',
+      {
+        method: 'POST',
+        body: 'mutation-payload'
+      },
+      workerEnv()
+    )
+
+    expect(res.status).toBe(404)
   })
 
   it('should handle 404 response', async () => {

--- a/workers/jf-proxy/src/index.ts
+++ b/workers/jf-proxy/src/index.ts
@@ -98,6 +98,11 @@ app.all('*', async (c) => {
   const publicUrl = new URL(c.req.url)
   const pathname = publicUrl.pathname
   const isWatchPath = pathname.startsWith('/watch')
+  const isReadRequest = c.req.method === 'GET' || c.req.method === 'HEAD'
+
+  if (!isWatchPath && !isReadRequest) {
+    return c.notFound()
+  }
 
   const proxyDest = isWatchPath
     ? (c.env.WATCH_PROXY_DEST ?? publicUrl.hostname)

--- a/workers/jf-proxy/src/index.ts
+++ b/workers/jf-proxy/src/index.ts
@@ -94,56 +94,50 @@ app.on(
   }
 )
 
-app.get('*', async (c) => {
-  const url = new URL(c.req.url)
-  const pathname = url.pathname
-
-  const cookieHeader = c.req.header('cookie')
+app.all('*', async (c) => {
+  const publicUrl = new URL(c.req.url)
+  const pathname = publicUrl.pathname
   const isWatchPath = pathname.startsWith('/watch')
 
   const proxyDest = isWatchPath
-    ? (c.env.WATCH_PROXY_DEST ?? url.hostname)
-    : (c.env.RESOURCES_PROXY_DEST ?? url.hostname)
+    ? (c.env.WATCH_PROXY_DEST ?? publicUrl.hostname)
+    : (c.env.RESOURCES_PROXY_DEST ?? publicUrl.hostname)
 
-  url.hostname = proxyDest
+  const upstreamUrl = new URL(publicUrl)
+  upstreamUrl.hostname = proxyDest
 
   let response: Response
 
-  // Extract headers from the original request, including cookies
-  const headers = new Headers()
-
-  // Copy all headers from the original request
-  const originalHeaders = c.req.header()
-  if (originalHeaders) {
-    Object.entries(originalHeaders).forEach(([key, value]) => {
-      if (value) {
-        headers.set(key, value)
-      }
-    })
-  }
-
-  // Ensure cookies are properly passed
-  if (cookieHeader) {
-    headers.set('cookie', cookieHeader)
-  }
+  const headers = new Headers(c.req.raw.headers)
+  headers.set('x-forwarded-host', publicUrl.host)
+  headers.set('x-forwarded-proto', publicUrl.protocol.slice(0, -1))
 
   try {
+    const normalizedUpstreamUrl = upstreamUrl
+      .toString()
+      .replace(/(%[0-9A-F][0-9A-F])/g, (match) => match.toLowerCase())
+    const body =
+      c.req.method === 'GET' || c.req.method === 'HEAD'
+        ? undefined
+        : c.req.raw.body
+
     response = await fetch(
-      url
-        .toString()
-        .replace(/(%[0-9A-F][0-9A-F])/g, (match) => match.toLowerCase()),
-      {
+      new Request(normalizedUpstreamUrl, {
         method: c.req.method,
         headers,
+        body,
         redirect: 'manual'
-      }
+      })
     )
   } catch (error) {
     console.error('Proxy fetch error:', error)
     return new Response('Service Unavailable', { status: 503 })
   }
 
-  if (response.status == 404 || response.status == 500) {
+  if (
+    c.req.method === 'GET' &&
+    (response.status === 404 || response.status === 500)
+  ) {
     const notFoundUrl = new URL(c.req.url)
     notFoundUrl.pathname = '/not-found.html'
     try {


### PR DESCRIPTION
## Summary

Watch search on `www.jesusfilm.org` can load normally but fails when a viewer submits a query because the canonical edge route handles GETs only. This change lets every `/watch*` server-action POST reach Forge with its framework headers, cookies, trusted forwarding metadata, and body intact, while preserving the existing GET/HEAD-only contract for non-Watch routes.

A dedicated Checkly browser monitor now opens search, enters `JESUS`, presses Enter, requires the real `Next-Action` POST to succeed, and verifies the exact `JESUS` result inside the dialog. A GET-only healthcheck can no longer report this user journey as healthy.

Linear: [FGE-16](https://linear.app/jesus-film-project/issue/FGE-16/p0-forward-watch-server-action-posts-through-the-www-edge-route)

## Verification

- `jf-proxy` Vitest: 38/38 passing, including action body/header transport, HTTPS forwarded-host/protocol overwrite, non-GET error pass-through, and rejection of non-Watch POSTs
- Watch E2E TypeScript: passing with TypeScript 7
- Changed-file ESLint, Prettier, and `git diff --check`: passing
- Browser control: direct Forge search returned the exact `JESUS` film result
- Browser outage proof: current canonical `POST https://www.jesusfilm.org/watch` returned `404 Not Found`, confirming the new monitor fails on the real outage instead of passing on the initial GET
- Local changed Worker: accepted and forwarded `POST /watch` to Forge; canonical post-deploy success remains the release gate

Checkly CLI discovery could not be read back locally because this environment has no `CHECKLY_API_KEY` or `CHECKLY_ACCOUNT_ID`. The connected Checkly project must materialize the new `Watch Search Monitoring` check from `main`.

## Post-Deploy Monitoring & Validation

- Owner: Forge Watch team / edge on-call
- Window: validate immediately after the Worker Deploy workflow completes, watch the first 30 minutes closely, then confirm the synthetic remains green for 24 hours
- Logs: inspect `jf-proxy-prod` for `POST /watch`; healthy requests return `200` with `text/x-component`, while any edge-generated plain `404` is a rollback signal
- Synthetic: confirm `Watch Search Monitoring` exists in Checkly, is active on its 10-minute schedule, and passes a fresh run
- User signal: a clean browser session on `https://www.jesusfilm.org/watch` must open search, submit `JESUS`, and show the exact `JESUS` result
- Failure trigger: revert through the normal PR-to-main workflow if Watch POSTs still return edge 404s, non-Watch mutation methods begin reaching Resources, or existing GET routing/fallback checks regress

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search requests on the Watch experience now support submission and return matching video results reliably.
  * Search results are validated through automated browser monitoring using the production Watch experience.

* **Bug Fixes**
  * Improved forwarding of Watch search requests, including request bodies and headers.
  * Preserved response status and content for Watch requests.
  * Prevented unsupported non-GET requests outside the Watch experience from being routed incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->