### PR TITLE
docs(agents): document Next Steps GitHub Project workflow

### DIFF
--- a/docs/agents/github-projects.md
+++ b/docs/agents/github-projects.md
@@ -1,0 +1,108 @@
+# GitHub Projects: the Next Steps board
+
+Work-pickup and ticket state for this repo live in **GitHub Issues** plus one org-level
+Project: [Next Steps (org project #8)](https://github.com/orgs/JesusFilm/projects/8).
+Issues are the tickets; the project's **Status field is the source of truth for ticket
+state**. This replaces Linear for the AI workflow trial (Linear ENG-3688).
+
+## Ticket state = the Status field
+
+One Status per ticket, moving left to right:
+
+| Status          | Meaning                                                        |
+| --------------- | -------------------------------------------------------------- |
+| **Triage**      | New or unevaluated; also covers "waiting on more info"          |
+| **Ready**       | Fully specified, up for grabs (by a human or the AI workflow)   |
+| **In progress** | Being worked, human or AI                                       |
+| **In review**   | PR up, awaiting review                                          |
+| **QA**          | Review passed, awaiting manual QA                               |
+| **Done**        | Closed — shipped, or rejected as not planned                    |
+
+State transitions:
+
+- **Humans** drag cards on the board or set Status in the issue sidebar.
+- **Agents/scripts** use the `gh project` commands (see below). The token needs the
+  `project` scope (`gh auth refresh -s project`).
+- **Automatic**: new `core` issues enter the project in Triage; closing an issue moves it
+  to Done and archives it (project built-in workflows).
+
+Rejecting a ticket ("wontfix"): add the `Won't do` label, then close the issue as
+**not planned**. No dedicated column — the close reason is the record.
+
+## Labels
+
+Labels carry everything that is not workflow state:
+
+| Label                  | Purpose                                                                 |
+| ---------------------- | ----------------------------------------------------------------------- |
+| `ai-auto-workflow`     | Marker: this ticket may be picked up by the AI workflow. Absent = human. |
+| `feature:<kebab-name>` | Feature membership; drives that feature's project view. One or more.     |
+| `Bug` / `Improvement`  | Ticket kind; drives the Bugs/Improvements view.                          |
+| `Won't do`             | Rejected at triage; closed as not planned.                               |
+| `type: feat` / `type: fix` | Pre-existing repo taxonomy, unchanged.                              |
+
+`ready-for-agent` belongs to a separate system (Phoebe) and is **not** part of this
+workflow — do not apply or remove it here.
+
+## Milestones
+
+Milestones are repo-level and encode phases/buckets. One per issue.
+
+- Feature phases: `<feature>: <stage>`, where the prefix matches the feature label's
+  value — e.g. `agent-pipeline: setup`, `agent-pipeline: mvp` for `feature:agent-pipeline`.
+- Rolling buckets: `bugs`, `improvements` (sectioning for the Bugs/Improvements view).
+- Give milestones due dates where possible; **close them when the phase ships** so the
+  list stays short.
+
+## Views
+
+Views are saved filters over the project — they cannot be created or edited via the API,
+only in the UI. Current set:
+
+| View              | Layout                                   | Filter                     |
+| ----------------- | ---------------------------------------- | -------------------------- |
+| View 1 (board)    | Board, Status columns                    | —                          |
+| Bugs/Improvements | Board, Status columns × Milestone swimlanes | `label:Bug,Improvement` |
+
+**Adding a feature ("custom milestone") view**: create the label
+(`gh label create "feature:<name>" --color 0e7c86`), then in the UI: New view → layout of
+choice → filter `label:"feature:<name>"` → Save. Anything with that label appears in the
+view automatically — the auto-add workflow puts every new issue in the project.
+
+Filter syntax reminders: comma = OR within a qualifier (`label:Bug,Improvement`);
+space = AND between qualifiers; no wildcards (you cannot express "has no feature label").
+
+## The AI workflow
+
+A ticket rides the AI lane when it carries `ai-auto-workflow` **and** its Status is
+Ready. The agent then:
+
+1. **Find work**
+   ```bash
+   gh project item-list 8 --owner JesusFilm --format json --limit 200 \
+     | jq '[.items[] | select(.status == "Ready" and ((.labels // []) | index("ai-auto-workflow")))]'
+   ```
+2. **Claim it** — set Status to In progress (IDs below):
+   ```bash
+   gh project item-edit --id <ITEM_ID> --project-id PVT_kwDOBNwqhs4BeMYJ \
+     --field-id PVTSSF_lADOBNwqhs4BeMYJzhYobGA --single-select-option-id b9c41da0
+   ```
+3. **Work it**, open a PR, set Status to In review (`ab210038`).
+4. **Bail out** if stuck: remove `ai-auto-workflow`, set Status back to Ready, and leave
+   a handoff comment on the issue — the ticket becomes ordinary human work.
+
+### Stable IDs
+
+| Thing                | ID                                 |
+| -------------------- | ---------------------------------- |
+| Project (Next Steps) | `PVT_kwDOBNwqhs4BeMYJ`             |
+| Status field         | `PVTSSF_lADOBNwqhs4BeMYJzhYobGA`   |
+| Status: Triage       | `e5a2c514`                         |
+| Status: Ready        | `3c63150a`                         |
+| Status: In progress  | `b9c41da0`                         |
+| Status: In review    | `ab210038`                         |
+| Status: QA           | `12a20fe3`                         |
+| Status: Done         | `5243b071`                         |
+
+(If the Status options are ever edited in the project settings, these option IDs change —
+re-read them with `gh project field-list 8 --owner JesusFilm --format json`.)

--- a/docs/agents/github-projects.md
+++ b/docs/agents/github-projects.md
@@ -50,7 +50,11 @@ Milestones are repo-level and encode phases/buckets. One per issue.
 
 - Feature phases: `<feature>: <stage>`, where the prefix matches the feature label's
   value — e.g. `agent-pipeline: setup`, `agent-pipeline: mvp` for `feature:agent-pipeline`.
-- Rolling buckets: `bugs`, `improvements` (sectioning for the Bugs/Improvements view).
+- Rolling buckets: `bugs`, `improvements` — permanent milestones that are **never
+  closed**, unlike feature-phase milestones. They pair with the `Bug`/`Improvement`
+  labels: the **label** puts a ticket in the Bugs/Improvements view; the **milestone**
+  places it in the right swimlane. Apply **both** — a labeled ticket without the
+  milestone lands in the view's "No milestone" lane.
 - Give milestones due dates where possible; **close them when the phase ships** so the
   list stays short.
 

--- a/docs/agents/github-projects.md
+++ b/docs/agents/github-projects.md
@@ -23,8 +23,8 @@ State transitions:
 - **Humans** drag cards on the board or set Status in the issue sidebar.
 - **Agents/scripts** use the `gh project` commands (see below). The token needs the
   `project` scope (`gh auth refresh -s project`).
-- **Automatic**: new `core` issues enter the project in Triage; closing an issue moves it
-  to Done and archives it (project built-in workflows).
+- **Automatic**: new `JesusFilm/core` issues enter the project in Triage; closing an
+  issue moves it to Done and archives it (project built-in workflows).
 
 Rejecting a ticket ("wontfix"): add the `Won't do` label, then close the issue as
 **not planned**. No dedicated column — the close reason is the record.
@@ -56,18 +56,27 @@ Milestones are repo-level and encode phases/buckets. One per issue.
 
 ## Views
 
-Views are saved filters over the project — they cannot be created or edited via the API,
-only in the UI. Current set:
+Views are saved filters over the project. They can be **created** via the Projects v2
+REST API, but not listed, edited, or deleted that way — configuration changes (layout
+switches, group-by, swimlanes, sort) are UI-only. Current set:
 
 | View              | Layout                                      | Filter                  |
 | ----------------- | ------------------------------------------- | ----------------------- |
 | View 1 (board)    | Board, Status columns                       | —                       |
 | Bugs/Improvements | Board, Status columns × Milestone swimlanes | `label:Bug,Improvement` |
+| agent-pipeline    | Table                                    | `label:"feature:agent-pipeline"` |
 
-**Adding a feature ("custom milestone") view**: create the label
-(`gh label create "feature:<name>" --color 0e7c86`), then in the UI: New view → layout of
-choice → filter `label:"feature:<name>"` → Save. Anything with that label appears in the
-view automatically — the auto-add workflow puts every new issue in the project.
+**Adding a feature ("custom milestone") view** — two commands:
+
+```bash
+gh label create "feature:<name>" --color 0e7c86
+gh api -X POST orgs/JesusFilm/projectsV2/8/views \
+  -f name="<name>" -f layout="table" -f filter='label:"feature:<name>"'
+```
+
+Fine-tune (group-by, swimlanes) in the UI afterwards if needed. Anything with that label
+appears in the view automatically — the auto-add workflow puts every new `JesusFilm/core`
+issue in the project.
 
 Filter syntax reminders: comma = OR within a qualifier (`label:Bug,Improvement`);
 space = AND between qualifiers; no wildcards (you cannot express "has no feature label").
@@ -79,9 +88,13 @@ Ready. The agent then:
 
 1. **Find work**
    ```bash
-   gh project item-list 8 --owner JesusFilm --format json --limit 200 \
+   gh project item-list 8 --owner JesusFilm --format json --limit 1000 \
      | jq '[.items[] | select(.status == "Ready" and ((.labels // []) | index("ai-auto-workflow")))]'
    ```
+   `gh project item-list` has no server-side filtering — the `jq` filter runs client-side
+   over a `--limit` window. Keep the limit comfortably above the project's item count
+   (archived items don't count), or page via GraphQL `items(first:100, after:...)` if the
+   project ever outgrows it.
 2. **Claim it** — set Status to In progress (IDs below):
    ```bash
    gh project item-edit --id <ITEM_ID> --project-id PVT_kwDOBNwqhs4BeMYJ \

--- a/docs/agents/github-projects.md
+++ b/docs/agents/github-projects.md
@@ -9,14 +9,14 @@ state**. This replaces Linear for the AI workflow trial (Linear ENG-3688).
 
 One Status per ticket, moving left to right:
 
-| Status          | Meaning                                                        |
-| --------------- | -------------------------------------------------------------- |
-| **Triage**      | New or unevaluated; also covers "waiting on more info"          |
-| **Ready**       | Fully specified, up for grabs (by a human or the AI workflow)   |
-| **In progress** | Being worked, human or AI                                       |
-| **In review**   | PR up, awaiting review                                          |
-| **QA**          | Review passed, awaiting manual QA                               |
-| **Done**        | Closed — shipped, or rejected as not planned                    |
+| Status          | Meaning                                                       |
+| --------------- | ------------------------------------------------------------- |
+| **Triage**      | New or unevaluated; also covers "waiting on more info"        |
+| **Ready**       | Fully specified, up for grabs (by a human or the AI workflow) |
+| **In progress** | Being worked, human or AI                                     |
+| **In review**   | PR up, awaiting review                                        |
+| **QA**          | Review passed, awaiting manual QA                             |
+| **Done**        | Closed — shipped, or rejected as not planned                  |
 
 State transitions:
 
@@ -33,13 +33,13 @@ Rejecting a ticket ("wontfix"): add the `Won't do` label, then close the issue a
 
 Labels carry everything that is not workflow state:
 
-| Label                  | Purpose                                                                 |
-| ---------------------- | ----------------------------------------------------------------------- |
-| `ai-auto-workflow`     | Marker: this ticket may be picked up by the AI workflow. Absent = human. |
-| `feature:<kebab-name>` | Feature membership; drives that feature's project view. One or more.     |
-| `Bug` / `Improvement`  | Ticket kind; drives the Bugs/Improvements view.                          |
-| `Won't do`             | Rejected at triage; closed as not planned.                               |
-| `type: feat` / `type: fix` | Pre-existing repo taxonomy, unchanged.                              |
+| Label                      | Purpose                                                                  |
+| -------------------------- | ------------------------------------------------------------------------ |
+| `ai-auto-workflow`         | Marker: this ticket may be picked up by the AI workflow. Absent = human. |
+| `feature:<kebab-name>`     | Feature membership; drives that feature's project view. One or more.     |
+| `Bug` / `Improvement`      | Ticket kind; drives the Bugs/Improvements view.                          |
+| `Won't do`                 | Rejected at triage; closed as not planned.                               |
+| `type: feat` / `type: fix` | Pre-existing repo taxonomy, unchanged.                                   |
 
 `ready-for-agent` belongs to a separate system (Phoebe) and is **not** part of this
 workflow — do not apply or remove it here.
@@ -59,9 +59,9 @@ Milestones are repo-level and encode phases/buckets. One per issue.
 Views are saved filters over the project — they cannot be created or edited via the API,
 only in the UI. Current set:
 
-| View              | Layout                                   | Filter                     |
-| ----------------- | ---------------------------------------- | -------------------------- |
-| View 1 (board)    | Board, Status columns                    | —                          |
+| View              | Layout                                      | Filter                  |
+| ----------------- | ------------------------------------------- | ----------------------- |
+| View 1 (board)    | Board, Status columns                       | —                       |
 | Bugs/Improvements | Board, Status columns × Milestone swimlanes | `label:Bug,Improvement` |
 
 **Adding a feature ("custom milestone") view**: create the label
@@ -93,16 +93,16 @@ Ready. The agent then:
 
 ### Stable IDs
 
-| Thing                | ID                                 |
-| -------------------- | ---------------------------------- |
-| Project (Next Steps) | `PVT_kwDOBNwqhs4BeMYJ`             |
-| Status field         | `PVTSSF_lADOBNwqhs4BeMYJzhYobGA`   |
-| Status: Triage       | `e5a2c514`                         |
-| Status: Ready        | `3c63150a`                         |
-| Status: In progress  | `b9c41da0`                         |
-| Status: In review    | `ab210038`                         |
-| Status: QA           | `12a20fe3`                         |
-| Status: Done         | `5243b071`                         |
+| Thing                | ID                               |
+| -------------------- | -------------------------------- |
+| Project (Next Steps) | `PVT_kwDOBNwqhs4BeMYJ`           |
+| Status field         | `PVTSSF_lADOBNwqhs4BeMYJzhYobGA` |
+| Status: Triage       | `e5a2c514`                       |
+| Status: Ready        | `3c63150a`                       |
+| Status: In progress  | `b9c41da0`                       |
+| Status: In review    | `ab210038`                       |
+| Status: QA           | `12a20fe3`                       |
+| Status: Done         | `5243b071`                       |
 
 (If the Status options are ever edited in the project settings, these option IDs change —
 re-read them with `gh project field-list 8 --owner JesusFilm --format json`.)

--- a/docs/agents/github-projects.md
+++ b/docs/agents/github-projects.md
@@ -58,6 +58,31 @@ Milestones are repo-level and encode phases/buckets. One per issue.
 - Give milestones due dates where possible; **close them when the phase ships** so the
   list stays short.
 
+## Sub-issues
+
+Use sub-issues to break a big ticket (an epic, a feature slice) into children. In the UI:
+**Create sub-issue** on the parent. Via CLI there are no native `gh` commands yet — use
+the REST endpoints with the child's **database id** (`.id`, not the `#number`):
+
+```bash
+CHILD_ID=$(gh api repos/JesusFilm/core/issues/<child-number> --jq .id)
+gh api -X POST repos/JesusFilm/core/issues/<parent-number>/sub_issues -F sub_issue_id="$CHILD_ID"
+gh api repos/JesusFilm/core/issues/<parent-number>/sub_issues        # list children
+gh api repos/JesusFilm/core/issues/<parent-number> --jq .sub_issues_summary  # progress
+```
+
+How they behave on the board:
+
+- Each sub-issue is **its own card** with its own independent Status — no visual nesting
+  on boards. Table views can **group by "Parent issue"** for epic-style sections, and the
+  **"Sub-issues progress"** field shows an X-of-Y bar on the parent (driven by children
+  being *closed*, not by their Status).
+- **Nothing is inherited.** A child does not get its parent's labels, milestone, or
+  Status — apply `feature:*`, `ai-auto-workflow`, `Bug`/`Improvement` + milestone, etc.
+  to each child explicitly.
+- Auto-add puts every sub-issue on the board individually. If a view should show only
+  top-level tickets, filter it with `no:parent-issue`.
+
 ## Views
 
 Views are saved filters over the project. They can be **created** via the Projects v2

--- a/docs/agents/github-projects.md
+++ b/docs/agents/github-projects.md
@@ -76,7 +76,7 @@ How they behave on the board:
 - Each sub-issue is **its own card** with its own independent Status — no visual nesting
   on boards. Table views can **group by "Parent issue"** for epic-style sections, and the
   **"Sub-issues progress"** field shows an X-of-Y bar on the parent (driven by children
-  being *closed*, not by their Status).
+  being _closed_, not by their Status).
 - **Nothing is inherited.** A child does not get its parent's labels, milestone, or
   Status — apply `feature:*`, `ai-auto-workflow`, `Bug`/`Improvement` + milestone, etc.
   to each child explicitly.

--- a/docs/agents/github-projects.md
+++ b/docs/agents/github-projects.md
@@ -60,11 +60,11 @@ Views are saved filters over the project. They can be **created** via the Projec
 REST API, but not listed, edited, or deleted that way — configuration changes (layout
 switches, group-by, swimlanes, sort) are UI-only. Current set:
 
-| View              | Layout                                      | Filter                  |
-| ----------------- | ------------------------------------------- | ----------------------- |
-| View 1 (board)    | Board, Status columns                       | —                       |
-| Bugs/Improvements | Board, Status columns × Milestone swimlanes | `label:Bug,Improvement` |
-| agent-pipeline    | Table                                    | `label:"feature:agent-pipeline"` |
+| View              | Layout                                      | Filter                           |
+| ----------------- | ------------------------------------------- | -------------------------------- |
+| View 1 (board)    | Board, Status columns                       | —                                |
+| Bugs/Improvements | Board, Status columns × Milestone swimlanes | `label:Bug,Improvement`          |
+| agent-pipeline    | Table                                       | `label:"feature:agent-pipeline"` |
 
 **Adding a feature ("custom milestone") view** — two commands:
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -13,6 +13,12 @@ Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all op
 
 Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
 
+## Ticket state and work pickup
+
+Ticket workflow state (Triage → Ready → In progress → In review → QA → Done) lives in the
+**Status field of the Next Steps org project**, not in labels. How to read it, set it, and
+how the AI workflow picks up work: see `docs/agents/github-projects.md`.
+
 ## Pull requests as a triage surface
 
 **PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_


### PR DESCRIPTION
## What

Adds `docs/agents/github-projects.md` — the working conventions for the [Next Steps org project](https://github.com/orgs/JesusFilm/projects/8), which replaces Linear for the AI-workflow trial (ENG-3688):

- **Status field as the source of truth**: Triage → Ready → In progress → In review → QA → Done
- **Labels**: `ai-auto-workflow` marker (AI lane), `feature:<name>` (one view per feature), `Bug`/`Improvement`, `Won't do` (rejected, closed as not planned)
- **Milestones**: `<feature>: <stage>` phases + rolling `bugs`/`improvements` buckets
- **View recipes** and the views-are-UI-only API constraint
- **AI pickup contract**: `gh project` commands with the stable project/field/option IDs

Also links it from `docs/agents/issue-tracker.md`.

## Why

The board, labels, and milestones were set up interactively today; this records the contract so humans and the agent work from one reference. The board itself carries a condensed human-facing README; this doc is the full version.

## Notes

`docs/agents/triage-labels.md` and the AGENTS.md triage section still describe the label-based `/triage` vocabulary (separate system, untouched) — reconciling the two is deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a complete guide to managing the Next Steps “Next Steps” board, including how ticket states are driven by the Projects **Status field** and the allowed left-to-right transitions.
  - Documented the full workflow from Triage through Done, including how review and QA fit into the process.
  - Explained conventions for milestones, saved Views, and sub-issues (independent cards with board grouping and progress tracking).
  - Clarified the AI workflow rules for when agents/scripts can discover, claim, and update items, including “wontfix” handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->