### PR TITLE
fix(api-media): resolve mediaUserRoles from auth context

### DIFF
--- a/apis/api-media/src/schema/user/user.spec.ts
+++ b/apis/api-media/src/schema/user/user.spec.ts
@@ -11,6 +11,8 @@ describe('user', () => {
     }
   })
 
+  const publicClient = getClient()
+
   const VIDEO_ROLES = graphql(`
     query VideoRoles {
       _entities(
@@ -54,6 +56,16 @@ describe('user', () => {
     const data = await authClient({
       document: VIDEO_ROLES
     })
+    expect(data).toHaveProperty('data._entities[0].mediaUserRoles', [])
+  })
+
+  it('should return no media roles for an unauthenticated request', async () => {
+    // Exercises the context.type !== 'authenticated' fallback: no auth context
+    // means no currentRoles, so the resolver returns [] without a DB lookup.
+    const data = await publicClient({
+      document: VIDEO_ROLES
+    })
+    expect(prismaMock.userMediaRole.findUnique).not.toHaveBeenCalled()
     expect(data).toHaveProperty('data._entities[0].mediaUserRoles', [])
   })
 })

--- a/apis/api-media/src/schema/user/user.spec.ts
+++ b/apis/api-media/src/schema/user/user.spec.ts
@@ -24,10 +24,10 @@ describe('user', () => {
     }
   `)
 
-  it('should return media roles', async () => {
+  it('should return media roles from the request context', async () => {
     prismaMock.userMediaRole.findUnique.mockResolvedValue({
-      id: 'id',
-      userId: 'userId',
+      id: 'mediaRoleId',
+      userId: 'testUserId',
       roles: [MediaRole.publisher],
       createdAt: new Date(),
       updatedAt: new Date()
@@ -35,11 +35,25 @@ describe('user', () => {
     const data = await authClient({
       document: VIDEO_ROLES
     })
+    // Roles are resolved from the auth context (keyed by Firebase uid via
+    // UserMediaRole.userId), the same source that gates publisher fields —
+    // never from a separate lookup on the federation id. See issue #9416.
     expect(prismaMock.userMediaRole.findUnique).toHaveBeenCalledWith({
+      where: { userId: 'testUserId' }
+    })
+    expect(prismaMock.userMediaRole.findUnique).not.toHaveBeenCalledWith({
       where: { id: 'id' }
     })
     expect(data).toHaveProperty('data._entities[0].mediaUserRoles', [
       MediaRole.publisher
     ])
+  })
+
+  it('should return no media roles when the user has none granted', async () => {
+    prismaMock.userMediaRole.findUnique.mockResolvedValue(null)
+    const data = await authClient({
+      document: VIDEO_ROLES
+    })
+    expect(data).toHaveProperty('data._entities[0].mediaUserRoles', [])
   })
 })

--- a/apis/api-media/src/schema/user/user.ts
+++ b/apis/api-media/src/schema/user/user.ts
@@ -1,5 +1,3 @@
-import { prisma } from '@core/prisma/media/client'
-
 import { builder } from '../builder'
 
 import { MediaRole } from './enums/mediaRole'
@@ -17,15 +15,14 @@ AuthenticatedUserRef.implement({
     mediaUserRoles: t.field({
       type: [MediaRole],
       nullable: false,
-      resolve: async (data) => {
-        return (
-          (
-            await prisma.userMediaRole.findUnique({
-              where: { id: data.id }
-            })
-          )?.roles ?? []
-        )
-      }
+      // Resolve from the request context so this field and the auth-scope
+      // publisher check (builder.ts) can never disagree. Both derive from the
+      // same UserMediaRole row, keyed by the Firebase uid (context.user.id via
+      // UserMediaRole.userId). Looking the row up by the federation `id`
+      // (api-users User.id) instead keys on a different column and returns a
+      // different — often empty — result. See issue #9416.
+      resolve: (_data, _args, context) =>
+        context.type === 'authenticated' ? context.currentRoles : []
     })
   })
 })


### PR DESCRIPTION
Closes #9416

## Problem

api-media resolved the same user's media roles through **two lookups keyed on different identifiers**, so they could disagree:

- **Auth-scope context** (gates `VideoVariant.asset` via `withAuth({ isPublisher: true })`) reads `context.currentRoles`, computed in `yoga.ts` from `UserMediaRole.userId` = the **Firebase uid** (`context.user.id`).
- **`AuthenticatedUser.mediaUserRoles`** (what the videos-admin proxy gate queries) looked up `UserMediaRole` by `id: data.id` = the **api-users `User.id`** federation key — a different column that only matched by seeding coincidence.

Net effect reported in the issue: an operator could sign into videos-admin as a publisher (lookup via `mediaUserRoles` succeeded) yet be denied `VideoVariant.asset` on every variant through the gateway (the scope check disagreed), breaking master-file downloads from Wheat.

## Fix

Resolve `mediaUserRoles` from `context.currentRoles` — the exact same value the `isPublisher` scope check reads — so the two can never diverge (issue's option 1, "resolving via context for `me`").

```ts
resolve: (_data, _args, context) =>
  context.type === 'authenticated' ? context.currentRoles : []
```

The field is now caller-scoped by design: it returns the authenticated caller's own roles and no longer keys on the requested federation `id`. This cannot leak another user's roles, and `mediaUserRoles` is only ever queried for `me` in practice. Unauthenticated contexts return `[]`.

The GraphQL schema surface is unchanged.

## Tests

`user.spec.ts` now asserts roles come from the context lookup (`{ where: { userId: 'testUserId' } }`), explicitly asserts the old `{ where: { id: 'id' } }` lookup is **not** made, and covers the null/empty-roles path.

## Verification

- `nx run api-media:type-check` — pass
- `nx run api-media:lint` — pass
- `nx run api-media:generate-graphql` — schema diff empty (no surface change)
- `nx run api-media:test` — user spec green (one unrelated pre-existing `video.spec.ts` failure exists on `main`)

## Follow-ups (out of scope for this issue)

- `apis/api-languages/src/schema/user/user.ts` has the **identical** latent bug in `languageUserRoles` (keys on `id: data.id`). The videos-admin proxy relies on that field too — worth a companion fix.
- The issue's optional audit query for half-granted `UserMediaRole` rows (rows whose `id`/`userId` don't line up with the api-users user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authenticated user media role resolution using the current request context.
  * Prevented incorrect role lookups based on user federation IDs.
  * Ensured users without media roles receive an empty roles list instead of an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->