### PR TITLE
fix(api-media): resolve Mongolian and Tagalog metadata to reachable language ids

### DIFF
--- a/apis/api-media/src/workers/crowdin/config.ts
+++ b/apis/api-media/src/workers/crowdin/config.ts
@@ -60,7 +60,7 @@ export const LANGUAGE_CODES = {
   ja: '7083',
   kk: '371',
   ko: '3804',
-  mn: '143871',
+  mn: '18259',
   'pt-BR': '584',
   ru: '3934',
   th: '13169',

--- a/apps/arclight/src/lib/getLanguageIdsFromTags.ts
+++ b/apps/arclight/src/lib/getLanguageIdsFromTags.ts
@@ -22,7 +22,10 @@ const LANGUAGE_MAPPINGS = new Map<string, string>([
   ['id-ID', 'id'],
   ['ja-JP', 'ja'],
   ['vi-VN', 'vi'],
-  ['th-TH', 'th']
+  ['th-TH', 'th'],
+  // Tagalog is stored against the `fil` row, but `tl` is the tag we advertise
+  // in metadata-language-tags, so requests for `tl` must resolve to `fil`.
+  ['tl', 'fil']
 ])
 
 function matchLocales(metadataLanguageTag: string): string | undefined {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the language identifier used for Mongolian translations.
  * Added support for resolving Tagalog (`tl`) language tags to the appropriate Filipino locale.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->