### PR TITLE
feat: add persistent Codex CLI support to the devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,8 +38,14 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 # ARG EXTRA_NODE_VERSION=20
 # RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
 
-# install global node modules
-RUN su node -c "npm install -g npm@latest"
+# Keep npm on the latest Node 20-compatible major. npm 12 requires Node 22.22.2
+# or newer and prevents this image from building.
+RUN su node -c "npm install -g npm@10.9.9"
+
+# Install Codex at a stable, NVM-independent path. The devcontainer feature may
+# select a newer Node version at create time, so installing into an NVM version's
+# bin directory would make the CLI disappear when `current` moves.
+RUN npm install -g --prefix /usr/local @openai/codex@0.146.0
 
 # Install Claude Code CLI (as node user so binary lands in /home/node/.local/bin)
 USER node
@@ -59,5 +65,5 @@ RUN curl -fsSL https://get.opentofu.org/install-opentofu.sh -o /tmp/install-open
     && /tmp/install-opentofu.sh --install-method standalone \
     && rm /tmp/install-opentofu.sh
 
-RUN mkdir /home/node/.doppler \
-    && chown -R node /home/node/.doppler
+RUN mkdir /home/node/.codex /home/node/.doppler \
+    && chown -R node /home/node/.codex /home/node/.doppler

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,12 +28,27 @@
   // Forward Claude Code auth tokens from host environment
   "remoteEnv": {
     "CLAUDE_CODE_OAUTH_TOKEN": "${localEnv:CLAUDE_CODE_OAUTH_TOKEN:}",
-    "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY:}"
+    "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY:}",
+    "CODEX_HOME": "/home/node/.codex"
   },
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  // 9747 is the port for the NX MCP server
-  "forwardPorts": [9747],
+  // 9747 is the port for the NX MCP server. 1455/1457 are Codex OAuth loopback
+  // callback ports.
+  "forwardPorts": [9747, 1455, 1457],
+  "portsAttributes": {
+    "1455": {
+      "label": "Codex login callback",
+      "onAutoForward": "notify"
+    },
+    "1457": {
+      "label": "Codex login fallback callback",
+      "onAutoForward": "notify"
+    },
+    "9747": {
+      "label": "NX MCP server"
+    }
+  },
 
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": "/workspaces/core/.devcontainer/post-create-command.sh",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -66,6 +66,7 @@ services:
     # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
     environment:
+      CODEX_HOME: /home/node/.codex
       KUBECONFIG: /workspaces/core/.kube/config
       PGHOST: db
       PGPASSWORD: postgres

--- a/.devcontainer/post-create-command.sh
+++ b/.devcontainer/post-create-command.sh
@@ -29,6 +29,15 @@ corepack enable && corepack prepare pnpm@10.33.2 --activate
 echo "Installing global CLIs..."
 npm i -g nx foreman apollo graphql
 
+echo "Verifying Codex CLI..."
+export CODEX_HOME="${CODEX_HOME:-/home/node/.codex}"
+mkdir -p "$CODEX_HOME"
+codex --version
+if ! codex login status; then
+  echo "Codex is installed but not authenticated."
+  echo "Run 'codex login --device-auth' in the devcontainer."
+fi
+
 # install all dependencies
 echo "Installing project dependencies..."
 pnpm install


### PR DESCRIPTION
## What changed

- Install pinned Codex CLI 0.146.0 at the stable, NVM-independent `/usr/local/bin/codex` path.
- Persist `CODEX_HOME` under the existing `/home/node` volume.
- Forward Codex OAuth callback ports and label them in the devcontainer configuration.
- Verify Codex and report authentication status during post-create setup.
- Pin npm to Node-20-compatible 10.9.9; `npm@latest` now resolves to npm 12 and prevented the image from building.

## Impact

Codex is available to both normal devcontainer terminals and Helm-launched login-shell panes. Authentication survives container recreation through the existing node-home volume.

## Validation

- Full `docker compose ... build app` succeeds.
- A fresh image run as `node` resolves `/usr/local/bin/codex` and reports `codex-cli 0.146.0`.
- Compose configuration, shell syntax, and whitespace checks pass.
- The currently running core service resolves Codex from the same login-shell command Helm uses and reports an authenticated ChatGPT session.