### PR TITLE
chore(agents): add Phoebe AFK agent runtime

### DIFF
--- a/.phoebe/.env.example
+++ b/.phoebe/.env.example
@@ -1,0 +1,33 @@
+# Phoebe environment — scaffolded by `phoebe init`. Copy to `.env` and fill in.
+#
+# GH_TOKEN is required; every `gh` call in the engine reads it, and `phoebe
+# boot` uses it to check the engine out from GitHub. The provider key is
+# required only for whichever agent you actually run — set the one that matches
+# your `defaultProvider` (or `PHOEBE_AGENT` at runtime).
+#
+# Which engine version runs is NOT set here: it is `engine.ref` in
+# phoebe.config.ts, which `boot` re-reads while the container runs.
+
+# --- Required ---
+GH_TOKEN=
+
+# --- Provider keys (set the one you use) ---
+ANTHROPIC_API_KEY=
+CURSOR_API_KEY=
+OPENAI_KEY=
+
+# --- One host, multiple repos (set this if so) ---
+# Namespaces this instance's containers and named volumes. REQUIRED to be unique
+# per repo when you run Phoebe for more than one repo on the same host —
+# otherwise every instance shares one /data/repo clone and works the wrong repo.
+# COMPOSE_PROJECT_NAME=phoebe-your-org-your-repo
+
+# --- Runtime toggles (optional) ---
+# PHOEBE_AGENT=claude
+# PHOEBE_MODEL=claude-sonnet-4-6
+# PHOEBE_POLL_INTERVAL_MS=300000
+# How often `boot` checks the config and the tracked engine ref (default 60000).
+# PHOEBE_RECONCILE_INTERVAL_MS=60000
+
+# --- Local engine checkout (compose.local.yml only, development) ---
+# PHOEBE_ENGINE_MOUNT=/path/to/phoebe

--- a/.phoebe/.gitignore
+++ b/.phoebe/.gitignore
@@ -1,0 +1,2 @@
+.env
+node_modules/

--- a/.phoebe/container/Dockerfile
+++ b/.phoebe/container/Dockerfile
@@ -1,0 +1,180 @@
+# Phoebe runtime image — scaffolded by `phoebe init`.
+#
+# Consumer-owned: commit this file, tweak it as you need. Phoebe treats the
+# resulting image as both orchestrator and execution environment.
+#
+# The image carries the *bootstrapper* (`phoebe-agent` from npm), not the engine.
+# `phoebe boot` is the container's long-lived main process: it reads the mounted
+# `phoebe.config.ts`, materializes the engine from the source named there
+# (`engine: { source: "github", ref }` by default), execs it, and keeps
+# supervising it — relaunching on a config or ref change, falling back to the
+# last engine commit that ran healthily if a new one will not boot, and draining
+# it gracefully on `SIGTERM`. So changing engine version is a config edit, not
+# an image rebuild; this image only changes when the toolchain around it does.
+#
+# What ships in this image:
+#   * Node.js 24 + git + GitHub CLI (`gh`) — the runtime the engine drives.
+#   * A globally installed `phoebe-agent` (the bootstrapper).
+#   * Your agent provider's CLI.
+#
+# What lives on named volumes (see compose.yml):
+#   * /data/repo       — Phoebe's private clone of the target repo.
+#   * /data/worktrees  — Per-work-unit git worktrees.
+#   * /data/state      — Lock, watermarks, logs, crash-loop record.
+#   * /data/engine     — Engine checkouts, so a restart fetches instead of cloning.
+#
+# The workload runs as the unprivileged `phoebe` user, not root — see the
+# privilege-drop block below for the two things that constrains.
+
+FROM node:24-bookworm-slim
+
+# gh CLI + git + tini for signal handling; keep the layer small.
+#
+# `openssl` is here for Prisma: core's install command runs `prisma-generate`,
+# and Prisma's engines need libssl, which node:24-bookworm-slim does not carry.
+# Without it generate fails with "Unable to require libquery_engine".
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates curl git gnupg tini openssl \
+ && install -m 0755 -d /etc/apt/keyrings \
+ && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | gpg --dearmor -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends gh \
+ && rm -rf /var/lib/apt/lists/*
+
+# The unprivileged user everything below the privilege drop runs as, and the
+# four volume mount points, created *now* while we are still root.
+#
+# The ordering matters and is not cosmetic: Docker seeds a **fresh named volume
+# from the image's contents at that path, ownership included**. If /data/repo
+# does not exist in the image, Docker creates the mount point as root:root and
+# the first `git clone` fails with EACCES. Creating and chowning them here is
+# what makes the volumes writable after the drop.
+#
+# (`node:24` already ships a uid-1000 `node` user. We add our own so the name
+# in `ps`, in log output, and on the volumes says what it is, and so the uid is
+# stable if the base image ever renumbers `node`. The uid is a literal rather
+# than a build ARG because nothing needs to vary it — everything Phoebe writes
+# lives on named volumes, which take their ownership from this image, not from
+# any host uid. Change it here if you have a reason to.)
+RUN useradd --create-home --shell /bin/bash --uid 10001 --user-group phoebe \
+ && mkdir -p /data/repo /data/worktrees /data/state /data/engine \
+ && chown -R phoebe:phoebe /data
+
+# The bootstrapper. Unpinned on purpose: which *engine* you run is `engine.ref`
+# in phoebe.config.ts, and this package is only the thin launcher around it.
+# Pin it (`phoebe-agent@<version>`) if you want the launcher itself frozen too.
+#
+# Installed as root into /usr/local, which `phoebe` only ever reads: at boot it
+# copies itself out to PHOEBE_ENGINE_DIR (/data/engine, owned by us) before
+# running anything, because Node 24 refuses to type-strip TypeScript under a
+# `node_modules/` path segment.
+RUN npm install -g phoebe-agent
+
+# pnpm, via corepack. core is a pnpm workspace and pins the exact version in its
+# root package.json `packageManager` field, hash included — enabling corepack as
+# root installs the shims into /usr/local/bin, and the first `pnpm` call as the
+# `phoebe` user materializes precisely that pinned version into the corepack
+# cache under $HOME. That keeps the image honest about versions: nothing here
+# claims a pnpm version that could drift from what the repo asks for.
+#
+# The download prompt has to be off — corepack asks for interactive confirmation
+# before fetching, and there is no TTY behind `phoebe boot`, so the install
+# command would hang instead of failing.
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+RUN corepack enable
+
+# Provider agent CLI. The engine spawns the selected provider's CLI as a child
+# (`agent` for cursor, `claude`, or `codex`), so the one matching your
+# `defaultProvider` / `PHOEBE_AGENT` must be on PATH — otherwise the run dies
+# with `spawn <cli> ENOENT`. Default below installs Cursor. Swap or add the
+# commented lines for the provider you actually run.
+#
+# This is deliberately NOT the `curl https://cursor.com/install | bash` one-liner
+# Cursor documents. That pipes whatever the vendor serves at build time straight
+# into a shell, so two builds of the same Dockerfile can produce different
+# images and neither records which agent it got. Cursor publishes no checksums
+# and no `latest` indirection, but its installer does resolve to a plain
+# versioned artifact, which is what we pin to. The digests below are ours,
+# computed on 2026-07-28 by fetching both architectures' tarballs from the URL
+# below — they pin the build, they are not a vendor attestation.
+#
+# To bump: run the vendor installer once and read the version out of the
+# DOWNLOAD_URL it echoes, then `sha256sum` the linux/x64 *and* linux/arm64
+# tarballs. Both, even if you only build one — an unchecked digest for the other
+# arch turns into a hard build failure the day someone builds on it.
+ARG CURSOR_AGENT_VERSION=2026.07.23-e383d2b
+ARG CURSOR_AGENT_SHA256_X64=702ad595213bee5df0268be9f80a19f29fcceaa2a42fc55e39f2b5199051f0c4
+ARG CURSOR_AGENT_SHA256_ARM64=f40b99647cb24e0da885e97620a2048034f1fe8961910d573d827d77c4d26dcb
+# Set by BuildKit; the fallback keeps the classic builder working.
+ARG TARGETARCH
+RUN set -eux; \
+    case "${TARGETARCH:-$(dpkg --print-architecture)}" in \
+      amd64) cursor_arch=x64;   cursor_sha="${CURSOR_AGENT_SHA256_X64}" ;; \
+      arm64) cursor_arch=arm64; cursor_sha="${CURSOR_AGENT_SHA256_ARM64}" ;; \
+      *) echo "cursor-agent publishes no build for ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /tmp/cursor-agent.tar.gz \
+      "https://downloads.cursor.com/lab/${CURSOR_AGENT_VERSION}/linux/${cursor_arch}/agent-cli-package.tar.gz"; \
+    echo "${cursor_sha}  /tmp/cursor-agent.tar.gz" | sha256sum -c -; \
+    mkdir -p /opt/cursor-agent; \
+    tar --strip-components=1 -xzf /tmp/cursor-agent.tar.gz -C /opt/cursor-agent; \
+    rm /tmp/cursor-agent.tar.gz; \
+    ln -s /opt/cursor-agent/cursor-agent /usr/local/bin/agent; \
+    ln -s /opt/cursor-agent/cursor-agent /usr/local/bin/cursor-agent
+# Both symlink names on purpose: the engine spawns `agent`, but the vendor
+# installer we replaced also created `cursor-agent`, and Cursor's own docs use
+# that name. Dropping it would make this a silent behaviour regression for
+# anyone whose scripts follow those docs.
+#
+# The installer would have put these in ~/.local/bin and needed a PATH entry
+# pointing into a home directory. /usr/local/bin is already on PATH for every
+# user, so the agent child resolves `agent` after the privilege drop with no
+# PATH edit — and no root-owned home directory leaks into its env
+# (src/agent-env.ts forwards PATH and HOME to the agent verbatim).
+#
+# Swapping providers? Pin these too — an unpinned `npm install -g` has the same
+# problem as the installer pipe above, just with a lockfile-shaped hole instead
+# of a shell-shaped one. Check the registry for the current version:
+# Claude Code:  RUN npm install -g @anthropic-ai/claude-code@<version>
+# Codex:        RUN npm install -g @openai/codex@<version>
+
+# Consumer install command, kept as an ARG so it lands in the image metadata
+# and can be inspected with `docker image inspect`. The engine re-runs the
+# command inside each worktree; this is just documentation for operators.
+ARG PHOEBE_INSTALL_COMMAND="pnpm install --frozen-lockfile"
+LABEL phoebe.install-command="${PHOEBE_INSTALL_COMMAND}"
+
+# Execution-gate marker: the engine refuses to mutate a clone, launch an agent,
+# or push unless `/.phoebe-container` exists (src/execution-gate.ts). Without it
+# the container refuses every non-dry-run unit. Root-owned and read-only to us
+# on purpose — the gate is only ever tested for existence, never written.
+RUN touch /.phoebe-container
+
+# The privilege drop. Everything past this line — `boot`, the engine, the agent
+# child, and your repo's install/check/test commands — runs unprivileged.
+#
+# Two things this constrains:
+#   * Anything the workload writes must be under /data (the volumes above) or
+#     $HOME. That covers the package manager and provider CLI caches, which is
+#     why HOME is set explicitly rather than left to the runtime: the engine
+#     forwards HOME to the agent child, and an unwritable one breaks the
+#     provider CLI in ways that surface as unrelated errors.
+#   * Files you bind-mount in (phoebe.config.ts, prompts/) must be readable by
+#     *other* — the default 0644 from a git checkout is, but a 0600 file is not
+#     and boot will fail to read its config.
+ENV HOME=/home/phoebe
+USER phoebe
+
+# Compose's `command:` fully replaces `CMD` (it does not append to
+# `ENTRYPOINT`), so the whole `phoebe boot` invocation must live in
+# `ENTRYPOINT` — otherwise a compose `command: ["--run-once"]` would strip the
+# bootstrapper away and tini would try to exec `--run-once` as a program.
+# Keeping `CMD []` here means the compose files only ever contribute engine
+# flags, which `boot` forwards to the engine it launches.
+ENTRYPOINT ["/usr/bin/tini", "--", "phoebe", "boot"]
+CMD []

--- a/.phoebe/container/compose.local.yml
+++ b/.phoebe/container/compose.local.yml
@@ -1,0 +1,37 @@
+# Local-engine overlay — scaffolded by `phoebe init`, consumer-owned.
+#
+# Development only. Instead of `boot` checking the engine out from GitHub, this
+# runs it straight from a checkout on your host, so an edit to the engine source
+# takes effect on the next launch with no rebuild and no push:
+#
+#   PHOEBE_ENGINE_MOUNT=/path/to/phoebe \
+#     docker compose -f compose.yml -f compose.local.yml run --rm phoebe
+#
+# It only takes effect if the mounted phoebe.config.ts also says so:
+#
+#   engine: { source: "local" }
+#
+# `boot` fails loudly when that field says "local" and nothing is mounted at
+# /opt/phoebe-engine — a missing mount is a misconfigured container, not a
+# reason to quietly fall back to GitHub.
+#
+# Two behaviours differ from the deployed topology, both by design:
+#   * No crash-loop fallback. It guards a moving github ref by pinning back to
+#     the last engine commit that ran healthily; a mount has no commit to pin,
+#     so a crashing engine here just exits.
+#   * The ref watch is inert — there is no remote to poll. `boot` still watches
+#     the config, so a config edit relaunches the engine as usual.
+
+services:
+  phoebe:
+    environment:
+      # A minute is a long time to wait when you are iterating; the reconcile
+      # poll is one stat plus (for a github source) one ls-remote, so a tight
+      # interval is cheap here.
+      PHOEBE_RECONCILE_INTERVAL_MS: '${PHOEBE_RECONCILE_INTERVAL_MS:-10000}'
+    volumes:
+      # The engine source `boot` execs for `engine: { source: "local" }`.
+      # Read-only: the engine works its target clone under /data, never its own
+      # source. Mount the repo *root* — package.json's `"type": "module"` has to
+      # sit alongside the `.ts` the engine runs under Node's type-stripping.
+      - '${PHOEBE_ENGINE_MOUNT:?PHOEBE_ENGINE_MOUNT must point at a local engine checkout}:/opt/phoebe-engine:ro'

--- a/.phoebe/container/compose.yml
+++ b/.phoebe/container/compose.yml
@@ -1,0 +1,84 @@
+# Phoebe compose file — scaffolded by `phoebe init`, consumer-owned.
+#
+# One long-lived container. Its main process is `phoebe boot` (pinned into the
+# image's ENTRYPOINT), which materializes the engine named by `engine` in
+# phoebe.config.ts, runs it, and keeps supervising it for the life of the
+# container — so this file describes a daemon, not a one-shot:
+#
+#   docker compose up -d          # run it
+#   docker compose logs -f        # watch it
+#   docker compose stop           # SIGTERM → the engine drains, finishing its
+#                                 # current work unit and starting no new one
+#
+# For a scoped, non-daemon invocation, pass engine flags — the image's `CMD []`
+# means anything here is forwarded straight through `boot` to the engine:
+#
+#   docker compose run --rm phoebe --dry-run --run-once   # selection preview
+#   docker compose run --rm phoebe --run-once             # work exactly one unit
+#
+# To upgrade the engine, edit `engine.ref` in phoebe.config.ts — `boot` notices
+# within a poll interval and relaunches at the next work-unit boundary. No
+# rebuild and no restart; rebuild only when this image's toolchain changes.
+
+# Project name — namespaces this instance's containers and named volumes. It
+# defaults to `phoebe`, but if you run Phoebe for more than one repo on the same
+# host you MUST make it unique per repo (set COMPOSE_PROJECT_NAME in `.env`).
+# Compose otherwise derives the project from this file's parent directory —
+# `container` — which is identical for every consumer, so the "private"
+# /data/repo, /data/state, … volumes would be shared across repos. Set it and
+# each repo gets its own `phoebe-<repo>_phoebe-repo` volume set.
+name: ${COMPOSE_PROJECT_NAME:-phoebe}
+
+services:
+  phoebe:
+    build:
+      context: .
+      args:
+        PHOEBE_INSTALL_COMMAND: 'pnpm install --frozen-lockfile'
+    image: phoebe-runtime:latest
+    restart: unless-stopped
+    environment:
+      # Secrets — populate via `.env` (see `.env.example`). GH_TOKEN also
+      # authenticates the engine checkout when `engine.source` is "github".
+      GH_TOKEN: '${GH_TOKEN:?GH_TOKEN is required}'
+      ANTHROPIC_API_KEY: '${ANTHROPIC_API_KEY:-}'
+      CURSOR_API_KEY: '${CURSOR_API_KEY:-}'
+      OPENAI_KEY: '${OPENAI_KEY:-}'
+      # Where `boot` keeps engine checkouts. Pointed at a named volume below so
+      # a restart fetches into an existing clone instead of cloning again.
+      PHOEBE_ENGINE_DIR: /data/engine
+      # Optional runtime toggles.
+      PHOEBE_AGENT: '${PHOEBE_AGENT:-}'
+      PHOEBE_MODEL: '${PHOEBE_MODEL:-}'
+      PHOEBE_POLL_INTERVAL_MS: '${PHOEBE_POLL_INTERVAL_MS:-}'
+      PHOEBE_RECONCILE_INTERVAL_MS: '${PHOEBE_RECONCILE_INTERVAL_MS:-}'
+    volumes:
+      - phoebe-repo:/data/repo
+      - phoebe-worktrees:/data/worktrees
+      - phoebe-state:/data/state
+      - phoebe-engine:/data/engine
+      # $HOME, persisted. It is not scratch space for a pnpm repo: the corepack
+      # cache (the pinned pnpm binary) and the pnpm content-addressable store
+      # both live under it. Without this volume every `docker compose up`
+      # re-downloads pnpm and re-fetches core's entire dependency tree from the
+      # registry on the first work unit, which is minutes of wall clock per
+      # container recreate. Seeded from the image, so it lands phoebe-owned.
+      - phoebe-home:/home/phoebe
+      # Consumer config + prompt overrides live in-repo; mount them read-only
+      # so `boot` can re-read the config without a rebuild.
+      #
+      # Caveat worth knowing: a single-file bind mount pins the host *inode*, so
+      # a save that writes a new file and renames it over the old one — most
+      # editors' atomic save, and what `git pull` does — is invisible in here,
+      # and `boot`'s config watch will never fire for it. Either edit in place,
+      # or follow the write with `docker compose up -d --force-recreate`.
+      - ../phoebe.config.ts:/etc/phoebe/phoebe.config.ts:ro
+      - ../prompts:/etc/phoebe/prompts:ro
+    working_dir: /etc/phoebe
+
+volumes:
+  phoebe-repo:
+  phoebe-worktrees:
+  phoebe-state:
+  phoebe-engine:
+  phoebe-home:

--- a/.phoebe/phoebe.config.ts
+++ b/.phoebe/phoebe.config.ts
@@ -1,0 +1,50 @@
+// Phoebe consumer config for JesusFilm/core.
+//
+// Deliberately minimal: only the toolchain fields and the engine pin are named
+// here. Everything that governs *what* Phoebe does — workOrder, prScope, the
+// ready/processing/opt-out labels, provider defaults, prompts — is omitted and
+// resolves to the engine defaults, so a `phoebe-agent` upgrade picks up new
+// defaults automatically. See docs/phoebe-core-onboarding.md in JesusFilm/phoebe.
+//
+// This is a *type-only* import on purpose. The container mounts this file at
+// /etc/phoebe and `phoebe boot` imports it before the engine exists, from a
+// directory with no reachable `node_modules` — a value import of `phoebe-agent`
+// could not resolve there under ESM. A type-only import is erased at runtime.
+
+import type { PhoebeUserConfig } from 'phoebe-agent'
+
+const config: PhoebeUserConfig = {
+  repoSlug: 'JesusFilm/core',
+  repoUrl: 'https://github.com/JesusFilm/core.git',
+
+  // pnpm, lockfile-exact — then generate the Prisma clients. The generate step
+  // is not optional: every `generator client` block writes to a gitignored
+  // `src/__generated__/client` (see libs/prisma/*/src/__generated__/.gitignore),
+  // so without it type-check and test fail on unresolved imports in a fresh
+  // clone. DISABLE_ERD matches CI, which skips the ERD renderer.
+  installCommand:
+    'pnpm install --frozen-lockfile && DISABLE_ERD=true pnpm exec nx run-many -t prisma-generate --all',
+
+  // Nx-affected lint + type-check, with formatting applied in WRITE mode so
+  // drift is fixed in place rather than failing the gate. NODE_OPTIONS matches
+  // .github/workflows/autofix.ci.yml — lint OOMs on the default heap.
+  // The target is `type-check` (hyphenated), which is what core's project.json
+  // files actually define.
+  checkCommand:
+    'pnpm exec nx format:write --base=origin/main && NODE_OPTIONS=--max-old-space-size=8192 pnpm exec nx affected -t lint type-check --base=origin/main',
+
+  // Nx-affected tests only — the point of affected is to skip the rest.
+  testCommand: 'pnpm exec nx affected -t test --base=origin/main',
+
+  // The all-in-one gate the agent runs before pushing. The shipped default is
+  // `npm run ready`, which core does not have, so it is check + test.
+  readyCommand:
+    'pnpm exec nx format:write --base=origin/main && NODE_OPTIONS=--max-old-space-size=8192 pnpm exec nx affected -t lint type-check test --base=origin/main',
+
+  // Which engine `phoebe boot` checks out and runs. This is the upgrade knob:
+  // edit it in place and the running container drains and relaunches on the new
+  // ref at the next work-unit boundary — no rebuild, no restart.
+  engine: { source: 'github', ref: 'v0.1.1' }
+}
+
+export default config

--- a/.phoebe/prompts/checks-prompt.md
+++ b/.phoebe/prompts/checks-prompt.md
@@ -1,0 +1,68 @@
+# Context
+
+## Assigned task
+
+Phoebe's host detected that **PR #{{PR_NUMBER}}** (`{{PR_BRANCH}}`) has failing CI on its current head. Your job is to fix the failures, verify locally, and push — or leave a PR comment if you cannot fix them.
+
+!`gh pr view {{PR_NUMBER}} --json number,title,body,headRefName,baseRefName`
+
+## Failing checks
+
+{{FAILING_CHECKS}}
+
+# Task
+
+You are Phoebe — fixing **failing CI** on an existing PR branch in this repository.
+
+**Before anything else, read `AGENTS.md` at the repo root, if present.** It is the single source of project guidance — toolchain, conventions, and any compliance requirements — and it overrides your defaults.
+
+## Workflow
+
+1. **Investigate** — pull failure logs for each failing check:
+   ```
+   gh run list --branch {{PR_BRANCH}} --limit 5
+   gh run view <run-id> --log-failed
+   ```
+2. **Reproduce** — run the same gates locally: `{{CHECK_COMMAND}}` and `{{TEST_COMMAND}}` (or `{{READY_COMMAND}}` if the project ships an all-in-one gate).
+3. **Baseline check** — before assuming a local `{{TEST_COMMAND}}` failure is yours, confirm whether it also fails on a clean `{{DEFAULT_BRANCH}}`. This distinguishes breakage _caused by this PR_ from **pre-existing baseline breakage** already red on `{{DEFAULT_BRANCH}}`.
+   - Establish a clean baseline without disturbing this branch, e.g.:
+     ```
+     git worktree add /tmp/baseline origin/{{DEFAULT_BRANCH}}
+     ```
+     then install (`{{INSTALL_COMMAND}}`) and run `{{TEST_COMMAND}}` inside `/tmp/baseline`. Remove it with `git worktree remove /tmp/baseline` when done.
+   - **Same failures present on the baseline → pre-existing and out of scope for this PR.** Do **not** try to fix them here.
+     - Proceed as long as _this change's own_ gate is green: `{{CHECK_COMMAND}}` passes and any tests newly relevant to your change pass.
+     - Leave a short PR comment noting the pre-existing failures. If no tracking issue already covers them, open one and link it:
+       ```
+       gh issue create --title "<baseline test failure>" --body "<what fails on {{DEFAULT_BRANCH}}, and where you saw it>"
+       ```
+   - **Failures absent from the baseline → attributable to this change.** These are yours; fix them in the next step.
+   - **Reconciling disagreeing gates:** a green `{{CHECK_COMMAND}}` with a red `{{TEST_COMMAND}}` clears you to proceed **only** when every red test is baseline-only. If any failing test is _not_ present on the baseline, `{{CHECK_COMMAND}}` passing does not excuse it — fix that test.
+4. **Fix** — make the smallest correct change that resolves the failures **attributable to this change** (those not present on the baseline).
+5. **Verify** — re-run `{{CHECK_COMMAND}}` and `{{TEST_COMMAND}}` and fix any remaining failures that are not baseline-only.
+6. **Commit** — one or more commits with the `Phoebe:` prefix. Do **not** force-push.
+7. **Push** — `git push origin {{PR_BRANCH}}`.
+8. **Flaky escape hatch** — if the failure does not reproduce locally and looks environmental or flaky, you may instead:
+   - `gh run rerun --failed` (once)
+   - Comment on the PR explaining why no code change was made:
+     ```
+     gh pr comment {{PR_NUMBER}} --body "<explanation>"
+     ```
+9. **Give up** — only if you cannot fix or rerun, leave a PR comment explaining what you tried:
+   ```
+   gh pr comment {{PR_NUMBER}} --body "<explanation>"
+   ```
+
+## Rules
+
+- Work on **this PR only** (#{{PR_NUMBER}}). Do not pick up issues or other PRs.
+- Only failures **caused by this change** are yours to fix. Pre-existing failures already red on `{{DEFAULT_BRANCH}}` are out of scope — note and track them, don't fix them here.
+- Do not leave commented-out code or TODO comments in committed code.
+- Never force-push (`git push --force`).
+- If you are blocked, comment on the PR and finish — do not push a broken fix.
+
+# Done
+
+When CI is fixed and pushed, or you have commented (rerun or give-up), output:
+
+<promise>COMPLETE</promise>

--- a/.phoebe/prompts/conflict-prompt.md
+++ b/.phoebe/prompts/conflict-prompt.md
@@ -1,0 +1,64 @@
+# Context
+
+## Assigned task
+
+Phoebe's host detected that **PR #{{PR_NUMBER}}** (`{{PR_BRANCH}}`) conflicts with `{{DEFAULT_BRANCH}}`. Your job is to reconcile this branch with `{{DEFAULT_BRANCH}}`, resolve any conflicts, verify, and push — or abort and leave a PR comment if you cannot fix it cleanly.
+
+!`gh pr view {{PR_NUMBER}} --json number,title,body,headRefName,baseRefName,mergeable,mergeStateStatus`
+
+# Task
+
+You are Phoebe — resolving a **merge conflict** on an existing PR branch in this repository.
+
+**Before anything else, read `AGENTS.md` at the repo root, if present.** It is the single source of project guidance — toolchain, conventions, and any compliance requirements — and it overrides your defaults.
+
+Your worktree already attempted the merge sequence below. If conflicts remain, resolve them now.
+
+## Merge order (stacked follow-ups)
+
+When `{{BLOCKER_PR_NUMBERS}}` is non-empty, this PR is a stacked follow-up whose blocker(s) already merged. Reconcile **blocker-first, then base** — never merge `origin/{{DEFAULT_BRANCH}}` alone first:
+
+1. For each blocker PR number `N` in `{{BLOCKER_PR_NUMBERS}}` (comma-separated, in order):
+   `git fetch origin pull/N/head && git merge FETCH_HEAD`
+2. Then: `git fetch origin {{DEFAULT_BRANCH}} && git merge origin/{{DEFAULT_BRANCH}}`
+
+When `{{BLOCKER_PR_NUMBERS}}` is empty, merge `origin/{{DEFAULT_BRANCH}}` only (standard conflict fix).
+
+## Workflow
+
+1. **Assess** — run `git status`. If no merge is in progress, run the merge order above from scratch.
+2. **Resolve** — fix every conflicted file. Prefer preserving both sides' intent; do not drop unrelated changes from `{{DEFAULT_BRANCH}}` or this branch.
+3. **Verify** — run `{{CHECK_COMMAND}}` and `{{TEST_COMMAND}}` (or `{{READY_COMMAND}}` if the project ships an all-in-one gate). Fix any failures the merge introduced before proceeding.
+   - **Baseline breakage:** if `{{TEST_COMMAND}}` fails, confirm whether the same failures already exist on a clean `{{DEFAULT_BRANCH}}` checkout before assuming the merge caused them:
+     ```
+     git worktree add /tmp/baseline origin/{{DEFAULT_BRANCH}}
+     ```
+     install (`{{INSTALL_COMMAND}}`) and run `{{TEST_COMMAND}}` there, then `git worktree remove /tmp/baseline`.
+   - Failures **present on the baseline** are pre-existing and out of scope for this reconciliation — do **not** fix them here. Proceed once the merge's own gate is green (`{{CHECK_COMMAND}}` passes and the merge introduced no _new_ test failures), then note the pre-existing failures in a PR comment and, if no tracking issue covers them, open one:
+     ```
+     gh issue create --title "<baseline test failure>" --body "<what fails on {{DEFAULT_BRANCH}}, and where you saw it>"
+     ```
+   - A green `{{CHECK_COMMAND}}` with a red `{{TEST_COMMAND}}` clears you only when every red test is baseline-only. Any failure the **merge** introduced must be fixed before you push.
+4. **Commit** — stage the resolution and commit each merge (e.g. `Phoebe: merge blocker PR #N into {{PR_BRANCH}}`, then `Phoebe: merge {{DEFAULT_BRANCH}} into {{PR_BRANCH}}`). Do **not** force-push.
+5. **Push** — `git push origin {{PR_BRANCH}}`.
+6. **Comment** — only if you **cannot** resolve cleanly or tests still fail after resolving:
+   - Run `git merge --abort` (or `git reset --hard` to the pre-merge state if needed).
+   - Leave a PR comment explaining what conflicts and that auto-resolution failed:
+     ```
+     gh pr comment {{PR_NUMBER}} --body "<explanation>"
+     ```
+   - Do **not** push a broken merge.
+
+## Rules
+
+- Work on **this PR only** (#{{PR_NUMBER}}). Do not pick up issues or other PRs.
+- Only failures the **merge** introduced are yours to fix. Pre-existing failures already red on `{{DEFAULT_BRANCH}}` are out of scope — note and track them, don't fix them here.
+- Do not leave commented-out code or TODO comments in committed code.
+- Never force-push (`git push --force`).
+- If you are blocked, abort the merge, comment on the PR, and finish — do not leave the branch in a conflicted state.
+
+# Done
+
+When the merge is resolved and pushed, or you have aborted and commented, output:
+
+<promise>COMPLETE</promise>

--- a/.phoebe/prompts/issues-prompt.md
+++ b/.phoebe/prompts/issues-prompt.md
@@ -1,0 +1,55 @@
+# Context
+
+## Assigned issue
+
+You are working **exactly** issue **#{{ISSUE_NUMBER}}** — the orchestrator selected it before this run started. Do not pick a different issue.
+
+!`gh issue view {{ISSUE_NUMBER}} --json number,title,body,labels,comments --jq '{number, title, body, labels: [.labels[].name], comments: [.comments[].body]}'`
+
+## Recent Phoebe commits (last 10)
+
+!`git log --oneline --grep="Phoebe" -10`
+
+# Task
+
+You are Phoebe — an autonomous coding agent working on issue **#{{ISSUE_NUMBER}}** in this repository.
+
+**Before anything else, read `AGENTS.md` at the repo root, if present.** It is the single source of project guidance — toolchain, conventions, and any compliance requirements — and it overrides your defaults.
+
+## Workflow
+
+1. **Claim** — immediately label the issue `{{PROCESSING_LABEL}}` so others know it is in flight:
+   ```
+   gh issue edit {{ISSUE_NUMBER}} --add-label "{{PROCESSING_LABEL}}" --remove-label "{{READY_LABEL}}"
+   ```
+2. **Explore** — read the issue carefully. Pull in the parent PRD if referenced. Read the relevant source files and tests before writing any code.
+3. **Plan** — decide what to change and why. Keep the change as small as possible.
+4. **Implement** — make the change, treating issue #{{ISSUE_NUMBER}} as the spec. Write or update tests alongside code when a behaviour change warrants coverage. If this repo ships an `implement` (or equivalent) workflow skill under `.claude/skills/`, read and follow it; otherwise apply your own tight edit → test loop.
+5. **Verify** — run the project's ready gate: `{{READY_COMMAND}}`. If the ready gate is not available, fall back to `{{CHECK_COMMAND}}` and `{{TEST_COMMAND}}`. Fix any failures before proceeding.
+6. **Commit** — make a single git commit. The message MUST:
+   - Start with the `Phoebe:` prefix
+   - Name the task completed and any PRD reference
+   - List key decisions made
+   - List files changed
+   - Note any blockers for the next iteration
+7. **PR** — open a pull request targeting `{{DEFAULT_BRANCH}}`. The body MUST include `Closes #{{ISSUE_NUMBER}}` so the issue closes automatically on merge:
+   ```
+   gh pr create --base {{DEFAULT_BRANCH}} --title "Phoebe: <title>" --body "Closes #{{ISSUE_NUMBER}}\n\n<summary>"
+   ```
+8. **Address** — remove the processing label and leave a pointer comment:
+   ```
+   gh issue edit {{ISSUE_NUMBER}} --remove-label "{{PROCESSING_LABEL}}" && gh issue comment {{ISSUE_NUMBER}} --body "Addressed by Phoebe: <PR URL>"
+   ```
+
+## Rules
+
+- Work on **this issue only** (#{{ISSUE_NUMBER}}). Do not attempt other issues in this run.
+- Do not open the PR until you have committed the fix and the project's check and test gates pass.
+- Do not leave commented-out code or TODO comments in committed code.
+- If you are blocked (missing context, failing tests you cannot fix, external dependency), leave a comment on the issue and move on — do not close it.
+
+# Done
+
+When the work for issue #{{ISSUE_NUMBER}} is complete (or you are blocked), output the completion signal:
+
+<promise>COMPLETE</promise>

--- a/.phoebe/prompts/research-prompt.md
+++ b/.phoebe/prompts/research-prompt.md
@@ -1,0 +1,61 @@
+# Context
+
+## Assigned research ticket
+
+You are resolving **exactly** wayfinder research ticket **#{{ISSUE_NUMBER}}** — the orchestrator selected it before this run started. Do not pick a different ticket. It is a child of a `wayfinder:map` issue and carries the `{{RESEARCH_LABEL}}` label.
+
+!`gh issue view {{ISSUE_NUMBER}} --json number,title,body,labels,comments --jq '{number, title, body, labels: [.labels[].name], comments: [.comments[].body]}'`
+
+## Candidate parent maps
+
+!`gh issue list --label "wayfinder:map" --state open --json number,title --jq '[.[] | {number, title}]'`
+
+# Task
+
+You are Phoebe — resolving a **wayfinder research ticket** (an AFK ticket type: reading primary sources and recording what you found). Your job is to answer the ticket's Question from authoritative sources, produce a Markdown summary, and run wayfinder's resolution protocol.
+
+**Before anything else, read `AGENTS.md` at the repo root, if present**, and — if it exists — the wayfinder skill at `.agents/skills/wayfinder/SKILL.md`. AGENTS.md is the single source of project guidance and overrides your defaults; the wayfinder skill defines the map/ticket protocol you are resolving against.
+
+## Workflow
+
+1. **Read the Question.** The ticket body holds a `## Question` — the decision or investigation this ticket resolves, sized to one session. Resolve _that_, nothing broader.
+
+2. **Find the parent map.** This ticket is a child of one `wayfinder:map` issue. Identify it from a reference in the ticket body, its sub-issue relationship, or by reading the candidate maps listed above (their bodies point at their tickets). Load the map body — you need its `## Decisions so far` and `## Notes` (the Notes name skills every session should consult). If you genuinely cannot identify the map, say so in the resolution comment and continue without the map update.
+
+3. **Investigate primary sources.** Read official documentation, third-party API references, and local resources (knowledge bases, source in this repo). Prefer authoritative **primary** sources over summaries; record exactly where each fact came from. Never invent findings — an honest "the docs don't say" is a valid answer.
+
+4. **Produce the Markdown summary — pick the output shape the finding needs:**
+   - **Issue-level artifact (default).** Most research resolves this way: the summary lives as a comment (or a linked asset) on the ticket, with no code change. Leave the worktree without commits.
+   - **Committed doc (PR).** _Only_ when the finding is naturally a document that belongs in the repo (a reference note others will read from the tree). Write it where the repo already keeps such notes — match the existing convention; do not invent a new location. Commit it with a `Phoebe:` prefix. The host will push the branch and open a PR whose body closes this ticket.
+
+5. **Verify (committed-doc case only).** If you committed a doc and the repo has gates, run `{{READY_COMMAND}}` (or `{{CHECK_COMMAND}}` and `{{TEST_COMMAND}}`) and fix any failure before finishing. A pure issue-level artifact skips this.
+
+6. **Resolve per wayfinder protocol:**
+   1. **Post the resolution comment** on ticket #{{ISSUE_NUMBER}} — the answer itself, or the summary with a link to the committed doc/asset:
+      ```
+      gh issue comment {{ISSUE_NUMBER}} --body "<answer + sources>"
+      ```
+   2. **Close the ticket — but only in the issue-level-artifact case:**
+      ```
+      gh issue close {{ISSUE_NUMBER}}
+      ```
+      If you committed a doc, **do not close it here** — the PR the host opens carries `Closes #{{ISSUE_NUMBER}}` and closes it on merge.
+   3. **Append a pointer to the map's `## Decisions so far`** — one line, referring to the ticket by name (never a bare number), gisting the answer so a future session can judge relevance and zoom the link for detail. Fetch the map body, add the line under that heading, and write it back:
+      ```
+      - [<ticket title>](<ticket url>) — <one-line gist of the answer>
+      ```
+      Use `gh issue edit <map-number> --body-file -` with the amended body. Do not restate the full answer on the map — it is an index, not a store.
+
+## Rules
+
+- Work on **this ticket only** (#{{ISSUE_NUMBER}}). Do not resolve other tickets or edit unrelated parts of the map.
+- Default to an **issue-level artifact**; commit a doc only when it genuinely belongs in the repo.
+- **Close the ticket yourself only when you did not commit a doc.** A committed-doc PR closes it on merge — closing twice or closing before merge is wrong.
+- Cite sources for every finding; do not present guesses as facts.
+- If you are blocked (the Question needs a human decision, a source is inaccessible, the map is unfindable), post what you have as a comment explaining the blocker and leave the ticket **open** — do not close it.
+
+# Done
+
+When ticket #{{ISSUE_NUMBER}} is resolved (or you are blocked and have commented), output the completion signal:
+
+<promise>COMPLETE</promise>

--- a/.phoebe/prompts/reviews-prompt.md
+++ b/.phoebe/prompts/reviews-prompt.md
@@ -1,0 +1,106 @@
+# Context
+
+## Assigned task
+
+Phoebe's host detected **new unresolved review-thread feedback** on **PR #{{PR_NUMBER}}** (`{{PR_BRANCH}}`). Your job is to triage every unresolved thread, address the ones that need code changes, and post the summary comment.
+
+!`gh pr view {{PR_NUMBER}} --json number,title,body,headRefName,baseRefName`
+
+# Task
+
+You are Phoebe — handling **PR review feedback** on an existing branch in this repository.
+
+**Before anything else, read `AGENTS.md` at the repo root, if present.** It is the single source of project guidance — toolchain, conventions, and any compliance requirements — and it overrides your defaults.
+
+## Workflow
+
+1. **Fetch unresolved threads** — page through GraphQL `reviewThreads` until `pageInfo.hasNextPage` is `false`, feeding the previous page's `endCursor` back as `$cursor`. **Do not stop after the first page** — a PR with more threads than one page holds would silently lose feedback. Accumulate nodes across pages and then filter to `isResolved === false && isOutdated === false`.
+
+   ```bash
+   OWNER=<OWNER>  REPO=<REPO>  PR={{PR_NUMBER}}
+   CURSOR=""      # start unset
+   while :; do
+     PAGE=$(gh api graphql \
+       -F owner="$OWNER" -F repo="$REPO" -F pr="$PR" -F cursor="$CURSOR" \
+       -f query='
+         query($owner:String!,$repo:String!,$pr:Int!,$cursor:String) {
+           repository(owner:$owner,name:$repo) {
+             pullRequest(number:$pr) {
+               reviewThreads(first:50, after:$cursor) {
+                 pageInfo { hasNextPage endCursor }
+                 nodes {
+                   id isResolved isOutdated
+                   path line
+                   comments(first:50) {
+                     nodes { id databaseId author{login} body createdAt }
+                   }
+                 }
+               }
+             }
+           }
+         }')
+     # append PAGE.data.repository.pullRequest.reviewThreads.nodes to your list
+     HAS_NEXT=$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+     [ "$HAS_NEXT" = "true" ] || break
+     CURSOR=$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
+   done
+   ```
+
+   If your runtime prefers a single call, pass `-F cursor=""` on the first call and re-invoke with the returned `endCursor` until `hasNextPage` is `false`.
+
+2. **Triage each unresolved thread** into one of four buckets. Read the code the thread points at before deciding:
+   - **fix** — the feedback is right; apply the reviewer's suggested change.
+   - **fix-adjusted** — the feedback identifies a real problem, but a different fix is better; apply your alternative and note the deviation in the inline reply.
+   - **challenge** — you disagree; explain why in an inline reply and leave the thread open for the reviewer.
+   - **skip** — outdated, already fixed, or not actionable; note it in the summary but leave no reply.
+
+3. **Look for holistic fixes** — if several threads point at the same underlying issue, address them together with one change rather than N patchwork edits.
+
+4. **Implement** — make the smallest correct changes. Update or add tests alongside code when a behaviour change warrants coverage.
+
+5. **Verify** — run `{{CHECK_COMMAND}}` and `{{TEST_COMMAND}}` (or `{{READY_COMMAND}}` if the project ships an all-in-one gate). Fix any failures before pushing. Do not push a red branch.
+
+6. **Commit** — one or more commits with the `Phoebe:` prefix. Do **not** force-push.
+
+7. **Push** — `git push origin {{PR_BRANCH}}` (non-force).
+
+8. **Resolve fixed threads** — for every thread in the **fix** or **fix-adjusted** buckets:
+
+   ```
+   gh api graphql -f query='
+     mutation($threadId:ID!) {
+       resolveReviewThread(input:{threadId:$threadId}) { thread { id isResolved } }
+     }' -F threadId=<THREAD_ID>
+   ```
+
+9. **Reply to challenges** — for every **challenge** thread, post an inline reply explaining your reasoning. Reply to the thread's first comment (its `databaseId` from step 1) so the reply threads correctly:
+
+   ```
+   gh api repos/<OWNER>/<REPO>/pulls/{{PR_NUMBER}}/comments/<COMMENT_ID>/replies \
+     -f body="<explanation>"
+   ```
+
+10. **Post the summary comment** — always post one PR comment, even if zero commits were pushed. Its **first line must be exactly** `{{REVIEWS_SUCCESS_HEADING}}` — the orchestrator matches on that heading to know the run finished cleanly. Follow it with a short breakdown, for example:
+
+    ```
+    gh pr comment {{PR_NUMBER}} --body "{{REVIEWS_SUCCESS_HEADING}}
+
+    **Fixed:** <n> thread(s)
+    **Challenged:** <n> thread(s) — see inline replies
+    **Skipped:** <n> thread(s) (outdated / already addressed)
+    "
+    ```
+
+## Rules
+
+- Work on **this PR only** (#{{PR_NUMBER}}). Do not pick up issues or other PRs.
+- Do not leave commented-out code or TODO comments in committed code.
+- Never force-push (`git push --force`).
+- Zero commits is a valid success when every thread is challenged, skipped, or already outdated — but you **must** still post the summary comment.
+- If you cannot fetch threads, cannot verify, or otherwise get stuck, post the best summary you can (still with the required heading) and finish.
+
+# Done
+
+When the summary comment is posted (and any fixes are pushed), output:
+
+<promise>COMPLETE</promise>

--- a/package.json
+++ b/package.json
@@ -350,6 +350,7 @@
     "null-loader": "^4.0.1",
     "nx": "22.7.1",
     "nx-mcp": "^0.6.0",
+    "phoebe-agent": "0.1.1",
     "pino-pretty": "^13.0.0",
     "playwright": "1.59.1",
     "playwright-core": "1.59.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -950,6 +950,9 @@ importers:
       nx-mcp:
         specifier: ^0.6.0
         version: 0.6.3
+      phoebe-agent:
+        specifier: 0.1.1
+        version: 0.1.1
       pino-pretty:
         specifier: ^13.0.0
         version: 13.0.0
@@ -18993,6 +18996,11 @@ packages:
 
   pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
+  phoebe-agent@0.1.1:
+    resolution: {integrity: sha512-4WW/foFHdwXl+mVlokxaztKraAPId1eKv1TTciiOr3eOFgujf1LRAFDt59Vv5NPcERT7wnaEqi4dN9pOvQkoMg==}
+    engines: {node: '>=24'}
+    hasBin: true
 
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
@@ -46835,6 +46843,8 @@ snapshots:
   pgpass@1.0.5:
     dependencies:
       split2: 4.2.0
+
+  phoebe-agent@0.1.1: {}
 
   picocolors@1.0.0: {}
 


### PR DESCRIPTION
Adds a committed runtime for [Phoebe](https://github.com/JesusFilm/phoebe), an AFK coding agent. It polls this repo for `ready-for-agent` issues, works each on its own branch in an isolated git worktree, runs our gates, and opens a PR. Between issues it sweeps open Phoebe PRs for merge conflicts, failing CI, and unresolved review feedback.

It runs as a single container that owns a private clone and pushes branches to origin — nobody's local checkout is touched, and nothing here runs in CI or changes how this repo builds. Merging this only makes the runtime available; an operator still has to supply `.phoebe/.env` and start the container.

## What's committed

`.phoebe/` — config, the shipped prompts left unedited, and the container files. Scaffolded from `phoebe-agent@0.1.1`, engine pinned to `v0.1.1`.

The config names only the toolchain commands and the engine pin. Work order, PR scope, the three labels, provider defaults, and prompts are all omitted so they resolve to engine defaults — a future upgrade picks up new defaults instead of drifting against a stale local fork.

Plus one line in `package.json`: `phoebe-agent` as a devDependency, so the `import type { PhoebeUserConfig }` in the config resolves in an editor.

## Toolchain values that differ from Phoebe's core onboarding doc

The upstream doc ships an example config for this repo. Three of its values don't survive contact with the repo, each verified here:

| Upstream example | What this PR uses | Why |
| --- | --- | --- |
| `typecheck` | `type-check` | 39 `project.json` files define the hyphenated target; none define the other. |
| install is just `pnpm install` | install also runs `prisma-generate` | Every `generator client` writes to a gitignored `src/__generated__/client`. Without it a fresh clone fails type-check and test on unresolved imports. CI runs it as its own step before every gate. |
| no heap flag | `NODE_OPTIONS=--max-old-space-size=8192` on lint/type-check | Matches `.github/workflows/autofix.ci.yml`, which sets it because the default heap isn't enough. |

`checkCommand` runs `nx format:write` rather than a check-only format pass, so formatting drift is fixed in place and committed instead of failing the gate.

## Image changes

The scaffolded image assumes an npm repo. Two additions:

- **pnpm, via corepack.** The shipped image carries no pnpm at all. Corepack materializes the exact version pinned in the root `package.json` `packageManager` field, hash included, so the image can't claim a version that drifts from what the repo asks for. `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` is required — there's no TTY behind `phoebe boot`, so the confirmation prompt would hang the install rather than fail it.
- **openssl.** Prisma's engines need libssl and `node:24-bookworm-slim` doesn't carry it.

Also added a named volume for `/home/phoebe` so the pnpm content-addressable store survives container recreates, instead of refetching the whole dependency tree on the first work unit each time.

## One deliberate deviation from convention

`phoebe-agent` is pinned exact (`"0.1.1"`) while the rest of `devDependencies` use caret ranges. It supplies the types for the engine that `engine.ref` pins to `v0.1.1`, so a floating range could describe a different engine than the one that actually runs. Bump the two together. Happy to switch to `^0.1.1` if reviewers prefer consistency over that coupling.

Nothing imports the package at runtime — the type import is erased before the file executes, and the container installs the engine itself from the ref.

## Verification

Image built and run locally. Confirmed as the unprivileged `phoebe` user: `pnpm --version` → `10.33.4` (exactly this repo's pin), OpenSSL 3.0.20, gh 2.97.0, cursor-agent 2026.07.23. Compose resolves the config and prompt bind mounts correctly from `.phoebe/`.

The devDependency was checked against a deliberately wrong config value and the type rejected it, so `PhoebeUserConfig` is genuinely enforced rather than silently resolving to `any`. The `pnpm-lock.yaml` change is 10 additive lines. Prettier passes on everything added.

Labels `processing` and `ready-for-human` were created on this repo out-of-band (`ready-for-agent` already existed) — Phoebe reads all three by their default names.

**Not yet verified**, and worth watching on the first real run: whether `pnpm install --frozen-lockfile && prisma-generate` completes cleanly inside the container, and how long an `nx affected` gate takes on a cold volume. Both need an operator token, so the first `--dry-run --run-once` is the real test.

## Secrets

`.phoebe/.env` is gitignored and holds `GH_TOKEN` plus one provider key. Nothing secret is committed. The intended token is a fine-grained PAT scoped to this repo alone (Contents/PRs/Issues read-write, Actions read), which requires org-owner approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
