### PR TITLE
fix(api-media): stop persisting zero size/bitrate Mux download renditions (VMT-239)

### DIFF
--- a/apis/api-media/src/lib/downloads/processing.spec.ts
+++ b/apis/api-media/src/lib/downloads/processing.spec.ts
@@ -724,7 +724,9 @@ describe('download processing utilities', () => {
       })
       expect(prismaMock.videoVariantDownload.create).not.toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.objectContaining({ quality: VideoVariantDownloadQuality.low })
+          data: expect.objectContaining({
+            quality: VideoVariantDownloadQuality.low
+          })
         })
       )
     })

--- a/apis/api-media/src/lib/downloads/processing.spec.ts
+++ b/apis/api-media/src/lib/downloads/processing.spec.ts
@@ -595,5 +595,186 @@ describe('download processing utilities', () => {
         }
       })
     })
+
+    it('should skip a ready file with missing filesize instead of persisting a zero size', async () => {
+      const muxVideoAsset = {
+        playback_ids: [{ id: 'test-playback-id' }],
+        static_renditions: {
+          files: [
+            {
+              resolution: '720p',
+              status: 'ready',
+              filesize: undefined,
+              height: 720,
+              width: 1280,
+              bitrate: 2500000
+            }
+          ]
+        }
+      }
+
+      const result = await createDownloadsFromMuxAsset({
+        variantId: 'variant-1',
+        muxVideoAsset
+      })
+
+      expect(result).toBe(0)
+      expect(prismaMock.videoVariantDownload.create).not.toHaveBeenCalled()
+    })
+
+    it('should skip a ready file with filesize of "0" instead of persisting a zero size', async () => {
+      const muxVideoAsset = {
+        playback_ids: [{ id: 'test-playback-id' }],
+        static_renditions: {
+          files: [
+            {
+              resolution: '720p',
+              status: 'ready',
+              filesize: '0',
+              height: 720,
+              width: 1280,
+              bitrate: 2500000
+            }
+          ]
+        }
+      }
+
+      const result = await createDownloadsFromMuxAsset({
+        variantId: 'variant-1',
+        muxVideoAsset
+      })
+
+      expect(result).toBe(0)
+      expect(prismaMock.videoVariantDownload.create).not.toHaveBeenCalled()
+    })
+
+    it('should skip a ready file with missing or zero bitrate instead of persisting a zero bitrate', async () => {
+      const muxVideoAsset = {
+        playback_ids: [{ id: 'test-playback-id' }],
+        static_renditions: {
+          files: [
+            {
+              resolution: '720p',
+              status: 'ready',
+              filesize: '157286400',
+              height: 720,
+              width: 1280,
+              bitrate: 0
+            }
+          ]
+        }
+      }
+
+      const result = await createDownloadsFromMuxAsset({
+        variantId: 'variant-1',
+        muxVideoAsset
+      })
+
+      expect(result).toBe(0)
+      expect(prismaMock.videoVariantDownload.create).not.toHaveBeenCalled()
+    })
+
+    it('should skip only the file with bad metadata and still persist valid files', async () => {
+      // 'low' (270p) has no fallback mechanism, so a bad-metadata 270p file
+      // should simply be dropped without affecting the unrelated 720p file.
+      const muxVideoAsset = {
+        playback_ids: [{ id: 'test-playback-id' }],
+        static_renditions: {
+          files: [
+            {
+              resolution: '270p',
+              status: 'ready',
+              filesize: '0',
+              height: 270,
+              width: 480,
+              bitrate: 0
+            },
+            {
+              resolution: '720p',
+              status: 'ready',
+              filesize: '157286400',
+              height: 720,
+              width: 1280,
+              bitrate: 2500000
+            }
+          ]
+        }
+      }
+
+      prismaMock.videoVariantDownload.create.mockResolvedValue({} as any)
+
+      const result = await createDownloadsFromMuxAsset({
+        variantId: 'variant-1',
+        muxVideoAsset
+      })
+
+      // Only 720p (high) + highest (inherits from 720p, since 270p was invalid)
+      expect(result).toBe(2)
+      expect(prismaMock.videoVariantDownload.create).toHaveBeenCalledWith({
+        data: {
+          videoVariantId: 'variant-1',
+          quality: VideoVariantDownloadQuality.high,
+          url: 'https://stream.mux.com/test-playback-id/720p.mp4',
+          version: 1,
+          size: 157286400,
+          height: 720,
+          width: 1280,
+          bitrate: 2500000
+        }
+      })
+      expect(prismaMock.videoVariantDownload.create).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ quality: VideoVariantDownloadQuality.low })
+        })
+      )
+    })
+
+    it('should fall back to a lower valid resolution when the target resolution has bad metadata', async () => {
+      const muxVideoAsset = {
+        playback_ids: [{ id: 'test-playback-id' }],
+        static_renditions: {
+          files: [
+            {
+              resolution: '480p',
+              status: 'ready',
+              filesize: '78643200',
+              height: 480,
+              width: 854,
+              bitrate: 1200000
+            },
+            {
+              resolution: '720p',
+              status: 'ready',
+              filesize: undefined,
+              height: 720,
+              width: 1280,
+              bitrate: 2500000
+            }
+          ]
+        }
+      }
+
+      prismaMock.videoVariantDownload.create.mockResolvedValue({} as any)
+
+      const result = await createDownloadsFromMuxAsset({
+        variantId: 'variant-1',
+        muxVideoAsset
+      })
+
+      // 480p (fallback high) + highest
+      expect(result).toBe(2)
+      expect(prismaMock.videoVariantDownload.create).toHaveBeenCalledWith({
+        data: {
+          videoVariantId: 'variant-1',
+          quality: VideoVariantDownloadQuality.high,
+          url: 'https://stream.mux.com/test-playback-id/480p.mp4',
+          version: 1,
+          size: 78643200,
+          height: 480,
+          width: 854,
+          bitrate: 1200000
+        }
+      })
+    })
   })
 })

--- a/apis/api-media/src/lib/downloads/processing.ts
+++ b/apis/api-media/src/lib/downloads/processing.ts
@@ -48,6 +48,18 @@ function getResolutionHeight(resolution: string): number {
   return parseInt(resolution.replace('p', ''))
 }
 
+// Mux can mark a static rendition file as `ready` before its filesize/bitrate
+// have propagated. Persisting those as 0 would silently serve broken download
+// metadata, so treat a `ready` file without usable metadata as not-yet-ready.
+function hasValidRenditionMetadata(file: {
+  filesize?: string | null
+  bitrate?: number | null
+}): boolean {
+  const size = file.filesize ? parseInt(file.filesize) : 0
+  const bitrate = file.bitrate ?? 0
+  return size > 0 && bitrate > 0
+}
+
 // Enhanced function that handles fallbacks for sd and high qualities
 export function mapStaticResolutionTierToDownloadQualityWithFallback(
   availableFiles: Array<{
@@ -196,17 +208,29 @@ export async function createDownloadsFromMuxAsset({
       )
 
       if (quality != null) {
-        directMappings.push({
-          videoVariantId: variantId,
-          quality,
-          url: `https://stream.mux.com/${playbackId}/${file.resolution}.mp4`,
-          version: 1,
-          size: file.filesize ? parseInt(file.filesize) : 0,
-          height: file.height ?? 0,
-          width: file.width ?? 0,
-          bitrate: file.bitrate ?? 0
-        })
-        processedQualities.add(quality)
+        if (!hasValidRenditionMetadata(file)) {
+          logger?.warn(
+            {
+              variantId,
+              resolution: file.resolution,
+              filesize: file.filesize,
+              bitrate: file.bitrate
+            },
+            'Mux static rendition is ready but missing filesize/bitrate metadata, skipping until refreshed'
+          )
+        } else {
+          directMappings.push({
+            videoVariantId: variantId,
+            quality,
+            url: `https://stream.mux.com/${playbackId}/${file.resolution}.mp4`,
+            version: 1,
+            size: file.filesize ? parseInt(file.filesize) : 0,
+            height: file.height ?? 0,
+            width: file.width ?? 0,
+            bitrate: file.bitrate ?? 0
+          })
+          processedQualities.add(quality)
+        }
       }
     }
   }
@@ -214,10 +238,16 @@ export async function createDownloadsFromMuxAsset({
   // Handle fallbacks for sd and high if they're missing
   const fallbackMappings: Prisma.VideoVariantDownloadCreateManyInput[] = []
 
+  // Fallback candidates must have usable metadata, otherwise we'd fall back
+  // into the same zero size/bitrate problem the direct mapping just avoided.
+  const filesWithValidMetadata = muxVideoAsset.static_renditions.files.filter(
+    (file) => file == null || hasValidRenditionMetadata(file)
+  )
+
   // Check for sd fallback (if 360p is not available)
   if (!processedQualities.has(VideoVariantDownloadQuality.sd)) {
     const sdFallback = mapStaticResolutionTierToDownloadQualityWithFallback(
-      muxVideoAsset.static_renditions.files,
+      filesWithValidMetadata,
       '360p'
     )
 
@@ -249,7 +279,7 @@ export async function createDownloadsFromMuxAsset({
   // Check for high fallback (if 720p is not available)
   if (!processedQualities.has(VideoVariantDownloadQuality.high)) {
     const highFallback = mapStaticResolutionTierToDownloadQualityWithFallback(
-      muxVideoAsset.static_renditions.files,
+      filesWithValidMetadata,
       '720p'
     )
 

--- a/apis/api-media/src/scripts/mux-videos.ts
+++ b/apis/api-media/src/scripts/mux-videos.ts
@@ -213,10 +213,15 @@ export async function processDownloads(): Promise<void> {
   const take = 100
   let hasMore = true
   let totalProcessed = 0
+  // Track variants already attempted this run so a variant whose Mux
+  // metadata is still incomplete after processing isn't re-selected forever
+  // by the same query - it remains eligible for the next script run instead.
+  const attemptedVariantIds: string[] = []
 
   while (hasMore) {
     const variants = await prisma.videoVariant.findMany({
       where: {
+        id: { notIn: attemptedVariantIds },
         muxVideoId: { not: null },
         muxVideo: {
           downloadable: true,
@@ -284,6 +289,8 @@ export async function processDownloads(): Promise<void> {
     )
 
     for (const variant of variants) {
+      attemptedVariantIds.push(variant.id)
+
       if (!variant.muxVideo?.assetId) {
         continue
       }

--- a/apis/api-media/src/scripts/mux-videos.ts
+++ b/apis/api-media/src/scripts/mux-videos.ts
@@ -246,6 +246,22 @@ export async function processDownloads(): Promise<void> {
                 }
               }
             }
+          },
+          {
+            // Variants with Mux downloads persisted with a zero size or
+            // bitrate (see VMT-239) - re-fetch from Mux in case the metadata
+            // has since propagated
+            downloads: {
+              some: {
+                quality: {
+                  notIn: ['distroLow', 'distroSd', 'distroHigh']
+                },
+                url: {
+                  startsWith: 'https://stream.mux.com'
+                },
+                OR: [{ size: 0 }, { bitrate: 0 }]
+              }
+            }
           }
         ]
       },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid video renditions with missing or zero file size or bitrate from being saved.
  * Improved fallback selection so valid lower-resolution renditions are used when needed.
  * Enabled incomplete download metadata to be refreshed automatically.
  * Added safeguards to ensure invalid files do not affect valid download processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->