### PR TITLE
fix(api-media): make video Algolia indexing durable and retriable (QA-543)

### DIFF
--- a/apis/api-media/src/index.ts
+++ b/apis/api-media/src/index.ts
@@ -7,6 +7,7 @@ import './workers/server'
 import './workers/processVideoDownloads/worker'
 import './workers/processVideoUploads/worker'
 import './workers/processImageBlurhash/worker'
+import './workers/videoAlgoliaSync/worker'
 
 const port = 4005
 // eslint-disable-next-line @typescript-eslint/no-misused-promises

--- a/apis/api-media/src/lib/algolia/algoliaVideoUpdate/algoliaVideoUpdate.qa-543-repro.spec.ts
+++ b/apis/api-media/src/lib/algolia/algoliaVideoUpdate/algoliaVideoUpdate.qa-543-repro.spec.ts
@@ -1,0 +1,93 @@
+import { Logger } from 'pino'
+import { vi } from 'vitest'
+
+import { prismaMock } from '../../../../test/prismaMock'
+
+import {
+  updateVideoInAlgolia,
+  updateVideoPublishedStatus
+} from './algoliaVideoUpdate'
+
+// QA-543: on-publish Algolia indexing was fire-and-forget. updateVideoInAlgolia
+// and updateVideoPublishedStatus caught every error, logged it, and returned
+// void — so a transient Algolia failure (timeout, rate limit, network blip)
+// left the DB record published while it silently never reached the index,
+// with no retry and no signal to the editor that anything had failed. This
+// spec used to assert exactly that swallow-and-drop behavior; it now asserts
+// the opposite — failures must propagate so the videoAlgoliaSync worker can
+// catch them and let BullMQ retry the job instead of losing the write.
+
+vi.mock('../algoliaClient', () => ({
+  getAlgoliaClient: () => ({
+    saveObjects: vi.fn().mockRejectedValue(new Error('Algolia unavailable')),
+    partialUpdateObjects: vi
+      .fn()
+      .mockRejectedValue(new Error('Algolia unavailable'))
+  }),
+  getAlgoliaConfig: () => ({
+    appId: 'test-app-id',
+    apiKey: 'test-api-key',
+    videosIndex: 'test-videos',
+    videoVariantsIndex: 'test-video-variants'
+  })
+}))
+
+vi.mock('../languages', () => ({
+  getLanguages: vi.fn().mockResolvedValue({})
+}))
+
+const mockLogger: Logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn()
+} as any
+
+describe('QA-543 repro: durable Algolia indexing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('propagates (does not swallow) a transient Algolia failure when updating a video record', async () => {
+    prismaMock.video.findUnique.mockResolvedValueOnce({
+      id: 'video-id',
+      label: 'segment',
+      primaryLanguageId: '529',
+      childIds: [],
+      published: true,
+      restrictDownloadPlatforms: [],
+      restrictViewPlatforms: [],
+      title: [],
+      description: [],
+      studyQuestions: [],
+      bibleCitation: [],
+      keywords: [],
+      images: [],
+      availableLanguages: [],
+      variants: []
+    } as any)
+
+    await expect(updateVideoInAlgolia('video-id', mockLogger)).rejects.toThrow(
+      'Algolia unavailable'
+    )
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.any(Error),
+      'failed to update video video-id in algolia'
+    )
+  })
+
+  it('propagates (does not swallow) a transient Algolia failure when updating variant published status', async () => {
+    prismaMock.videoVariant.findMany.mockResolvedValueOnce([
+      { id: 'variant-id' } as any
+    ])
+
+    await expect(
+      updateVideoPublishedStatus('video-id', true, mockLogger)
+    ).rejects.toThrow('Algolia unavailable')
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.any(Error),
+      'failed to update video published status for video video-id'
+    )
+  })
+})

--- a/apis/api-media/src/lib/algolia/algoliaVideoUpdate/algoliaVideoUpdate.qa-543-repro.spec.ts
+++ b/apis/api-media/src/lib/algolia/algoliaVideoUpdate/algoliaVideoUpdate.qa-543-repro.spec.ts
@@ -43,8 +43,15 @@ const mockLogger: Logger = {
 } as any
 
 describe('QA-543 repro: durable Algolia indexing', () => {
+  const previousVideoVariantsIndex = process.env.ALGOLIA_INDEX_VIDEO_VARIANTS
+
   beforeEach(() => {
     vi.clearAllMocks()
+    process.env.ALGOLIA_INDEX_VIDEO_VARIANTS = 'test-video-variants'
+  })
+
+  afterEach(() => {
+    process.env.ALGOLIA_INDEX_VIDEO_VARIANTS = previousVideoVariantsIndex
   })
 
   it('propagates (does not swallow) a transient Algolia failure when updating a video record', async () => {

--- a/apis/api-media/src/lib/algolia/algoliaVideoUpdate/algoliaVideoUpdate.qa-543-repro.spec.ts
+++ b/apis/api-media/src/lib/algolia/algoliaVideoUpdate/algoliaVideoUpdate.qa-543-repro.spec.ts
@@ -1,6 +1,8 @@
 import { Logger } from 'pino'
 import { vi } from 'vitest'
 
+import { Video, VideoVariant } from '@core/prisma/media/client'
+
 import { prismaMock } from '../../../../test/prismaMock'
 
 import {
@@ -36,11 +38,11 @@ vi.mock('../languages', () => ({
   getLanguages: vi.fn().mockResolvedValue({})
 }))
 
-const mockLogger: Logger = {
+const mockLogger = {
   info: vi.fn(),
   warn: vi.fn(),
   error: vi.fn()
-} as any
+} as unknown as Logger
 
 describe('QA-543 repro: durable Algolia indexing', () => {
   const previousVideoVariantsIndex = process.env.ALGOLIA_INDEX_VIDEO_VARIANTS
@@ -71,7 +73,7 @@ describe('QA-543 repro: durable Algolia indexing', () => {
       images: [],
       availableLanguages: [],
       variants: []
-    } as any)
+    } as unknown as Video)
 
     await expect(updateVideoInAlgolia('video-id', mockLogger)).rejects.toThrow(
       'Algolia unavailable'
@@ -85,7 +87,7 @@ describe('QA-543 repro: durable Algolia indexing', () => {
 
   it('propagates (does not swallow) a transient Algolia failure when updating variant published status', async () => {
     prismaMock.videoVariant.findMany.mockResolvedValueOnce([
-      { id: 'variant-id' } as any
+      { id: 'variant-id' } as unknown as VideoVariant
     ])
 
     await expect(

--- a/apis/api-media/src/lib/algolia/algoliaVideoUpdate/algoliaVideoUpdate.spec.ts
+++ b/apis/api-media/src/lib/algolia/algoliaVideoUpdate/algoliaVideoUpdate.spec.ts
@@ -7,11 +7,13 @@ import { getLanguages } from '../languages'
 import { updateVideoInAlgolia } from './algoliaVideoUpdate'
 
 const saveObjectsSpy = vi.fn()
+const deleteObjectSpy = vi.fn()
 
 // Mock the algolia client helper
 vi.mock('../algoliaClient', () => ({
   getAlgoliaClient: () => ({
-    saveObjects: saveObjectsSpy
+    saveObjects: saveObjectsSpy,
+    deleteObject: deleteObjectSpy
   }),
   getAlgoliaConfig: () => ({
     appId: 'test-app-id',
@@ -55,6 +57,7 @@ describe('algoliaVideoUpdate', () => {
 
     // Reset the spy mock return values
     saveObjectsSpy.mockResolvedValue([{ taskID: 'test-task-123' }])
+    deleteObjectSpy.mockResolvedValue({ taskID: 'test-delete-task-123' })
 
     mockedGetLanguages.mockResolvedValue(mockLanguages)
   })
@@ -63,14 +66,18 @@ describe('algoliaVideoUpdate', () => {
     vi.resetAllMocks()
   })
 
-  it('should warn when video is not found', async () => {
+  it('removes the video from algolia when it no longer exists (deleted)', async () => {
     prismaMock.video.findUnique.mockResolvedValueOnce(null)
 
     await updateVideoInAlgolia('non-existent-video', mockLogger)
 
     expect(mockLogger.warn).toHaveBeenCalledWith(
-      'video non-existent-video not found'
+      'video non-existent-video not found, removing from algolia'
     )
+    expect(deleteObjectSpy).toHaveBeenCalledWith({
+      indexName: 'test-videos',
+      objectID: 'non-existent-video'
+    })
     expect(saveObjectsSpy).not.toHaveBeenCalled()
   })
 

--- a/apis/api-media/src/lib/algolia/algoliaVideoUpdate/algoliaVideoUpdate.spec.ts
+++ b/apis/api-media/src/lib/algolia/algoliaVideoUpdate/algoliaVideoUpdate.spec.ts
@@ -7,13 +7,13 @@ import { getLanguages } from '../languages'
 import { updateVideoInAlgolia } from './algoliaVideoUpdate'
 
 const saveObjectsSpy = vi.fn()
-const deleteObjectSpy = vi.fn()
+const deleteObjectsSpy = vi.fn()
 
 // Mock the algolia client helper
 vi.mock('../algoliaClient', () => ({
   getAlgoliaClient: () => ({
     saveObjects: saveObjectsSpy,
-    deleteObject: deleteObjectSpy
+    deleteObjects: deleteObjectsSpy
   }),
   getAlgoliaConfig: () => ({
     appId: 'test-app-id',
@@ -57,7 +57,7 @@ describe('algoliaVideoUpdate', () => {
 
     // Reset the spy mock return values
     saveObjectsSpy.mockResolvedValue([{ taskID: 'test-task-123' }])
-    deleteObjectSpy.mockResolvedValue({ taskID: 'test-delete-task-123' })
+    deleteObjectsSpy.mockResolvedValue([{ taskID: 'test-delete-task-123' }])
 
     mockedGetLanguages.mockResolvedValue(mockLanguages)
   })
@@ -74,9 +74,10 @@ describe('algoliaVideoUpdate', () => {
     expect(mockLogger.warn).toHaveBeenCalledWith(
       'video non-existent-video not found, removing from algolia'
     )
-    expect(deleteObjectSpy).toHaveBeenCalledWith({
+    expect(deleteObjectsSpy).toHaveBeenCalledWith({
       indexName: 'test-videos',
-      objectID: 'non-existent-video'
+      objectIDs: ['non-existent-video'],
+      waitForTasks: true
     })
     expect(saveObjectsSpy).not.toHaveBeenCalled()
   })

--- a/apis/api-media/src/lib/algolia/algoliaVideoUpdate/algoliaVideoUpdate.spec.ts
+++ b/apis/api-media/src/lib/algolia/algoliaVideoUpdate/algoliaVideoUpdate.spec.ts
@@ -306,12 +306,14 @@ describe('algoliaVideoUpdate', () => {
     })
   })
 
-  it('should handle errors gracefully', async () => {
+  it('logs and rethrows so the caller can retry', async () => {
     prismaMock.video.findUnique.mockRejectedValueOnce(
       new Error('Database error')
     )
 
-    await updateVideoInAlgolia('test-video-id', mockLogger)
+    await expect(
+      updateVideoInAlgolia('test-video-id', mockLogger)
+    ).rejects.toThrow('Database error')
 
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.any(Error),

--- a/apis/api-media/src/lib/algolia/algoliaVideoUpdate/algoliaVideoUpdate.ts
+++ b/apis/api-media/src/lib/algolia/algoliaVideoUpdate/algoliaVideoUpdate.ts
@@ -96,9 +96,14 @@ export async function updateVideoInAlgolia(
 
     if (video == null) {
       logger?.warn(`video ${videoId} not found, removing from algolia`)
-      await client.deleteObject({
+      // deleteObjects(waitForTasks) rather than deleteObject, so the job only
+      // completes once Algolia has actually applied the removal — a
+      // fire-and-forget accept would let a failed delete look like success and
+      // skip the retry. Matches the waitForTasks writes above.
+      await client.deleteObjects({
         indexName: algoliaConfig.videosIndex,
-        objectID: videoId
+        objectIDs: [videoId],
+        waitForTasks: true
       })
       return
     }

--- a/apis/api-media/src/lib/algolia/algoliaVideoUpdate/algoliaVideoUpdate.ts
+++ b/apis/api-media/src/lib/algolia/algoliaVideoUpdate/algoliaVideoUpdate.ts
@@ -95,7 +95,11 @@ export async function updateVideoInAlgolia(
     })
 
     if (video == null) {
-      logger?.warn(`video ${videoId} not found`)
+      logger?.warn(`video ${videoId} not found, removing from algolia`)
+      await client.deleteObject({
+        indexName: algoliaConfig.videosIndex,
+        objectID: videoId
+      })
       return
     }
 

--- a/apis/api-media/src/lib/algolia/algoliaVideoUpdate/algoliaVideoUpdate.ts
+++ b/apis/api-media/src/lib/algolia/algoliaVideoUpdate/algoliaVideoUpdate.ts
@@ -222,6 +222,7 @@ export async function updateVideoInAlgolia(
     )
   } catch (error) {
     logger?.error(error, `failed to update video ${videoId} in algolia`)
+    throw error
   }
 }
 
@@ -267,5 +268,6 @@ export async function updateVideoPublishedStatus(
       error,
       `failed to update video published status for video ${videoId}`
     )
+    throw error
   }
 }

--- a/apis/api-media/src/schema/video/lib/updateAvailableLanguages.spec.ts
+++ b/apis/api-media/src/schema/video/lib/updateAvailableLanguages.spec.ts
@@ -1,5 +1,7 @@
 import { vi } from 'vitest'
 
+import { Prisma, Video } from '@core/prisma/media/client'
+
 import { prismaMock } from '../../../../test/prismaMock'
 import { videoCacheReset } from '../../../lib/videoCacheReset'
 import { enqueueVideoAlgoliaSync } from '../../../workers/videoAlgoliaSync'
@@ -28,6 +30,18 @@ vi.mock('../../../lib/videoCacheReset', () => ({
 const mockedEnqueueVideoAlgoliaSync = vi.mocked(enqueueVideoAlgoliaSync)
 const mockedVideoCacheReset = vi.mocked(videoCacheReset)
 
+type AvailableLanguagesVideoPayload = Prisma.VideoGetPayload<{
+  select: {
+    label: true
+    variants: { select: { languageId: true } }
+    children: { select: { availableLanguages: true } }
+  }
+}>
+
+type ContainerParentPayload = Prisma.VideoGetPayload<{
+  select: { id: true }
+}>
+
 describe('updateVideoAvailableLanguages', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -35,7 +49,7 @@ describe('updateVideoAvailableLanguages', () => {
       label: 'series',
       variants: [],
       children: []
-    } as any)
+    } as AvailableLanguagesVideoPayload as unknown as Video)
     prismaMock.video.update.mockResolvedValue({} as any)
     mockedVideoCacheReset.mockResolvedValue(undefined)
   })
@@ -43,13 +57,17 @@ describe('updateVideoAvailableLanguages', () => {
   it('enqueues a video-only Algolia sync by default', async () => {
     await updateVideoAvailableLanguages('video-id')
 
-    expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith('video-id', {
-      syncVideoRecord: true,
-      syncAllVariants: false,
-      syncPublishedFlag: false,
-      dirtyVariantIds: [],
-      deletedVariantIds: []
-    })
+    expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith(
+      'video-id',
+      {
+        syncVideoRecord: true,
+        syncAllVariants: false,
+        syncPublishedFlag: false,
+        dirtyVariantIds: [],
+        deletedVariantIds: []
+      },
+      expect.anything()
+    )
   })
 
   it('does not enqueue an Algolia sync when skipAlgolia is set', async () => {
@@ -64,7 +82,7 @@ describe('findContainerParentIds', () => {
     prismaMock.video.findMany.mockResolvedValueOnce([
       { id: 'parent-1' },
       { id: 'parent-2' }
-    ] as any)
+    ] as ContainerParentPayload[] as unknown as Video[])
 
     const parentIds = await findContainerParentIds('child-id')
 
@@ -84,23 +102,31 @@ describe('updateParentCollectionLanguages', () => {
     prismaMock.video.findMany.mockResolvedValueOnce([
       { id: 'parent-1' },
       { id: 'parent-2' }
-    ] as any)
+    ] as ContainerParentPayload[] as unknown as Video[])
 
     await updateParentCollectionLanguages('child-id')
 
-    expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith('parent-1', {
-      syncVideoRecord: true,
-      syncAllVariants: false,
-      syncPublishedFlag: false,
-      dirtyVariantIds: [],
-      deletedVariantIds: []
-    })
-    expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith('parent-2', {
-      syncVideoRecord: true,
-      syncAllVariants: false,
-      syncPublishedFlag: false,
-      dirtyVariantIds: [],
-      deletedVariantIds: []
-    })
+    expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith(
+      'parent-1',
+      {
+        syncVideoRecord: true,
+        syncAllVariants: false,
+        syncPublishedFlag: false,
+        dirtyVariantIds: [],
+        deletedVariantIds: []
+      },
+      expect.anything()
+    )
+    expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith(
+      'parent-2',
+      {
+        syncVideoRecord: true,
+        syncAllVariants: false,
+        syncPublishedFlag: false,
+        dirtyVariantIds: [],
+        deletedVariantIds: []
+      },
+      expect.anything()
+    )
   })
 })

--- a/apis/api-media/src/schema/video/lib/updateAvailableLanguages.spec.ts
+++ b/apis/api-media/src/schema/video/lib/updateAvailableLanguages.spec.ts
@@ -42,14 +42,19 @@ type ContainerParentPayload = Prisma.VideoGetPayload<{
   select: { id: true }
 }>
 
-// The prismaMock signatures promise a full Video, but each call site here only
-// ever reads the columns its own `select` asked for. Typing the fixture as the
-// selected payload keeps the select/mock mismatch a compile error, then the
-// widening cast satisfies the mock's declared return type.
-const availableLanguagesVideo: AvailableLanguagesVideoPayload = {
-  label: 'series',
-  variants: [],
-  children: []
+// prismaMock is typed against the full Video model, but every function under
+// test reads only the columns its own `select` asked for. These helpers take
+// the selected-payload type — so a fixture that drifts from the `select` in
+// updateAvailableLanguages.ts is a compile error — and confine the widening
+// the deep mock's signature forces to one place per query.
+function mockCalculateAvailableLanguagesQuery(
+  video: AvailableLanguagesVideoPayload
+): void {
+  prismaMock.video.findUnique.mockResolvedValue(video as unknown as Video)
+}
+
+function mockContainerParentQuery(parents: ContainerParentPayload[]): void {
+  prismaMock.video.findMany.mockResolvedValueOnce(parents as unknown as Video[])
 }
 
 const containerParents: ContainerParentPayload[] = [
@@ -60,9 +65,11 @@ const containerParents: ContainerParentPayload[] = [
 describe('updateVideoAvailableLanguages', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    prismaMock.video.findUnique.mockResolvedValue(
-      availableLanguagesVideo as unknown as Video
-    )
+    mockCalculateAvailableLanguagesQuery({
+      label: 'series',
+      variants: [],
+      children: []
+    })
     // updateVideoAvailableLanguages ignores the update() result
     prismaMock.video.update.mockResolvedValue({} as unknown as Video)
     mockedVideoCacheReset.mockResolvedValue(undefined)
@@ -93,9 +100,7 @@ describe('updateVideoAvailableLanguages', () => {
 
 describe('findContainerParentIds', () => {
   it('queries collection/series/featureFilm videos that list the child', async () => {
-    prismaMock.video.findMany.mockResolvedValueOnce(
-      containerParents as unknown as Video[]
-    )
+    mockContainerParentQuery(containerParents)
 
     const parentIds = await findContainerParentIds('child-id')
 
@@ -112,9 +117,7 @@ describe('findContainerParentIds', () => {
 
 describe('updateParentCollectionLanguages', () => {
   it('enqueues an Algolia sync for every parent found', async () => {
-    prismaMock.video.findMany.mockResolvedValueOnce(
-      containerParents as unknown as Video[]
-    )
+    mockContainerParentQuery(containerParents)
 
     await updateParentCollectionLanguages('child-id')
 

--- a/apis/api-media/src/schema/video/lib/updateAvailableLanguages.spec.ts
+++ b/apis/api-media/src/schema/video/lib/updateAvailableLanguages.spec.ts
@@ -42,15 +42,29 @@ type ContainerParentPayload = Prisma.VideoGetPayload<{
   select: { id: true }
 }>
 
+// The prismaMock signatures promise a full Video, but each call site here only
+// ever reads the columns its own `select` asked for. Typing the fixture as the
+// selected payload keeps the select/mock mismatch a compile error, then the
+// widening cast satisfies the mock's declared return type.
+const availableLanguagesVideo: AvailableLanguagesVideoPayload = {
+  label: 'series',
+  variants: [],
+  children: []
+}
+
+const containerParents: ContainerParentPayload[] = [
+  { id: 'parent-1' },
+  { id: 'parent-2' }
+]
+
 describe('updateVideoAvailableLanguages', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    prismaMock.video.findUnique.mockResolvedValue({
-      label: 'series',
-      variants: [],
-      children: []
-    } as AvailableLanguagesVideoPayload as unknown as Video)
-    prismaMock.video.update.mockResolvedValue({} as any)
+    prismaMock.video.findUnique.mockResolvedValue(
+      availableLanguagesVideo as unknown as Video
+    )
+    // updateVideoAvailableLanguages ignores the update() result
+    prismaMock.video.update.mockResolvedValue({} as unknown as Video)
     mockedVideoCacheReset.mockResolvedValue(undefined)
   })
 
@@ -79,10 +93,9 @@ describe('updateVideoAvailableLanguages', () => {
 
 describe('findContainerParentIds', () => {
   it('queries collection/series/featureFilm videos that list the child', async () => {
-    prismaMock.video.findMany.mockResolvedValueOnce([
-      { id: 'parent-1' },
-      { id: 'parent-2' }
-    ] as ContainerParentPayload[] as unknown as Video[])
+    prismaMock.video.findMany.mockResolvedValueOnce(
+      containerParents as unknown as Video[]
+    )
 
     const parentIds = await findContainerParentIds('child-id')
 
@@ -99,10 +112,9 @@ describe('findContainerParentIds', () => {
 
 describe('updateParentCollectionLanguages', () => {
   it('enqueues an Algolia sync for every parent found', async () => {
-    prismaMock.video.findMany.mockResolvedValueOnce([
-      { id: 'parent-1' },
-      { id: 'parent-2' }
-    ] as ContainerParentPayload[] as unknown as Video[])
+    prismaMock.video.findMany.mockResolvedValueOnce(
+      containerParents as unknown as Video[]
+    )
 
     await updateParentCollectionLanguages('child-id')
 

--- a/apis/api-media/src/schema/video/lib/updateAvailableLanguages.spec.ts
+++ b/apis/api-media/src/schema/video/lib/updateAvailableLanguages.spec.ts
@@ -1,0 +1,106 @@
+import { vi } from 'vitest'
+
+import { prismaMock } from '../../../../test/prismaMock'
+import { videoCacheReset } from '../../../lib/videoCacheReset'
+import { enqueueVideoAlgoliaSync } from '../../../workers/videoAlgoliaSync'
+
+import {
+  findContainerParentIds,
+  updateParentCollectionLanguages,
+  updateVideoAvailableLanguages
+} from './updateAvailableLanguages'
+
+vi.mock('../../../workers/videoAlgoliaSync', () => ({
+  enqueueVideoAlgoliaSync: vi.fn(),
+  videoOnlyScope: {
+    syncVideoRecord: true,
+    syncAllVariants: false,
+    syncPublishedFlag: false,
+    dirtyVariantIds: [],
+    deletedVariantIds: []
+  }
+}))
+
+vi.mock('../../../lib/videoCacheReset', () => ({
+  videoCacheReset: vi.fn()
+}))
+
+const mockedEnqueueVideoAlgoliaSync = vi.mocked(enqueueVideoAlgoliaSync)
+const mockedVideoCacheReset = vi.mocked(videoCacheReset)
+
+describe('updateVideoAvailableLanguages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    prismaMock.video.findUnique.mockResolvedValue({
+      label: 'series',
+      variants: [],
+      children: []
+    } as any)
+    prismaMock.video.update.mockResolvedValue({} as any)
+    mockedVideoCacheReset.mockResolvedValue(undefined)
+  })
+
+  it('enqueues a video-only Algolia sync by default', async () => {
+    await updateVideoAvailableLanguages('video-id')
+
+    expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith('video-id', {
+      syncVideoRecord: true,
+      syncAllVariants: false,
+      syncPublishedFlag: false,
+      dirtyVariantIds: [],
+      deletedVariantIds: []
+    })
+  })
+
+  it('does not enqueue an Algolia sync when skipAlgolia is set', async () => {
+    await updateVideoAvailableLanguages('video-id', { skipAlgolia: true })
+
+    expect(mockedEnqueueVideoAlgoliaSync).not.toHaveBeenCalled()
+  })
+})
+
+describe('findContainerParentIds', () => {
+  it('queries collection/series/featureFilm videos that list the child', async () => {
+    prismaMock.video.findMany.mockResolvedValueOnce([
+      { id: 'parent-1' },
+      { id: 'parent-2' }
+    ] as any)
+
+    const parentIds = await findContainerParentIds('child-id')
+
+    expect(prismaMock.video.findMany).toHaveBeenCalledWith({
+      where: {
+        children: { some: { id: 'child-id' } },
+        label: { in: ['collection', 'series', 'featureFilm'] }
+      },
+      select: { id: true }
+    })
+    expect(parentIds).toEqual(['parent-1', 'parent-2'])
+  })
+})
+
+describe('updateParentCollectionLanguages', () => {
+  it('enqueues an Algolia sync for every parent found', async () => {
+    prismaMock.video.findMany.mockResolvedValueOnce([
+      { id: 'parent-1' },
+      { id: 'parent-2' }
+    ] as any)
+
+    await updateParentCollectionLanguages('child-id')
+
+    expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith('parent-1', {
+      syncVideoRecord: true,
+      syncAllVariants: false,
+      syncPublishedFlag: false,
+      dirtyVariantIds: [],
+      deletedVariantIds: []
+    })
+    expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith('parent-2', {
+      syncVideoRecord: true,
+      syncAllVariants: false,
+      syncPublishedFlag: false,
+      dirtyVariantIds: [],
+      deletedVariantIds: []
+    })
+  })
+})

--- a/apis/api-media/src/schema/video/lib/updateAvailableLanguages.ts
+++ b/apis/api-media/src/schema/video/lib/updateAvailableLanguages.ts
@@ -5,8 +5,11 @@
 
 import { prisma } from '@core/prisma/media/client'
 
-import { updateVideoInAlgolia } from '../../../lib/algolia/algoliaVideoUpdate'
 import { videoCacheReset } from '../../../lib/videoCacheReset'
+import {
+  enqueueVideoAlgoliaSync,
+  videoOnlyScope
+} from '../../../workers/videoAlgoliaSync'
 
 // Calculates what availableLanguages should be for a given video
 // Does NOT update the database - only calculates the correct value
@@ -73,11 +76,7 @@ export async function updateVideoAvailableLanguages(
 
   // Update cache and search index unless skipped
   if (!options.skipAlgolia) {
-    try {
-      await updateVideoInAlgolia(videoId)
-    } catch (error) {
-      console.error('Algolia update error:', error)
-    }
+    await enqueueVideoAlgoliaSync(videoId, videoOnlyScope)
   }
 
   if (!options.skipCache) {
@@ -151,11 +150,12 @@ export async function removeLanguageFromVideoIfUnused(
   })
 }
 
-// Updates all parent videos (collections) when a child video's languages change
-// Ensures collections always reflect the union of their children's languages
-export async function updateParentCollectionLanguages(
+// Finds the container videos (collections/series/featureFilms) that list
+// the given video as a child. Shared by language-cascade and Algolia
+// parent-cascade callers.
+export async function findContainerParentIds(
   childVideoId: string
-): Promise<void> {
+): Promise<string[]> {
   const parents = await prisma.video.findMany({
     where: {
       children: {
@@ -168,9 +168,19 @@ export async function updateParentCollectionLanguages(
     select: { id: true }
   })
 
+  return parents.map((parent) => parent.id)
+}
+
+// Updates all parent videos (collections) when a child video's languages change
+// Ensures collections always reflect the union of their children's languages
+export async function updateParentCollectionLanguages(
+  childVideoId: string
+): Promise<void> {
+  const parentIds = await findContainerParentIds(childVideoId)
+
   // Update each parent collection
-  for (const parent of parents) {
-    await updateVideoAvailableLanguages(parent.id, {
+  for (const parentId of parentIds) {
+    await updateVideoAvailableLanguages(parentId, {
       skipCache: false,
       skipAlgolia: false
     })

--- a/apis/api-media/src/schema/video/lib/updateAvailableLanguages.ts
+++ b/apis/api-media/src/schema/video/lib/updateAvailableLanguages.ts
@@ -10,6 +10,7 @@ import {
   enqueueVideoAlgoliaSync,
   videoOnlyScope
 } from '../../../workers/videoAlgoliaSync'
+import { logger } from '../../logger'
 
 // Calculates what availableLanguages should be for a given video
 // Does NOT update the database - only calculates the correct value
@@ -76,7 +77,7 @@ export async function updateVideoAvailableLanguages(
 
   // Update cache and search index unless skipped
   if (!options.skipAlgolia) {
-    await enqueueVideoAlgoliaSync(videoId, videoOnlyScope)
+    await enqueueVideoAlgoliaSync(videoId, videoOnlyScope, logger)
   }
 
   if (!options.skipCache) {

--- a/apis/api-media/src/schema/video/video.spec.ts
+++ b/apis/api-media/src/schema/video/video.spec.ts
@@ -23,13 +23,32 @@ import { ResultOf, graphql } from '@core/shared/gql'
 
 import { getClient } from '../../../test/client'
 import { prismaMock } from '../../../test/prismaMock'
+import { enqueueVideoAlgoliaSync } from '../../workers/videoAlgoliaSync'
 
-import { updateVideoAvailableLanguages } from './lib/updateAvailableLanguages'
+import {
+  findContainerParentIds,
+  updateVideoAvailableLanguages
+} from './lib/updateAvailableLanguages'
 import { getLanguageIdFromInfo } from './video'
 
 vi.mock('./lib/updateAvailableLanguages', () => ({
-  updateVideoAvailableLanguages: vi.fn()
+  updateVideoAvailableLanguages: vi.fn(),
+  findContainerParentIds: vi.fn().mockResolvedValue([])
 }))
+
+vi.mock('../../workers/videoAlgoliaSync', () => ({
+  enqueueVideoAlgoliaSync: vi.fn(),
+  videoOnlyScope: {
+    syncVideoRecord: true,
+    syncAllVariants: false,
+    syncPublishedFlag: false,
+    dirtyVariantIds: [],
+    deletedVariantIds: []
+  }
+}))
+
+const mockedFindContainerParentIds = vi.mocked(findContainerParentIds)
+const mockedEnqueueVideoAlgoliaSync = vi.mocked(enqueueVideoAlgoliaSync)
 
 describe('video', () => {
   const client = getClient()
@@ -2594,6 +2613,10 @@ describe('video', () => {
         expect(result).toHaveProperty('data.videoCreate', {
           id: 'id'
         })
+        expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith(
+          'id',
+          expect.objectContaining({ syncVideoRecord: true })
+        )
       })
 
       it('should fail if not publisher', async () => {
@@ -2797,6 +2820,17 @@ describe('video', () => {
         expect(result).toHaveProperty('data.videoUpdate', {
           id: 'id'
         })
+
+        // label/childIds changed and published flipped false -> true: full
+        // variant re-index plus the published-flag batch update
+        expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith('id', {
+          syncVideoRecord: true,
+          syncAllVariants: true,
+          syncPublishedFlag: true,
+          dirtyVariantIds: [],
+          deletedVariantIds: []
+        })
+        expect(mockedFindContainerParentIds).toHaveBeenCalledWith('id')
       })
 
       it('should enable restrictTranslations', async () => {
@@ -3319,6 +3353,92 @@ describe('video', () => {
           id: 'id'
         })
       })
+
+      it('should request a video-only Algolia scope for fields not embedded in variant records', async () => {
+        mockedFindContainerParentIds.mockClear()
+        prismaMock.userMediaRole.findUnique.mockResolvedValue({
+          id: 'userId',
+          userId: 'userId',
+          roles: ['publisher'],
+          createdAt: new Date(),
+          updatedAt: new Date()
+        })
+        prismaMock.video.findUnique.mockResolvedValue({
+          published: true,
+          publishedAt: new Date(),
+          slug: 'old-slug',
+          variants: []
+        } as any)
+        prismaMock.video.update.mockResolvedValue({
+          id: 'id',
+          slug: 'old-slug',
+          noIndex: true
+        } as unknown as Video)
+
+        await authClient({
+          document: VIDEO_UPDATE_MUTATION,
+          variables: {
+            input: {
+              id: 'id',
+              noIndex: true
+            }
+          }
+        })
+
+        // noIndex isn't embedded in any variant's Algolia record and
+        // published wasn't touched, so this should stay video-only
+        expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith('id', {
+          syncVideoRecord: true,
+          syncAllVariants: false,
+          syncPublishedFlag: false,
+          dirtyVariantIds: [],
+          deletedVariantIds: []
+        })
+        expect(mockedFindContainerParentIds).not.toHaveBeenCalled()
+      })
+
+      it("should re-sync parent collections when a child video's published status changes", async () => {
+        prismaMock.userMediaRole.findUnique.mockResolvedValue({
+          id: 'userId',
+          userId: 'userId',
+          roles: ['publisher'],
+          createdAt: new Date(),
+          updatedAt: new Date()
+        })
+        prismaMock.video.findUnique.mockResolvedValue({
+          published: false,
+          publishedAt: null,
+          slug: 'slug',
+          variants: []
+        } as any)
+        prismaMock.video.update.mockResolvedValue({
+          id: 'child-id',
+          published: true
+        } as unknown as Video)
+        mockedFindContainerParentIds.mockResolvedValueOnce(['parent-id'])
+
+        await authClient({
+          document: VIDEO_UPDATE_MUTATION,
+          variables: {
+            input: {
+              id: 'child-id',
+              published: true
+            }
+          }
+        })
+
+        expect(mockedFindContainerParentIds).toHaveBeenCalledWith('child-id')
+        expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith(
+          'parent-id',
+          {
+            syncVideoRecord: true,
+            syncAllVariants: false,
+            syncPublishedFlag: false,
+            dirtyVariantIds: [],
+            deletedVariantIds: []
+          }
+        )
+      })
     })
 
     describe('videoDelete', () => {
@@ -3373,6 +3493,10 @@ describe('video', () => {
         expect(result).toHaveProperty('data.videoDelete', {
           id: 'videoId'
         })
+        expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith(
+          'videoId',
+          expect.objectContaining({ syncVideoRecord: true })
+        )
       })
 
       it('should fail to delete video that has been published', async () => {

--- a/apis/api-media/src/schema/video/video.spec.ts
+++ b/apis/api-media/src/schema/video/video.spec.ts
@@ -2615,7 +2615,8 @@ describe('video', () => {
         })
         expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith(
           'id',
-          expect.objectContaining({ syncVideoRecord: true })
+          expect.objectContaining({ syncVideoRecord: true }),
+          expect.anything()
         )
       })
 
@@ -2823,13 +2824,17 @@ describe('video', () => {
 
         // label/childIds changed and published flipped false -> true: full
         // variant re-index plus the published-flag batch update
-        expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith('id', {
-          syncVideoRecord: true,
-          syncAllVariants: true,
-          syncPublishedFlag: true,
-          dirtyVariantIds: [],
-          deletedVariantIds: []
-        })
+        expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith(
+          'id',
+          {
+            syncVideoRecord: true,
+            syncAllVariants: true,
+            syncPublishedFlag: true,
+            dirtyVariantIds: [],
+            deletedVariantIds: []
+          },
+          expect.anything()
+        )
         expect(mockedFindContainerParentIds).toHaveBeenCalledWith('id')
       })
 
@@ -3387,13 +3392,17 @@ describe('video', () => {
 
         // noIndex isn't embedded in any variant's Algolia record and
         // published wasn't touched, so this should stay video-only
-        expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith('id', {
-          syncVideoRecord: true,
-          syncAllVariants: false,
-          syncPublishedFlag: false,
-          dirtyVariantIds: [],
-          deletedVariantIds: []
-        })
+        expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith(
+          'id',
+          {
+            syncVideoRecord: true,
+            syncAllVariants: false,
+            syncPublishedFlag: false,
+            dirtyVariantIds: [],
+            deletedVariantIds: []
+          },
+          expect.anything()
+        )
         expect(mockedFindContainerParentIds).not.toHaveBeenCalled()
       })
 
@@ -3436,7 +3445,8 @@ describe('video', () => {
             syncPublishedFlag: false,
             dirtyVariantIds: [],
             deletedVariantIds: []
-          }
+          },
+          expect.anything()
         )
       })
     })
@@ -3495,7 +3505,8 @@ describe('video', () => {
         })
         expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith(
           'videoId',
-          expect.objectContaining({ syncVideoRecord: true })
+          expect.objectContaining({ syncVideoRecord: true }),
+          expect.anything()
         )
       })
 

--- a/apis/api-media/src/schema/video/video.spec.ts
+++ b/apis/api-media/src/schema/video/video.spec.ts
@@ -3474,6 +3474,7 @@ describe('video', () => {
           publishedAt: null,
           variants: [
             {
+              id: 'variantId1',
               muxVideoId: 'muxVideoId1',
               muxVideo: { assetId: 'assetId1' }
             }
@@ -3503,9 +3504,13 @@ describe('video', () => {
         expect(result).toHaveProperty('data.videoDelete', {
           id: 'videoId'
         })
+        // the cascaded-away variants must be removed from the variants index too
         expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith(
           'videoId',
-          expect.objectContaining({ syncVideoRecord: true }),
+          expect.objectContaining({
+            syncVideoRecord: true,
+            deletedVariantIds: ['variantId1']
+          }),
           expect.anything()
         )
       })

--- a/apis/api-media/src/schema/video/video.ts
+++ b/apis/api-media/src/schema/video/video.ts
@@ -9,11 +9,11 @@ import {
   prisma
 } from '@core/prisma/media/client'
 
-import {
-  updateVideoInAlgolia,
-  updateVideoPublishedStatus
-} from '../../lib/algolia/algoliaVideoUpdate'
 import { videoCacheReset } from '../../lib/videoCacheReset'
+import {
+  enqueueVideoAlgoliaSync,
+  videoOnlyScope
+} from '../../workers/videoAlgoliaSync'
 import { builder } from '../builder'
 import { ImageAspectRatio } from '../cloudflare/image/enums'
 import { deleteR2File } from '../cloudflare/r2/asset'
@@ -34,7 +34,10 @@ import { VideoLabel } from './enums/videoLabel'
 import { VideoCreateInput } from './inputs/videoCreate'
 import { VideosFilter } from './inputs/videosFilter'
 import { VideoUpdateInput } from './inputs/videoUpdate'
-import { updateVideoAvailableLanguages } from './lib/updateAvailableLanguages'
+import {
+  findContainerParentIds,
+  updateVideoAvailableLanguages
+} from './lib/updateAvailableLanguages'
 import { videosFilter } from './lib/videosFilter'
 
 // Helper function to check if video viewing is restricted for the current platform
@@ -688,11 +691,7 @@ builder.mutationFields((t) => ({
           ...query,
           data
         })
-        try {
-          await updateVideoInAlgolia(video.id)
-        } catch (error) {
-          console.error('Algolia update error:', error)
-        }
+        await enqueueVideoAlgoliaSync(video.id, videoOnlyScope)
 
         try {
           await videoCacheReset(video.id)
@@ -850,40 +849,58 @@ builder.mutationFields((t) => ({
       }
 
       // Handle parent variant changes if video published status changed
-      if (currentVideo && input.published !== undefined) {
-        const wasPublished = currentVideo.published
-        const isNowPublished = input.published
+      const publishedChanged =
+        currentVideo != null &&
+        input.published !== undefined &&
+        currentVideo.published !== input.published
 
-        if (
-          wasPublished !== isNowPublished &&
-          currentVideo.variants.length > 0
-        ) {
-          try {
-            for (const variant of currentVideo.variants) {
-              if (isNowPublished) {
-                // Video was unpublished and is now published - create parent variants for all published variants
-                await handleParentVariantCreation(input.id, variant.languageId)
-              } else {
-                // Video was published and is now unpublished - cleanup parent variants for all variants
-                await handleParentVariantCleanup(input.id, variant.languageId)
-              }
-            }
-          } catch (error) {
-            console.error('Parent variant video update error:', error)
-          }
-        }
-        // Update variants' videoPublished status in Algolia when published status changes
+      if (
+        publishedChanged &&
+        currentVideo &&
+        currentVideo.variants.length > 0
+      ) {
         try {
-          await updateVideoPublishedStatus(input.id, isNowPublished ?? false)
+          for (const variant of currentVideo.variants) {
+            if (input.published) {
+              // Video was unpublished and is now published - create parent variants for all published variants
+              await handleParentVariantCreation(input.id, variant.languageId)
+            } else {
+              // Video was published and is now unpublished - cleanup parent variants for all variants
+              await handleParentVariantCleanup(input.id, variant.languageId)
+            }
+          }
         } catch (error) {
-          console.error('Video variants Algolia update error:', error)
+          console.error('Parent variant video update error:', error)
         }
       }
 
-      try {
-        await updateVideoInAlgolia(video.id)
-      } catch (error) {
-        console.error('Algolia update error:', error)
+      // label/childIds/restrictViewPlatforms are embedded in every variant's
+      // Algolia record (see buildVideoVariantAlgoliaObject), so changing any
+      // of them requires re-indexing all of this video's variants.
+      const variantEmbeddedFieldsChanged =
+        input.label !== undefined ||
+        input.childIds !== undefined ||
+        input.restrictViewPlatforms !== undefined
+
+      await enqueueVideoAlgoliaSync(video.id, {
+        syncVideoRecord: true,
+        syncAllVariants: variantEmbeddedFieldsChanged,
+        syncPublishedFlag: publishedChanged,
+        dirtyVariantIds: [],
+        deletedVariantIds: []
+      })
+
+      // A child's publish state isn't embedded in its own variant records,
+      // but it changes whether the child shows up under its parent
+      // collection/series - re-sync the parent(s) too so the series-level
+      // page and episode navigation reflect the newly published child.
+      if (publishedChanged) {
+        const parentIds = await findContainerParentIds(video.id)
+        await Promise.all(
+          parentIds.map((parentId) =>
+            enqueueVideoAlgoliaSync(parentId, videoOnlyScope)
+          )
+        )
       }
 
       try {
@@ -990,11 +1007,7 @@ builder.mutationFields((t) => ({
         where: { id }
       })
 
-      try {
-        await updateVideoInAlgolia(id)
-      } catch (error) {
-        console.error('Algolia update error:', error)
-      }
+      await enqueueVideoAlgoliaSync(id, videoOnlyScope)
 
       try {
         await videoCacheReset(id)

--- a/apis/api-media/src/schema/video/video.ts
+++ b/apis/api-media/src/schema/video/video.ts
@@ -20,6 +20,7 @@ import { deleteR2File } from '../cloudflare/r2/asset'
 import { IdType, IdTypeShape } from '../enums/idType'
 import { NotUniqueError } from '../error/NotUniqueError'
 import { Language, LanguageWithSlug } from '../language'
+import { logger } from '../logger'
 import { deleteVideo } from '../mux/video/service'
 import { VideoSource, VideoSourceShape } from '../videoSource/videoSource'
 import { VideoVariantFilter } from '../videoVariant/inputs/videoVariantFilter'
@@ -691,7 +692,7 @@ builder.mutationFields((t) => ({
           ...query,
           data
         })
-        await enqueueVideoAlgoliaSync(video.id, videoOnlyScope)
+        await enqueueVideoAlgoliaSync(video.id, videoOnlyScope, logger)
 
         try {
           await videoCacheReset(video.id)
@@ -882,13 +883,17 @@ builder.mutationFields((t) => ({
         input.childIds !== undefined ||
         input.restrictViewPlatforms !== undefined
 
-      await enqueueVideoAlgoliaSync(video.id, {
-        syncVideoRecord: true,
-        syncAllVariants: variantEmbeddedFieldsChanged,
-        syncPublishedFlag: publishedChanged,
-        dirtyVariantIds: [],
-        deletedVariantIds: []
-      })
+      await enqueueVideoAlgoliaSync(
+        video.id,
+        {
+          syncVideoRecord: true,
+          syncAllVariants: variantEmbeddedFieldsChanged,
+          syncPublishedFlag: publishedChanged,
+          dirtyVariantIds: [],
+          deletedVariantIds: []
+        },
+        logger
+      )
 
       // A child's publish state isn't embedded in its own variant records,
       // but it changes whether the child shows up under its parent
@@ -898,7 +903,7 @@ builder.mutationFields((t) => ({
         const parentIds = await findContainerParentIds(video.id)
         await Promise.all(
           parentIds.map((parentId) =>
-            enqueueVideoAlgoliaSync(parentId, videoOnlyScope)
+            enqueueVideoAlgoliaSync(parentId, videoOnlyScope, logger)
           )
         )
       }
@@ -1007,7 +1012,7 @@ builder.mutationFields((t) => ({
         where: { id }
       })
 
-      await enqueueVideoAlgoliaSync(id, videoOnlyScope)
+      await enqueueVideoAlgoliaSync(id, videoOnlyScope, logger)
 
       try {
         await videoCacheReset(id)

--- a/apis/api-media/src/schema/video/video.ts
+++ b/apis/api-media/src/schema/video/video.ts
@@ -932,6 +932,7 @@ builder.mutationFields((t) => ({
           // Get data for cleanup that won't cascade automatically
           variants: {
             select: {
+              id: true,
               muxVideoId: true,
               muxVideo: {
                 select: {
@@ -1012,7 +1013,18 @@ builder.mutationFields((t) => ({
         where: { id }
       })
 
-      await enqueueVideoAlgoliaSync(id, videoOnlyScope, logger)
+      // Deleting the video cascades its variants away in the DB, but their
+      // Algolia records are not cascaded — name them explicitly so the sync
+      // removes them too, rather than leaving orphans in the variants index
+      // that Watch search still returns.
+      await enqueueVideoAlgoliaSync(
+        id,
+        {
+          ...videoOnlyScope,
+          deletedVariantIds: video.variants.map((variant) => variant.id)
+        },
+        logger
+      )
 
       try {
         await videoCacheReset(id)

--- a/apis/api-media/src/schema/video/videoPublishChildren.mutation.spec.ts
+++ b/apis/api-media/src/schema/video/videoPublishChildren.mutation.spec.ts
@@ -1,7 +1,15 @@
 import { parse } from 'graphql'
+import { vi } from 'vitest'
 
 import { getClient } from '../../../test/client'
 import { prismaMock } from '../../../test/prismaMock'
+import { enqueueVideoAlgoliaSync } from '../../workers/videoAlgoliaSync'
+
+vi.mock('../../workers/videoAlgoliaSync', () => ({
+  enqueueVideoAlgoliaSync: vi.fn()
+}))
+
+const mockedEnqueueVideoAlgoliaSync = vi.mocked(enqueueVideoAlgoliaSync)
 
 const authClient = getClient({
   headers: {
@@ -104,6 +112,7 @@ describe('videoPublishChildren', () => {
     prismaMock.$transaction.mockImplementation(async (callback: any) =>
       callback(prismaMock)
     )
+    mockedEnqueueVideoAlgoliaSync.mockReset().mockResolvedValue(undefined)
   })
 
   describe('childrenVideosOnly mode', () => {
@@ -276,6 +285,24 @@ describe('videoPublishChildren', () => {
         where: { id: { in: ['pv1', 'cv1'] } },
         data: { published: true }
       })
+
+      // parent and c1 are both newly published this run (videoIdsToPublish),
+      // so both get the published-flag batch update plus their own newly
+      // published variant
+      expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith('parent', {
+        syncVideoRecord: true,
+        syncAllVariants: false,
+        syncPublishedFlag: true,
+        dirtyVariantIds: ['pv1'],
+        deletedVariantIds: []
+      })
+      expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith('c1', {
+        syncVideoRecord: true,
+        syncAllVariants: false,
+        syncPublishedFlag: true,
+        dirtyVariantIds: ['cv1'],
+        deletedVariantIds: []
+      })
     })
 
     it('publishes draft variants on already published children', async () => {
@@ -338,7 +365,7 @@ describe('videoPublishChildren', () => {
           videoId: { in: ['parent', 'c1', 'c2'] },
           published: false
         },
-        select: { id: true }
+        select: { id: true, videoId: true }
       })
       expect(prismaMock.videoVariant.updateMany).toHaveBeenCalledWith({
         where: { id: { in: ['c1-spanish-draft'] } },
@@ -581,7 +608,7 @@ describe('videoPublishChildren', () => {
         videoId: { in: ['parent', 'valid-child', 'published-child'] },
         published: false
       },
-      select: { id: true }
+      select: { id: true, videoId: true }
     })
   })
 

--- a/apis/api-media/src/schema/video/videoPublishChildren.mutation.spec.ts
+++ b/apis/api-media/src/schema/video/videoPublishChildren.mutation.spec.ts
@@ -289,20 +289,28 @@ describe('videoPublishChildren', () => {
       // parent and c1 are both newly published this run (videoIdsToPublish),
       // so both get the published-flag batch update plus their own newly
       // published variant
-      expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith('parent', {
-        syncVideoRecord: true,
-        syncAllVariants: false,
-        syncPublishedFlag: true,
-        dirtyVariantIds: ['pv1'],
-        deletedVariantIds: []
-      })
-      expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith('c1', {
-        syncVideoRecord: true,
-        syncAllVariants: false,
-        syncPublishedFlag: true,
-        dirtyVariantIds: ['cv1'],
-        deletedVariantIds: []
-      })
+      expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith(
+        'parent',
+        {
+          syncVideoRecord: true,
+          syncAllVariants: false,
+          syncPublishedFlag: true,
+          dirtyVariantIds: ['pv1'],
+          deletedVariantIds: []
+        },
+        expect.anything()
+      )
+      expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith(
+        'c1',
+        {
+          syncVideoRecord: true,
+          syncAllVariants: false,
+          syncPublishedFlag: true,
+          dirtyVariantIds: ['cv1'],
+          deletedVariantIds: []
+        },
+        expect.anything()
+      )
     })
 
     it('publishes draft variants on already published children', async () => {

--- a/apis/api-media/src/schema/video/videoPublishChildren.mutation.ts
+++ b/apis/api-media/src/schema/video/videoPublishChildren.mutation.ts
@@ -1,11 +1,10 @@
 import { prisma } from '@core/prisma/media/client'
 
-import { updateVideoInAlgolia } from '../../lib/algolia/algoliaVideoUpdate'
-import { updateVideoVariantInAlgolia } from '../../lib/algolia/algoliaVideoVariantUpdate'
 import {
   videoCacheReset,
   videoVariantCacheReset
 } from '../../lib/videoCacheReset'
+import { enqueueVideoAlgoliaSync } from '../../workers/videoAlgoliaSync'
 import { builder } from '../builder'
 import { logger } from '../logger'
 import { handleParentVariantCreation } from '../videoVariant/videoVariant'
@@ -320,15 +319,21 @@ export async function executeVideoPublishChildren(
   }
 
   let variantIdsToPublish: string[] = []
+  const variantIdsToPublishByVideoId = new Map<string, string[]>()
   if (variantVideoIds.length > 0) {
     const unpublishedVariants = await prisma.videoVariant.findMany({
       where: {
         videoId: { in: variantVideoIds },
         published: false
       },
-      select: { id: true }
+      select: { id: true, videoId: true }
     })
     variantIdsToPublish = unpublishedVariants.map((variant) => variant.id)
+    for (const variant of unpublishedVariants) {
+      const ids = variantIdsToPublishByVideoId.get(variant.videoId) ?? []
+      ids.push(variant.id)
+      variantIdsToPublishByVideoId.set(variant.videoId, ids)
+    }
   }
 
   if (
@@ -397,25 +402,21 @@ export async function executeVideoPublishChildren(
   }
 
   await Promise.allSettled(
-    variantIdsToPublish.map(async (variantId) => {
-      try {
-        await updateVideoVariantInAlgolia(variantId)
-      } catch (error) {
-        logger.error({ error, variantId }, 'Variant Algolia update failed')
-      }
-
-      await videoVariantCacheReset(variantId).catch((error) => {
+    variantIdsToPublish.map((variantId) =>
+      videoVariantCacheReset(variantId).catch((error) => {
         logger.error({ error, variantId }, 'Variant cache reset failed')
       })
-    })
+    )
   )
   await Promise.allSettled(
     affectedVideoIds.map(async (videoId) => {
-      try {
-        await updateVideoInAlgolia(videoId)
-      } catch (error) {
-        logger.error({ error, videoId }, 'Video Algolia update failed')
-      }
+      await enqueueVideoAlgoliaSync(videoId, {
+        syncVideoRecord: true,
+        syncAllVariants: false,
+        syncPublishedFlag: videoIdsToPublish.includes(videoId),
+        dirtyVariantIds: variantIdsToPublishByVideoId.get(videoId) ?? [],
+        deletedVariantIds: []
+      })
 
       await videoCacheReset(videoId).catch((error) => {
         logger.error({ error, videoId }, 'Video cache reset failed')

--- a/apis/api-media/src/schema/video/videoPublishChildren.mutation.ts
+++ b/apis/api-media/src/schema/video/videoPublishChildren.mutation.ts
@@ -410,13 +410,17 @@ export async function executeVideoPublishChildren(
   )
   await Promise.allSettled(
     affectedVideoIds.map(async (videoId) => {
-      await enqueueVideoAlgoliaSync(videoId, {
-        syncVideoRecord: true,
-        syncAllVariants: false,
-        syncPublishedFlag: videoIdsToPublish.includes(videoId),
-        dirtyVariantIds: variantIdsToPublishByVideoId.get(videoId) ?? [],
-        deletedVariantIds: []
-      })
+      await enqueueVideoAlgoliaSync(
+        videoId,
+        {
+          syncVideoRecord: true,
+          syncAllVariants: false,
+          syncPublishedFlag: videoIdsToPublish.includes(videoId),
+          dirtyVariantIds: variantIdsToPublishByVideoId.get(videoId) ?? [],
+          deletedVariantIds: []
+        },
+        logger
+      )
 
       await videoCacheReset(videoId).catch((error) => {
         logger.error({ error, videoId }, 'Video cache reset failed')

--- a/apis/api-media/src/schema/videoVariant/videoVariant.spec.ts
+++ b/apis/api-media/src/schema/videoVariant/videoVariant.spec.ts
@@ -12,12 +12,12 @@ import { graphql } from '@core/shared/gql'
 
 import { getClient } from '../../../test/client'
 import { prismaMock } from '../../../test/prismaMock'
-import { updateVideoVariantInAlgolia } from '../../lib/algolia/algoliaVideoVariantUpdate'
 import { notifyMediaSlackOfOperationFailure } from '../../lib/slack'
 import {
   videoCacheReset,
   videoVariantCacheReset
 } from '../../lib/videoCacheReset'
+import { enqueueVideoAlgoliaSync } from '../../workers/videoAlgoliaSync'
 import { deleteR2File } from '../cloudflare/r2/asset'
 import { deleteVideo } from '../mux/video/service'
 import {
@@ -47,9 +47,9 @@ vi.mock('../cloudflare/r2/asset', async () => ({
   deleteR2File: vi.fn()
 }))
 
-// Mock the Algolia service
-vi.mock('../../lib/algolia/algoliaVideoVariantUpdate', () => ({
-  updateVideoVariantInAlgolia: vi.fn()
+// Mock the Algolia sync enqueue boundary
+vi.mock('../../workers/videoAlgoliaSync', () => ({
+  enqueueVideoAlgoliaSync: vi.fn()
 }))
 
 // Mock the video available languages functions
@@ -67,7 +67,7 @@ const mockedVideoCacheReset = vi.mocked(videoCacheReset)
 const mockedVideoVariantCacheReset = vi.mocked(videoVariantCacheReset)
 const mockedDeleteVideo = vi.mocked(deleteVideo)
 const mockedDeleteR2File = vi.mocked(deleteR2File)
-const mockedUpdateVideoVariantInAlgolia = vi.mocked(updateVideoVariantInAlgolia)
+const mockedEnqueueVideoAlgoliaSync = vi.mocked(enqueueVideoAlgoliaSync)
 const mockedAddLanguageToVideo = vi.mocked(addLanguageToVideo)
 const mockedRemoveLanguageFromVideoIfUnused = vi.mocked(
   removeLanguageFromVideoIfUnused
@@ -106,7 +106,7 @@ describe('videoVariant', () => {
     mockedVideoVariantCacheReset.mockImplementation(() => Promise.resolve())
     mockedDeleteVideo.mockResolvedValue(undefined)
     mockedDeleteR2File.mockResolvedValue(undefined)
-    mockedUpdateVideoVariantInAlgolia.mockResolvedValue(true)
+    mockedEnqueueVideoAlgoliaSync.mockResolvedValue(undefined)
     mockedAddLanguageToVideo.mockResolvedValue(undefined)
     mockedRemoveLanguageFromVideoIfUnused.mockResolvedValue(undefined)
     mockedUpdateParentCollectionLanguages.mockResolvedValue(undefined)
@@ -1267,6 +1267,15 @@ describe('videoVariant', () => {
         // Verify cache reset functions were called
         expect(mockedVideoVariantCacheReset).toHaveBeenCalledWith('id')
         expect(mockedVideoCacheReset).toHaveBeenCalledWith('videoId')
+
+        // Verify Algolia sync was enqueued (not called inline) for the new variant
+        expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith('videoId', {
+          syncVideoRecord: true,
+          syncAllVariants: false,
+          syncPublishedFlag: false,
+          dirtyVariantIds: ['id'],
+          deletedVariantIds: []
+        })
       })
 
       it('notifies Slack when video variant creation fails', async () => {
@@ -1611,6 +1620,15 @@ describe('videoVariant', () => {
 
         // Verify cache reset function was called
         expect(mockedVideoVariantCacheReset).toHaveBeenCalledWith('id')
+
+        // Verify Algolia sync was enqueued (not called inline) for the updated variant
+        expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith('videoId', {
+          syncVideoRecord: true,
+          syncAllVariants: false,
+          syncPublishedFlag: false,
+          dirtyVariantIds: ['id'],
+          deletedVariantIds: []
+        })
       })
 
       it('should continue even if cache reset function throws', async () => {
@@ -1789,6 +1807,16 @@ describe('videoVariant', () => {
         // Verify cache reset functions were called
         expect(mockedVideoVariantCacheReset).toHaveBeenCalledWith('id')
         expect(mockedVideoCacheReset).toHaveBeenCalledWith('videoId')
+
+        // Verify Algolia sync was enqueued (not called inline) with the
+        // deleted variant so the worker removes its stale index record
+        expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith('videoId', {
+          syncVideoRecord: true,
+          syncAllVariants: false,
+          syncPublishedFlag: false,
+          dirtyVariantIds: [],
+          deletedVariantIds: ['id']
+        })
       })
 
       it('should continue even if cache reset functions throw', async () => {

--- a/apis/api-media/src/schema/videoVariant/videoVariant.spec.ts
+++ b/apis/api-media/src/schema/videoVariant/videoVariant.spec.ts
@@ -1269,13 +1269,17 @@ describe('videoVariant', () => {
         expect(mockedVideoCacheReset).toHaveBeenCalledWith('videoId')
 
         // Verify Algolia sync was enqueued (not called inline) for the new variant
-        expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith('videoId', {
-          syncVideoRecord: true,
-          syncAllVariants: false,
-          syncPublishedFlag: false,
-          dirtyVariantIds: ['id'],
-          deletedVariantIds: []
-        })
+        expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith(
+          'videoId',
+          {
+            syncVideoRecord: true,
+            syncAllVariants: false,
+            syncPublishedFlag: false,
+            dirtyVariantIds: ['id'],
+            deletedVariantIds: []
+          },
+          expect.anything()
+        )
       })
 
       it('notifies Slack when video variant creation fails', async () => {
@@ -1622,13 +1626,17 @@ describe('videoVariant', () => {
         expect(mockedVideoVariantCacheReset).toHaveBeenCalledWith('id')
 
         // Verify Algolia sync was enqueued (not called inline) for the updated variant
-        expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith('videoId', {
-          syncVideoRecord: true,
-          syncAllVariants: false,
-          syncPublishedFlag: false,
-          dirtyVariantIds: ['id'],
-          deletedVariantIds: []
-        })
+        expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith(
+          'videoId',
+          {
+            syncVideoRecord: true,
+            syncAllVariants: false,
+            syncPublishedFlag: false,
+            dirtyVariantIds: ['id'],
+            deletedVariantIds: []
+          },
+          expect.anything()
+        )
       })
 
       it('should continue even if cache reset function throws', async () => {
@@ -1810,13 +1818,17 @@ describe('videoVariant', () => {
 
         // Verify Algolia sync was enqueued (not called inline) with the
         // deleted variant so the worker removes its stale index record
-        expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith('videoId', {
-          syncVideoRecord: true,
-          syncAllVariants: false,
-          syncPublishedFlag: false,
-          dirtyVariantIds: [],
-          deletedVariantIds: ['id']
-        })
+        expect(mockedEnqueueVideoAlgoliaSync).toHaveBeenCalledWith(
+          'videoId',
+          {
+            syncVideoRecord: true,
+            syncAllVariants: false,
+            syncPublishedFlag: false,
+            dirtyVariantIds: [],
+            deletedVariantIds: ['id']
+          },
+          expect.anything()
+        )
       })
 
       it('should continue even if cache reset functions throw', async () => {

--- a/apis/api-media/src/schema/videoVariant/videoVariant.ts
+++ b/apis/api-media/src/schema/videoVariant/videoVariant.ts
@@ -3,14 +3,13 @@ import compact from 'lodash/compact'
 import { Platform, prisma } from '@core/prisma/media/client'
 import type { VideoVariant as PrismaVideoVariant } from '@core/prisma/media/client'
 
-import { updateVideoInAlgolia } from '../../lib/algolia/algoliaVideoUpdate'
-import { updateVideoVariantInAlgolia } from '../../lib/algolia/algoliaVideoVariantUpdate'
 import { ensureLanguageHasVideosTrue } from '../../lib/languages/ensureLanguageHasVideos'
 import { notifyMediaSlackOfOperationFailure } from '../../lib/slack'
 import {
   videoCacheReset,
   videoVariantCacheReset
 } from '../../lib/videoCacheReset'
+import { enqueueVideoAlgoliaSync } from '../../workers/videoAlgoliaSync'
 import { builder, toPrismaDateTimeFilter } from '../builder'
 import { deleteR2File } from '../cloudflare/r2/asset'
 import { Language } from '../language'
@@ -528,12 +527,6 @@ builder.mutationFields((t) => ({
       if (newVariant.published) {
         await addLanguageToVideo(newVariant.videoId, newVariant.languageId)
         await updateParentCollectionLanguages(newVariant.videoId)
-        // Keep videos index (hasAvailableLanguages) in sync
-        try {
-          await updateVideoInAlgolia(newVariant.videoId)
-        } catch (error) {
-          console.error('Algolia update error:', error)
-        }
       }
 
       try {
@@ -566,11 +559,13 @@ builder.mutationFields((t) => ({
       // Save the videoId before the try/catch block
       const { id, videoId } = newVariant
 
-      try {
-        await updateVideoVariantInAlgolia(id)
-      } catch (error) {
-        console.error('Algolia update error:', error)
-      }
+      await enqueueVideoAlgoliaSync(videoId, {
+        syncVideoRecord: true,
+        syncAllVariants: false,
+        syncPublishedFlag: false,
+        dirtyVariantIds: [id],
+        deletedVariantIds: []
+      })
 
       try {
         void videoVariantCacheReset(id)
@@ -696,13 +691,6 @@ builder.mutationFields((t) => ({
 
           // Cascade update to parent collections
           await updateParentCollectionLanguages(currentVariant.videoId)
-
-          // Keep videos index (hasAvailableLanguages) in sync
-          try {
-            await updateVideoInAlgolia(currentVariant.videoId)
-          } catch (error) {
-            console.error('Algolia update error:', error)
-          }
         } catch (error) {
           console.error('Language management update error:', error)
           notifyMediaSlackOfOperationFailure({
@@ -729,11 +717,13 @@ builder.mutationFields((t) => ({
       // Store the videoId before the try/catch block
       const videoId = input.videoId ?? updated.videoId
 
-      try {
-        await updateVideoVariantInAlgolia(updated.id)
-      } catch (error) {
-        console.error('Algolia update error:', error)
-      }
+      await enqueueVideoAlgoliaSync(videoId, {
+        syncVideoRecord: true,
+        syncAllVariants: false,
+        syncPublishedFlag: false,
+        dirtyVariantIds: [updated.id],
+        deletedVariantIds: []
+      })
 
       try {
         void videoVariantCacheReset(updated.id)
@@ -901,13 +891,6 @@ builder.mutationFields((t) => ({
 
         // Cascade update to parent collections
         await updateParentCollectionLanguages(videoId)
-
-        // Keep videos index (hasAvailableLanguages) in sync
-        try {
-          await updateVideoInAlgolia(videoId)
-        } catch (error) {
-          console.error('Algolia update error:', error)
-        }
       } catch (error) {
         console.error('Language management cleanup error:', error)
         notifyMediaSlackOfOperationFailure({
@@ -921,11 +904,13 @@ builder.mutationFields((t) => ({
         })
       }
 
-      try {
-        await updateVideoVariantInAlgolia(id)
-      } catch (error) {
-        console.error('Algolia update error:', error)
-      }
+      await enqueueVideoAlgoliaSync(videoId, {
+        syncVideoRecord: true,
+        syncAllVariants: false,
+        syncPublishedFlag: false,
+        dirtyVariantIds: [],
+        deletedVariantIds: [id]
+      })
       try {
         void videoVariantCacheReset(id)
         void videoCacheReset(videoId)

--- a/apis/api-media/src/schema/videoVariant/videoVariant.ts
+++ b/apis/api-media/src/schema/videoVariant/videoVariant.ts
@@ -13,6 +13,7 @@ import { enqueueVideoAlgoliaSync } from '../../workers/videoAlgoliaSync'
 import { builder, toPrismaDateTimeFilter } from '../builder'
 import { deleteR2File } from '../cloudflare/r2/asset'
 import { Language } from '../language'
+import { logger } from '../logger'
 import { deleteVideo } from '../mux/video/service'
 import {
   addLanguageToVideo,
@@ -559,13 +560,17 @@ builder.mutationFields((t) => ({
       // Save the videoId before the try/catch block
       const { id, videoId } = newVariant
 
-      await enqueueVideoAlgoliaSync(videoId, {
-        syncVideoRecord: true,
-        syncAllVariants: false,
-        syncPublishedFlag: false,
-        dirtyVariantIds: [id],
-        deletedVariantIds: []
-      })
+      await enqueueVideoAlgoliaSync(
+        videoId,
+        {
+          syncVideoRecord: true,
+          syncAllVariants: false,
+          syncPublishedFlag: false,
+          dirtyVariantIds: [id],
+          deletedVariantIds: []
+        },
+        logger
+      )
 
       try {
         void videoVariantCacheReset(id)
@@ -717,13 +722,17 @@ builder.mutationFields((t) => ({
       // Store the videoId before the try/catch block
       const videoId = input.videoId ?? updated.videoId
 
-      await enqueueVideoAlgoliaSync(videoId, {
-        syncVideoRecord: true,
-        syncAllVariants: false,
-        syncPublishedFlag: false,
-        dirtyVariantIds: [updated.id],
-        deletedVariantIds: []
-      })
+      await enqueueVideoAlgoliaSync(
+        videoId,
+        {
+          syncVideoRecord: true,
+          syncAllVariants: false,
+          syncPublishedFlag: false,
+          dirtyVariantIds: [updated.id],
+          deletedVariantIds: []
+        },
+        logger
+      )
 
       try {
         void videoVariantCacheReset(updated.id)
@@ -904,13 +913,17 @@ builder.mutationFields((t) => ({
         })
       }
 
-      await enqueueVideoAlgoliaSync(videoId, {
-        syncVideoRecord: true,
-        syncAllVariants: false,
-        syncPublishedFlag: false,
-        dirtyVariantIds: [],
-        deletedVariantIds: [id]
-      })
+      await enqueueVideoAlgoliaSync(
+        videoId,
+        {
+          syncVideoRecord: true,
+          syncAllVariants: false,
+          syncPublishedFlag: false,
+          dirtyVariantIds: [],
+          deletedVariantIds: [id]
+        },
+        logger
+      )
       try {
         void videoVariantCacheReset(id)
         void videoCacheReset(videoId)

--- a/apis/api-media/src/workers/videoAlgoliaSync/config.ts
+++ b/apis/api-media/src/workers/videoAlgoliaSync/config.ts
@@ -1,0 +1,2 @@
+export const queueName = 'api-media-video-algolia-sync'
+export const jobName = `${queueName}-job`

--- a/apis/api-media/src/workers/videoAlgoliaSync/enqueueVideoAlgoliaSync.spec.ts
+++ b/apis/api-media/src/workers/videoAlgoliaSync/enqueueVideoAlgoliaSync.spec.ts
@@ -1,14 +1,18 @@
+import { Job } from 'bullmq'
 import { Logger } from 'pino'
 import { vi } from 'vitest'
 
 import { jobName } from './config'
 import {
   enqueueVideoAlgoliaSync,
+  mergeScope,
   videoOnlyScope
 } from './enqueueVideoAlgoliaSync'
 import { queue } from './queue'
+import { VideoAlgoliaSyncJobData } from './types'
 
 const mockedQueueAdd = vi.mocked(queue.add)
+const mockedGetJob = vi.mocked(queue.getJob)
 
 const mockLogger = {
   info: vi.fn(),
@@ -16,14 +20,28 @@ const mockLogger = {
   error: vi.fn()
 } as unknown as Logger
 
+function fakeJob(
+  data: VideoAlgoliaSyncJobData,
+  state: { isWaiting?: boolean; isDelayed?: boolean } = {}
+): Job<VideoAlgoliaSyncJobData> {
+  return {
+    data,
+    isWaiting: vi.fn().mockResolvedValue(state.isWaiting ?? false),
+    isDelayed: vi.fn().mockResolvedValue(state.isDelayed ?? false),
+    updateData: vi.fn().mockResolvedValue(undefined)
+  } as unknown as Job<VideoAlgoliaSyncJobData>
+}
+
 describe('enqueueVideoAlgoliaSync', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockedGetJob.mockResolvedValue(undefined)
   })
 
-  it('enqueues a durable, per-video-deduped job with the given scope', async () => {
+  it('enqueues a durable, per-video-deduped job when none is pending', async () => {
     await enqueueVideoAlgoliaSync('video-id', videoOnlyScope)
 
+    expect(mockedGetJob).toHaveBeenCalledWith('algolia:video-id')
     expect(mockedQueueAdd).toHaveBeenCalledWith(
       jobName,
       { videoId: 'video-id', scope: videoOnlyScope },
@@ -37,6 +55,83 @@ describe('enqueueVideoAlgoliaSync', () => {
     )
   })
 
+  it('adds a fresh job when the pending job is already active (not waiting/delayed)', async () => {
+    const activeJob = fakeJob({ videoId: 'video-id', scope: videoOnlyScope })
+    mockedGetJob.mockResolvedValueOnce(activeJob)
+
+    await enqueueVideoAlgoliaSync('video-id', videoOnlyScope)
+
+    expect(activeJob.updateData).not.toHaveBeenCalled()
+    expect(mockedQueueAdd).toHaveBeenCalledWith(
+      jobName,
+      { videoId: 'video-id', scope: videoOnlyScope },
+      expect.objectContaining({ jobId: 'algolia:video-id' })
+    )
+  })
+
+  it('unions the scope into an already-queued waiting job instead of dropping it', async () => {
+    const existingScope = {
+      syncVideoRecord: true,
+      syncAllVariants: false,
+      syncPublishedFlag: false,
+      dirtyVariantIds: ['variant-1'],
+      deletedVariantIds: []
+    }
+    const waitingJob = fakeJob(
+      { videoId: 'video-id', scope: existingScope },
+      { isWaiting: true }
+    )
+    mockedGetJob.mockResolvedValueOnce(waitingJob)
+
+    await enqueueVideoAlgoliaSync('video-id', {
+      syncVideoRecord: false,
+      syncAllVariants: false,
+      syncPublishedFlag: true,
+      dirtyVariantIds: ['variant-2'],
+      deletedVariantIds: []
+    })
+
+    expect(waitingJob.updateData).toHaveBeenCalledWith({
+      videoId: 'video-id',
+      scope: {
+        syncVideoRecord: true,
+        syncAllVariants: false,
+        syncPublishedFlag: true,
+        dirtyVariantIds: ['variant-1', 'variant-2'],
+        deletedVariantIds: []
+      }
+    })
+    expect(mockedQueueAdd).not.toHaveBeenCalled()
+  })
+
+  it('unions the scope into an already-queued delayed (mid-backoff) job', async () => {
+    const delayedJob = fakeJob(
+      { videoId: 'video-id', scope: videoOnlyScope },
+      { isDelayed: true }
+    )
+    mockedGetJob.mockResolvedValueOnce(delayedJob)
+
+    await enqueueVideoAlgoliaSync('video-id', {
+      syncVideoRecord: false,
+      syncAllVariants: false,
+      syncPublishedFlag: false,
+      dirtyVariantIds: [],
+      deletedVariantIds: ['variant-3']
+    })
+
+    expect(delayedJob.updateData).toHaveBeenCalledWith({
+      videoId: 'video-id',
+      scope: {
+        syncVideoRecord: true,
+        syncAllVariants: false,
+        syncPublishedFlag: false,
+        dirtyVariantIds: [],
+        deletedVariantIds: ['variant-3']
+      }
+    })
+    expect(mockedQueueAdd).not.toHaveBeenCalled()
+  })
+
   it('logs and swallows a failed enqueue instead of throwing', async () => {
     mockedQueueAdd.mockRejectedValueOnce(new Error('Redis unavailable'))
 
@@ -48,5 +143,54 @@ describe('enqueueVideoAlgoliaSync', () => {
       expect.any(Error),
       'failed to enqueue algolia sync for video video-id'
     )
+  })
+
+  it('logs and swallows a failed updateData instead of throwing', async () => {
+    const waitingJob = fakeJob(
+      { videoId: 'video-id', scope: videoOnlyScope },
+      { isWaiting: true }
+    )
+    vi.mocked(waitingJob.updateData).mockRejectedValueOnce(
+      new Error('job already completed')
+    )
+    mockedGetJob.mockResolvedValueOnce(waitingJob)
+
+    await expect(
+      enqueueVideoAlgoliaSync('video-id', videoOnlyScope, mockLogger)
+    ).resolves.toBeUndefined()
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.any(Error),
+      'failed to enqueue algolia sync for video video-id'
+    )
+  })
+})
+
+describe('mergeScope', () => {
+  it('ORs booleans and unions id arrays, deduping', () => {
+    const merged = mergeScope(
+      {
+        syncVideoRecord: true,
+        syncAllVariants: false,
+        syncPublishedFlag: false,
+        dirtyVariantIds: ['a', 'b'],
+        deletedVariantIds: ['x']
+      },
+      {
+        syncVideoRecord: false,
+        syncAllVariants: true,
+        syncPublishedFlag: false,
+        dirtyVariantIds: ['b', 'c'],
+        deletedVariantIds: ['y']
+      }
+    )
+
+    expect(merged).toEqual({
+      syncVideoRecord: true,
+      syncAllVariants: true,
+      syncPublishedFlag: false,
+      dirtyVariantIds: ['a', 'b', 'c'],
+      deletedVariantIds: ['x', 'y']
+    })
   })
 })

--- a/apis/api-media/src/workers/videoAlgoliaSync/enqueueVideoAlgoliaSync.spec.ts
+++ b/apis/api-media/src/workers/videoAlgoliaSync/enqueueVideoAlgoliaSync.spec.ts
@@ -22,13 +22,19 @@ const mockLogger = {
 
 function fakeJob(
   data: VideoAlgoliaSyncJobData,
-  state: { isWaiting?: boolean; isDelayed?: boolean } = {}
+  state: {
+    isWaiting?: boolean
+    isDelayed?: boolean
+    isFailed?: boolean
+  } = {}
 ): Job<VideoAlgoliaSyncJobData> {
   return {
     data,
     isWaiting: vi.fn().mockResolvedValue(state.isWaiting ?? false),
     isDelayed: vi.fn().mockResolvedValue(state.isDelayed ?? false),
-    updateData: vi.fn().mockResolvedValue(undefined)
+    isFailed: vi.fn().mockResolvedValue(state.isFailed ?? false),
+    updateData: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined)
   } as unknown as Job<VideoAlgoliaSyncJobData>
 }
 
@@ -55,7 +61,10 @@ describe('enqueueVideoAlgoliaSync', () => {
     )
   })
 
-  it('adds a fresh job when the pending job is already active (not waiting/delayed)', async () => {
+  it('does not mutate an already-active job, falling through to add()', async () => {
+    // An active job has already been read by a worker, so updateData() would
+    // not reach it. BullMQ dedups the add() away while that job's key exists —
+    // the residual window VMT-320's durable dirty-state closes.
     const activeJob = fakeJob({ videoId: 'video-id', scope: videoOnlyScope })
     mockedGetJob.mockResolvedValueOnce(activeJob)
 
@@ -130,6 +139,54 @@ describe('enqueueVideoAlgoliaSync', () => {
       }
     })
     expect(mockedQueueAdd).not.toHaveBeenCalled()
+  })
+
+  it('re-drives a retained failed job instead of letting its key block the add', async () => {
+    // removeOnFail retains an exhausted job's Redis hash for five days, and
+    // BullMQ no-ops add() while a hash for that jobId exists — so without
+    // clearing it every later publish of this video would be dropped.
+    const failedJob = fakeJob(
+      {
+        videoId: 'video-id',
+        scope: {
+          syncVideoRecord: true,
+          syncAllVariants: false,
+          syncPublishedFlag: false,
+          dirtyVariantIds: ['variant-1'],
+          deletedVariantIds: []
+        }
+      },
+      { isFailed: true }
+    )
+    mockedGetJob.mockResolvedValueOnce(failedJob)
+
+    await enqueueVideoAlgoliaSync('video-id', {
+      syncVideoRecord: false,
+      syncAllVariants: false,
+      syncPublishedFlag: true,
+      dirtyVariantIds: ['variant-2'],
+      deletedVariantIds: []
+    })
+
+    expect(failedJob.remove).toHaveBeenCalled()
+    // the failed job's scope is carried forward, not lost with the job
+    expect(mockedQueueAdd).toHaveBeenCalledWith(
+      jobName,
+      {
+        videoId: 'video-id',
+        scope: {
+          syncVideoRecord: true,
+          syncAllVariants: false,
+          syncPublishedFlag: true,
+          dirtyVariantIds: ['variant-1', 'variant-2'],
+          deletedVariantIds: []
+        }
+      },
+      expect.objectContaining({
+        jobId: 'algolia:video-id',
+        attempts: 5
+      })
+    )
   })
 
   it('logs and swallows a failed enqueue instead of throwing', async () => {

--- a/apis/api-media/src/workers/videoAlgoliaSync/enqueueVideoAlgoliaSync.spec.ts
+++ b/apis/api-media/src/workers/videoAlgoliaSync/enqueueVideoAlgoliaSync.spec.ts
@@ -1,0 +1,52 @@
+import { Logger } from 'pino'
+import { vi } from 'vitest'
+
+import { jobName } from './config'
+import {
+  enqueueVideoAlgoliaSync,
+  videoOnlyScope
+} from './enqueueVideoAlgoliaSync'
+import { queue } from './queue'
+
+const mockedQueueAdd = vi.mocked(queue.add)
+
+const mockLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn()
+} as unknown as Logger
+
+describe('enqueueVideoAlgoliaSync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('enqueues a durable, per-video-deduped job with the given scope', async () => {
+    await enqueueVideoAlgoliaSync('video-id', videoOnlyScope)
+
+    expect(mockedQueueAdd).toHaveBeenCalledWith(
+      jobName,
+      { videoId: 'video-id', scope: videoOnlyScope },
+      {
+        jobId: 'algolia:video-id',
+        attempts: 5,
+        backoff: { type: 'exponential', delay: 2000 },
+        removeOnComplete: true,
+        removeOnFail: { age: 432000, count: 50 }
+      }
+    )
+  })
+
+  it('logs and swallows a failed enqueue instead of throwing', async () => {
+    mockedQueueAdd.mockRejectedValueOnce(new Error('Redis unavailable'))
+
+    await expect(
+      enqueueVideoAlgoliaSync('video-id', videoOnlyScope, mockLogger)
+    ).resolves.toBeUndefined()
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.any(Error),
+      'failed to enqueue algolia sync for video video-id'
+    )
+  })
+})

--- a/apis/api-media/src/workers/videoAlgoliaSync/enqueueVideoAlgoliaSync.ts
+++ b/apis/api-media/src/workers/videoAlgoliaSync/enqueueVideoAlgoliaSync.ts
@@ -25,8 +25,7 @@ export function mergeScope(
   return {
     syncVideoRecord: existing.syncVideoRecord || incoming.syncVideoRecord,
     syncAllVariants: existing.syncAllVariants || incoming.syncAllVariants,
-    syncPublishedFlag:
-      existing.syncPublishedFlag || incoming.syncPublishedFlag,
+    syncPublishedFlag: existing.syncPublishedFlag || incoming.syncPublishedFlag,
     dirtyVariantIds: Array.from(
       new Set([...existing.dirtyVariantIds, ...incoming.dirtyVariantIds])
     ),

--- a/apis/api-media/src/workers/videoAlgoliaSync/enqueueVideoAlgoliaSync.ts
+++ b/apis/api-media/src/workers/videoAlgoliaSync/enqueueVideoAlgoliaSync.ts
@@ -1,3 +1,4 @@
+import { Job } from 'bullmq'
 import { Logger } from 'pino'
 
 import { jobName } from './config'
@@ -14,8 +15,40 @@ export const videoOnlyScope: VideoAlgoliaSyncScope = {
   deletedVariantIds: []
 }
 
-// Enqueues durable, retriable Algolia indexing work for a video. Errors from
-// the enqueue itself (e.g. Redis unavailable) are logged and swallowed here
+// Unions two scopes for the same video: booleans OR together, id arrays
+// union (deduped). Used to fold a newly-requested scope into an
+// already-queued, not-yet-started job instead of dropping it.
+export function mergeScope(
+  existing: VideoAlgoliaSyncScope,
+  incoming: VideoAlgoliaSyncScope
+): VideoAlgoliaSyncScope {
+  return {
+    syncVideoRecord: existing.syncVideoRecord || incoming.syncVideoRecord,
+    syncAllVariants: existing.syncAllVariants || incoming.syncAllVariants,
+    syncPublishedFlag:
+      existing.syncPublishedFlag || incoming.syncPublishedFlag,
+    dirtyVariantIds: Array.from(
+      new Set([...existing.dirtyVariantIds, ...incoming.dirtyVariantIds])
+    ),
+    deletedVariantIds: Array.from(
+      new Set([...existing.deletedVariantIds, ...incoming.deletedVariantIds])
+    )
+  }
+}
+
+// Enqueues durable, retriable Algolia indexing work for a video, keyed by a
+// per-video jobId so redundant enqueues coalesce. BullMQ's default dedup
+// silently drops a second add() for an already-queued jobId — including its
+// scope — so a wider sync requested while a narrower one is still pending
+// would be lost. To avoid that, a still-waiting (or delayed, e.g. mid
+// backoff) job's scope is unioned in via updateData() instead of being
+// dropped. A job that's already active (a worker has it and already read
+// its data), or doesn't exist, falls back to a normal add() — same
+// best-effort behaviour as before for that narrower window. Fully closing
+// that residual gap needs a persisted source of truth outside the queue;
+// VMT-320 tracks that as a durable dirty-state table.
+//
+// Errors anywhere in this (e.g. Redis unavailable) are logged and swallowed
 // rather than propagated, so a queueing blip never fails the publish
 // mutation that triggered it — mirrors how the direct Algolia calls this
 // replaces were already treated as best-effort at every call site.
@@ -24,12 +57,29 @@ export async function enqueueVideoAlgoliaSync(
   scope: VideoAlgoliaSyncScope,
   logger?: Logger
 ): Promise<void> {
+  const jobId = `algolia:${videoId}`
+
   try {
+    const existingJob = (await queue.getJob(jobId)) as
+      | Job<VideoAlgoliaSyncJobData>
+      | undefined
+
+    if (
+      existingJob != null &&
+      ((await existingJob.isWaiting()) || (await existingJob.isDelayed()))
+    ) {
+      await existingJob.updateData({
+        videoId,
+        scope: mergeScope(existingJob.data.scope, scope)
+      } satisfies VideoAlgoliaSyncJobData)
+      return
+    }
+
     await queue.add(
       jobName,
       { videoId, scope } satisfies VideoAlgoliaSyncJobData,
       {
-        jobId: `algolia:${videoId}`,
+        jobId,
         attempts: 5,
         backoff: { type: 'exponential', delay: 2000 },
         removeOnComplete: true,

--- a/apis/api-media/src/workers/videoAlgoliaSync/enqueueVideoAlgoliaSync.ts
+++ b/apis/api-media/src/workers/videoAlgoliaSync/enqueueVideoAlgoliaSync.ts
@@ -36,21 +36,36 @@ export function mergeScope(
 }
 
 // Enqueues durable, retriable Algolia indexing work for a video, keyed by a
-// per-video jobId so redundant enqueues coalesce. BullMQ's default dedup
-// silently drops a second add() for an already-queued jobId — including its
-// scope — so a wider sync requested while a narrower one is still pending
-// would be lost. To avoid that, a still-waiting (or delayed, e.g. mid
-// backoff) job's scope is unioned in via updateData() instead of being
-// dropped. A job that's already active (a worker has it and already read
-// its data), or doesn't exist, falls back to a normal add() — same
-// best-effort behaviour as before for that narrower window. Fully closing
-// that residual gap needs a persisted source of truth outside the queue;
-// VMT-320 tracks that as a durable dirty-state table.
+// per-video jobId so redundant enqueues coalesce.
+//
+// BullMQ keys a job's Redis hash on its jobId and treats add() for an id that
+// still EXISTS as a no-op (see addStandardJob's handleDuplicatedJob) — the new
+// payload, and therefore the new scope, is silently discarded. That makes the
+// state of any already-present job decide what we have to do:
+//
+//   waiting / delayed (mid-backoff) — the job hasn't been read by a worker
+//     yet, so union the new scope into it via updateData().
+//   failed — attempts are exhausted but removeOnFail retains the hash for
+//     FIVE_DAYS, so a plain add() would be a no-op and every subsequent
+//     publish of this video would be dropped for days. That is exactly the
+//     QA-543 symptom, aimed at the videos already known to be failing, so
+//     carry the failed job's scope forward, drop the stale job, and re-add
+//     with a full attempt budget.
+//   active — a worker already holds the job and has read its data. add() is a
+//     no-op here too, so a scope requested during that window is still lost.
+//     The window is one job execution rather than days, and closing it
+//     properly needs a source of truth that outlives the queue: VMT-320
+//     tracks that as a durable dirty-state table.
 //
 // Errors anywhere in this (e.g. Redis unavailable) are logged and swallowed
-// rather than propagated, so a queueing blip never fails the publish
-// mutation that triggered it — mirrors how the direct Algolia calls this
-// replaces were already treated as best-effort at every call site.
+// rather than propagated, so a queueing blip never fails the publish mutation
+// that triggered it — mirrors how the direct Algolia calls this replaces were
+// already treated as best-effort at every call site. Note that swallowing
+// still loses the sync, because the failure happens before BullMQ has a job to
+// retry. Making the intent survive that requires persisting it in the same
+// transaction as the mutation (a transactional outbox), which is the durable
+// dirty-state VMT-320 introduces; a rethrow here would only fail the mutation
+// after its data has already been committed, without making the sync durable.
 export async function enqueueVideoAlgoliaSync(
   videoId: string,
   scope: VideoAlgoliaSyncScope,
@@ -63,20 +78,32 @@ export async function enqueueVideoAlgoliaSync(
       | Job<VideoAlgoliaSyncJobData>
       | undefined
 
-    if (
-      existingJob != null &&
-      ((await existingJob.isWaiting()) || (await existingJob.isDelayed()))
-    ) {
-      await existingJob.updateData({
-        videoId,
-        scope: mergeScope(existingJob.data.scope, scope)
-      } satisfies VideoAlgoliaSyncJobData)
-      return
+    let scopeToEnqueue = scope
+
+    if (existingJob != null) {
+      const [isWaiting, isDelayed, isFailed] = await Promise.all([
+        existingJob.isWaiting(),
+        existingJob.isDelayed(),
+        existingJob.isFailed()
+      ])
+
+      if (isWaiting || isDelayed) {
+        await existingJob.updateData({
+          videoId,
+          scope: mergeScope(existingJob.data.scope, scope)
+        } satisfies VideoAlgoliaSyncJobData)
+        return
+      }
+
+      if (isFailed) {
+        scopeToEnqueue = mergeScope(existingJob.data.scope, scope)
+        await existingJob.remove()
+      }
     }
 
     await queue.add(
       jobName,
-      { videoId, scope } satisfies VideoAlgoliaSyncJobData,
+      { videoId, scope: scopeToEnqueue } satisfies VideoAlgoliaSyncJobData,
       {
         jobId,
         attempts: 5,

--- a/apis/api-media/src/workers/videoAlgoliaSync/enqueueVideoAlgoliaSync.ts
+++ b/apis/api-media/src/workers/videoAlgoliaSync/enqueueVideoAlgoliaSync.ts
@@ -1,0 +1,42 @@
+import { Logger } from 'pino'
+
+import { jobName } from './config'
+import { queue } from './queue'
+import { VideoAlgoliaSyncJobData, VideoAlgoliaSyncScope } from './types'
+
+const FIVE_DAYS = 5 * 24 * 60 * 60
+
+export const videoOnlyScope: VideoAlgoliaSyncScope = {
+  syncVideoRecord: true,
+  syncAllVariants: false,
+  syncPublishedFlag: false,
+  dirtyVariantIds: [],
+  deletedVariantIds: []
+}
+
+// Enqueues durable, retriable Algolia indexing work for a video. Errors from
+// the enqueue itself (e.g. Redis unavailable) are logged and swallowed here
+// rather than propagated, so a queueing blip never fails the publish
+// mutation that triggered it — mirrors how the direct Algolia calls this
+// replaces were already treated as best-effort at every call site.
+export async function enqueueVideoAlgoliaSync(
+  videoId: string,
+  scope: VideoAlgoliaSyncScope,
+  logger?: Logger
+): Promise<void> {
+  try {
+    await queue.add(
+      jobName,
+      { videoId, scope } satisfies VideoAlgoliaSyncJobData,
+      {
+        jobId: `algolia:${videoId}`,
+        attempts: 5,
+        backoff: { type: 'exponential', delay: 2000 },
+        removeOnComplete: true,
+        removeOnFail: { age: FIVE_DAYS, count: 50 }
+      }
+    )
+  } catch (error) {
+    logger?.error(error, `failed to enqueue algolia sync for video ${videoId}`)
+  }
+}

--- a/apis/api-media/src/workers/videoAlgoliaSync/index.ts
+++ b/apis/api-media/src/workers/videoAlgoliaSync/index.ts
@@ -1,0 +1,7 @@
+export { service } from './service'
+export { jobName, queueName } from './config'
+export {
+  enqueueVideoAlgoliaSync,
+  videoOnlyScope
+} from './enqueueVideoAlgoliaSync'
+export type { VideoAlgoliaSyncJobData, VideoAlgoliaSyncScope } from './types'

--- a/apis/api-media/src/workers/videoAlgoliaSync/queue.ts
+++ b/apis/api-media/src/workers/videoAlgoliaSync/queue.ts
@@ -1,0 +1,7 @@
+import { Queue } from 'bullmq'
+
+import { connection } from '../lib/connection'
+
+import { queueName } from './config'
+
+export const queue = new Queue(queueName, { connection })

--- a/apis/api-media/src/workers/videoAlgoliaSync/service/index.ts
+++ b/apis/api-media/src/workers/videoAlgoliaSync/service/index.ts
@@ -1,0 +1,1 @@
+export { service } from './service'

--- a/apis/api-media/src/workers/videoAlgoliaSync/service/service.spec.ts
+++ b/apis/api-media/src/workers/videoAlgoliaSync/service/service.spec.ts
@@ -1,0 +1,161 @@
+import { Job } from 'bullmq'
+import { Logger } from 'pino'
+import { vi } from 'vitest'
+
+import { prismaMock } from '../../../../test/prismaMock'
+import {
+  updateVideoInAlgolia,
+  updateVideoPublishedStatus
+} from '../../../lib/algolia/algoliaVideoUpdate'
+import { updateVideoVariantInAlgolia } from '../../../lib/algolia/algoliaVideoVariantUpdate'
+import { VideoAlgoliaSyncJobData } from '../types'
+
+import { service } from './service'
+
+vi.mock('../../../lib/algolia/algoliaVideoUpdate', () => ({
+  updateVideoInAlgolia: vi.fn(),
+  updateVideoPublishedStatus: vi.fn()
+}))
+
+vi.mock('../../../lib/algolia/algoliaVideoVariantUpdate', () => ({
+  updateVideoVariantInAlgolia: vi.fn()
+}))
+
+const mockedUpdateVideoInAlgolia = vi.mocked(updateVideoInAlgolia)
+const mockedUpdateVideoPublishedStatus = vi.mocked(updateVideoPublishedStatus)
+const mockedUpdateVideoVariantInAlgolia = vi.mocked(updateVideoVariantInAlgolia)
+
+const mockLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn()
+} as unknown as Logger
+
+function buildJob(
+  scope: Partial<VideoAlgoliaSyncJobData['scope']>
+): Job<VideoAlgoliaSyncJobData> {
+  return {
+    data: {
+      videoId: 'video-id',
+      scope: {
+        syncVideoRecord: false,
+        syncAllVariants: false,
+        syncPublishedFlag: false,
+        dirtyVariantIds: [],
+        deletedVariantIds: [],
+        ...scope
+      }
+    }
+  } as Job<VideoAlgoliaSyncJobData>
+}
+
+describe('videoAlgoliaSync service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockedUpdateVideoInAlgolia.mockResolvedValue(undefined)
+    mockedUpdateVideoPublishedStatus.mockResolvedValue(undefined)
+    mockedUpdateVideoVariantInAlgolia.mockResolvedValue(true)
+  })
+
+  it('re-indexes the video record when syncVideoRecord is set', async () => {
+    await service(buildJob({ syncVideoRecord: true }), mockLogger)
+
+    expect(mockedUpdateVideoInAlgolia).toHaveBeenCalledWith(
+      'video-id',
+      mockLogger
+    )
+  })
+
+  it('always processes deletedVariantIds regardless of other scope flags', async () => {
+    prismaMock.videoVariant.findMany.mockResolvedValueOnce([])
+
+    await service(
+      buildJob({ syncAllVariants: true, deletedVariantIds: ['deleted-1'] }),
+      mockLogger
+    )
+
+    expect(mockedUpdateVideoVariantInAlgolia).toHaveBeenCalledWith(
+      'deleted-1',
+      mockLogger
+    )
+  })
+
+  it('re-indexes every current variant when syncAllVariants is set, superseding narrower flags', async () => {
+    prismaMock.videoVariant.findMany.mockResolvedValueOnce([
+      { id: 'variant-1' },
+      { id: 'variant-2' }
+    ] as any)
+
+    await service(
+      buildJob({
+        syncAllVariants: true,
+        syncPublishedFlag: true,
+        dirtyVariantIds: ['should-be-ignored']
+      }),
+      mockLogger
+    )
+
+    expect(prismaMock.videoVariant.findMany).toHaveBeenCalledWith({
+      where: { videoId: 'video-id' },
+      select: { id: true }
+    })
+    expect(mockedUpdateVideoVariantInAlgolia).toHaveBeenCalledWith(
+      'variant-1',
+      mockLogger
+    )
+    expect(mockedUpdateVideoVariantInAlgolia).toHaveBeenCalledWith(
+      'variant-2',
+      mockLogger
+    )
+    expect(mockedUpdateVideoVariantInAlgolia).not.toHaveBeenCalledWith(
+      'should-be-ignored',
+      mockLogger
+    )
+    // syncAllVariants supersedes the batched published-flag update
+    expect(mockedUpdateVideoPublishedStatus).not.toHaveBeenCalled()
+  })
+
+  it('re-derives published status from the DB (not the job payload) for syncPublishedFlag', async () => {
+    prismaMock.video.findUnique.mockResolvedValueOnce({
+      published: true
+    } as any)
+
+    await service(buildJob({ syncPublishedFlag: true }), mockLogger)
+
+    expect(prismaMock.video.findUnique).toHaveBeenCalledWith({
+      where: { id: 'video-id' },
+      select: { published: true }
+    })
+    expect(mockedUpdateVideoPublishedStatus).toHaveBeenCalledWith(
+      'video-id',
+      true,
+      mockLogger
+    )
+  })
+
+  it('re-indexes dirtyVariantIds when syncAllVariants is not set', async () => {
+    await service(
+      buildJob({ dirtyVariantIds: ['dirty-1', 'dirty-2'] }),
+      mockLogger
+    )
+
+    expect(mockedUpdateVideoVariantInAlgolia).toHaveBeenCalledWith(
+      'dirty-1',
+      mockLogger
+    )
+    expect(mockedUpdateVideoVariantInAlgolia).toHaveBeenCalledWith(
+      'dirty-2',
+      mockLogger
+    )
+  })
+
+  it('propagates an Algolia failure so BullMQ retries the job', async () => {
+    mockedUpdateVideoInAlgolia.mockRejectedValueOnce(
+      new Error('Algolia unavailable')
+    )
+
+    await expect(
+      service(buildJob({ syncVideoRecord: true }), mockLogger)
+    ).rejects.toThrow('Algolia unavailable')
+  })
+})

--- a/apis/api-media/src/workers/videoAlgoliaSync/service/service.spec.ts
+++ b/apis/api-media/src/workers/videoAlgoliaSync/service/service.spec.ts
@@ -2,6 +2,8 @@ import { Job } from 'bullmq'
 import { Logger } from 'pino'
 import { vi } from 'vitest'
 
+import { Video, VideoVariant } from '@core/prisma/media/client'
+
 import { prismaMock } from '../../../../test/prismaMock'
 import {
   updateVideoInAlgolia,
@@ -84,7 +86,7 @@ describe('videoAlgoliaSync service', () => {
     prismaMock.videoVariant.findMany.mockResolvedValueOnce([
       { id: 'variant-1' },
       { id: 'variant-2' }
-    ] as any)
+    ] as unknown as VideoVariant[])
 
     await service(
       buildJob({
@@ -118,7 +120,7 @@ describe('videoAlgoliaSync service', () => {
   it('re-derives published status from the DB (not the job payload) for syncPublishedFlag', async () => {
     prismaMock.video.findUnique.mockResolvedValueOnce({
       published: true
-    } as any)
+    } as unknown as Video)
 
     await service(buildJob({ syncPublishedFlag: true }), mockLogger)
 

--- a/apis/api-media/src/workers/videoAlgoliaSync/service/service.ts
+++ b/apis/api-media/src/workers/videoAlgoliaSync/service/service.ts
@@ -1,0 +1,61 @@
+import { Job } from 'bullmq'
+import { Logger } from 'pino'
+
+import { prisma } from '@core/prisma/media/client'
+
+import {
+  updateVideoInAlgolia,
+  updateVideoPublishedStatus
+} from '../../../lib/algolia/algoliaVideoUpdate'
+import { updateVideoVariantInAlgolia } from '../../../lib/algolia/algoliaVideoVariantUpdate'
+import { VideoAlgoliaSyncJobData } from '../types'
+
+// Re-derives what to write from current DB state rather than trusting the
+// job payload for anything beyond videoId/scope, so a retried job always
+// reflects the latest truth. Any Algolia failure below propagates (the
+// helpers throw) so BullMQ fails the job and retries it.
+export async function service(
+  job: Job<VideoAlgoliaSyncJobData>,
+  logger?: Logger
+): Promise<void> {
+  const { videoId, scope } = job.data
+
+  const variantIdsToDelete = new Set(scope.deletedVariantIds)
+  for (const variantId of variantIdsToDelete) {
+    await updateVideoVariantInAlgolia(variantId, logger)
+  }
+
+  if (scope.syncVideoRecord) {
+    await updateVideoInAlgolia(videoId, logger)
+  }
+
+  if (scope.syncAllVariants) {
+    const variants = await prisma.videoVariant.findMany({
+      where: { videoId },
+      select: { id: true }
+    })
+    for (const variant of variants) {
+      await updateVideoVariantInAlgolia(variant.id, logger)
+    }
+    return
+  }
+
+  if (scope.syncPublishedFlag) {
+    const video = await prisma.video.findUnique({
+      where: { id: videoId },
+      select: { published: true }
+    })
+    if (video != null) {
+      await updateVideoPublishedStatus(
+        videoId,
+        video.published ?? false,
+        logger
+      )
+    }
+  }
+
+  for (const variantId of scope.dirtyVariantIds) {
+    if (variantIdsToDelete.has(variantId)) continue
+    await updateVideoVariantInAlgolia(variantId, logger)
+  }
+}

--- a/apis/api-media/src/workers/videoAlgoliaSync/types.ts
+++ b/apis/api-media/src/workers/videoAlgoliaSync/types.ts
@@ -1,0 +1,17 @@
+// Scope model for a videoAlgoliaSync job — the narrowest set of Algolia
+// writes a publish path knows it needs. Booleans/arrays are per-job (not
+// accumulated across jobs): a jobId-deduped enqueue can drop a wider scope
+// queued behind a narrower one for the same video. That gap is accepted for
+// now; QA-543/VMT-320 replaces this with a durable, unionable dirty-state.
+export interface VideoAlgoliaSyncScope {
+  syncVideoRecord: boolean
+  syncAllVariants: boolean
+  syncPublishedFlag: boolean
+  dirtyVariantIds: string[]
+  deletedVariantIds: string[]
+}
+
+export interface VideoAlgoliaSyncJobData {
+  videoId: string
+  scope: VideoAlgoliaSyncScope
+}

--- a/apis/api-media/src/workers/videoAlgoliaSync/types.ts
+++ b/apis/api-media/src/workers/videoAlgoliaSync/types.ts
@@ -1,8 +1,8 @@
 // Scope model for a videoAlgoliaSync job — the narrowest set of Algolia
-// writes a publish path knows it needs. Booleans/arrays are per-job (not
-// accumulated across jobs): a jobId-deduped enqueue can drop a wider scope
-// queued behind a narrower one for the same video. That gap is accepted for
-// now; QA-543/VMT-320 replaces this with a durable, unionable dirty-state.
+// writes a publish path knows it needs. enqueueVideoAlgoliaSync unions a
+// new scope into an already-queued, not-yet-started job rather than
+// dropping it (see its jsdoc for the residual gap while a job is active).
+// VMT-320 tracks replacing this with a durable, unionable dirty-state.
 export interface VideoAlgoliaSyncScope {
   syncVideoRecord: boolean
   syncAllVariants: boolean

--- a/apis/api-media/src/workers/videoAlgoliaSync/worker.ts
+++ b/apis/api-media/src/workers/videoAlgoliaSync/worker.ts
@@ -1,0 +1,25 @@
+import { Job, Worker } from 'bullmq'
+
+import { connection } from '../lib/connection'
+import { logger } from '../lib/logger'
+
+import { queueName } from './config'
+import { service } from './service'
+import { VideoAlgoliaSyncJobData } from './types'
+
+export const worker = new Worker(queueName, processJob, {
+  connection
+})
+
+async function processJob(job: Job<VideoAlgoliaSyncJobData>): Promise<void> {
+  const childLogger = logger.child({
+    queue: queueName,
+    jobId: job.id
+  })
+
+  childLogger.info(`started job: ${job.name}`)
+  await service(job, childLogger)
+  childLogger.info(`finished job: ${job.name}`)
+}
+
+logger.info({ queue: queueName }, 'videoAlgoliaSync worker waiting for jobs')

--- a/apis/api-media/src/workers/videoAlgoliaSync/worker.ts
+++ b/apis/api-media/src/workers/videoAlgoliaSync/worker.ts
@@ -7,9 +7,13 @@ import { queueName } from './config'
 import { service } from './service'
 import { VideoAlgoliaSyncJobData } from './types'
 
-export const worker = new Worker(queueName, processJob, {
-  connection
-})
+export const worker = new Worker<VideoAlgoliaSyncJobData>(
+  queueName,
+  processJob,
+  {
+    connection
+  }
+)
 
 async function processJob(job: Job<VideoAlgoliaSyncJobData>): Promise<void> {
   const childLogger = logger.child({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added background synchronization for video and variant search indexing.
  - Video, variant, publication, language, and parent-content changes now update search indexes automatically.
  - Overlapping updates are combined, with automatic retries for temporary failures.

- **Bug Fixes**
  - Removed stale search records when videos are deleted or unavailable.
  - Indexing errors are logged and propagated so failed updates can be retried.

- **Tests**
  - Added regression and coverage tests for queued synchronization, publishing, language updates, variants, and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->