### PR TITLE
fix(api-media): sync upload variant languages (NES-1760)

### DIFF
--- a/apis/api-media/src/schema/video/lib/updateAvailableLanguages.spec.ts
+++ b/apis/api-media/src/schema/video/lib/updateAvailableLanguages.spec.ts
@@ -7,6 +7,7 @@ import { videoCacheReset } from '../../../lib/videoCacheReset'
 import { enqueueVideoAlgoliaSync } from '../../../workers/videoAlgoliaSync'
 
 import {
+  addLanguageToVideo,
   findContainerParentIds,
   updateParentCollectionLanguages,
   updateVideoAvailableLanguages
@@ -95,6 +96,50 @@ describe('updateVideoAvailableLanguages', () => {
     await updateVideoAvailableLanguages('video-id', { skipAlgolia: true })
 
     expect(mockedEnqueueVideoAlgoliaSync).not.toHaveBeenCalled()
+  })
+})
+
+describe('addLanguageToVideo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    prismaMock.$executeRaw.mockResolvedValue(1)
+  })
+
+  it('issues a single atomic conditional UPDATE instead of a read-then-write', async () => {
+    await addLanguageToVideo('video-id', 'lang-1')
+
+    // Regression guard for the lost-update race: two concurrent published
+    // uploads for the same video must not read the same availableLanguages
+    // snapshot and clobber each other's language. There must be no
+    // separate read before the write.
+    expect(prismaMock.video.findUnique).not.toHaveBeenCalled()
+    expect(prismaMock.video.update).not.toHaveBeenCalled()
+    expect(prismaMock.$executeRaw).toHaveBeenCalledTimes(1)
+
+    const [sqlParts, ...values] = prismaMock.$executeRaw.mock.calls[0] as [
+      readonly string[],
+      ...unknown[]
+    ]
+    const sql = sqlParts.join(' ')
+    expect(sql).toContain('array_append')
+    expect(sql).toContain('ANY')
+    expect(values).toEqual(['lang-1', 'video-id', 'lang-1'])
+  })
+
+  it('does not clobber a language added by a concurrent call for the same video', async () => {
+    // Each call is an independent atomic statement handled entirely by
+    // Postgres — there is no shared client-side array read between the two
+    // calls that a "last write wins" bug could stomp on.
+    await Promise.all([
+      addLanguageToVideo('video-id', 'lang-en'),
+      addLanguageToVideo('video-id', 'lang-fr')
+    ])
+
+    expect(prismaMock.$executeRaw).toHaveBeenCalledTimes(2)
+    const calledLanguages = prismaMock.$executeRaw.mock.calls.map(
+      (call) => (call as [readonly string[], ...unknown[]])[1]
+    )
+    expect(calledLanguages.sort()).toEqual(['lang-en', 'lang-fr'])
   })
 })
 

--- a/apis/api-media/src/schema/video/lib/updateAvailableLanguages.ts
+++ b/apis/api-media/src/schema/video/lib/updateAvailableLanguages.ts
@@ -91,29 +91,25 @@ export async function updateVideoAvailableLanguages(
   return availableLanguages
 }
 
-// Adds a language to a video's availableLanguages if not already present
-// Uses atomic operation to prevent duplicates
+// Adds a language to a video's availableLanguages if not already present.
+//
+// Concurrent published uploads for the same video (different languages
+// finishing around the same time) must not lose each other's language. A
+// read-then-set (`findUnique` -> `set: [...current, next]`) is a classic
+// lost-update race: both transactions read the same array and the second
+// write clobbers the first. Instead, do the read-modify-write as a single
+// atomic UPDATE so Postgres serializes concurrent callers on the row.
+// COALESCE handles the nullable column so array_append always has a base array.
 export async function addLanguageToVideo(
   videoId: string,
   languageId: string
 ): Promise<void> {
-  // availableLanguages is nullable in the DB. If it's NULL, Prisma filters like
-  // "NOT { availableLanguages: { has: ... } }" can silently no-op due to SQL NULL
-  // semantics. Coalesce NULL -> [] in code, then set the updated array.
-  const video = await prisma.video.findUnique({
-    where: { id: videoId },
-    select: { availableLanguages: true }
-  })
-
-  if (video == null) return
-
-  const currentLanguages = video.availableLanguages ?? []
-  if (currentLanguages.includes(languageId)) return
-
-  await prisma.video.update({
-    where: { id: videoId },
-    data: { availableLanguages: { set: [...currentLanguages, languageId] } }
-  })
+  await prisma.$executeRaw`
+    UPDATE "Video"
+    SET "availableLanguages" = array_append(COALESCE("availableLanguages", ARRAY[]::TEXT[]), ${languageId})
+    WHERE id = ${videoId}
+      AND NOT (${languageId} = ANY(COALESCE("availableLanguages", ARRAY[]::TEXT[])))
+  `
 }
 
 // Removes a language from a video's availableLanguages if no published variants use it

--- a/apis/api-media/src/schema/videoVariantUpload/service.ts
+++ b/apis/api-media/src/schema/videoVariantUpload/service.ts
@@ -11,7 +11,13 @@ import { Logger } from 'pino'
 import { prisma } from '@core/prisma/media/client'
 import type { MuxVideo, VideoVariantUpload } from '@core/prisma/media/client'
 
+import { updateVideoInAlgolia } from '../../lib/algolia/algoliaVideoUpdate'
+import { updateVideoVariantInAlgolia } from '../../lib/algolia/algoliaVideoVariantUpdate'
 import { notifyMediaSlackOfOperationFailure } from '../../lib/slack'
+import {
+  videoCacheReset,
+  videoVariantCacheReset
+} from '../../lib/videoCacheReset'
 import { jobName as processVideoUploadsJobName } from '../../workers/processVideoUploads/config'
 import { queue as processVideoUploadsQueue } from '../../workers/processVideoUploads/queue'
 import {
@@ -19,6 +25,10 @@ import {
   getMaxResolutionValue,
   getVideo
 } from '../mux/video/service'
+import {
+  addLanguageToVideo,
+  updateParentCollectionLanguages
+} from '../video/lib/updateAvailableLanguages'
 
 const FIVE_DAYS = 5 * 24 * 60 * 60
 
@@ -133,6 +143,67 @@ function getVariantId(videoId: string, languageId: string): string {
   return `${source}_${languageId}-${restOfId}`
 }
 
+async function syncPublishedVariantState({
+  variantId,
+  videoId,
+  languageId,
+  published,
+  muxVideoId,
+  uploadId,
+  logger
+}: {
+  variantId: string
+  videoId: string
+  languageId: string
+  published: boolean
+  muxVideoId: string
+  uploadId?: string
+  logger?: Logger
+}): Promise<void> {
+  if (!published) return
+
+  try {
+    await addLanguageToVideo(videoId, languageId)
+    await updateParentCollectionLanguages(videoId)
+  } catch (error) {
+    logger?.error(
+      { error, videoId, languageId, variantId, muxVideoId, uploadId },
+      'Failed to sync video available languages after upload variant creation'
+    )
+    notifyMediaSlackOfOperationFailure({
+      operation: 'Video variant upload language sync failed',
+      error,
+      context: {
+        videoId,
+        languageId,
+        variantId,
+        muxVideoId,
+        uploadId
+      }
+    })
+    throw error
+  }
+
+  try {
+    await updateVideoInAlgolia(videoId)
+  } catch (error) {
+    console.error('Algolia video update error:', error)
+  }
+
+  try {
+    await updateVideoVariantInAlgolia(variantId)
+  } catch (error) {
+    console.error('Algolia video variant update error:', error)
+  }
+
+  try {
+    void videoVariantCacheReset(variantId)
+    void videoCacheReset(videoId)
+  } catch (error) {
+    console.error('Cache reset error:', error)
+  }
+}
+
 export async function createOrUpdateVideoVariant({
   videoId,
   edition,
@@ -207,6 +278,16 @@ export async function createOrUpdateVideoVariant({
               ...variantData
             }
           })
+
+    await syncPublishedVariantState({
+      variantId: variant.id,
+      videoId,
+      languageId,
+      published,
+      muxVideoId,
+      uploadId,
+      logger
+    })
 
     if (uploadId != null) {
       await prisma.videoVariantUpload.update({

--- a/apis/api-media/src/schema/videoVariantUpload/service.ts
+++ b/apis/api-media/src/schema/videoVariantUpload/service.ts
@@ -11,8 +11,6 @@ import { Logger } from 'pino'
 import { prisma } from '@core/prisma/media/client'
 import type { MuxVideo, VideoVariantUpload } from '@core/prisma/media/client'
 
-import { updateVideoInAlgolia } from '../../lib/algolia/algoliaVideoUpdate'
-import { updateVideoVariantInAlgolia } from '../../lib/algolia/algoliaVideoVariantUpdate'
 import { notifyMediaSlackOfOperationFailure } from '../../lib/slack'
 import {
   videoCacheReset,
@@ -20,6 +18,7 @@ import {
 } from '../../lib/videoCacheReset'
 import { jobName as processVideoUploadsJobName } from '../../workers/processVideoUploads/config'
 import { queue as processVideoUploadsQueue } from '../../workers/processVideoUploads/queue'
+import { enqueueVideoAlgoliaSync } from '../../workers/videoAlgoliaSync'
 import {
   createVideoFromUrl,
   getMaxResolutionValue,
@@ -184,17 +183,21 @@ async function syncPublishedVariantState({
     throw error
   }
 
-  try {
-    await updateVideoInAlgolia(videoId)
-  } catch (error) {
-    console.error('Algolia video update error:', error)
-  }
-
-  try {
-    await updateVideoVariantInAlgolia(variantId)
-  } catch (error) {
-    console.error('Algolia video variant update error:', error)
-  }
+  // Durable, retriable Algolia sync (QA-543) — matches the videoVariant
+  // create/update mutations rather than calling updateVideoInAlgolia /
+  // updateVideoVariantInAlgolia directly, so a transient Algolia outage
+  // gets BullMQ retries instead of being silently dropped.
+  await enqueueVideoAlgoliaSync(
+    videoId,
+    {
+      syncVideoRecord: true,
+      syncAllVariants: false,
+      syncPublishedFlag: false,
+      dirtyVariantIds: [variantId],
+      deletedVariantIds: []
+    },
+    logger
+  )
 
   try {
     void videoVariantCacheReset(variantId)

--- a/apis/api-media/src/schema/videoVariantUpload/videoVariantUpload.spec.ts
+++ b/apis/api-media/src/schema/videoVariantUpload/videoVariantUpload.spec.ts
@@ -20,6 +20,23 @@ vi.mock('../../workers/processVideoUploads/queue', () => ({
   }
 }))
 
+vi.mock('../../lib/algolia/algoliaVideoUpdate', () => ({
+  updateVideoInAlgolia: vi.fn()
+}))
+
+vi.mock('../../lib/algolia/algoliaVideoVariantUpdate', () => ({
+  updateVideoVariantInAlgolia: vi.fn()
+}))
+
+vi.mock('../../lib/videoCacheReset', () => ({
+  videoCacheReset: vi.fn(),
+  videoVariantCacheReset: vi.fn()
+}))
+
+vi.mock('../../lib/slack', () => ({
+  notifyMediaSlackOfOperationFailure: vi.fn()
+}))
+
 describe('videoVariantUpload lifecycle API', () => {
   const publisherClient = getClient({
     headers: {
@@ -883,7 +900,10 @@ describe('videoVariantUpload lifecycle API', () => {
       playback_ids: [{ id: 'playback-id' }],
       duration: 11.2
     })
-    prismaMock.video.findUnique.mockResolvedValue({ slug: 'video-slug' } as any)
+    prismaMock.video.findUnique
+      .mockResolvedValueOnce({ slug: 'video-slug' } as any)
+      .mockResolvedValueOnce({ availableLanguages: [] } as any)
+    prismaMock.video.findMany.mockResolvedValue([] as any)
     prismaMock.videoVariant.findFirst.mockResolvedValue({
       id: 'variant-id',
       slug: 'video-slug/en'
@@ -919,6 +939,18 @@ describe('videoVariantUpload lifecycle API', () => {
       status: 'variantCreated',
       videoVariantId: 'variant-id'
     })
+    expect(prismaMock.video.update).toHaveBeenCalledWith({
+      where: { id: 'video-id' },
+      data: { availableLanguages: { set: ['529'] } }
+    })
+    expect(prismaMock.videoVariantUpload.update).toHaveBeenCalledWith({
+      where: { id: 'upload-id' },
+      data: {
+        status: 'variantCreated',
+        videoVariantId: 'variant-id',
+        errorMessage: null
+      }
+    })
   })
 
   it('resumes a ready Mux upload by creating the final video variant', async () => {
@@ -951,7 +983,10 @@ describe('videoVariantUpload lifecycle API', () => {
         playbackId: 'playback-id'
       }
     } as any)
-    prismaMock.video.findUnique.mockResolvedValue({ slug: 'video-slug' } as any)
+    prismaMock.video.findUnique
+      .mockResolvedValueOnce({ slug: 'video-slug' } as any)
+      .mockResolvedValueOnce({ availableLanguages: [] } as any)
+    prismaMock.video.findMany.mockResolvedValue([] as any)
     prismaMock.videoVariant.findFirst.mockResolvedValue({
       id: 'variant-id',
       slug: 'video-slug/en'
@@ -979,6 +1014,10 @@ describe('videoVariantUpload lifecycle API', () => {
     expect(prismaMock.videoVariant.update).toHaveBeenCalledWith({
       where: { id: 'variant-id' },
       data: expect.objectContaining({ muxVideoId: 'mux-id' })
+    })
+    expect(prismaMock.video.update).toHaveBeenCalledWith({
+      where: { id: 'video-id' },
+      data: { availableLanguages: { set: ['529'] } }
     })
     expect(prismaMock.videoVariantUpload.update).toHaveBeenCalledWith({
       where: { id: 'upload-id' },

--- a/apis/api-media/src/schema/videoVariantUpload/videoVariantUpload.spec.ts
+++ b/apis/api-media/src/schema/videoVariantUpload/videoVariantUpload.spec.ts
@@ -20,12 +20,8 @@ vi.mock('../../workers/processVideoUploads/queue', () => ({
   }
 }))
 
-vi.mock('../../lib/algolia/algoliaVideoUpdate', () => ({
-  updateVideoInAlgolia: vi.fn()
-}))
-
-vi.mock('../../lib/algolia/algoliaVideoVariantUpdate', () => ({
-  updateVideoVariantInAlgolia: vi.fn()
+vi.mock('../../workers/videoAlgoliaSync', () => ({
+  enqueueVideoAlgoliaSync: vi.fn()
 }))
 
 vi.mock('../../lib/videoCacheReset', () => ({
@@ -900,10 +896,11 @@ describe('videoVariantUpload lifecycle API', () => {
       playback_ids: [{ id: 'playback-id' }],
       duration: 11.2
     })
-    prismaMock.video.findUnique
-      .mockResolvedValueOnce({ slug: 'video-slug' } as any)
-      .mockResolvedValueOnce({ availableLanguages: [] } as any)
+    prismaMock.video.findUnique.mockResolvedValueOnce({
+      slug: 'video-slug'
+    } as any)
     prismaMock.video.findMany.mockResolvedValue([] as any)
+    prismaMock.$executeRaw.mockResolvedValue(1)
     prismaMock.videoVariant.findFirst.mockResolvedValue({
       id: 'variant-id',
       slug: 'video-slug/en'
@@ -939,10 +936,12 @@ describe('videoVariantUpload lifecycle API', () => {
       status: 'variantCreated',
       videoVariantId: 'variant-id'
     })
-    expect(prismaMock.video.update).toHaveBeenCalledWith({
-      where: { id: 'video-id' },
-      data: { availableLanguages: { set: ['529'] } }
-    })
+    expect(prismaMock.$executeRaw).toHaveBeenCalledWith(
+      expect.anything(),
+      '529',
+      'video-id',
+      '529'
+    )
     expect(prismaMock.videoVariantUpload.update).toHaveBeenCalledWith({
       where: { id: 'upload-id' },
       data: {
@@ -983,10 +982,11 @@ describe('videoVariantUpload lifecycle API', () => {
         playbackId: 'playback-id'
       }
     } as any)
-    prismaMock.video.findUnique
-      .mockResolvedValueOnce({ slug: 'video-slug' } as any)
-      .mockResolvedValueOnce({ availableLanguages: [] } as any)
+    prismaMock.video.findUnique.mockResolvedValueOnce({
+      slug: 'video-slug'
+    } as any)
     prismaMock.video.findMany.mockResolvedValue([] as any)
+    prismaMock.$executeRaw.mockResolvedValue(1)
     prismaMock.videoVariant.findFirst.mockResolvedValue({
       id: 'variant-id',
       slug: 'video-slug/en'
@@ -1015,10 +1015,12 @@ describe('videoVariantUpload lifecycle API', () => {
       where: { id: 'variant-id' },
       data: expect.objectContaining({ muxVideoId: 'mux-id' })
     })
-    expect(prismaMock.video.update).toHaveBeenCalledWith({
-      where: { id: 'video-id' },
-      data: { availableLanguages: { set: ['529'] } }
-    })
+    expect(prismaMock.$executeRaw).toHaveBeenCalledWith(
+      expect.anything(),
+      '529',
+      'video-id',
+      '529'
+    )
     expect(prismaMock.videoVariantUpload.update).toHaveBeenCalledWith({
       where: { id: 'upload-id' },
       data: {

--- a/apis/api-media/src/workers/processVideoUploads/service/service.spec.ts
+++ b/apis/api-media/src/workers/processVideoUploads/service/service.spec.ts
@@ -10,6 +10,8 @@ import { queue as processVideoDownloadsQueue } from '../../processVideoDownloads
 import { ProcessVideoUploadJobData, service } from './service'
 
 vi.mock('../../../schema/mux/video/service', () => ({
+  createVideoFromUrl: vi.fn(),
+  getMaxResolutionValue: vi.fn(),
   getVideo: vi.fn()
 }))
 
@@ -17,6 +19,23 @@ vi.mock('../../processVideoDownloads/queue', () => ({
   queue: {
     add: vi.fn()
   }
+}))
+
+vi.mock('../../../lib/algolia/algoliaVideoUpdate', () => ({
+  updateVideoInAlgolia: vi.fn()
+}))
+
+vi.mock('../../../lib/algolia/algoliaVideoVariantUpdate', () => ({
+  updateVideoVariantInAlgolia: vi.fn()
+}))
+
+vi.mock('../../../lib/videoCacheReset', () => ({
+  videoCacheReset: vi.fn(),
+  videoVariantCacheReset: vi.fn()
+}))
+
+vi.mock('../../../lib/slack', () => ({
+  notifyMediaSlackOfOperationFailure: vi.fn()
 }))
 
 const mockLogger = {
@@ -59,7 +78,10 @@ describe('processVideoUploads service', () => {
     })
 
     prismaMock.muxVideo.update.mockResolvedValue({} as any)
-    prismaMock.video.findUnique.mockResolvedValue({ slug: 'video-slug' } as any)
+    prismaMock.video.findUnique
+      .mockResolvedValueOnce({ slug: 'video-slug' } as any)
+      .mockResolvedValueOnce({ availableLanguages: [] } as any)
+    prismaMock.video.findMany.mockResolvedValue([] as any)
     prismaMock.videoVariant.findFirst.mockResolvedValue({
       id: 'variant-id',
       slug: 'variant-slug'
@@ -102,6 +124,10 @@ describe('processVideoUploads service', () => {
         version: 1
       })
     })
+    expect(prismaMock.video.update).toHaveBeenCalledWith({
+      where: { id: 'video-id' },
+      data: { availableLanguages: { set: ['529'] } }
+    })
   })
 
   it('updates an existing variant idempotently and marks the durable upload complete', async () => {
@@ -125,6 +151,7 @@ describe('processVideoUploads service', () => {
     prismaMock.muxVideo.update.mockResolvedValue({} as any)
     prismaMock.videoVariantUpload.update.mockResolvedValue({} as any)
     prismaMock.video.findUnique.mockResolvedValue({ slug: 'video-slug' } as any)
+    prismaMock.video.findMany.mockResolvedValue([] as any)
     prismaMock.videoVariant.findFirst.mockResolvedValue({
       id: 'variant-id',
       slug: 'variant-slug'

--- a/apis/api-media/src/workers/processVideoUploads/service/service.spec.ts
+++ b/apis/api-media/src/workers/processVideoUploads/service/service.spec.ts
@@ -21,12 +21,8 @@ vi.mock('../../processVideoDownloads/queue', () => ({
   }
 }))
 
-vi.mock('../../../lib/algolia/algoliaVideoUpdate', () => ({
-  updateVideoInAlgolia: vi.fn()
-}))
-
-vi.mock('../../../lib/algolia/algoliaVideoVariantUpdate', () => ({
-  updateVideoVariantInAlgolia: vi.fn()
+vi.mock('../../../workers/videoAlgoliaSync', () => ({
+  enqueueVideoAlgoliaSync: vi.fn()
 }))
 
 vi.mock('../../../lib/videoCacheReset', () => ({
@@ -78,10 +74,11 @@ describe('processVideoUploads service', () => {
     })
 
     prismaMock.muxVideo.update.mockResolvedValue({} as any)
-    prismaMock.video.findUnique
-      .mockResolvedValueOnce({ slug: 'video-slug' } as any)
-      .mockResolvedValueOnce({ availableLanguages: [] } as any)
+    prismaMock.video.findUnique.mockResolvedValueOnce({
+      slug: 'video-slug'
+    } as any)
     prismaMock.video.findMany.mockResolvedValue([] as any)
+    prismaMock.$executeRaw.mockResolvedValue(1)
     prismaMock.videoVariant.findFirst.mockResolvedValue({
       id: 'variant-id',
       slug: 'variant-slug'
@@ -124,10 +121,13 @@ describe('processVideoUploads service', () => {
         version: 1
       })
     })
-    expect(prismaMock.video.update).toHaveBeenCalledWith({
-      where: { id: 'video-id' },
-      data: { availableLanguages: { set: ['529'] } }
-    })
+    expect(prismaMock.$executeRaw).toHaveBeenCalledTimes(1)
+    const [sqlParts, ...values] = prismaMock.$executeRaw.mock.calls[0] as [
+      readonly string[],
+      ...unknown[]
+    ]
+    expect(sqlParts.join(' ')).toContain('array_append')
+    expect(values).toEqual(['529', 'video-id', '529'])
   })
 
   it('updates an existing variant idempotently and marks the durable upload complete', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Published video variants now automatically synchronize the parent video’s available-language metadata.
  * Search results and cached video data are refreshed after successful variant updates.

* **Bug Fixes**
  * Improved upload processing to keep video language information accurate.
  * Upload status and error details are reliably finalized after processing.

* **Reliability**
  * Language synchronization failures are reported while noncritical search and cache refresh failures are handled without blocking uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->