### PR TITLE
fix(journeys-admin): surface silent auth failures instead of looping

### DIFF
--- a/apps/journeys-admin/proxy.spec.ts
+++ b/apps/journeys-admin/proxy.spec.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from 'next/server'
+import { authMiddleware } from 'next-firebase-auth-edge'
 
 import proxy, { COOKIE_FINGERPRINT } from './proxy'
 
@@ -152,6 +153,72 @@ describe('proxy', () => {
       expect(result?.headers.get('set-cookie')).toBe(
         `NEXT_LOCALE=${COOKIE_FINGERPRINT}---zh-Hans-CN; Path=/`
       )
+    })
+  })
+
+  describe('auth error', () => {
+    // The module-level mock delegates to handleInvalidToken; these tests need
+    // the handleError branch instead. Typed loosely so the stub only has to
+    // describe the one option it calls.
+    const mockAuthMiddleware = authMiddleware as unknown as {
+      mockImplementationOnce: (
+        fn: (
+          req: NextRequest,
+          options: { handleError: (error: unknown) => Promise<Response> }
+        ) => Promise<Response>
+      ) => void
+    }
+
+    function mockHandleError(): void {
+      mockAuthMiddleware.mockImplementationOnce(
+        async (_req, options) =>
+          await options.handleError(new Error('Invalid credentials'))
+      )
+    }
+
+    beforeEach(() => {
+      vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should return 503 on /api/login so the client does not reload without a cookie', async () => {
+      mockHandleError()
+      const req = new NextRequest(
+        new Request('http://localhost:4200/api/login'),
+        requestInit
+      )
+
+      const result = await proxy(req)
+
+      expect(result?.status).toBe(503)
+      expect(result?.headers.get('set-cookie')).toBeNull()
+    })
+
+    it('should return 503 on /api/refresh-token', async () => {
+      mockHandleError()
+      const req = new NextRequest(
+        new Request('http://localhost:4200/api/refresh-token'),
+        requestInit
+      )
+
+      expect((await proxy(req))?.status).toBe(503)
+    })
+
+    it('should still serve normal pages when the auth exchange fails', async () => {
+      mockHandleError()
+      const req = new NextRequest(
+        new Request('http://localhost:4200/templates', {
+          headers: new Headers({
+            cookie: `NEXT_LOCALE=${COOKIE_FINGERPRINT}---en`
+          })
+        }),
+        requestInit
+      )
+
+      expect((await proxy(req))?.status).toBe(200)
     })
   })
 })

--- a/apps/journeys-admin/proxy.ts
+++ b/apps/journeys-admin/proxy.ts
@@ -151,6 +151,12 @@ function handleLocaleRedirect(
   return response
 }
 
+// Endpoints whose entire job is to mint or refresh the session cookie. If the
+// auth exchange fails on one of these, returning `next()` hands the client a
+// 200 with no cookie — it reloads, finds itself signed out, and loops. These
+// must fail loudly so the client can surface the error.
+const AUTH_EXCHANGE_PATHS = ['/api/login', '/api/refresh-token']
+
 export default async function proxy(req: NextRequest): Promise<NextResponse> {
   return await authMiddleware(req, {
     ...authConfig,
@@ -175,6 +181,8 @@ export default async function proxy(req: NextRequest): Promise<NextResponse> {
         pathname: req.nextUrl.pathname,
         errorMessage: error instanceof Error ? error.message : String(error)
       })
+      if (AUTH_EXCHANGE_PATHS.includes(req.nextUrl.pathname))
+        return NextResponse.json({ error: 'auth_unavailable' }, { status: 503 })
       return applyLocale(req) ?? NextResponse.next()
     }
   })

--- a/apps/journeys-admin/src/components/SignIn/SignIn.spec.tsx
+++ b/apps/journeys-admin/src/components/SignIn/SignIn.spec.tsx
@@ -79,4 +79,24 @@ describe('SignIn', () => {
       '/users/verify?redirect=/journeys/123'
     )
   })
+
+  it('should not redirect back to verify page when arriving from it', () => {
+    mockUseRouter.mockReturnValue({
+      asPath: '/signin?redirect=%2Fusers%2Fverify',
+      replace: mockReplace,
+      query: { redirect: '/users/verify' }
+    } as unknown as ReturnType<typeof useRouter>)
+
+    mockUseAuth.mockReturnValue({
+      user: { id: 'user-1', isAnonymous: false }
+    })
+
+    render(
+      <MockedProvider>
+        <SignIn />
+      </MockedProvider>
+    )
+
+    expect(mockReplace).not.toHaveBeenCalled()
+  })
 })

--- a/apps/journeys-admin/src/components/SignIn/SignIn.tsx
+++ b/apps/journeys-admin/src/components/SignIn/SignIn.tsx
@@ -27,6 +27,15 @@ export function SignIn(): ReactElement {
     if (user == null) return
     if (user.isAnonymous === true) return
 
+    // This page only renders when the server found no valid session cookie, so
+    // a client-side Firebase user here may be stale. /users/verify redirects
+    // straight back when the cookie is missing, and arriving with
+    // ?redirect=/users/verify means we have already made that round trip —
+    // going again would bounce forever.
+    const redirect = router.query.redirect
+    if (typeof redirect === 'string' && redirect.startsWith('/users/verify'))
+      return
+
     const search = getSearchFromAsPath(router.asPath)
     void router.replace(`/users/verify${search}`)
   }, [router, user?.id, user?.isAnonymous])

--- a/apps/journeys-admin/src/components/SignIn/SignInServiceButton/SignInServiceButton.spec.tsx
+++ b/apps/journeys-admin/src/components/SignIn/SignInServiceButton/SignInServiceButton.spec.tsx
@@ -414,5 +414,101 @@ describe('SignInServiceButton', () => {
         expect(mockLogin).toHaveBeenCalledWith('new-token')
       })
     })
+
+    it('should surface the error when the recovery path fails', async () => {
+      const credentialAlreadyInUseError = Object.assign(
+        new Error('credential already in use'),
+        { code: 'auth/credential-already-in-use' }
+      )
+      mockLinkWithPopup.mockRejectedValueOnce(credentialAlreadyInUseError)
+
+      mockCredentialFromError.mockReturnValueOnce({
+        providerId: 'google.com'
+      } as ReturnType<typeof OAuthProvider.credentialFromError>)
+
+      mockSignInWithCredential.mockResolvedValueOnce({
+        user: { getIdToken: vi.fn().mockResolvedValue('new-token') }
+      } as unknown as UserCredential)
+      mockLogin.mockRejectedValueOnce(
+        new Error('/api/login responded with status 503')
+      )
+
+      render(
+        <MockedProvider>
+          <SignInServiceButton service="google.com" />
+        </MockedProvider>
+      )
+
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Continue with Google' })
+      )
+
+      await waitFor(() =>
+        expect(
+          screen.getByTestId('SignInServiceButtonError')
+        ).toHaveTextContent('/api/login responded with status 503')
+      )
+      expect(
+        screen.getByRole('button', { name: 'Continue with Google' })
+      ).toBeEnabled()
+    })
+
+    it('should surface the error when signInWithCredential fails', async () => {
+      const credentialAlreadyInUseError = Object.assign(
+        new Error('credential already in use'),
+        { code: 'auth/credential-already-in-use' }
+      )
+      mockLinkWithPopup.mockRejectedValueOnce(credentialAlreadyInUseError)
+
+      mockCredentialFromError.mockReturnValueOnce({
+        providerId: 'google.com'
+      } as ReturnType<typeof OAuthProvider.credentialFromError>)
+
+      mockSignInWithCredential.mockRejectedValueOnce({
+        code: 'auth/invalid-credential'
+      })
+
+      render(
+        <MockedProvider>
+          <SignInServiceButton service="google.com" />
+        </MockedProvider>
+      )
+
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Continue with Google' })
+      )
+
+      await waitFor(() =>
+        expect(
+          screen.getByTestId('SignInServiceButtonError')
+        ).toHaveTextContent('auth/invalid-credential')
+      )
+    })
+
+    it('should surface the original error when no credential can be recovered', async () => {
+      const credentialAlreadyInUseError = Object.assign(
+        new Error('credential already in use'),
+        { code: 'auth/credential-already-in-use' }
+      )
+      mockLinkWithPopup.mockRejectedValueOnce(credentialAlreadyInUseError)
+      mockCredentialFromError.mockReturnValueOnce(null)
+
+      render(
+        <MockedProvider>
+          <SignInServiceButton service="google.com" />
+        </MockedProvider>
+      )
+
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Continue with Google' })
+      )
+
+      await waitFor(() =>
+        expect(
+          screen.getByTestId('SignInServiceButtonError')
+        ).toHaveTextContent('auth/credential-already-in-use')
+      )
+      expect(mockSignInWithCredential).not.toHaveBeenCalled()
+    })
   })
 })

--- a/apps/journeys-admin/src/components/SignIn/SignInServiceButton/SignInServiceButton.spec.tsx
+++ b/apps/journeys-admin/src/components/SignIn/SignInServiceButton/SignInServiceButton.spec.tsx
@@ -107,6 +107,54 @@ describe('SignInServiceButton', () => {
     await waitFor(() => expect(mockLoginWithCredential).toHaveBeenCalled())
   })
 
+  it('should surface the error code when sign-in fails', async () => {
+    mockSignInWithPopup.mockRejectedValueOnce({
+      code: 'auth/popup-closed-by-user'
+    })
+
+    render(
+      <MockedProvider>
+        <SignInServiceButton service="google.com" />
+      </MockedProvider>
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Continue with Google' })
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId('SignInServiceButtonError')).toHaveTextContent(
+        'auth/popup-closed-by-user'
+      )
+    )
+    expect(
+      screen.getByRole('button', { name: 'Continue with Google' })
+    ).toBeEnabled()
+  })
+
+  it('should surface the error when the session cookie exchange fails', async () => {
+    mockSignInWithPopup.mockResolvedValueOnce({} as unknown as UserCredential)
+    mockLoginWithCredential.mockRejectedValueOnce(
+      new Error('/api/login responded with status 503')
+    )
+
+    render(
+      <MockedProvider>
+        <SignInServiceButton service="google.com" />
+      </MockedProvider>
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Continue with Google' })
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId('SignInServiceButtonError')).toHaveTextContent(
+        '/api/login responded with status 503'
+      )
+    )
+  })
+
   it('should handle Facebook sign-in correctly', async () => {
     mockSignInWithPopup.mockResolvedValueOnce({} as unknown as UserCredential)
 

--- a/apps/journeys-admin/src/components/SignIn/SignInServiceButton/SignInServiceButton.tsx
+++ b/apps/journeys-admin/src/components/SignIn/SignInServiceButton/SignInServiceButton.tsx
@@ -1,5 +1,7 @@
 import { useMutation } from '@apollo/client'
+import Alert from '@mui/material/Alert'
 import Button from '@mui/material/Button'
+import Stack from '@mui/material/Stack'
 import { FirebaseError } from 'firebase/app'
 import type { AuthProvider, User } from 'firebase/auth'
 import {
@@ -35,6 +37,7 @@ export function SignInServiceButton({
   const router = useRouter()
   const [journeyPublish] = useMutation(JOURNEY_PUBLISH)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [errorCode, setErrorCode] = useState<string | null>(null)
 
   async function linkAnonymousUserWithProvider(
     currentUser: User,
@@ -92,9 +95,20 @@ export function SignInServiceButton({
     await loginWithCredential(userCredential)
   }
 
+  // Surfaced next to the button so a failed sign-in is visible to the user and
+  // reportable to support. Without it every failure below re-renders this same
+  // page with no feedback, which reads as an endless sign-in loop.
+  function getErrorCode(err: unknown): string {
+    const code = (err as { code?: string })?.code
+    if (code != null) return code
+    if (err instanceof Error) return err.message
+    return 'unknown'
+  }
+
   async function handleSignIn(): Promise<void> {
     if (isSubmitting) return
     setIsSubmitting(true)
+    setErrorCode(null)
     const auth = getFirebaseAuth()
     const currentUser = auth.currentUser
     const authProvider =
@@ -140,36 +154,44 @@ export function SignInServiceButton({
         }
       }
       console.error(err)
+      setErrorCode(getErrorCode(err))
     } finally {
       setIsSubmitting(false)
     }
   }
 
   return (
-    <Button
-      variant="blockOutlined"
-      color="solid"
-      startIcon={
-        service === 'google.com' ? (
-          <GoogleIcon />
-        ) : service === 'facebook.com' ? (
-          <FacebookIcon />
-        ) : (
-          <OktaIcon />
-        )
-      }
-      onClick={handleSignIn}
-      disabled={isSubmitting}
-      fullWidth
-    >
-      {t('Continue with {{service}}', {
-        service:
-          service === 'google.com'
-            ? t('Google')
-            : service === 'facebook.com'
-              ? t('Facebook')
-              : t('Okta')
-      })}
-    </Button>
+    <Stack spacing={2}>
+      <Button
+        variant="blockOutlined"
+        color="solid"
+        startIcon={
+          service === 'google.com' ? (
+            <GoogleIcon />
+          ) : service === 'facebook.com' ? (
+            <FacebookIcon />
+          ) : (
+            <OktaIcon />
+          )
+        }
+        onClick={handleSignIn}
+        disabled={isSubmitting}
+        fullWidth
+      >
+        {t('Continue with {{service}}', {
+          service:
+            service === 'google.com'
+              ? t('Google')
+              : service === 'facebook.com'
+                ? t('Facebook')
+                : t('Okta')
+        })}
+      </Button>
+      {errorCode != null && (
+        <Alert severity="error" data-testid="SignInServiceButtonError">
+          {`${t('Something went wrong, please try again!')} (${errorCode})`}
+        </Alert>
+      )}
+    </Stack>
   )
 }

--- a/apps/journeys-admin/src/components/SignIn/SignInServiceButton/SignInServiceButton.tsx
+++ b/apps/journeys-admin/src/components/SignIn/SignInServiceButton/SignInServiceButton.tsx
@@ -3,7 +3,7 @@ import Alert from '@mui/material/Alert'
 import Button from '@mui/material/Button'
 import Stack from '@mui/material/Stack'
 import { FirebaseError } from 'firebase/app'
-import type { AuthProvider, User } from 'firebase/auth'
+import type { Auth, AuthProvider, OAuthCredential, User } from 'firebase/auth'
 import {
   FacebookAuthProvider,
   GoogleAuthProvider,
@@ -105,6 +105,57 @@ export function SignInServiceButton({
     return 'unknown'
   }
 
+  // Reached when the account behind the popup already exists. Signing in with
+  // the credential lifted off the error completes what the link could not.
+  async function signInWithRecoveredCredential(
+    auth: Auth,
+    oauthCredential: OAuthCredential
+  ): Promise<void> {
+    const userCredential = await signInWithCredential(auth, oauthCredential)
+    const idToken = await userCredential.user.getIdToken()
+    await login(idToken)
+
+    const pending = getPendingGuestJourney()
+    if (pending != null) {
+      const existingRedirect = router.query.redirect as string | undefined
+      const redirectUrl =
+        existingRedirect ?? `/templates/${pending.journeyId}/customize`
+      window.location.href = `/users/sign-in?redirect=${encodeURIComponent(redirectUrl)}`
+      return
+    }
+
+    window.location.reload()
+  }
+
+  // Recovery is attempted here rather than in handleSignIn's catch: a throw
+  // inside a catch block escapes it, so failures in the recovery path would
+  // bypass the error handling entirely. Letting them propagate out of this
+  // function keeps handleSignIn's catch the single sink for every failure.
+  async function signInOrRecover(
+    auth: Auth,
+    authProvider: AuthProvider,
+    currentUser: User | null
+  ): Promise<void> {
+    try {
+      if (currentUser?.isAnonymous === true) {
+        await linkAnonymousUserWithProvider(currentUser, authProvider)
+        return
+      }
+      const credential = await signInWithPopup(auth, authProvider)
+      await loginWithCredential(credential)
+    } catch (err: unknown) {
+      const firebaseErr = err as { code?: string }
+      if (firebaseErr.code !== 'auth/credential-already-in-use') throw err
+
+      const oauthCredential = OAuthProvider.credentialFromError(
+        err as FirebaseError
+      )
+      if (oauthCredential == null) throw err
+
+      await signInWithRecoveredCredential(auth, oauthCredential)
+    }
+  }
+
   async function handleSignIn(): Promise<void> {
     if (isSubmitting) return
     setIsSubmitting(true)
@@ -120,39 +171,8 @@ export function SignInServiceButton({
     authProvider.setCustomParameters({ prompt: 'select_account' })
 
     try {
-      if (currentUser?.isAnonymous === true) {
-        await linkAnonymousUserWithProvider(currentUser, authProvider)
-      } else {
-        const credential = await signInWithPopup(auth, authProvider)
-        await loginWithCredential(credential)
-      }
+      await signInOrRecover(auth, authProvider, currentUser)
     } catch (err: unknown) {
-      const firebaseErr = err as { code?: string }
-      if (firebaseErr.code === 'auth/credential-already-in-use') {
-        const oauthCredential = OAuthProvider.credentialFromError(
-          err as FirebaseError
-        )
-        if (oauthCredential != null) {
-          const userCredential = await signInWithCredential(
-            auth,
-            oauthCredential
-          )
-          const idToken = await userCredential.user.getIdToken()
-          await login(idToken)
-
-          const pending = getPendingGuestJourney()
-          if (pending != null) {
-            const existingRedirect = router.query.redirect as string | undefined
-            const redirectUrl =
-              existingRedirect ?? `/templates/${pending.journeyId}/customize`
-            window.location.href = `/users/sign-in?redirect=${encodeURIComponent(redirectUrl)}`
-            return
-          }
-
-          window.location.reload()
-          return
-        }
-      }
       console.error(err)
       setErrorCode(getErrorCode(err))
     } finally {

--- a/apps/journeys-admin/src/libs/auth/firebase.spec.ts
+++ b/apps/journeys-admin/src/libs/auth/firebase.spec.ts
@@ -1,0 +1,32 @@
+import { login } from './firebase'
+
+describe('login', () => {
+  const originalFetch = global.fetch
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('should resolve when the session cookie is minted', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 })
+    global.fetch = mockFetch as unknown as typeof fetch
+
+    await expect(login('id-token')).resolves.toBeUndefined()
+    expect(mockFetch).toHaveBeenCalledWith('/api/login', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer id-token' },
+      cache: 'no-store'
+    })
+  })
+
+  it('should throw when /api/login fails so the caller does not reload signed out', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: false, status: 503 }) as unknown as typeof fetch
+
+    await expect(login('id-token')).rejects.toThrow(
+      '/api/login responded with status 503'
+    )
+  })
+})

--- a/apps/journeys-admin/src/libs/auth/firebase.ts
+++ b/apps/journeys-admin/src/libs/auth/firebase.ts
@@ -18,11 +18,16 @@ export function getFirebaseAuth(): Auth {
 }
 
 export async function login(token: string): Promise<void> {
-  await fetch('/api/login', {
+  const response = await fetch('/api/login', {
     method: 'GET',
     headers: { Authorization: `Bearer ${token}` },
     cache: 'no-store'
   })
+  // A non-ok response means the session cookie was never minted. Without this
+  // check the caller reloads onto a page it is not authenticated for, which
+  // presents to the user as an endless sign-in loop instead of an error.
+  if (!response.ok)
+    throw new Error(`/api/login responded with status ${response.status}`)
 }
 
 export async function loginWithCredential(


### PR DESCRIPTION
## Why

Users have been hitting an endless sign-in loop:

> You already have an account → Continue with Google → choose an account → You already have an account

The live cause is a VPC Service Controls denial blocking session-cookie minting — tracked separately in #9452, and fixed in GCP, not here.

What this PR fixes is why it took so long to find. Every layer of the auth path swallowed the failure, so a hard 403 in the middleware surfaced to the user as a page that simply did nothing, and to us as an empty API log. Nothing was written down anywhere that pointed at the actual error.

## What changed

**`login()` checks `response.ok`** (`src/libs/auth/firebase.ts`)

It previously ignored the response entirely, so a `/api/login` that never set a cookie still resolved, and `loginWithCredential` went on to call `window.location.reload()` — dropping the user onto a page they weren't authenticated for. It now throws.

**`proxy.ts` fails loudly on the auth-exchange endpoints**

`handleError` returned `NextResponse.next()` for everything, which on `/api/login` means a 200 with no `Set-Cookie` — indistinguishable from success. Those two paths now return 503. Normal page requests still degrade to signed-out browsing as before.

**`SignInServiceButton` shows the error**

The catch was `console.error(err)` with no error state, and `finally { setIsSubmitting(false) }` re-enabled the button on the same page — which is precisely the "loop" users described. The firebase error code (or the `/api/login` status) now renders in an Alert next to the button, so the next report arrives with the code attached.

**`SignIn` no longer bounces off `/users/verify`**

`AuthProvider` can hold a persisted client-side Firebase user while no session cookie exists. The effect redirected to `/users/verify`, whose `getServerSideProps` found no cookie and redirected straight back — forever. It now returns early when it arrived from there (`?redirect=/users/verify`).

## Testing

`apps/journeys-admin` — 95 tests passing across the auth and SignIn suites, including 8 new ones:

- `firebase.spec.ts` — resolves on ok, throws on non-ok
- `proxy.spec.ts` — 503 on `/api/login` and `/api/refresh-token`, normal pages still 200
- `SignInServiceButton.spec.tsx` — surfaces a firebase error code, and a failed cookie exchange
- `SignIn.spec.tsx` — no redirect when arriving from `/users/verify`

`nx type-check` and `nx lint` clean for the changed files.

## Note

This does **not** resolve #9452. The perimeter fix is an infra change; this only guarantees the next occurrence is visible immediately rather than after a multi-day investigation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sign-in error handling with clear messages for authentication and session failures.
  - Sign-in controls now re-enable after failed attempts and display helpful alerts.
  - Prevented repeated redirects during user verification.
  - Authentication service failures now return a clear temporary-unavailability response.
  - Login failures are detected and surfaced instead of being silently ignored.

- **Tests**
  - Expanded coverage for authentication errors, login failures, redirect behavior, and sign-in feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->