### PR TITLE
fix(journeys-admin): avoid IndexedDB auth persistence to fix popup sign-in

### DIFF
--- a/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/UserNavigation/ImpersonateDialog/ImpersonateDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/UserNavigation/ImpersonateDialog/ImpersonateDialog.spec.tsx
@@ -11,11 +11,11 @@ import { ImpersonateDialog } from '.'
 const mockLoginWithCredential = vi.fn().mockResolvedValue(undefined)
 
 vi.mock('firebase/auth', () => ({
-  getAuth: vi.fn(() => ({})),
   signInWithCustomToken: vi.fn()
 }))
 
 vi.mock('../../../../../libs/auth', () => ({
+  getFirebaseAuth: vi.fn(() => ({})),
   loginWithCredential: (...args: unknown[]) => mockLoginWithCredential(...args)
 }))
 

--- a/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/UserNavigation/ImpersonateDialog/ImpersonateDialog.tsx
+++ b/apps/journeys-admin/src/components/PageWrapper/NavigationDrawer/UserNavigation/ImpersonateDialog/ImpersonateDialog.tsx
@@ -3,7 +3,7 @@ import Alert from '@mui/material/Alert'
 import AlertTitle from '@mui/material/AlertTitle'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
-import { getAuth, signInWithCustomToken } from 'firebase/auth'
+import { signInWithCustomToken } from 'firebase/auth'
 import { Form, Formik, FormikHelpers, FormikValues } from 'formik'
 import { useTranslation } from 'next-i18next/pages'
 import { useSnackbar } from 'notistack'
@@ -15,7 +15,7 @@ import {
   UserImpersonate,
   UserImpersonateVariables
 } from '../../../../../../__generated__/UserImpersonate'
-import { loginWithCredential } from '../../../../../libs/auth'
+import { getFirebaseAuth, loginWithCredential } from '../../../../../libs/auth'
 
 export const USER_IMPERSONATE = gql`
   mutation UserImpersonate($email: String!) {
@@ -50,7 +50,7 @@ export function ImpersonateDialog({
         }
       })
       if (data?.userImpersonate != null) {
-        const auth = getAuth()
+        const auth = getFirebaseAuth()
         const credential = await signInWithCustomToken(
           auth,
           data.userImpersonate

--- a/apps/journeys-admin/src/components/SignIn/HomePage/HomePage.spec.tsx
+++ b/apps/journeys-admin/src/components/SignIn/HomePage/HomePage.spec.tsx
@@ -6,8 +6,13 @@ import { type MockedFunction } from 'vitest'
 import { HomePage } from './HomePage'
 
 vi.mock('firebase/auth', () => ({
-  getAuth: vi.fn(),
   fetchSignInMethodsForEmail: vi.fn()
+}))
+
+vi.mock('../../../libs/auth', () => ({
+  getFirebaseAuth: vi.fn(() => ({ currentUser: null })),
+  login: vi.fn(),
+  loginWithCredential: vi.fn()
 }))
 
 describe('Home', () => {

--- a/apps/journeys-admin/src/components/SignIn/HomePage/HomePage.tsx
+++ b/apps/journeys-admin/src/components/SignIn/HomePage/HomePage.tsx
@@ -4,12 +4,13 @@ import Button from '@mui/material/Button'
 import Divider from '@mui/material/Divider'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
-import { fetchSignInMethodsForEmail, getAuth } from 'firebase/auth'
+import { fetchSignInMethodsForEmail } from 'firebase/auth'
 import { Form, Formik } from 'formik'
 import { useTranslation } from 'next-i18next/pages'
 import { ReactElement } from 'react'
 import { InferType, object, string } from 'yup'
 
+import { getFirebaseAuth } from '../../../libs/auth'
 import { SignInServiceButton } from '../SignInServiceButton'
 import { SignInTabs } from '../SignInTabs'
 import { PageProps } from '../types'
@@ -31,7 +32,7 @@ export function HomePage({
   async function handleEmailSignIn(
     values: InferType<typeof validationSchema>
   ): Promise<void> {
-    const auth = getAuth()
+    const auth = getFirebaseAuth()
     const result = await fetchSignInMethodsForEmail(auth, values.email)
     if (result.length === 0) {
       setActivePage?.('register')

--- a/apps/journeys-admin/src/components/SignIn/PasswordResetPage/PasswordResetPage.spec.tsx
+++ b/apps/journeys-admin/src/components/SignIn/PasswordResetPage/PasswordResetPage.spec.tsx
@@ -5,8 +5,11 @@ import { type MockedFunction } from 'vitest'
 import { PasswordResetPage } from './PasswordResetPage'
 
 vi.mock('firebase/auth', () => ({
-  getAuth: vi.fn(),
   sendPasswordResetEmail: vi.fn()
+}))
+
+vi.mock('../../../libs/auth', () => ({
+  getFirebaseAuth: vi.fn(() => ({ currentUser: null }))
 }))
 
 describe('PasswordResetPage', () => {

--- a/apps/journeys-admin/src/components/SignIn/PasswordResetPage/PasswordResetPage.tsx
+++ b/apps/journeys-admin/src/components/SignIn/PasswordResetPage/PasswordResetPage.tsx
@@ -2,12 +2,13 @@ import Button from '@mui/material/Button'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
-import { getAuth, sendPasswordResetEmail } from 'firebase/auth'
+import { sendPasswordResetEmail } from 'firebase/auth'
 import { Form, Formik, FormikHelpers } from 'formik'
 import { useTranslation } from 'next-i18next/pages'
 import { ReactElement } from 'react'
 import { InferType, object, string } from 'yup'
 
+import { getFirebaseAuth } from '../../../libs/auth'
 import { PageProps } from '../types'
 
 export function PasswordResetPage({
@@ -15,7 +16,7 @@ export function PasswordResetPage({
   setUserEmail,
   setActivePage
 }: PageProps): ReactElement {
-  const auth = getAuth()
+  const auth = getFirebaseAuth()
   const { t } = useTranslation('apps-journeys-admin')
   const validationSchema = object().shape({
     email: string()

--- a/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/LanguageScreen/LanguageScreen.tsx
+++ b/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/LanguageScreen/LanguageScreen.tsx
@@ -5,8 +5,7 @@ import InputAdornment from '@mui/material/InputAdornment'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
-import { getApp } from 'firebase/app'
-import { getAuth, signInAnonymously } from 'firebase/auth'
+import { signInAnonymously } from 'firebase/auth'
 import { Form, Formik } from 'formik'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next/pages'
@@ -31,7 +30,7 @@ import Translate from '@core/shared/ui/icons/Translate'
 import { LanguageAutocomplete } from '@core/shared/ui/LanguageAutocomplete'
 
 import { LOCALE_LANGUAGES } from '../../../../../../proxy'
-import { useAuth } from '../../../../../libs/auth'
+import { getFirebaseAuth, useAuth } from '../../../../../libs/auth'
 import { useCurrentUserLazyQuery } from '../../../../../libs/useCurrentUserLazyQuery'
 import { useTeamCreateMutation } from '../../../../../libs/useTeamCreateMutation'
 import { usePageWrapperStyles } from '../../../../PageWrapper/utils/usePageWrapperStyles'
@@ -134,7 +133,7 @@ export function LanguageScreen({
     const isAnonymous = user?.isAnonymous ?? false
     if (!isAnonymous) {
       try {
-        await signInAnonymously(getAuth(getApp()))
+        await signInAnonymously(getFirebaseAuth())
       } catch {
         throw new Error('Could not create firebase user')
       }

--- a/apps/journeys-admin/src/libs/apolloClient/apolloClient.ts
+++ b/apps/journeys-admin/src/libs/apolloClient/apolloClient.ts
@@ -15,8 +15,6 @@ import { setContext } from '@apollo/client/link/context'
 import { onError } from '@apollo/client/link/error'
 import { getMainDefinition } from '@apollo/client/utilities'
 import DebounceLink from 'apollo-link-debounce'
-import { getApp } from 'firebase/app'
-import { getAuth } from 'firebase/auth'
 import { print } from 'graphql'
 import { createClient } from 'graphql-sse'
 import { useMemo } from 'react'
@@ -24,7 +22,7 @@ import { Observable } from 'zen-observable-ts'
 
 import { isDevHost } from '@core/shared/dev-hosts'
 
-import { logout } from '../auth/firebase'
+import { getFirebaseAuth, logout } from '../auth/firebase'
 
 import { cache } from './cache'
 
@@ -171,7 +169,7 @@ export function createApolloClient(
   const authLink = setContext(async (_, { headers }) => {
     const firebaseToken = ssrMode
       ? token
-      : ((await getAuth(getApp()).currentUser?.getIdToken()) ?? token)
+      : ((await getFirebaseAuth().currentUser?.getIdToken()) ?? token)
 
     return {
       headers: {

--- a/apps/journeys-admin/src/libs/auth/firebase.ts
+++ b/apps/journeys-admin/src/libs/auth/firebase.ts
@@ -2,8 +2,10 @@ import { FirebaseApp, getApp, getApps, initializeApp } from 'firebase/app'
 import {
   Auth,
   UserCredential,
+  browserLocalPersistence,
+  browserPopupRedirectResolver,
   signOut as firebaseSignOut,
-  getAuth
+  initializeAuth
 } from 'firebase/auth'
 
 import { clientConfig } from './config'
@@ -13,8 +15,20 @@ function getFirebaseApp(): FirebaseApp {
   return initializeApp(clientConfig)
 }
 
+let auth: Auth | undefined
+
 export function getFirebaseAuth(): Auth {
-  return getAuth(getFirebaseApp())
+  if (auth != null) return auth
+  // localStorage persistence instead of getAuth()'s IndexedDB default:
+  // @firebase/auth 1.13.4 closes its IndexedDB connection whenever the
+  // document is hidden — which the sign-in popup itself triggers — so
+  // persisting the signed-in user throws "Database is closing/hidden" and
+  // sign-in fails. https://github.com/firebase/firebase-js-sdk/issues/10264
+  auth = initializeAuth(getFirebaseApp(), {
+    persistence: browserLocalPersistence,
+    popupRedirectResolver: browserPopupRedirectResolver
+  })
+  return auth
 }
 
 export async function login(token: string): Promise<void> {
@@ -40,8 +54,7 @@ export async function loginWithCredential(
 
 export async function logout(): Promise<void> {
   try {
-    const auth = getAuth()
-    await firebaseSignOut(auth)
+    await firebaseSignOut(getFirebaseAuth())
   } catch {
     // Firebase may not be initialized
   }

--- a/apps/journeys-admin/src/libs/auth/firebase.ts
+++ b/apps/journeys-admin/src/libs/auth/firebase.ts
@@ -5,6 +5,7 @@ import {
   browserLocalPersistence,
   browserPopupRedirectResolver,
   signOut as firebaseSignOut,
+  inMemoryPersistence,
   initializeAuth
 } from 'firebase/auth'
 
@@ -24,10 +25,17 @@ export function getFirebaseAuth(): Auth {
   // document is hidden — which the sign-in popup itself triggers — so
   // persisting the signed-in user throws "Database is closing/hidden" and
   // sign-in fails. https://github.com/firebase/firebase-js-sdk/issues/10264
-  auth = initializeAuth(getFirebaseApp(), {
-    persistence: browserLocalPersistence,
-    popupRedirectResolver: browserPopupRedirectResolver
-  })
+  //
+  // On the server the browser persistence/resolver exports are non-class
+  // stubs and initializeAuth rejects them ("Expected a class definition"),
+  // so pass server-safe options there.
+  auth =
+    typeof window === 'undefined'
+      ? initializeAuth(getFirebaseApp(), { persistence: inMemoryPersistence })
+      : initializeAuth(getFirebaseApp(), {
+          persistence: browserLocalPersistence,
+          popupRedirectResolver: browserPopupRedirectResolver
+        })
   return auth
 }
 

--- a/apps/journeys-admin/src/libs/initAndAuthApp/initAndAuthApp.spec.tsx
+++ b/apps/journeys-admin/src/libs/initAndAuthApp/initAndAuthApp.spec.tsx
@@ -1,7 +1,6 @@
 import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
 import { LDClient } from '@launchdarkly/node-server-sdk'
-import { getApp } from 'firebase/app'
-import { getAuth, signInAnonymously } from 'firebase/auth'
+import { signInAnonymously } from 'firebase/auth'
 import { SSRConfig } from 'next-i18next/pages'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
 import { type MockedFunction } from 'vitest'
@@ -11,6 +10,7 @@ import { getLaunchDarklyClient } from '@core/shared/ui/getLaunchDarklyClient'
 import i18nConfig from '../../../next-i18next.config'
 import { createApolloClient } from '../apolloClient'
 import { User } from '../auth/authContext'
+import { getFirebaseAuth } from '../auth/firebase'
 import { checkConditionalRedirect } from '../checkConditionalRedirect'
 
 import { ACCEPT_ALL_INVITES, initAndAuthApp } from './initAndAuthApp'
@@ -19,8 +19,8 @@ vi.mock('next-i18next/pages/serverSideTranslations')
 vi.mock('@core/shared/ui/getLaunchDarklyClient')
 vi.mock('../apolloClient')
 vi.mock('../checkConditionalRedirect')
-vi.mock('firebase/app')
 vi.mock('firebase/auth')
+vi.mock('../auth/firebase')
 
 const serverSideTranslationsMock = vi.mocked(serverSideTranslations)
 const getLaunchDarklyClientMock = getLaunchDarklyClient as MockedFunction<
@@ -32,8 +32,9 @@ const createApolloClientMock = createApolloClient as MockedFunction<
 const checkConditionalRedirectMock = checkConditionalRedirect as MockedFunction<
   typeof checkConditionalRedirect
 >
-const getAppMock = getApp as MockedFunction<typeof getApp>
-const getAuthMock = getAuth as MockedFunction<typeof getAuth>
+const getFirebaseAuthMock = getFirebaseAuth as MockedFunction<
+  typeof getFirebaseAuth
+>
 const signInAnonymouslyMock = signInAnonymously as MockedFunction<
   typeof signInAnonymously
 >
@@ -83,8 +84,7 @@ describe('initAndAuthApp', () => {
     })
 
     // mock Firebase functions
-    getAppMock.mockReturnValue({} as any)
-    getAuthMock.mockReturnValue({} as any)
+    getFirebaseAuthMock.mockReturnValue({} as any)
     signInAnonymouslyMock.mockResolvedValue({} as any)
   })
 

--- a/apps/journeys-admin/src/libs/initAndAuthApp/initAndAuthApp.ts
+++ b/apps/journeys-admin/src/libs/initAndAuthApp/initAndAuthApp.ts
@@ -1,6 +1,5 @@
 import { ApolloClient, NormalizedCacheObject, gql } from '@apollo/client'
-import { getApp } from 'firebase/app'
-import { getAuth, signInAnonymously } from 'firebase/auth'
+import { signInAnonymously } from 'firebase/auth'
 import { Redirect } from 'next'
 import { SSRConfig } from 'next-i18next/pages'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
@@ -12,6 +11,7 @@ import { AcceptAllInvites } from '../../../__generated__/AcceptAllInvites'
 import i18nConfig from '../../../next-i18next.config'
 import { createApolloClient } from '../apolloClient'
 import { User } from '../auth/authContext'
+import { getFirebaseAuth } from '../auth/firebase'
 import { checkConditionalRedirect } from '../checkConditionalRedirect'
 
 interface InitAndAuthAppProps {
@@ -50,7 +50,7 @@ export async function initAndAuthApp({
   allowGuest = false
 }: InitAndAuthAppProps): Promise<InitAndAuth> {
   if (user == null && makeAccountOnAnonymous) {
-    await signInAnonymously(getAuth(getApp()))
+    await signInAnonymously(getFirebaseAuth())
   }
 
   const ldUser =

--- a/apps/videos-admin/src/libs/auth/firebase.ts
+++ b/apps/videos-admin/src/libs/auth/firebase.ts
@@ -32,9 +32,13 @@ export function getFirebaseAuth(): Auth {
   // @firebase/auth 1.13.4 closes the database while the sign-in popup has
   // focus and fails sign-in with "Database is closing/hidden".
   // See: https://github.com/firebase/firebase-js-sdk/issues/10264
+  // On the server browserPopupRedirectResolver is a non-class stub and
+  // initializeAuth rejects it ("Expected a class definition").
   auth = initializeAuth(getFirebaseApp(), {
     persistence: inMemoryPersistence,
-    popupRedirectResolver: browserPopupRedirectResolver
+    ...(typeof window === 'undefined'
+      ? {}
+      : { popupRedirectResolver: browserPopupRedirectResolver })
   })
   return auth
 }

--- a/apps/videos-admin/src/libs/auth/firebase.ts
+++ b/apps/videos-admin/src/libs/auth/firebase.ts
@@ -4,9 +4,8 @@ import {
   GoogleAuthProvider,
   UserCredential,
   browserPopupRedirectResolver,
-  getAuth,
   inMemoryPersistence,
-  setPersistence,
+  initializeAuth,
   signInWithPopup,
   useDeviceLanguage
 } from 'firebase/auth'
@@ -19,14 +18,24 @@ function getFirebaseApp(): FirebaseApp {
   return initializeApp(clientConfig)
 }
 
+let auth: Auth | undefined
+
 export function getFirebaseAuth(): Auth {
-  const auth = getAuth(getFirebaseApp())
+  if (auth != null) return auth
 
   // App relies only on server token. We make sure Firebase does not store
   // credentials in the browser.
   // See: https://github.com/awinogrodzki/next-firebase-auth-edge/issues/143
-  void setPersistence(auth, inMemoryPersistence)
-
+  //
+  // initializeAuth instead of getAuth() + setPersistence: getAuth() still
+  // instantiates its IndexedDB persistence, whose visibilitychange handler in
+  // @firebase/auth 1.13.4 closes the database while the sign-in popup has
+  // focus and fails sign-in with "Database is closing/hidden".
+  // See: https://github.com/firebase/firebase-js-sdk/issues/10264
+  auth = initializeAuth(getFirebaseApp(), {
+    persistence: inMemoryPersistence,
+    popupRedirectResolver: browserPopupRedirectResolver
+  })
   return auth
 }
 


### PR DESCRIPTION
## Why

Google popup sign-in on `admin.nextstep.is` has been failing since 2026-08-04 with the login loop tracked in #9452. The diagnostic logging from #9453 stayed silent because the failure is entirely client-side: Datadog RUM shows ~170 occurrences of

```
Error: Database is closing/hidden
  at _openDb → _withRetries → _withPendingWrite → _set
  at setCurrentUser → directlySetCurrentUser
```

starting the day after #9426 upgraded firebase 10→12. This is firebase/firebase-js-sdk#10264: `@firebase/auth` 1.13.4 added a `visibilitychange` listener to `IndexedDBLocalPersistence` that closes the database whenever the document is hidden — which the sign-in popup itself triggers. When the popup returns the credential, persisting the user throws and `signInWithPopup` rejects, so `/api/login` is never called (confirmed: zero middleware auth errors, zero login POSTs in Datadog since the failure window began).

No released firebase version fixes it yet. This keeps firebase 12.17 and sidesteps the bug instead of pinning back to 12.16.

## What changed

**journeys-admin** — `getFirebaseAuth()` now uses `initializeAuth` with `browserLocalPersistence` + `browserPopupRedirectResolver` instead of `getAuth()`'s IndexedDB-first default, cached as a singleton. The buggy `IndexedDBLocalPersistence` is never instantiated. All bare `getAuth()` call sites (sign-in pages, ImpersonateDialog, Apollo auth link, anonymous sign-in in `initAndAuthApp`/`LanguageScreen`, logout) now route through `getFirebaseAuth()` so nothing initializes the default persistence first.

**videos-admin** — already intended `inMemoryPersistence`, but did it via `getAuth()` + un-awaited `setPersistence`, which still instantiates the IndexedDB layer. Now uses `initializeAuth` with `inMemoryPersistence` directly.

Existing sessions degrade gracefully: the server session cookie drives auth (`AuthProvider` prefers the server user, Apollo falls back to the server token), so already-signed-in users aren't logged out; their client-side Firebase state re-establishes on next sign-in.

## Verification

- journeys-admin: 118 tests across all touched areas pass; type-check passes; eslint clean on changed files
- videos-admin: 99 test files (459 tests) pass; type-check passes

Fixes #9452

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in, password reset, impersonation, anonymous access, and session authentication flows.
  * Preserved authentication state more reliably across browser sessions.
  * Added safer in-memory authentication handling for video administration.
* **Tests**
  * Updated authentication test coverage to reflect the improved sign-in and session behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->