### PR TITLE
fix(devcontainer): reap zombie processes in the app service

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -59,6 +59,10 @@ services:
     volumes:
       - core-workspace:/workspaces
       - core-node-user:/home/node
+    # Run an init process as PID 1 so exited children are reaped. Without it
+    # `sleep infinity` is PID 1 and never reaps, so tooling that spawns and
+    # abandons children accumulates zombies over a long-lived session.
+    init: true
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
     # Uncomment the next line to use a non-root user for all processes.


### PR DESCRIPTION
`command: sleep infinity` makes `sleep` PID 1, and `sleep` never calls `wait()`, so
children orphaned by tooling are never reaped and accumulate as zombies over a
long-lived session. `init: true` runs docker-init (tini) as PID 1 instead, with
`sleep infinity` as its child, so orphans reparent to tini and get reaped.

**Measured on the built image: 5 zombies before, 0 after.**

### Side effect worth knowing

SIGTERM now reaches `sleep` immediately rather than being ignored by PID 1, so the
container stops in ~0.1s instead of waiting out the stop timeout — measured
3.115s → 0.100s with `docker stop -t 3`.

Processes attached via `docker exec` (VS Code Server, Nx daemon, terminal shells)
are not signalled by tini and lose the grace period they previously had on
stop/rebuild. Worth avoiding "Rebuild Container" mid-install or mid-test-run.

### Scope note

An earlier revision of this PR also bumped the devcontainer from Node 20 to 22.
That has been dropped.

`.devcontainer/devcontainer.json` installs `ghcr.io/devcontainers/features/node:1`
pinned to `"version": "lts"`. Devcontainer features install after the image build
and win on PATH, so the `VARIANT` build arg does not determine the container's
effective Node version — bumping it would not have delivered "the devcontainer now
runs Node 22".

The version-alignment work is real but separate: it needs a decision on whether the
node feature should be pinned instead of floating on `lts`, and existing
contributors' persisted `core-workspace` / `core-node-user` volumes hold
ABI-sensitive native builds (`canvas`) compiled against the current Node, which a
version change would invalidate. That belongs in its own change rather than riding
along with a process-reaping fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development environment to use Node.js 22.
  * Improved application container process handling for more reliable development workflows.
  * Enabled improved startup and shutdown behavior for development containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->