### PR TITLE
fix(api-media): remove suppressed languages, emit numeric languageId (QA-375)

### DIFF
--- a/apis/api-media/project.json
+++ b/apis/api-media/project.json
@@ -163,7 +163,10 @@
     },
     "reindex-languages-algolia": {
       "executor": "nx:run-commands",
-      "dependsOn": ["prisma-languages:prisma-generate"],
+      "dependsOn": [
+        "prisma-languages:prisma-generate",
+        "prisma-media:prisma-generate"
+      ],
       "options": {
         "command": "pnpm exec tsx --tsconfig apis/api-media/tsconfig.app.json apis/api-media/src/scripts/algolia-helpers/reindex-languages-with-videos.ts"
       }

--- a/apis/api-media/src/lib/languages/updateLanguageInAlgolia.spec.ts
+++ b/apis/api-media/src/lib/languages/updateLanguageInAlgolia.spec.ts
@@ -116,7 +116,9 @@ describe('updateLanguageInAlgolia', () => {
     })
 
     it('emits languageId as a number while objectID stays a string', () => {
-      const record = buildAlgoliaLanguageRecord(createLanguage({ id: '143846' }))
+      const record = buildAlgoliaLanguageRecord(
+        createLanguage({ id: '143846' })
+      )
 
       // The rest of the index stores languageId numerically and arclight's
       // AlgoliaLanguageHit types it as a number, so a string here would make

--- a/apis/api-media/src/lib/languages/updateLanguageInAlgolia.spec.ts
+++ b/apis/api-media/src/lib/languages/updateLanguageInAlgolia.spec.ts
@@ -102,7 +102,7 @@ describe('updateLanguageInAlgolia', () => {
 
       expect(record).toEqual({
         objectID: '1234',
-        languageId: '1234',
+        languageId: 1234,
         bcp47: 'plu',
         iso3: 'plu',
         nameNative: 'Parikwaki',
@@ -113,6 +113,16 @@ describe('updateLanguageInAlgolia', () => {
           { value: 'Parikwaki', languageId: '1234', bcp47: 'plu' }
         ]
       })
+    })
+
+    it('emits languageId as a number while objectID stays a string', () => {
+      const record = buildAlgoliaLanguageRecord(createLanguage({ id: '143846' }))
+
+      // The rest of the index stores languageId numerically and arclight's
+      // AlgoliaLanguageHit types it as a number, so a string here would make
+      // the index heterogeneous.
+      expect(record.languageId).toBe(143846)
+      expect(record.objectID).toBe('143846')
     })
 
     it('only counts speakers from non-suggested country languages', () => {

--- a/apis/api-media/src/lib/languages/updateLanguageInAlgolia.spec.ts
+++ b/apis/api-media/src/lib/languages/updateLanguageInAlgolia.spec.ts
@@ -8,14 +8,19 @@ import {
 import {
   buildAlgoliaLanguageRecord,
   reindexLanguagesWithVideosInAlgolia,
+  removeLanguagesFromAlgolia,
   updateLanguageInAlgoliaFromMedia
 } from './updateLanguageInAlgolia'
 
 const saveObjectsSpy = vi.fn()
+const deleteObjectSpy = vi.fn()
+const deleteObjectsSpy = vi.fn()
 
 vi.mock('algoliasearch', () => ({
   algoliasearch: () => ({
-    saveObjects: saveObjectsSpy
+    saveObjects: saveObjectsSpy,
+    deleteObject: deleteObjectSpy,
+    deleteObjects: deleteObjectsSpy
   })
 }))
 
@@ -36,8 +41,15 @@ type AlgoliaLanguageInput = Parameters<typeof buildAlgoliaLanguageRecord>[0]
 // comes back is the narrower AlgoliaLanguageInput. These two helpers keep that
 // one unavoidable widening in a single named place instead of `any` at every
 // fixture.
-function mockFindUnique(language: AlgoliaLanguageInput | null): void {
-  languagesPrismaMock.language.findUnique.mockResolvedValue(language as never)
+// updateLanguageInAlgoliaFromMedia additionally selects hasVideos, which
+// defaults to true in the schema, so fixtures opt out rather than opt in.
+function mockFindUnique(
+  language: AlgoliaLanguageInput | null,
+  hasVideos = true
+): void {
+  languagesPrismaMock.language.findUnique.mockResolvedValue(
+    (language == null ? null : { ...language, hasVideos }) as never
+  )
 }
 
 function mockFindManyOnce(languages: AlgoliaLanguageInput[]): void {
@@ -94,6 +106,8 @@ describe('updateLanguageInAlgolia', () => {
     process.env.ALGOLIA_API_KEY = 'api-key'
     process.env.ALGOLIA_INDEX_LANGUAGES = 'languages-index'
     saveObjectsSpy.mockResolvedValue([{ taskID: 'task-1' }])
+    deleteObjectSpy.mockResolvedValue({ taskID: 'task-2' })
+    deleteObjectsSpy.mockResolvedValue([{ taskID: 'task-3' }])
   })
 
   describe('buildAlgoliaLanguageRecord', () => {
@@ -155,12 +169,31 @@ describe('updateLanguageInAlgolia', () => {
       })
     })
 
-    it('does not save when the language is not found', async () => {
+    it('removes the record instead of saving when the language is not found', async () => {
       mockFindUnique(null)
 
       await updateLanguageInAlgoliaFromMedia('missing')
 
       expect(saveObjectsSpy).not.toHaveBeenCalled()
+      expect(deleteObjectSpy).toHaveBeenCalledWith({
+        indexName: 'languages-index',
+        objectID: 'missing'
+      })
+    })
+
+    it('removes the record when hasVideos is false', async () => {
+      // Hiding a language is done by hand-editing hasVideos to false. Since the
+      // sync is otherwise upsert-only, skipping the write here would leave an
+      // already-indexed language searchable forever.
+      mockFindUnique(createLanguage(), false)
+
+      await updateLanguageInAlgoliaFromMedia('1234')
+
+      expect(saveObjectsSpy).not.toHaveBeenCalled()
+      expect(deleteObjectSpy).toHaveBeenCalledWith({
+        indexName: 'languages-index',
+        objectID: '1234'
+      })
     })
   })
 
@@ -219,6 +252,47 @@ describe('updateLanguageInAlgolia', () => {
       saveObjectsSpy.mockRejectedValueOnce(new Error('algolia unavailable'))
 
       await expect(reindexLanguagesWithVideosInAlgolia()).rejects.toThrow(
+        'algolia unavailable'
+      )
+    })
+  })
+
+  describe('removeLanguagesFromAlgolia', () => {
+    it('deletes the given object ids from the languages index', async () => {
+      const result = await removeLanguagesFromAlgolia(['20525', '117014'])
+
+      expect(result).toEqual({ removed: 2 })
+      expect(deleteObjectsSpy).toHaveBeenCalledWith({
+        indexName: 'languages-index',
+        objectIDs: ['20525', '117014'],
+        waitForTasks: true
+      })
+    })
+
+    it('does nothing and touches no client when there is nothing to remove', async () => {
+      const result = await removeLanguagesFromAlgolia([])
+
+      expect(result).toEqual({ removed: 0 })
+      expect(deleteObjectsSpy).not.toHaveBeenCalled()
+    })
+
+    it('splits removals into batches', async () => {
+      const ids = Array.from({ length: 1001 }, (_, index) => `id-${index}`)
+
+      const result = await removeLanguagesFromAlgolia(ids)
+
+      expect(result).toEqual({ removed: 1001 })
+      expect(deleteObjectsSpy).toHaveBeenCalledTimes(2)
+      expect(deleteObjectsSpy).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ objectIDs: ['id-1000'] })
+      )
+    })
+
+    it('propagates a delete failure so the caller exits non-zero', async () => {
+      deleteObjectsSpy.mockRejectedValueOnce(new Error('algolia unavailable'))
+
+      await expect(removeLanguagesFromAlgolia(['20525'])).rejects.toThrow(
         'algolia unavailable'
       )
     })

--- a/apis/api-media/src/lib/languages/updateLanguageInAlgolia.ts
+++ b/apis/api-media/src/lib/languages/updateLanguageInAlgolia.ts
@@ -66,7 +66,7 @@ type AlgoliaLanguage = Prisma.LanguageGetPayload<{
 // stays assignable to Algolia's `Record<string, unknown>` object type.
 type AlgoliaLanguageRecord = {
   objectID: string
-  languageId: string
+  languageId: number
   bcp47: string | null
   iso3: string | null
   nameNative: string
@@ -107,7 +107,12 @@ export function buildAlgoliaLanguageRecord(
 
   return {
     objectID: language.id,
-    languageId: language.id,
+    // Numeric to match every other record in the index and the `languageId:
+    // number` contract arclight declares in _resources/index.ts. Prisma types
+    // Language.id as a String, so it needs coercing here. Every id in the index
+    // is a numeric string, and arclight already relies on that via
+    // `Number(hit.objectID)`, so this cannot produce NaN in practice.
+    languageId: Number(language.id),
     bcp47: language.bcp47,
     iso3: language.iso3,
     nameNative,

--- a/apis/api-media/src/lib/languages/updateLanguageInAlgolia.ts
+++ b/apis/api-media/src/lib/languages/updateLanguageInAlgolia.ts
@@ -130,11 +130,22 @@ export async function updateLanguageInAlgoliaFromMedia(
     const { client, languagesIndex } = getAlgoliaLanguagesClient()
     const language = await languagesPrisma.language.findUnique({
       where: { id: languageId },
-      select: languageAlgoliaSelect
+      select: { ...languageAlgoliaSelect, hasVideos: true }
     })
 
-    if (language == null) {
-      logger?.warn(`language ${languageId} not found`)
+    // A language that is gone, or that hasVideos says must not be searchable,
+    // has to be removed rather than skipped. The sync is otherwise upsert-only,
+    // so a language that was indexed while hasVideos was true stays searchable
+    // forever once the flag is turned back off — which is how a language gets
+    // hidden today, by hand-editing hasVideos to false.
+    if (language == null || !language.hasVideos) {
+      logger?.info(
+        `removing language ${languageId} from algolia (${language == null ? 'not found' : 'hasVideos false'})`
+      )
+      await client.deleteObject({
+        indexName: languagesIndex,
+        objectID: languageId
+      })
       return
     }
 
@@ -195,4 +206,40 @@ export async function reindexLanguagesWithVideosInAlgolia(
   }
 
   return { count }
+}
+
+interface RemoveLanguagesResult {
+  removed: number
+}
+
+/**
+ * Removes the given languages from the Algolia languages index.
+ *
+ * Deleting an objectID that is not in the index is a no-op, so callers can pass
+ * every candidate rather than first working out which are actually indexed --
+ * the api-media Algolia key cannot browse, so that check is not available.
+ */
+export async function removeLanguagesFromAlgolia(
+  languageIds: string[],
+  logger?: Logger
+): Promise<RemoveLanguagesResult> {
+  if (languageIds.length === 0) return { removed: 0 }
+
+  const { client, languagesIndex } = getAlgoliaLanguagesClient()
+
+  for (let i = 0; i < languageIds.length; i += REINDEX_BATCH_SIZE) {
+    const batch = languageIds.slice(i, i + REINDEX_BATCH_SIZE)
+
+    await client.deleteObjects({
+      indexName: languagesIndex,
+      objectIDs: batch,
+      waitForTasks: true
+    })
+
+    logger?.info(
+      `removed ${Math.min(i + REINDEX_BATCH_SIZE, languageIds.length)} of ${languageIds.length} languages from algolia`
+    )
+  }
+
+  return { removed: languageIds.length }
 }

--- a/apis/api-media/src/scripts/algolia-helpers/reindex-languages-with-videos.ts
+++ b/apis/api-media/src/scripts/algolia-helpers/reindex-languages-with-videos.ts
@@ -1,25 +1,71 @@
 /**
- * Pushes every language with videos into the Algolia languages index.
+ * Reconciles the Algolia languages index with the languages database.
  *
- * Languages default to hasVideos: true in the schema, so the incremental sync
- * (which only fired on a false -> true transition) never pushed them and they
- * are missing from search. This repairs the index in one pass.
+ * Two passes:
+ *
+ * 1. Push every language with hasVideos: true. Languages default to
+ *    hasVideos: true in the schema, so the incremental sync (which only fired
+ *    on a false -> true transition) never pushed them and they are missing
+ *    from search.
+ * 2. Remove languages that have video content but hasVideos: false. Hiding a
+ *    language is done by hand-editing hasVideos to false, and the sync is
+ *    otherwise upsert-only, so a language indexed while the flag was true stays
+ *    searchable after it is turned back off.
+ *
+ * The second pass is scoped to languages that actually have variants because
+ * the api-media Algolia key cannot browse the index, so there is no way to ask
+ * which objectIDs are really in it. Languages that were never indexed are the
+ * overwhelming majority and deleting them would be ~90k pointless operations;
+ * deleting an absent objectID is a harmless no-op, so the smaller candidate set
+ * costs nothing in correctness.
  *
  * Errors are not caught: the run stops on the first failing batch and exits
- * non-zero. Re-running is safe, because saveObjects upserts derived data.
+ * non-zero. Re-running is safe, because saveObjects upserts derived data and
+ * deleteObjects is idempotent.
  *
  * Usage: nx run api-media:reindex-languages-algolia
  */
 
-import { reindexLanguagesWithVideosInAlgolia } from '../../lib/languages/updateLanguageInAlgolia'
+import { prisma as languagesPrisma } from '@core/prisma/languages/client'
+import { prisma as mediaPrisma } from '@core/prisma/media/client'
+
+import {
+  reindexLanguagesWithVideosInAlgolia,
+  removeLanguagesFromAlgolia
+} from '../../lib/languages/updateLanguageInAlgolia'
 import { logger } from '../../logger'
+
+/**
+ * Languages that have at least one video variant but are flagged
+ * hasVideos: false, so they must not be searchable.
+ */
+async function findSuppressedLanguageIds(): Promise<string[]> {
+  const withVariants = await mediaPrisma.videoVariant.groupBy({
+    by: ['languageId']
+  })
+  const candidateIds = withVariants.map(({ languageId }) => languageId)
+
+  if (candidateIds.length === 0) return []
+
+  const suppressed = await languagesPrisma.language.findMany({
+    where: { id: { in: candidateIds }, hasVideos: false },
+    select: { id: true }
+  })
+
+  return suppressed.map(({ id }) => id)
+}
 
 async function main(): Promise<void> {
   logger.info('reindexing languages with videos in algolia')
 
   const { count } = await reindexLanguagesWithVideosInAlgolia(logger)
 
-  logger.info(`reindexed ${count} languages in algolia`)
+  const suppressedIds = await findSuppressedLanguageIds()
+  const { removed } = await removeLanguagesFromAlgolia(suppressedIds, logger)
+
+  logger.info(
+    `reindexed ${count} languages and removed ${removed} suppressed languages in algolia`
+  )
 }
 
 if (require.main === module) {


### PR DESCRIPTION
Related to #9474 — the Algolia-side half of the `hasVideos` suppression problem. The operator-owned flag itself lands in #9482, which closes that issue.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Language records in search results now expose language IDs in a consistent numeric format.
  * Preserved existing string-based record identifiers for compatibility.
  * Removed outdated language records when languages are unavailable or no longer contain videos.
  * Improved language index synchronization to keep searchable results aligned with available video content.
* **Maintenance**
  * Enhanced language reindexing to report both updated and removed records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
