### PR TITLE
docs(context-map): mark T7 as no longer a live class (ENG-3704)

### DIFF
--- a/CONTEXT-MAP-intake.md
+++ b/CONTEXT-MAP-intake.md
@@ -28,7 +28,7 @@ ENG-3686). Distilled from 2 years of #nextsteps-bugs history (AI Bug-Intake Play
 - **T4** cache / revalidation / stale page
 - **T5** client-side state sync / optimistic-update drift
 - **T6** rendering / visual / UI display
-- **T7** editor / canvas block-state
+- **T7** editor / canvas block-state — _no longer a live class (confirmed 2026-08-13, ENG-3704); no intake section_
 - **T8** i18n / translation / language lists
 - **T9** template duplication / language-id collision — _resolved by removal (#9151); reports stale_
 - **T10** media / video / external-content pipeline


### PR DESCRIPTION
## What

One-line annotation in `CONTEXT-MAP-intake.md`: T7 (editor / canvas block-state) is marked **no longer a live class — no intake section**, same treatment as T9's resolved-by-removal note.

## Why

The ENG-3704 evidence audit found T7 was the only taxonomy type in the intake bot's initial scope with no shipped intake section and a purely inferred question sequence. Siyang confirmed (2026-08-13, on [ENG-3704](https://linear.app/jesus-film-project/issue/ENG-3704/worked-example-sessions)) that editor canvas block-state crashes are no longer a live bug class, so the annotation prevents agents reading the taxonomy from hunting for a section that intentionally doesn't exist — and tells ENG-3708 to omit T7 when absorbing the playbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated intake guidance to reflect that T7 is no longer an active failure category.
  * Removed the obsolete T7 intake section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->