### PR TITLE
docs(context-map): absorb playbook question sequences and readiness gates (ENG-3708)

### DIFF
--- a/CONTEXT-MAP-intake.md
+++ b/CONTEXT-MAP-intake.md
@@ -10,8 +10,8 @@ trigger-phrases that route a report to it. The ENG-3707 accessor fetches an area
 
 ## Areas (NextSteps)
 
-- **journeys-admin** (creator/editor surface) | domain: `apps/journeys-admin/CONTEXT.md` | intake: `apps/journeys-admin/CONTEXT-intake.md` | triggers: "block won't save", "changes not showing in preview", "have to refresh", "can't translate into <language>", "template won't let me customize", "transfer ownership", "analytics numbers are wrong", "historical data disappeared"
-- **journeys (published viewer)** (audience surface) | domain: `apps/journeys/CONTEXT.md` | intake: `apps/journeys/CONTEXT-intake.md` | triggers: "button doesn't go to the next card", "goes to the wrong card", "video won't load", "video is slow", "image is cropped / wrong fit", "can't click / can't type on the card", "looks wrong when published", "custom domain / embed not working"
+- **journeys-admin** (creator/editor surface) | domain: `apps/journeys-admin/CONTEXT.md` | intake: `apps/journeys-admin/CONTEXT-intake.md` | triggers: "block won't save", "changes not showing in preview", "have to refresh", "can't translate into <language>", "template won't let me customize", "transfer ownership", "analytics numbers are wrong", "historical data disappeared", "can't log in", "name shows Unknown", "works in incognito", "invite email never arrived", "I can see another team's data"
+- **journeys (published viewer)** (audience surface) | domain: `apps/journeys/CONTEXT.md` | intake: `apps/journeys/CONTEXT-intake.md` | triggers: "button doesn't go to the next card", "goes to the wrong card", "video won't load", "video is slow", "video plays the wrong language", "image is cropped / wrong fit", "can't click / can't type on the card", "looks wrong when published", "custom domain / embed not working"
 
 _The two intake surfaces are where bugs are **reported** (creator editor, audience viewer). The
 backend (`api-journeys`) and shared kernel (`libs/journeys/ui`) are reached via each surface's

--- a/CONTEXT-MAP-intake.md
+++ b/CONTEXT-MAP-intake.md
@@ -10,8 +10,8 @@ trigger-phrases that route a report to it. The ENG-3707 accessor fetches an area
 
 ## Areas (NextSteps)
 
-- **journeys-admin** (creator/editor surface) | domain: `apps/journeys-admin/CONTEXT.md` | intake: `apps/journeys-admin/CONTEXT-intake.md` | triggers: "block won't save", "changes not showing in preview", "have to refresh", "can't translate into <language>", "template won't let me customize", "transfer ownership", "analytics numbers are wrong", "historical data disappeared", "can't log in", "name shows Unknown", "works in incognito", "invite email never arrived", "I can see another team's data"
-- **journeys (published viewer)** (audience surface) | domain: `apps/journeys/CONTEXT.md` | intake: `apps/journeys/CONTEXT-intake.md` | triggers: "button doesn't go to the next card", "goes to the wrong card", "video won't load", "video is slow", "video plays the wrong language", "image is cropped / wrong fit", "can't click / can't type on the card", "looks wrong when published", "custom domain / embed not working"
+- **journeys-admin** (creator/editor surface) | domain: `apps/journeys-admin/CONTEXT.md` | intake: `apps/journeys-admin/CONTEXT-intake.md` | triggers: "block won't save", "changes not showing in preview", "have to refresh to see it", "can't translate into <language>", "template won't let me customize", "transfer ownership", "analytics numbers are wrong", "historical data disappeared", "can't log in", "name shows Unknown", "works in incognito", "invite email never arrived", "I can see another team's data"
+- **journeys (published viewer)** (audience surface) | domain: `apps/journeys/CONTEXT.md` | intake: `apps/journeys/CONTEXT-intake.md` | triggers: "button doesn't go to the next card", "goes to the wrong card", "video won't load", "video is slow to load", "video plays the wrong language", "image is cropped / wrong fit", "can't click / can't type on the card", "looks wrong when published", "custom domain / embed not working"
 
 _The two intake surfaces are where bugs are **reported** (creator editor, audience viewer). The
 backend (`api-journeys`) and shared kernel (`libs/journeys/ui`) are reached via each surface's

--- a/CONTEXT-MAP-intake.md
+++ b/CONTEXT-MAP-intake.md
@@ -28,7 +28,7 @@ ENG-3686). Distilled from 2 years of #nextsteps-bugs history (AI Bug-Intake Play
 - **T4** cache / revalidation / stale page
 - **T5** client-side state sync / optimistic-update drift
 - **T6** rendering / visual / UI display
-- **T7** editor / canvas block-state
+- **T7** editor / canvas block-state — _no longer a live class (confirmed 2026-08-13, ENG-3704); no intake section_
 - **T8** i18n / translation / language lists
 - **T9** template duplication / language-id collision — _resolved by removal (#9151); reports stale_
 - **T10** media / video / external-content pipeline

--- a/apps/journeys-admin/CONTEXT-intake.md
+++ b/apps/journeys-admin/CONTEXT-intake.md
@@ -208,11 +208,11 @@ product/env is confirmed.
 **Google Sheets Sync (real):** recurring **auth** (OAuth) issues and **sync reliability** (rows not
 created / sync not running).
 
-- Look first (fixer): OAuth connection → `apis/api-journeys/src/schema/integration/google/`
+- **Look first (fixer):** OAuth connection → `apis/api-journeys/src/schema/integration/google/`
   (`googleCreate.mutation.ts`, `googleUpdate.mutation.ts`); the sync worker →
   `apis/api-journeys/src/workers/googleSheetsSync/`; the row/header build + write-to-sheet →
   `apis/api-journeys/src/schema/googleSheetsSync/appendEventToGoogleSheets.ts`.
-- Handoff: OAuth reconnect → often human; sync-job defects → agent-able.
+- **Handoff:** OAuth reconnect → often human; sync-job defects → agent-able.
   **Growth Spaces:** dormant — no recent reports, believed unused. Map stays thin; route to a human.
 
 ## Email notifications

--- a/apps/journeys-admin/CONTEXT-intake.md
+++ b/apps/journeys-admin/CONTEXT-intake.md
@@ -14,15 +14,23 @@ trigger_phrases:
   - 'transfer ownership'
   - 'analytics numbers are wrong'
   - 'historical data disappeared'
+  - "can't log in"
+  - 'name shows Unknown'
+  - 'works in incognito'
+  - 'invite email never arrived'
+  - "I can see another team's data"
 type_tags: [T1, T2, T3, T4, T5, T8, T11]
-updated: 2026-07-15
+updated: 2026-08-13
 ---
 
 > Diagnosis layer for reported bugs in journeys-admin. Read this when triaging or debugging a
 > reported issue — not for feature work. Domain model: ./CONTEXT.md.
 > Failure types (T1–T11) reference the shared taxonomy in the repo-root AGENTS.md.
 > Each entry: what it looks like → the question that localizes it (reporter can answer) →
-> where the fixer looks first → whether it is safe for an autonomous agent.
+> the follow-up asks in order ("Then ask") → the readiness gate ("Ready when" — stop asking and
+> hand off once met) → where the fixer looks first → whether it is safe for an autonomous agent.
+> A working-vs-broken pair (row, URL, journey) is the highest-leverage artifact for any type —
+> ask for a counter-example whenever one could exist.
 
 ## Saving / preview / cache — T4 (cache) · T5 (optimistic drift)
 
@@ -34,6 +42,17 @@ edit shows in the Editor but not on the journey preview; a newly-created block n
 - refresh doesn't fix it, the change is gone → it genuinely didn't save
 - saved, correct in the Editor, wrong only in preview → rendering bug, not here — see
   `apps/journeys/CONTEXT-intake.md`
+  **Then ask (T4, stale view):** which exact edit/action went stale, and where the stale value shows
+  — the Editor itself, the admin list, or the published page? Before fixing, enumerate **every**
+  mutation that feeds the stale view (NES-1199: the template journey-count had nine feeding paths —
+  patching one is not a fix).
+  **Then ask (T5, optimistic drift):** what action across what — e.g. "moved journey A→B and it
+  shows in both until refresh." "Right only after refresh" plus a duplicate/leftover is the
+  optimistic-update tell; ask them to reproduce it across a second pair of collections.
+  **Ready when (T4):** "after mutation M, view V doesn't reflect it without a refresh" — M and V
+  named, all mutations feeding V enumerated, refresh-test result recorded.
+  **Ready when (T5):** "after action A there's a stale duplicate/missing item until refresh" —
+  refresh confirmed to fix it (Apollo client-cache bug).
   **Look first (fixer):** Network tab → the block create/update mutation (did it fire? payload
   correct? error code?); if it fired cleanly but the UI is stale → the manual cache `update` in
   `Editor/utils/useBlockCreateCommand` and `src/libs/blockCreateUpdate`.
@@ -47,6 +66,12 @@ forget. Any future migration can reintroduce it.
 rows — usually shortly after a schema change / migration.
 **Localizing question (reporter):** is it _all_ the old data and only the old data (recent fine)?
 That "all-historical-vs-recent-fine" split is the tell.
+**Then ask:** which list/view exactly; when were the missing rows created vs when the suspect
+migration/feature shipped; and one working row + one broken row (the working-vs-broken pair makes
+the cutoff date checkable).
+**Ready when:** "rows created before X are gone, rows after X are fine" is pinned on a named view,
+with a working-vs-broken row pair — the NULL-vs-false filter hypothesis is directly testable from
+there.
 **Look first (fixer):** the recent migration + the query filter on the affected list. Classic cause:
 a new column is `NULL` on existing rows but the query filters `column = false/true`, and `NULL`
 matches neither in SQL, so old rows vanish.
@@ -63,6 +88,12 @@ looks off.
 it to count (raw events vs unique users), and — for template families — "are you 100% sure this is
 the only journey from that template?" (aggregate-vs-child mix-ups are common).
 **Heuristic:** an analytics discrepancy is almost always a **name/unit mismatch, not bad math.**
+**Then ask:** which event on which card, and which goal/label it is expected to map to; was the
+journey **edited after** events were already collected; what date range is being read.
+**Ready when (for the human handoff):** aggregation level (template aggregate vs single journey) +
+expected semantics (raw events vs unique users) + the event→goal mapping + post-edit status are all
+recorded. Hand off even without a diagnosis — the goal here is a well-framed question for a human,
+not a root cause.
 **Look first (fixer):** drop-off % and time-on-card are computed **client-side** in
 `libs/journeys/ui/src/libs/useJourneyAnalyticsQuery/transformJourneyAnalytics/transformJourneyAnalytics.ts`
 (these are the numbers shown in reports); the underlying Plausible aggregates come from
@@ -83,6 +114,12 @@ the event-sync worker is `apis/api-journeys/src/workers/plausible/service.ts`.
 - template-gallery filter = the gallery's own list
   **Localizing question (reporter):** is the wrong/missing text the _journey's own content_ (blocks,
   titles) or the _app's UI/labels_? And which language?
+  **Then ask:** the exact language (name, plus the JF language ID if visible); which surface
+  (builder, AI-translate dialog, published journey, template gallery); team-scoped or public.
+  **Quota branch:** a suddenly **broad** failure — many/all languages at once, recent onset, usage
+  spike — points at provider quota/billing, not code → route to ops; don't debug the allowlist.
+  **Ready when:** the affected list + language ID + surface are identified and a quota/ops cause is
+  ruled out (an isolated language on one list, not a sudden broad failure).
   **Look first (fixer):** content translation → `apis/api-journeys/.../journeyAiTranslate.ts` +
   `translateCustomizationFields`. "Can't translate into language X" is usually X not being in
   `SUPPORTED_LANGUAGE_IDS` — the fix is often just adding the ID.
@@ -138,6 +175,12 @@ another team — it stays in its owning team. This is by design (a known limitat
 frequently reported as a bug.
 **High severity:** any cross-team data exposure ("I can see another team's data") → escalate to a
 human, never auto-fix.
+**Then ask:** the reporter's role (team member / manager / journey owner); what exactly is exposed
+or blocked; what they expected — i.e. which rule they think applies. For invite emails: the invitee
+address and whether a resend was tried.
+**Ready when (invite-email path):** "role R invited address X, no email arrived after a resend" —
+with addresses and rough timestamps. Cross-team exposure is never held to a gate: capture role +
+what's visible, then escalate immediately.
 **Look first (fixer):** the resolver auth guard + `UserJourney` / `UserTeam` roles in api-journeys;
 for invite emails, the invite-email pipeline.
 **Handoff:** how-to / access → human or FAQ; invite-email pipeline → agent-able; cross-team exposure
@@ -150,6 +193,11 @@ for invite emails, the invite-email pipeline.
 Auth** — the two can diverge (a record existing in one but not the other causes odd behavior).
 **Localizing question (reporter): does it work in incognito?** Incognito working ⇒ a stale token —
 the single most diagnostic auth signal.
+**Then ask:** the exact entry path (which page/button started sign-in); the account email and
+whether it has signed in successfully before; which product/environment (infer from the URL,
+challenge mismatches); and "is it still happening right now?" — many auth reports are transient.
+**Ready when:** the failing path reproduces reliably, the incognito result is recorded, and
+product/env is confirmed.
 **Look first (fixer):** `getAuthTokens.ts`, `checkConditionalRedirect.ts`, `verify.tsx`,
 `SignIn.tsx`, `findOrFetchUser.ts`, `firebase.ts` (the projection reconciliation lives around
 `findOrFetchUser`).

--- a/apps/journeys-admin/CONTEXT-intake.md
+++ b/apps/journeys-admin/CONTEXT-intake.md
@@ -55,7 +55,9 @@ edit shows in the Editor but not on the journey preview; a newly-created block n
   refresh confirmed to fix it (Apollo client-cache bug).
   **Look first (fixer):** Network tab → the block create/update mutation (did it fire? payload
   correct? error code?); if it fired cleanly but the UI is stale → the manual cache `update` in
-  `Editor/utils/useBlockCreateCommand` and `src/libs/blockCreateUpdate`.
+  `Editor/utils/useBlockCreateCommand` and `src/libs/blockCreateUpdate`. For non-block stale views
+  (admin lists, counts, the published page) there is no single pointer yet — start from the
+  enumerated feeding mutations and their cache `update` / `refetchQueries` handling.
   **Handoff:** agent-able.
 
 ## Data semantics / historical data disappearing — T1

--- a/apps/journeys/CONTEXT-intake.md
+++ b/apps/journeys/CONTEXT-intake.md
@@ -33,7 +33,7 @@ view (the "saved fine, wrong only in preview" branch handed over from journeys-a
 **Then ask:** an annotated screenshot (mark what's wrong on it); device/browser/OS **from the
 reporter** — never guess it from context (the guess is often wrong); cosmetic, or does it block
 interaction? For image bugs, also the image's file format.
-**Ready when:** annotated screenshot + the affected block/card + confirmed device/viewport.
+**Ready when:** annotated screenshot + the affected block/card + confirmed device/browser/OS/viewport.
 **Look first (fixer):** the shared Block Renderer + Card rendering in `libs/journeys/ui`
 (`src/components/BlockRenderer`, `src/components/Card/Card.tsx`) — the viewer injects different
 Wrappers than the admin, so a divergence is usually in render-mode / wrapper handling, not the data.

--- a/apps/journeys/CONTEXT-intake.md
+++ b/apps/journeys/CONTEXT-intake.md
@@ -14,7 +14,7 @@ trigger_phrases:
   - "can't click / can't type on the card"
   - 'looks wrong when published'
   - 'custom domain / embed not working'
-type_tags: [T6, T10]
+type_tags: [T6, T8, T10]
 updated: 2026-08-13
 ---
 
@@ -52,7 +52,7 @@ wires swipe/hotkey/button nav) → `libs/journeys/ui/src/libs/block/block.ts` (`
 `libs/journeys/ui/src/libs/action/getNextStepSlug.ts` (URL-level next-step).
 **Handoff:** authoring "didn't link it" → how-to; genuine resolution bug → agent-able.
 
-## Video won't load / slow to load — T10 (known weak spot)
+## Video won't load / slow to load / wrong language — T10 (known weak spot) · T8 (language variant)
 
 **Signatures:** videos don't load fast enough; a video won't play; background video doesn't render
 (notably first card / Android); a video plays in the wrong language.
@@ -64,12 +64,16 @@ device/OS/browser, and a **working-vs-failing** example if possible.
 recently (an edit, a new upload, "started Monday" → bisect to a deploy)? For wrong-language: which
 language is set on the video vs on the journey? A very old browser/OS (e.g. a 7-year-old WebKit) ⇒
 likely not-a-code-bug — close with an explanation.
-**Ready when:** a failing-vs-working URL pair + video source + device/OS/browser + any recent
-change are recorded.
+**Ready when:** video source + device/OS/browser + any recent change are recorded, plus a
+failing-vs-working URL pair where one exists — if every video fails, record that instead; it is
+the stronger signal.
 **Look first (fixer):** `libs/journeys/ui/src/components/Video/Video.tsx` (video.js setup, poster,
 autoplay/preload) → `libs/journeys/ui/src/components/Video/InitAndPlay/InitAndPlay.tsx` (init + play
 lifecycle — load/preload timing) → `libs/journeys/ui/src/components/Card/ContainedCover/BackgroundVideo/BackgroundVideo.tsx`
-(cover-card background video).
+(cover-card background video). Wrong-language playback is **not** in those playback files — the
+language variant is chosen by the block's `videoVariantLanguageId` (set in the editor), resolved in
+`apis/api-journeys/src/schema/block/video/video.ts` (fetches the video's content in that language)
+with variant-by-language selection in `apis/api-media/src/schema/video/video.ts`.
 **Handoff:** old browser/OS → not-a-code-bug (explain); genuine load bug → agent-able.
 
 ## Image fit (crop / fit / fill) — T6, expectation mismatch

--- a/apps/journeys/CONTEXT-intake.md
+++ b/apps/journeys/CONTEXT-intake.md
@@ -9,12 +9,13 @@ trigger_phrases:
   - 'goes to the wrong card'
   - "video won't load"
   - 'video is slow to load'
+  - 'video plays the wrong language'
   - 'image is cropped / wrong fit'
   - "can't click / can't type on the card"
   - 'looks wrong when published'
   - 'custom domain / embed not working'
 type_tags: [T6, T10]
-updated: 2026-07-15
+updated: 2026-08-13
 ---
 
 > Diagnosis layer for reported bugs in the **published journey viewer** (what the audience sees).
@@ -29,6 +30,10 @@ updated: 2026-07-15
 **Signatures:** a block/card renders correctly in the Editor but wrong only in the published/preview
 view (the "saved fine, wrong only in preview" branch handed over from journeys-admin).
 **Localizing question (reporter):** does it look right while editing but wrong once published?
+**Then ask:** an annotated screenshot (mark what's wrong on it); device/browser/OS **from the
+reporter** — never guess it from context (the guess is often wrong); cosmetic, or does it block
+interaction? For image bugs, also the image's file format.
+**Ready when:** annotated screenshot + the affected block/card + confirmed device/viewport.
 **Look first (fixer):** the shared Block Renderer + Card rendering in `libs/journeys/ui`
 (`src/components/BlockRenderer`, `src/components/Card/Card.tsx`) — the viewer injects different
 Wrappers than the admin, so a divergence is usually in render-mode / wrapper handling, not the data.
@@ -50,11 +55,17 @@ wires swipe/hotkey/button nav) → `libs/journeys/ui/src/libs/block/block.ts` (`
 ## Video won't load / slow to load — T10 (known weak spot)
 
 **Signatures:** videos don't load fast enough; a video won't play; background video doesn't render
-(notably first card / Android).
+(notably first card / Android); a video plays in the wrong language.
 **Status:** preloading is a **known weak spot** — attempted a few times, never much success. Treat
 "slow to load" as a known limitation, not a fresh regression, unless something clearly broke.
 **Localizing question (reporter):** which video source (library / YouTube / upload), which
 device/OS/browser, and a **working-vs-failing** example if possible.
+**Then ask:** background cover video or a video block — and is it the first card? What changed
+recently (an edit, a new upload, "started Monday" → bisect to a deploy)? For wrong-language: which
+language is set on the video vs on the journey? A very old browser/OS (e.g. a 7-year-old WebKit) ⇒
+likely not-a-code-bug — close with an explanation.
+**Ready when:** a failing-vs-working URL pair + video source + device/OS/browser + any recent
+change are recorded.
 **Look first (fixer):** `libs/journeys/ui/src/components/Video/Video.tsx` (video.js setup, poster,
 autoplay/preload) → `libs/journeys/ui/src/components/Video/InitAndPlay/InitAndPlay.tsx` (init + play
 lifecycle — load/preload timing) → `libs/journeys/ui/src/components/Card/ContainedCover/BackgroundVideo/BackgroundVideo.tsx`


### PR DESCRIPTION
Finishes migrating the **AI Bug-Intake Playbook** into the per-area bug-diagnosis map files, so the playbook can retire as a source of truth for the covered areas (journeys-admin editor, journeys viewer). Docs-only: the two `CONTEXT-intake.md` files + the intake index.

Linear: [ENG-3708](https://linear.app/jesus-film-project/issue/ENG-3708/absorb-playbook-into-map-sections)

## What was absorbed, per type

The shipped sections already had signatures, one localizing question, look-first pointers, and `Handoff:` verdicts. The consistent gap was the playbook's **follow-up question sequences** and **per-type readiness gates**, plus some reporter vocabulary. Each touched section gains a `**Then ask:**` line (the ordered follow-ups) and a `**Ready when:**` line (the gate), matching the existing bold-label format.

| Type | Status | What this PR adds |
|---|---|---|
| T1 data semantics | absorbed remainder | which view; rows-created vs migration-shipped timing; working-vs-broken row pair; gate |
| T2 auth/sign-in | absorbed remainder | entry path, email/used-before, product/env, still-happening; gate. New trigger phrases ("can't log in", "works in incognito", "name shows Unknown") |
| T3 analytics | absorbed remainder | event→goal mapping, edited-after-collection, date range; gate reframed as ready-for-**human**-handoff (stays route-to-human per grill) |
| T4/T5 cache & drift | absorbed remainder | enumerate-all-feeding-mutations (NES-1199's nine paths), stale-view location, two-collection repro; separate T4/T5 gates |
| T6 rendering | absorbed remainder | annotated screenshot, device from reporter (never guess), cosmetic-vs-functional, image file format; gate |
| T7 canvas crash | not live — no section | the one-line not-live note in the index taxonomy is **folded into this PR** (from #9475, which closes in favour of this one); no intake section, per Siyang's 2026-08-13 call |
| T8 i18n/translation | absorbed remainder | exact language + JF ID, surface, public-vs-team; **quota/ops branch** (broad sudden failure ⇒ provider quota, not code); gate. Playbook's stale list counts (~14/~32/~46/~25) deliberately **not** imported — grill-corrected four-list model kept |
| T9 duplication collision | retired — kept as-is | none (resolved by removal, #9151; stale-report note already shipped) |
| T10 media/video | absorbed remainder | wrong-language signature + branch (video language vs journey language), BG-cover vs block / first card, what-changed-recently, old-WebKit rule-out; gate. New trigger "video plays the wrong language" |
| T11 permissions/ACL | absorbed remainder | role, exposed-vs-blocked, expected policy, invite resend; gate for the agent-able invite-email path; cross-team exposure explicitly never gated — escalate immediately. New triggers ("invite email never arrived", "I can see another team's data") |

Also: a cross-cutting "working-vs-broken pair is the highest-leverage artifact" heuristic added to the admin file preamble; new trigger phrases synced frontmatter ↔ `CONTEXT-MAP-intake.md`; `updated:` bumped.

Follow-up commits folded in after review discussion:

- the **T7 not-live taxonomy note** from #9475 (that PR closes in favour of this one)
- the admin **Integrations** section's `- Look first (fixer):` / `- Handoff:` labels bolded to match `CONTEXT-MAP-contract.md`'s reserved-label format (flagged by the ENG-3707 validator; the viewer Chat/AI section's missing Handoff line is left as-is deliberately — unreleased feature)

## Deliberately not absorbed

Harness/procedure content that belongs to the intake agent (ENG-3706), not the map: the 5-bucket triage flow, universal questions, repro-access handling (§6), escalate-not-nag, FAQ-deflection candidate, and §7 open questions (audit found them answered or absorbed elsewhere). Where the ENG-3685 grill corrections conflict with the playbook, the corrections win throughout.

## Verification

- Every T1–T11 type is now either embodied in a core-area file or carries an explicit not-live/retired note (T7 note included in this PR, T9 already shipped).
- Frontmatter `code_paths` on touched files verified to exist; no code paths added or changed.
- No app code, no skill changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded intake guidance for authentication, identity, invitations, access, translations, analytics, historical data, caching, and optimistic updates.
  * Added clearer triage questions and readiness criteria for stale views, quota issues, sign-in problems, invite-email failures, and data visibility.
  * Improved video troubleshooting for language mismatches, rendering issues, video types, first-card behavior, and working versus failing examples.
  * Added trigger phrases, preview-specific refresh guidance, refreshed documentation dates, and clarified editor/canvas block-state classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
