### PR TITLE
chore: scoped lint-changed script + agent-gated pre-push lint hook (ENG-3691)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,9 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+# Agent-gated lint (ENG-3691): agents must lint what they push; manual human
+# pushes are not gated (run `pnpm lint:changed` yourself anytime). Escape
+# hatch for emergencies: `git push --no-verify`.
+if [ -n "${CLAUDECODE:-}" ] || [ -n "${CURSOR_AGENT:-}" ]; then
+  tools/scripts/lint-changed.sh --committed
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ This is an **Nx monorepo** (TypeScript). Apps live in `apps/`, GraphQL APIs in `
 
 Agent pushes are lint-gated. When an agent environment is detected (`CLAUDECODE`/`CURSOR_AGENT`), `.husky/pre-push` runs the `lint:changed` script on committed changes. It lints only changed files, scoped per workspace; full `nx lint` is far too slow. Manual human pushes skip the gate, and `git push --no-verify` skips everything. Run `pnpm lint:changed [--fix]` yourself anytime. [autofix.ci](https://autofix.ci) stays the CI backstop and owns Prettier formatting.
 
-Contract of the gate: it lints the branch diff against a freshly fetched `origin/main` — not the literal ref-range of the push. Pushes to other remotes or forks are judged against `origin/main` all the same.
+Contract of the gate: it lints the branch diff against `origin/main`, refreshed when the network allows. It does not lint the literal ref-range of the push. Forks, other remotes, and branches cut from `stage` are all judged against `origin/main`, so a `stage`-cut branch may over-lint (use `git push --no-verify` if that blocks you). `LINT_CHANGED_JOBS` caps parallel workspaces (default 4).
 
 ### Documented Solutions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ This is an **Nx monorepo** (TypeScript). Apps live in `apps/`, GraphQL APIs in `
 
 ### Lint before push
 
-Agents are lint-gated at push: `.husky/pre-push` runs `pnpm lint:changed --committed` (scoped ESLint over changed files only; full `nx lint` is far too slow) when an agent environment is detected (`CLAUDECODE`/`CURSOR_AGENT`) — manual human pushes skip it, and `git push --no-verify` skips everything. Run `pnpm lint:changed [--fix]` yourself anytime; [autofix.ci](https://autofix.ci) stays the CI backstop and owns Prettier formatting.
+Agent pushes are lint-gated. When an agent environment is detected (`CLAUDECODE`/`CURSOR_AGENT`), `.husky/pre-push` runs the `lint:changed` script on committed changes. It lints only changed files, scoped per workspace; full `nx lint` is far too slow. Manual human pushes skip the gate, and `git push --no-verify` skips everything. Run `pnpm lint:changed [--fix]` yourself anytime. [autofix.ci](https://autofix.ci) stays the CI backstop and owns Prettier formatting.
 
 ### Documented Solutions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,10 @@ This is an **Nx monorepo** (TypeScript). Apps live in `apps/`, GraphQL APIs in `
 - Use descriptive variable and function/const names.
 - Define TypeScript types; avoid `any`.
 
+### Lint before commit
+
+Run `pnpm lint:changed` before committing — scoped ESLint over changed files only (`--fix` applies autofixes; full `nx lint` is far too slow). Deliberately not a git hook; [autofix.ci](https://autofix.ci) stays the CI backstop and owns Prettier formatting.
+
 ### Documented Solutions
 
 The context map (`CONTEXT.md`, and `CONTEXT-intake.md` when diagnosing) is the primary knowledge source — rely on it by default. `docs/solutions/` is a **secondary, opt-in** archive of past problem write-ups (bugs, best practices, workflow patterns), organized by category with descriptive filenames and YAML frontmatter (`module`, `tags`, `problem_type`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,9 +31,9 @@ This is an **Nx monorepo** (TypeScript). Apps live in `apps/`, GraphQL APIs in `
 - Use descriptive variable and function/const names.
 - Define TypeScript types; avoid `any`.
 
-### Lint before commit
+### Lint before push
 
-Run `pnpm lint:changed` before committing — scoped ESLint over changed files only (`--fix` applies autofixes; full `nx lint` is far too slow). Deliberately not a git hook; [autofix.ci](https://autofix.ci) stays the CI backstop and owns Prettier formatting.
+Agents are lint-gated at push: `.husky/pre-push` runs `pnpm lint:changed --committed` (scoped ESLint over changed files only; full `nx lint` is far too slow) when an agent environment is detected (`CLAUDECODE`/`CURSOR_AGENT`) — manual human pushes skip it, and `git push --no-verify` skips everything. Run `pnpm lint:changed [--fix]` yourself anytime; [autofix.ci](https://autofix.ci) stays the CI backstop and owns Prettier formatting.
 
 ### Documented Solutions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,8 @@ This is an **Nx monorepo** (TypeScript). Apps live in `apps/`, GraphQL APIs in `
 
 Agent pushes are lint-gated. When an agent environment is detected (`CLAUDECODE`/`CURSOR_AGENT`), `.husky/pre-push` runs the `lint:changed` script on committed changes. It lints only changed files, scoped per workspace; full `nx lint` is far too slow. Manual human pushes skip the gate, and `git push --no-verify` skips everything. Run `pnpm lint:changed [--fix]` yourself anytime. [autofix.ci](https://autofix.ci) stays the CI backstop and owns Prettier formatting.
 
+Contract of the gate: it lints the branch diff against a freshly fetched `origin/main` — not the literal ref-range of the push. Pushes to other remotes or forks are judged against `origin/main` all the same.
+
 ### Documented Solutions
 
 The context map (`CONTEXT.md`, and `CONTEXT-intake.md` when diagnosing) is the primary knowledge source — rely on it by default. `docs/solutions/` is a **secondary, opt-in** archive of past problem write-ups (bugs, best practices, workflow patterns), organized by category with descriptive filenames and YAML frontmatter (`module`, `tags`, `problem_type`).

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "demo": "nx demo",
     "lint": "nx run-many --target=lint",
     "lint:fix": "nx run-many --target=lint --fix",
+    "lint:changed": "tools/scripts/lint-changed.sh",
     "prettier": "npx prettier .",
     "prettier:fix": "npx prettier . --write",
     "e2e": "nx e2e",

--- a/tools/scripts/lint-changed.sh
+++ b/tools/scripts/lint-changed.sh
@@ -27,11 +27,12 @@ FIX_ARGS=()
 for arg in "$@"; do
   case "$arg" in
     --staged | --committed)
-      if [ "$MODE" != "all" ]; then
+      new_mode="${arg#--}"
+      if [ "$MODE" != "all" ] && [ "$MODE" != "$new_mode" ]; then
         echo "conflicting options: --$MODE and $arg" >&2
         exit 2
       fi
-      MODE="${arg#--}"
+      MODE="$new_mode"
       ;;
     --fix) FIX_ARGS=(--fix) ;;
     *)
@@ -41,6 +42,12 @@ for arg in "$@"; do
       ;;
   esac
 done
+
+MAX_JOBS=${LINT_CHANGED_JOBS:-4}
+if ! [ "$MAX_JOBS" -gt 0 ] 2>/dev/null; then
+  echo "LINT_CHANGED_JOBS must be a positive integer (got '$MAX_JOBS')" >&2
+  exit 2
+fi
 
 diff_names() {
   git diff --name-only --diff-filter=ACMR "$@"
@@ -130,19 +137,19 @@ fi
 OUTDIR=$(mktemp -d)
 trap 'rm -rf "$OUTDIR"' EXIT
 
-MAX_JOBS=${LINT_CHANGED_JOBS:-4}
 i=0
 for ws in "${WS_LIST[@]}"; do
   ws_files=()
   while IFS= read -r f; do ws_files+=("$f"); done <<<"${WS_FILES[$i]}"
+  tag="$i-${ws//\//-}"
   echo "linting $ws (${#ws_files[@]} file(s))..."
   while [ "$(jobs -rp | wc -l)" -ge "$MAX_JOBS" ]; do sleep 0.2; done
   (
     set +e
     pnpm exec eslint --config "$ws/eslint.config.mjs" --no-warn-ignored \
       ${FIX_ARGS[@]+"${FIX_ARGS[@]}"} "${ws_files[@]}" \
-      >"$OUTDIR/$i-${ws//\//-}.out" 2>&1
-    echo $? >"$OUTDIR/$i-${ws//\//-}.code"
+      >"$OUTDIR/$tag.out" 2>&1
+    echo $? >"$OUTDIR/$tag.code"
   ) &
   i=$((i + 1))
 done

--- a/tools/scripts/lint-changed.sh
+++ b/tools/scripts/lint-changed.sh
@@ -7,13 +7,14 @@
 # pattern base is the cwd). Workspaces are linted in parallel.
 #
 # Usage:
-#   tools/scripts/lint-changed.sh           # all changes vs merge-base with origin/main (incl. uncommitted + untracked)
-#   tools/scripts/lint-changed.sh --staged  # staged files only (lints their working-tree contents)
-#   tools/scripts/lint-changed.sh --fix     # apply autofixes
+#   tools/scripts/lint-changed.sh              # all changes vs merge-base with origin/main (incl. uncommitted + untracked)
+#   tools/scripts/lint-changed.sh --committed  # committed changes only (what a push would send)
+#   tools/scripts/lint-changed.sh --staged     # staged files only (lints their working-tree contents)
+#   tools/scripts/lint-changed.sh --fix        # apply autofixes
 #
 # Expect roughly 5-20s per touched workspace: type-aware lint rules build a
-# TypeScript program per workspace on every run. That is why this is a manual
-# pre-commit step, not a git hook.
+# TypeScript program per workspace on every run. That is why the only hook on
+# this is the agent-gated pre-push (.husky/pre-push), not a per-commit hook.
 
 set -u
 
@@ -24,10 +25,11 @@ FIX=""
 for arg in "$@"; do
   case "$arg" in
     --staged) MODE=staged ;;
+    --committed) MODE=committed ;;
     --fix) FIX="--fix" ;;
     *)
       echo "unknown option: $arg" >&2
-      echo "usage: tools/scripts/lint-changed.sh [--staged] [--fix]" >&2
+      echo "usage: tools/scripts/lint-changed.sh [--staged|--committed] [--fix]" >&2
       exit 2
       ;;
   esac
@@ -35,6 +37,9 @@ done
 
 if [ "$MODE" = "staged" ]; then
   FILES=$(git diff --name-only --cached --diff-filter=ACMR)
+elif [ "$MODE" = "committed" ]; then
+  BASE=$(git merge-base HEAD origin/main) || exit 1
+  FILES=$(git diff --name-only --diff-filter=ACMR "$BASE" HEAD)
 else
   BASE=$(git merge-base HEAD origin/main) || exit 1
   FILES=$(

--- a/tools/scripts/lint-changed.sh
+++ b/tools/scripts/lint-changed.sh
@@ -4,13 +4,14 @@
 # Groups files by their nearest eslint.config.mjs and runs ESLint once per
 # workspace from the repo root with --config, which is how flat-config path
 # patterns like 'apps/journeys-admin/**' resolve correctly (with --config the
-# pattern base is the cwd). Workspaces are linted in parallel.
+# pattern base is the cwd). Workspaces are linted in parallel (capped at
+# LINT_CHANGED_JOBS, default 4 — each run builds its own TypeScript program).
 #
 # Usage:
 #   tools/scripts/lint-changed.sh              # all changes vs merge-base with origin/main (incl. uncommitted + untracked)
-#   tools/scripts/lint-changed.sh --committed  # committed changes only (what a push would send); refreshes origin/main first
+#   tools/scripts/lint-changed.sh --committed  # committed changes vs origin/main (refreshed first); what the pre-push gate lints
 #   tools/scripts/lint-changed.sh --staged     # staged files only (lints their working-tree contents)
-#   tools/scripts/lint-changed.sh --fix        # apply autofixes (after --staged --fix, re-stage the fixed files yourself)
+#   tools/scripts/lint-changed.sh --fix        # apply autofixes to the working tree (re-stage/re-commit them yourself)
 #
 # Expect roughly 5-20s per touched workspace: type-aware lint rules build a
 # TypeScript program per workspace on every run. That is why the only hook on
@@ -18,7 +19,8 @@
 
 set -euo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
 
 MODE=all
 FIX_ARGS=()
@@ -40,9 +42,14 @@ for arg in "$@"; do
   esac
 done
 
+diff_names() {
+  git diff --name-only --diff-filter=ACMR "$@"
+}
+
 resolve_base() {
   if [ "$MODE" = "committed" ]; then
-    # refresh the ref the push will be judged against; tolerate being offline
+    # refresh the ref the gate lints against; tolerate being offline (an
+    # offline push would fail moments later anyway)
     git fetch origin main --quiet 2>/dev/null || true
   fi
   if ! BASE=$(git merge-base HEAD origin/main 2>/dev/null); then
@@ -53,15 +60,15 @@ resolve_base() {
 }
 
 if [ "$MODE" = "staged" ]; then
-  RAW=$(git diff --name-only --cached --diff-filter=ACMR)
+  RAW=$(diff_names --cached)
 elif [ "$MODE" = "committed" ]; then
   resolve_base
-  RAW=$(git diff --name-only --diff-filter=ACMR "$BASE" HEAD)
+  RAW=$(diff_names "$BASE" HEAD)
 else
   resolve_base
   RAW=$(
     {
-      git diff --name-only --diff-filter=ACMR "$BASE"
+      diff_names "$BASE"
       git ls-files --others --exclude-standard
     } | sort -u
   )
@@ -123,17 +130,19 @@ fi
 OUTDIR=$(mktemp -d)
 trap 'rm -rf "$OUTDIR"' EXIT
 
+MAX_JOBS=${LINT_CHANGED_JOBS:-4}
 i=0
 for ws in "${WS_LIST[@]}"; do
   ws_files=()
   while IFS= read -r f; do ws_files+=("$f"); done <<<"${WS_FILES[$i]}"
-  tag=${ws//\//-}
   echo "linting $ws (${#ws_files[@]} file(s))..."
+  while [ "$(jobs -rp | wc -l)" -ge "$MAX_JOBS" ]; do sleep 0.2; done
   (
     set +e
     pnpm exec eslint --config "$ws/eslint.config.mjs" --no-warn-ignored \
-      ${FIX_ARGS[@]+"${FIX_ARGS[@]}"} "${ws_files[@]}" >"$OUTDIR/$tag.out" 2>&1
-    echo $? >"$OUTDIR/$tag.code"
+      ${FIX_ARGS[@]+"${FIX_ARGS[@]}"} "${ws_files[@]}" \
+      >"$OUTDIR/$i-${ws//\//-}.out" 2>&1
+    echo $? >"$OUTDIR/$i-${ws//\//-}.code"
   ) &
   i=$((i + 1))
 done
@@ -141,12 +150,20 @@ done
 wait
 
 FAILED=0
+i=0
 for ws in "${WS_LIST[@]}"; do
-  tag=${ws//\//-}
-  cat "$OUTDIR/$tag.out"
-  if [ "$(cat "$OUTDIR/$tag.code")" != "0" ]; then
-    FAILED=1
+  tag="$i-${ws//\//-}"
+  if [ -f "$OUTDIR/$tag.out" ]; then
+    cat "$OUTDIR/$tag.out"
   fi
+  code=$(cat "$OUTDIR/$tag.code" 2>/dev/null || echo missing)
+  if [ "$code" != "0" ]; then
+    FAILED=1
+    if [ "$code" = "missing" ]; then
+      echo "🛑 - lint worker for $ws produced no result (killed?); treating as failure"
+    fi
+  fi
+  i=$((i + 1))
 done
 
 if [ "$FAILED" = "1" ]; then

--- a/tools/scripts/lint-changed.sh
+++ b/tools/scripts/lint-changed.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+# Lint only changed files (full `nx lint` is far too slow for commit-time feedback).
+# Groups files by their nearest eslint.config.mjs and runs ESLint once per
+# workspace from the repo root with --config, which is how flat-config path
+# patterns like 'apps/journeys-admin/**' resolve correctly (with --config the
+# pattern base is the cwd). Workspaces are linted in parallel.
+#
+# Usage:
+#   tools/scripts/lint-changed.sh           # all changes vs merge-base with origin/main (incl. uncommitted + untracked)
+#   tools/scripts/lint-changed.sh --staged  # staged files only (lints their working-tree contents)
+#   tools/scripts/lint-changed.sh --fix     # apply autofixes
+#
+# Expect roughly 5-20s per touched workspace: type-aware lint rules build a
+# TypeScript program per workspace on every run. That is why this is a manual
+# pre-commit step, not a git hook.
+
+set -u
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+MODE=all
+FIX=""
+for arg in "$@"; do
+  case "$arg" in
+    --staged) MODE=staged ;;
+    --fix) FIX="--fix" ;;
+    *)
+      echo "unknown option: $arg" >&2
+      echo "usage: tools/scripts/lint-changed.sh [--staged] [--fix]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$MODE" = "staged" ]; then
+  FILES=$(git diff --name-only --cached --diff-filter=ACMR)
+else
+  BASE=$(git merge-base HEAD origin/main) || exit 1
+  FILES=$(
+    (
+      git diff --name-only --diff-filter=ACMR "$BASE"
+      git ls-files --others --exclude-standard
+    ) | sort -u
+  )
+fi
+
+LINTABLE=""
+SKIPPED=""
+for f in $FILES; do
+  case "$f" in
+    *.ts | *.tsx | *.js | *.jsx | *.cjs | *.mjs) ;;
+    *) continue ;;
+  esac
+  [ -f "$f" ] || continue
+  # find the nearest workspace eslint config above the file
+  d=$(dirname "$f")
+  ws=""
+  while [ "$d" != "." ] && [ "$d" != "/" ]; do
+    if [ -f "$d/eslint.config.mjs" ]; then
+      ws="$d"
+      break
+    fi
+    d=$(dirname "$d")
+  done
+  if [ -z "$ws" ]; then
+    SKIPPED="$SKIPPED $f"
+    continue
+  fi
+  LINTABLE="$LINTABLE$ws|$f
+"
+done
+
+if [ -n "$SKIPPED" ]; then
+  echo "skipped (no workspace eslint.config.mjs):"
+  for f in $SKIPPED; do echo "  $f"; done
+fi
+
+WORKSPACES=$(printf '%s' "$LINTABLE" | cut -d'|' -f1 | sort -u)
+if [ -z "$WORKSPACES" ]; then
+  echo "✅ - no changed lintable files"
+  exit 0
+fi
+
+OUTDIR=$(mktemp -d)
+trap 'rm -rf "$OUTDIR"' EXIT
+
+i=0
+PIDS=""
+for ws in $WORKSPACES; do
+  i=$((i + 1))
+  ws_files=$(printf '%s' "$LINTABLE" | grep "^$ws|" | cut -d'|' -f2-)
+  echo "linting $ws ($(echo "$ws_files" | wc -l | tr -d ' ') file(s))..."
+  (
+    # shellcheck disable=SC2086 # ws_files is a list of paths without spaces
+    pnpm exec eslint --config "$ws/eslint.config.mjs" --no-warn-ignored $FIX $ws_files \
+      >"$OUTDIR/$i.out" 2>&1
+    echo $? >"$OUTDIR/$i.code"
+  ) &
+  PIDS="$PIDS $!"
+done
+
+wait $PIDS
+
+FAILED=0
+for out in "$OUTDIR"/*.out; do
+  cat "$out"
+  code=$(cat "${out%.out}.code")
+  [ "$code" = "0" ] || FAILED=1
+done
+
+if [ "$FAILED" = "1" ]; then
+  echo "🛑 - lint failed (file and rule named above); fix or rerun with --fix for autofixable issues"
+  exit 1
+fi
+echo "✅ - lint passed"

--- a/tools/scripts/lint-changed.sh
+++ b/tools/scripts/lint-changed.sh
@@ -8,25 +8,30 @@
 #
 # Usage:
 #   tools/scripts/lint-changed.sh              # all changes vs merge-base with origin/main (incl. uncommitted + untracked)
-#   tools/scripts/lint-changed.sh --committed  # committed changes only (what a push would send)
+#   tools/scripts/lint-changed.sh --committed  # committed changes only (what a push would send); refreshes origin/main first
 #   tools/scripts/lint-changed.sh --staged     # staged files only (lints their working-tree contents)
-#   tools/scripts/lint-changed.sh --fix        # apply autofixes
+#   tools/scripts/lint-changed.sh --fix        # apply autofixes (after --staged --fix, re-stage the fixed files yourself)
 #
 # Expect roughly 5-20s per touched workspace: type-aware lint rules build a
 # TypeScript program per workspace on every run. That is why the only hook on
 # this is the agent-gated pre-push (.husky/pre-push), not a per-commit hook.
 
-set -u
+set -euo pipefail
 
-cd "$(git rev-parse --show-toplevel)" || exit 1
+cd "$(git rev-parse --show-toplevel)"
 
 MODE=all
-FIX=""
+FIX_ARGS=()
 for arg in "$@"; do
   case "$arg" in
-    --staged) MODE=staged ;;
-    --committed) MODE=committed ;;
-    --fix) FIX="--fix" ;;
+    --staged | --committed)
+      if [ "$MODE" != "all" ]; then
+        echo "conflicting options: --$MODE and $arg" >&2
+        exit 2
+      fi
+      MODE="${arg#--}"
+      ;;
+    --fix) FIX_ARGS=(--fix) ;;
     *)
       echo "unknown option: $arg" >&2
       echo "usage: tools/scripts/lint-changed.sh [--staged|--committed] [--fix]" >&2
@@ -35,30 +40,45 @@ for arg in "$@"; do
   esac
 done
 
+resolve_base() {
+  if [ "$MODE" = "committed" ]; then
+    # refresh the ref the push will be judged against; tolerate being offline
+    git fetch origin main --quiet 2>/dev/null || true
+  fi
+  if ! BASE=$(git merge-base HEAD origin/main 2>/dev/null); then
+    echo "🛑 - could not resolve merge-base with origin/main" >&2
+    echo "    run \`git fetch origin main\` and check that the 'origin' remote exists" >&2
+    exit 1
+  fi
+}
+
 if [ "$MODE" = "staged" ]; then
-  FILES=$(git diff --name-only --cached --diff-filter=ACMR)
+  RAW=$(git diff --name-only --cached --diff-filter=ACMR)
 elif [ "$MODE" = "committed" ]; then
-  BASE=$(git merge-base HEAD origin/main) || exit 1
-  FILES=$(git diff --name-only --diff-filter=ACMR "$BASE" HEAD)
+  resolve_base
+  RAW=$(git diff --name-only --diff-filter=ACMR "$BASE" HEAD)
 else
-  BASE=$(git merge-base HEAD origin/main) || exit 1
-  FILES=$(
-    (
+  resolve_base
+  RAW=$(
+    {
       git diff --name-only --diff-filter=ACMR "$BASE"
       git ls-files --others --exclude-standard
-    ) | sort -u
+    } | sort -u
   )
 fi
 
-LINTABLE=""
-SKIPPED=""
-for f in $FILES; do
+# group lintable files by their nearest workspace eslint config; parallel
+# arrays because macOS ships bash 3.2 (no associative arrays)
+WS_LIST=()
+WS_FILES=() # newline-joined file list per WS_LIST entry
+SKIPPED=()
+while IFS= read -r f; do
+  if [ -z "$f" ]; then continue; fi
   case "$f" in
     *.ts | *.tsx | *.js | *.jsx | *.cjs | *.mjs) ;;
     *) continue ;;
   esac
-  [ -f "$f" ] || continue
-  # find the nearest workspace eslint config above the file
+  if [ ! -f "$f" ]; then continue; fi
   d=$(dirname "$f")
   ws=""
   while [ "$d" != "." ] && [ "$d" != "/" ]; do
@@ -69,20 +89,33 @@ for f in $FILES; do
     d=$(dirname "$d")
   done
   if [ -z "$ws" ]; then
-    SKIPPED="$SKIPPED $f"
+    SKIPPED+=("$f")
     continue
   fi
-  LINTABLE="$LINTABLE$ws|$f
-"
-done
+  idx=-1
+  i=0
+  for existing in ${WS_LIST[@]+"${WS_LIST[@]}"}; do
+    if [ "$existing" = "$ws" ]; then
+      idx=$i
+      break
+    fi
+    i=$((i + 1))
+  done
+  if [ "$idx" -eq -1 ]; then
+    WS_LIST+=("$ws")
+    WS_FILES+=("$f")
+  else
+    WS_FILES[$idx]="${WS_FILES[$idx]}
+$f"
+  fi
+done <<<"$RAW"
 
-if [ -n "$SKIPPED" ]; then
+if [ ${#SKIPPED[@]} -gt 0 ]; then
   echo "skipped (no workspace eslint.config.mjs):"
-  for f in $SKIPPED; do echo "  $f"; done
+  printf '  %s\n' "${SKIPPED[@]}"
 fi
 
-WORKSPACES=$(printf '%s' "$LINTABLE" | cut -d'|' -f1 | sort -u)
-if [ -z "$WORKSPACES" ]; then
+if [ ${#WS_LIST[@]} -eq 0 ]; then
   echo "✅ - no changed lintable files"
   exit 0
 fi
@@ -91,27 +124,29 @@ OUTDIR=$(mktemp -d)
 trap 'rm -rf "$OUTDIR"' EXIT
 
 i=0
-PIDS=""
-for ws in $WORKSPACES; do
-  i=$((i + 1))
-  ws_files=$(printf '%s' "$LINTABLE" | grep "^$ws|" | cut -d'|' -f2-)
-  echo "linting $ws ($(echo "$ws_files" | wc -l | tr -d ' ') file(s))..."
+for ws in "${WS_LIST[@]}"; do
+  ws_files=()
+  while IFS= read -r f; do ws_files+=("$f"); done <<<"${WS_FILES[$i]}"
+  tag=${ws//\//-}
+  echo "linting $ws (${#ws_files[@]} file(s))..."
   (
-    # shellcheck disable=SC2086 # ws_files is a list of paths without spaces
-    pnpm exec eslint --config "$ws/eslint.config.mjs" --no-warn-ignored $FIX $ws_files \
-      >"$OUTDIR/$i.out" 2>&1
-    echo $? >"$OUTDIR/$i.code"
+    set +e
+    pnpm exec eslint --config "$ws/eslint.config.mjs" --no-warn-ignored \
+      ${FIX_ARGS[@]+"${FIX_ARGS[@]}"} "${ws_files[@]}" >"$OUTDIR/$tag.out" 2>&1
+    echo $? >"$OUTDIR/$tag.code"
   ) &
-  PIDS="$PIDS $!"
+  i=$((i + 1))
 done
 
-wait $PIDS
+wait
 
 FAILED=0
-for out in "$OUTDIR"/*.out; do
-  cat "$out"
-  code=$(cat "${out%.out}.code")
-  [ "$code" = "0" ] || FAILED=1
+for ws in "${WS_LIST[@]}"; do
+  tag=${ws//\//-}
+  cat "$OUTDIR/$tag.out"
+  if [ "$(cat "$OUTDIR/$tag.code")" != "0" ]; then
+    FAILED=1
+  fi
 done
 
 if [ "$FAILED" = "1" ]; then


### PR DESCRIPTION
Closes ENG-3691.

## What

Two pieces:

1. `pnpm lint:changed` (`tools/scripts/lint-changed.sh`): scoped ESLint over changed files only, grouped by nearest `eslint.config.mjs` and run once per workspace from the repo root with `--config`, so flat-config path patterns resolve exactly as under `nx lint`. Workspaces lint in parallel, capped at `LINT_CHANGED_JOBS` (default 4). Modes: default (all changes vs merge-base with `origin/main`, incl. uncommitted/untracked), `--committed` (branch commits vs a freshly fetched `origin/main` — what the pre-push gate lints), `--staged`, `--fix` (fixes the working tree; re-stage/re-commit yourself). Conflicting mode flags exit 2.
2. An **agent-gated pre-push hook** (`.husky/pre-push`): when an agent environment is detected (`CLAUDECODE`/`CURSOR_AGENT`), the push is blocked until `lint:changed --committed` passes. Manual human pushes are not gated — for humans the script is advisory, documented in root `AGENTS.md`.

## Why this shape (measured)

The ticket deferred hook-vs-convention to measured efficiency. Timings on real files (M-series Mac, ESLint 9 flat config, type-aware rules via `projectService`):

| Run | Time |
| --- | --- |
| 2 files in `apps/journeys-admin`, cold | 21.5s |
| 1 file in `apps/journeys-admin`, warm | 7.4s |
| 1 file in `apis/api-journeys`, warm | 5.2s |
| Two workspaces, parallel, incl. `origin/main` fetch | 7.0s wall |
| Two workspaces forced serial (`LINT_CHANGED_JOBS=1`) | 14.4s |
| Non-agent push (hook skips) | <1s |
| No lintable changes (incl. fetch) | <1s |

The cost is the per-workspace TypeScript program build for type-aware rules — paid on every invocation regardless of file count. ~8–20s (tens of seconds cold) is too slow for a per-commit hook (the ticket's "few seconds" bar), but fine once per push, and only agents — whose loops this is for — are forced through it. No `lint-staged`, zero new dependencies.

## Contract and edge cases

- `--committed` refreshes `origin/main` when the network allows (best-effort `git fetch origin main --quiet`; offline, the base may be stale — but an offline push fails moments later anyway) before computing the merge-base, so a stale clone can't widen the diff onto unrelated code. If the merge-base still can't resolve (fresh clone, missing remote), it exits with an actionable message instead of a bare git error.
- The gate deliberately lints the branch diff vs `origin/main`, not the literal ref-range of the push; pushes to forks/other remotes — and branches cut from `stage`, which may over-lint — are judged against `origin/main` all the same (documented in `AGENTS.md`). `LINT_CHANGED_JOBS` caps parallel workspaces (default 4; validated).
- Filenames with spaces/glob chars are handled (array-based throughout, `set -euo pipefail`); a lint worker dying without a result fails the run loudly rather than silently passing the gate.
- Warnings don't fail (parity with CI's `nx lint`). Files outside any workspace config are printed as "skipped" — parity with `nx lint`, which only lints projects.

## Verified

- Deliberate error-severity violation (incl. in a `space test.tsx` filename), agent env set → push blocked, output names file/line/rule; `--fix` → passes.
- Same push without agent env → sails through in <1s.
- Missing `origin/main` (scratch repo) → actionable failure message.
- `--staged --committed` → conflict error, exit 2. `LINT_CHANGED_JOBS=1` serializes (14.4s vs 7.0s parallel, identical findings).
- Pre-existing branch-name/commitlint hooks untouched; every push on this PR went through the new hook.

## Escape hatch

`git push --no-verify` skips the hook (documented in the hook and `AGENTS.md`). Skipping just defers to autofix.ci/CI, which stay untouched as the backstop. Prettier is deliberately excluded: autofix.ci owns formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated lint checks for changed JavaScript and TypeScript files before pushes initiated by supported coding agents.
  * Added optional autofix support and clearer reporting for skipped or failed checks.
  * Human-initiated pushes remain unaffected, with an emergency bypass available when needed.

* **Documentation**
  * Documented changed-file linting commands, autofix usage, CI formatting responsibilities, comparison behavior, and bypass instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
