### PR TITLE
fix(journeys-admin-e2e): assert drawer width instead of stale aria-hidden marker

### DIFF
--- a/apps/journeys-admin-e2e/src/pages/journey-level-actions-page.ts
+++ b/apps/journeys-admin-e2e/src/pages/journey-level-actions-page.ts
@@ -341,18 +341,14 @@ export class JourneyLevelActions {
 
   async verifyNavigationSideMenuOpened(): Promise<void> {
     await expect(
-      this.page.locator(
-        'div[data-testid="NavigationDrawer"] div[aria-hidden="true"][style*="visibility: hidden"]'
-      )
-    ).toBeHidden()
+      this.page.locator('div[data-testid="NavigationDrawer"] .MuiDrawer-paper')
+    ).toHaveCSS('width', '237px')
   }
 
   async verifyNavigationSideMenuClosed(): Promise<void> {
     await expect(
-      this.page.locator(
-        'div[data-testid="NavigationDrawer"] div[aria-hidden="true"][style*="visibility: hidden"]'
-      )
-    ).toHaveCount(1)
+      this.page.locator('div[data-testid="NavigationDrawer"] .MuiDrawer-paper')
+    ).toHaveCSS('width', '72px')
   }
 
   async clickHelpBtn(): Promise<void> {


### PR DESCRIPTION
## Summary
- `verifyNavigationSideMenuOpened`/`verifyNavigationSideMenuClosed` in `journey-level-actions-page.ts` asserted on a `div[aria-hidden="true"][style*="visibility: hidden"]` marker that MUI 7's `Drawer` produced during its transition — MUI 9 (#9445) no longer renders that markup, so the test started failing on the very next daily run after the upgrade merged.
- `NavigationDrawer.tsx` uses `variant="permanent"` and collapses purely via a CSS `width` transition (237px open / 72px collapsed) — the assertions now check that actual rendered width directly instead of MUI's internal transition markup.

## Why this is safe
- Ran an ad-hoc axe-core accessibility scan against the collapsed drawer: **0 WCAG 2.0/2.1 A/AA violations**, and the collapsed nav buttons still expose "Projects"/"Templates" as their accessible name — confirming MUI 9 didn't regress accessibility here, so no follow-up is needed in the MUI upgrade PR itself.
- Ran the full `journeys-admin-e2e` suite locally against the daily Vercel preview: **50 passed, 24 skipped (pre-existing, unrelated `publisher-and-templates.spec.ts` skips), 0 failed** — no other tests affected by this change.

## Test plan
- [x] `Verify navigation side menu open and close via navigation list item toggle` passes against `journeys-admin-daily-e2e-jesusfilm.vercel.app`
- [x] Full `journeys-admin-e2e` suite passes with no new failures
- [x] axe-core accessibility scan on collapsed drawer: 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated navigation side-menu checks to verify the drawer width in both open and closed states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->