### PR TITLE
fix(api-journeys): batch Journey.userJourneys to stop pg pool exhaustion

### DIFF
--- a/apis/api-journeys/src/schema/builder.ts
+++ b/apis/api-journeys/src/schema/builder.ts
@@ -2,6 +2,7 @@
 import { tracer } from '@core/yoga/tracer'
 
 import SchemaBuilder from '@pothos/core'
+import DataloaderPlugin from '@pothos/plugin-dataloader'
 import DirectivesPlugin from '@pothos/plugin-directives'
 import FederationPlugin from '@pothos/plugin-federation'
 import pluginName from '@pothos/plugin-prisma'
@@ -59,7 +60,8 @@ export const builder = new SchemaBuilder<{
     RelayPlugin,
     WithInputPlugin,
     DirectivesPlugin,
-    FederationPlugin
+    FederationPlugin,
+    DataloaderPlugin
   ],
   tracing: {
     default: (config) => isRootField(config),

--- a/apis/api-journeys/src/schema/journey/journey.ts
+++ b/apis/api-journeys/src/schema/journey/journey.ts
@@ -240,42 +240,58 @@ export const JourneyRef = builder.prismaObject('Journey', {
         return journeyTags.map((jt) => ({ id: jt.tagId }))
       }
     }),
-    userJourneys: t.field({
-      type: [UserJourneyRef],
+    // Batched across every Journey in the response. Resolving this per journey
+    // fired one query per journey (each re-loading the journey, its
+    // userJourneys and its team's userTeams), so a large adminJourneys result
+    // opened hundreds of concurrent connections and exhausted the pg pool.
+    userJourneys: t.loadableGroup({
+      type: UserJourneyRef,
       nullable: true,
-      resolve: async (journey, _args, context) => {
+      resolve: (journey) => journey.id,
+      group: (userJourney) => userJourney.journeyId,
+      load: async (journeyIds: string[], context) => {
         if (context.type !== 'authenticated') return []
-
-        const userJourneys = await prisma.userJourney.findMany({
-          where: { journeyId: journey.id },
-          include: {
-            journey: {
-              include: {
-                userJourneys: true,
-                team: { include: { userTeams: true } }
-              }
-            }
-          }
-        })
-
         const userId = context.user.id
-        return userJourneys.filter((uj) => {
-          const isTeamMember = uj.journey?.team?.userTeams.some(
-            (ut) =>
-              ut.userId === userId &&
-              (ut.role === UserTeamRole.manager ||
-                ut.role === UserTeamRole.member)
-          )
-          if (isTeamMember === true) return true
 
-          const isJourneyOwnerOrEditor = uj.journey?.userJourneys?.some(
-            (j) =>
-              j.userId === userId &&
-              (j.role === UserJourneyRole.owner ||
-                j.role === UserJourneyRole.editor)
-          )
-          return isJourneyOwnerOrEditor === true
-        })
+        const [userJourneys, teamAccessibleJourneys] = await Promise.all([
+          prisma.userJourney.findMany({
+            where: { journeyId: { in: journeyIds } }
+          }),
+          prisma.journey.findMany({
+            where: {
+              id: { in: journeyIds },
+              team: {
+                userTeams: {
+                  some: {
+                    userId,
+                    role: { in: [UserTeamRole.manager, UserTeamRole.member] }
+                  }
+                }
+              }
+            },
+            select: { id: true }
+          })
+        ])
+
+        const teamAccessibleJourneyIds = new Set(
+          teamAccessibleJourneys.map(({ id }) => id)
+        )
+        const ownedOrEditedJourneyIds = new Set(
+          userJourneys
+            .filter(
+              (uj) =>
+                uj.userId === userId &&
+                (uj.role === UserJourneyRole.owner ||
+                  uj.role === UserJourneyRole.editor)
+            )
+            .map((uj) => uj.journeyId)
+        )
+
+        return userJourneys.filter(
+          (uj) =>
+            teamAccessibleJourneyIds.has(uj.journeyId) ||
+            ownedOrEditedJourneyIds.has(uj.journeyId)
+        )
       }
     }),
     // journeyCollections field will be added via extension in journeyCollection module

--- a/apis/api-journeys/src/schema/journey/journey.userJourneys.spec.ts
+++ b/apis/api-journeys/src/schema/journey/journey.userJourneys.spec.ts
@@ -1,0 +1,248 @@
+import { ExecutionResult } from 'graphql'
+import { type MockedFunction, vi } from 'vitest'
+
+import { getUserFromPayload } from '@core/yoga/firebaseClient'
+
+import { getClient } from '../../../test/client'
+import { prismaMock } from '../../../test/prismaMock'
+import { graphql } from '../../lib/graphql/subgraphGraphql'
+
+vi.mock('@core/yoga/firebaseClient', () => ({
+  getUserFromPayload: vi.fn()
+}))
+
+const mockGetUserFromPayload = getUserFromPayload as MockedFunction<
+  typeof getUserFromPayload
+>
+
+describe('Journey.userJourneys', () => {
+  const mockUser = {
+    id: 'userId',
+    email: 'test@example.com',
+    emailVerified: true,
+    firstName: 'Test',
+    lastName: 'User',
+    imageUrl: null,
+    roles: []
+  }
+
+  const authClient = getClient({
+    headers: { authorization: 'token' },
+    context: { currentUser: mockUser }
+  })
+  const publicClient = getClient()
+
+  const ADMIN_JOURNEYS_QUERY = graphql(`
+    query AdminJourneysWithUserJourneys {
+      adminJourneys {
+        id
+        userJourneys {
+          id
+          role
+        }
+      }
+    }
+  `)
+
+  const JOURNEYS_QUERY = graphql(`
+    query JourneysWithUserJourneys {
+      journeys {
+        id
+        userJourneys {
+          id
+        }
+      }
+    }
+  `)
+
+  function journey(id: string, teamId: string) {
+    return {
+      id,
+      title: 'Test Journey',
+      description: null,
+      slug: id,
+      languageId: '529',
+      themeMode: 'dark',
+      themeName: 'base',
+      status: 'published',
+      template: false,
+      teamId,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      publishedAt: new Date(),
+      archivedAt: null,
+      trashedAt: null,
+      deletedAt: null,
+      featuredAt: null,
+      seoTitle: null,
+      seoDescription: null,
+      primaryImageBlockId: null,
+      creatorImageBlockId: null,
+      logoImageBlockId: null,
+      creatorDescription: null,
+      website: false,
+      showShareButton: null,
+      showLikeButton: null,
+      showDislikeButton: null,
+      displayTitle: null,
+      showHosts: null,
+      showChatButtons: null,
+      showReactionButtons: null,
+      showLogo: null,
+      showMenu: null,
+      showDisplayTitle: null,
+      showAssistant: null,
+      menuButtonIcon: null,
+      menuStepBlockId: null,
+      socialNodeX: null,
+      socialNodeY: null,
+      strategySlug: null,
+      plausibleToken: null,
+      templateSite: null,
+      fromTemplateId: null,
+      hostId: null,
+      journeyCustomizationDescription: null,
+      customizable: null
+    }
+  }
+
+  const journeys = [
+    journey('teamJourney', 'teamId'),
+    journey('ownJourney', 'otherTeamId'),
+    journey('foreignJourney', 'otherTeamId')
+  ]
+
+  const userJourneys = [
+    {
+      id: 'teamUserJourney',
+      journeyId: 'teamJourney',
+      userId: 'otherUserId',
+      role: 'owner',
+      openedAt: null,
+      updatedAt: new Date()
+    },
+    {
+      id: 'ownUserJourney',
+      journeyId: 'ownJourney',
+      userId: 'userId',
+      role: 'editor',
+      openedAt: null,
+      updatedAt: new Date()
+    },
+    {
+      id: 'foreignUserJourney',
+      journeyId: 'foreignJourney',
+      userId: 'otherUserId',
+      role: 'owner',
+      openedAt: null,
+      updatedAt: new Date()
+    }
+  ]
+
+  /**
+   * `journey.findMany` serves two callers: the `adminJourneys`/`journeys`
+   * resolver, and the userJourneys loader's team-access lookup (which selects
+   * `id` only).
+   */
+  function mockJourneyFindMany(teamAccessibleIds: string[]) {
+    prismaMock.journey.findMany.mockImplementation((async (args: {
+      select?: { id?: boolean }
+    }) =>
+      args?.select?.id === true
+        ? teamAccessibleIds.map((id) => ({ id }))
+        : journeys) as never)
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetUserFromPayload.mockReturnValue(mockUser)
+    prismaMock.userRole.findUnique.mockResolvedValue({
+      id: 'userRoleId',
+      userId: mockUser.id,
+      roles: []
+    })
+    prismaMock.userJourney.findMany.mockResolvedValue(userJourneys as never)
+  })
+
+  it('batches every journey in the response into a single query', async () => {
+    mockJourneyFindMany(['teamJourney'])
+
+    const result = (await authClient({
+      document: ADMIN_JOURNEYS_QUERY
+    })) as ExecutionResult<{
+      adminJourneys: Array<{ id: string; userJourneys: Array<{ id: string }> }>
+    }>
+
+    expect(result.errors).toBeUndefined()
+    expect(prismaMock.userJourney.findMany).toHaveBeenCalledTimes(1)
+    expect(prismaMock.userJourney.findMany).toHaveBeenCalledWith({
+      where: {
+        journeyId: { in: ['teamJourney', 'ownJourney', 'foreignJourney'] }
+      }
+    })
+  })
+
+  it('returns user journeys for a journey in a team the user belongs to', async () => {
+    mockJourneyFindMany(['teamJourney'])
+
+    const result = (await authClient({
+      document: ADMIN_JOURNEYS_QUERY
+    })) as ExecutionResult<{
+      adminJourneys: Array<{ id: string; userJourneys: Array<{ id: string }> }>
+    }>
+
+    expect(result.data?.adminJourneys[0]).toEqual({
+      id: 'teamJourney',
+      userJourneys: [{ id: 'teamUserJourney', role: 'owner' }]
+    })
+  })
+
+  it('returns user journeys for a journey the user owns or edits', async () => {
+    mockJourneyFindMany([])
+
+    const result = (await authClient({
+      document: ADMIN_JOURNEYS_QUERY
+    })) as ExecutionResult<{
+      adminJourneys: Array<{ id: string; userJourneys: Array<{ id: string }> }>
+    }>
+
+    expect(result.data?.adminJourneys[1]).toEqual({
+      id: 'ownJourney',
+      userJourneys: [{ id: 'ownUserJourney', role: 'editor' }]
+    })
+  })
+
+  it('returns no user journeys for a journey the user cannot access', async () => {
+    mockJourneyFindMany(['teamJourney'])
+
+    const result = (await authClient({
+      document: ADMIN_JOURNEYS_QUERY
+    })) as ExecutionResult<{
+      adminJourneys: Array<{ id: string; userJourneys: Array<{ id: string }> }>
+    }>
+
+    expect(result.data?.adminJourneys[2]).toEqual({
+      id: 'foreignJourney',
+      userJourneys: []
+    })
+  })
+
+  it('returns no user journeys and issues no query when unauthenticated', async () => {
+    mockGetUserFromPayload.mockReturnValue(null)
+    mockJourneyFindMany([])
+
+    const result = (await publicClient({
+      document: JOURNEYS_QUERY
+    })) as ExecutionResult<{
+      journeys: Array<{ id: string; userJourneys: Array<{ id: string }> }>
+    }>
+
+    expect(result.errors).toBeUndefined()
+    expect(result.data?.journeys.map((j) => j.userJourneys)).toEqual([
+      [],
+      [],
+      []
+    ])
+    expect(prismaMock.userJourney.findMany).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## The bug

Stage is throwing `timeout exceeded when trying to connect` from `pg-pool`, on the path `["adminJourneys", 372, "userJourneys"]`.

`Journey.userJourneys` ran **one query per journey**, and each one re-loaded the journey it was already attached to, plus that journey's userJourneys and its team's userTeams:

```ts
prisma.userJourney.findMany({
  where: { journeyId: journey.id },
  include: { journey: { include: { userJourneys: true, team: { include: { userTeams: true } } } } }
})
```

`adminJourneys` is unpaginated — the error path index of 372 means that response carried at least 373 journeys. GraphQL resolves list items concurrently, so ~373 joined queries hit the pool at once. The pool is `PrismaPg` with pg's default `max: 10` and `connectionTimeoutMillis: 5_000` (`libs/prisma/journeys/src/client.ts`), so everything past the first 10 waits and times out. The admin journeys list requests `userJourneys` on every journey, so this fires on every visit to a large team's journey list.

The ACL filter was also doing redundant work: its predicate depends only on the journey and the viewer, never on the individual `userJourney` row — so it fetched the same journey N times to answer one question per journey.

## The fix

Rewrote the field as a batched `t.loadableGroup`. **Two queries per request regardless of journey count:**

1. all `userJourney` rows for the batched journey ids
2. which of those journeys the viewer reaches via team membership (`select: { id: true }`)

Owner/editor access is derived in JS from the rows already loaded in (1).

`DataloaderPlugin` added to the api-journeys builder — this mirrors api-media's existing setup, and `initContextCache()` was already in the Yoga context, which is what the plugin needs for per-request loader caching.

## Behaviour

ACL semantics are unchanged: a team manager/member sees all rows on the journey, otherwise an owner/editor on the journey sees them, otherwise `[]`. Unauthenticated callers still get `[]` with no query issued.

`nx generate-graphql api-journeys` produces a byte-identical `schema.graphql` (`userJourneys: [UserJourney!]`), so there is no subgraph contract change.

## Verification

- `tsc --noEmit` clean on both `tsconfig.app.json` and `tsconfig.spec.json`
- New `journey.userJourneys.spec.ts` (5 tests): batching into a single query, team-member access, owner/editor access, denial, unauthenticated
- Full `schema/journey` suite: 250 tests passing
- `nx lint api-journeys`: 0 errors, no new warnings

## Follow-ups not in this PR

- **Same-class N+1s remain** on `Journey.tags`, `Journey.blocks`, and `Journey.blockTypenames`. `tags` is the one that matters: the public templates query (`libs/journeys/ui/src/libs/useJourneysQuery`) requests `tags` *and* `userJourneys` across the whole gallery, so the gallery can still exhaust the pool the same way. Batching `tags` needs a small cast (the federated `Tag` shape is `{ id }` only, so the group key has to ride along), which is why it is not bundled here.
- **Pool size**: no `max` is set, so it is pg's default of 10 per task — thin for this service even with the N+1 gone. Raising it spends RDS `max_connections` across every task and service, so that is a deliberate infra call rather than part of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved loading performance for journeys with multiple associated user journeys.
  * User journeys are now retrieved in batches, reducing unnecessary loading delays.
  * Access results more consistently reflect team membership, ownership, and editing permissions.
  * Unauthenticated requests continue to receive no user journey results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->