### PR TITLE
fix(api-media): revalidate cache after backfilling Mux download metadata

### DIFF
--- a/apis/api-media/src/scripts/mux-videos.spec.ts
+++ b/apis/api-media/src/scripts/mux-videos.spec.ts
@@ -7,6 +7,7 @@ import {
   createDownloadsFromMuxAsset,
   previewMuxDownloadsFromAsset
 } from '../lib/downloads'
+import { videoVariantCacheReset } from '../lib/videoCacheReset'
 import { getVideo } from '../schema/mux/video/service'
 
 import { processDownloads } from './mux-videos'
@@ -25,11 +26,16 @@ vi.mock('../lib/downloads', async () => {
   }
 })
 
+vi.mock('../lib/videoCacheReset', () => ({
+  videoVariantCacheReset: vi.fn()
+}))
+
 const mockedGetVideo = getVideo as unknown as Mock
 const mockedCreateDownloadsFromMuxAsset =
   createDownloadsFromMuxAsset as unknown as Mock
 const mockedPreviewMuxDownloadsFromAsset =
   previewMuxDownloadsFromAsset as unknown as Mock
+const mockedVideoVariantCacheReset = videoVariantCacheReset as unknown as Mock
 
 function download(
   overrides: Partial<{
@@ -200,6 +206,32 @@ describe('processDownloads', () => {
       muxVideoAsset: readyMuxVideoAsset
     })
     expect(mockedPreviewMuxDownloadsFromAsset).not.toHaveBeenCalled()
+    expect(mockedVideoVariantCacheReset).toHaveBeenCalledWith('variant-1')
+  })
+
+  it('does not reset the cache when apply mode writes no download rows', async () => {
+    process.env.MUX_DOWNLOAD_BACKFILL_APPLY = 'true'
+    ;(prismaMock.videoVariantDownload.findMany as Mock).mockResolvedValueOnce([
+      download()
+    ])
+    mockedGetVideo.mockResolvedValue(readyMuxVideoAsset)
+    mockedCreateDownloadsFromMuxAsset.mockResolvedValue(0)
+
+    await runProcessDownloads()
+
+    expect(mockedVideoVariantCacheReset).not.toHaveBeenCalled()
+  })
+
+  it('does not reset the cache in preview mode', async () => {
+    ;(prismaMock.videoVariantDownload.findMany as Mock).mockResolvedValueOnce([
+      download()
+    ])
+    mockedGetVideo.mockResolvedValue(readyMuxVideoAsset)
+    mockedPreviewMuxDownloadsFromAsset.mockReturnValue([])
+
+    await runProcessDownloads()
+
+    expect(mockedVideoVariantCacheReset).not.toHaveBeenCalled()
   })
 
   it('skips a variant whose Mux asset is not ready to store downloads', async () => {

--- a/apis/api-media/src/scripts/mux-videos.ts
+++ b/apis/api-media/src/scripts/mux-videos.ts
@@ -10,6 +10,7 @@ import {
   downloadsReadyToStore,
   previewMuxDownloadsFromAsset
 } from '../lib/downloads'
+import { videoVariantCacheReset } from '../lib/videoCacheReset'
 import { getVideo } from '../schema/mux/video/service'
 
 const MUX_STREAM_BASE_URL = 'https://stream.mux.com'
@@ -349,6 +350,10 @@ export async function processDownloads(): Promise<void> {
         console.log(
           `Successfully created or refreshed ${createdCount} video downloads for variant ${variant.id}, muxVideoId: ${variant.muxVideo.id}`
         )
+
+        if (createdCount > 0) {
+          await videoVariantCacheReset(variant.id)
+        }
       } else {
         console.log(
           `Video not ready for download processing - variant: ${variant.id}, assetId: ${variant.muxVideo.assetId}, status: ${muxVideoAsset.status}, hasPlaybackId: ${!!muxVideoAsset.playback_ids?.[0]?.id}, downloadsReady: ${downloadsReadyToStore(muxVideoAsset)}`


### PR DESCRIPTION
Related to #9382 — adjacent to the Download-size backfill deliverable, but not one of its two named items. Does not close it.

## Summary

The Mux download backfill script (`processDownloads` in `apis/api-media/src/scripts/mux-videos.ts`) writes `VideoVariantDownload` rows but never invalidated any cache afterwards. The watch page and the Yoga response cache kept serving the pre-backfill download metadata until something unrelated happened to evict them — so a successful backfill could leave users seeing stale (or missing) download options indefinitely.

## Change

- Call `videoVariantCacheReset(variant.id)` after a successful write, gated on `createdCount > 0`.

That gate is what keeps the reset honest in the script's two non-writing paths:

- **Preview mode** (`MUX_DOWNLOAD_BACKFILL_APPLY` unset) never writes, so it never resets.
- **Apply mode that stores zero rows** — nothing changed, so there is nothing to invalidate.

`videoVariantCacheReset` already swallows its own errors, so a revalidation outage degrades to a stale cache rather than failing the backfill mid-run.

## Tests

- Existing apply-mode test now asserts `videoVariantCacheReset` is called with the variant id.
- New: apply mode that writes no download rows does **not** reset the cache.
- New: preview mode does **not** reset the cache.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated video processing to refresh cached video variants after new downloads are created or refreshed.
  * Avoided unnecessary cache resets when no downloads are changed or when running in preview mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
