### PR TITLE
docs: normalise labeled to labelled in template-info plan

### DIFF
--- a/docs/plans/2026-05-14-001-feat-nes-1538-template-info-side-panel-plan.md
+++ b/docs/plans/2026-05-14-001-feat-nes-1538-template-info-side-panel-plan.md
@@ -23,7 +23,7 @@ The Linear ticket plus Siyang's five canonical Figma frames specify the panel ch
 
 ## Requirements
 
-- R1. Render `TemplateInfoPanel` on the local template tab (`/?type=templates`, also labeled "Team Templates") when the `templateInfoSidePanel` LaunchDarkly flag is on. The panel mounts as a sibling of the templates grid and shifts the grid narrower; it does not overlay.
+- R1. Render `TemplateInfoPanel` on the local template tab (`/?type=templates`, also labelled "Team Templates") when the `templateInfoSidePanel` LaunchDarkly flag is on. The panel mounts as a sibling of the templates grid and shifts the grid narrower; it does not overlay.
 - R2. The panel renders an **always-visible header** with the exact ticket copy:
   - Title: `What templates are about:`
   - Body: `You can share projects created on our platform with others. This allows you to track the performance of every project generated from your template.`


### PR DESCRIPTION
🤖 **Hatsu toy proof** — ENG-3701 acceptance test of the pipeline plumbing (issue → worktree → headless agent → draft PR). Do not merge; this PR will be closed.

Refs #9486

Transcript + handoff log under /data/logs on ns-ai-pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)