### PR TITLE
chore(hatsu): add .hatsu/ pipeline descriptor (ENG-3733)

### DIFF
--- a/.hatsu/Dockerfile
+++ b/.hatsu/Dockerfile
@@ -1,0 +1,16 @@
+# STUB — not built or used yet. See .hatsu/README.md.
+#
+# Hatsu's per-ticket isolation is a git worktree on the pipeline VM
+# (ENG-3699); this Dockerfile reserves the sandbox seam for the one case
+# that may later need real containers: parallel QA runs booting the full
+# stack with namespaced ports/DB (ENG-3719). Vera's tickets will make this
+# real; until then it documents the intended base.
+
+FROM node:22-bookworm-slim
+
+# Match the VM toolchain (ENG-3701): pnpm via corepack, git for worktrees.
+RUN corepack enable && apt-get update && apt-get install -y --no-install-recommends \
+    git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace

--- a/.hatsu/Dockerfile
+++ b/.hatsu/Dockerfile
@@ -13,4 +13,8 @@ RUN corepack enable && apt-get update && apt-get install -y --no-install-recomme
     git ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
+# Non-root by default (Sandcastle precedent: agents never run as root; any
+# mounted worktree must be owned compatibly with the node user).
+RUN mkdir -p /workspace && chown node:node /workspace
 WORKDIR /workspace
+USER node

--- a/.hatsu/README.md
+++ b/.hatsu/README.md
@@ -1,9 +1,9 @@
 # .hatsu — Hatsu pipeline descriptor
 
 [Hatsu](https://github.com/JesusFilm/hatsu) is the autonomous bug-fixing
-pipeline (intake → build → QA) that works this repo's issues. This folder is
-how core **self-describes** to it, so the engine stays generic and everything
-repo-specific lives here, versioned alongside the code it describes
+pipeline (intake → build → QA) that processes issues in this repo. This folder
+is how core **self-describes** to the pipeline, so the engine stays generic and
+all repo-specific data lives here, versioned alongside the code it describes
 (ENG-3699 / ENG-3733).
 
 - `target.json` — the target descriptor: repo identity, default branch, and

--- a/.hatsu/README.md
+++ b/.hatsu/README.md
@@ -1,0 +1,21 @@
+# .hatsu — Hatsu pipeline descriptor
+
+[Hatsu](https://github.com/JesusFilm/hatsu) is the autonomous bug-fixing
+pipeline (intake → build → QA) that works this repo's issues. This folder is
+how core **self-describes** to it, so the engine stays generic and everything
+repo-specific lives here, versioned alongside the code it describes
+(ENG-3699 / ENG-3733).
+
+- `target.json` — the target descriptor: repo identity, default branch, and
+  the gate commands agents run inside a ticket worktree. The pipeline's
+  `hatsu.config.ts` currently carries an operational copy of these values;
+  teaching the engine to read this file at runtime (and which side wins) is
+  tracked on Cade's MVP ticket.
+- `Dockerfile` — **stub, not yet built or used.** Per-ticket isolation today
+  is a git worktree on the pipeline VM, not a container (ENG-3699 decision).
+  This file reserves the seam for the one place that may later need real
+  containers: parallel QA runs booting the app stack (ENG-3719).
+
+Changing gate commands here is safe and encouraged when the toolchain
+changes; the pipeline picks them up without an engine release once the
+runtime merge lands.

--- a/.hatsu/target.json
+++ b/.hatsu/target.json
@@ -1,0 +1,10 @@
+{
+  "$comment": "Hatsu target descriptor — see .hatsu/README.md. Gate commands run inside a ticket worktree.",
+  "repoSlug": "JesusFilm/core",
+  "defaultBranch": "main",
+  "gates": {
+    "install": "pnpm install",
+    "check": "pnpm affected:lint",
+    "test": "pnpm affected:test"
+  }
+}


### PR DESCRIPTION
Adds the `.hatsu/` folder so core self-describes to the [Hatsu pipeline](https://github.com/JesusFilm/hatsu) and the engine stays generic (ENG-3699 architecture; built under [ENG-3733](https://linear.app/jesus-film-project/issue/ENG-3733/hatsu-foundation-platform-contracts-harness-skeleton-config-seam-test)).

Docs/config only — nothing reads this at runtime yet:

- `target.json` — repo identity + gate commands (install / check / test) agents run inside a ticket worktree. The runtime merge with the engine's `hatsu.config.ts` is tracked on Cade's MVP ticket.
- `Dockerfile` — explicit **stub** reserving the sandbox seam for parallel QA environments (ENG-3719); per-ticket isolation today is a git worktree on the pipeline VM, per the ENG-3699 decision.
- `README.md` — what this folder is and who owns changes.

Companion PRs: JesusFilm/hatsu#1 (the pipeline foundation this describes) · #9495 (ticket-state doc update, `docs/agents/github-projects.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)