### PR TITLE
feat(api-languages): sync WESS native language names into LanguageName

### DIFF
--- a/apis/api-gateway/schema.graphql
+++ b/apis/api-gateway/schema.graphql
@@ -2447,6 +2447,7 @@ Summary of a completed WESS import run.
 type WessImportResult @join__type(graph: API_LANGUAGES)  {
   success: Boolean!
   languagesImported: Int!
+  nativeNamesImported: Int!
   countriesImported: Int!
   countryLanguagesImported: Int!
   message: String!

--- a/apis/api-languages/schema.graphql
+++ b/apis/api-languages/schema.graphql
@@ -214,6 +214,7 @@ interface User {
 type WessImportResult {
   success: Boolean!
   languagesImported: Int!
+  nativeNamesImported: Int!
   countriesImported: Int!
   countryLanguagesImported: Int!
   message: String!

--- a/apis/api-languages/src/schema/wessImport/wessImport.spec.ts
+++ b/apis/api-languages/src/schema/wessImport/wessImport.spec.ts
@@ -29,6 +29,7 @@ const WESS_IMPORT_MUTATION = parse(`
     wessImport {
       success
       languagesImported
+      nativeNamesImported
       countriesImported
       countryLanguagesImported
       message
@@ -56,7 +57,9 @@ describe('wessImport', () => {
   let lockHeld = false
 
   beforeEach(() => {
-    vi.mocked(runWessLanguagesImport).mockReset().mockResolvedValue(10)
+    vi.mocked(runWessLanguagesImport)
+      .mockReset()
+      .mockResolvedValue({ languagesImported: 10, nativeNamesImported: 3 })
     vi.mocked(runWessCountriesImport).mockReset().mockResolvedValue(5)
     vi.mocked(runWessCountryLanguagesImport).mockReset().mockResolvedValue(20)
 
@@ -101,10 +104,11 @@ describe('wessImport', () => {
     expect(data).toHaveProperty('data.wessImport', {
       success: true,
       languagesImported: 10,
+      nativeNamesImported: 3,
       countriesImported: 5,
       countryLanguagesImported: 20,
       message:
-        'Imported 10 language(s), 5 country(ies), and 20 country-language(s).'
+        'Imported 10 language(s) (3 native name(s)), 5 country(ies), and 20 country-language(s).'
     })
   })
 
@@ -127,7 +131,7 @@ describe('wessImport', () => {
       .mockReset()
       .mockImplementationOnce(async () => {
         await firstImportGate
-        return 10
+        return { languagesImported: 10, nativeNamesImported: 3 }
       })
 
     const first = authClient({ document: WESS_IMPORT_MUTATION })

--- a/apis/api-languages/src/schema/wessImport/wessImport.ts
+++ b/apis/api-languages/src/schema/wessImport/wessImport.ts
@@ -7,6 +7,7 @@ import { builder } from '../builder'
 interface WessImportResultShape {
   success: boolean
   languagesImported: number
+  nativeNamesImported: number
   countriesImported: number
   countryLanguagesImported: number
   message: string
@@ -19,6 +20,9 @@ const WessImportResult = builder
     fields: (t) => ({
       success: t.exposeBoolean('success', { nullable: false }),
       languagesImported: t.exposeInt('languagesImported', { nullable: false }),
+      nativeNamesImported: t.exposeInt('nativeNamesImported', {
+        nullable: false
+      }),
       countriesImported: t.exposeInt('countriesImported', { nullable: false }),
       countryLanguagesImported: t.exposeInt('countryLanguagesImported', {
         nullable: false
@@ -37,16 +41,18 @@ builder.mutationFields((t) => ({
       'take several minutes; requires WESS_API_TOKEN in the server environment.',
     resolve: async () =>
       withWessImportLock(async () => {
-        const languagesImported = await runWessLanguagesImport()
+        const { languagesImported, nativeNamesImported } =
+          await runWessLanguagesImport()
         const countriesImported = await runWessCountriesImport()
         const countryLanguagesImported = await runWessCountryLanguagesImport()
 
         return {
           success: true,
           languagesImported,
+          nativeNamesImported,
           countriesImported,
           countryLanguagesImported,
-          message: `Imported ${languagesImported.toLocaleString()} language(s), ${countriesImported.toLocaleString()} country(ies), and ${countryLanguagesImported.toLocaleString()} country-language(s).`
+          message: `Imported ${languagesImported.toLocaleString()} language(s) (${nativeNamesImported.toLocaleString()} native name(s)), ${countriesImported.toLocaleString()} country(ies), and ${countryLanguagesImported.toLocaleString()} country-language(s).`
         }
       })
   })

--- a/apis/api-languages/src/scripts/README.md
+++ b/apis/api-languages/src/scripts/README.md
@@ -67,13 +67,14 @@ Each WESS import maps one WESS QueryRunner query id (`QueryId=…`) to a Prisma 
 
 ### WESS Languages Import (QueryId 154)
 
-Imports language rows into `Language` and `LanguageName` (English label, `languageId=529`).
+Imports language rows into `Language` and `LanguageName` (English label, `languageId=529`; native name/autonym, `languageId=<the language's own id>`).
 
 ```bash
 nx run api-languages:wess-languages-import
 ```
 
 - **Slug:** derived from WESS `slug` if set, otherwise display name, otherwise `id` — lowercased, spaces/commas/underscores and other non-alphanumeric runs become `-`, collisions get `-2`, `-3`, … . Set on **create**, and on **update** only when `slug` is currently null or empty (existing non-empty slugs are not overwritten).
+- **`NATIVE_LAN_NAME`** (native name / autonym): when present, upserted as a second `LanguageName` row where `languageId` equals the language's own id (`parentLanguageId === languageId`) and `primary: true`. This becomes the language's Primary Name; the English `LanguageName` row (`languageId=529`) is written with `primary: false` instead. Blank/whitespace-only values are treated as absent, same as every other field read via `readStringField`. A later WESS response that temporarily omits `NATIVE_LAN_NAME` does not delete or blank out a previously-imported autonym row — the write is conditional on the value being present, so absence is a no-op. English's own WESS row carries `NATIVE_LAN_NAME: "English"`, so it flows through this same path (no special case) and produces one row: `parentLanguageId: '529', languageId: '529', value: 'English', primary: true`.
 - `ImportTimes.modelName`: `wessLanguageImport`.
 
 ### WESS Countries Import (QueryId 156)

--- a/apis/api-languages/src/scripts/wess-language-parsers.ts
+++ b/apis/api-languages/src/scripts/wess-language-parsers.ts
@@ -19,6 +19,7 @@ const WESS_LANGUAGE_ID_KEYS: string[] = [
 export interface WessLanguageRow {
   id: string
   name: string | null
+  nativeName: string | null
   bcp47: string | null
   iso3: string | null
   slug: string | null
@@ -45,6 +46,11 @@ export function normalizeWessLanguageRow(
     'LanName',
     'lan_name'
   ])
+  const nativeName = readStringField(row, [
+    'nativeName',
+    'NativeName',
+    'NATIVE_LAN_NAME'
+  ])
   const bcp47 = readStringField(
     row,
     ['bcp47', 'BCP47', 'languageTag', 'LanguageTag', 'ietf'],
@@ -63,6 +69,7 @@ export function normalizeWessLanguageRow(
   return {
     id,
     name,
+    nativeName,
     bcp47,
     iso3,
     slug,

--- a/apis/api-languages/src/scripts/wess-languages-import.spec.ts
+++ b/apis/api-languages/src/scripts/wess-languages-import.spec.ts
@@ -84,6 +84,7 @@ describe('normalizeWessLanguageRow', () => {
     expect(normalized).toEqual({
       id: '185035',
       name: 'Wekais',
+      nativeName: null,
       bcp47: null,
       iso3: null,
       slug: null,
@@ -111,5 +112,44 @@ describe('normalizeWessLanguageRow', () => {
 
   it('returns null when id is missing', () => {
     expect(normalizeWessLanguageRow({ name: 'x' })).toBeNull()
+  })
+
+  it('maps WESS NATIVE_LAN_NAME field', () => {
+    const normalized = normalizeWessLanguageRow({
+      id: '1',
+      NATIVE_LAN_NAME: 'Deutsch'
+    })
+    expect(normalized?.nativeName).toBe('Deutsch')
+  })
+
+  it('falls back through nativeName / NativeName key aliases', () => {
+    expect(
+      normalizeWessLanguageRow({ id: '1', nativeName: 'Deutsch' })?.nativeName
+    ).toBe('Deutsch')
+    expect(
+      normalizeWessLanguageRow({ id: '1', NativeName: 'Deutsch' })?.nativeName
+    ).toBe('Deutsch')
+  })
+
+  it('normalizes a blank or whitespace-only NATIVE_LAN_NAME to null', () => {
+    expect(
+      normalizeWessLanguageRow({ id: '1', NATIVE_LAN_NAME: '' })?.nativeName
+    ).toBeNull()
+    expect(
+      normalizeWessLanguageRow({ id: '1', NATIVE_LAN_NAME: '   ' })?.nativeName
+    ).toBeNull()
+  })
+
+  it('trims trailing whitespace from NATIVE_LAN_NAME', () => {
+    expect(
+      normalizeWessLanguageRow({ id: '1', NATIVE_LAN_NAME: 'Golin ' })
+        ?.nativeName
+    ).toBe('Golin')
+  })
+
+  it('returns null nativeName when NATIVE_LAN_NAME is absent', () => {
+    expect(
+      normalizeWessLanguageRow({ id: '1', name: 'English' })?.nativeName
+    ).toBeNull()
   })
 })

--- a/apis/api-languages/src/scripts/wess-languages-import.ts
+++ b/apis/api-languages/src/scripts/wess-languages-import.ts
@@ -156,7 +156,8 @@ async function upsertLanguageNameEntry(params: {
   })
 }
 
-async function upsertLanguage(row: WessLanguageRow): Promise<void> {
+/** Returns whether an autonym `LanguageName` row was created or updated for this language. */
+async function upsertLanguage(row: WessLanguageRow): Promise<boolean> {
   const existing = await prisma.language.findUnique({
     where: { id: row.id },
     select: { id: true, slug: true }
@@ -190,31 +191,48 @@ async function upsertLanguage(row: WessLanguageRow): Promise<void> {
     }
   })
 
-  if (row.name == null) {
-    return
-  }
-
   const englishLanguageId = WESS_ENGLISH_LANGUAGE_ID
+  const hasNativeName = row.nativeName != null
 
-  if (row.id === englishLanguageId) {
-    return
+  if (row.name != null && row.id !== englishLanguageId) {
+    // WESS only gives one label per row; store it as the English `LanguageName` (GraphQL default uses `languageId` 529).
+    // Once a native name is known for this language it becomes the Primary Name instead.
+    await upsertLanguageNameEntry({
+      parentLanguageId: row.id,
+      languageId: englishLanguageId,
+      value: row.name,
+      primary: !hasNativeName
+    })
   }
 
-  // WESS only gives one label per row; store it as the English `LanguageName` (GraphQL default uses `languageId` 529).
+  if (!hasNativeName) {
+    return false
+  }
+
+  // The autonym: a `LanguageName` row where the Name Language is the language itself.
+  // Runs for every language, including English's own row (id 529), through this same path.
   await upsertLanguageNameEntry({
     parentLanguageId: row.id,
-    languageId: englishLanguageId,
-    value: row.name,
+    languageId: row.id,
+    value: row.nativeName as string,
     primary: true
   })
+
+  return true
+}
+
+export interface WessLanguagesImportResult {
+  languagesImported: number
+  nativeNamesImported: number
 }
 
 /**
- * Runs the WESS languages import and returns the number of rows upserted.
+ * Runs the WESS languages import and returns the number of rows upserted,
+ * plus the number of autonym `LanguageName` rows created or updated.
  * Safe to call in-process (e.g. from a GraphQL resolver): it never calls
  * `process.exit` and throws on failure so the caller can handle the error.
  */
-export async function runWessLanguagesImport(): Promise<number> {
+export async function runWessLanguagesImport(): Promise<WessLanguagesImportResult> {
   log.info('Starting (this can take a while over HTTP and per-row DB upserts)…')
   const rows = await fetchWessLanguages()
 
@@ -223,12 +241,16 @@ export async function runWessLanguagesImport(): Promise<number> {
     `Database: upserting ${total.toLocaleString()} language(s) (progress every ${WESS_IMPORT_PROGRESS_LOG_EVERY.toLocaleString()} rows)…`
   )
 
+  let nativeNamesImported = 0
   for (let i = 0; i < total; i++) {
     const n = i + 1
     if (n === 1 || n === total || n % WESS_IMPORT_PROGRESS_LOG_EVERY === 0) {
       log.info(`Upsert ${n.toLocaleString()}/${total.toLocaleString()}…`)
     }
-    await upsertLanguage(rows[i])
+    const nativeNameWritten = await upsertLanguage(rows[i])
+    if (nativeNameWritten) {
+      nativeNamesImported++
+    }
   }
 
   if (rows.length > 0) {
@@ -240,8 +262,10 @@ export async function runWessLanguagesImport(): Promise<number> {
     })
   }
 
-  log.info(`Finished successfully (${total.toLocaleString()} row(s)).`)
-  return total
+  log.info(
+    `Finished successfully (${total.toLocaleString()} row(s), ${nativeNamesImported.toLocaleString()} native name(s)).`
+  )
+  return { languagesImported: total, nativeNamesImported }
 }
 
 async function main(): Promise<void> {

--- a/apis/api-languages/src/scripts/wess-languages-import.ts
+++ b/apis/api-languages/src/scripts/wess-languages-import.ts
@@ -194,6 +194,21 @@ async function upsertLanguage(row: WessLanguageRow): Promise<boolean> {
   const englishLanguageId = WESS_ENGLISH_LANGUAGE_ID
   const hasNativeName = row.nativeName != null
 
+  // A later WESS response can temporarily omit NATIVE_LAN_NAME for a language that already
+  // has a persisted autonym. Don't promote English back to primary in that case — check
+  // whether an autonym row already exists before deciding.
+  const hasPersistedAutonym =
+    !hasNativeName &&
+    (await prisma.languageName.findUnique({
+      where: {
+        parentLanguageId_languageId: {
+          parentLanguageId: row.id,
+          languageId: row.id
+        }
+      },
+      select: { id: true }
+    })) != null
+
   if (row.name != null && row.id !== englishLanguageId) {
     // WESS only gives one label per row; store it as the English `LanguageName` (GraphQL default uses `languageId` 529).
     // Once a native name is known for this language it becomes the Primary Name instead.
@@ -201,7 +216,7 @@ async function upsertLanguage(row: WessLanguageRow): Promise<boolean> {
       parentLanguageId: row.id,
       languageId: englishLanguageId,
       value: row.name,
-      primary: !hasNativeName
+      primary: !hasNativeName && !hasPersistedAutonym
     })
   }
 


### PR DESCRIPTION
Closes #9483

## Summary

Extends the existing WESS languages sync (the same code path already wired to the "Run WESS import" admin button) to also read `NATIVE_LAN_NAME` and store it as each language's autonym — a second `LanguageName` row where the Name Language is the language itself. Once a language has a real native name, that becomes its Primary Name; the English gloss remains stored and reachable by its own language id (529), just no longer flagged primary.

## Key decisions

- `WessLanguageRow` gains `nativeName: string | null`, read via the existing `readStringField` helper against a new key-alias list (`nativeName`, `NativeName`, `NATIVE_LAN_NAME`) — blank/whitespace-only values normalize to `null` with no additional sanitization logic (it falls out of reusing `readStringField`).
- `upsertLanguage` additionally upserts `{ parentLanguageId: row.id, languageId: row.id, value: row.nativeName, primary: true }` whenever `row.nativeName != null`, and flips the existing English `LanguageName` row's `primary` to `false` in that case (stays `true` when no native name exists).
- The importer's special-case skip for `row.id === englishLanguageId` is removed **only** for the native-name path, so English's own WESS row (`NATIVE_LAN_NAME: "English"`) flows through the same autonym branch as every other language — producing exactly one row (`parentLanguageId: '529', languageId: '529', value: 'English', primary: true`), not a special case.
- Sync semantics on absence: the autonym write is conditional on `row.nativeName != null`, so a later WESS response that temporarily omits the field is a no-op — it never deletes or blanks an existing autonym row.
- `runWessLanguagesImport` now returns `{ languagesImported, nativeNamesImported }`; `WessImportResult` gains `nativeNamesImported: Int!` and the mutation's success message folds the count in.
- No Prisma schema/migration changes — `LanguageName`'s existing `@@unique([parentLanguageId, languageId])` already supports this shape.

## Testing

- Added `normalizeWessLanguageRow` cases for `NATIVE_LAN_NAME` mapping, key-alias fallbacks, and blank/whitespace-only → `null` normalization, following the existing describe block's style.
- Updated `wessImport.spec.ts` mocks/assertions for the new return shape and message format.
- Per the issue's testing decisions, the upsert/primary-flip DB-writing behavior is **not** covered by a new Prisma-mock test — matching existing precedent in this directory (`wess-languages-import.spec.ts`, `wess-countries-import.spec.ts`, `wess-country-languages-import.spec.ts` only unit-test the pure parsing/normalization functions). That behavior should be validated by running the import against stage before production, per the issue's Rollout section.
- `apis/api-languages/schema.graphql` regenerated to reflect the new `nativeNamesImported` field.

## Verification

`pnpm exec nx affected -t lint,type-check,test --base=origin/main` — 0 lint errors (11 pre-existing warnings, unrelated to this change), type-check clean, 118/118 tests passing.

## Out of scope (tracked separately, per the issue)

- The ~5 frontend call sites reading `Language.name[0]` with no arguments that would start showing native-script names.
- The audit/pruning of the ~44,000 `Language` rows present in our DB but absent from WESS's current response.
- `apis/api-gateway/schema.graphql` recomposition — requires live subgraph servers via `hive dev`, not feasible in this headless run; CI's `graphql-schema-check` job will regenerate and verify it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WESS language imports now capture native language names and identify how many were imported.
  * Imported native names are marked as primary, with English names retained or demoted appropriately.
  * Import results and completion messages now include native-name totals.
* **Bug Fixes**
  * Blank or missing native-name values are handled consistently while preserving existing names when appropriate.
* **Documentation**
  * Updated guidance explains native-name import behavior, including English-language handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->