### PR TITLE
fix(NES-1866): delete selected card when a deselected edge is backspaced

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/libs/useDeleteOnKeyPress/useDeleteOnKeyPress.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/libs/useDeleteOnKeyPress/useDeleteOnKeyPress.spec.tsx
@@ -114,4 +114,53 @@ describe('useDeleteOnKeyPress', () => {
     })
     await waitFor(async () => expect(deleteBlock).toHaveBeenCalled())
   })
+
+  it('should delete the selected card when a previously selected edge is deselected', async () => {
+    mockUseKeyPress.mockReturnValue(false)
+    const stepBlock = {
+      __typename: 'StepBlock',
+      id: 'step.id'
+    } as unknown as TreeBlock<StepBlock>
+    const initialState = {
+      selectedBlock: stepBlock,
+      activeSlide: ActiveSlide.JourneyFlow,
+      steps: [stepBlock]
+    } as unknown as EditorState
+    const edge = {
+      id: 'edge.id',
+      source: 'source',
+      target: 'target'
+    } as unknown as Edge
+
+    const { result, rerender } = renderHook(() => useDeleteOnKeyPress(), {
+      wrapper: ({ children }) => (
+        <JourneyProvider value={{ journey: defaultJourney }}>
+          <EditorProvider initialState={initialState}>
+            <MockedProvider>
+              <MuxVideoUploadProvider>{children}</MuxVideoUploadProvider>
+            </MockedProvider>
+          </EditorProvider>
+        </JourneyProvider>
+      )
+    })
+
+    // select the edge, then deselect it (empty selection)
+    await act(async () =>
+      result.current.onSelectionChange({
+        edges: [edge]
+      } as unknown as OnSelectionChangeParams)
+    )
+    await act(async () =>
+      result.current.onSelectionChange({
+        edges: []
+      } as unknown as OnSelectionChangeParams)
+    )
+
+    // pressing delete should now remove the selected card, not the edge
+    mockUseKeyPress.mockReturnValue(true)
+    rerender()
+
+    await waitFor(async () => expect(deleteBlock).toHaveBeenCalled())
+    expect(deleteEdge).not.toHaveBeenCalled()
+  })
 })

--- a/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/libs/useDeleteOnKeyPress/useDeleteOnKeyPress.ts
+++ b/apps/journeys-admin/src/components/Editor/Slider/JourneyFlow/libs/useDeleteOnKeyPress/useDeleteOnKeyPress.ts
@@ -25,6 +25,10 @@ export function useDeleteOnKeyPress(): {
   const onSelectionChange: OnSelectionChangeFunc = ({ edges }) => {
     if (edges.length > 0) {
       setSelected(edges[0])
+    } else if (selectedBlock?.__typename === 'StepBlock') {
+      setSelected(selectedBlock)
+    } else {
+      setSelected(undefined)
     }
   }
 


### PR DESCRIPTION
## Description

Fixes [NES-1866](https://linear.app/jesus-film-project/issue/NES-1866/backspace-deletes-a-journey-map-connection-you-already-deselected).

On the journey map, clicking a connection arrow selects it (highlights, shows the delete X). Clicking empty canvas visibly deselects it. But the delete handler kept its **own** copy of the selection and never cleared it on deselect, so pressing **Backspace/Delete** removed the connection the user believed was deselected and orphaned the downstream card, with nothing selected on screen.

## Root cause

In `useDeleteOnKeyPress`, `onSelectionChange` only updated the remembered selection when an edge was present, and did nothing on deselect, so the remembered selection drifted out of sync with what is visible. Every sibling selection tracker (`BaseEdge`, `BaseNode`, `CustomEdge`) already handles the empty/deselect case; this hook was the outlier.

## Fix

Add the missing `else` branch so an empty selection falls back to the currently selected card (`StepBlock`), else clears it. Deselect the arrow, and Backspace now deletes the selected card (the ticket expected behaviour). Deleting a genuinely selected connection is unchanged.

## Testing

- Added a unit test: select an edge, deselect it, press Delete, and the selected card is deleted while `deleteEdge` is not called.
- Manual QA on the preview: open a journey with 2+ connected cards, go to the journey map, click an arrow, click empty canvas, then Backspace deletes the selected card, not the connection.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard deletion so that, after deselecting an edge, pressing Delete removes the selected card instead of the previously selected edge.

* **Tests**
  * Added regression coverage for switching selection from an edge to a card.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->