### PR TITLE
docs(context-map): give both remaining sections a bolded Handoff verdict

### DIFF
--- a/CONTEXT-MAP-contract.md
+++ b/CONTEXT-MAP-contract.md
@@ -58,16 +58,13 @@ Authors may add further keys freely (additive); consumers must ignore unknown ke
   `— T4 (cache) · T5 (optimistic drift)`, `— T6, expectation mismatch`). Sections with no T-token
   are untyped (how-to / FAQ / flagged entries) — allowed.
 - `type_tags` in frontmatter equals the union of T-tags found in the file's headings.
-- Bodies are built from bold-label lines (`**Signatures:**`, `**Localizing question (reporter):**`,
-  `**Then ask:**`, `**Ready when:**`, `**Status:**`, `**Look first (fixer):**`, `**Handoff:**`, …).
-  A label line matches after stripping leading indentation and an optional `- ` list marker — the
-  flush-left, indented (list-item continuation), and list-bullet (`- **Handoff:** …`) forms are
-  all accepted. The bold may extend past the label over the whole line, label and value
-  together (e.g. `**Localizing question (reporter): does a refresh fix it?**`).
-  The label vocabulary is **open** — authors may introduce new labels; consumers must not assume a
-  fixed set or order — with one exception:
-- **`Handoff:` is reserved.** Every section closes its diagnosis with a `**Handoff:**` verdict
-  (agent-able / human / how-to-FAQ / ops), the one label consumers may key on semantically.
+- Bodies are prose. Bold labels (`**Signatures:**`, `**Localizing question (reporter):**`,
+  `**Then ask:**`, `**Ready when:**`, `**Status:**`, `**Look first (fixer):**`, …) are the
+  recommended layout so a reader knows where to look; the vocabulary is open, and consumers read
+  bodies as prose — they do not parse labels.
+- **One exception: `Handoff:`.** Every section closes with a `**Handoff:**` verdict
+  (agent-able / human / how-to-FAQ / ops). The validator warns when a section lacks one, and
+  recognises it flush-left, indented, or as a `- ` bullet.
   - A section with no diagnosis layer yet still closes with one: route it to a human, and let a
     `**Status:**` line explain why there is nothing more to say.
 

--- a/CONTEXT-MAP-contract.md
+++ b/CONTEXT-MAP-contract.md
@@ -61,17 +61,19 @@ Authors may add further keys freely (additive); consumers must ignore unknown ke
 - Bodies are built from bold-label lines (`**Signatures:**`, `**Localizing question (reporter):**`,
   `**Then ask:**`, `**Ready when:**`, `**Status:**`, `**Look first (fixer):**`, `**Handoff:**`, …).
   A label line matches after stripping leading indentation and an optional `- ` list marker — the
-  flush-left, indented (list-item continuation), and list-bullet (`- **Handoff:** …`) forms all
-  occur on `main` today. The bold may extend past the label over the whole line, label and value
-  together (e.g. `**Localizing question (reporter): does a refresh fix it?**`).
+  flush-left, indented (list-item continuation), and list-bullet (`- **Look first (fixer):** …`)
+  forms all occur on `main` today. The reserved `Handoff:` label below is the exception: consumers
+  key on it semantically, so it is written flush-left or indented, never as a list bullet. The bold
+  may extend past the label over the whole line, label and value together (e.g.
+  `**Localizing question (reporter): does a refresh fix it?**`).
   The label vocabulary is **open** — authors may introduce new labels; consumers must not assume a
   fixed set or order — with one exception:
 - **`Handoff:` is reserved.** Every section closes its diagnosis with a `**Handoff:**` verdict
   (agent-able / human / how-to-FAQ / ops), the one label consumers may key on semantically.
-  - _Known deviation on `main` today: `apps/journeys/CONTEXT-intake.md` § "Chat / AI assistant"
-    embeds its verdict in `**Status:**` with no `**Handoff:**` line — left as-is deliberately
-    (unreleased feature, plan not settled; Siyang, 2026-08-13). The validator reports it as a
-    warning until the section gets a real diagnosis layer._
+  - A section with no diagnosis layer yet still closes with one: `apps/journeys/CONTEXT-intake.md`
+    § "Chat / AI assistant" carries `**Handoff:** route to a human.` while its `**Status:**` line
+    explains why there is nothing more to say. "Too new to diagnose" is a verdict, not an excuse
+    for omitting one.
 
 ## Index ↔ frontmatter sync
 

--- a/CONTEXT-MAP-contract.md
+++ b/CONTEXT-MAP-contract.md
@@ -61,18 +61,15 @@ Authors may add further keys freely (additive); consumers must ignore unknown ke
 - Bodies are built from bold-label lines (`**Signatures:**`, `**Localizing question (reporter):**`,
   `**Then ask:**`, `**Ready when:**`, `**Status:**`, `**Look first (fixer):**`, `**Handoff:**`, …).
   A label line matches after stripping leading indentation and an optional `- ` list marker — the
-  flush-left, indented (list-item continuation), and list-bullet (`- **Look first (fixer):** …`)
-  forms are all accepted. The reserved `Handoff:` label below is the exception: consumers key on it
-  semantically, so it is written flush-left or indented, never as a list bullet. The bold may
-  extend past the label over the whole line, label and value together (e.g.
-  `**Localizing question (reporter): does a refresh fix it?**`).
+  flush-left, indented (list-item continuation), and list-bullet (`- **Handoff:** …`) forms are
+  all accepted. The bold may extend past the label over the whole line, label and value
+  together (e.g. `**Localizing question (reporter): does a refresh fix it?**`).
   The label vocabulary is **open** — authors may introduce new labels; consumers must not assume a
   fixed set or order — with one exception:
 - **`Handoff:` is reserved.** Every section closes its diagnosis with a `**Handoff:**` verdict
   (agent-able / human / how-to-FAQ / ops), the one label consumers may key on semantically.
-  - A section with no diagnosis layer yet still closes with one. "Too new to diagnose", "too
-    low-signal to encode" and "dormant, route to a human" are verdicts; a `**Status:**` line
-    explaining why there is nothing more to say does not replace one.
+  - A section with no diagnosis layer yet still closes with one: route it to a human, and let a
+    `**Status:**` line explain why there is nothing more to say.
 
 ## Index ↔ frontmatter sync
 

--- a/CONTEXT-MAP-contract.md
+++ b/CONTEXT-MAP-contract.md
@@ -58,13 +58,12 @@ Authors may add further keys freely (additive); consumers must ignore unknown ke
   `— T4 (cache) · T5 (optimistic drift)`, `— T6, expectation mismatch`). Sections with no T-token
   are untyped (how-to / FAQ / flagged entries) — allowed.
 - `type_tags` in frontmatter equals the union of T-tags found in the file's headings.
-- Bodies are prose. Bold labels (`**Signatures:**`, `**Localizing question (reporter):**`,
-  `**Then ask:**`, `**Ready when:**`, `**Status:**`, `**Look first (fixer):**`, …) are the
-  recommended layout so a reader knows where to look; the vocabulary is open, and consumers read
-  bodies as prose — they do not parse labels.
-- **One exception: `Handoff:`.** Every section closes with a `**Handoff:**` verdict
-  (agent-able / human / how-to-FAQ / ops). The validator warns when a section lacks one, and
-  recognises it flush-left, indented, or as a `- ` bullet.
+- Bodies are prose. Bold labels (`**Signatures:**`, `**Look first (fixer):**`, …) are a
+  recommended layout so a reader knows where to look — the vocabulary is open, and consumers
+  read bodies as prose rather than parsing labels.
+- **One exception: `Handoff:`.** Every section carries a `**Handoff:**` verdict
+  (agent-able / human / how-to-FAQ / ops), closing its diagnosis. The validator warns when a
+  section lacks one.
   - A section with no diagnosis layer yet still closes with one: route it to a human, and let a
     `**Status:**` line explain why there is nothing more to say.
 

--- a/CONTEXT-MAP-contract.md
+++ b/CONTEXT-MAP-contract.md
@@ -62,18 +62,17 @@ Authors may add further keys freely (additive); consumers must ignore unknown ke
   `**Then ask:**`, `**Ready when:**`, `**Status:**`, `**Look first (fixer):**`, `**Handoff:**`, …).
   A label line matches after stripping leading indentation and an optional `- ` list marker — the
   flush-left, indented (list-item continuation), and list-bullet (`- **Look first (fixer):** …`)
-  forms all occur on `main` today. The reserved `Handoff:` label below is the exception: consumers
-  key on it semantically, so it is written flush-left or indented, never as a list bullet. The bold
-  may extend past the label over the whole line, label and value together (e.g.
+  forms are all accepted. The reserved `Handoff:` label below is the exception: consumers key on it
+  semantically, so it is written flush-left or indented, never as a list bullet. The bold may
+  extend past the label over the whole line, label and value together (e.g.
   `**Localizing question (reporter): does a refresh fix it?**`).
   The label vocabulary is **open** — authors may introduce new labels; consumers must not assume a
   fixed set or order — with one exception:
 - **`Handoff:` is reserved.** Every section closes its diagnosis with a `**Handoff:**` verdict
   (agent-able / human / how-to-FAQ / ops), the one label consumers may key on semantically.
-  - A section with no diagnosis layer yet still closes with one: `apps/journeys/CONTEXT-intake.md`
-    § "Chat / AI assistant" carries `**Handoff:** route to a human.` while its `**Status:**` line
-    explains why there is nothing more to say. "Too new to diagnose" is a verdict, not an excuse
-    for omitting one.
+  - A section with no diagnosis layer yet still closes with one. "Too new to diagnose", "too
+    low-signal to encode" and "dormant, route to a human" are verdicts; a `**Status:**` line
+    explaining why there is nothing more to say does not replace one.
 
 ## Index ↔ frontmatter sync
 

--- a/apps/journeys-admin/CONTEXT-intake.md
+++ b/apps/journeys-admin/CONTEXT-intake.md
@@ -214,8 +214,9 @@ created / sync not running).
   (`googleCreate.mutation.ts`, `googleUpdate.mutation.ts`); the sync worker →
   `apis/api-journeys/src/workers/googleSheetsSync/`; the row/header build + write-to-sheet →
   `apis/api-journeys/src/schema/googleSheetsSync/appendEventToGoogleSheets.ts`.
-  **Handoff:** OAuth reconnect → often human; sync-job defects → agent-able.
-  **Growth Spaces:** dormant — no recent reports, believed unused. Map stays thin; route to a human.
+
+**Handoff:** OAuth reconnect → often human; sync-job defects → agent-able.
+**Growth Spaces:** dormant — no recent reports, believed unused. Map stays thin; route to a human.
 
 ## Email notifications
 

--- a/apps/journeys-admin/CONTEXT-intake.md
+++ b/apps/journeys-admin/CONTEXT-intake.md
@@ -214,7 +214,7 @@ created / sync not running).
   (`googleCreate.mutation.ts`, `googleUpdate.mutation.ts`); the sync worker →
   `apis/api-journeys/src/workers/googleSheetsSync/`; the row/header build + write-to-sheet →
   `apis/api-journeys/src/schema/googleSheetsSync/appendEventToGoogleSheets.ts`.
-- **Handoff:** OAuth reconnect → often human; sync-job defects → agent-able.
+  **Handoff:** OAuth reconnect → often human; sync-job defects → agent-able.
   **Growth Spaces:** dormant — no recent reports, believed unused. Map stays thin; route to a human.
 
 ## Email notifications

--- a/apps/journeys-admin/CONTEXT-intake.md
+++ b/apps/journeys-admin/CONTEXT-intake.md
@@ -214,9 +214,8 @@ created / sync not running).
   (`googleCreate.mutation.ts`, `googleUpdate.mutation.ts`); the sync worker →
   `apis/api-journeys/src/workers/googleSheetsSync/`; the row/header build + write-to-sheet →
   `apis/api-journeys/src/schema/googleSheetsSync/appendEventToGoogleSheets.ts`.
-
-**Handoff:** OAuth reconnect → often human; sync-job defects → agent-able.
-**Growth Spaces:** dormant — no recent reports, believed unused. Map stays thin; route to a human.
+- **Handoff:** OAuth reconnect → often human; sync-job defects → agent-able.
+  **Growth Spaces:** dormant — no recent reports, believed unused. Map stays thin; route to a human.
 
 ## Email notifications
 

--- a/apps/journeys/CONTEXT-intake.md
+++ b/apps/journeys/CONTEXT-intake.md
@@ -104,3 +104,4 @@ oEmbed-shape — but treat as human-diagnosed until we have real cases.)
 
 **Status:** still new, behind a flag, not widely used, not officially released → no accurate failure
 data yet. Don't encode a diagnosis layer; route to a human. Revisit after release.
+**Handoff:** route to a human.


### PR DESCRIPTION
Docs only. Two `validate-map` warnings against `main` prompted this; one was a real gap in the map, the other was not.

**`apps/journeys/CONTEXT-intake.md` § "Chat / AI assistant"** genuinely lacked an explicit verdict — it had one embedded in `**Status:**` and no `**Handoff:**` line — so it gains one line, `**Handoff:** route to a human.` Every section closes with an explicit agent-able / human / how-to-FAQ / ops verdict, so a reader has one consistent place to look; the `**Status:**` line is untouched and still explains why there is nothing more to say.

**`apps/journeys-admin/CONTEXT-intake.md` § Integrations is deliberately untouched.** Its warning is a bug in the hatsu validator, not a problem with the map: `CONTEXT-MAP-contract.md` says a label line matches "after stripping leading indentation and an optional `- ` list marker", and `extractHandoff` is `/^\s*\*\*Handoff:\*\*/`, which never strips the marker. The bullet form is contract-conforming, so it stays, and the parser is fixed in [JesusFilm/hatsu#6](https://github.com/JesusFilm/hatsu/pull/6). **With that PR this branch is clean; against hatsu `main` before it lands, the one warning is the parser bug and not a regression here.** The two PRs are independent — either order works.

**`CONTEXT-MAP-contract.md`** stops describing what `main` happens to look like — the observation that went stale and made this PR necessary in the first place. Its "known deviation on `main`" note becomes a one-sentence rule: a section with no diagnosis layer yet still closes with a verdict.

§Section anatomy also stops teaching authors the parser's line forms: bold labels are stated as the recommended layout, not syntax, and consumers read bodies as prose — the only thing checked is that a section closes with a `**Handoff:**` verdict, in any line form.

### Verification

- `validate-map` against this branch, both measured: **0 errors, 0 warnings** with [hatsu#6](https://github.com/JesusFilm/hatsu/pull/6)'s parser fix, **0 errors, 1 warning** against hatsu `main` before it — the bullet-form bug described above.
- Prettier clean on both changed files.
- Diff against `main` is 2 files, +10/−14: one added line in journeys, the rest the contract.

Linear: ENG-3706

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified accepted formatting for section labels, including flush-left, indented, and bulleted forms.
  * Clarified that bold labels may include their associated values.
  * Updated requirements so every section includes a handoff verdict, including sections without a diagnosis layer.
  * Added guidance to escalate out-of-scope Chat or AI assistant issues to a human.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

