### PR TITLE
feat(videos-admin): add label filter to Algolia video search debugger

### DIFF
--- a/apps/videos-admin/src/app/(dashboard)/videos/_VideoList/VideoList.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/_VideoList/VideoList.tsx
@@ -22,6 +22,7 @@ import {
   GridValidRowModel,
   MuiEvent,
   getGridBooleanOperators,
+  getGridSingleSelectOperators,
   getGridStringOperators,
   gridClasses,
   useGridApiContext
@@ -35,6 +36,7 @@ import { ResultOf, VariablesOf, graphql } from '@core/shared/gql'
 import Lock1 from '@core/shared/ui/icons/Lock1'
 
 import { PublishedChip } from '../../../../components/PublishedChip'
+import { videoLabels } from '../../../../constants'
 import { useVideoFilter } from '../../../../libs/useVideoFilter'
 
 import { VideoListHeader } from './_VideoListHeader'
@@ -79,6 +81,7 @@ export const GET_ADMIN_VIDEOS_AND_COUNT = graphql(`
   ) {
     adminVideos(limit: $limit, offset: $offset, where: $where) {
       id
+      label
       locked
       title @include(if: $showTitle) {
         primary
@@ -302,6 +305,7 @@ export function VideoList(): ReactElement {
       const description = video?.snippet?.find(({ primary }) => primary)?.value
       return {
         id: video.id,
+        label: video.label,
         title,
         description,
         published: video.published,
@@ -333,6 +337,19 @@ export function VideoList(): ReactElement {
       minWidth: 200,
       filterOperators: getGridStringOperators().filter(
         (operator) => operator.value === 'equals'
+      )
+    },
+    {
+      field: 'label',
+      headerName: 'Label',
+      width: 140,
+      type: 'singleSelect',
+      valueOptions: videoLabels.map(({ label, value }) => ({
+        label,
+        value
+      })),
+      filterOperators: getGridSingleSelectOperators().filter(
+        (operator) => operator.value === 'is'
       )
     },
     {

--- a/apps/videos-admin/src/libs/useVideoFilter/useVideoFilter.spec.tsx
+++ b/apps/videos-admin/src/libs/useVideoFilter/useVideoFilter.spec.tsx
@@ -35,6 +35,7 @@ describe('useVideoFilter', () => {
         locked: true,
         id: true,
         title: true,
+        label: true,
         description: true,
         published: true
       },
@@ -80,6 +81,7 @@ describe('useVideoFilter', () => {
         locked: true,
         id: true,
         title: false,
+        label: true,
         description: true,
         published: true
       },
@@ -165,6 +167,23 @@ describe('useVideoFilter', () => {
     })
   })
 
+  it('should return initial state with label filter from query params', () => {
+    const search = new URLSearchParams(
+      'filters[label][is]=collection'
+    ) as ReadonlyURLSearchParams
+
+    mockUseSearchParams.mockReturnValue(search)
+
+    const { result } = renderHook(useVideoFilter)
+
+    expect(result.current.filters.where).toStrictEqual({
+      labels: ['collection']
+    })
+    expect(result.current.tableFilterProps.filterModel).toStrictEqual({
+      items: [{ field: 'label', operator: 'is', value: 'collection' }]
+    })
+  })
+
   it('should update query params', () => {
     const search = new URLSearchParams() as ReadonlyURLSearchParams
 
@@ -191,6 +210,7 @@ describe('useVideoFilter', () => {
         locked: true,
         id: true,
         title: true,
+        label: true,
         description: true,
         published: true
       },
@@ -257,6 +277,25 @@ describe('useVideoFilter', () => {
           ids: ['11_Advent'],
           title: 'Jesus',
           published: false
+        }
+      })
+    })
+
+    it('should handle FilterChange action with label filter', () => {
+      const filterModel = {
+        items: [{ field: 'label', operator: 'is', value: 'collection' }]
+      }
+
+      expect(
+        reducer(initialState, {
+          type: 'FilterChange',
+          model: filterModel
+        })
+      ).toEqual({
+        ...initialState,
+        filterModel: filterModel,
+        whereArgs: {
+          labels: ['collection']
         }
       })
     })

--- a/apps/videos-admin/src/libs/useVideoFilter/useVideoFilter.tsx
+++ b/apps/videos-admin/src/libs/useVideoFilter/useVideoFilter.tsx
@@ -52,6 +52,17 @@ export function reducer(state: FilterState, action: FilterAction): FilterState {
   }
 }
 
+const VideoLabelSchema = z.enum([
+  'collection',
+  'episode',
+  'featureFilm',
+  'segment',
+  'series',
+  'shortFilm',
+  'trailer',
+  'behindTheScenes'
+])
+
 /**
  * Every field catches its own parse failure, so one malformed query param
  * drops only that filter instead of discarding the whole model.
@@ -72,6 +83,12 @@ const FilterModelSchema = z.object({
   title: z
     .object({
       equals: z.string()
+    })
+    .optional()
+    .catch(undefined),
+  label: z
+    .object({
+      is: VideoLabelSchema
     })
     .optional()
     .catch(undefined),
@@ -117,6 +134,7 @@ function getColumnVisibilityModel(
     'locked',
     'id',
     'title',
+    'label',
     'description',
     'published'
   ]
@@ -162,6 +180,14 @@ function getWhereArgs(model: GridFilterModel): VideosWhereFilter {
         item.value != null
       )
         where.locked = item.value
+
+      if (
+        item.field === 'label' &&
+        item.operator === 'is' &&
+        item.value != null &&
+        item.value !== ''
+      )
+        where.labels = [item.value]
     })
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Label column to the video administration list.
  * Added single-select label filtering with available video label options.
  * Label filters can be applied from the table and reflected in URL-based filtering.
  * Label filtering supports selecting a specific label and updating results accordingly.

* **Tests**
  * Added coverage for label visibility, query parsing, URL-based filtering, and filter application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->