### PR TITLE
fix(api-journeys): restore publisher access to template customization fields (QA-563)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ## Before you push
 
-**Asked to push? Run `pnpm lint:changed --fix` first, commit anything it changes, and push that in the same go.** Never push without it.
+**Asked to push? Run `pnpm lint:changed --fix` first, commit anything it changes, type-check the affected projects, and push that in the same go.** Never push without it.
 
 It applies the same fixes [autofix.ci](https://autofix.ci) would otherwise commit to your PR afterwards — formatting, lint fixes, translation extraction. They are generated output, so they belong in your commit, not in a bot commit on top of it. There is no pre-push hook and nothing will stop you: if you skip this, the bot does it for you and the PR grows a `fix: lint issues` commit. Details in [Lint before push](#lint-before-push-agents).
 
@@ -55,6 +55,10 @@ if [ -n "$(git status --porcelain)" ]; then
   git commit --no-verify -m "chore: lint fixes" || { echo "could not commit generated fixes; aborting push"; exit 1; }
 fi
 
+# Type-check what the branch touched — CI's lint-work job runs this exact
+# target, and lint:changed cannot catch type errors (see below).
+pnpm exec nx affected --target=type-check --base=origin/main || { echo "type-check failed — fix the errors above, then re-run"; exit 1; }
+
 git push
 ```
 
@@ -78,7 +82,9 @@ Not covered locally: **`codegen`** is the one autofix.ci step that can still com
 
 It is deliberately not gated, because it only works where `apollo` is already installed globally. The devcontainer installs it in [`post-create-command.sh`](.devcontainer/post-create-command.sh) (`npm i -g nx foreman apollo graphql`) and autofix.ci does the same, which is why it works in both. On a plain host checkout `apollo` is absent, so `npx` tries to fetch it and fails with `EOVERRIDE` from the `next` override in `package.json` — gating it would mean requiring that global install everywhere, which we chose not to do. Work in the devcontainer, or expect autofix.ci to commit the regenerated files.
 
-The remaining steps cannot produce a commit at all: `type-check` and `subgraph-check` only report (and `subgraph-check` needs a Hive token), and `prisma-generate` writes nothing that is tracked.
+**`type-check`** cannot produce a commit (it only reports), but it is still gated in the ritual above because CI's `lint-work` job fails on it and nothing in `lint:changed` covers types. Two traps: each project's `type-check` target runs `tsc7` (the TypeScript 7 preview via `tsconfig.ts7.json`), which is stricter than editor tsc — code your IDE accepts can still fail it. And nx prints the same trailing summary block on success and failure, so never judge the outcome from the tail of piped output — check the exit code.
+
+The remaining steps cannot produce a commit at all: `subgraph-check` only reports (and needs a Hive token), and `prisma-generate` writes nothing that is tracked.
 
 ### Documented Solutions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,8 @@ fi
 
 # Type-check what the branch touched — CI's lint-work job runs this exact
 # target, and lint:changed cannot catch type errors (see below).
-pnpm exec nx affected --target=type-check --base=origin/main || { echo "type-check failed — fix the errors above, then re-run"; exit 1; }
+git fetch origin main --quiet || true
+pnpm exec nx affected --target=type-check --base=origin/main || { echo "type-check failed — either real type errors above, or an environment gap (origin/main unfetched, node_modules not installed in this worktree)"; exit 1; }
 
 git push
 ```
@@ -82,7 +83,7 @@ Not covered locally: **`codegen`** is the one autofix.ci step that can still com
 
 It is deliberately not gated, because it only works where `apollo` is already installed globally. The devcontainer installs it in [`post-create-command.sh`](.devcontainer/post-create-command.sh) (`npm i -g nx foreman apollo graphql`) and autofix.ci does the same, which is why it works in both. On a plain host checkout `apollo` is absent, so `npx` tries to fetch it and fails with `EOVERRIDE` from the `next` override in `package.json` — gating it would mean requiring that global install everywhere, which we chose not to do. Work in the devcontainer, or expect autofix.ci to commit the regenerated files.
 
-**`type-check`** cannot produce a commit (it only reports), but it is still gated in the ritual above because CI's `lint-work` job fails on it and nothing in `lint:changed` covers types. Two traps: each project's `type-check` target runs `tsc7` (the TypeScript 7 preview via `tsconfig.ts7.json`), which is stricter than editor tsc — code your IDE accepts can still fail it. And nx prints the same trailing summary block on success and failure, so never judge the outcome from the tail of piped output — check the exit code.
+**`type-check`** cannot produce a commit (it only reports), but it is still gated in the ritual above because CI's `lint-work` job fails on it and nothing in `lint:changed` covers types. It is the slowest step of the four — expect tens of seconds for a typical branch (a few seconds per affected project, plus nx overhead), so a pause is normal. Two traps: each project's `type-check` target runs `tsc7` (the TypeScript 7 preview via `tsconfig.ts7.json`), which is stricter than editor tsc — code your IDE accepts can still fail it. And nx prints the same trailing summary block on success and failure, so never judge the outcome from the tail of piped output — check the exit code. The command also exits non-zero on environment gaps (`origin/main` not fetched, `node_modules` missing in a fresh worktree) — rule those out before hunting for type errors.
 
 The remaining steps cannot produce a commit at all: `subgraph-check` only reports (and needs a Hive token), and `prisma-generate` writes nothing that is tracked.
 

--- a/apis/api-journeys/src/schema/journey/journey.acl.spec.ts
+++ b/apis/api-journeys/src/schema/journey/journey.acl.spec.ts
@@ -409,9 +409,20 @@ describe('canManageTemplateField', () => {
   } as unknown as Journey
 
   describe('publisher', () => {
-    it('allows any template without team or journey roles (QA-563)', () => {
+    it('allows jfp-team templates without team or journey roles (QA-563)', () => {
       expect(canManageTemplateField(jfpTemplateNoRoles, publisher)).toBe(true)
-      expect(canManageTemplateField(localTemplateNoRoles, publisher)).toBe(true)
+    })
+
+    it('denies other teams local templates without team or journey roles', () => {
+      expect(canManageTemplateField(localTemplateNoRoles, publisher)).toBe(
+        false
+      )
+    })
+
+    it('allows local templates through team or journey roles', () => {
+      expect(canManageTemplateField(localTemplateTeamMember, publisher)).toBe(
+        true
+      )
     })
 
     it('allows converting an owned journey to a template', () => {

--- a/apis/api-journeys/src/schema/journey/journey.acl.spec.ts
+++ b/apis/api-journeys/src/schema/journey/journey.acl.spec.ts
@@ -349,8 +349,8 @@ describe('journeyAcl', () => {
 })
 
 describe('canManageTemplateField', () => {
-  const user = { id: 'userId' }
-  const publisher = { id: 'userId', roles: ['publisher'] }
+  const user = { id: 'userId', firstName: 'Test', emailVerified: true }
+  const publisher = { ...user, roles: ['publisher'] }
 
   const jfpTemplateNoRoles = {
     id: 'journeyId',

--- a/apis/api-journeys/src/schema/journey/journey.acl.spec.ts
+++ b/apis/api-journeys/src/schema/journey/journey.acl.spec.ts
@@ -6,7 +6,7 @@ import {
 
 import { Action } from '../../lib/auth/ability'
 
-import { Journey, journeyAcl } from './journey.acl'
+import { Journey, canManageTemplateField, journeyAcl } from './journey.acl'
 
 describe('journeyAcl', () => {
   const user = { id: 'userId' }
@@ -344,6 +344,108 @@ describe('journeyAcl', () => {
 
     it('denies when user has no userTeam or userJourneys', () => {
       expect(can(Action.Export, journeyEmpty, user)).toBe(false)
+    })
+  })
+})
+
+describe('canManageTemplateField', () => {
+  const user = { id: 'userId' }
+  const publisher = { id: 'userId', roles: ['publisher'] }
+
+  const jfpTemplateNoRoles = {
+    id: 'journeyId',
+    template: true,
+    teamId: 'jfp-team',
+    userJourneys: [],
+    team: { userTeams: [] }
+  } as unknown as Journey
+
+  const jfpTemplateTeamManager = {
+    id: 'journeyId',
+    template: true,
+    teamId: 'jfp-team',
+    userJourneys: [],
+    team: { userTeams: [{ userId: user.id, role: UserTeamRole.manager }] }
+  } as unknown as Journey
+
+  const localTemplateNoRoles = {
+    id: 'journeyId',
+    template: true,
+    teamId: 'teamId',
+    userJourneys: [],
+    team: { userTeams: [] }
+  } as unknown as Journey
+
+  const localTemplateTeamMember = {
+    id: 'journeyId',
+    template: true,
+    teamId: 'teamId',
+    userJourneys: [],
+    team: { userTeams: [{ userId: user.id, role: UserTeamRole.member }] }
+  } as unknown as Journey
+
+  const localTemplateJourneyEditor = {
+    id: 'journeyId',
+    template: true,
+    teamId: 'teamId',
+    userJourneys: [{ userId: user.id, role: UserJourneyRole.editor }],
+    team: { userTeams: [] }
+  } as unknown as Journey
+
+  const journeyOwnerNonTemplate = {
+    id: 'journeyId',
+    template: false,
+    teamId: 'teamId',
+    userJourneys: [{ userId: user.id, role: UserJourneyRole.owner }],
+    team: { userTeams: [] }
+  } as unknown as Journey
+
+  const journeyNoRolesNonTemplate = {
+    id: 'journeyId',
+    template: false,
+    teamId: 'teamId',
+    userJourneys: [],
+    team: { userTeams: [] }
+  } as unknown as Journey
+
+  describe('publisher', () => {
+    it('allows any template without team or journey roles (QA-563)', () => {
+      expect(canManageTemplateField(jfpTemplateNoRoles, publisher)).toBe(true)
+      expect(canManageTemplateField(localTemplateNoRoles, publisher)).toBe(true)
+    })
+
+    it('allows converting an owned journey to a template', () => {
+      expect(canManageTemplateField(journeyOwnerNonTemplate, publisher)).toBe(
+        true
+      )
+    })
+
+    it('denies a non-template journey without team or journey roles', () => {
+      expect(canManageTemplateField(journeyNoRolesNonTemplate, publisher)).toBe(
+        false
+      )
+    })
+  })
+
+  describe('non-publisher', () => {
+    it('allows local templates for team members and journey editors', () => {
+      expect(canManageTemplateField(localTemplateTeamMember, user)).toBe(true)
+      expect(canManageTemplateField(localTemplateJourneyEditor, user)).toBe(
+        true
+      )
+    })
+
+    it('denies jfp-team templates even for team managers', () => {
+      expect(canManageTemplateField(jfpTemplateTeamManager, user)).toBe(false)
+    })
+
+    it('denies templates without team or journey roles', () => {
+      expect(canManageTemplateField(jfpTemplateNoRoles, user)).toBe(false)
+      expect(canManageTemplateField(localTemplateNoRoles, user)).toBe(false)
+    })
+
+    it('denies non-template journeys even for owners', () => {
+      expect(canManageTemplateField(journeyOwnerNonTemplate, user)).toBe(false)
     })
   })
 })

--- a/apis/api-journeys/src/schema/journey/journey.acl.ts
+++ b/apis/api-journeys/src/schema/journey/journey.acl.ts
@@ -243,11 +243,13 @@ export function canManageTemplateField(
 
   if (user.roles?.includes('publisher') !== true) return false
 
-  // Publishers manage any existing template without needing a team/journey
-  // role: in the legacy CASL, can(Manage, 'Journey', { template: true }) was
-  // declared after cannot(Manage, 'Journey', 'template'), so it re-unlocked
-  // the template field for every template (QA-563).
-  if (journey.template === true) return true
+  // Publishers manage global (jfp-team) templates without needing a
+  // team/journey role (QA-563). Deliberately narrower than the legacy CASL,
+  // which — via rule ordering, can(Manage, 'Journey', { template: true })
+  // declared after cannot(Manage, 'Journey', 'template') — accidentally
+  // unlocked every team's templates; publishers only govern the global
+  // template library, so other teams' local templates stay membership-only.
+  if (journey.template === true && journey.teamId === 'jfp-team') return true
 
   // Converting their own journey to a template still requires a role on it.
   return hasJourneyRole || hasTeamRole

--- a/apis/api-journeys/src/schema/journey/journey.acl.ts
+++ b/apis/api-journeys/src/schema/journey/journey.acl.ts
@@ -241,11 +241,14 @@ export function canManageTemplateField(
 
   if (isLocalTemplate && (hasJourneyRole || hasTeamRole)) return true
 
-  if (
-    user.roles?.includes('publisher') === true &&
-    (hasJourneyRole || hasTeamRole)
-  )
-    return true
+  if (user.roles?.includes('publisher') !== true) return false
 
-  return false
+  // Publishers manage any existing template without needing a team/journey
+  // role: in the legacy CASL, can(Manage, 'Journey', { template: true }) was
+  // declared after cannot(Manage, 'Journey', 'template'), so it re-unlocked
+  // the template field for every template (QA-563).
+  if (journey.template === true) return true
+
+  // Converting their own journey to a template still requires a role on it.
+  return hasJourneyRole || hasTeamRole
 }

--- a/apis/api-journeys/src/schema/journeyCustomizationField/journeyCustomizationFieldPublisherUpdate.mutation.spec.ts
+++ b/apis/api-journeys/src/schema/journeyCustomizationField/journeyCustomizationFieldPublisherUpdate.mutation.spec.ts
@@ -1,7 +1,11 @@
 import { ExecutionResult } from 'graphql'
 import { type MockedFunction, vi } from 'vitest'
 
-import { UserJourneyRole, UserTeamRole } from '@core/prisma/journeys/client'
+import {
+  Role,
+  UserJourneyRole,
+  UserTeamRole
+} from '@core/prisma/journeys/client'
 import { getUserFromPayload } from '@core/yoga/firebaseClient'
 
 import { getClient } from '../../../test/client'
@@ -71,7 +75,7 @@ describe('journeyCustomizationFieldPublisherUpdate', () => {
     }
   }
 
-  function mockRoles(roles: string[]): void {
+  function mockRoles(roles: Role[]): void {
     prismaMock.userRole.findUnique.mockResolvedValue({
       id: 'userRoleId',
       userId: mockUser.id,

--- a/apis/api-journeys/src/schema/journeyCustomizationField/journeyCustomizationFieldPublisherUpdate.mutation.spec.ts
+++ b/apis/api-journeys/src/schema/journeyCustomizationField/journeyCustomizationFieldPublisherUpdate.mutation.spec.ts
@@ -1,0 +1,219 @@
+import { ExecutionResult } from 'graphql'
+import { type MockedFunction, vi } from 'vitest'
+
+import { UserJourneyRole, UserTeamRole } from '@core/prisma/journeys/client'
+import { getUserFromPayload } from '@core/yoga/firebaseClient'
+
+import { getClient } from '../../../test/client'
+import { prismaMock } from '../../../test/prismaMock'
+import { graphql } from '../../lib/graphql/subgraphGraphql'
+
+vi.mock('@core/yoga/firebaseClient', () => ({
+  getUserFromPayload: vi.fn()
+}))
+
+const mockGetUserFromPayload = getUserFromPayload as MockedFunction<
+  typeof getUserFromPayload
+>
+
+describe('journeyCustomizationFieldPublisherUpdate', () => {
+  const mockUser = {
+    id: 'userId',
+    email: 'test@example.com',
+    emailVerified: true,
+    firstName: 'Test',
+    lastName: 'User',
+    imageUrl: null
+  }
+
+  const authClient = getClient({
+    headers: { authorization: 'token' },
+    context: { currentUser: mockUser }
+  })
+
+  const JOURNEY_CUSTOMIZATION_DESCRIPTION_UPDATE = graphql(`
+    mutation JourneyCustomizationDescriptionUpdate(
+      $journeyId: ID!
+      $string: String!
+    ) {
+      journeyCustomizationFieldPublisherUpdate(
+        journeyId: $journeyId
+        string: $string
+      ) {
+        id
+        journeyId
+        key
+        value
+        defaultValue
+      }
+    }
+  `)
+
+  const inputString = 'Share this with {{ name: "a friend" }}'
+
+  const updatedFields = [
+    {
+      id: 'fieldId',
+      journeyId: 'journeyId',
+      key: 'name',
+      value: 'a friend',
+      defaultValue: 'a friend'
+    }
+  ]
+
+  const tx = {
+    journeyCustomizationField: {
+      deleteMany: vi.fn(),
+      createMany: vi.fn()
+    },
+    journey: {
+      update: vi.fn()
+    }
+  }
+
+  function mockRoles(roles: string[]): void {
+    prismaMock.userRole.findUnique.mockResolvedValue({
+      id: 'userRoleId',
+      userId: mockUser.id,
+      roles
+    })
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetUserFromPayload.mockReturnValue(mockUser)
+    prismaMock.$transaction.mockImplementation(async (cb: any) => await cb(tx))
+    prismaMock.journeyCustomizationField.findMany.mockResolvedValue(
+      updatedFields as any
+    )
+  })
+
+  it('allows a publisher without team or journey roles to update a template', async () => {
+    mockRoles(['publisher'])
+    prismaMock.journey.findUnique.mockResolvedValueOnce({
+      id: 'journeyId',
+      template: true,
+      teamId: 'jfp-team',
+      userJourneys: [],
+      team: { id: 'jfp-team', userTeams: [] }
+    } as any)
+
+    const result = (await authClient({
+      document: JOURNEY_CUSTOMIZATION_DESCRIPTION_UPDATE,
+      variables: { journeyId: 'journeyId', string: inputString }
+    })) as ExecutionResult<{
+      journeyCustomizationFieldPublisherUpdate: typeof updatedFields
+    }>
+
+    expect(result.errors).toBeUndefined()
+    expect(result.data?.journeyCustomizationFieldPublisherUpdate).toEqual(
+      updatedFields
+    )
+    expect(tx.journeyCustomizationField.deleteMany).toHaveBeenCalledWith({
+      where: { journeyId: 'journeyId' }
+    })
+    expect(tx.journey.update).toHaveBeenCalledWith({
+      where: { id: 'journeyId' },
+      data: { journeyCustomizationDescription: inputString }
+    })
+    expect(tx.journeyCustomizationField.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          journeyId: 'journeyId',
+          key: 'name',
+          value: 'a friend',
+          defaultValue: 'a friend'
+        })
+      ]
+    })
+  })
+
+  it('allows a team member to update a local template', async () => {
+    mockRoles([])
+    prismaMock.journey.findUnique.mockResolvedValueOnce({
+      id: 'journeyId',
+      template: true,
+      teamId: 'teamId',
+      userJourneys: [],
+      team: {
+        id: 'teamId',
+        userTeams: [{ userId: mockUser.id, role: UserTeamRole.member }]
+      }
+    } as any)
+
+    const result = (await authClient({
+      document: JOURNEY_CUSTOMIZATION_DESCRIPTION_UPDATE,
+      variables: { journeyId: 'journeyId', string: inputString }
+    })) as ExecutionResult<{
+      journeyCustomizationFieldPublisherUpdate: typeof updatedFields
+    }>
+
+    expect(result.errors).toBeUndefined()
+    expect(result.data?.journeyCustomizationFieldPublisherUpdate).toEqual(
+      updatedFields
+    )
+  })
+
+  it('denies a non-publisher without team or journey roles', async () => {
+    mockRoles([])
+    prismaMock.journey.findUnique.mockResolvedValueOnce({
+      id: 'journeyId',
+      template: true,
+      teamId: 'jfp-team',
+      userJourneys: [],
+      team: { id: 'jfp-team', userTeams: [] }
+    } as any)
+
+    const result = (await authClient({
+      document: JOURNEY_CUSTOMIZATION_DESCRIPTION_UPDATE,
+      variables: { journeyId: 'journeyId', string: inputString }
+    })) as ExecutionResult
+
+    expect(result.errors?.[0]?.message).toBe(
+      'user is not allowed to update journey customization field'
+    )
+    expect(tx.journeyCustomizationField.deleteMany).not.toHaveBeenCalled()
+  })
+
+  it('denies a non-publisher team member of a jfp-team template', async () => {
+    mockRoles([])
+    prismaMock.journey.findUnique.mockResolvedValueOnce({
+      id: 'journeyId',
+      template: true,
+      teamId: 'jfp-team',
+      userJourneys: [],
+      team: {
+        id: 'jfp-team',
+        userTeams: [{ userId: mockUser.id, role: UserTeamRole.manager }]
+      }
+    } as any)
+
+    const result = (await authClient({
+      document: JOURNEY_CUSTOMIZATION_DESCRIPTION_UPDATE,
+      variables: { journeyId: 'journeyId', string: inputString }
+    })) as ExecutionResult
+
+    expect(result.errors?.[0]?.message).toBe(
+      'user is not allowed to update journey customization field'
+    )
+  })
+
+  it('rejects a non-template journey even when the publisher owns it', async () => {
+    mockRoles(['publisher'])
+    prismaMock.journey.findUnique.mockResolvedValueOnce({
+      id: 'journeyId',
+      template: false,
+      teamId: 'teamId',
+      userJourneys: [{ userId: mockUser.id, role: UserJourneyRole.owner }],
+      team: { id: 'teamId', userTeams: [] }
+    } as any)
+
+    const result = (await authClient({
+      document: JOURNEY_CUSTOMIZATION_DESCRIPTION_UPDATE,
+      variables: { journeyId: 'journeyId', string: inputString }
+    })) as ExecutionResult
+
+    expect(result.errors?.[0]?.message).toBe('journey is not a template')
+    expect(tx.journeyCustomizationField.deleteMany).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Fixes [QA-563](https://linear.app/jesus-film-project/issue/QA-563/error-when-deselecting-featured-template-and-saving).

## Problem

Saving Template Settings (e.g. after deselecting **Featured**) failed with:

> User is not allowed to update journey customization field

for publishers who hold no userTeam/userJourney role on the template. The `journeyUpdate` mutation succeeded, then `journeyCustomizationFieldPublisherUpdate` threw FORBIDDEN — and because the dialog runs its mutations sequentially, the `journeyFeature` mutation never fired, so the featured change was lost as well.

## Root cause

`canManageTemplateField` (introduced in the NestJS→Pothos migration, #9255) mistranslated the legacy CASL rules: it requires publishers to *also* hold a team/journey role on the journey.

In the legacy ACL, `can(Manage, 'Journey', { template: true })` for publishers was declared **after** `cannot(Manage, 'Journey', 'template')`; CASL's last-rule-wins semantics meant that rule re-unlocked the `template` field for publishers on **any** existing template, no membership needed. The membership-scoped publisher field rules only governed a different case — converting your own non-template journey into a template. The migration collapsed both cases into the stricter one, so every publisher who isn't a member of `jfp-team` has been unable to save template settings since.

## Fix

Restore the legacy truth table in `canManageTemplateField`, except deliberately narrowed for publishers to global templates (see second row):

| Case | Result |
| --- | --- |
| publisher + jfp-team template | allow (no membership needed) |
| publisher + other team's local template, no role | deny — deliberately narrower than legacy, whose CASL rule ordering accidentally unlocked every team's templates; publishers only govern the global (jfp-team) template library |
| publisher + non-template + own team/journey role | allow (convert-to-template path) |
| local template + team/journey role | allow (unchanged) |
| anything else | deny |

The function's only caller is `journeyCustomizationFieldPublisherUpdate`, and non-publisher paths are untouched.

## Testing

- **New** `journeyCustomizationFieldPublisherUpdate.mutation.spec.ts` — exercises the real GraphQL mutation with the real ACL (prisma mocked). The publisher-without-membership case reproduced the exact reported error red-first and passes with the fix; guard cases confirm non-publishers, jfp-team managers without the publisher role, and non-template journeys are still denied.
- `journey.acl.spec.ts` — added unit coverage for `canManageTemplateField`'s full truth table (previously untested).
- Full `api-journeys` suite, `type-check`, and `pnpm lint:changed --fix` all pass.

## Also included: AGENTS.md — pre-push ritual gains type-check

The first push of this branch failed CI's `lint-work` type-check even though the documented agent pre-push ritual passed: the ritual only runs `pnpm lint:changed --fix`, and nothing at push time required a type-check. The agent pre-push instructions in `AGENTS.md` now gate `pnpm exec nx affected --target=type-check --base=origin/main` (the same target `lint-work` runs) before `git push`, and document the two traps that let this slip through: each project's `type-check` target runs `tsc7` (stricter than editor tsc), and nx prints the same trailing summary block on success and failure, so the exit code — not the tail of piped output — is the signal. Verified red/green: the command exits 1 on the exact code that broke CI and 0 on the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Publishers can manage fields on JFP templates without additional journey or team roles.
  * Managing fields on local templates and converting journeys into templates now requires appropriate journey or team permissions.
  * Unauthorized users and non-publishers remain restricted from template field updates.

* **Tests**
  * Added comprehensive coverage for publisher, team-member, role-based, conversion, and unauthorized access scenarios.

* **Documentation**
  * Updated development guidance to include type-checking affected projects before pushing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

