### PR TITLE
fix(journeys-admin): featured checkbox desync and stale refetch race (QA-564)

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/TemplateSettingsItem/TemplateSettingsDialog/MetadataTabPanel/MetadataTabPanel.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/TemplateSettingsItem/TemplateSettingsDialog/MetadataTabPanel/MetadataTabPanel.tsx
@@ -92,9 +92,8 @@ export function MetadataTabPanel({
                 <Checkbox
                   sx={{ mr: 1 }}
                   color="secondary"
-                  defaultChecked={values.featured}
+                  checked={values.featured}
                   onChange={handleChange}
-                  value={values.featured}
                   name="featured"
                 />
               }

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/TemplateSettingsItem/TemplateSettingsDialog/TemplateSettingsDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/TemplateSettingsItem/TemplateSettingsDialog/TemplateSettingsDialog.spec.tsx
@@ -1,6 +1,7 @@
 import { MockedProvider } from '@apollo/client/testing'
 import { fireEvent, render, waitFor, within } from '@testing-library/react'
 import { SnackbarProvider } from 'notistack'
+import { ReactElement } from 'react'
 
 import { JourneyProvider } from '@core/journeys/ui/JourneyProvider'
 import {
@@ -585,5 +586,117 @@ describe('TemplateSettingsDialog', () => {
       </MockedProvider>
     )
     expect(queryByRole('tab', { name: 'Categories' })).not.toBeInTheDocument()
+  })
+
+  // QA-564: the checkbox was uncontrolled (defaultChecked), so its visual
+  // state could diverge from Formik's — a cache-driven reinitialize would
+  // reset values.featured while the box still displayed the user's tick,
+  // making Save skip journeyFeature and report success without saving.
+  it('keeps the featured checkbox in sync with journey.featuredAt', async () => {
+    const tree = (featuredAt: string | null): ReactElement => (
+      <MockedProvider mocks={[]}>
+        <SnackbarProvider>
+          <JourneyProvider
+            value={{
+              journey: { ...defaultJourney, featuredAt },
+              renderMode: 'admin'
+            }}
+          >
+            <TemplateSettingsDialog open onClose={onClose} />
+          </JourneyProvider>
+        </SnackbarProvider>
+      </MockedProvider>
+    )
+
+    const { getByRole, rerender } = render(tree(null))
+    expect(getByRole('checkbox')).not.toBeChecked()
+
+    rerender(tree('2026-08-20T00:00:00.000Z'))
+    await waitFor(() => expect(getByRole('checkbox')).toBeChecked())
+  })
+
+  // QA-564: the customization update triggers an unawaited refetch of
+  // GetPublisherTemplate. If it were issued before journeyFeature, it could
+  // read pre-feature state and land after journeyFeature's response,
+  // overwriting featuredAt in the cache with a stale null.
+  it('applies the featured change before the customization update fires its refetch', async () => {
+    const journeyUpdateResult = vi.fn(() => ({
+      data: {
+        journeyUpdate: {
+          __typename: 'Journey',
+          id: defaultJourney.id,
+          title: defaultJourney.title,
+          description: defaultJourney.description
+        }
+      }
+    }))
+    const customizationResult = vi.fn(() => ({
+      data: { journeyCustomizationFieldPublisherUpdate: [] }
+    }))
+    const featureResult = vi.fn(() => ({
+      data: {
+        journeyFeature: {
+          __typename: 'Journey',
+          id: defaultJourney.id,
+          featuredAt: '2026-08-20T00:00:00.000Z'
+        }
+      }
+    }))
+
+    const { getByRole } = render(
+      <MockedProvider
+        mocks={[
+          {
+            request: {
+              query: JOURNEY_SETTINGS_UPDATE,
+              variables: {
+                id: defaultJourney.id,
+                input: {
+                  title: defaultJourney.title,
+                  description: defaultJourney.description,
+                  strategySlug: null,
+                  tagIds: [],
+                  creatorDescription: null,
+                  languageId: '529'
+                }
+              }
+            },
+            result: journeyUpdateResult
+          },
+          {
+            request: {
+              query: JOURNEY_CUSTOMIZATION_DESCRIPTION_UPDATE,
+              variables: { journeyId: defaultJourney.id, string: '' }
+            },
+            result: customizationResult
+          },
+          {
+            request: {
+              query: JOURNEY_FEATURE_UPDATE,
+              variables: { id: defaultJourney.id, feature: true }
+            },
+            result: featureResult
+          }
+        ]}
+      >
+        <SnackbarProvider>
+          <JourneyProvider
+            value={{ journey: defaultJourney, renderMode: 'admin' }}
+          >
+            <TemplateSettingsDialog open onClose={onClose} />
+          </JourneyProvider>
+        </SnackbarProvider>
+      </MockedProvider>
+    )
+
+    fireEvent.click(getByRole('checkbox'))
+    fireEvent.click(getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(customizationResult).toHaveBeenCalled())
+    expect(featureResult).toHaveBeenCalled()
+    expect(journeyUpdateResult).toHaveBeenCalled()
+    expect(featureResult.mock.invocationCallOrder[0]).toBeLessThan(
+      customizationResult.mock.invocationCallOrder[0]
+    )
   })
 })

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/TemplateSettingsItem/TemplateSettingsDialog/TemplateSettingsDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/TemplateSettingsItem/TemplateSettingsDialog/TemplateSettingsDialog.spec.tsx
@@ -615,11 +615,36 @@ describe('TemplateSettingsDialog', () => {
     await waitFor(() => expect(getByRole('checkbox')).toBeChecked())
   })
 
-  // QA-564: the customization update triggers an unawaited refetch of
-  // GetPublisherTemplate. If it were issued before journeyFeature, it could
-  // read pre-feature state and land after journeyFeature's response,
-  // overwriting featuredAt in the cache with a stale null.
-  it('applies the featured change before the customization update fires its refetch', async () => {
+  // QA-564: the reported symptom — user ticks the box, a cache-driven
+  // reinitialize resets Formik's values, and the (previously uncontrolled)
+  // box kept displaying the tick, so Save saw "no change" and skipped
+  // journeyFeature while reporting success. The controlled box must snap
+  // back so display and form state never diverge.
+  it('snaps the checkbox back when a reinitialize resets the form mid-edit', async () => {
+    const tree = (journey: typeof defaultJourney): ReactElement => (
+      <MockedProvider mocks={[]}>
+        <SnackbarProvider>
+          <JourneyProvider value={{ journey, renderMode: 'admin' }}>
+            <TemplateSettingsDialog open onClose={onClose} />
+          </JourneyProvider>
+        </SnackbarProvider>
+      </MockedProvider>
+    )
+
+    const { getByRole, rerender } = render(tree(defaultJourney))
+    fireEvent.click(getByRole('checkbox'))
+    expect(getByRole('checkbox')).toBeChecked()
+
+    // A translation-poll/cache update changes another field while
+    // featuredAt is still null — enableReinitialize resets the form.
+    rerender(tree({ ...defaultJourney, title: 'Updated Title' }))
+    await waitFor(() => expect(getByRole('checkbox')).not.toBeChecked())
+  })
+
+  // QA-564: mutations run via Promise.allSettled so one failure cannot
+  // silently drop the others — a journeyFeature rejection must not lose the
+  // user's customization edit.
+  it('still saves the customization description when journeyFeature fails', async () => {
     const journeyUpdateResult = vi.fn(() => ({
       data: {
         journeyUpdate: {
@@ -633,17 +658,8 @@ describe('TemplateSettingsDialog', () => {
     const customizationResult = vi.fn(() => ({
       data: { journeyCustomizationFieldPublisherUpdate: [] }
     }))
-    const featureResult = vi.fn(() => ({
-      data: {
-        journeyFeature: {
-          __typename: 'Journey',
-          id: defaultJourney.id,
-          featuredAt: '2026-08-20T00:00:00.000Z'
-        }
-      }
-    }))
 
-    const { getByRole } = render(
+    const { getByRole, getByText } = render(
       <MockedProvider
         mocks={[
           {
@@ -675,7 +691,7 @@ describe('TemplateSettingsDialog', () => {
               query: JOURNEY_FEATURE_UPDATE,
               variables: { id: defaultJourney.id, feature: true }
             },
-            result: featureResult
+            error: new Error('user is not allowed to update featured date')
           }
         ]}
       >
@@ -692,11 +708,13 @@ describe('TemplateSettingsDialog', () => {
     fireEvent.click(getByRole('checkbox'))
     fireEvent.click(getByRole('button', { name: 'Save' }))
 
-    await waitFor(() => expect(customizationResult).toHaveBeenCalled())
-    expect(featureResult).toHaveBeenCalled()
-    expect(journeyUpdateResult).toHaveBeenCalled()
-    expect(featureResult.mock.invocationCallOrder[0]).toBeLessThan(
-      customizationResult.mock.invocationCallOrder[0]
+    await waitFor(() =>
+      expect(
+        getByText('Field update failed. Reload the page or try again.')
+      ).toBeInTheDocument()
     )
+    expect(customizationResult).toHaveBeenCalled()
+    expect(journeyUpdateResult).toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
   })
 })

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/TemplateSettingsItem/TemplateSettingsDialog/TemplateSettingsDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/TemplateSettingsItem/TemplateSettingsDialog/TemplateSettingsDialog.spec.tsx
@@ -1,5 +1,7 @@
+import { InMemoryCache } from '@apollo/client'
 import { MockedProvider } from '@apollo/client/testing'
 import { fireEvent, render, waitFor, within } from '@testing-library/react'
+import { GraphQLError } from 'graphql'
 import { SnackbarProvider } from 'notistack'
 import { ReactElement } from 'react'
 
@@ -691,7 +693,13 @@ describe('TemplateSettingsDialog', () => {
               query: JOURNEY_FEATURE_UPDATE,
               variables: { id: defaultJourney.id, feature: true }
             },
-            error: new Error('user is not allowed to update featured date')
+            // GraphQL error, not a network error — models the real ACL
+            // rejection shape and exercises the generic-message branch.
+            result: {
+              errors: [
+                new GraphQLError('user is not allowed to update featured date')
+              ]
+            }
           }
         ]}
       >
@@ -710,11 +718,95 @@ describe('TemplateSettingsDialog', () => {
 
     await waitFor(() =>
       expect(
-        getByText('Field update failed. Reload the page or try again.')
+        getByText('Something went wrong, please reload the page and try again')
       ).toBeInTheDocument()
     )
     expect(customizationResult).toHaveBeenCalled()
     expect(journeyUpdateResult).toHaveBeenCalled()
     expect(onClose).not.toHaveBeenCalled()
+  })
+
+  // QA-564: the cache.modify patch replaced the GetPublisherTemplate refetch
+  // and is what keeps journey.journeyCustomizationDescription fresh — without
+  // it, saving then reopening the dialog shows the pre-save description.
+  it('patches journeyCustomizationDescription into the Journey cache entity on save', async () => {
+    const cache = new InMemoryCache()
+    cache.restore({
+      [`Journey:${defaultJourney.id}`]: {
+        __typename: 'Journey',
+        id: defaultJourney.id,
+        journeyCustomizationDescription: 'stale cache value'
+      }
+    })
+
+    const journeyWithDescription = {
+      ...defaultJourney,
+      journeyCustomizationDescription: 'Share this with {{ name }}'
+    }
+    const customizationResult = vi.fn(() => ({
+      data: { journeyCustomizationFieldPublisherUpdate: [] }
+    }))
+
+    const { getByRole } = render(
+      <MockedProvider
+        cache={cache}
+        mocks={[
+          {
+            request: {
+              query: JOURNEY_SETTINGS_UPDATE,
+              variables: {
+                id: defaultJourney.id,
+                input: {
+                  title: defaultJourney.title,
+                  description: defaultJourney.description,
+                  strategySlug: null,
+                  tagIds: [],
+                  creatorDescription: null,
+                  languageId: '529'
+                }
+              }
+            },
+            result: {
+              data: {
+                journeyUpdate: {
+                  __typename: 'Journey',
+                  id: defaultJourney.id,
+                  title: defaultJourney.title,
+                  description: defaultJourney.description
+                }
+              }
+            }
+          },
+          {
+            request: {
+              query: JOURNEY_CUSTOMIZATION_DESCRIPTION_UPDATE,
+              variables: {
+                journeyId: defaultJourney.id,
+                string: 'Share this with {{ name }}'
+              }
+            },
+            result: customizationResult
+          }
+        ]}
+      >
+        <SnackbarProvider>
+          <JourneyProvider
+            value={{ journey: journeyWithDescription, renderMode: 'admin' }}
+          >
+            <TemplateSettingsDialog open onClose={onClose} />
+          </JourneyProvider>
+        </SnackbarProvider>
+      </MockedProvider>
+    )
+
+    fireEvent.click(getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(customizationResult).toHaveBeenCalled())
+    await waitFor(() =>
+      expect(
+        cache.extract()[`Journey:${defaultJourney.id}`]
+          ?.journeyCustomizationDescription
+      ).toBe('Share this with {{ name }}')
+    )
   })
 })

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/TemplateSettingsItem/TemplateSettingsDialog/TemplateSettingsDialog.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/TemplateSettingsItem/TemplateSettingsDialog/TemplateSettingsDialog.tsx
@@ -101,6 +101,14 @@ export function TemplateSettingsDialog({
           }
         }
       })
+      if (Boolean(journey.featuredAt) !== values.featured)
+        await journeyFeature({
+          variables: { id: journey.id, feature: values.featured }
+        })
+      // Must run after journeyFeature: the refetch it triggers is not awaited,
+      // so if it were issued first it could read pre-feature state and land
+      // after journeyFeature's response, overwriting featuredAt in the cache
+      // with a stale null for the rest of the session (QA-564).
       await journeyCustomizationDescriptionUpdate({
         variables: {
           journeyId: journey.id,
@@ -108,10 +116,6 @@ export function TemplateSettingsDialog({
         },
         refetchQueries: ['GetPublisherTemplate']
       })
-      if (Boolean(journey.featuredAt) !== values.featured)
-        await journeyFeature({
-          variables: { id: journey.id, feature: values.featured }
-        })
       enqueueSnackbar(t('Template settings have been saved'), {
         variant: 'success',
         preventDuplicate: true

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/TemplateSettingsItem/TemplateSettingsDialog/TemplateSettingsDialog.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/TemplateSettingsItem/TemplateSettingsDialog/TemplateSettingsDialog.tsx
@@ -91,9 +91,12 @@ export function TemplateSettingsDialog({
     values: TemplateSettingsFormValues
   ): Promise<void> {
     if (journey == null) return
-    try {
-      // Submit other form values
-      await journeySettingsUpdate({
+    // Mutations run via Promise.allSettled (mirroring
+    // LocalTemplateDetailsDialog) so one failure cannot silently drop the
+    // others — e.g. a journeyFeature rejection must not lose the user's
+    // customization edit, and vice versa (QA-564).
+    const tasks: Array<Promise<unknown>> = [
+      journeySettingsUpdate({
         variables: {
           id: journey.id,
           input: {
@@ -101,49 +104,58 @@ export function TemplateSettingsDialog({
           }
         }
       })
-      if (Boolean(journey.featuredAt) !== values.featured)
-        await journeyFeature({
+    ]
+    if (Boolean(journey.featuredAt) !== values.featured)
+      tasks.push(
+        journeyFeature({
           variables: { id: journey.id, feature: values.featured }
         })
-      // Must run after journeyFeature: the refetch it triggers is not awaited,
-      // so if it were issued first it could read pre-feature state and land
-      // after journeyFeature's response, overwriting featuredAt in the cache
-      // with a stale null for the rest of the session (QA-564).
-      await journeyCustomizationDescriptionUpdate({
+      )
+    tasks.push(
+      journeyCustomizationDescriptionUpdate({
         variables: {
           journeyId: journey.id,
           string: values.journeyCustomizationDescription
         },
-        refetchQueries: ['GetPublisherTemplate']
+        // The mutation returns customization fields, not a Journey, so patch
+        // the Journey entity directly (as LocalTemplateDetailsDialog does)
+        // instead of refetching GetPublisherTemplate — a refetch issued here
+        // could read pre-feature state and land after journeyFeature's
+        // response, clobbering featuredAt in the cache with a stale value
+        // (QA-564).
+        update(cache) {
+          cache.modify({
+            id: cache.identify({ __typename: 'Journey', id: journey.id }),
+            fields: {
+              journeyCustomizationDescription() {
+                return values.journeyCustomizationDescription
+              }
+            }
+          })
+        }
       })
+    )
+
+    const results = await Promise.allSettled(tasks)
+    const failed = results.find((result) => result.status === 'rejected')
+
+    if (failed == null) {
       enqueueSnackbar(t('Template settings have been saved'), {
         variant: 'success',
         preventDuplicate: true
       })
       onClose()
-    } catch (error) {
-      if (error instanceof ApolloError) {
-        if (error.networkError != null) {
-          enqueueSnackbar(
-            t('Field update failed. Reload the page or try again.'),
-            {
-              variant: 'error',
-              preventDuplicate: true
-            }
-          )
-          return
-        }
-      }
-      if (error instanceof Error) {
-        enqueueSnackbar(
-          'Something went wrong, please reload the page and try again',
-          {
-            variant: 'error',
-            preventDuplicate: true
-          }
-        )
-      }
+      return
     }
+
+    const networkError =
+      failed.reason instanceof ApolloError && failed.reason.networkError != null
+    enqueueSnackbar(
+      networkError
+        ? t('Field update failed. Reload the page or try again.')
+        : t('Something went wrong, please reload the page and try again'),
+      { variant: 'error', preventDuplicate: true }
+    )
   }
 
   return (

--- a/apps/journeys-admin/src/components/Editor/Toolbar/Items/TemplateSettingsItem/TemplateSettingsDialog/TemplateSettingsDialog.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/Items/TemplateSettingsItem/TemplateSettingsDialog/TemplateSettingsDialog.tsx
@@ -137,9 +137,8 @@ export function TemplateSettingsDialog({
     )
 
     const results = await Promise.allSettled(tasks)
-    const failed = results.find((result) => result.status === 'rejected')
 
-    if (failed == null) {
+    if (results.every((result) => result.status === 'fulfilled')) {
       enqueueSnackbar(t('Template settings have been saved'), {
         variant: 'success',
         preventDuplicate: true
@@ -148,8 +147,14 @@ export function TemplateSettingsDialog({
       return
     }
 
-    const networkError =
-      failed.reason instanceof ApolloError && failed.reason.networkError != null
+    // Prefer the network-error message whichever task it came from — it is
+    // the actionable one, so it must not lose to an earlier GraphQL error.
+    const networkError = results.some(
+      (result) =>
+        result.status === 'rejected' &&
+        result.reason instanceof ApolloError &&
+        result.reason.networkError != null
+    )
     enqueueSnackbar(
       networkError
         ? t('Field update failed. Reload the page or try again.')

--- a/apps/journeys-admin/src/components/Editor/Toolbar/JourneyDetails/LocalTemplateDetailsDialog/LocalTemplateDetailsDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Toolbar/JourneyDetails/LocalTemplateDetailsDialog/LocalTemplateDetailsDialog.spec.tsx
@@ -1,3 +1,4 @@
+import { InMemoryCache } from '@apollo/client'
 import { MockedProvider } from '@apollo/client/testing'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { SnackbarProvider } from 'notistack'
@@ -220,6 +221,72 @@ describe('LocalTemplateDetailsDialog', () => {
     await waitFor(() => expect(customizationResult).toHaveBeenCalled())
     expect(titleMock.result).not.toHaveBeenCalled()
     await waitFor(() => expect(onClose).toHaveBeenCalled())
+  })
+
+  // QA-564 (review follow-through): the update(cache) patch here is what
+  // keeps journey.journeyCustomizationDescription fresh so reopening the
+  // dialog does not show a stale value — pinned the same way as
+  // TemplateSettingsDialog's equivalent.
+  it('patches journeyCustomizationDescription into the Journey cache entity on save', async () => {
+    const cache = new InMemoryCache()
+    cache.restore({
+      [`Journey:${publishedLocalTemplate.id}`]: {
+        __typename: 'Journey',
+        id: publishedLocalTemplate.id,
+        journeyCustomizationDescription: 'stale cache value'
+      }
+    })
+    const customizationResult = vi.fn(() => ({
+      data: {
+        journeyCustomizationFieldPublisherUpdate: {
+          __typename: 'JourneyCustomizationField',
+          id: 'field-id',
+          key: 'description',
+          value: 'Edited customization'
+        }
+      }
+    }))
+
+    render(
+      <MockedProvider
+        cache={cache}
+        mocks={[
+          getLanguagesMock,
+          {
+            request: {
+              query: JOURNEY_CUSTOMIZATION_DESCRIPTION_UPDATE,
+              variables: {
+                journeyId: publishedLocalTemplate.id,
+                string: 'Edited customization'
+              }
+            },
+            result: customizationResult
+          }
+        ]}
+      >
+        <SnackbarProvider>
+          <JourneyProvider value={{ journey: publishedLocalTemplate }}>
+            <LocalTemplateDetailsDialog open onClose={onClose} />
+          </JourneyProvider>
+        </SnackbarProvider>
+      </MockedProvider>
+    )
+
+    const customizationField = screen
+      .getByTestId('CustomizationDescriptionEdit')
+      .querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.change(customizationField, {
+      target: { value: 'Edited customization' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(customizationResult).toHaveBeenCalled())
+    await waitFor(() =>
+      expect(
+        cache.extract()[`Journey:${publishedLocalTemplate.id}`]
+          ?.journeyCustomizationDescription
+      ).toBe('Edited customization')
+    )
   })
 
   it('shows a "Required" error and blocks submit when the title is empty', async () => {


### PR DESCRIPTION
Fixes [QA-564](https://linear.app/jesus-film-project/issue/QA-564/featured-checkbox-desyncs-from-saved-state-in-template-settings-dialog) — follow-on from [QA-563](https://linear.app/jesus-film-project/issue/QA-563/error-when-deselecting-featured-template-and-saving) / #9526. Frontend-only; deliberately split from the backend PR per FE/BE separation (no schema or deploy-order coupling — either can ship first).

## Problem

Stage testing of the QA-563 server fix surfaced remaining client bugs in `TemplateSettingsDialog`:

1. Ticking **Featured** → Save showed the success snackbar but sometimes didn't feature the template.
2. Reopening Template Settings showed the Featured box permanently unticked for the rest of the session, even though the journey was correctly featured.

## Root causes

1. **Uncontrolled checkbox.** `MetadataTabPanel` used `defaultChecked={values.featured}`. With Formik's `enableReinitialize`, a journey cache update landing between the user's click and Save silently resets `values.featured` while the box still displays the tick — submit then sees "no change", skips `journeyFeature`, and reports success without saving.
2. **Stale refetch race.** `handleSubmit` ran journeyUpdate → customization update (with an unawaited `refetchQueries: ['GetPublisherTemplate']`) → `journeyFeature`. The refetch could read the journey *before* `journeyFeature` committed and land *after* its response, overwriting `featuredAt` back to `null` in the Apollo cache for the rest of the session.

## Fix

- Checkbox is now controlled: `checked={values.featured}`.
- The save now mirrors `LocalTemplateDetailsDialog` (per review): the three mutations run via `Promise.allSettled` so one failure cannot silently drop the others, and `refetchQueries: ['GetPublisherTemplate']` is replaced with a targeted `cache.modify` patch of `journeyCustomizationDescription` — with no refetch, nothing can race `journeyFeature`, and the ordering invariant ceases to exist rather than being held by statement order.

## Testing

Red/green verified. Regression tests pin: the checkbox following `featuredAt` across rerenders; the reported symptom direction (box snaps back when a reinitialize resets the form mid-edit); and the partial-failure guarantee (a `journeyFeature` rejection still saves the customization description — verified red against the sequential structure). All 34 tests across the `TemplateSettingsItem` tree pass. `lint:changed --fix` and affected type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the featured setting so its checkbox stays synchronized with the journey’s current state.
  * Ensured featured status updates are applied before customization changes, preventing stale settings after refresh.
  * Avoided unnecessary featured-status updates when the value has not changed.

* **Tests**
  * Added regression coverage for checkbox state synchronization and update ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
