### PR TITLE
fix(api-media): sync videoChildren worker as true replace, not additive

### DIFF
--- a/apis/api-media/src/workers/videoChildren/service/service.spec.ts
+++ b/apis/api-media/src/workers/videoChildren/service/service.spec.ts
@@ -72,6 +72,12 @@ describe('videoChildren/service', () => {
           { id: 'video1', childIds: [] } as unknown as Video
         ])
       await service()
+      expect(prismaMock.video.findMany).toHaveBeenNthCalledWith(2, {
+        select: { id: true, childIds: true },
+        where: {
+          OR: [{ childIds: { isEmpty: false } }, { children: { some: {} } }]
+        }
+      })
       expect(prismaMock.video.update).toHaveBeenCalledWith({
         where: { id: 'video1' },
         data: {

--- a/apis/api-media/src/workers/videoChildren/service/service.spec.ts
+++ b/apis/api-media/src/workers/videoChildren/service/service.spec.ts
@@ -22,7 +22,7 @@ describe('videoChildren/service', () => {
         where: { id: 'video1' },
         data: {
           children: {
-            connect: [{ id: 'video2' }, { id: 'video3' }]
+            set: [{ id: 'video2' }, { id: 'video3' }]
           }
         }
       })
@@ -30,7 +30,85 @@ describe('videoChildren/service', () => {
         where: { id: 'video2' },
         data: {
           children: {
-            connect: [{ id: 'video3' }]
+            set: [{ id: 'video3' }]
+          }
+        }
+      })
+    })
+
+    it('should disconnect a child removed from childIds, not just connect new ones', async () => {
+      // video1 used to have both video2 and video3 as children; video2 has
+      // since been removed from childIds and should be disconnected, while
+      // video3 remains connected.
+      prismaMock.video.findMany
+        .mockResolvedValueOnce([
+          { id: 'video1', childIds: [] } as unknown as Video,
+          { id: 'video2', childIds: [] } as unknown as Video,
+          { id: 'video3', childIds: [] } as unknown as Video
+        ])
+        .mockResolvedValueOnce([
+          { id: 'video1', childIds: ['video3'] } as unknown as Video
+        ])
+      await service()
+      expect(prismaMock.video.update).toHaveBeenCalledWith({
+        where: { id: 'video1' },
+        data: {
+          children: {
+            set: [{ id: 'video3' }]
+          }
+        }
+      })
+    })
+
+    it('should disconnect all children when childIds becomes empty', async () => {
+      // video1's childIds has shrunk to empty, but it still has stale
+      // connected children from a previous run that must be cleared.
+      prismaMock.video.findMany
+        .mockResolvedValueOnce([
+          { id: 'video1', childIds: [] } as unknown as Video,
+          { id: 'video2', childIds: [] } as unknown as Video
+        ])
+        .mockResolvedValueOnce([
+          { id: 'video1', childIds: [] } as unknown as Video
+        ])
+      await service()
+      expect(prismaMock.video.update).toHaveBeenCalledWith({
+        where: { id: 'video1' },
+        data: {
+          children: {
+            set: []
+          }
+        }
+      })
+    })
+
+    it('should be idempotent when run twice against unchanged data', async () => {
+      const videoIds = [
+        { id: 'video1', childIds: [] } as unknown as Video,
+        { id: 'video2', childIds: [] } as unknown as Video,
+        { id: 'video3', childIds: [] } as unknown as Video
+      ]
+      const relevantVideos = [
+        { id: 'video1', childIds: ['video2', 'video3'] } as unknown as Video
+      ]
+      prismaMock.video.findMany
+        .mockResolvedValueOnce(videoIds)
+        .mockResolvedValueOnce(relevantVideos)
+      await service()
+
+      prismaMock.video.update.mockClear()
+
+      prismaMock.video.findMany
+        .mockResolvedValueOnce(videoIds)
+        .mockResolvedValueOnce(relevantVideos)
+      await service()
+
+      expect(prismaMock.video.update).toHaveBeenCalledTimes(1)
+      expect(prismaMock.video.update).toHaveBeenCalledWith({
+        where: { id: 'video1' },
+        data: {
+          children: {
+            set: [{ id: 'video2' }, { id: 'video3' }]
           }
         }
       })

--- a/apis/api-media/src/workers/videoChildren/service/service.ts
+++ b/apis/api-media/src/workers/videoChildren/service/service.ts
@@ -19,17 +19,23 @@ export async function service(logger?: Logger): Promise<void> {
     return
   }
 
-  const children = await prisma.video.findMany({
+  // A video is relevant if it currently declares children via childIds, or
+  // if it still has stale children connected from a previous run whose
+  // childIds has since shrunk to empty — both need their children relation
+  // replaced to match childIds exactly.
+  const videos = await prisma.video.findMany({
     select: { id: true, childIds: true },
-    where: { childIds: { isEmpty: false } }
+    where: {
+      OR: [{ childIds: { isEmpty: false } }, { children: { some: {} } }]
+    }
   })
-  for (const video of children) {
+  for (const video of videos) {
     try {
       await prisma.video.update({
         where: { id: video.id },
         data: {
           children: {
-            connect: video.childIds
+            set: video.childIds
               .filter((id) => videoIds.includes(id))
               .map((id) => ({ id }))
           }


### PR DESCRIPTION
Closes #9522

## Summary

Sub-issue of #9515. Hardens the `videoChildren` worker (`apis/api-media/src/workers/videoChildren/service/service.ts`) that syncs the `Video.children` relation from the `childIds` scalar array, so it's a true replace instead of additive-only.

## Changes

- `children: { connect: [...] }` → `children: { set: [...] }` — each run now replaces the relation to match `childIds` exactly. A childId removed from the array is disconnected, not left as a stale edge.
- The candidate query is widened from `childIds: { isEmpty: false }` to also include videos where `children: { some: {} }`. Without this, a video whose `childIds` shrinks all the way to empty would be skipped entirely by the old filter, leaving its previously connected children stuck forever — the same latent-drift bug the issue targets, at the boundary case.
- `set` is naturally idempotent: running the worker twice against unchanged data recomputes and reissues the same target list, so the resulting relation state is unchanged.

## Testing

- Added test coverage for: a child removed from `childIds` gets disconnected (not just new children connected), `childIds` shrinking all the way to empty disconnects all stale children, and running the worker twice against unchanged data is idempotent — alongside the existing grow-case coverage.
- `bash tools/scripts/lint-changed.sh` — pass
- `pnpm tsc7 -p apis/api-media/tsconfig.ts7.json` — clean
- `vitest run` against apis/api-media's full suite — 78 files, 782 tests, all passing (includes the 4 `videoChildren/service` tests)

Note: `pnpm exec nx affected` itself is broken in this worktree (`TypeError: WorkspaceContext is not a constructor` on every subcommand, including `nx show projects` and `nx reset`) — unrelated to this change, so verification was done via the direct commands above instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Video child relationships now stay synchronized with the latest configured list.
  * Removed child relationships are automatically disconnected.
  * All child relationships are cleared when no children remain.
  * Repeated synchronization produces consistent results without duplicating changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->