### PR TITLE
fix(api-media): filter Video.variantLanguages to published variants

### DIFF
--- a/apis/api-media/src/schema/video/video.spec.ts
+++ b/apis/api-media/src/schema/video/video.spec.ts
@@ -746,6 +746,9 @@ describe('video', () => {
           variants: {
             select: {
               languageId: true
+            },
+            where: {
+              published: true
             }
           },
           videoEditions: true,
@@ -942,6 +945,9 @@ describe('video', () => {
           variants: {
             select: {
               languageId: true
+            },
+            where: {
+              published: true
             }
           },
           videoEditions: true,
@@ -1278,6 +1284,67 @@ describe('video', () => {
         {
           id: 'videoId',
           variantLanguagesCount: 2
+        }
+      ])
+    })
+
+    it('should query video.variantLanguages filtered to published variants', async () => {
+      prismaMock.video.findMany.mockResolvedValueOnce(videos)
+
+      await client({
+        document: graphql(`
+          query VideoWithVariantLanguages {
+            videos {
+              id
+              variantLanguages {
+                id
+              }
+            }
+          }
+        `)
+      })
+      expect(prismaMock.video.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          include: {
+            variants: {
+              select: {
+                languageId: true
+              },
+              where: {
+                published: true
+              }
+            }
+          }
+        })
+      )
+    })
+
+    it('should only return the published variant language when a video has one published and one unpublished variant', async () => {
+      const videoWithOnlyPublishedVariant: VideoAndIncludes = {
+        ...videos[0],
+        // simulates prisma applying the resolver's published: true filter
+        variants: videos[0].variants.filter(({ published }) => published)
+      }
+      prismaMock.video.findMany.mockResolvedValueOnce([
+        videoWithOnlyPublishedVariant
+      ])
+
+      const data = await client({
+        document: graphql(`
+          query VideoWithVariantLanguages {
+            videos {
+              id
+              variantLanguages {
+                id
+              }
+            }
+          }
+        `)
+      })
+      expect(data).toHaveProperty('data.videos', [
+        {
+          id: 'videoId',
+          variantLanguages: [{ id: 'languageId2' }]
         }
       ])
     })
@@ -2027,6 +2094,9 @@ describe('video', () => {
           variants: {
             select: {
               languageId: true
+            },
+            where: {
+              published: true
             }
           },
           bibleCitation: {
@@ -2245,6 +2315,9 @@ describe('video', () => {
           variants: {
             select: {
               languageId: true
+            },
+            where: {
+              published: true
             }
           },
           imageAlt: {

--- a/apis/api-media/src/schema/video/video.ts
+++ b/apis/api-media/src/schema/video/video.ts
@@ -223,6 +223,9 @@ export const Video = builder.prismaObject('Video', {
         variants: {
           select: {
             languageId: true
+          },
+          where: {
+            published: true
           }
         }
       }),


### PR DESCRIPTION
Closes #9524

## Summary

`Video.variantLanguages` was missing the `published: true` filter that its sibling field `variantLanguagesCount` already applies, so an unpublished variant's language could show up in language pickers meant to reflect only what's actually available.

## Change

- Added `where: { published: true }` to the variants selection used by `variantLanguages`, matching `variantLanguagesCount`'s existing filter exactly.
- `variantLanguages`' semantics are otherwise unchanged: still a flat, own-video-only field (no recursion, no new input args) — this is unrelated to and independent of the broader #9515 `availableLanguages` rework.

## Tests

- Updated the four existing `prismaMock.video.findMany` include assertions to expect the new `where: { published: true }` clause on the `variants` selection for `variantLanguages`.
- Added a test asserting the query shape sent to Prisma.
- Added a test asserting that for a video with one published and one unpublished variant, `variantLanguages` resolves to only the published variant's language.

## Verification

- `pnpm lint:changed` — passed (only 2 pre-existing, unrelated `no-empty` warnings)
- `tsc --noEmit` on `apis/api-media`'s app and spec tsconfigs — passed
- `vitest run src/schema/video/video.spec.ts` — 67/67 passed

Note: `pnpm exec nx affected` fails in this worktree environment with `TypeError: WorkspaceContext is not a constructor`, reproducing even on a no-op like `nx show projects` in every worktree here — unrelated to this change. Verified via the underlying tools directly instead (see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Video variant results now include only published variants.
  * Language filters for videos now show languages associated with published variants only.
* **Tests**
  * Added coverage to verify published-variant filtering for video and administrative video queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->