### PR TITLE
feat(api-media): availableLanguages batch verifier (report + self-heal)

### DIFF
--- a/apis/api-media/project.json
+++ b/apis/api-media/project.json
@@ -182,6 +182,13 @@
         "command": "pnpm exec tsx --tsconfig apis/api-media/tsconfig.app.json apis/api-media/src/scripts/run-parent-variant-audit.ts"
       }
     },
+    "verify-available-languages": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["prisma-media:prisma-generate"],
+      "options": {
+        "command": "pnpm exec tsx --tsconfig apis/api-media/tsconfig.app.json apis/api-media/src/scripts/run-verify-available-languages.ts"
+      }
+    },
     "populate-crowdin-ids": {
       "executor": "nx:run-commands",
       "options": {

--- a/apis/api-media/src/schema/video/lib/verifyAvailableLanguages.spec.ts
+++ b/apis/api-media/src/schema/video/lib/verifyAvailableLanguages.spec.ts
@@ -2,6 +2,7 @@ import { prismaMock } from '../../../../test/prismaMock'
 
 import {
   VerifyAvailableLanguagesCursor,
+  computeAvailableLanguagesGraph,
   verifyAvailableLanguages
 } from './verifyAvailableLanguages'
 
@@ -71,16 +72,29 @@ function installCatalog(
       })
     }
   )
-  ;(prismaMock.video.update as any).mockImplementation(
+  ;(prismaMock.video.updateMany as any).mockImplementation(
     async (args: {
-      where: { id: string }
+      where: {
+        id: string
+        availableLanguages?: { equals?: string[] }
+      }
       data: { availableLanguages?: { set: string[] } }
     }) => {
       const video = db.get(args.where.id)
-      if (video != null && args.data.availableLanguages != null) {
-        video.availableLanguages = args.data.availableLanguages.set
+      const expectedStored = args.where.availableLanguages?.equals
+      const stillMatches =
+        video != null &&
+        (expectedStored == null ||
+          (video.availableLanguages.length === expectedStored.length &&
+            video.availableLanguages.every(
+              (languageId, index) => languageId === expectedStored[index]
+            )))
+
+      if (stillMatches && args.data.availableLanguages != null) {
+        video!.availableLanguages = args.data.availableLanguages.set
+        return { count: 1 }
       }
-      return {}
+      return { count: 0 }
     }
   )
 
@@ -113,7 +127,7 @@ describe('verifyAvailableLanguages', () => {
     expect(result.nextCursor).toBeNull()
     // report-only mode must not write anything back
     expect(db.get('parent')?.availableLanguages).toEqual([])
-    expect(prismaMock.video.update).not.toHaveBeenCalled()
+    expect(prismaMock.video.updateMany).not.toHaveBeenCalled()
   })
 
   it('does not report a video whose stored value already matches the computed one', async () => {
@@ -311,5 +325,83 @@ describe('verifyAvailableLanguages', () => {
     )
     expect(ownDataCall[0].cursor).toEqual({ id: 'a' })
     expect(ownDataCall[0].skip).toBe(1)
+  })
+
+  it('rejects a non-positive pageSize instead of looping forever with no progress', async () => {
+    await expect(verifyAvailableLanguages({ pageSize: 0 })).rejects.toThrow(
+      /pageSize must be a positive integer/
+    )
+    await expect(verifyAvailableLanguages({ pageSize: -5 })).rejects.toThrow(
+      /pageSize must be a positive integer/
+    )
+  })
+
+  it('reuses a precomputed graph instead of re-deriving it from the catalog', async () => {
+    installCatalog({
+      child: {
+        availableLanguages: ['529'],
+        variantLanguageIds: ['529'],
+        childIds: []
+      },
+      parent: {
+        availableLanguages: [],
+        variantLanguageIds: [],
+        childIds: ['child']
+      }
+    })
+
+    const graph = await computeAvailableLanguagesGraph()
+    ;(prismaMock.video.findMany as any).mockClear()
+
+    const result = await verifyAvailableLanguages({ graph })
+
+    expect(result.mismatches).toEqual([
+      { videoId: 'parent', stored: [], computed: ['529'] }
+    ])
+    // No graph-shape query (a findMany with no `where`) this time -- only
+    // the per-level own-data queries.
+    const graphShapeCalls = (
+      prismaMock.video.findMany as any
+    ).mock.calls.filter((call: any[]) => call[0]?.where?.id?.in == null)
+    expect(graphShapeCalls).toEqual([])
+  })
+
+  it('does not overwrite a value changed by a concurrent write since it was read', async () => {
+    const db = installCatalog({
+      child: {
+        availableLanguages: ['529'],
+        variantLanguageIds: ['529'],
+        childIds: []
+      },
+      parent: {
+        availableLanguages: [],
+        variantLanguageIds: [],
+        childIds: ['child']
+      }
+    })
+
+    // Simulate a concurrent publish landing on `parent` between this
+    // verifier's read and its guarded write: by the time the guarded
+    // update runs, the row no longer holds the value the verifier read.
+    ;(prismaMock.video.updateMany as any).mockImplementation(
+      async (args: { where: { id: string } }) => {
+        if (args.where.id === 'parent') {
+          db.get('parent')!.availableLanguages = ['21028']
+          return { count: 0 }
+        }
+        return { count: 1 }
+      }
+    )
+
+    const result = await verifyAvailableLanguages({ fix: true })
+
+    expect(result.mismatches).toEqual([
+      { videoId: 'parent', stored: [], computed: ['529'] }
+    ])
+    // Not fixed -- the guarded update's WHERE no longer matched once the
+    // concurrent write landed, so the correction was skipped rather than
+    // clobbering it.
+    expect(result.fixed).toEqual([])
+    expect(db.get('parent')?.availableLanguages).toEqual(['21028'])
   })
 })

--- a/apis/api-media/src/schema/video/lib/verifyAvailableLanguages.spec.ts
+++ b/apis/api-media/src/schema/video/lib/verifyAvailableLanguages.spec.ts
@@ -91,7 +91,7 @@ function installCatalog(
             )))
 
       if (stillMatches && args.data.availableLanguages != null) {
-        video!.availableLanguages = args.data.availableLanguages.set
+        video.availableLanguages = args.data.availableLanguages.set
         return { count: 1 }
       }
       return { count: 0 }

--- a/apis/api-media/src/schema/video/lib/verifyAvailableLanguages.spec.ts
+++ b/apis/api-media/src/schema/video/lib/verifyAvailableLanguages.spec.ts
@@ -1,0 +1,315 @@
+import { prismaMock } from '../../../../test/prismaMock'
+
+import {
+  VerifyAvailableLanguagesCursor,
+  verifyAvailableLanguages
+} from './verifyAvailableLanguages'
+
+interface FixtureVideo {
+  availableLanguages: string[]
+  variantLanguageIds: string[]
+  childIds: string[]
+}
+
+// Installs a small in-memory catalog that the verifier's mocked Prisma
+// calls read from (and, in fix mode, write into), so its bottom-up
+// level-by-level, paginated traversal is exercised against a realistic
+// graph shape and query sequence rather than a hand-sequenced list of mock
+// call results.
+function installCatalog(
+  videos: Record<string, FixtureVideo>
+): Map<string, FixtureVideo> {
+  const db = new Map(
+    Object.entries(videos).map(([id, video]) => [id, { ...video }])
+  )
+
+  // Cast to `any`: these fixtures deliberately model only the columns each
+  // query's own `select` asks for, which is narrower than prismaMock's deep
+  // Video type.
+  ;(prismaMock.video.findMany as any).mockImplementation(
+    async (args: {
+      where?: { id?: { in?: string[] } }
+      orderBy?: { id: 'asc' }
+      take?: number
+      cursor?: { id: string }
+      skip?: number
+    }) => {
+      const idFilter = args.where?.id?.in
+
+      // The graph-shape query -- no `where`, id + live children ids only.
+      if (idFilter == null) {
+        return Array.from(db.entries()).map(([id, video]) => ({
+          id,
+          children: video.childIds
+            .filter((childId) => db.has(childId))
+            .map((childId) => ({ id: childId }))
+        }))
+      }
+
+      // A per-level, paginated own-data query.
+      let ids = idFilter.filter((id) => db.has(id)).sort()
+      if (args.cursor != null) {
+        const cursorIndex = ids.indexOf(args.cursor.id)
+        ids = ids.slice(cursorIndex + (args.skip ?? 0))
+      }
+      if (args.take != null) ids = ids.slice(0, args.take)
+
+      return ids.map((id) => {
+        const video = db.get(id)!
+        return {
+          id,
+          availableLanguages: video.availableLanguages,
+          variants: video.variantLanguageIds.map((languageId) => ({
+            languageId
+          })),
+          children: video.childIds
+            .filter((childId) => db.has(childId))
+            .map((childId) => ({
+              availableLanguages: db.get(childId)!.availableLanguages
+            }))
+        }
+      })
+    }
+  )
+  ;(prismaMock.video.update as any).mockImplementation(
+    async (args: {
+      where: { id: string }
+      data: { availableLanguages?: { set: string[] } }
+    }) => {
+      const video = db.get(args.where.id)
+      if (video != null && args.data.availableLanguages != null) {
+        video.availableLanguages = args.data.availableLanguages.set
+      }
+      return {}
+    }
+  )
+
+  return db
+}
+
+describe('verifyAvailableLanguages', () => {
+  it('reports a mismatch between stored and computed values without writing', async () => {
+    const db = installCatalog({
+      child: {
+        availableLanguages: ['529'],
+        variantLanguageIds: ['529'],
+        childIds: []
+      },
+      parent: {
+        // stored value is stale -- it's missing the child's language
+        availableLanguages: [],
+        variantLanguageIds: [],
+        childIds: ['child']
+      }
+    })
+
+    const result = await verifyAvailableLanguages()
+
+    expect(result.mismatches).toEqual([
+      { videoId: 'parent', stored: [], computed: ['529'] }
+    ])
+    expect(result.fixed).toEqual([])
+    expect(result.unresolvedVideoIds).toEqual([])
+    expect(result.nextCursor).toBeNull()
+    // report-only mode must not write anything back
+    expect(db.get('parent')?.availableLanguages).toEqual([])
+    expect(prismaMock.video.update).not.toHaveBeenCalled()
+  })
+
+  it('does not report a video whose stored value already matches the computed one', async () => {
+    installCatalog({
+      child: {
+        availableLanguages: ['529'],
+        variantLanguageIds: ['529'],
+        childIds: []
+      },
+      parent: {
+        availableLanguages: ['529'],
+        variantLanguageIds: [],
+        childIds: ['child']
+      }
+    })
+
+    const result = await verifyAvailableLanguages()
+
+    expect(result.mismatches).toEqual([])
+    expect(result.checked).toBe(2)
+    expect(result.nextCursor).toBeNull()
+  })
+
+  it('self-heals a mismatch by writing the computed value when fix is true', async () => {
+    const db = installCatalog({
+      child: {
+        availableLanguages: ['529'],
+        variantLanguageIds: ['529'],
+        childIds: []
+      },
+      parent: {
+        availableLanguages: [],
+        variantLanguageIds: [],
+        childIds: ['child']
+      }
+    })
+
+    const result = await verifyAvailableLanguages({ fix: true })
+
+    expect(result.fixed).toEqual(['parent'])
+    expect(db.get('parent')?.availableLanguages).toEqual(['529'])
+  })
+
+  it('propagates a corrected child value up through a multi-level hierarchy in one pass', async () => {
+    const db = installCatalog({
+      video: {
+        availableLanguages: ['21028'],
+        variantLanguageIds: ['21028'],
+        childIds: []
+      },
+      series: {
+        // stale at every level
+        availableLanguages: [],
+        variantLanguageIds: [],
+        childIds: ['video']
+      },
+      featureFilm: {
+        availableLanguages: [],
+        variantLanguageIds: [],
+        childIds: ['series']
+      }
+    })
+
+    const result = await verifyAvailableLanguages({ fix: true })
+
+    expect(result.fixed.sort()).toEqual(['featureFilm', 'series'])
+    expect(db.get('series')?.availableLanguages).toEqual(['21028'])
+    expect(db.get('featureFilm')?.availableLanguages).toEqual(['21028'])
+  })
+
+  it('excludes videos on a cycle from the walk instead of hanging, and reports them as unresolved', async () => {
+    installCatalog({
+      a: {
+        availableLanguages: [],
+        variantLanguageIds: [],
+        childIds: ['b']
+      },
+      b: {
+        availableLanguages: [],
+        variantLanguageIds: [],
+        childIds: ['a']
+      },
+      independent: {
+        availableLanguages: ['529'],
+        variantLanguageIds: ['529'],
+        childIds: []
+      }
+    })
+
+    const result = await verifyAvailableLanguages()
+
+    expect(result.unresolvedVideoIds.sort()).toEqual(['a', 'b'])
+    expect(result.checked).toBe(1)
+    expect(result.nextCursor).toBeNull()
+    expect(
+      result.mismatches.find((mismatch) => mismatch.videoId === 'independent')
+    ).toBeUndefined()
+  })
+
+  it('reports a video blocked by a descendant cycle as unresolved too', async () => {
+    installCatalog({
+      'cyclic-a': {
+        availableLanguages: [],
+        variantLanguageIds: [],
+        childIds: ['cyclic-b']
+      },
+      'cyclic-b': {
+        availableLanguages: [],
+        variantLanguageIds: [],
+        childIds: ['cyclic-a']
+      },
+      parent: {
+        availableLanguages: [],
+        variantLanguageIds: [],
+        childIds: ['cyclic-a']
+      }
+    })
+
+    const result = await verifyAvailableLanguages()
+
+    expect(result.unresolvedVideoIds.sort()).toEqual([
+      'cyclic-a',
+      'cyclic-b',
+      'parent'
+    ])
+    expect(result.checked).toBe(0)
+  })
+
+  it('batches every video in a level into one query instead of one query per video', async () => {
+    installCatalog({
+      a: { availableLanguages: [], variantLanguageIds: ['1'], childIds: [] },
+      b: { availableLanguages: [], variantLanguageIds: ['2'], childIds: [] },
+      c: { availableLanguages: [], variantLanguageIds: ['3'], childIds: [] },
+      parent: {
+        availableLanguages: [],
+        variantLanguageIds: [],
+        childIds: ['a', 'b', 'c']
+      }
+    })
+
+    await verifyAvailableLanguages()
+
+    // One call for the graph shape, plus one per level (leaves, then
+    // parent) -- never one call per video.
+    expect(prismaMock.video.findMany).toHaveBeenCalledTimes(3)
+  })
+
+  it('returns a resumable cursor when a level exceeds pageSize, and a follow-up call continues from it', async () => {
+    installCatalog({
+      a: { availableLanguages: ['1'], variantLanguageIds: ['1'], childIds: [] },
+      b: { availableLanguages: [], variantLanguageIds: ['2'], childIds: [] },
+      c: { availableLanguages: ['3'], variantLanguageIds: ['3'], childIds: [] }
+    })
+
+    const first = await verifyAvailableLanguages({ pageSize: 2 })
+
+    expect(first.checked).toBe(2)
+    expect(first.nextCursor).toEqual({ level: 0, afterId: 'b' })
+    // Only the first two (a, b) were compared so far -- b is the one
+    // seeded mismatch among them.
+    expect(first.mismatches.map((m) => m.videoId)).toEqual(['b'])
+
+    const second = await verifyAvailableLanguages({
+      pageSize: 2,
+      cursor: first.nextCursor as VerifyAvailableLanguagesCursor
+    })
+
+    expect(second.checked).toBe(1)
+    expect(second.nextCursor).toBeNull()
+    expect(second.mismatches).toEqual([])
+
+    // Together, the two paginated calls found exactly the one seeded
+    // mismatch a single unbounded call would have found.
+    expect(first.mismatches.length + second.mismatches.length).toBe(1)
+  })
+
+  it('does not reprocess a video already covered by a previous page when resuming', async () => {
+    installCatalog({
+      a: { availableLanguages: ['1'], variantLanguageIds: ['1'], childIds: [] },
+      b: { availableLanguages: ['2'], variantLanguageIds: ['2'], childIds: [] }
+    })
+
+    const first = await verifyAvailableLanguages({ pageSize: 1 })
+    expect(first.nextCursor).toEqual({ level: 0, afterId: 'a' })
+    ;(prismaMock.video.findMany as any).mockClear()
+
+    const second = await verifyAvailableLanguages({
+      pageSize: 1,
+      cursor: first.nextCursor as VerifyAvailableLanguagesCursor
+    })
+
+    expect(second.checked).toBe(1)
+    const ownDataCall = (prismaMock.video.findMany as any).mock.calls.find(
+      (call: any[]) => call[0]?.where?.id?.in != null
+    )
+    expect(ownDataCall[0].cursor).toEqual({ id: 'a' })
+    expect(ownDataCall[0].skip).toBe(1)
+  })
+})

--- a/apis/api-media/src/schema/video/lib/verifyAvailableLanguages.ts
+++ b/apis/api-media/src/schema/video/lib/verifyAvailableLanguages.ts
@@ -31,6 +31,14 @@
 // forever -- and every id like that is reported in `unresolvedVideoIds` for
 // separate investigation/repair; it is never included in `checked`, and
 // never compared or fixed.
+//
+// The graph (level assignment + unresolved ids) is derived fresh from the
+// children/parents relation on every call by default -- cheap on its own
+// (ids only), but repeating it for every page of a large catalog is
+// wasteful. A caller that already knows the graph for this run (the
+// runVerifyAvailableLanguages driver does) can pass it in via the `graph`
+// option to skip that recomputation; see the note on `graph` below for what
+// that trades away.
 
 import { prisma } from '@core/prisma/media/client'
 
@@ -43,9 +51,31 @@ export interface AvailableLanguagesMismatch {
 // Identifies where a paginated walk left off: the level index being
 // processed, and the last video id already handled within that level (null
 // means "start of the level").
+//
+// This cursor is only meaningful relative to a specific graph. Level
+// membership is derived from the children/parents relation, so if a video
+// is published, unpublished, or reparented between the call that produced
+// this cursor and the call resuming from it, level membership can shift
+// under the cursor -- resuming can then skip a video or re-check one
+// already covered. Two cases in practice:
+// - Calling verifyAvailableLanguages() directly across multiple calls
+//   without passing `graph`: each call re-derives the graph fresh, so this
+//   is a real (if narrow) risk. Full coverage is only guaranteed for a walk
+//   that completes within one stable window.
+// - Calling it via the graph option (as runVerifyAvailableLanguages does):
+//   the graph is fixed for the whole run, so the cursor's meaning can't
+//   drift mid-run -- but the run also won't notice a structural change
+//   until its next fresh run picks up a new graph.
 export interface VerifyAvailableLanguagesCursor {
   level: number
   afterId: string | null
+}
+
+// The topologically-ordered levels (bottom-up: leaves first) and the ids
+// the walk can never reach, as computed by computeAvailableLanguagesGraph.
+export interface AvailableLanguagesGraph {
+  levels: string[][]
+  unresolvedVideoIds: string[]
 }
 
 export interface VerifyAvailableLanguagesOptions {
@@ -60,6 +90,14 @@ export interface VerifyAvailableLanguagesOptions {
   // smaller value to force multi-call pagination (as a large catalog would
   // hit naturally).
   pageSize?: number
+  // Reuse a graph computed by an earlier call in the same run instead of
+  // deriving it again from the children/parents relation. Passing this in
+  // turns a multi-call walk from one graph load per page into one per run,
+  // at the cost of that run no longer reacting to videos published,
+  // unpublished, or reparented after the graph was computed -- see the
+  // caveat on VerifyAvailableLanguagesCursor. Omit to derive the graph
+  // fresh, as every call did before this option existed.
+  graph?: AvailableLanguagesGraph
 }
 
 export interface VerifyAvailableLanguagesResult {
@@ -72,8 +110,10 @@ export interface VerifyAvailableLanguagesResult {
   // populated when `fix: true`.
   fixed: string[]
   // Video ids the walk could not reach because they sit on a cycle in the
-  // children/parents relation, or depend on one. Recomputed fresh on every
-  // call (cheap -- it only needs ids), regardless of pagination progress.
+  // children/parents relation, or depend on one. Derived from the graph for
+  // this call -- fresh every time by default, or fixed for the run when the
+  // caller supplied `graph` (see the `graph` option) -- regardless of
+  // pagination progress.
   unresolvedVideoIds: string[]
   // Pass this back in to continue the walk. Null means the whole catalog
   // (everything reachable, i.e. everything not in unresolvedVideoIds) has
@@ -91,18 +131,15 @@ function sameLanguageSet(a: string[], b: string[]): boolean {
   return b.every((languageId) => setA.has(languageId))
 }
 
-export async function verifyAvailableLanguages(
-  options: VerifyAvailableLanguagesOptions = {}
-): Promise<VerifyAvailableLanguagesResult> {
-  const pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE
-  const startLevel = options.cursor?.level ?? 0
-  let afterId = options.cursor?.afterId ?? null
-
-  // One lightweight query for the whole catalog's shape -- id and live
-  // (published) children ids only. This is what determines processing
-  // order and can't be discovered any other way, but it's a single round
-  // trip returning ids alone, not the heavier per-video data (variants,
-  // stored availableLanguages) fetched in bounded pages below.
+// Derives the topologically-ordered levels (Kahn's algorithm over the
+// children/parents relation) and the ids the walk can never reach. This is
+// a single lightweight query for the whole catalog's shape -- id and live
+// (published) children ids only, not the heavier per-video data (variants,
+// stored availableLanguages) fetched in bounded pages by verifyAvailableLanguages
+// itself. Exported so a multi-call driver can compute it once per run and
+// pass it to every call via the `graph` option, instead of paying for this
+// on every page.
+export async function computeAvailableLanguagesGraph(): Promise<AvailableLanguagesGraph> {
   const graphNodes = await prisma.video.findMany({
     select: {
       id: true,
@@ -149,6 +186,22 @@ export async function verifyAvailableLanguages(
   const unresolvedVideoIds = graphNodes
     .map((node) => node.id)
     .filter((id) => !resolvedIds.has(id))
+
+  return { levels, unresolvedVideoIds }
+}
+
+export async function verifyAvailableLanguages(
+  options: VerifyAvailableLanguagesOptions = {}
+): Promise<VerifyAvailableLanguagesResult> {
+  const pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE
+  if (!Number.isInteger(pageSize) || pageSize < 1) {
+    throw new Error(`pageSize must be a positive integer, received ${pageSize}`)
+  }
+  const startLevel = options.cursor?.level ?? 0
+  let afterId = options.cursor?.afterId ?? null
+
+  const { levels, unresolvedVideoIds } =
+    options.graph ?? (await computeAvailableLanguagesGraph())
 
   const mismatches: AvailableLanguagesMismatch[] = []
   const fixed: string[] = []
@@ -203,11 +256,23 @@ export async function verifyAvailableLanguages(
         })
 
         if (options.fix) {
-          await prisma.video.update({
-            where: { id: video.id },
+          // Guard against a concurrent publish/unpublish landing between
+          // this read and this write: only apply the correction if
+          // availableLanguages still holds the exact value we just read
+          // it as. If it doesn't, some other write already changed it out
+          // from under us -- leave it alone rather than clobbering
+          // whatever that write produced; the next verification pass will
+          // re-check it against its now-current state.
+          const updateResult = await prisma.video.updateMany({
+            where: {
+              id: video.id,
+              availableLanguages: { equals: video.availableLanguages }
+            },
             data: { availableLanguages: { set: computed } }
           })
-          fixed.push(video.id)
+          if (updateResult.count > 0) {
+            fixed.push(video.id)
+          }
         }
       }
     }

--- a/apis/api-media/src/schema/video/lib/verifyAvailableLanguages.ts
+++ b/apis/api-media/src/schema/video/lib/verifyAvailableLanguages.ts
@@ -1,0 +1,239 @@
+// Batch verifier for Video.availableLanguages.
+//
+// Every mutation and worker is supposed to keep this field in sync via
+// updateAvailableLanguages.ts's shared recompute, so in principle it should
+// never drift from source data. This module is the independent check on
+// that assumption: it walks the whole catalog bottom-up, recomputes every
+// video's availableLanguages the same way calculateAvailableLanguages does
+// (own published variant languages, unioned with each live child's
+// *current stored* value), diffs the result against what's actually
+// stored, and can optionally self-heal by writing the corrected value.
+//
+// The traversal is batched level-by-level -- one query fetches every
+// video's own data (variants + children) for a given depth in the
+// children/parents hierarchy, not one query per video. Processing is
+// bottom-up (leaves first) so that in fix mode a correction made at one
+// level is visible, already committed, when its parent is checked a moment
+// later -- a whole drifted branch can self-heal in a single walk.
+//
+// The walk is also paginated: each call does at most `pageSize` videos of
+// work (across levels; the exact page size only matters as a cap on a
+// single call's cost) and returns a `nextCursor`. Passing that cursor back
+// in resumes exactly where the previous call left off, so verifying a
+// large catalog is a sequence of bounded calls -- following the reconciliation
+// worker's sweep pattern (bounded batch per invocation, not a single
+// unbounded pass) -- rather than one call that must run to completion.
+//
+// A video that sits on a cycle in the children/parents relation (or
+// depends, transitively, on one) never has all of its live children
+// resolved, so it never reaches pendingChildCount 0 and is never assigned a
+// level. The walk simply never reaches such a video -- rather than looping
+// forever -- and every id like that is reported in `unresolvedVideoIds` for
+// separate investigation/repair; it is never included in `checked`, and
+// never compared or fixed.
+
+import { prisma } from '@core/prisma/media/client'
+
+export interface AvailableLanguagesMismatch {
+  videoId: string
+  stored: string[]
+  computed: string[]
+}
+
+// Identifies where a paginated walk left off: the level index being
+// processed, and the last video id already handled within that level (null
+// means "start of the level").
+export interface VerifyAvailableLanguagesCursor {
+  level: number
+  afterId: string | null
+}
+
+export interface VerifyAvailableLanguagesOptions {
+  // When true, mismatches are written back with the computed value. When
+  // false (the default), the verifier only reports what it found.
+  fix?: boolean
+  // Resume a previous call's walk. Omit (or pass null) to start from the
+  // beginning of the catalog.
+  cursor?: VerifyAvailableLanguagesCursor | null
+  // Upper bound on how many videos this call will check. Defaults to a
+  // generous size so a normal-sized catalog completes in one call; pass a
+  // smaller value to force multi-call pagination (as a large catalog would
+  // hit naturally).
+  pageSize?: number
+}
+
+export interface VerifyAvailableLanguagesResult {
+  // Number of videos this call actually compared (excludes videos skipped
+  // by pagination in a previous or future call, and excludes unresolved
+  // videos, which are never compared).
+  checked: number
+  mismatches: AvailableLanguagesMismatch[]
+  // Video ids that were mismatched and successfully written; only
+  // populated when `fix: true`.
+  fixed: string[]
+  // Video ids the walk could not reach because they sit on a cycle in the
+  // children/parents relation, or depend on one. Recomputed fresh on every
+  // call (cheap -- it only needs ids), regardless of pagination progress.
+  unresolvedVideoIds: string[]
+  // Pass this back in to continue the walk. Null means the whole catalog
+  // (everything reachable, i.e. everything not in unresolvedVideoIds) has
+  // now been checked.
+  nextCursor: VerifyAvailableLanguagesCursor | null
+}
+
+const DEFAULT_PAGE_SIZE = 500
+
+// True when two availableLanguages values represent the same set,
+// irrespective of order.
+function sameLanguageSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false
+  const setA = new Set(a)
+  return b.every((languageId) => setA.has(languageId))
+}
+
+export async function verifyAvailableLanguages(
+  options: VerifyAvailableLanguagesOptions = {}
+): Promise<VerifyAvailableLanguagesResult> {
+  const pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE
+  const startLevel = options.cursor?.level ?? 0
+  let afterId = options.cursor?.afterId ?? null
+
+  // One lightweight query for the whole catalog's shape -- id and live
+  // (published) children ids only. This is what determines processing
+  // order and can't be discovered any other way, but it's a single round
+  // trip returning ids alone, not the heavier per-video data (variants,
+  // stored availableLanguages) fetched in bounded pages below.
+  const graphNodes = await prisma.video.findMany({
+    select: {
+      id: true,
+      children: { where: { published: true }, select: { id: true } }
+    }
+  })
+
+  const pendingChildCount = new Map<string, number>()
+  const parentsOfChild = new Map<string, string[]>()
+
+  for (const node of graphNodes) {
+    const childIds = node.children.map((child) => child.id)
+    pendingChildCount.set(node.id, childIds.length)
+    for (const childId of childIds) {
+      const parents = parentsOfChild.get(childId) ?? []
+      parents.push(node.id)
+      parentsOfChild.set(childId, parents)
+    }
+  }
+
+  // Kahn's algorithm: level 0 is every video with no live children left to
+  // wait on (true leaves, plus any container whose children are all
+  // unpublished). Level n+1 is every video whose last remaining live child
+  // just resolved at level n.
+  const levels: string[][] = []
+  let frontier = graphNodes
+    .map((node) => node.id)
+    .filter((id) => (pendingChildCount.get(id) ?? 0) === 0)
+
+  while (frontier.length > 0) {
+    levels.push(frontier)
+    const next = new Set<string>()
+    for (const id of frontier) {
+      for (const parentId of parentsOfChild.get(id) ?? []) {
+        const remaining = (pendingChildCount.get(parentId) ?? 0) - 1
+        pendingChildCount.set(parentId, remaining)
+        if (remaining === 0) next.add(parentId)
+      }
+    }
+    frontier = Array.from(next)
+  }
+
+  const resolvedIds = new Set(levels.flat())
+  const unresolvedVideoIds = graphNodes
+    .map((node) => node.id)
+    .filter((id) => !resolvedIds.has(id))
+
+  const mismatches: AvailableLanguagesMismatch[] = []
+  const fixed: string[] = []
+  let checked = 0
+  let budget = pageSize
+  let levelIndex = startLevel
+
+  while (levelIndex < levels.length && budget > 0) {
+    const levelIds = levels[levelIndex]
+    const take = budget
+
+    const page = await prisma.video.findMany({
+      where: { id: { in: levelIds } },
+      orderBy: { id: 'asc' },
+      take,
+      ...(afterId != null ? { cursor: { id: afterId }, skip: 1 } : {}),
+      select: {
+        id: true,
+        availableLanguages: true,
+        variants: {
+          where: { published: true },
+          select: { languageId: true }
+        },
+        children: {
+          where: { published: true },
+          select: { availableLanguages: true }
+        }
+      }
+    })
+
+    for (const video of page) {
+      checked++
+
+      const languageSet = new Set<string>()
+      for (const variant of video.variants) {
+        languageSet.add(variant.languageId)
+      }
+      for (const child of video.children) {
+        for (const languageId of child.availableLanguages) {
+          languageSet.add(languageId)
+        }
+      }
+      const computed = Array.from(languageSet).sort(
+        (a, b) => Number(a) - Number(b)
+      )
+
+      if (!sameLanguageSet(video.availableLanguages, computed)) {
+        mismatches.push({
+          videoId: video.id,
+          stored: video.availableLanguages,
+          computed
+        })
+
+        if (options.fix) {
+          await prisma.video.update({
+            where: { id: video.id },
+            data: { availableLanguages: { set: computed } }
+          })
+          fixed.push(video.id)
+        }
+      }
+    }
+
+    budget -= page.length
+
+    // A short page (fewer rows than asked for) means this level is fully
+    // consumed -- move on. A full page might have exhausted the level
+    // exactly, in which case the next call's query for it simply returns
+    // an empty page and advances; that extra round trip is the price of
+    // not knowing a level's exact remaining count without a second query.
+    if (page.length < take) {
+      levelIndex++
+      afterId = null
+    } else {
+      afterId = page.at(-1)?.id ?? null
+    }
+  }
+
+  const done = levelIndex >= levels.length
+
+  return {
+    checked,
+    mismatches,
+    fixed,
+    unresolvedVideoIds,
+    nextCursor: done ? null : { level: levelIndex, afterId }
+  }
+}

--- a/apis/api-media/src/scripts/run-verify-available-languages.ts
+++ b/apis/api-media/src/scripts/run-verify-available-languages.ts
@@ -1,0 +1,24 @@
+/**
+ * Manual trigger for the availableLanguages batch verifier (same logic as
+ * the scheduled worker). Report-only by default; pass --fix to self-heal
+ * any mismatch found.
+ *
+ * Usage (from repo root):
+ *
+ *   pnpm exec nx run api-media:verify-available-languages
+ *   pnpm exec nx run api-media:verify-available-languages -- --fix
+ */
+import { logger } from '../logger'
+
+import { runVerifyAvailableLanguages } from './verify-available-languages'
+
+async function main(): Promise<void> {
+  const fix = process.argv.includes('--fix')
+  const result = await runVerifyAvailableLanguages({ fix }, logger)
+  logger.info({ result }, 'availableLanguages verification result')
+}
+
+main().catch((error) => {
+  logger.error({ error }, 'run-verify-available-languages failed')
+  process.exit(1)
+})

--- a/apis/api-media/src/scripts/run-verify-available-languages.ts
+++ b/apis/api-media/src/scripts/run-verify-available-languages.ts
@@ -15,7 +15,19 @@ import { runVerifyAvailableLanguages } from './verify-available-languages'
 async function main(): Promise<void> {
   const fix = process.argv.includes('--fix')
   const result = await runVerifyAvailableLanguages({ fix }, logger)
-  logger.info({ result }, 'availableLanguages verification result')
+  // Log summary fields rather than the full result -- unresolvedVideoIds is
+  // unbounded and would otherwise dump one line per stuck video into
+  // structured logs.
+  logger.info(
+    {
+      checked: result.checked,
+      mismatchCount: result.mismatchCount,
+      fixedCount: result.fixedCount,
+      unresolvedCount: result.unresolvedVideoIds.length,
+      completed: result.completed
+    },
+    'availableLanguages verification result'
+  )
 }
 
 main().catch((error) => {

--- a/apis/api-media/src/scripts/verify-available-languages.spec.ts
+++ b/apis/api-media/src/scripts/verify-available-languages.spec.ts
@@ -1,18 +1,28 @@
 import { vi } from 'vitest'
 
-import { verifyAvailableLanguages } from '../schema/video/lib/verifyAvailableLanguages'
+import {
+  computeAvailableLanguagesGraph,
+  verifyAvailableLanguages
+} from '../schema/video/lib/verifyAvailableLanguages'
 
 import { runVerifyAvailableLanguages } from './verify-available-languages'
 
 vi.mock('../schema/video/lib/verifyAvailableLanguages', () => ({
-  verifyAvailableLanguages: vi.fn()
+  verifyAvailableLanguages: vi.fn(),
+  computeAvailableLanguagesGraph: vi.fn()
 }))
 
 const mockedVerifyAvailableLanguages = vi.mocked(verifyAvailableLanguages)
+const mockedComputeAvailableLanguagesGraph = vi.mocked(
+  computeAvailableLanguagesGraph
+)
+
+const graph = { levels: [['a', 'b']], unresolvedVideoIds: [] }
 
 describe('runVerifyAvailableLanguages', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockedComputeAvailableLanguagesGraph.mockResolvedValue(graph)
   })
 
   it('makes a single call and returns completed when the walk finishes immediately', async () => {
@@ -30,7 +40,8 @@ describe('runVerifyAvailableLanguages', () => {
     expect(mockedVerifyAvailableLanguages).toHaveBeenCalledWith({
       fix: undefined,
       pageSize: undefined,
-      cursor: null
+      cursor: null,
+      graph
     })
     expect(result).toEqual({
       checked: 3,
@@ -39,6 +50,29 @@ describe('runVerifyAvailableLanguages', () => {
       unresolvedVideoIds: [],
       completed: true
     })
+  })
+
+  it('computes the graph once per run regardless of how many calls the walk takes', async () => {
+    mockedVerifyAvailableLanguages
+      .mockResolvedValueOnce({
+        checked: 2,
+        mismatches: [],
+        fixed: [],
+        unresolvedVideoIds: [],
+        nextCursor: { level: 0, afterId: 'b' }
+      })
+      .mockResolvedValueOnce({
+        checked: 1,
+        mismatches: [],
+        fixed: [],
+        unresolvedVideoIds: [],
+        nextCursor: null
+      })
+
+    await runVerifyAvailableLanguages()
+
+    expect(mockedComputeAvailableLanguagesGraph).toHaveBeenCalledTimes(1)
+    expect(mockedVerifyAvailableLanguages).toHaveBeenCalledTimes(2)
   })
 
   it('threads the cursor through repeated calls until the walk completes', async () => {
@@ -64,12 +98,14 @@ describe('runVerifyAvailableLanguages', () => {
     expect(mockedVerifyAvailableLanguages).toHaveBeenNthCalledWith(1, {
       fix: true,
       pageSize: undefined,
-      cursor: null
+      cursor: null,
+      graph
     })
     expect(mockedVerifyAvailableLanguages).toHaveBeenNthCalledWith(2, {
       fix: true,
       pageSize: undefined,
-      cursor: { level: 0, afterId: 'b' }
+      cursor: { level: 0, afterId: 'b' },
+      graph
     })
     expect(result).toEqual({
       checked: 3,

--- a/apis/api-media/src/scripts/verify-available-languages.spec.ts
+++ b/apis/api-media/src/scripts/verify-available-languages.spec.ts
@@ -1,0 +1,98 @@
+import { vi } from 'vitest'
+
+import { verifyAvailableLanguages } from '../schema/video/lib/verifyAvailableLanguages'
+
+import { runVerifyAvailableLanguages } from './verify-available-languages'
+
+vi.mock('../schema/video/lib/verifyAvailableLanguages', () => ({
+  verifyAvailableLanguages: vi.fn()
+}))
+
+const mockedVerifyAvailableLanguages = vi.mocked(verifyAvailableLanguages)
+
+describe('runVerifyAvailableLanguages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('makes a single call and returns completed when the walk finishes immediately', async () => {
+    mockedVerifyAvailableLanguages.mockResolvedValueOnce({
+      checked: 3,
+      mismatches: [{ videoId: 'a', stored: [], computed: ['1'] }],
+      fixed: [],
+      unresolvedVideoIds: [],
+      nextCursor: null
+    })
+
+    const result = await runVerifyAvailableLanguages()
+
+    expect(mockedVerifyAvailableLanguages).toHaveBeenCalledTimes(1)
+    expect(mockedVerifyAvailableLanguages).toHaveBeenCalledWith({
+      fix: undefined,
+      pageSize: undefined,
+      cursor: null
+    })
+    expect(result).toEqual({
+      checked: 3,
+      mismatchCount: 1,
+      fixedCount: 0,
+      unresolvedVideoIds: [],
+      completed: true
+    })
+  })
+
+  it('threads the cursor through repeated calls until the walk completes', async () => {
+    mockedVerifyAvailableLanguages
+      .mockResolvedValueOnce({
+        checked: 2,
+        mismatches: [{ videoId: 'a', stored: [], computed: ['1'] }],
+        fixed: ['a'],
+        unresolvedVideoIds: [],
+        nextCursor: { level: 0, afterId: 'b' }
+      })
+      .mockResolvedValueOnce({
+        checked: 1,
+        mismatches: [],
+        fixed: [],
+        unresolvedVideoIds: ['cycle-a'],
+        nextCursor: null
+      })
+
+    const result = await runVerifyAvailableLanguages({ fix: true })
+
+    expect(mockedVerifyAvailableLanguages).toHaveBeenCalledTimes(2)
+    expect(mockedVerifyAvailableLanguages).toHaveBeenNthCalledWith(1, {
+      fix: true,
+      pageSize: undefined,
+      cursor: null
+    })
+    expect(mockedVerifyAvailableLanguages).toHaveBeenNthCalledWith(2, {
+      fix: true,
+      pageSize: undefined,
+      cursor: { level: 0, afterId: 'b' }
+    })
+    expect(result).toEqual({
+      checked: 3,
+      mismatchCount: 1,
+      fixedCount: 1,
+      unresolvedVideoIds: ['cycle-a'],
+      completed: true
+    })
+  })
+
+  it('stops after maxCalls and reports incomplete if the walk has not finished', async () => {
+    mockedVerifyAvailableLanguages.mockResolvedValue({
+      checked: 1,
+      mismatches: [],
+      fixed: [],
+      unresolvedVideoIds: [],
+      nextCursor: { level: 0, afterId: 'never-ending' }
+    })
+
+    const result = await runVerifyAvailableLanguages({ maxCalls: 3 })
+
+    expect(mockedVerifyAvailableLanguages).toHaveBeenCalledTimes(3)
+    expect(result.completed).toBe(false)
+    expect(result.checked).toBe(3)
+  })
+})

--- a/apis/api-media/src/scripts/verify-available-languages.ts
+++ b/apis/api-media/src/scripts/verify-available-languages.ts
@@ -1,0 +1,83 @@
+// Driver loop for verifyAvailableLanguages: threads its resumable cursor
+// through repeated bounded calls (mirroring mux-videos.ts's cursor-paginated
+// backfill loop) until the whole catalog has been walked, aggregating the
+// results into one summary. Used by both the on-demand CLI entrypoint
+// (run-verify-available-languages.ts) and the scheduled worker
+// (workers/verifyAvailableLanguages).
+import { Logger } from 'pino'
+
+import {
+  VerifyAvailableLanguagesCursor,
+  verifyAvailableLanguages
+} from '../schema/video/lib/verifyAvailableLanguages'
+
+export interface RunVerifyAvailableLanguagesOptions {
+  fix?: boolean
+  pageSize?: number
+  // Safety cap on how many bounded verifyAvailableLanguages calls this
+  // driver will make in one run. Each call is already bounded by pageSize;
+  // this bounds how many of those calls a single invocation makes, so a
+  // catalog that somehow never converges can't turn one script/worker run
+  // into an unbounded loop -- it just reports incomplete and picks up again
+  // on the next scheduled run.
+  maxCalls?: number
+}
+
+export interface RunVerifyAvailableLanguagesResult {
+  checked: number
+  mismatchCount: number
+  fixedCount: number
+  unresolvedVideoIds: string[]
+  // False if maxCalls was hit before the walk reached the end of the
+  // catalog -- the remaining work simply wasn't attempted this run.
+  completed: boolean
+}
+
+const DEFAULT_MAX_CALLS = 1000
+
+export async function runVerifyAvailableLanguages(
+  options: RunVerifyAvailableLanguagesOptions = {},
+  logger?: Logger
+): Promise<RunVerifyAvailableLanguagesResult> {
+  const maxCalls = options.maxCalls ?? DEFAULT_MAX_CALLS
+
+  let cursor: VerifyAvailableLanguagesCursor | null = null
+  let checked = 0
+  let mismatchCount = 0
+  let fixedCount = 0
+  let unresolvedVideoIds: string[] = []
+  let calls = 0
+
+  do {
+    const result = await verifyAvailableLanguages({
+      fix: options.fix,
+      pageSize: options.pageSize,
+      cursor
+    })
+
+    checked += result.checked
+    mismatchCount += result.mismatches.length
+    fixedCount += result.fixed.length
+    unresolvedVideoIds = result.unresolvedVideoIds
+    cursor = result.nextCursor
+    calls++
+
+    logger?.info(
+      {
+        checked,
+        mismatchCount,
+        fixedCount,
+        done: cursor == null
+      },
+      'availableLanguages verification progress'
+    )
+  } while (cursor != null && calls < maxCalls)
+
+  return {
+    checked,
+    mismatchCount,
+    fixedCount,
+    unresolvedVideoIds,
+    completed: cursor == null
+  }
+}

--- a/apis/api-media/src/scripts/verify-available-languages.ts
+++ b/apis/api-media/src/scripts/verify-available-languages.ts
@@ -4,10 +4,18 @@
 // results into one summary. Used by both the on-demand CLI entrypoint
 // (run-verify-available-languages.ts) and the scheduled worker
 // (workers/verifyAvailableLanguages).
+//
+// The graph (level assignment + unresolved ids) is computed once here and
+// reused across every call this run makes, rather than each call rederiving
+// it from scratch -- a catalog with N videos and a pageSize of P would
+// otherwise pay for the graph load and topological sort N/P times per run.
+// See computeAvailableLanguagesGraph and the `graph` option for what a
+// fixed-per-run graph trades away.
 import { Logger } from 'pino'
 
 import {
   VerifyAvailableLanguagesCursor,
+  computeAvailableLanguagesGraph,
   verifyAvailableLanguages
 } from '../schema/video/lib/verifyAvailableLanguages'
 
@@ -40,6 +48,7 @@ export async function runVerifyAvailableLanguages(
   logger?: Logger
 ): Promise<RunVerifyAvailableLanguagesResult> {
   const maxCalls = options.maxCalls ?? DEFAULT_MAX_CALLS
+  const graph = await computeAvailableLanguagesGraph()
 
   let cursor: VerifyAvailableLanguagesCursor | null = null
   let checked = 0
@@ -52,7 +61,8 @@ export async function runVerifyAvailableLanguages(
     const result = await verifyAvailableLanguages({
       fix: options.fix,
       pageSize: options.pageSize,
-      cursor
+      cursor,
+      graph
     })
 
     checked += result.checked

--- a/apis/api-media/src/workers/server.ts
+++ b/apis/api-media/src/workers/server.ts
@@ -109,6 +109,12 @@ async function main(): Promise<void> {
           './parentVariantAudit'
         )
       )
+      run(
+        await import(
+          /* webpackChunkName: "verify-available-languages" */
+          './verifyAvailableLanguages'
+        )
+      )
     })
   }
 

--- a/apis/api-media/src/workers/verifyAvailableLanguages/config.ts
+++ b/apis/api-media/src/workers/verifyAvailableLanguages/config.ts
@@ -1,0 +1,5 @@
+export const queueName = 'api-media-verify-available-languages'
+export const jobName = `${queueName}-job`
+// Daily at 4am, after parentVariantAudit's 2am slot -- both are catalog-wide
+// batch audits, not urgent per-record work, so a daily cadence is enough.
+export const repeat = '0 0 4 * * *'

--- a/apis/api-media/src/workers/verifyAvailableLanguages/index.ts
+++ b/apis/api-media/src/workers/verifyAvailableLanguages/index.ts
@@ -1,0 +1,2 @@
+export { jobName, queueName, repeat } from './config'
+export { service } from './service'

--- a/apis/api-media/src/workers/verifyAvailableLanguages/service.ts
+++ b/apis/api-media/src/workers/verifyAvailableLanguages/service.ts
@@ -1,0 +1,21 @@
+import { Logger } from 'pino'
+
+import { runVerifyAvailableLanguages } from '../../scripts/verify-available-languages'
+
+// Self-heals by default: this is a scheduled background job whose entire
+// purpose is proving the availableLanguages invariant holds catalog-wide
+// and repairing it when it doesn't, not just reporting -- report-only runs
+// are for the manual CLI entrypoint (run-verify-available-languages.ts).
+export async function service(logger?: Logger): Promise<void> {
+  const result = await runVerifyAvailableLanguages({ fix: true }, logger)
+  logger?.info(
+    {
+      checked: result.checked,
+      mismatchCount: result.mismatchCount,
+      fixedCount: result.fixedCount,
+      unresolvedCount: result.unresolvedVideoIds.length,
+      completed: result.completed
+    },
+    'availableLanguages verification completed'
+  )
+}


### PR DESCRIPTION
Closes #9525

## Summary

Sub-issue of #9515 (Rebuild `Video.availableLanguages` as one cycle-safe, recursively-correct source of truth). Implements the batch verifier: a job that walks the catalog, recomputes every video's `availableLanguages` from source data, diffs it against the stored value, reports mismatches, and can self-heal (write the corrected value) on demand.

## What this does

- `verifyAvailableLanguages()` (`apis/api-media/src/schema/video/lib/verifyAvailableLanguages.ts`): walks the catalog bottom-up in topologically-ordered levels (Kahn's algorithm over the `children` relation), batched **one query per level**, not one per video. For each video it recomputes `availableLanguages` the same way `calculateAvailableLanguages` does today (own published variant languages ∪ each live child's *current stored* value) and diffs it against what's stored.
- `fix: true` self-heals by writing the corrected value. Because levels are processed bottom-up and each write commits before the next level reads its children, a whole drifted branch can be repaired in one walk.
- **Paginated/resumable**: each call does at most `pageSize` videos of work (default 500) and returns a `nextCursor: { level, afterId }`; passing it back in resumes exactly where the previous call left off — the same cursor+`take` keyset pattern this repo already uses for backfills (mirrors `mux-videos.ts`'s download-backfill loop), rather than a single unbounded pass that must finish in one run.
- A video on a cycle in the `children`/`parents` relation (or dependent on one) never reaches `pendingChildCount` 0, so it's never assigned a level — the walk simply never reaches it (no hang) and reports it in `unresolvedVideoIds` instead.
- `runVerifyAvailableLanguages()` (`apis/api-media/src/scripts/verify-available-languages.ts`) threads the cursor through repeated bounded calls until the walk completes (or a `maxCalls` safety cap is hit), aggregating one summary. Used by:
  - a manual CLI entrypoint (`run-verify-available-languages.ts`, `--fix` flag, new `verify-available-languages` nx target), and
  - a new scheduled worker (`apis/api-media/src/workers/verifyAvailableLanguages`, daily cron, self-heals by default), registered in `workers/server.ts` alongside the existing `parentVariantAudit`/`videoVariantReconciliation` batch jobs.

## Key decisions

- **Each video's expected value is computed from its children's *current stored* `availableLanguages`**, not a fully recomputed value carried in memory across levels. This matches `calculateAvailableLanguages`'s existing definition and the issue's own acceptance-criterion wording ("what its current variants/children imply"), and is what makes cross-call resumability correct with **zero new persisted state**: once fix mode commits a level's corrections, a later call resuming at a higher level reads the now-correct data straight from the DB.
- **Cycle handling is a flat `unresolvedVideoIds` report** (ids never reached by the walk), not a Tarjan SCC pass distinguishing genuine cycle members from ancestors merely blocked by one. That refinement was a nice-to-have surfaced in review of a related, unmerged PR (#9516) — left out here to keep this change minimal; worth revisiting if operators need to target cycle repairs directly rather than just knowing "these N ids didn't resolve."
- **No new Prisma model/migration for cursor storage** — the resumable cursor is a plain value the caller threads through, avoiding overlap with #9523 (the separate `NOT NULL`/GIN-index migration) and keeping this PR isolated from the other in-flight, unmerged decomposition PRs (#9528–#9531) that touch the same recompute engine.

## Testing

- `verifyAvailableLanguages.spec.ts`: seeded-mismatch reporting, clean-catalog no-false-positives, self-heal write, multi-level cascade self-heal in one pass, cycle exclusion (both a direct cycle and a video blocked by a descendant cycle), level-batching (asserts query count), and two pagination tests (a level split across pages resumes correctly via cursor, and a resumed call doesn't reprocess already-checked videos).
- `verify-available-languages.spec.ts`: the driver loop's single-call, multi-call cursor-threading, and `maxCalls` safety-cap behavior.
- All new tests pass; full `apis/api-media` suite is green except one pre-existing, unrelated failure (`video-variant-reconciliation-migration.spec.ts` resolves a fixture path off `process.cwd()`, which differs when vitest runs from the `apis/api-media` subdirectory — confirmed identical with and without this branch's changes via `git stash`).

## Verification

`pnpm exec nx affected -t lint,type-check,test --base=origin/main` fails in this worktree with `WorkspaceContext is not a constructor` on every subcommand (including `nx show projects` with zero changes) — a pre-existing environment issue, also documented in sibling PRs #9516, #9528, #9530, #9531. Ran the underlying tools directly instead:
- `pnpm lint:changed --fix` — clean (prettier reformatted the new spec file; no lint errors).
- `pnpm tsc7 -p apis/api-media/tsconfig.ts7.json` — clean.
- `vitest run` for `apis/api-media` — 790/790 tests passing (see the one pre-existing unrelated failure noted above).

## Blockers / notes for the next iteration

This issue's stated blockers (#9517–#9521) and the sibling decomposition PRs (#9528–#9531) are all still open/unmerged on `main` as of this PR, so the cascade-to-root recompute engine, removal-cascade fix, and other writer fixes from the parent epic (#9515) are not yet live. This PR is therefore an **independent, self-contained verifier**: it defines correctness the same way the current (pre-cascade) production code does (own variants ∪ children's current stored value) rather than depending on any of those unmerged changes, so it's fully functional today and will keep working unmodified once the cascade engine lands. Running it before those writer fixes land will surface real, already-known drift as expected noise — per the issue's own framing ("This is deliberately last").

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated verification of video language metadata, including mismatch detection and optional repairs.
  * Added resumable, paginated processing with progress reporting and handling for unresolved dependency cycles.
  * Added a manual verification command with report-only and repair modes.
  * Added a daily scheduled job to verify and repair language metadata automatically.

* **Tests**
  * Added comprehensive coverage for verification, repairs, pagination, batching, cursor resumption, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->