### PR TITLE
refactor(api-media): dedupe Algolia client factories

### DIFF
--- a/apis/api-media/src/lib/algolia/algoliaClient.ts
+++ b/apis/api-media/src/lib/algolia/algoliaClient.ts
@@ -5,6 +5,7 @@ export type AlgoliaConfig = {
   apiKey: string
   videosIndex: string
   videoVariantsIndex: string
+  languagesIndex: string
 }
 
 function getRequiredEnv(name: string): string {
@@ -21,13 +22,28 @@ function getRequiredEnv(name: string): string {
  * NOTE: This is intentionally a function (not a module-level constant) so
  * unit tests that import GraphQL schema modules don't immediately throw
  * when Algolia env vars are not present.
+ *
+ * The index names are exposed as getters rather than eagerly-evaluated
+ * properties: appId/apiKey are shared by every caller so those still resolve
+ * up front, but each index's env var is only required at the point a caller
+ * actually reads that index. This lets video call sites destructure
+ * `videosIndex`/`videoVariantsIndex` without ever requiring
+ * ALGOLIA_INDEX_LANGUAGES to be set, and vice versa for language call sites -
+ * requiring one index cannot break callers of another.
  */
 export function getAlgoliaConfig(): AlgoliaConfig {
   return {
     appId: getRequiredEnv('ALGOLIA_APPLICATION_ID'),
     apiKey: getRequiredEnv('ALGOLIA_API_KEY'),
-    videosIndex: getRequiredEnv('ALGOLIA_INDEX_VIDEOS'),
-    videoVariantsIndex: getRequiredEnv('ALGOLIA_INDEX_VIDEO_VARIANTS')
+    get videosIndex(): string {
+      return getRequiredEnv('ALGOLIA_INDEX_VIDEOS')
+    },
+    get videoVariantsIndex(): string {
+      return getRequiredEnv('ALGOLIA_INDEX_VIDEO_VARIANTS')
+    },
+    get languagesIndex(): string {
+      return getRequiredEnv('ALGOLIA_INDEX_LANGUAGES')
+    }
   }
 }
 

--- a/apis/api-media/src/lib/languages/updateLanguageInAlgolia.ts
+++ b/apis/api-media/src/lib/languages/updateLanguageInAlgolia.ts
@@ -1,4 +1,3 @@
-import { type SearchClient, algoliasearch } from 'algoliasearch'
 import type { Logger } from 'pino'
 
 import {
@@ -6,29 +5,7 @@ import {
   prisma as languagesPrisma
 } from '@core/prisma/languages/client'
 
-function getRequiredEnv(name: string): string {
-  const value = process.env[name]
-  if (value == null || value.trim() === '') {
-    throw new Error(`Missing required env var: ${name}`)
-  }
-  return value
-}
-
-interface AlgoliaLanguagesClient {
-  client: SearchClient
-  languagesIndex: string
-}
-
-// Deliberately local rather than reusing lib/algolia/algoliaClient, whose
-// getAlgoliaConfig also requires the video index env vars. Coupling the
-// languages sync to those would break video indexing wherever they are unset.
-function getAlgoliaLanguagesClient(): AlgoliaLanguagesClient {
-  const appId = getRequiredEnv('ALGOLIA_APPLICATION_ID')
-  const apiKey = getRequiredEnv('ALGOLIA_API_KEY')
-  const languagesIndex = getRequiredEnv('ALGOLIA_INDEX_LANGUAGES')
-
-  return { client: algoliasearch(appId, apiKey), languagesIndex }
-}
+import { getAlgoliaClient, getAlgoliaConfig } from '../algolia/algoliaClient'
 
 const languageAlgoliaSelect = {
   id: true,
@@ -122,7 +99,8 @@ export async function updateLanguageInAlgoliaFromMedia(
   logger?: Logger
 ): Promise<void> {
   try {
-    const { client, languagesIndex } = getAlgoliaLanguagesClient()
+    const client = getAlgoliaClient()
+    const { languagesIndex } = getAlgoliaConfig()
     const language = await languagesPrisma.language.findUnique({
       where: { id: languageId },
       select: languageAlgoliaSelect
@@ -160,7 +138,8 @@ interface ReindexLanguagesResult {
 export async function reindexLanguagesWithVideosInAlgolia(
   logger?: Logger
 ): Promise<ReindexLanguagesResult> {
-  const { client, languagesIndex } = getAlgoliaLanguagesClient()
+  const client = getAlgoliaClient()
+  const { languagesIndex } = getAlgoliaConfig()
 
   let count = 0
   let cursor: string | undefined


### PR DESCRIPTION
Closes #9434

## Summary

`apis/api-media` had two independent Algolia client/config factories: the shared `algoliaClient.ts` (used by ~12 video/video-variant call sites) and a near-identical private one in `updateLanguageInAlgolia.ts`. The obvious merge was tried and reverted in #9343 because `getAlgoliaConfig()` read every index env var eagerly — adding `languagesIndex` would have made every video call site hard-fail if `ALGOLIA_INDEX_LANGUAGES` was unset.

This PR does the merge the issue suggested: make index resolution **lazy per-index** instead of eager.

## What changed

- `algoliaClient.ts`: `AlgoliaConfig` now exposes `videosIndex`, `videoVariantsIndex`, and `languagesIndex` as **getters**. `appId`/`apiKey` stay eager (every caller needs both). Each index's `ALGOLIA_INDEX_*` env var is only required at the point a caller actually destructures that property — so requiring `ALGOLIA_INDEX_LANGUAGES` can no longer break video/variant callers, and vice versa. No call-site changes needed for the existing ~12 video/variant sites; they already do `const { videosIndex } = getAlgoliaConfig()`.
- `updateLanguageInAlgolia.ts`: dropped its local `getRequiredEnv` + `getAlgoliaLanguagesClient`, now calls the shared `getAlgoliaClient()` / `getAlgoliaConfig().languagesIndex`, matching the pattern every video call site already uses.

## The two-key question

The issue also asked to confirm whether api-media writing the languages index with `ALGOLIA_API_KEY` while api-languages uses a separate `ALGOLIA_API_KEY_LANGUAGES` for the same index is intentional. Both are separately Terraform-provisioned per service (`apis/api-media/infrastructure/locals.tf` vs `apis/api-languages/infrastructure/locals.tf`), which reads as an intentional least-privilege credential split across services rather than accidental drift. Unifying it would be a cross-service infra change and is out of scope for this dedupe.

## Testing

- `pnpm exec nx affected -t lint,type-check,test --base=origin/main` — passes (api-media: 78 files / 779 tests, lint 0 errors, type-check clean).
- `pnpm lint:changed --fix` — clean, no changes.
- Existing Algolia specs (`algoliaVideoUpdate`, `algoliaVideoVariantUpdate`, `videoAlgolia`, `updateLanguageInAlgolia`) pass unchanged — they either fully mock the module or only set/touch the index they care about, which is exactly what the lazy-getter change was designed to keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a dedicated language search index.
  * Language updates and full reindexing now use shared search configuration.

* **Bug Fixes**
  * Search configuration errors are now reported when the affected index is used, while core credentials remain validated immediately.
  * Blank or whitespace-only search configuration values are now rejected with clear validation errors.

* **Tests**
  * Added coverage for search configuration loading, validation, and client creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->