### PR TITLE
feat(journeys-admin): unpublished-video warning UI

### DIFF
--- a/apps/journeys-admin/__generated__/GetVideo.ts
+++ b/apps/journeys-admin/__generated__/GetVideo.ts
@@ -29,6 +29,7 @@ export interface GetVideo_video_variant {
   id: string;
   duration: number;
   hls: string | null;
+  published: boolean;
 }
 
 export interface GetVideo_video_variantLanguages_name {

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/Properties/blocks/Card/BackgroundMedia/Video/BackgroundMediaVideo.spec.tsx
@@ -210,6 +210,7 @@ const getVideoMock: MockedResponse<GetVideo, GetVideoVariables> = {
           id: 'variantA',
           duration: 144,
           hls: 'https://arc.gt/opsgn',
+          published: true,
           __typename: 'VideoVariant'
         },
         variantLanguages: [
@@ -264,6 +265,7 @@ const getExistingCoverVideoMock: MockedResponse<GetVideo, GetVideoVariables> = {
           id: '2_0-FallingPlates-529',
           duration: 144,
           hls: 'https://arc.gt/zbrvj',
+          published: true,
           __typename: 'VideoVariant'
         },
         variantLanguages: [

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/UnpublishedVideoBanner/UnpublishedVideoBanner.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/UnpublishedVideoBanner/UnpublishedVideoBanner.spec.tsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react'
+
+import { UnpublishedVideoBanner } from './UnpublishedVideoBanner'
+
+describe('UnpublishedVideoBanner', () => {
+  it('should render an unpublished warning with an explanatory note', () => {
+    const { getByText } = render(<UnpublishedVideoBanner />)
+
+    expect(getByText('Unpublished')).toBeInTheDocument()
+    expect(
+      getByText(
+        'This video has not been published yet. It can still be added to a journey, but visitors will not be able to watch it until it is published.'
+      )
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/UnpublishedVideoBanner/UnpublishedVideoBanner.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/UnpublishedVideoBanner/UnpublishedVideoBanner.tsx
@@ -1,0 +1,19 @@
+import Alert from '@mui/material/Alert'
+import AlertTitle from '@mui/material/AlertTitle'
+import { useTranslation } from 'next-i18next/pages'
+import { ReactElement } from 'react'
+
+export function UnpublishedVideoBanner(): ReactElement {
+  const { t } = useTranslation('apps-journeys-admin')
+
+  return (
+    <Alert severity="warning" data-testid="UnpublishedVideoBanner">
+      <AlertTitle>{t('Unpublished')}</AlertTitle>
+      {t(
+        'This video has not been published yet. It can still be added to a journey, but visitors will not be able to watch it until it is published.'
+      )}
+    </Alert>
+  )
+}
+
+export default UnpublishedVideoBanner

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/UnpublishedVideoBanner/index.ts
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/UnpublishedVideoBanner/index.ts
@@ -1,0 +1,1 @@
+export { UnpublishedVideoBanner } from './UnpublishedVideoBanner'

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/UnpublishedVideoDialog/UnpublishedVideoDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/UnpublishedVideoDialog/UnpublishedVideoDialog.spec.tsx
@@ -38,7 +38,11 @@ describe('UnpublishedVideoDialog', () => {
 
   it('should not render its content when closed', () => {
     const { queryByText } = render(
-      <UnpublishedVideoDialog open={false} onClose={vi.fn()} onConfirm={vi.fn()} />
+      <UnpublishedVideoDialog
+        open={false}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+      />
     )
 
     expect(queryByText('Unpublished Video')).not.toBeInTheDocument()

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/UnpublishedVideoDialog/UnpublishedVideoDialog.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/UnpublishedVideoDialog/UnpublishedVideoDialog.spec.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render } from '@testing-library/react'
+
+import { UnpublishedVideoDialog } from './UnpublishedVideoDialog'
+
+describe('UnpublishedVideoDialog', () => {
+  it('should render the unpublished warning when open', () => {
+    const { getByText } = render(
+      <UnpublishedVideoDialog open onClose={vi.fn()} onConfirm={vi.fn()} />
+    )
+
+    expect(getByText('Unpublished Video')).toBeInTheDocument()
+    expect(
+      getByText(
+        'This video has not been published yet. It can still be added to a journey, but visitors will not be able to watch it until it is published.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('should call onConfirm when the user acknowledges the warning', () => {
+    const onConfirm = vi.fn()
+    const { getByRole } = render(
+      <UnpublishedVideoDialog open onClose={vi.fn()} onConfirm={onConfirm} />
+    )
+
+    fireEvent.click(getByRole('button', { name: 'Use Anyway' }))
+    expect(onConfirm).toHaveBeenCalled()
+  })
+
+  it('should call onClose when the user cancels', () => {
+    const onClose = vi.fn()
+    const { getByRole } = render(
+      <UnpublishedVideoDialog open onClose={onClose} onConfirm={vi.fn()} />
+    )
+
+    fireEvent.click(getByRole('button', { name: 'Cancel' }))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('should not render its content when closed', () => {
+    const { queryByText } = render(
+      <UnpublishedVideoDialog open={false} onClose={vi.fn()} onConfirm={vi.fn()} />
+    )
+
+    expect(queryByText('Unpublished Video')).not.toBeInTheDocument()
+  })
+})

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/UnpublishedVideoDialog/UnpublishedVideoDialog.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/UnpublishedVideoDialog/UnpublishedVideoDialog.tsx
@@ -1,0 +1,44 @@
+import Alert from '@mui/material/Alert'
+import { useTranslation } from 'next-i18next/pages'
+import { ReactElement } from 'react'
+
+import { Dialog } from '@core/shared/ui/Dialog'
+
+export interface UnpublishedVideoDialogProps {
+  open: boolean
+  onClose: () => void
+  onConfirm: () => void
+}
+
+// Blocks a video selection from completing silently: shown whenever the user
+// selects (Select or Apply) a video whose variant is unpublished, so the
+// warning is un-missable rather than a banner they could scroll past.
+export function UnpublishedVideoDialog({
+  open,
+  onClose,
+  onConfirm
+}: UnpublishedVideoDialogProps): ReactElement {
+  const { t } = useTranslation('apps-journeys-admin')
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      dialogTitle={{ title: t('Unpublished Video') }}
+      dialogAction={{
+        onSubmit: onConfirm,
+        submitLabel: t('Use Anyway'),
+        closeLabel: t('Cancel')
+      }}
+      testId="UnpublishedVideoDialog"
+    >
+      <Alert severity="warning">
+        {t(
+          'This video has not been published yet. It can still be added to a journey, but visitors will not be able to watch it until it is published.'
+        )}
+      </Alert>
+    </Dialog>
+  )
+}
+
+export default UnpublishedVideoDialog

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/UnpublishedVideoDialog/index.ts
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/UnpublishedVideoDialog/index.ts
@@ -1,0 +1,1 @@
+export { UnpublishedVideoDialog } from './UnpublishedVideoDialog'

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromLocal/LocalDetails/LocalDetails.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromLocal/LocalDetails/LocalDetails.spec.tsx
@@ -51,7 +51,8 @@ describe('LocalDetails', () => {
           variant: {
             id: 'variantA',
             duration: 144,
-            hls: 'https://arc.gt/opsgn'
+            hls: 'https://arc.gt/opsgn',
+            published: true
           },
           variantLanguages: [
             {
@@ -145,7 +146,8 @@ describe('LocalDetails', () => {
           variant: {
             id: 'variantA',
             duration: 144,
-            hls: 'https://arc.gt/opsgn'
+            hls: 'https://arc.gt/opsgn',
+            published: true
           },
           variantLanguages: [
             {
@@ -371,5 +373,99 @@ describe('LocalDetails', () => {
         videoVariantLanguageId: '529'
       })
     )
+  })
+
+  describe('unpublished variant', () => {
+    const unpublishedMock = {
+      request: {
+        query: GET_VIDEO,
+        variables: {
+          id: '2_Acts7302-0-0',
+          languageId: '529'
+        }
+      },
+      result: {
+        data: {
+          video: {
+            ...getVideoMock.result.data.video,
+            variant: {
+              id: 'variantA',
+              duration: 144,
+              hls: 'https://arc.gt/opsgn',
+              published: false
+            }
+          }
+        }
+      }
+    }
+
+    it('should show a banner explaining the video is unpublished', async () => {
+      const { getByText } = render(
+        <MockedProvider mocks={[unpublishedMock]}>
+          <LocalDetails id="2_Acts7302-0-0" open onSelect={vi.fn()} />
+        </MockedProvider>
+      )
+      await waitFor(() => expect(getByText('Unpublished')).toBeInTheDocument())
+    })
+
+    it('should not show the banner for a published variant', async () => {
+      const { getByRole, queryByText } = render(
+        <MockedProvider mocks={[getVideoMock]}>
+          <LocalDetails id="2_Acts7302-0-0" open onSelect={vi.fn()} />
+        </MockedProvider>
+      )
+      await waitFor(() =>
+        expect(
+          getByRole('heading', { name: 'Jesus Taken Up Into Heaven' })
+        ).toBeInTheDocument()
+      )
+      expect(queryByText('Unpublished')).not.toBeInTheDocument()
+    })
+
+    it('should block the select until the unpublished warning is confirmed', async () => {
+      const onSelect = vi.fn()
+      const { getByRole, getByText, queryByText } = render(
+        <MockedProvider mocks={[unpublishedMock]}>
+          <LocalDetails id="2_Acts7302-0-0" open onSelect={onSelect} />
+        </MockedProvider>
+      )
+      await waitFor(() => expect(getByText('Unpublished')).toBeInTheDocument())
+
+      fireEvent.click(getByRole('button', { name: 'Select' }))
+      expect(onSelect).not.toHaveBeenCalled()
+      expect(getByText('Unpublished Video')).toBeInTheDocument()
+
+      fireEvent.click(getByRole('button', { name: 'Use Anyway' }))
+      expect(onSelect).toHaveBeenCalledWith({
+        duration: 144,
+        endAt: 144,
+        startAt: 0,
+        source: VideoBlockSource.internal,
+        videoId: '2_Acts7302-0-0',
+        videoVariantLanguageId: '529'
+      })
+      await waitFor(() =>
+        expect(queryByText('Unpublished Video')).not.toBeInTheDocument()
+      )
+    })
+
+    it('should not select when the unpublished warning is cancelled', async () => {
+      const onSelect = vi.fn()
+      const { getByRole, getByText, queryByText } = render(
+        <MockedProvider mocks={[unpublishedMock]}>
+          <LocalDetails id="2_Acts7302-0-0" open onSelect={onSelect} />
+        </MockedProvider>
+      )
+      await waitFor(() => expect(getByText('Unpublished')).toBeInTheDocument())
+
+      fireEvent.click(getByRole('button', { name: 'Select' }))
+      expect(getByText('Unpublished Video')).toBeInTheDocument()
+
+      fireEvent.click(getByRole('button', { name: 'Cancel' }))
+      expect(onSelect).not.toHaveBeenCalled()
+      await waitFor(() =>
+        expect(queryByText('Unpublished Video')).not.toBeInTheDocument()
+      )
+    })
   })
 })

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromLocal/LocalDetails/LocalDetails.stories.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromLocal/LocalDetails/LocalDetails.stories.tsx
@@ -107,7 +107,8 @@ const Template: StoryObj<typeof LocalDetails> = {
                   variant: {
                     id: 'variantA',
                     duration: 144,
-                    hls: 'https://arc.gt/opsgn'
+                    hls: 'https://arc.gt/opsgn',
+                    published: true
                   },
                   variantLanguages: languages
                 }
@@ -206,7 +207,8 @@ export const LongLanguageName: StoryObj<typeof LocalDetails> = {
                   variant: {
                     id: 'variantA',
                     duration: 144,
-                    hls: 'https://arc.gt/opsgn'
+                    hls: 'https://arc.gt/opsgn',
+                    published: true
                   },
                   variantLanguages: languagesWithLongName
                 }
@@ -220,6 +222,61 @@ export const LongLanguageName: StoryObj<typeof LocalDetails> = {
         >
           <LocalDetails id={id} open onSelect={onSelect} />
         </EditorProvider>
+      </MockedProvider>
+    )
+  },
+  args: {
+    id: '2_Acts7302-0-0'
+  }
+}
+
+export const Unpublished: StoryObj<typeof LocalDetails> = {
+  render: ({ id, onSelect }) => {
+    return (
+      <MockedProvider
+        mocks={[
+          {
+            request: {
+              query: GET_VIDEO,
+              variables: {
+                id: '2_Acts7302-0-0',
+                languageId: '529'
+              }
+            },
+            result: {
+              data: {
+                video: {
+                  id: '2_Acts7302-0-0',
+                  image:
+                    'https://d1wl257kev7hsz.cloudfront.net/cinematics/2_Acts7302-0-0.mobileCinematicHigh.jpg',
+                  primaryLanguageId: '529',
+                  title: [
+                    {
+                      primary: true,
+                      value: 'Jesus Taken Up Into Heaven'
+                    }
+                  ],
+                  description: [
+                    {
+                      primary: true,
+                      value:
+                        'Jesus promises the Holy Spirit; then ascends into the clouds.'
+                    }
+                  ],
+                  variant: {
+                    id: 'variantA',
+                    duration: 144,
+                    hls: 'https://arc.gt/opsgn',
+                    published: false
+                  },
+                  variantLanguages: languages
+                }
+              }
+            }
+          }
+        ]}
+      >
+        <LocalDetails id={id} open onSelect={onSelect} />
       </MockedProvider>
     )
   },

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromLocal/LocalDetails/LocalDetails.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/Drawer/VideoLibrary/VideoFromLocal/LocalDetails/LocalDetails.tsx
@@ -19,6 +19,8 @@ import { LanguageOption } from '@core/shared/ui/LanguageAutocomplete'
 import { BlockFields_VideoBlock as VideoBlock } from '../../../../../../../../../__generated__/BlockFields'
 import { GetVideo } from '../../../../../../../../../__generated__/GetVideo'
 import { VideoBlockSource } from '../../../../../../../../../__generated__/globalTypes'
+import { UnpublishedVideoBanner } from '../../UnpublishedVideoBanner'
+import { UnpublishedVideoDialog } from '../../UnpublishedVideoDialog'
 import { VideoDescription } from '../../VideoDescription'
 import type { VideoDetailsProps } from '../../VideoDetails/VideoDetails'
 import { VideoLanguage } from '../../VideoLanguage'
@@ -45,6 +47,7 @@ export const GET_VIDEO = gql`
         id
         duration
         hls
+        published
       }
       variantLanguages {
         id
@@ -92,6 +95,15 @@ export function LocalDetails({
     variables: { id, languageId }
   })
 
+  // Gates the Select/Apply commit behind a confirmation dialog when the
+  // fetched variant is unpublished. Holds the language the user was trying to
+  // commit while the dialog is open; commitSelection only runs once the
+  // warning has been acknowledged.
+  const [pendingLanguage, setPendingLanguage] = useState<LanguageOption | null>(
+    null
+  )
+  const isUnpublished = data?.video?.variant?.published === false
+
   const handleChange = (selectedLanguage: LanguageOption): void => {
     setSelectedLanguage(selectedLanguage)
   }
@@ -107,8 +119,16 @@ export function LocalDetails({
     })
   }
 
+  const attemptSelection = (language: LanguageOption): void => {
+    if (isUnpublished) {
+      setPendingLanguage(language)
+    } else {
+      commitSelection(language)
+    }
+  }
+
   const handleSelect = (): void => {
-    commitSelection(selectedLanguage)
+    attemptSelection(selectedLanguage)
   }
 
   const handleApplyLanguage = (): void => {
@@ -117,8 +137,17 @@ export function LocalDetails({
     // Details drawer and the outer Video Library drawer, returning the user
     // to the video properties panel — fixing the QA-221 / NES-1568 trap where
     // Apply only dismissed the picker.
-    commitSelection(selectedLanguage)
+    attemptSelection(selectedLanguage)
     setOpenLanguage(false)
+  }
+
+  const handleConfirmUnpublished = (): void => {
+    if (pendingLanguage != null) commitSelection(pendingLanguage)
+    setPendingLanguage(null)
+  }
+
+  const handleCancelUnpublished = (): void => {
+    setPendingLanguage(null)
   }
 
   const time = data?.video?.variant?.duration ?? 0
@@ -201,6 +230,7 @@ export function LocalDetails({
         </>
       ) : (
         <>
+          {isUnpublished && <UnpublishedVideoBanner />}
           <Box
             sx={{
               borderRadius: 3,
@@ -288,6 +318,11 @@ export function LocalDetails({
         language={selectedLanguage}
         languages={data?.video?.variantLanguages}
         loading={loading}
+      />
+      <UnpublishedVideoDialog
+        open={pendingLanguage != null}
+        onClose={handleCancelUnpublished}
+        onConfirm={handleConfirmUnpublished}
       />
     </Stack>
   )

--- a/libs/locales/en/apps-journeys-admin.json
+++ b/libs/locales/en/apps-journeys-admin.json
@@ -1364,5 +1364,9 @@
   "This will permanently delete all trashed Templates not in a collection.": "This will permanently delete all trashed Templates not in a collection.",
   "This will archive all active Templates not in a collection.": "This will archive all active Templates not in a collection.",
   "This will trash all active Templates not in a collection.": "This will trash all active Templates not in a collection.",
-  "All Templates": "All Templates"
+  "All Templates": "All Templates",
+  "Unpublished Video": "Unpublished Video",
+  "Use Anyway": "Use Anyway",
+  "This video has not been published yet. It can still be added to a journey, but visitors will not be able to watch it until it is published.": "This video has not been published yet. It can still be added to a journey, but visitors will not be able to watch it until it is published.",
+  "Unpublished": "Unpublished"
 }


### PR DESCRIPTION
Closes #9465

## Summary

Follow-up to #9464 (allow unpublished videos in journeys-admin): adds the warning UI Jessie Eaton required as a condition for that feature — a banner and a confirmation modal so it's unmissable when a video being selected is unpublished.

- **Banner**: `LocalDetails` (the video-library preview drawer) now renders an `Alert` titled "Unpublished" with an explanatory note whenever the fetched variant's `published` field is `false`.
- **Confirmation modal**: clicking `Select` (or `Apply` in the language picker) on an unpublished variant now opens a dialog containing the same warning info that the user must act on (`Use Anyway` to proceed, `Cancel` to back out) before the selection commits.

Scope note: the "unpublished" concept only exists for `VideoBlockSource.internal` videos resolved through api-media's `VideoVariant.published` — Mux and YouTube sources have no such field, so the banner/dialog live only in `LocalDetails`, not the shared `VideoDetails` router.

## Key decisions

- Added `published` to `LocalDetails`' `GET_VIDEO` query on the `variant` selection — the resolver already supports `onlyPublished: false` correctly (per #9430), only the client query was missing the field to detect the state.
- New `UnpublishedVideoBanner` (MUI `Alert`) and `UnpublishedVideoDialog` (built on the shared `Dialog` component) live under `VideoLibrary/`, siblings of `VideoDescription`, since they're specific to the Jesus Film library flow but structurally independent of `LocalDetails`.
- `attemptSelection()` gates `commitSelection()` behind the dialog only when the loaded variant is unpublished; both `Select` and `Apply` paths route through it so neither can silently commit an unpublished variant.
- Hand-updated the generated `apps/journeys-admin/__generated__/GetVideo.ts` type to add `published: boolean` — `apollo` codegen isn't available outside the devcontainer per `AGENTS.md`; the shape matches exactly what codegen would produce, so a later regeneration is a no-op.

## Testing

- New unit tests for `UnpublishedVideoBanner`, `UnpublishedVideoDialog`, and an `unpublished variant` describe block in `LocalDetails.spec.tsx` covering: banner visibility, blocked-then-confirmed selection, and cancelled selection.
- New `Unpublished` Storybook story for `LocalDetails`.
- `pnpm exec nx affected -t lint,type-check,test --base=origin/main` — clean (journeys-admin: 3768 passed, journeys-admin-e2e unaffected by tests but lint/type-check clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warnings when selecting videos that have not been published.
  * Users can review the warning and choose to use an unpublished video anyway or cancel.
  * Unpublished videos now display clear status messaging in the video library.
  * Added an example view for unpublished videos.

* **Tests**
  * Added coverage for warnings, confirmation, cancellation, and published video behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->