### PR TITLE
fix(journeys): hand mailto off via location assignment, not a popup (ENG-2802)

### DIFF
--- a/libs/journeys/ui/src/libs/action/action.spec.ts
+++ b/libs/journeys/ui/src/libs/action/action.spec.ts
@@ -21,8 +21,27 @@ describe('action', () => {
       push: vi.fn()
     } as unknown as NextRouter
 
+    // jsdom cannot navigate, so assert on a swapped-in location object. The
+    // window property itself is configurable, which is what makes this work.
+    const originalLocationDescriptor = Object.getOwnPropertyDescriptor(
+      window,
+      'location'
+    )
+
     beforeEach(() => {
       vi.resetAllMocks()
+
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        enumerable: false,
+        value: { ...window.location, href: '', reload: vi.fn() }
+      })
+    })
+
+    afterEach(() => {
+      if (originalLocationDescriptor != null) {
+        Object.defineProperty(window, 'location', originalLocationDescriptor)
+      }
     })
 
     it('should handle empty action', () => {
@@ -50,13 +69,12 @@ describe('action', () => {
         customizable: false,
         parentStepId: null
       })
-      expect(window.open).toHaveBeenCalledWith(
-        'mailto:edmondshen@gmail.com',
-        '_blank'
-      )
+      expect(window.location.href).toBe('mailto:edmondshen@gmail.com')
+      // A popup would be blocked on iOS Safari and stranded on Android Chrome.
+      expect(window.open).not.toHaveBeenCalled()
     })
 
-    it.skip('should handle PhoneAction call', () => {
+    it('should handle PhoneAction call', () => {
       handleAction(router, {
         __typename: 'PhoneAction',
         parentBlockId: 'parent-id',
@@ -70,8 +88,7 @@ describe('action', () => {
       expect(window.location.href).toBe('tel:+1234567890')
     })
 
-    // TODO: Fix this test
-    it.skip('should handle PhoneAction text', () => {
+    it('should handle PhoneAction text', () => {
       handleAction(router, {
         __typename: 'PhoneAction',
         parentBlockId: 'parent-id',

--- a/libs/journeys/ui/src/libs/action/action.ts
+++ b/libs/journeys/ui/src/libs/action/action.ts
@@ -38,7 +38,12 @@ export function handleAction(
       }
       break
     case 'EmailAction':
-      window.open(`mailto:${action.email}`, '_blank')
+      // Assign location rather than window.open: mailto: is a non-HTTP scheme,
+      // so a popup is blocked outright on iOS Safari and leaves a stranded blank
+      // tab on Android Chrome. Assignment also needs no transient user
+      // activation, which VideoTrigger and SignUp have already lost by the time
+      // they call handleAction. Same reason PhoneAction below assigns location.
+      window.location.href = `mailto:${action.email}`
       break
     case 'ChatAction':
       if (


### PR DESCRIPTION
Fixes the long-standing "mailto links don't work" reports in the published journeys viewer.

## The bug

`handleAction` opened email actions as a popup:

```ts
case 'EmailAction':
  window.open(`mailto:${action.email}`, '_blank')
```

A popup is the wrong primitive for a non-HTTP scheme, and it fails differently on every platform — which is why this kept getting closed as unreproducible:

| Platform | Behaviour |
| --- | --- |
| Desktop Chrome | Works — mail handler dialog appears |
| Android Chrome | Opens a stranded blank tab showing the raw `mailto:` URL |
| iOS Safari | Blocked outright, nothing happens, no error |

That is verbatim the symptom table in #6855 / ENG-2802:

> Email: Android — a new webpage is opened with `mailto:[email@email.com]` and iOS does nothing and PC works it opens up the options to mail

`PhoneAction`, eleven lines below in the same switch, has always done it correctly with `window.location.href = 'tel:'`. `EmailAction` was simply the odd one out.

## Second failure mode: lost user activation

`window.open` requires transient user activation. Two of the four `handleAction` callers have already lost it by the time they call:

- **`VideoTrigger.tsx`** fires from a video `timeupdate` handler — no user activation at all. This is exactly the "action after a video block finishes playing" case in the original report.
- **`SignUp.tsx`** calls it inside `.then()` after an awaited mutation, so activation has expired.

`Button.tsx` and `RadioOption.tsx` are synchronous within the click, which is why a plain email button works on desktop but a video-triggered one never does.

Assigning `window.location.href` needs no activation, so both of those paths are fixed by the same one-line change rather than needing their own workarounds.

## Also in here

Un-skips the two `PhoneAction` tests. They were `it.skip` with a `// TODO: Fix this test` comment, blocked on jsdom not letting you observe a location assignment. The fix needed a location stub anyway, so they come along for free — using the same swap-the-whole-`window.location`-object pattern already established in `UseThisTemplateButton.spec.tsx`. Test count in the file goes 7 → 9.

## Test plan

- [x] `libs/journeys/ui` action + Button/SignUp/RadioOption specs pass (90 passed)
- [x] `pnpm lint:changed --fix` clean
- [x] `nx affected --target=type-check` clean (10 projects)
- [ ] Manual QA on stage: email button on Android Chrome and iOS Safari should open the mail app with the address prefilled, with no blank tab left behind

## Not addressed

`LinkAction` still falls through to `router.push()` if a `url` ever holds a `mailto:` value (`action.ts:28-36`), which the Next router can't navigate. The admin editor rejects `mailto:` in `checkURL` today, but that validation postdates a lot of journey data and nothing guards the API. Left alone pending a look at production data — worth a follow-up if any such rows exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Email actions now open the default email application directly.
  * Phone and text actions reliably navigate to the appropriate calling and messaging apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->