### PR TITLE
fix(journeys-admin): stop mangling chat widget email links into https://mailto:

### DIFF
--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/JourneyAppearance/Chat/ChatOption/Details/Details.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/JourneyAppearance/Chat/ChatOption/Details/Details.spec.tsx
@@ -151,6 +151,57 @@ describe('Details', () => {
     await waitFor(() => expect(result).toHaveBeenCalled())
   })
 
+  it.each([
+    ['mailto:eli.perez@jesusfilm.org', 'mailto:eli.perez@jesusfilm.org'],
+    ['eli.perez@jesusfilm.org', 'mailto:eli.perez@jesusfilm.org']
+  ])('should save %s as %s rather than prefixing https', async (typed, saved) => {
+    const props = {
+      ...defaultProps,
+      currentPlatform: MessagePlatform.mail1
+    }
+
+    const result = vi.fn(() => ({
+      data: {
+        chatButtonUpdate: {
+          __typename: 'ChatButton' as const,
+          id: 'chat.id',
+          link: saved,
+          platform: MessagePlatform.mail1,
+          customizable: null
+        }
+      }
+    }))
+
+    const { getByRole } = render(
+      <MockedProvider
+        mocks={[
+          {
+            request: {
+              query: JOURNEY_CHAT_BUTTON_UPDATE,
+              variables: {
+                chatButtonUpdateId: 'chat.id',
+                journeyId: 'journeyId',
+                input: { link: saved }
+              }
+            },
+            result
+          }
+        ]}
+      >
+        <SnackbarProvider>
+          <CommandProvider>
+            <Details {...props} />
+          </CommandProvider>
+        </SnackbarProvider>
+      </MockedProvider>
+    )
+
+    fireEvent.change(getByRole('textbox'), { target: { value: typed } })
+    fireEvent.blur(getByRole('textbox'))
+
+    await waitFor(() => expect(result).toHaveBeenCalled())
+  })
+
   it('should update platform', async () => {
     const props = {
       ...defaultProps,

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/JourneyAppearance/Chat/ChatOption/Details/Details.spec.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/JourneyAppearance/Chat/ChatOption/Details/Details.spec.tsx
@@ -154,53 +154,56 @@ describe('Details', () => {
   it.each([
     ['mailto:eli.perez@jesusfilm.org', 'mailto:eli.perez@jesusfilm.org'],
     ['eli.perez@jesusfilm.org', 'mailto:eli.perez@jesusfilm.org']
-  ])('should save %s as %s rather than prefixing https', async (typed, saved) => {
-    const props = {
-      ...defaultProps,
-      currentPlatform: MessagePlatform.mail1
-    }
-
-    const result = vi.fn(() => ({
-      data: {
-        chatButtonUpdate: {
-          __typename: 'ChatButton' as const,
-          id: 'chat.id',
-          link: saved,
-          platform: MessagePlatform.mail1,
-          customizable: null
-        }
+  ])(
+    'should save %s as %s rather than prefixing https',
+    async (typed, saved) => {
+      const props = {
+        ...defaultProps,
+        currentPlatform: MessagePlatform.mail1
       }
-    }))
 
-    const { getByRole } = render(
-      <MockedProvider
-        mocks={[
-          {
-            request: {
-              query: JOURNEY_CHAT_BUTTON_UPDATE,
-              variables: {
-                chatButtonUpdateId: 'chat.id',
-                journeyId: 'journeyId',
-                input: { link: saved }
-              }
-            },
-            result
+      const result = vi.fn(() => ({
+        data: {
+          chatButtonUpdate: {
+            __typename: 'ChatButton' as const,
+            id: 'chat.id',
+            link: saved,
+            platform: MessagePlatform.mail1,
+            customizable: null
           }
-        ]}
-      >
-        <SnackbarProvider>
-          <CommandProvider>
-            <Details {...props} />
-          </CommandProvider>
-        </SnackbarProvider>
-      </MockedProvider>
-    )
+        }
+      }))
 
-    fireEvent.change(getByRole('textbox'), { target: { value: typed } })
-    fireEvent.blur(getByRole('textbox'))
+      const { getByRole } = render(
+        <MockedProvider
+          mocks={[
+            {
+              request: {
+                query: JOURNEY_CHAT_BUTTON_UPDATE,
+                variables: {
+                  chatButtonUpdateId: 'chat.id',
+                  journeyId: 'journeyId',
+                  input: { link: saved }
+                }
+              },
+              result
+            }
+          ]}
+        >
+          <SnackbarProvider>
+            <CommandProvider>
+              <Details {...props} />
+            </CommandProvider>
+          </SnackbarProvider>
+        </MockedProvider>
+      )
 
-    await waitFor(() => expect(result).toHaveBeenCalled())
-  })
+      fireEvent.change(getByRole('textbox'), { target: { value: typed } })
+      fireEvent.blur(getByRole('textbox'))
+
+      await waitFor(() => expect(result).toHaveBeenCalled())
+    }
+  )
 
   it('should update platform', async () => {
     const props = {

--- a/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/JourneyAppearance/Chat/ChatOption/Details/Details.tsx
+++ b/apps/journeys-admin/src/components/Editor/Slider/Settings/CanvasDetails/JourneyAppearance/Chat/ChatOption/Details/Details.tsx
@@ -16,6 +16,7 @@ import ChevronDownIcon from '@core/shared/ui/icons/ChevronDown'
 
 import { MessagePlatform } from '../../../../../../../../../../__generated__/globalTypes'
 import { JourneyChatButtonUpdate } from '../../../../../../../../../../__generated__/JourneyChatButtonUpdate'
+import { normalizeChatButtonLink } from '../../../../../../../../../libs/normalizeChatButtonLink'
 import { TextFieldForm } from '../../../../../../../../TextFieldForm'
 import { messagePlatformToLabel } from '../../../../../../../../VisitorInfo/VisitorJourneysList/utils/messagePlatformToLabel'
 import { getMessagePlatformOptions } from '../../utils/getMessagePlatformOptions'
@@ -81,13 +82,7 @@ export function Details({
     if (chatButtonId == null) return
 
     if (type === 'link') {
-      const hasProtocolPrefix = /^\w+:\/\//
-      const newLink =
-        value === ''
-          ? ''
-          : hasProtocolPrefix.test(value ?? '')
-            ? (value ?? '')
-            : `https://${value}`
+      const newLink = normalizeChatButtonLink(value)
       const oldLink = currentLink
 
       add({

--- a/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/LinksScreen/LinksScreen.tsx
+++ b/apps/journeys-admin/src/components/TemplateCustomization/MultiStepForm/Screens/LinksScreen/LinksScreen.tsx
@@ -21,6 +21,7 @@ import {
   MessagePlatform
 } from '../../../../../../__generated__/globalTypes'
 import { JourneyChatButtonUpdate } from '../../../../../../__generated__/JourneyChatButtonUpdate'
+import { normalizeChatButtonLink } from '../../../../../libs/normalizeChatButtonLink'
 import { useBlockActionEmailUpdateMutation } from '../../../../../libs/useBlockActionEmailUpdateMutation'
 import { useBlockActionLinkUpdateMutation } from '../../../../../libs/useBlockActionLinkUpdateMutation'
 import { useBlockActionPhoneUpdateMutation } from '../../../../../libs/useBlockActionPhoneUpdateMutation'
@@ -115,12 +116,6 @@ export function LinksScreen({ handleNext }: LinksScreenProps): ReactElement {
       true
     )
 
-    const hasProtocolPrefix = /^\w+:\/\//
-    const normalizeChatLink = (val: string): string => {
-      if (val === '') return ''
-      return hasProtocolPrefix.test(val) ? val : `https://${val}`
-    }
-
     const updatePromises = links.map((link) => {
       const oldValueRaw = (link.url ?? '').trim()
       const newValueRaw =
@@ -152,8 +147,8 @@ export function LinksScreen({ handleNext }: LinksScreenProps): ReactElement {
 
         if (chatButton == null) return Promise.resolve(undefined)
 
-        const normalizedLink = normalizeChatLink(newValueRaw)
-        const normalizedOldLink = normalizeChatLink(oldValueRaw)
+        const normalizedLink = normalizeChatButtonLink(newValueRaw)
+        const normalizedOldLink = normalizeChatButtonLink(oldValueRaw)
 
         if (normalizedLink === normalizedOldLink)
           return Promise.resolve(undefined)

--- a/apps/journeys-admin/src/libs/normalizeChatButtonLink/index.ts
+++ b/apps/journeys-admin/src/libs/normalizeChatButtonLink/index.ts
@@ -1,0 +1,1 @@
+export { normalizeChatButtonLink } from './normalizeChatButtonLink'

--- a/apps/journeys-admin/src/libs/normalizeChatButtonLink/normalizeChatButtonLink.spec.ts
+++ b/apps/journeys-admin/src/libs/normalizeChatButtonLink/normalizeChatButtonLink.spec.ts
@@ -1,0 +1,54 @@
+import { normalizeChatButtonLink } from './normalizeChatButtonLink'
+
+describe('normalizeChatButtonLink', () => {
+  it('should return an empty string for empty or missing input', () => {
+    expect(normalizeChatButtonLink('')).toBe('')
+    expect(normalizeChatButtonLink('   ')).toBe('')
+    expect(normalizeChatButtonLink(undefined)).toBe('')
+  })
+
+  it('should preserve a link that already has a scheme and authority', () => {
+    expect(normalizeChatButtonLink('https://church.org/chat')).toBe(
+      'https://church.org/chat'
+    )
+    expect(normalizeChatButtonLink('http://church.org')).toBe(
+      'http://church.org'
+    )
+  })
+
+  it('should preserve authority-less schemes rather than prefixing them', () => {
+    expect(normalizeChatButtonLink('mailto:eli.perez@jesusfilm.org')).toBe(
+      'mailto:eli.perez@jesusfilm.org'
+    )
+    expect(normalizeChatButtonLink('MAILTO:eli.perez@jesusfilm.org')).toBe(
+      'MAILTO:eli.perez@jesusfilm.org'
+    )
+    expect(normalizeChatButtonLink('tel:+1234567890')).toBe('tel:+1234567890')
+    expect(normalizeChatButtonLink('sms:+1234567890')).toBe('sms:+1234567890')
+  })
+
+  it('should turn a bare email address into a mailto link', () => {
+    expect(normalizeChatButtonLink('eli.perez@jesusfilm.org')).toBe(
+      'mailto:eli.perez@jesusfilm.org'
+    )
+  })
+
+  it('should prefix a bare host with https', () => {
+    expect(normalizeChatButtonLink('church.org')).toBe('https://church.org')
+    expect(normalizeChatButtonLink('church.org/chat')).toBe(
+      'https://church.org/chat'
+    )
+  })
+
+  it('should not mistake a url containing an @ for an email address', () => {
+    expect(normalizeChatButtonLink('church.org/@pastor')).toBe(
+      'https://church.org/@pastor'
+    )
+  })
+
+  it('should trim surrounding whitespace', () => {
+    expect(normalizeChatButtonLink('  eli.perez@jesusfilm.org  ')).toBe(
+      'mailto:eli.perez@jesusfilm.org'
+    )
+  })
+})

--- a/apps/journeys-admin/src/libs/normalizeChatButtonLink/normalizeChatButtonLink.ts
+++ b/apps/journeys-admin/src/libs/normalizeChatButtonLink/normalizeChatButtonLink.ts
@@ -1,0 +1,24 @@
+// http:// and https:// — a scheme followed by an authority.
+const SCHEME_WITH_AUTHORITY = /^\w+:\/\//
+// mailto:, tel: and sms: carry no authority, so they have no `//` to match on.
+// Without this the `https://` fallback below mangles them into `https://mailto:…`.
+const SCHEME_WITHOUT_AUTHORITY = /^(?:mailto|tel|sms):/i
+// One `@`, a dot in the domain, no slashes — an address, not a host.
+const BARE_EMAIL = /^[^\s@/]+@[^\s@/]+\.[^\s@/]+$/
+
+/**
+ * Normalizes a chat button link on its way to the API.
+ *
+ * The chat widget is not URL-only: the Mail icon takes an email address and the
+ * phone icons take a number, so a value can legitimately arrive already carrying
+ * a `mailto:`/`tel:`/`sms:` scheme, or as a bare email address. Only a value that
+ * is none of those gets the `https://` prefix a bare hostname needs.
+ */
+export function normalizeChatButtonLink(value?: string): string {
+  const trimmed = value?.trim() ?? ''
+  if (trimmed === '') return ''
+  if (SCHEME_WITH_AUTHORITY.test(trimmed)) return trimmed
+  if (SCHEME_WITHOUT_AUTHORITY.test(trimmed)) return trimmed
+  if (BARE_EMAIL.test(trimmed)) return `mailto:${trimmed}`
+  return `https://${trimmed}`
+}

--- a/libs/journeys/ui/src/components/StepFooter/ChatButtons/ChatButtons.spec.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/ChatButtons/ChatButtons.spec.tsx
@@ -204,6 +204,75 @@ describe('ChatButtons', () => {
     })
   })
 
+  it('assigns location instead of opening a popup for a mailto link', async () => {
+    // jsdom cannot navigate, so assert on a swapped-in location object.
+    const originalLocationDescriptor = Object.getOwnPropertyDescriptor(
+      window,
+      'location'
+    )
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      enumerable: false,
+      value: { ...window.location, href: '' }
+    })
+    window.open = vi.fn()
+    blockHistoryVar([stepBlock])
+    mockUsePlausible.mockReturnValue(vi.fn())
+
+    const mailButton: ChatButton = {
+      __typename: 'ChatButton',
+      id: '1',
+      link: 'mailto:eli.perez@jesusfilm.org',
+      platform: MessagePlatform.mail1,
+      customizable: null
+    }
+
+    const { getAllByRole } = render(
+      <MockedProvider
+        mocks={[
+          {
+            request: {
+              query: CHAT_BUTTON_EVENT_CREATE,
+              variables: {
+                input: {
+                  blockId: stepBlock?.id,
+                  stepId: stepBlock?.id,
+                  value: mailButton.platform
+                }
+              }
+            },
+            result: {
+              data: {
+                chatOpenEventCreate: {
+                  __typename: 'ChatOpenEvent',
+                  id: mailButton.id
+                }
+              }
+            }
+          }
+        ]}
+      >
+        <JourneyProvider
+          value={{ journey: { ...journey, chatButtons: [mailButton] } }}
+        >
+          <ChatButtons />
+        </JourneyProvider>
+      </MockedProvider>
+    )
+
+    fireEvent.click(getAllByRole('button')[0])
+
+    await waitFor(() =>
+      expect(window.location.href).toBe('mailto:eli.perez@jesusfilm.org')
+    )
+    // A popup would be blocked on iOS Safari and stranded on Android Chrome.
+    expect(window.open).not.toHaveBeenCalled()
+
+    if (originalLocationDescriptor != null) {
+      Object.defineProperty(window, 'location', originalLocationDescriptor)
+    }
+  })
+
   it('does not open a new window or send a mutation for admin user', async () => {
     window.open = vi.fn()
 

--- a/libs/journeys/ui/src/components/StepFooter/ChatButtons/ChatButtons.tsx
+++ b/libs/journeys/ui/src/components/StepFooter/ChatButtons/ChatButtons.tsx
@@ -27,6 +27,8 @@ import {
   ChatButtonEventCreateVariables
 } from './__generated__/ChatButtonEventCreate'
 
+const AUTHORITY_LESS_SCHEME = /^(?:mailto|tel|sms):/i
+
 export const CHAT_BUTTON_EVENT_CREATE = gql`
   mutation ChatButtonEventCreate($input: ChatOpenEventCreateInput!) {
     chatOpenEventCreate(input: $input) {
@@ -72,7 +74,15 @@ export function ChatButtons(): ReactElement {
       (renderMode === 'default' || renderMode === 'embed') &&
       chatButton.link != null
     ) {
-      window.open(chatButton.link, '_blank')
+      // mailto:/tel:/sms: are handed off by assigning location, not by opening a
+      // popup: a popup to a non-HTTP scheme is blocked on iOS Safari and leaves a
+      // stranded blank tab on Android Chrome. Matches handleAction's PhoneAction
+      // and EmailAction cases.
+      if (AUTHORITY_LESS_SCHEME.test(chatButton.link)) {
+        window.location.href = chatButton.link
+      } else {
+        window.open(chatButton.link, '_blank')
+      }
       const input: ChatOpenEventCreateInput = {
         id: chatButton?.id,
         blockId: activeBlock?.id,


### PR DESCRIPTION
Reported as "can't add an email in the chat widget's Mail section — it adds `https://mailto:` to emails."

Confirmed in production. `https://your.nextstep.is/cma-rally` currently serves:

```json
{"id":"4da3572c-…","link":"https://mailto:eli.perez@jesusfilm.org","platform":"mail1","customizable":null}
```

## Root cause

Chat button links were normalized by detecting a scheme via its `//`:

```ts
const hasProtocolPrefix = /^\w+:\/\//
hasProtocolPrefix.test(value) ? value : `https://${value}`
```

`mailto:`, `tel:` and `sms:` carry no authority, so they have no `//` to match. They fell through to the `https://` branch that exists for bare hostnames:

| Typed into "Paste URL here" | Saved before | Saved now |
| --- | --- | --- |
| `mailto:eli.perez@jesusfilm.org` | `https://mailto:eli.perez@jesusfilm.org` | `mailto:eli.perez@jesusfilm.org` |
| `eli.perez@jesusfilm.org` | `https://eli.perez@jesusfilm.org` | `mailto:eli.perez@jesusfilm.org` |
| `church.org` | `https://church.org` | `https://church.org` (unchanged) |

The bare-address case is the quieter half of the bug: `https://eli.perez@jesusfilm.org` is a *syntactically valid* URL — `eli.perez` parses as userinfo — so nothing downstream ever complained. It just silently pointed at the wrong place.

## Two write paths, one rule

The rule was duplicated, so both entry points had the bug independently:

- `Chat/ChatOption/Details/Details.tsx` — the editor's Chat Widget accordion
- `TemplateCustomization/.../LinksScreen.tsx` — template customization, which has its own local `normalizeChatLink`

Both now call a shared `normalizeChatButtonLink`. It keeps the existing `https://` behaviour for anything that looks like a bare host, recognises authority-less schemes, and treats a bare email address as `mailto:`. The scheme list is deliberately narrow (`mailto|tel|sms`) rather than "any scheme" so that a value like `localhost:3000` still gets the `https://` it always got.

## Viewer end

`ChatButtons.tsx` opened every link with `window.open(link, '_blank')`, so a *correctly* stored `mailto:` link still wouldn't work — blocked on iOS Safari, stranded blank tab on Android Chrome. Same defect and same fix as #9540: assign `window.location.href` for authority-less schemes. Without this, fixing the admin side alone would just move the failure one layer down.

## Existing data

**Not repaired by this PR.** Rows already saved as `https://mailto:…` stay broken until a creator re-enters the address — at which point they now save correctly. cma-rally is one confirmed instance; I have no way to count the rest from here. If that set turns out to be large, a backfill rewriting `https://mailto:x` → `mailto:x` over the `ChatButton` table is the follow-up, and worth its own review.

## Test plan

- [x] `normalizeChatButtonLink` unit tests — 7 cases covering schemes, bare emails, bare hosts, and a URL containing `@`
- [x] `Details.spec.tsx` — parameterized test that both `mailto:addr` and a bare `addr` reach the mutation as `mailto:addr`
- [x] `ChatButtons.spec.tsx` — asserts location assignment and that no popup is opened
- [x] Affected suites pass: journeys-admin chat + LinksScreen (88 tests), journeys/ui StepFooter (48 tests)
- [x] `pnpm lint:changed --fix` and `nx affected --target=type-check` clean
- [ ] Manual QA on stage: set a Mail chat button by pasting a bare address, confirm it stores as `mailto:` and opens the mail app on iOS Safari and Android Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)
