### PR TITLE
fix(journeys): guard hover on touch devices for polls, multiselect and nav (NES-1894)

### DIFF
--- a/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.tsx
+++ b/apps/journeys/src/components/Conductor/NavigationButton/NavigationButton.tsx
@@ -10,6 +10,7 @@ import type { TreeBlock } from '@core/journeys/ui/block'
 import { useBlocks } from '@core/journeys/ui/block'
 import { useJourney } from '@core/journeys/ui/JourneyProvider'
 import { useStepNavigationEvents } from '@core/journeys/ui/useStepNavigationEvents'
+import { hoverOnly } from '@core/shared/ui/hoverOnly'
 import ChevronLeftIcon from '@core/shared/ui/icons/ChevronLeft'
 import ChevronRightIcon from '@core/shared/ui/icons/ChevronRight'
 
@@ -127,17 +128,18 @@ export function NavigationButton({
           size="small"
           onClick={() => handleNavigation(variant)}
           disableRipple
-          sx={{
+          sx={(theme) => ({
             pointerEvents: 'all',
             mx: { xs: 2, lg: 8 },
             p: 2,
-            color: (theme) => theme.palette.common.white,
-            backgroundColor: (theme) => `${theme.palette.grey[700]}33`,
-            '&:hover': {
-              color: (theme) => theme.palette.common.white,
-              backgroundColor: (theme) => `${theme.palette.grey[700]}4d`
-            }
-          }}
+            color: theme.palette.common.white,
+            backgroundColor: `${theme.palette.grey[700]}33`,
+            // Pointer devices only, so the chevron does not stay lit after a tap
+            ...hoverOnly({
+              color: theme.palette.common.white,
+              backgroundColor: `${theme.palette.grey[700]}4d`
+            })
+          })}
         >
           {alignment === 'left' ? <ChevronLeftIcon /> : <ChevronRightIcon />}
         </IconButton>

--- a/libs/journeys/ui/src/components/MultiselectOption/MultiselectOption.tsx
+++ b/libs/journeys/ui/src/components/MultiselectOption/MultiselectOption.tsx
@@ -2,6 +2,7 @@ import Button, { ButtonProps } from '@mui/material/Button'
 import { styled, useTheme } from '@mui/material/styles'
 import { MouseEvent, ReactElement } from 'react'
 
+import { hoverOnly } from '@core/shared/ui/hoverOnly'
 import CheckSquareContainedIcon from '@core/shared/ui/icons/CheckSquareContained'
 import SquareIcon from '@core/shared/ui/icons/Square'
 
@@ -42,8 +43,10 @@ export const StyledListMultiselectOption = styled(Button)<ButtonProps>(({
         ? 'rgba(255,255,255,0.6)'
         : 'rgba(0, 0, 0, 0.6)',
 
-    // Hover state
-    '&:hover': {
+    // Hover state - pointer devices only. This matters most here: the hover
+    // background is a shade off the genuine selected background, so a hover
+    // left over from a tap would read as a ticked option.
+    ...hoverOnly({
       backgroundColor:
         theme.palette.mode === 'dark'
           ? 'rgba(255,255,255,0.8)'
@@ -52,7 +55,7 @@ export const StyledListMultiselectOption = styled(Button)<ButtonProps>(({
         theme.palette.mode === 'dark'
           ? 'rgba(150, 150, 150, 0.5) !important'
           : 'rgba(255, 255, 255, 0.5) !important'
-    },
+    }),
 
     // Selected state (persistent)
     '&.selected': {

--- a/libs/journeys/ui/src/components/RadioOption/GridVariant/GridVariant.tsx
+++ b/libs/journeys/ui/src/components/RadioOption/GridVariant/GridVariant.tsx
@@ -6,6 +6,7 @@ import { styled } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
 import { ReactElement, useState } from 'react'
 
+import { hoverOnly } from '@core/shared/ui/hoverOnly'
 import LogoGrayscale from '@core/shared/ui/icons/LogoGrayscale'
 import { NextImage } from '@core/shared/ui/NextImage'
 
@@ -101,13 +102,14 @@ export const StyledGridRadioOption = styled(Card)<CardProps>(({ theme }) => ({
   borderColor: pollCustomTheme.default[theme.palette.mode].borderColor,
   boxShadow: pollCustomTheme.default[theme.palette.mode].boxShadow,
 
-  // Hover
-  '&:hover': {
+  // Hover - pointer devices only, so a hover left over from a tap on the
+  // previous card cannot read as an already-selected option
+  ...hoverOnly({
     backgroundColor: pollCustomTheme.hover[theme.palette.mode].backgroundColor,
     borderColor: pollCustomTheme.hover[theme.palette.mode].borderColor,
     boxShadow: pollCustomTheme.hover[theme.palette.mode].boxShadow,
     transform: 'translateY(-2px)'
-  },
+  }),
 
   // Selected
   '&.selected': {

--- a/libs/journeys/ui/src/components/RadioOption/ListVariant/ListVariant.tsx
+++ b/libs/journeys/ui/src/components/RadioOption/ListVariant/ListVariant.tsx
@@ -2,12 +2,17 @@ import Button, { ButtonProps } from '@mui/material/Button'
 import { styled } from '@mui/material/styles'
 import { ReactElement } from 'react'
 
-import { getPollOptionBorderStyles } from '../../RadioQuestion/utils/getPollOptionBorderStyles'
+import { hoverOnly } from '@core/shared/ui/hoverOnly'
+
+import {
+  getPollOptionBorderColors,
+  getPollOptionBorderStyles
+} from '../../RadioQuestion/utils/getPollOptionBorderStyles'
 
 export const StyledListRadioOption = styled(Button)<ButtonProps>(({
   theme
 }) => {
-  const borderStyles = getPollOptionBorderStyles(theme, { important: true })
+  const borderColors = getPollOptionBorderColors(theme, { important: true })
 
   return {
     fontFamily: theme.typography.button.fontFamily,
@@ -32,7 +37,7 @@ export const StyledListRadioOption = styled(Button)<ButtonProps>(({
     ),
     wordBreak: 'break-word',
     color: 'text.primary',
-    ...borderStyles,
+    ...getPollOptionBorderStyles(theme, { important: true }),
 
     // Default state
     opacity: theme.palette.mode === 'dark' ? 1 : 0.7,
@@ -41,9 +46,10 @@ export const StyledListRadioOption = styled(Button)<ButtonProps>(({
         ? 'rgba(255, 255, 255, 0.6)'
         : 'rgba(0, 0, 0, 0.6)',
 
-    // Hover state
-    '&:hover': {
-      ...borderStyles['&:hover'],
+    // Hover state - pointer devices only, so a hover left over from a tap on
+    // the previous card cannot read as an already-selected option
+    ...hoverOnly({
+      borderColor: borderColors.hover,
       backgroundColor:
         theme.palette.mode === 'dark'
           ? 'rgba(255, 255, 255, 0.8)'
@@ -53,11 +59,11 @@ export const StyledListRadioOption = styled(Button)<ButtonProps>(({
         theme.palette.mode === 'dark'
           ? '0 4px 12px rgba(0, 0, 0, 0.4)'
           : '0 4px 12px rgba(0, 0, 0, 0.15)'
-    },
+    }),
 
-    // Selected state
+    // Pressed state
     '&:active': {
-      ...borderStyles['&:active'],
+      borderColor: borderColors.active,
       backgroundColor:
         theme.palette.mode === 'dark'
           ? 'rgba(255, 255, 255, 0.9)'
@@ -74,7 +80,7 @@ export const StyledListRadioOption = styled(Button)<ButtonProps>(({
 
     // Disabled state
     '&.Mui-disabled': {
-      ...borderStyles['&.disabled'],
+      borderColor: borderColors.disabled,
       backgroundColor:
         theme.palette.mode === 'dark'
           ? 'rgba(255, 255, 255, 0.4)'

--- a/libs/journeys/ui/src/components/RadioQuestion/ListVariant/ListVariant.tsx
+++ b/libs/journeys/ui/src/components/RadioQuestion/ListVariant/ListVariant.tsx
@@ -15,36 +15,23 @@ import {
   getPollOptionBorderStyles
 } from '../utils/getPollOptionBorderStyles'
 
-const StyledListRadioQuestion = styled(Box)<BoxProps>(({ theme }) => {
-  const borderColors = getPollOptionBorderColors(theme)
-  const optionBorderStyles = {
-    ...getPollOptionBorderStyles(theme),
-    ...hoverOnly({ borderColor: borderColors.hover }),
-    '&:active': { borderColor: borderColors.active },
-    '&.disabled': { borderColor: borderColors.disabled }
-  }
-
-  return {
-    marginBottom: theme.spacing(4),
-    '& .MuiButtonGroup-root': {
-      boxShadow: 'none',
-      gap: theme.spacing(2),
-      '& .MuiButtonGroup-grouped': {
-        border: 'none',
-        borderBottom: 'none',
-        borderRight: 'none',
-        borderRadius: '12px',
-        margin: '0 !important',
-        '&:not(:last-of-type)': {
-          borderBottom: 'none'
-        },
-        '& .MuiButtonGroup-firstButton': optionBorderStyles,
-        '& .MuiButtonGroup-middleButton': optionBorderStyles,
-        '& .MuiButtonGroup-lastButton': optionBorderStyles
+const StyledListRadioQuestion = styled(Box)<BoxProps>(({ theme }) => ({
+  marginBottom: theme.spacing(4),
+  '& .MuiButtonGroup-root': {
+    boxShadow: 'none',
+    gap: theme.spacing(2),
+    '& .MuiButtonGroup-grouped': {
+      border: 'none',
+      borderBottom: 'none',
+      borderRight: 'none',
+      borderRadius: '12px',
+      margin: '0 !important',
+      '&:not(:last-of-type)': {
+        borderBottom: 'none'
       }
     }
   }
-})
+}))
 
 const adminPrimaryColor = adminTheme.palette
   .primary as SimplePaletteColorOptions
@@ -88,8 +75,7 @@ export function ListVariant({
                   borderBottomRightRadius: 8,
                   ...getPollOptionBorderStyles(theme, { important: true }),
                   ...hoverOnly({ borderColor: borderColors.hover }),
-                  '&:active': { borderColor: borderColors.active },
-                  '&.disabled': { borderColor: borderColors.disabled }
+                  '&:active': { borderColor: borderColors.active }
                 }
               }}
             >

--- a/libs/journeys/ui/src/components/RadioQuestion/ListVariant/ListVariant.tsx
+++ b/libs/journeys/ui/src/components/RadioQuestion/ListVariant/ListVariant.tsx
@@ -5,38 +5,46 @@ import Typography from '@mui/material/Typography'
 import { useTranslation } from 'next-i18next/pages'
 import { ReactElement } from 'react'
 
+import { hoverOnly } from '@core/shared/ui/hoverOnly'
 import AddSquare4Icon from '@core/shared/ui/icons/AddSquare4'
 import { adminTheme } from '@core/shared/ui/themes/journeysAdmin/theme'
 
 import { StyledListRadioOption } from '../../RadioOption/ListVariant'
-import { getPollOptionBorderStyles } from '../utils/getPollOptionBorderStyles'
+import {
+  getPollOptionBorderColors,
+  getPollOptionBorderStyles
+} from '../utils/getPollOptionBorderStyles'
 
-const StyledListRadioQuestion = styled(Box)<BoxProps>(({ theme }) => ({
-  marginBottom: theme.spacing(4),
-  '& .MuiButtonGroup-root': {
-    boxShadow: 'none',
-    gap: theme.spacing(2),
-    '& .MuiButtonGroup-grouped': {
-      border: 'none',
-      borderBottom: 'none',
-      borderRight: 'none',
-      borderRadius: '12px',
-      margin: '0 !important',
-      '&:not(:last-of-type)': {
-        borderBottom: 'none'
-      },
-      '& .MuiButtonGroup-firstButton': {
-        ...getPollOptionBorderStyles(theme)
-      },
-      '& .MuiButtonGroup-middleButton': {
-        ...getPollOptionBorderStyles(theme)
-      },
-      '& .MuiButtonGroup-lastButton': {
-        ...getPollOptionBorderStyles(theme)
+const StyledListRadioQuestion = styled(Box)<BoxProps>(({ theme }) => {
+  const borderColors = getPollOptionBorderColors(theme)
+  const optionBorderStyles = {
+    ...getPollOptionBorderStyles(theme),
+    ...hoverOnly({ borderColor: borderColors.hover }),
+    '&:active': { borderColor: borderColors.active },
+    '&.disabled': { borderColor: borderColors.disabled }
+  }
+
+  return {
+    marginBottom: theme.spacing(4),
+    '& .MuiButtonGroup-root': {
+      boxShadow: 'none',
+      gap: theme.spacing(2),
+      '& .MuiButtonGroup-grouped': {
+        border: 'none',
+        borderBottom: 'none',
+        borderRight: 'none',
+        borderRadius: '12px',
+        margin: '0 !important',
+        '&:not(:last-of-type)': {
+          borderBottom: 'none'
+        },
+        '& .MuiButtonGroup-firstButton': optionBorderStyles,
+        '& .MuiButtonGroup-middleButton': optionBorderStyles,
+        '& .MuiButtonGroup-lastButton': optionBorderStyles
       }
     }
   }
-}))
+})
 
 const adminPrimaryColor = adminTheme.palette
   .primary as SimplePaletteColorOptions
@@ -70,11 +78,20 @@ export function ListVariant({
                 <AddSquare4Icon sx={{ color: `${adminPrimaryColor.main}` }} />
               }
               onClick={addOption}
-              sx={(theme) => ({
-                borderBottomLeftRadius: 8,
-                borderBottomRightRadius: 8,
-                ...getPollOptionBorderStyles(theme, { important: true })
-              })}
+              sx={(theme) => {
+                const borderColors = getPollOptionBorderColors(theme, {
+                  important: true
+                })
+
+                return {
+                  borderBottomLeftRadius: 8,
+                  borderBottomRightRadius: 8,
+                  ...getPollOptionBorderStyles(theme, { important: true }),
+                  ...hoverOnly({ borderColor: borderColors.hover }),
+                  '&:active': { borderColor: borderColors.active },
+                  '&.disabled': { borderColor: borderColors.disabled }
+                }
+              }}
             >
               <Typography variant="body1">{t('Add Option')}</Typography>
             </StyledListRadioOption>

--- a/libs/journeys/ui/src/components/RadioQuestion/utils/getPollOptionBorderStyles/getPollOptionBorderStyles.spec.ts
+++ b/libs/journeys/ui/src/components/RadioQuestion/utils/getPollOptionBorderStyles/getPollOptionBorderStyles.spec.ts
@@ -1,6 +1,6 @@
 import { Theme } from '@mui/material/styles'
 
-import { getPollOptionBorderStyles } from '.'
+import { getPollOptionBorderColors, getPollOptionBorderStyles } from '.'
 
 describe('getPollOptionBorderStyles', () => {
   const mockLightTheme = {
@@ -15,106 +15,69 @@ describe('getPollOptionBorderStyles', () => {
     }
   } as Theme
 
-  describe('light theme', () => {
-    let styles: ReturnType<typeof getPollOptionBorderStyles>
-
-    beforeEach(() => {
-      styles = getPollOptionBorderStyles(mockLightTheme)
-    })
-
-    it('should return correct default border styles for light theme', () => {
-      expect(styles.borderColor).toBe('rgba(225, 225, 225, 0.3)')
-      expect(styles.borderWidth).toBe('1px')
-      expect(styles.borderStyle).toBe('solid')
-    })
-
-    it('should return correct hover border styles for light theme', () => {
-      expect(styles['&:hover'].borderColor).toBe('rgba(255, 255, 255, 0.5)')
-    })
-
-    it('should return correct active border styles for light theme', () => {
-      expect(styles['&:active'].borderColor).toBe('rgba(255, 255, 255, 0.7)')
-    })
-
-    it('should return correct disabled border styles for light theme', () => {
-      expect(styles['&.disabled'].borderColor).toBe('rgba(255, 255, 255, 0.15)')
-    })
-  })
-
-  describe('dark theme', () => {
-    let styles: ReturnType<typeof getPollOptionBorderStyles>
-
-    beforeEach(() => {
-      styles = getPollOptionBorderStyles(mockDarkTheme)
-    })
-
-    it('should return correct default border styles for dark theme', () => {
-      expect(styles.borderColor).toBe('rgba(150, 150, 150, 0.2)')
-      expect(styles.borderWidth).toBe('1px')
-      expect(styles.borderStyle).toBe('solid')
-    })
-
-    it('should return correct hover border styles for dark theme', () => {
-      expect(styles['&:hover'].borderColor).toBe('rgba(150, 150, 150, 0.5)')
-    })
-
-    it('should return correct selected border styles for dark theme', () => {
-      expect(styles['&:active'].borderColor).toBe('rgba(150, 150, 150, 0.7)')
-    })
-
-    it('should return correct disabled border styles for dark theme', () => {
-      expect(styles['&.disabled'].borderColor).toBe('rgba(150, 150, 150, 0.15)')
-    })
-  })
-
-  describe('options', () => {
-    it('should handle important', () => {
-      const styles = getPollOptionBorderStyles(mockLightTheme, {
-        important: true
-      })
-
-      expect(styles.borderColor).toBe('rgba(225, 225, 225, 0.3) !important')
-      expect(styles.borderWidth).toBe('1px !important')
-      expect(styles.borderStyle).toBe('solid !important')
-    })
-  })
-
-  describe('return value structure', () => {
-    it('should return an object with correct structure for light theme', () => {
-      const styles = getPollOptionBorderStyles(mockLightTheme)
-
-      expect(styles).toEqual({
+  describe('getPollOptionBorderStyles', () => {
+    it('should return base border styles for light theme', () => {
+      expect(getPollOptionBorderStyles(mockLightTheme)).toEqual({
         borderColor: 'rgba(225, 225, 225, 0.3)',
         borderWidth: '1px',
-        borderStyle: 'solid',
-        '&:hover': {
-          borderColor: 'rgba(255, 255, 255, 0.5)'
-        },
-        '&:active': {
-          borderColor: 'rgba(255, 255, 255, 0.7)'
-        },
-        '&.disabled': {
-          borderColor: 'rgba(255, 255, 255, 0.15)'
-        }
+        borderStyle: 'solid'
       })
     })
 
-    it('should return an object with correct structure for dark theme', () => {
-      const styles = getPollOptionBorderStyles(mockDarkTheme)
-
-      expect(styles).toEqual({
+    it('should return base border styles for dark theme', () => {
+      expect(getPollOptionBorderStyles(mockDarkTheme)).toEqual({
         borderColor: 'rgba(150, 150, 150, 0.2)',
         borderWidth: '1px',
-        borderStyle: 'solid',
-        '&:hover': {
-          borderColor: 'rgba(150, 150, 150, 0.5)'
-        },
-        '&:active': {
-          borderColor: 'rgba(150, 150, 150, 0.7)'
-        },
-        '&.disabled': {
-          borderColor: 'rgba(150, 150, 150, 0.15)'
-        }
+        borderStyle: 'solid'
+      })
+    })
+
+    it('should not return state selectors, so callers own them', () => {
+      const styles = getPollOptionBorderStyles(mockLightTheme)
+
+      expect(styles).not.toHaveProperty('&:hover')
+      expect(styles).not.toHaveProperty('&:active')
+      expect(styles).not.toHaveProperty('&.disabled')
+    })
+
+    it('should handle important', () => {
+      expect(
+        getPollOptionBorderStyles(mockLightTheme, { important: true })
+      ).toEqual({
+        borderColor: 'rgba(225, 225, 225, 0.3) !important',
+        borderWidth: '1px !important',
+        borderStyle: 'solid !important'
+      })
+    })
+  })
+
+  describe('getPollOptionBorderColors', () => {
+    it('should return a colour per state for light theme', () => {
+      expect(getPollOptionBorderColors(mockLightTheme)).toEqual({
+        default: 'rgba(225, 225, 225, 0.3)',
+        hover: 'rgba(255, 255, 255, 0.5)',
+        active: 'rgba(255, 255, 255, 0.7)',
+        disabled: 'rgba(255, 255, 255, 0.15)'
+      })
+    })
+
+    it('should return a colour per state for dark theme', () => {
+      expect(getPollOptionBorderColors(mockDarkTheme)).toEqual({
+        default: 'rgba(150, 150, 150, 0.2)',
+        hover: 'rgba(150, 150, 150, 0.5)',
+        active: 'rgba(150, 150, 150, 0.7)',
+        disabled: 'rgba(150, 150, 150, 0.15)'
+      })
+    })
+
+    it('should handle important', () => {
+      expect(
+        getPollOptionBorderColors(mockDarkTheme, { important: true })
+      ).toEqual({
+        default: 'rgba(150, 150, 150, 0.2) !important',
+        hover: 'rgba(150, 150, 150, 0.5) !important',
+        active: 'rgba(150, 150, 150, 0.7) !important',
+        disabled: 'rgba(150, 150, 150, 0.15) !important'
       })
     })
   })

--- a/libs/journeys/ui/src/components/RadioQuestion/utils/getPollOptionBorderStyles/getPollOptionBorderStyles.tsx
+++ b/libs/journeys/ui/src/components/RadioQuestion/utils/getPollOptionBorderStyles/getPollOptionBorderStyles.tsx
@@ -1,31 +1,64 @@
 import { Theme } from '@mui/material/styles'
 
+export interface PollOptionBorderColors {
+  default: string
+  hover: string
+  active: string
+  disabled: string
+}
+
+const LIGHT_BORDER_COLORS: PollOptionBorderColors = {
+  default: 'rgba(225, 225, 225, 0.3)',
+  hover: 'rgba(255, 255, 255, 0.5)',
+  active: 'rgba(255, 255, 255, 0.7)',
+  disabled: 'rgba(255, 255, 255, 0.15)'
+}
+
+const DARK_BORDER_COLORS: PollOptionBorderColors = {
+  default: 'rgba(150, 150, 150, 0.2)',
+  hover: 'rgba(150, 150, 150, 0.5)',
+  active: 'rgba(150, 150, 150, 0.7)',
+  disabled: 'rgba(150, 150, 150, 0.15)'
+}
+
+/**
+ * Poll option border colours, one per interaction state.
+ *
+ * Callers apply each colour to whichever selector they need. Pair `hover` with
+ * `hoverOnly()` so it only paints on devices with a real pointer — this util
+ * deliberately returns no selector keys of its own, so there is only ever one
+ * `@media (hover: hover)` block per style object to merge.
+ */
+export const getPollOptionBorderColors = (
+  theme: Theme,
+  options?: { important?: boolean }
+): PollOptionBorderColors => {
+  const colors =
+    theme.palette.mode === 'dark' ? DARK_BORDER_COLORS : LIGHT_BORDER_COLORS
+  const suffix = options?.important === true ? ' !important' : ''
+
+  return {
+    default: `${colors.default}${suffix}`,
+    hover: `${colors.hover}${suffix}`,
+    active: `${colors.active}${suffix}`,
+    disabled: `${colors.disabled}${suffix}`
+  }
+}
+
+/**
+ * Base (unselected, un-hovered) border styles for a poll option.
+ *
+ * State colours are not included — take them from `getPollOptionBorderColors`.
+ */
 export const getPollOptionBorderStyles = (
   theme: Theme,
   options?: { important?: boolean }
-) => ({
-  borderColor:
-    theme.palette.mode === 'dark'
-      ? `rgba(150, 150, 150, 0.2)${options?.important ? ' !important' : ''}`
-      : `rgba(225, 225, 225, 0.3)${options?.important ? ' !important' : ''}`,
-  borderWidth: `1px${options?.important ? ' !important' : ''}`,
-  borderStyle: `solid${options?.important ? ' !important' : ''}`,
-  '&:hover': {
-    borderColor:
-      theme.palette.mode === 'dark'
-        ? `rgba(150, 150, 150, 0.5)${options?.important ? ' !important' : ''}`
-        : `rgba(255, 255, 255, 0.5)${options?.important ? ' !important' : ''}`
-  },
-  '&:active': {
-    borderColor:
-      theme.palette.mode === 'dark'
-        ? `rgba(150, 150, 150, 0.7)${options?.important ? '!important' : ''}`
-        : `rgba(255, 255, 255, 0.7)${options?.important ? '!important' : ''}`
-  },
-  '&.disabled': {
-    borderColor:
-      theme.palette.mode === 'dark'
-        ? `rgba(150, 150, 150, 0.15)${options?.important ? '!important' : ''}`
-        : `rgba(255, 255, 255, 0.15)${options?.important ? '!important' : ''}`
+) => {
+  const suffix = options?.important === true ? ' !important' : ''
+
+  return {
+    borderColor: getPollOptionBorderColors(theme, options).default,
+    borderWidth: `1px${suffix}`,
+    borderStyle: `solid${suffix}`
   }
-})
+}

--- a/libs/journeys/ui/src/components/RadioQuestion/utils/getPollOptionBorderStyles/index.ts
+++ b/libs/journeys/ui/src/components/RadioQuestion/utils/getPollOptionBorderStyles/index.ts
@@ -1,1 +1,5 @@
-export { getPollOptionBorderStyles } from './getPollOptionBorderStyles'
+export {
+  getPollOptionBorderColors,
+  getPollOptionBorderStyles
+} from './getPollOptionBorderStyles'
+export type { PollOptionBorderColors } from './getPollOptionBorderStyles'

--- a/libs/shared/ui/src/libs/hoverOnly/hoverOnly.spec.ts
+++ b/libs/shared/ui/src/libs/hoverOnly/hoverOnly.spec.ts
@@ -6,8 +6,11 @@ import { hoverOnly } from '.'
  * after a card transition - cannot make poll and multiselect options read as
  * already-selected (NES-1894).
  *
- * These tests pin the wrapper shape: if the media query is ever simplified
- * away, the bug returns silently.
+ * Scope: these tests pin this helper's return shape only. They do not reach the
+ * call sites, so they will not catch a component reverting to a bare `&:hover`
+ * (how the bug returned after #1793), nor a guarded block being clobbered by a
+ * second `@media (hover: hover)` spread. Catching either needs an assertion on
+ * emitted CSS, which this repo has no precedent for.
  */
 describe('hoverOnly', () => {
   it('should wrap styles in a hover media query', () => {

--- a/libs/shared/ui/src/libs/hoverOnly/hoverOnly.spec.ts
+++ b/libs/shared/ui/src/libs/hoverOnly/hoverOnly.spec.ts
@@ -1,0 +1,49 @@
+import { hoverOnly } from '.'
+
+/**
+ * hoverOnly guards hover styles behind `@media (hover: hover)` so that sticky
+ * hover on touch devices - which paints the last-touched element as hovered
+ * after a card transition - cannot make poll and multiselect options read as
+ * already-selected (NES-1894).
+ *
+ * These tests pin the wrapper shape: if the media query is ever simplified
+ * away, the bug returns silently.
+ */
+describe('hoverOnly', () => {
+  it('should wrap styles in a hover media query', () => {
+    expect(hoverOnly({ backgroundColor: 'red', color: 'white' })).toEqual({
+      '@media (hover: hover)': {
+        '&:hover': {
+          backgroundColor: 'red',
+          color: 'white'
+        }
+      }
+    })
+  })
+
+  it('should pass styles through unaltered', () => {
+    expect(
+      hoverOnly({
+        borderColor: 'rgba(255, 255, 255, 0.5) !important',
+        opacity: 1,
+        '& .MuiSvgIcon-root': { color: 'inherit' }
+      })
+    ).toEqual({
+      '@media (hover: hover)': {
+        '&:hover': {
+          borderColor: 'rgba(255, 255, 255, 0.5) !important',
+          opacity: 1,
+          '& .MuiSvgIcon-root': { color: 'inherit' }
+        }
+      }
+    })
+  })
+
+  it('should invent no keys when given empty styles', () => {
+    expect(hoverOnly({})).toEqual({
+      '@media (hover: hover)': {
+        '&:hover': {}
+      }
+    })
+  })
+})

--- a/libs/shared/ui/src/libs/hoverOnly/hoverOnly.ts
+++ b/libs/shared/ui/src/libs/hoverOnly/hoverOnly.ts
@@ -20,6 +20,15 @@ export interface HoverOnlyStyles {
  *
  * Hybrid devices (an iPad with a trackpad, a touchscreen laptop) report
  * `hover: hover`, so a tap there can still leave a stale highlight. Accepted.
+ *
+ * Two hazards to know about, both silent:
+ *
+ * - The returned object's only key is `@media (hover: hover)`, so spreading two
+ *   `hoverOnly()` results into the same style object makes the second replace
+ *   the first. Merge the styles into a single call instead.
+ * - Pairing this with a hand-written `&:hover` in the same object does *not*
+ *   collide - the two keys differ, so both apply and the hand-written block
+ *   stays unguarded. Route every hover style for an element through here.
  */
 export function hoverOnly(styles: CSSObject): HoverOnlyStyles {
   return {

--- a/libs/shared/ui/src/libs/hoverOnly/hoverOnly.ts
+++ b/libs/shared/ui/src/libs/hoverOnly/hoverOnly.ts
@@ -1,0 +1,30 @@
+import { CSSObject } from '@mui/material/styles'
+
+export interface HoverOnlyStyles {
+  '@media (hover: hover)': {
+    '&:hover': CSSObject
+  }
+}
+
+/**
+ * Wraps hover styles in `@media (hover: hover)` so they only paint on devices
+ * with a real pointer.
+ *
+ * Touch browsers keep `:hover` on whatever the finger last touched and
+ * synthesise mouse events at those coordinates. Because a card advance is a
+ * client-side transition, whatever ends up under that point paints as hovered —
+ * on a poll option that reads as "already selected". Guarding hover this way is
+ * how the base theme has handled buttons since #1793; components that override
+ * the theme with their own `&:hover` must use this helper or they reintroduce
+ * the bug.
+ *
+ * Hybrid devices (an iPad with a trackpad, a touchscreen laptop) report
+ * `hover: hover`, so a tap there can still leave a stale highlight. Accepted.
+ */
+export function hoverOnly(styles: CSSObject): HoverOnlyStyles {
+  return {
+    '@media (hover: hover)': {
+      '&:hover': styles
+    }
+  }
+}

--- a/libs/shared/ui/src/libs/hoverOnly/index.ts
+++ b/libs/shared/ui/src/libs/hoverOnly/index.ts
@@ -1,0 +1,2 @@
+export { hoverOnly } from './hoverOnly'
+export type { HoverOnlyStyles } from './hoverOnly'


### PR DESCRIPTION
Fixes poll options appearing pre-selected on touch devices. Reported by Riah on a marketing journey going live around October — the first time that department has used NextSteps as a marketing piece, pushed via ads to a large audience.

## The bug

Touch browsers keep `:hover` on whatever the finger last touched and synthesise mouse events at those coordinates. A card advance is a client-side transition, so whatever ends up under that point paints as hovered — and on a poll option that reads as "already selected".

Nothing is actually selected: `selectedId` starts `null` and clears when the block goes inactive, so no answer is recorded and the card doesn't advance. Reproduced on a phone. Not a regression — these styles date to #7262 / #7286 (Jul–Aug 2025).

## Why it happened

[#1793](https://github.com/JesusFilm/core/pull/1793) guarded button hover behind `@media (hover: hover)` in the base theme in Aug 2023. Poll options were written two years later, define their own `&:hover` at higher specificity, and never got the guard — re-opening exactly the bug #1793 closed.

## The fix

A `hoverOnly()` helper in `libs/shared/ui`, so the guard is the path of least resistance rather than something each new component has to remember:

```ts
hoverOnly(styles) // → { '@media (hover: hover)': { '&:hover': styles } }
```

Routed through it: poll options (list **and** image/grid variants — separate files, each with its own hover block), multiselect options, and the Conductor prev/next chevrons.

`getPollOptionBorderStyles` now returns base borders only, with state colours moved to `getPollOptionBorderColors` so callers apply selectors themselves. That leaves one `@media (hover: hover)` block per style object — otherwise the second spread would silently clobber the first and drop the hover border.

## Multiselect was the worst case

Its hover background (`0.8` alpha) is a shade off its genuine selected background (`0.9`), and unlike a poll, tapping doesn't advance the card — so nothing cleared the phantom highlight; it persisted through the whole selection. The checkbox icon stayed honest throughout.

## Scope

Limited to the card-navigation path. Deliberately excluded: footer buttons, share icons, AI chat (out of scope until release), and gallery/admin surfaces. The card `Button` was checked and is fine — its own `&:hover` only applies during editor inline-editing, so the viewer uses the theme's guarded rule.

Poll options' missing `&.selected` rule is left alone — that was removed intentionally.

## Known limitation

`@media (hover: hover)` resolves **true** on hybrid devices (iPad with a trackpad, touchscreen laptops), so a tap there can still leave a stale highlight. Accepted as rare for a mobile ad audience; the alternatives (a JS touch-neutraliser, or redesigning hover so it can't resemble selection) cost more than the residual risk.

## Testing

- Typecheck clean on `libs/journeys/ui` and `apps/journeys`.
- 97 tests pass — 35 across the poll/multiselect components, 62 in Conductor including NavigationButton.
- Verification is a manual check on a real phone: Playwright emulation would verify the guard, not the platform sticky-hover behaviour it guards against.

> [!WARNING]
> ESLint could not be run locally — the worktree shares a `node_modules` predating this branch's ESLint 10 upgrade, so `eslint-plugin-import-x` is missing. Relying on CI for lint.

Closes NES-1894

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented hover highlights from lingering after taps on touch devices.
  - Improved radio and multiselect option states across pointer and touch interactions.
  - Refined border colors for default, hover, active, and disabled states in light and dark themes.

- **New Features**
  - Added consistent hover behavior for navigation buttons and selectable options.
  - Improved visual feedback for radio question choices and add-option controls.

- **Tests**
  - Updated coverage for option border styles and state-specific colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->