### PR TITLE
fix(api-media): stop blocking child publication on media-bearing parents (QA-554)

### DIFF
--- a/apis/api-media/src/schema/videoVariantReconciliation/reconcileParentVariants.ts
+++ b/apis/api-media/src/schema/videoVariantReconciliation/reconcileParentVariants.ts
@@ -18,7 +18,6 @@ import {
   failedStage,
   generatedParentStages
 } from './reconciliationStages'
-import { videoVariantContainsMedia } from './videoVariantContainsMedia'
 
 type ChildVariant = {
   id: string
@@ -95,14 +94,18 @@ async function reconcileParentVariant({
     include: { downloads: { select: { id: true } } }
   })
 
-  if (parentVariant != null && videoVariantContainsMedia(parentVariant)) {
-    stages.parentSync = failedStage(
-      `Parent Variant ${parentVariant.id} contains media and requires operator review`,
-      stages.parentSync.attempts + 1
-    )
-    await persistStatus('degraded', stages.parentSync)
-    return { publicationReady: false, status: 'degraded' }
-  }
+  // A container parent that already carries its own media-bearing Variant is
+  // normal, not an anomaly: findContainerParentIds includes `featureFilm`, and
+  // a featureFilm (1_jf-0-0) legitimately has real media in every language it
+  // is dubbed in while also owning its chapter children. Nothing below writes
+  // to an *existing* parent Variant -- the only variant write is the create on
+  // the `parentVariant == null` branch -- so there was nothing here to clobber.
+  // Blocking instead stranded the CHILD's publication: reconcile returned
+  // early, the child never got `published: true` or an Algolia entry, and the
+  // record retried five futile times before alerting #data-lang-products.
+  // Operator review for genuinely ambiguous parents belongs to the offline
+  // audit (`src/scripts/audit-parent-variants.ts`), which reports them as
+  // `ambiguous` without touching live publication.
 
   try {
     if (parentVariant == null) {

--- a/apis/api-media/src/schema/videoVariantReconciliation/reconcileVideoVariantReconciliation.spec.ts
+++ b/apis/api-media/src/schema/videoVariantReconciliation/reconcileVideoVariantReconciliation.spec.ts
@@ -108,6 +108,85 @@ describe('reconcileVideoVariantReconciliation', () => {
     expect(result).toMatchObject({ publicationReady: true, status: 'complete' })
   })
 
+  // A featureFilm parent (1_jf-0-0) legitimately has real media in every
+  // language it is dubbed in, so its chapter children hit this path routinely.
+  // Treating that as "requires operator review" blocked the child's own
+  // publication and alerted #data-lang-products every 15-minute sweep.
+  it.each([
+    ['hls', { hls: 'https://arc.gt/parent.m3u8' }],
+    ['share', { share: 'https://arc.gt/parent-share' }],
+    ['duration', { duration: 7860 }],
+    ['downloads', { downloads: [{ id: 'download-1' }] }]
+  ])(
+    'publishes a child Variant when its container parent already has a Variant with %s',
+    async (_field, parentMedia) => {
+      const reconciliation: ReconciliationRecord = {
+        reason: 'video-variant-publication-change',
+        videoId: '1_jf6142-0-0',
+        languageId: '145621',
+        published: true,
+        videoVariantId: '1_145621-jf6142-0-0',
+        processingStages: {},
+        createdAt: new Date(),
+        videoVariant: {
+          id: '1_145621-jf6142-0-0',
+          videoId: '1_jf6142-0-0',
+          languageId: '145621',
+          slug: 'jesus/145621',
+          published: false,
+          downloadable: false,
+          hls: 'https://arc.gt/child.m3u8',
+          share: '',
+          muxVideo: { readyToStream: true }
+        }
+      }
+      prismaMock.videoVariantReconciliation.findUniqueOrThrow.mockResolvedValue(
+        reconciliation as never
+      )
+      vi.mocked(findContainerParentIds).mockResolvedValue(['1_jf-0-0'])
+      prismaMock.video.findMany.mockResolvedValue([
+        { id: '1_jf-0-0', slug: 'jesus' }
+      ] as never)
+      prismaMock.videoVariant.findFirst.mockResolvedValue({
+        id: '1_145621-jf-0-0',
+        videoId: '1_jf-0-0',
+        languageId: '145621',
+        hls: '',
+        dash: '',
+        share: '',
+        duration: 0,
+        downloads: [],
+        ...parentMedia
+      } as never)
+      prismaMock.videoVariantDownload.count.mockResolvedValue(0)
+
+      const result = await reconcileVideoVariantReconciliation(
+        'reconciliation-1'
+      )
+
+      // The existing parent Variant is never rewritten -- only the parent's
+      // availableLanguages and the search indexes are refreshed.
+      expect(prismaMock.videoVariant.create).not.toHaveBeenCalled()
+      expect(addLanguageToVideo).toHaveBeenCalledWith('1_jf-0-0', '145621')
+      expect(updateVideoInAlgolia).toHaveBeenCalledWith('1_jf-0-0')
+      expect(updateVideoVariantInAlgolia).toHaveBeenCalledWith(
+        '1_145621-jf-0-0'
+      )
+      // The child itself publishes and indexes rather than being stranded.
+      expect(prismaMock.videoVariant.update).toHaveBeenCalledWith({
+        where: { id: '1_145621-jf6142-0-0' },
+        data: { published: true }
+      })
+      expect(updateVideoVariantInAlgolia).toHaveBeenCalledWith(
+        '1_145621-jf6142-0-0'
+      )
+      expect(result).toMatchObject({
+        publicationReady: true,
+        status: 'complete'
+      })
+    }
+  )
+
   it('keeps a new Variant unpublished when parent indexing fails', async () => {
     const reconciliation: ReconciliationRecord = {
       reason: 'video-variant-publication-change',

--- a/apis/api-media/src/schema/videoVariantReconciliation/reconcileVideoVariantReconciliation.spec.ts
+++ b/apis/api-media/src/schema/videoVariantReconciliation/reconcileVideoVariantReconciliation.spec.ts
@@ -160,9 +160,8 @@ describe('reconcileVideoVariantReconciliation', () => {
       } as never)
       prismaMock.videoVariantDownload.count.mockResolvedValue(0)
 
-      const result = await reconcileVideoVariantReconciliation(
-        'reconciliation-1'
-      )
+      const result =
+        await reconcileVideoVariantReconciliation('reconciliation-1')
 
       // The existing parent Variant is never rewritten -- only the parent's
       // availableLanguages and the search indexes are refreshed.


### PR DESCRIPTION
Stops video variant reconciliation from blocking a child's publication whenever its container parent already has real media. Surfaced by a recurring alert in #data-lang-products:

```
Variant processing blocked after retries: 1_145621-jf6142-0-0
Parent Variant 1_145621-jf-0-0 contains media and requires operator review
```

## The bug

`reconcileParentVariants` refused to sync a container parent that already had its own media-bearing Variant, marked the record `degraded`, and returned before the child was ever published or indexed. Nothing about the parent's media changes between sweeps, so the five retries were guaranteed futile — they just burned backoff (1/2/4/8 min) before alerting.

The parent lookup is `findContainerParentIds`, which includes `featureFilm`. A featureFilm such as `1_jf-0-0` legitimately carries real media in every language it is dubbed in *while also* owning its chapter children. So the guard fired on the normal, healthy shape rather than an anomaly — in principle every JESUS film segment, in every language the feature film already exists in.

## The guard protected nothing

The only write to a parent Variant is the `create` on the `parentVariant == null` branch, which the guard cannot reach — it returns first. On the existing-parent branch reconciliation only calls `addLanguageToVideo`, `updateParentCollectionLanguages`, `videoCacheReset` and the two Algolia reindexes. All idempotent, none of them touch the parent Variant row. There was no clobbering to prevent.

Its actual effect was on the **child**: `reconcileVideoVariantReconciliation` returns at the parent-sync result, before the publish step, so the child never got `published: true` and never got an Algolia entry. That language silently never went live.

## The fix

Remove the blocking guard. Operator review for genuinely ambiguous parents stays where it belongs — the offline, read-only audit in `src/scripts/audit-parent-variants.ts`, which already reports these as `ambiguous` (with a runner at `run-parent-variant-audit.ts`) without touching live publication. That distinction is the point: the concept was deliberate, but as a report, not as a runtime gate on publication.

`videoVariantContainsMedia` is unchanged and still used by the audit.

## Follow-up: stranded records need requeuing

**This fix does not heal what is already stuck.** `dueRecordWhere()` matches either `status='processing' AND retryAt IS NULL` or `retryAt <= now`. A blocked record is `degraded` with a null `retryAt`, so it satisfies neither and the worker will never sweep it again. Those records stay invisible until something calls `requestVideoVariantReconciliation` for that variant (which resets `status`/`retryAt`), or until they are requeued by hand.

After this deploys, size and requeue:

```sql
-- size it
SELECT count(*) FILTER (WHERE "published") AS wanted_live, count(*) AS stranded
FROM "VideoVariantReconciliation"
WHERE "status" = 'degraded' AND "retryAt" IS NULL
  AND "errorMessage" LIKE '%contains media and requires operator review%';

-- requeue (mirrors what requestVideoVariantReconciliation writes)
UPDATE "VideoVariantReconciliation"
SET "status" = 'processing', "retryAt" = now(), "errorMessage" = NULL,
    "processingStages" = '{"mux":{"state":"pending","attempts":0},
                           "parentSync":{"state":"pending","attempts":0},
                           "downloads":{"state":"pending","attempts":0},
                           "algoliaVideo":{"state":"pending","attempts":0},
                           "algoliaVariant":{"state":"pending","attempts":0}}'::jsonb
WHERE "status" = 'degraded' AND "retryAt" IS NULL
  AND "errorMessage" LIKE '%contains media and requires operator review%';
```

Resetting the stage counters matters: `parentSync.attempts` sits at 5, and `retryAtFor` suppresses retries at >= 5, so any *other* failure on a requeued record would alert immediately instead of retrying.

Don't flip `VideoVariant.published` by hand — let the worker publish and index so `availableLanguages` and Algolia are written through the canonical path. Drain is capped at `SWEEP_BATCH_SIZE = 200` per 15-minute sweep (~800/hour), so a large backlog takes a while.

Blast radius is bounded: the worker was activated in 48cb3434 on 2026-08-25.

## Testing

Four parametrised cases at the `reconcileVideoVariantReconciliation` seam, one per media field (`hls`, `share`, `duration`, `downloads`), asserting that the child publishes and indexes and that the existing parent Variant is never rewritten. Verified red against the previous behaviour (4 failed / 5 passed with the guard restored), green with the fix (9/9).

Diagnosis ran against a mocked-Prisma repro that reproduced the alert string verbatim; minimisation showed *any single* media field on the parent is sufficient to trip it, and that a media-free parent reconciles to `complete`.

Not verified: the "stranded records never re-sweep" claim is read from `dueRecordWhere()` plus SQL NULL-comparison semantics — I had no media DB connection to execute it against. Worth a second pair of eyes before running the requeue.

## Unrelated, noticed in passing

`src/scripts/video-variant-reconciliation-migration.spec.ts` resolves a migration path off `process.cwd()`, expecting the repo root, but the workspace's `setupFiles` are relative and only resolve from `apis/api-media`. The two can't both be satisfied in one vitest invocation. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BaWbGKspfHXi4YdUY7fTD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Child video variants can now be published successfully when an existing parent variant already contains media.
  * Existing parent variants are preserved while associated language metadata and search indexes are refreshed.
  * Prevents affected child publications from becoming unnecessarily degraded.

* **Tests**
  * Added coverage for parent variants containing streaming, sharing, duration, and download media.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->