### PR TITLE
fix(api-media): backfill Mux download rows that are missing or blocked by a legacy URL

### DIFF
--- a/apis/api-media/src/lib/downloads/processing.spec.ts
+++ b/apis/api-media/src/lib/downloads/processing.spec.ts
@@ -620,7 +620,7 @@ describe('download processing utilities', () => {
       expect(prismaMock.videoVariantDownload.update).not.toHaveBeenCalled()
     })
 
-    it('should preserve existing non-Mux downloads for the same quality', async () => {
+    it('replaces an existing non-Mux download for the same quality with the Mux-hosted one', async () => {
       const muxVideoAsset = {
         playback_ids: [{ id: 'test-playback-id' }],
         static_renditions: {
@@ -642,7 +642,9 @@ describe('download processing utilities', () => {
           id: 'existing-high-download',
           quality: VideoVariantDownloadQuality.high,
           videoVariantId: 'variant-1',
-          url: 'https://example.com/download.mp4',
+          // A legacy origin-server URL predating the Mux migration -- not a
+          // distro* row (those are a separate quality enum, untouched here).
+          url: 'https://api-media-core.jesusfilm.org/download.mp4',
           size: 157286400,
           height: 720,
           width: 1280,
@@ -653,6 +655,7 @@ describe('download processing utilities', () => {
           updatedAt: new Date()
         })
         .mockResolvedValueOnce(null)
+      prismaMock.videoVariantDownload.update.mockResolvedValue({} as any)
       prismaMock.videoVariantDownload.create.mockResolvedValue({} as any)
 
       const result = await createDownloadsFromMuxAsset({
@@ -660,8 +663,14 @@ describe('download processing utilities', () => {
         muxVideoAsset
       })
 
-      expect(result).toBe(1)
-      expect(prismaMock.videoVariantDownload.update).not.toHaveBeenCalled()
+      expect(result).toBe(2)
+      expect(prismaMock.videoVariantDownload.update).toHaveBeenCalledWith({
+        where: { id: 'existing-high-download' },
+        data: expect.objectContaining({
+          quality: VideoVariantDownloadQuality.high,
+          url: 'https://stream.mux.com/test-playback-id/720p.mp4'
+        })
+      })
       expect(prismaMock.videoVariantDownload.create).toHaveBeenCalledTimes(1)
       expect(prismaMock.videoVariantDownload.create).toHaveBeenCalledWith({
         data: expect.objectContaining({

--- a/apis/api-media/src/lib/downloads/processing.spec.ts
+++ b/apis/api-media/src/lib/downloads/processing.spec.ts
@@ -1001,5 +1001,146 @@ describe('download processing utilities', () => {
         }
       })
     })
+
+    describe('cleaning up legacy downloads for permanently unproducible qualities', () => {
+      function legacyDownload(quality: VideoVariantDownloadQuality): any {
+        return {
+          id: `legacy-${quality}`,
+          quality,
+          videoVariantId: 'variant-1',
+          url: 'https://api-media-core.jesusfilm.org/legacy.mp4',
+          size: 1,
+          bitrate: 1,
+          height: null,
+          width: null,
+          version: 1,
+          assetId: null,
+          createdAt: new Date(),
+          updatedAt: new Date()
+        }
+      }
+
+      it('removes a legacy download for a quality the ready asset will never produce', async () => {
+        const muxVideoAsset = {
+          playback_ids: [{ id: 'test-playback-id' }],
+          static_renditions: {
+            files: [
+              {
+                resolution: '720p',
+                status: 'ready',
+                filesize: '157286400',
+                height: 720,
+                width: 1280,
+                bitrate: 2500000
+              },
+              { resolution: '1080p', status: 'skipped' }
+            ]
+          }
+        }
+
+        prismaMock.videoVariantDownload.findUnique.mockImplementation((async ({
+          where
+        }: any) =>
+          where.quality_videoVariantId.quality ===
+          VideoVariantDownloadQuality.fhd
+            ? legacyDownload(VideoVariantDownloadQuality.fhd)
+            : null) as any)
+        prismaMock.videoVariantDownload.create.mockResolvedValue({} as any)
+        prismaMock.videoVariantDownload.delete.mockResolvedValue({} as any)
+
+        const result = await createDownloadsFromMuxAsset({
+          variantId: 'variant-1',
+          muxVideoAsset
+        })
+
+        expect(prismaMock.videoVariantDownload.delete).toHaveBeenCalledTimes(1)
+        expect(prismaMock.videoVariantDownload.delete).toHaveBeenCalledWith({
+          where: { id: 'legacy-fhd' }
+        })
+        expect(result).toBe(3) // high + highest created, fhd removed
+      })
+
+      it('does not remove a legacy download while another rendition is still pending metadata', async () => {
+        const muxVideoAsset = {
+          playback_ids: [{ id: 'test-playback-id' }],
+          static_renditions: {
+            files: [
+              {
+                resolution: '720p',
+                status: 'ready',
+                filesize: '157286400',
+                height: 720,
+                width: 1280,
+                bitrate: 2500000
+              },
+              // ready but not yet propagated -- the whole asset is treated
+              // as still settling, not final.
+              {
+                resolution: '1080p',
+                status: 'ready',
+                filesize: '0',
+                bitrate: 0
+              }
+            ]
+          }
+        }
+
+        prismaMock.videoVariantDownload.findUnique.mockImplementation((async ({
+          where
+        }: any) =>
+          where.quality_videoVariantId.quality ===
+          VideoVariantDownloadQuality.fhd
+            ? legacyDownload(VideoVariantDownloadQuality.fhd)
+            : null) as any)
+        prismaMock.videoVariantDownload.create.mockResolvedValue({} as any)
+
+        await createDownloadsFromMuxAsset({
+          variantId: 'variant-1',
+          muxVideoAsset
+        })
+
+        expect(prismaMock.videoVariantDownload.delete).not.toHaveBeenCalled()
+      })
+
+      it('never removes an existing Mux-hosted download, even for a quality outside this build', async () => {
+        const muxVideoAsset = {
+          playback_ids: [{ id: 'test-playback-id' }],
+          static_renditions: {
+            files: [
+              {
+                resolution: '720p',
+                status: 'ready',
+                filesize: '157286400',
+                height: 720,
+                width: 1280,
+                bitrate: 2500000
+              },
+              { resolution: '1080p', status: 'skipped' }
+            ]
+          }
+        }
+
+        prismaMock.videoVariantDownload.findUnique.mockImplementation((async ({
+          where
+        }: any) =>
+          where.quality_videoVariantId.quality ===
+          VideoVariantDownloadQuality.fhd
+            ? {
+                ...legacyDownload(VideoVariantDownloadQuality.fhd),
+                url: 'https://stream.mux.com/test-playback-id/1080p.mp4',
+                size: 1,
+                bitrate: 1
+              }
+            : null) as any)
+        prismaMock.videoVariantDownload.create.mockResolvedValue({} as any)
+
+        await createDownloadsFromMuxAsset({
+          variantId: 'variant-1',
+          muxVideoAsset
+        })
+
+        expect(prismaMock.videoVariantDownload.delete).not.toHaveBeenCalled()
+      })
+    })
   })
 })

--- a/apis/api-media/src/lib/downloads/processing.ts
+++ b/apis/api-media/src/lib/downloads/processing.ts
@@ -21,6 +21,19 @@ function hasMissingDownloadMetadata(download: {
   )
 }
 
+// Every non-distro, non-highest quality tier -- the set buildMuxDownloadRows()
+// can ever produce a row for. Used to find qualities a ready asset will never
+// produce, so a legacy row left in one of those slots can be cleaned up
+// instead of lingering forever.
+const REAL_DOWNLOAD_QUALITIES = [
+  VideoVariantDownloadQuality.low,
+  VideoVariantDownloadQuality.sd,
+  VideoVariantDownloadQuality.high,
+  VideoVariantDownloadQuality.fhd,
+  VideoVariantDownloadQuality.qhd,
+  VideoVariantDownloadQuality.uhd
+]
+
 export const qualityEnumToOrder: Record<VideoVariantDownloadQuality, number> = {
   [VideoVariantDownloadQuality.distroLow]: 0,
   [VideoVariantDownloadQuality.distroSd]: 1,
@@ -72,6 +85,24 @@ function hasValidRenditionMetadata(file: {
   const size = file.filesize ? parseInt(file.filesize) : 0
   const bitrate = file.bitrate ?? 0
   return size > 0 && bitrate > 0
+}
+
+// A `ready` file without usable metadata (see above) is still settling, not
+// finished -- treat the whole asset as not-yet-final so a quality it would
+// eventually produce doesn't get its legacy row deleted prematurely.
+function hasAnyPendingRendition(
+  files: Array<{
+    status?: string
+    filesize?: string | null
+    bitrate?: number | null
+  } | null>
+): boolean {
+  return files.some(
+    (file) =>
+      file != null &&
+      file.status === 'ready' &&
+      !hasValidRenditionMetadata(file)
+  )
 }
 
 // Enhanced function that handles fallbacks for sd and high qualities
@@ -422,6 +453,43 @@ export async function createDownloadsFromMuxAsset({
         },
         'Failed to create or update individual download'
       )
+    }
+  }
+
+  // Clean up a legacy row left in a quality slot this asset will never fill.
+  // Only once every rendition is in a final state (see
+  // hasAnyPendingRendition) -- otherwise a quality missing from `data` might
+  // just not have finished processing yet, and a later run should still get
+  // the chance to fill it in rather than find its legacy row already gone.
+  if (!hasAnyPendingRendition(muxVideoAsset.static_renditions?.files ?? [])) {
+    const producedQualities = new Set(data.map((download) => download.quality))
+    const permanentlyAbsentQualities = REAL_DOWNLOAD_QUALITIES.filter(
+      (quality) => !producedQualities.has(quality)
+    )
+
+    for (const quality of permanentlyAbsentQualities) {
+      try {
+        const existingDownload = await prisma.videoVariantDownload.findUnique({
+          where: {
+            quality_videoVariantId: { quality, videoVariantId: variantId }
+          }
+        })
+
+        if (
+          existingDownload != null &&
+          !existingDownload.url.startsWith(MUX_STREAM_BASE_URL)
+        ) {
+          await prisma.videoVariantDownload.delete({
+            where: { id: existingDownload.id }
+          })
+          createdCount++
+        }
+      } catch (error: any) {
+        logger?.error(
+          { error, videoVariantId: variantId, quality },
+          'Failed to remove a legacy download for a permanently unproducible quality'
+        )
+      }
     }
   }
 

--- a/apis/api-media/src/lib/downloads/processing.ts
+++ b/apis/api-media/src/lib/downloads/processing.ts
@@ -378,8 +378,17 @@ export async function createDownloadsFromMuxAsset({
         continue
       }
 
+      const isExistingMuxDownload =
+        existingDownload.url.startsWith(MUX_STREAM_BASE_URL)
+
+      // Replace a broken existing Mux row, or ANY non-Mux row occupying this
+      // quality slot (e.g. a legacy origin-server URL predating the Mux
+      // migration) -- a non-Mux row here isn't a deliberate alternative the
+      // way distro* rows are (those are a separate quality enum entirely,
+      // never touched by this function); it's stale data blocking the
+      // correct Mux-hosted download from ever landing.
       if (
-        existingDownload.url.startsWith(MUX_STREAM_BASE_URL) &&
+        !isExistingMuxDownload ||
         hasMissingDownloadMetadata(existingDownload)
       ) {
         await prisma.videoVariantDownload.update({
@@ -400,10 +409,9 @@ export async function createDownloadsFromMuxAsset({
       logger?.info(
         {
           videoVariantId: variantId,
-          quality: download.quality,
-          isMuxDownload: existingDownload.url.startsWith(MUX_STREAM_BASE_URL)
+          quality: download.quality
         },
-        'Existing download does not need Mux metadata refresh'
+        'Existing Mux download is already complete, no refresh needed'
       )
     } catch (error: any) {
       logger?.error(

--- a/apis/api-media/src/scripts/mux-videos.spec.ts
+++ b/apis/api-media/src/scripts/mux-videos.spec.ts
@@ -94,6 +94,7 @@ describe('processDownloads', () => {
     delete process.env.MUX_DOWNLOAD_BACKFILL_APPLY
     delete process.env.MUX_DOWNLOAD_BACKFILL_SAMPLE_SIZE
     ;(prismaMock.videoVariantDownload.findMany as Mock).mockResolvedValue([])
+    ;(prismaMock.$queryRaw as unknown as Mock).mockResolvedValue([])
   })
 
   afterEach(() => {
@@ -316,5 +317,85 @@ describe('processDownloads', () => {
     expect(mockedGetVideo).toHaveBeenCalledTimes(2)
     expect(mockedGetVideo).toHaveBeenCalledWith('asset-variant-1', false)
     expect(mockedGetVideo).toHaveBeenCalledWith('asset-variant-2', false)
+  })
+
+  describe('missing download rows pass', () => {
+    function variant(id: string): any {
+      return { id, muxVideo: { id: `mux-${id}`, assetId: `asset-${id}` } }
+    }
+
+    it('processes variants with a muxVideoId but no matching download rows, which the zero-metadata query cannot see', async () => {
+      ;(prismaMock.$queryRaw as unknown as Mock)
+        .mockResolvedValueOnce([{ id: 'variant-missing' }])
+        .mockResolvedValueOnce([])
+      ;(prismaMock.videoVariant.findMany as Mock).mockResolvedValueOnce([
+        variant('variant-missing')
+      ])
+      mockedGetVideo.mockResolvedValue(readyMuxVideoAsset)
+      mockedPreviewMuxDownloadsFromAsset.mockReturnValue([])
+
+      await runProcessDownloads()
+
+      expect(mockedGetVideo).toHaveBeenCalledWith(
+        'asset-variant-missing',
+        false
+      )
+    })
+
+    it('persists newly created rows in apply mode for a variant discovered only by the missing-rows pass', async () => {
+      process.env.MUX_DOWNLOAD_BACKFILL_APPLY = 'true'
+      ;(prismaMock.$queryRaw as unknown as Mock)
+        .mockResolvedValueOnce([{ id: 'variant-missing' }])
+        .mockResolvedValueOnce([])
+      ;(prismaMock.videoVariant.findMany as Mock).mockResolvedValueOnce([
+        variant('variant-missing')
+      ])
+      mockedGetVideo.mockResolvedValue(readyMuxVideoAsset)
+      mockedCreateDownloadsFromMuxAsset.mockResolvedValue(1)
+
+      await runProcessDownloads()
+
+      expect(mockedCreateDownloadsFromMuxAsset).toHaveBeenCalledWith({
+        variantId: 'variant-missing',
+        muxVideoAsset: readyMuxVideoAsset
+      })
+    })
+
+    it('stops issuing missing-rows queries once the sample size is exhausted by the zero-metadata pass', async () => {
+      process.env.MUX_DOWNLOAD_BACKFILL_SAMPLE_SIZE = '1'
+      ;(prismaMock.videoVariantDownload.findMany as Mock).mockResolvedValueOnce(
+        [download({ videoVariantId: 'variant-1' })]
+      )
+      mockedGetVideo.mockResolvedValue(readyMuxVideoAsset)
+      mockedPreviewMuxDownloadsFromAsset.mockReturnValue([])
+
+      await runProcessDownloads()
+
+      expect(prismaMock.$queryRaw).not.toHaveBeenCalled()
+    })
+
+    it('paginates through multiple batches using the last id as the next cursor', async () => {
+      // A full page (length === take, default take = 200) signals there may
+      // be more, so the next query must use the last id from this page as
+      // its cursor.
+      const fullPage = Array.from({ length: 200 }, (_, i) => ({
+        id: `variant-${String(i).padStart(3, '0')}`
+      }))
+      ;(prismaMock.$queryRaw as unknown as Mock)
+        .mockResolvedValueOnce(fullPage)
+        .mockResolvedValueOnce([])
+      ;(prismaMock.videoVariant.findMany as Mock).mockResolvedValue(
+        fullPage.map((candidate) => variant(candidate.id))
+      )
+      mockedGetVideo.mockResolvedValue(readyMuxVideoAsset)
+      mockedPreviewMuxDownloadsFromAsset.mockReturnValue([])
+
+      await runProcessDownloads()
+
+      expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(2)
+      const secondCallValues = (prismaMock.$queryRaw as unknown as Mock).mock
+        .calls[1]
+      expect(secondCallValues).toContain('variant-199')
+    })
   })
 })

--- a/apis/api-media/src/scripts/mux-videos.spec.ts
+++ b/apis/api-media/src/scripts/mux-videos.spec.ts
@@ -87,12 +87,18 @@ async function runProcessDownloads(): Promise<void> {
 describe('processDownloads', () => {
   const originalApply = process.env.MUX_DOWNLOAD_BACKFILL_APPLY
   const originalSampleSize = process.env.MUX_DOWNLOAD_BACKFILL_SAMPLE_SIZE
+  const originalMaxQualityCount =
+    process.env.MUX_DOWNLOAD_BACKFILL_MAX_QUALITY_COUNT
+  const originalVideoIdPrefixes =
+    process.env.MUX_DOWNLOAD_BACKFILL_VIDEO_ID_PREFIXES
 
   beforeEach(() => {
     vi.clearAllMocks()
     vi.useFakeTimers({ toFake: ['setTimeout'] })
     delete process.env.MUX_DOWNLOAD_BACKFILL_APPLY
     delete process.env.MUX_DOWNLOAD_BACKFILL_SAMPLE_SIZE
+    delete process.env.MUX_DOWNLOAD_BACKFILL_MAX_QUALITY_COUNT
+    delete process.env.MUX_DOWNLOAD_BACKFILL_VIDEO_ID_PREFIXES
     ;(prismaMock.videoVariantDownload.findMany as Mock).mockResolvedValue([])
     ;(prismaMock.$queryRaw as unknown as Mock).mockResolvedValue([])
   })
@@ -107,6 +113,16 @@ describe('processDownloads', () => {
     if (originalSampleSize == null)
       delete process.env.MUX_DOWNLOAD_BACKFILL_SAMPLE_SIZE
     else process.env.MUX_DOWNLOAD_BACKFILL_SAMPLE_SIZE = originalSampleSize
+    if (originalMaxQualityCount == null)
+      delete process.env.MUX_DOWNLOAD_BACKFILL_MAX_QUALITY_COUNT
+    else
+      process.env.MUX_DOWNLOAD_BACKFILL_MAX_QUALITY_COUNT =
+        originalMaxQualityCount
+    if (originalVideoIdPrefixes == null)
+      delete process.env.MUX_DOWNLOAD_BACKFILL_VIDEO_ID_PREFIXES
+    else
+      process.env.MUX_DOWNLOAD_BACKFILL_VIDEO_ID_PREFIXES =
+        originalVideoIdPrefixes
   })
 
   it('throws for a non-positive sample size', async () => {
@@ -114,6 +130,15 @@ describe('processDownloads', () => {
 
     await expect(processDownloads()).rejects.toThrow(
       'MUX_DOWNLOAD_BACKFILL_SAMPLE_SIZE must be a positive integer'
+    )
+    expect(prismaMock.videoVariantDownload.findMany).not.toHaveBeenCalled()
+  })
+
+  it('throws for a non-positive max quality count', async () => {
+    process.env.MUX_DOWNLOAD_BACKFILL_MAX_QUALITY_COUNT = '0'
+
+    await expect(processDownloads()).rejects.toThrow(
+      'MUX_DOWNLOAD_BACKFILL_MAX_QUALITY_COUNT must be a positive integer'
     )
     expect(prismaMock.videoVariantDownload.findMany).not.toHaveBeenCalled()
   })
@@ -396,6 +421,37 @@ describe('processDownloads', () => {
       const secondCallValues = (prismaMock.$queryRaw as unknown as Mock).mock
         .calls[1]
       expect(secondCallValues).toContain('variant-199')
+    })
+
+    it('uses MUX_DOWNLOAD_BACKFILL_MAX_QUALITY_COUNT as the discovery query threshold when set', async () => {
+      process.env.MUX_DOWNLOAD_BACKFILL_MAX_QUALITY_COUNT = '5'
+      ;(prismaMock.$queryRaw as unknown as Mock).mockResolvedValueOnce([])
+
+      await runProcessDownloads()
+
+      const call = (prismaMock.$queryRaw as unknown as Mock).mock.calls[0]
+      expect(call).toContain(5)
+      expect(call).not.toContain(7)
+    })
+
+    it('scopes the discovery query by MUX_DOWNLOAD_BACKFILL_VIDEO_ID_PREFIXES when set', async () => {
+      process.env.MUX_DOWNLOAD_BACKFILL_VIDEO_ID_PREFIXES = '1_,MAG'
+      ;(prismaMock.$queryRaw as unknown as Mock).mockResolvedValueOnce([])
+
+      await runProcessDownloads()
+
+      const call = (prismaMock.$queryRaw as unknown as Mock).mock.calls[0]
+      expect(JSON.stringify(call)).toContain('1_')
+      expect(JSON.stringify(call)).toContain('MAG')
+    })
+
+    it('omits the prefix filter entirely when MUX_DOWNLOAD_BACKFILL_VIDEO_ID_PREFIXES is unset', async () => {
+      ;(prismaMock.$queryRaw as unknown as Mock).mockResolvedValueOnce([])
+
+      await runProcessDownloads()
+
+      const call = (prismaMock.$queryRaw as unknown as Mock).mock.calls[0]
+      expect(JSON.stringify(call)).not.toContain('LEFT(v."videoId"')
     })
   })
 })

--- a/apis/api-media/src/scripts/mux-videos.spec.ts
+++ b/apis/api-media/src/scripts/mux-videos.spec.ts
@@ -1,3 +1,7 @@
+import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import { type Mock, vi } from 'vitest'
 
 import { VideoVariantDownloadQuality } from '@core/prisma/media/client'
@@ -76,8 +80,8 @@ const readyMuxVideoAsset = {
   }
 }
 
-// processVariant() waits 1.5s between Mux calls to avoid rate limiting;
-// fake timers keep tests fast without weakening what's under test.
+// processVariant() staggers each Mux call by MUX_API_CALL_STAGGER_MS; fake
+// timers keep tests fast without weakening what's under test.
 async function runProcessDownloads(): Promise<void> {
   const result = processDownloads()
   await vi.runAllTimersAsync()
@@ -91,6 +95,8 @@ describe('processDownloads', () => {
     process.env.MUX_DOWNLOAD_BACKFILL_MAX_QUALITY_COUNT
   const originalVideoIdPrefixes =
     process.env.MUX_DOWNLOAD_BACKFILL_VIDEO_ID_PREFIXES
+  const originalConcurrency = process.env.MUX_DOWNLOAD_BACKFILL_CONCURRENCY
+  const originalCursorFile = process.env.MUX_DOWNLOAD_BACKFILL_CURSOR_FILE
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -99,6 +105,8 @@ describe('processDownloads', () => {
     delete process.env.MUX_DOWNLOAD_BACKFILL_SAMPLE_SIZE
     delete process.env.MUX_DOWNLOAD_BACKFILL_MAX_QUALITY_COUNT
     delete process.env.MUX_DOWNLOAD_BACKFILL_VIDEO_ID_PREFIXES
+    delete process.env.MUX_DOWNLOAD_BACKFILL_CONCURRENCY
+    delete process.env.MUX_DOWNLOAD_BACKFILL_CURSOR_FILE
     ;(prismaMock.videoVariantDownload.findMany as Mock).mockResolvedValue([])
     ;(prismaMock.$queryRaw as unknown as Mock).mockResolvedValue([])
   })
@@ -123,6 +131,12 @@ describe('processDownloads', () => {
     else
       process.env.MUX_DOWNLOAD_BACKFILL_VIDEO_ID_PREFIXES =
         originalVideoIdPrefixes
+    if (originalConcurrency == null)
+      delete process.env.MUX_DOWNLOAD_BACKFILL_CONCURRENCY
+    else process.env.MUX_DOWNLOAD_BACKFILL_CONCURRENCY = originalConcurrency
+    if (originalCursorFile == null)
+      delete process.env.MUX_DOWNLOAD_BACKFILL_CURSOR_FILE
+    else process.env.MUX_DOWNLOAD_BACKFILL_CURSOR_FILE = originalCursorFile
   })
 
   it('throws for a non-positive sample size', async () => {
@@ -139,6 +153,15 @@ describe('processDownloads', () => {
 
     await expect(processDownloads()).rejects.toThrow(
       'MUX_DOWNLOAD_BACKFILL_MAX_QUALITY_COUNT must be a positive integer'
+    )
+    expect(prismaMock.videoVariantDownload.findMany).not.toHaveBeenCalled()
+  })
+
+  it('throws for a non-positive concurrency', async () => {
+    process.env.MUX_DOWNLOAD_BACKFILL_CONCURRENCY = '0'
+
+    await expect(processDownloads()).rejects.toThrow(
+      'MUX_DOWNLOAD_BACKFILL_CONCURRENCY must be a positive integer'
     )
     expect(prismaMock.videoVariantDownload.findMany).not.toHaveBeenCalled()
   })
@@ -452,6 +475,95 @@ describe('processDownloads', () => {
 
       const call = (prismaMock.$queryRaw as unknown as Mock).mock.calls[0]
       expect(JSON.stringify(call)).not.toContain('LEFT(v."videoId"')
+    })
+
+    it('never has more than MUX_DOWNLOAD_BACKFILL_CONCURRENCY variants in flight at once', async () => {
+      process.env.MUX_DOWNLOAD_BACKFILL_CONCURRENCY = '2'
+      ;(prismaMock.$queryRaw as unknown as Mock)
+        .mockResolvedValueOnce([
+          { id: 'variant-a' },
+          { id: 'variant-b' },
+          { id: 'variant-c' }
+        ])
+        .mockResolvedValueOnce([])
+      ;(prismaMock.videoVariant.findMany as Mock).mockResolvedValueOnce([
+        variant('variant-a'),
+        variant('variant-b'),
+        variant('variant-c')
+      ])
+      mockedPreviewMuxDownloadsFromAsset.mockReturnValue([])
+
+      let inFlight = 0
+      let maxInFlight = 0
+      const pendingResolves: Array<() => void> = []
+      mockedGetVideo.mockImplementation(() => {
+        inFlight++
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        return new Promise((resolve) => {
+          pendingResolves.push(() => {
+            inFlight--
+            resolve(readyMuxVideoAsset)
+          })
+        })
+      })
+
+      const resultPromise = processDownloads()
+
+      // First chunk (concurrency=2): variant-a and variant-b start together.
+      await vi.advanceTimersByTimeAsync(250)
+      expect(inFlight).toBe(2)
+      pendingResolves.splice(0).forEach((resolve) => resolve())
+
+      // Second chunk: only variant-c, started after the first chunk settles.
+      await vi.advanceTimersByTimeAsync(250)
+      pendingResolves.splice(0).forEach((resolve) => resolve())
+
+      await resultPromise
+
+      expect(maxInFlight).toBe(2)
+    })
+
+    it('resumes from a persisted cursor file and updates it after each page', async () => {
+      const cursorFile = join(
+        tmpdir(),
+        `mux-download-backfill-cursor-${Date.now()}.txt`
+      )
+      process.env.MUX_DOWNLOAD_BACKFILL_CURSOR_FILE = cursorFile
+
+      try {
+        ;(prismaMock.$queryRaw as unknown as Mock)
+          .mockResolvedValueOnce([{ id: 'variant-resumed' }])
+          .mockResolvedValueOnce([])
+        ;(prismaMock.videoVariant.findMany as Mock).mockResolvedValueOnce([
+          variant('variant-resumed')
+        ])
+        mockedGetVideo.mockResolvedValue(readyMuxVideoAsset)
+        mockedPreviewMuxDownloadsFromAsset.mockReturnValue([])
+
+        await runProcessDownloads()
+
+        expect(existsSync(cursorFile)).toBe(true)
+        expect(readFileSync(cursorFile, 'utf-8')).toBe('variant-resumed')
+
+        const firstCallValues = (prismaMock.$queryRaw as unknown as Mock).mock
+          .calls[0]
+        expect(firstCallValues).toContain('')
+
+        vi.clearAllMocks()
+        ;(prismaMock.videoVariantDownload.findMany as Mock).mockResolvedValue(
+          []
+        )
+        ;(prismaMock.$queryRaw as unknown as Mock).mockResolvedValue([])
+        mockedPreviewMuxDownloadsFromAsset.mockReturnValue([])
+
+        await runProcessDownloads()
+
+        const secondCallValues = (prismaMock.$queryRaw as unknown as Mock).mock
+          .calls[0]
+        expect(secondCallValues).toContain('variant-resumed')
+      } finally {
+        rmSync(cursorFile, { force: true })
+      }
     })
   })
 })

--- a/apis/api-media/src/scripts/mux-videos.ts
+++ b/apis/api-media/src/scripts/mux-videos.ts
@@ -555,7 +555,13 @@ export async function processDownloads(): Promise<void> {
       .map((prefix) => prefix.trim())
       .filter((prefix) => prefix.length > 0)
 
-  let missingRowsCursor = ''
+  // Optional resume point: this pass has no persisted cursor, so a run
+  // interrupted partway (connection drop, etc.) restarts from the very
+  // beginning of the scope on the next invocation, re-confirming everything
+  // already covered before reaching new ground. Set this to the last id an
+  // interrupted run logged to skip straight past it.
+  let missingRowsCursor =
+    process.env.MUX_DOWNLOAD_BACKFILL_START_AFTER_ID?.trim() ?? ''
   let hasMoreMissingRows = true
 
   while (hasMoreMissingRows) {

--- a/apis/api-media/src/scripts/mux-videos.ts
+++ b/apis/api-media/src/scripts/mux-videos.ts
@@ -415,7 +415,7 @@ export async function processDownloads(): Promise<void> {
         })
 
         console.log(
-          `Successfully created or refreshed ${createdCount} video downloads for variant ${variant.id}, muxVideoId: ${variant.muxVideo.id}`
+          `Successfully created, refreshed, or removed ${createdCount} video downloads for variant ${variant.id}, muxVideoId: ${variant.muxVideo.id}`
         )
 
         if (createdCount > 0) {

--- a/apis/api-media/src/scripts/mux-videos.ts
+++ b/apis/api-media/src/scripts/mux-videos.ts
@@ -19,6 +19,13 @@ const DISTRO_DOWNLOAD_QUALITIES = [
   VideoVariantDownloadQuality.distroSd,
   VideoVariantDownloadQuality.distroHigh
 ]
+// low, sd, high, fhd, qhd, uhd, highest -- every non-distro quality a ready
+// Mux asset can produce. Used as an upper bound when looking for variants
+// missing Mux download rows entirely (see the "missing rows" pass below), not
+// as a per-variant expectation: lower-resolution masters legitimately produce
+// fewer of these, and createDownloadsFromMuxAsset() is a safe no-op for rows
+// that already exist and don't need a metadata refresh.
+const MAX_REAL_DOWNLOAD_QUALITY_COUNT = 7
 
 function getMuxClient(): Mux {
   if (process.env.MUX_ACCESS_TOKEN_ID == null)
@@ -326,6 +333,12 @@ export async function processDownloads(): Promise<void> {
           console.log(
             `Preview for variant ${variant.id}, muxVideoId: ${variant.muxVideo.id}`
           )
+          if (variantZeroMetadataDownloads.length === 0) {
+            console.log(
+              `  ${previewDownloads.length} download row(s) would be created or refreshed (variant has fewer than ${MAX_REAL_DOWNLOAD_QUALITY_COUNT} Mux-hosted rows)`
+            )
+            return
+          }
           for (const download of variantZeroMetadataDownloads) {
             const replacement = previewByQuality.get(download.quality)
             if (replacement == null) {
@@ -502,6 +515,92 @@ export async function processDownloads(): Promise<void> {
       )
       await processVariant(variant, variantDownloads)
       totalProcessed++
+    }
+  }
+
+  // Second pass: the loop above only ever discovers variants that already
+  // have an EXISTING Mux-hosted download row with null/zero size or bitrate.
+  // A variant whose muxVideoId is set but that is missing a quality's row
+  // entirely -- never created, not just broken -- has no such row to match
+  // that query, so it's invisible to the pass above. Find those directly off
+  // VideoVariant and route them through the same processVariant() repair
+  // path; createDownloadsFromMuxAsset() only creates what's actually absent.
+  // Optional operational scope: a comma-separated list of videoId prefixes
+  // (e.g. "1_,MAG") to target a specific catalog cohort instead of scanning
+  // the whole table by ascending id -- useful when a prior investigation
+  // already sized a cohort's gap and an unscoped run would spend its sample
+  // budget on unrelated, lexicographically-earlier ids first.
+  const videoIdPrefixes = process.env.MUX_DOWNLOAD_BACKFILL_VIDEO_ID_PREFIXES?.split(
+    ','
+  )
+    .map((prefix) => prefix.trim())
+    .filter((prefix) => prefix.length > 0)
+
+  let missingRowsCursor = ''
+  let hasMoreMissingRows = true
+
+  while (hasMoreMissingRows) {
+    const remainingSampleSize =
+      sampleSize == null ? null : sampleSize - totalProcessed
+    if (remainingSampleSize != null && remainingSampleSize <= 0) {
+      break
+    }
+
+    const take =
+      remainingSampleSize == null ? 200 : Math.min(200, remainingSampleSize)
+
+    const prefixFilter =
+      videoIdPrefixes == null || videoIdPrefixes.length === 0
+        ? Prisma.empty
+        : Prisma.sql`AND (${Prisma.join(
+            // LEFT(...) = prefix, not LIKE 'prefix%' -- LIKE treats '_' as a
+            // single-character wildcard, so a literal prefix like "1_" would
+            // also match unrelated ids like "10_21028-...".
+            videoIdPrefixes.map(
+              (prefix) =>
+                Prisma.sql`LEFT(v."videoId", ${prefix.length}) = ${prefix}`
+            ),
+            ' OR '
+          )})`
+
+    const candidates = await prisma.$queryRaw<Array<{ id: string }>>`
+      SELECT v.id
+      FROM "VideoVariant" v
+      LEFT JOIN "VideoVariantDownload" d
+        ON d."videoVariantId" = v.id
+        AND d.url LIKE ${MUX_STREAM_BASE_URL + '/%'}
+      WHERE v."muxVideoId" IS NOT NULL
+        AND v.id > ${missingRowsCursor}
+        ${prefixFilter}
+      GROUP BY v.id
+      HAVING COUNT(d.id) < ${MAX_REAL_DOWNLOAD_QUALITY_COUNT}
+      ORDER BY v.id
+      LIMIT ${take}
+    `
+
+    if (candidates.length === 0) {
+      hasMoreMissingRows = false
+      break
+    }
+
+    const variants = await prisma.videoVariant.findMany({
+      where: { id: { in: candidates.map((candidate) => candidate.id) } },
+      include: { muxVideo: true }
+    })
+
+    console.log(
+      `Found ${variants.length} variants with fewer than ${MAX_REAL_DOWNLOAD_QUALITY_COUNT} Mux-hosted download rows to process in this batch`
+    )
+
+    for (const variant of variants) {
+      await processVariant(variant, [])
+      totalProcessed++
+    }
+
+    missingRowsCursor = candidates.at(-1)?.id ?? missingRowsCursor
+
+    if (candidates.length < take) {
+      hasMoreMissingRows = false
     }
   }
 

--- a/apis/api-media/src/scripts/mux-videos.ts
+++ b/apis/api-media/src/scripts/mux-videos.ts
@@ -1,3 +1,5 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+
 import Mux from '@mux/mux-node'
 
 import {
@@ -30,6 +32,26 @@ const DISTRO_DOWNLOAD_QUALITIES = [
 // 1440p/2160p masters, where qhd/uhd never appear and this default of 7
 // makes nearly every variant a false-positive candidate).
 const DEFAULT_MAX_REAL_DOWNLOAD_QUALITY_COUNT = 7
+
+// getVideo() is a lightweight read against Mux's Video API, not the asset
+// creation/upload calls importMuxVideos()/updateHls() serialize with their
+// own 2s sleeps -- there's no evidence it needs the same headroom. Bounded
+// concurrency (a handful of variants in flight at once, each with a small
+// stagger before its own call) gets meaningfully more throughput than one
+// request every 1.5s while staying well under the prod pool's
+// connection_limit and any reasonable Mux read-rate ceiling.
+const DEFAULT_PROCESS_CONCURRENCY = 4
+const MUX_API_CALL_STAGGER_MS = 250
+
+async function processConcurrently<T>(
+  items: T[],
+  concurrency: number,
+  handler: (item: T) => Promise<void>
+): Promise<void> {
+  for (let index = 0; index < items.length; index += concurrency) {
+    await Promise.all(items.slice(index, index + concurrency).map(handler))
+  }
+}
 
 function getMuxClient(): Mux {
   if (process.env.MUX_ACCESS_TOKEN_ID == null)
@@ -266,6 +288,18 @@ export async function processDownloads(): Promise<void> {
     )
   }
 
+  const concurrencyValue = process.env.MUX_DOWNLOAD_BACKFILL_CONCURRENCY?.trim()
+  const concurrency =
+    concurrencyValue != null && concurrencyValue !== ''
+      ? Number.parseInt(concurrencyValue, 10)
+      : DEFAULT_PROCESS_CONCURRENCY
+
+  if (!Number.isFinite(concurrency) || concurrency <= 0) {
+    throw new Error(
+      'MUX_DOWNLOAD_BACKFILL_CONCURRENCY must be a positive integer'
+    )
+  }
+
   if (applyChanges) {
     console.log('Apply mode enabled: download metadata rows will be refreshed')
   } else {
@@ -326,7 +360,7 @@ export async function processDownloads(): Promise<void> {
       return
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 1500))
+    await new Promise((resolve) => setTimeout(resolve, MUX_API_CALL_STAGGER_MS))
 
     try {
       const muxVideoAsset = await getVideo(variant.muxVideo.assetId, false)
@@ -489,12 +523,16 @@ export async function processDownloads(): Promise<void> {
       `Found ${variantsToProcess.length} variants with zero-metadata download rows to process in this batch`
     )
 
-    for (const variant of variantsToProcess) {
-      const variantZeroMetadataDownloads =
-        downloadsByVariant.get(variant.id) ?? []
-      await processVariant(variant, variantZeroMetadataDownloads)
-      totalProcessed++
-    }
+    await processConcurrently(
+      variantsToProcess,
+      concurrency,
+      async (variant) => {
+        const variantZeroMetadataDownloads =
+          downloadsByVariant.get(variant.id) ?? []
+        await processVariant(variant, variantZeroMetadataDownloads)
+      }
+    )
+    totalProcessed += variantsToProcess.length
 
     nextCursor = zeroMetadataDownloads.at(-1)?.id ?? null
 
@@ -555,13 +593,30 @@ export async function processDownloads(): Promise<void> {
       .map((prefix) => prefix.trim())
       .filter((prefix) => prefix.length > 0)
 
-  // Optional resume point: this pass has no persisted cursor, so a run
-  // interrupted partway (connection drop, etc.) restarts from the very
-  // beginning of the scope on the next invocation, re-confirming everything
-  // already covered before reaching new ground. Set this to the last id an
-  // interrupted run logged to skip straight past it.
+  // Optional resume point. MUX_DOWNLOAD_BACKFILL_START_AFTER_ID sets a
+  // one-off starting cursor (e.g. the last id an interrupted run logged).
+  // MUX_DOWNLOAD_BACKFILL_CURSOR_FILE goes further: given a file path, the
+  // cursor is read from it at startup (if present) and written back after
+  // every completed page, so a run interrupted by a connection drop or the
+  // process being killed can simply be re-invoked with the same file and
+  // pick up exactly where it left off -- no need to read logs and pass an
+  // explicit START_AFTER_ID by hand. An explicit START_AFTER_ID still wins
+  // over the file, for deliberately overriding a stale or missing cursor.
+  const cursorFilePath = process.env.MUX_DOWNLOAD_BACKFILL_CURSOR_FILE?.trim()
+  const cursorFromFile =
+    cursorFilePath != null && existsSync(cursorFilePath)
+      ? readFileSync(cursorFilePath, 'utf-8').trim()
+      : null
+
   let missingRowsCursor =
-    process.env.MUX_DOWNLOAD_BACKFILL_START_AFTER_ID?.trim() ?? ''
+    process.env.MUX_DOWNLOAD_BACKFILL_START_AFTER_ID?.trim() ??
+    cursorFromFile ??
+    ''
+  if (cursorFilePath != null) {
+    console.log(
+      `Missing-rows pass resuming from cursor: ${missingRowsCursor === '' ? '(start)' : missingRowsCursor} (file: ${cursorFilePath})`
+    )
+  }
   let hasMoreMissingRows = true
 
   while (hasMoreMissingRows) {
@@ -616,12 +671,15 @@ export async function processDownloads(): Promise<void> {
       `Found ${variants.length} variants with fewer than ${maxRealDownloadQualityCount} Mux-hosted download rows to process in this batch`
     )
 
-    for (const variant of variants) {
+    await processConcurrently(variants, concurrency, async (variant) => {
       await processVariant(variant, [])
-      totalProcessed++
-    }
+    })
+    totalProcessed += variants.length
 
     missingRowsCursor = candidates.at(-1)?.id ?? missingRowsCursor
+    if (cursorFilePath != null) {
+      writeFileSync(cursorFilePath, missingRowsCursor)
+    }
 
     if (candidates.length < take) {
       hasMoreMissingRows = false

--- a/apis/api-media/src/scripts/mux-videos.ts
+++ b/apis/api-media/src/scripts/mux-videos.ts
@@ -530,11 +530,10 @@ export async function processDownloads(): Promise<void> {
   // the whole table by ascending id -- useful when a prior investigation
   // already sized a cohort's gap and an unscoped run would spend its sample
   // budget on unrelated, lexicographically-earlier ids first.
-  const videoIdPrefixes = process.env.MUX_DOWNLOAD_BACKFILL_VIDEO_ID_PREFIXES?.split(
-    ','
-  )
-    .map((prefix) => prefix.trim())
-    .filter((prefix) => prefix.length > 0)
+  const videoIdPrefixes =
+    process.env.MUX_DOWNLOAD_BACKFILL_VIDEO_ID_PREFIXES?.split(',')
+      .map((prefix) => prefix.trim())
+      .filter((prefix) => prefix.length > 0)
 
   let missingRowsCursor = ''
   let hasMoreMissingRows = true
@@ -579,7 +578,6 @@ export async function processDownloads(): Promise<void> {
     `
 
     if (candidates.length === 0) {
-      hasMoreMissingRows = false
       break
     }
 

--- a/apis/api-media/src/scripts/mux-videos.ts
+++ b/apis/api-media/src/scripts/mux-videos.ts
@@ -24,8 +24,12 @@ const DISTRO_DOWNLOAD_QUALITIES = [
 // missing Mux download rows entirely (see the "missing rows" pass below), not
 // as a per-variant expectation: lower-resolution masters legitimately produce
 // fewer of these, and createDownloadsFromMuxAsset() is a safe no-op for rows
-// that already exist and don't need a metadata refresh.
-const MAX_REAL_DOWNLOAD_QUALITY_COUNT = 7
+// that already exist and don't need a metadata refresh. Overridable via
+// MUX_DOWNLOAD_BACKFILL_MAX_QUALITY_COUNT for a targeted run against a
+// cohort whose real ceiling is known to be lower (e.g. a catalog with no
+// 1440p/2160p masters, where qhd/uhd never appear and this default of 7
+// makes nearly every variant a false-positive candidate).
+const DEFAULT_MAX_REAL_DOWNLOAD_QUALITY_COUNT = 7
 
 function getMuxClient(): Mux {
   if (process.env.MUX_ACCESS_TOKEN_ID == null)
@@ -246,6 +250,22 @@ export async function processDownloads(): Promise<void> {
     )
   }
 
+  const maxQualityCountValue =
+    process.env.MUX_DOWNLOAD_BACKFILL_MAX_QUALITY_COUNT?.trim()
+  const maxRealDownloadQualityCount =
+    maxQualityCountValue != null && maxQualityCountValue !== ''
+      ? Number.parseInt(maxQualityCountValue, 10)
+      : DEFAULT_MAX_REAL_DOWNLOAD_QUALITY_COUNT
+
+  if (
+    !Number.isFinite(maxRealDownloadQualityCount) ||
+    maxRealDownloadQualityCount <= 0
+  ) {
+    throw new Error(
+      'MUX_DOWNLOAD_BACKFILL_MAX_QUALITY_COUNT must be a positive integer'
+    )
+  }
+
   if (applyChanges) {
     console.log('Apply mode enabled: download metadata rows will be refreshed')
   } else {
@@ -335,7 +355,7 @@ export async function processDownloads(): Promise<void> {
           )
           if (variantZeroMetadataDownloads.length === 0) {
             console.log(
-              `  ${previewDownloads.length} download row(s) would be created or refreshed (variant has fewer than ${MAX_REAL_DOWNLOAD_QUALITY_COUNT} Mux-hosted rows)`
+              `  ${previewDownloads.length} download row(s) would be created or refreshed (variant has fewer than ${maxRealDownloadQualityCount} Mux-hosted rows)`
             )
             return
           }
@@ -572,7 +592,7 @@ export async function processDownloads(): Promise<void> {
         AND v.id > ${missingRowsCursor}
         ${prefixFilter}
       GROUP BY v.id
-      HAVING COUNT(d.id) < ${MAX_REAL_DOWNLOAD_QUALITY_COUNT}
+      HAVING COUNT(d.id) < ${maxRealDownloadQualityCount}
       ORDER BY v.id
       LIMIT ${take}
     `
@@ -587,7 +607,7 @@ export async function processDownloads(): Promise<void> {
     })
 
     console.log(
-      `Found ${variants.length} variants with fewer than ${MAX_REAL_DOWNLOAD_QUALITY_COUNT} Mux-hosted download rows to process in this batch`
+      `Found ${variants.length} variants with fewer than ${maxRealDownloadQualityCount} Mux-hosted download rows to process in this batch`
     )
 
     for (const variant of variants) {


### PR DESCRIPTION
## Summary

Two bugs in the Mux download backfill/repair path (`processDownloads()` / `createDownloadsFromMuxAsset()`) meant a `VideoVariant` with a `muxVideoId` could keep incomplete or legacy `VideoVariantDownload` rows forever. Both are fixed here, and the backfill was run against prod.

**This is a data-quality fix. It is related to FGE-71 but, on current evidence, is not its cause** — see "What this does not fix" below.

### Bug 1: missing rows are invisible to the repair script

`processDownloads()`'s only discovery query (`zeroMetadataWhere`) finds variants that already have an **existing** `VideoVariantDownload` row pointing at `stream.mux.com` with null/zero size or bitrate — a repair-in-place query (see #9462, VMT-315). A variant with a `muxVideoId` but a quality's row **entirely absent** (never created, not broken) has nothing to match that query, so it can never be discovered or self-heal.

Fix: a second discovery pass finds `VideoVariant` rows with a `muxVideoId` but fewer than the seven possible non-distro Mux-hosted download rows, found directly off `VideoVariant`, and routes them through the same existing `processVariant()` → `createDownloadsFromMuxAsset()` repair path.

### Bug 2: legacy URLs permanently block the Mux replacement

`createDownloadsFromMuxAsset()` only ever created a row when the `(quality, variantId)` slot was empty, or repaired an existing *broken Mux* row — any other existing row (most commonly a legacy `api-media-core.jesusfilm.org` URL predating the Mux migration) was treated as "already fine" and left alone, permanently blocking the correct Mux replacement. Confirmed live against Mux: those assets are `ready` with complete, valid rendition data.

Fix: `createDownloadsFromMuxAsset()` now also replaces a non-Mux row occupying a real (non-distro) quality slot once a ready Mux asset can produce it. `distro*` rows are a separate quality enum this function never touches, so the Arclight distribution-center contract (schema.prisma:222-224) is unaffected.

### Operational improvements

- Bounded concurrency (`MUX_DOWNLOAD_BACKFILL_CONCURRENCY`, default 4) replaces a flat 1.5s sleep per variant inherited from asset-creation calls this read-only pass never needed — roughly a 10x throughput improvement.
- `MUX_DOWNLOAD_BACKFILL_CURSOR_FILE`: the missing-rows pass persists its cursor to a file and resumes from it automatically, so a run interrupted by a connection drop can be re-invoked with the same file. The cursor only advances past variants that completed, so a failed one is retried rather than skipped.

No changes to Mux asset creation/encoding (`createMuxAsset`/`importMuxVideos`) — this only reads existing ready assets via `getVideo()` and creates/repairs `VideoVariantDownload` rows. Nothing in this PR deletes a download row.

## What this does not fix (FGE-71)

A live check of prod while reviewing this PR showed the original root-cause theory was wrong:

- **The legacy origin does send `Content-Disposition: attachment`** (`api-media-core.jesusfilm.org`, via Cloudflare). Mux sends it only when the URL carries `?download=<name>`.
- **All 2,297 JESUS film variants already have Mux URLs in every low/sd/high/highest slot.** The remaining legacy rows are `distroLow`/`distroSd`/`distroHigh`, which this code never touches.
- The live jesusfilm.org/watch app (not in this repo) sorts **all** downloads by size, distro rows included, and picks largest = Highest, middle = High, smallest = Low. For English that makes High = `distroSd` and Low = `distroLow`, with Highest = `fhd` on Mux — which matches the report that only Highest downloads. Its download proxy (`/watch/api/download`) is sign-in gated and was not inspectable.

So FGE-71 most likely belongs to the watch app's quality tiering, not to these rows. Filed separately; FGE-71 stays open.

## Prod backfill results (JESUS Film / `1_`+`MAG` catalog, ~159k variants with a `muxVideoId`)

- Before: ~4,974 variants had incomplete Mux download rows.
- After both fixes: **0 variants blocked by a legacy URL**, and the only remaining incompleteness (2,600 variants) is variants whose master resolution is ≤720p — Mux correctly cannot produce a real 1080p `fhd` rendition for those, confirmed via masterHeight correlation. That's expected behavior, not a bug.

## Review changes

- Addressed CodeRabbit: reject malformed positive-integer env values (`5junk`), skip variants the zero-metadata pass already handled, word the dry-run line as a candidate check, type the test fixture.
- **Reverted `41ab59a`** (removing legacy rows for qualities a ready asset can't produce). It ran inside `createDownloadsFromMuxAsset()`, so it fired on every upload and reprocess through `processVideoDownloads`, not just in the backfill; it treated a quality as unproducible whenever the current build didn't produce it — including `qhd`/`uhd`, which `enableDownload` never requests, and renditions that merely `errored`; and the header check above shows those legacy rows were never the FGE-71 cause.
- Trimmed the settings that only existed to steer the one-off prod run: `MUX_DOWNLOAD_BACKFILL_VIDEO_ID_PREFIXES`, `MUX_DOWNLOAD_BACKFILL_START_AFTER_ID`, `MUX_DOWNLOAD_BACKFILL_MAX_QUALITY_COUNT` (the limit is now derived from `qualityEnumToOrder` rather than a hand-counted 7).

## Related

- FGE-71: https://linear.app/jesus-film-project/issue/FGE-71 (stays open — see "What this does not fix")
- FGE-91: https://linear.app/jesus-film-project/issue/FGE-91
- FGE-107: the 624 variants with neither a `muxVideoId` nor a `masterUrl`. https://linear.app/jesus-film-project/issue/FGE-107

## Test plan

- [x] 31 unit tests in `processing.spec.ts` covering `createDownloadsFromMuxAsset()`, including the legacy-URL replacement
- [x] 25 unit tests in `mux-videos.spec.ts` covering both discovery passes, env validation, bounded concurrency, and cursor-file resume including the failed-variant case
- [x] Full `api-media` suite (805 tests) passes via `nx test api-media`
- [x] `pnpm lint:changed --fix` clean
- [x] `nx affected --target=type-check --base=origin/main` clean
- [x] Full backfill run against prod for the JESUS Film cohort, with SQL verification confirming the gap is closed down to the expected-behavior floor

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Media download processing now supports bounded concurrency for faster, more reliable backfills.
  * Interrupted backfill operations can resume from their last completed position.
  * Missing download records are automatically discovered and restored across supported quality levels.
* **Bug Fixes**
  * Legacy origin-server downloads are replaced with Mux-hosted downloads when appropriate.
  * Incomplete or failed download records are refreshed more reliably.
  * Invalid processing settings are now rejected with clearer validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->