### PR TITLE
fix(api-media): fix Know God slug and reject non-public-style Video slugs (FGE-97/98)

### DIFF
--- a/apis/api-media/project.json
+++ b/apis/api-media/project.json
@@ -182,6 +182,13 @@
         "command": "pnpm exec tsx --tsconfig apis/api-media/tsconfig.app.json apis/api-media/src/scripts/run-parent-variant-audit.ts"
       }
     },
+    "fix-know-god-slug": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["prisma-media:prisma-generate"],
+      "options": {
+        "command": "pnpm exec tsx --tsconfig apis/api-media/tsconfig.app.json apis/api-media/src/scripts/run-fix-know-god-slug.ts"
+      }
+    },
     "populate-crowdin-ids": {
       "executor": "nx:run-commands",
       "options": {

--- a/apis/api-media/src/lib/slugify/index.ts
+++ b/apis/api-media/src/lib/slugify/index.ts
@@ -1,1 +1,1 @@
-export { slugify } from './slugify'
+export { slugify, isPublicSlug } from './slugify'

--- a/apis/api-media/src/lib/slugify/slugify.spec.ts
+++ b/apis/api-media/src/lib/slugify/slugify.spec.ts
@@ -1,4 +1,4 @@
-import { slugify } from '.'
+import { isPublicSlug, slugify } from '.'
 
 describe('slugify', () => {
   it('transforms My Title to my-title', () => {
@@ -41,5 +41,27 @@ describe('slugify', () => {
 
   it('replaces dash space with dash', () => {
     expect(slugify('id', 'Bob- And- Mary')).toBe('bob-and-mary')
+  })
+})
+
+describe('isPublicSlug', () => {
+  it('accepts an already public-style slug', () => {
+    expect(isPublicSlug('know-god')).toBe(true)
+  })
+
+  it('rejects an internal-style slug with underscores and mixed case', () => {
+    expect(isPublicSlug('Nua_Know_God')).toBe(false)
+  })
+
+  it('rejects uppercase letters', () => {
+    expect(isPublicSlug('Know-God')).toBe(false)
+  })
+
+  it('rejects underscores even when already lowercase', () => {
+    expect(isPublicSlug('know_god')).toBe(false)
+  })
+
+  it('rejects spaces', () => {
+    expect(isPublicSlug('know god')).toBe(false)
   })
 })

--- a/apis/api-media/src/lib/slugify/slugify.ts
+++ b/apis/api-media/src/lib/slugify/slugify.ts
@@ -35,3 +35,10 @@ export function slugify(
   usedSlugs[slug] = id
   return slug
 }
+
+// A slug is public-style if it's already a fixed point of convertToSlug -
+// i.e. lowercase, with runs of anything other than letters/numbers collapsed
+// to single hyphens and no leading/trailing hyphen.
+export function isPublicSlug(slug: string): boolean {
+  return convertToSlug(slug) === slug
+}

--- a/apis/api-media/src/schema/video/video.spec.ts
+++ b/apis/api-media/src/schema/video/video.spec.ts
@@ -2724,6 +2724,41 @@ describe('video', () => {
         expect(result).toHaveProperty('data', null)
       })
 
+      it('should reject a non-public-style slug', async () => {
+        prismaMock.userMediaRole.findUnique.mockResolvedValue({
+          id: 'userId',
+          userId: 'userId',
+          roles: ['publisher'],
+          createdAt: new Date(),
+          updatedAt: new Date()
+        })
+
+        const result = await authClient({
+          document: CREATE_VIDEO_MUTATION,
+          variables: {
+            input: {
+              id: 'id',
+              label: VideoLabel.featureFilm,
+              primaryLanguageId: 'primaryLanguageId',
+              published: true,
+              slug: 'Nua_Know_God',
+              noIndex: true,
+              childIds: [],
+              originId: 'originId'
+            }
+          }
+        })
+
+        expect(prismaMock.video.create).not.toHaveBeenCalled()
+        expect(result).toHaveProperty('data', null)
+        expect(result).toHaveProperty('errors')
+        expect(
+          'errors' in result ? result.errors?.[0]?.message : undefined
+        ).toBe(
+          'Slug must be lowercase, with words separated by hyphens (e.g. "jesus-walks-on-water")'
+        )
+      })
+
       it('should create video with publishedAt when published is true', async () => {
         prismaMock.userMediaRole.findUnique.mockResolvedValue({
           id: 'userId',
@@ -2921,6 +2956,41 @@ describe('video', () => {
           expect.anything()
         )
         expect(mockedFindContainerParentIds).toHaveBeenCalledWith('id')
+      })
+
+      it('should reject a non-public-style slug', async () => {
+        prismaMock.userMediaRole.findUnique.mockResolvedValue({
+          id: 'userId',
+          userId: 'userId',
+          roles: ['publisher'],
+          createdAt: new Date(),
+          updatedAt: new Date()
+        })
+        prismaMock.video.findUnique.mockResolvedValue({
+          published: false,
+          publishedAt: null,
+          slug: 'old-slug',
+          variants: []
+        } as any)
+
+        const result = await authClient({
+          document: VIDEO_UPDATE_MUTATION,
+          variables: {
+            input: {
+              id: 'id',
+              slug: 'Nua_Know_God'
+            }
+          }
+        })
+
+        expect(prismaMock.video.update).not.toHaveBeenCalled()
+        expect(result).toHaveProperty('data', null)
+        expect(result).toHaveProperty('errors')
+        expect(
+          'errors' in result ? result.errors?.[0]?.message : undefined
+        ).toBe(
+          'Slug must be lowercase, with words separated by hyphens (e.g. "jesus-walks-on-water")'
+        )
       })
 
       it('should enable restrictTranslations', async () => {

--- a/apis/api-media/src/schema/video/video.ts
+++ b/apis/api-media/src/schema/video/video.ts
@@ -9,6 +9,7 @@ import {
   prisma
 } from '@core/prisma/media/client'
 
+import { isPublicSlug } from '../../lib/slugify'
 import { videoCacheReset } from '../../lib/videoCacheReset'
 import {
   enqueueVideoAlgoliaSync,
@@ -662,6 +663,12 @@ builder.mutationFields((t) => ({
       input: t.arg({ type: VideoCreateInput, required: true })
     },
     resolve: async (query, _parent, { input }) => {
+      if (!isPublicSlug(input.slug)) {
+        throw new Error(
+          'Slug must be lowercase, with words separated by hyphens (e.g. "jesus-walks-on-water")'
+        )
+      }
+
       // Handle child relation synchronization if childIds is provided
       let childRelationData = {}
       if (input.childIds && input.childIds.length > 0) {
@@ -764,6 +771,12 @@ builder.mutationFields((t) => ({
         currentVideo?.publishedAt != null
       ) {
         throw new Error('Cannot change slug after video has been published')
+      }
+
+      if (input.slug != null && !isPublicSlug(input.slug)) {
+        throw new Error(
+          'Slug must be lowercase, with words separated by hyphens (e.g. "jesus-walks-on-water")'
+        )
       }
 
       if (

--- a/apis/api-media/src/scripts/README.md
+++ b/apis/api-media/src/scripts/README.md
@@ -196,7 +196,10 @@ If any error occurs, the script will log the error and continue processing other
 One-off fix for the "Know God" video (id `7_KnowGod`), which was imported with
 an internal-style slug (`Nua_Know_God`) instead of a public-style slug.
 Renames `Video.slug` to `know-god` and every `VideoVariant.slug` that still
-carries the `Nua_Know_God/` prefix to the matching `know-god/` prefix.
+carries the `Nua_Know_God/` prefix to the matching `know-god/` prefix, then
+calls `videoCacheReset`/`videoVariantCacheReset` for each row it changes so
+the Yoga response cache and the Watch app's ISR cache don't keep serving the
+old slug.
 
 ### Usage
 
@@ -209,3 +212,13 @@ nx run api-media:fix-know-god-slug
 The script is idempotent: it reads the current slug first, and only writes
 when it still matches the old value, so re-running it after the fix has
 already landed is a no-op.
+
+### Note on the slug-permanence invariant
+
+`Video.slug`'s GraphQL description states "slug is a permanent link to the
+video" (`apis/api-media/src/schema/video/video.ts`), and the `videoUpdate`
+mutation enforces that once a video is published. This script deliberately
+overrides that invariant for one already-malformed, non-functional slug
+(`Nua_Know_God` never resolved to a working public route — see FGE-97), not
+as a general-purpose slug-editing tool. Don't reuse this script's approach
+for a video whose old slug is a live, working public route.

--- a/apis/api-media/src/scripts/README.md
+++ b/apis/api-media/src/scripts/README.md
@@ -190,3 +190,22 @@ The script includes comprehensive error handling for:
 - Network connectivity issues
 
 If any error occurs, the script will log the error and continue processing other items when possible.
+
+## Fix Know God Slug Script (FGE-97/98)
+
+One-off fix for the "Know God" video (id `7_KnowGod`), which was imported with
+an internal-style slug (`Nua_Know_God`) instead of a public-style slug.
+Renames `Video.slug` to `know-god` and every `VideoVariant.slug` that still
+carries the `Nua_Know_God/` prefix to the matching `know-god/` prefix.
+
+### Usage
+
+```bash
+nx run api-media:fix-know-god-slug
+```
+
+### Process
+
+The script is idempotent: it reads the current slug first, and only writes
+when it still matches the old value, so re-running it after the fix has
+already landed is a no-op.

--- a/apis/api-media/src/scripts/fix-know-god-slug.spec.ts
+++ b/apis/api-media/src/scripts/fix-know-god-slug.spec.ts
@@ -1,8 +1,17 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Mock, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { prismaMock } from '../../test/prismaMock'
+import { videoCacheReset, videoVariantCacheReset } from '../lib/videoCacheReset'
 
 import { fixKnowGodSlug } from './fix-know-god-slug'
+
+vi.mock('../lib/videoCacheReset', () => ({
+  videoCacheReset: vi.fn(),
+  videoVariantCacheReset: vi.fn()
+}))
+
+const mockedVideoCacheReset = videoCacheReset as unknown as Mock
+const mockedVideoVariantCacheReset = videoVariantCacheReset as unknown as Mock
 
 describe('fixKnowGodSlug', () => {
   beforeEach(() => {
@@ -36,6 +45,9 @@ describe('fixKnowGodSlug', () => {
       where: { id: '3934_7_KnowGod' },
       data: { slug: 'know-god/russian' }
     })
+    expect(mockedVideoCacheReset).toHaveBeenCalledWith('7_KnowGod')
+    expect(mockedVideoVariantCacheReset).toHaveBeenCalledWith('529_7_KnowGod')
+    expect(mockedVideoVariantCacheReset).toHaveBeenCalledWith('3934_7_KnowGod')
   })
 
   it('is a no-op when the slug has already been fixed', async () => {
@@ -49,6 +61,8 @@ describe('fixKnowGodSlug', () => {
     expect(result).toEqual({ videoUpdated: false, variantIdsUpdated: [] })
     expect(prismaMock.video.update).not.toHaveBeenCalled()
     expect(prismaMock.videoVariant.update).not.toHaveBeenCalled()
+    expect(mockedVideoCacheReset).not.toHaveBeenCalled()
+    expect(mockedVideoVariantCacheReset).not.toHaveBeenCalled()
   })
 
   it('does not touch a variant slug belonging to a different video prefix', async () => {

--- a/apis/api-media/src/scripts/fix-know-god-slug.spec.ts
+++ b/apis/api-media/src/scripts/fix-know-god-slug.spec.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { prismaMock } from '../../test/prismaMock'
+
+import { fixKnowGodSlug } from './fix-know-god-slug'
+
+describe('fixKnowGodSlug', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renames the video slug and every variant slug that still uses the old prefix', async () => {
+    prismaMock.video.findUniqueOrThrow.mockResolvedValue({
+      slug: 'Nua_Know_God',
+      variants: [
+        { id: '529_7_KnowGod', slug: 'Nua_Know_God/english' },
+        { id: '3934_7_KnowGod', slug: 'Nua_Know_God/russian' }
+      ]
+    } as never)
+
+    const result = await fixKnowGodSlug()
+
+    expect(result).toEqual({
+      videoUpdated: true,
+      variantIdsUpdated: ['529_7_KnowGod', '3934_7_KnowGod']
+    })
+    expect(prismaMock.video.update).toHaveBeenCalledWith({
+      where: { id: '7_KnowGod' },
+      data: { slug: 'know-god' }
+    })
+    expect(prismaMock.videoVariant.update).toHaveBeenCalledWith({
+      where: { id: '529_7_KnowGod' },
+      data: { slug: 'know-god/english' }
+    })
+    expect(prismaMock.videoVariant.update).toHaveBeenCalledWith({
+      where: { id: '3934_7_KnowGod' },
+      data: { slug: 'know-god/russian' }
+    })
+  })
+
+  it('is a no-op when the slug has already been fixed', async () => {
+    prismaMock.video.findUniqueOrThrow.mockResolvedValue({
+      slug: 'know-god',
+      variants: [{ id: '529_7_KnowGod', slug: 'know-god/english' }]
+    } as never)
+
+    const result = await fixKnowGodSlug()
+
+    expect(result).toEqual({ videoUpdated: false, variantIdsUpdated: [] })
+    expect(prismaMock.video.update).not.toHaveBeenCalled()
+    expect(prismaMock.videoVariant.update).not.toHaveBeenCalled()
+  })
+
+  it('does not touch a variant slug belonging to a different video prefix', async () => {
+    prismaMock.video.findUniqueOrThrow.mockResolvedValue({
+      slug: 'Nua_Know_God',
+      variants: [
+        { id: '529_7_KnowGod', slug: 'Nua_Know_God/english' },
+        { id: 'other-variant', slug: 'some-other-video/english' }
+      ]
+    } as never)
+
+    const result = await fixKnowGodSlug()
+
+    expect(result.variantIdsUpdated).toEqual(['529_7_KnowGod'])
+    expect(prismaMock.videoVariant.update).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apis/api-media/src/scripts/fix-know-god-slug.ts
+++ b/apis/api-media/src/scripts/fix-know-god-slug.ts
@@ -1,5 +1,7 @@
 import { prisma } from '@core/prisma/media/client'
 
+import { videoCacheReset, videoVariantCacheReset } from '../lib/videoCacheReset'
+
 // FGE-97/98: the "Know God" video was imported with an internal-style slug
 // (Nua_Know_God) instead of the public-style slug used by other videos.
 const VIDEO_ID = '7_KnowGod'
@@ -26,6 +28,7 @@ export async function fixKnowGodSlug(): Promise<FixKnowGodSlugResult> {
       where: { id: VIDEO_ID },
       data: { slug: NEW_SLUG }
     })
+    await videoCacheReset(VIDEO_ID)
   }
 
   const variantIdsUpdated: string[] = []
@@ -36,6 +39,7 @@ export async function fixKnowGodSlug(): Promise<FixKnowGodSlugResult> {
       where: { id: variant.id },
       data: { slug: variant.slug.replace(`${OLD_SLUG}/`, `${NEW_SLUG}/`) }
     })
+    await videoVariantCacheReset(variant.id)
     variantIdsUpdated.push(variant.id)
   }
 

--- a/apis/api-media/src/scripts/fix-know-god-slug.ts
+++ b/apis/api-media/src/scripts/fix-know-god-slug.ts
@@ -1,0 +1,43 @@
+import { prisma } from '@core/prisma/media/client'
+
+// FGE-97/98: the "Know God" video was imported with an internal-style slug
+// (Nua_Know_God) instead of the public-style slug used by other videos.
+const VIDEO_ID = '7_KnowGod'
+const OLD_SLUG = 'Nua_Know_God'
+const NEW_SLUG = 'know-god'
+
+export type FixKnowGodSlugResult = {
+  videoUpdated: boolean
+  variantIdsUpdated: string[]
+}
+
+export async function fixKnowGodSlug(): Promise<FixKnowGodSlugResult> {
+  const video = await prisma.video.findUniqueOrThrow({
+    where: { id: VIDEO_ID },
+    select: {
+      slug: true,
+      variants: { select: { id: true, slug: true } }
+    }
+  })
+
+  const videoUpdated = video.slug === OLD_SLUG
+  if (videoUpdated) {
+    await prisma.video.update({
+      where: { id: VIDEO_ID },
+      data: { slug: NEW_SLUG }
+    })
+  }
+
+  const variantIdsUpdated: string[] = []
+  for (const variant of video.variants) {
+    if (!variant.slug.startsWith(`${OLD_SLUG}/`)) continue
+
+    await prisma.videoVariant.update({
+      where: { id: variant.id },
+      data: { slug: variant.slug.replace(`${OLD_SLUG}/`, `${NEW_SLUG}/`) }
+    })
+    variantIdsUpdated.push(variant.id)
+  }
+
+  return { videoUpdated, variantIdsUpdated }
+}

--- a/apis/api-media/src/scripts/run-fix-know-god-slug.ts
+++ b/apis/api-media/src/scripts/run-fix-know-god-slug.ts
@@ -1,0 +1,10 @@
+import { logger } from '../logger'
+
+import { fixKnowGodSlug } from './fix-know-god-slug'
+
+async function main(): Promise<void> {
+  const result = await fixKnowGodSlug()
+  logger.info({ result }, 'Know God slug fix result')
+}
+
+void main()

--- a/apps/videos-admin/src/app/(dashboard)/videos/_VideoCreateForm/VideoCreateForm.spec.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/_VideoCreateForm/VideoCreateForm.spec.tsx
@@ -201,6 +201,20 @@ describe('VideoCreateForm', () => {
       })
     })
 
+    it('warns when slug contains underscores', async () => {
+      const user = userEvent.setup()
+      await user.type(screen.getByLabelText(/Slug/i), 'jesus_walks')
+      fireEvent.click(screen.getByText('Create'))
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'Slug can only contain lowercase letters, numbers and hyphens'
+          )
+        ).toBeInTheDocument()
+      })
+    })
+
     it('navigates to videos list when Cancel button is clicked', () => {
       fireEvent.click(screen.getByText('Cancel'))
       expect(mockRouterPush).toHaveBeenCalledWith('/videos')

--- a/apps/videos-admin/src/app/(dashboard)/videos/_VideoCreateForm/VideoCreateForm.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/_VideoCreateForm/VideoCreateForm.tsx
@@ -90,7 +90,7 @@ export function VideoCreateForm({
     slug: string()
       .trim()
       .required('Slug is required')
-      .test('lowercase-no-spaces', function lowercaseNoSpaces(value) {
+      .test('valid-slug-format', function validSlugFormat(value) {
         if (value == null || value === '') return true
         const hasUppercase = /[A-Z]/.test(value)
         const hasSpaces = /\s/.test(value)
@@ -107,6 +107,14 @@ export function VideoCreateForm({
         if (hasSpaces) {
           return this.createError({
             message: 'Slug cannot contain spaces'
+          })
+        }
+        // Anything left over that isn't a lowercase letter, number or hyphen
+        // (underscores included) is not a public-style slug.
+        if (/[^a-z0-9-]/.test(value)) {
+          return this.createError({
+            message:
+              'Slug can only contain lowercase letters, numbers and hyphens'
           })
         }
         return true


### PR DESCRIPTION
## Summary

- Fixes the "Know God" video's malformed slug (`Nua_Know_God` → `know-god`) via a one-off, idempotent data-fix script (`nx run api-media:fix-know-god-slug`), following the repo's existing direct-Prisma script pattern (`audit-parent-variants`). **Already run against production** — `Video 7_KnowGod` and its 5 `VideoVariant` rows are confirmed live with the new slug.
- Adds prevention: `Video.slug` had no format validation anywhere (only a DB uniqueness constraint), and the videos-admin create form only caught uppercase/spaces, not underscores. `videoCreate`/`videoUpdate` now reject non-public-style slugs server-side, and the admin form catches underscores/other punctuation before submit too.

## Context

Root-caused via Linear (FGE-97/FGE-98, closed as Duplicate of FGE-27): searching "Know God" on Watch found the series but clicking it bounced to the homepage. Production `watchSearch` confirmed every candidate URL under the old slug 404'd — the malformed internal-style slug (`Nua_Know_God`) never resolved to a working public route.

**Note:** this fixes the Core-side data (surface #1 of 3 identified in FGE-97's root-cause comment). Two more surfaces remain open in the separate `JesusFilm/forge` repo — Admin's collection-availability derivation for containers with no route at all, and the still-unmerged FGE-2 web fallback fix (so a null action never silently renders as a `/watch` link). The public Watch page still 404s as of this PR; that requires the forge-side work too. Flagging so FGE-97/98 aren't treated as fully resolved by this alone.

The `fge2-slug-audit` (sibling session) is running a full catalog-wide audit of this same slug-format bug class (687+ high-confidence hits found) — this PR doesn't duplicate that scan, just fixes the one reported record and closes the validation gap that let it happen.

## Changes

- `apis/api-media/src/scripts/fix-know-god-slug.ts` (+spec, +runner, +nx target, +README) — the data fix, with cache invalidation (`videoCacheReset`/`videoVariantCacheReset`) after each write.
- `apis/api-media/src/lib/slugify/slugify.ts` — new `isPublicSlug()`, reusing the existing `convertToSlug` rules (a slug is valid if it's already its own fixed point).
- `apis/api-media/src/schema/video/video.ts` — `videoCreate`/`videoUpdate` reject non-public-style slugs.
- `apps/videos-admin/.../VideoCreateForm.tsx` — form validation now also catches underscores/other invalid characters, not just uppercase/spaces.

Deliberately **not** extended to `VideoVariant.slug` (`videoVariantUpdate`) — same gap, but a different two-segment shape and an existing, more permissive helper (`extractLanguageSlugFromVariantSlug`) that needs separate, careful handling. Left as a known follow-up.

## Test plan

- [x] `apis/api-media` full suite: 79 files / 802 tests passing
- [x] `apps/videos-admin` full suite: 100 files / 469 tests passing (10 pre-existing skips)
- [x] `pnpm lint:changed --fix` clean
- [x] `nx affected --target=type-check --base=origin/main` clean (api-media, videos-admin, videos-admin-e2e)
- [x] Verified live in production via read-only GraphQL query: `Video.slug` and all 5 `VideoVariant.slug` rows updated correctly
- [ ] Public Watch page rendering — **not** covered by this PR (forge-repo work required)

https://claude.ai/code/session_01QVMcMpTmUyZaNM4gtwh6Hf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation requiring video slugs to use lowercase letters, numbers, and hyphens.
  - Added an automated migration to update the affected “Know God” video and related variants to public-friendly slugs.
- **Bug Fixes**
  - Prevented video creation and updates when slugs contain underscores, uppercase letters, spaces, or other invalid characters.
  - Added clear validation feedback in the video administration form.
- **Documentation**
  - Documented the one-time slug migration and its cache-refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->