### PR TITLE
feat(videos-admin): demote superseded Variant Upload attempts on the Audio Languages tab

### DIFF
--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/audio/_IncompleteVideoVariantUploadItems.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/audio/_IncompleteVideoVariantUploadItems.tsx
@@ -2,18 +2,21 @@
 
 import AddIcon from '@mui/icons-material/Add'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import ExpandLessIcon from '@mui/icons-material/ExpandLess'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import ReplayIcon from '@mui/icons-material/Replay'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Chip from '@mui/material/Chip'
+import Collapse from '@mui/material/Collapse'
 import IconButton from '@mui/material/IconButton'
 import ListItem from '@mui/material/ListItem'
 import Stack from '@mui/material/Stack'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import { useSnackbar } from 'notistack'
-import { useCallback } from 'react'
+import { type ReactElement, useCallback, useState } from 'react'
 
 type VideoVariantUploadStatus =
   | 'created'
@@ -48,7 +51,7 @@ export interface VideoVariantUploadRow {
   createdAt?: string | null
 }
 
-export const incompleteUploadStatuses: VideoVariantUploadStatus[] = [
+const incompleteUploadStatuses: VideoVariantUploadStatus[] = [
   'created',
   'r2Prepared',
   'r2Uploaded',
@@ -56,6 +59,23 @@ export const incompleteUploadStatuses: VideoVariantUploadStatus[] = [
   'muxReady',
   'failed'
 ]
+
+// Successful attempts are requested alongside the incomplete ones because they
+// are the only evidence that an earlier incomplete attempt has been superseded.
+export const uploadHistoryStatuses: VideoVariantUploadStatus[] = [
+  ...incompleteUploadStatuses,
+  'variantCreated'
+]
+
+const uploadStatusLabels: Record<VideoVariantUploadStatus, string> = {
+  created: 'Upload not complete',
+  r2Prepared: 'Upload not complete',
+  r2Uploaded: 'Ready to process',
+  muxCreated: 'Processing',
+  muxReady: 'Ready to finalize',
+  variantCreated: 'Complete',
+  failed: 'Failed'
+}
 
 const STANDARD_MUX_PROCESSING_STALE_MS = 30 * 60 * 1000
 const NON_STANDARD_MUX_PROCESSING_STALE_MS = 2 * 60 * 60 * 1000
@@ -70,7 +90,8 @@ interface IncompleteUploadDisplayState {
 }
 
 interface IncompleteVideoVariantUploadItemsProps {
-  uploads: VideoVariantUploadRow[]
+  outstandingUploads: VideoVariantUploadRow[]
+  supersededUploads: VideoVariantUploadRow[]
   resumingUploadId: string | null
   isResumeRequestInFlight: boolean
   onAddAudioLanguage: () => void
@@ -234,17 +255,17 @@ function getIncompleteUploadDisplayState(
     case 'created':
     case 'r2Prepared':
       return {
-        label: 'Upload not complete',
+        label: uploadStatusLabels[upload.status],
         color: 'warning',
         message:
-          'This upload cannot be resumed because the browser did not finish sending the file to R2. Add this audio language again.',
+          'This upload cannot be resumed because the browser did not finish sending the file to R2. Start a fresh upload for this language.',
         processingDurationLabel: null,
         action: 'addAgain',
-        actionLabel: 'Add again'
+        actionLabel: 'Start fresh upload'
       }
     case 'r2Uploaded':
       return {
-        label: 'Ready to process',
+        label: uploadStatusLabels[upload.status],
         color: 'warning',
         message:
           'The file uploaded successfully. Start processing to continue.',
@@ -265,7 +286,7 @@ function getIncompleteUploadDisplayState(
       }
 
       return {
-        label: 'Processing',
+        label: uploadStatusLabels[upload.status],
         color: 'info',
         message: 'Mux is processing this upload. No action needed.',
         processingDurationLabel: getMuxProcessingDurationLabel(upload),
@@ -274,7 +295,7 @@ function getIncompleteUploadDisplayState(
       }
     case 'muxReady':
       return {
-        label: 'Ready to finalize',
+        label: uploadStatusLabels[upload.status],
         color: 'info',
         message: 'Mux is ready. Finalize this audio language.',
         processingDurationLabel: null,
@@ -283,7 +304,7 @@ function getIncompleteUploadDisplayState(
       }
     case 'failed':
       return {
-        label: 'Failed',
+        label: uploadStatusLabels[upload.status],
         color: 'error',
         message: null,
         processingDurationLabel: null,
@@ -292,7 +313,7 @@ function getIncompleteUploadDisplayState(
       }
     case 'variantCreated':
       return {
-        label: 'Complete',
+        label: uploadStatusLabels[upload.status],
         color: 'info',
         message: null,
         processingDurationLabel: null,
@@ -302,14 +323,83 @@ function getIncompleteUploadDisplayState(
   }
 }
 
+function getUploadMetaLabel(upload: VideoVariantUploadRow): string {
+  const languagePrefix =
+    upload.language?.name?.[0]?.value != null ? `${upload.languageId} • ` : ''
+  const filenameSuffix =
+    upload.originalFilename != null ? ` • ${upload.originalFilename}` : ''
+
+  return `${languagePrefix}${upload.edition} • ${upload.source}${filenameSuffix}`
+}
+
+interface SupersededUploadGroup {
+  languageId: string
+  languageLabel: string
+  uploads: VideoVariantUploadRow[]
+}
+
+/**
+ * One summary line per audio language, so a language that took five attempts
+ * occupies one row rather than five. Input order is preserved, so groups and
+ * the attempts within them stay newest-first.
+ */
+function groupSupersededUploadsByLanguage(
+  uploads: VideoVariantUploadRow[]
+): SupersededUploadGroup[] {
+  const groups = new Map<string, SupersededUploadGroup>()
+
+  for (const upload of uploads) {
+    const group = groups.get(upload.languageId)
+
+    if (group == null) {
+      groups.set(upload.languageId, {
+        languageId: upload.languageId,
+        languageLabel: getUploadLanguageLabel(upload),
+        uploads: [upload]
+      })
+      continue
+    }
+
+    group.uploads.push(upload)
+  }
+
+  return [...groups.values()]
+}
+
+export function getUploadCreatedAtMs(
+  upload: VideoVariantUploadRow
+): number | null {
+  if (upload.createdAt == null) return null
+
+  const createdAtMs = Date.parse(upload.createdAt)
+  return Number.isFinite(createdAtMs) ? createdAtMs : null
+}
+
+function getUploadTimestampLabel(upload: VideoVariantUploadRow): string | null {
+  const createdAtMs = getUploadCreatedAtMs(upload)
+  if (createdAtMs == null) return null
+
+  return new Date(createdAtMs).toLocaleString()
+}
+
 export function IncompleteVideoVariantUploadItems({
-  uploads,
+  outstandingUploads,
+  supersededUploads,
   resumingUploadId,
   isResumeRequestInFlight,
   onAddAudioLanguage,
   onResumeUpload
-}: IncompleteVideoVariantUploadItemsProps) {
+}: IncompleteVideoVariantUploadItemsProps): ReactElement {
   const { enqueueSnackbar } = useSnackbar()
+  const [expandedLanguageIds, setExpandedLanguageIds] = useState<string[]>([])
+
+  const handleTogglePreviousAttempts = useCallback((languageId: string) => {
+    setExpandedLanguageIds((expanded) =>
+      expanded.includes(languageId)
+        ? expanded.filter((id) => id !== languageId)
+        : [...expanded, languageId]
+    )
+  }, [])
 
   const handleCopyUploadDetails = useCallback(
     async (upload: VideoVariantUploadRow) => {
@@ -323,145 +413,258 @@ export function IncompleteVideoVariantUploadItems({
     [enqueueSnackbar]
   )
 
-  return uploads.map((upload) => {
-    const isResuming = resumingUploadId === upload.id
-    const displayState = getIncompleteUploadDisplayState(upload)
-
-    return (
-      <ListItem
-        key={upload.id}
-        sx={{
-          border: '1px solid',
-          borderColor: 'warning.light',
-          backgroundColor: 'background.default',
-          borderRadius: 1,
-          p: 1,
-          mb: 1,
-          minHeight: 66,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between'
-        }}
-      >
-        <Box sx={{ minWidth: 0 }}>
-          <Stack
-            direction="row"
-            sx={{
-              gap: 1,
-              alignItems: 'center',
-              flexWrap: 'wrap'
-            }}
-          >
-            <Typography
-              variant="body2"
-              sx={{
-                fontWeight: 600
-              }}
-            >
-              {getUploadLanguageLabel(upload)}
-            </Typography>
-            <Chip
-              size="small"
-              label={displayState.label}
-              color={displayState.color}
-            />
-          </Stack>
-          <Typography
-            variant="caption"
-            sx={{
-              color: 'text.secondary'
-            }}
-          >
-            {upload.language?.name?.[0]?.value != null
-              ? `${upload.languageId} • `
-              : ''}
-            {upload.edition} • {upload.source}
-            {upload.originalFilename != null
-              ? ` • ${upload.originalFilename}`
-              : ''}
-          </Typography>
-          {displayState.message != null && (
-            <Typography
-              variant="caption"
-              sx={{
-                color: 'text.secondary',
-                display: 'block'
-              }}
-            >
-              {displayState.message}
-            </Typography>
-          )}
-          {displayState.processingDurationLabel != null && (
-            <Typography
-              variant="caption"
-              sx={{
-                color: 'text.secondary',
-                display: 'block'
-              }}
-            >
-              {displayState.processingDurationLabel}
-            </Typography>
-          )}
-          {upload.errorMessage != null && (
-            <Typography
-              variant="caption"
-              sx={{
-                color: 'error.main',
-                display: 'block'
-              }}
-            >
-              {upload.errorMessage}
-            </Typography>
-          )}
-        </Box>
-        <Stack
-          direction="row"
-          sx={{
-            gap: 0.5,
-            alignItems: 'center',
-            ml: 1
-          }}
+  const renderUploadDetailActions = (upload: VideoVariantUploadRow) => (
+    <>
+      <Tooltip title={getUploadDebugTooltip(upload)} placement="left" arrow>
+        <IconButton size="small" aria-label="view upload details">
+          <InfoOutlinedIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Copy upload details" arrow>
+        <IconButton
+          size="small"
+          aria-label="copy upload details"
+          onClick={() => void handleCopyUploadDetails(upload)}
         >
-          <Tooltip title={getUploadDebugTooltip(upload)} placement="left" arrow>
-            <IconButton size="small" aria-label="view upload details">
-              <InfoOutlinedIcon fontSize="small" />
-            </IconButton>
-          </Tooltip>
-          <Tooltip title="Copy upload details" arrow>
-            <IconButton
-              size="small"
-              aria-label="copy upload details"
-              onClick={() => void handleCopyUploadDetails(upload)}
-            >
-              <ContentCopyIcon fontSize="small" />
-            </IconButton>
-          </Tooltip>
-          {displayState.action != null && displayState.actionLabel != null && (
-            <Button
-              size="small"
-              variant="outlined"
-              startIcon={
-                isResuming ? undefined : displayState.action === 'addAgain' ? (
-                  <AddIcon />
-                ) : (
-                  <ReplayIcon />
-                )
-              }
-              disabled={resumingUploadId != null || isResumeRequestInFlight}
-              onClick={() => {
-                if (displayState.action === 'addAgain') {
-                  onAddAudioLanguage()
-                  return
-                }
+          <ContentCopyIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+    </>
+  )
 
-                onResumeUpload(upload.id)
+  return (
+    <>
+      {outstandingUploads.map((upload) => {
+        const isResuming = resumingUploadId === upload.id
+        const displayState = getIncompleteUploadDisplayState(upload)
+
+        return (
+          <ListItem
+            key={upload.id}
+            sx={{
+              border: '1px solid',
+              borderColor: 'warning.light',
+              backgroundColor: 'background.default',
+              borderRadius: 1,
+              p: 1,
+              mb: 1,
+              minHeight: 66,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between'
+            }}
+          >
+            <Box sx={{ minWidth: 0 }}>
+              <Stack
+                direction="row"
+                sx={{
+                  gap: 1,
+                  alignItems: 'center',
+                  flexWrap: 'wrap'
+                }}
+              >
+                <Typography
+                  variant="body2"
+                  sx={{
+                    fontWeight: 600
+                  }}
+                >
+                  {getUploadLanguageLabel(upload)}
+                </Typography>
+                <Chip
+                  size="small"
+                  label={displayState.label}
+                  color={displayState.color}
+                />
+              </Stack>
+              <Typography
+                variant="caption"
+                sx={{
+                  color: 'text.secondary'
+                }}
+              >
+                {getUploadMetaLabel(upload)}
+              </Typography>
+              {displayState.message != null && (
+                <Typography
+                  variant="caption"
+                  sx={{
+                    color: 'text.secondary',
+                    display: 'block'
+                  }}
+                >
+                  {displayState.message}
+                </Typography>
+              )}
+              {displayState.processingDurationLabel != null && (
+                <Typography
+                  variant="caption"
+                  sx={{
+                    color: 'text.secondary',
+                    display: 'block'
+                  }}
+                >
+                  {displayState.processingDurationLabel}
+                </Typography>
+              )}
+              {upload.errorMessage != null && (
+                <Typography
+                  variant="caption"
+                  sx={{
+                    color: 'error.main',
+                    display: 'block'
+                  }}
+                >
+                  {upload.errorMessage}
+                </Typography>
+              )}
+            </Box>
+            <Stack
+              direction="row"
+              sx={{
+                gap: 0.5,
+                alignItems: 'center',
+                ml: 1
               }}
             >
-              {isResuming ? 'Working...' : displayState.actionLabel}
-            </Button>
-          )}
-        </Stack>
-      </ListItem>
-    )
-  })
+              {renderUploadDetailActions(upload)}
+              {displayState.action != null &&
+                displayState.actionLabel != null && (
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    startIcon={
+                      isResuming ? undefined : displayState.action ===
+                        'addAgain' ? (
+                        <AddIcon />
+                      ) : (
+                        <ReplayIcon />
+                      )
+                    }
+                    disabled={
+                      resumingUploadId != null || isResumeRequestInFlight
+                    }
+                    onClick={() => {
+                      if (displayState.action === 'addAgain') {
+                        onAddAudioLanguage()
+                        return
+                      }
+
+                      onResumeUpload(upload.id)
+                    }}
+                  >
+                    {isResuming ? 'Working...' : displayState.actionLabel}
+                  </Button>
+                )}
+            </Stack>
+          </ListItem>
+        )
+      })}
+      {groupSupersededUploadsByLanguage(supersededUploads).map((group) => {
+        const isExpanded = expandedLanguageIds.includes(group.languageId)
+
+        return (
+          <ListItem
+            key={`superseded-${group.languageId}`}
+            sx={{
+              border: '1px solid',
+              borderColor: 'divider',
+              backgroundColor: 'background.default',
+              borderRadius: 1,
+              p: 1,
+              mb: 1,
+              display: 'block'
+            }}
+          >
+            <Stack
+              direction="row"
+              sx={{ gap: 1, alignItems: 'center', flexWrap: 'wrap' }}
+            >
+              <Typography
+                variant="body2"
+                sx={{ fontWeight: 600, color: 'text.secondary' }}
+              >
+                {group.languageLabel}
+              </Typography>
+              <Button
+                size="small"
+                aria-expanded={isExpanded}
+                aria-label={`previous attempts for ${group.languageLabel}`}
+                startIcon={isExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                onClick={() => handleTogglePreviousAttempts(group.languageId)}
+                sx={{ color: 'text.secondary', textTransform: 'none' }}
+              >
+                {`Previous attempts (${group.uploads.length})`}
+              </Button>
+            </Stack>
+            <Typography
+              variant="caption"
+              sx={{ color: 'text.secondary', display: 'block' }}
+            >
+              Superseded by a later successful upload. No action needed.
+            </Typography>
+            <Collapse in={isExpanded} unmountOnExit>
+              <Stack sx={{ gap: 1, mt: 1 }}>
+                {group.uploads.map((upload) => {
+                  const timestampLabel = getUploadTimestampLabel(upload)
+
+                  return (
+                    <Box
+                      key={upload.id}
+                      data-testid="SupersededUploadAttempt"
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        gap: 1,
+                        borderTop: '1px solid',
+                        borderColor: 'divider',
+                        pt: 1
+                      }}
+                    >
+                      <Box sx={{ minWidth: 0 }}>
+                        <Chip
+                          size="small"
+                          variant="outlined"
+                          label={uploadStatusLabels[upload.status]}
+                        />
+                        <Typography
+                          variant="caption"
+                          sx={{ color: 'text.secondary', display: 'block' }}
+                        >
+                          {getUploadMetaLabel(upload)}
+                        </Typography>
+                        {timestampLabel != null && (
+                          <Typography
+                            variant="caption"
+                            sx={{ color: 'text.secondary', display: 'block' }}
+                          >
+                            {timestampLabel}
+                          </Typography>
+                        )}
+                        {upload.errorMessage != null && (
+                          <Typography
+                            variant="caption"
+                            sx={{ color: 'text.secondary', display: 'block' }}
+                          >
+                            {upload.errorMessage}
+                          </Typography>
+                        )}
+                      </Box>
+                      <Stack
+                        direction="row"
+                        sx={{ gap: 0.5, alignItems: 'center', ml: 1 }}
+                      >
+                        {renderUploadDetailActions(upload)}
+                      </Stack>
+                    </Box>
+                  )
+                })}
+              </Stack>
+            </Collapse>
+          </ListItem>
+        )
+      })}
+    </>
+  )
 }

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/audio/_IncompleteVideoVariantUploadItems.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/audio/_IncompleteVideoVariantUploadItems.tsx
@@ -77,6 +77,14 @@ const uploadStatusLabels: Record<VideoVariantUploadStatus, string> = {
   failed: 'Failed'
 }
 
+const uploadCardSx = {
+  border: '1px solid',
+  backgroundColor: 'background.default',
+  borderRadius: 1,
+  p: 1,
+  mb: 1
+} as const
+
 const STANDARD_MUX_PROCESSING_STALE_MS = 30 * 60 * 1000
 const NON_STANDARD_MUX_PROCESSING_STALE_MS = 2 * 60 * 60 * 1000
 
@@ -251,11 +259,15 @@ function getUploadDebugTooltip(upload: VideoVariantUploadRow) {
 function getIncompleteUploadDisplayState(
   upload: VideoVariantUploadRow
 ): IncompleteUploadDisplayState {
+  // The status alone decides the label; the switch decides only how the row
+  // reads and what it offers. Stale Mux processing is the one override.
+  const label = uploadStatusLabels[upload.status]
+
   switch (upload.status) {
     case 'created':
     case 'r2Prepared':
       return {
-        label: uploadStatusLabels[upload.status],
+        label,
         color: 'warning',
         message:
           'This upload cannot be resumed because the browser did not finish sending the file to R2. Start a fresh upload for this language.',
@@ -265,7 +277,7 @@ function getIncompleteUploadDisplayState(
       }
     case 'r2Uploaded':
       return {
-        label: uploadStatusLabels[upload.status],
+        label,
         color: 'warning',
         message:
           'The file uploaded successfully. Start processing to continue.',
@@ -286,7 +298,7 @@ function getIncompleteUploadDisplayState(
       }
 
       return {
-        label: uploadStatusLabels[upload.status],
+        label,
         color: 'info',
         message: 'Mux is processing this upload. No action needed.',
         processingDurationLabel: getMuxProcessingDurationLabel(upload),
@@ -295,7 +307,7 @@ function getIncompleteUploadDisplayState(
       }
     case 'muxReady':
       return {
-        label: uploadStatusLabels[upload.status],
+        label,
         color: 'info',
         message: 'Mux is ready. Finalize this audio language.',
         processingDurationLabel: null,
@@ -304,16 +316,18 @@ function getIncompleteUploadDisplayState(
       }
     case 'failed':
       return {
-        label: uploadStatusLabels[upload.status],
+        label,
         color: 'error',
         message: null,
         processingDurationLabel: null,
         action: 'resume',
         actionLabel: 'Retry'
       }
+    // Unreachable in practice — the partition never renders a successful
+    // attempt — but the switch must stay exhaustive over the status union.
     case 'variantCreated':
       return {
-        label: uploadStatusLabels[upload.status],
+        label,
         color: 'info',
         message: null,
         processingDurationLabel: null,
@@ -333,15 +347,20 @@ function getUploadMetaLabel(upload: VideoVariantUploadRow): string {
 }
 
 interface SupersededUploadGroup {
-  languageId: string
+  key: string
   languageLabel: string
+  edition: string
   uploads: VideoVariantUploadRow[]
 }
 
 /**
- * One summary line per audio language, so a language that took five attempts
- * occupies one row rather than five. Input order is preserved, so groups and
- * the attempts within them stay newest-first.
+ * One summary line per audio language *and edition*, matching the key the
+ * supersession rule itself uses, so a completed `base` history never reports a
+ * count that silently includes Burned In attempts.
+ *
+ * Display ordering is owned here rather than by the caller: attempts run
+ * newest-first within a group, and groups run newest-first by their most
+ * recent attempt.
  */
 function groupSupersededUploadsByLanguage(
   uploads: VideoVariantUploadRow[]
@@ -349,12 +368,14 @@ function groupSupersededUploadsByLanguage(
   const groups = new Map<string, SupersededUploadGroup>()
 
   for (const upload of uploads) {
-    const group = groups.get(upload.languageId)
+    const key = `${upload.languageId}\u0000${upload.edition}`
+    const group = groups.get(key)
 
     if (group == null) {
-      groups.set(upload.languageId, {
-        languageId: upload.languageId,
+      groups.set(key, {
+        key,
         languageLabel: getUploadLanguageLabel(upload),
+        edition: upload.edition,
         uploads: [upload]
       })
       continue
@@ -363,7 +384,19 @@ function groupSupersededUploadsByLanguage(
     group.uploads.push(upload)
   }
 
-  return [...groups.values()]
+  const byCreatedAtDescending = (
+    a: VideoVariantUploadRow,
+    b: VideoVariantUploadRow
+  ): number => (getUploadCreatedAtMs(b) ?? 0) - (getUploadCreatedAtMs(a) ?? 0)
+
+  const sortedGroups = [...groups.values()].map((group) => ({
+    ...group,
+    uploads: [...group.uploads].sort(byCreatedAtDescending)
+  }))
+
+  return sortedGroups.sort((a, b) =>
+    byCreatedAtDescending(a.uploads[0], b.uploads[0])
+  )
 }
 
 export function getUploadCreatedAtMs(
@@ -391,13 +424,13 @@ export function IncompleteVideoVariantUploadItems({
   onResumeUpload
 }: IncompleteVideoVariantUploadItemsProps): ReactElement {
   const { enqueueSnackbar } = useSnackbar()
-  const [expandedLanguageIds, setExpandedLanguageIds] = useState<string[]>([])
+  const [expandedGroupKeys, setExpandedGroupKeys] = useState<string[]>([])
 
-  const handleTogglePreviousAttempts = useCallback((languageId: string) => {
-    setExpandedLanguageIds((expanded) =>
-      expanded.includes(languageId)
-        ? expanded.filter((id) => id !== languageId)
-        : [...expanded, languageId]
+  const handleTogglePreviousAttempts = useCallback((groupKey: string) => {
+    setExpandedGroupKeys((expanded) =>
+      expanded.includes(groupKey)
+        ? expanded.filter((key) => key !== groupKey)
+        : [...expanded, groupKey]
     )
   }, [])
 
@@ -413,7 +446,9 @@ export function IncompleteVideoVariantUploadItems({
     [enqueueSnackbar]
   )
 
-  const renderUploadDetailActions = (upload: VideoVariantUploadRow) => (
+  const renderUploadDetailActions = (
+    upload: VideoVariantUploadRow
+  ): ReactElement => (
     <>
       <Tooltip title={getUploadDebugTooltip(upload)} placement="left" arrow>
         <IconButton size="small" aria-label="view upload details">
@@ -442,12 +477,8 @@ export function IncompleteVideoVariantUploadItems({
           <ListItem
             key={upload.id}
             sx={{
-              border: '1px solid',
+              ...uploadCardSx,
               borderColor: 'warning.light',
-              backgroundColor: 'background.default',
-              borderRadius: 1,
-              p: 1,
-              mb: 1,
               minHeight: 66,
               display: 'flex',
               alignItems: 'center',
@@ -561,20 +592,12 @@ export function IncompleteVideoVariantUploadItems({
         )
       })}
       {groupSupersededUploadsByLanguage(supersededUploads).map((group) => {
-        const isExpanded = expandedLanguageIds.includes(group.languageId)
+        const isExpanded = expandedGroupKeys.includes(group.key)
 
         return (
           <ListItem
-            key={`superseded-${group.languageId}`}
-            sx={{
-              border: '1px solid',
-              borderColor: 'divider',
-              backgroundColor: 'background.default',
-              borderRadius: 1,
-              p: 1,
-              mb: 1,
-              display: 'block'
-            }}
+            key={`superseded-${group.key}`}
+            sx={{ ...uploadCardSx, borderColor: 'divider', display: 'block' }}
           >
             <Stack
               direction="row"
@@ -586,12 +609,15 @@ export function IncompleteVideoVariantUploadItems({
               >
                 {group.languageLabel}
               </Typography>
+              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                {group.edition}
+              </Typography>
               <Button
                 size="small"
                 aria-expanded={isExpanded}
-                aria-label={`previous attempts for ${group.languageLabel}`}
+                aria-label={`previous attempts for ${group.languageLabel} (${group.edition})`}
                 startIcon={isExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-                onClick={() => handleTogglePreviousAttempts(group.languageId)}
+                onClick={() => handleTogglePreviousAttempts(group.key)}
                 sx={{ color: 'text.secondary', textTransform: 'none' }}
               >
                 {`Previous attempts (${group.uploads.length})`}

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/audio/layout.spec.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/audio/layout.spec.tsx
@@ -233,7 +233,8 @@ describe('ClientLayout', () => {
               'r2Uploaded',
               'muxCreated',
               'muxReady',
-              'failed'
+              'failed',
+              'variantCreated'
             ]
           },
           limit: 100,
@@ -264,7 +265,8 @@ describe('ClientLayout', () => {
               'r2Uploaded',
               'muxCreated',
               'muxReady',
-              'failed'
+              'failed',
+              'variantCreated'
             ]
           },
           limit: 100,
@@ -555,7 +557,7 @@ describe('ClientLayout', () => {
     dateNowSpy.mockRestore()
 
     expect(screen.getAllByText('Upload not complete')).toHaveLength(2)
-    expect(screen.getAllByText('Add again')).toHaveLength(2)
+    expect(screen.getAllByText('Start fresh upload')).toHaveLength(2)
     expect(screen.getByText('Ready to process')).toBeTruthy()
     expect(screen.getByText('Start processing')).toBeTruthy()
     expect(screen.getByText('Processing')).toBeTruthy()
@@ -676,7 +678,7 @@ describe('ClientLayout', () => {
       </MockedProvider>
     )
 
-    fireEvent.click(screen.getAllByText('Add again')[0])
+    fireEvent.click(screen.getAllByText('Start fresh upload')[0])
 
     expect(mockPush).toHaveBeenCalledWith('/videos/video123/audio/add', {
       scroll: false
@@ -1282,6 +1284,546 @@ describe('ClientLayout', () => {
       )
       expect(mockRefetch).toHaveBeenCalled()
     })
+  })
+
+  function buildQueryResult(
+    data: unknown,
+    overrides: Partial<QueryResult<any, OperationVariables>> = {}
+  ): QueryResult<any, OperationVariables> {
+    return {
+      data,
+      loading: false,
+      error: undefined,
+      fetchMore: vi.fn(),
+      refetch: mockRefetch,
+      networkStatus: NetworkStatus.ready,
+      client: {} as any,
+      called: true,
+      startPolling: vi.fn(),
+      stopPolling: vi.fn(),
+      subscribeToMore: vi.fn(),
+      updateQuery: vi.fn(),
+      observable: {} as any,
+      variables: {},
+      reobserve: vi.fn(),
+      previousData: undefined,
+      ...overrides
+    } as QueryResult<any, OperationVariables>
+  }
+
+  function mockUploadQueries(
+    getUploads: () => any[],
+    uploadOverrides: Partial<QueryResult<any, OperationVariables>> = {},
+    variants: any[] = mockVideoVariants
+  ) {
+    const mockedUseQuery = useQuery as MockedFunction<typeof useQuery>
+
+    mockedUseQuery.mockImplementation((_query, options?: any) => {
+      if (options?.variables?.input?.statuses != null) {
+        return buildQueryResult(
+          { videoVariantUploads: getUploads() },
+          { variables: options.variables, ...uploadOverrides }
+        )
+      }
+
+      return buildQueryResult({
+        adminVideo: {
+          id: 'video123',
+          slug: 'test-video',
+          published: true,
+          variants
+        }
+      })
+    })
+  }
+
+  function uploadRow(overrides: Record<string, unknown>) {
+    return {
+      source: 'videos-admin',
+      sourceKey: 'source-key',
+      videoId: 'video123',
+      languageId: '184631',
+      language: { id: '184631', name: [{ value: 'Farsi' }] },
+      edition: 'base',
+      originalFilename: 'farsi.mp4',
+      contentType: 'video/mp4',
+      contentLength: '12345',
+      errorMessage: null,
+      r2AssetId: null,
+      muxVideoId: null,
+      muxNonStandardInputDetectedAt: null,
+      videoVariantId: null,
+      updatedAt: '2026-06-18T00:00:00.000Z',
+      createdAt: '2026-06-18T00:00:00.000Z',
+      ...overrides
+    }
+  }
+
+  function renderLayout() {
+    return render(
+      <MockedProvider>
+        <ClientLayout>
+          <div>Child content</div>
+        </ClientLayout>
+      </MockedProvider>
+    )
+  }
+
+  it('demotes an incomplete attempt that a later successful attempt superseded', () => {
+    mockUploadQueries(() => [
+      uploadRow({
+        id: 'upload-failed',
+        status: 'failed',
+        errorMessage: 'Mux video processing errored',
+        createdAt: '2026-06-18T00:00:00.000Z'
+      }),
+      uploadRow({
+        id: 'upload-succeeded',
+        status: 'variantCreated',
+        videoVariantId: 'variant-1',
+        createdAt: '2026-06-19T00:00:00.000Z'
+      })
+    ])
+
+    renderLayout()
+
+    expect(screen.queryByText('Failed')).toBeNull()
+    expect(screen.queryByText('Retry')).toBeNull()
+    expect(screen.getByText('Previous attempts (1)')).toBeInTheDocument()
+  })
+
+  it('never renders a successful attempt as an incomplete row', () => {
+    mockUploadQueries(() => [
+      uploadRow({
+        id: 'upload-succeeded',
+        status: 'variantCreated',
+        videoVariantId: 'variant-1',
+        createdAt: '2026-06-19T00:00:00.000Z'
+      })
+    ])
+
+    renderLayout()
+
+    expect(screen.queryByText('Complete')).toBeNull()
+    expect(screen.queryByText(/Previous attempts/)).toBeNull()
+    expect(screen.queryByText('Farsi')).toBeNull()
+  })
+
+  it('keeps an attempt outstanding when no later attempt succeeded', () => {
+    mockUploadQueries(() => [
+      uploadRow({
+        id: 'upload-failed',
+        status: 'failed',
+        errorMessage: 'Mux video processing errored',
+        createdAt: '2026-06-18T00:00:00.000Z'
+      })
+    ])
+
+    renderLayout()
+
+    expect(screen.getByText('Failed')).toBeInTheDocument()
+    expect(screen.getByText('Retry')).toBeInTheDocument()
+    expect(screen.queryByText(/Previous attempts/)).toBeNull()
+  })
+
+  it('keeps an attempt outstanding when the only later success is a different edition', () => {
+    mockUploadQueries(() => [
+      uploadRow({
+        id: 'upload-failed',
+        status: 'failed',
+        edition: 'burnedIn',
+        errorMessage: 'Mux video processing errored',
+        createdAt: '2026-06-18T00:00:00.000Z'
+      }),
+      uploadRow({
+        id: 'upload-succeeded',
+        status: 'variantCreated',
+        edition: 'base',
+        videoVariantId: 'variant-1',
+        createdAt: '2026-06-19T00:00:00.000Z'
+      })
+    ])
+
+    renderLayout()
+
+    expect(screen.getByText('Failed')).toBeInTheDocument()
+    expect(screen.queryByText(/Previous attempts/)).toBeNull()
+  })
+
+  it('keeps an attempt outstanding when the only later success is a different audio language', () => {
+    mockUploadQueries(() => [
+      uploadRow({
+        id: 'upload-failed',
+        status: 'failed',
+        languageId: '184631',
+        language: { id: '184631', name: [{ value: 'Farsi' }] },
+        errorMessage: 'Mux video processing errored',
+        createdAt: '2026-06-18T00:00:00.000Z'
+      }),
+      uploadRow({
+        id: 'upload-succeeded',
+        status: 'variantCreated',
+        languageId: '496',
+        language: { id: '496', name: [{ value: 'French' }] },
+        videoVariantId: 'variant-1',
+        createdAt: '2026-06-19T00:00:00.000Z'
+      })
+    ])
+
+    renderLayout()
+
+    expect(screen.getByText('Failed')).toBeInTheDocument()
+    expect(screen.queryByText(/Previous attempts/)).toBeNull()
+  })
+
+  it('keeps an attempt that failed after the most recent success outstanding', () => {
+    mockUploadQueries(() => [
+      uploadRow({
+        id: 'upload-succeeded',
+        status: 'variantCreated',
+        videoVariantId: 'variant-1',
+        createdAt: '2026-06-18T00:00:00.000Z'
+      }),
+      uploadRow({
+        id: 'upload-failed',
+        status: 'failed',
+        errorMessage: 'Replacement dub failed',
+        createdAt: '2026-06-19T00:00:00.000Z'
+      })
+    ])
+
+    renderLayout()
+
+    expect(screen.getByText('Failed')).toBeInTheDocument()
+    expect(screen.getByText('Replacement dub failed')).toBeInTheDocument()
+    expect(screen.getByText('Retry')).toBeInTheDocument()
+    expect(screen.queryByText(/Previous attempts/)).toBeNull()
+  })
+
+  it('collapses a language with several superseded attempts into one summary reporting the count', () => {
+    mockUploadQueries(() => [
+      uploadRow({
+        id: 'upload-1',
+        status: 'r2Prepared',
+        createdAt: '2026-06-15T00:00:00.000Z'
+      }),
+      uploadRow({
+        id: 'upload-2',
+        status: 'failed',
+        errorMessage: 'first failure',
+        createdAt: '2026-06-16T00:00:00.000Z'
+      }),
+      uploadRow({
+        id: 'upload-3',
+        status: 'muxCreated',
+        createdAt: '2026-06-17T00:00:00.000Z'
+      }),
+      uploadRow({
+        id: 'upload-succeeded',
+        status: 'variantCreated',
+        videoVariantId: 'variant-1',
+        createdAt: '2026-06-19T00:00:00.000Z'
+      })
+    ])
+
+    renderLayout()
+
+    expect(screen.getByText('Previous attempts (3)')).toBeInTheDocument()
+    expect(screen.queryByText('first failure')).toBeNull()
+    expect(screen.queryByText('Upload not complete')).toBeNull()
+  })
+
+  it('summarises previous attempts per audio language', () => {
+    mockUploadQueries(() => [
+      uploadRow({
+        id: 'farsi-1',
+        status: 'failed',
+        errorMessage: 'farsi failure',
+        createdAt: '2026-06-15T00:00:00.000Z'
+      }),
+      uploadRow({
+        id: 'farsi-2',
+        status: 'r2Prepared',
+        createdAt: '2026-06-16T00:00:00.000Z'
+      }),
+      uploadRow({
+        id: 'farsi-success',
+        status: 'variantCreated',
+        videoVariantId: 'variant-farsi',
+        createdAt: '2026-06-19T00:00:00.000Z'
+      }),
+      uploadRow({
+        id: 'french-1',
+        status: 'failed',
+        languageId: '496',
+        language: { id: '496', name: [{ value: 'French' }] },
+        errorMessage: 'french failure',
+        createdAt: '2026-06-15T00:00:00.000Z'
+      }),
+      uploadRow({
+        id: 'french-success',
+        status: 'variantCreated',
+        languageId: '496',
+        language: { id: '496', name: [{ value: 'French' }] },
+        videoVariantId: 'variant-french',
+        createdAt: '2026-06-19T00:00:00.000Z'
+      })
+    ])
+
+    renderLayout()
+
+    expect(
+      screen.getByLabelText('previous attempts for Farsi')
+    ).toHaveTextContent('Previous attempts (2)')
+    expect(
+      screen.getByLabelText('previous attempts for French')
+    ).toHaveTextContent('Previous attempts (1)')
+
+    fireEvent.click(screen.getByLabelText('previous attempts for French'))
+
+    expect(screen.getByText('french failure')).toBeInTheDocument()
+    expect(screen.queryByText('farsi failure')).toBeNull()
+  })
+
+  it('reveals each superseded attempt in newest-first order when the summary is expanded', () => {
+    mockUploadQueries(() => [
+      uploadRow({
+        id: 'upload-older',
+        status: 'r2Prepared',
+        originalFilename: 'older-farsi.mp4',
+        createdAt: '2026-06-15T00:00:00.000Z'
+      }),
+      uploadRow({
+        id: 'upload-newer',
+        status: 'failed',
+        originalFilename: 'newer-farsi.mp4',
+        errorMessage: 'second attempt failed',
+        createdAt: '2026-06-16T00:00:00.000Z'
+      }),
+      uploadRow({
+        id: 'upload-succeeded',
+        status: 'variantCreated',
+        videoVariantId: 'variant-1',
+        createdAt: '2026-06-19T00:00:00.000Z'
+      })
+    ])
+
+    renderLayout()
+
+    fireEvent.click(screen.getByText('Previous attempts (2)'))
+
+    expect(screen.getByText('Failed')).toBeInTheDocument()
+    expect(screen.getByText('Upload not complete')).toBeInTheDocument()
+    expect(screen.getByText(/newer-farsi\.mp4/)).toBeInTheDocument()
+    expect(screen.getByText(/older-farsi\.mp4/)).toBeInTheDocument()
+    expect(screen.getByText('second attempt failed')).toBeInTheDocument()
+    expect(
+      screen.getByText(new Date('2026-06-16T00:00:00.000Z').toLocaleString())
+    ).toBeInTheDocument()
+
+    const attemptFilenames = screen
+      .getAllByTestId('SupersededUploadAttempt')
+      .map((element) => element.textContent)
+    expect(attemptFilenames[0]).toContain('newer-farsi.mp4')
+    expect(attemptFilenames[1]).toContain('older-farsi.mp4')
+  })
+
+  it('renders no action control on superseded attempts but keeps the copy action', () => {
+    mockUploadQueries(() => [
+      uploadRow({
+        id: 'upload-unresumable',
+        status: 'r2Prepared',
+        createdAt: '2026-06-15T00:00:00.000Z'
+      }),
+      uploadRow({
+        id: 'upload-failed',
+        status: 'failed',
+        errorMessage: 'first failure',
+        createdAt: '2026-06-16T00:00:00.000Z'
+      }),
+      uploadRow({
+        id: 'upload-succeeded',
+        status: 'variantCreated',
+        videoVariantId: 'variant-1',
+        createdAt: '2026-06-19T00:00:00.000Z'
+      })
+    ])
+
+    renderLayout()
+    fireEvent.click(screen.getByText('Previous attempts (2)'))
+
+    expect(screen.queryByText('Start fresh upload')).toBeNull()
+    expect(screen.queryByText('Retry')).toBeNull()
+    expect(screen.getAllByLabelText('copy upload details')).toHaveLength(2)
+  })
+
+  it('starts polling while an outstanding attempt exists', () => {
+    const uploadStartPolling = vi.fn()
+    mockUploadQueries(
+      () => [
+        uploadRow({
+          id: 'upload-failed',
+          status: 'failed',
+          errorMessage: 'still outstanding',
+          createdAt: '2026-06-19T00:00:00.000Z'
+        })
+      ],
+      { startPolling: uploadStartPolling }
+    )
+
+    renderLayout()
+
+    expect(uploadStartPolling).toHaveBeenCalledWith(3000)
+  })
+
+  it('stops polling when only superseded attempts remain', () => {
+    const uploadStartPolling = vi.fn()
+    const uploadStopPolling = vi.fn()
+    mockUploadQueries(
+      () => [
+        uploadRow({
+          id: 'upload-failed',
+          status: 'failed',
+          errorMessage: 'old failure',
+          createdAt: '2026-06-18T00:00:00.000Z'
+        }),
+        uploadRow({
+          id: 'upload-succeeded',
+          status: 'variantCreated',
+          videoVariantId: 'variant-1',
+          createdAt: '2026-06-19T00:00:00.000Z'
+        })
+      ],
+      { startPolling: uploadStartPolling, stopPolling: uploadStopPolling }
+    )
+
+    renderLayout()
+
+    expect(uploadStartPolling).not.toHaveBeenCalled()
+    expect(uploadStopPolling).toHaveBeenCalled()
+  })
+
+  it('shows only the history affordance when every incomplete attempt is superseded', () => {
+    mockUploadQueries(
+      () => [
+        uploadRow({
+          id: 'upload-failed',
+          status: 'failed',
+          errorMessage: 'old failure',
+          createdAt: '2026-06-18T00:00:00.000Z'
+        }),
+        uploadRow({
+          id: 'upload-succeeded',
+          status: 'variantCreated',
+          videoVariantId: 'variant-1',
+          createdAt: '2026-06-19T00:00:00.000Z'
+        })
+      ],
+      {},
+      []
+    )
+
+    renderLayout()
+
+    expect(screen.queryByText('No audio languages found')).toBeNull()
+    expect(screen.getByText('Previous attempts (1)')).toBeInTheDocument()
+    expect(screen.queryByText('old failure')).toBeNull()
+  })
+
+  it('renders normally for a video with no upload history', () => {
+    mockUploadQueries(() => [])
+
+    renderLayout()
+
+    expect(screen.queryByText(/Previous attempts/)).toBeNull()
+    expect(screen.getAllByRole('listitem')).toHaveLength(3)
+  })
+
+  it('tells a publisher to start a fresh upload when an attempt cannot be resumed', () => {
+    mockUploadQueries(() => [
+      uploadRow({
+        id: 'upload-unresumable',
+        status: 'r2Prepared',
+        createdAt: '2026-06-19T00:00:00.000Z'
+      })
+    ])
+
+    renderLayout()
+
+    expect(
+      screen.getByText(
+        'This upload cannot be resumed because the browser did not finish sending the file to R2. Start a fresh upload for this language.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('moves a retried attempt into history once a later attempt succeeds', async () => {
+    const mockedUseMutation = useMutation as MockedFunction<typeof useMutation>
+    const resumeMutation = vi.fn().mockResolvedValue({
+      data: {
+        videoVariantUploadResume: {
+          id: 'upload-processing',
+          status: 'muxCreated',
+          errorMessage: null,
+          muxVideoId: 'mux-id',
+          videoVariantId: null,
+          updatedAt: '2026-06-18T00:00:00.000Z'
+        }
+      }
+    })
+    mockedUseMutation.mockReturnValue([
+      resumeMutation,
+      {
+        loading: false,
+        error: undefined,
+        data: undefined,
+        called: false,
+        client: {} as any,
+        reset: vi.fn()
+      }
+    ])
+
+    let uploadRows = [
+      uploadRow({
+        id: 'upload-processing',
+        status: 'r2Uploaded',
+        createdAt: '2026-06-18T00:00:00.000Z'
+      })
+    ]
+    mockUploadQueries(() => uploadRows)
+
+    const { rerender } = renderLayout()
+
+    fireEvent.click(screen.getByText('Start processing'))
+
+    uploadRows = [
+      uploadRow({
+        id: 'upload-processing',
+        status: 'r2Uploaded',
+        createdAt: '2026-06-18T00:00:00.000Z'
+      }),
+      uploadRow({
+        id: 'upload-succeeded',
+        status: 'variantCreated',
+        videoVariantId: 'variant-1',
+        createdAt: '2026-06-19T00:00:00.000Z'
+      })
+    ]
+    rerender(
+      <MockedProvider>
+        <ClientLayout>
+          <div>Child content</div>
+        </ClientLayout>
+      </MockedProvider>
+    )
+
+    await waitFor(() => {
+      expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
+        'Audio language restored',
+        { variant: 'success' }
+      )
+    })
+    expect(screen.getByText('Previous attempts (1)')).toBeInTheDocument()
   })
 
   it('should render Audio Languages header', () => {

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/audio/layout.spec.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/audio/layout.spec.tsx
@@ -1315,7 +1315,7 @@ describe('ClientLayout', () => {
     getUploads: () => any[],
     uploadOverrides: Partial<QueryResult<any, OperationVariables>> = {},
     variants: any[] = mockVideoVariants
-  ) {
+  ): void {
     const mockedUseQuery = useQuery as MockedFunction<typeof useQuery>
 
     mockedUseQuery.mockImplementation((_query, options?: any) => {
@@ -1337,7 +1337,9 @@ describe('ClientLayout', () => {
     })
   }
 
-  function uploadRow(overrides: Record<string, unknown>) {
+  function uploadRow(
+    overrides: Record<string, unknown>
+  ): Record<string, unknown> {
     return {
       source: 'videos-admin',
       sourceKey: 'source-key',
@@ -1573,16 +1575,66 @@ describe('ClientLayout', () => {
     renderLayout()
 
     expect(
-      screen.getByLabelText('previous attempts for Farsi')
+      screen.getByLabelText('previous attempts for Farsi (base)')
     ).toHaveTextContent('Previous attempts (2)')
     expect(
-      screen.getByLabelText('previous attempts for French')
+      screen.getByLabelText('previous attempts for French (base)')
     ).toHaveTextContent('Previous attempts (1)')
 
-    fireEvent.click(screen.getByLabelText('previous attempts for French'))
+    fireEvent.click(
+      screen.getByLabelText('previous attempts for French (base)')
+    )
 
     expect(screen.getByText('french failure')).toBeInTheDocument()
     expect(screen.queryByText('farsi failure')).toBeNull()
+  })
+
+  it('summarises previous attempts separately per edition', () => {
+    mockUploadQueries(() => [
+      uploadRow({
+        id: 'base-failed',
+        status: 'failed',
+        edition: 'base',
+        errorMessage: 'base failure',
+        createdAt: '2026-06-15T00:00:00.000Z'
+      }),
+      uploadRow({
+        id: 'base-success',
+        status: 'variantCreated',
+        edition: 'base',
+        videoVariantId: 'variant-base',
+        createdAt: '2026-06-19T00:00:00.000Z'
+      }),
+      uploadRow({
+        id: 'burned-in-failed-1',
+        status: 'failed',
+        edition: 'burnedIn',
+        errorMessage: 'burned in failure',
+        createdAt: '2026-06-15T00:00:00.000Z'
+      }),
+      uploadRow({
+        id: 'burned-in-failed-2',
+        status: 'r2Prepared',
+        edition: 'burnedIn',
+        createdAt: '2026-06-16T00:00:00.000Z'
+      }),
+      uploadRow({
+        id: 'burned-in-success',
+        status: 'variantCreated',
+        edition: 'burnedIn',
+        videoVariantId: 'variant-burned-in',
+        createdAt: '2026-06-19T00:00:00.000Z'
+      })
+    ])
+
+    renderLayout()
+
+    expect(
+      screen.getByLabelText('previous attempts for Farsi (base)')
+    ).toHaveTextContent('Previous attempts (1)')
+    expect(
+      screen.getByLabelText('previous attempts for Farsi (burnedIn)')
+    ).toHaveTextContent('Previous attempts (2)')
   })
 
   it('reveals each superseded attempt in newest-first order when the summary is expanded', () => {

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/audio/layout.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/audio/layout.tsx
@@ -26,8 +26,75 @@ import { DEFAULT_VIDEO_LANGUAGE_ID } from '../../constants'
 import {
   IncompleteVideoVariantUploadItems,
   type VideoVariantUploadRow,
-  incompleteUploadStatuses
+  getUploadCreatedAtMs,
+  uploadHistoryStatuses
 } from './_IncompleteVideoVariantUploadItems'
+
+interface VideoVariantUploadPartition {
+  /** Attempts still needing the publisher's attention. */
+  outstanding: VideoVariantUploadRow[]
+  /** Attempts a later successful attempt has made irrelevant. */
+  superseded: VideoVariantUploadRow[]
+}
+
+function getSupersessionKey(upload: VideoVariantUploadRow): string {
+  return [upload.videoId, upload.languageId, upload.edition].join('\u0000')
+}
+
+/**
+ * An attempt is superseded when a later attempt for the same video, audio
+ * language and edition reached `variantCreated`. Variants are deliberately not
+ * consulted, so a failed re-upload over an existing variant stays outstanding.
+ *
+ * Supersession cannot be proven without a usable `createdAt` on both sides, so
+ * an attempt with a missing or unparseable one stays outstanding: a real
+ * failure must never be demoted on the strength of unreadable data.
+ */
+function partitionVideoVariantUploads(
+  uploads: VideoVariantUploadRow[]
+): VideoVariantUploadPartition {
+  const latestSuccessMsByKey = new Map<string, number>()
+
+  for (const upload of uploads) {
+    if (upload.status !== 'variantCreated') continue
+
+    const createdAtMs = getUploadCreatedAtMs(upload)
+    if (createdAtMs == null) continue
+
+    const key = getSupersessionKey(upload)
+    const latestMs = latestSuccessMsByKey.get(key)
+    if (latestMs == null || createdAtMs > latestMs) {
+      latestSuccessMsByKey.set(key, createdAtMs)
+    }
+  }
+
+  const outstanding: VideoVariantUploadRow[] = []
+  const superseded: VideoVariantUploadRow[] = []
+
+  for (const upload of uploads) {
+    if (upload.status === 'variantCreated') continue
+
+    const createdAtMs = getUploadCreatedAtMs(upload)
+    const latestSuccessMs = latestSuccessMsByKey.get(getSupersessionKey(upload))
+
+    if (
+      createdAtMs != null &&
+      latestSuccessMs != null &&
+      latestSuccessMs > createdAtMs
+    ) {
+      superseded.push(upload)
+      continue
+    }
+
+    outstanding.push(upload)
+  }
+
+  superseded.sort(
+    (a, b) => (getUploadCreatedAtMs(b) ?? 0) - (getUploadCreatedAtMs(a) ?? 0)
+  )
+
+  return { outstanding, superseded }
+}
 
 const GET_ADMIN_VIDEO_VARIANTS = graphql(`
   query GetAdminVideoVariants($id: ID!, $languageId: ID) {
@@ -130,7 +197,7 @@ export default function ClientLayout({
     stopPolling: stopUploadPolling
   } = useQuery(GET_VIDEO_VARIANT_UPLOADS, {
     variables: {
-      input: { videoId, statuses: incompleteUploadStatuses },
+      input: { videoId, statuses: uploadHistoryStatuses },
       limit: 100,
       languageId: DEFAULT_VIDEO_LANGUAGE_ID
     },
@@ -139,10 +206,14 @@ export default function ClientLayout({
 
   const [resumeVideoVariantUpload] = useMutation(RESUME_VIDEO_VARIANT_UPLOAD)
 
-  const incompleteUploads = useMemo(
-    () => (uploadsData?.videoVariantUploads ?? []) as VideoVariantUploadRow[],
-    [uploadsData?.videoVariantUploads]
-  )
+  const { outstanding: outstandingUploads, superseded: supersededUploads } =
+    useMemo(
+      () =>
+        partitionVideoVariantUploads(
+          (uploadsData?.videoVariantUploads ?? []) as VideoVariantUploadRow[]
+        ),
+      [uploadsData?.videoVariantUploads]
+    )
 
   useEffect(() => {
     if (reloadOnPathChange) {
@@ -158,14 +229,14 @@ export default function ClientLayout({
   }, [pathname])
 
   useEffect(() => {
-    if (incompleteUploads.length > 0 || resumingUploadId != null) {
+    if (outstandingUploads.length > 0 || resumingUploadId != null) {
       startUploadPolling(3000)
       return () => stopUploadPolling()
     }
 
     stopUploadPolling()
   }, [
-    incompleteUploads.length,
+    outstandingUploads.length,
     resumingUploadId,
     startUploadPolling,
     stopUploadPolling
@@ -181,7 +252,7 @@ export default function ClientLayout({
   useEffect(() => {
     if (resumingUploadId == null || isResumeRequestInFlight) return
 
-    const upload = incompleteUploads.find((row) => row.id === resumingUploadId)
+    const upload = outstandingUploads.find((row) => row.id === resumingUploadId)
     if (upload == null) {
       completeResumedUpload()
       return
@@ -198,7 +269,7 @@ export default function ClientLayout({
     enqueueSnackbar,
     resumingUploadId,
     isResumeRequestInFlight,
-    incompleteUploads
+    outstandingUploads
   ])
 
   const handleAddAudioLanguage = useCallback((): void => {
@@ -328,7 +399,8 @@ export default function ClientLayout({
 
     if (
       (!data?.adminVideo.variants || data.adminVideo.variants.length === 0) &&
-      incompleteUploads.length === 0
+      outstandingUploads.length === 0 &&
+      supersededUploads.length === 0
     ) {
       return (
         <Box
@@ -364,7 +436,8 @@ export default function ClientLayout({
       >
         <List disablePadding>
           <IncompleteVideoVariantUploadItems
-            uploads={incompleteUploads}
+            outstandingUploads={outstandingUploads}
+            supersededUploads={supersededUploads}
             resumingUploadId={resumingUploadId}
             isResumeRequestInFlight={isResumeRequestInFlight}
             onAddAudioLanguage={handleAddAudioLanguage}

--- a/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/audio/layout.tsx
+++ b/apps/videos-admin/src/app/(dashboard)/videos/[videoId]/audio/layout.tsx
@@ -49,6 +49,9 @@ function getSupersessionKey(upload: VideoVariantUploadRow): string {
  * Supersession cannot be proven without a usable `createdAt` on both sides, so
  * an attempt with a missing or unparseable one stays outstanding: a real
  * failure must never be demoted on the strength of unreadable data.
+ *
+ * This decides membership only. How the superseded attempts are grouped and
+ * ordered for display is owned by the component that renders them.
  */
 function partitionVideoVariantUploads(
   uploads: VideoVariantUploadRow[]
@@ -88,10 +91,6 @@ function partitionVideoVariantUploads(
 
     outstanding.push(upload)
   }
-
-  superseded.sort(
-    (a, b) => (getUploadCreatedAtMs(b) ?? 0) - (getUploadCreatedAtMs(a) ?? 0)
-  )
 
   return { outstanding, superseded }
 }


### PR DESCRIPTION
Closes #9561

## The problem

The Audio Languages tab showed "Upload not complete" rows for languages that were **already published and streaming**, each instructing the publisher to *"Add this audio language again."* Following that instruction meant re-uploading a multi-gigabyte master for work that was already done — and if the re-upload also failed, it left behind another permanent row.

Reported on Augustine: six rows displayed since July for three languages (Farsi, French, Turkish) that were all live. Four of the six were repeat attempts at the same French file.

## The rule

An attempt is **superseded** when a later attempt for the same Video, Audio Language and Edition reached `variantCreated`:

```
superseded(u) ⟺ ∃ s : s.videoId = u.videoId ∧ s.languageId = u.languageId
                    ∧ s.edition = u.edition ∧ s.status = 'variantCreated'
                    ∧ s.createdAt > u.createdAt
```

Edition is part of the key, so a completed `base` upload never hides an outstanding Burned In one. The `Variant` table is **not** consulted — that is what keeps a failed re-upload over an existing Variant fully visible.

Nothing is deleted. Retention is the policy; demotion is the mechanism.

## What a publisher sees

Superseded attempts collapse into a per-language `Previous attempts (N)` disclosure — neutral label, no call to action, status/filename/timestamp/error readable on expand, newest first. The copy-details affordance stays, so diagnostics are still gatherable for a support request.

Every attempt that is *not* superseded renders exactly as it does today.

## Notable side effect: polling

The polling condition keyed on the length of the incomplete list, which is why videos with stale rows have been refetching **every three seconds continuously since July**. The partition is derived once and drives both the rendered list and the polling condition, which now keys on outstanding attempts only. Widening the query without this would have made it worse.

## Two deliberate deviations from the spec's letter

1. **The unresumable action button now reads "Start fresh upload"** (was "Add again"). The spec's Copy section named only "the message", but US22 says *"so that I am not told to 'add again'"* — and the button is what gets clicked. This updated two existing tests the spec did not flag as needing changes.
2. **The history disclosure is per language, not one per video.** US5 (*"a language that took five attempts occupies one row rather than five"*) and US6 (*"whether a language was troublesome"*) both read per-language. On the Augustine case this gives three rows with their own counts rather than one `Previous attempts (6)`.

## One risk left open, per the spec's explicit decision

The query still uses `limit: 100` and now also requests `variantCreated`. The resolver orders `updatedAt desc`, so on a Video with 100+ completed uploads a genuinely *outstanding* older attempt could fall outside the window and vanish — the opposite of US3. The spec states *"Volume is bounded — one Video, existing limit of 100 — so no pagination change is needed"*, which holds only while successes are few. Worth a follow-up if any Video approaches that many audio languages.

## Scope

No schema change, no new API field, no codegen or subgraph check — the rule is client-side, scoped to the one surface that needs it. Attempts with an unparseable `createdAt` stay outstanding: a real failure is never demoted on the strength of unreadable data.

## Testing

13 new tests through the existing Audio Languages layout seam (`useQuery` mocked), asserting rendered output rather than reaching for the helper — which stays unexported, so no test can couple to it.

Covered: demotion by a later success; no later success stays outstanding; a later success in a different Edition or a different Audio Language does not demote; a failure *after* the most recent success stays outstanding; several attempts collapse to one summary with the count; per-language grouping; expansion reveals each attempt newest-first; no action control on superseded rows; polling starts with an outstanding attempt and not without one; a retried attempt moves to history on refresh; the resume and stale-Mux retry flows unchanged.

- 42 tests in the audio layout spec, full `videos-admin` suite **484 passed** across 100 files
- `pnpm lint:changed --fix` clean, `nx affected --target=type-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RavwMiFD6nKQxHYJswZeF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Previous video upload attempts are grouped by language and edition in collapsible history sections.
  * Users can distinguish active uploads from attempts superseded by a newer completed upload.
  * Added clearer upload status labels and a “Start fresh upload” action.
  * Upload history supports improved retry and restore flows.

* **Bug Fixes**
  * Polling and resume behavior now focus on outstanding attempts, preventing superseded uploads from appearing as active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->