### PR TITLE
fix(api-journeys): ask for JSON in metadata translation prompts and retry bad answers

### DIFF
--- a/apis/api-journeys/src/schema/journeyAiTranslate/translateJourneyMetadata/translateJourneyMetadata.contract.spec.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/translateJourneyMetadata/translateJourneyMetadata.contract.spec.ts
@@ -1,44 +1,92 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import {
   createStubModel,
   createStubSession,
-  systemPromptsSentTo
+  systemPromptsSentTo,
+  userPromptsSentTo
 } from '@core/shared/ai/testModel'
 
 import { translateJourneyMetadata } from './translateJourneyMetadata'
 
+vi.mock('../../../logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn() }
+}))
+
 /**
  * The sibling `translateJourneyMetadata.spec.ts` mocks the whole `ai` module,
- * so it never exercises the SDK's own prompt validation. This spec runs the
- * real `generateText` against a stub model instead, because that validation is
- * where AI SDK v7 changed behaviour: `messages` may no longer carry a
- * `role: 'system'` entry — the system prompt has to be passed via
- * `instructions` — and a violation throws at runtime, not at compile time.
+ * so it never exercises the SDK's own prompt validation or structured-output
+ * parsing. This spec runs the real `generateText` against a stub model
+ * instead, because that is where AI SDK v7 changed behaviour: `messages` may
+ * no longer carry a `role: 'system'` entry — the system prompt has to be
+ * passed via `instructions` — and a violation throws at runtime, not at
+ * compile time.
  *
- * Asserting on what the model was called with pins the behaviour that actually
- * matters: however we pass it, the model must still receive the system prompt.
+ * Asserting on what the model was called with, and on how the SDK's parse
+ * failures are handled, pins the behaviour that actually matters.
  */
 describe('translateJourneyMetadata prompt contract', () => {
+  const titleOnlyInput = {
+    sourceLanguageName: 'English',
+    targetLanguageName: 'Spanish',
+    journeyTitle: 'Title',
+    journeyDisplayTitle: null,
+    journeyDescription: null,
+    seoTitle: null,
+    seoDescription: null,
+    cardBlocksContent: ['Card one']
+  }
+
   it('sends the translation system prompt to the model', async () => {
     const model = createStubModel({
       text: JSON.stringify({ analysis: 'ANALYSIS', translation: 'TRANSLATED' })
     })
 
     await translateJourneyMetadata({
-      sourceLanguageName: 'English',
-      targetLanguageName: 'Spanish',
-      journeyTitle: 'Title',
-      journeyDisplayTitle: null,
-      journeyDescription: null,
-      seoTitle: null,
-      seoDescription: null,
-      cardBlocksContent: ['Card one'],
+      ...titleOnlyInput,
       session: createStubSession(model)
     })
 
     const systemPrompts = systemPromptsSentTo(model)
     expect(systemPrompts.length).toBeGreaterThan(0)
     expect(systemPrompts[0]).toContain('professional translator')
+  })
+
+  it('tells the model the exact JSON object each call must return', async () => {
+    const model = createStubModel({
+      text: JSON.stringify({ analysis: 'ANALYSIS', translation: 'TRANSLATED' })
+    })
+
+    await translateJourneyMetadata({
+      ...titleOnlyInput,
+      session: createStubSession(model)
+    })
+
+    const [analysisPrompt, titlePrompt] = userPromptsSentTo(model)
+    expect(analysisPrompt).toContain('{"analysis": "<your analysis>"}')
+    expect(titlePrompt).toContain(
+      '{"translation": "<the translated journey title>"}'
+    )
+  })
+
+  it('recovers when the model answers a field call with bare text before JSON', async () => {
+    // The production failure behind QA-578: the model returned the translated
+    // title as plain text, the SDK could not parse it as the requested object,
+    // and the whole translation was abandoned. A second attempt should land.
+    const model = createStubModel({
+      text: [
+        JSON.stringify({ analysis: 'ANALYSIS' }),
+        'जब गेंद खेल में हो...',
+        JSON.stringify({ translation: 'जब गेंद खेल में हो...' })
+      ]
+    })
+
+    const result = await translateJourneyMetadata({
+      ...titleOnlyInput,
+      session: createStubSession(model)
+    })
+
+    expect(result.title).toBe('जब गेंद खेल में हो...')
+    expect(model.doGenerateCalls).toHaveLength(3)
   })
 })

--- a/apis/api-journeys/src/schema/journeyAiTranslate/translateJourneyMetadata/translateJourneyMetadata.spec.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/translateJourneyMetadata/translateJourneyMetadata.spec.ts
@@ -1,11 +1,18 @@
 import { generateText } from 'ai'
 import { type MockedFunction, vi } from 'vitest'
 
-import type { OpenrouterFallbackSession } from '@core/shared/ai/openrouterModel'
+import {
+  AiRequestTimeoutError,
+  type OpenrouterFallbackSession
+} from '@core/shared/ai/openrouterModel'
 
 import { promptOf } from '../../../../test/promptOf'
+import { logger } from '../../../logger'
 
-import { translateJourneyMetadata } from './translateJourneyMetadata'
+import {
+  MAX_METADATA_ATTEMPTS,
+  translateJourneyMetadata
+} from './translateJourneyMetadata'
 
 vi.mock('ai', () => ({
   Output: {
@@ -19,15 +26,18 @@ vi.mock('@core/shared/ai/prompts', () => ({
   preSystemPrompt: 'mocked system prompt'
 }))
 
+vi.mock('../../../logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn() }
+}))
+
 const mockGenerateText = generateText as MockedFunction<typeof generateText>
 
 // A session that simply runs the operation with a placeholder model. The
 // generateText mock ignores the model, so its concrete value is irrelevant.
-const session = {
-  execute: vi.fn((operation: (model: unknown) => Promise<unknown>) =>
-    operation('mocked-model')
-  )
-} as unknown as OpenrouterFallbackSession
+const execute = vi.fn((operation: (model: unknown) => Promise<unknown>) =>
+  operation('mocked-model')
+)
+const session = { execute } as unknown as OpenrouterFallbackSession
 
 function aiResult(output: unknown): unknown {
   return {
@@ -47,7 +57,7 @@ function aiResult(output: unknown): unknown {
 function defaultImplementation(): void {
   mockGenerateText.mockImplementation((async (options: unknown) => {
     const text = promptOf(options)
-    if (text.includes('produce only the analysis')) {
+    if (text.includes('Analyze this journey')) {
       return aiResult({ analysis: 'ANALYSIS CONTEXT' })
     }
     if (text.includes('Translate the journey display title below')) {
@@ -69,6 +79,27 @@ function defaultImplementation(): void {
   }) as never)
 }
 
+// Like defaultImplementation, but the title call is scripted by the test so it
+// can fail on demand. Every other call succeeds.
+function implementationWithTitle(onTitleCall: () => unknown): void {
+  mockGenerateText.mockImplementation((async (options: unknown) => {
+    const text = promptOf(options)
+    if (text.includes('Analyze this journey')) {
+      return aiResult({ analysis: 'ANALYSIS CONTEXT' })
+    }
+    if (text.includes('Translate the journey title below')) {
+      return onTitleCall()
+    }
+    return aiResult({ translation: 'Descripción traducida' })
+  }) as never)
+}
+
+function titleCallCount(): number {
+  return mockGenerateText.mock.calls.filter((call) =>
+    promptOf(call[0]).includes('Translate the journey title below')
+  ).length
+}
+
 const baseInput = {
   sourceLanguageName: 'English',
   targetLanguageName: 'Spanish',
@@ -79,6 +110,15 @@ const baseInput = {
   seoDescription: 'My SEO Description',
   cardBlocksContent: ['Card content'],
   session
+}
+
+// Only the analysis call and the title call run for this input.
+const titleOnlyInput = {
+  ...baseInput,
+  journeyDisplayTitle: null,
+  journeyDescription: null,
+  seoTitle: null,
+  seoDescription: null
 }
 
 describe('translateJourneyMetadata', () => {
@@ -130,7 +170,7 @@ describe('translateJourneyMetadata', () => {
     await translateJourneyMetadata(baseInput)
 
     const fieldCalls = mockGenerateText.mock.calls.filter(
-      (call) => !promptOf(call[0]).includes('produce only the analysis')
+      (call) => !promptOf(call[0]).includes('Analyze this journey')
     )
 
     expect(fieldCalls).toHaveLength(5)
@@ -139,6 +179,47 @@ describe('translateJourneyMetadata', () => {
         '<hardened>ANALYSIS CONTEXT</hardened>'
       )
     }
+  })
+
+  it('spells out the JSON object each call must return, in the schema field names', async () => {
+    await translateJourneyMetadata(titleOnlyInput)
+
+    const analysisCall = mockGenerateText.mock.calls.find((call) =>
+      promptOf(call[0]).includes('Analyze this journey')
+    )
+    const titleCall = mockGenerateText.mock.calls.find((call) =>
+      promptOf(call[0]).includes('Translate the journey title below')
+    )
+
+    // The SDK only sends the schema as request metadata, so the prompt text
+    // itself has to name the field — otherwise a host that does not enforce
+    // the schema returns bare text.
+    expect(promptOf(analysisCall?.[0])).toContain(
+      '{"analysis": "<your analysis>"}'
+    )
+    const titlePrompt = promptOf(titleCall?.[0])
+    expect(titlePrompt).toContain(
+      '{"translation": "<the translated journey title>"}'
+    )
+    expect(titlePrompt).toContain(
+      'The "translation" value must contain only the translated text'
+    )
+    expect(titlePrompt).not.toContain('Return only the translated text')
+  })
+
+  it('reads the structured output inside the fallback session', async () => {
+    await translateJourneyMetadata(titleOnlyInput)
+
+    // The SDK's `output` getter throws when the model produced nothing. The
+    // operation must return the output itself so that throw happens inside
+    // the session (and inside the retry loop), not after it has resolved.
+    const outputs = await Promise.all(
+      execute.mock.results.map((result) => result.value)
+    )
+    expect(outputs).toEqual([
+      { analysis: 'ANALYSIS CONTEXT' },
+      { translation: 'Título traducido' }
+    ])
   })
 
   it('returns empty strings for absent fields without making AI calls for them', async () => {
@@ -161,16 +242,9 @@ describe('translateJourneyMetadata', () => {
   })
 
   it('strips field-label prefixes and surrounding quotes from translated values', async () => {
-    mockGenerateText.mockImplementation((async (options: unknown) => {
-      const text = promptOf(options)
-      if (text.includes('produce only the analysis')) {
-        return aiResult({ analysis: 'ANALYSIS CONTEXT' })
-      }
-      if (text.includes('Translate the journey title below')) {
-        return aiResult({ translation: 'Journey Title: "Título limpio"' })
-      }
-      return aiResult({ translation: 'Descripción traducida' })
-    }) as never)
+    implementationWithTitle(() =>
+      aiResult({ translation: 'Journey Title: "Título limpio"' })
+    )
 
     const result = await translateJourneyMetadata({
       ...baseInput,
@@ -180,5 +254,78 @@ describe('translateJourneyMetadata', () => {
     })
 
     expect(result.title).toBe('Título limpio')
+  })
+
+  describe('retries', () => {
+    it('retries a call whose answer could not be parsed and uses the next answer', async () => {
+      const parseError = new Error(
+        'No object generated: could not parse the response.'
+      )
+      let attempts = 0
+      implementationWithTitle(() => {
+        attempts += 1
+        if (attempts === 1) throw parseError
+        return aiResult({ translation: 'Título traducido' })
+      })
+
+      const result = await translateJourneyMetadata(titleOnlyInput)
+
+      expect(result.title).toBe('Título traducido')
+      expect(titleCallCount()).toBe(2)
+      expect(logger.warn).toHaveBeenCalledWith(
+        {
+          error: parseError,
+          label: 'journey title',
+          attempt: 1,
+          maxAttempts: MAX_METADATA_ATTEMPTS
+        },
+        'Journey metadata AI call failed'
+      )
+    })
+
+    it('retries the analysis call as well', async () => {
+      let attempts = 0
+      mockGenerateText.mockImplementation((async (options: unknown) => {
+        const text = promptOf(options)
+        if (text.includes('Analyze this journey')) {
+          attempts += 1
+          if (attempts === 1) throw new Error('No output generated.')
+          return aiResult({ analysis: 'ANALYSIS CONTEXT' })
+        }
+        return aiResult({ translation: 'Título traducido' })
+      }) as never)
+
+      const result = await translateJourneyMetadata(titleOnlyInput)
+
+      expect(result.analysis).toBe('ANALYSIS CONTEXT')
+      expect(attempts).toBe(2)
+    })
+
+    it('gives up after the attempt cap and rethrows the last error', async () => {
+      const parseError = new Error(
+        'No object generated: could not parse the response.'
+      )
+      implementationWithTitle(() => {
+        throw parseError
+      })
+
+      await expect(translateJourneyMetadata(titleOnlyInput)).rejects.toBe(
+        parseError
+      )
+      expect(titleCallCount()).toBe(MAX_METADATA_ATTEMPTS)
+    })
+
+    it('does not retry a timeout, since the session has already exhausted its models', async () => {
+      const timeout = new AiRequestTimeoutError(60_000)
+      implementationWithTitle(() => {
+        throw timeout
+      })
+
+      await expect(translateJourneyMetadata(titleOnlyInput)).rejects.toBe(
+        timeout
+      )
+      expect(titleCallCount()).toBe(1)
+      expect(logger.warn).not.toHaveBeenCalled()
+    })
   })
 })

--- a/apis/api-journeys/src/schema/journeyAiTranslate/translateJourneyMetadata/translateJourneyMetadata.ts
+++ b/apis/api-journeys/src/schema/journeyAiTranslate/translateJourneyMetadata/translateJourneyMetadata.ts
@@ -1,8 +1,13 @@
 import { Output, generateText } from 'ai'
 import { z } from 'zod'
 
-import type { OpenrouterFallbackSession } from '@core/shared/ai/openrouterModel'
+import {
+  AiRequestTimeoutError,
+  type OpenrouterFallbackSession
+} from '@core/shared/ai/openrouterModel'
 import { hardenPrompt, preSystemPrompt } from '@core/shared/ai/prompts'
+
+import { logger } from '../../../logger'
 
 export const TRANSLATION_SYSTEM_PROMPT = `${preSystemPrompt}
 
@@ -12,6 +17,17 @@ You are a professional translator for interactive journey content.
 - Preserve all {{variable}} template syntax exactly as-is — never translate content inside {{ }}
 - For Bible passages, use an established translation in the target language — never translate scripture yourself. If none is identified, use the most popular English Bible translation.
 - DO NOT translate proper nouns`
+
+/**
+ * How many times one structured-output call is attempted before the metadata
+ * step gives up on it.
+ *
+ * Mirrors the card path's batch attempts. The model occasionally answers a
+ * single-field call with prose instead of the requested JSON object, or with
+ * nothing at all; a fresh sample nearly always lands, and without a retry one
+ * bad sample used to abandon the whole translation.
+ */
+export const MAX_METADATA_ATTEMPTS = 3
 
 /**
  * Strips field-label prefixes and formatting artifacts that some models
@@ -43,6 +59,15 @@ const JourneyFieldTranslationSchema = z.object({
     )
 })
 
+/**
+ * The prompts below spell out the JSON object each call must return, in the
+ * schema's own field names. The AI SDK sends the schema only as request
+ * metadata (`response_format`) and adds nothing to the prompt text, so when a
+ * serving host does not enforce that metadata the model follows the words it
+ * was given. A prompt that said "return only the translated text" while the
+ * request asked for `{ "translation": "..." }` produced bare text on exactly
+ * those hosts; naming the shape in the prompt keeps the two in agreement.
+ */
 function buildAnalysisPrompt({
   sourceLanguageName,
   targetLanguageName,
@@ -66,7 +91,7 @@ function buildAnalysisPrompt({
 
 Identify themes, target audience, and cultural adaptation needs.
 If the content references the Bible, identify the most appropriate Bible translation in the target language.
-Do not translate anything yet — produce only the analysis.
+Do not translate anything yet.
 
 Journey Title: ${hardenPrompt(journeyTitle)}
 ${hasDescription ? `Journey Description: ${hardenPrompt(journeyDescription)}` : '(No description provided)'}
@@ -74,7 +99,97 @@ ${seoTitle ? `SEO Title: ${hardenPrompt(seoTitle)}` : '(No SEO title provided)'}
 ${seoDescription ? `SEO Description: ${hardenPrompt(seoDescription)}` : '(No SEO description provided)'}
 
 Journey Content:
-${hardenPrompt(cardBlocksContent.join('\n'))}`
+${hardenPrompt(cardBlocksContent.join('\n'))}
+
+Respond with a JSON object of exactly this shape:
+{"analysis": "<your analysis>"}
+
+The "analysis" value must contain only the analysis — no translations, no commentary.`
+}
+
+function buildFieldPrompt({
+  fieldName,
+  value,
+  sourceLanguageName,
+  targetLanguageName,
+  journeyAnalysis
+}: {
+  fieldName: string
+  value: string
+  sourceLanguageName: string
+  targetLanguageName: string
+  journeyAnalysis: string
+}): string {
+  return `Context from journey analysis:
+${hardenPrompt(journeyAnalysis)}
+
+Translate the ${fieldName} below from ${hardenPrompt(sourceLanguageName)} to ${hardenPrompt(targetLanguageName)}.
+
+${fieldName}:
+${hardenPrompt(value)}
+
+Respond with a JSON object of exactly this shape:
+{"translation": "<the translated ${fieldName}>"}
+
+The "translation" value must contain only the translated text — no field labels, no commentary, nothing but the translation itself.`
+}
+
+/**
+ * Runs one structured-output call through the fallback session, retrying the
+ * whole call on failure up to {@link MAX_METADATA_ATTEMPTS}.
+ *
+ * The session itself only moves to the next model on a timeout, a 429, or a
+ * 403. A malformed answer — prose where a JSON object was requested, or no
+ * output at all — is none of those, so it used to escape straight to the
+ * caller and fail the translation. This loop is the metadata equivalent of
+ * the card path's retry loop.
+ *
+ * Timeouts are not retried: by the time one surfaces the session has already
+ * walked its whole model chain, and another attempt would only wait again.
+ */
+async function generateObjectWithRetry<T>({
+  label,
+  prompt,
+  schema,
+  session
+}: {
+  label: string
+  prompt: string
+  schema: z.ZodType<T>
+  session: OpenrouterFallbackSession
+}): Promise<T> {
+  let lastError: unknown
+  for (let attempt = 1; attempt <= MAX_METADATA_ATTEMPTS; attempt++) {
+    try {
+      return await session.execute(async (model, abortSignal) => {
+        const result = await generateText({
+          model,
+          abortSignal,
+          maxRetries: 0,
+          instructions: TRANSLATION_SYSTEM_PROMPT,
+          messages: [
+            {
+              role: 'user',
+              content: [{ type: 'text', text: prompt }]
+            }
+          ],
+          output: Output.object({ schema })
+        })
+        // `output` is a getter that throws when the model produced nothing.
+        // Read it inside the operation so that failure belongs to this
+        // attempt rather than surfacing after the session has returned.
+        return result.output
+      })
+    } catch (error) {
+      if (error instanceof AiRequestTimeoutError) throw error
+      lastError = error
+      logger.warn(
+        { error, label, attempt, maxAttempts: MAX_METADATA_ATTEMPTS },
+        'Journey metadata AI call failed'
+      )
+    }
+  }
+  throw lastError
 }
 
 /**
@@ -100,32 +215,20 @@ async function translateJourneyField({
   journeyAnalysis: string
   session: OpenrouterFallbackSession
 }): Promise<string> {
-  const prompt = `Context from journey analysis:
-${hardenPrompt(journeyAnalysis)}
+  const { translation } = await generateObjectWithRetry({
+    label: fieldName,
+    prompt: buildFieldPrompt({
+      fieldName,
+      value,
+      sourceLanguageName,
+      targetLanguageName,
+      journeyAnalysis
+    }),
+    schema: JourneyFieldTranslationSchema,
+    session
+  })
 
-Translate the ${fieldName} below from ${hardenPrompt(sourceLanguageName)} to ${hardenPrompt(targetLanguageName)}.
-Return only the translated text — no field labels, no surrounding quotes, no extra commentary.
-
-${fieldName}:
-${hardenPrompt(value)}`
-
-  const { output } = await session.execute((model, abortSignal) =>
-    generateText({
-      model,
-      abortSignal,
-      maxRetries: 0,
-      instructions: TRANSLATION_SYSTEM_PROMPT,
-      messages: [
-        {
-          role: 'user',
-          content: [{ type: 'text', text: prompt }]
-        }
-      ],
-      output: Output.object({ schema: JourneyFieldTranslationSchema })
-    })
-  )
-
-  return cleanFieldOutput(output.translation)
+  return cleanFieldOutput(translation)
 }
 
 export interface JourneyMetadataTranslation {
@@ -142,7 +245,8 @@ export interface JourneyMetadataTranslation {
  *
  * The journey-wide analysis is generated once and reused as shared context.
  * Each metadata field is then translated in its own single-field call so the
- * model cannot swap values between fields. Fields that have no source value
+ * model cannot swap values between fields. Every call is retried on a
+ * malformed answer before the step fails. Fields that have no source value
  * resolve to an empty string without an AI call.
  */
 export async function translateJourneyMetadata({
@@ -181,24 +285,12 @@ export async function translateJourneyMetadata({
     cardBlocksContent
   })
 
-  const { output: analysisOutput } = await session.execute(
-    (model, abortSignal) =>
-      generateText({
-        model,
-        abortSignal,
-        maxRetries: 0,
-        instructions: TRANSLATION_SYSTEM_PROMPT,
-        messages: [
-          {
-            role: 'user',
-            content: [{ type: 'text', text: analysisPrompt }]
-          }
-        ],
-        output: Output.object({ schema: JourneyAnalysisSchema })
-      })
-  )
-
-  const analysis = analysisOutput.analysis
+  const { analysis } = await generateObjectWithRetry({
+    label: 'journey analysis',
+    prompt: analysisPrompt,
+    schema: JourneyAnalysisSchema,
+    session
+  })
 
   const [
     title,

--- a/libs/shared/ai/src/testModel/testModel.ts
+++ b/libs/shared/ai/src/testModel/testModel.ts
@@ -14,8 +14,12 @@ import type { OpenrouterFallbackSession } from '../openrouterModel'
  */
 
 interface CreateStubModelOptions {
-  /** Text the model returns. Pass a JSON string for structured-output calls. */
-  text: string
+  /**
+   * Text the model returns. Pass a JSON string for structured-output calls.
+   * Pass an array to script one answer per call, in call order; the last
+   * entry repeats once the array runs out.
+   */
+  text: string | string[]
   /**
    * URL patterns the model accepts by media type. Real vision providers
    * declare these; without them the SDK downloads the asset itself.
@@ -23,27 +27,34 @@ interface CreateStubModelOptions {
   supportedUrls?: Record<string, RegExp[]>
 }
 
-/** A language model that answers every call with `text`. */
+/** A language model that answers each call with the scripted `text`. */
 export function createStubModel({
   text,
   supportedUrls = {}
 }: CreateStubModelOptions): MockLanguageModelV4 {
+  const answers = Array.isArray(text) ? text : [text]
+  let callIndex = 0
+
   return new MockLanguageModelV4({
     supportedUrls,
-    doGenerate: async () => ({
-      content: [{ type: 'text', text }],
-      finishReason: { unified: 'stop', raw: 'stop' },
-      usage: {
-        inputTokens: {
-          total: 1,
-          noCache: 1,
-          cacheRead: undefined,
-          cacheWrite: undefined
+    doGenerate: async () => {
+      const answer = answers[Math.min(callIndex, answers.length - 1)]
+      callIndex += 1
+      return {
+        content: [{ type: 'text', text: answer }],
+        finishReason: { unified: 'stop', raw: 'stop' },
+        usage: {
+          inputTokens: {
+            total: 1,
+            noCache: 1,
+            cacheRead: undefined,
+            cacheWrite: undefined
+          },
+          outputTokens: { total: 1, text: 1, reasoning: undefined }
         },
-        outputTokens: { total: 1, text: 1, reasoning: undefined }
-      },
-      warnings: []
-    })
+        warnings: []
+      }
+    }
   })
 }
 
@@ -66,5 +77,15 @@ export function systemPromptsSentTo(model: MockLanguageModelV4): string[] {
     call.prompt
       .filter((message) => message.role === 'system')
       .map((message) => String(message.content))
+  )
+}
+
+/** The user-turn text `model` was called with, one entry per call. */
+export function userPromptsSentTo(model: MockLanguageModelV4): string[] {
+  return model.doGenerateCalls.map((call) =>
+    call.prompt
+      .flatMap((message) => (message.role === 'user' ? message.content : []))
+      .flatMap((part) => (part.type === 'text' ? [part.text] : []))
+      .join('\n')
   )
 }


### PR DESCRIPTION
Fixes [QA-578](https://linear.app/jesus-film-project/issue/QA-578/hindi-translation-is-not-working).

## Problem

AI translation has failed with "Translation failed" for Hindi (and some French) journeys since Aug 19. The title, display title, description and SEO fields are each translated in a single-field call whose prompt ended with *"Return only the translated text"*, while the request's `response_format` asked for `{ "translation": "..." }`. The AI SDK sends the schema only as request metadata and adds nothing to the prompt, so on OpenRouter hosts that stopped enforcing it the model followed the prompt and returned bare text. The SDK could not parse that, and the resulting `NoObjectGeneratedError` is not one of the errors the fallback session reacts to (timeout, 429, 403), so a single bad sample failed the whole translation. The card path never hit this: its prompt already names the schema fields, and it has its own retry loop.

## Fix

Mirrors what the card path already does:

- **Prompts name the JSON shape.** Every metadata prompt (analysis plus each field) now spells out the object it must return, in the schema's own field names, so prompt and schema agree even without host-side enforcement.
- **Metadata calls retry.** Each call is retried up to three times on any failure other than a timeout (by then the session has already walked its model chain). The structured output is read inside the session operation, so an empty answer (`NoOutputGeneratedError`, the Aug 19 case) lands in the retry too instead of surfacing after the session returns.

## Tests

- Unit spec: prompt shape, retry on parse failure (title and analysis), attempt cap rethrows the last error, timeouts are not retried, output is read inside the session.
- Contract spec (real `generateText` against a stub model): replays the production failure, bare Hindi text first then JSON, and asserts the translation lands on the second attempt.
- `createStubModel` in `libs/shared/ai` now accepts a list of answers, one per call, plus a `userPromptsSentTo` helper.

## Verify after deploy

`"Translation error"` in Datadog for `api-journeys-modern` should drop to zero; `"Journey metadata AI call failed"` warnings show how often the retry is doing work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved AI-powered journey metadata translation with more consistent structured responses.
  * Added automatic recovery when the AI returns malformed or incomplete results.
  * Translation requests now retry failed responses up to three times, helping preserve translated titles and metadata.
  * Timeouts continue to be handled promptly without unnecessary retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->