### PR TITLE
feat(resources): remove header tab buttons on resources page

### DIFF
--- a/apps/resources/src/components/Header/Header.spec.tsx
+++ b/apps/resources/src/components/Header/Header.spec.tsx
@@ -3,6 +3,8 @@ import useScrollTrigger from '@mui/material/useScrollTrigger'
 import { fireEvent, render, screen } from '@testing-library/react'
 import type { Mock } from 'vitest'
 
+import { FlagsProvider } from '@core/shared/ui/FlagsProvider'
+
 import { Header } from './Header'
 
 vi.mock('@mui/material/useScrollTrigger', async () => ({
@@ -54,6 +56,28 @@ describe('Header', () => {
       </MockedProvider>
     )
     expect(screen.queryByTestId('BottomAppBar')).not.toBeInTheDocument()
+  })
+
+  it('should show bottom app bar when flags are on', () => {
+    render(
+      <MockedProvider>
+        <FlagsProvider flags={{ strategies: true, journeys: true }}>
+          <Header />
+        </FlagsProvider>
+      </MockedProvider>
+    )
+    expect(screen.getByTestId('HeaderBottomAppBar')).toBeInTheDocument()
+  })
+
+  it('should remove bottom app bar when hideTabButtons is true', () => {
+    render(
+      <MockedProvider>
+        <FlagsProvider flags={{ strategies: true, journeys: true }}>
+          <Header hideTabButtons />
+        </FlagsProvider>
+      </MockedProvider>
+    )
+    expect(screen.queryByTestId('HeaderBottomAppBar')).not.toBeInTheDocument()
   })
 
   it('should hide spacer', () => {

--- a/apps/resources/src/components/Header/Header.tsx
+++ b/apps/resources/src/components/Header/Header.tsx
@@ -23,6 +23,8 @@ interface HeaderProps {
   hideTopAppBar?: boolean
   /** Flag to hide the bottom app bar. */
   hideBottomAppBar?: boolean
+  /** Flag to remove the bottom app bar with the tab buttons. */
+  hideTabButtons?: boolean
   /** Flag to hide the spacer element (only needed on /watch). */
   hideSpacer?: boolean
   /** Theme mode to apply to the header. */
@@ -43,6 +45,7 @@ interface HeaderProps {
 export function Header({
   hideTopAppBar,
   hideBottomAppBar,
+  hideTabButtons,
   hideSpacer,
   themeMode = ThemeMode.light,
   showLanguageSwitcher = false
@@ -68,7 +71,8 @@ export function Header({
   })
 
   /** Determines if the bottom app bar should be displayed based on feature flags. */
-  const shouldShowBottomAppBar = strategies || journeys
+  const shouldShowBottomAppBar =
+    (strategies || journeys) && hideTabButtons !== true
   /** Determines if the bottom app bar should fade based on props and scroll position. */
   const shouldFade = hideBottomAppBar !== true || bottomBarTrigger
 

--- a/apps/resources/src/components/PageWrapper/PageWrapper.tsx
+++ b/apps/resources/src/components/PageWrapper/PageWrapper.tsx
@@ -16,6 +16,7 @@ interface PageWrapperProps {
   children?: ReactNode
   hideHeader?: boolean
   hideHeaderSpacer?: boolean
+  hideHeaderTabButtons?: boolean
   testId?: string
   headerThemeMode?: ThemeMode
   hideFooter?: boolean
@@ -28,6 +29,7 @@ export function PageWrapper({
   children,
   hideHeader,
   hideHeaderSpacer,
+  hideHeaderTabButtons,
   testId,
   headerThemeMode,
   hideFooter = false,
@@ -40,6 +42,7 @@ export function PageWrapper({
         <Header
           themeMode={headerThemeMode}
           hideSpacer={hideHeaderSpacer}
+          hideTabButtons={hideHeaderTabButtons}
           showLanguageSwitcher={showLanguageSwitcher}
         />
       )}

--- a/apps/resources/src/components/ResourcesView/ResourceSections/ResourceSection/ResourceSection.tsx
+++ b/apps/resources/src/components/ResourcesView/ResourceSections/ResourceSection/ResourceSection.tsx
@@ -1,5 +1,4 @@
 import Box from '@mui/material/Box'
-import Container from '@mui/material/Container'
 import { useTheme } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
 import { ReactElement, useEffect } from 'react'
@@ -60,15 +59,15 @@ export function ResourceSection({
       {items.length > 0 ? (
         <Box data-testid="ResourceSection">
           <Typography variant="h5">{label}</Typography>
-          <Container maxWidth={false}>
+          {/* ml offsets the card padding, so the card image aligns with the heading */}
+          <Box sx={{ ml: -2 }}>
             <ContentCarousel
               items={items}
               renderItem={(itemProps) => <ResourceCard {...itemProps} />}
               breakpoints={swiperBreakpoints}
-              slidesOffsetBefore={-32}
               content="strategies-section"
             />
-          </Container>
+          </Box>
         </Box>
       ) : (
         <></>

--- a/apps/resources/src/components/ResourcesView/ResourcesView.tsx
+++ b/apps/resources/src/components/ResourcesView/ResourcesView.tsx
@@ -12,7 +12,7 @@ import { ResourceSections } from './ResourceSections'
 
 export function ResourcesView(): ReactElement {
   return (
-    <PageWrapper>
+    <PageWrapper hideHeaderTabButtons>
       <Container maxWidth="xxl" sx={{ px: { xs: 0 }, py: { xs: 6, sm: 9 } }}>
         <Stack sx={{ p: 0, gap: 10 }}>
           <ResourceHeading heading="Resources" />

--- a/prds/resources/09-02-VM-feat-hide-resources-tab-buttons.md
+++ b/prds/resources/09-02-VM-feat-hide-resources-tab-buttons.md
@@ -1,0 +1,38 @@
+# Remove the header tab buttons on the Resources page
+
+## Goals
+
+- Remove the header tab-button section from the `/resources` page.
+- The section shows the Resources, Journeys, Watch, and Metaverse tabs on desktop.
+- The same section shows one dropdown button on mobile.
+- Keep the section on the other pages that use the shared `Header`.
+
+## Implementation Strategy
+
+- [x] Add a `hideTabButtons` prop to `Header`. When true, the `Header` does not render the `BottomAppBar` or its spacer.
+- [x] Add a `hideHeaderTabButtons` prop to `PageWrapper` that passes through to `Header`.
+- [x] Set `hideHeaderTabButtons` on the `PageWrapper` in `ResourcesView`.
+- [x] Add unit tests for the new prop in `Header.spec.tsx`.
+
+## Obstacles
+
+- The existing `hideBottomAppBar` prop does not remove the bar. It hides the bar until the user scrolls. `VideoHero` depends on this behavior. A new prop was necessary.
+- The existing test "should hide bottom app bar" queries the test id `BottomAppBar`, but the component uses `HeaderBottomAppBar`. The test passes without the prop. The test stays unchanged; the new tests query the correct test id.
+
+## Resolutions
+
+- The new `hideTabButtons` prop removes the bar fully and does not change the `VideoHero` fade behavior.
+
+## Test Coverage
+
+- `Header.spec.tsx`: a test shows the bar when the flags are on, and a test shows no bar when `hideTabButtons` is true.
+- Full suite: `pnpm dlx nx run resources:test`.
+
+## User Flows
+
+- Open `/resources` → the page shows the heading and the search bar → the tab-button section is not visible.
+- Open `/watch` or `/journeys` → the tab-button section is still visible.
+
+## Follow-up Ideas
+
+- Remove the section from more pages with the same prop, if the design asks for it.

--- a/prds/resources/09-02-VM-feat-hide-resources-tab-buttons.md
+++ b/prds/resources/09-02-VM-feat-hide-resources-tab-buttons.md
@@ -36,3 +36,30 @@
 ## Follow-up Ideas
 
 - Remove the section from more pages with the same prop, if the design asks for it.
+
+## Addendum: align the section cards with the headings
+
+### Goals
+
+- Align the left edge of the card images with the section headings on `/resources`.
+
+### Obstacles
+
+- `ResourceSection` wrapped the carousel in a `Container` with 24 px padding.
+- The `slidesOffsetBefore={-32}` compensation in `ContentCarousel` sets a margin through the `sx` prop.
+- The Swiper stylesheet sets `margin-left: auto` on `.swiper`, and it can win the cascade. The margin then computes to 0 and the cards sit 32 px right of the headings.
+
+### Resolutions
+
+- The `Container` wrapper and the `slidesOffsetBefore` value are removed.
+- A `Box` with `ml: -2` now offsets the 8 px card padding. The card image aligns with the heading at all breakpoints.
+- `ContentCarousel` is a shared library component, so the fix stays local to `ResourceSection`.
+
+### Test Coverage
+
+- `nx run resources:test`: all tests pass.
+- Manual check in Chrome on `http://localhost:4310/resources`: the headings, the search bar, and the card images share one left edge.
+
+### User Flows
+
+- Open `/resources` → each section heading and its card images start at the same left edge.


### PR DESCRIPTION
## What this does

Two changes to the [/resources](https://www.jesusfilm.org/resources) page.

### 1. Remove the header tab buttons

Removes the header tab-button section from the page. The section showed the Resources, Journeys, Watch, and Metaverse tabs on desktop, and one dropdown button on mobile. The other pages that use the shared `Header` keep the section.

- Adds a `hideTabButtons` prop to `Header`. When true, the `Header` does not render the `BottomAppBar` or its spacer.
- Adds a `hideHeaderTabButtons` prop to `PageWrapper` that passes through to `Header`.
- Sets the prop on the `PageWrapper` in `ResourcesView`.

Why a new prop: the existing `hideBottomAppBar` prop does not remove the bar. It hides the bar until the user scrolls, and `VideoHero` depends on that behavior. The new prop removes the bar fully and does not change `VideoHero`.

### 2. Align the section cards with the headings

The cards sat 32 px right of the section headings: 24 px from a `Container` wrapper, plus 8 px from the card hover padding. The `slidesOffsetBefore={-32}` compensation in `ContentCarousel` sets a margin through the `sx` prop, but the Swiper stylesheet can win the cascade with `margin-left: auto`. The margin then computes to 0 and the compensation fails.

The fix removes the `Container` wrapper and the `slidesOffsetBefore` value in `ResourceSection`. A `Box` with `ml: -2` now offsets the card padding, so the card image aligns with the heading at all breakpoints. `ContentCarousel` is a shared library component, so the fix stays local to `ResourceSection`.

## Tests

- New tests in `Header.spec.tsx`: the bar shows when the flags are on, and the bar is absent when `hideTabButtons` is true.
- `nx run resources:test`: all tests pass.
- `nx affected --target=type-check` and `pnpm lint:changed --fix`: pass, no fixes.
- Manual check in Chrome on localhost: the headings, the search bar, and the card images share one left edge.

## Note for the reviewer

The tab-section removal applies to the /resources page only. Tell us if the section must go from more pages — the same prop covers that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Removed header tab buttons from the Resources page on desktop and mobile.
  * Adjusted resource card carousel alignment to better match section headings.
* **Bug Fixes**
  * Ensured the header navigation bar appears correctly when relevant feature flags are enabled, unless explicitly hidden.
* **Tests**
  * Added coverage for showing and hiding the header navigation bar under supported conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->