### PR TITLE
ci: right-size 5 runners

### DIFF
--- a/.github/workflows/autofix.ci.yml
+++ b/.github/workflows/autofix.ci.yml
@@ -18,7 +18,7 @@ jobs:
     if: >-
       ${{ !contains(github.head_ref, '-chore-ce-sync-') &&
           !contains(github.event.merge_group.head_commit.message, 'sync compound-engineering skills and agents') }}
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
       NODE_OPTIONS: '--max-old-space-size=8192'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build:
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: blacksmith-8vcpu-ubuntu-2204
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     steps:
@@ -163,7 +163,7 @@ jobs:
           fi
           ./tools/scripts/check-prisma-migrations.sh "origin/$GITHUB_BASE_REF"
   test:
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: blacksmith-8vcpu-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Right-sizes the five selected CI jobs from the 30-day utilization review. The three test recommendations share one matrix job, so one `runs-on` update applies to all three shards.

## Apply for reliability

- **autofix.ci / lint-work**, 2 to 4 vCPU, medium confidence. About 501 monthly runs showed 94.4% peak memory and full CPU utilization. Estimated monthly cost changes from $8.14 to $9.77 (+$1.63), while projected runtime improves about 40%. Median runtime moves from 167s to 99.2s and p95 from 421.8s to 267.6s. [Median sample](https://app.blacksmith.sh/JesusFilm/runs/33550237688/jobs/99997596229?tab=metrics), [p95 sample](https://app.blacksmith.sh/JesusFilm/runs/31037111323/jobs/92411838623?tab=metrics).

## Test before applying

- **Main / build**, 4 to 8 vCPU, medium confidence. About 500 monthly runs saturated all four cores. Estimated monthly cost changes from $8.25 to $10.66 (+$2.41), with projected runtime improving about 35%. Median runtime moves from 80s to 51.3s and p95 from 229.3s to 155.2s. [Median sample](https://app.blacksmith.sh/JesusFilm/runs/31017710993/jobs/92346030648?tab=metrics), [p95 sample](https://app.blacksmith.sh/JesusFilm/runs/33209225083/jobs/98978030953?tab=metrics).
- **Main / test (1/3)**, 4 to 8 vCPU, medium confidence. About 499 monthly runs saturated all four cores. Estimated monthly cost changes from $9.68 to $12.99 (+$3.31), with projected runtime improving about 33%. Median runtime moves from 76s to 50.6s and p95 from 306.6s to 214.4s. [Median sample](https://app.blacksmith.sh/JesusFilm/runs/31066280421/jobs/92504562396?tab=metrics), [p95 sample](https://app.blacksmith.sh/JesusFilm/runs/32167622008/jobs/95810803665?tab=metrics).
- **Main / test (2/3)**, 4 to 8 vCPU, medium confidence. About 502 monthly runs saturated all four cores. Estimated monthly cost changes from $9.43 to $12.39 (+$2.96), with projected runtime improving about 34%. Median runtime moves from 73s to 47.6s and p95 from 291.4s to 200.1s. [Median sample](https://app.blacksmith.sh/JesusFilm/runs/31728635354/jobs/94543212238?tab=metrics), [p95 sample](https://app.blacksmith.sh/JesusFilm/runs/32785296270/jobs/97615874975?tab=metrics).
- **Main / test (3/3)**, 4 to 8 vCPU, medium confidence. About 499 monthly runs saturated all four cores. Estimated monthly cost changes from $9.36 to $12.47 (+$3.11), with projected runtime improving about 33%. Median runtime moves from 73s to 48.3s and p95 from 300.4s to 208.8s. [Median sample](https://app.blacksmith.sh/JesusFilm/runs/32520404826/jobs/96891148601?tab=metrics), [p95 sample](https://app.blacksmith.sh/JesusFilm/runs/31746175186/jobs/94601143624?tab=metrics).

The focal workflow changes are:

```yaml
# autofix.ci
runs-on: blacksmith-4vcpu-ubuntu-2204

# Main build and test matrix
runs-on: blacksmith-8vcpu-ubuntu-2204
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated linting, build, and test workflows to use higher-capacity runners.
  * Improved CI resource allocation for faster or more reliable workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->