### PR TITLE
ci: use Blacksmith node cache in main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: actions/setup-node@v5
+      - uses: useblacksmith/setup-node@v5
         with:
           node-version: 22
           cache: 'pnpm'
@@ -79,7 +79,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: actions/setup-node@v5
+      - uses: useblacksmith/setup-node@v5
         with:
           node-version: 22
           cache: 'pnpm'
@@ -182,7 +182,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-      - uses: actions/setup-node@v5
+      - uses: useblacksmith/setup-node@v5
         with:
           node-version: 22
           cache: 'pnpm'


### PR DESCRIPTION
Switches the Main workflow's dependency-installing jobs to Blacksmith's setup-node action. This avoids concurrent cold-key jobs racing to save the same pnpm cache while preserving the existing Node version and cache inputs.

```yaml
- uses: useblacksmith/setup-node@v5
  with:
    node-version: 22
    cache: 'pnpm'
```

Applied to `build`, `graphql-schema-check`, and all `test` shards. `pnpm lint:changed --fix` and the affected type-check were attempted, but this bare checkout has no `node_modules`, so `node_modules/.bin` and `nx` were unavailable.