### PR TITLE
ci: skip Puppeteer downloads in main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
+env:
+  PUPPETEER_SKIP_DOWNLOAD: 'true'
 jobs:
   build:
     runs-on: blacksmith-4vcpu-ubuntu-2204


### PR DESCRIPTION
Stops the Main workflow's five dependency installs from downloading Chromium binaries that none of its build, schema, or unit-test jobs use. The sample build downloaded both Chrome and chrome-headless-shell, accounting for roughly 418 MB of network input.

```yaml
env:
  PUPPETEER_SKIP_DOWNLOAD: 'true'
```

This is scoped to Main, so browser-oriented workflows can continue installing their required browsers explicitly.