### PR TITLE
perf(ci): use shallow deploy checkouts

### DIFF
--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -78,8 +78,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           environment: Preview - ${{ matrix.app }}
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -90,7 +88,6 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - uses: nrwl/nx-set-shas@v4
       - name: vercel deployment
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -318,8 +315,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           environment: Production - ${{ matrix.app }}
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -331,7 +326,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - uses: nrwl/nx-set-shas@v4
       - name: vercel deployment
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
App deployment jobs currently fetch the complete repository history and calculate affected SHAs even though they deploy an explicit matrix project. Blacksmith samples show these checkouts taking 23-50 seconds, compared with 3-4 seconds for the workflow's shallow Playwright checkout.

This keeps full history and `nx-set-shas` in the `affected` job, where Nx needs them, while making preview and production deploy checkouts shallow. The deploy command remains unchanged:

```yaml
- uses: actions/checkout@v4
# ...
- name: vercel deployment
  run: pnpm exec nx run-many --target=deploy --projects=${{ matrix.app }}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined preview and production deployment workflows by using shallow repository checkouts.
  - Removed an internal commit-resolution step from deployment jobs.
  - No changes to application functionality or the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->