### PR TITLE
perf(ci): reduce autofix workflow work

### DIFF
--- a/.github/workflows/autofix.ci.yml
+++ b/.github/workflows/autofix.ci.yml
@@ -8,7 +8,7 @@ on:
   merge_group:
     branches: [main]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 jobs:
   lint-work:

--- a/.github/workflows/autofix.ci.yml
+++ b/.github/workflows/autofix.ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main, feature/*]
   merge_group:
     branches: [main]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 jobs:
   lint-work:
     # Skip /sync-ce PRs so autofix doesn't reformat CE-managed files.
@@ -26,9 +29,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Fetch other branches
-        if: ${{ github.event_name == 'pull_request' }}
-        run: git fetch --no-tags --prune --depth=5 origin $GITHUB_BASE_REF
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -53,28 +53,12 @@ jobs:
         with:
           targets: codegen
           all: true
-      - name: Run Prettier
-        run: pnpm run prettier:fix --check '!./.cache'
+      - name: Apply changed-file fixes
+        run: pnpm lint:changed --fix
       - name: Type Check
         uses: mansagroup/nrwl-nx-action@v3
         with:
           targets: type-check
-      - name: Cache lint artifacts # after prettier and type-check
-        uses: actions/cache@v4
-        with:
-          path: ./.cache
-          key: ${{ runner.os }}-node-22-lint-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-22-lint-
-      - name: Run ESLint
-        uses: mansagroup/nrwl-nx-action@v3
-        with:
-          targets: lint
-          args: --fix
-      - name: Extract Translations
-        uses: mansagroup/nrwl-nx-action@v3
-        with:
-          targets: extract-translations
       - name: Subgraph Check
         uses: mansagroup/nrwl-nx-action@v3
         with:


### PR DESCRIPTION
Cuts recurring autofix work identified in the 30-day workflow deep dive. Full-repository Prettier took 48s at p50 and 64s at p95, while the existing changed-file gate already mirrors Prettier, ESLint fixes, and translation extraction. The workflow now uses that gate and cancels superseded PR runs without cancelling merge-queue or push runs.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
  cancel-in-progress: true

- name: Apply changed-file fixes
  run: pnpm lint:changed --fix
```

The redundant shallow base fetch is also removed because full checkout already provides `origin/main`; retaining full history keeps Nx affected calculations safe for pull requests, pushes, and merge groups. Type checking, Prisma generation, GraphQL codegen, subgraph validation, branch validation, and autofix commits remain unchanged.

Local lint and affected type-check could not run in the dependency-free environment because `node_modules` is absent. The diff passed whitespace validation; CI will perform repository validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code-quality workflows to cancel redundant in-progress runs.
  * Changed lint automation to apply fixes only to changed files.
  * Retained automated type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->