### PR TITLE
fix(ci): correct codegen cache inputs

### DIFF
--- a/.github/workflows/autofix.ci.yml
+++ b/.github/workflows/autofix.ci.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           DISABLE_ERD: true
       - name: Install apollo and graphql for codegen
-        run: npm i -g apollo graphql # npm because apollo is deprecated and conflicts with graphql
+        run: npm i -g apollo@2.34.0 graphql@16.10.0 # npm because apollo is deprecated and conflicts with graphql
       - name: Codegen
         uses: mansagroup/nrwl-nx-action@v3
         with:

--- a/apps/journeys-admin/project.json
+++ b/apps/journeys-admin/project.json
@@ -157,6 +157,7 @@
     },
     "codegen": {
       "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/__generated__"],
       "options": {
         "commands": [
           {

--- a/apps/journeys/project.json
+++ b/apps/journeys/project.json
@@ -153,6 +153,7 @@
     },
     "codegen": {
       "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/__generated__"],
       "options": {
         "commands": [
           {

--- a/apps/resources/project.json
+++ b/apps/resources/project.json
@@ -159,6 +159,7 @@
     },
     "codegen": {
       "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/__generated__"],
       "options": {
         "commands": [
           {

--- a/libs/journeys/ui/project.json
+++ b/libs/journeys/ui/project.json
@@ -42,6 +42,10 @@
     },
     "codegen": {
       "executor": "nx:run-commands",
+      "outputs": [
+        "{projectRoot}/__generated__",
+        "{projectRoot}/src/**/__generated__/**/*"
+      ],
       "options": {
         "commands": [
           {

--- a/libs/shared/gql/project.json
+++ b/libs/shared/gql/project.json
@@ -7,6 +7,7 @@
   "targets": {
     "codegen": {
       "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/src/__generated__"],
       "options": {
         "command": "gql.tada generate output --tsconfig libs/shared/gql/tsconfig.json"
       }

--- a/nx.json
+++ b/nx.json
@@ -69,7 +69,18 @@
     },
     "codegen": {
       "cache": true,
-      "inputs": ["{workspaceRoot}/apis/api-gateway/schema.graphql"]
+      "inputs": [
+        "default",
+        "!{projectRoot}/__generated__/**/*",
+        "!{projectRoot}/src/**/__generated__/**/*",
+        "{workspaceRoot}/apis/api-gateway/schema.graphql",
+        "{workspaceRoot}/libs/journeys/ui/**/*",
+        "!{workspaceRoot}/libs/journeys/ui/**/__generated__/**/*",
+        "{workspaceRoot}/.github/workflows/autofix.ci.yml",
+        "{workspaceRoot}/package.json",
+        "{workspaceRoot}/pnpm-lock.yaml",
+        { "externalDependencies": ["gql.tada"] }
+      ]
     },
     "extract-translations": {
       "cache": false,


### PR DESCRIPTION
Prevents Nx from reusing stale GraphQL codegen results when project documents or shared Journeys UI operations change. The existing cache key only included the gateway schema, and no target declared the generated files that Nx must restore on a cache hit.

The shared cache contract now hashes project and shared inputs while excluding generated output, and each target declares its output locations:

```json
"codegen": {
  "cache": true,
  "inputs": [
    "default",
    "!{projectRoot}/__generated__/**/*",
    "{workspaceRoot}/apis/api-gateway/schema.graphql",
    "{workspaceRoot}/libs/journeys/ui/**/*"
  ]
}
```

The deprecated global Apollo toolchain is pinned to the versions currently resolved in CI so tool drift also invalidates predictably rather than silently changing generated output. JSON and diff syntax checks pass. Repository tests were left to CI per the execution environment constraints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Code generation now uses fixed Apollo and GraphQL versions for more consistent results across environments.
  - Generated code outputs are now tracked and cached more reliably, helping avoid unnecessary regeneration and improving build efficiency.
  - Code generation reruns are better triggered when relevant schemas, source files, configuration, workflows, or dependency manifests change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->