### PR TITLE
perf(ci): reduce autofix checkout transfer

### DIFF
--- a/.github/workflows/autofix.ci.yml
+++ b/.github/workflows/autofix.ci.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
Reduces the historical Git data fetched by `autofix.ci` while retaining complete commit history for Nx affected calculations and `lint:changed` merge-base resolution. Three recent runs downloaded 476-482 MiB from GitHub and spent 15-19 seconds in checkout.

```yaml
- uses: actions/checkout@v4
  with:
    fetch-depth: 0
    filter: blob:none
```

Git will fetch required working-tree blobs lazily. The PR intentionally changes only this workflow so its CI run can measure the actual transfer and timing improvement before wider adoption. Diff whitespace validation passes; CI will validate the workflow in the repository environment.